### PR TITLE
A host-bound mesh builder carries its configuration — the SERVE half of #1209 (#2517)

### DIFF
--- a/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
+++ b/memex/Memex.Portal.Shared/StaticRepoSyncExtensions.cs
@@ -5,6 +5,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Diagnostics;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 
@@ -48,7 +49,11 @@ public static class StaticRepoSyncExtensions
             // enumeration snapshot can be taken while this import is still landing content, and
             // every type it misses is left to compile on a user's first click. See
             // StaticRepoImportSettled.
-            services.AddSingleton<StaticRepoImportSettled>();
+            // TryAdd: the AI module registers this same signal for its provider-credential seed
+            // (AiMeshModuleAttribute), because a module may not depend on a service its host
+            // happens to have wired. Both sides TryAdd so there is exactly ONE instance whichever
+            // runs first — two would mean the importer marks a signal nobody is waiting on.
+            services.TryAddSingleton<StaticRepoImportSettled>();
 
             // The provider-credential seed rides the AI module for the same reason — it is the
             // DB-synced path of a ModelProvider node, which is AI's own business.

--- a/src/MeshWeaver.AI/AiMeshModuleAttribute.cs
+++ b/src/MeshWeaver.AI/AiMeshModuleAttribute.cs
@@ -5,6 +5,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 [assembly: MeshWeaver.AI.AiMeshModule]
 
@@ -33,12 +34,44 @@ public sealed class AiMeshModuleAttribute : MeshNodeProviderAttribute
     /// <inheritdoc />
     public override IEnumerable<Func<MeshBuilder, MeshBuilder>> BuilderConfigurations =>
     [
-        builder => builder
+        builder => ReportIfUnconfigured(builder)
             .AddAI(ServeFromPartitions(builder.Configuration))
             // The AI menu's navigation entries, seeded as platform-static UiContribution nodes.
             .AddAiMenuContributions()
             .ConfigureServices(services => AddAiComposition(services, builder.Configuration))
     ];
+
+    /// <summary>
+    /// Says so — on stderr, which is the pod log — when this module is installed onto a builder that
+    /// carries no configuration.
+    ///
+    /// <para>🚨 The fallback below (no configuration ⇒ in-memory serving) is a FAIL-CLOSED default
+    /// whose wrong answer is invisible: the portal boots, the AI menu appears, agents answer, and
+    /// the only symptom is that every AI partition's in-memory type-definition node quietly wins its
+    /// own top-level path — so <c>/Agent</c> and <c>/Skill</c> serve the built-in NodeType instead of
+    /// the authored Store package (#2517) and the static-repo import never runs (#2507). Nobody
+    /// files a bug against something that looks like it works. This line is the difference between
+    /// "the deployment chose in-memory" and "nobody ever told this module anything", which are the
+    /// two readings of a null and are not the same event.</para>
+    ///
+    /// <para>Pre-DI by construction — a module attribute contributes inside
+    /// <c>MeshBuilder.InstallAssemblies</c>, before any logging pipeline exists — so stderr is the
+    /// channel, matching <c>MeshBuilderModuleActivation</c>'s own boot diagnostics.</para>
+    /// </summary>
+    private static MeshBuilder ReportIfUnconfigured(MeshBuilder builder)
+    {
+        if (builder.Configuration is null)
+            Console.Error.WriteLine(
+                "[ModuleActivation] MeshWeaver.AI installed onto a builder with NO configuration: "
+                + "Features:StaticRepoSync:Partitions cannot be read, so every AI partition (Agent, "
+                + "Skill, Harness, Model, Provider) is served IN-MEMORY and the static-repo import is "
+                + "not registered. On a deployment that stores AI content in the database this is "
+                + "wrong and silent — the in-memory type-definition node shadows the durable row at "
+                + "the same top-level path. A host binding a mesh to an IHostApplicationBuilder gets "
+                + "this for free; a bespoke host must call MeshBuilder.WithConfiguration(...) BEFORE "
+                + "InstallAssemblies.");
+        return builder;
+    }
 
     /// <summary>
     /// The partitions Postgres serves, from <c>Features:StaticRepoSync:Partitions</c>.
@@ -141,7 +174,19 @@ public sealed class AiMeshModuleAttribute : MeshNodeProviderAttribute
             // BuiltInLanguageModelProvider re-projects configuration into the served node on every
             // read, so there is nothing to converge and nothing to persist.
             if (serve.Contains(ModelProviderNodeType.RootNamespace))
+            {
+                // 🚨 Register the seed's OWN dependency. StaticRepoImportSettled is the one-shot
+                // boot signal the seed sequences on; the portal's AddStaticRepoSync also registers
+                // it, and until now the module simply ASSUMED that — so this hosted service could
+                // only be constructed on a host that separately wired the portal's static-repo
+                // sync. On any other host it throws at GetServices<IHostedService>() and takes boot
+                // with it, which is not a fault the module may hand to its host. TryAdd on BOTH
+                // sides means exactly one instance whichever registers first — it must stay one,
+                // because a second instance is a signal the importer never marks and a seed that
+                // waits for it forever.
+                services.TryAddSingleton<Graph.StaticRepoImportSettled>();
                 services.AddSingleton<Microsoft.Extensions.Hosting.IHostedService, ProviderCredentialSeedHostedService>();
+            }
         }
 
         return services;

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-agent-and-skill-pages-show-their-own-content.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-agent-and-skill-pages-show-their-own-content.md
@@ -1,0 +1,31 @@
+---
+Name: Agent and Skill pages show their own content again
+Category: Fix
+Description: Fixed the built-in type definitions taking over the /Agent, /Skill, /Harness, /Model and /Provider pages, which made them render a bare placeholder instead of the published package.
+Icon: Sparkle
+Order: -20260827
+---
+
+# Agent and Skill pages show their own content again
+
+Opening **/Agent** or **/Skill** showed a bare page: the right name was missing, the
+description was missing, and a link to either page shared as an empty card on Slack, Teams
+or LinkedIn. The published packages behind those pages were fine the whole time — nothing
+was reading them.
+
+Five top-level pages share a name with something the platform defines internally:
+**Agent**, **Skill**, **Harness**, **Model** and **Provider**. A deployment says whether it
+stores that content in its database, and when it does, the internal definition steps aside
+and the stored content owns the page. A recent internal change stopped that setting reaching
+the part of the platform that reads it, so every deployment behaved as if it had no setting
+at all: the internal definition took the page and the stored content became unreachable —
+not just outranked, but invisible to the page, to search, and to anything trying to update
+it.
+
+The setting now reaches it on every deployment, and a page can no longer be quietly taken
+over this way. Two related effects are fixed with it: content for those five areas is
+imported and kept up to date on start-up again, and the model **Provider** area — which had
+never been created on affected deployments — now appears.
+
+If you maintain a deployment: nothing to change. Your existing configuration was always
+correct; it simply was not being read.

--- a/src/MeshWeaver.Hosting/MeshHostApplicationBuilder.cs
+++ b/src/MeshWeaver.Hosting/MeshHostApplicationBuilder.cs
@@ -20,6 +20,29 @@ public record MeshHostApplicationBuilder : MeshBuilder
     public MeshHostApplicationBuilder(IHostApplicationBuilder Host, Address address) : base(x => x.Invoke(Host.Services), address)
     {
         this.Host = Host;
+        // 🚨 The deployment's configuration reaches the builder HERE — at construction, before any
+        // caller can install a module — because a module attribute's contribution runs inside
+        // MeshBuilder.InstallAssemblies and reads MeshBuilder.Configuration to decide what to
+        // BUILD (see MeshBuilder.Configuration). A host that binds a mesh to an
+        // IHostApplicationBuilder always HAS the configuration; making each composition root
+        // remember to hand it over is what failed.
+        //
+        // MeshBuilderModuleActivation.InstallConfiguredModules also hands it over, and that was
+        // believed to be enough. It is not: it covers only the hosts that install modules through
+        // THAT helper. The portal composes its own module union (baseline + activation sidecar +
+        // platform floor) and calls InstallAssemblies directly, so it never reached the hand-off —
+        // and from 16497893b, when the AI engine became an attribute-carried module reading this
+        // very property, every deployed portal answered "no configuration" and therefore
+        // "Features:StaticRepoSync:Partitions is absent". The AI partitions (Agent, Skill, Harness,
+        // Model, Provider) then fell back to in-memory serving, so each in-memory type-definition
+        // node was served as the RUNTIME node at its own top-level path and SHADOWED the durable
+        // package root there: /Agent and /Skill served the built-in NodeType instead of the
+        // authored Store/Plugin node (#2517), and the static-repo import never registered at all,
+        // so the Provider partition never materialized (#2507).
+        //
+        // Configuration is a live ConfigurationManager on this interface, so sources added after
+        // this ctor are still visible to whatever reads it later.
+        this.WithConfiguration(Host.Configuration);
         Host.ConfigureContainer(new MessageHubServiceProviderFactory(BuildHub));
         this.RegisterMeshQueryCoreOnMeshHub();
         // Drain the mesh root hub (action blocks + IoPool + AsyncDisposeQueue) during host shutdown,

--- a/test/MeshWeaver.AI.Test/AiCatalogPathOwnershipTest.cs
+++ b/test/MeshWeaver.AI.Test/AiCatalogPathOwnershipTest.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// Who owns a TOP-LEVEL path that a built-in NodeType and a durable package node both name.
+///
+/// <para>Every AI catalog ships an in-memory type-definition MeshNode whose path IS its
+/// discriminator — <c>Agent</c>, <c>Skill</c>, <c>Harness</c>, <c>Provider</c> — and those are
+/// exactly the paths the Store's own packages are published at. Two claimants, one path. The static
+/// one wins every serve seam by construction (<c>MeshDataSource.WithMeshNodes</c> seeds the per-node
+/// hub from it via <c>WithInitialData</c>, bypassing persistence entirely), so when it is served the
+/// durable row is not merely out-ranked, it is unreachable: <c>/Agent</c> and <c>/Skill</c> rendered
+/// the built-in NodeType's name and icon with no description and no JSON-LD, because the node the
+/// page resolved to was the type definition (#2517). #1209 is the same collision on the INSTALL
+/// path, and its cure is the rule this pins: when the deployment serves the partition from the
+/// database, the durable row owns the path and the type-def stands down to
+/// <see cref="MeshNode.IsDefinitionOnly"/> — still supplying its HubConfiguration BY NAME, never
+/// serving as the runtime node.</para>
+///
+/// <para>🚨 The deployment states that through <c>Features:StaticRepoSync:Partitions</c>, which the
+/// AI engine reads off <see cref="MeshBuilder.Configuration"/> at INSTALL time
+/// (<see cref="AiMeshModuleAttribute"/>) — so this test goes through the MODULE, with a
+/// configuration shaped like the portal's appsettings, rather than calling
+/// <c>AddAI(serveFromPartition)</c> with a hand-built set. The sibling guards
+/// (<c>AgentPartitionSyncGateTest</c>, <c>NodeTypeCatalogTest</c>) call <c>AddAI</c> directly, which
+/// was the real production entry until 16497893b moved it behind the module attribute; they stayed
+/// green across that move while every deployed portal served its AI partitions in-memory. That the
+/// configuration actually REACHES the builder is a separate claim, pinned by
+/// <c>ModuleConfigurationVisibilityTest</c>.</para>
+/// </summary>
+public class AiCatalogPathOwnershipTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The distributed portal's own appsettings list, verbatim.</summary>
+    private static readonly string[] ServedPartitions =
+        ["Doc", "Agent", "Model", "Provider", "Harness", "Skill"];
+
+    /// <summary>
+    /// The AI engine as a deployment installs it: a configuration carrying the served-partition
+    /// list, then the assembly attribute's contributions — the same two steps
+    /// <c>MeshBuilder.InstallAssemblies</c> performs for <c>MeshWeaver.AI.dll</c>.
+    /// </summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        var configured = base.ConfigureMesh(builder);
+        configured.WithConfiguration(new ConfigurationBuilder()
+            .AddInMemoryCollection(ServedPartitions.Select((p, i) =>
+                new KeyValuePair<string, string?>($"Features:StaticRepoSync:Partitions:{i}", p)))
+            .Build());
+        return new AiMeshModuleAttribute().BuilderConfigurations
+            .Aggregate(configured, (current, configure) => configure(current));
+    }
+
+    private CancellationToken Ct => TestContext.Current.CancellationToken;
+
+    /// <summary>
+    /// Nothing static SERVES an AI catalog's top-level path, so the durable row is the only claimant
+    /// — while the type definition itself survives, because it is what carries the HubConfiguration
+    /// delegate for every instance of that NodeType.
+    /// </summary>
+    [Theory(Timeout = 60000)]
+    [InlineData("Agent")]
+    [InlineData("Skill")]
+    [InlineData("Harness")]
+    public void ADbServedCatalogPath_HasNoStaticClaimant_ButKeepsItsTypeDefinition(string path)
+    {
+        Mesh.ServiceProvider.FindServedStaticNode(path).Should().BeNull(
+            $"'{path}' is served from the database, so nothing may serve it statically — a static "
+            + "claimant seeds the per-node hub from a node that is by design NEVER persisted, which "
+            + "leaves the path simultaneously unreadable, un-creatable and un-writable (#1209)");
+
+        Mesh.ServiceProvider.DescribeStaticServeCollision(path).Should().BeNull(
+            "the collision diagnostic is the one description of this fault; it must have nothing to "
+            + "report once the durable row owns the path");
+
+        var definition = Mesh.ServiceProvider.FindStaticNode(path);
+        definition.Should().NotBeNull(
+            $"the '{path}' type definition must remain — it supplies the HubConfiguration delegate "
+            + "by name, which is not serialisable and cannot come from the database");
+        definition!.IsDefinitionOnly.Should().BeTrue(
+            "a definition is not a runtime node: it proves the type exists and configures instance "
+            + "hubs, and is excluded from serving and from query results");
+    }
+
+    /// <summary>
+    /// The SERVE path, end to end: a durable node published at a catalog's top-level path is what
+    /// resolution answers with. <c>IPathResolver.ResolvePath</c> is the exact call the crawler-facing
+    /// head makes (<c>SeoResolver.Resolve</c>) before reading the node's name, description, icon and
+    /// JSON-LD off it — so this is the assertion that <c>/Agent</c> renders the package and not the
+    /// built-in NodeType.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ADurableNodeAtACatalogPath_IsWhatTheServePathResolves()
+    {
+        var ct = Ct;
+        // Stands in for the Store package published at this path — what matters is that it is a
+        // DURABLE row at the same top-level path as the built-in "Agent" type definition, carrying
+        // the name and description the page is supposed to render.
+        await NodeFactory.CreateNode(new MeshNode("Agent")
+        {
+            Name = "Agents",
+            NodeType = "Space",
+            Description = "Ready-made agents you can talk to, and a place to build your own.",
+            State = MeshNodeState.Active,
+        }).FirstAsync().ToTask(ct);
+
+        var resolution = await PathResolver.ResolvePath("Agent")
+            .Where(r => r?.Node is not null)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(30))
+            .FirstAsync()
+            .ToTask(ct);
+
+        resolution.Should().NotBeNull("'/Agent' must resolve to a node");
+        resolution!.Remainder.Should().BeNullOrEmpty("the whole path was matched");
+        resolution.Node!.Name.Should().Be("Agents",
+            "the page must serve the AUTHORED node. 'Agent' here would be the built-in NodeType "
+            + "definition winning the path — the #2517 symptom, visible as og:title=\"Agent\"");
+        resolution.Node.Description.Should().NotBeNullOrEmpty(
+            "the type definition carries no description, so an empty one is the tell that the "
+            + "definition was served: the live pages emitted no og:description and no JSON-LD");
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleConfigurationVisibilityTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleConfigurationVisibilityTest.cs
@@ -2,10 +2,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 using Xunit;
 
 [assembly: MeshWeaver.Hosting.Monolith.Test.ConfigurationVisibilityModule]
@@ -92,5 +94,53 @@ public class ModuleConfigurationVisibilityTest
             "the module has to see the deployment's OWN configuration, and see it BEFORE its "
             + "contribution runs — a value that arrived afterwards is a value the module could not "
             + "have used to decide what to build");
+    }
+
+    /// <summary>
+    /// 🚨 The test above measured the WRONG PATH, and was green for it while every deployed portal
+    /// was broken (#2517, #2507). It covers <c>InstallConfiguredModules</c> — one helper, used by
+    /// the hosts simple enough to read <c>Modules:Assemblies</c> and install it. The PORTAL does not
+    /// use it: it composes its own module union (appsettings baseline + activation sidecar +
+    /// platform floor + generation resolution) and calls <see cref="MeshBuilder.InstallAssemblies"/>
+    /// directly — so it never reached the hand-off, and every module contribution ran against a
+    /// <c>null</c> configuration.
+    ///
+    /// <para>That is not a portal bug to fix in the portal. <c>InstallAssemblies</c> is where module
+    /// contributions RUN, it takes no configuration, and any composition root may call it — so
+    /// "remember to hand the configuration over first" is a rule each new composer has to
+    /// rediscover, and one of them already did not. A host that binds a mesh to an
+    /// <see cref="IHostApplicationBuilder"/> always HAS the configuration, so
+    /// <c>MeshHostApplicationBuilder</c> takes it at construction and no caller can be too late.</para>
+    ///
+    /// <para>This test installs through <c>InstallAssemblies</c> — deliberately NOT through the
+    /// helper — because that is the call the portal makes.</para>
+    /// </summary>
+    [Fact]
+    public void AHostBoundBuilder_ExposesTheHostsConfiguration_ToAModuleInstalledDirectly()
+    {
+        var host = Host.CreateApplicationBuilder();
+        var builder = new MeshHostApplicationBuilder(host, AddressExtensions.CreateMeshAddress());
+
+        // The portal's call — the module union it computed itself, straight to InstallAssemblies.
+        builder.InstallAssemblies(typeof(ModuleConfigurationVisibilityTest).Assembly.Location);
+
+        // Read the registration rather than building a provider: the value the module captured is
+        // registered as a singleton INSTANCE, so the descriptor already holds the answer, and this
+        // cannot fail for reasons unrelated to the claim.
+        var captured = host.Services
+            .LastOrDefault(d => d.ServiceType == typeof(CapturedConfiguration))?
+            .ImplementationInstance as CapturedConfiguration;
+
+        captured.Should().NotBeNull(
+            "the module's BuilderConfigurations must have run — otherwise this test proves nothing "
+            + "about what it saw and must fail rather than pass vacuously");
+        captured!.Value.Should().BeSameAs(host.Configuration,
+            "a module installed by ANY composition root must see the deployment's configuration. "
+            + "When it does not, the failure is silent and total: the AI engine reads exactly this "
+            + "property to decide whether Agent/Skill/Harness/Model/Provider are served from the "
+            + "database, a null answers 'in-memory', and each in-memory type-definition node then "
+            + "shadows the durable package root at its own top-level path — /Agent and /Skill "
+            + "served the built-in NodeType instead of the authored Store page (#2517) and the "
+            + "static-repo import never registered (#2507)");
     }
 }


### PR DESCRIPTION
Fixes #2517 — the serve half of #1209.

> **Relationship to #2525 (merged ~20 min ago, closes #2507).** Both PRs trace to the same null `MeshBuilder.Configuration`; we found it independently and in parallel. #2525 fixes it **at the caller** (`ConfigureMemexMesh` now calls `WithConfiguration` before `InstallAssemblies`) and that is what unblocks the portal — nothing here is needed to close #2507. This PR makes the same guarantee **structural instead of remembered**, and carries the #2517 serve-half rule, the blast-radius enumeration, a latent boot break, and the tests, none of which #2525 has. The two changes touch different files and compose.

## The symptom, measured live

```
$ curl https://memex.meshweaver.cloud/Agent | grep og:
<meta property="og:title" content="Agent" …          ← the built-in NodeType, not the package
   (no og:description, no JSON-LD; favicon /static/NodeTypeIcons/bot.svg)
```

`get @Agent` returns `{"id":"Agent","name":"Agent","icon":"/static/NodeTypeIcons/bot.svg"}` — no `nodeType`, no `version`: the in-memory type-definition node, exactly as `AgentNodeType.CreateMeshNode()` builds it. Meanwhile `nodeType:Store/Plugin` finds the durable row at the same path, `name: "Agents"`, version 8. Same shape on `@Skill` and `@Harness`; `@Provider` answers **Not found**.

## Why this is the serve half of #1209, not a ranking bug

The static claim wins **by construction**: `MeshDataSource.WithMeshNodes` seeds the per-node hub from it via `WithInitialData`, bypassing persistence entirely. So the durable row is not out-ranked — it is unreachable. Unreadable, un-creatable, un-writable, which is why `Skill` stopped appearing as a `Store/Plugin` row at all. #1209 documented that exact collision on the **install** path and shipped `DescribeStaticServeCollision` for it; this is the same collision on the **serve** path, reached whenever `serveFromPartition` is not set.

## Blast radius: five, not two

Derived, not assumed — the intersection of "top-level path with a static claimant" and "published package root":

| Path | Static claimant | Gate |
|---|---|---|
| `Agent` | partition claim + `@Agent` type-def | `AgentNodeType.cs:34` |
| `Skill` | partition claim + `@Skill` type-def | `SkillNodeType.cs:38` |
| `Harness` | partition claim + `@Harness` type-def | `HarnessNodeType.cs:41` |
| `Model` | partition claim | `LanguageModelNodeType.cs:78-80` |
| `Provider` | partition claim | `ModelProviderNodeType.cs:127-128` |

All five gated on the same `serveFromPartition` switch. The other 80 package roots have **no** static claimant: the module DLLs sharing brand names (`Anthropic`, `Mcp`, `Teams`, …) register under dot-qualified `MeshWeaver.*` paths. `Agent` and `Skill` are the two with authored Store packages, so they are the two a visitor could see. `Model`/`Provider` is #2507 seen from the other end.

## The change

**`MeshHostApplicationBuilder` takes the configuration at construction.** `InstallAssemblies` is where module contributions run, it takes no configuration, and any composition root may call it — so "hand the configuration over first" is a rule each new composer must rediscover, and one already did not. A host binding a mesh to an `IHostApplicationBuilder` always has it, so no caller can be too late. Covers `UseMeshWeaver` (monolith, LocalMesh) and `UseOrleansMeshServer` (distributed); a bare `MeshBuilder` stays unconfigured as before.

**A latent boot break, surfaced by making the path reachable.** The AI module registered `ProviderCredentialSeedHostedService` while assuming another assembly had registered its `StaticRepoImportSettled` dependency — true on the portal, false in general. Now that the configuration arrives, a host without the portal's static-repo sync fails at `GetServices<IHostedService>()` and takes boot with it. Both registrars now `TryAdd`: exactly one instance whichever runs first (two would be a signal the importer marks and the seed never sees). This was caught by the new test, not by inspection — it is the failure #2525 also arms.

**A null `Configuration` is now reported on stderr** rather than silently read as "this deployment chose in-memory". Two different events; the wrong one is invisible.

## Tests

- **`ModuleConfigurationVisibilityTest`** gains the case its existing sibling missed. That one covers `InstallConfiguredModules` — a helper the portal does not use — so it stayed green across the move that broke every deployment. The new one installs through `InstallAssemblies`, the call a portal makes. **Verified RED without this change**, green with it.
- **`AiCatalogPathOwnershipTest`** pins the resolution rule, going through the **module** with the deployment's own served-partition list rather than a hand-built `AddAI(...)` set — which is what `AgentPartitionSyncGateTest` and `NodeTypeCatalogTest` do, and why they stayed green too. Nothing static serves `Agent`/`Skill`/`Harness`, `DescribeStaticServeCollision` has nothing to report, the type definitions survive as `IsDefinitionOnly`, and **a durable node published at a catalog path is what `IPathResolver.ResolvePath` answers with** — the exact call `SeoResolver` makes before reading name, description, icon and JSON-LD off it.

## Verification

`dotnet build -c Release -warnaserror` over the full solution → **0 Warning(s), 0 Error(s)**. `Memex.Portal.Shared.Test` 350/350; `AiCatalogPathOwnershipTest` 4/4; `ModuleConfigurationVisibilityTest` 3/3; `WhatsNewEntryIntegrityTest` green.

## Known follow-up (data, not code) — scoped by a direct read of Postgres

The shadowing blocked the write at the **top-level package path**, not inside the partition. A read-only query against `memex-cloud` confirms the partitions themselves are intact: `agent.mesh_nodes` = **17** rows, `skill.mesh_nodes` = **25** rows, against the 16 nodes currently served in-memory under `Agent/`. So the flip to DB-served is a **clean cutover, not a cliff** — the platform agent catalog comes back from `agent.mesh_nodes` and nothing needs pre-installing.

What did not survive is one specific object: **there is no `Store/Plugin` row at the top-level path `Skill`**, while `skill.mesh_nodes` holds its 25 rows. `/Agent`'s package row did survive (version 8) and recovers on deploy; `/Skill`'s never landed and needs the package re-installed once this ships.

So when verifying live: `/Agent` should recover, and `/Skill` should **not** until it is re-installed — a `/Skill` that still looks wrong afterwards is expected, not a failed fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
