### PR TITLE
/api/mesh: no await reaches into hub code — three endpoints become one composed chain + one edge bridge

### DIFF
--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -254,22 +254,30 @@ public static class MeshApiEndpoints
             .FirstAsync().ToTask(ct);
     }
 
-    private static async Task<IResult> HandleMirror(
+    /// <summary>
+    /// <c>POST /api/mesh/mirror</c>. Shaped like <see cref="HandleRenderArea"/>: the body is one
+    /// composed observable and the ONLY bridge to <see cref="Task"/> is the trailing
+    /// <c>.FirstAsync().ToTask(ct)</c> at the ASP.NET edge. It used to <c>await</c> the hub
+    /// round-trip mid-method — the shape that reaches into hub code from an await chain, and the
+    /// one the endpoint's own <c>Task&lt;IResult&gt;</c> signature is not licence for.
+    /// </summary>
+    private static Task<IResult> HandleMirror(
         HttpContext http, IMessageHub rootHub, MirrorRequest body, CancellationToken ct)
     {
         var sessionHub = ResolveSession(http, rootHub);
-        var delivery = await sessionHub.Observe<MirrorResult>(body, o => o.WithTarget(new Address("mesh")))
+        return sessionHub.Observe<MirrorResult>(body, o => o.WithTarget(new Address("mesh")))
             .Catch((Exception _) => Observable.Return((IMessageDelivery<MirrorResult>)null!))
+            .Select(delivery => delivery?.Message ?? new MirrorResult
+            {
+                Status = "Error",
+                Direction = body.Direction,
+                SourcePath = body.SourcePath,
+                TargetPath = body.TargetPath ?? body.SourcePath,
+                Error = "No response from mirror handler — is the mesh hub reachable and AddPersistence configured?",
+            })
+            .Select(result => (IResult)Results.Content(
+                JsonSerializer.Serialize(result, sessionHub.JsonSerializerOptions), "application/json"))
             .FirstAsync().ToTask(ct);
-        var result = delivery?.Message ?? new MirrorResult
-        {
-            Status = "Error",
-            Direction = body.Direction,
-            SourcePath = body.SourcePath,
-            TargetPath = body.TargetPath ?? body.SourcePath,
-            Error = "No response from mirror handler — is the mesh hub reachable and AddPersistence configured?",
-        };
-        return Results.Content(JsonSerializer.Serialize(result, sessionHub.JsonSerializerOptions), "application/json");
     }
 
     private static IResult HandleNavigateTo(HttpContext http, IOptions<McpConfiguration>? mcp, NavigateBody body)
@@ -282,27 +290,48 @@ public static class MeshApiEndpoints
     private static IResult HandleBaseUrl(HttpContext http, IOptions<McpConfiguration>? mcp) =>
         Results.Json(new { url = ResolveBaseUrl(http, mcp) });
 
-    private static async Task<IResult> HandleUpload(HttpContext http, IMessageHub rootHub, CancellationToken ct)
+    /// <summary>
+    /// <c>POST /api/mesh/upload</c>. The multipart read stays <c>async</c> — <c>ReadFormAsync</c> and
+    /// <c>CopyToAsync</c> over the request body are ASP.NET's own IO and belong at this edge — but it
+    /// is quarantined in <see cref="ReadUploadAsync"/>, which never touches the mesh. The MESH call
+    /// is composed, not awaited: the single bridge back to <see cref="Task"/> is the trailing
+    /// <c>.FirstAsync().ToTask(ct)</c>. An <c>await</c> that reaches into hub code is the shape the
+    /// endpoint's <c>Task&lt;IResult&gt;</c> signature is not licence for, however far from a hub
+    /// scheduler this particular request thread happens to be.
+    /// </summary>
+    private static Task<IResult> HandleUpload(HttpContext http, IMessageHub rootHub, CancellationToken ct) =>
+        ReadUploadAsync(http, ct).ToObservable()
+            .SelectMany(upload => upload.Failure is not null
+                ? Observable.Return(upload.Failure)
+                : new MeshOperations(ResolveSession(http, rootHub))
+                    .Upload(upload.Path!, upload.Bytes!)
+                    .Select(result => (IResult)Results.Content(result, "application/json")))
+            .FirstAsync().ToTask(ct);
+
+    /// <summary>
+    /// Reads the multipart body: either a <c>Failure</c> result to ship as-is, or the target path
+    /// and the file's bytes. Pure ASP.NET — no mesh call, so nothing here can park a hub, and
+    /// <c>internal</c> so <c>MeshApiUploadBodyTest</c> can pin each refusal without standing up an
+    /// authenticated pipeline and a mesh just to assert a 400.
+    /// </summary>
+    internal static async Task<(IResult? Failure, string? Path, byte[]? Bytes)> ReadUploadAsync(
+        HttpContext http, CancellationToken ct)
     {
         if (!http.Request.HasFormContentType)
-            return Results.BadRequest(new { error = "Content-Type must be multipart/form-data." });
+            return (Results.BadRequest(new { error = "Content-Type must be multipart/form-data." }), null, null);
 
         var form = await http.Request.ReadFormAsync(ct);
         var path = form["path"].FirstOrDefault();
         var file = form.Files.FirstOrDefault();
         if (string.IsNullOrWhiteSpace(path))
-            return Results.BadRequest(new { error = "Form field 'path' is required." });
+            return (Results.BadRequest(new { error = "Form field 'path' is required." }), null, null);
         if (file is null || file.Length == 0)
-            return Results.BadRequest(new { error = "Form file 'file' is required." });
+            return (Results.BadRequest(new { error = "Form file 'file' is required." }), null, null);
 
         using var ms = new MemoryStream();
         await using (var stream = file.OpenReadStream())
             await stream.CopyToAsync(ms, ct);
-
-        var sessionHub = ResolveSession(http, rootHub);
-        var ops = new MeshOperations(sessionHub);
-        var result = await ops.Upload(path, ms.ToArray()).FirstAsync().ToTask(ct);
-        return Results.Content(result, "application/json");
+        return (null, path, ms.ToArray());
     }
 
     /// <summary>
@@ -338,7 +367,12 @@ public static class MeshApiEndpoints
         return SessionHubResolver.ResolveSessionHub(rootHub, http, "api", logger);
     }
 
-    private static async Task<IResult> RunString(
+    /// <summary>
+    /// The shared body of every string-returning verb on this surface. <c>work</c>'s observable is
+    /// composed, never awaited: the single bridge to <see cref="Task"/> is the trailing
+    /// <c>.FirstAsync().ToTask(ct)</c>, which is the ASP.NET edge itself.
+    /// </summary>
+    private static Task<IResult> RunString(
         HttpContext http,
         IMessageHub rootHub,
         CancellationToken ct,
@@ -346,11 +380,12 @@ public static class MeshApiEndpoints
     {
         var sessionHub = ResolveSession(http, rootHub);
         var ops = new MeshOperations(sessionHub);
-        var result = await work(ops).FirstAsync().ToTask(ct);
         // MeshOperations returns either a JSON document or an "Error: …" sentinel string.
         // Both are safe to ship as application/json — the error string is just a JSON-quoted
         // value the client can branch on (mirrors the MCP-tool contract).
-        return Results.Content(result, "application/json");
+        return work(ops)
+            .Select(result => (IResult)Results.Content(result, "application/json"))
+            .FirstAsync().ToTask(ct);
     }
 
     private static string ResolveBaseUrl(HttpContext http, IOptions<McpConfiguration>? mcp)

--- a/test/Memex.Portal.Shared.Test/MeshApiUploadBodyTest.cs
+++ b/test/Memex.Portal.Shared.Test/MeshApiUploadBodyTest.cs
@@ -1,0 +1,136 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Api;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Primitives;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The refusal contract of <c>POST /api/mesh/upload</c>'s multipart read.
+///
+/// <para><b>Why it exists.</b> <c>HandleUpload</c> used to be one <c>async</c> method that read the
+/// form, validated it, and then <c>await</c>ed <c>MeshOperations.Upload</c> — an await chain
+/// reaching into hub code, which is the shape an endpoint's <c>Task&lt;IResult&gt;</c> signature is
+/// not licence for. Splitting it moved the three refusals across a new seam
+/// (<c>ReadUploadAsync</c> returns them; the composed chain ships them without ever constructing a
+/// session hub), and a refusal that quietly became a 500 — or one that started resolving a session
+/// before deciding the request was malformed — would look like working code from anywhere else.</para>
+///
+/// <para>Asserted at that seam rather than over HTTP on purpose: the route is Bearer-only, so an
+/// end-to-end 400 test would need the whole token pipeline and a live mesh in order to prove
+/// something about a branch that reaches neither.</para>
+/// </summary>
+public class MeshApiUploadBodyTest
+{
+    [Fact]
+    public async Task A_non_multipart_request_is_refused_before_the_body_is_read()
+    {
+        var http = NewContext();
+        http.Request.ContentType = "application/json";
+
+        var (failure, path, bytes) = await MeshApiEndpoints.ReadUploadAsync(
+            http, TestContext.Current.CancellationToken);
+
+        StatusOf(failure).Should().Be((int)HttpStatusCode.BadRequest);
+        path.Should().BeNull();
+        bytes.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_missing_path_field_is_refused()
+    {
+        var http = NewMultipart(path: null, fileName: "logo.png", content: "png-bytes");
+
+        var (failure, path, bytes) = await MeshApiEndpoints.ReadUploadAsync(
+            http, TestContext.Current.CancellationToken);
+
+        StatusOf(failure).Should().Be((int)HttpStatusCode.BadRequest);
+        path.Should().BeNull();
+        bytes.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task A_missing_file_is_refused()
+    {
+        var http = NewMultipart(path: "@Foo/content/logo.png", fileName: null, content: null);
+
+        var (failure, path, bytes) = await MeshApiEndpoints.ReadUploadAsync(
+            http, TestContext.Current.CancellationToken);
+
+        StatusOf(failure).Should().Be((int)HttpStatusCode.BadRequest);
+        path.Should().BeNull();
+        bytes.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task An_empty_file_is_refused()
+    {
+        var http = NewMultipart(path: "@Foo/content/logo.png", fileName: "logo.png", content: "");
+
+        var (failure, path, bytes) = await MeshApiEndpoints.ReadUploadAsync(
+            http, TestContext.Current.CancellationToken);
+
+        StatusOf(failure).Should().Be((int)HttpStatusCode.BadRequest);
+        path.Should().BeNull();
+        bytes.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The success shape: no failure, the declared path, and the file's bytes VERBATIM — including
+    /// a non-ASCII byte, since these bytes are what reaches <c>MeshOperations.Upload</c> and a
+    /// re-encode here would land a corrupt asset rather than fail.
+    /// </summary>
+    [Fact]
+    public async Task A_well_formed_upload_yields_the_path_and_the_exact_bytes()
+    {
+        var body = "the-file-contents ÿ";
+        var http = NewMultipart(path: "@Foo/content/logo.png", fileName: "logo.png", content: body);
+
+        var (failure, path, bytes) = await MeshApiEndpoints.ReadUploadAsync(
+            http, TestContext.Current.CancellationToken);
+
+        failure.Should().BeNull();
+        path.Should().Be("@Foo/content/logo.png");
+        bytes.Should().Equal(Encoding.UTF8.GetBytes(body));
+    }
+
+    private static int? StatusOf(IResult? result) =>
+        (result as IStatusCodeHttpResult)?.StatusCode;
+
+    private static DefaultHttpContext NewContext()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        return new DefaultHttpContext { RequestServices = services.BuildServiceProvider() };
+    }
+
+    /// <summary>A multipart/form-data request carrying the given (optional) field and file.</summary>
+    private static DefaultHttpContext NewMultipart(string? path, string? fileName, string? content)
+    {
+        var http = NewContext();
+        var files = new FormFileCollection();
+        var fields = new Dictionary<string, StringValues>();
+
+        if (path is not null)
+            fields["path"] = path;
+
+        if (fileName is not null)
+        {
+            var bytes = Encoding.UTF8.GetBytes(content ?? string.Empty);
+            files.Add(new FormFile(new MemoryStream(bytes), 0, bytes.Length, "file", fileName)
+            {
+                Headers = new HeaderDictionary(),
+            });
+        }
+
+        http.Request.ContentType = "multipart/form-data; boundary=----test";
+        http.Request.Form = new FormCollection(fields, files);
+        return http;
+    }
+}


### PR DESCRIPTION
Part of the "tasks are evil" sweep, portal-API half. Companion to #2531 (framework half).

An ASP.NET endpoint genuinely returns `Task<IResult>` — that is a legitimate external boundary, and **none of these signatures changes**. What is not licence is an `await` chain reaching into hub code from inside one. Three handlers did exactly that, while their sibling `HandleRenderArea` already showed the shape: reactive body, single `.FirstAsync().ToTask(ct)` at the edge.

## Converted (3)

| Handler | Was |
|---|---|
| `HandleMirror` | awaited the hub round-trip mid-method, then built the fallback and serialised |
| `RunString` — the shared body of **18 verbs** (`get`/`search`/`create`/`update`/`patch`/`delete`/`move`/`copy`/`recycle`/`compile`/`execute-script`/…) | awaited `work(ops)` |
| `HandleUpload` | awaited `ops.Upload` after reading the multipart body |

For upload, the ASP.NET IO (`ReadFormAsync`, `CopyToAsync`) is quarantined in a new `ReadUploadAsync` that never touches the mesh; the mesh call is composed.

## Kept, and why each is a genuine external boundary

- **`ApiTokenController`, `OAuthConnectController`** — already correct: no `async`, `Task.FromResult` for the synchronous guard returns, one `.ToTask(ct)` per verb. One of them already says so in a comment.
- **`PluginRegistryEndpoints.List`/`Files`, `PluginBundleEndpoints.Index`/`Bundle`** — same shape, already correct.
- **The two `AddEndpointFilter` lambdas and `PluginBundleEndpoints`' publish `POST`** — their awaits are the ASP.NET pipeline continuation (`await next(ctx)`) and request-body IO, on a request thread that is not a hub action block, grain turn or Blazor circuit. Rewriting a 100-line multipart publish handler into Rx would trade a real regression risk for a deadlock that cannot occur there.

## Behaviour

Ordering is preserved at every site: `ResolveSession` stays exactly where it was relative to the first await, so nothing moves across an `ExecutionContext` hop (both shapes resume on a flowed continuation, so the `AccessContext` AsyncLocal is unaffected). `HandleUpload`'s `MemoryStream` is now released *before* the mesh call rather than after — `ms.ToArray()` had already copied the bytes.

## Tests

- **`MeshApiUploadBodyTest`** (5 new) pins the seam the upload split created: each of the four refusals still 400s **without constructing a session hub**, and a well-formed upload yields the path plus byte-exact content (non-ASCII included — these are the bytes `MeshOperations.Upload` lands).
- **`MeshApiCookieAuthTest`** reads the REAL routing table `MapMeshApi` registers and asserts, exhaustively in both directions, which policy guards each verb — so it is the regression gate on every route touched here.
- `Memex.Portal.Shared.Test`: **356/356 green** (351 before + 5). `dotnet build -c Release -warnaserror`: `0 Warning(s), 0 Error(s)`.

No What's New entry: pure-internal refactor, no user-visible effect.

Refs #2489

🤖 Generated with [Claude Code](https://claude.com/claude-code)