### PR TITLE
AI tools: 22 Task bridges gone, 17 uncancellable tool calls fixed, the ThreadPool hop made drainable

### DIFF
--- a/src/MeshWeaver.AI/AgentChatClient.cs
+++ b/src/MeshWeaver.AI/AgentChatClient.cs
@@ -2066,62 +2066,6 @@ public class AgentChatClient : IAgentChat
     }
 
     /// <summary>
-    /// Creates ChatClientAgent instances for all loaded configurations.
-    /// </summary>
-    [Obsolete("Use CreateAgentsSync — CreateAgentsAsync deadlocks in Orleans")]
-    private async Task CreateAgentsAsync()
-    {
-        if (chatClientFactories.Count == 0)
-        {
-            logger.LogWarning("[AgentChatClient] No IChatClientFactory available, cannot create agents");
-            return;
-        }
-
-        if (agentsInitialized)
-            return;
-
-        // Select the appropriate factory based on the requested model
-        var factory = GetFactoryForModel(currentModelName);
-        if (factory == null)
-        {
-            logger.LogWarning("[AgentChatClient] No factory can serve model: {ModelName}", currentModelName);
-            throw new ArgumentException($"No factory can serve model: {currentModelName}");
-        }
-
-        isPersistentFactory = factory.IsPersistent;
-        logger.LogDebug("[AgentChatClient] Using factory {FactoryName} for model {ModelName} (persistent={IsPersistent})",
-            factory.Name, currentModelName ?? "default", isPersistentFactory);
-
-        var configs = loadedAgents.Select(a => a.AgentConfiguration).ToImmutableList();
-        var createdAgents = ImmutableDictionary<string, ChatClientAgent>.Empty;
-
-        // Order agents: non-delegating first, delegating second, default last
-        var orderedConfigs = OrderAgentsForCreation(configs);
-
-        // First pass: Create all agents in order
-        foreach (var agentConfig in orderedConfigs)
-        {
-            var agent = await factory.CreateAgentAsync(
-                agentConfig, this, createdAgents, configs, currentModelName);
-            createdAgents = createdAgents.SetItem(agentConfig.Id, agent);
-            agents = agents.SetItem(agentConfig.Id, agent);
-        }
-
-        // Second pass: Update agents with cyclic dependencies
-        var cyclicAgents = FindCyclicDelegations(configs);
-        foreach (var agentConfig in cyclicAgents)
-        {
-            var updatedAgent = await factory.CreateAgentAsync(
-                agentConfig, this, createdAgents, configs, currentModelName);
-            createdAgents = createdAgents.SetItem(agentConfig.Id, updatedAgent);
-            agents = agents.SetItem(agentConfig.Id, updatedAgent);
-        }
-
-        agentsInitialized = true;
-        logger.LogDebug("[AgentChatClient] Created {Count} agents", agents.Count);
-    }
-
-    /// <summary>
     /// Resolves <see cref="currentModelName"/> to a model that can actually serve this round. Two
     /// cases land here, and they are NOT the same thing:
     ///

--- a/src/MeshWeaver.AI/MeshPlugin.cs
+++ b/src/MeshWeaver.AI/MeshPlugin.cs
@@ -1,8 +1,8 @@
 using MeshWeaver.Mesh;
 using System.ComponentModel;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using MeshWeaver.AI.Navigation;
+using MeshWeaver.AI.Plugins;
 using MeshWeaver.Layout;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
@@ -39,8 +39,9 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
     /// <returns>A task with the node JSON or a descriptive error string.</returns>
     [Description("Retrieves a node or content from the mesh by path. Paths are relative to current context; use @/ prefix for absolute paths. Supports Unified Path prefixes: content/, data/, schema/, model/, collection/, area/.")]
     public Task<string> Get(
-        [Description("Path to data. Relative: @content/file.docx, @MyChild/*. Absolute: @/OrgA/Doc, @/OrgA/content/file.docx. For spaces: \"@content/My File.docx\"")] string path)
-        => WithContext(() => ops.Get(ResolveContextPath(path))).FirstAsync().ToTask();
+        [Description("Path to data. Relative: @content/file.docx, @MyChild/*. Absolute: @/OrgA/Doc, @/OrgA/content/file.docx. For spaces: \"@content/My File.docx\"")] string path,
+        CancellationToken cancellationToken = default)
+        => Tool("get", path, cancellationToken, () => ops.Get(ResolveContextPath(path)));
 
     /// <summary>MCP/agent tool: searches the mesh with GitHub-style query syntax, scoping to an optional base path.</summary>
     /// <param name="query">The query string (e.g. <c>nodeType:Agent</c>).</param>
@@ -51,24 +52,28 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
     public Task<string> Search(
         [Description("Query string (e.g., 'nodeType:Agent', 'path:ACME scope:descendants', 'name:*sales*')")] string query,
         [Description("Base path to search from (e.g., @graph). Empty for all.")] string? basePath = null,
-        [Description("Maximum number of results to return. Default 50, max 200.")] int limit = 50)
-        => WithContext(() => ops.Search(query, basePath != null ? ResolveContextPath(basePath) : null, limit)).FirstAsync().ToTask();
+        [Description("Maximum number of results to return. Default 50, max 200.")] int limit = 50,
+        CancellationToken cancellationToken = default)
+        => Tool("search", query, cancellationToken,
+            () => ops.Search(query, basePath != null ? ResolveContextPath(basePath) : null, limit));
 
     /// <summary>MCP/agent tool: creates a new node in the mesh from a JSON MeshNode.</summary>
     /// <param name="node">The JSON MeshNode (requires id, name, nodeType, namespace).</param>
     /// <returns>A task with <c>"Created: {path}"</c> or a descriptive error string.</returns>
     [Description("Creates a new node in the mesh. ALWAYS set the 'name' property to a human-readable display name.")]
     public Task<string> Create(
-        [Description("JSON MeshNode with required: id, name, nodeType, namespace. Example: {\"id\":\"my-page\",\"namespace\":\"MyOrg\",\"name\":\"My Page\",\"nodeType\":\"Markdown\"}")] string node)
-        => WithContext(() => ops.Create(node)).FirstAsync().ToTask();
+        [Description("JSON MeshNode with required: id, name, nodeType, namespace. Example: {\"id\":\"my-page\",\"namespace\":\"MyOrg\",\"name\":\"My Page\",\"nodeType\":\"Markdown\"}")] string node,
+        CancellationToken cancellationToken = default)
+        => Tool("create", "the supplied node", cancellationToken, () => ops.Create(node));
 
     /// <summary>MCP/agent tool: full-replacement update of existing nodes from a JSON array of complete MeshNodes.</summary>
     /// <param name="nodes">A JSON array of complete MeshNode objects fetched via Get and modified.</param>
     /// <returns>A task with a per-node result/error summary.</returns>
     [Description("Full replacement update of existing nodes. ALWAYS Get the node first, modify the returned object, then send it back here unchanged-except-for-edits. The 'content' field MUST be present and non-null — null content is rejected and the response will include the expected schema. Prefer Patch for small changes.")]
     public Task<string> Update(
-        [Description("JSON array of complete MeshNode objects fetched via Get and then modified")] string nodes)
-        => WithContext(() => ops.Update(nodes)).FirstAsync().ToTask();
+        [Description("JSON array of complete MeshNode objects fetched via Get and then modified")] string nodes,
+        CancellationToken cancellationToken = default)
+        => Tool("update", "the supplied nodes", cancellationToken, () => ops.Update(nodes));
 
     /// <summary>MCP/agent tool: partial update of a single node — only the supplied fields change, with <c>content</c> deep-merged (RFC 7396).</summary>
     /// <param name="path">The path of the node to patch (resolved against context).</param>
@@ -77,8 +82,9 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
     [Description("Partial update of a single node. Only the keys present in 'fields' are changed; omitted keys preserve existing values. 'content' deep-merges (RFC 7396): nested keys you send are updated, omitted keys are kept, a null member deletes that one key — so you can change a single content field without resending the rest. Setting the whole 'content' to null is rejected (with the schema). Prefer this over Update for small edits like icon/name/category.")]
     public Task<string> Patch(
         [Description("Path to the node (e.g., @User/rbuergi/my-node)")] string path,
-        [Description("JSON object with ONLY the fields to change. Examples: {\"icon\": \"<svg>...</svg>\"}, {\"name\": \"New Name\"}, {\"content\":{\"logo\":\"https://…\"}} (deep-merges into existing content). Never set 'content' to null.")] string fields)
-        => WithContext(() => ops.Patch(ResolveContextPath(path), fields)).FirstAsync().ToTask();
+        [Description("JSON object with ONLY the fields to change. Examples: {\"icon\": \"<svg>...</svg>\"}, {\"name\": \"New Name\"}, {\"content\":{\"logo\":\"https://…\"}} (deep-merges into existing content). Never set 'content' to null.")] string fields,
+        CancellationToken cancellationToken = default)
+        => Tool("patch", path, cancellationToken, () => ops.Patch(ResolveContextPath(path), fields));
 
     /// <summary>MCP/agent tool: anchored text edit on a node's Markdown body or Code source — replaces an exact snippet.</summary>
     /// <param name="path">The path of the node to edit (resolved against context).</param>
@@ -91,32 +97,37 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
         [Description("Path to the node (e.g., @User/rbuergi/my-doc or @ACME/Story/Source/Story.cs)")] string path,
         [Description("The exact text to replace — copy it verbatim from Get, including whitespace and line breaks. Must match exactly once (or set replaceAll).")] string oldText,
         [Description("The replacement text.")] string newText,
-        [Description("Replace every occurrence instead of requiring a unique match. Default: false.")] bool replaceAll = false)
-        => WithContext(() => ops.EditContent(ResolveContextPath(path), oldText, newText, replaceAll)).FirstAsync().ToTask();
+        [Description("Replace every occurrence instead of requiring a unique match. Default: false.")] bool replaceAll = false,
+        CancellationToken cancellationToken = default)
+        => Tool("edit_content", path, cancellationToken,
+            () => ops.EditContent(ResolveContextPath(path), oldText, newText, replaceAll));
 
     /// <summary>MCP/agent tool: deletes nodes (and their descendants) from the mesh by path.</summary>
     /// <param name="paths">A JSON array of path strings to delete.</param>
     /// <returns>A task with the deletion result or a descriptive error string.</returns>
     [Description("Deletes nodes from the mesh by path. Recursive: deleting a parent removes all descendants — pass the subtree root, no need to enumerate children. This operation can be BLOCKED by permissions: the current identity often holds no Delete on shared or system-synced spaces, and a refusal is not an error to retry. The result then names the refused path with its Delete page link (/{path}/Delete) — present that URL to the user so they review and confirm the deletion under their OWN identity in the GUI. A whole SET of nodes can be offered the same way via /{anchorPath}/Delete?q=<url-encoded mesh query> (multiple queries newline-separated inside the one encoded parameter).")]
     public Task<string> Delete(
-        [Description("JSON array of path strings to delete")] string paths)
-        => WithContext(() => ops.Delete(paths)).FirstAsync().ToTask();
+        [Description("JSON array of path strings to delete")] string paths,
+        CancellationToken cancellationToken = default)
+        => Tool("delete", paths, cancellationToken, () => ops.Delete(paths));
 
     /// <summary>MCP/agent tool: returns compilation diagnostics (Ok/Error/Unknown) for a NodeType or an instance of one.</summary>
     /// <param name="path">The path of a NodeType, or of any instance of one.</param>
     /// <returns>A task with the diagnostics JSON (status and any error message).</returns>
     [Description("Returns compilation diagnostics for a NodeType or an instance of one. Status is 'Ok' when the type compiled cleanly, 'Error' with a detailed message when it failed, or 'Unknown' when no compile has happened yet. Use this after creating/updating a NodeType to verify it actually compiles — a NodeType that doesn't compile is not 'done'.")]
     public Task<string> GetDiagnostics(
-        [Description("Path to a NodeType (e.g., @Systemorph/SocialMedia/Profile) or to any instance of one")] string path)
-        => WithContext(() => ops.GetDiagnostics(ResolveContextPath(path))).FirstAsync().ToTask();
+        [Description("Path to a NodeType (e.g., @Systemorph/SocialMedia/Profile) or to any instance of one")] string path,
+        CancellationToken cancellationToken = default)
+        => Tool("get_diagnostics", path, cancellationToken, () => ops.GetDiagnostics(ResolveContextPath(path)));
 
     /// <summary>MCP/agent tool: disposes the hub at a path so it re-initialises fresh on next access — used after fixing a broken NodeType or a stuck grain.</summary>
     /// <param name="path">The path whose hub should be recycled (NodeType path for the whole type, or an instance path).</param>
     /// <returns>A task with <c>{status:'Recycled', path}</c> or a descriptive error string.</returns>
     [Description("Recycles the hub at the given path by posting DisposeRequest. Forces a fresh hub initialization on the next access — use this after fixing a broken NodeType, after editing the `sources` list, or whenever a grain is stuck. Returns {status:'Recycled', path}. Wait ~100ms before the next access so the grain teardown completes.")]
     public Task<string> Recycle(
-        [Description("Path to the node (e.g., @Systemorph/SocialMedia/Profile). Use the NodeType path to recycle the whole type; use an instance path to recycle just that instance's hub.")] string path)
-        => WithContext(() => ops.Recycle(ResolveContextPath(path))).FirstAsync().ToTask();
+        [Description("Path to the node (e.g., @Systemorph/SocialMedia/Profile). Use the NodeType path to recycle the whole type; use an instance path to recycle just that instance's hub.")] string path,
+        CancellationToken cancellationToken = default)
+        => Tool("recycle", path, cancellationToken, () => ops.Recycle(ResolveContextPath(path)));
 
     /// <summary>MCP/agent tool: moves a node and its descendants to a new path.</summary>
     /// <param name="sourcePath">The current full path of the node.</param>
@@ -125,8 +136,10 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
     [Description("Moves a node and its descendants to a new path. Equivalent to the Move menu item. Requires Delete on the source namespace and Create on the target. Source and target are full paths (namespace + id), e.g. 'OrgA/Child' -> 'OrgB/Child'.")]
     public Task<string> Move(
         [Description("Current path of the node (e.g., @OrgA/Child)")] string sourcePath,
-        [Description("New path for the node (e.g., @OrgB/Child)")] string targetPath)
-        => WithContext(() => ops.Move(ResolveContextPath(sourcePath), ResolveContextPath(targetPath))).FirstAsync().ToTask();
+        [Description("New path for the node (e.g., @OrgB/Child)")] string targetPath,
+        CancellationToken cancellationToken = default)
+        => Tool("move", sourcePath, cancellationToken,
+            () => ops.Move(ResolveContextPath(sourcePath), ResolveContextPath(targetPath)));
 
     /// <summary>MCP/agent tool: copies a node and all its descendants under a target namespace, preserving source ids.</summary>
     /// <param name="sourcePath">The current path of the node to copy.</param>
@@ -137,14 +150,16 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
     public Task<string> Copy(
         [Description("Current path of the node to copy (e.g., @OrgA/Child)")] string sourcePath,
         [Description("Target namespace to copy under (e.g., @OrgB)")] string targetNamespace,
-        [Description("Overwrite existing nodes at the target. Default: false (skip if any target path already exists).")] bool force = false)
-        => WithContext(() => ops.Copy(ResolveContextPath(sourcePath), ResolveContextPath(targetNamespace), force)).FirstAsync().ToTask();
+        [Description("Overwrite existing nodes at the target. Default: false (skip if any target path already exists).")] bool force = false,
+        CancellationToken cancellationToken = default)
+        => Tool("copy", sourcePath, cancellationToken,
+            () => ops.Copy(ResolveContextPath(sourcePath), ResolveContextPath(targetNamespace), force));
 
     // MCP adapter helper: re-seeds the user's AccessContext on Subscribe, then runs the
     // observable. AsyncLocal doesn't flow reliably through the AI framework's streaming +
     // tool invocation pipeline, so each plugin entry point must explicitly re-seed before
-    // hitting hub-backed ops. Defer ensures the seed runs on Subscribe (same call as ToTask),
-    // keeping each public method a strict one-line MCP adapter per AsynchronousCalls.md.
+    // hitting hub-backed ops. Defer ensures the seed runs on Subscribe (which ToolTask.Bridge
+    // performs), keeping each public method a strict one-line MCP adapter per AsynchronousCalls.md.
     //
     // CAPTURE THE EFFECTIVE IDENTITY SYNCHRONOUSLY, on the calling thread, where it is reliable:
     // the agent's execution context wins; else the request-scoped Context an active delivery set;
@@ -153,6 +168,41 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
     // ambient AsyncLocal can be lost past a thread hop for one operation, so its hub-post stamps an
     // empty AccessContext → "Access denied". Capturing once, here, and re-seeding the request-scoped
     // Context on Subscribe makes every operation carry the caller's identity regardless of flow.
+    /// <summary>
+    /// The ONE boundary adapter every mesh tool goes through: re-seed the caller's identity, then
+    /// hand the reactive operation to <see cref="ToolTask.Bridge{T}"/>.
+    ///
+    /// <para>🚨 <b>Why not <c>.FirstAsync().ToTask()</c>, which is what all thirteen of these used
+    /// to be.</b> That bridge takes no <see cref="CancellationToken"/>, and none of these tools
+    /// declared one — so the returned <c>Task</c> could not be cancelled by anything. The whole
+    /// round runs as a leaf on the bounded <c>IoPoolNames.Ai</c> pool and holds one gate permit for
+    /// its entire duration; <c>IoPool.Drain()</c> — the join every teardown performs before
+    /// disposing the service scope and unloading collectible node ALCs — cancels the pool token and
+    /// re-acquires every permit. A round parked in <c>get</c> or <c>search</c> against a hub that
+    /// never answers therefore held its permit through the full drain budget and teardown proceeded
+    /// over live code, and the Stop button did nothing. This is the #1956 defect class, fixed for
+    /// <c>VersionPlugin</c>/<c>SkillTool</c>/<c>PlanStorageTool</c>/<c>CollaborationPlugin</c> and
+    /// left standing here; <see cref="ToolTask.Bridge{T}"/> is the shared cure.</para>
+    ///
+    /// <para>It also supplies the two terminals the old bridge got wrong: an EMPTY completion
+    /// (which <c>FirstAsync</c> turned into an <c>InvalidOperationException</c> about a sequence
+    /// containing no elements — a stack trace where the model needed an answer) and a fault, both
+    /// formatted as the <c>"Error: …"</c> string the rest of this surface already speaks. Callers
+    /// like <c>AgentChatClient.LoadToolDocumentationAsync</c> already branch on that prefix.</para>
+    /// </summary>
+    /// <param name="operation">Tool name, for the failure answers.</param>
+    /// <param name="subject">What the call was about (a path or query), for the failure answers.</param>
+    /// <param name="cancellationToken">The round's token, bound by <c>AIFunctionFactory</c>.</param>
+    /// <param name="work">The reactive operation. Runs under the caller's re-seeded identity.</param>
+    private Task<string> Tool(
+        string operation, string subject, CancellationToken cancellationToken, Func<IObservable<string>> work)
+        => ToolTask.Bridge(
+            WithContext(work),
+            cancellationToken,
+            answer => answer,
+            ex => $"Error: {operation} on '{subject}' failed — {ex.Message}",
+            () => $"Error: {operation} on '{subject}' produced no answer.");
+
     private IObservable<T> WithContext<T>(Func<IObservable<T>> work)
     {
         var captured = chat.ExecutionContext?.UserAccessContext
@@ -176,13 +226,13 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
     /// <returns>A task with an honest confirmation of where it navigated, or that nothing matched.</returns>
     [Description("Takes the user to a node, doc, or page in the UI. Resilient (resolves the best match even when the path is imperfect) and honest (NEVER claims to open a place that doesn't exist — if nothing matches it says so and lists the closest candidates). Pass a path (@/Doc/AI/ModelProviderSettings) or plain words describing where to go (\"model settings\").")]
     public Task<string> NavigateTo(
-        [Description("A path (@/Doc/AI/ModelProviderSettings), or what the user is looking for in words.")] string path)
+        [Description("A path (@/Doc/AI/ModelProviderSettings), or what the user is looking for in words.")] string path,
+        CancellationToken cancellationToken = default)
     {
         logger.LogInformation("NavigateTo called with path={Path}", path);
-        return WithContext(() =>
-            new NavigationResolver(hub).Resolve(path, chat.Context?.Context)
-                .Select(resolution => NavigateToResult(path, resolution)))
-            .FirstAsync().ToTask();
+        return Tool("navigate_to", path, cancellationToken,
+            () => new NavigationResolver(hub).Resolve(path, chat.Context?.Context)
+                .Select(resolution => NavigateToResult(path, resolution)));
     }
 
     // Renders the resolved target inline and returns an honest result string. A page ROUTE can't render as
@@ -213,7 +263,8 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
     [Description("Runs xUnit tests via `dotnet test` on the given test project path (repo-relative, e.g. 'test/MeshWeaver.Acme.Test'). Optional filter uses the xunit `--filter` syntax: 'FullyQualifiedName~TodoViewsTest' to narrow by class, or '...Test.MethodName' for a single method. Returns the condensed test runner output (stdout + pass/fail summary). Dev-only — intended for the Monolith portal, not production.")]
     public Task<string> RunTests(
         [Description("Repo-relative path to the test project or its directory (e.g. 'test/MeshWeaver.Acme.Test')")] string projectPath,
-        [Description("Optional xunit filter expression (e.g. 'FullyQualifiedName~TodoViewsTest')")] string? filter = null)
+        [Description("Optional xunit filter expression (e.g. 'FullyQualifiedName~TodoViewsTest')")] string? filter = null,
+        CancellationToken cancellationToken = default)
     {
         logger.LogInformation("RunTests called project={Project} filter={Filter}", projectPath, filter ?? "<none>");
 
@@ -236,13 +287,15 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
 
         // Route the thread-holding `dotnet test` wait onto the bounded Process pool
         // (off the hub/grain scheduler). InvokeBlocking dispatches on the pool's
-        // LimitedConcurrencyLevelTaskScheduler; the .ToTask() at the MCP/AI-tool
-        // boundary is the only Task bridge (the AIFunctionFactory surface requires
-        // a Task<string>). Behavior is identical to the previous inline await.
-        return _processPool
-            .InvokeBlocking(ct => RunTestsCore(repoRoot, projectPath, filter, args, ct))
-            .FirstAsync()
-            .ToTask();
+        // LimitedConcurrencyLevelTaskScheduler; ToolTask.Bridge is the only Task
+        // bridge (the AIFunctionFactory surface requires a Task<string>), and it is
+        // what makes a five-minute test run observe the round's cancellation.
+        return ToolTask.Bridge(
+            _processPool.InvokeBlocking(ct => RunTestsCore(repoRoot, projectPath, filter, args, ct)),
+            cancellationToken,
+            answer => answer,
+            ex => $"{{\"status\":\"Error\",\"message\":\"{ex.Message}\"}}",
+            () => "{\"status\":\"Error\",\"message\":\"The test runner produced no result.\"}");
     }
 
     private static string RunTestsCore(

--- a/src/MeshWeaver.AI/MeshPlugin.cs
+++ b/src/MeshWeaver.AI/MeshPlugin.cs
@@ -294,9 +294,15 @@ public class MeshPlugin(IMessageHub hub, IAgentChat chat)
             _processPool.InvokeBlocking(ct => RunTestsCore(repoRoot, projectPath, filter, args, ct)),
             cancellationToken,
             answer => answer,
-            ex => $"{{\"status\":\"Error\",\"message\":\"{ex.Message}\"}}",
-            () => "{\"status\":\"Error\",\"message\":\"The test runner produced no result.\"}");
+            // Serialized, not interpolated: an exception message is arbitrary text and a single
+            // quote or backslash in it would emit invalid JSON to a tool whose contract is a JSON
+            // object. (The hand-written literals above are constant or a repo-relative path.)
+            ex => RunTestsError(ex.Message),
+            () => RunTestsError("The test runner produced no result."));
     }
+
+    private static string RunTestsError(string message) =>
+        System.Text.Json.JsonSerializer.Serialize(new { status = "Error", message });
 
     private static string RunTestsCore(
         string repoRoot, string projectPath, string? filter,

--- a/src/MeshWeaver.AI/Plugins/AgentFilesPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/AgentFilesPlugin.cs
@@ -1,6 +1,5 @@
 using System.ComponentModel;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Text;
 using MeshWeaver.AI.Stores;
 using MeshWeaver.Messaging;
@@ -68,7 +67,16 @@ public sealed class AgentFilesPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
     ];
 
     // Boundary adapters. AIFunctionFactory requires Task<string>; the bodies are reactive and each
-    // ends in exactly one FirstAsync().ToTask() — the store's own API is IObservable throughout.
+    // ends in the ONE shared bridge, ToolTask.Bridge — the store's own API is IObservable throughout.
+    //
+    // 🚨 These used to end in `.Catch(...).FirstAsync().ToTask(ct)`. The token was observed and the
+    // fault was handled fluently, so the two loud terminals were covered — but the THIRD one was
+    // not. A source that completes WITHOUT emitting reaches FirstAsync, which signals
+    // InvalidOperationException("Sequence contains no elements") — past the .Catch, which sits
+    // upstream of it — so the model got a stack trace where it needed an answer. And that terminal
+    // is reachable here, not theoretical: MeshNodeStreamCache completes its per-path subjects on
+    // eviction and on dispose, which is exactly what a thread whose hub is going away does.
+    // ToolTask.Bridge makes the empty completion an ANSWER, and keeps the other three.
 
     private Task<string> ReadFile(
         [Description("Path of the file within your working area, e.g. 'notes.md' or 'research/findings.md'.")]
@@ -76,12 +84,12 @@ public sealed class AgentFilesPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
         CancellationToken cancellationToken) =>
         Store is not { } store
             ? Task.FromResult(NoThread)
-            : store.Read(path)
-                .Take(1)
-                .Select(content => content ?? $"No file at '{path}'.")
-                .Catch<string, Exception>(ex => Observable.Return($"Could not read '{path}': {ex.Message}"))
-                .FirstAsync()
-                .ToTask(cancellationToken);
+            : ToolTask.Bridge(
+                store.Read(path).Select(content => content ?? $"No file at '{path}'."),
+                cancellationToken,
+                answer => answer,
+                ex => $"Could not read '{path}': {ex.Message}",
+                () => $"No file at '{path}'.");
 
     private Task<string> WriteFile(
         [Description("Path of the file within your working area, e.g. 'notes.md' or 'research/findings.md'.")]
@@ -91,11 +99,13 @@ public sealed class AgentFilesPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
         CancellationToken cancellationToken) =>
         Store is not { } store
             ? Task.FromResult(NoThread)
-            : store.Write(path, content)
-                .Select(node => $"Saved '{path}' ({content.Length} characters) at {node.Path}.")
-                .Catch<string, Exception>(ex => Observable.Return($"Could not save '{path}': {ex.Message}"))
-                .FirstAsync()
-                .ToTask(cancellationToken);
+            : ToolTask.Bridge(
+                store.Write(path, content)
+                    .Select(node => $"Saved '{path}' ({content.Length} characters) at {node.Path}."),
+                cancellationToken,
+                answer => answer,
+                ex => $"Could not save '{path}': {ex.Message}",
+                () => $"Could not save '{path}': the write produced no result.");
 
     private Task<string> ListFiles(
         [Description("Folder within your working area to list. Empty string lists the top level.")]
@@ -103,12 +113,12 @@ public sealed class AgentFilesPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
         CancellationToken cancellationToken) =>
         Store is not { } store
             ? Task.FromResult(NoThread)
-            : store.ListChildren(directory ?? "")
-                .Take(1)
-                .Select(FormatListing)
-                .Catch<string, Exception>(ex => Observable.Return($"Could not list '{directory}': {ex.Message}"))
-                .FirstAsync()
-                .ToTask(cancellationToken);
+            : ToolTask.Bridge(
+                store.ListChildren(directory ?? "").Select(FormatListing),
+                cancellationToken,
+                answer => answer,
+                ex => $"Could not list '{directory}': {ex.Message}",
+                () => "(empty)");
 
     private Task<string> SearchFiles(
         [Description("Folder within your working area to search. Empty string searches from the top level.")]
@@ -122,12 +132,13 @@ public sealed class AgentFilesPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
         CancellationToken cancellationToken) =>
         Store is not { } store
             ? Task.FromResult(NoThread)
-            : store.Search(directory ?? "", pattern, string.IsNullOrWhiteSpace(glob) ? null : glob, recursive)
-                .Take(1)
-                .Select(FormatMatches)
-                .Catch<string, Exception>(ex => Observable.Return($"Could not search '{directory}': {ex.Message}"))
-                .FirstAsync()
-                .ToTask(cancellationToken);
+            : ToolTask.Bridge(
+                store.Search(directory ?? "", pattern, string.IsNullOrWhiteSpace(glob) ? null : glob, recursive)
+                    .Select(FormatMatches),
+                cancellationToken,
+                answer => answer,
+                ex => $"Could not search '{directory}': {ex.Message}",
+                () => "No matches.");
 
     private Task<string> DeleteFile(
         [Description("Path of the file within your working area to delete.")]
@@ -135,11 +146,12 @@ public sealed class AgentFilesPlugin(IMessageHub hub, IAgentChat chat) : IAgentP
         CancellationToken cancellationToken) =>
         Store is not { } store
             ? Task.FromResult(NoThread)
-            : store.Delete(path)
-                .Select(deleted => deleted ? $"Deleted '{path}'." : $"No file at '{path}'.")
-                .Catch<string, Exception>(ex => Observable.Return($"Could not delete '{path}': {ex.Message}"))
-                .FirstAsync()
-                .ToTask(cancellationToken);
+            : ToolTask.Bridge(
+                store.Delete(path).Select(deleted => deleted ? $"Deleted '{path}'." : $"No file at '{path}'."),
+                cancellationToken,
+                answer => answer,
+                ex => $"Could not delete '{path}': {ex.Message}",
+                () => $"No file at '{path}'.");
 
     private const string NoThread =
         "No working area is available — this conversation has no thread yet. Try again after the "

--- a/src/MeshWeaver.AI/Plugins/CollaborationPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/CollaborationPlugin.cs
@@ -1,5 +1,4 @@
 using System.ComponentModel;
-using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using MeshWeaver.Graph;
 using MeshWeaver.Markdown.Collaboration;
@@ -14,10 +13,12 @@ namespace MeshWeaver.AI.Plugins;
 /// Agent plugin providing tools for adding comments and suggesting edits on
 /// Markdown documents via the collaborative editing infrastructure.
 ///
-/// Every method is await-free — reads are moved onto the <see cref="TaskPoolScheduler"/>
-/// with <c>.SubscribeOn(TaskPoolScheduler.Default)</c> (NEVER
-/// <c>Observable.FromAsync</c>, which is forbidden outside <c>IoPool</c>) so blocking
-/// enumeration never touches the hub scheduler, and writes go through
+/// Every method is await-free — reads leave the caller's scheduler through
+/// <see cref="ToolTask.Pooled{T}"/> (NEVER <c>Observable.FromAsync</c>, which is forbidden
+/// outside <c>IoPool</c>) so blocking enumeration never touches the hub scheduler AND the
+/// read stays visible to <c>IoPool.Drain()</c> — the bare
+/// <c>SubscribeOn(TaskPoolScheduler.Default)</c> this replaces achieved the first and
+/// silently gave up the second. Writes go through
 /// <c>hub.Observe(...)</c>, with <see cref="ToolTask.Bridge{T}"/> bridging the off-hub
 /// callback thread back to the caller — every terminal settles (value, error, EMPTY
 /// completion) and the round's cancellation token is observed (#1956).
@@ -76,8 +77,7 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
         // completed WITHOUT emitting, and `cancellationToken` appeared only in the doc comment — so
         // a parked AddComment held its Ai-pool gate permit through IoPool.Drain and Stop no-opped.
         return ToolTask.Bridge(
-            ops.Get(resolvedInput)
-                .SubscribeOn(TaskPoolScheduler.Default)
+            ToolTask.Pooled(hub, ops.Get(resolvedInput))
                 .Take(1)
                 .SelectMany(docJson => AddCommentContinuation(
                     docJson, resolvedPath, documentPath, selectedText, commentText)),
@@ -171,8 +171,7 @@ public class CollaborationPlugin(IMessageHub hub, IAgentChat chat) : IAgentPlugi
         // path reports for an address that routes nowhere. Same three-terminal bridge as
         // AddComment: value, error, and the EMPTY completion that used to park the round (#1956).
         return ToolTask.Bridge(
-            ops.Get(resolvedInput)
-                .SubscribeOn(TaskPoolScheduler.Default)
+            ToolTask.Pooled(hub, ops.Get(resolvedInput))
                 .Take(1)
                 .SelectMany(docJson => SuggestEditContinuation(
                     docJson, resolvedPath, documentPath, originalText, newText)),

--- a/src/MeshWeaver.AI/Plugins/DelegationTool.cs
+++ b/src/MeshWeaver.AI/Plugins/DelegationTool.cs
@@ -84,6 +84,15 @@ public record SubThreadInfo(
 public static class DelegationTool
 {
     /// <summary>
+    /// Moves a delegation's SUBSCRIBE off the caller's scheduler, through the mesh-scoped
+    /// <c>AgentStore</c> I/O pool when a hub is available so <c>IoPool.Drain()</c> can see and join
+    /// it, and through the bare ThreadPool otherwise (the legacy, workspace-less path, which is
+    /// exactly what it had before).
+    /// </summary>
+    private static IObservable<T> HopOffCallerScheduler<T>(IObservable<T> source, IMessageHub? hub) =>
+        hub is null ? source.SubscribeOn(TaskPoolScheduler.Default) : ToolTask.Pooled(hub, source);
+
+    /// <summary>
     /// Creates the suite of delegation tools: <c>delegate_to_agent</c>, plus
     /// <c>list_sub_threads</c> and <c>send_to_sub_thread</c> when the parent
     /// passes the needed accessor delegates.
@@ -211,9 +220,24 @@ public static class DelegationTool
 
             // Settle ONCE and release what the wait was holding. Every resolution path goes through
             // here — a bare tcs.TrySet* would resolve the caller and leave the subscriptions live.
+            //
+            // 🚨 DISPOSE FIRST, THEN SETTLE — the same invariant, and for the same reason, as
+            // ToolTask.Settle. This read `if (set()) pending.Dispose();`, i.e. the caller was told
+            // the delegation had ended and the subscriptions were released afterwards. Those are not
+            // interchangeable: `tcs` is created RunContinuationsAsynchronously, so TrySet* completes
+            // the task and schedules the parent round's continuation on the pool, which then runs
+            // CONCURRENTLY with the rest of this callback. On the cancellation path the round could
+            // therefore observe the cancel — release its IoPoolNames.Ai permit, let IoPool.Drain()
+            // through, let teardown dispose the service scope and unload collectible node ALCs —
+            // while this call still held a live subscription to the sub-thread's node stream.
+            // Disposing first makes "the work stopped" established before "the call ended" is
+            // observable. Dispose and TrySet* are both idempotent, so a losing terminal disposes an
+            // already-disposed bag and sets nothing; the lambdas keep returning bool because the
+            // chunk-aggregate path logs only when its TrySetResult actually won.
             void Settle(Func<bool> set)
             {
-                if (set()) pending.Dispose();
+                pending.Dispose();
+                set();
             }
 
             // 🚨 THE ROUND'S CANCELLATION MUST REACH THIS TASK. Nothing else can end the wait
@@ -336,16 +360,28 @@ public static class DelegationTool
             // above which reads Thread.Summary). No await foreach, no Task.Run, no
             // Observable.Create wrapper.
             //
-            // SubscribeOn(TaskPoolScheduler.Default): the parent agent loop's
-            // continuation (Orleans grain scheduler in prod, single-threaded pump in
-            // the DelegationDeadlockTest) MUST NOT host the sub-thread drain. The
-            // typical executeAsync impl is Observable.Create<async> over an
-            // IAsyncEnumerable, which captures the Subscribe-time SynchronizationContext
-            // for every MoveNextAsync — if that's the grain scheduler, every sub-thread
-            // continuation posts back through it and wedges the grain. Hop the Subscribe
-            // to ThreadPool so the entire drain runs free of the caller's context.
-            pending.Add(executeAsync(agentName, task, context, cancellationToken)
-            .SubscribeOn(TaskPoolScheduler.Default)
+            // The parent agent loop's continuation (Orleans grain scheduler in prod,
+            // single-threaded pump in the DelegationDeadlockTest) MUST NOT host the
+            // sub-thread drain. The typical executeAsync impl is Observable.Create<async>
+            // over an IAsyncEnumerable, which captures the Subscribe-time
+            // SynchronizationContext for every MoveNextAsync — if that's the grain
+            // scheduler, every sub-thread continuation posts back through it and wedges
+            // the grain. So the Subscribe hops off the caller's context.
+            //
+            // 🚨 It hops through ToolTask.Pooled — the mesh-scoped AgentStore pool — and no
+            // longer through a bare `.SubscribeOn(TaskPoolScheduler.Default)`. Both leave the
+            // caller's scheduler, which is all the paragraph above ever asked for; only one of
+            // them is visible to IoPool.Drain(). A sub-thread drain running on the raw ThreadPool
+            // is counted by nothing and waited for by nobody, so teardown disposes the service
+            // scope and unloads collectible node ALCs while it is still executing — the
+            // use-after-unload precondition Drain exists to rule out, and the reason
+            // IIoPool.SubscribeThroughPool documents itself as "the tracked, drainable
+            // replacement for a bare .SubscribeOn(TaskPoolScheduler.Default), which the drain
+            // cannot reach". AgentStore, never Ai: this call already sits inside a round holding
+            // an Ai permit. With no workspace (the legacy path) there is no hub to resolve the
+            // registry from, so that path keeps the untracked hop — which is what it had.
+            pending.Add(HopOffCallerScheduler(
+                    executeAsync(agentName, task, context, cancellationToken), workspace?.Hub)
             .Subscribe(
                 chunk => sb.Append(chunk),
                 ex =>

--- a/src/MeshWeaver.AI/Plugins/LspPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/LspPlugin.cs
@@ -1,7 +1,6 @@
 using MeshWeaver.Mesh;
 using System.ComponentModel;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services.LanguageServer;
@@ -55,13 +54,14 @@ Returns `{ok: true, diagnostics: []}` when the substituted source compiles clean
     public Task<string> LspCheckNode(
         [Description("Path to the NodeType (e.g., @ACME/Story).")] string nodeTypePath,
         [Description("Path of the Source Code node being edited (e.g., @ACME/Story/Source/StoryTypes.cs). If not in the current source set, the proposed code is added as a new file.")] string sourcePath,
-        [Description("The proposed full source text for that file.")] string proposedCode)
-        => WithContext(() => languageService!.CheckSpeculative(
-                MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, nodeTypePath)),
-                MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, sourcePath)),
-                proposedCode ?? string.Empty))
-            .Select(diagnostics => FormatDiagnosticsJson(diagnostics))
-            .FirstAsync().ToTask();
+        [Description("The proposed full source text for that file.")] string proposedCode,
+        CancellationToken cancellationToken = default)
+        => Tool("LspCheckNode", nodeTypePath, cancellationToken,
+            () => WithContext(() => languageService!.CheckSpeculative(
+                    MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, nodeTypePath)),
+                    MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, sourcePath)),
+                    proposedCode ?? string.Empty))
+                .Select(diagnostics => FormatDiagnosticsJson(diagnostics)));
 
     /// <summary>
     /// Agent tool: enumerates every Roslyn diagnostic (errors, warnings, info) from the NodeType's
@@ -73,12 +73,13 @@ Returns `{ok: true, diagnostics: []}` when the substituted source compiles clean
 
 Returns `{ok: true|false, diagnostics: [...]}` — same shape as `LspCheckNode`. Empty `diagnostics` plus `ok:true` means clean.")]
     public Task<string> LspDiagnosticsForNode(
-        [Description("Path to the NodeType (e.g., @ACME/Story).")] string nodeTypePath)
+        [Description("Path to the NodeType (e.g., @ACME/Story).")] string nodeTypePath,
+        CancellationToken cancellationToken = default)
     {
         var resolved = MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, nodeTypePath));
-        return WithContext(() => languageService!.GetDiagnostics(resolved))
-            .Select(outcome => FormatDiagnosticsJson(outcome, resolved))
-            .FirstAsync().ToTask();
+        return Tool("LspDiagnosticsForNode", nodeTypePath, cancellationToken,
+            () => WithContext(() => languageService!.GetDiagnostics(resolved))
+                .Select(outcome => FormatDiagnosticsJson(outcome, resolved)));
     }
 
     /// <summary>
@@ -97,15 +98,16 @@ Returns `{markdown: ""..."" }` when a symbol resolves at the position, or `{}` w
         [Description("Path to the NodeType (e.g., @ACME/Story).")] string nodeTypePath,
         [Description("Path of the Source Code node (e.g., @ACME/Story/Source/StoryTypes.cs).")] string sourcePath,
         [Description("0-based line number.")] int line,
-        [Description("0-based character offset within the line.")] int character)
-        => WithContext(() => languageService!.GetHover(
-                MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, nodeTypePath)),
-                MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, sourcePath)),
-                new SourcePosition(line, character)))
-            .Select(hover => JsonSerializer.Serialize(
-                hover is null ? new { } : (object)new { markdown = hover.ContentMarkdown },
-                hub.JsonSerializerOptions))
-            .FirstAsync().ToTask();
+        [Description("0-based character offset within the line.")] int character,
+        CancellationToken cancellationToken = default)
+        => Tool("LspHoverForNode", nodeTypePath, cancellationToken,
+            () => WithContext(() => languageService!.GetHover(
+                    MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, nodeTypePath)),
+                    MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, sourcePath)),
+                    new SourcePosition(line, character)))
+                .Select(hover => JsonSerializer.Serialize(
+                    hover is null ? new { } : (object)new { markdown = hover.ContentMarkdown },
+                    hub.JsonSerializerOptions)));
 
     /// <summary>
     /// Agent tool: Roslyn code completions at a position in a Source Code file, returning up to
@@ -125,26 +127,66 @@ Returns `{items: [{label, kind, insertText, detail?, sortText?}, ...]}`. `kind` 
         [Description("Path of the Source Code node (e.g., @ACME/Story/Source/StoryTypes.cs).")] string sourcePath,
         [Description("0-based line number.")] int line,
         [Description("0-based character offset within the line.")] int character,
-        [Description("Maximum number of completions to return. Default 20.")] int max = 20)
-        => WithContext(() => languageService!.GetCompletions(
-                MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, nodeTypePath)),
-                MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, sourcePath)),
-                new SourcePosition(line, character),
-                max))
-            .Select(items => JsonSerializer.Serialize(
-                new
-                {
-                    items = items.Select(i => new
+        [Description("Maximum number of completions to return. Default 20.")] int max = 20,
+        CancellationToken cancellationToken = default)
+        => Tool("LspCompletionsForNode", nodeTypePath, cancellationToken,
+            () => WithContext(() => languageService!.GetCompletions(
+                    MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, nodeTypePath)),
+                    MeshOperations.ResolvePath(AgentChatPaths.ResolveContextPath(chat, sourcePath)),
+                    new SourcePosition(line, character),
+                    max))
+                .Select(items => JsonSerializer.Serialize(
+                    new
                     {
-                        label = i.Label,
-                        kind = i.Kind.ToString(),
-                        insertText = i.InsertText,
-                        detail = i.Detail,
-                        sortText = i.SortText,
-                    }).ToArray()
-                },
-                hub.JsonSerializerOptions))
-            .FirstAsync().ToTask();
+                        items = items.Select(i => new
+                        {
+                            label = i.Label,
+                            kind = i.Kind.ToString(),
+                            insertText = i.InsertText,
+                            detail = i.Detail,
+                            sortText = i.SortText,
+                        }).ToArray()
+                    },
+                    hub.JsonSerializerOptions)));
+
+    /// <summary>
+    /// The boundary adapter every LSP tool goes through — <see cref="ToolTask.Bridge{T}"/>, the same
+    /// bridge <see cref="MeshPlugin"/> and the version/skill/collaboration tools use.
+    ///
+    /// <para>🚨 These four were <c>.FirstAsync().ToTask()</c> with no
+    /// <see cref="CancellationToken"/> parameter at all, so nothing could end the wait — and a
+    /// Roslyn compilation over a NodeType's whole source set is one of the longest things an agent
+    /// tool does. A round parked here holds an <c>IoPoolNames.Ai</c> gate permit that
+    /// <c>IoPool.Drain()</c> cannot re-acquire, so teardown proceeds over live code while the
+    /// compilation is still running — and the running compilation is exactly what holds the
+    /// collectible <c>AssemblyLoadContext</c> that teardown is about to unload. Same #1956 defect
+    /// class as the version tools.</para>
+    ///
+    /// <para>A fault or an empty completion answers <c>{ok:false, status:"Unavailable", error}</c>
+    /// for ALL FOUR tools, including hover and completions whose success shape is
+    /// <c>{markdown}</c>/<c>{items}</c>. That is deliberate: <c>Unavailable</c> is the
+    /// <c>NodeDiagnosticsStatus</c> for "the owning hub did not answer", and an explicit failure
+    /// marker is the honest answer. Returning the SUCCESS shape empty — <c>{}</c> for a hover,
+    /// <c>{items:[]}</c> for completions — would say "no symbol here" / "no completions here", which
+    /// is a different fact and a false one, and is the #1592 mistake (<c>ok:true</c> for a check
+    /// that never happened) wearing a different hat.</para>
+    /// </summary>
+    /// <param name="operation">Tool name, for the failure answers.</param>
+    /// <param name="nodeTypePath">The NodeType the call was about, for the failure answers.</param>
+    /// <param name="cancellationToken">The round's token, bound by <c>AIFunctionFactory</c>.</param>
+    /// <param name="work">The reactive operation, already producing the tool's JSON answer.</param>
+    private Task<string> Tool(
+        string operation, string nodeTypePath, CancellationToken cancellationToken, Func<IObservable<string>> work)
+        => ToolTask.Bridge(
+            Observable.Defer(work),
+            cancellationToken,
+            answer => answer,
+            ex => JsonSerializer.Serialize(
+                new { ok = false, status = "Unavailable", error = $"{operation} on '{nodeTypePath}' failed — {ex.Message}", diagnostics = Array.Empty<object>() },
+                hub.JsonSerializerOptions),
+            () => JsonSerializer.Serialize(
+                new { ok = false, status = "Unavailable", error = $"{operation} on '{nodeTypePath}' produced no answer.", diagnostics = Array.Empty<object>() },
+                hub.JsonSerializerOptions));
 
     /// <summary>
     /// AccessContext re-seed on Subscribe — mirrors <see cref="MeshPlugin.WithContext{T}"/>.

--- a/src/MeshWeaver.AI/Plugins/ToolTask.cs
+++ b/src/MeshWeaver.AI/Plugins/ToolTask.cs
@@ -1,5 +1,8 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.AI.Plugins;
 
@@ -35,8 +38,11 @@ namespace MeshWeaver.AI.Plugins;
 ///
 /// <para><b>And cancellation is a fourth.</b> The token is registered before the source is
 /// subscribed, and firing it DISPOSES the subscription and only then cancels the task — in that
-/// order — so the work the tool started has provably stopped before anyone can act on the call
-/// having ended. See <c>Settle</c> for why the order is the invariant.</para>
+/// order — so the work the tool started is provably torn DOWN, not merely abandoned, before anyone
+/// can act on the call having ended. See <c>Settle</c> for why the order is the invariant — and for
+/// its limit: where the pipeline hops a scheduler, Rx runs the unsubscribe on that scheduler too, so
+/// the teardown is REQUESTED synchronously and completes shortly after. Joining it at teardown is
+/// the pool's job, not the bridge's, which is what <see cref="Pooled{T}"/> is for.</para>
 /// </summary>
 public static class ToolTask
 {
@@ -95,11 +101,24 @@ public static class ToolTask
         // leaf is torn down, teardown proceeds over live code. "The work stopped" must therefore be
         // established, not hoped for, before anyone can act on "the call ended".
         //
-        // Disposing first is what makes it established rather than raced: Rx disposal here is
-        // synchronous, so by the time TrySet* runs, the source's own teardown has already run.
+        // Disposing first is what makes it established rather than raced WHERE Rx disposal is
+        // synchronous: by the time TrySet* runs, the source's own teardown has already run.
         // Idempotence covers the rest — CompositeDisposable.Dispose and TrySet* are both safe to
         // race, so a losing terminal simply disposes an already-disposed bag and sets nothing.
         // Pinned by ToolTaskSettlementTest.Cancelling_StopsTheWork_BeforeTheCallerCanObserveIt.
+        //
+        // 🚨 AND THE LIMIT OF THAT GUARANTEE, stated so nobody reads more into it than it gives.
+        // Rx disposal is synchronous only for a chain that is entirely synchronous to dispose. Put
+        // a scheduler in it — `.SubscribeOn(...)`, which several tools need so the subscribe leaves
+        // the caller's scheduler — and Rx runs the UNSUBSCRIBE on that scheduler too, so
+        // `pending.Dispose()` returns once the unsubscribe is SCHEDULED and the source is torn down
+        // some time later, possibly after the caller's task has already thrown. Ordering still buys
+        // the caller-visible half (nobody observes the end before teardown was *requested*), but the
+        // bridge alone cannot promise the work has STOPPED. What promises that is the pool:
+        // <see cref="Pooled{T}"/> puts the subscribe on the mesh-scoped, DRAINABLE AgentStore pool,
+        // so `IoPool.Drain()` — the join teardown performs before unloading collectible ALCs — sees
+        // and waits for the leaf a bare `.SubscribeOn(TaskPoolScheduler.Default)` hides from it.
+        // AgentToolCancellationTest waits for the disposal rather than reading it, for this reason.
         void Settle(Func<bool> set)
         {
             pending.Dispose();
@@ -123,5 +142,45 @@ public static class ToolTask
                 error => Settle(() => tcs.TrySetResult(onError(error)))));
 
         return tcs.Task;
+    }
+
+    /// <summary>
+    /// Runs a tool pipeline's SUBSCRIBE through the mesh-scoped, drainable
+    /// <see cref="IoPoolNames.AgentStore"/> pool — the sanctioned replacement for a bare
+    /// <c>.SubscribeOn(TaskPoolScheduler.Default)</c>.
+    ///
+    /// <para><b>What the bare hop got right and what it got wrong.</b> Right: the subscribe must
+    /// not run on the caller's scheduler — a tool invoked from the agent loop would otherwise open
+    /// providers, read nodes and create hubs on whatever scheduler happens to be current (an
+    /// Orleans grain in prod), and the continuation of everything downstream posts back through it.
+    /// Wrong: <c>TaskPoolScheduler.Default</c> is the raw ThreadPool, which <c>IoPool.Drain()</c>
+    /// cannot see. Drain cancels the pool token and re-acquires every permit precisely so that no
+    /// pooled work is still running when the service scope is disposed and collectible NodeType
+    /// <c>AssemblyLoadContext</c>s are unloaded — and work on an untracked ThreadPool thread is
+    /// counted by nothing, waited for by nobody, and unloaded out from under.
+    /// <see cref="IIoPool.SubscribeThroughPool{T}"/> keeps the hop and makes it countable.</para>
+    ///
+    /// <para>🚨 <b>AgentStore, deliberately not Ai.</b> The call already runs inside a round holding
+    /// an <see cref="IoPoolNames.Ai"/> permit; re-entering the same bounded pool from inside a
+    /// permit it already holds is the nested-gate deadlock — at the cap, every holder waits for a
+    /// slot only a holder can release. For the same reason, do NOT wrap a pipeline that itself
+    /// reaches the mesh through <c>MeshStoreAccess</c>: that is already on this pool, and stacking
+    /// them re-creates the nesting one level down.</para>
+    ///
+    /// <para>Falls back to <see cref="IoPool.Unbounded"/> when no registry is wired, whose
+    /// <c>SubscribeThroughPool</c> IS <c>.SubscribeOn(TaskPoolScheduler.Default)</c> — so a mesh
+    /// without pools behaves exactly as before.</para>
+    /// </summary>
+    /// <typeparam name="T">Element type of the pipeline.</typeparam>
+    /// <param name="hub">Hub supplying the mesh-scoped <see cref="IoPoolRegistry"/>.</param>
+    /// <param name="source">The tool pipeline whose subscribe should leave the caller's scheduler.</param>
+    /// <returns>The same sequence, subscribed through the pool.</returns>
+    public static IObservable<T> Pooled<T>(IMessageHub hub, IObservable<T> source)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        ArgumentNullException.ThrowIfNull(source);
+        var pool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.AgentStore)
+                   ?? IoPool.Unbounded;
+        return pool.SubscribeThroughPool(source);
     }
 }

--- a/src/MeshWeaver.AI/Plugins/VersionPlugin.cs
+++ b/src/MeshWeaver.AI/Plugins/VersionPlugin.cs
@@ -1,6 +1,5 @@
 using System.Collections.Immutable;
 using System.ComponentModel;
-using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
@@ -19,11 +18,17 @@ namespace MeshWeaver.AI.Plugins;
 /// <see cref="IVersionQuery"/> to list versions, retrieve snapshots, and restore nodes.
 ///
 /// Every method is await-free: <see cref="IVersionQuery"/> already returns
-/// <c>IObservable</c>, and those reads are moved onto <see cref="TaskPoolScheduler"/>
-/// with <c>.SubscribeOn(TaskPoolScheduler.Default)</c> (NEVER
-/// <c>Observable.FromAsync</c>, which is forbidden outside <c>IoPool</c>) so they never
-/// occupy the hub scheduler, and restores go through <c>IMeshService.UpdateNode</c>
-/// which is already reactive (<c>IObservable&lt;MeshNode&gt;</c>).
+/// <c>IObservable</c>, and those reads leave the caller's scheduler through
+/// <see cref="ToolTask.Pooled{T}"/> (NEVER <c>Observable.FromAsync</c>, which is
+/// forbidden outside <c>IoPool</c>) so they never occupy the hub scheduler, and restores
+/// go through <c>IMeshService.UpdateNode</c> which is already reactive
+/// (<c>IObservable&lt;MeshNode&gt;</c>).
+///
+/// <para>🚨 That hop used to be a bare <c>SubscribeOn(TaskPoolScheduler.Default)</c>, which
+/// took the work off the hub scheduler and put it somewhere <c>IoPool.Drain()</c> cannot
+/// reach: a version read still running on the raw ThreadPool is counted by nothing and
+/// waited for by nobody, so teardown unloads the assemblies it is reading through.
+/// <see cref="ToolTask.Pooled{T}"/> keeps the hop and makes it drainable.</para>
 /// <see cref="ToolTask.Bridge{T}"/> bridges the off-hub completions back to the caller —
 /// every terminal settles (value, error, EMPTY completion) and the round's cancellation token
 /// is observed, so a parked read cannot hold an <c>IoPoolNames.Ai</c> gate permit through
@@ -147,11 +152,10 @@ public class VersionPlugin(IMessageHub hub)
                         v.NodeType
                     })
                     .ToList();
-            })
-            .SubscribeOn(TaskPoolScheduler.Default);
+            });
 
         return ToolTask.Bridge(
-            pipeline,
+            ToolTask.Pooled(hub, pipeline),
             cancellationToken,
             versions => versions.Count == 0
                 ? $"No version history found for '{path}'."
@@ -198,11 +202,10 @@ public class VersionPlugin(IMessageHub hub)
                     return Observable.Return<MeshNode?>(null);
                 }
                 return versionQuery.GetVersion(path, version, hub.JsonSerializerOptions);
-            })
-            .SubscribeOn(TaskPoolScheduler.Default);
+            });
 
         return ToolTask.Bridge(
-            pipeline,
+            ToolTask.Pooled(hub, pipeline),
             cancellationToken,
             node => node == null
                 ? $"Version {version} not found for '{path}'."
@@ -248,7 +251,6 @@ public class VersionPlugin(IMessageHub hub)
                 }
                 return versionQuery.GetVersion(path, version, hub.JsonSerializerOptions);
             })
-            .SubscribeOn(TaskPoolScheduler.Default)
             .SelectMany(historicalNode =>
             {
                 if (historicalNode == null)
@@ -258,7 +260,7 @@ public class VersionPlugin(IMessageHub hub)
             });
 
         return ToolTask.Bridge(
-            pipeline,
+            ToolTask.Pooled(hub, pipeline),
             cancellationToken,
             result => result.restored == null
                 ? $"Version {result.requestedVersion} not found for '{path}'."
@@ -309,7 +311,6 @@ public class VersionPlugin(IMessageHub hub)
                     .Take(1)
                     .DefaultIfEmpty();
             })
-            .SubscribeOn(TaskPoolScheduler.Default)
             .SelectMany(targetVersion =>
             {
                 if (targetVersion == null)
@@ -325,7 +326,7 @@ public class VersionPlugin(IMessageHub hub)
             });
 
         return ToolTask.Bridge(
-            pipeline,
+            ToolTask.Pooled(hub, pipeline),
             cancellationToken,
             result =>
             {

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-stop-actually-stops-tool-calls.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-stop-actually-stops-tool-calls.md
@@ -1,0 +1,18 @@
+---
+Name: Stop now actually stops a running tool call
+Category: Fix
+Description: Pressing Stop mid-tool-call unwinds the round instead of leaving it running, and a tool that fails now answers the agent instead of throwing.
+Icon: Bug
+Order: -20260827
+---
+
+# Stop now actually stops a running tool call
+
+Pressing **Stop** while an agent was in the middle of a mesh operation — reading a node, searching, patching, moving, or running a code check — did not stop it. The button ended the round on screen while the operation kept running underneath, so the work carried on invisibly and the thread could take a long time to settle.
+
+Every one of those tools now listens for the stop signal: `get`, `search`, `create`, `update`, `patch`, `edit_content`, `delete`, `move`, `copy`, `get_diagnostics`, `recycle`, `navigate_to`, `run_tests`, the four code-intelligence tools, and the agent's own working-files tools. Stop unwinds them straight away, and the work is torn down rather than merely abandoned.
+
+Two smaller things came with it:
+
+- **A tool that fails now answers.** A failure used to surface as a raw error; the agent now receives it as an ordinary result it can read, explain, and work around.
+- **A tool that comes back with nothing now says so** — previously that case produced no answer at all, which is what left some rounds waiting indefinitely.

--- a/test/MeshWeaver.AI.Test/AgentToolCancellationTest.cs
+++ b/test/MeshWeaver.AI.Test/AgentToolCancellationTest.cs
@@ -180,12 +180,14 @@ public class AgentToolCancellationTest(ITestOutputHelper output) : MonolithMeshT
         // 🚨 WAIT for the disposal; do not read the counter and hope (#2346).
         //
         // The disposal is ASYNCHRONOUS by construction and no ordering trick in the bridge can make
-        // it otherwise: every one of these tools ends its pipeline with
-        // `.SubscribeOn(TaskPoolScheduler.Default)`, and Rx's SubscribeOn runs the sequence's
-        // *unsubscription* logic on that scheduler as well as its subscription. So the bridge's
+        // it otherwise: every one of these tools runs its pipeline's SUBSCRIBE on a scheduler
+        // (`ToolTask.Pooled` — the mesh-scoped, drainable AgentStore pool, which replaced a bare
+        // `.SubscribeOn(TaskPoolScheduler.Default)` the drain could not reach), and Rx runs a
+        // sequence's *unsubscription* logic on the scheduler it subscribed on. So the bridge's
         // `pending.Dispose()` returns as soon as the unsubscribe is SCHEDULED, and the inner
         // subscription to the parking store is torn down on a pool thread some time after the
-        // caller's task has already thrown.
+        // caller's task has already thrown. What guarantees the work is JOINED before teardown is
+        // therefore the pool, not the bridge — see ToolTask.Pooled.
         //
         // Reading `Disposals` the instant the task threw therefore asserted a synchronicity the
         // code does not provide: locally the pool thread always won, on a loaded runner it did not,

--- a/test/MeshWeaver.AI.Test/MeshToolCancellationTest.cs
+++ b/test/MeshWeaver.AI.Test/MeshToolCancellationTest.cs
@@ -1,0 +1,354 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.AI.Plugins;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services.LanguageServer;
+using Microsoft.Extensions.AI;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.AI.Test;
+
+/// <summary>
+/// 🚨 The second half of the #1956 audit: the seventeen tools <see cref="AgentToolCancellationTest"/>
+/// did NOT cover.
+///
+/// <para><b>The defect.</b> Every tool on <see cref="MeshPlugin"/> (thirteen — <c>get</c>,
+/// <c>search</c>, <c>create</c>, <c>update</c>, <c>patch</c>, <c>edit_content</c>, <c>delete</c>,
+/// <c>move</c>, <c>copy</c>, <c>get_diagnostics</c>, <c>recycle</c>, <c>navigate_to</c>,
+/// <c>run_tests</c>) and every tool on <see cref="LspPlugin"/> (four) ended in
+/// <c>.FirstAsync().ToTask()</c> — the overload that takes NO
+/// <see cref="CancellationToken"/> — and declared no token parameter at all. So the returned
+/// <c>Task</c> could not be cancelled by anything: not the Stop button, not
+/// <c>IoPool.Drain()</c>, not the round's own timeout.</para>
+///
+/// <para><b>Why that is a teardown defect and not a slow tool.</b> Identical to the version tools:
+/// the round runs as a leaf on the bounded <c>IoPoolNames.Ai</c> pool and holds one gate permit for
+/// its whole duration, and <c>Drain()</c> — the join teardown performs before disposing the service
+/// scope and unloading collectible node <c>AssemblyLoadContext</c>s — cancels the pool token and
+/// re-acquires every permit. A round parked in an uncancellable tool call never reaches the code
+/// that would notice. The LSP tools are the sharpest case of it: a speculative Roslyn compilation
+/// over a NodeType's whole source set is one of the longest things an agent does, and the running
+/// compilation is holding the very ALC teardown is about to unload.</para>
+///
+/// <para><b>Non-vacuity.</b> The park test drives the tools through their <see cref="AIFunction"/>
+/// surface — the same surface the agent loop uses, and the one that binds the invocation token — so
+/// it compiles unchanged against the unfixed code and fails on BEHAVIOUR: on <c>origin/main</c>
+/// nothing can end the wait and the bounded assertion fails with a <see cref="TimeoutException"/>
+/// rather than the <see cref="OperationCanceledException"/> asserted here. The ratchet
+/// (<see cref="EveryToolBindsTheRoundsCancellationToken"/>) is the guard that keeps the next tool
+/// from re-introducing it.</para>
+/// </summary>
+public class MeshToolCancellationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Share Mesh/SP across [Fact]s — the per-test container costs more than these tests do.</summary>
+    protected override bool ShareMeshAcrossTests => true;
+
+    /// <summary>
+    /// A language service that ACCEPTS the request and then never answers — the shape of a Roslyn
+    /// compilation that does not come back. It records disposal so the tests can assert the
+    /// compilation actually STOPPED, not merely that the caller stopped waiting.
+    /// </summary>
+    private sealed class ParkingLanguageService : IMeshLanguageService
+    {
+        private int disposals;
+        private int subscriptions;
+
+        /// <summary>How many subscriptions to this service have been disposed.</summary>
+        public int Disposals => Volatile.Read(ref disposals);
+
+        /// <summary>
+        /// How many calls have actually REACHED the park. The disposal assertion depends on a call
+        /// having got this far and nothing else tells you that it did — see
+        /// <see cref="AssertParkedThenCancellable"/>, and #2346 for why a sleep cannot stand in.
+        /// </summary>
+        public int Subscriptions => Volatile.Read(ref subscriptions);
+
+        private IObservable<T> Park<T>() => Observable.Create<T>(_ =>
+        {
+            Interlocked.Increment(ref subscriptions);
+            return Disposable.Create(() => Interlocked.Increment(ref disposals));
+        });
+
+        public IObservable<NodeDiagnosticsOutcome> GetDiagnostics(string nodeTypePath) => Park<NodeDiagnosticsOutcome>();
+
+        public IObservable<HoverInfo?> GetHover(string nodeTypePath, string sourcePath, SourcePosition position) =>
+            Park<HoverInfo?>();
+
+        public IObservable<IReadOnlyList<CompletionEntry>> GetCompletions(
+            string nodeTypePath, string sourcePath, SourcePosition position, int maxResults = 20) =>
+            Park<IReadOnlyList<CompletionEntry>>();
+
+        public IObservable<IReadOnlyList<CompletionEntry>> GetCompletions(
+            string nodeTypePath, string sourcePath, string sourceText, SourcePosition position, int maxResults = 20) =>
+            Park<IReadOnlyList<CompletionEntry>>();
+
+        public IObservable<IReadOnlyList<DiagnosticInfo>> CheckSpeculative(
+            string nodeTypePath, string sourcePath, string proposedCode) =>
+            Park<IReadOnlyList<DiagnosticInfo>>();
+
+        public void RecordCompletionAccepted(string prefix, string label, CompletionKind kind) { }
+
+        public void Evict(string nodeTypePath) { }
+    }
+
+    private static readonly ParkingLanguageService LanguageService = new();
+
+    // 🚨 The parking service is registered on the HUB, and AFTER AddGraph() — both halves matter.
+    // AddGraph() registers the real MeshNodeLanguageService inside
+    // `ConfigureHub(c => c.WithServices(...))`, i.e. in the hub's own container, which shadows a
+    // mesh-level `builder.ConfigureServices` registration entirely; and within one container the
+    // LAST plain AddSingleton is what GetService<T>() returns. Register at the wrong level or in the
+    // wrong order and the tests silently drive the REAL compiler, which ANSWERS ("No workspace for
+    // 'ACME/Story' — read status Absent") rather than parking — so the park precondition is never
+    // established and the failure reads as a timeout in the assertion helper.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder) =>
+        base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddAI()
+            .ConfigureHub(config => config.WithServices(services =>
+                services.AddSingleton<IMeshLanguageService>(LanguageService)));
+
+    private static AIFunctionArguments Args(params (string Name, object? Value)[] values)
+    {
+        var dict = new Dictionary<string, object?>();
+        foreach (var (name, value) in values)
+            dict[name] = value;
+        return new AIFunctionArguments(dict);
+    }
+
+    /// <summary>
+    /// Asserts <paramref name="call"/> is genuinely parked, then that cancelling the round unwinds
+    /// it promptly. Every failure mode stays distinguishable: a call that resolves before the cancel
+    /// fails the first check, and the bounded wait's own giving-up is a
+    /// <see cref="TimeoutException"/>, which is NOT an <see cref="OperationCanceledException"/>.
+    /// </summary>
+    private static async Task AssertParkedThenCancellable(
+        Task call, CancellationTokenSource round, string because, int subscriptionsBefore)
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // Wait for the call to actually REACH the park, on the service's own signal — never on a
+        // fixed sleep, which establishes only that the call has not answered yet (#2346).
+        await Observable.Interval(TimeSpan.FromMilliseconds(20)).StartWith(0L)
+            .Where(_ => LanguageService.Subscriptions > subscriptionsBefore)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask(ct);
+
+        // Now the negative check means what it says: the call is parked IN THE SERVICE and the
+        // service never answers, so nothing may settle it. (A sleep is correct here — the sanctioned
+        // "confirm nothing happened" case, where there is no positive signal to wait for.)
+        var settledEarly = await Task.WhenAny(call, Task.Delay(500, ct));
+        settledEarly.Should().NotBeSameAs(call,
+            "the language service never answers — the tool call must not resolve before the round is cancelled");
+
+        await round.CancelAsync();
+
+        var act = async () => await call.WaitAsync(5.Seconds(), ct);
+        await act.Should().ThrowAsync<OperationCanceledException>(because);
+    }
+
+    private LspPlugin Lsp() => new(Mesh, new NoopChat());
+
+    /// <summary><c>LspCheckNode</c> — the speculative Roslyn compile, against a service that never answers.</summary>
+    [Fact(Timeout = 60_000)]
+    public async Task LspCheckNode_ParkedOnAStalledCompiler_UnwindsWhenTheRoundIsCancelled()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var disposalsBefore = LanguageService.Disposals;
+        var subscribedBefore = LanguageService.Subscriptions;
+        var tool = (AIFunction)Lsp().CreateTools()[0];
+        using var round = new CancellationTokenSource();
+
+        var call = tool.InvokeAsync(
+            Args(("nodeTypePath", "ACME/Story"), ("sourcePath", "ACME/Story/Source/S.cs"), ("proposedCode", "class S{}")),
+            round.Token).AsTask();
+
+        await AssertParkedThenCancellable(call, round,
+            "a round parked in LspCheckNode holds an Ai-pool gate permit that IoPool.Drain() cannot "
+            + "re-acquire, so teardown unloads the ALC the compilation is still running in",
+            subscribedBefore);
+
+        // 🚨 WAIT for the disposal; do not read the counter and hope (#2346). ToolTask.Bridge
+        // disposes before it settles, but the pipeline hops schedulers, and Rx runs a sequence's
+        // UNSUBSCRIBE on the scheduler it subscribed on — so the teardown lands shortly after the
+        // caller's task has already thrown. The contract is "cancelling disposes the compile"; the
+        // way to observe an asynchronous fact is to wait for it, bounded, so a disposal that never
+        // comes still fails loudly rather than hanging.
+        await Observable.Interval(TimeSpan.FromMilliseconds(20)).StartWith(0L)
+            .Where(_ => LanguageService.Disposals > disposalsBefore)
+            .FirstAsync()
+            .Timeout(20.Seconds())
+            .ToTask(ct);
+
+        LanguageService.Disposals.Should().BeGreaterThan(disposalsBefore,
+            "cancelling must dispose the speculative compilation — otherwise it runs on unobserved");
+    }
+
+    /// <summary><c>LspDiagnosticsForNode</c> — same service, same contract.</summary>
+    [Fact(Timeout = 60_000)]
+    public async Task LspDiagnosticsForNode_ParkedOnAStalledCompiler_UnwindsWhenTheRoundIsCancelled()
+    {
+        var subscribedBefore = LanguageService.Subscriptions;
+        var tool = (AIFunction)Lsp().CreateTools()[1];
+        using var round = new CancellationTokenSource();
+
+        var call = tool.InvokeAsync(Args(("nodeTypePath", "ACME/Story")), round.Token).AsTask();
+
+        await AssertParkedThenCancellable(call, round,
+            "LspDiagnosticsForNode must observe the round's token", subscribedBefore);
+    }
+
+    /// <summary><c>LspHoverForNode</c> — the third of the four.</summary>
+    [Fact(Timeout = 60_000)]
+    public async Task LspHoverForNode_ParkedOnAStalledCompiler_UnwindsWhenTheRoundIsCancelled()
+    {
+        var subscribedBefore = LanguageService.Subscriptions;
+        var tool = (AIFunction)Lsp().CreateTools()[2];
+        using var round = new CancellationTokenSource();
+
+        var call = tool.InvokeAsync(
+            Args(("nodeTypePath", "ACME/Story"), ("sourcePath", "ACME/Story/Source/S.cs"),
+                 ("line", 0), ("character", 0)),
+            round.Token).AsTask();
+
+        await AssertParkedThenCancellable(call, round,
+            "LspHoverForNode must observe the round's token", subscribedBefore);
+    }
+
+    /// <summary><c>LspCompletionsForNode</c> — the fourth.</summary>
+    [Fact(Timeout = 60_000)]
+    public async Task LspCompletionsForNode_ParkedOnAStalledCompiler_UnwindsWhenTheRoundIsCancelled()
+    {
+        var subscribedBefore = LanguageService.Subscriptions;
+        var tool = (AIFunction)Lsp().CreateTools()[3];
+        using var round = new CancellationTokenSource();
+
+        var call = tool.InvokeAsync(
+            Args(("nodeTypePath", "ACME/Story"), ("sourcePath", "ACME/Story/Source/S.cs"),
+                 ("line", 0), ("character", 0)),
+            round.Token).AsTask();
+
+        await AssertParkedThenCancellable(call, round,
+            "LspCompletionsForNode must observe the round's token", subscribedBefore);
+    }
+
+    /// <summary>
+    /// The positive control the cancellation tests need: an UNcancelled mesh tool still answers.
+    /// Without this, "everything throws OperationCanceledException" would pass the tests above.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task MeshTool_WithALiveToken_StillAnswers()
+    {
+        var plugin = new MeshPlugin(Mesh, new NoopChat());
+
+        var answer = await plugin.Search("nodeType:Markdown", limit: 1, cancellationToken: TestContext.Current.CancellationToken)
+            .WaitAsync(30.Seconds(), TestContext.Current.CancellationToken);
+
+        answer.Should().NotBeNullOrWhiteSpace("the search must still produce its JSON envelope");
+    }
+
+    /// <summary>
+    /// A round that is ALREADY cancelled when the tool is called must come back cancelled rather
+    /// than doing the work.
+    ///
+    /// <para>The token is registered before the source is subscribed
+    /// (<c>ToolTask.Bridge</c>), which is what makes an already-cancelled token settle first.
+    /// On <c>origin/main</c> this test does not compile at all: <c>MeshPlugin.Get</c> had no
+    /// <see cref="CancellationToken"/> parameter to pass — which is the defect stated as a
+    /// signature rather than as a hang.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task MeshTool_WithAnAlreadyCancelledRound_DoesNotRun()
+    {
+        var plugin = new MeshPlugin(Mesh, new NoopChat());
+        using var round = new CancellationTokenSource();
+        await round.CancelAsync();
+
+        var act = async () => await plugin.Get("Doc/Overview", round.Token);
+
+        await act.Should().ThrowAsync<OperationCanceledException>(
+            "a tool called with a cancelled round must unwind instead of holding its Ai-pool permit");
+    }
+
+    /// <summary>
+    /// 🚨 THE RATCHET. Every agent tool these plugins expose must bind the round's cancellation
+    /// token — checked on the tool objects themselves, so a new tool added without one fails here
+    /// rather than in a teardown three months later.
+    ///
+    /// <para><c>AIFunctionFactory</c> binds a <see cref="CancellationToken"/> parameter from the
+    /// invocation and keeps it OUT of the JSON schema, so declaring one costs the model nothing —
+    /// there is no reason for an AWAITING tool not to have it, and therefore no exemption list.</para>
+    ///
+    /// <para>The obligation is on tools that WAIT, i.e. whose method returns a <see cref="Task"/> or
+    /// <see cref="ValueTask"/>; a tool that computes its answer synchronously and returns a
+    /// <see cref="string"/> (<c>handoff_to_agent</c>, <c>submit_message</c>, <c>check_inbox</c>) has
+    /// no wait to cancel, so the check is keyed off the return type rather than listing exceptions.
+    /// Scope: the five plugins that can be constructed from (hub, chat) alone — the tools built by
+    /// static factories with wider dependencies are not reachable from here.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void EveryToolBindsTheRoundsCancellationToken()
+    {
+        var chat = new NoopChat();
+        var tools = new List<AITool>();
+        tools.AddRange(new MeshPlugin(Mesh, chat).CreateAllTools());
+        tools.AddRange(new LspPlugin(Mesh, chat).CreateTools());
+        tools.AddRange(new VersionPlugin(Mesh).CreateTools());
+        tools.AddRange(new CollaborationPlugin(Mesh, chat).CreateTools());
+        tools.AddRange(new AgentFilesPlugin(Mesh, chat).CreateTools());
+
+        tools.Should().NotBeEmpty("the plugins under test must actually expose tools");
+
+        static bool Awaits(Type returnType) =>
+            typeof(Task).IsAssignableFrom(returnType)
+            || returnType == typeof(ValueTask)
+            || (returnType.IsGenericType && returnType.GetGenericTypeDefinition() == typeof(ValueTask<>));
+
+        var missing = tools
+            .OfType<AIFunction>()
+            .Where(f => f.UnderlyingMethod is not null)
+            .Where(f => Awaits(f.UnderlyingMethod!.ReturnType))
+            .Where(f => !f.UnderlyingMethod!.GetParameters().Any(p => p.ParameterType == typeof(CancellationToken)))
+            .Select(f => $"{f.UnderlyingMethod!.DeclaringType?.Name}.{f.UnderlyingMethod!.Name}")
+            .ToList();
+
+        tools.OfType<AIFunction>().Count(f => Awaits(f.UnderlyingMethod?.ReturnType ?? typeof(void)))
+            .Should().BeGreaterThan(20,
+                "the ratchet must actually be looking at the awaiting tools — a filter that matches "
+                + "nothing passes silently");
+
+        missing.Should().BeEmpty(
+            "an agent tool that cannot be cancelled parks its round's IoPoolNames.Ai gate permit "
+            + "through IoPool.Drain(), so teardown proceeds over live code and the Stop button lies");
+    }
+
+    /// <summary>Minimal <see cref="IAgentChat"/> stub — the tools under test read only Context/ExecutionContext.</summary>
+    private sealed class NoopChat : IAgentChat
+    {
+        public AgentContext? Context => null;
+
+        public void SetContext(AgentContext? applicationContext) => throw new NotImplementedException();
+        public void SetSelectedAgent(string? agentName) => throw new NotImplementedException();
+        public Task ResumeAsync(AI.Persistence.ChatConversation conversation) => throw new NotImplementedException();
+        public Task<IReadOnlyList<AgentDisplayInfo>> GetOrderedAgentsAsync() => throw new NotImplementedException();
+        public IAsyncEnumerable<ChatMessage> GetResponseAsync(
+            IReadOnlyCollection<ChatMessage> messages,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public IAsyncEnumerable<ChatResponseUpdate> GetStreamingResponseAsync(
+            IReadOnlyCollection<ChatMessage> messages,
+            CancellationToken cancellationToken = default) => throw new NotImplementedException();
+        public void SetThreadId(string threadId) => throw new NotImplementedException();
+        public void DisplayLayoutArea(MeshWeaver.Layout.LayoutAreaControl layoutAreaControl) => throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
Maintainer instruction: *"get rid of any task. tasks are evil."* — for `src/MeshWeaver.AI/`.

`src/MeshWeaver.AI/` held **29** sites in the `Task`/blocking family. **22 converted**, **1 dead async method deleted**, **9 kept** — each of the nine named below with why it is a genuine external boundary. Classified by reading what each site does, never by grep shape.

## 1. The real defect — 17 agent tools could not be cancelled at all

Every tool on `MeshPlugin` (13: `get`, `search`, `create`, `update`, `patch`, `edit_content`, `delete`, `move`, `copy`, `get_diagnostics`, `recycle`, `navigate_to`, `run_tests`) and every tool on `LspPlugin` (4) ended in `.FirstAsync().ToTask()` — the overload taking **no** `CancellationToken` — and declared no token parameter. Nothing could end the wait: not Stop, not the round timeout, not `IoPool.Drain()`.

This is the **#1956** defect class, fixed for `VersionPlugin` / `SkillTool` / `PlanStorageTool` / `CollaborationPlugin` and left standing on these seventeen. The round runs as a leaf on the bounded `IoPoolNames.Ai` pool holding one gate permit for its whole duration; `Drain()` — the join teardown performs before disposing the service scope and unloading collectible node ALCs — cancels the pool token and re-acquires every permit. A round parked in an uncancellable tool call never reaches the code that would notice, so Drain sits out its full 30 s budget and **teardown proceeds over live code**. The LSP four are the sharpest case: a speculative Roslyn compile over a NodeType's whole source set is holding the very ALC teardown is about to unload.

All seventeen now take the round's token (`AIFunctionFactory` binds it and keeps it out of the JSON schema, so it costs the model nothing) and go through the folder's one shared bridge, `ToolTask.Bridge`. That also supplies two terminals these got wrong: a fault escaped as an exception where the model needed an answer, and an **empty completion** reached `FirstAsync` as `"Sequence contains no elements"`.

## 2. `AgentFilesPlugin` (5) — the terminal the `.Catch` could not see

These *did* observe the token and *did* handle faults fluently — but the `.Catch` sat **upstream** of `FirstAsync`, so an empty completion still surfaced as `InvalidOperationException`. Reachable, not theoretical: `MeshNodeStreamCache` completes its per-path subjects on eviction and on dispose, which is exactly what a thread whose hub is going away does.

## 3. The #2488 question, answered: `ToolTask.Bridge` stops **waiting**, and *requests* the teardown

You asked me to establish whether the bridge actually stops the work or only stops waiting for it. **It stops waiting and requests teardown — it cannot promise the work has stopped, and the file claimed it could.**

`Bridge` disposes before it settles, which is correct and stays. But Rx disposal is synchronous only for a chain that is synchronous to dispose, and every one of these pipelines hops a scheduler — and **Rx runs a sequence's *unsubscribe* on the scheduler it subscribed on**. So `pending.Dispose()` returns once the unsubscribe is *scheduled*. The repo already knew half of this: `AgentToolCancellationTest` waits for the disposal rather than reading it, and says why. `ToolTask`'s own summary asserted the stronger claim. Corrected — in the summary and at `Settle`.

What *can* promise it is the pool, so the mechanism now matches the claim. The **seven** bare `.SubscribeOn(TaskPoolScheduler.Default)` hops (`VersionPlugin` ×4, `CollaborationPlugin` ×2, `DelegationTool` ×1) go through new `ToolTask.Pooled` → `IIoPool.SubscribeThroughPool` on the mesh-scoped **`AgentStore`** pool — which documents itself as precisely *"the tracked, drainable replacement for a bare `.SubscribeOn(TaskPoolScheduler.Default)`, which the drain cannot reach"*. Both leave the caller's scheduler, which is all those comments ever asked for; only one is visible to `Drain`.

`AgentStore` and never `Ai`: the call already sits inside a round holding an `Ai` permit, and re-entering the same bounded pool from inside a permit it holds is the classic nested-gate deadlock (that is why the pool exists). With no `IoPoolRegistry` the fallback is `IoPool.Unbounded`, whose `SubscribeThroughPool` **is** `.SubscribeOn(TaskPoolScheduler.Default)` — so a mesh without pools behaves exactly as before.

## 4. `DelegationTool.Settle` had the ordering defect `ToolTask` documents

It read `if (set()) pending.Dispose();` — the exact shape `ToolTask`'s comment names as the defect it removed. `tcs` is `RunContinuationsAsynchronously`, so `TrySet*` schedules the round's continuation concurrently with the rest of the callback: on cancellation the round could observe the cancel, release its `Ai` permit and let teardown through **while this call still held a live subscription to the sub-thread's node stream**. Now dispose-then-set.

## 5. Deleted

`AgentChatClient.CreateAgentsAsync` — 55 lines, private, **no callers**, marked `[Obsolete("… deadlocks in Orleans")]`. `CreateAgentsSync` is the live path.

## Kept (9) — every one an external boundary we do not own

| Site | Why |
|---|---|
| `MeshNodeAgentFileStore` ×7 | Overrides of MAF's abstract `AgentFileStore` (`WriteAsync`, `ReadAsync`, `FileExistsAsync`, `DeleteAsync`, `CreateDirectoryAsync`, `ListChildrenAsync`, `SearchAsync`). Signatures are Microsoft's. One line each over a fully reactive body, token observed. |
| `MeshAgentSkillsSource` ×1 | Override of MAF's `AgentSkillsSource.GetSkillsAsync`. |
| `ToolTask` ×1 `TaskCompletionSource` | The ONE shared bridge to `AIFunctionFactory`'s `Task<string>` — now used by every tool in the folder. |

**Verified already-correct and left alone** (read, not grepped): `ThreadExecution`'s `aiPool.Invoke(async poolCt => …)`, `ImageGenerator`, `ProviderModelLister`, `ClaudeConnectStrategy` — all `IIoPool` leaf bodies, the one sanctioned async boundary; `AgentChatClient`'s remaining `async` methods, which run **inside** that Ai-pool leaf's enumeration rather than on a hub scheduler; `ChatClientAgentFactory.InvokeCoreAsync`, MAF's `AIFunction` override; and `HandoffTool` / `ThreadMessageTool` / `InboxTool`, synchronous `string`-returning tools with no wait to cancel.

## Findings that are NOT fixed here

1. **`IChatClientFactory.CreateAgentAsync` now has no production caller** — its only one was the dead method deleted here. Removing it from the interface deletes ~40 `Task`-returning test doubles across four test projects plus the plugins repo: a separate mechanical PR, not this one.
2. **`DelegationTool`'s `TaskCompletionSource` is the last hand-rolled bridge in the folder**, and is not a drop-in for `ToolTask.Bridge`: it fans in three independent settle sources (delegation-lifecycle event, sub-thread terminal state, chunk aggregate) where one must be *subscribed for its side effect* — it launches the sub-thread — while not owning the answer. Expressible as a `Merge`, but that is a behaviour-carrying refactor with its own test surface. The ordering defect it actually had **is** fixed here.

## Tests

New `MeshToolCancellationTest`: four park→cancel→dispose tests driving the LSP tools through their `AIFunction` surface against an injected language service that **accepts the request and never answers**; a live-token positive control (so "everything throws cancelled" cannot pass); an already-cancelled-round test; and a **ratchet** asserting every *awaiting* tool on these five plugins binds a `CancellationToken` — keyed off the return type, so the synchronous tools need no exemption list.

**Non-vacuity measured, not asserted.** With the token deliberately disconnected the four park tests fail 4/4 with `Expected a OperationCanceledException …, but found TimeoutException` — the predicted failure mode exactly. With it wired: 7/7 in 5 s.

- `MeshWeaver.AI.Test` — 1479/1479 (3 pre-existing skips)
- `MeshWeaver.Threading.Test` — 139/139
- `MeshWeaver.Documentation.Test` — 92/92
- `dotnet build -c Release -warnaserror` — 0 warnings, 0 errors

What's New entry included (`Category: Fix` — Stop now actually stops a running tool call).

Refs #2488, #1956.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
