### PR TITLE
Modules__Required: the ceiling written down and guarded, and the OVERWRITE nobody could see (Memex#131)

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -349,8 +349,14 @@ data:
   FrameworkBroadcast__Subscribers__2: "{{ .Values.config.memex_portal.FrameworkBroadcast__Subscribers__2 | default "" }}"
   FrameworkBroadcast__Subscribers__3: "{{ .Values.config.memex_portal.FrameworkBroadcast__Subscribers__3 | default "" }}"
   # The MODULES a deployment refuses to run without (MeshBuilderModuleActivation.RequiredKey).
-  # The image ships a baseline list in appsettings; a deployment OVERRIDES an entry by name here,
-  # and blanks one it cannot satisfy.
+  # The image ships a baseline list in appsettings; a deployment OVERRIDES an entry here and
+  # blanks one it cannot satisfy.
+  #
+  # 🚨 It overrides BY INDEX, and it never APPENDS. Configuration merges an array element per
+  # key, so Modules__Required__5 REPLACES whatever the image baseline holds at index 5 — it does
+  # not add a sixth requirement. The baseline is 7 entries today (0..6: Radzen, Analysis,
+  # EntityViews, GoogleMaps, Speech, Social, AI), so an overlay ADDING a module must start at the
+  # first index PAST it, and an overlay that restates the baseline must restate all of it.
   #
   # 🚨 Un-templated, an override is silently dropped and the health check wins anyway — the #1925
   # defect, third occurrence. Not cosmetic here: `required_modules` reports Unhealthy, /health
@@ -363,6 +369,20 @@ data:
   # key explicitly, and EveryConfigKeySetInAValuesFile_IsBoundInTheConfigMap enforces exactly that
   # by looking for the key. A range renders correctly and is invisible to the guard — which is how
   # the first draft of this block passed helm and failed the test, correctly.
+  #
+  # 🚨 THE CEILING IS 9 — the block renders 0..9 and NOTHING ABOVE. A ceiling is not an oversight
+  # here, it is the price of the literal-key contract above: a bounded list is what the guard can
+  # check, and an unbounded `range` is what it cannot. So the ceiling has to be stated where it is
+  # raised, because twice now an overlay declared the first index past it and the key reached no
+  # container at all — Memex#128/#131 (MeshWeaver.Mcp, /mcp answering 404 with Mcp__BaseUrl
+  # configured beside it) and Memex#129. Why 9 and not 7: the baseline consumes 0..6, so a ceiling
+  # of 7 leaves exactly ONE appendable slot; ten slots leave three. RAISING IT is one hasKey block
+  # per index and nothing else — do that rather than reusing a baseline index.
+  #
+  # Two guards in test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs hold this shape:
+  # ModulesRequired_IsRenderedAsAContiguousRangeFromZero (a gap silently truncates nothing and
+  # drops exactly the missing index) and NoValuesFile_DeclaresAModulesRequiredIndexAboveTheCeiling
+  # (whose failure message names the ceiling, so the next person is told the number).
   #
   # Each index is emitted only when a deployment sets it, so an install that overrides nothing
   # keeps the image's own list rather than blanking entry 0.
@@ -381,10 +401,6 @@ data:
   {{- if hasKey .Values.config.memex_portal "Modules__Required__4" }}
   Modules__Required__4: "{{ .Values.config.memex_portal.Modules__Required__4 }}"
   {{- end }}
-  {{- /* Indices 5-7: headroom so the NEXT required module does not silently vanish. The list
-     stopped at 4 while the overlays grew to 5 (MeshWeaver.AI, the engine guard after the
-     2026-08-27 outage) — the config-key coverage gate caught the overlay key reaching NO
-     container, the 5th recurrence of the named-key omission (#1925/#1778/#1780/#2203). */}}
   {{- if hasKey .Values.config.memex_portal "Modules__Required__5" }}
   Modules__Required__5: "{{ .Values.config.memex_portal.Modules__Required__5 }}"
   {{- end }}
@@ -393,6 +409,12 @@ data:
   {{- end }}
   {{- if hasKey .Values.config.memex_portal "Modules__Required__7" }}
   Modules__Required__7: "{{ .Values.config.memex_portal.Modules__Required__7 }}"
+  {{- end }}
+  {{- if hasKey .Values.config.memex_portal "Modules__Required__8" }}
+  Modules__Required__8: "{{ .Values.config.memex_portal.Modules__Required__8 }}"
+  {{- end }}
+  {{- if hasKey .Values.config.memex_portal "Modules__Required__9" }}
+  Modules__Required__9: "{{ .Values.config.memex_portal.Modules__Required__9 }}"
   {{- end }}
   # Convergence policy (MeshWeaver#2192): when a NodeType publishes a usable build, instances
   # self-recycle onto it instead of waiting behind the "Recycle" banner. Off = the image default

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-required-modules-ceiling.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-required-modules-ceiling.md
@@ -13,3 +13,7 @@ of those slots. A sixth entry was accepted everywhere it was written and then re
 at all — which is how one portal's MCP endpoint kept answering 404 while its configuration said it
 was switched on. There is room for ten now, and an entry past that limit fails the build with the
 limit named, rather than disappearing quietly.
+
+The same list had a quieter way to go wrong: because entries are numbered, a new one written over
+an existing number replaced that module's requirement instead of adding to it, and nothing said so.
+A portal now reports at startup exactly which requirement was replaced and what to do about it.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-required-modules-ceiling.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-required-modules-ceiling.md
@@ -1,0 +1,15 @@
+---
+Name: Deployments can require more modules
+Category: Fix
+Description: A deployment can now declare up to ten required modules; an index past the ceiling fails the build instead of silently reaching no container.
+Icon: Sparkle
+Order: -20260827
+---
+
+# Deployments can require more modules
+
+A deployment states the modules it refuses to run without, and the chart used to carry only five
+of those slots. A sixth entry was accepted everywhere it was written and then reached no container
+at all — which is how one portal's MCP endpoint kept answering 404 while its configuration said it
+was switched on. There is room for ten now, and an entry past that limit fails the build with the
+limit named, rather than disappearing quietly.

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilderModuleActivation.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilderModuleActivation.cs
@@ -77,6 +77,18 @@ public static class MeshBuilderModuleActivation
                 + "registry has not landed yet is reported degraded and named (it is not something "
                 + "a held rollout could deliver).");
 
+        // The SILENT half of the same key: a requirement that did not go missing but was
+        // OVERWRITTEN. Nothing above can see it — the entry is not absent, it was never asked for.
+        foreach (var shadowed in ShadowedRequired(configuration))
+            report($"REQUIRED module '{shadowed}' was silently REPLACED at its index and is no "
+                + $"longer required by this deployment. {RequiredKey} is an ARRAY and an override "
+                + "binds BY INDEX: setting one entry does not append to the list, it replaces "
+                + $"whatever the image declared at that position. Nothing else reports this — the "
+                + "module is simply not required any more, so it is never missing, the deploy "
+                + "succeeds and the health check stays green with the guard gone. Move the new "
+                + "entry to the first index PAST the image's own list, or restate the entry you "
+                + "replaced at a free index.");
+
         // Hand the configuration to the builder BEFORE anything is installed: an attribute's
         // BuilderConfigurations runs inside InstallAssemblies, so a module asking "what did this
         // deployment configure?" must find the answer already there. We hold it either way — not
@@ -101,6 +113,73 @@ public static class MeshBuilderModuleActivation
             .Where(entry => !string.IsNullOrWhiteSpace(entry))
             .Where(entry => !exists(resolve(entry!)))
             .Select(entry => entry!)];
+    }
+
+    /// <summary>
+    /// The required modules an override SILENTLY REPLACED — declared by one configuration source
+    /// and overwritten at the same index by a later one, with the replaced module named nowhere
+    /// else in the effective list.
+    ///
+    /// <para>🚨 <b>Why this is not the same question as <see cref="MissingRequired"/>, and why
+    /// nothing else can ask it.</b> <c>Modules:Required</c> is an ARRAY, so an override binds BY
+    /// INDEX: <c>Modules__Required__5</c> replaces whatever the image's own list holds at index 5 —
+    /// it does not append a sixth requirement. The failure that follows is invisible from every
+    /// direction. The replaced module is not MISSING (nobody asked for it any more), so
+    /// <see cref="MissingRequired"/> and the readiness contract both have nothing to say; the
+    /// override is not un-rendered, so the chart's coverage gate passes; the deploy succeeds and
+    /// <c>/health</c> stays green having quietly stopped guarding a module. Measured on Memex#131:
+    /// an overlay added <c>MeshWeaver.Mcp.dll</c> at index 5 to require the MCP endpoint, and index
+    /// 5 of the image's list is <c>MeshWeaver.Social.dll</c>.</para>
+    ///
+    /// <para>The two halves are only ever visible TOGETHER in the running process — the image's
+    /// baseline ships in one repository and the overlay lives in another — which is why this is a
+    /// boot-time check and not a chart guard. Provider ORDER is the whole mechanism: a value a
+    /// provider supplies that is not the effective one has been shadowed by a later provider, so no
+    /// provider-type sniffing is needed and any layering (files, env, command line) is covered.</para>
+    ///
+    /// <para>Two shapes are deliberately NOT reported, because both are how the key is meant to be
+    /// used: <b>blanking</b> an entry the deployment cannot satisfy (the effective value is empty —
+    /// an explicit "not required here", and the whole remedy the 2026-08-23 rollouts had), and
+    /// <b>reordering</b>, where the replaced module still appears at some other index and no
+    /// requirement was lost.</para>
+    /// </summary>
+    /// <param name="configuration">The host configuration. A non-root <see cref="IConfiguration"/>
+    /// carries no provider list and yields an empty result — the check simply does not apply.</param>
+    public static string[] ShadowedRequired(IConfiguration configuration)
+    {
+        ArgumentNullException.ThrowIfNull(configuration);
+        if (configuration is not IConfigurationRoot root)
+            return [];
+
+        var effective = root.GetSection(RequiredKey).GetChildren()
+            .ToDictionary(child => child.Key, child => child.Value, StringComparer.Ordinal);
+        var stillRequired = effective.Values
+            .Where(value => !string.IsNullOrWhiteSpace(value))
+            .Select(value => value!)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var shadowed = new List<string>();
+        foreach (var (index, winner) in effective)
+        {
+            // A BLANK winner is an explicit "this deployment cannot satisfy it" — the sanctioned
+            // way to drop a requirement, and never a mistake to report.
+            if (string.IsNullOrWhiteSpace(winner))
+                continue;
+
+            foreach (var provider in root.Providers)
+            {
+                if (!provider.TryGet($"{RequiredKey}:{index}", out var supplied)
+                    || string.IsNullOrWhiteSpace(supplied)
+                    || string.Equals(supplied, winner, StringComparison.OrdinalIgnoreCase)
+                    // Reordered, not lost: the module is still required, at another index.
+                    || stillRequired.Contains(supplied))
+                    continue;
+
+                shadowed.Add(supplied);
+            }
+        }
+
+        return [.. shadowed.Distinct(StringComparer.OrdinalIgnoreCase)];
     }
 
     /// <summary>

--- a/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -421,19 +422,7 @@ public class PlatformBakeLaneGuard
         var configMap = File.ReadAllText(Path.Combine(
             root, "deploy", "helm", "templates", "memex-portal", "config.yaml"));
 
-        // EVERY tracked file that becomes a values overlay — not only the three the chart is
-        // rendered with directly. values.deploy.example.yaml is copied to the overlay
-        // deploy/aks/scripts/deploy.sh passes, and values.local.yaml to the one memex-local
-        // generates for a new install; both carry config.memex_portal mappings, so an untemplated
-        // key added to either reaches no container in exactly the same way (Copilot review, #2104).
-        var missing = new[]
-            {
-                Path.Combine(root, "deploy", "helm", "values.yaml"),
-                Path.Combine(root, "deploy", "aks", "values.aks.yaml"),
-                Path.Combine(root, "deploy", "aks", "scripts", "values.deploy.example.yaml"),
-                Path.Combine(root, "deploy", "homebrew", "share", "values.local.defaults.yaml"),
-                Path.Combine(root, "deploy", "homebrew", "share", "values.local.yaml"),
-            }
+        var missing = ValuesFiles(root)
             .Where(File.Exists)
             .SelectMany(f => PortalConfigKeysOf(File.ReadAllLines(f))
                 .Select(key => (file: Path.GetFileName(f), key)))
@@ -451,6 +440,157 @@ public class PlatformBakeLaneGuard
             + ". Template each one — and give a TYPED key a real default, because '' is not a "
             + "valid TimeSpan/int and crashes the portal at startup rather than reading as unset.");
     }
+
+    /// <summary>
+    /// EVERY tracked file that becomes a values overlay — not only the three the chart is rendered
+    /// with directly. <c>values.deploy.example.yaml</c> is copied to the overlay
+    /// <c>deploy/aks/scripts/deploy.sh</c> passes, and <c>values.local.yaml</c> to the one
+    /// memex-local generates for a new install; both carry <c>config.memex_portal</c> mappings, so
+    /// an untemplated key added to either reaches no container in exactly the same way (Copilot
+    /// review, #2104).
+    /// </summary>
+    private static string[] ValuesFiles(string root) =>
+    [
+        Path.Combine(root, "deploy", "helm", "values.yaml"),
+        Path.Combine(root, "deploy", "aks", "values.aks.yaml"),
+        Path.Combine(root, "deploy", "aks", "scripts", "values.deploy.example.yaml"),
+        Path.Combine(root, "deploy", "homebrew", "share", "values.local.defaults.yaml"),
+        Path.Combine(root, "deploy", "homebrew", "share", "values.local.yaml"),
+    ];
+
+    /// <summary>The key family whose rendered range this pair of guards holds.</summary>
+    private const string RequiredModulePrefix = "Modules__Required__";
+
+    /// <summary>
+    /// 🚨 The <c>Modules__Required__N</c> block must render a CONTIGUOUS range from 0, because a
+    /// gap is invisible in exactly the way the whole key family already proved it can be.
+    ///
+    /// <para>The block is written index by index on purpose — a Helm <c>range</c> renders
+    /// correctly and is invisible to <see cref="EveryConfigKeySetInAValuesFile_IsBoundInTheConfigMap"/>,
+    /// which looks for the literal key. That contract is what makes the list checkable, and it is
+    /// also what gives it a CEILING: a hand-written list stops somewhere. Both failure modes of a
+    /// hand-written list are silent at deploy time, so both are asserted here:</para>
+    /// <list type="number">
+    ///   <item><b>A gap.</b> Delete the index-3 block and an overlay's
+    ///     <c>Modules__Required__3</c> reaches no container while 4 and 5 still do — the
+    ///     deployment then requires a DIFFERENT set than the one it declared, with helm
+    ///     reporting success.</item>
+    ///   <item><b>The ceiling drifting out of the comment.</b> The comment states the rendered
+    ///     range so the next person adding a module reads the number instead of counting blocks;
+    ///     this asserts the sentence still matches the template.</item>
+    /// </list>
+    ///
+    /// <para>Both came from Memex#131: the block stopped at 4 while memex-cloud declared index 5
+    /// (<c>MeshWeaver.Mcp.dll</c>), so <c>/mcp</c> went on answering 404 with <c>Mcp__BaseUrl</c>
+    /// configured a few lines below it — the fifth recurrence of the named-key omission class
+    /// (#1925/#1778/#1780/#2203/#2104).</para>
+    /// </summary>
+    [Fact]
+    public void ModulesRequired_IsRenderedAsAContiguousRangeFromZero()
+    {
+        var configMap = ReadPortalConfigMap();
+        var rendered = RenderedRequiredModuleIndices(configMap);
+
+        Assert.True(rendered.Length > 0,
+            $"deploy/helm/templates/memex-portal/config.yaml renders NO {RequiredModulePrefix}N "
+            + "key at all. The overlays override the image's required-module list by index "
+            + "through this block; with it gone every override reaches no container and the "
+            + "image's own list silently wins (Memex#131).");
+
+        Assert.True(rendered[0] == 0,
+            $"the {RequiredModulePrefix}N block starts at index {rendered[0]}, not 0. "
+            + "Configuration binds the array by index, so a list that does not start at 0 cannot "
+            + "override the image's first entry.");
+
+        var ceiling = rendered[^1];
+        var gaps = Enumerable.Range(0, ceiling + 1).Except(rendered).ToArray();
+        Assert.True(gaps.Length == 0,
+            $"the {RequiredModulePrefix}N block renders "
+            + string.Join(", ", rendered)
+            + $" — index {string.Join(", ", gaps)} missing. A gap is silent: an overlay that sets "
+            + "the missing index reaches NO container while its neighbours do, so the deployment "
+            + "requires a different module set than the one it declares and helm still reports "
+            + "success. Render every index from 0 to the ceiling.");
+
+        // The comment must still name the range it renders. This is the only thing standing
+        // between "the ceiling is written down where the next person reads it" and a sentence
+        // that quietly describes the previous ceiling — which is how Memex#128 came to declare
+        // index 5 against a comment that said the chart renders 0..4.
+        Assert.True(configMap.Contains($"renders 0..{ceiling}", StringComparison.Ordinal),
+            $"the {RequiredModulePrefix}N block renders 0..{ceiling}, but no comment in "
+            + "deploy/helm/templates/memex-portal/config.yaml says so. The ceiling is only useful "
+            + "written down: the overlay that hits it lives in another repository, and its author "
+            + "sees this file, not this test. Say `renders 0..N` in the block's comment.");
+    }
+
+    /// <summary>
+    /// 🚨 No values file may declare a <c>Modules__Required__N</c> ABOVE the rendered ceiling —
+    /// and the failure says what the ceiling is.
+    ///
+    /// <para><see cref="EveryConfigKeySetInAValuesFile_IsBoundInTheConfigMap"/> already fails on
+    /// such a key, but it fails as one of a generic list of "template each one", which is the
+    /// wrong instruction for this family: the fix is not a new key somewhere, it is one more
+    /// <c>hasKey</c> block on an ordered list whose ceiling the author has to know. Memex#131 is
+    /// the whole argument — the person adding index 5 could see the key was refused but not what
+    /// the limit was, and the chart is in a different repository from the overlay.</para>
+    /// </summary>
+    [Fact]
+    public void NoValuesFile_DeclaresAModulesRequiredIndexAboveTheCeiling()
+    {
+        var root = FindRepoRoot();
+        var configMap = ReadPortalConfigMap();
+        var rendered = RenderedRequiredModuleIndices(configMap);
+        var ceiling = rendered.Length == 0 ? -1 : rendered[^1];
+
+        var over = ValuesFiles(root)
+            .Where(File.Exists)
+            .SelectMany(f => PortalConfigKeysOf(File.ReadAllLines(f))
+                .Where(k => k.StartsWith(RequiredModulePrefix, StringComparison.Ordinal))
+                .Select(k => (file: Path.GetFileName(f), key: k, index: IndexOfKey(k))))
+            .Where(x => x.index > ceiling)
+            .Distinct()
+            .ToList();
+
+        Assert.True(over.Count == 0,
+            "These values entries declare a required-module index the chart does not render, so "
+            + "they reach NO container and the module is not required at all — silently, with "
+            + "helm reporting success: "
+            + string.Join(", ", over.Select(x => $"{x.key} (set in {x.file})"))
+            + $". deploy/helm/templates/memex-portal/config.yaml renders {RequiredModulePrefix}"
+            + $"0..{ceiling} — RAISE THE CEILING by adding one more `hasKey` block per index (a "
+            + "Helm range would render correctly and be invisible to the key-literal guards), and "
+            + "update the comment that states the rendered range.");
+    }
+
+    private static string ReadPortalConfigMap() =>
+        File.ReadAllText(Path.Combine(
+            FindRepoRoot(), "deploy", "helm", "templates", "memex-portal", "config.yaml"));
+
+    /// <summary>
+    /// The <c>Modules__Required__N</c> indices the configmap actually BINDS, ascending. Candidates
+    /// come from executable template text only and each is confirmed through
+    /// <see cref="IsWiredInConfigMap"/>, so a key named in a Helm comment — this file has nine
+    /// such blocks, and the one above this very family names indices in prose — can never count as
+    /// rendered.
+    /// </summary>
+    private static int[] RenderedRequiredModuleIndices(string configMap) =>
+        Regex.Matches(
+                ExecutableTemplateOf(configMap),
+                $@"^\s{{2}}{Regex.Escape(RequiredModulePrefix)}(\d+):\s",
+                RegexOptions.Multiline)
+            .Select(m => int.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture))
+            .Where(i => IsWiredInConfigMap(configMap, $"{RequiredModulePrefix}{i}"))
+            .Distinct()
+            .Order()
+            .ToArray();
+
+    /// <summary>The numeric suffix of a <c>Modules__Required__N</c> key; -1 when it is not one.
+    /// </summary>
+    private static int IndexOfKey(string key) =>
+        int.TryParse(key[RequiredModulePrefix.Length..], NumberStyles.None,
+            CultureInfo.InvariantCulture, out var index)
+            ? index
+            : -1;
 
     /// <summary>
     /// The keys under <c>config.memex_portal</c> of a values file — section-scoped, so the

--- a/test/MeshWeaver.Graph.Test/ConfiguredModuleActivationTest.cs
+++ b/test/MeshWeaver.Graph.Test/ConfiguredModuleActivationTest.cs
@@ -133,4 +133,101 @@ public class ConfiguredModuleActivationTest
         Assert.Equal(["MeshWeaver.Speech.dll"],
             MeshBuilderModuleActivation.MissingRequired(config, Resolve, _ => false));
     }
+
+    // ───────── the SILENT half: an override that REPLACES a requirement ─────────
+
+    /// <summary>
+    /// The layering a deployment actually has: the image's own appsettings baseline first, then the
+    /// container environment the ConfigMap supplies. Two providers, in that order — which is the
+    /// whole mechanism, since the later one wins per KEY and a key here is an array INDEX.
+    /// </summary>
+    private static IConfiguration ImagePlusOverlay(
+        IEnumerable<string> baseline, IDictionary<string, string?> overlay)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(baseline.Select((entry, i) =>
+                new KeyValuePair<string, string?>($"Modules:Required:{i}", entry)))
+            .AddInMemoryCollection(overlay)
+            .Build();
+
+    /// <summary>The image's list as it stands: seven entries, Social at index 5.</summary>
+    private static readonly string[] ImageBaseline =
+    [
+        "MeshWeaver.Blazor.Radzen.dll",
+        "MeshWeaver.Blazor.Analysis.dll",
+        "MeshWeaver.Blazor.EntityViews.dll",
+        "MeshWeaver.Blazor.GoogleMaps.dll",
+        "MeshWeaver.Speech.dll",
+        "MeshWeaver.Social.dll",
+        "MeshWeaver.AI.dll",
+    ];
+
+    [Fact]
+    public void AnOverlayEntryThatOverwritesABaselineRequirement_IsReported()
+    {
+        // The literal Memex#131 shape: the overlay restates 0..4 and then adds MCP "at the end" —
+        // except index 5 is not the end, it is MeshWeaver.Social.dll. Nothing else in the system
+        // can see this: Social is not MISSING, it is no longer REQUIRED.
+        var config = ImagePlusOverlay(ImageBaseline, new Dictionary<string, string?>
+        {
+            ["Modules:Required:0"] = "MeshWeaver.Blazor.Radzen.dll",
+            ["Modules:Required:1"] = "MeshWeaver.Blazor.Analysis.dll",
+            ["Modules:Required:2"] = "MeshWeaver.Blazor.EntityViews.dll",
+            ["Modules:Required:3"] = "MeshWeaver.Blazor.GoogleMaps.dll",
+            ["Modules:Required:4"] = "MeshWeaver.Speech.dll",
+            ["Modules:Required:5"] = "MeshWeaver.Mcp.dll",
+        });
+
+        Assert.Equal(["MeshWeaver.Social.dll"], MeshBuilderModuleActivation.ShadowedRequired(config));
+
+        // And the guard it is NOT: every entry still resolves, so the loud half says nothing.
+        Assert.Empty(MeshBuilderModuleActivation.MissingRequired(config, Resolve, _ => true));
+    }
+
+    [Fact]
+    public void AnOverlayEntryPastTheBaseline_AddsWithoutReplacing()
+    {
+        // The fix, pinned: index 7 is the first free slot, so MCP is required IN ADDITION.
+        var config = ImagePlusOverlay(ImageBaseline, new Dictionary<string, string?>
+        {
+            ["Modules:Required:7"] = "MeshWeaver.Mcp.dll",
+        });
+
+        Assert.Empty(MeshBuilderModuleActivation.ShadowedRequired(config));
+    }
+
+    [Fact]
+    public void BlankingAnEntry_IsNotAShadow()
+    {
+        // Blanking is the SANCTIONED way to drop a requirement a deployment cannot satisfy — it was
+        // the only remedy the 2026-08-23 rollouts had. Reporting it would make the check noise on
+        // every install that legitimately opts out.
+        var config = ImagePlusOverlay(ImageBaseline, new Dictionary<string, string?>
+        {
+            ["Modules:Required:0"] = "",
+            ["Modules:Required:5"] = "",
+        });
+
+        Assert.Empty(MeshBuilderModuleActivation.ShadowedRequired(config));
+    }
+
+    [Fact]
+    public void ReorderingTheList_IsNotAShadow()
+    {
+        // Every baseline module is still required, at a different index. Nothing was lost, so
+        // nothing is reported — the check is about the SET, not the positions.
+        var config = ImagePlusOverlay(ImageBaseline, new Dictionary<string, string?>
+        {
+            ["Modules:Required:0"] = "MeshWeaver.Social.dll",
+            ["Modules:Required:5"] = "MeshWeaver.Blazor.Radzen.dll",
+        });
+
+        Assert.Empty(MeshBuilderModuleActivation.ShadowedRequired(config));
+    }
+
+    [Fact]
+    public void AnUnlayeredConfiguration_HasNothingToShadow()
+    {
+        // One source, no overrides — today's default, and it must stay silent.
+        Assert.Empty(MeshBuilderModuleActivation.ShadowedRequired(Config(ImageBaseline)));
+    }
 }


### PR DESCRIPTION
## What Memex#131 reported, and what it turned out to be

memex-cloud declares `Modules__Required__5: "MeshWeaver.Mcp.dll"`. The chart's block rendered `0..4`, so the key reached **no container**, `/mcp` went on answering 404 with `Mcp__BaseUrl` configured a few lines below it, and Memex's `config-key-coverage` gate went red. #2512 already widened the block to `0..7` for the same failure on Memex#129 — so that red is gone.

**Fixing it exposed a worse, live defect.** `Modules:Required` is an **array**, so an overlay entry binds **by index and never appends**. Index 5 of the image's own list is `MeshWeaver.Social.dll`. So the moment index 5 started rendering, `MeshWeaver.Mcp.dll` did not *add* MCP — it *replaced Social's requirement*. Rendered through this chart with Memex `main`'s overlay:

```
Modules__Required__4: "MeshWeaver.Speech.dll"
Modules__Required__5: "MeshWeaver.Mcp.dll"     <- was MeshWeaver.Social.dll
```

That is invisible from every direction: the replaced module is not *missing* (nobody asks for it any more), so `MissingRequired` and `RequiredModuleStatus` have nothing to say; the override *is* rendered, so the coverage gate passes; the deploy succeeds and `/health` stays green having quietly stopped guarding a module.

## Three changes

**1. Ceiling 7 → 9, and the reason is now in the block.**

Why a ceiling exists at all: this ConfigMap's contract is that it names every key **literally**, because that is what `EveryConfigKeySetInAValuesFile_IsBoundInTheConfigMap` can check — a Helm `range` renders correctly and is invisible to the guard. A bounded list is the price of a checkable template, and the person who hits the bound sits in a *different repository* from the chart, so it has to be written down rather than counted off the template.

Why **9**: the image's baseline `Modules:Required` is **seven** entries (`0..6` — Radzen, Analysis, EntityViews, GoogleMaps, Speech, Social, AI). An overlay restating the baseline consumes `0..6`, so anything it *adds* starts at 7. A ceiling of 7 leaves exactly **one** appendable slot. Ten leaves three.

**2. Two static guards** in `test/MeshWeaver.Documentation.Test/PlatformBakeLaneGuard.cs`, beside the existing coverage guard — for **overflow**:

- `ModulesRequired_IsRenderedAsAContiguousRangeFromZero` — renders `0..N` with **no gap**, and a comment still says `renders 0..N`. A gap is the silent variant: the overlay's index reaches no container while its neighbours do, so the deployment requires a *different set* than it declares.
- `NoValuesFile_DeclaresAModulesRequiredIndexAboveTheCeiling` — an over-ceiling index fails **with the ceiling named**. The general guard already refuses such a key, but its instruction is "template each one", which is the wrong instruction for an ordered list whose bound the author cannot see.

**3. A boot-time check** in `MeshBuilderModuleActivation.ShadowedRequired` — for **collision**:

Reports every entry a **later** configuration provider replaced with a different module that appears nowhere else in the effective list. Provider *order* is the whole mechanism — a value a provider supplies that is not the effective one has been shadowed — so there is no provider-type sniffing and any layering (files, env, command line) is covered. It sits beside `MissingRequired`, reads the same key the same way, and reports on the same channel.

It has to be at boot rather than in a chart guard: the image's baseline ships from one repository and the overlay from another, and the two are only ever visible **together** in the running process.

Two shapes are deliberately *not* reported, because both are how the key is meant to be used, and both are pinned by tests: **blanking** an entry a deployment cannot satisfy (the sanctioned opt-out, and the only remedy the 2026-08-23 rollouts had), and **reordering**, where the module is still required at another index.

## Proven RED — five seeds, each restored

A guard nobody watched fail is not a guard.

| # | Seed | Result |
|---|---|---|
| A | delete the index-3 `hasKey` block | contiguity guard **FAILS**: *"renders 0, 1, 2, 4, 5, 6, 7, 8, 9 — index 3 missing"* |
| B | a values file declares `Modules__Required__10` | ceiling guard **FAILS**: *"…renders Modules__Required__0..9 — RAISE THE CEILING…"* |
| C | the literal Memex#131 shape (block back to `0..4`, overlay declares 5) | **both** fail; ceiling message names `0..4`, and the comment-drift assertion catches the stale sentence |
| D | `ShadowedRequired` returns `[]` (i.e. main today) | the memex-cloud shape reports **nothing** — `Expected: ["MeshWeaver.Social.dll"] / Actual: []` |
| E | `ShadowedRequired` made naive (drop the blank + reorder exclusions) | `BlankingAnEntry_IsNotAShadow` and `ReorderingTheList_IsNotAShadow` both fail with two false positives each — neither exclusion is decoration |

## Verification

- `dotnet build test/MeshWeaver.Documentation.Test/… -c Release -warnaserror` → `0 Warning(s) 0 Error(s)`; **94/94 passed**
- `dotnet build test/MeshWeaver.Graph.Test/… -c Release -warnaserror --no-incremental` → `0 Warning(s) 0 Error(s)`; `ConfiguredModuleActivationTest` **13/13 passed**
- `dotnet build src/MeshWeaver.Mesh.Contract -c Release -warnaserror` → clean. The change is **purely additive** (one new public static + one extra report loop), so no binary break.
- `helm template` of Memex `main`'s memex-cloud overlay renders as expected
- `scripts/check-config-key-coverage.py` against Memex `main`'s overlays with this chart → **PASS**

## Companion

The Memex-side PR moves MCP to index **7** — the first index past the baseline — which is what actually makes `/mcp` required without dropping Social, and which needs this ceiling to exist.

Refs Memex#131.

🤖 Generated with [Claude Code](https://claude.com/claude-code)