### PR TITLE
Localization: two keys the dev-login page needs to stop lying in English

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -390,6 +390,8 @@
   "auth.avatarUrl": "Avatar-URL",
   "auth.getStarted": "Loslegen",
   "auth.loadingPersons": "Personen werden geladen…",
+  "auth.noUsersFound": "Auf diesem Mesh wurden keine Benutzer gefunden.",
+  "auth.errorLoadingUsers": "Die Benutzerliste konnte nicht geladen werden: {0}",
   "auth.publishing": "Veröffentlichung",
   "error.notFoundTitle": "Nicht gefunden",
   "error.nothingAtAddress": "Unter dieser Adresse ist leider nichts zu finden.",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -390,6 +390,8 @@
   "auth.avatarUrl": "Avatar URL",
   "auth.getStarted": "Get started",
   "auth.loadingPersons": "Loading persons...",
+  "auth.noUsersFound": "No users found on this mesh.",
+  "auth.errorLoadingUsers": "Could not load the list of users: {0}",
   "auth.publishing": "Publishing",
   "error.notFoundTitle": "Not found",
   "error.nothingAtAddress": "Sorry, there's nothing at this address.",


### PR DESCRIPTION
Platform half of Systemorph/MeshWeaver.Plugins#712.

The developer-login page (`src/Memex.Portal.Gui/Pages/DevLogin.razor`, in the plugins repo) renders two strings outside the catalog:

- its empty state, hard-coded English: *"No persons found. Add Person nodes to the graph to enable dev login."*
- its error state, interpolated: `$"Error loading persons: {ex.Message}"`

Every other string on that page already goes through `Access.Localize`, so these two are the outliers — a German viewer reads them in English regardless of their choice.

The empty-state wording is **also wrong on the merits**, which is why this is not a pure i18n tidy-up. Plugins#712 root-causes the empty list: the page's user query runs as Anonymous (choosing whom to sign in as necessarily happens before anyone is signed in) and a user's partition-root `User` node is private. So the list is empty on a portal that has users, and the message sends the reader off to create data that already exists. `auth.noUsersFound` states what is true once that fix lands, instead of naming a cause that is not the cause.

| key | en | de |
|---|---|---|
| `auth.noUsersFound` | No users found on this mesh. | Auf diesem Mesh wurden keine Benutzer gefunden. |
| `auth.errorLoadingUsers` | Could not load the list of users: {0} | Die Benutzerliste konnte nicht geladen werden: {0} |

`Mesh` stays English per AGENTS.md's glossary.

**Mirrors:** none. `clients/react/src/i18n/` was removed on 2026-08-25 (AGENTS.md's instruction to mirror there was itself stale and was corrected in #2520), so the two server catalogs are the whole surface.

**Ordering.** This lands first; the plugins repo floats `MW_PLATFORM_REF: main`, so its next build picks the keys up. The plugins-side change (the impersonation fix plus these keys) follows — reversing the order would render the raw key strings to users in the window between.

`LocalizationTest`: 56/56. `dotnet build -c Release -warnaserror`: 0 Warning(s), 0 Error(s).

**What's New:** no entry — the dev-login page is gated behind `Authentication__EnableDevLogin` and is not a surface a portal user reaches.