### PR TITLE
The ALC drain is a subscription, not a spin against a deadline (#2488)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
@@ -375,11 +375,23 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         private int _released;
         public void Dispose()
         {
-            if (Interlocked.Exchange(ref _released, 1) == 0
-                && Interlocked.Decrement(ref ctx._pins) == 0)
-                // The LAST scan out announces the drain. This is what makes waiting for it a
-                // SUBSCRIPTION rather than a spin loop against a deadline (#2488): the unload
-                // runs because the scans finished, never because a clock expired.
+            if (Interlocked.Exchange(ref _released, 1) != 0
+                || Interlocked.Decrement(ref ctx._pins) != 0)
+                return;
+
+            // The LAST scan out announces the drain — but ONLY once Dispose has started. This is
+            // what makes waiting for it a SUBSCRIPTION rather than a spin loop against a deadline
+            // (#2488): the unload runs because the scans finished, never because a clock expired.
+            //
+            // 🚨 The _unloading guard is load-bearing, not a tidiness check (Copilot review).
+            // Pins hit zero all the time during NORMAL operation, and AsyncSubject completion is
+            // PERMANENT: announcing then would complete the signal while the context is perfectly
+            // healthy, and a Dispose arriving later — with a NEW scan pinned — would subscribe to
+            // an already-completed subject, replay instantly, and unload with _pins > 0. That is
+            // precisely the use-after-unload this change exists to remove, reintroduced through
+            // the fix itself. Once _unloading is set, Pin() refuses new scans, so the count can
+            // only shrink and zero really is the drain.
+            if (ctx._unloading)
                 ctx.AnnounceDrained();
         }
     }

--- a/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
+++ b/src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs
@@ -1,6 +1,9 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.Reactive;
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Reflection;
 using System.Runtime.Loader;
 using MeshWeaver.Compiler;
@@ -372,9 +375,43 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         private int _released;
         public void Dispose()
         {
-            if (Interlocked.Exchange(ref _released, 1) == 0)
-                Interlocked.Decrement(ref ctx._pins);
+            if (Interlocked.Exchange(ref _released, 1) == 0
+                && Interlocked.Decrement(ref ctx._pins) == 0)
+                // The LAST scan out announces the drain. This is what makes waiting for it a
+                // SUBSCRIPTION rather than a spin loop against a deadline (#2488): the unload
+                // runs because the scans finished, never because a clock expired.
+                ctx.AnnounceDrained();
         }
+    }
+
+    /// <summary>
+    /// Completes once no assembly SCAN is in flight — the positive signal <see cref="Dispose"/>
+    /// unloads on.
+    ///
+    /// <para>🚨 Waiting for disposal is a subscription, never a race (#2488). This replaced a
+    /// <c>SpinWait</c> against a 5 s deadline whose own comment conceded it then "unloads anyway":
+    /// the single case where we KNEW a scanner was still live was also the case where we pulled
+    /// its assembly out from under it — <c>TypeLoadException '…format is invalid'</c> mid
+    /// <c>GetTypes</c>, the #613 use-after-unload family. With a signal there is no branch to get
+    /// wrong: pins reach zero and the context unloads, or they do not and the context is simply
+    /// RETAINED. Retaining memory beats corrupting an assembly a hub is executing, and a drain
+    /// that never completes is a leak to fix — not a budget to spend.</para>
+    ///
+    /// <para><see cref="AsyncSubject{T}"/>: it replays completion to late subscribers, so a
+    /// subscriber arriving after the last pin released still runs immediately — the ordering
+    /// hazard a bare <c>Subject</c> would leave.</para>
+    /// </summary>
+    private readonly AsyncSubject<Unit> _drained = new();
+
+    /// <summary>Signals <see cref="_drained"/> once. Idempotent — the last pin release and the
+    /// already-quiet path both call it, and an <see cref="AsyncSubject{T}"/> that has completed
+    /// ignores further notifications.</summary>
+    private void AnnounceDrained()
+    {
+        if (_drained.IsCompleted)
+            return;
+        _drained.OnNext(Unit.Default);
+        _drained.OnCompleted();
     }
 
     // LIFETIME leases (distinct from the millisecond scan _pins above): one per live hub whose
@@ -655,60 +692,80 @@ internal sealed class NodeAssemblyLoadContext : AssemblyLoadContext, IDisposable
         }
 
         // Drain in-flight assembly SCANS before tearing down the LoaderAllocator. _unloading is set
-        // above, so Pin() now rejects NEW scans; wait (time-bounded) for the ones already running to
-        // release. Unloading mid-GetTypes/attribute-resolution corrupts the assembly the scanner is
-        // holding (TypeLoadException '…format is invalid'), the race that flakes the concurrent
-        // Orleans dynamic-compilation tests and risks the same under a live-mesh recompile. A scan
-        // is milliseconds; the 5 s ceiling can never deadlock teardown — after it we unload anyway
-        // (last-resort, matching the prior always-unload behaviour).
-        var drainDeadline = Environment.TickCount64 + 5_000;
-        var spin = new SpinWait();
-        while (Volatile.Read(ref _pins) > 0 && Environment.TickCount64 < drainDeadline)
-            spin.SpinOnce();
+        // above, so Pin() rejects NEW scans; the ones already running announce through _drained as
+        // the last of them releases. Unloading mid-GetTypes/attribute-resolution corrupts the
+        // assembly the scanner is holding (TypeLoadException '…format is invalid'), the race that
+        // flakes the concurrent Orleans dynamic-compilation tests and risks the same under a
+        // live-mesh recompile.
+        //
+        // 🚨 A SUBSCRIPTION, never a timed race (#2488). This method returns immediately; the
+        // unload belongs to the drain signal. If a scan never finishes, the context is RETAINED —
+        // memory we can find and fix, rather than an assembly pulled out from under running code.
+        if (Volatile.Read(ref _pins) == 0)
+            AnnounceDrained();   // already quiet: complete now, so the subscribe below runs inline
 
-        // The drain is over: from here a load really is unsafe, so close the door for good. Plain
-        // field writes, deliberately NOT under _loadLock — a scanner that overran the 5 s ceiling
-        // still holds that lock inside LoadNodeAssembly, and taking it here would block teardown
-        // behind the very scan the ceiling exists to stop waiting for.
+        _drained
+            .Take(1)
+            .Catch<Unit, Exception>(ex =>
+            {
+                _logger?.LogError(ex,
+                    "Drain signal for AssemblyLoadContext {ContextName} faulted — KEEPING its load "
+                    + "context rather than unloading an assembly a scan may still be reading",
+                    Name);
+                return Observable.Empty<Unit>();
+            })
+            .Subscribe(_ => CompleteUnload());
+    }
+
+    /// <summary>
+    /// The second half of <see cref="Dispose"/>, run ONLY on the drain signal (#2488): close the
+    /// door for good, unload, and run the opt-in post-unload GC probe. Never called on a timer —
+    /// reaching here means every in-flight scan released.
+    /// </summary>
+    private void CompleteUnload()
+    {
+        // From here a load really is unsafe. Plain field writes, deliberately NOT under _loadLock:
+        // nothing else may take that lock on this path, and the drain has already proven no scan
+        // is holding it.
         _disposed = true;
         _loadedAssembly = null;
 
-        // Initiate unload outside the lock - the context will be collected when all references are released
+        // Initiate unload outside the lock — the context is collected once all references release.
         Unload();
 
-        // Diagnostic probe (opt-in, off by default): drive a collection right after the unload so a
-        // use-after-unload dangling native pointer trips at THIS unload — naming the culprit node
-        // and yielding a corruption-time dump — instead of a delayed SIGSEGV with no precursor. Used
-        // by the alc-unload-probe workflow to pin the reflection/serialization cache that retains
-        // an accessor into a collectible node assembly (the exit=139 crash).
-        if (UnloadGcProbe)
-        {
-            // Write to Console DIRECTLY, not via _logger: this runs INSIDE ServiceProvider.Dispose()
-            // where the ILogger (XUnitFileLogger.GetMinLogLevel) resolves from the already-disposed
-            // container and throws ObjectDisposedException BEFORE writing — so the probe never named
-            // the culprit. Console is the only sink alive during teardown.
-            Console.Error.WriteLine($"ALC_UNLOAD_PROBE forcing GC after unloading {Name}");
+            // Diagnostic probe (opt-in, off by default): drive a collection right after the unload so a
+            // use-after-unload dangling native pointer trips at THIS unload — naming the culprit node
+            // and yielding a corruption-time dump — instead of a delayed SIGSEGV with no precursor. Used
+            // by the alc-unload-probe workflow to pin the reflection/serialization cache that retains
+            // an accessor into a collectible node assembly (the exit=139 crash).
+            if (UnloadGcProbe)
+            {
+                // Write to Console DIRECTLY, not via _logger: this runs INSIDE ServiceProvider.Dispose()
+                // where the ILogger (XUnitFileLogger.GetMinLogLevel) resolves from the already-disposed
+                // container and throws ObjectDisposedException BEFORE writing — so the probe never named
+                // the culprit. Console is the only sink alive during teardown.
+                Console.Error.WriteLine($"ALC_UNLOAD_PROBE forcing GC after unloading {Name}");
 
-            // 🚨 BACKGROUND leg first. A parameterless GC.Collect() is blocking:true — it runs the
-            // non-concurrent gen2 path (mark_phase / plan_phase) and never enters background_sweep,
-            // so the probe originally exercised only a path on which no crash has ever been observed.
-            // Every FutuRe exit=139 dump so far faults on the CONCURRENT collector
-            // (bgc_thread_function → gc1 → background_sweep), so the probe has to start one.
-            //
-            // NB this probe is aimed at the use-after-unload hypothesis (a dangling pointer into a
-            // freed collectible LoaderAllocator). The 2026-08-06 dump does NOT support that
-            // hypothesis: the swept object's MethodTable pointer was exactly 0, and a freed-metadata
-            // pointer is non-null-but-unmapped, not zero. Keep the probe honest about what it can
-            // prove — see Doc/Architecture/DebuggingNativeCrashes.
-            GC.Collect(2, GCCollectionMode.Forced, blocking: false);
+                // 🚨 BACKGROUND leg first. A parameterless GC.Collect() is blocking:true — it runs the
+                // non-concurrent gen2 path (mark_phase / plan_phase) and never enters background_sweep,
+                // so the probe originally exercised only a path on which no crash has ever been observed.
+                // Every FutuRe exit=139 dump so far faults on the CONCURRENT collector
+                // (bgc_thread_function → gc1 → background_sweep), so the probe has to start one.
+                //
+                // NB this probe is aimed at the use-after-unload hypothesis (a dangling pointer into a
+                // freed collectible LoaderAllocator). The 2026-08-06 dump does NOT support that
+                // hypothesis: the swept object's MethodTable pointer was exactly 0, and a freed-metadata
+                // pointer is non-null-but-unmapped, not zero. Keep the probe honest about what it can
+                // prove — see Doc/Architecture/DebuggingNativeCrashes.
+                GC.Collect(2, GCCollectionMode.Forced, blocking: false);
 
-            // Then the blocking pair, unchanged: it forces finalizers to run so a dead collectible
-            // LoaderAllocator is actually destroyed (rather than merely detected) before the next
-            // unload, which is what makes a dangling pointer fault deterministically.
-            GC.Collect();
-            GC.WaitForPendingFinalizers();
-            GC.Collect();
-        }
+                // Then the blocking pair, unchanged: it forces finalizers to run so a dead collectible
+                // LoaderAllocator is actually destroyed (rather than merely detected) before the next
+                // unload, which is what makes a dangling pointer fault deterministically.
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
+                GC.Collect();
+            }
     }
 }
 

--- a/test/MeshWeaver.Graph.Test/AlcDrainIsReactiveTest.cs
+++ b/test/MeshWeaver.Graph.Test/AlcDrainIsReactiveTest.cs
@@ -1,4 +1,3 @@
-using System.Reflection;
 using MeshWeaver.Graph.Configuration;
 using Xunit;
 
@@ -18,10 +17,9 @@ namespace MeshWeaver.Graph.Test;
 /// </summary>
 public class AlcDrainIsReactiveTest
 {
-    private static bool IsUnloaded(NodeAssemblyLoadContext context) =>
-        (bool)typeof(NodeAssemblyLoadContext)
-            .GetField("_disposed", BindingFlags.Instance | BindingFlags.NonPublic)!
-            .GetValue(context)!;
+    // The type's own public surface — no reflection, so a field rename cannot quietly turn this
+    // suite green against a broken implementation (Copilot review).
+    private static bool IsUnloaded(NodeAssemblyLoadContext context) => context.IsDisposed;
 
     [Fact]
     public void Dispose_WithNoScanInFlight_UnloadsImmediately()
@@ -54,6 +52,32 @@ public class AlcDrainIsReactiveTest
 
         Assert.True(IsUnloaded(context),
             "the last pin release announces the drain, and the subscription unloads on it");
+    }
+
+    [Fact]
+    public void AnEarlierScanReachingZero_DoesNotPreArmTheUnload()
+    {
+        // 🚨 THE REGRESSION THIS SUITE ALMOST MISSED (Copilot review on #2549). Pins hit zero all
+        // the time during normal operation, and AsyncSubject completion is PERMANENT — so
+        // announcing the drain on every zero would complete the signal while the context is
+        // healthy, and a Dispose arriving later with a NEW scan pinned would subscribe to an
+        // already-completed subject, replay instantly, and unload with _pins > 0. That is the very
+        // use-after-unload this change removes, reintroduced through the fix itself.
+        var context = new NodeAssemblyLoadContext("MeshWeaver.Test.Rearmed", dllPath: null);
+
+        // A perfectly ordinary scan, completing long before anyone disposes anything.
+        context.Pin().Dispose();
+
+        // A second scan is running when disposal begins.
+        var live = context.Pin();
+        context.Dispose();
+
+        Assert.False(IsUnloaded(context),
+            "the earlier scan's release must NOT have pre-armed the unload — this context still "
+            + "has a live scan reading its assembly");
+
+        live.Dispose();
+        Assert.True(IsUnloaded(context), "and it unloads when THAT scan finishes, not before");
     }
 
     [Fact]

--- a/test/MeshWeaver.Graph.Test/AlcDrainIsReactiveTest.cs
+++ b/test/MeshWeaver.Graph.Test/AlcDrainIsReactiveTest.cs
@@ -1,0 +1,73 @@
+using System.Reflection;
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// #2488 for the assembly-load-context drain: waiting for disposal is a SUBSCRIPTION, never a race.
+///
+/// <para>🚨 What this refuses to let back in. <c>Dispose</c> used to spin against a 5 s deadline and
+/// then — by its own comment — "unload anyway". That makes the one case where we KNOW a scanner is
+/// still live also the case where its assembly is pulled out from under it: a
+/// <c>TypeLoadException '…format is invalid'</c> mid <c>GetTypes</c>/attribute resolution, which
+/// surfaces far from the cause as a render that never completes or a use-after-unload crash. The
+/// fix has no branch to get wrong: the unload runs when the last scan releases, or the context is
+/// simply RETAINED. Retaining memory beats corrupting a live assembly, and a drain that never
+/// completes is a leak to FIX, not a budget to spend.</para>
+/// </summary>
+public class AlcDrainIsReactiveTest
+{
+    private static bool IsUnloaded(NodeAssemblyLoadContext context) =>
+        (bool)typeof(NodeAssemblyLoadContext)
+            .GetField("_disposed", BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(context)!;
+
+    [Fact]
+    public void Dispose_WithNoScanInFlight_UnloadsImmediately()
+    {
+        var context = new NodeAssemblyLoadContext("MeshWeaver.Test.Quiet", dllPath: null);
+
+        context.Dispose();
+
+        Assert.True(IsUnloaded(context),
+            "with no scan pinned the drain is already complete, so the unload runs inline — the "
+            + "signal replays to the subscriber rather than waiting for a future notification");
+    }
+
+    [Fact]
+    public void Dispose_WhileAScanIsPinned_WaitsForIt_ThenUnloadsOnRelease()
+    {
+        var context = new NodeAssemblyLoadContext("MeshWeaver.Test.Pinned", dllPath: null);
+        var scan = context.Pin();
+
+        context.Dispose();
+
+        // THE INVARIANT: a scan is in flight, so nothing has been unloaded — and critically, no
+        // clock is running that would unload it anyway.
+        Assert.False(IsUnloaded(context),
+            "an assembly a scan is still reading must NOT be unloaded — this is the corruption the "
+            + "old 5 s ceiling caused every time it expired");
+
+        // The scan finishes: the release IS the signal, and the unload happens because of it.
+        scan.Dispose();
+
+        Assert.True(IsUnloaded(context),
+            "the last pin release announces the drain, and the subscription unloads on it");
+    }
+
+    [Fact]
+    public void Pin_IsRefusedOnceDisposeHasStarted_SoTheDrainCanOnlyShrink()
+    {
+        var context = new NodeAssemblyLoadContext("MeshWeaver.Test.Closing", dllPath: null);
+        var scan = context.Pin();
+        context.Dispose();
+
+        // Without this the drain could never complete: a new scan arriving after Dispose would keep
+        // the count above zero indefinitely, turning "retain until quiet" into "retain forever".
+        Assert.Throws<ObjectDisposedException>(() => context.Pin());
+
+        scan.Dispose();
+        Assert.True(IsUnloaded(context));
+    }
+}

--- a/test/MeshWeaver.Graph.Test/AssemblyLoadContextLeakTest.cs
+++ b/test/MeshWeaver.Graph.Test/AssemblyLoadContextLeakTest.cs
@@ -233,24 +233,26 @@ public sealed class AssemblyLoadContextLeakTest : IDisposable
     /// while a pin is held and completes once released.
     /// </summary>
     [Fact]
-    public void Pin_MakesDispose_DrainBeforeUnload()
+    public void Pin_DefersTheUnload_UntilTheScanReleases()
     {
         var ctx = _service.GetOrCreateLoadContext("pin_drain_node");
         var pin = ctx.Pin();
 
-        var disposeReturned = new ManualResetEventSlim(false);
-        var disposer = new Thread(() => { ctx.Dispose(); disposeReturned.Set(); }) { IsBackground = true };
-        disposer.Start();
+        // 🚨 Dispose RETURNS IMMEDIATELY now (#2488/#2549) — it hands the unload to the drain
+        // signal instead of blocking on it. This test used to assert the blocking itself, which
+        // was the MECHANISM; the PROPERTY it existed for ("or it unloads the LoaderAllocator
+        // mid-scan") is what is asserted below, and it is now guaranteed rather than merely
+        // likely: the old spin drain gave up after 5 s and unloaded anyway.
+        ctx.Dispose();
 
-        // While the pin is held, Dispose() must still be draining — it must NOT have returned.
-        disposeReturned.Wait(300).Should().BeFalse(
-            "Dispose() must block (drain) while a scan pin is held, or it unloads the LoaderAllocator mid-scan");
+        ctx.IsDisposed.Should().BeFalse(
+            "a scan pin is still held, so the LoaderAllocator must NOT be unloaded — that is the "
+            + "use-after-unload this pin exists to prevent");
 
-        // Release the pin → the drain completes and Dispose() returns.
         pin.Dispose();
-        disposeReturned.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue(
-            "releasing the pin must let Dispose() finish the unload");
-        disposer.Join();
+
+        ctx.IsDisposed.Should().BeTrue(
+            "releasing the last pin IS the drain signal, and the unload runs on it");
     }
 
     /// <summary>Once a context starts unloading, a NEW scan must not be able to pin it — the caller
@@ -286,38 +288,34 @@ public sealed class AssemblyLoadContextLeakTest : IDisposable
     /// load has been attempted, so the interleaving this asserts is the one that always happens.</para>
     /// </summary>
     [Fact]
-    public void PinnedScan_StillLoadsTheAssembly_WhileDisposeIsDraining()
+    public void PinnedScan_StillLoadsTheAssembly_WhileTheUnloadIsDeferred()
     {
         const string nodeName = "pin_load_during_drain";
         var dllPath = EmitTinyAssemblyToDisk(nodeName, "Widget");
         var ctx = _service.GetOrCreateLoadContextForPath(nodeName, dllPath);
 
         // A scan pins the context — exactly what CompileResultFromAssembly does via PinForScan.
-        using var pin = ctx.Pin();
+        // Not a `using`: the release below IS the drain signal, and the assertion after it needs
+        // the unload to have happened.
+        var pin = ctx.Pin();
 
-        // Teardown starts underneath it (a concurrent recompile/eviction/hub disposal) and parks
-        // in the drain, because our pin is outstanding.
-        var disposeReturned = new ManualResetEventSlim(false);
-        var disposer = new Thread(() => { ctx.Dispose(); disposeReturned.Set(); }) { IsBackground = true };
-        disposer.Start();
-        disposeReturned.Wait(300).Should().BeFalse(
-            "Dispose() must be draining — the pin is still held");
+        // Teardown starts underneath it (a concurrent recompile/eviction/hub disposal). Dispose
+        // returns at once and the unload waits on the drain signal (#2488/#2549).
+        ctx.Dispose();
 
-        // THE ASSERTION: the pinned scan can still load. Before the fix this threw
-        // ObjectDisposedException and the caller recorded a permanent CompilationStatus.Error.
+        // THE ASSERTION, unchanged in substance: the pinned scan can still load. Before the
+        // original fix this threw ObjectDisposedException and the caller recorded a permanent
+        // CompilationStatus.Error.
         var assembly = ctx.LoadNodeAssembly();
         assembly.Should().NotBeNull(
-            "a pin held across a concurrent Dispose must keep the assembly loadable: Dispose drains "
-            + "pins BEFORE Unload, so the LoaderAllocator is still alive and refusing the load only "
-            + "manufactures a compile 'failure' that parks the NodeType for good");
+            "a pin held across a concurrent Dispose must keep the assembly loadable: the unload "
+            + "waits for the pins, so the LoaderAllocator is still alive and refusing the load "
+            + "would only manufacture a compile 'failure' that parks the NodeType for good");
         assembly!.GetTypes().Should().NotBeEmpty(
             "the scan the pin exists to protect is GetTypes — it must complete against live metadata");
 
-        // Releasing the pin lets the deferred unload finish, exactly as before.
+        // Releasing the last pin completes the drain, and the deferred unload runs on it.
         pin.Dispose();
-        disposeReturned.Wait(TimeSpan.FromSeconds(5)).Should().BeTrue(
-            "releasing the pin must let Dispose() finish the unload");
-        disposer.Join();
 
         // …and once the drain is over the context IS closed: a later load must not resurrect it.
         Assert.Throws<ObjectDisposedException>(() => ctx.LoadNodeAssembly());


### PR DESCRIPTION
## The defect

`NodeAssemblyLoadContext.Dispose` spun on `_pins` against a 5 s ceiling and then — by its own comment — *"unload[ed] anyway (last-resort, matching the prior always-unload behaviour)"*.

So the one case where we **know** a scanner is still live (pins still held when the deadline expires) was also the case where its assembly got pulled out from under it: `TypeLoadException '…format is invalid'` mid `GetTypes`/attribute resolution — the #613 use-after-unload family, which surfaces far from its cause as a render that never completes or a delayed crash.

This is the same anti-pattern `MessageHubGrain.OnDeactivateAsync` had already removed, and `/async` Rule 1a names the cure: **hang the work off the signal and let the turn return.**

## The fix

The last `PinScope` release announces through an `AsyncSubject<Unit>`; `Dispose` subscribes (`.Take(1)`, fluent `.Catch` that **keeps** the context on a fault) and returns immediately. `CompleteUnload()` — close the door, `Unload()`, run the opt-in post-unload GC probe — is the callback.

No branch is left to get wrong: pins reach zero and the context unloads, or they do not and the context is **retained**. Retaining memory beats corrupting an assembly a hub is executing, and a drain that never completes is a leak to find, not a budget to spend. `AsyncSubject` (not a bare `Subject`) so a subscriber arriving after the last release still runs — the ordering hazard the inline path would otherwise have.

## Tests

`AlcDrainIsReactiveTest` pins all three properties:
- no scan in flight → unloads inline (the signal replays);
- **a scan pinned → does NOT unload**, then unloads exactly on its release;
- `Pin()` refused once `Dispose` started, so the drain can only shrink (otherwise "retain until quiet" becomes "retain forever").

**Red-proven:** restoring the spin loop fails the pinned case — and takes 10 s doing it, which is the ceiling being spent.

## Scope

Sites 2 and 3 from the issue (`MeshTeardownExtensions`, `MonolithMeshTestBase`) already carry the reactive shape via `ObserveCompletion`; site 1 was the outstanding one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz1i2fFcJhvR1Eje8yFH5F