### PR TITLE
An empty image can boot into setup, and knows what to default to (#2550)

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -330,7 +330,16 @@ public static class MemexConfiguration
             // them byte-identical — an additive mechanism that changed a configured instance's
             // storage would be a data-loss bug, not a feature.
             var graphStorageConfig = configuration.GetSection("Graph:Storage").Get<GraphStorageConfig>();
-            if (graphStorageConfig is null && setupManifest?.Storage is { } chosen)
+            // 🚨 COMPLETE, and with a real backend named (Copilot review). A manifest that exists
+            // is not a manifest that ANSWERS: the wizard's own starting point is
+            // State=AwaitingStorage with a pre-filled type, and an Unreadable one answers nothing
+            // at all. Treating either as configured storage would boot past setup and fail later,
+            // deeper, on an unknown backend or a missing connection string — a worse failure than
+            // the setup surface, and further from its cause.
+            if (graphStorageConfig is null
+                && setupManifest is { State: InstanceSetupState.Complete } complete
+                && complete.HasStorage
+                && complete.Storage is { } chosen)
             {
                 graphStorageConfig = new GraphStorageConfig
                 {
@@ -358,11 +367,25 @@ public static class MemexConfiguration
                 // storage backend, because a wrong guess writes real data somewhere nobody chose
                 // (an ephemeral container path, silently lost on the next roll — issue #435's
                 // shape).
+                // Say WHICH of the three states this is — "no manifest" would be a lie for an
+                // unreadable or half-answered one, and setup/boot diagnostics are exactly where a
+                // misleading message costs the most (Copilot review).
+                var manifestState = setupManifest switch
+                {
+                    null => "no instance manifest exists there",
+                    { State: InstanceSetupState.Unreadable } =>
+                        "the instance manifest there could NOT BE READ (see the error above) — "
+                        + "repair or delete it to re-run setup",
+                    { State: var state } =>
+                        $"the instance manifest there is INCOMPLETE (state {state}"
+                        + $"{(setupManifest.HasStorage ? "" : ", no storage chosen")}) — finish the "
+                        + "setup wizard",
+                };
                 Console.Error.WriteLine(
-                    "[InstanceSetup] No Graph:Storage configuration and no instance manifest at "
-                    + $"{InstanceManifest.PathFor(moduleRoot)} — this instance is AWAITING SETUP. "
-                    + "Configure Graph:Storage in appsettings, or complete the setup wizard, which "
-                    + "writes the manifest and restarts into a configured mesh.");
+                    "[InstanceSetup] No Graph:Storage configuration, and "
+                    + $"{manifestState} ({InstanceManifest.PathFor(moduleRoot)}). This instance is "
+                    + "AWAITING SETUP. Configure Graph:Storage in appsettings, or complete the "
+                    + "setup wizard, which writes the manifest and restarts into a configured mesh.");
                 builder.MarkAwaitingSetup();
                 return builder;
             }

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -189,6 +189,18 @@ public static class MemexConfiguration
             // read from somewhere else is simply invisible, and on a deployment whose /app is
             // read-only the writer cannot use AppContext.BaseDirectory at all.
             var moduleRoot = ModuleRoot.Resolve(configuration);
+
+            // The instance manifest (#2550) — read BEFORE anything else needs it, on the same
+            // writable root the module activation sidecar lives on, and for the same reason it is
+            // a file: at this point there is no storage provider, hub or connection string, and
+            // WHICH STORAGE TO USE is precisely what it answers.
+            //
+            // A corrupt manifest resolves to InstanceManifest.Unreadable rather than null: it
+            // EXISTS, so the instance is not treated as never-configured, and it answers nothing,
+            // so it cannot leave setup. Offering a fresh setup over a database that already holds
+            // data is the failure that distinction prevents.
+            var setupManifest = InstanceManifest.Read(moduleRoot,
+                msg => Console.Error.WriteLine($"[InstanceSetup] {msg}"));
             // Generations GC — delete only what NO activation entry references and nothing holds
             // open (skip-on-locked). Landing never deletes anything on a shared volume; this is
             // the one reclaim point. See ModuleLandingService.CollectGarbage.
@@ -309,13 +321,50 @@ public static class MemexConfiguration
                         + $"{ex.Message}) — the flag stays set; activation itself is unaffected.");
                 }
 
-            // Read graph storage config
+            // Read graph storage config — from this host's configuration, or from the INSTANCE
+            // MANIFEST an earlier setup wrote (#2550).
+            //
+            // 🚨 Configuration WINS. The manifest answers what configuration has not already said;
+            // it never overrides a host that stated its own storage. Every deployment that exists
+            // today is appsettings-configured and has no manifest, and this path must leave all of
+            // them byte-identical — an additive mechanism that changed a configured instance's
+            // storage would be a data-loss bug, not a feature.
             var graphStorageConfig = configuration.GetSection("Graph:Storage").Get<GraphStorageConfig>();
+            if (graphStorageConfig is null && setupManifest?.Storage is { } chosen)
+            {
+                graphStorageConfig = new GraphStorageConfig
+                {
+                    Type = chosen.Type,
+                    BasePath = chosen.BasePath,
+                    ConnectionString = chosen.ConnectionString,
+                };
+                Console.WriteLine(
+                    $"[InstanceSetup] storage '{chosen.Type}' comes from the instance manifest at "
+                    + $"{InstanceManifest.PathFor(moduleRoot)} (set up "
+                    + $"{setupManifest.SetUpAt?.ToString("u") ?? "at an unrecorded time"}"
+                    + $"{(setupManifest.SetUpBy is { } who ? $" by {who}" : "")}).");
+            }
+
             if (graphStorageConfig == null)
             {
-                throw new InvalidOperationException(
-                    "Graph:Storage configuration is required. " +
-                    "Configure it in appsettings.json with Type and BasePath/ConnectionString.");
+                // 🚨 NOT a throw any more (#2550). An image with no storage configured is an
+                // instance AWAITING SETUP, and the whole point of the setup wizard is that such an
+                // image comes up far enough to ask which database to use. Throwing here is what
+                // made "install the empty image, then configure it" impossible: the process died
+                // before anything could serve, so there was nowhere to ask the question.
+                //
+                // The caller decides what to do with this state; it is reported, never guessed at.
+                // A SETUP mesh serves the wizard and nothing else — it must never quietly invent a
+                // storage backend, because a wrong guess writes real data somewhere nobody chose
+                // (an ephemeral container path, silently lost on the next roll — issue #435's
+                // shape).
+                Console.Error.WriteLine(
+                    "[InstanceSetup] No Graph:Storage configuration and no instance manifest at "
+                    + $"{InstanceManifest.PathFor(moduleRoot)} — this instance is AWAITING SETUP. "
+                    + "Configure Graph:Storage in appsettings, or complete the setup wizard, which "
+                    + "writes the manifest and restarts into a configured mesh.");
+                builder.MarkAwaitingSetup();
+                return builder;
             }
 
             // Resolve relative BasePath to absolute

--- a/src/MeshWeaver.Mesh.Contract/InstanceManifest.cs
+++ b/src/MeshWeaver.Mesh.Contract/InstanceManifest.cs
@@ -1,0 +1,205 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// What a NEW INSTANCE was set up to be — the durable answer to "which database, which modules
+/// boot, which packages are provisioned, and which of those land for every user" (#2550).
+///
+/// <para>🚨 <b>A FILE, not a mesh node, and for the same reason the module activation sidecar is
+/// one:</b> it is consumed before any storage provider, hub, or connection string exists. At the
+/// moment this is read there is by definition no database to read a node from — choosing the
+/// database is what it answers. It lives on the writable root beside <c>modules/</c> so it travels
+/// with the deployment it describes.</para>
+///
+/// <para><b>Two authors, one artifact.</b> The interactive setup wizard writes this by hand on an
+/// empty image; a fleet <c>Hosting/Deployment</c> record renders the identical file when it
+/// provisions an instance. That is deliberate — a second provisioning path that produced a
+/// different shape is how the interactive and fleet routes drift until only one of them works.</para>
+///
+/// <para><b>Absent is not an error.</b> Every deployment configured through appsettings today has
+/// no manifest and must keep booting exactly as it does. The manifest only ANSWERS what
+/// configuration has not already said; it never overrides a host that stated its own storage.</para>
+/// </summary>
+public sealed record InstanceManifest
+{
+    /// <summary>The manifest's file name on the writable root.</summary>
+    public const string FileName = "instance.json";
+
+    /// <summary>
+    /// The setup state this manifest records. A manifest that exists but is not
+    /// <see cref="InstanceSetupState.Complete"/> keeps the instance in SETUP — a half-answered
+    /// wizard must not boot a half-configured mesh.
+    /// </summary>
+    public InstanceSetupState State { get; init; } = InstanceSetupState.AwaitingStorage;
+
+    /// <summary>The storage the operator chose. Null until the wizard's first step is answered.</summary>
+    public InstanceStorageSelection? Storage { get; init; }
+
+    /// <summary>
+    /// Module entry assemblies this instance BOOTS — the <c>Modules:Assemblies</c> lane, loaded
+    /// into the process. These are the ones the image ships and the deployment turns on.
+    /// </summary>
+    public ImmutableList<string> BootModules { get; init; } = [];
+
+    /// <summary>
+    /// Packages PROVISIONED into the mesh at first boot — Store installs, the registry lane. A
+    /// package here is content (and possibly a module) landed once for the instance, not a DLL
+    /// listed for the loader; those are two different mechanisms and the wizard keeps them apart.
+    /// </summary>
+    public ImmutableList<string> ProvisionPackages { get; init; } = [];
+
+    /// <summary>
+    /// Packages PRE-INSTALLED FOR USERS — landed per user rather than once per instance. Recorded
+    /// as the deployment's answer; the package's own <c>preInstalled</c> declaration is the
+    /// platform baseline, and this is the per-instance addition to it.
+    /// </summary>
+    public ImmutableList<string> UserPreInstallPackages { get; init; } = [];
+
+    /// <summary>Who completed setup, for provenance. Never a credential.</summary>
+    public string? SetUpBy { get; init; }
+
+    /// <summary>When setup completed.</summary>
+    public DateTimeOffset? SetUpAt { get; init; }
+
+    /// <summary>Whether this manifest answers the storage question — the gate that decides
+    /// whether the instance may leave setup mode. Pure.</summary>
+    [JsonIgnore]
+    public bool HasStorage => Storage is { } s && !string.IsNullOrWhiteSpace(s.Type);
+
+    private static readonly JsonSerializerOptions Json = new()
+    {
+        WriteIndented = true,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        Converters = { new JsonStringEnumConverter() },
+    };
+
+    /// <summary>The manifest's path under <paramref name="rootDirectory"/>.</summary>
+    public static string PathFor(string rootDirectory) =>
+        Path.Combine(rootDirectory, FileName);
+
+    /// <summary>
+    /// Reads the manifest, or null when this instance has none — which is the ordinary state of
+    /// every deployment configured through appsettings.
+    ///
+    /// <para>🚨 An UNREADABLE manifest is not the same as an absent one, and the difference decides
+    /// whether an instance serves. Absent means "configured elsewhere, carry on"; corrupt or
+    /// unreadable means "this instance was set up and we cannot tell how", which must surface
+    /// through <paramref name="onUnreadable"/> and keep the instance in SETUP rather than boot it
+    /// as if it had never been configured — booting a configured instance into a fresh setup wizard
+    /// would invite an operator to re-answer questions against a database that already holds data.</para>
+    /// </summary>
+    /// <param name="rootDirectory">The writable root (<c>ModuleRoot.Resolve</c>).</param>
+    /// <param name="onUnreadable">Called with a human-readable reason when a manifest EXISTS but
+    /// cannot be read. Pre-DI, so production passes stderr.</param>
+    /// <returns>The manifest, or null when the file does not exist.</returns>
+    public static InstanceManifest? Read(string rootDirectory, Action<string>? onUnreadable = null)
+    {
+        var path = PathFor(rootDirectory);
+        string text;
+        try
+        {
+            if (!File.Exists(path))
+                return null;
+            text = File.ReadAllText(path);
+        }
+        catch (Exception ex) when (ex is FileNotFoundException or DirectoryNotFoundException)
+        {
+            // Vanished between the check and the read — genuinely absent.
+            return null;
+        }
+        catch (Exception ex)
+        {
+            onUnreadable?.Invoke(
+                $"The instance manifest at '{path}' exists but could not be READ "
+                + $"({ex.GetType().Name}: {ex.Message}). This instance stays in SETUP: it was "
+                + "configured once, and booting it as if it never had been would offer a fresh "
+                + "setup over a database that may already hold data.");
+            return Unreadable;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<InstanceManifest>(text, Json) ?? Unreadable;
+        }
+        catch (JsonException ex)
+        {
+            onUnreadable?.Invoke(
+                $"The instance manifest at '{path}' is malformed ({ex.Message}). This instance "
+                + "stays in SETUP — repair or delete the file to re-run setup.");
+            return Unreadable;
+        }
+    }
+
+    /// <summary>
+    /// The manifest a corrupt file resolves to: it EXISTS (so the instance is not treated as
+    /// unconfigured) but answers nothing (so it cannot leave setup). Never written to disk.
+    /// </summary>
+    public static InstanceManifest Unreadable { get; } =
+        new() { State = InstanceSetupState.Unreadable };
+
+    /// <summary>
+    /// Writes the manifest atomically — a temp file in the same directory, then a rename — so a
+    /// crash mid-write leaves the previous answer intact rather than a truncated file that reads
+    /// as <see cref="Unreadable"/> and parks the instance in setup.
+    /// </summary>
+    public void Write(string rootDirectory)
+    {
+        Directory.CreateDirectory(rootDirectory);
+        var path = PathFor(rootDirectory);
+        var temp = path + "." + Guid.NewGuid().ToString("N") + ".tmp";
+        File.WriteAllText(temp, JsonSerializer.Serialize(this, Json));
+        File.Move(temp, path, overwrite: true);
+    }
+}
+
+/// <summary>How far setup has got. The instance serves normally only at
+/// <see cref="Complete"/>.</summary>
+public enum InstanceSetupState
+{
+    /// <summary>The storage question is unanswered — the wizard's first step.</summary>
+    AwaitingStorage,
+
+    /// <summary>Storage is chosen; the module questions are unanswered.</summary>
+    AwaitingModules,
+
+    /// <summary>Setup finished. The next boot configures the mesh from this manifest.</summary>
+    Complete,
+
+    /// <summary>A manifest exists but could not be read. Not a state the wizard writes — it is
+    /// what a corrupt file resolves to, and it keeps the instance in setup deliberately.</summary>
+    Unreadable,
+}
+
+/// <summary>
+/// The storage an instance was set up with — the answer to "which database", in the shape
+/// <c>Graph:Storage</c> already takes.
+///
+/// <para>🚨 <b>A connection string is a SECRET and a manifest is a record.</b> A deployment that
+/// names <see cref="SecretName"/> keeps the value in its secret store, exactly as
+/// <c>DeploymentContent</c>'s mounts do; <see cref="ConnectionString"/> exists for local and
+/// single-operator installs where there is no secret store to name, and is the reason a manifest
+/// must never be synced to git.</para>
+/// </summary>
+public sealed record InstanceStorageSelection
+{
+    /// <summary>
+    /// The backend key — the value <c>Graph:Storage:Type</c> takes, resolved against the KEYED
+    /// <c>IStorageAdapterFactory</c> registrations this image ships. Discovered, never hardcoded:
+    /// an image without the Cosmos module must not be able to record Cosmos here.
+    /// </summary>
+    public string Type { get; init; } = "";
+
+    /// <summary>The connection string, for installs with no secret store. Mutually exclusive with
+    /// <see cref="SecretName"/> — see the type remarks.</summary>
+    public string? ConnectionString { get; init; }
+
+    /// <summary>The NAME of the secret carrying the connection string. Never a value.</summary>
+    public string? SecretName { get; init; }
+
+    /// <summary>Base path, for the file-system backend.</summary>
+    public string? BasePath { get; init; }
+}

--- a/src/MeshWeaver.Mesh.Contract/InstanceSetupDefaults.cs
+++ b/src/MeshWeaver.Mesh.Contract/InstanceSetupDefaults.cs
@@ -1,0 +1,94 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// What a new instance is offered BEFORE anyone answers a question (#2550) — the setup wizard's
+/// pre-filled profile, derived from what a working first-party deployment actually runs rather
+/// than from a wish list.
+///
+/// <para>🚨 <b>Defaults, never a policy.</b> Every value here is something the operator can change
+/// in the wizard; the point is that "next, next, finish" produces an instance that WORKS, instead
+/// of an empty mesh whose owner has to already know which seven modules make a portal render.</para>
+/// </summary>
+public static class InstanceSetupDefaults
+{
+    /// <summary>
+    /// The default storage backend. <c>PostgreSql</c> because that is what every deployed
+    /// installation runs — the file-system backend exists for local development, and offering it
+    /// as the default is how someone ends up running a portal on container-ephemeral disk.
+    ///
+    /// <para>🚨 Offered, not imposed: the wizard lists what the IMAGE actually ships (the keyed
+    /// <c>IStorageAdapterFactory</c> registrations) and pre-selects this one only when present.</para>
+    /// </summary>
+    public const string StorageType = "PostgreSql";
+
+    /// <summary>
+    /// The source a fresh instance provisions from. Matches the first-party package source name
+    /// that stamps every package the registry serves.
+    /// </summary>
+    public const string FirstPartySource = "Plugins";
+
+    /// <summary>
+    /// What a fresh instance PROVISIONS: everything the first-party source serves, as a PATTERN.
+    ///
+    /// <para>🚨 <b>A pattern, never an enumerated list</b>, and this is the whole point. The
+    /// catalog already understands <c>Source/*</c> (<c>PluginCatalog:InstallByDefault</c>, matched
+    /// source-scoped and failing closed on an unqualified id), so a wildcard covers what the source
+    /// serves TODAY and what it publishes tomorrow. A hand-typed list of package names is stale the
+    /// moment the next package ships, and — the failure that makes this worth stating — its symptom
+    /// lands nowhere near its cause: the new package simply is not there, no error, no log line,
+    /// and whoever published it sees a working store with their package missing from it.</para>
+    /// </summary>
+    public static readonly ImmutableList<string> ProvisionPackages =
+        [$"{FirstPartySource}/*"];
+
+    /// <summary>
+    /// The modules a portal needs LOADED to render and serve — the registry-served set every
+    /// first-party deployment declares under <c>Modules:Required</c>, so an absence is loud rather
+    /// than a silently blank page.
+    ///
+    /// <para>These are <c>Required</c>, not <c>Assemblies</c>: they arrive from the registry, and a
+    /// baseline entry would SHADOW the landed store module. The distinction is not cosmetic — it
+    /// decides whether the deployment binds an app-closure copy the image may not even ship.</para>
+    /// </summary>
+    public static readonly ImmutableList<string> RequiredModules =
+    [
+        "MeshWeaver.Blazor.Radzen.dll",      // charts and the rich control pack
+        "MeshWeaver.Blazor.Analysis.dll",    // analysis views
+        "MeshWeaver.Blazor.EntityViews.dll", // entity edit forms
+        "MeshWeaver.AI.dll",                 // the agent runtime + its catalogs
+    ];
+
+    /// <summary>
+    /// Modules that ship IN THE IMAGE and are turned on by listing them — the
+    /// <c>Modules:Assemblies</c> lane.
+    ///
+    /// <para>gRPC is default-on in every deployment: it is not only the foreign-participant
+    /// transport, it is the React GUI's browser data plane. Delisting it silently breaks that
+    /// frontend's live connection, which is why a fresh instance starts with it on.</para>
+    /// </summary>
+    public static readonly ImmutableList<string> BootModules =
+    [
+        "MeshWeaver.Hosting.Grpc.dll",
+    ];
+
+    /// <summary>
+    /// What lands FOR EVERY USER rather than once for the instance. Empty by default and
+    /// deliberately so: a package's own <c>preInstalled</c> declaration is the platform baseline,
+    /// and everything beyond it costs every user storage they did not ask for. An operator adds to
+    /// this knowingly.
+    /// </summary>
+    public static readonly ImmutableList<string> UserPreInstallPackages = [];
+
+    /// <summary>The manifest a wizard opens with — every question pre-answered the way a working
+    /// deployment answers it, and every answer still editable.</summary>
+    public static InstanceManifest Manifest() => new()
+    {
+        State = InstanceSetupState.AwaitingStorage,
+        Storage = new InstanceStorageSelection { Type = StorageType },
+        BootModules = BootModules,
+        ProvisionPackages = ProvisionPackages,
+        UserPreInstallPackages = UserPreInstallPackages,
+    };
+}

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -52,6 +52,28 @@ public record MeshBuilder
     public IConfiguration? Configuration { get; private set; }
 
     /// <summary>
+    /// Whether this instance has NO storage yet and is awaiting the setup wizard (#2550).
+    ///
+    /// <para>🚨 A host that reads this true must serve the SETUP surface and nothing else. It must
+    /// not invent a storage backend to get going: a guessed backend writes real data somewhere
+    /// nobody chose — typically the container's ephemeral working directory, which reads back fine
+    /// for minutes and is gone at the next roll (issue #435's shape). Awaiting setup is a state to
+    /// SERVE, not a gap to paper over.</para>
+    ///
+    /// <para>False for every deployment configured through appsettings, which is all of them until
+    /// an operator installs an empty image on purpose.</para>
+    /// </summary>
+    public bool IsAwaitingSetup { get; private set; }
+
+    /// <summary>Records that this instance has no storage configured and no completed setup
+    /// manifest. One-way: nothing clears it, because the cure is a restart with an answer.</summary>
+    public MeshBuilder MarkAwaitingSetup()
+    {
+        IsAwaitingSetup = true;
+        return this;
+    }
+
+    /// <summary>
     /// Supplies the deployment configuration that <see cref="Configuration"/> exposes to
     /// attribute-carried module contributions. Called for you by
     /// <c>MeshBuilderModuleActivation.InstallConfiguredModules</c>, which already holds it;

--- a/test/Memex.Portal.Shared.Test/ConfigurationHandOverTest.cs
+++ b/test/Memex.Portal.Shared.Test/ConfigurationHandOverTest.cs
@@ -32,6 +32,46 @@ namespace Memex.Portal.Shared.Test;
 /// </summary>
 public class ConfigurationHandOverTest
 {
+    [Theory]
+    [InlineData(InstanceSetupState.AwaitingStorage)]
+    [InlineData(InstanceSetupState.AwaitingModules)]
+    [InlineData(InstanceSetupState.Unreadable)]
+    public void AnIncompleteManifest_LeavesTheInstanceAwaitingSetup_NeverPosesAsConfiguredStorage(
+        InstanceSetupState state)
+    {
+        // 🚨 Copilot review on #2552. A manifest that EXISTS is not a manifest that ANSWERS: the
+        // wizard's own starting point (InstanceSetupDefaults) is AwaitingStorage with a type
+        // already pre-filled, and an Unreadable one answers nothing at all. Accepting either as
+        // configured storage boots past setup and fails later and deeper — on an unknown backend
+        // or a missing connection string — which is both a worse failure and further from its
+        // cause than simply serving the setup surface.
+        var root = Directory.CreateTempSubdirectory("mw-2552-").FullName;
+        try
+        {
+            new InstanceManifest
+            {
+                State = state,
+                Storage = new InstanceStorageSelection { Type = "PostgreSql" },
+            }.Write(root);
+
+            var configuration = new ConfigurationBuilder()
+                .AddInMemoryCollection(new Dictionary<string, string?> { ["Modules:Root"] = root })
+                .Build();
+            var builder = new MeshBuilder(configure => configure(new ServiceCollection()),
+                new Address("mesh", "test"));
+
+            builder.ConfigureMemexMesh(configuration);
+
+            Assert.True(builder.IsAwaitingSetup,
+                $"a manifest in state {state} does not answer the storage question, so the "
+                + "instance must stay in setup rather than boot on it");
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* OS problem, not a failure */ }
+        }
+    }
+
     [Fact]
     public void ConfigureMemexMesh_HandsTheHostConfigurationToTheBuilder_BeforeModulesFold()
     {

--- a/test/Memex.Portal.Shared.Test/InstanceManifestTest.cs
+++ b/test/Memex.Portal.Shared.Test/InstanceManifestTest.cs
@@ -1,0 +1,167 @@
+using System.Collections.Immutable;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The instance manifest (#2550) — the durable answer to "which database, which modules boot,
+/// which packages are provisioned, and which land for every user", written by the setup wizard on
+/// an empty image and by a fleet Deployment record when it provisions one.
+///
+/// <para>These pin the properties that decide whether an instance SERVES, since every one of them
+/// fails silently if it is wrong.</para>
+/// </summary>
+public class InstanceManifestTest : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-instance-" + Guid.NewGuid().ToString("N"));
+
+    public InstanceManifestTest() => Directory.CreateDirectory(root);
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+    }
+
+    [Fact]
+    public void NoManifest_ReadsAsAbsent_NotAsAnError()
+    {
+        // Every deployment configured through appsettings today has no manifest. If absence were
+        // an error — or anything other than null — this feature would break all of them at once.
+        Assert.Null(InstanceManifest.Read(root));
+    }
+
+    [Fact]
+    public void ARoundTrip_KeepsEveryAnswerTheWizardCollects()
+    {
+        var manifest = new InstanceManifest
+        {
+            State = InstanceSetupState.Complete,
+            Storage = new InstanceStorageSelection
+            {
+                Type = "PostgreSql",
+                SecretName = "memex-db-connection",
+            },
+            BootModules = ["MeshWeaver.Hosting.PostgreSql.dll"],
+            ProvisionPackages = ["AI", "Store"],
+            UserPreInstallPackages = ["MyAi"],
+            SetUpBy = "rbuergi",
+            SetUpAt = DateTimeOffset.Parse("2026-08-27T21:00:00Z"),
+        };
+
+        manifest.Write(root);
+        var read = InstanceManifest.Read(root);
+
+        Assert.NotNull(read);
+        Assert.Equal(InstanceSetupState.Complete, read!.State);
+        Assert.Equal("PostgreSql", read.Storage!.Type);
+        Assert.Equal("memex-db-connection", read.Storage.SecretName);
+        // The three module questions stay THREE lists: booting a DLL, provisioning a package into
+        // the mesh, and landing one per user are different mechanisms, and collapsing them is how
+        // a deployment ends up with content installed but no module to render it.
+        Assert.Equal(["MeshWeaver.Hosting.PostgreSql.dll"], read.BootModules);
+        Assert.Equal(["AI", "Store"], read.ProvisionPackages);
+        Assert.Equal(["MyAi"], read.UserPreInstallPackages);
+        Assert.Equal("rbuergi", read.SetUpBy);
+    }
+
+    [Fact]
+    public void ACorruptManifest_ReadsAsUnreadable_NeverAsAbsent()
+    {
+        // 🚨 The distinction that protects an instance's DATA. Absent means "configured elsewhere,
+        // carry on". Corrupt must NOT collapse to that: an instance that was set up once and now
+        // reads as never-configured would offer a fresh setup wizard over a database that already
+        // holds data, inviting an operator to point it somewhere new.
+        File.WriteAllText(InstanceManifest.PathFor(root), "{ not json");
+        string? reported = null;
+
+        var read = InstanceManifest.Read(root, msg => reported = msg);
+
+        Assert.NotNull(read);
+        Assert.Equal(InstanceSetupState.Unreadable, read!.State);
+        Assert.False(read.HasStorage, "an unreadable manifest answers nothing, so it cannot leave setup");
+        Assert.NotNull(reported);
+        Assert.Contains("SETUP", reported!);
+    }
+
+    [Fact]
+    public void HasStorage_IsFalseUntilTheFirstQuestionIsAnswered()
+    {
+        Assert.False(new InstanceManifest().HasStorage);
+        Assert.False(
+            new InstanceManifest { Storage = new InstanceStorageSelection { Type = "  " } }.HasStorage,
+            "a blank type is an unanswered question, not a backend named ' '");
+        Assert.True(
+            new InstanceManifest { Storage = new InstanceStorageSelection { Type = "FileSystem" } }
+                .HasStorage);
+    }
+
+    [Fact]
+    public void TheDefaultProfile_ProvisionsByPATTERN_NotAHandTypedList()
+    {
+        // 🚨 The failure this refuses. A default built as an enumerated list of package names is
+        // stale the moment the next package ships, and its symptom lands nowhere near its cause:
+        // the new package simply is not on a fresh instance — no error, no log line — and whoever
+        // published it sees a working store with their package missing. The catalog already
+        // understands source-scoped wildcards, so the default uses one.
+        var manifest = InstanceSetupDefaults.Manifest();
+
+        Assert.Equal(["Plugins/*"], manifest.ProvisionPackages);
+        Assert.All(manifest.ProvisionPackages, p => Assert.Contains('/', p));
+    }
+
+    [Fact]
+    public void TheDefaultProfile_MatchesWhatAWorkingDeploymentRuns()
+    {
+        var manifest = InstanceSetupDefaults.Manifest();
+
+        // Postgres, because that is what every DEPLOYED installation runs — defaulting to the
+        // file-system backend is how a portal ends up on container-ephemeral disk.
+        Assert.Equal("PostgreSql", manifest.Storage!.Type);
+
+        // gRPC boots from the image: it is the React GUI's browser data plane, not merely the
+        // foreign-participant transport, so a fresh instance starts with it on.
+        Assert.Contains("MeshWeaver.Hosting.Grpc.dll", manifest.BootModules);
+
+        // Nothing lands per-user by default — a package's own preInstalled declaration is the
+        // baseline, and anything beyond it spends every user's storage on their behalf.
+        Assert.Empty(manifest.UserPreInstallPackages);
+    }
+
+    [Fact]
+    public void RequiredModules_AreTheRegistryServedOnes_NeverBaselineAssemblies()
+    {
+        // The two lists are mutually exclusive for one name: a Modules:Assemblies entry SHADOWS a
+        // landed store module (baseline wins, then dedupes by name), pinning the instance to an
+        // app-closure copy the image may not ship at all.
+        Assert.Empty(InstanceSetupDefaults.RequiredModules
+            .Intersect(InstanceSetupDefaults.BootModules));
+        Assert.Contains("MeshWeaver.AI.dll", InstanceSetupDefaults.RequiredModules);
+    }
+
+    [Fact]
+    public void WriteIsAtomic_SoACrashMidWriteCannotStrandTheInstanceInSetup()
+    {
+        var first = new InstanceManifest
+        {
+            State = InstanceSetupState.Complete,
+            Storage = new InstanceStorageSelection { Type = "FileSystem", BasePath = "/data/graph" },
+        };
+        first.Write(root);
+
+        // A second write lands whole or not at all — never a truncated file that would read as
+        // Unreadable and park a working instance in setup.
+        new InstanceManifest
+        {
+            State = InstanceSetupState.Complete,
+            Storage = new InstanceStorageSelection { Type = "PostgreSql", SecretName = "conn" },
+        }.Write(root);
+
+        var read = InstanceManifest.Read(root);
+        Assert.Equal("PostgreSql", read!.Storage!.Type);
+        // No temp files left behind to be mistaken for a manifest.
+        Assert.Empty(Directory.EnumerateFiles(root, "*.tmp"));
+    }
+}


### PR DESCRIPTION
Phase 1 of the new-instance setup wizard (design: #2550) — the durable artifact and the boot seam. No GUI yet; that plugs into this.

## The blocker this removes

`ConfigureMemexMesh` threw `"Graph:Storage configuration is required"`, so an **empty image died before anything could serve**. That is exactly why "install the image, then tell it which database" was impossible: there was nowhere to ask the question. It now reports the state and marks the builder `AwaitingSetup`.

It deliberately does **not** invent a backend to get going. A guessed one writes real data somewhere nobody chose — typically the container's ephemeral working directory, which reads back fine for minutes and is gone at the next roll (#435's shape). Awaiting setup is a state to serve, not a gap to paper over.

## The artifact

`InstanceManifest` — a **file** on the writable root beside `modules/activation.d/`, for the same reason the activation sidecar is one: when it is read there is no storage provider, hub, or connection string, and *which storage to use* is what it answers.

- **Configuration always wins.** The manifest answers only what appsettings has not; every deployment that exists today is unaffected.
- **Corrupt ≠ absent.** A malformed manifest resolves to `Unreadable`, so an instance that was configured once is never offered a fresh setup over a database that already holds data.
- **Atomic write**, so a crash mid-write cannot strand a working instance in setup.
- **Secrets:** `SecretName` (a name, never a value) is the deployment path; a literal connection string exists for local installs with no secret store.

## Defaults from what actually works

Derived from a running first-party deployment, not invented:

| question | default | why |
|---|---|---|
| storage | `PostgreSql` | what every *deployed* installation runs; defaulting to FileSystem puts a portal on ephemeral disk |
| boots | `MeshWeaver.Hosting.Grpc.dll` | default-on — it is the React GUI's browser data plane, not just the foreign-participant transport |
| required | Radzen, Analysis, EntityViews, AI | registry-served, so `Required` (a baseline entry would *shadow* the landed module) |
| provisioned | **`Plugins/*`** | a PATTERN, not a list |
| per-user | *(none)* | a package's own `preInstalled` is the baseline; more spends every user's storage for them |

🚨 **`Plugins/*` being a pattern is the load-bearing choice.** The catalog already matches source-scoped wildcards (`PluginCatalog:InstallByDefault`, failing closed on an unqualified id), so it covers what the source serves today *and* what it publishes tomorrow. A hand-typed list goes stale at the next package, and its symptom lands nowhere near its cause: the package simply is not on fresh instances, with no error and no log line.

## Tests

`InstanceManifestTest` (9): absence is not an error; full round trip keeping the three module lists distinct; corrupt-vs-absent; `HasStorage` gating; atomic write leaves no temp files; and the default profile (pattern not list, Postgres, gRPC, empty per-user, Required ∩ Assemblies = ∅).

Full solution build `-c Release -warnaserror`: 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz1i2fFcJhvR1Eje8yFH5F