### PR TITLE
CD: the migration image takes its version from THIS repo, like every other leg (#2555)

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -861,19 +861,36 @@ jobs:
         uses: actions/setup-dotnet@v6
         with:
           dotnet-version: 10.0.x
-      # Same $(Version) computation as the portal leg: both jobs run inside ONE
-      # workflow run, so GITHUB_RUN_NUMBER — and therefore the computed
-      # 3.0.0-ci.<n> tag — is identical across the two legs by construction.
-      # 🚨 This one is load-bearing beyond tidiness: the self-updater patches the portal AND the
-      # migration Deployment to the SAME tag (SelfUpdateOptions.MigrationImage), so a portal
-      # version tag without a matching migration version tag is an ImagePullBackOff on rollout.
+      # 🚨 Read the version from a project that stays in THIS repo — the same rule, and the same
+      # project, the portal leg above already follows, and for the same reason. This used to read
+      # `plugins-repo/src/Memex.Database.Migration`, which lives in MeshWeaver.Plugins and does NOT
+      # inherit this repo's root Directory.Build.props. It therefore evaluated to the csproj's own
+      # default and published `memex-migration:1.0.0` on every run, while the portal published
+      # `3.0.0-rc8.ci.<n>` — the two repositories silently stopped sharing a tagging convention.
+      #
+      # 🚨 That is load-bearing beyond tidiness, and it broke production for 6.5 h on 2026-08-27
+      # (#2555). `helm-release.yml` derives the migration tag from the PORTAL image's tag, on the
+      # documented reasoning that a migration must ride the same build as the code it migrates for.
+      # With no matching version tag on memex-migration, every `helm upgrade` minted a Job pinned to
+      # `memex-migration:3.0.0-rc8.ci.<n>` — a tag that had never existed — and the Job sat in
+      # ImagePullBackOff (1699 pull attempts) where nothing was watching. It is invisible while the
+      # schema happens to be current, because DbVersionGate only refuses to serve when db_version is
+      # BELOW Latest; a migration that can never run surfaces only at the deploy that needs it.
+      #
+      # Both jobs run inside ONE workflow run, so GITHUB_RUN_NUMBER — and therefore the computed
+      # 3.0.0-ci.<n> tag — is identical across the legs by construction.
       - name: Compute image version
         id: vars
         run: |
           set -euo pipefail
-          VERSION=$(dotnet msbuild plugins-repo/src/Memex.Database.Migration/Memex.Database.Migration.csproj \
-            -p:MeshWeaverRoot=${{ github.workspace }} \
+          VERSION=$(dotnet msbuild src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj \
             -getProperty:Version -p:CIRun=true -nologo | tr -d '[:space:]')
+          # Refuse rather than invent — same as the portal leg. An empty version becomes `:` or
+          # `latest` downstream, which is the failure where a tag exists and points at the wrong thing.
+          if [ -z "$VERSION" ]; then
+            echo "::error::could not resolve Version from the platform checkout. Refusing to invent one."
+            exit 1
+          fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "Computed image version: $VERSION (run #$GITHUB_RUN_NUMBER)"
       - name: Ensure Azure CLI

--- a/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
@@ -1,0 +1,113 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>Every image in a published set must be version-tagged from the SAME source of truth</b>
+/// (#2555).
+///
+/// <para><b>What went wrong.</b> <c>main-cd.yml</c>'s portal leg computes <c>$(Version)</c> from a
+/// project in THIS repo, so it publishes <c>memex-portal-ai:3.0.0-rc8.ci.&lt;n&gt;</c>. The migration
+/// leg read <c>plugins-repo/src/Memex.Database.Migration</c> — a project in <b>MeshWeaver.Plugins</b>,
+/// which does not inherit this repo's root <c>Directory.Build.props</c>. It therefore evaluated to
+/// the csproj's own default and published <c>memex-migration:1.0.0</c>, run after run, while a
+/// comment three lines above asserted the two tags were "identical across the two legs by
+/// construction".</para>
+///
+/// <para><b>Why it is a correctness problem.</b> <c>helm-release.yml</c> derives the migration image
+/// tag from the PORTAL image's tag, on the sound reasoning that a schema migration must ride the
+/// same build as the code that will run against it. With no matching version tag on
+/// <c>memex-migration</c>, every <c>helm upgrade</c> minted a Job pinned to a tag that had never
+/// existed. On 2026-08-27 that Job sat in <c>ImagePullBackOff</c> for 6 h 27 m — 1699 pull attempts —
+/// and nothing reported it, because <c>DbVersionGate</c> only refuses to serve when
+/// <c>db_version</c> is BELOW <c>DbVersion.Latest</c>. A migration that can never run is invisible
+/// until the deploy that needs it.</para>
+///
+/// <para><b>Why a text guard.</b> The invariant lives in a workflow file and is about which
+/// repository a path points into — there is no assembly to reflect over, and the failure is
+/// silent by construction: both legs succeed, both push, and only the pair of tags is wrong.</para>
+/// </summary>
+public class CdImageVersionsShareOneSourceGuard
+{
+    private const string Workflow = ".github/workflows/main-cd.yml";
+
+    /// <summary>
+    /// Every <c>-getProperty:Version</c> in CD must read a project that lives in THIS repository.
+    /// Any local project works — they all inherit the root <c>Directory.Build.props</c>, so they
+    /// resolve one value per run — but a path into a sibling checkout resolves that repository's
+    /// own scheme instead, which is exactly how the published set stopped sharing a tag.
+    /// </summary>
+    [Fact]
+    public void EveryVersionIsComputedFromThisRepository()
+    {
+        var offenders = VersionSources().Where(IsForeignCheckout).ToList();
+
+        Assert.True(offenders.Count == 0,
+            "main-cd.yml computes an image version from a project outside this repository:\n  "
+            + string.Join("\n  ", offenders)
+            + "\nA project in another checkout does not inherit this repo's root Directory.Build.props, "
+            + "so it yields a different version and the published set stops sharing one tag (#2555). "
+            + "Read it from a project in this repo — the portal leg's comment says which, and why.");
+    }
+
+    /// <summary>
+    /// The checkout paths CD clones sibling repositories into. Named explicitly rather than
+    /// inferred from "does the file exist", because this test must fail on a workflow file it can
+    /// read even when the sibling checkout is absent — which is the normal state locally, and
+    /// would otherwise make the guard pass for the wrong reason.
+    /// </summary>
+    private static bool IsForeignCheckout(string project) =>
+        project.StartsWith("plugins-repo/", StringComparison.Ordinal)
+        || project.StartsWith("chart-src/", StringComparison.Ordinal)
+        || project.StartsWith("/", StringComparison.Ordinal)
+        || project.Contains("${{", StringComparison.Ordinal);
+
+    /// <summary>
+    /// 🚨 Discovery found something. Without this, a rename of the step or a change to the
+    /// <c>-getProperty</c> spelling would empty the set and turn the assertion above green while
+    /// verifying nothing — the failure mode this repo hits most often.
+    /// </summary>
+    [Fact]
+    public void TheWorkflowActuallyYieldsVersionComputations()
+    {
+        var sources = VersionSources();
+
+        Assert.True(sources.Count >= 2,
+            $"Expected at least the portal and migration legs to compute a version; found {sources.Count}. "
+            + "Either the steps were renamed or the matcher no longer recognises them — in both cases "
+            + "this guard checks nothing.");
+    }
+
+    /// <summary>
+    /// Every project path handed to <c>-getProperty:Version</c>, normalised and with any
+    /// <c>${{ }}</c> expression left intact so an interpolated path is visible rather than silently
+    /// rewritten into something that looks local.
+    /// </summary>
+    private static IReadOnlyList<string> VersionSources()
+    {
+        var body = File.ReadAllText(Path.Combine(FindRepoRoot(), Workflow));
+
+        // `dotnet msbuild <project> \` … `-getProperty:Version` — the project is the first argument,
+        // and the flag may sit on a continuation line, so the two are matched together.
+        var matches = Regex.Matches(
+            body,
+            @"dotnet\s+msbuild\s+(?<project>[^\s\\]+)(?<tail>(?:[^\n]|\\\s*\n)*?-getProperty:Version)",
+            RegexOptions.Singleline);
+
+        return [.. matches.Select(m => m.Groups["project"].Value.Replace('\\', '/'))];
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+               ?? throw new InvalidOperationException("Could not locate the repository root (no MeshWeaver.slnx above the test binary).");
+    }
+}


### PR DESCRIPTION
Fixes #2555.

## The defect

`main-cd.yml`'s migration leg computed `$(Version)` from
`plugins-repo/src/Memex.Database.Migration` — a project in **MeshWeaver.Plugins**, which does not
inherit this repo's root `Directory.Build.props`. It resolved the csproj's own default and published
**`memex-migration:1.0.0`** on every run, while the portal published `3.0.0-rc8.ci.<n>`.

A comment three lines above asserted the opposite:

> Same `$(Version)` computation as the portal leg … the computed `3.0.0-ci.<n>` tag is identical
> across the two legs **by construction**.

It was not. ACR is the evidence: `memex-portal-ai` carries `3.0.0-rc8.ci.6178`; `memex-migration`
carries only commit-shas, `staging-*`, `main` and `1.0.0`.

**The portal leg had already learned this exact lesson** and says so in its own comment — *"Read
from a project that STAYS in this repo. This used to read `Memex.Portal.Distributed`, which moved to
MeshWeaver.Plugins — and CD then failed here for every commit on main, publishing nothing, until
someone noticed nothing had shipped."* The migration leg was simply never brought along.

## What it cost

`helm-release.yml:357` derives the migration tag from the **portal** image's tag:

```bash
tag="${LIVE_IMAGE##*:}"
sets="--set portal.image=${LIVE_IMAGE} --set migration.image=${registry}/memex-migration:${tag}"
```

on reasoning that is **correct and must be preserved** — *"a migration from a different build than
the code that will run against it is how a schema lands half-applied."*

With no matching version tag, every `helm upgrade` minted a Job pinned to a tag that had never
existed. On 2026-08-27 `memex-migration-26` sat in `ImagePullBackOff` for **6 h 27 m — 1699 pull
attempts** — and nothing reported it.

🚨 **It is invisible by design, which is the part worth fixing loudly.** `DbVersionGate` only refuses
to serve when `db_version` is **below** `DbVersion.Latest`. While the schema happens to be current, a
migration that can never run looks exactly like one that was not needed. It surfaces at the deploy
that needs it — with the Job already hours into a backoff nobody was watching.

## The guard, and what it deliberately does not assert

`CdImageVersionsShareOneSourceGuard` asserts what the old comment merely claimed: **no CD leg may
compute a version from a sibling checkout.**

It does **not** require every leg to name the same project. Three legs read three *local* projects
(`Mesh.Contract`, `PluginTester`, and now the migration leg) and all resolve one value per run,
because `GITHUB_RUN_NUMBER` is fixed for the run. I wrote that stricter assertion first and it failed
on correct code — which is the kind of guard people delete rather than debug, so it is gone.

Foreign checkouts are named explicitly (`plugins-repo/`, `chart-src/`, absolute paths, `${{ }}`
interpolation) rather than inferred from whether the path exists on disk: the guard must fail on a
workflow it can *read* even when the sibling checkout is absent, which is the normal state locally.

**Controls, both run:**

| control | result |
|---|---|
| with the fix | 2/2 pass |
| migration leg restored to `plugins-repo/src/Memex.Database.Migration` | `EveryVersionIsComputedFromThisRepository` **fails**, naming that path; the discovery case correctly stays green |

The discovery case (`TheWorkflowActuallyYieldsVersionComputations`) exists because renaming the step
or changing the `-getProperty` spelling would empty the matched set and turn the real assertion green
over nothing.

## Deliberately out of scope

Two things #2555 raises that this PR does not touch, because they are separate changes with
different blast radii:

- **`KubernetesDeploymentUpdater.PatchToVersionAsync` still patches a `memex-migration` Deployment
  the chart never defines** (`kubectl get deploy -n memex` returns three, none of them that). It is a
  no-op today, but its `LogInformation` sits after that await, which is a candidate explanation for
  the silence in #2553. Removing it must come **before** the chart's RBAC grant is dropped, or a
  harmless call becomes a 403 mid-roll — `MigrationWorkloadModelGuard`'s doc-comment already records
  that ordering.
- **Whether the `1.0.0` tag on `memex-migration` should be cleaned up.** It is now stale by
  construction, but deleting a published tag is its own decision (see the ACR purge that took the
  brand site down for 11 h).

## What's New

No entry — this is a CI/CD tagging fix with no user-visible surface. The user-visible *consequence*
(a deploy that cannot migrate) has never reached a user, because the schema was current throughout.
