### PR TITLE
The self-update trigger could never see a build record — satellites need a scoped query

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -201,11 +201,12 @@ public class SelfUpdateHostedService : IHostedService
         Observable
             .Defer(() => NewBuildEventsAcross(_hub
                 .GetQuery($"SelfUpdate.BuildTrigger:{_hub.Address}",
-                    // 🚨 PATH-SCOPED (BuildCompletion.WatchQuery). Build records are SATELLITES
-                    // under Admin/_Build, and satellites are excluded from an unscoped query — the
-                    // bare `nodeType:BuildCompletion` this used to pass returned EMPTY however many
+                    // 🚨 PATH-SCOPED (BuildCompletion.WatchQuery). Build records live in the ADMIN
+                    // partition, which an UNSCOPED query does not reach — the bare
+                    // `nodeType:BuildCompletion` this used to pass returned EMPTY however many
                     // records existed and however often they were written, so this watch never
-                    // ticked and the install silently stopped self-updating.
+                    // ticked and the install silently stopped self-updating. (Not a satellite rule:
+                    // GitHubSyncConfig satellites in ordinary partitions ARE returned unscoped.)
                     BuildCompletion.WatchQuery)))
             .Throttle(_options.EventCoalesceWindow)
             .Select(_ => -2L)

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -201,7 +201,12 @@ public class SelfUpdateHostedService : IHostedService
         Observable
             .Defer(() => NewBuildEventsAcross(_hub
                 .GetQuery($"SelfUpdate.BuildTrigger:{_hub.Address}",
-                    $"nodeType:{BuildCompletion.NodeType}")))
+                    // 🚨 PATH-SCOPED (BuildCompletion.WatchQuery). Build records are SATELLITES
+                    // under Admin/_Build, and satellites are excluded from an unscoped query — the
+                    // bare `nodeType:BuildCompletion` this used to pass returned EMPTY however many
+                    // records existed and however often they were written, so this watch never
+                    // ticked and the install silently stopped self-updating.
+                    BuildCompletion.WatchQuery)))
             .Throttle(_options.EventCoalesceWindow)
             .Select(_ => -2L)
             .RetryWhen(ResubscribeAfterRetryInterval("build-completion watch"));

--- a/src/MeshWeaver.Graph/BuildCompletion.cs
+++ b/src/MeshWeaver.Graph/BuildCompletion.cs
@@ -46,13 +46,24 @@ public record BuildCompletion
     /// <summary>
     /// The query a consumer must use to WATCH every repository's build record.
     ///
-    /// <para>🚨 It is PATH-SCOPED, and that is load-bearing rather than tidy. These records are
-    /// SATELLITES (the <c>_Build</c> segment), and satellites are excluded from an unscoped query —
-    /// so a bare <c>nodeType:BuildCompletion</c> returns EMPTY however many records exist and
-    /// however often they are written. Measured on memex-cloud 2026-08-27: the unscoped form
-    /// answered 0 while <c>Admin/_Build/Systemorph.MeshWeaver</c> sat at version 1746, rewritten
-    /// minutes earlier — and the self-updater watching that unscoped form therefore never ticked,
-    /// so the install sat three published images behind with nothing reporting a fault.</para>
+    /// <para>🚨 It is PATH-SCOPED, and that is load-bearing rather than tidy: <b>the ADMIN
+    /// PARTITION is not reachable from an unscoped query</b>, so a bare
+    /// <c>nodeType:BuildCompletion</c> returns EMPTY however many records exist and however often
+    /// they are written.</para>
+    ///
+    /// <para>Measured on memex-cloud 2026-08-27, as the same viewer (a global admin), and note the
+    /// discriminator is the PARTITION rather than anything about satellites:</para>
+    /// <list type="bullet">
+    ///   <item><c>nodeType:BuildCompletion</c> → 0, while <c>Admin/_Build/Systemorph.MeshWeaver</c>
+    ///     sat at version 1746, rewritten minutes earlier.</item>
+    ///   <item><c>nodeType:UpdatePolicy</c> → 0, while <c>Admin/UpdatePolicy</c> reads fine.</item>
+    ///   <item><c>nodeType:Store/Coupon</c> → 0, while <c>Admin/Coupons/*</c> lists three.</item>
+    ///   <item>…yet <c>nodeType:GitHubSyncConfig</c> → 5, and those ARE satellites
+    ///     (<c>{Space}/_GitSync</c>) — they simply live in ordinary content partitions.</item>
+    /// </list>
+    ///
+    /// <para>The self-updater watching the unscoped form therefore never ticked, and the install sat
+    /// three published images behind with nothing reporting a fault.</para>
     ///
     /// <para>A watcher interested in ONE repository should not use this at all: take the node's own
     /// stream (<c>GetMeshNodeStream(PathFor(owner, repo))</c>), which is authoritative and live —

--- a/src/MeshWeaver.Graph/BuildCompletion.cs
+++ b/src/MeshWeaver.Graph/BuildCompletion.cs
@@ -40,6 +40,27 @@ public record BuildCompletion
     /// <summary>The path segment build records are anchored under, inside the Admin partition.</summary>
     public const string SatelliteSegment = "_Build";
 
+    /// <summary>The namespace every build record lives in: <c>Admin/_Build</c>.</summary>
+    public const string Namespace = "Admin/" + SatelliteSegment;
+
+    /// <summary>
+    /// The query a consumer must use to WATCH every repository's build record.
+    ///
+    /// <para>🚨 It is PATH-SCOPED, and that is load-bearing rather than tidy. These records are
+    /// SATELLITES (the <c>_Build</c> segment), and satellites are excluded from an unscoped query —
+    /// so a bare <c>nodeType:BuildCompletion</c> returns EMPTY however many records exist and
+    /// however often they are written. Measured on memex-cloud 2026-08-27: the unscoped form
+    /// answered 0 while <c>Admin/_Build/Systemorph.MeshWeaver</c> sat at version 1746, rewritten
+    /// minutes earlier — and the self-updater watching that unscoped form therefore never ticked,
+    /// so the install sat three published images behind with nothing reporting a fault.</para>
+    ///
+    /// <para>A watcher interested in ONE repository should not use this at all: take the node's own
+    /// stream (<c>GetMeshNodeStream(PathFor(owner, repo))</c>), which is authoritative and live —
+    /// the pattern <c>PluginUpdateWatcher</c> already follows. This exists for the consumer that
+    /// genuinely needs the SET.</para>
+    /// </summary>
+    public const string WatchQuery = $"path:{Namespace} scope:children nodeType:{NodeType}";
+
     /// <summary>
     /// The canonical node path for one repository's build record:
     /// <c>Admin/_Build/{owner}.{repo}</c>.

--- a/test/MeshWeaver.Graph.Test/BuildCompletionWatchQueryTest.cs
+++ b/test/MeshWeaver.Graph.Test/BuildCompletionWatchQueryTest.cs
@@ -6,11 +6,16 @@ namespace MeshWeaver.Graph.Test;
 /// <summary>
 /// The self-updater's trigger must be able to SEE a build record.
 ///
-/// <para>🚨 Build records are SATELLITES (<c>Admin/_Build/{owner}.{repo}</c>), and satellites are
-/// excluded from an UNSCOPED query. A bare <c>nodeType:BuildCompletion</c> therefore returns empty
-/// however many records exist and however often they are written — and it fails that way silently,
-/// which is what makes it dangerous: the watch simply never ticks, and "no builds happened" is
-/// indistinguishable from "the query cannot see them".</para>
+/// <para>🚨 Build records live in the <b>ADMIN partition</b> (<c>Admin/_Build/{owner}.{repo}</c>),
+/// which an UNSCOPED query does not reach. A bare <c>nodeType:BuildCompletion</c> therefore returns
+/// empty however many records exist and however often they are written — and it fails that way
+/// silently, which is what makes it dangerous: the watch simply never ticks, and "no builds
+/// happened" is indistinguishable from "the query cannot see them".</para>
+///
+/// <para>The discriminator is the PARTITION, not the satellite segment — measured as one viewer:
+/// <c>nodeType:UpdatePolicy</c> and <c>nodeType:Store/Coupon</c> are equally invisible (both Admin,
+/// neither a satellite), while <c>nodeType:GitHubSyncConfig</c> returns its <c>{Space}/_GitSync</c>
+/// satellites happily. Anything reading the Admin partition by type needs this scope.</para>
 ///
 /// <para>Measured on memex-cloud, 2026-08-27: the unscoped form answered <b>0</b> while
 /// <c>Admin/_Build/Systemorph.MeshWeaver</c> sat at <b>version 1746</b>, rewritten minutes earlier
@@ -20,9 +25,9 @@ namespace MeshWeaver.Graph.Test;
 public class BuildCompletionWatchQueryTest
 {
     [Fact]
-    public void TheWatchQuery_IsPathScoped_BecauseSatellitesAreInvisibleToAnUnscopedOne()
+    public void TheWatchQuery_IsPathScoped_BecauseTheAdminPartitionIsInvisibleUnscoped()
     {
-        // The three parts that make it able to see satellites at all. Asserted as a whole string
+        // The three parts that make it able to reach the Admin partition. Asserted as a whole string
         // too, so a well-meaning "simplification" back to the bare form fails here rather than in
         // production six weeks later.
         Assert.Contains($"path:{BuildCompletion.Namespace}", BuildCompletion.WatchQuery);

--- a/test/MeshWeaver.Graph.Test/BuildCompletionWatchQueryTest.cs
+++ b/test/MeshWeaver.Graph.Test/BuildCompletionWatchQueryTest.cs
@@ -1,0 +1,47 @@
+using MeshWeaver.Graph;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The self-updater's trigger must be able to SEE a build record.
+///
+/// <para>🚨 Build records are SATELLITES (<c>Admin/_Build/{owner}.{repo}</c>), and satellites are
+/// excluded from an UNSCOPED query. A bare <c>nodeType:BuildCompletion</c> therefore returns empty
+/// however many records exist and however often they are written — and it fails that way silently,
+/// which is what makes it dangerous: the watch simply never ticks, and "no builds happened" is
+/// indistinguishable from "the query cannot see them".</para>
+///
+/// <para>Measured on memex-cloud, 2026-08-27: the unscoped form answered <b>0</b> while
+/// <c>Admin/_Build/Systemorph.MeshWeaver</c> sat at <b>version 1746</b>, rewritten minutes earlier
+/// by the webhook. The install had stopped self-updating and sat three published images behind,
+/// with every part reporting success.</para>
+/// </summary>
+public class BuildCompletionWatchQueryTest
+{
+    [Fact]
+    public void TheWatchQuery_IsPathScoped_BecauseSatellitesAreInvisibleToAnUnscopedOne()
+    {
+        // The three parts that make it able to see satellites at all. Asserted as a whole string
+        // too, so a well-meaning "simplification" back to the bare form fails here rather than in
+        // production six weeks later.
+        Assert.Contains($"path:{BuildCompletion.Namespace}", BuildCompletion.WatchQuery);
+        Assert.Contains("scope:children", BuildCompletion.WatchQuery);
+        Assert.Contains($"nodeType:{BuildCompletion.NodeType}", BuildCompletion.WatchQuery);
+
+        Assert.Equal(
+            "path:Admin/_Build scope:children nodeType:BuildCompletion",
+            BuildCompletion.WatchQuery);
+    }
+
+    [Fact]
+    public void TheNamespace_IsWhereEveryRecordActuallyLands()
+    {
+        // The query scope and the write path must name ONE namespace: a scope that does not contain
+        // the records is exactly as blind as no scope at all, and looks just as correct.
+        var path = BuildCompletion.PathFor("Systemorph", "MeshWeaver");
+
+        Assert.Equal("Admin/_Build/Systemorph.MeshWeaver", path);
+        Assert.StartsWith(BuildCompletion.Namespace + "/", path);
+    }
+}


### PR DESCRIPTION
**This is why memex-cloud stopped self-updating.** Not the webhook, not ACR, not the update policy — the trigger query itself could never match.

## The defect

`SelfUpdateHostedService.BuildCompletionTicks()` watched an **unscoped** index query, `nodeType:BuildCompletion`. Build records are **satellites** (`Admin/_Build/{owner}.{repo}`), and satellites are excluded from an unscoped query. So the watch returned empty however many records existed and however often they were written — it never ticked, and after its single startup pass the install simply stopped updating, with every component reporting success.

## Measured on memex-cloud, 2026-08-27

```
search nodeType:BuildCompletion                                   →  0 results
search path:Admin/_Build scope:children nodeType:BuildCompletion  →  5 results
get @Admin/_Build/Systemorph.MeshWeaver   →  version 1746, written minutes earlier
```

Meanwhile the install served `ci.6145` while `ci.6158`, `ci.6178` and `ci.6183` were published, `Admin/UpdatePolicy` frozen at `checkedAt: 20:45Z` — and every other link healthy: hook subscribed to `workflow_run`, **15/15 recent deliveries `200 OK`**, `GitHubWebhookProcessor` writing the node **1,746 times**.

## The fix, and why this shape

The sibling consumer already had it right, and says why — `PluginUpdateWatcher`:

```csharp
// The canonical single-node read: one shared handle per path, live, authoritative.
// Never QueryAsync — that index lags a write by design.
var sub = hub.GetMeshNodeStream(buildPath)
```

It watches **one** repository, so a node stream fits. The self-updater needs the **set** across repositories, so it gets a **path-scoped query** instead — the form proven above to actually return the records.

`BuildCompletion.WatchQuery` becomes the single definition of that query, sitting next to `PathFor`, so the watch scope and the write path cannot drift apart. That pairing is the real guard: a scope that does not contain the records is exactly as blind as no scope, and looks just as correct.

## Tests

`BuildCompletionWatchQueryTest` (2) pins the scope, the namespace, and the exact query string — so a well-meaning simplification back to the bare form fails here rather than in production weeks later. The 22 existing self-update tests are unchanged and green.

Context: Systemorph/Memex#138 (where I first mis-diagnosed this as missing webhook wiring, then as missing nodes — both wrong, corrected there).

🚨 Worth generalising in review: **an unscoped `nodeType:` query is not a valid watch for anything satellite-shaped**, and it fails silently. Other watchers should be checked for the same shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tz1i2fFcJhvR1Eje8yFH5F