### PR TITLE
DevAuthController's two pre-auth reads use RunAsSystem, and five allowances retire (#2545)

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
@@ -57,17 +57,23 @@ public class DevAuthController : ControllerBase
         // (e.g. a reused dev DB) therefore throws UnauthorizedAccessException ("Anonymous lacks Read on
         // '{personId}'"), which — uncaught — 500s the signin and blocks onboarding entirely. Resolving an
         // existing user pre-auth is legitimate auth infrastructure, so impersonate System (same as
-        // ProvisionDevUser's grants). Observable.Using captures System at SUBSCRIBE and disposes it when
-        // the read completes — the sanctioned reactive impersonation (ApiTokenService / DeviceOnboarding).
+        // ProvisionDevUser's grants).
+        //
+        // 🚨 RunAsSystem, NOT Observable.Using(ImpersonateAsSystem, …). Impersonation is an AsyncLocal
+        // store/restore pair, and Using splits the halves across threads: it opens the scope on the
+        // SUBSCRIBING thread and disposes it when the inner observable TERMINATES — for a cross-hub
+        // read, the owning hub's response thread. Nothing disposes it here, so this ASP.NET request
+        // thread goes back to the pool still holding system-security (#1790). RunAsSystem opens and
+        // closes inside one synchronous Subscribe and delivers notifications under the subscriber's
+        // own identity (#1444).
         // Read the partition-root User node as System (pre-auth, private node). A brand-new user has
         // none, so routing the read to '{personId}' surfaces "No node found" (a DeliveryFailureException)
         // through the Rx OnError channel — NOT as a throw a try/catch around the await would see. Handle it
         // REACTIVELY: a .Catch that maps the not-found (and the 5s timeout miss) to NO emission, so
         // FirstOrDefaultAsync yields null and we fall through to the fallback query + DevLogin
         // self-provisioning. Any OTHER error is rethrown (never silently swallowed).
-        var node = await Observable.Using(
-                () => _accessService.ImpersonateAsSystem(),
-                _ => _hub.GetMeshNodeStream(personId)
+        var node = await _accessService.RunAsSystem(
+                () => _hub.GetMeshNodeStream(personId)
                     .Where(n => n is not null
                         && string.Equals(n.NodeType, "User", StringComparison.OrdinalIgnoreCase)
                         && n.Content is not null)
@@ -86,9 +92,8 @@ public class DevAuthController : ControllerBase
         {
             // Same pre-auth rationale: under Anonymous the nodeType:User query is RLS-filtered to nothing
             // (private user partitions), so an existing user is MISSED → spurious re-provision. Read as System.
-            var change = await Observable.Using(
-                    () => _accessService.ImpersonateAsSystem(),
-                    _ => _meshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery("nodeType:User")))
+            var change = await _accessService.RunAsSystem(
+                    () => _meshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery("nodeType:User")))
                 .FirstAsync();
             node = change.Items.FirstOrDefault(n =>
                 string.Equals(n.Id, personId, StringComparison.OrdinalIgnoreCase)

--- a/test/ImpersonationScopeSites.allow
+++ b/test/ImpersonationScopeSites.allow
@@ -40,7 +40,6 @@
 memex/Memex.Portal.Shared/Api/SeoEndpoints.cs	1
 memex/Memex.Portal.Shared/Authentication/ApiTokenService.cs	1
 memex/Memex.Portal.Shared/Authentication/BootstrapController.cs	1
-memex/Memex.Portal.Shared/Authentication/DevAuthController.cs	2
 memex/Memex.Portal.Shared/Authentication/InvitationService.cs	2
 memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs	3
 memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs	1
@@ -68,9 +67,6 @@ src/MeshWeaver.Graph/StaticRepoImporter.cs	1
 src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs	1
 src/MeshWeaver.Hosting/MeshNodeStreamCache.cs	1
 src/MeshWeaver.Hosting/NodeUpdatePipeline.cs	1
-src/MeshWeaver.InstanceSync/InstanceSyncCoordinator.cs	1
-src/MeshWeaver.InstanceSync/InstanceSyncService.cs	1
-src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs	1
 src/MeshWeaver.Mesh.Contract/MeshExtensions.cs	1
 src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs	6
 src/MeshWeaver.PluginCatalog/InstanceComboReader.cs	1

--- a/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
@@ -64,7 +64,7 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
     /// the shape; this stops the list as a WHOLE from growing — including by the trick of adding a
     /// new file's line. Lower it whenever you delete or lower an entry.
     /// </summary>
-    private const int TotalBudget = 83;
+    private const int TotalBudget = 78;
 
     /// <summary>Production roots. <c>test/</c> and <c>samples/</c> are deliberately out of scope —
     /// the leak there costs test isolation, not a user's permissions, and listing 21 more entries


### PR DESCRIPTION
Fixes #2545.

## The change

`DevAuthController`'s two pre-auth reads move from
`Observable.Using(() => access.ImpersonateAsSystem(), _ => work)` to `RunAsSystem`.

The idiom opens an `AsyncLocal` scope on the **subscribing** thread and disposes it when the inner
observable **terminates** — for a cross-hub read, the owning hub's response thread. Nothing disposes
it on the subscriber, which keeps `system-security` latched (#1790). Here the subscriber is an
**ASP.NET request thread**: it returns to the pool still elevated.

The impersonation itself was always correct and stays. Resolving an existing user *before anyone is
signed in* is legitimate auth infrastructure, and the partition-root `User` node is private — the
controller's own comments say so and they are unchanged.

## 🚨 Correcting how I filed the issue

I wrote in #2545 that the guards had "missed" this. **They had not.**
`ImpersonationScopeSiteRatchetGuard` scans `src`, `memex` and `tools`, and carried the site as a
budgeted allowance:

```
memex/Memex.Portal.Shared/Authentication/DevAuthController.cs	2
```

Known, counted, deliberately grandfathered — with the guard's own doc explaining the ordering (the
chart's RBAC grant must not be dropped before the updater stops patching, or a harmless call becomes
a 403 mid-roll). The guard was doing its job. What was missing was someone spending the allowance
down. That is what this PR does; the entry is deleted, so the ratchet now enforces **zero** there.

## Three more stale allowances, surfaced by doing it

Removing that line made the ratchet report what it had been saying to no one:

```
STALE (please tidy): src/MeshWeaver.InstanceSync/InstanceSyncCoordinator.cs — 0 found, 1 allowed
STALE (please tidy): src/MeshWeaver.InstanceSync/InstanceSyncService.cs     — 0 found, 1 allowed
STALE (please tidy): src/MeshWeaver.InstanceSync/InstanceSyncWorker.cs      — 0 found, 1 allowed
```

Those sites were converted at some point and their lines left behind. **A stale allowance is not
harmless** — it is a budget a future site can silently occupy, which is precisely how a ratchet
loosens without anyone deciding to loosen it. All three retired.

`TotalBudget` 83 → 78, matching the allow file exactly (2 + 3).

## Controls

| | |
|---|---|
| with the fix | `MeshWeaver.Documentation.Test` **98/98** |
| one site restored to the raw idiom | ratchet fails: `NEW SITE memex/Memex.Portal.Shared/Authentication/DevAuthController.cs (1) — … Do NOT add a line to ImpersonationScopeSites.allow` |

That message is the one an author needs — it names the file, the count, the replacement, and
forecloses the tempting fix of widening the allow file.

`dotnet build -c Release -warnaserror` clean on `Memex.Portal.Shared` and the test project.

## What's New

No entry — an identity-scope correction on a dev-login path gated behind `EnableDevLogin` and forced
off in production. Nothing a portal user observes changes.
