### PR TITLE
The bake compiles against modules, like the portal it bakes for (#2563)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-portals-update-again-after-a-module-moves.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-portals-update-again-after-a-module-moves.md
@@ -1,0 +1,23 @@
+---
+Name: Portals update again after a module moves
+Category: Fix
+Description: Content that uses a module now builds ahead of time as well as at run time, so installs no longer stop updating when a feature moves into a module.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Portals update again after a module moves
+
+Content can use the features a portal has installed — an installer that adds a plugin's skills to
+your AI settings, a page that draws a map. When one of those features moved out of the platform and
+became a module you install, that content still worked in the portal but could no longer be built
+ahead of time. The prepared build is what an install checks for before it updates itself, so
+installs correctly declined every new version and stayed on the last one they had a build for.
+
+Everything reported success while that happened, which is what made it hard to see: the checks that
+run against a live portal passed, because a live portal has its modules. Only the ahead-of-time
+build was missing them, and its failure looked like the content was broken rather than like a
+feature had moved.
+
+The ahead-of-time build now uses exactly the modules a portal does, so content that uses an
+installed feature builds the same way in both places, and updates resume on their own.

--- a/test/MeshWeaver.PluginTester.Test/BakeCompilesAgainstModulesTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeCompilesAgainstModulesTest.cs
@@ -1,0 +1,152 @@
+using System;
+using System.IO;
+using System.Text;
+using MeshWeaver.PluginTester;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// 🚨 <b>The bake compiles against the same modules a portal does.</b> A module is published into
+/// <c>modules/&lt;name&gt;/</c> and is therefore, by construction, NOT in
+/// <c>TRUSTED_PLATFORM_ASSEMBLIES</c> — so it reaches a compile only by being composed in
+/// (<c>CompileReferences.ComposeWithModules</c>). The portal does that from its installed-module
+/// set; until this test the bake used the bare TPA baseline and could not resolve a single module
+/// type.
+///
+/// <para><b>How that stayed invisible, and why it needed a test rather than care.</b> The two lanes
+/// of this same tool disagreed silently. The GATE stands up a mesh, so it composed modules for
+/// free and its <c>compile-check</c> went GREEN; only <c>publish-bake</c> went red — on the same
+/// content, the same image and the same commit. A reader sees a green compile gate beside a red
+/// bake and concludes the BAKE is broken, not that a reference is missing. Nothing in the failure
+/// names a module: it arrives as <c>CS0246: The type or namespace name 'AiSettings' could not be
+/// found</c>, which reads as a content defect.</para>
+///
+/// <para><b>What it cost, measured.</b> When the AI engine left the content surface to become a
+/// module (#2276), five <c>Store/*</c> NodeTypes stopped resolving <c>AiSettings</c> in the bake
+/// and nowhere else. No bundle was sealed for the new framework identity; every install then
+/// CORRECTLY declined to self-update onto an image whose content had no bake, and the fleet sat
+/// three published images behind with every component reporting success (#2563). The self-updater
+/// was working perfectly — it was refusing an image the bake had never covered.</para>
+///
+/// <para><b>The control is the point.</b> The same tree is baked twice: once with the module set
+/// composed, once with none. If the second did NOT fail, this test would be asserting nothing —
+/// it would pass just as happily against the broken behaviour it exists to pin.</para>
+/// </summary>
+public class BakeCompilesAgainstModulesTest(ITestOutputHelper output)
+{
+    private const string IndexJson =
+        """{"$type":"MeshNode","id":"ModuleBound","namespace":"","path":"ModuleBound","mainNode":"ModuleBound","name":"Module Bound","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"Content that binds a module type."}}""";
+
+    private const string TypeJson =
+        """{"$type":"MeshNode","id":"Bound","namespace":"ModuleBound","path":"ModuleBound/Bound","mainNode":"ModuleBound/Bound","name":"Bound","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"Binds a type that lives in a MODULE, not on the content surface.","configuration":"config => config.WithContentType<Bound>().AddDefaultLayoutAreas()","includeGlobalTypes":true}}""";
+
+    /// <summary>
+    /// Source that binds <c>MeshWeaver.AI.AiSettings</c> — a type in a module (<c>MeshWeaver.AI</c>
+    /// left <c>ContentSurfaceAssemblies</c> in #2276), so it resolves ONLY through module
+    /// composition. Real content does exactly this: <c>Store/Installer</c>'s Localizer merges a
+    /// plugin's Skill folder into the viewer's <c>AiSettings</c>.
+    /// </summary>
+    private const string BoundSource =
+        """
+        using MeshWeaver.AI;
+
+        public record Bound
+        {
+            public AiSettings Settings { get; init; } = new();
+        }
+        """;
+
+    [Fact(Timeout = 300_000)]
+    public void ContentBindingAModuleType_Bakes_AndCannotWithoutTheModule()
+    {
+        var repo = TempDirectory("mw-module-bound-repo");
+        var withModules = TempDirectory("mw-module-bound-bake-with");
+        var withoutModules = TempDirectory("mw-module-bound-bake-without");
+        try
+        {
+            Write(repo, "ModuleBound/index.json", IndexJson);
+            Write(repo, "ModuleBound/Bound.json", TypeJson);
+            Write(repo, "ModuleBound/Bound/Source/Bound.cs", BoundSource);
+
+            // ── The claim: composed modules ⇒ the module-bound type compiles. ──
+            var composedLog = new StringWriter();
+            var composed = TreeBake.Run(new TreeBake.Options
+            {
+                RepoRoot = repo,
+                OutputDirectory = withModules,
+                Output = composedLog,
+                ModuleAssemblyPaths = TesterModules.ResolvedPaths(null),
+            });
+            output.WriteLine("── with modules ──");
+            output.WriteLine(composedLog.ToString());
+
+            Assert.Null(composed.FatalError);
+            Assert.All(composed.Types, t => Assert.Null(t.Error));
+            Assert.NotEmpty(composed.Types);
+
+            // ── THE CONTROL. Without the modules the SAME tree must fail, and fail by not finding
+            //    the type — otherwise this test cannot tell the fix from the regression. ──
+            var bareLog = new StringWriter();
+            var bare = TreeBake.Run(new TreeBake.Options
+            {
+                RepoRoot = repo,
+                OutputDirectory = withoutModules,
+                Output = bareLog,
+                ModuleAssemblyPaths = [],
+            });
+            output.WriteLine("── without modules (control) ──");
+            output.WriteLine(bareLog.ToString());
+
+            var failure = Assert.Single(
+                Array.FindAll(bare.Types.ToArray(), t => !t.Success));
+            Assert.Contains("AiSettings", failure.Error);
+        }
+        finally
+        {
+            Cleanup(repo);
+            Cleanup(withModules);
+            Cleanup(withoutModules);
+        }
+    }
+
+    /// <summary>
+    /// The two lanes read ONE list. This is the property whose absence caused the outage: the gate
+    /// activated a module the bake never referenced, so "the gate has it" said nothing about the
+    /// bake — and the divergence was only observable as a red bake beside a green gate.
+    /// </summary>
+    [Fact]
+    public void BothLanes_TakeTheirModulesFromOneList()
+    {
+        var external = new[] { "/mnt/modules/Acme.Widgets/Acme.Widgets.dll" };
+
+        var entries = TesterModules.Entries(external);
+
+        // The image-shipped set comes first and is never dropped when externals are supplied —
+        // forgetting it is exactly how the bake would go back to resolving fewer types than the
+        // portal that consumes its bundles.
+        Assert.Equal(TesterModules.ImageShipped[0], entries[0]);
+        Assert.Contains(external[0], entries);
+        Assert.Equal(TesterModules.ImageShipped.Length + external.Length, entries.Count);
+
+        // An absolute path survives resolution untouched, so a mounted module can never be
+        // silently substituted by an image copy of the same name.
+        Assert.Contains(external[0], TesterModules.ResolvedPaths(external));
+    }
+
+    private static string TempDirectory(string prefix) =>
+        Path.Combine(Path.GetTempPath(), prefix + "-" + Guid.NewGuid().ToString("N"));
+
+    private static void Write(string root, string relative, string content)
+    {
+        var full = Path.Combine(root, relative.Replace('/', Path.DirectorySeparatorChar));
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content, new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
+
+    private static void Cleanup(string directory)
+    {
+        try { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+        catch { /* best effort — a locked temp dir must not fail the test */ }
+    }
+}

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -649,21 +649,21 @@ public static class PluginGateRunner
             // node repo's own CI built the bytes, mounts them, and names them here. Absolute paths
             // pass through ResolveModulePath untouched, so a mounted module is used exactly as
             // given — an image copy can never silently substitute for it.
+            // 🚨 The entry list is TesterModules' — shared with the bake, which compiles against
+            // exactly these. Both lanes reading one list is the fix for the two having disagreed
+            // (see TesterModules): a module added for the gate can no longer go missing from the
+            // bake's reference set, which is how five Store NodeTypes came to read as content
+            // errors while the gate's own compile-check stayed green.
             var moduleEntries = new Dictionary<string, string?>
             {
-                ["Modules:Assemblies:0"] = "MeshWeaver.AI.dll",
-                // The .dll suffix is the convention every host uses AND load-bearing: the
-                // resolver derives the folder with GetFileNameWithoutExtension, so a bare
-                // "MeshWeaver.AI" would probe modules/MeshWeaver/ and read as absent.
-                ["Modules:Required:0"] = "MeshWeaver.AI.dll",
                 ["Features:StaticRepoSync:Partitions:0"] = "Agent",
             };
-            var externalIndex = 1;
-            foreach (var module in externalModules ?? [])
+            var moduleIndex = 0;
+            foreach (var module in TesterModules.Entries(externalModules))
             {
-                moduleEntries[$"Modules:Assemblies:{externalIndex}"] = module;
-                moduleEntries[$"Modules:Required:{externalIndex}"] = module;
-                externalIndex++;
+                moduleEntries[$"Modules:Assemblies:{moduleIndex}"] = module;
+                moduleEntries[$"Modules:Required:{moduleIndex}"] = module;
+                moduleIndex++;
             }
             var gateModules = new ConfigurationBuilder()
                 .AddInMemoryCollection(moduleEntries)

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -79,6 +79,7 @@ static int RunCompile(string[] args)
     string? compileSourceSha = null;
     var compileAllow = GateAllowlist.Empty;
     var compileAllowApplied = false;
+    var compileModules = new List<string>();
     for (var i = 0; i < args.Length; i++)
     {
         switch (args[i])
@@ -119,13 +120,34 @@ static int RunCompile(string[] args)
                 compileAllowApplied = true;
                 break;
             }
-            case "--output" or "--source-sha" or "--allow":
+            // 🚨 THE SAME MODULE SET THE GATE LOADS — and for a stronger reason here. The gate
+            // needs a module to ACTIVATE its node types; the bake needs it to COMPILE against,
+            // because a module under modules/<name>/ is absent from TRUSTED_PLATFORM_ASSEMBLIES.
+            // Omit it and the bake resolves fewer types than the portal that consumes the bundles,
+            // then reports the shortfall as content errors (#2563). Repeatable, validated here for
+            // the same reason the gate validates it: a bake that quietly ran without a module it
+            // was told to load blames the CONTENT for a missing reference.
+            case "--module" when i + 1 < args.Length:
+            {
+                var compileModulePath = Path.GetFullPath(args[++i]);
+                if (!File.Exists(compileModulePath))
+                {
+                    Console.Error.WriteLine(
+                        $"compile: --module '{compileModulePath}' does not exist. Pass the module's "
+                        + "ENTRY assembly (…/<Name>/<Name>.dll) and make sure it is mounted into "
+                        + "the container.");
+                    return 2;
+                }
+                compileModules.Add(compileModulePath);
+                break;
+            }
+            case "--output" or "--source-sha" or "--allow" or "--module":
                 Console.Error.WriteLine($"Option '{args[i]}' requires a value.");
                 return 2;
             case "--help" or "-h":
                 Console.WriteLine(
                     "usage: mw-compiler compile <checkout-root> --output <dir> [--allow <file>] "
-                    + "[--source-sha <sha>]");
+                    + "[--source-sha <sha>] [--module <dll>]...");
                 return 0;
             default:
                 if (args[i].StartsWith('-') || compileRoot is not null)
@@ -153,6 +175,10 @@ static int RunCompile(string[] args)
         RepoRoot = compileRoot,
         OutputDirectory = outputDirectory,
         SourceSha = compileSourceSha,
+        // Resolved HERE, at the CLI boundary: TesterModules is the one list the gate reads too, and
+        // resolution names MeshBuilder — which MeshFreeBakePathTest forbids anywhere the bake can
+        // reach. The bake gets paths; it never meets a mesh type.
+        ModuleAssemblyPaths = TesterModules.ResolvedPaths(compileModules),
     });
     if (bake.FatalError is not null)
         Console.Error.WriteLine($"compile: FATAL — {bake.FatalError}");

--- a/tools/MeshWeaver.PluginTester/TesterModules.cs
+++ b/tools/MeshWeaver.PluginTester/TesterModules.cs
@@ -1,0 +1,55 @@
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// The ONE definition of "which modules does this tester run" — read by BOTH lanes: the gate
+/// (<see cref="PluginGateRunner"/>, which activates them so package node types register) and the
+/// bake (<see cref="TreeBake"/>, which compiles against them).
+///
+/// <para>🚨 It exists because the two lanes silently disagreed, and that disagreement reached
+/// production. The gate stands up a mesh, so it composed its installed modules into the compile
+/// reference set for free; the bake has no mesh and used the bare TPA baseline — and a module lives
+/// under <c>modules/&lt;name&gt;/</c>, which is by construction NOT in
+/// <c>TRUSTED_PLATFORM_ASSEMBLIES</c>. So the moment the AI engine became a module (#2276), the
+/// gate went on compiling <c>Store/Installer</c>'s <c>AiSettings</c> calls while the bake could no
+/// longer resolve the type at all: <b>compile-check green, publish-bake red, same content, same
+/// commit</b>. Five Store NodeTypes read as content errors, no bundle was sealed for the new
+/// framework identity, and every install correctly declined to self-update onto an image whose
+/// content had no bake — a fleet pinned by a reference list (#2563).</para>
+///
+/// <para>One list, two readers: a module added for one lane cannot go missing from the other.</para>
+/// </summary>
+internal static class TesterModules
+{
+    /// <summary>
+    /// Modules this IMAGE ships, laid beside the binary by the <c>MeshModuleClosure</c> lane in
+    /// <c>MeshWeaver.PluginTester.csproj</c>.
+    ///
+    /// <para>🚨 The <c>.dll</c> suffix is the convention every host uses AND load-bearing:
+    /// <see cref="MeshBuilder.ResolveModulePath(string)"/> derives the folder with
+    /// <c>GetFileNameWithoutExtension</c>, so a bare <c>"MeshWeaver.AI"</c> would probe
+    /// <c>modules/MeshWeaver/</c> and read as absent.</para>
+    /// </summary>
+    public static readonly string[] ImageShipped = ["MeshWeaver.AI.dll"];
+
+    /// <summary>
+    /// Every module entry this run activates: the image-shipped set, then the <c>--module</c>
+    /// externals in the order given. Entries are names (resolved beside the binary) or absolute
+    /// paths (used exactly as given, so a mounted module can never be silently substituted by an
+    /// image copy — <see cref="MeshBuilder.ResolveModulePath(string)"/> passes rooted paths through).
+    /// </summary>
+    public static IReadOnlyList<string> Entries(IReadOnlyList<string>? external) =>
+        external is null || external.Count == 0
+            ? ImageShipped
+            : [.. ImageShipped, .. external];
+
+    /// <summary>
+    /// <see cref="Entries"/> resolved to the assembly files on disk, for the lane that needs paths
+    /// rather than configuration keys (the bake). Resolution is
+    /// <see cref="MeshBuilder.ResolveModulePath(string)"/> — the same probe the mesh uses, so both
+    /// lanes bind the same bytes.
+    /// </summary>
+    public static IReadOnlyList<string> ResolvedPaths(IReadOnlyList<string>? external) =>
+        [.. Entries(external).Select(MeshBuilder.ResolveModulePath)];
+}

--- a/tools/MeshWeaver.PluginTester/TesterModules.cs
+++ b/tools/MeshWeaver.PluginTester/TesterModules.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using MeshWeaver.Mesh;
 
 namespace MeshWeaver.PluginTester;
@@ -31,7 +32,7 @@ internal static class TesterModules
     /// <c>GetFileNameWithoutExtension</c>, so a bare <c>"MeshWeaver.AI"</c> would probe
     /// <c>modules/MeshWeaver/</c> and read as absent.</para>
     /// </summary>
-    public static readonly string[] ImageShipped = ["MeshWeaver.AI.dll"];
+    public static readonly ImmutableArray<string> ImageShipped = ["MeshWeaver.AI.dll"];
 
     /// <summary>
     /// Every module entry this run activates: the image-shipped set, then the <c>--module</c>

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Reactive.Linq;
+using System.Reflection;
 using MeshWeaver.Compiler;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph.Configuration;
@@ -58,6 +59,22 @@ public static class TreeBake
         /// <summary>Factory for the leaf loggers the toolchain's own services want (the NuGet
         /// resolver). Null keeps them silent.</summary>
         public ILoggerFactory? LoggerFactory { get; init; }
+
+        /// <summary>
+        /// The module assemblies this bake compiles against, as RESOLVED file paths — build them
+        /// with <see cref="TesterModules.ResolvedPaths"/>, which is the one list the gate reads too.
+        ///
+        /// <para>A module lives under <c>modules/&lt;name&gt;/</c> and is therefore NOT in
+        /// <c>TRUSTED_PLATFORM_ASSEMBLIES</c>, so it reaches the compile only by being composed in
+        /// — see <see cref="InstalledModuleAssembly"/>, which names this as its first purpose.</para>
+        ///
+        /// <para>🚨 Already-resolved PATHS, not entry names, and deliberately so: resolving means
+        /// calling <c>MeshBuilder.ResolveModulePath</c>, and <c>MeshFreeBakePathTest</c> fails the
+        /// build if anything reachable from <see cref="Run"/> so much as NAMES a mesh type. That
+        /// guard is right — a bake is a build step and must not touch a mesh — so resolution
+        /// happens at the CLI boundary and the bake receives the answer.</para>
+        /// </summary>
+        public IReadOnlyList<string> ModuleAssemblyPaths { get; init; } = [];
     }
 
     /// <summary>One NodeType's outcome.</summary>
@@ -149,15 +166,31 @@ public static class TreeBake
             $"bake: {treeNodes.Length} node(s) from {packages.Count} package(s); "
             + $"framework={frameworkIdentity}");
 
+        // 🚨 The bake compiles against the SAME reference set a portal does — the TPA baseline PLUS
+        // this deployment's installed modules. No mesh here, but "no mesh" never meant "no modules":
+        // a module published into modules/<name>/ is by construction absent from
+        // TRUSTED_PLATFORM_ASSEMBLIES, so a bake using the bare Default set cannot see ONE module
+        // type, while a portal — which composes them — compiles the very same content fine.
+        //
+        // That asymmetry hides itself. The gate's compile-check stands up a mesh and therefore
+        // composes modules, so it goes GREEN; only publish-bake goes red, which reads as a bake
+        // infrastructure failure rather than as a missing reference. It shipped exactly that way
+        // when the AI engine left the content surface (#2276): Store/Installer's `AiSettings` calls
+        // stopped resolving HERE and nowhere else, five Store NodeTypes went RED, no bundle was
+        // sealed for the new framework identity, and every install then correctly declined to
+        // self-update onto an image whose content had no bake (#2563) — a fleet held back by a
+        // reference list, with nothing in the failure naming a reference.
+        var modules = LoadExternalModules(options);
         var idOf = CompiledDependencies.CreateIdResolver(
             FrameworkBuildIdentity.ProcessSurfacePairs,
-            // No mesh ⇒ no installed modules. A deployment that installs modules keys its own
-            // record on them; a type that binds one is DECLINED by the consumer's dependency check
-            // rather than silently adopted, which is the safe direction.
-            ImmutableDictionary<string, string>.Empty,
+            // Modules resolve FIRST and by exact-build MVID, so the record a consumer checks names
+            // the same build it will bind. Empty here (the old value) made a module-bound type
+            // fall through to the platform branch and record `ref:`/absent, which cannot match the
+            // `mvid:` a module-installing portal computes — the second half of #2563.
+            ModuleMvidsOf(modules),
             FrameworkBuildIdentity.ProcessImplMvidOf);
         var toolchainId = CompiledDependencies.ComputeToolchainId(FrameworkBuildIdentity.ProcessImplMvidOf);
-        var references = CompileReferences.Default;
+        var references = CompileReferences.ComposeWithModules(modules);
 
         // 🚨 The NuGet resolver is WIRED, not omitted. `#r "nuget:…"` is a compile input like any
         // other — samples/Graph/Data/MathDemo/Matrix declares `#r "nuget:MathNet.Numerics, 5.0.0"` —
@@ -190,6 +223,59 @@ public static class TreeBake
                 // A leftover temp directory costs disk, never correctness.
             }
         }
+    }
+
+    /// <summary>
+    /// Loads the module entry assemblies the same way a mesh installs them —
+    /// <see cref="Assembly.LoadFrom(string)"/>, so they land in the Default ALC, file-backed, and
+    /// expose a <c>Location</c> the compiler can turn into a Roslyn <c>MetadataReference</c>.
+    ///
+    /// <para>🚨 A module that will not load is FATAL, never skipped. Skipping would produce the
+    /// precise failure this whole change exists to remove: a bake that silently compiled without a
+    /// module's types, reported the resulting misses as CONTENT errors, and named nothing about a
+    /// reference. Loud here, once, beats five red NodeTypes and a fleet that will not roll.</para>
+    /// </summary>
+    private static IReadOnlyList<InstalledModuleAssembly> LoadExternalModules(Options options)
+    {
+        var paths = options.ModuleAssemblyPaths;
+        if (paths.Count == 0)
+            return [];
+        var loaded = new List<InstalledModuleAssembly>(paths.Count);
+        foreach (var path in paths)
+        {
+            Assembly assembly;
+            try
+            {
+                assembly = Assembly.LoadFrom(Path.GetFullPath(path));
+            }
+            catch (Exception ex) when (ex is IOException or BadImageFormatException)
+            {
+                throw new InvalidOperationException(
+                    $"bake: --module '{path}' could not be loaded — {ex.Message}. Pass the module's "
+                    + "ENTRY assembly (…/<Name>/<Name>.dll), built for this framework.", ex);
+            }
+            loaded.Add(new InstalledModuleAssembly(assembly));
+            options.Output.WriteLine(
+                $"bake: module {assembly.GetName().Name} "
+                + $"mvid={assembly.ManifestModule.ModuleVersionId:N} — composed into the reference set");
+        }
+        return loaded;
+    }
+
+    /// <summary>Installed module simple name → implementation MVID ("N"). Deliberately the same
+    /// projection the mesh makes (<c>NodeTypeCompilationHelpers.ModuleMvidsOf</c>): producer and
+    /// consumer have to compute one id for one build, or every bundle is declined.</summary>
+    private static IReadOnlyDictionary<string, string> ModuleMvidsOf(
+        IReadOnlyList<InstalledModuleAssembly> modules)
+    {
+        var map = new Dictionary<string, string>(StringComparer.Ordinal);
+        foreach (var module in modules)
+        {
+            var name = module.Assembly.GetName().Name;
+            if (!string.IsNullOrEmpty(name))
+                map[name] = module.Mvid.ToString("N");
+        }
+        return map;
     }
 
     private static Report BakeAll(

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -250,9 +250,18 @@ public static class TreeBake
             }
             catch (Exception ex) when (ex is IOException or BadImageFormatException)
             {
+                // 🚨 Name BOTH provenances, because this list carries both and they have opposite
+                // fixes: an image-shipped module missing is a broken image build, while a mounted
+                // one missing is a bad path. Blaming `--module` for the first would be this PR's
+                // own bug in miniature — an error naming the wrong cause. Mirrors the gate's
+                // message (PluginGateRunner) so the two lanes explain a missing module alike.
                 throw new InvalidOperationException(
-                    $"bake: --module '{path}' could not be loaded — {ex.Message}. Pass the module's "
-                    + "ENTRY assembly (…/<Name>/<Name>.dll), built for this framework.", ex);
+                    $"bake: module '{path}' could not be loaded — {ex.Message}. Modules this image "
+                    + "ships come from the MeshModulesPublish closure lane in "
+                    + "MeshWeaver.PluginTester.csproj; modules passed with --module must exist at "
+                    + "the absolute path given (mount them into the container). A bake whose "
+                    + "modules are missing would resolve fewer types than the portal that consumes "
+                    + "its bundles.", ex);
             }
             loaded.Add(new InstalledModuleAssembly(assembly));
             options.Output.WriteLine(


### PR DESCRIPTION
## The fleet was held back by a reference list

`memex-cloud` has been sitting three published images behind on `ci.6145`, and every component
reported success. The self-updater was working perfectly — it was **correctly declining** an image
whose content had no bake.

Here is why there was no bake.

A module is published into `modules/<name>/`, so it is by construction **absent from
`TRUSTED_PLATFORM_ASSEMBLIES`**. It reaches a compile only by being composed in
(`CompileReferences.ComposeWithModules`). The portal does that from its installed-module set. The
bake used the bare TPA baseline and could not resolve a single module type.

So when the AI engine left the content surface to become a module (#2276), five `Store/*` NodeTypes
stopped resolving `AiSettings` **in the bake and nowhere else**.

## Why nobody saw it

The two lanes of the *same tool* disagreed, silently:

| lane | mesh? | modules composed | verdict |
|---|---|---|---|
| `compile-check` (gate) | yes | yes, for free | 🟢 green |
| `publish-bake` | no | **no** | 🔴 red |

Same content, same image, same commit. A reader sees a green compile gate beside a red bake and
concludes the *bake* is broken — not that a reference is missing. And nothing in the failure names a
module; it arrives as `CS0246: The type or namespace name 'AiSettings' could not be found`, which
reads as a content defect.

## The fix

The module set now lives in **one place both lanes read** (`TesterModules`). That is the actual
fix — a module added for the gate can no longer go missing from the bake's reference set.

The bake also records module ids by **exact-build MVID** instead of leaving the map empty, so the
dependency record a consumer checks names the build it will bind. That is the second half of #2563,
where a bundle's `ref:` entry could never match a module-installing portal's `mvid:`.

Resolution happens at the **CLI boundary** deliberately: resolving names `MeshBuilder`, and
`MeshFreeBakePathTest` fails the build if anything reachable from `TreeBake.Run` so much as *names*
a mesh type. That guard is right — a bake is a build step, not a mesh — so the bake receives
resolved paths and never meets a mesh type. **The guard caught this during development**, which is
why the shape changed.

No workflow changes: no caller passes `--module` today, and the image-shipped set is resolved
beside the binary exactly as the gate resolves it.

## Verification

- **End to end on the real content that failed.** The actual `MeshWeaver.Plugins` tree —
  the one CI could not compile — bakes **75/75 NodeTypes into 33 bundles, exit 0**, logging
  `bake: module MeshWeaver.AI mvid=… — composed into the reference set`.
- **The causal chain is closed, not inferred.** `MeshWeaver.AI.dll` appears in **zero** `deps.json`
  entries and exists only at `modules/MeshWeaver.AI/`, so `CompileReferences.Default` could never
  have contained it.
- **The new test has a control.** It bakes the same tree with no modules and *requires* it to fail
  on the missing type — so the test cannot pass against the behaviour it pins.
- Full `MeshWeaver.PluginTester.Test` suite: **96/96 pass**. `MeshFreeBakePathTest` still green.
- Release + `-warnaserror` clean.

The framework identity is unchanged — no `ProjectReference` was added or removed, so this does not
flip the identity again.

## What this unblocks

Once this is in an image, the satellites' scheduled runs (which follow the released image) bake
against the current identity, bundles get sealed, and installs resume updating on their own.

`MeshWeaver.Plugins` has a **second, unrelated** blocker in its `test-repos` gate —
`ProvisionPlan 'Analysis' FAILED in phase 2/7 'Create home root': timed out`. That one compiles
fine (`compile=Ok`) and is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
