### PR TITLE
A prebuilt mount that backs NOTHING now says why, at Information

### DIFF
--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -241,14 +241,15 @@ public static class ShippedPrebuiltBundles
     /// and destroy the signal. <see cref="Covered"/> is therefore what callers see, and the log
     /// names both halves.</para>
     /// </summary>
-    private readonly record struct SeedTally(int Adopted, int AlreadyCurrent)
+    private readonly record struct SeedTally(int Adopted, int AlreadyCurrent, int FilteredOut = 0)
     {
         /// <summary>Assemblies this bundle has BACKED on the store — adopted now or already there.
         /// This is the coverage number; it is unchanged by the skip optimisation.</summary>
         public int Covered => Adopted + AlreadyCurrent;
 
         public static SeedTally operator +(SeedTally left, SeedTally right) =>
-            new(left.Adopted + right.Adopted, left.AlreadyCurrent + right.AlreadyCurrent);
+            new(left.Adopted + right.Adopted, left.AlreadyCurrent + right.AlreadyCurrent,
+                left.FilteredOut + right.FilteredOut);
     }
 
     /// <summary>
@@ -373,18 +374,19 @@ public static class ShippedPrebuiltBundles
                                         // is precisely what the "Loud, so an operator can see WHY an image that
                                         // ships bundles still compiled" comment below is meant to prevent.
                                         // ONE aggregate line, only in the pathological case — never per bundle.
-                                        if (tally.Covered == 0)
+                                        if (tally.Covered == 0 && tally.FilteredOut > 0)
                                             logger?.LogInformation(
-                                                "ShippedPrebuiltBundles: NONE of the {Bundles} bundle(s) under "
-                                                + "{Directory} backed an assembly, and none was declined for "
-                                                + "framework identity — so every one named only NodeTypes this "
+                                                "ShippedPrebuiltBundles: nothing was backed, and {Filtered} of "
+                                                + "{Bundles} bundle(s) under {Directory} named only NodeTypes this "
                                                 + "mesh does not hold. This mesh's NodeType snapshot carries "
                                                 + "{Types} path(s). A snapshot of 0 means the content is not "
                                                 + "imported YET, which is normal for a mesh that installs after "
                                                 + "boot: adoption then depends entirely on the install-time "
                                                 + "re-seed (IPrebuiltAssemblyConsumer.SeedForTypes), not on this "
-                                                + "pass. The sweep compiles whatever stays uncovered",
-                                                bundles.Count, dir, existing.Paths.Count);
+                                                + "pass. Any bundle NOT counted here exited for a reason already "
+                                                + "logged above (identity decline, hollow bundle, fault). The "
+                                                + "sweep compiles whatever stays uncovered",
+                                                tally.FilteredOut, bundles.Count, dir, existing.Paths.Count);
                                     }))
                                 .Select(tally => tally.Covered);
                         }))
@@ -465,7 +467,13 @@ public static class ShippedPrebuiltBundles
                         + "serves a subset)",
                         Path.GetFileName(bundlePath), assemblies.Count - present.Count);
                 if (present.Count == 0)
-                    return Observable.Return(default(SeedTally));
+                    // 🚨 COUNTED, not just skipped. Every other zero-coverage exit here — an
+                    // identity decline, a hollow bundle, a fault — already says so at Information
+                    // or louder. This one is the silent one, so it is the only one the aggregate
+                    // line below may attribute a zero to; a bare `default` would make "0 covered"
+                    // indistinguishable from "0 covered because everything was DECLINED", and the
+                    // line would then assert the opposite of what happened.
+                    return Observable.Return(new SeedTally(0, 0, FilteredOut: 1));
 
                 // Sequential (Concat, never Merge) for the same reason NodeTypeBakeStatus.Probe is:
                 // the store is typically a shared network volume or blob container, and a fan-out

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -352,15 +352,40 @@ public static class ShippedPrebuiltBundles
                                     .Select(bundle => SeedBundle(
                                         mesh, pool, store, bundle, existing, logger))
                                     .Concat()
-                                    .Aggregate(default(SeedTally), (total, one) => total + one))
-                                .Do(tally => logger?.LogInformation(
-                                    "ShippedPrebuiltBundles: {Covered} prebuilt assembly(ies) from "
-                                    + "{Bundles} shipped bundle(s) under {Directory} are backed by "
-                                    + "the assembly store — {Adopted} adopted now, {Current} already "
-                                    + "current and skipped WITHOUT activating their NodeType hubs — "
-                                    + "in {Elapsed}",
-                                    tally.Covered, bundles.Count, dir, tally.Adopted,
-                                    tally.AlreadyCurrent, DateTimeOffset.UtcNow - startedAt))
+                                    .Aggregate(default(SeedTally), (total, one) => total + one)
+                                    .Do(tally =>
+                                    {
+                                        logger?.LogInformation(
+                                            "ShippedPrebuiltBundles: {Covered} prebuilt assembly(ies) from "
+                                            + "{Bundles} shipped bundle(s) under {Directory} are backed by "
+                                            + "the assembly store — {Adopted} adopted now, {Current} already "
+                                            + "current and skipped WITHOUT activating their NodeType hubs — "
+                                            + "in {Elapsed}",
+                                            tally.Covered, bundles.Count, dir, tally.Adopted,
+                                            tally.AlreadyCurrent, DateTimeOffset.UtcNow - startedAt);
+                                        // 🚨 A mount that backed NOTHING needs its reason at the SAME level as
+                                        // the summary, or the summary is unactionable. "0 of N, 0 declined" has
+                                        // exactly one cause left once identity is ruled out: every bundle named
+                                        // only NodeTypes absent from this mesh, and the per-bundle line saying so
+                                        // is LogDebug — invisible wherever this actually matters (CI and prod both
+                                        // run at Information). Diagnosing one 0-of-37 boot on the Education gate
+                                        // cost a source read of this file to learn the filter even existed, which
+                                        // is precisely what the "Loud, so an operator can see WHY an image that
+                                        // ships bundles still compiled" comment below is meant to prevent.
+                                        // ONE aggregate line, only in the pathological case — never per bundle.
+                                        if (tally.Covered == 0)
+                                            logger?.LogInformation(
+                                                "ShippedPrebuiltBundles: NONE of the {Bundles} bundle(s) under "
+                                                + "{Directory} backed an assembly, and none was declined for "
+                                                + "framework identity — so every one named only NodeTypes this "
+                                                + "mesh does not hold. This mesh's NodeType snapshot carries "
+                                                + "{Types} path(s). A snapshot of 0 means the content is not "
+                                                + "imported YET, which is normal for a mesh that installs after "
+                                                + "boot: adoption then depends entirely on the install-time "
+                                                + "re-seed (IPrebuiltAssemblyConsumer.SeedForTypes), not on this "
+                                                + "pass. The sweep compiles whatever stays uncovered",
+                                                bundles.Count, dir, existing.Paths.Count);
+                                    }))
                                 .Select(tally => tally.Covered);
                         }))
                 // The seeding is an optimisation in front of the sweep — a fault here must degrade

--- a/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
@@ -690,7 +690,8 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
             adopted.Should().Be(0, "this mesh holds no NodeType at that path");
 
             log.Information.Should().Contain(
-                line => line.Contains("NONE of the") && line.Contains("backed an assembly"),
+                line => line.Contains("nothing was backed")
+                        && line.Contains("named only NodeTypes this mesh does not hold"),
                 "0-of-N with 0 declines has exactly one remaining cause once identity is ruled "
                 + "out, and an operator must be able to read it without opening the source");
             log.Information.Should().Contain(

--- a/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
@@ -1,6 +1,8 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
@@ -15,6 +17,7 @@ using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using MeshWeaver.Plugin.Packaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace MeshWeaver.PluginCatalog.Test;
@@ -650,6 +653,76 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
             .FirstAsync()
             .Timeout(TimeSpan.FromSeconds(30))
             .ToTask();
+    }
+
+    /// <summary>
+    /// A mount that backs NOTHING must name its reason at INFORMATION. The per-bundle
+    /// "names {n} NodeType(s) this mesh does not hold" line is <c>LogDebug</c>, and CI and prod
+    /// both run at Information — so the summary reads "0 prebuilt assembly(ies) from N shipped
+    /// bundle(s) … 0 adopted, 0 already current", with zero declines, and nothing anywhere says
+    /// why. Diagnosing exactly that on the Education gate (37 bundles, 0 covered, 0 declined, 16 ms)
+    /// required reading this file to discover the NodeType filter existed at all, which is what the
+    /// seeder's own "Loud, so an operator can see WHY an image that ships bundles still compiled"
+    /// intent is supposed to prevent.
+    ///
+    /// <para>The fixture is the real-world shape: a bundle whose framework identity MATCHES (so it
+    /// is never declined) naming a NodeType this mesh does not hold — i.e. a mesh that installs its
+    /// content after boot.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ABundleNamingOnlyAbsentTypes_SaysWhyAtInformation_NotJustZero()
+    {
+        // Deliberately NOT calling CreateNodeType: the absence IS the fixture.
+        var typePath = $"{TestPartition}/NeverImported";
+        var dir = CreateBundleDirectory();
+        var log = new CapturingLogger();
+        try
+        {
+            WriteBundle(
+                Path.Combine(dir, "absent.zip"),
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream([1, 2, 3])));
+
+            var adopted = await ShippedPrebuiltBundles.SeedAll(Mesh, dir, log)
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+
+            adopted.Should().Be(0, "this mesh holds no NodeType at that path");
+
+            log.Information.Should().Contain(
+                line => line.Contains("NONE of the") && line.Contains("backed an assembly"),
+                "0-of-N with 0 declines has exactly one remaining cause once identity is ruled "
+                + "out, and an operator must be able to read it without opening the source");
+            log.Information.Should().Contain(
+                line => line.Contains("NodeType snapshot carries"),
+                "the snapshot size is what separates 'content not imported yet' (0) from "
+                + "'bundles for a content set this mesh does not serve' (>0)");
+        }
+        finally
+        {
+            TryDelete(dir);
+        }
+    }
+
+    /// <summary>Test-local <see cref="ILogger"/> that keeps what was written, per level. Not a mock
+    /// of a framework interface — the seeder takes an <c>ILogger?</c> and this is a real one.</summary>
+    private sealed class CapturingLogger : ILogger
+    {
+        private readonly ConcurrentQueue<string> information = new();
+
+        public IEnumerable<string> Information => information;
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            if (logLevel == LogLevel.Information)
+                information.Enqueue(formatter(state, exception));
+        }
     }
 
     private static string CreateBundleDirectory()


### PR DESCRIPTION
## The gap

`ShippedPrebuiltBundles` reports its outcome at **Information**:

> `ShippedPrebuiltBundles: {Covered} prebuilt assembly(ies) from {Bundles} shipped bundle(s) under {Directory} are backed by the assembly store — {Adopted} adopted now, {Current} already current…`

…but the one line that explains a **zero** — the per-bundle *"bundle {Bundle} names {Absent} NodeType(s) this mesh does not hold — skipped"* — is `LogDebug`. CI and production both run at Information. So what an operator actually sees is:

```
ShippedPrebuiltBundles: 0 prebuilt assembly(ies) from 37 shipped bundle(s) under /bundles
  are backed by the assembly store — 0 adopted now, 0 already current … in 00:00:00.0162182
DECLINED (framework identity mismatch): 0
```

Thirty-seven bundles, nothing adopted, nothing declined, sixteen milliseconds, **and no reason anywhere**.

This is a real diagnosis, not a hypothetical: that is verbatim from the Education bake gate (Systemorph/MeshWeaver.Education#211), and working out why took reading `ShippedPrebuiltBundles.cs` to discover the NodeType filter existed at all. The seeder's own comment states the intent this defeats — *"Loud, so an operator can see WHY an image that ships bundles still compiled."*

## The change

Framework-identity declines are **already** reported at Information. Once they are ruled out, `0-of-N` has exactly one remaining cause: every bundle named only NodeTypes this mesh does not hold. So emit **one aggregate line** in that case, carrying the NodeType snapshot size — the number that separates the two situations an operator must tell apart:

| snapshot | meaning |
|---|---|
| `0` | content not imported **yet** — normal for a mesh that installs after boot; adoption then rests entirely on the install-time re-seed (`IPrebuiltAssemblyConsumer.SeedForTypes`), not on this pass |
| `> 0` | the bundles are for a content set this mesh does not serve |

**Cost/value, stated deliberately** (AGENTS.md forbids tweaking levels for a debugging session — this is a permanent fix with a real trade-off): one extra line, **only** when coverage is zero, **never** per bundle. A healthy boot logs exactly what it logs today.

## Verification

- **Red-proof.** `ABundleNamingOnlyAbsentTypes_SaysWhyAtInformation_NotJustZero` fails on the pre-change source — `Expected collection to contain an item matching the predicate` — and passes after. Verified by reverting the source hunk, rebuilding, re-running, then restoring.
- **No regression.** All **10** tests in `ShippedPrebuiltBundlesTest` pass (the change restructures the observable chain so the summary can see the snapshot, so the whole class was run, not just the new test).
- `dotnet build src/MeshWeaver.Hosting -c Release -warnaserror` → `0 Warning(s), 0 Error(s)`.

The fixture is the real-world shape: a bundle whose framework identity **matches** (so it is never declined) naming a NodeType the mesh does not hold.

## What's New

Skipped — no user-visible effect. This changes a server-side log line only; the audience is an operator reading portal logs, not a portal user.
