### PR TITLE
CI: bounded retry on the ACR login, so a TCP reset stops reddening required checks

### DIFF
--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -92,7 +92,14 @@ jobs:
           # 🚨 Bounded retry, and deliberately NOT a skip-trapdoor: after the last attempt this
           # still fails RED, and a CREDENTIAL rejection fails IMMEDIATELY rather than being retried
           # three times — retrying a 401 only delays the same red while hiding which kind of
-          # failure it was. Only connection-level errors are retried.
+          # failure it was.
+          #
+          # Everything else IS retried, including failures this does not recognise. That is the
+          # intended default rather than an oversight: an unclassified docker login failure is far
+          # more often transient (daemon not ready, DNS, TLS reset) than permanent, and the one
+          # class known to be permanent — bad credentials — is carved out above. A positive
+          # allow-list of "connection-level" strings would fail fast on the next transient error
+          # nobody predicted, which is the failure mode this exists to remove.
           #
           # Three ACR logins failed on 2026-08-28 in two separate incidents an hour apart
           # ("dial tcp 51.12.25.80:443: connect: connection refused", registry healthy throughout),

--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -88,9 +88,34 @@ jobs:
       - name: Log in to the image registry
         env:
           TEST_IMAGE: ${{ inputs.test-image }}
-        run: >
-          echo "${{ secrets.acr-password }}" |
-          docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" --password-stdin
+        run: |
+          # 🚨 Bounded retry, and deliberately NOT a skip-trapdoor: after the last attempt this
+          # still fails RED, and a CREDENTIAL rejection fails IMMEDIATELY rather than being retried
+          # three times — retrying a 401 only delays the same red while hiding which kind of
+          # failure it was. Only connection-level errors are retried.
+          #
+          # Three ACR logins failed on 2026-08-28 in two separate incidents an hour apart
+          # ("dial tcp 51.12.25.80:443: connect: connection refused", registry healthy throughout),
+          # reddening three REQUIRED checks across two repos. On a strict:true repo the cost is not
+          # one re-run: the re-run lands against a moved main, the branch goes BEHIND, and it needs
+          # another sync and another full run — so one TCP reset re-stales every open PR (#2570).
+          for attempt in 1 2 3; do
+            if echo "${{ secrets.acr-password }}" \
+                 | docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" \
+                     --password-stdin 2>login.err; then
+              rm -f login.err
+              exit 0
+            fi
+            cat login.err
+            if grep -qiE 'unauthorized|authentication required|denied|401' login.err; then
+              echo "::error::ACR rejected the credentials for ${TEST_IMAGE%%/*} — that is not a"\
+                   "transient failure, so it is not retried. Check the acr-username/acr-password secrets."
+              exit 1
+            fi
+            if [ "$attempt" -lt 3 ]; then sleep $((attempt * 5)); fi
+          done
+          echo "::error::docker login to ${TEST_IMAGE%%/*} failed after 3 connection-level attempts."
+          exit 1
       - name: Take the framework assemblies from the platform image
         env:
           TEST_IMAGE: ${{ inputs.test-image }}

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -214,7 +214,14 @@ jobs:
           # 🚨 Bounded retry, and deliberately NOT a skip-trapdoor: after the last attempt this
           # still fails RED, and a CREDENTIAL rejection fails IMMEDIATELY rather than being retried
           # three times — retrying a 401 only delays the same red while hiding which kind of
-          # failure it was. Only connection-level errors are retried.
+          # failure it was.
+          #
+          # Everything else IS retried, including failures this does not recognise. That is the
+          # intended default rather than an oversight: an unclassified docker login failure is far
+          # more often transient (daemon not ready, DNS, TLS reset) than permanent, and the one
+          # class known to be permanent — bad credentials — is carved out above. A positive
+          # allow-list of "connection-level" strings would fail fast on the next transient error
+          # nobody predicted, which is the failure mode this exists to remove.
           #
           # Three ACR logins failed on 2026-08-28 in two separate incidents an hour apart
           # ("dial tcp 51.12.25.80:443: connect: connection refused", registry healthy throughout),

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -210,9 +210,34 @@ jobs:
       - name: Log in to the image registry
         env:
           TEST_IMAGE: ${{ inputs.test-image }}
-        run: >
-          echo "${{ secrets.acr-password }}" |
-          docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" --password-stdin
+        run: |
+          # 🚨 Bounded retry, and deliberately NOT a skip-trapdoor: after the last attempt this
+          # still fails RED, and a CREDENTIAL rejection fails IMMEDIATELY rather than being retried
+          # three times — retrying a 401 only delays the same red while hiding which kind of
+          # failure it was. Only connection-level errors are retried.
+          #
+          # Three ACR logins failed on 2026-08-28 in two separate incidents an hour apart
+          # ("dial tcp 51.12.25.80:443: connect: connection refused", registry healthy throughout),
+          # reddening three REQUIRED checks across two repos. On a strict:true repo the cost is not
+          # one re-run: the re-run lands against a moved main, the branch goes BEHIND, and it needs
+          # another sync and another full run — so one TCP reset re-stales every open PR (#2570).
+          for attempt in 1 2 3; do
+            if echo "${{ secrets.acr-password }}" \
+                 | docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" \
+                     --password-stdin 2>login.err; then
+              rm -f login.err
+              exit 0
+            fi
+            cat login.err
+            if grep -qiE 'unauthorized|authentication required|denied|401' login.err; then
+              echo "::error::ACR rejected the credentials for ${TEST_IMAGE%%/*} — that is not a"\
+                   "transient failure, so it is not retried. Check the acr-username/acr-password secrets."
+              exit 1
+            fi
+            if [ "$attempt" -lt 3 ]; then sleep $((attempt * 5)); fi
+          done
+          echo "::error::docker login to ${TEST_IMAGE%%/*} failed after 3 connection-level attempts."
+          exit 1
       # Cross-repo `requires` must resolve for the package roots to bind — the tester installs
       # whatever the mount holds, so the required modules are STAGED into it, exactly like
       # production resolves the requires from the store's package sources.

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -377,7 +377,14 @@ jobs:
           # 🚨 Bounded retry, and deliberately NOT a skip-trapdoor: after the last attempt this
           # still fails RED, and a CREDENTIAL rejection fails IMMEDIATELY rather than being retried
           # three times — retrying a 401 only delays the same red while hiding which kind of
-          # failure it was. Only connection-level errors are retried.
+          # failure it was.
+          #
+          # Everything else IS retried, including failures this does not recognise. That is the
+          # intended default rather than an oversight: an unclassified docker login failure is far
+          # more often transient (daemon not ready, DNS, TLS reset) than permanent, and the one
+          # class known to be permanent — bad credentials — is carved out above. A positive
+          # allow-list of "connection-level" strings would fail fast on the next transient error
+          # nobody predicted, which is the failure mode this exists to remove.
           #
           # Three ACR logins failed on 2026-08-28 in two separate incidents an hour apart
           # ("dial tcp 51.12.25.80:443: connect: connection refused", registry healthy throughout),

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -373,9 +373,34 @@ jobs:
       - name: Log in to the image registry
         env:
           TEST_IMAGE: ${{ inputs.test-image }}
-        run: >
-          echo "${{ secrets.acr-password }}" |
-          docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" --password-stdin
+        run: |
+          # 🚨 Bounded retry, and deliberately NOT a skip-trapdoor: after the last attempt this
+          # still fails RED, and a CREDENTIAL rejection fails IMMEDIATELY rather than being retried
+          # three times — retrying a 401 only delays the same red while hiding which kind of
+          # failure it was. Only connection-level errors are retried.
+          #
+          # Three ACR logins failed on 2026-08-28 in two separate incidents an hour apart
+          # ("dial tcp 51.12.25.80:443: connect: connection refused", registry healthy throughout),
+          # reddening three REQUIRED checks across two repos. On a strict:true repo the cost is not
+          # one re-run: the re-run lands against a moved main, the branch goes BEHIND, and it needs
+          # another sync and another full run — so one TCP reset re-stales every open PR (#2570).
+          for attempt in 1 2 3; do
+            if echo "${{ secrets.acr-password }}" \
+                 | docker login "${TEST_IMAGE%%/*}" -u "${{ secrets.acr-username }}" \
+                     --password-stdin 2>login.err; then
+              rm -f login.err
+              exit 0
+            fi
+            cat login.err
+            if grep -qiE 'unauthorized|authentication required|denied|401' login.err; then
+              echo "::error::ACR rejected the credentials for ${TEST_IMAGE%%/*} — that is not a"\
+                   "transient failure, so it is not retried. Check the acr-username/acr-password secrets."
+              exit 1
+            fi
+            if [ "$attempt" -lt 3 ]; then sleep $((attempt * 5)); fi
+          done
+          echo "::error::docker login to ${TEST_IMAGE%%/*} failed after 3 connection-level attempts."
+          exit 1
       # ───────────────────── THE UPSTREAM GATE (#1755) ─────────────────────
       # A repo's build must not start until every upstream it depends on has a published artifact
       # for the TARGET framework. Otherwise it compiles and gates against an upstream that no


### PR DESCRIPTION
Closes #2570.

## The incidents

Three **required** checks failed today at the same step, `Log in to the image registry`, in two separate incidents an hour apart:

| when | repo / PR | check |
|---|---|---|
| 06:01Z | SocialMedia #94 | `Compile + render node repos (MeshWeaver from ACR)` |
| ~07:00Z | Plugins #788 | `Compile + render node repos (MeshWeaver from ACR)` |
| ~07:00Z | Plugins #789 | `Compile every NodeType (vs core)` |

```
Error response from daemon: Get "https://meshweaver.azurecr.io/v2/":
  dial tcp 51.12.25.80:443: connect: connection refused
```

**The registry was healthy throughout** — `az acr check-health -n meshweaver` passes every probe and `/v2/` returns the expected `401`. The login was simply a single unretried network call sitting in a required gate.

## Why this is worth fixing rather than re-running

On a `strict: true` repo the cost is not one re-run. The re-run lands against a `main` that has moved, the branch goes `BEHIND`, and it needs another sync **and another full run**. Measured on #788/#789 today: three full runs each, neither landed. With several PRs open, one TCP reset re-stales all of them.

## The change

Three attempts with 5s/10s backoff, applied to the three **reusable** workflows — so this covers Education, Reinsurance, SocialMedia and Manufacturing, which call them, rather than patching each repo.

**Two properties keep it a gate rather than a trapdoor** (AGENTS.md → "A gate NEVER tests its own inputs"):

1. It still **fails RED** after the last attempt — no `continue-on-error`, no success-on-exhaustion.
2. A **credential rejection** (`unauthorized` / `authentication required` / `denied` / `401`) fails **immediately** and says so. Retrying a 401 three times only delays the same red while hiding which kind of failure it was, and an unprovisioned secret must stay instantly diagnosable.

## Verification

The logic is shell, so I exercised it against a stub `docker` for all three paths before pushing:

```
success on attempt 1                    → exit 0
"unauthorized: authentication required" → exit 1, NOT retried
"connect: connection refused"           → retries, then fails red after 3
```

All three YAML files parse.

## Not in scope

MeshWeaver.Plugins' own workflows have the identical shape at six more sites (`ci.yml` ×4, `portal-ai-image.yml`, `portal-next-image.yml`) — and those are the ones that actually failed on #788/#789. Separate repo, separate PR; this one covers the satellites via the shared workflows.

## What's New

Skipped — CI-only change, no user-visible effect.
