### PR TITLE
GitHub webhook: cap the body BEFORE the HMAC can be checked

### DIFF
--- a/memex/Memex.Portal.Shared/Api/BoundedBody.cs
+++ b/memex/Memex.Portal.Shared/Api/BoundedBody.cs
@@ -19,6 +19,29 @@ public static class BoundedBody
     /// </summary>
     public static async Task<string?> ReadAsync(Stream body, long maxBytes, CancellationToken ct)
     {
+        var buffer = await ReadBufferAsync(body, maxBytes, ct);
+        return buffer is null ? null : Encoding.UTF8.GetString(buffer.GetBuffer(), 0, (int)buffer.Length);
+    }
+
+    /// <summary>
+    /// The body as RAW BYTES, or <c>null</c> if it exceeds <paramref name="maxBytes"/>. Same reader,
+    /// same cap.
+    ///
+    /// <para>🚨 Byte-exact, and that is the point: a signature is computed over the bytes GitHub
+    /// sent. Reading through <see cref="ReadAsync"/> and re-encoding the string would round-trip
+    /// through UTF-8, and any byte sequence that is not valid UTF-8 comes back as U+FFFD — a body
+    /// that verifies at the sender would fail here, and worse, one crafted around the substitution
+    /// could differ from what was verified. Signature verification must never see a decoded copy.</para>
+    /// </summary>
+    public static async Task<byte[]?> ReadBytesAsync(Stream body, long maxBytes, CancellationToken ct)
+    {
+        var buffer = await ReadBufferAsync(body, maxBytes, ct);
+        return buffer?.ToArray();
+    }
+
+    /// <summary>The one reader both public forms share, so the cap semantics cannot drift apart.</summary>
+    private static async Task<MemoryStream?> ReadBufferAsync(Stream body, long maxBytes, CancellationToken ct)
+    {
         var buffer = new MemoryStream();
         var chunk = new byte[16 * 1024];
         while (true)
@@ -34,6 +57,6 @@ public static class BoundedBody
             if (buffer.Length + read > maxBytes) return null;
             buffer.Write(chunk, 0, read);
         }
-        return Encoding.UTF8.GetString(buffer.GetBuffer(), 0, (int)buffer.Length);
+        return buffer;
     }
 }

--- a/memex/Memex.Portal.Shared/Social/GitHubWebhookEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubWebhookEndpoints.cs
@@ -4,6 +4,7 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Memex.Portal.Shared.Api;
 using MeshWeaver.GitSync;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -30,6 +31,13 @@ namespace Memex.Portal.Shared.Social;
 /// </summary>
 public static class GitHubWebhookEndpoints
 {
+    /// <summary>
+    /// Hard ceiling on the request body this anonymous endpoint will buffer before the HMAC can be
+    /// checked. 25 MiB is GitHub's own documented maximum payload, so it can never refuse a genuine
+    /// delivery — it only bounds what a forged one costs.
+    /// </summary>
+    public const long MaxWebhookBodyBytes = 25L * 1024 * 1024;
+
     private const string WebhookPath = "/webhooks/github";
 
     public static IEndpointRouteBuilder MapGitHubWebhook(this IEndpointRouteBuilder endpoints)
@@ -49,12 +57,24 @@ public static class GitHubWebhookEndpoints
                 return Results.StatusCode(503);
             }
 
-            // Read the raw body (needed byte-exact for the HMAC).
-            byte[] body;
-            using (var ms = new MemoryStream())
+            // Read the raw body (needed byte-exact for the HMAC) — UNDER A CAP.
+            //
+            // 🚨 This endpoint is anonymous: the HMAC below is the ONLY thing authenticating it, and
+            // it cannot run until the body is in memory. A plain CopyToAsync therefore let an
+            // unauthenticated caller make the server buffer an arbitrarily large request before a
+            // single byte was checked, and a chunked request carries no Content-Length to reject it
+            // on (#2302). The cap bounds that to one GitHub-sized delivery per request.
+            //
+            // 25 MiB is GitHub's own documented maximum payload, so this can never refuse a genuine
+            // delivery — it is strictly a ceiling on what a forged one can cost.
+            var body = await BoundedBody.ReadBytesAsync(
+                http.Request.Body, MaxWebhookBodyBytes, http.RequestAborted);
+            if (body is null)
             {
-                await http.Request.Body.CopyToAsync(ms, http.RequestAborted);
-                body = ms.ToArray();
+                logger.LogWarning(
+                    "GitHub webhook body exceeded {MaxBytes} bytes — refused before signature verification.",
+                    MaxWebhookBodyBytes);
+                return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
             }
 
             var signature = http.Request.Headers["X-Hub-Signature-256"].ToString();

--- a/test/Memex.Portal.Shared.Test/BoundedBodyTest.cs
+++ b/test/Memex.Portal.Shared.Test/BoundedBodyTest.cs
@@ -57,4 +57,39 @@ public class BoundedBodyTest
         using var s = new MemoryStream();
         Assert.Equal("", await BoundedBody.ReadAsync(s, maxBytes: 10, CancellationToken.None));
     }
+
+    /// <summary>
+    /// The bytes form must be BYTE-EXACT. A signature is computed over what the sender sent, so a
+    /// body that is not valid UTF-8 must survive the read unchanged — reading it as a string and
+    /// re-encoding turns every invalid sequence into U+FFFD, and the HMAC would then be computed
+    /// over bytes nobody signed. 0xFF 0xFE is not valid UTF-8, which is exactly why it is the probe.
+    /// </summary>
+    [Fact]
+    public async Task ReadBytes_is_byte_exact_for_input_that_is_not_valid_utf8()
+    {
+        byte[] raw = [0x7B, 0xFF, 0xFE, 0x00, 0x7D];
+        var got = await BoundedBody.ReadBytesAsync(new MemoryStream(raw), 1024, TestContext.Current.CancellationToken);
+        Assert.Equal(raw, got);
+
+        // And the contrast that makes the point: the string form cannot round-trip these bytes.
+        var viaString = await BoundedBody.ReadAsync(new MemoryStream(raw), 1024, TestContext.Current.CancellationToken);
+        Assert.NotEqual(raw, System.Text.Encoding.UTF8.GetBytes(viaString!));
+    }
+
+    [Fact]
+    public async Task ReadBytes_over_the_cap_is_refused()
+    {
+        var over = new byte[65];
+        var got = await BoundedBody.ReadBytesAsync(new MemoryStream(over), 64, TestContext.Current.CancellationToken);
+        Assert.Null(got);
+    }
+
+    [Fact]
+    public async Task ReadBytes_at_exactly_the_cap_is_returned()
+    {
+        var exact = new byte[64];
+        for (var i = 0; i < exact.Length; i++) exact[i] = (byte)i;
+        var got = await BoundedBody.ReadBytesAsync(new MemoryStream(exact), 64, TestContext.Current.CancellationToken);
+        Assert.Equal(exact, got);
+    }
 }


### PR DESCRIPTION
**#2302, finding 3** — verified still live on `main` before fixing.

## The defect

`GitHubWebhookEndpoints` read the body with a plain copy and only then computed the signature:

```csharp
using (var ms = new MemoryStream())
{
    await http.Request.Body.CopyToAsync(ms, http.RequestAborted);   // unbounded
    body = ms.ToArray();
}
var signature = http.Request.Headers["X-Hub-Signature-256"].ToString();
if (!GitHubWebhookProcessor.VerifySignature(secret, body, signature))
```

The endpoint is **anonymous** — the HMAC is the only thing authenticating it, and it cannot run until the body is in memory. So an unauthenticated caller could make the server buffer an arbitrarily large request before a single byte was checked. A chunked request carries no `Content-Length`, so there was nothing to reject it on either.

## Why `BoundedBody` could not just be reused

The sibling finding (`WebhookInboxEndpoints`) was fixed with `BoundedBody` — but that helper returns a **string**, and a signature must be computed over the bytes GitHub actually sent.

Round-tripping through UTF-8 replaces every invalid sequence with U+FFFD. A body that verifies at the sender would fail here, and a crafted one could differ from what was verified. **Reusing it as-is would have traded a DoS for a correctness bug in signature verification** — which is worse.

So `BoundedBody` gains `ReadBytesAsync`, and both public forms now delegate to one private reader, so the cap semantics — including the deliberate `max + 1` probe that detects "over" without holding it — cannot drift between them.

## The cap

**25 MiB — GitHub's own documented maximum payload.** It can never refuse a genuine delivery; it only bounds what a forged one costs. Over the cap returns `413` and logs, before verification.

## Tests

`BoundedBodyTest` goes 4 → **7, all passing**:

- **byte-exactness on input that is not valid UTF-8** (`0xFF 0xFE`), *including the contrast that the string form cannot round-trip those bytes* — which is the entire reason the bytes overload exists, so the test states it rather than leaving it to the comment;
- over-cap refused;
- exactly-at-cap returned.

## The other two findings in this area are already fixed — I checked

Rather than assume, I verified both before scoping this PR to finding 3:

| finding | state on `main` |
|---|---|
| open redirect in `ExternalAuthController` (2 sites) | **fixed** — both go through `ReturnUrlPolicy.Sanitize`, which correctly rejects `//evil.com` and `/\evil.com` |
| uncapped anonymous read in `WebhookInboxEndpoints` | **fixed** — already uses `BoundedBody.ReadAsync` with a 413 |

#2302 stays open for its remaining findings.

## What's New

Skipped — no user-visible effect; a correctly-sized GitHub delivery behaves identically.
