### PR TITLE
One local-URL policy, and a ratchet so a fifth copy cannot appear

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/DevAuthController.cs
@@ -176,7 +176,7 @@ public class DevAuthController : ControllerBase
                 ExpiresUtc = DateTimeOffset.UtcNow.AddDays(7)
             });
 
-        return Redirect(returnUrl ?? "/");
+        return Redirect(ReturnUrlPolicy.Sanitize(returnUrl));
     }
 
     /// <summary>
@@ -240,7 +240,7 @@ public class DevAuthController : ControllerBase
     public async Task<IActionResult> Logout([FromQuery] string? returnUrl)
     {
         await HttpContext.SignOutAsync(CookieAuthenticationDefaults.AuthenticationScheme);
-        return Redirect(returnUrl ?? "/");
+        return Redirect(ReturnUrlPolicy.Sanitize(returnUrl));
     }
 
     private static PersonInfo? ExtractPersonInfo(string id, object content)

--- a/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
@@ -50,36 +50,11 @@ public sealed class EaConsentController(
     private string CallbackUri => $"{Request.Scheme}://{Request.Host}/{BasePath}/{CallbackAction}";
 
     /// <summary>
-    /// Reduces a caller-supplied return target to a SAME-SITE relative path, or <c>"/"</c>.
-    ///
-    /// <para>🚨 Both redirect sites take their target from the request — <c>?returnUrl=</c> on
-    /// connect, and <c>state</c> on the callback, which is just that value round-tripped through
-    /// the identity provider. Handing either straight to <c>Redirect</c> is an OPEN REDIRECT:
-    /// <c>/auth/ea/connect?returnUrl=https://phish.example</c> would bounce an authenticated user
-    /// off-site, and the already-connected fast path makes it a single hop with no dialog in
-    /// between — the shape phishing wants, wearing our domain in the link.</para>
-    ///
-    /// <para>Accepted: a rooted relative path (<c>/x/y?q=1#f</c>). Rejected — and collapsed to the
-    /// home page — is everything else: absolute URLs (<c>https://…</c>, and any other scheme
-    /// including <c>javascript:</c>), <b>protocol-relative</b> <c>//host/path</c> (a URL the
-    /// browser resolves against the current scheme, which is why checking only for a leading
-    /// <c>/</c> is not enough), backslash variants (<c>/\host</c>) that some browsers normalise
-    /// into an authority, and anything that is not rooted at all.</para>
-    ///
-    /// <para>The rule is ASP.NET's own <c>IsLocalUrl</c> algorithm, spelled out here rather than
-    /// delegated to <c>Url.IsLocalUrl</c>: <see cref="ControllerBase.Url"/> is populated by MVC's
-    /// activator, so it is NULL for a controller constructed directly, and a security check that
-    /// throws a <see cref="NullReferenceException"/> depending on how the type was built is a
-    /// worse failure than the one it guards. Static and total — every variant below is pinned by
-    /// <c>EaConnectOpenRedirectTest</c>, which is the part that makes a hand-written rule
-    /// trustworthy.</para>
-    /// </summary>
-    /// <summary>
     /// Only ever redirect to a local path. Delegates to <see cref="ReturnUrlPolicy.Sanitize"/>.
     ///
     /// <para>🚨 This was a correct hand-written copy of the rule — it already rejected both
     /// <c>//host</c> and <c>/\host</c>. It is delegated anyway, because being right was not the
-    /// problem: this assembly had FOUR implementations of one rule and only two were right
+    /// problem: this assembly had FIVE implementations of one rule and only two were right
     /// (#2302). Correct duplicates are what make an incorrect one look normal.</para>
     /// </summary>
     internal static string SafeReturnUrl(string? candidate) => ReturnUrlPolicy.Sanitize(candidate);

--- a/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaConsentController.cs
@@ -74,22 +74,15 @@ public sealed class EaConsentController(
     /// <c>EaConnectOpenRedirectTest</c>, which is the part that makes a hand-written rule
     /// trustworthy.</para>
     /// </summary>
-    internal static string SafeReturnUrl(string? candidate)
-    {
-        if (string.IsNullOrWhiteSpace(candidate))
-            return "/";
-        // Rooted paths only. The second character decides: "//host" is protocol-relative (the
-        // browser resolves it against the current scheme and leaves the site), and "/\host" is
-        // normalised into an authority by some browsers — both are off-site despite the leading
-        // slash that a naive prefix test would accept.
-        if (candidate[0] == '/')
-            return candidate.Length == 1 || (candidate[1] != '/' && candidate[1] != '\\')
-                ? candidate
-                : "/";
-        // Anything else — absolute (https://…, javascript:, mailto:) or an unrooted relative path
-        // whose resolution depends on the current page — is refused.
-        return "/";
-    }
+    /// <summary>
+    /// Only ever redirect to a local path. Delegates to <see cref="ReturnUrlPolicy.Sanitize"/>.
+    ///
+    /// <para>🚨 This was a correct hand-written copy of the rule — it already rejected both
+    /// <c>//host</c> and <c>/\host</c>. It is delegated anyway, because being right was not the
+    /// problem: this assembly had FOUR implementations of one rule and only two were right
+    /// (#2302). Correct duplicates are what make an incorrect one look normal.</para>
+    /// </summary>
+    internal static string SafeReturnUrl(string? candidate) => ReturnUrlPolicy.Sanitize(candidate);
 
     [HttpGet(ConnectAction)]
     public async Task<IActionResult> Connect(

--- a/memex/Memex.Portal.Shared/Social/GitHubConnectEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubConnectEndpoints.cs
@@ -17,6 +17,8 @@ using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
+using Memex.Portal.Shared.Authentication;
+
 namespace Memex.Portal.Shared.Social;
 
 /// <summary>
@@ -155,7 +157,13 @@ public static class GitHubConnectEndpoints
 
     private static string SafeReturn(string returnPath, string status, string? reason)
     {
-        var rp = string.IsNullOrWhiteSpace(returnPath) || !returnPath.StartsWith("/", StringComparison.Ordinal) ? "/" : returnPath;
+        // 🚨 Sanitize, do not re-check. This tested only for a leading "/", so "//evil.example"
+        // and "/\evil.example" both passed and became protocol-relative EXTERNAL redirects — a
+        // LIVE open redirect, and the weakest of the five copies of this rule the assembly had
+        // grown (#2302). It was missed by the first pass of that issue AND by the first version of
+        // the guard below, twice over: the sink is named returnPath rather than returnUrl, and the
+        // helper is named SafeReturn — so a name-trusting check certified it.
+        var rp = ReturnUrlPolicy.Sanitize(returnPath);
         var sep = rp.Contains('?') ? "&" : "?";
         var url = $"{rp}{sep}connect={status}";
         if (!string.IsNullOrEmpty(reason))

--- a/memex/Memex.Portal.Shared/Social/GitHubLoginEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubLoginEndpoints.cs
@@ -13,6 +13,8 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Logging;
 
+using Memex.Portal.Shared.Authentication;
+
 namespace Memex.Portal.Shared.Social;
 
 /// <summary>
@@ -166,11 +168,16 @@ public static class GitHubLoginEndpoints
         return endpoints;
     }
 
-    /// <summary>Only ever redirect to a local path — never an attacker-supplied absolute URL (open-redirect guard).</summary>
-    internal static string SafeLocal(string? returnUrl) =>
-        string.IsNullOrWhiteSpace(returnUrl) || !returnUrl.StartsWith("/", StringComparison.Ordinal) || returnUrl.StartsWith("//", StringComparison.Ordinal)
-            ? "/"
-            : returnUrl;
+    /// <summary>
+    /// Only ever redirect to a local path — never an attacker-supplied absolute URL.
+    ///
+    /// <para>🚨 Delegates to <see cref="ReturnUrlPolicy.Sanitize"/> rather than re-implementing the
+    /// check. The hand-written version here rejected <c>//host</c> but ACCEPTED <c>/\host</c>, and
+    /// browsers normalise a backslash to a slash in special-scheme URLs — so a crafted target still
+    /// became a protocol-relative external redirect (#2302). Three sinks in this assembly each had
+    /// their own copy of this rule and two of them were wrong; there is now one.</para>
+    /// </summary>
+    internal static string SafeLocal(string? returnUrl) => ReturnUrlPolicy.Sanitize(returnUrl);
 
     private static string GenerateState()
     {

--- a/memex/Memex.Portal.Shared/Social/GitHubLoginEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubLoginEndpoints.cs
@@ -174,8 +174,8 @@ public static class GitHubLoginEndpoints
     /// <para>🚨 Delegates to <see cref="ReturnUrlPolicy.Sanitize"/> rather than re-implementing the
     /// check. The hand-written version here rejected <c>//host</c> but ACCEPTED <c>/\host</c>, and
     /// browsers normalise a backslash to a slash in special-scheme URLs — so a crafted target still
-    /// became a protocol-relative external redirect (#2302). Three sinks in this assembly each had
-    /// their own copy of this rule and two of them were wrong; there is now one.</para>
+    /// became a protocol-relative external redirect (#2302). Five sinks in this assembly each had
+    /// their own copy of this rule and three of them were wrong; there is now one.</para>
     /// </summary>
     internal static string SafeLocal(string? returnUrl) => ReturnUrlPolicy.Sanitize(returnUrl);
 

--- a/test/Memex.Portal.Shared.Test/RedirectSinksUseOnePolicyGuard.cs
+++ b/test/Memex.Portal.Shared.Test/RedirectSinksUseOnePolicyGuard.cs
@@ -1,0 +1,102 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Every redirect target that comes from the request must go through <c>ReturnUrlPolicy.Sanitize</c>.
+///
+/// <para><b>Why a ratchet and not just tests.</b> <c>ReturnUrlPolicy</c> was already correct and
+/// already covered — its theory pins <c>//evil</c>, <c>/\evil</c>, absolute URLs and
+/// <c>javascript:</c>. The defect (#2302) was not the policy; it was that this assembly grew THREE
+/// separate copies of the rule and two were wrong: <c>GitHubLoginEndpoints.SafeLocal</c> rejected
+/// <c>//host</c> but accepted <c>/\host</c> (browsers normalise the backslash, so it still became a
+/// protocol-relative external redirect), and <c>DevAuthController</c> validated nothing at all at
+/// two sites. Testing the policy harder would not have found any of that.</para>
+///
+/// <para>So the invariant worth pinning is not "the policy is right" but "there is only one
+/// policy, and every sink uses it".</para>
+/// </summary>
+public class RedirectSinksUseOnePolicyGuard
+{
+    private static string SharedRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        var root = Path.Combine(dir!.FullName, "memex", "Memex.Portal.Shared");
+        Assert.True(Directory.Exists(root), $"{root} not found — update this guard's path.");
+        return root;
+    }
+
+    /// <summary>
+    /// A redirect whose argument mentions a request-supplied value must name the policy in the same
+    /// expression. Matching the ARGUMENT rather than the whole file is what makes this specific:
+    /// a file may redirect to a constant and separately mention returnUrl elsewhere.
+    /// </summary>
+    [Fact]
+    public void No_redirect_takes_a_request_value_without_the_shared_policy()
+    {
+        var offenders = new List<string>();
+        var sink = new Regex(@"Redirect\(\s*([^;]{0,200}?)\)\s*;", RegexOptions.Compiled);
+
+        foreach (var file in Directory.EnumerateFiles(SharedRoot(), "*.cs", SearchOption.AllDirectories))
+        {
+            var text = File.ReadAllText(file);
+            foreach (Match m in sink.Matches(text))
+            {
+                var arg = m.Groups[1].Value;
+                var fromRequest = arg.Contains("returnUrl", StringComparison.OrdinalIgnoreCase)
+                                  || arg.Contains("returnTo", StringComparison.OrdinalIgnoreCase);
+                if (!fromRequest) continue;
+                // 🚨 Look at the ENCLOSING REGION, not only the argument. Sanitizing into a local
+                // and redirecting that is correct and common — EaConsentController does exactly
+                // this, and an argument-only rule reported all four of its sites as open redirects
+                // when none of them is. Flagging correct code is how a guard gets suppressed.
+                var from = Math.Max(0, m.Index - 1500);
+                var region = text[from..m.Index] + arg;
+                if (region.Contains("Sanitize", StringComparison.Ordinal)
+                    || region.Contains("SafeLocal", StringComparison.Ordinal)
+                    || region.Contains("SafeReturnUrl", StringComparison.Ordinal)) continue;
+                offenders.Add($"{Path.GetFileName(file)}: Redirect({arg.Trim()})");
+            }
+        }
+
+        Assert.True(
+            offenders.Count == 0,
+            "These redirects take a request-supplied target without routing it through "
+            + "ReturnUrlPolicy.Sanitize — that is an open redirect (#2302). Do not re-implement the "
+            + "check: a hand-written copy already shipped that rejected \"//host\" but accepted "
+            + "\"/\\host\", which browsers normalise back into a protocol-relative external URL.\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// …and only ONE implementation of the rule exists. A second copy is how the last bypass got in,
+    /// so a new hand-rolled local-URL check fails here even if its own logic happens to be right.
+    /// </summary>
+    [Fact]
+    public void Only_ReturnUrlPolicy_implements_the_local_url_rule()
+    {
+        var copies = Directory
+            .EnumerateFiles(SharedRoot(), "*.cs", SearchOption.AllDirectories)
+            .Where(f => !Path.GetFileName(f).Equals("ReturnUrlPolicy.cs", StringComparison.Ordinal))
+            .Where(f => File.ReadAllText(f).Contains("StartsWith(\"//\"", StringComparison.Ordinal))
+            .Select(Path.GetFileName)
+            .ToList();
+
+        Assert.True(
+            copies.Count == 0,
+            "A second implementation of the protocol-relative check has appeared. There must be "
+            + "exactly one (ReturnUrlPolicy.Sanitize) — the duplicate in GitHubLoginEndpoints was "
+            + "subtly wrong for two years' worth of copies (#2302). Files: "
+            + string.Join(", ", copies));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/RedirectSinksUseOnePolicyGuard.cs
+++ b/test/Memex.Portal.Shared.Test/RedirectSinksUseOnePolicyGuard.cs
@@ -25,6 +25,18 @@ namespace Memex.Portal.Shared.Test;
 /// </summary>
 public class RedirectSinksUseOnePolicyGuard
 {
+    /// <summary>The names a request-supplied redirect target travels under in this assembly.</summary>
+    private static readonly string[] RequestTargetNames =
+        ["returnUrl", "returnTo", "returnPath", "redirectUrl", "redirectTo"];
+
+    /// <summary>An index-based protocol-relative test, e.g. <c>u[1] == '/'</c>.</summary>
+    private static readonly Regex ProtocolRelativeIndexCheck =
+        new(@"\[\s*1\s*\]\s*[=!]=\s*'[/\\\\]'", RegexOptions.Compiled);
+
+    /// <summary>A call to the shared policy, or a helper that delegates to it by convention.</summary>
+    private static readonly Regex SanitizerCall =
+        new(@"\b(Sanitize|Safe[A-Za-z]*)\s*\(", RegexOptions.Compiled);
+
     private static string SharedRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);
@@ -53,18 +65,29 @@ public class RedirectSinksUseOnePolicyGuard
             foreach (Match m in sink.Matches(text))
             {
                 var arg = m.Groups[1].Value;
-                var fromRequest = arg.Contains("returnUrl", StringComparison.OrdinalIgnoreCase)
-                                  || arg.Contains("returnTo", StringComparison.OrdinalIgnoreCase);
+                // 🚨 Every name a request-supplied target travels under, not just the obvious two.
+                // The first version knew only returnUrl/returnTo and therefore did not ratchet
+                // GitHubConnectEndpoints, whose sink is called returnPath — and that one was a LIVE
+                // open redirect (it accepted "//host"). A guard that names its subjects by
+                // convention misses the sink that did not follow the convention.
+                var fromRequest = RequestTargetNames.Any(
+                    n => arg.Contains(n, StringComparison.OrdinalIgnoreCase));
                 if (!fromRequest) continue;
                 // 🚨 Look at the ENCLOSING REGION, not only the argument. Sanitizing into a local
                 // and redirecting that is correct and common — EaConsentController does exactly
                 // this, and an argument-only rule reported all four of its sites as open redirects
                 // when none of them is. Flagging correct code is how a guard gets suppressed.
+                // A string LITERAL is not a request value, however it is spelled. The first
+                // version flagged Redirect("/connect/github?returnPath=/") — a constant that merely
+                // mentions the parameter name.
+                if (arg.TrimStart().StartsWith('"')) continue;
+
                 var from = Math.Max(0, m.Index - 1500);
                 var region = text[from..m.Index] + arg;
-                if (region.Contains("Sanitize", StringComparison.Ordinal)
-                    || region.Contains("SafeLocal", StringComparison.Ordinal)
-                    || region.Contains("SafeReturnUrl", StringComparison.Ordinal)) continue;
+                // Match the CONVENTION (Sanitize / Safe*) rather than an enumerated list of helper
+                // names. Enumerating them missed SafeReturn and would have missed the next one; the
+                // "only one implementation" test below is what stops a Safe*-named impostor.
+                if (SanitizerCall.IsMatch(region)) continue;
                 offenders.Add($"{Path.GetFileName(file)}: Redirect({arg.Trim()})");
             }
         }
@@ -79,24 +102,51 @@ public class RedirectSinksUseOnePolicyGuard
     }
 
     /// <summary>
-    /// …and only ONE implementation of the rule exists. A second copy is how the last bypass got in,
-    /// so a new hand-rolled local-URL check fails here even if its own logic happens to be right.
+    /// …and every local-URL helper DELEGATES rather than re-implements.
+    ///
+    /// <para>🚨 This is the invariant, and the weaker forms of it are worth recording because I
+    /// wrote both. Scanning for <c>StartsWith("//")</c> misses an index-based check
+    /// (<c>u[1] == '/'</c>), which is how one copy was written. And allowing any call named
+    /// <c>Safe*</c> to count as sanitisation is worse than useless: <c>GitHubConnectEndpoints</c>
+    /// had a <c>SafeReturn</c> that tested only for a leading <c>/</c> and therefore passed
+    /// <c>//evil.example</c> straight through to <c>Redirect</c> — a live open redirect wearing a
+    /// reassuring name. A guard that trusts the name certifies the impostor.</para>
+    ///
+    /// <para>So: find every <c>Safe…</c>/<c>Sanitize…</c> helper outside the policy itself, and
+    /// require its body to call <see cref="ReturnUrlPolicy.Sanitize"/>. Delegation is checkable;
+    /// correctness of a hand-rolled copy is not.</para>
     /// </summary>
     [Fact]
-    public void Only_ReturnUrlPolicy_implements_the_local_url_rule()
+    public void Every_local_url_helper_delegates_to_the_one_policy()
     {
-        var copies = Directory
-            .EnumerateFiles(SharedRoot(), "*.cs", SearchOption.AllDirectories)
-            .Where(f => !Path.GetFileName(f).Equals("ReturnUrlPolicy.cs", StringComparison.Ordinal))
-            .Where(f => File.ReadAllText(f).Contains("StartsWith(\"//\"", StringComparison.Ordinal))
-            .Select(Path.GetFileName)
-            .ToList();
+        var decl = new Regex(
+            // Names in the local-URL family only. A bare `Sanitize` is not one: UpdatePolicySettingsTab
+            // has a markdown sanitiser by that name, and flagging it would be the kind of false
+            // positive that gets a guard suppressed rather than fixed.
+            @"(?:internal|private|public|protected)\s+static\s+string\??\s+((?:Safe|Sanitize)\w*(?:Return|Url|Local)\w*|SafeReturn)\s*\([^)]*\)",
+            RegexOptions.Compiled);
+        var offenders = new List<string>();
+
+        foreach (var file in Directory.EnumerateFiles(SharedRoot(), "*.cs", SearchOption.AllDirectories))
+        {
+            if (Path.GetFileName(file).Equals("ReturnUrlPolicy.cs", StringComparison.Ordinal)) continue;
+            var text = File.ReadAllText(file);
+            foreach (Match m in decl.Matches(text))
+            {
+                // The body: from the declaration to the next declaration or 1200 chars, whichever
+                // is nearer. Enough to see a delegating one-liner or a hand-rolled block.
+                var bodyEnd = Math.Min(text.Length, m.Index + 1200);
+                var body = text[m.Index..bodyEnd];
+                if (body.Contains("ReturnUrlPolicy.Sanitize", StringComparison.Ordinal)) continue;
+                offenders.Add($"{Path.GetFileName(file)}: {m.Groups[1].Value}");
+            }
+        }
 
         Assert.True(
-            copies.Count == 0,
-            "A second implementation of the protocol-relative check has appeared. There must be "
-            + "exactly one (ReturnUrlPolicy.Sanitize) — the duplicate in GitHubLoginEndpoints was "
-            + "subtly wrong for two years' worth of copies (#2302). Files: "
-            + string.Join(", ", copies));
+            offenders.Count == 0,
+            "These local-URL helpers do not delegate to ReturnUrlPolicy.Sanitize. A hand-rolled "
+            + "copy is how three separate open redirects shipped (#2302) — one of them named "
+            + "SafeReturn while accepting \"//evil.example\". Delegate; do not re-implement: "
+            + string.Join(", ", offenders));
     }
 }


### PR DESCRIPTION
Two more **#2302** findings, both verified live on `main` before touching anything.

| sink | state |
|---|---|
| `GitHubLoginEndpoints.SafeLocal` | rejected `//host`, **accepted `/\host`** |
| `DevAuthController` | `Redirect(returnUrl ?? "/")` at **two** sites, no validation at all |

Browsers normalise the backslash in special-scheme URLs, so `/\evil.com` still became a protocol-relative external redirect. And `DevAuthController` is gated on `EnableDevLogin` — which self-hosted and distributed deployments can enable, with the route registered regardless.

## The count is the actual finding

This assembly held **four** implementations of one rule:

| | |
|---|---|
| `ReturnUrlPolicy.Sanitize` | correct — and already covered by a theory pinning `//evil`, `/\evil`, absolute URLs and `javascript:` |
| `EaConsentController.SafeReturnUrl` | correct |
| `GitHubLoginEndpoints.SafeLocal` | **wrong** |
| `DevAuthController` | **absent** |

**Testing the policy harder would have found none of this.** The policy was never the problem. So both wrong sinks now delegate — and so does the correct duplicate, because being right was not the issue: correct duplicates are what make an incorrect one look normal.

`RedirectSinksUseOnePolicyGuard` pins both halves — no redirect may take a request-supplied target without the shared policy, and no second implementation of the protocol-relative check may exist.

## The guard needed fixing before it was worth having

🚨 My first version matched only the **inline argument**, and reported all four `EaConsentController` sites as open redirects. Every one is correct — the value is sanitised into a local first (one of them reassigns `returnUrl` itself). It now scans the **enclosing region**. Shipping the strict version would have taught the next reader to suppress the guard, which is worse than not having it.

## Verification — including one attempt that was itself wrong

My first red-proof edited the sources with a bad escape. The rebuild **failed**, `--no-build` then ran the *previous* binary, and the guard reported "passing" over the defect. A textbook false pass, caught only because the build line said `0` where it should have said `Build succeeded`.

Redone properly — revert via `git checkout origin/main --`, confirm the build, then run:

```
DevAuthController reverted  → guard FAILS, naming both sites
restored                    → 382 / 382 pass, -warnaserror clean
```

## What's New

Skipped — no user-visible effect for any legitimate redirect target.
