### PR TITLE
feat: official-mark oversteer — real vendor logos on cards, MeshWeaver mark in the tab

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-official-vendor-marks.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-official-vendor-marks.md
@@ -1,0 +1,21 @@
+---
+Name: Official vendor logos on store cards
+Category: Feature
+Description: Packages that connect to an outside service can now show that service's real logo, unaltered, while the browser tab keeps the MeshWeaver mark.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Official vendor logos on store cards
+
+Packages that talk to an outside service — an AI provider, a hosted API — can now display that
+service's real logo on their store card, in its own colors, exactly as the vendor publishes it.
+Until now every icon was repainted white and dropped onto a colored tile, which kept house icons
+readable but altered logos in ways their owners' brand guidelines do not permit.
+
+An icon opts in by marking itself as an official logo. It then keeps its own colors and sits on a
+plain white tile, so it stays legible on both the light and the dark theme without being recolored.
+
+The browser tab is deliberately left alone: a page whose node carries an official vendor logo still
+shows the MeshWeaver mark in the tab strip. A favicon says whose site you are on, not which service
+the page happens to talk to.

--- a/src/MeshWeaver.Graph/IconBackplate.cs
+++ b/src/MeshWeaver.Graph/IconBackplate.cs
@@ -44,6 +44,38 @@ public static partial class IconBackplate
         "#334155", // slate
     ];
 
+    /// <summary>
+    /// 🚨 THE OVERSTEER: the attribute an authored icon sets on its root <c>&lt;svg&gt;</c> to declare
+    /// itself an OFFICIAL third-party mark — <c>data-mw-mark="official"</c>.
+    ///
+    /// <para>The default policy recolors <c>currentColor</c> to white and drops the glyph on a plate
+    /// in a hash-derived hue. For a house icon that is exactly right. For a vendor's registered mark
+    /// it is exactly wrong: every brand guideline these packages are nominatively invoking (we ship
+    /// API clients to those services) forbids recoloring the mark or placing it on an arbitrary
+    /// colored ground. An authored mark had no way to say so, so this is that way.</para>
+    ///
+    /// <para>It is a marker in the MARKUP rather than a field on the node deliberately: an icon
+    /// travels as one opaque string through four different forms, so the declaration has to ride
+    /// along with it — no service to thread, no plumbing to add, and it survives serialization,
+    /// copy, export and re-import intact.</para>
+    /// </summary>
+    public const string OfficialMarkAttribute = "data-mw-mark";
+
+    /// <summary>The value of <see cref="OfficialMarkAttribute"/> that claims official-mark treatment.</summary>
+    public const string OfficialMarkValue = "official";
+
+    /// <summary>
+    /// The plate an official mark gets: white, not a hue from <see cref="Palette"/>.
+    ///
+    /// <para>🚨 An official mark is NOT passed through bare, and that is not a compromise — it is the
+    /// same defect the generated plate exists to prevent. The OpenAI mark is near-black
+    /// (<c>#111827</c>); rendered plateless it vanishes on the dark theme exactly as the AppleMusic
+    /// mark did (2026-08-22). A white plate is also what the guidelines themselves prescribe — the
+    /// dark mark on a light ground, with clear space — so this keeps the mark byte-identical AND
+    /// legible on both themes, rather than trading one for the other.</para>
+    /// </summary>
+    public const string OfficialPlate = "#ffffff";
+
     /// <summary>The corner radius of a generated plate on the canonical 24-unit canvas.</summary>
     public const int CornerRadius = 5;
 
@@ -72,6 +104,23 @@ public static partial class IconBackplate
             hash *= 16777619u;
         }
         return Palette[(int)(hash % (uint)Palette.Count)];
+    }
+
+    /// <summary>
+    /// Whether <paramref name="svg"/> declares itself an official third-party mark — its ROOT
+    /// <c>&lt;svg&gt;</c> carries <c>data-mw-mark="official"</c>. Only the root counts: a nested
+    /// element could otherwise smuggle the claim in from arbitrary authored content.
+    /// </summary>
+    public static bool IsOfficialMark(string? svg)
+    {
+        if (string.IsNullOrWhiteSpace(svg))
+            return false;
+        var open = RootTag().Match(svg);
+        return open.Success
+               && string.Equals(
+                   AttrOf(open.Groups["attrs"].Value, OfficialMarkAttribute),
+                   OfficialMarkValue,
+                   StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>
@@ -127,10 +176,18 @@ public static partial class IconBackplate
         if (HasBackplate(svg))
             return svg;
 
-        var hue = HueFor(svg);
-        var inner = svg.Replace("currentColor", "#fff", StringComparison.OrdinalIgnoreCase);
+        // An official mark keeps its own colors on a white plate; a house icon is recolored to white
+        // on a hash-derived hue. Both are plated — only the ground and the recolor differ.
+        var official = IsOfficialMark(svg);
+        var hue = official ? OfficialPlate : HueFor(svg);
+        var inner = official
+            ? svg
+            : svg.Replace("currentColor", "#fff", StringComparison.OrdinalIgnoreCase);
         inner = InsetRoot(inner);
-        return "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>"
+        // The wrapper re-declares the claim, so "is this an official mark" survives plating and a
+        // caller downstream of Ensure reads the same answer as one upstream of it.
+        var claim = official ? $" {OfficialMarkAttribute}='{OfficialMarkValue}'" : "";
+        return $"<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'{claim}>"
                + $"<rect width='24' height='24' rx='{CornerRadius}' fill='{hue}' stroke='none'/>"
                + inner
                + "</svg>";

--- a/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
+++ b/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
@@ -314,8 +314,43 @@ public static class MeshNodeImageHelper
     /// never silently keeps the previous page's icon.</para>
     /// </summary>
     /// <param name="node">The node whose page is being shown.</param>
-    public static IconLink ResolveIconLink(MeshNode node) =>
-        IconLinkFor(ResolveNodeIcon(node));
+    public static IconLink ResolveIconLink(MeshNode node)
+    {
+        var icon = ResolveNodeIcon(node);
+
+        // 🚨 THE ONE PLACE THE TAB AND THE CARD DELIBERATELY DIVERGE. A card showing a vendor's mark
+        // is nominative use — the package is an API client to that service, and the mark says which
+        // one. A FAVICON is not: it identifies the site occupying the tab, so a vendor mark there
+        // claims the tab IS theirs. The portal's own mark is the honest answer, and it is why
+        // IsOfficialMark exists as a query rather than only a render switch.
+        return IsOfficialMark(icon)
+            ? IconLinkFor(MeshWeaverMarkUrl)
+            : IconLinkFor(icon);
+    }
+
+    /// <summary>The portal's own mark, shipped as <c>Icons/meshweaver-logo.svg</c>.</summary>
+    private const string MeshWeaverMarkIcon = "meshweaver-logo";
+
+    /// <summary>
+    /// The URL of <see cref="MeshWeaverMarkIcon"/> — the browser-tab icon used wherever a node's own
+    /// icon is an official third-party mark.
+    ///
+    /// <para>🚨 Built as a URL rather than passed as a NAME on purpose: <see cref="ShippedIconFor"/>
+    /// only resolves names <see cref="IsFluentIconName"/> accepts, which requires an uppercase
+    /// initial and all-ASCII-letters — so the hyphenated, lower-case <c>meshweaver-logo</c> resolves
+    /// to null through that path and the tab would silently fall back to the neutral box. Same
+    /// construction as <see cref="NeutralIconUrl"/>.</para>
+    /// </summary>
+    public static readonly string MeshWeaverMarkUrl = $"/static/NodeTypeIcons/{MeshWeaverMarkIcon}.svg";
+
+    /// <summary>
+    /// Whether an icon VALUE is an official third-party mark — inline svg carrying
+    /// <see cref="IconBackplate.OfficialMarkAttribute"/>. Any other form (URL, glyph, Fluent name)
+    /// cannot make the claim, so it is false for them.
+    /// </summary>
+    public static bool IsOfficialMark(string? icon) =>
+        DomainIcon.Parse(icon) is { Provider: DomainIcon.InlineSvgProvider } parsed
+        && IconBackplate.IsOfficialMark(parsed.Id);
 
     /// <summary>
     /// The <c>&lt;link rel="icon"&gt;</c> form of one icon value, classified the same way the

--- a/test/MeshWeaver.Graph.Test/OfficialMarkTest.cs
+++ b/test/MeshWeaver.Graph.Test/OfficialMarkTest.cs
@@ -1,0 +1,150 @@
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>The official-mark oversteer</b> — the seam that lets a vendor's registered mark render
+/// unaltered on a store card while the browser tab keeps the portal's own mark.
+///
+/// <para>Two rules, and each one is a bug in the other's direction. <b>Recoloring a vendor mark is a
+/// brand violation</b> — the default policy repaints <c>currentColor</c> white on a hash-derived hue,
+/// which is right for a house glyph and forbidden for a mark we are invoking nominatively (these
+/// packages are API clients to those services). <b>Putting a vendor mark in the tab is a
+/// misrepresentation</b> — a favicon identifies the site occupying the tab, not a service it talks
+/// to.</para>
+///
+/// <para>Neither failure raises anything: a recolored mark still renders, and a wrong favicon still
+/// loads. So both are pinned here or they drift back.</para>
+/// </summary>
+public class OfficialMarkTest
+{
+    /// <summary>A vendor mark, near-black like the real OpenAI one — the color that makes plateless
+    /// pass-through invisible on the dark theme.</summary>
+    private const string OfficialMark =
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' data-mw-mark='official'>"
+        + "<path d='M4 4h16v16H4z' fill='#111827'/></svg>";
+
+    private const string HouseOutline =
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' "
+        + "stroke='currentColor'><path d='M4 4h16v16H4z'/></svg>";
+
+    // ---- the mark itself is never altered -------------------------------------------------
+
+    [Fact]
+    public void AnOfficialMark_KeepsItsOwnColors()
+    {
+        var rendered = IconBackplate.Ensure(OfficialMark);
+
+        // The brand color survives verbatim. This is the whole point of the oversteer.
+        Assert.Contains("#111827", rendered);
+    }
+
+    [Fact]
+    public void AnOfficialMark_IsNotRecoloredWhite()
+    {
+        // currentColor recoloring is what the default policy does; on a vendor mark it repaints the
+        // logo. A mark authored with currentColor must keep it.
+        var withCurrentColor =
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' data-mw-mark='official'>"
+            + "<path d='M4 4h16v16H4z' fill='currentColor'/></svg>";
+
+        Assert.Contains("currentColor", IconBackplate.Ensure(withCurrentColor));
+    }
+
+    [Fact]
+    public void AnOfficialMark_SitsOnAWhitePlate_NotAHashedHue()
+    {
+        var rendered = IconBackplate.Ensure(OfficialMark);
+
+        // 🚨 NOT bare pass-through: a near-black mark with no plate vanishes on the dark theme —
+        // the exact defect IconBackplate exists to prevent. White is also what the guidelines
+        // prescribe, so the mark stays unaltered AND legible on both grounds.
+        Assert.Contains(IconBackplate.OfficialPlate, rendered);
+        Assert.DoesNotContain(IconBackplate.HueFor(OfficialMark), rendered);
+    }
+
+    [Fact]
+    public void AHouseIcon_IsUnaffectedByTheOversteer()
+    {
+        // The control. Without it, "official marks work" could be satisfied by disabling the policy
+        // for everything, which would silently return every currentColor outline to invisibility.
+        var rendered = IconBackplate.Ensure(HouseOutline);
+
+        Assert.DoesNotContain("currentColor", rendered);
+        Assert.Contains(IconBackplate.HueFor(HouseOutline), rendered);
+        Assert.DoesNotContain(IconBackplate.OfficialMarkValue, rendered);
+    }
+
+    // ---- claiming the treatment -----------------------------------------------------------
+
+    [Fact]
+    public void TheClaimSurvivesPlating()
+    {
+        // A caller downstream of Ensure must read the same answer as one upstream of it, or the
+        // favicon rule silently stops applying to an already-rendered mark.
+        Assert.True(IconBackplate.IsOfficialMark(OfficialMark));
+        Assert.True(IconBackplate.IsOfficialMark(IconBackplate.Ensure(OfficialMark)));
+    }
+
+    [Theory]
+    [InlineData("<svg viewBox='0 0 24 24'><path d='M0 0h1v1H0z' data-mw-mark='official'/></svg>")]
+    [InlineData("<svg viewBox='0 0 24 24'><!-- data-mw-mark='official' --><path d='M0 0h1v1H0z'/></svg>")]
+    public void OnlyTheROOTMayClaimIt(string svg)
+    {
+        // A nested element (or a comment) must not be able to smuggle the claim in from arbitrary
+        // authored content — otherwise any Store package could opt its icon out of the legibility
+        // policy without declaring it.
+        Assert.False(IconBackplate.IsOfficialMark(svg));
+    }
+
+    [Fact]
+    public void NonSvgFormsCannotClaimIt()
+    {
+        Assert.False(MeshNodeImageHelper.IsOfficialMark(null));
+        Assert.False(MeshNodeImageHelper.IsOfficialMark(""));
+        Assert.False(MeshNodeImageHelper.IsOfficialMark("/static/NodeTypeIcons/box.svg"));
+        Assert.False(MeshNodeImageHelper.IsOfficialMark("🤖"));
+    }
+
+    // ---- the favicon diverges -------------------------------------------------------------
+
+    [Fact]
+    public void TheTabShowsTheMESHWEAVERMark_NotTheVendors()
+    {
+        var node = new MeshNode("Providers/OpenAI") { Icon = OfficialMark };
+
+        var link = MeshNodeImageHelper.ResolveIconLink(node);
+
+        // The vendor's mark must not reach the tab in any form — the data: URI would carry it
+        // percent-encoded, so assert on the resolved target instead of scanning for the color.
+        Assert.Contains(MeshNodeImageHelper.MeshWeaverMarkUrl, link.Href);
+        Assert.DoesNotContain("111827", Uri.UnescapeDataString(link.Href));
+    }
+
+    [Fact]
+    public void AnOrdinaryNodeIconStillReachesTheTab()
+    {
+        // The control for the favicon half: the substitution must apply ONLY to official marks, or
+        // every node page silently loses its own tab icon.
+        var node = new MeshNode("Docs/Page") { Icon = HouseOutline };
+
+        var link = MeshNodeImageHelper.ResolveIconLink(node);
+
+        Assert.DoesNotContain(MeshNodeImageHelper.MeshWeaverMarkUrl, link.Href);
+        Assert.Equal(MeshNodeImageHelper.SvgMediaType, link.Type);
+    }
+
+    [Fact]
+    public void TheCardKeepsTheVendorMarkWhileTheTabDoesNot()
+    {
+        // The two seams in one assertion — the divergence IS the feature, and a change that
+        // collapses them back together (in either direction) has to fail something.
+        var card = MeshNodeImageHelper.ResolveRenderable(OfficialMark);
+        var tab = MeshNodeImageHelper.ResolveIconLink(new MeshNode("Providers/OpenAI") { Icon = OfficialMark });
+
+        Assert.Contains("#111827", card.Value);
+        Assert.Contains(MeshNodeImageHelper.MeshWeaverMarkUrl, tab.Href);
+    }
+}


### PR DESCRIPTION
## What

An authored icon can now declare itself an **official third-party mark** — `data-mw-mark="official"`
on the root `<svg>` — and two behaviours key off it, deliberately diverging:

| surface | official mark | everything else (unchanged) |
|---|---|---|
| store card / tree / menus | own colors, **white** plate | `currentColor`→white, hash-derived hue plate |
| **browser tab (favicon)** | **the MeshWeaver mark** | the node's own icon |

## Why

The backplate policy recolors every inline-svg icon and grounds it on a hashed hue. That is right
for a house glyph and wrong for a vendor's registered mark: these packages are API clients to those
services, so showing the mark is nominative use, and the brand guidelines it invokes forbid
recoloring it or placing it on an arbitrary colored ground. There was no way for an icon to say so.

The favicon is the opposite case. A card showing a vendor logo says *which service this package
talks to*. A favicon says *whose site occupies this tab* — so a vendor mark there would claim the
tab is theirs. Only that one is overridden.

## Two things worth review attention

**The mark is not passed through bare, and that is deliberate.** The OpenAI mark is near-black
(`#111827`); plateless it vanishes on the dark theme — the exact defect `IconBackplate` exists to
prevent (AppleMusic, 2026-08-22). A white plate is also what the guidelines themselves prescribe
(dark mark, light ground, clear space), so the mark stays byte-identical *and* legible on both
themes rather than trading one for the other.

**The claim lives in the markup, not on the node.** An icon travels as one opaque string through
four different forms, so a marker in the SVG rides along with it — no service to thread, no plumbing,
and it survives serialization, copy, export and re-import. Only the ROOT element may claim it, so
authored content cannot smuggle the opt-out in from a nested node.

## A defect the guards caught

`MeshWeaverMarkUrl` is built as a URL rather than passed as a name: `ShippedIconFor` only resolves
names `IsFluentIconName` accepts (uppercase initial, all ASCII letters), so the hyphenated lower-case
`meshweaver-logo` resolves to **null** through that path and the tab silently fell back to the
neutral box. Same construction as the existing `NeutralIconUrl`.

## Verification

- `MeshWeaver.Graph.Test` — **1680/1680 green**; 11 new tests in `OfficialMarkTest`.
- Each half ships its **control**: a house icon must still be recolored and plated, and an ordinary
  node icon must still reach the tab. Without those, "official marks work" could be satisfied by
  disabling the policy for everything.
- `src/MeshWeaver.Graph` and `test/MeshWeaver.Graph.Test` build clean under `-c Release -warnaserror`.

Neither failure mode raises anything on its own — a recolored logo still renders, a wrong favicon
still loads — which is why they are pinned rather than left to review.

## Follow-up (not in this PR)

The actual vendor SVGs live in the Store packages in `MeshWeaver.Plugins`; this is only the seam
they need. Shipping them is the next change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)