### PR TITLE
Module static assets follow the loaded assembly, not a folder NAME (#2562)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-installed-view-packs-keep-their-styling.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-installed-view-packs-keep-their-styling.md
@@ -1,0 +1,21 @@
+---
+Name: Installed view packs keep their styling
+Category: Fix
+Description: Portals that install their views as packs render correctly again — the packs' stylesheets and scripts were being requested but not served, leaving pages unstyled.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Installed view packs keep their styling
+
+The views that draw a portal's buttons, grids, editors and dialogs are installed as packs rather
+than built into the portal itself. Each pack brings its own stylesheets and scripts along with it.
+
+A recent change to how a portal stores those packs on disk meant it stopped finding the styling that
+came with them. The views themselves still loaded and pages still rendered — but every stylesheet
+and script the packs provide came back empty, so pages appeared unstyled and controls could be hard
+to read or use. Nothing in the portal's log said so, which made it look like a display problem
+rather than a missing file.
+
+Portals now serve those files wherever the packs are stored, and say so plainly when a pack brings
+no styling at all. Existing installs pick this up on their next update; nothing needs reinstalling.

--- a/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/MeshModuleStaticAssetExtensions.cs
@@ -354,7 +354,20 @@ public static partial class MeshModuleStaticAssetExtensions
             // serving it. That is what makes this safe to switch on before any pack flips.
             var moduleWwwroot = ModuleWwwrootPath(module.Assembly.Location, baseDirectory, name);
             if (!Directory.Exists(moduleWwwroot))
+            {
+                // 🚨 Say so. A module that ships assets, loads fine and then 404s every one of them
+                // is the hardest shape of this to diagnose — the portal renders unstyled and the log
+                // is silent, which is exactly how #2562 stayed invisible. Debug, not Warning: for a
+                // module still riding the app closure this path is legitimately absent and is the
+                // expected outcome, so it must not shout on every boot. Naming the path is the
+                // point — it is what distinguishes "nothing to mount" from "looked in the wrong
+                // place".
+                logger.LogDebug(
+                    "Module {Module} contributes no static assets — no wwwroot at {Path} "
+                    + "(assembly loaded from {Location}).",
+                    name, moduleWwwroot, module.Assembly.Location);
                 continue;
+            }
 
             // 1. The module's own assets, re-based onto its _content/<Name> namespace. A module
             //    name is unique, so this mount can never collide with another module's.
@@ -498,12 +511,48 @@ public static partial class MeshModuleStaticAssetExtensions
         var assemblyDirectory = string.IsNullOrEmpty(assemblyLocation)
             ? null
             : Path.GetDirectoryName(assemblyLocation);
-        var parent = string.IsNullOrEmpty(assemblyDirectory)
-            ? null
-            : Path.GetFileName(Path.GetDirectoryName(assemblyDirectory));
-        return string.Equals(parent, "modules", StringComparison.OrdinalIgnoreCase)
-            ? Path.Combine(assemblyDirectory!, "wwwroot")
-            : Path.Combine(baseDirectory, "modules", moduleName, "wwwroot");
+
+        // 🚨 The test is "is this the APP's own directory?", NOT "is the parent folder called
+        // modules?". The invariant being protected is the one the remarks above describe — never
+        // mount the host's web root through a module namespace — and only the app directory can do
+        // that. Keying on the FOLDER NAME instead was an accident of the two layouts that existed
+        // when this was written, and it broke the moment #2509 started loading modules from a
+        // process-local pin: `<tmp>/meshweaver-pinned-modules/<n>-<hash>/<Name>@<gen>/`, whose
+        // parent is a pin id rather than `modules`. Every landed module then fell back to the
+        // absent legacy path and every asset it ships 404'd, with the module itself loading fine —
+        // an unstyled portal and nothing in the log (#2562). Comparing against the app directory
+        // tests the actual hazard and is blind to where the loader put the bytes, so it survives
+        // the next relocation too.
+        // "The app's directory" has TWO senses here and both mean the same hazard. The REAL one is
+        // AppContext.BaseDirectory — what a module riding the app closure actually reports at
+        // runtime. The DECLARED one is the baseDirectory argument, which a caller passing a
+        // laid-out folder uses to say "treat this as the app root"; the discovery tests drive the
+        // mapping that way, with a real test assembly whose own folder holds no wwwroot.
+        var ridesTheAppClosure =
+            string.IsNullOrEmpty(assemblyDirectory)
+            || SameDirectory(assemblyDirectory!, baseDirectory)
+            || SameDirectory(assemblyDirectory!, AppContext.BaseDirectory);
+
+        return ridesTheAppClosure
+            ? Path.Combine(baseDirectory, "modules", moduleName, "wwwroot")
+            : Path.Combine(assemblyDirectory!, "wwwroot");
+    }
+
+    /// <summary>
+    /// Whether two paths name the same directory — compared as full paths with any trailing
+    /// separator removed, because <see cref="AppContext.BaseDirectory"/> carries one and
+    /// <see cref="Path.GetDirectoryName(string)"/> does not, so a raw string comparison would
+    /// answer "different" for the one case that must answer "same".
+    /// </summary>
+    private static bool SameDirectory(string left, string right)
+    {
+        static string Normalize(string path) =>
+            Path.TrimEndingDirectorySeparator(Path.GetFullPath(path));
+
+        return string.Equals(
+            Normalize(left),
+            Normalize(right),
+            OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/ModuleStaticAssetDiscoveryTest.cs
@@ -307,11 +307,40 @@ public class ModuleStaticAssetDiscoveryTest : IDisposable
     }
 
     /// <summary>
+    /// 🚨 <b>The PINNED shape — the one that shipped broken (#2562).</b>
+    ///
+    /// <para>#2509 stopped loading a landed module from the shared <c>modules/</c> tree and began
+    /// copying its generation into a process-local pin first:
+    /// <c>&lt;tmp&gt;/meshweaver-pinned-modules/&lt;n&gt;-&lt;hash&gt;/&lt;Name&gt;@&lt;gen&gt;/</c>.
+    /// The pin carries <c>wwwroot</c> with it, so the assets sit directly beside the loaded
+    /// assembly — but the resolver keyed on the PARENT FOLDER being named <c>modules</c>, and here
+    /// it is a pin id. Every landed module fell back to the absent legacy path, contributed no
+    /// mounts, and every asset it ships 404'd: the portal came up unstyled with the modules loading
+    /// perfectly and nothing in the log to say why.</para>
+    ///
+    /// <para>This is why the rule is now "not the app's own directory" rather than a folder name —
+    /// a name-based test only ever knew about the layouts that existed when it was written.</para>
+    /// </summary>
+    [Fact]
+    public void PinnedGenerationModule_TakesItsAssetsFromTheLoadedAssemblysOwnFolder()
+    {
+        // The shape #2509 introduced: a pin id, not "modules", is the parent folder.
+        var pinned = Path.Combine(
+            Path.GetTempPath(), "meshweaver-pinned-modules", "1-a457e6a1", $"{ModuleName}@96af4c59");
+
+        MeshModuleStaticAssetExtensions.ModuleWwwrootPath(
+                Path.Combine(pinned, $"{ModuleName}.dll"),
+                AppContext.BaseDirectory,
+                ModuleName)
+            .Should().Be(Path.Combine(pinned, "wwwroot"));
+    }
+
+    /// <summary>
     /// 🚨 A module still riding the APP CLOSURE must contribute NOTHING. Its assembly sits in the
     /// app folder, whose <c>wwwroot</c> is the HOST's — mounting that under
     /// <c>_content/&lt;Name&gt;</c> would serve the entire host web root through a module
-    /// namespace. Only an assembly sitting directly inside a <c>modules/</c> tree supplies its own
-    /// folder; everything else falls back to the (absent) legacy name-based path.
+    /// namespace. This is the invariant the resolver actually protects, and the reason it compares
+    /// against the app directory rather than trusting a folder name.
     /// </summary>
     [Fact]
     public void AppClosureModule_NeverMountsTheHostsOwnWwwroot()


### PR DESCRIPTION
Fixes #2562.

## Symptom

Every landed view pack's CSS and JS 404s. The portal renders **unstyled** while the packs themselves
load perfectly, and nothing appears in the log — so it presents as a display problem rather than a
missing file. Since #2169 Phase B2, `DefaultViews` and `GraphViews` reach a deployment only as
packs, which makes this the portal's whole chrome.

## Cause — an interaction, not a regression in either change

`ModuleWwwrootPath` decided whether to trust a module's own folder by asking whether the assembly's
**grandparent directory was named `modules`**. True for the two layouts that existed when it was
written.

Then #2509 stopped loading a landed generation from the shared `modules/` tree and began copying it
into a process-local pin first — `<tmp>/meshweaver-pinned-modules/<n>-<hash>/<Name>@<gen>/` — so a
sibling replica's GC can no longer delete files a running process still needs. The pin carries
`wwwroot` with it, so the assets sit **directly beside the loaded assembly**. Only the folder *name*
changed, and the name was what the rule keyed on.

| | assembly directory | grandparent | branch |
|---|---|---|---|
| before #2509 | `/data/modules/<Name>@<gen>/` | `modules` | own folder ✅ |
| after #2509 | `<tmp>/meshweaver-pinned-modules/<n>-<hash>/<Name>@<gen>/` | `<n>-<hash>` | fallback ❌ |

The fallback resolves to `/app/modules/<Name>/wwwroot`, which is not written at all any more
(#1949), so `Directory.Exists` fails and the loop hits `continue` — silently.

## Fix

The invariant that test protects was never the folder name. It is **"never mount the APP's own web
root through a module namespace"**, since that is the only directory whose `wwwroot` belongs to the
host. It now asks exactly that, and is blind to where the loader put the bytes — so it survives the
next relocation too.

"The app's directory" is checked in both its senses: `AppContext.BaseDirectory` (what a module
riding the app closure reports at runtime) and the `baseDirectory` argument (what a caller passing a
laid-out folder declares as the app root — the shape the discovery tests drive). My first attempt
compared against only the argument and broke 12 discovery tests; the suite caught it, inspection had
not.

**The skip is no longer silent.** A module with no resolvable `wwwroot` logs the path it tried, at
Debug — not Warning, because for a module still riding the app closure that path is legitimately
absent and is the expected outcome, so it must not shout on every boot. But the silence is what made
this expensive to find, and `ModuleWwwrootPath`'s own remarks predicted the symptom verbatim:
*"the module loads, its components render, and every asset they request 404s."*

## Verification

Live portal, before and after the same rebuild:

```
_content/<Views>/…styles.css     404  →  200 (102,407 B)
_content/<Graph>/…styles.css     404  →  200 (15,708 B)
stylesheets linked by the page     3  →  5
```

Real Chromium (Playwright), not curl — the login page is Blazor-interactive, so its buttons exist
only after the circuit connects:

- login page renders both providers: `["Microsoft", "🛠️ Developer login"]`
- dev login completes end to end → `MemexAuth` cookie → *"Welcome back, …"*
- Microsoft button reaches `login.microsoftonline.com/…/oauth2/v2.0/authorize`, no `AADSTS` error
- **zero** console errors, zero failed requests, zero 404s

## Tests

`PinnedGenerationModule_TakesItsAssetsFromTheLoadedAssemblysOwnFolder` pins the shape that shipped
broken. Reverting **only** the rule fails exactly that one test, with the other 16 green — 17/17
with the fix. The regression test targets the pinned layout specifically, not just the two shapes
that existed when #1724 was written.

## What's New

Included — `Category: Fix`. An unstyled portal is about as user-visible as a defect gets.