### PR TITLE
content/ai becomes the one master for built-in agents and skills

### DIFF
--- a/content/ai/Agent/Assistant.md
+++ b/content/ai/Agent/Assistant.md
@@ -52,6 +52,7 @@ create one of these, you MUST load its skill and follow it** — do not hand-imp
 - **A Markdown page** (or any node with a markdown body) → **`/markdown`** — `load_skill('Skill/markdown')`.
 - **A Space** (top-level container / partition) → **`/space`** — `load_skill('Skill/space')`.
 - **An access Group** (the Group + its grant + members/invites) → **`/group`** — `load_skill('Skill/group')`.
+- **User feedback** (capture the user's location + name, file it in the Feedback space) → **`/feedback`** — `load_skill('Skill/feedback')`.
 
 A **NodeType / source / data model / layout area / Script** is the **`/code`** skill (above). Load the skill
 that matches what you're about to create; when several apply across a multi-step task, load each as you reach

--- a/content/ai/Skill/driver-release.md
+++ b/content/ai/Skill/driver-release.md
@@ -1,0 +1,142 @@
+---
+name: /driver-release
+nodeType: Skill
+displayName: Driver release — how a compiled module reaches an instance
+description: Ship or diagnose a compiled MeshWeaver module (a driver — AI provider, MCP, mail, notifications, observability, indexing, export, self-update). Use when a package declares content.module, when a release removes drivers from the image, or when a mesh cannot activate a package's nodes.
+icon: 🔌
+category: Engineering
+order: 45
+---
+
+# Driver release — how a compiled module reaches an instance
+
+A **driver** is a package that ships compiled C# — its root declares `content.module` (the entry
+assembly, e.g. `MeshWeaver.AI.OpenAI`). That is different from an ordinary node-native plugin,
+whose `Source/` the mesh compiles itself with Roslyn. A driver's bytes are built by CI and must
+physically arrive on the instance.
+
+**The fourteen drivers in this repo** — `AzureFoundry`, `ClaudeCode`, `Copilot`, `OpenAI`,
+`WebSearch`, `Mcp`, `Mail`, `Teams`, `Notifications`, `Observability`, `Indexing`, `Export`,
+`Hosting`, `Edu`. Regenerate the list, never retype it:
+
+```bash
+python3 -c "
+import json,glob
+for f in sorted(glob.glob('*/index.json')):
+    c=(json.load(open(f)).get('content') or {})
+    if c.get('module'): print(f.split('/')[0], '->', c['module'], c.get('minMeshVersion'))
+"
+```
+
+## Drivers are platform-administered, never sold
+
+Every driver root carries **`preInstalled: true`** and **`price: null`**. That flag is the
+manifest's ONE statement of *"this ships with the platform"*, and it changes three things at once:
+
+- the Store never sells it — there is no price, no entitlement, no per-viewer funnel;
+- its content is **not** gated — `PluginGate`'s reconcile retracts a pre-installed package's child
+  denies, so it reads like platform surface rather than a purchase;
+- **`InstanceAutoRegistrationService` installs it at boot**, from the instance's configured
+  registries. `PluginCatalogOptions.InstallPreInstalledPackages` defaults to `true`.
+
+So the global-admin action is *provisioning the package on the registry* and issuing the grants —
+not clicking Get on fourteen cards. A driver a viewer could buy would be a bug.
+
+## The two places a module's bytes can live — and the precedence
+
+| location | written by | when |
+|---|---|---|
+| `<app>/modules/<Name>/` | the **image build** (`MeshModulesPublish.targets`, the `MeshModuleClosure` lane) | at docker build time |
+| `<ModuleRoot>/modules/<Name>/` | **`ModuleLandingService`**, from a registry publish | at run time |
+
+`MeshBuilder.ResolveModulePath(entry, moduleRoot)` probes **landed → image → app closure**. A
+landed module is the one an operator just published, so it wins over a stale baseline of the same
+name. During a transition BOTH exist, and that overlap is what makes a zero-downtime driver
+migration possible (below).
+
+## 🚨 The module root must be writable AND shared
+
+`ModuleRoot` (config key **`Modules:Root`**) is resolved once and used by the writer and by boot
+activation, because a landed module read from a different directory is simply invisible. It
+defaults to `AppContext.BaseDirectory`.
+
+**That default cannot be used on a deployed portal**, for two independent reasons:
+
+1. `/app` is the **read-only** image layer. The image WRITES `modules/` at build time; the runtime
+   only reads it — so the defect is invisible until the first thing that must write it, which is
+   the registry's publish route. On 2026-08-19 that failed all fourteen bundles with
+   `Access to the path '/app/modules/.staging-…' is denied`, surfaced to the build as **HTTP 409**,
+   four steps from the cause.
+2. Even where it is writable, `/app` is **per-pod**. A module landed by whichever replica served
+   the publish must be visible to every other replica, so the root has to be the deployment's
+   shared volume — on AKS the RWX `/data` PVC every portal pod already mounts.
+
+Set `Modules:Root=/data` on any deployment that lands modules.
+
+## Shipping a driver
+
+```
+build  →  bundle  →  publish to the registry  →  land  →  restart  →  provision the package
+```
+
+1. **CI packs** the module (`node-repo-module-pack.yml`) into a `.module.nupkg` carrying the entry
+   assembly, its private closure, `minMeshVersion` and the framework MVID.
+2. **Publish** it: `POST /api/plugins/bundles/{plugin}` with the publish token
+   (`Plugins:Registry:PublishToken`). 🚨 When that key is unset the route is **not mapped at all** —
+   an unconfigured registry has no publish surface rather than one answering 401.
+3. **Land**: the registry writes `<ModuleRoot>/modules/<Name>/` and appends the
+   `modules/activation.json` entry with `PendingRestart = true`.
+4. **Restart-as-activation** — nothing is loaded into the running process. The next boot folds the
+   sidecar's enabled entries into `Modules:Assemblies` and each pack's `MeshNodeProviderAttribute`
+   registers.
+5. **Provision** the package partition so its NODES exist too (`Store/Provision`, System identity).
+
+## 🚨 Never roll a driver-removing release before the drivers have landed
+
+A release that deletes drivers from the image (MeshWeaver #1882 removed fourteen) means the
+instance must get them from the registry instead. But landing requires a writable `Modules:Root`,
+which only exists in an image carrying that support — so the order is forced:
+
+1. roll onto an image that has the writable root **and still ships the drivers**;
+2. set `Modules:Root`, publish the bundles, let them land, restart;
+3. provision the packages and **verify** (chat, MCP, mail — whatever those drivers serve);
+4. only then merge the removal and roll the release without them.
+
+Doing it the other way leaves a window with no chat, no MCP, no mail, no notifications, no
+observability. **A missing driver does not error — it HANGS**: a node whose module is absent cannot
+activate, so every read costs the caller the full 60s `SubscribeRequest` timeout and the page dies
+with nothing saying "missing module".
+
+## Retiring a driver's NuGet package
+
+A module that leaves the platform stops being packed, but everything it already published stays on
+nuget.org **listed** — in search and in `dotnet add package`, offered as current while nothing
+builds or patches it. Retire it:
+
+```bash
+python3 scripts/orphaned-nuget-packages.py --root .          # report (MeshWeaver repo)
+```
+
+The set is DERIVED — *(published under the MeshWeaver prefix) minus (what this tree still packs)* —
+so it needs no editing as further modules move out. Apply it through the
+**Unlist orphaned NuGet packages** workflow (`apply` + `confirm: UNLIST`).
+
+- ⚠️ **Check the scope before applying.** A package that left core might still be published by a
+  satellite. Today none are: the satellites' publish workflows are `dry-run: true` and target
+  GitHub Packages, so **nuget.org is fed only by core's tag-triggered `release-packages.yml`**.
+- `dotnet nuget delete` **unlists**; it does not erase. Existing pins keep resolving by exact
+  version and a listing can be restored from the UI — that reversibility is what makes automating
+  it safe.
+
+## Diagnosing
+
+| symptom | look at |
+|---|---|
+| publish returns **409** `Access to the path … is denied` | `Modules:Root` is unset or not writable |
+| publish returns **401** | the publish token; a *missing* token unmaps the route entirely (404) |
+| package provisions but pages hang ~60s | its module never landed, or landed and the pod never restarted |
+| the Store card says *available from package source* with a **Provision** button | the package is not on this mesh at all — that is accurate, not a display bug |
+| `get @{Package}` → *Not found* | authoritative. An HTTP 200 on `/{Package}` proves nothing: the SPA routes client-side |
+
+Read the live state, never infer it: `get @{Package}` through the mesh MCP, and the landed set from
+`<ModuleRoot>/modules/activation.json`.

--- a/content/ai/Skill/package-versions.md
+++ b/content/ai/Skill/package-versions.md
@@ -1,0 +1,80 @@
+---
+name: /package-versions
+nodeType: Skill
+displayName: Package versions — one file, five repos
+description: How package versions resolve across the platform and every plugin repo, and how to audit a pin before removing it. Use when adding a PackageReference in a plugin repo, when a module build fails naming only a package, or when pruning Directory.Packages.props.
+icon: 📌
+category: Engineering
+order: 45
+---
+
+# Package versions — one file, five repos
+
+**The platform's `Directory.Packages.props` is the ONE source of package versions for every
+plugin repo.** The plugin repos declare no `PackageVersion` of their own: their
+`src/Directory.Packages.props` exists to say so, and every version resolves from the platform
+checkout through `$(MeshWeaverRoot)`.
+
+That is the whole mechanism, and it has one sharp consequence.
+
+## 🚨 Auditing a pin means auditing FIVE repos
+
+A pin with no `PackageReference` in the platform is **not** dead. The extracted modules — the AI
+providers, Mail/Graph, the agent SDKs, the Azure backends — live in the plugin repos and reference
+their packages from there, while their versions still resolve from the platform's file.
+
+Measured 2026-08-21: an audit that scanned the platform alone called 60 pins orphaned. Fourteen of
+them were live satellite dependencies (`Azure.AI.OpenAI`, `Microsoft.Agents.AI.*`,
+`Microsoft.Extensions.AI.OpenAI`, `Microsoft.Graph`, `ClaudeAgentSdk`, `GitHub.Copilot.SDK`,
+`OpenAI`, …). Removing them turned **nine module-bundle jobs red** on the plugins trunk — and the
+failure named only the package, at "Build the module", four steps from the cause.
+
+**Before removing any pin, scan all five repos:**
+
+```bash
+python3 - <<'PY'
+import re, glob, os
+used = set()
+for repo in ['~/code/MeshWeaver', '~/code/MeshWeaver.Plugins', '~/code/MeshWeaver.SocialMedia',
+             '~/code/MeshWeaver.Reinsurance', '~/code/MeshWeaver.Education']:
+    root = os.path.expanduser(repo)
+    for pat in ('**/*.csproj', '**/*.props', '**/*.targets'):
+        for f in glob.glob(os.path.join(root, pat), recursive=True):
+            if any(x in f for x in ('/bin/', '/obj/', '.worktrees', '.claude')): continue
+            try: used.update(re.findall(r'PackageReference\s+(?:Include|Update)="([^"]+)"', open(f).read()))
+            except Exception: pass
+pinned = re.findall(r'PackageVersion Include="([^"]+)"',
+                    open(os.path.expanduser('~/code/MeshWeaver/Directory.Packages.props')).read())
+print('\n'.join(sorted(p for p in pinned if p not in used)))
+PY
+```
+
+Three details that make the scan honest:
+
+- **Match `Update=` as well as `Include=`.** Analyzer pins (Roslynator) and similar arrive through
+  `PackageReference Update="…"`, which an `Include`-only regex misses.
+- **Scan `tools/` and `samples/`, not just `src/` and `test/`.** `SixLabors.ImageSharp` is used by
+  `tools/MeshWeaver.ThumbnailGenerator` alone.
+- **Scan `.props`/`.targets` too** — a globally injected reference lives there, not in a csproj.
+
+## Transitive pinning is OFF — a CVE override may be doing nothing
+
+`CentralPackageTransitivePinningEnabled` is not set, so a `PackageVersion` only takes effect for a
+package something references **directly**. Two pins in the file carry "pinned to override transitive
+…" CVE comments (`Microsoft.AspNetCore.DataProtection`, `OpenTelemetry.Api`) and override nothing
+today. They are kept as the intent record with that stated plainly; making them effective changes
+resolution repo-wide and belongs in its own change.
+
+## Multi-line entries are elements, not lines
+
+Some pins carry child metadata (`IncludeAssets`, `PrivateAssets`). A line-wise edit orphans the
+body and produces a file that still *looks* fine and breaks restore in an unrelated project — the
+Aspire AppHost failed with "needs a package reference to Aspire.Hosting.AppHost" when its own pin
+was untouched. Edit whole elements, and validate the XML afterwards:
+
+```bash
+python3 -c "import xml.dom.minidom as m; m.parse('Directory.Packages.props'); print('XML OK')"
+```
+
+**The gate for any pin change is a whole-solution restore**, not a project build:
+`MW_ALLOW_SOLUTION_BUILD=1 dotnet restore MeshWeaver.slnx`.

--- a/content/ai/Skill/pull-request.md
+++ b/content/ai/Skill/pull-request.md
@@ -1,7 +1,7 @@
 ---
 nodeType: Skill
 name: /pull-request
-description: Open a pull request for your worktree's branch, trigger a GitHub Copilot review, and land it — build green FIRST, then merge
+description: Open a pull request for your worktree's branch, get it reviewed, and MERGE it once the check suite is green — build green FIRST, then land it
 icon: Sparkle
 category: Skills
 order: 5
@@ -10,9 +10,11 @@ autoMount: false
 
 You are finishing a coding task and want to **ship it as a pull request** — the same way a
 Claude Code session does: build green locally, push the branch, open the PR, request a **GitHub
-Copilot** review, wait for CI to go green, address the review — then **merge it**. You carry the
-change all the way to landed; a green, reviewed PR left open is an unfinished task handed back, and
-the tail is where changes get lost.
+Copilot** review, wait for CI to go green, and address the review.
+
+🚨 **You MERGE it — in every repo — once the check SUITE is green and the review is addressed.**
+There is no per-repo carve-out any more: finishing the job means landing it. The gate is the CI
+suite's verdict, never a feeling that it is probably fine — see the one non-negotiable rule below.
 
 This is the end of the develop-in-a-worktree loop: the coder started on **its own branch in its own
 working tree** (`GitWorkingTreeService.Checkout(userId, repoFullName, branch)`), made and committed
@@ -21,7 +23,7 @@ changes there, and now turns that branch into a reviewed PR. One thread → one 
 
 # 🚨 The one non-negotiable rule: green BEFORE you merge
 
-The pull-based self-update deploys `main`'s image — a red `main` wedges every install's rollout. So
+A red `main` is never acceptable: in core it wedges every install's pull-based image rollout, and in a plugin repo the registry re-serves `main` to every installation. So
 the PR's CI **must be GREEN before you merge**, and you must make CI green **locally first**,
 never discover red on CI:
 
@@ -41,10 +43,17 @@ Only when that Release/`-warnaserror` build + tests are clean do you push.
 
 # The flow
 
-## 1. Commit your work (only when the user asked you to ship)
+## 1. Commit your work
 
-Never commit or push on your own initiative — wait for the explicit "ship it" / "open a PR". Then
-commit through the working tree: `GitWorkingTreeService.CommitAndPush(userId, repoSlug, message,
+**Committing and pushing are part of finishing, not a separate permission.** Carry the work to
+merged and deployed; asking "shall I push?" on a finished change hands back an unfinished task, and
+the tail is where changes get lost. What still stops and asks FIRST is the narrow list — anything
+FATAL (it would ship something broken to consumers), SYSTEM-CHANGING (it alters a running system's
+configuration or lifecycle rather than a repo) or DESTRUCTIVE (it removes or overwrites something
+with no cheap inverse). Merging a green PR is none of those; rolling an instance's image or
+deleting a partition is.
+
+Then commit through the working tree: `GitWorkingTreeService.CommitAndPush(userId, repoSlug, message,
 branch)` (or `git add -A && git commit` in the worktree). Follow the repo's commit convention —
 end the message with a `Co-Authored-By:` trailer identifying you as the author:
 
@@ -63,12 +72,20 @@ git push -u origin <branch>
 gh pr create --base main --head <branch> --title "…" --body "…"   # what changed · why · how tested
 ```
 
-## 3. Request the GitHub Copilot review — REST API only
+## 3. The GitHub Copilot review — CHECK THE REPO FIRST
 
-`gh pr edit --add-reviewer` CANNOT add Copilot. Request it through the REST API:
+🚨 **Whether you request this review is a PER-REPO decision, and getting it wrong costs money or
+costs the review.** Read your repo's `/pullrequest` delta before doing anything here:
+
+- **Repo has a `copilot_code_review` RULESET** (MeshWeaver.Plugins and its satellites): the review
+  is AUTOMATIC on every PR, draft included. **Never POST to `/requested_reviewers`** — it duplicates
+  the ruleset's review and burns extra Copilot credits — and **never delete the request** "to save
+  credits", which cancels a review the maintainer wants. Just wait for it.
+- **Repo has no such ruleset**: request it yourself. `gh pr edit --add-reviewer` CANNOT add Copilot;
+  use the REST API (substitute your own repo for `<owner>/<repo>`):
 
 ```bash
-gh api --method POST /repos/Systemorph/MeshWeaver/pulls/<PR>/requested_reviewers \
+gh api --method POST /repos/<owner>/<repo>/pulls/<PR>/requested_reviewers \
   -f "reviewers[]=copilot-pull-request-reviewer[bot]"
 ```
 
@@ -82,26 +99,36 @@ them. Re-run the affected test locally after each fix; push; CI re-runs.
 
 ## 5. Merge it
 
-When the check **suite** is green and the review is addressed, **merge** — `gh pr merge <PR> --merge`
-(or `--auto`, which arms it to land the moment the required contexts report). Then report what
-landed: the PR number, the URL, and what actually shipped.
+When the check SUITE is **green** and the review is addressed, **merge** (`gh pr merge <PR>
+--merge`), then report what landed: the PR number, the URL, and what actually shipped.
 
-- **Green means the SUITE concluded green**, not that no check has failed yet. Poll the suite; a PR
-  with no check suite at all (`mergeable` unreadable) will otherwise be waited on forever.
-- **A branch behind `main` may need a trunk merge first** where the repo protects `main` with
-  `strict: true` — auto-merge waits indefinitely on a `BEHIND` PR because nothing updates it for you.
+Three things this does NOT license, because each has cost a red `main`:
+
+- **Green means the SUITE concluded green.** Poll the check suite and merge only on
+  `conclusion == SUCCESS`. A pending check is not a green one, and a PR carrying a CONFLICT gets no
+  check suite at all — read `mergeable` first, or you will wait forever on checks that were never
+  scheduled.
+- **The review is part of "addressed", not a formality.** The ruleset's Copilot review can land
+  well AFTER CI goes green — measured at ~13 minutes on `MeshWeaver.Plugins` #436, which merged in
+  that window and shipped four real defects, one of them a silent data loss that needed a follow-up
+  PR to remove. Wait for the review, then merge.
 - **Merging is not shipping.** A merge changes nothing on any mesh by itself; carry on into the
-  deploy, which is a separate, system-changing step and IS the one to check in about.
-
-**Stop and ask FIRST only when the next step is fatal, system-changing or destructive** — shipping
-something broken to consumers, changing a running system's configuration or lifecycle, or removing
-something with no cheap inverse. A flaky job unrelated to your diff, a review finding you disagree
-with, and a merge that needs a trunk merge or a re-run are **not** reasons to stop.
+  deploy your repo's delta describes, and verify it landed against something you know CHANGED —
+  never against a status field, which is produced by whatever code is already running.
+- **In core, verify CD actually BUILT after your merge** — three states ship nothing while looking
+  fine, all measured 2026-08-22 (`Doc/Architecture/ContinuousDeliveryContract` → "The standing
+  trap"): a CD run with **zero jobs** ("workflow file issue") means `main-cd.yml` itself is
+  invalid — classic cause: a `needs:` naming a deleted job, so parse every `needs:` against the
+  job set before pushing any workflow edit; a **green run whose jobs all read `skipped`** shipped
+  nothing by decision — read the `Decide` step's LAST line and believe it over the tick; and a
+  **red required check on main switches CD off entirely** ("⛔ nothing will be built" — a red,
+  paging run since 2026-08-22; a flake → `gh run rerun <id> --failed`, a green rerun re-enters CD
+  by itself). The positive check that covers all three: the newest `memex-portal-ai` release tag
+  on ACR must POSTDATE your merge.
 
 # Boundaries
 
-- **Never merge a red or still-pending PR**, and never force-push over `main`
-  (`--force-with-lease` on your own PR branch is routine).
+- **Never merge a red or still-pending PR**, and never force-push over `main`.
 - **Never change log levels, add band-aids, or widen a timeout** to make CI pass — fix the defect.
 - Everything the agent writes into the codebase still obeys the [/code](@/Skill/code) rules
   (no `async`/`await` in mesh-reachable code, `GetMeshNodeStream(path).Update(...)` for mutations,

--- a/src/MeshWeaver.AI/MeshWeaver.AI.csproj
+++ b/src/MeshWeaver.AI/MeshWeaver.AI.csproj
@@ -14,12 +14,13 @@
              2) Content copy-to-output ("AiContent" beside the assembly) for a deployed offline build;
              3) the repo working tree itself — a dev edits it in the mesh and syncs it back here.
 
-             🚨 ROLES since the Agent plugin (MeshWeaver.Plugins/Agent): on a portal that serves the
-             Agent partition from the DB, the PLUGIN is the served master — nothing here is imported
-             any more (AgentStaticRepoSource is retired). This embedded copy exists for the
-             IN-MEMORY path only: tests, the monolith, MAUI offline — the fixture the framework's
-             delegation/picker/tool-wiring suites run against. A content improvement belongs in the
-             plugin first; mirror it here when the framework tests depend on it. -->
+             🚨 THIS SECTION IS THE ONE MASTER (2026-08-28). The duplicate Agent/ and Skill/
+             packages in MeshWeaver.Plugins were consolidated away — the built-in roster is served
+             from HERE on every portal by BuiltInAgentProvider / BuiltInSkillProvider, delivered
+             with the AI engine module. Edit content/ai and re-pin the entry in
+             test/MeshWeaver.AI.Test/TestData/AiContentPackSync.json (AiContentPackDriftTest) —
+             these files are every deployment's default chat instructions, so changes are recorded
+             decisions, never drift. -->
         <EmbeddedResource Include="..\..\content\ai\**\*.md" LinkBase="Data" />
         <Content Include="..\..\content\ai\**\*.md"
                  Link="AiContent\%(RecursiveDir)%(Filename)%(Extension)"

--- a/test/MeshWeaver.AI.Test/AiContentPackDriftTest.cs
+++ b/test/MeshWeaver.AI.Test/AiContentPackDriftTest.cs
@@ -14,24 +14,24 @@ using Xunit;
 namespace MeshWeaver.AI.Test;
 
 /// <summary>
-/// 🚨 <b>content/ai IS A MIRROR, AND THE MIRROR MUST NOT DRIFT SILENTLY</b> — issue #1627.
+/// 🚨 <b>content/ai IS THE ONE MASTER for the built-in agents and skills</b> — and edits to it
+/// must be DELIBERATE, never drift. Originally issue #1627, reframed 2026-08-28.
 ///
-/// <para>The <b>served</b> master for the built-in agents and skills is the
-/// <c>Systemorph/MeshWeaver.Plugins</c> pack (<c>Agent/</c>, <c>Skill/</c>);
-/// <c>src/MeshWeaver.AI/MeshWeaver.AI.csproj</c> says so in as many words. This repo's
-/// <c>content/ai</c> is the in-memory fixture the framework's delegation / picker / tool-wiring
-/// suites run against. Two copies of the same text, edited by different people at different times,
-/// with <b>nothing comparing them</b> — so drift accumulated in BOTH directions and was found only
-/// by measuring by hand.</para>
+/// <para><b>History, because the ledger's field names still show it:</b> the roster used to exist
+/// twice — here AND as the <c>Agent/</c> + <c>Skill/</c> packages in the private
+/// <c>Systemorph/MeshWeaver.Plugins</c> repo. The copies drifted in both directions for weeks.
+/// On 2026-08-28 the duplicate packages were consolidated away (their genuine deltas adopted
+/// here first), so <c>content/ai</c> — served on every portal by the AI engine's
+/// <c>BuiltIn*Provider</c>s — is the single master, and every ledger entry is
+/// <c>PackAbsent</c> by construction.</para>
 ///
-/// <para><b>Why this is a guard and not a sync.</b> The pack repo is <b>private</b> and this repo is
-/// <b>public</b>. A "just copy the master over" job would have published a real customer's node path
-/// into a public repository — that difference is a deliberate <b>sanitisation</b>, not drift, and it
-/// is the one divergence that must be preserved forever. So the guard does two things a diff cannot:
-/// it pins the reconciliation point (<c>TestData/AiContentPackSync.json</c>) so a core edit has to
-/// state what it did about the master, and it refuses any file <b>in this section</b> carrying an
-/// identifier that must never appear in public. Everything below is scoped to
-/// <c>content/ai/**</c> — this is a mirror guard, not a repository-wide secret scan.</para>
+/// <para><b>What the guard still does, and why it stays:</b> it pins the ROSTER and every file's
+/// content hash (<c>TestData/AiContentPackSync.json</c>), so adding, deleting or editing a
+/// built-in agent/skill is a recorded decision rather than an accident — these are the DEFAULT
+/// CHAT INSTRUCTIONS of every deployment. And it refuses any file <b>in this section</b> carrying
+/// an identifier that must never appear in public: the retired pack was private, this repo is
+/// public, and the sanitised placeholders are permanent. Everything below is scoped to
+/// <c>content/ai/**</c> — it is not a repository-wide secret scan.</para>
 ///
 /// <para><b>The forbidden identifiers are stored as HASHES</b>, and a hit is reported by
 /// <c>file:line</c> only — never by echoing the token. A deny-list that spells the name out, or a
@@ -139,8 +139,8 @@ public class AiContentPackDriftTest
 
         onDisk.Should().Equal(pinned,
             "every file under content/ai must have a ledger entry and vice versa. Added: [{0}]. "
-            + "Removed: [{1}]. Add or delete the entry in test/MeshWeaver.AI.Test/TestData/{2} and "
-            + "state in it what you did about the MeshWeaver.Plugins master.",
+            + "Removed: [{1}]. Add or delete the entry in test/MeshWeaver.AI.Test/TestData/{2} — "
+            + "this roster is the built-in default of every deployment, so it changes on purpose.",
             string.Join(", ", onDisk.Except(pinned, StringComparer.Ordinal)),
             string.Join(", ", pinned.Except(onDisk, StringComparer.Ordinal)),
             LedgerFileName);
@@ -169,11 +169,10 @@ public class AiContentPackDriftTest
             .ToArray();
 
         drifted.Should().BeEmpty(
-            "content/ai mirrors the Systemorph/MeshWeaver.Plugins pack, which is what actually SERVES "
-            + "— so an edit here that is not carried over to the master is a change production never "
-            + "sees, and an edit there that is not carried here is one the framework tests never see. "
-            + "Re-pin the entry in test/MeshWeaver.AI.Test/TestData/{0} (paste the new hash, set the "
-            + "state, say what you did about the master). Drifted: {1}",
+            "content/ai is the ONE master for the built-in agents and skills — what every portal "
+            + "serves as its default chat instructions — so an edit must be a recorded decision, "
+            + "not an accident. Re-pin the entry in test/MeshWeaver.AI.Test/TestData/{0} (paste "
+            + "the new hash and say in the note what changed). Drifted: {1}",
             LedgerFileName, string.Join(" | ", drifted));
     }
 
@@ -234,9 +233,11 @@ public class AiContentPackDriftTest
                 "{0} must keep its sanitised placeholder '{1}' — this repo is PUBLIC and the pack "
                 + "master is PRIVATE, so this divergence is permanent, never something to reconcile",
                 entry.File, entry.SanitisedToken!);
-            entry.State.Should().Be("SanitisedOnly",
-                "{0} differs from the master only by the placeholder; recording it as anything else "
-                + "invites a future sync to 'fix' it", entry.File);
+            // With the pack retired every entry is PackAbsent; the placeholder rule above is the
+            // half that outlives the pack, and SanitisedOnly remains valid for history.
+            entry.State.Should().BeOneOf(["SanitisedOnly", "PackAbsent"],
+                "{0} carries a sanitised placeholder — its entry must not claim the un-sanitised "
+                + "text is fine", entry.File);
         }
     }
 

--- a/test/MeshWeaver.AI.Test/TestData/AiContentPackSync.json
+++ b/test/MeshWeaver.AI.Test/TestData/AiContentPackSync.json
@@ -1,23 +1,10 @@
 {
-  "$comment": [
-    "PACK SYNC LEDGER for content/ai — the drift guard's pinned reconciliation point (#1627).",
-    "content/ai is a MIRROR: the served master is Systemorph/MeshWeaver.Plugins (Agent/, Skill/),",
-    "and drift runs in BOTH directions. Nothing compares the two automatically, because that repo",
-    "is PRIVATE and this one is PUBLIC — so this file records the reconciliation point instead,",
-    "and AiContentPackDriftTest fails the build when a core file moves away from it.",
-    "REGENERATE: edit the file, run the test, and paste the 'core' hash it prints into this entry",
-    "together with the state/note that says what you did about the pack master."
-  ],
-  "hash": "sha256 of the file's text as UTF-8, BOM stripped, CRLF/CR folded to LF, trailing newlines trimmed",
   "pack": {
     "repo": "Systemorph/MeshWeaver.Plugins",
-    "commit": "c29a0de",
-    "observed": "2026-08-25",
-    "note": "The pack half cannot be checked from this repo's CI — it is private and this repo holds no credential for it. The 'pack' hashes are an ATTESTATION of what was measured at the commit above, not something the test verifies."
+    "commit": null,
+    "observed": "2026-08-28",
+    "note": "THE PACK IS RETIRED. The duplicate Agent/ and Skill/ packages in Systemorph/MeshWeaver.Plugins were consolidated away on 2026-08-28 (Roland: 'remove agents and skill package and serve from the main ai package') after their genuine deltas were adopted here (/pull-request body, Assistant's /feedback row, /driver-release, /package-versions) — ThreadNamer was already core-code-defined (BuiltInAgentProvider.CreateThreadNamerNode), so the pack's copy simply dies. content/ai is the ONE master, served on every portal by the AI engine's providers; every entry is PackAbsent by construction and the ledger's remaining job is pinning deliberate core edits and the sanitisation guard."
   },
-  "notes": [
-    "Skill/*.md entries have pack:null because the pack master still stores its skills as typed .json nodes (Skill/*.json), not the .md-with-front-matter format this repo uses. A byte comparison is therefore impossible for skills; only the roster and the sanitisation rules apply to them."
-  ],
   "forbiddenIdentifiers": [
     {
       "sha256": "eaf8859353effdd6182703ab92af8cd88360df4d3452bd3ab27d763947ff97e5",
@@ -27,92 +14,89 @@
   "files": [
     {
       "file": "Agent/Assistant.md",
-      "core": "9386bc34d4f5e60430a9f035f929c907642ddc29f6db69f6424a53e88934e6e3",
-      "pack": "4a9cb965ee065983446a9c97d275fd1d1ae6f046edcca6971898e7b76212d0b3",
-      "state": "PackAhead",
-      "note": "The pack master carries one extra skill row the core fixture does not. Reconciling it is a change to agent INSTRUCTIONS and needs its own review (#1627)."
+      "core": "4a9cb965ee065983446a9c97d275fd1d1ae6f046edcca6971898e7b76212d0b3",
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/CommentingReference.md",
       "core": "8ca83e8185749880750607b29c671ea4b293d144b4b63cf5fa5b1cae67e479e6",
-      "pack": "d7db39e2185ea89e624ff01b3763b297294b31bf368d6c257bb91fef459ef175",
-      "state": "SanitisedOnly",
-      "note": "Byte-identical to the pack master EXCEPT the example namespace, which is sanitised here. This divergence is PERMANENT and must never be reconciled: the pack repo is private, this one is public.",
+      "pack": null,
+      "state": "PackAbsent",
+      "note": "The example namespace stays the sanitised placeholder — the private pack copy that carried a real customer name is deleted with the pack, and the placeholder is the only form this PUBLIC repo may ever hold.",
       "sanitisedToken": "Acme"
     },
     {
       "file": "Agent/DescriptionWriter.md",
       "core": "28bad6b71e891f57d04d49df76119dee22328a8bccfe74a0f28579406f4befa1",
-      "pack": "28bad6b71e891f57d04d49df76119dee22328a8bccfe74a0f28579406f4befa1",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/EmailRouter.md",
       "core": "00c014318f7a029ff9b6773bdcf5329556ec14fc361f0cf1f84d5dcecfd6afd9",
-      "pack": "00c014318f7a029ff9b6773bdcf5329556ec14fc361f0cf1f84d5dcecfd6afd9",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/ExecutiveAssistant.md",
       "core": "3985e92e165e859ba83a8a92fba35ddb3beb2ded67d561ce5008c56e5407b9ca",
-      "pack": "3985e92e165e859ba83a8a92fba35ddb3beb2ded67d561ce5008c56e5407b9ca",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/LogTriage.md",
       "core": "49a7468dc8910259f8ed066fdd9a2aae3f8b56133675a603a534e280dd65ef82",
-      "pack": "99769e78e6497b33b093205ec3692a81f4d21566878571c0e281fda9687e50f9",
-      "state": "CoreAhead",
-      "note": "Core documents the current incident shape (normalizedDetail / variants); the pack master still describes the earlier single-field shape. The pack is what SERVES, so production runs the older text (#1627)."
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/NodeInitializer.md",
       "core": "4852779220d127d30d8f577cc314ec5903ec4329c0774d8c61162ad6ef06d987",
-      "pack": "4852779220d127d30d8f577cc314ec5903ec4329c0774d8c61162ad6ef06d987",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/NotificationTriage.md",
       "core": "4787815823cff81136848cb9fa86ff6e83f55908ac15304426f4d67c67d0dc25",
-      "pack": "4787815823cff81136848cb9fa86ff6e83f55908ac15304426f4d67c67d0dc25",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/PullRequestWriter.md",
       "core": "57ec31e3d007de116ef526e51be31a9c1d6653cd71afef866091d7152593bc24",
-      "pack": "57ec31e3d007de116ef526e51be31a9c1d6653cd71afef866091d7152593bc24",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/Researcher.md",
       "core": "8f93b1d3644730c9340000b3bb12b5ea06ed6e656fbd0e8ad202c01c09a5bf56",
-      "pack": "8f93b1d3644730c9340000b3bb12b5ea06ed6e656fbd0e8ad202c01c09a5bf56",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/ToolsReference.md",
       "core": "3dcd15ddf71d7bd826aa6cd054603e69902caf694d1610f12ac70805ba560b4c",
-      "pack": "3dcd15ddf71d7bd826aa6cd054603e69902caf694d1610f12ac70805ba560b4c",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/TrainingSim.md",
       "core": "dfe6749a31fd7baf70456e904999f802021175829cf640ed1609929b14d3db98",
-      "pack": "dfe6749a31fd7baf70456e904999f802021175829cf640ed1609929b14d3db98",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/Tutor.md",
       "core": "4112c94f27b91a6e5971358faddf5d17fc3f25b5f609f9770fe45b19b04d11df",
-      "pack": "0a66bfbb4c14c8945683295c0959fd2fe53d2a217995783d83ada935d56475e3",
-      "state": "CoreAhead",
-      "note": "Core describes the node-native course model (Edu/Module, Edu/Lesson, Edu/Exercise); the pack master still describes the retired Course/Module/ExerciseAttempt model. The pack is what SERVES (#1627)."
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Agent/Worker.md",
       "core": "b881490b3ca767ca11a44c6d596615ebd053ff4277e4bccc9bc613ddd05ba5a9",
-      "pack": "b881490b3ca767ca11a44c6d596615ebd053ff4277e4bccc9bc613ddd05ba5a9",
-      "state": "InSync"
+      "pack": null,
+      "state": "PackAbsent"
     },
     {
       "file": "Skill/access.md",
@@ -145,6 +129,13 @@
       "state": "PackAbsent"
     },
     {
+      "file": "Skill/driver-release.md",
+      "core": "5e4214b62e80a07b0d0bba3470d383e6f34255509df44694fe6ab8ee23d18ce2",
+      "pack": null,
+      "state": "PackAbsent",
+      "note": "Adopted from the retired MeshWeaver.Plugins pack in the same change that deleted it — content/ai is the one master now."
+    },
+    {
       "file": "Skill/group.md",
       "core": "c72243ed16ffa6639ad09643befeef35cef9eab20647442bc40d14489195afd9",
       "pack": null,
@@ -160,8 +151,7 @@
       "file": "Skill/layout-area.md",
       "core": "aa1d75d5c1bad31d61116bf93347f292bf2745ee5dc58428af4b8a07eed6c90d",
       "pack": null,
-      "state": "PackAbsent",
-      "note": "MAUI residue sweep: dropped the retired client's data-binding paragraph; master pack absent, nothing to carry over"
+      "state": "PackAbsent"
     },
     {
       "file": "Skill/logon-action.md",
@@ -194,6 +184,13 @@
       "state": "PackAbsent"
     },
     {
+      "file": "Skill/package-versions.md",
+      "core": "91460797f3207082b54e6bdda1bd0264e7941ecd68cc86f84d8b5f6484a64cd1",
+      "pack": null,
+      "state": "PackAbsent",
+      "note": "Adopted from the retired MeshWeaver.Plugins pack in the same change that deleted it — content/ai is the one master now."
+    },
+    {
       "file": "Skill/presentation.md",
       "core": "394db08b881f6455b2b9b4561bb94ad2c00db167a89ca78413dd5be32a1d0087",
       "pack": null,
@@ -207,7 +204,7 @@
     },
     {
       "file": "Skill/pull-request.md",
-      "core": "27eb0a672388e20e5be33f5c2f9a18a1fd7f6fc5ef4b7b6456ec6412905fb550",
+      "core": "26ba5d477849311e6dec67f5bc32cfcd7e3e5041b5b9c83d6bbde82c5e9ae0af",
       "pack": null,
       "state": "PackAbsent"
     },
@@ -239,8 +236,7 @@
       "file": "Skill/ui-extensibility.md",
       "core": "845eb2a1a309d3dc474d5bacfc2b04b62e84593d667e16e429a6f09b28eb55ac",
       "pack": null,
-      "state": "PackAbsent",
-      "note": "MAUI residue sweep: dropped the optional MauiViewRegistry step; master pack absent, nothing to carry over"
+      "state": "PackAbsent"
     }
   ]
 }


### PR DESCRIPTION
Consolidation, plugins-side counterpart: Systemorph/MeshWeaver.Plugins deletes its duplicate `Agent/` and `Skill/` packages (never deployed, drifting both ways). Their genuine deltas are adopted HERE first — `/pull-request`'s newer body, Assistant's `/feedback` row, `/driver-release` and `/package-versions` (pack-only skills). ThreadNamer was already core-code-defined and is not ported.

`AiContentPackDriftTest` reframed: content/ai IS the served master; ledger entries are `PackAbsent`; the roster/hash pinning and the sanitisation guard (public repo — placeholders permanent) remain. `MeshWeaver.AI.Test`: 1483 passed / 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJ5Lj4z9dWuv2ZKabLo4hr