### PR TITLE
fix: name the Composition parameter column after what it contains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -522,13 +522,22 @@ Two shapes, pick by whether the text hangs off a declaration:
 
 🚨 **But the REQUIREMENT survived the move, and this paragraph briefly said otherwise.** It read *"That is gone … do not go looking for the mirror"*, which is true of the directory and false of the rule. On 2026-08-27 that cost two keys: they were added server-side, the mirror was looked for **in core**, its absence was read as deletion, and "there is no mirror" went into a merged PR body. The mirror was three keys behind by then. **Deleted and relocated look identical from one repo** — assume relocated until you have looked in the other one.
 
-🚨 **And do not count on the guard to catch it for you.** MeshWeaver.Plugins#771: **nothing currently runs those specs** — core's `clients.yml` covers only `clients/python` after the move, and the plugins repo runs `npm ci` there and nothing else. The drift guard whose entire job is to stop a server-side key reaching users as a raw string has been reporting to no one. Until that lane exists, run it by hand from the plugins checkout:
+✅ **The drift guard DOES run — this paragraph used to say it did not, and that was the dangerous half.** It read *"nothing currently runs those specs … the drift guard has been reporting to no one"* (from MeshWeaver.Plugins#771). That lane now exists: the plugins repo's **`RN app + web clients (typecheck + test)`** job runs `src/i18n/localize.test.ts`, and on 2026-08-28 it caught a real drift within minutes of the push — a `composition.column.provision` value changed in the client catalog but not in core's:
+
+```
+FAIL src/i18n/localize.test.ts > catalog drift guard > strings.en.json is identical to the server catalog
+AssertionError: value drift for "composition.column.provision": expected 'Install as' to be 'Provision as'
+```
+
+**Core is the source of truth, so the order is fixed**: the core catalog change merges FIRST, and the plugins mirror PR stays red until it does. Do not "fix" that red by reverting the mirror — it is the guard doing its job across a repo boundary.
+
+To run it by hand from the plugins checkout (it fails loudly, naming the paths it probed, when it cannot find a core checkout — so a green there is real and a skip is impossible):
 
 ```bash
 cd clients/react && MESHWEAVER_CORE=/path/to/MeshWeaver npx vitest run src/i18n/localize.test.ts
 ```
 
-It fails loudly, naming the paths it probed, when it cannot find a core checkout — so a green there is real, and a skip is impossible.
+🚨 **The guard compares VALUES, not just keys** — so it also catches the case `LocalizationTest` cannot see: a key present in both catalogs whose text has diverged.
 
 🚨 **Never resolve from `CultureInfo.CurrentUICulture` or `CurrentCulture`** — and this covers *formatting* (dates, numbers, calendars), not just translated strings. Two independent reasons: (1) a layout-area render hops the hub scheduler and an ambient AsyncLocal culture does not survive it, so one user's UI would pick up another user's language; (2) on Blazor Server the ambient culture is the **server process's**, i.e. the container the portal runs in — identical for every simultaneous viewer and unrelated to any of them. `DateTimeView` defaulted its calendar culture that way until 2026-08-17 and rendered English month names for German users regardless of their choice. Resolution is always explicit off `AccessContext.Locale` (`AccessService.ViewerLocale()` / `host.ViewerLocale()`); derive a `CultureInfo` from that when you need one.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-composition-parameter-column.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-composition-parameter-column.md
@@ -1,0 +1,15 @@
+---
+Name: Clearer column in Composition settings
+Category: Fix
+Description: The Composition tab's parameter table now names the environment variable it lists, instead of the internal word "Provision as".
+Icon: Sparkle
+Order: -20260828
+---
+
+# Clearer column in Composition settings
+
+Administration ▸ Composition lists the parameters each installed package requires. One column was
+headed "Provision as", which is internal vocabulary and did not say what the column actually shows:
+the name of the environment variable the value is read from.
+
+It now reads "Environment variable" (German: "Umgebungsvariable"), which is what is in it.

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -949,7 +949,7 @@
   "composition.column.package": "Paket",
   "composition.column.parameter": "Parameter",
   "composition.column.kind": "Art",
-  "composition.column.provision": "Bereitstellen als",
+  "composition.column.provision": "Umgebungsvariable",
   "composition.column.supplied": "Bereitgestellt",
   "composition.supplied.yes": "Ja",
   "composition.supplied.no": "Nein – Installation verweigert",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -949,7 +949,7 @@
   "composition.column.package": "Package",
   "composition.column.parameter": "Parameter",
   "composition.column.kind": "Kind",
-  "composition.column.provision": "Provision as",
+  "composition.column.provision": "Environment variable",
   "composition.column.supplied": "Supplied",
   "composition.supplied.yes": "Yes",
   "composition.supplied.no": "No — install refused",


### PR DESCRIPTION
## What

Administration ▸ Composition's parameter table had a column headed **"Provision as"**. Every cell in
it holds an **environment variable name** — it is populated by `PackageParameters.EnvironmentVariable(p)`
(`src/MeshWeaver.PluginCatalog/CompositionAdminSettingsTab.cs:170`). It now says **"Environment
variable"** / **"Umgebungsvariable"**.

## The near-miss worth recording

Read as a bare string, "Provision as" looks like installation vocabulary, and the obvious
de-jargoned replacement is *"Install as"* — which is what I first wrote and pushed. The call site
says otherwise: the neighbouring columns are `Package | Parameter | Kind | … | Supplied`, so the
table is about how a required **parameter** is supplied, not about installing anything.

Renaming a user-facing string without reading its call site just swaps one wrong word for another.

## 🚨 This catalog is only HALF a change

`clients/react/src/i18n/strings.{en,de}.json` in **MeshWeaver.Plugins** mirrors this catalog, and
`src/i18n/localize.test.ts` there compares the two **value by value** and fails on drift.

**AGENTS.md says that spec runs nowhere. That is stale.** It runs in the plugins repo's
*"RN app + web clients (typecheck + test)"* job, and it caught this exact drift on
MeshWeaver.Plugins#797 within minutes of the push:

```
FAIL src/i18n/localize.test.ts > catalog drift guard > strings.en.json is identical to the server catalog
AssertionError: value drift for "composition.column.provision":
  expected 'Install as' to be 'Provision as'
```

The mirroring half rides on **MeshWeaver.Plugins#797**, which stays red until this merges — core is
the source of truth, so the order is fixed. I'd suggest a follow-up correcting that AGENTS.md
paragraph, since believing it is what makes a server-side key ship as a raw string to users.

## Verification

`MeshWeaver.Messaging.Hub.Test` — 56/56 green, including `LocalizationTest` (which fails if either
language is missing a key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)