### PR TITLE
Pin the two temporal guarantees of UntilDetermined (#2302 finding 10)

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/UntilDeterminedTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/UntilDeterminedTest.cs
@@ -1,0 +1,111 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Hosting.AspNetCore.Portal;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// The two temporal guarantees of <see cref="UserIdentityLookup.UntilDetermined"/>, which were the
+/// point of the subscribe-before-read change and had no test (MeshWeaver#2302, finding 10).
+///
+/// <para>Both are pure: a <see cref="Subject{T}"/> for the hot feed and a lambda for the lookup —
+/// no mesh, hub or query subscription, exactly as that method's own remarks promise. That matters
+/// because the window under test is one a live-mesh test cannot hold open.</para>
+///
+/// <para>🚨 Without these, a future rewrite that restores the tempting <c>Defer</c>/<c>StartWith</c>
+/// shape — read, then subscribe — reintroduces a 60-second hang for any visitor whose index
+/// snapshot lands in that gap, and every build stays green.</para>
+/// </summary>
+public class UntilDeterminedTest
+{
+    /// <summary>
+    /// An index snapshot that is applied WHILE the initial reading is being taken must still be
+    /// delivered.
+    ///
+    /// <para>The lookup pushes the feed on its first call, which places the emission precisely in
+    /// the gap the read-then-subscribe order leaves open: with the correct order the subscription
+    /// already exists and the emission is seen; with the old order it is published to nobody and
+    /// is unrecoverable, so the sequence never produces a determinate answer.</para>
+    /// </summary>
+    [Fact]
+    public void An_emission_during_the_initial_lookup_is_still_delivered()
+    {
+        var feed = new Subject<Unit>();
+        var calls = 0;
+
+        UserIdentityLookup Lookup()
+        {
+            calls++;
+            if (calls == 1)
+            {
+                // Applied *during* the initial read — the exact race this method exists to survive.
+                feed.OnNext(Unit.Default);
+                return UserIdentityLookup.Unavailable("index not hydrated");
+            }
+            return UserIdentityLookup.Unknown;
+        }
+
+        var seen = new List<UserIdentityLookup>();
+        var completed = false;
+        using var sub = UserIdentityLookup.UntilDetermined(feed, Lookup)
+            .Subscribe(seen.Add, () => completed = true);
+
+        Assert.True(
+            completed,
+            "UntilDetermined never produced a determinate answer. The snapshot applied during the "
+            + "initial lookup was published to a feed nobody had subscribed to yet — the "
+            + "read-then-subscribe order this method was changed away from. A visitor in that "
+            + "window waits out the full request budget.");
+        Assert.Single(seen);
+        Assert.False(seen[0].IsUnavailable);
+    }
+
+    /// <summary>
+    /// "Unknown" is a determinate answer and must terminate the sequence — continuing to listen
+    /// would hold a subscription to a hot, process-wide stream open for every never-onboarded
+    /// visitor.
+    /// </summary>
+    [Fact]
+    public void Unknown_is_an_answer_and_ends_the_subscription()
+    {
+        var feed = new Subject<Unit>();
+        var completed = false;
+        using var sub = UserIdentityLookup.UntilDetermined(feed, () => UserIdentityLookup.Unknown)
+            .Subscribe(_ => { }, () => completed = true);
+
+        Assert.True(completed, "Unknown must terminate UntilDetermined, not keep listening.");
+        Assert.False(feed.HasObservers, "the feed subscription must be released once determined");
+    }
+
+    /// <summary>
+    /// A throwing initial lookup must tear the feed subscription down before surfacing the fault.
+    ///
+    /// <para>Subscribing FIRST is what creates this obligation: the subscription already exists when
+    /// the reading throws, so simply letting the exception escape would leave a live subscription to
+    /// a hot, process-wide stream that nobody holds — re-invoking the lookup for the life of the
+    /// cache. <c>HasObservers</c> is the assertion that the teardown actually happened; asserting
+    /// only the OnError would pass while the leak remained.</para>
+    /// </summary>
+    [Fact]
+    public void A_throwing_initial_lookup_disposes_the_feed_subscription()
+    {
+        var feed = new Subject<Unit>();
+        var boom = new InvalidOperationException("index read failed");
+
+        Exception? caught = null;
+        using var sub = UserIdentityLookup.UntilDetermined(feed, () => throw boom)
+            .Subscribe(_ => { }, ex => caught = ex);
+
+        Assert.Same(boom, caught);
+        Assert.False(
+            feed.HasObservers,
+            "the hot-feed subscription outlived a throwing initial lookup — it would re-invoke the "
+            + "lookup for the life of the cache with nobody holding the result");
+    }
+}


### PR DESCRIPTION
Closes the last actionable item on #2302 (finding 10).

`UserIdentityLookup.UntilDetermined` had **no test anywhere** — `grep -rln UntilDetermined --include='*.cs' test/ src/` returns exactly one hit, the implementation. (The finding's path is also stale: the file moved from `MeshWeaver.Blazor/Infrastructure` to `MeshWeaver.Hosting.AspNetCore/Portal`.)

Three cases, all pure — a `Subject<Unit>` for the hot feed and a lambda for the lookup, no mesh, hub or query subscription, exactly as the method's own remarks promise. That is the point rather than a convenience: the unavailable window is one a live-mesh test cannot hold open.

| Test | Guarantee |
|---|---|
| `An_emission_during_the_initial_lookup_is_still_delivered` | An index snapshot applied *while* the initial reading is taken is still seen. The lookup pushes the feed on its first call, placing the emission precisely in the gap the old order leaves open. |
| `Unknown_is_an_answer_and_ends_the_subscription` | `Unknown` terminates rather than listening on for every never-onboarded visitor. |
| `A_throwing_initial_lookup_disposes_the_feed_subscription` | The feed subscription is torn down before the fault surfaces. |

## Red-proof

Both mutations were applied to the implementation, built, and run — and they fail **disjoint** tests, so each test pins a distinct defect rather than all three riding on one:

- **read-then-subscribe** (the old `Defer`/`StartWith` order) → fails only `An_emission_during_the_initial_lookup_is_still_delivered`, with the assert message naming the cause: *"published to a feed nobody had subscribed to yet … a visitor in that window waits out the full request budget."*
- **dropping `changes.Dispose()`** from the catch → fails only `A_throwing_initial_lookup_disposes_the_feed_subscription`.

That second mutation is why the throwing case asserts `feed.HasObservers` and not merely the `OnError`. Subscribing first is what *creates* the teardown obligation; asserting the fault alone would pass while a subscription to a hot, process-wide stream leaked and re-invoked the lookup for the life of the cache. Note the ordering revert leaves that test green — with read-first, nothing is subscribed when the throw happens — which is correct, and is the reason it needed its own proof.

Implementation restored byte-identical to `main` afterwards: the diff is the one new test file.

**No What's New entry** — test-only, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)