### PR TITLE
fix: a recycle now reaches the subscribers it orphans (#2551)

### DIFF
--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -71,6 +71,127 @@ public class Workspace : IWorkspace
         // and adapt the Subscribe(Action<MeshChangeEvent>, MeshChangeKind?) signature.
         _changeFeedSubscription = TrySubscribeToChangeFeed(hub.ServiceProvider, _logger,
             evtPath => EvictForPath(evtPath));
+
+        // 🚨 Give the hub the goodbye it cannot say for itself — see RecycleAnnouncement and
+        // AnnounceRecycleToClientSubscriptions. Registered here because the client-subscription
+        // registry lives on THIS workspace, and it is the only thing that knows who is listening.
+        hub.Set(new RecycleAnnouncement(AnnounceRecycleToClientSubscriptions));
+    }
+
+    /// <summary>
+    /// 🚨 <b>Tells every live client subscription that its owner is being RECYCLED</b> — the
+    /// missing half of <c>StreamEndedEvent</c>, whose own contract already promises the case
+    /// ("the owning hub tearing down — deactivation, recycle, restart") that its emitter
+    /// deliberately refuses to send, because a dying hub must never speak (see
+    /// <c>JsonSynchronizationStream</c>'s teardown guard, and <see cref="RecycleAnnouncement"/>
+    /// for the full history).
+    ///
+    /// <para><b>Called on the recycled hub's own turn</b>, before its disposal starts — so the
+    /// registry below is intact and the parent hub is resolvable. What it does NOT do is post
+    /// anything yet: the delivery is deferred to <see cref="IMessageHub.DisposalCompleted"/> and
+    /// carried by the PARENT hub, which outlives this one. Both halves of that are load-bearing:</para>
+    /// <list type="bullet">
+    /// <item><description><b>Posted by the parent</b>, because a hub that is tearing down cannot
+    /// reliably deliver its own last message — and the version of this that reached up the tree
+    /// from INSIDE the teardown resurrected the very Orleans activation it was retiring
+    /// (OrleansGrainTeardownStragglerTest). Here the parent speaks about a recycle it hosted, to a
+    /// third party, with nothing routed at the dead address.</description></item>
+    /// <item><description><b>After DisposalCompleted</b>, because the subscriber answers this
+    /// event with ONE bounded re-ask (JsonSynchronizationStream's recycle re-arm). Announcing
+    /// earlier makes that re-ask race the teardown: it lands on the still-dying instance, is
+    /// NACKed <c>ShuttingDown</c>, and burns a budget that exists for a genuinely non-converging
+    /// owner — the #1360 shape, "four rejections in 11 ms". Waiting for the signal the hub already
+    /// publishes costs no timer, no poll and no watchdog.</description></item>
+    /// </list>
+    ///
+    /// <para>Fires at most once per stream (the registry is emptied by the disposal that follows),
+    /// and never at all when nothing is subscribed — a recycle of an unwatched hub stays exactly
+    /// as cheap as it was.</para>
+    /// </summary>
+    private void AnnounceRecycleToClientSubscriptions()
+    {
+        // Snapshot NOW: the streams (and with them these registry entries) are torn down by the
+        // disposal we are about to precede.
+        var orphaned = _clientSubscriptions
+            .Select(kv => (kv.Value.Subscriber, kv.Key.StreamId))
+            .ToArray();
+        if (orphaned.Length == 0)
+            return;
+
+        // The carrier must OUTLIVE the target. A per-node hub is hosted by the mesh hub, a client
+        // hub by whoever created it; when there is no parent there is nothing that can still speak
+        // after we are gone, and the subscriber falls back to the pre-fix recovery (the owner's
+        // next write, or a reload).
+        IMessageHub? carrier;
+        try
+        {
+            carrier = Hub.Configuration.ParentHub;
+        }
+        catch (Exception ex)
+        {
+            // ParentHub re-resolves from the parent service provider, which can already be
+            // disposed when a whole tree is going down. Probing must never throw into a teardown.
+            _logger.LogDebug(ex,
+                "Workspace {WorkspaceId}: could not resolve a carrier for the recycle announcement",
+                Id);
+            return;
+        }
+
+        // 🚨 A SELF-PARENT IS NOT A CARRIER. `Configuration.ParentHub` resolves `IMessageHub` from
+        // the parent DI scope, and for a root hub that is the hub ITSELF (the same self-parent
+        // DataExtensions.RouteStreamMessage terminates its walk on). Posting through it would be
+        // posting from the dying hub — exactly the thing this indirection exists to avoid.
+        if (carrier is null || ReferenceEquals(carrier, Hub) || carrier.Address.Equals(Hub.Address))
+        {
+            _logger.LogDebug(
+                "Workspace {WorkspaceId}: recycled hub has no parent to announce through — "
+                + "{Count} live subscription(s) fall back to the change-feed latch",
+                Id, orphaned.Length);
+            return;
+        }
+
+        _logger.LogDebug(
+            "Workspace {WorkspaceId}: recycling — announcing the end of {Count} live client "
+            + "subscription(s) through {Carrier} once teardown completes",
+            Id, orphaned.Length, carrier.Address);
+
+        void Announce()
+        {
+            foreach (var (subscriber, streamId) in orphaned)
+            {
+                try
+                {
+                    carrier.Post(new StreamEndedEvent(streamId), o => o.WithTarget(subscriber));
+                }
+                catch (Exception ex)
+                {
+                    // Best-effort per subscriber: one unreachable mirror must not silence the rest.
+                    // StreamEndedEvent is [CanBeIgnored], so a subscriber that has itself gone away
+                    // is dropped by routing rather than NACKed.
+                    _logger.LogDebug(ex,
+                        "Workspace {WorkspaceId}: could not announce the recycle of stream "
+                        + "{StreamId} to {Subscriber}", Id, streamId, subscriber);
+                }
+            }
+        }
+
+        // Event-driven, not timed: DisposalCompleted is a ReplaySubject(1) that the hub signals as
+        // the last act of its teardown (the disposal watchdog force-completes it if the phased path
+        // ever wedges), so this leg is already guaranteed terminal and needs no deadline of its own.
+        Hub.DisposalCompleted
+            .Take(1)
+            .Subscribe(
+                _ => Announce(),
+                // A FAULTED disposal is still a disposal: the address is gone either way, and
+                // leaving the subscriber silent is the defect this exists to fix. The fault itself
+                // is surfaced by the disposal path, never swallowed here.
+                ex =>
+                {
+                    _logger.LogDebug(ex,
+                        "Workspace {WorkspaceId}: disposal faulted — announcing the recycle anyway",
+                        Id);
+                    Announce();
+                });
     }
 
     private static IDisposable? TrySubscribeToChangeFeed(
@@ -1019,8 +1140,15 @@ public class Workspace : IWorkspace
     // GetHashCode/Equals recurse into StreamConfiguration (which holds the stream back) — a
     // record wrapper around one stack-overflows the process the moment the dictionary hashes
     // or compares it. See the _evictedRemoteStreams field note.
-    private sealed class ClientSubscription(WorkspaceReference reference, ISynchronizationStream stream)
+    private sealed class ClientSubscription(
+        Address subscriber, WorkspaceReference reference, ISynchronizationStream stream)
     {
+        /// <summary>
+        /// The subscriber's ADDRESS, kept alongside the string that keys the dictionary: a recycle
+        /// announcement has to post back to it, and an Address cannot be reconstructed faithfully
+        /// from its own ToString() (a routed target can carry a Host qualifier).
+        /// </summary>
+        public Address Subscriber { get; } = subscriber;
         public WorkspaceReference Reference { get; } = reference;
         public ISynchronizationStream Stream { get; } = stream;
     }
@@ -1059,7 +1187,7 @@ public class Workspace : IWorkspace
         if (subscriber is null || string.IsNullOrEmpty(streamId))
             return;
         var key = (subscriber.ToString(), streamId);
-        _clientSubscriptions[key] = new ClientSubscription(reference, stream);
+        _clientSubscriptions[key] = new ClientSubscription(subscriber, reference, stream);
         // Pair-exact removal by REFERENCE identity (never value equality — see ClientSubscription):
         // a later stream that legitimately took over this key must not be unregistered by an
         // earlier stream's teardown.

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -349,6 +349,66 @@ change-feed resubscribe latch **stay armed** and the subscriber rehydrates after
 
 ---
 
+## A recycle owes its subscribers a goodbye — and can only say it BEFORE the teardown
+
+A routed `DisposeRequest` is a **recycle**, not an end: the address comes back on the next
+access. The automatic ones exist *for* the people currently looking at a page —
+`NodeTypeEnrichmentHelpers.WithOverlaySelfHeal` recycles an instance hub the moment its NodeType
+reaches a usable build, so the compile-progress overlay is replaced by the real page;
+`NodeTypeRebindWatcher` and the stale-build convergence branch do the same for a superseded
+binding.
+
+**But the teardown itself is structurally mute.** `JsonSynchronizationStream` emits
+`StreamEndedEvent` from the server-side stream's disposal, and that emission is *deliberately
+suppressed* once the owning hub is winding down — a dying owner that reaches up the hub tree for
+a last word re-activates the very Orleans activation it is retiring. It delegates the
+owning-hub-tearing-down case to two other recoveries, and **neither can fire for a recycle**:
+
+- the **recycle re-arm** needs an in-flight `SubscribeRequest` to be NACKed — an *established*
+  subscription has none;
+- the **change-feed latch** needs a WRITE to the owner's path — and a recycle is not a write.
+
+So the subscriber received no frame, no completion and no error, and its mirror served the last
+snapshot it ever saw for the life of the page. The visible symptom was a page frozen on the
+compile-progress overlay while the compile had succeeded seconds earlier — and because a
+framework-identity bump recompiles every dynamic NodeType at once, that is every open page in the
+portal on one deploy (Systemorph/MeshWeaver#2533 / #2551).
+
+**The seam is `RecycleAnnouncement`,** hung on the hub with `hub.Set(...)` and invoked by
+`HandleDispose` on the recycle's own turn:
+
+```csharp
+// MessageHub.HandleDispose
+if (!IsShuttingDown)          // an ancestor's cascade is NOT a recycle — see below
+    AnnounceRecycle();        // Get<RecycleAnnouncement>()?.Announce()
+Dispose();
+```
+
+`Workspace` registers the one real implementation, because the client-subscription registry that
+knows who is listening lives there. Three properties make it safe, and each is load-bearing:
+
+| Property | Why |
+|---|---|
+| **Announced BEFORE `Dispose()`** | The hub is still whole: the registry is intact and `Configuration.ParentHub` still resolves. Both are gone or unreliable a phase later. |
+| **DELIVERED after `DisposalCompleted`, through the PARENT hub** | The subscriber answers with ONE bounded re-ask. Delivered earlier, that re-ask lands on the still-dying instance, is NACKed `ShuttingDown`, and burns a budget meant for a genuinely non-converging owner. Delivered by the dying hub itself, it is the up-the-tree post that resurrects the activation. The parent outlives the target and speaks to a third party. |
+| **Never for an ancestor's cascade** (`IsShuttingDown` already true) | There the address is *not* coming back, every subscriber is going down with it, and telling them to re-ask is exactly the resurrection the suppression exists to prevent. A direct `Dispose()` — how `HostedHubsCollection` tears its children down — never reaches `HandleDispose` at all, so it stays silent by construction. |
+
+Nothing here polls, retries or times out: `DisposalCompleted` is the event, and the re-ask it
+triggers is the pre-existing bounded one. A recycle of a hub nobody is subscribed to costs
+exactly what it did before.
+
+Repros: `RecycleStrandsLiveSubscriberTest` (Hosting.Monolith.Test — a live layout-area
+subscription re-converges on the re-activated hub after a bare `DisposeRequest`, with no node
+write anywhere) and `RecycleAnnouncementTest` (Messaging.Hub.Test — announced once, before the
+teardown; silent on a direct `Dispose()`).
+
+> Only the *automatic* recycles were affected. `MeshOperations.Recycle` (the MCP tool) publishes a
+> `MeshChangeEvent` for the path before its `DisposeRequest`, which is what fed the change-feed
+> latch and made that path look fine; `RecycleLayoutArea` is driven by the page shell, which
+> navigates on its own. The self-heal posted the dispose alone.
+
+---
+
 ## Adding disposal work — the rule
 
 - **Need to run sync cleanup on dispose?** `hub.RegisterForDisposal(IDisposable)`

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-open-pages-recover-when-their-hub-restarts.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-open-pages-recover-when-their-hub-restarts.md
@@ -1,0 +1,21 @@
+---
+Name: Open pages recover when their hub restarts
+Category: Fix
+Description: A page you already have open now reloads itself when the thing serving it restarts, instead of sitting on the "compiling" placeholder until you refresh.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Open pages recover when their hub restarts
+
+When a page's code is still being compiled, the portal shows a short "compiling" placeholder and
+then restarts the page's server side so it picks up the finished build. Anyone who arrived after
+that restart got the real page. Anyone who was already looking at the placeholder did not: their
+page was never told the restart had happened, so it kept showing the placeholder — with no error and
+no spinner — until they reloaded the browser.
+
+That was easiest to hit right after an upgrade, which recompiles every page's code at once and so
+opens the window on every open page in the portal at the same time.
+
+A restart now tells the pages it was serving, and they re-connect on their own as soon as it
+finishes. The page you were already looking at fills in by itself.

--- a/src/MeshWeaver.Messaging.Contract/RecycleAnnouncement.cs
+++ b/src/MeshWeaver.Messaging.Contract/RecycleAnnouncement.cs
@@ -1,0 +1,35 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// 🚨 <b>The seam that lets a RECYCLE say goodbye.</b> A higher layer hangs this on a hub
+/// (<c>hub.Set(new RecycleAnnouncement(...))</c>) to be handed the ONE turn a recycled hub still
+/// has while it is whole: the turn in which its routed <see cref="DisposeRequest"/> is handled,
+/// BEFORE <c>Dispose()</c> begins.
+///
+/// <para><b>Why the hub cannot do this itself, and why the moment matters.</b> A hub's own
+/// teardown callbacks run in the ShutDown phase, by which time it can no longer speak for itself —
+/// <c>JsonSynchronizationStream</c>'s end-of-stream announcement is suppressed there on purpose
+/// ("a hub must speak only for itself, and never while it is dying"), because a dying owner that
+/// reaches UP the hub tree to get a last word out resurrects the very Orleans activation it is
+/// saying goodbye for. So the terminal event was being emitted after the thing that would deliver
+/// it had been torn down, and a live subscriber of a RECYCLED hub was told nothing at all: no
+/// frame, no completion, no error. It kept its last snapshot forever
+/// (Systemorph/MeshWeaver#2533 / #2551 — a page stranded on the compile-progress overlay after
+/// <c>NodeTypeEnrichmentHelpers.WithOverlaySelfHeal</c> recycled the instance hub underneath it).
+/// </para>
+///
+/// <para><b>The contract.</b> <see cref="Announce"/> is invoked SYNCHRONOUSLY on the hub's own
+/// action block, once, only for a message-routed recycle (never for an ancestor's teardown
+/// cascade, where the address is not coming back), and only while the hub is still
+/// <c>Started</c>. It must not block and must not throw — the hub logs and continues either way,
+/// because a recycle that cannot announce must still recycle. Implementations are expected to
+/// CAPTURE what they need in that turn and defer the actual delivery to a carrier that outlives
+/// the teardown (see <c>Workspace.AnnounceRecycleToClientSubscriptions</c>, which posts through
+/// the parent hub once <c>DisposalCompleted</c> has fired, so the re-ask it triggers lands on a
+/// fresh activation instead of racing the dying one).</para>
+/// </summary>
+/// <param name="Announce">
+/// Invoked on the recycled hub's own turn, before its disposal starts. Fire-and-forget: it may
+/// arrange later work, but must return promptly.
+/// </param>
+public sealed record RecycleAnnouncement(Action Announce);

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -2574,8 +2574,59 @@ public sealed class MessageHub : IMessageHub
                 Address, request.Sender);
             return request.Ignored();
         }
+
+        // 🚨 A RECYCLE MUST REACH THE SUBSCRIBERS IT IS ABOUT TO ORPHAN — and this turn is the
+        // only place it can (Systemorph/MeshWeaver#2533 / #2551).
+        //
+        // A routed DisposeRequest is a RECYCLE: the address is coming back, and the whole point of
+        // the automatic ones (NodeTypeEnrichmentHelpers.WithOverlaySelfHeal, NodeTypeRebindWatcher,
+        // the stale-build convergence branch) is to get LIVE viewers off a degraded page. But the
+        // teardown itself is silent by construction: JsonSynchronizationStream's StreamEndedEvent
+        // announcement is deliberately suppressed once the owning hub is disposing ("a hub must
+        // speak only for itself, and never while it is dying" — a dying owner reaching up the hub
+        // tree for a last word RESURRECTS the Orleans activation it is retiring). It delegates the
+        // teardown case to the recycle re-arm and the change-feed latch, and NEITHER can fire here:
+        // the re-arm needs an in-flight SubscribeRequest to be NACKed, and the latch needs a WRITE
+        // — and, as the same file says elsewhere, "a recycle IS NOT A WRITE". So the self-heal was
+        // tearing the hub down under the exact audience it exists for, and every one of them held
+        // its last frame (the compile-progress overlay) until the page was reloaded. On a
+        // framework-identity bump that is every instance hub in the fleet at once.
+        //
+        // Hence: announce FIRST, on this turn, while the hub is whole — the workspace's client
+        // subscription registry is intact and the parent hub is resolvable. The announcement
+        // implementation captures what it needs now and delivers AFTER DisposalCompleted through a
+        // carrier that outlives this hub, so nothing is posted from a dying hub and no re-ask races
+        // the teardown it is a response to.
+        //
+        // NOT for an ancestor's cascade (IsShuttingDown is already true because CloseCreation has
+        // frozen this subtree): there the address is NOT coming back, telling subscribers to re-ask
+        // is exactly the resurrection the suppression above exists to prevent, and the carrier
+        // (our parent) is going down with us.
+        if (!IsShuttingDown)
+            AnnounceRecycle();
+
         Dispose();
         return request.Processed();
+    }
+
+    /// <summary>
+    /// Hands the <see cref="RecycleAnnouncement"/> hung on this hub (if any) its one turn — see
+    /// that type for the contract. Best-effort by design: a recycle that cannot announce must
+    /// still recycle, so a faulting announcement is logged and never propagated into the teardown.
+    /// </summary>
+    private void AnnounceRecycle()
+    {
+        try
+        {
+            Get<RecycleAnnouncement>()?.Announce();
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex,
+                "Recycle announcement for hub {Address} faulted — its live subscribers fall back to "
+                + "the pre-fix behaviour (they recover on the owner's next write, or on reload)",
+                Address);
+        }
     }
 
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/RecycleStrandsLiveSubscriberTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/RecycleStrandsLiveSubscriberTest.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// Deterministic repro for <b>the recycle that strands its own audience</b> — the defect behind
+/// <c>FutuReAnalysisTest.EuropeRe_AnnualReport_EmbeddedCharts_ShouldRenderViaPathResolution</c>
+/// (issues #2533 / #2551) and, far more importantly, behind every framework-identity bump.
+///
+/// <para><b>The mechanism.</b> A per-instance hub that came up while its NodeType was still
+/// compiling binds the compile-in-progress overlay, and
+/// <c>NodeTypeEnrichmentHelpers.WithOverlaySelfHeal</c> then posts a self-<see cref="DisposeRequest"/>
+/// the moment the type reaches a usable build — "the next access re-enriches against the settled
+/// type". <b>An already-open subscription is not a next access.</b> The owner tears down, and the
+/// one message that would have told the subscriber — <c>StreamEndedEvent</c> — is deliberately
+/// suppressed while the owning hub is tearing down (<c>JsonSynchronizationStream</c>: "a hub must
+/// speak only for itself, and never while it is dying"). The two recoveries that comment delegates
+/// to cannot fire either: the recycle re-arm needs an in-flight <c>SubscribeRequest</c> to be
+/// NACKed, and the change-feed latch needs a WRITE — and, as the same file says 600 lines earlier,
+/// "a recycle IS NOT A WRITE". So the subscriber gets no frame, no completion and no error, and
+/// holds its last snapshot forever.</para>
+///
+/// <para><b>Why it is a production risk and not a test nuisance.</b> A framework-identity bump
+/// recompiles EVERY dynamic NodeType fleet-wide (AGENTS.md), so on that deploy every instance hub
+/// takes the cold-compile path, crosses the 5 s overlay grace, is overlaid and is then recycled —
+/// and every user with a page open at that moment is left on the progress page until they reload.
+/// The 37.7 s of total silence in run 33150985489's trace is exactly this: the compile SUCCEEDED
+/// 43 s before the test gave up.</para>
+///
+/// <para><b>What this test pins</b>, with no Roslyn and no overlay: a client holding a LIVE layout
+/// area subscription must re-converge on the RE-ACTIVATED hub after that hub is recycled by a bare
+/// <see cref="DisposeRequest"/> — the byte-for-byte idiom of the self-heal watcher — with NOBODY
+/// writing the node (the MCP <c>Recycle</c> tool publishes a <c>MeshChangeEvent</c> before its
+/// dispose and is therefore NOT affected; the self-heal posts the dispose alone and is). The area
+/// renders a per-activation marker, so "the subscriber saw the new activation" is a fact about the
+/// rendered content, never about timing.</para>
+/// </summary>
+public class RecycleStrandsLiveSubscriberTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string TypePath = "type/RecycleAnnounce";
+    private const string MarkerArea = "ActivationMarker";
+    private const string MarkerPrefix = "ACTIVATION_";
+
+    /// <summary>
+    /// One counter per TEST INSTANCE — never static (AGENTS.md → "No static collections"): its
+    /// lifetime is this test's mesh, so nothing bleeds into the next test class.
+    /// </summary>
+    private int activations;
+
+    // The recycle round-trip is a teardown plus a fresh activation plus a re-subscribe; a
+    // REGRESSION here is a wait that runs out, so the per-test watchdogs must outlast the two
+    // render budgets below or the failure reads as a harness abort instead of the assertion it is.
+    protected override TimeSpan TestSoftDeadline => TimeSpan.FromSeconds(120);
+    protected override TimeSpan TestHardDeadline => TimeSpan.FromSeconds(240);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            // A STATIC NodeType (no Roslyn, no compile lifecycle) whose one area renders the
+            // ORDINAL of the activation serving it. That ordinal is what makes "the subscriber is
+            // still bound to the dead activation" observable: the pre-recycle and post-recycle
+            // renders are different strings, so the assertion never has to guess.
+            .AddMeshNodes(MeshNode.FromPath(TypePath) with
+            {
+                Name = "RecycleAnnounce",
+                State = MeshNodeState.Active,
+                HubConfiguration = config =>
+                {
+                    var ordinal = Interlocked.Increment(ref activations);
+                    return config.AddLayout(layout => layout.WithView(
+                        MarkerArea,
+                        (LayoutAreaHost _, RenderingContext _) =>
+                            Observable.Return<UiControl?>(Controls.Html($"{MarkerPrefix}{ordinal}"))));
+                }
+            });
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    [Fact(Timeout = 240_000)]
+    public async Task LiveSubscriber_ReConverges_WhenItsOwnerIsRecycled()
+    {
+        var instancePath = $"type/RecycleAnnounce{Guid.NewGuid():N}";
+
+        await MeshService.CreateNode(MeshNode.FromPath(instancePath) with
+        {
+            Name = "Instance",
+            NodeType = TypePath,
+            State = MeshNodeState.Active,
+            Content = JsonSerializer.SerializeToElement(new { title = "instance" }),
+        }).Should().Emit();
+
+        // 1. A LIVE subscription — the page a user has open, and the shape the FutuRe test uses.
+        var client = GetClient();
+        var reference = new LayoutAreaReference(MarkerArea);
+        var controls = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(new Address(instancePath), reference)
+            .GetControlStream(reference.Area!);
+
+        var first = await controls.Should().Within(60.Seconds())
+            .Match(c => c is HtmlControl h
+                && h.Data?.ToString()?.StartsWith(MarkerPrefix, StringComparison.Ordinal) == true);
+        var firstMarker = ((HtmlControl)first!).Data!.ToString()!;
+        Output.WriteLine($"Live subscription is bound to {firstMarker}.");
+
+        // 2. THE RECYCLE. A bare DisposeRequest and nothing else — exactly what
+        //    NodeTypeEnrichmentHelpers.WithOverlaySelfHeal's `recycle:` callback posts. No node
+        //    write, no change-feed publish: those are what every OTHER recycle path pairs with the
+        //    dispose, and their absence here is the whole point.
+        client.Post(new DisposeRequest(), o => o.WithTarget(new Address(instancePath)));
+        Output.WriteLine($"Posted DisposeRequest to {instancePath}.");
+
+        // 3. THE CONTRACT. The SAME subscription — never re-opened by the caller — must land on the
+        //    re-activated hub. Before the fix nothing at all reaches it: no frame, no completion,
+        //    no error, and this wait runs its full budget out while the healthy new activation sits
+        //    unasked-for (the prod symptom: a page stuck on the compile-progress overlay).
+        var healed = await controls.Should().Within(60.Seconds())
+            .Match(c => c is HtmlControl h
+                    && h.Data?.ToString()?.StartsWith(MarkerPrefix, StringComparison.Ordinal) == true
+                    && !string.Equals(h.Data.ToString(), firstMarker, StringComparison.Ordinal),
+                "a recycle must reach the subscribers the recycled hub was serving — the self-heal "
+                + "exists FOR the viewer who is on the degraded page, and a teardown it is never "
+                + "told about leaves that viewer on it forever");
+
+        Output.WriteLine($"Live subscription re-converged on {((HtmlControl)healed!).Data}.");
+        activations.Should().BeGreaterThan(1,
+            "the re-ask must have driven a FRESH activation of the instance hub");
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/RecycleAnnouncementTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RecycleAnnouncementTest.cs
@@ -1,0 +1,101 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins the firing contract of <see cref="RecycleAnnouncement"/> — the seam that lets a RECYCLED
+/// hub tell its live subscribers it is going, which nothing else could do
+/// (Systemorph/MeshWeaver#2533 / #2551).
+///
+/// <para><b>Why a seam was needed at all.</b> A hub's own teardown callbacks run in the ShutDown
+/// phase, and <c>JsonSynchronizationStream</c> deliberately SUPPRESSES its end-of-stream
+/// announcement there — "a hub must speak only for itself, and never while it is dying", because a
+/// dying owner reaching up the tree for a last word resurrects the Orleans activation it is
+/// retiring. So the terminal event was emitted after the thing that would deliver it had been torn
+/// down, and a subscriber of a recycled hub got no frame, no completion and no error: it held its
+/// last snapshot forever. The end-to-end consequence is pinned by
+/// <c>RecycleStrandsLiveSubscriberTest</c>; what THIS test pins is the two properties that make
+/// the seam safe.</para>
+///
+/// <list type="number">
+/// <item><description><b>It fires for a routed <see cref="DisposeRequest"/> — a RECYCLE — and
+/// fires while the hub is still WHOLE</b> (<c>IsDisposing == false</c>). That is not decoration:
+/// the announcement implementation reads the workspace's client-subscription registry and resolves
+/// the parent hub that will carry the message, and both are only available before the
+/// teardown starts.</description></item>
+/// <item><description><b>It does NOT fire on a direct <c>Dispose()</c></b> — the host-teardown /
+/// ancestor-cascade route. There the address is NOT coming back, so telling subscribers to re-ask
+/// is precisely the resurrection the suppression above exists to prevent.</description></item>
+/// </list>
+/// </summary>
+public class RecycleAnnouncementTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private static readonly Address RecycledAddress = new("recycled", "1");
+    private static readonly Address DirectAddress = new("direct", "1");
+
+    [HubFact]
+    public async Task RoutedDisposeRequest_Announces_Once_AndBeforeTheTeardownStarts()
+    {
+        var host = GetHost();
+        var announcements = 0;
+        // Read INSIDE the announcement: "the hub is still whole" is a fact about the moment the
+        // callback runs, and a probe taken afterwards would always read true.
+        var disposingWhenAnnounced = true;
+
+        var recycled = host.GetHostedHub(RecycledAddress, c => c.WithInitialization(h =>
+            h.Set(new RecycleAnnouncement(() =>
+            {
+                Interlocked.Increment(ref announcements);
+                disposingWhenAnnounced = h.IsDisposing;
+            }))));
+        recycled.Should().NotBeNull();
+        await recycled!.Started.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        // THE RECYCLE — byte-for-byte what NodeTypeEnrichmentHelpers.WithOverlaySelfHeal posts.
+        host.Post(new DisposeRequest(), o => o.WithTarget(RecycledAddress));
+
+        // The announcement necessarily precedes the teardown, so the hub's own completion signal is
+        // the exact "the recycle has happened" event to wait on — no poll, no sleep, no watchdog.
+        await recycled.DisposalCompleted.FirstOrDefaultAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        announcements.Should().Be(1,
+            "a recycle must give its live subscribers exactly one goodbye — none strands them on a "
+            + "dead activation, and more than one multiplies the bounded re-ask they answer with");
+        disposingWhenAnnounced.Should().BeFalse(
+            "the announcement runs on the recycle's own turn, BEFORE Dispose() — that is what lets "
+            + "it read the client-subscription registry and resolve the carrier that outlives the "
+            + "teardown; announcing from inside the teardown is the phase inversion being fixed");
+    }
+
+    [HubFact]
+    public async Task DirectDispose_DoesNotAnnounce()
+    {
+        var host = GetHost();
+        var announcements = 0;
+
+        var direct = host.GetHostedHub(DirectAddress, c => c.WithInitialization(h =>
+            h.Set(new RecycleAnnouncement(() => Interlocked.Increment(ref announcements)))));
+        direct.Should().NotBeNull();
+        await direct!.Started.WaitAsync(TimeSpan.FromSeconds(30), TestContext.Current.CancellationToken);
+
+        // The host-teardown route: HostedHubsCollection disposes its children with a direct
+        // Dispose(), never a DisposeRequest, and a whole-tree teardown must stay SILENT — every
+        // subscriber it could speak to is going down with it, and on Orleans a re-ask would
+        // reactivate the very activation being retired.
+        direct.Dispose();
+        await direct.DisposalCompleted.FirstOrDefaultAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        announcements.Should().Be(0,
+            "only a message-routed DisposeRequest is a RECYCLE — an address that is coming back. A "
+            + "direct Dispose() is a teardown, and announcing it would tell subscribers to re-ask "
+            + "for something that is gone");
+    }
+}


### PR DESCRIPTION
## A recycle tore the hub down under the exact audience it exists for

`NodeTypeEnrichmentHelpers.WithOverlaySelfHeal` posts a bare `DisposeRequest` the moment a
NodeType reaches a usable build, on the stated premise that *"the next access re-enriches against
the settled type"*. **An already-open subscription is not a next access** — and the self-heal's
whole population is the viewer who is *currently* looking at the compile-progress overlay.

### The exact edge

`JsonSynchronizationStream` emits `StreamEndedEvent` from the server-side stream's disposal, and
that emission is **deliberately suppressed once the owning hub is winding down**:

> *"a hub must speak only for itself, and never while it is dying"* — a dying owner reaching up
> the hub tree for a last word RESURRECTS the Orleans activation it is retiring
> (`OrleansGrainTeardownStragglerTest`).

It delegates the owning-hub-tearing-down case to two other recoveries. **Neither can fire for a
recycle**, and the same file says so 600 lines earlier:

- the **recycle re-arm** needs an in-flight `SubscribeRequest` to be NACKed — an *established*
  subscription has none;
- the **change-feed latch** needs a WRITE to the owner's path — *"a recycle IS NOT A WRITE"*.

So the delegation is to a mechanism that does not cover the case. The subscriber gets **no frame,
no completion and no error**, and its mirror serves the last snapshot it ever saw forever. That is
the "burst of work, then total silence" signature in run `33150985489`: the compile SUCCEEDED at
`07:39:04.9` and the type was usable at `07:39:05.2` — **43 s before** the test gave up.

`StreamEndedEvent`'s own docstring already promises this case ("the owning hub tearing down —
deactivation, recycle, restart"). The emitter refuses to send it in exactly that case. The gap
between those two comments is the bug.

### Why it is a production risk, not a test nuisance

A framework-identity bump recompiles **every** dynamic NodeType fleet-wide, so on that deploy every
instance hub takes the cold-compile path, crosses the 5 s overlay grace, is overlaid and is then
recycled — and every user with a page open at that moment is stranded on the progress page until
they reload. #2568 (removing `MeshWeaver.AI` from `FrameworkBuildIdentity.ContentSurfaceAssemblies`)
flips exactly that identity, which is why the FutuRe test fails **2/2** there and only rarely on
`main`, where a warm assembly cache keeps the compile under 5 s.

Only the *automatic* recycles were affected, which is why this hid for so long:
`MeshOperations.Recycle` (the MCP tool) publishes a `MeshChangeEvent` for the path **before** its
`DisposeRequest` — that fed the change-feed latch and made the recycle path look healthy — and
`RecycleLayoutArea` is driven by the page shell, which navigates on its own. The self-heal posts the
dispose alone.

## The fix — announce before the teardown, deliver after it

A new `RecycleAnnouncement` seam (`MeshWeaver.Messaging.Contract`), hung on a hub with
`hub.Set(...)` and invoked by `MessageHub.HandleDispose` on the recycle's own turn:

```csharp
if (!IsShuttingDown)      // an ancestor's cascade is NOT a recycle
    AnnounceRecycle();
Dispose();
```

`Workspace` registers the one real implementation, because the client-subscription registry that
knows who is listening lives there. Three properties, each load-bearing:

| Property | Why |
|---|---|
| **Announced BEFORE `Dispose()`** | The hub is still whole — the registry is intact and `Configuration.ParentHub` still resolves. Both are gone or unreliable a phase later. |
| **DELIVERED after `DisposalCompleted`, through the PARENT hub** | The subscriber answers with ONE bounded re-ask. Delivered earlier it lands on the still-dying instance, is NACKed `ShuttingDown` and burns a budget meant for a genuinely non-converging owner (the #1360 shape). Delivered by the dying hub itself it is the up-the-tree post that resurrects the activation. The parent outlives the target and speaks to a third party. |
| **Never for an ancestor's cascade** | There the address is not coming back. A direct `Dispose()` — how `HostedHubsCollection` tears its children down — never reaches `HandleDispose` at all, so a whole-tree teardown stays silent by construction. |

**No band-aid:** no bound was raised, no timer, poll, retry or watchdog was added. `DisposalCompleted`
is the event; the re-ask it feeds is the pre-existing, bounded `MaxRecycleReArms` ladder. A recycle
of a hub nobody is subscribed to costs exactly what it did before.

## Verification

**Deterministic repro, written first and confirmed red on `main`** —
`RecycleStrandsLiveSubscriberTest` (Hosting.Monolith.Test): a client holds a live layout-area
subscription to a static-NodeType instance whose area renders a per-activation marker; a bare
`DisposeRequest` recycles it; the SAME subscription must land on the re-activated hub, with no node
write anywhere.

- **before:** fails after its full 60 s wait, still holding `ACTIVATION_1` — and the log shows the
  hub re-activating on its own 4.8 s in (the heartbeat), with the subscriber never told.
- **after:** passes in **659 ms**.

`RecycleAnnouncementTest` (Messaging.Hub.Test) pins the seam: announced exactly once and *before*
the teardown starts (`IsDisposing == false` inside the callback), and silent on a direct `Dispose()`.

Local runs (all green):

| Project | Result |
|---|---|
| `MeshWeaver.Messaging.Hub.Test` | 302 / 302 |
| `MeshWeaver.Data.Test` | 391 / 391 |
| `MeshWeaver.Layout.Test` | 431 / 431 (incl. `SubscribeDuringRecycleTest`) |
| `MeshWeaver.FutuRe.Test` | 59 / 59 |
| `MeshWeaver.Hosting.Monolith.Test` | 742 / 745 (3 pre-existing skips) |
| `MeshWeaver.Documentation.Test` | 98 / 98 |
| `MeshWeaver.Hosting.Orleans.Test` | 215 / 215 |

`dotnet build … -c Release -warnaserror` clean for `MeshWeaver.Messaging.Contract`,
`MeshWeaver.Messaging.Hub`, `MeshWeaver.Data`, `MeshWeaver.Graph`, `MeshWeaver.Layout`,
`MeshWeaver.Hosting`, `MeshWeaver.Documentation`.

Docs: `HubDisposalModel.md` gains "A recycle owes its subscribers a goodbye". What's New entry
shipped (`Category: Fix`).

Closes #2551. Very likely also #2533 (same test, same mechanism — a waiter that never observes a
terminal state reports whatever it last held).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
