### PR TITLE
Check that the key can be stored BEFORE spending the instance id (#2585)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-registration-cannot-burn-an-instance-id.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-registration-cannot-burn-an-instance-id.md
@@ -1,0 +1,20 @@
+---
+Name: Registering an instance can no longer burn its id
+Category: Fix
+Description: A first-startup registration that could not store its issued key used to take the instance id permanently and lose the key, with no way back.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Registering an instance can no longer burn its id
+
+When an installation registered itself with a registry for the first time, it asked for its
+instance key before checking that it could actually store one. If storing then failed, the result
+was the worst of both worlds: the registry had taken the instance id for good, and the key — issued
+exactly once — was gone. Retrying could not help, and the message blamed the bootstrap key, which
+had worked perfectly.
+
+The check now happens first. If the installation cannot store a key, it declines to register at all
+and says so, leaving the id and the bootstrap key unspent so a corrected setup still works. And if
+storing does fail after a successful registration, the message now says exactly that, instead of
+sending you to re-check a credential that was never the problem.

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -236,11 +236,26 @@ public sealed class InstanceAutoRegistrationService(
             // genuinely is none.
             : EnsureRegistered(options, registry).Catch((Exception ex) =>
             {
-                logger.LogError(ex,
-                    "First-startup instance registration against {Url} failed (401 = invalid or "
-                    + "revoked bootstrap key, 409 = instance id already taken). Continuing to the "
-                    + "install phase, which uses whatever key this installation already holds.",
-                    registry.Url);
+                if (ex is RegistrationPersistException persist)
+                    // 🚨 NOT a failed registration, and the difference is the whole message: the
+                    // registry ACCEPTED this instance and issued its key, and we then failed to
+                    // store it. The key is issued exactly once, so it is gone; the id is taken, so
+                    // re-running this cannot recover it. Say that, rather than sending the operator
+                    // to re-check a bootstrap key that worked perfectly.
+                    logger.LogError(persist.InnerException,
+                        "Instance '{InstanceId}' WAS registered at {Url} — and storing its issued "
+                        + "key then failed, so the key is lost (the registry issues it exactly "
+                        + "once) and the id is permanently taken. Retrying will not recover it: "
+                        + "mint a NEW bootstrap key, choose a NEW PluginCatalog:InstanceId, and fix "
+                        + "the underlying store failure first. Continuing to the install phase, "
+                        + "which uses whatever key this installation already holds.",
+                        persist.InstanceId, persist.RegistryUrl);
+                else
+                    logger.LogError(ex,
+                        "First-startup instance registration against {Url} failed (401 = invalid or "
+                        + "revoked bootstrap key, 409 = instance id already taken). Continuing to the "
+                        + "install phase, which uses whatever key this installation already holds.",
+                        registry.Url);
                 return Observable.Return(Unit.Default);
             });
 
@@ -363,6 +378,28 @@ public sealed class InstanceAutoRegistrationService(
         var client = hub.ServiceProvider.GetRequiredService<InstanceRegistrationClient>();
         var credentialPath = PluginRegistryCredentials.Path(registry.Url);
 
+        // 🚨 Resolved BEFORE the register call, and that ordering is the fix (#2585).
+        // Registration is IRREVERSIBLE in two ways at once: the registry takes the instance id
+        // permanently, and it issues the instance key EXACTLY ONCE. So every local precondition
+        // for STORING that key has to hold before we ask for it. Resolving the protector
+        // afterwards — with GetRequiredService, inside the success callback — turned a missing
+        // registration into the worst available outcome: the remote instance exists, the key was
+        // issued and then dropped on the floor, and the id can never be registered again, so a
+        // retry cannot fix it and the operator has to mint a fresh bootstrap key AND a new id.
+        var protector = hub.ServiceProvider.GetService<IProviderKeyProtector>();
+        if (protector is null)
+        {
+            logger.LogError(
+                "PluginCatalog:BootstrapKey is set, but this mesh registers no IProviderKeyProtector, "
+                + "so an issued instance key could not be stored in the clear-text-free form the "
+                + "credential node requires. NOT registering '{InstanceId}' at {Url}: the registry "
+                + "would take the id permanently and issue the key exactly once, so asking for it "
+                + "now would burn both for nothing. Add the protector (AddGraph registers it) and "
+                + "restart — nothing has been consumed.",
+                instanceId, registry.Url);
+            return Observable.Empty<Unit>();      // nothing burned — a retry can still succeed
+        }
+
         return (Observable.Using(
                 () => accessService.ImpersonateAsSystem(),
                 _ => hub.GetMeshNode(credentialPath, TimeSpan.FromSeconds(10)))
@@ -385,8 +422,8 @@ public sealed class InstanceAutoRegistrationService(
                         // 🚨 Required, and no `?? result.InstanceKey` fallback: the issued key is
                         // this installation's credential at the registry. Storing it in the clear
                         // is the same defect as a plaintext provider key, so a protector that
-                        // cannot encrypt it means we do not store it at all.
-                        var protector = hub.ServiceProvider.GetRequiredService<IProviderKeyProtector>();
+                        // cannot encrypt it means we do not store it at all — which is why its
+                        // absence is now decided ABOVE, before the id is spent.
                         var node = new MeshNode(
                             credentialPath.Split('/').Last(), PluginRegistryCredentials.Namespace)
                         {
@@ -416,7 +453,14 @@ public sealed class InstanceAutoRegistrationService(
                                     return Unit.Default;
                                 })
                                 .Finally(() => write.Dispose());
-                        });
+                        })
+                        // Everything from here on runs AFTER the id was spent and the key issued,
+                        // so a failure here is a categorically different event from a failed
+                        // request — and reporting it as one is what sent the operator to check a
+                        // bootstrap key that was never the problem (#2585). Tag it so the handler
+                        // at the top of Phase 1 can say what actually happened.
+                        .Catch((Exception ex) => Observable.Throw<Unit>(
+                            new RegistrationPersistException(result.InstanceId, registry.Url, ex)));
                     })
                     // Concurrent replicas race this whole block: both read "no credential", one
                     // registers first, and the loser sees 409 (the id is taken) — or, narrower, the
@@ -1372,4 +1416,26 @@ public readonly record struct DefaultInstallSummary(
         $"{Installed} installed, {UpToDate} up to date, {Failed} failed "
         + $"[{string.Join(", ", Packages)}]"
         + (Failures is { Count: > 0 } f ? $" — FAILED: [{string.Join(", ", f)}]" : "");
+}
+
+/// <summary>
+/// Raised when the registry ACCEPTED an instance registration and storing the issued key then
+/// failed — the one failure in this flow that cannot be retried into success (#2585).
+///
+/// <para>🚨 It exists to keep two events that look alike from being REPORTED alike. A failed
+/// request leaves nothing consumed and is fixed by correcting the bootstrap key or the id. This
+/// one leaves the id permanently taken and the key — issued exactly once — gone, so the same
+/// advice sends the operator to re-check a credential that worked. The distinction is carried as
+/// a type rather than a log string because the handler is several operators away from the throw
+/// site, with a convergence <c>Catch</c> in between that legitimately swallows the sibling-replica
+/// case.</para>
+/// </summary>
+internal sealed class RegistrationPersistException(string instanceId, string registryUrl, Exception inner)
+    : Exception($"Instance '{instanceId}' was registered at {registryUrl}, but its issued key could not be stored.", inner)
+{
+    /// <summary>The instance id the registry has now taken permanently.</summary>
+    public string InstanceId { get; } = instanceId;
+
+    /// <summary>The registry that accepted the registration and issued the key.</summary>
+    public string RegistryUrl { get; } = registryUrl;
 }

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -387,18 +387,6 @@ public sealed class InstanceAutoRegistrationService(
         // issued and then dropped on the floor, and the id can never be registered again, so a
         // retry cannot fix it and the operator has to mint a fresh bootstrap key AND a new id.
         var protector = hub.ServiceProvider.GetService<IProviderKeyProtector>();
-        if (protector is null)
-        {
-            logger.LogError(
-                "PluginCatalog:BootstrapKey is set, but this mesh registers no IProviderKeyProtector, "
-                + "so an issued instance key could not be stored in the clear-text-free form the "
-                + "credential node requires. NOT registering '{InstanceId}' at {Url}: the registry "
-                + "would take the id permanently and issue the key exactly once, so asking for it "
-                + "now would burn both for nothing. Add the protector (AddGraph registers it) and "
-                + "restart — nothing has been consumed.",
-                instanceId, registry.Url);
-            return Observable.Empty<Unit>();      // nothing burned — a retry can still succeed
-        }
 
         return (Observable.Using(
                 () => accessService.ImpersonateAsSystem(),
@@ -410,6 +398,31 @@ public sealed class InstanceAutoRegistrationService(
                 {
                     logger.LogDebug("Registry credential already stored at {Path} — no registration needed.",
                         credentialPath);
+                    return Observable.Return(Unit.Default);
+                }
+
+                // 🚨 Decline HERE, not earlier, and emit rather than completing empty.
+                //
+                // Two things this placement gets right that an early return did not (both caught
+                // by review on the first draft). (1) It sits AFTER the "is there already a stored
+                // credential?" read, so an installation that registered long ago is untouched by a
+                // missing protector — bailing out above would have punished every already-
+                // registered portal for a service it no longer needs. (2) It returns a VALUE:
+                // `Start()` chains `.SelectMany(_ => registered).SelectMany(_ => InstallDefaults(…))`,
+                // so an empty observable completes without emitting and silently skips the entire
+                // default install phase — contradicting this file's own rule that "a failed
+                // registration must NOT sink the install phase. The phases are independent."
+                // Phase 2 resolves whatever key exists and fails closed on its own if there is none.
+                if (protector is null)
+                {
+                    logger.LogError(
+                        "PluginCatalog:BootstrapKey is set, but this mesh registers no "
+                        + "IProviderKeyProtector, so an issued instance key could not be stored. NOT "
+                        + "registering '{InstanceId}' at {Url}: the registry takes the id "
+                        + "permanently and issues the key exactly once, so asking for it now would "
+                        + "burn both for nothing. Add the protector (AddGraph registers it) and "
+                        + "restart — nothing has been consumed. Continuing to the install phase.",
+                        instanceId, registry.Url);
                     return Observable.Return(Unit.Default);
                 }
 

--- a/test/MeshWeaver.Documentation.Test/IrreversibleRegistrationOrderingGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/IrreversibleRegistrationOrderingGuard.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Instance registration is IRREVERSIBLE twice over: the registry takes the instance id
+/// permanently, and it issues the instance key EXACTLY ONCE. So every local precondition for
+/// STORING that key must be satisfied BEFORE the key is requested.
+///
+/// <para>🚨 <b>Why a source guard and not a test.</b> The failure cannot be reproduced without
+/// causing it — there is no way to observe "the id was burned" except by burning one against a
+/// real registry, and <c>InstanceRegistrationClient</c> is sealed with a non-virtual
+/// <c>Register</c>, so the call cannot be faked either. What IS checkable, cheaply and exactly, is
+/// the ordering that makes the failure impossible.</para>
+///
+/// <para>This is not hypothetical (#2585): resolving <c>IProviderKeyProtector</c> with
+/// <c>GetRequiredService</c> INSIDE the success callback meant a mesh without that service
+/// registered its instance, received the one-time key, threw while storing it, and left the
+/// operator with an id that can never be registered again and a key nobody will ever see. The
+/// error even blamed the bootstrap key, which had worked perfectly.</para>
+/// </summary>
+public class IrreversibleRegistrationOrderingGuard
+{
+    private const string File_ = "src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs";
+
+    [Fact]
+    public void Everything_needed_to_store_the_key_is_resolved_before_it_is_requested()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var path = Path.Combine(root, File_);
+        Assert.True(File.Exists(path), $"guarded file moved — update this guard: {File_}");
+
+        var whole = SourceScan.MaskCommentsAndStrings(File.ReadAllText(path));
+
+        // 🚨 Scope to EnsureRegistered's body. The file resolves the protector in ANOTHER method
+        // too, and a whole-file search finds that one and reports the ordering as fine no matter
+        // what EnsureRegistered does — a guard that passes by looking at the wrong occurrence,
+        // which is worse than no guard. (Caught while red-proofing this one.)
+        var start = whole.IndexOf("EnsureRegistered(PluginCatalogOptions", StringComparison.Ordinal);
+        Assert.True(start >= 0, "EnsureRegistered(PluginCatalogOptions …) not found — update this guard");
+        var next = whole.IndexOf("\n    private ", start + 1, StringComparison.Ordinal);
+        var masked = next > start ? whole[start..next] : whole[start..];
+
+        var register = Regex.Match(masked, @"\bclient\s*\.\s*Register\s*\(");
+        Assert.True(
+            register.Success,
+            "no `client.Register(` call found — either the registration moved or this guard has "
+            + "stopped watching the thing it was written for");
+
+        var protectorResolve = Regex.Match(masked, @"GetService<\s*IProviderKeyProtector\s*>\s*\(");
+        Assert.True(
+            protectorResolve.Success,
+            "IProviderKeyProtector is no longer resolved with GetService in this file. If the "
+            + "credential no longer needs a protector, delete this guard deliberately; if it moved "
+            + "to GetRequiredService inside the success path, that is exactly the #2585 defect.");
+
+        Assert.True(
+            protectorResolve.Index < register.Index,
+            "IProviderKeyProtector is resolved AFTER client.Register — the ordering #2585 fixed. "
+            + "Registration spends the instance id permanently and yields the key exactly once, so "
+            + "a precondition checked afterwards converts a missing service into a burned id and a "
+            + "lost key that no retry can recover. Resolve it (and anything else the credential "
+            + "write needs) before the register call, and refuse to register when it is absent.");
+
+        // GetRequiredService for the protector anywhere in this file re-arms the original defect:
+        // it throws instead of letting the caller decline to register.
+        Assert.DoesNotMatch(
+            new Regex(@"GetRequiredService<\s*IProviderKeyProtector\s*>"),
+            masked);
+    }
+}


### PR DESCRIPTION
Closes #2585.

Registration is irreversible **twice over**: the registry takes the instance id permanently, and it issues the instance key **exactly once**. The one local precondition for storing that key — `IProviderKeyProtector` — was resolved with `GetRequiredService` *inside the success callback*, after both had already been spent.

On a mesh without that service (a fresh harness mesh — `AddGraph()` is what registers it) the measured outcome was the worst one available: the instance was created at the registry, the one-time key was received and dropped, and the id can never be registered again. Retrying cannot recover it. The error then offered 401/409 guidance, sending the operator to re-check a bootstrap key that had worked perfectly.

## Two changes

1. **Resolve the protector before the register call**, with `GetService`, and decline to register when it is absent. Nothing is consumed, so a corrected configuration still works.
2. **Tag a post-registration store failure** (`RegistrationPersistException`) so the handler reports what actually happened: the instance *is* registered, the key is lost, the id is taken, retrying will not help — instead of blaming the request.

The type carries the distinction rather than a log string because the handler sits several operators away from the throw site, with a convergence `Catch` in between that legitimately swallows the sibling-replica 409.

## Why a source guard rather than a test

The failure cannot be observed without causing it — there is no way to see "the id was burned" except by burning one against a real registry — and `InstanceRegistrationClient` is `sealed` with a non-virtual `Register`, so the call cannot be faked either. What *is* checkable, exactly, is the ordering that makes the failure impossible.

🚨 **The guard is scoped to `EnsureRegistered`'s body, and that is load-bearing.** The file resolves the protector in another method too (line 95), and my first version searched the whole file, matched *that* occurrence, and reported the ordering as fine while main's defect was restored — a guard passing by looking at the wrong line, which is worse than none. Caught while red-proofing it.

Red-proof: reverting the source to main fails the guard; the fix passes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)