### PR TITLE
Fix #2473: prune retired nodes on a full node-repo install

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-retired-node-prune.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-retired-node-prune.md
@@ -1,0 +1,17 @@
+---
+Name: Retired plugin nodes are pruned on update
+Category: Fix
+Description: A node a plugin repo removes is now deleted from the mesh on the next update instead of surviving forever.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Retired plugin nodes are pruned on update
+
+When a plugin's source repository deletes a node — a NodeType, a document, an agent — updating
+the installed plugin now removes that node from the mesh instead of leaving an orphaned copy
+behind forever. Previously this only happened on a narrow "incremental update" path; a full
+re-install (which also runs whenever a plugin changes shared source code) silently kept every
+node the repo had already retired. A left-behind NodeType with no source left to compile against
+could later fail to rebuild and delay the affected instances from starting up. Updates are now
+consistent: whatever the repo no longer ships is removed from the installed partition.

--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -568,8 +568,11 @@ public static class CatalogLayoutAreas
     /// rewrite); a differing one fetches only <c>manifest.lock</c>, diffs it against the record's
     /// installed-files baseline and updates just the changed nodes (pruning removed ones). Every
     /// other case — no manifest, no baseline, a shared-Source change (whose blast radius is every
-    /// type in the package), or ANY error on the incremental path — falls back to the legacy full
-    /// install, which is always correct.
+    /// type in the package), or ANY error on the incremental path — falls back to the full install
+    /// (<see cref="PackageInstaller.Install"/>), which prunes nodes the repo retired against the
+    /// SAME previous-record baseline whenever one exists (Systemorph/MeshWeaver#2473) — a node this
+    /// package shipped before but not any more never merely survives because the incremental path
+    /// declined to touch it.
     /// </summary>
     internal static IObservable<InstallResult> InstallOrUpdate(
         IMessageHub hub, IPackageSource source, string sourceRef, PackageManifest pkg, ILogger? logger,

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -2773,10 +2773,12 @@ public static class PackageInstaller
                 .SelectMany(current =>
                     current is not null && current.SyncBehavior != SyncBehavior.Include
                         ? Observable.Return(0)
-                        : Observable.Using(
-                                () => accessService?.ImpersonateAsSystem()
-                                      ?? System.Reactive.Disposables.Disposable.Empty,
-                                _ => meshService.DeleteNode(path))
+                        // Sealed at Subscribe (RunAsSystem), never Observable.Using(ImpersonateAsSystem):
+                        // impersonation is an AsyncLocal store/restore pair, and Using disposes on the
+                        // TERMINATING thread — for a cross-hub delete, the owning hub's response thread,
+                        // not the one that opened the scope — which latches system-security onto whatever
+                        // runs next on the subscribing thread (#1790).
+                        : accessService.RunAsSystem(() => meshService.DeleteNode(path))
                             .Take(1)
                             .Select(deleted => deleted ? 1 : 0))
                 .Catch<int, Exception>(ex =>

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -2117,6 +2117,7 @@ public static class PackageInstaller
 
         var options = hub.JsonSerializerOptions;
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
         var nodeTypePaths = nodes.Where(n => n.Content is NodeTypeDefinition).Select(n => n.Path).ToArray();
 
         // Ordering solves two chicken-and-eggs at once:
@@ -2640,6 +2641,16 @@ public static class PackageInstaller
                 // an install that reports success while its partition is unreadable is the failure
                 // this whole ordering exists to make impossible, and it must never be silent.
                 return VerifyDeclaredAccess(hub, manifest, manifest.TargetPartition ?? manifest.Id, logger)
+                    // 🚨 Prune nodes THIS package no longer ships — read BEFORE WriteInstalledRecord
+                    // overwrites the baseline below, so a node the repo retired is deleted rather
+                    // than surviving forever (Systemorph/MeshWeaver#2473). A full install runs here
+                    // whenever the delta path refuses an update (CatalogLayoutAreas.IncrementalUpdate,
+                    // "changed shared Source/Test files; full install required") as well as on a
+                    // fresh install — the exact route by which a retired NodeType with its Source
+                    // deleted kept serving its last-built assembly until the framework identity
+                    // moved, then recompiled against zero sources and parked the portal's readiness.
+                    .SelectMany(_ => PruneRetiredNodes(
+                        hub, manifest, moduleManifest, nodes, persistence, meshService, options, logger))
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, nodes.Length, moduleManifest, authorizingUserId))
                     // Adoption first (it can settle a release without compiling at all), then the
@@ -2673,6 +2684,107 @@ public static class PackageInstaller
                     .Select(_ => result);
             }));
             });
+    }
+
+    /// <summary>
+    /// The FULL install's counterpart to <see cref="InstallNodeRepoDeltaCore"/>'s prune — applied
+    /// without a caller-handed diff, because a full install is exactly what runs when there IS no
+    /// diff to hand in: a fresh install (nothing installed before — nothing to prune, and this
+    /// returns 0 immediately) and, critically, whenever <c>CatalogLayoutAreas.IncrementalUpdate</c>
+    /// refuses an update because it touches the package's shared <c>Source/</c>/<c>Test/</c> and
+    /// falls back here. That fallback is the route by which a node the source repo retired used to
+    /// survive in the mesh FOREVER (Systemorph/MeshWeaver#2473): the full install upserts everything
+    /// the package still ships and, before this method existed, pruned nothing — so a NodeType whose
+    /// <c>Source/</c> the repo deleted kept serving its last-built assembly until the framework
+    /// identity next moved, at which point it recompiled against zero sources, parked at
+    /// <c>CompileError</c>, and held every instance hub for the full 60 s activation budget.
+    ///
+    /// <para>Reads THIS package's own previous install record (<c>{InstalledPartition}/{Id}</c>) for
+    /// its <see cref="PackageManifest.InstalledFiles"/> baseline — read here, BEFORE the caller's
+    /// <c>WriteInstalledRecord</c> overwrites it — and diffs it against <paramref name="moduleManifest"/>
+    /// via the same <see cref="ModuleManifest.DiffFrom"/> the delta path uses. A removed file whose
+    /// node path is still produced by a currently-shipped file (the <c>X.json</c> → <c>X/index.json</c>
+    /// layout-move case) is never a prune candidate. Bounded by construction to paths THIS package's
+    /// own record previously listed — never a scan of the shared partition — so it can never touch
+    /// another package's content. No-ops (returns 0) when the package ships no <c>manifest.lock</c>
+    /// (no file-level baseline exists at all) or has no prior record with a file map.</para>
+    /// </summary>
+    private static IObservable<int> PruneRetiredNodes(
+        IMessageHub hub, PackageManifest manifest, ModuleManifest? moduleManifest,
+        IReadOnlyList<MeshNode> nodes, IStorageAdapter? persistence, IMeshService? meshService,
+        JsonSerializerOptions options, ILogger? logger)
+    {
+        if (moduleManifest is null || persistence is null)
+            return Observable.Return(0);
+
+        var recordPath = $"{InstalledPartition}/{manifest.Id}";
+        return persistence.Read(recordPath, options).Take(1)
+            .Select(n => n?.ContentAs<PackageManifest>(options)?.InstalledFiles)
+            .Catch<ImmutableSortedDictionary<string, string>?, Exception>(
+                _ => Observable.Return<ImmutableSortedDictionary<string, string>?>(null))
+            .SelectMany(previousFiles =>
+            {
+                if (previousFiles is not { Count: > 0 })
+                    return Observable.Return(0);
+
+                var currentNodePaths = nodes.Select(n => n.Path)
+                    .ToImmutableHashSet(StringComparer.Ordinal);
+                var removedNodePaths = moduleManifest.DiffFrom(previousFiles).RemovedFiles
+                    .Select(NodePathForFile)
+                    .Where(p => p is not null && !currentNodePaths.Contains(p))
+                    .Select(p => p!)
+                    .ToImmutableHashSet(StringComparer.Ordinal);
+
+                return PruneRemovedNodes(hub, meshService, persistence, removedNodePaths, options, logger)
+                    .Do(pruned =>
+                    {
+                        if (pruned > 0)
+                            logger?.LogInformation(
+                                "[PackageInstaller] {Id}: pruned {Pruned} node(s) the repo no longer "
+                                + "ships (full install).", manifest.Id, pruned);
+                    });
+            });
+    }
+
+    /// <summary>
+    /// Deletes each of <paramref name="removedNodePaths"/>, System-impersonated per delete like
+    /// every installer write. A failed/absent delete degrades to a log line — never fails the
+    /// install/update it runs inside. Shared by <see cref="InstallNodeRepoDeltaCore"/>'s prune
+    /// (whose removed set comes from a caller-handed manifest diff) and
+    /// <see cref="PruneRetiredNodes"/>'s (whose removed set comes from the same diff computed
+    /// against the package's own previous install record).
+    ///
+    /// <para>Read-before-delete: a CLAIMED node (<see cref="MeshNode.SyncBehavior"/> other than
+    /// <see cref="SyncBehavior.Include"/>) is the user's, not the repo's — the repo dropping its
+    /// file revokes the PACKAGE's copy, never the user's claim. The same fence
+    /// <see cref="UpsertIfChanged"/> applies on the write side.</para>
+    /// </summary>
+    private static IObservable<int> PruneRemovedNodes(
+        IMessageHub hub, IMeshService? meshService, IStorageAdapter? persistence,
+        IReadOnlyCollection<string> removedNodePaths, JsonSerializerOptions options, ILogger? logger)
+    {
+        if (meshService is null || removedNodePaths.Count == 0)
+            return Observable.Return(0);
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        return removedNodePaths
+            .Select(path => (persistence is not null
+                    ? persistence.Read(path, options).Take(1)
+                    : Observable.Return<MeshNode?>(null))
+                .SelectMany(current =>
+                    current is not null && current.SyncBehavior != SyncBehavior.Include
+                        ? Observable.Return(0)
+                        : Observable.Using(
+                                () => accessService?.ImpersonateAsSystem()
+                                      ?? System.Reactive.Disposables.Disposable.Empty,
+                                _ => meshService.DeleteNode(path))
+                            .Take(1)
+                            .Select(deleted => deleted ? 1 : 0))
+                .Catch<int, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex, "Pruning removed node {Path} failed.", path);
+                    return Observable.Return(0);
+                }))
+            .ToObservable().Concat().Sum();
     }
 
     /// <summary>
@@ -2785,27 +2897,7 @@ public static class PackageInstaller
         // removedNodePaths is already restricted to previously-installed paths, so a user-ADDED
         // node was never a prune candidate to begin with.
         IObservable<int> Prune() =>
-            meshService is null || removedNodePaths.Count == 0
-                ? Observable.Return(0)
-                : removedNodePaths
-                    .Select(path => (persistence is not null
-                            ? persistence.Read(path, options).Take(1)
-                            : Observable.Return<MeshNode?>(null))
-                        .SelectMany(current =>
-                            current is not null && current.SyncBehavior != SyncBehavior.Include
-                                ? Observable.Return(0)
-                                : Observable.Using(
-                                        () => hub.ServiceProvider.GetService<AccessService>()?.ImpersonateAsSystem()
-                                              ?? System.Reactive.Disposables.Disposable.Empty,
-                                        _ => meshService.DeleteNode(path))
-                                    .Take(1)
-                                    .Select(deleted => deleted ? 1 : 0))
-                        .Catch<int, Exception>(ex =>
-                        {
-                            logger?.LogWarning(ex, "Pruning removed node {Path} failed.", path);
-                            return Observable.Return(0);
-                        }))
-                    .ToObservable().Concat().Sum();
+            PruneRemovedNodes(hub, meshService, persistence, removedNodePaths, options, logger);
 
         // 🚨 The declared access is re-asserted BEFORE the delta's writes, not after them (#1758).
         // An UPDATE re-asserts it at all so a package that only just flipped its declaration (or

--- a/test/MeshWeaver.PluginCatalog.Test/RetiredNodePruneTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RetiredNodePruneTest.cs
@@ -33,6 +33,22 @@ namespace MeshWeaver.PluginCatalog.Test;
 /// framework-identity flip, which recompiles every dynamic NodeType: with zero sources left to
 /// compile against, it fails, parks at <c>CompileError</c>, and holds every instance hub for the
 /// full 60 s activation budget (see NodeTypeCompilation.md).</para>
+///
+/// <para>🚨 A live orphan of exactly this shape was found on memex-cloud (<c>LinkedIn/Skill</c>) with
+/// its ENTIRE <c>Release/*</c> compile-history subtree still attached under the retired type's path —
+/// so the second thing this test pins is that the prune removes the SUBTREE, not just the retired
+/// node itself. It does, for free: <c>PruneRemovedNodes</c> prunes via
+/// <c>IMeshService.DeleteNode</c>, which <c>MeshService.DeleteNode</c> always issues with
+/// <c>Recursive = true</c>; the recursive delete's path collection
+/// (<c>IStorageAdapter.ListDescendantPaths</c>) is a prefix scan under the deleted root regardless of
+/// which physical table a descendant lives in (the production Postgres adapter UNIONs
+/// <c>mesh_nodes</c> with every satellite table). A compile's <c>Release/{version}</c> history node
+/// is never routed to a satellite table at all (<c>PartitionDefinition.StandardTableMappings</c>
+/// never routed it — see Memex.Database.Migration's <c>V19_DeleteLegacyReleaseNodes</c>), so it is an
+/// ordinary <c>mesh_nodes</c> row whose namespace is prefixed by the type's path — squarely inside
+/// the deleted subtree. <c>ReleaseHistorySurvivesUnderThePrunedType</c> below plants exactly such a
+/// node directly (bypassing the package installer, the way a live compile would create one) and
+/// pins it disappears along with its owning type.</para>
 /// </summary>
 public class RetiredNodePruneTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -160,6 +176,50 @@ public class RetiredNodePruneTest(ITestOutputHelper output) : MonolithMeshTestBa
 
         // The surviving root is untouched in content — only Thing left, nothing else broke.
         (await persistence.Exists("Widget").FirstAsync().ToTask()).Should().BeTrue();
+    }
+
+    [Fact(Timeout = 120_000)]
+    public async Task ReleaseHistorySurvivesUnderThePrunedType_ThenIsPrunedWithIt()
+    {
+        var persistence = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        // ── v1: install, then plant a Release-history child the way a live compile does —
+        // NEVER through the package installer (compile history is never shipped by a repo; it is
+        // written directly by MeshDataSource.TryCreateReleaseNode against the type's own path). ──
+        await PackageInstaller.Install(Mesh, Pkg(V1Module, "commit-1"), V1Files, "commit-1")
+            .FirstAsync().ToTask();
+        await Mesh.GetMeshNodeStream("Widget/Thing")
+            .Should().Within(90.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus is CompilationStatus.Ok or CompilationStatus.Error);
+
+        var release = MeshNode.FromPath("Widget/Thing/Release/v1-abc123") with
+        {
+            NodeType = "Markdown",
+            Name = "Release v1",
+            State = MeshNodeState.Active,
+            Content = "# compiled at v1",
+        };
+        await meshService.CreateNode(release).FirstAsync().ToTask();
+        (await persistence.Exists("Widget/Thing/Release/v1-abc123").FirstAsync().ToTask()).Should().BeTrue(
+            "the planted release-history node must actually be there before the prune runs");
+
+        // ── v2: the repo retires Thing (and its compile history is never part of any manifest —
+        // the diff never names it, so ONLY a recursive delete of Thing's subtree removes it) ──
+        var v2Source = new RecordingSource(V2Files);
+        await CatalogLayoutAreas.InstallOrUpdate(Mesh, v2Source, "commit-2", Pkg(V2Module, "commit-2"), null)
+            .FirstAsync().ToTask();
+
+        // The RED-adjacent proof for the coordinator's concern: pruning Thing must take its
+        // Release history with it, not leave it orphaned under a now-nonexistent parent.
+        await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)
+            .SelectMany(_ => persistence.Exists("Widget/Thing"))
+            .Where(exists => !exists)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        (await persistence.Exists("Widget/Thing/Release/v1-abc123").FirstAsync().ToTask()).Should().BeFalse(
+            "the retired type's Release history must be pruned WITH it (recursive delete), " +
+            "not left orphaned under a path nothing owns any more");
     }
 
     private static async Task<PackageManifest> ReadRecord(

--- a/test/MeshWeaver.PluginCatalog.Test/RetiredNodePruneTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RetiredNodePruneTest.cs
@@ -1,0 +1,175 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// Systemorph/MeshWeaver#2473 — a node the source repo RETIRES must not survive in the mesh.
+///
+/// <para>The manifest-diff incremental update refuses to touch a package whose SHARED
+/// <c>Source/</c>/<c>Test/</c> changed (the blast radius is every type in the package) and falls
+/// back to a full install (<c>CatalogLayoutAreas.IncrementalUpdate</c>, "changed shared Source/Test
+/// files; full install required"). Before #2473's fix, the full install path
+/// (<c>PackageInstaller.InstallNodeRepo</c>) upserted only the nodes the package still ships and
+/// pruned NOTHING, so a NodeType the repo deleted — <c>Thing</c>, whose <c>index.json</c> and
+/// <c>Source/*.cs</c> both left the repo in the same commit that also touched the package's shared
+/// <c>Source/</c> — kept serving its last-built assembly forever. It only detonated on the NEXT
+/// framework-identity flip, which recompiles every dynamic NodeType: with zero sources left to
+/// compile against, it fails, parks at <c>CompileError</c>, and holds every instance hub for the
+/// full 60 s activation budget (see NodeTypeCompilation.md).</para>
+/// </summary>
+public class RetiredNodePruneTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddGraph().AddPluginCatalog();
+
+    private const string V1Module = "bbbbbbbbbbbbbbb1";
+    private const string V2Module = "bbbbbbbbbbbbbbb2";
+
+    // v1: a root, a NodeType (Thing) with its own Source, and the package's SHARED Source/ (code
+    // every type in the package may reference — not nested under any one type).
+    private static readonly IReadOnlyList<PackageFile> V1Files =
+    [
+        new("Widget/index.json",
+            """{"$type":"MeshNode","id":"Widget","namespace":"","path":"Widget","mainNode":"Widget","name":"Widget Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A widget plugin.","minMeshVersion":"1.0.0"}}"""),
+        new("Widget/Thing.json",
+            """{"$type":"MeshNode","id":"Thing","namespace":"Widget","path":"Widget/Thing","mainNode":"Widget/Thing","name":"Thing","nodeType":"NodeType","state":"Active","content":{"$type":"NodeTypeDefinition","description":"A thing.","configuration":"config => config.WithContentType<Thing>()","includeGlobalTypes":true}}"""),
+        new("Widget/Thing/Source/Thing.cs",
+            "public record Thing { public string Name { get; init; } = string.Empty; }"),
+        new("Widget/Source/Shared.cs",
+            "public static class SharedV1 { public const string Value = \"v1\"; }"),
+        new("Widget/manifest.lock",
+            $$$"""{"schema":"mw-manifest/1","module":"Widget","moduleVersion":"{{{V1Module}}}","sourceCommit":"c1","files":{"Widget/index.json":"h-root-1","Widget/Thing.json":"h-type-1","Widget/Thing/Source/Thing.cs":"h-src-1","Widget/Source/Shared.cs":"h-shared-1"}}"""),
+    ];
+
+    // v2: the repo RETIRES Thing (its NodeType node AND its Source both drop out) in the same
+    // commit that also touches the package's SHARED Source/ — the exact combination that forces
+    // the incremental path to refuse and fall back to a full install.
+    private static readonly IReadOnlyList<PackageFile> V2Files =
+    [
+        V1Files[0],
+        new("Widget/Source/Shared.cs",
+            "public static class SharedV1 { public const string Value = \"v2\"; }"),
+        new("Widget/manifest.lock",
+            $$$"""{"schema":"mw-manifest/1","module":"Widget","moduleVersion":"{{{V2Module}}}","sourceCommit":"c2","files":{"Widget/index.json":"h-root-1","Widget/Source/Shared.cs":"h-shared-2"}}"""),
+    ];
+
+    /// <summary>A package source that records every fetch (full or subset) so the test can pin
+    /// exactly which install path ran — mirrors IncrementalUpdateTest's.</summary>
+    private sealed class RecordingSource(IReadOnlyList<PackageFile> files) : IPackageSource
+    {
+        public readonly List<IReadOnlyCollection<string>?> Fetches = [];
+
+        public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
+            Observable.Return<IReadOnlyList<PackageManifest>>([]);
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef)
+        {
+            Fetches.Add(null);
+            return Observable.Return(files);
+        }
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(
+            PackageManifest package, string gitRef, IReadOnlyCollection<string>? paths)
+        {
+            Fetches.Add(paths);
+            var wanted = paths is null ? null : new HashSet<string>(paths, StringComparer.Ordinal);
+            return Observable.Return<IReadOnlyList<PackageFile>>(
+                wanted is null ? files : files.Where(f => wanted.Contains(f.RelativePath)).ToList());
+        }
+    }
+
+    private static PackageManifest Pkg(string moduleVersion, string version) => new()
+    {
+        Id = "Widget",
+        Name = "Widget Plugin",
+        Kind = PackageKind.NodeRepo,
+        TargetPartition = "Widget",
+        SourceFolder = "Widget",
+        Version = version,
+        ModuleVersion = moduleVersion,
+    };
+
+    [Fact(Timeout = 120_000)]
+    public async Task SharedSourceChange_FallsBackToFullInstall_AndPrunesTheRetiredNodeType()
+    {
+        var persistence = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var options = Mesh.JsonSerializerOptions;
+
+        // ── v1: full install stamps the manifest baseline, including the now-doomed Thing ──
+        var v1 = await PackageInstaller.Install(Mesh, Pkg(V1Module, "commit-1"), V1Files, "commit-1")
+            .FirstAsync().ToTask();
+        v1.Written.Should().Be(4, "4 nodes: root, Thing, Thing/Source/Thing, Source/Shared");
+
+        var nt = await Mesh.GetMeshNodeStream("Widget/Thing")
+            .Should().Within(90.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus is CompilationStatus.Ok or CompilationStatus.Error);
+        ((NodeTypeDefinition)nt.Content!).CompilationStatus.Should().Be(CompilationStatus.Ok);
+
+        (await persistence.Exists("Widget/Thing").FirstAsync().ToTask()).Should().BeTrue();
+        (await persistence.Exists("Widget/Thing/Source/Thing").FirstAsync().ToTask()).Should().BeTrue();
+
+        // ── v2: the repo retires Thing AND touches the shared Source/ in the same update ──
+        var v2Source = new RecordingSource(V2Files);
+        var v2 = await CatalogLayoutAreas.InstallOrUpdate(Mesh, v2Source, "commit-2", Pkg(V2Module, "commit-2"), null)
+            .FirstAsync().ToTask();
+
+        // Pin that this really is the full-install FALLBACK, not the ordinary delta path: the
+        // incremental attempt fetches the manifest first, discovers the shared-Source conflict and
+        // throws, and the catch falls back to a FULL fetch (paths: null).
+        v2Source.Fetches.Should().Contain(paths => paths is null,
+            "the shared Source/ change must force a full re-fetch, not a manifest-diff delta");
+
+        v2.Written.Should().BeGreaterThan(0, "the root's re-publish and Source/Shared's new content are both writes");
+
+        // The RED PROOF: before #2473's fix, InstallNodeRepo's full path pruned nothing, so the
+        // retired NodeType and its Source node survived the update forever.
+        await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)
+            .SelectMany(_ => persistence.Exists("Widget/Thing"))
+            .Where(exists => !exists)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+        await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)
+            .SelectMany(_ => persistence.Exists("Widget/Thing/Source/Thing"))
+            .Where(exists => !exists)
+            .FirstAsync().Timeout(30.Seconds()).ToTask();
+
+        // The record's baseline no longer names the retired files either — the NEXT update's diff
+        // must not think Thing is still installed.
+        var record = await ReadRecord(persistence, options);
+        record.ModuleVersion.Should().Be(V2Module);
+        record.InstalledFiles.Should().NotBeNull();
+        record.InstalledFiles!.Should().NotContainKey("Widget/Thing.json");
+        record.InstalledFiles!.Should().NotContainKey("Widget/Thing/Source/Thing.cs");
+
+        // The surviving root is untouched in content — only Thing left, nothing else broke.
+        (await persistence.Exists("Widget").FirstAsync().ToTask()).Should().BeTrue();
+    }
+
+    private static async Task<PackageManifest> ReadRecord(
+        IStorageAdapter persistence, System.Text.Json.JsonSerializerOptions options)
+    {
+        var node = await persistence.Read($"{PackageInstaller.InstalledPartition}/Widget", options)
+            .FirstAsync().ToTask();
+        node.Should().NotBeNull();
+        var manifest = node!.ContentAs<PackageManifest>(options);
+        manifest.Should().NotBeNull();
+        return manifest!;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2473.

A node the source repo deletes used to stay in the mesh forever whenever the
plugin update fell back to a **full** node-repo install instead of the
manifest-diff **delta** path — the only path that pruned removed nodes. The
fallback is not an edge case: `CatalogLayoutAreas.IncrementalUpdate` refuses
and falls back to full whenever the update touches the package's shared
`Source/`/`Test/` (whose blast radius is every type in the package), or
whenever there is no previous install record with a file-level baseline.

Concretely, this is how `LinkedIn/Skill` (MeshWeaver.SocialMedia@75f3f3d)
survived in `memex.meshweaver.cloud` after its file was deleted from the
source repo: it kept serving its last-built assembly with an empty
`Source/` until the next framework-identity flip forced every dynamic
NodeType to recompile — at which point it failed against zero sources,
parked at `CompileError`, and held every instance hub for the full 60s
activation budget (see `NodeTypeCompilation.md`). This is a live,
currently-present condition on memex-cloud today, not a hypothetical: the
NodeType is still the only one on that mesh sitting at `CompileError`, with
`src=0` source discovery and its entire `Release/*` compile-history subtree
still attached under the retired type's path.

## Fix

`PackageInstaller.InstallNodeRepo` (the full-install path) now:
- reads the package's own previous install record (`{Plugins}/{Id}`) for
  its `InstalledFiles` baseline, before that record is overwritten;
- diffs it against the incoming `manifest.lock` via the same
  `ModuleManifest.DiffFrom` the delta path already uses;
- prunes exactly `previously-installed ∖ now-shipped`, through the same
  user-claim fence (`SyncBehavior.Include`) and System-impersonated delete
  the delta path uses — via `IMeshService.DeleteNode`, which is always
  **recursive** (`MeshService.DeleteNode` hard-codes `Recursive = true`),
  so pruning a retired NodeType takes its entire subtree with it in one
  call — including compile-history `Release/*` children, which are never
  routed to a satellite table (`PartitionDefinition.StandardTableMappings`
  never routed `_Release`/`Release` — see Memex.Database.Migration's
  `V19_DeleteLegacyReleaseNodes`) and so live as ordinary `mesh_nodes` rows
  squarely inside the deleted path prefix. Verified with a dedicated test
  (see Red-proof) rather than assumed from reading the delete path.

Bounded by construction: the candidate set only ever contains paths *this
package's own* previous install record listed, so it can never touch a
shared partition's other content — the same reasoning that already makes
the delta path's prune safe, applied without a caller-handed diff. The
delta path's prune logic is now a shared helper (`PruneRemovedNodes`)
instead of duplicated.

No-ops safely when there's nothing to prune: a fresh install (no previous
record) or a package that ships no `manifest.lock` (no file-level baseline
exists at all) — matching the two conditions the issue names as the ones
that make the delta path unavailable.

**Review fix**: the automatic Copilot review flagged that the shared prune
helper used `Observable.Using(() => access.ImpersonateAsSystem(), …)` —
the exact shape #1790 banned (impersonation is an `AsyncLocal` store/restore
pair; `Using` opens on the subscribing thread but disposes on the
*terminating* thread, which for a cross-hub delete latches `system-security`
onto whatever runs next on the subscriber). Replaced with the sealed
`AccessService.RunAsSystem` helper, which opens and closes the scope inside
one synchronous `Subscribe`. This also retroactively fixes the identical
pre-existing pattern in the delta path's `Prune()`, which now shares this
helper.

## Red-proof

- `RetiredNodePruneTest.SharedSourceChange_FallsBackToFullInstall_AndPrunesTheRetiredNodeType`
  reproduces the exact trigger: a NodeType (`Widget/Thing`) is retired in the
  same update that also changes the package's shared `Source/`, which forces
  `IncrementalUpdate` to throw and `InstallOrUpdateCore` to fall back to
  `Full()`. Confirmed RED against the pre-fix code (reverted locally, times
  out waiting for the retired node to disappear — `TimeoutException` at 31s)
  and GREEN with the fix.
- `RetiredNodePruneTest.ReleaseHistorySurvivesUnderThePrunedType_ThenIsPrunedWithIt`
  plants a `Release`-shaped child directly under the doomed type (the way a
  live compile would, never through the package installer, since compile
  history is never a repo file and so never appears in any manifest diff),
  then asserts it disappears along with its owning type — empirically
  confirming the prune is a subtree delete, not a single-node delete, which
  is what protects against the orphaned-`Release`-history shape found live
  on memex-cloud.
- Full `MeshWeaver.PluginCatalog.Test` suite (651 tests, including
  `IncrementalUpdateTest` and `NodeRepoInstallTest`, which exercise the code
  this change refactors) — all green, no regressions.

## What's New

`src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-retired-node-prune.md`
— `Category: Fix` (a user/operator can notice a plugin update leaving stale
content behind, and the downstream portal-readiness stall it can cause).

## Test plan

- [x] `dotnet build src/MeshWeaver.PluginCatalog -c Release -warnaserror` — clean
- [x] `dotnet build test/MeshWeaver.PluginCatalog.Test -c Release -warnaserror` — clean
- [x] `RetiredNodePruneTest` (both cases) — RED on reverted code, GREEN with the fix
- [x] Full `MeshWeaver.PluginCatalog.Test` suite — 651/651 passed
- [x] Automatic Copilot review addressed (`RunAsSystem`) and thread resolved
- [ ] CI green (`Consolidate test results`)

## Not covered by this PR

`LinkedIn/Skill` itself still needs deleting on memex-cloud — this PR fixes
the mechanism so a FUTURE retirement prunes correctly; it does not reach
back and clean up a node that already survived past the point this fix
lands. That cleanup needs someone with Delete on the LinkedIn partition
(noted in #2473's own "Immediate cleanup this issue does not cover"
section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
