### PR TITLE
What's New accepts entries from every repo, not just this one (#2539)

### DIFF
--- a/.claude/skills/pullrequest/SKILL.md
+++ b/.claude/skills/pullrequest/SKILL.md
@@ -135,8 +135,22 @@ dotnet build src/<TheProjectYouTouched> -c Release -warnaserror --no-restore   #
 #       fix/                     → Category: Fix       (bundled into the day's one-line fix summary)
 #     Order is -YYYYMMDD (a NEGATIVE date), which sorts the doc tree and the Doc/WhatsNew folder
 #     page newest-first — without it they fall back to alphabetical by title.
+#
+#     🚨 IN A SATELLITE REPO (Plugins, Education, Reinsurance, SocialMedia, Memex) the path below
+#     does not exist — it is core-only. Write the entry into YOUR repo instead, at
+#     `WhatsNew/${DATE}-<slug>.md`, and add ONE line to the front matter:
+#
+#         nodeType: WhatsNew
+#
+#     That is the whole difference. The feed lists entries by node TYPE as well as by the core
+#     path (#2539), so an entry declaring it reaches the one Doc/WhatsNew feed from any repo, with
+#     no cross-repo PR. Everything else — Name / Category / Description / Icon / Order, and the
+#     rule that a user-noticeable FIX gets an entry — is identical.
+#
+#     Before #2539 there was no route at all, so satellite fixes were simply skipped, and the feed
+#     drifted toward being a platform-only changelog while reading as a complete one.
 DATE=$(date -u +%Y-%m-%d)                   # no clock in scripts elsewhere, but this is a shell step
-NOTE_FILE=src/MeshWeaver.Documentation/Data/WhatsNew/${DATE}-<slug>.md
+NOTE_FILE=src/MeshWeaver.Documentation/Data/WhatsNew/${DATE}-<slug>.md   # core; satellites: WhatsNew/${DATE}-<slug>.md
 # Frontmatter is printf'd (Order needs the date substituted); the PROSE goes in a QUOTED heredoc so
 # a note containing `$`, `${…}` or backticks is written literally instead of being expanded by bash.
 printf -- '---\nName: %s\nCategory: %s\nDescription: %s\nIcon: Sparkle\nOrder: -%s\n---\n\n' \

--- a/memex/Memex.Portal.Shared/Settings/WhatsNewSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/WhatsNewSettingsTab.cs
@@ -40,6 +40,37 @@ public static class WhatsNewSettingsTab
     public const string WhatsNewNamespace = "Doc/WhatsNew";
 
     /// <summary>
+    /// The node type a release-note entry declares in its front matter (<c>nodeType: WhatsNew</c>)
+    /// when it does NOT live under <see cref="WhatsNewNamespace"/> — which is every entry authored
+    /// outside this repository.
+    /// </summary>
+    public const string EntryNodeType = "WhatsNew";
+
+    /// <summary>
+    /// The listing, as a UNION of two lanes (#2539) — <c>GetQuery</c> takes several queries and
+    /// unions their result sets, deduped by path.
+    ///
+    /// <para><b>Why two.</b> The feed used to be a single <c>path:Doc/WhatsNew scope:children</c>
+    /// listing, and that path exists only in the platform repository. A satellite — Plugins,
+    /// Education, Reinsurance, SocialMedia, Memex — had NO route to file an entry from its own PR,
+    /// so a user-noticeable fix landing there was simply absent from the changelog. That is not a
+    /// gap that holds steady: every extraction moves more user-visible behaviour out of core, so
+    /// the feed acquires a systematic bias toward platform work and a reader would conclude that
+    /// plugin-side fixes had stopped happening.</para>
+    ///
+    /// <para>The second lane keys on the node TYPE instead of a path, so a satellite writes
+    /// <c>WhatsNew/&lt;date&gt;-&lt;slug&gt;.md</c> in its own tree with <c>nodeType: WhatsNew</c>
+    /// in the front matter and it appears in the one feed — authorship stays with the change and no
+    /// cross-repo PR is needed. The 612 entries already under <c>Doc/WhatsNew</c> keep working
+    /// untouched, which is why this is a union and not a migration.</para>
+    /// </summary>
+    public static readonly string[] ListingQueries =
+    [
+        $"path:{WhatsNewNamespace} scope:children",
+        $"nodeType:{EntryNodeType}",
+    ];
+
+    /// <summary>
     /// <c>Category</c> of an entry that announces something new or improved — rendered in full, with
     /// its description. Written by the <c>/pullrequest</c> skill from the branch prefix.
     /// </summary>
@@ -63,7 +94,7 @@ public static class WhatsNewSettingsTab
         // entry content is rendered by the doc view when the link is opened (never read from the
         // lagging query index).
         stack = stack.WithView((h, _) =>
-            h.Hub.GetQuery("whatsnew:list", $"path:{WhatsNewNamespace} scope:children")
+            h.Hub.GetQuery("whatsnew:list", ListingQueries)
             .Select(nodes => (UiControl?)Controls.Markdown(Render(nodes, h)))
             // Generic message to the (ungated, any-user) UI — never surface the raw exception; log it
             // server-side instead so an internal detail can't leak into the page.
@@ -85,7 +116,10 @@ public static class WhatsNewSettingsTab
     /// </summary>
     private static string Render(IEnumerable<MeshNode> nodes, LayoutAreaHost host)
     {
-        var entries = (nodes ?? []).Where(n => n is not null).ToList();
+        // DistinctBy: an entry that lives under Doc/WhatsNew AND declares nodeType:WhatsNew matches
+        // both lanes. The synced layer already dedupes by path, so this is belt-and-braces — but a
+        // duplicated entry is VISIBLE in the feed, and the cost of being sure is one operator.
+        var entries = (nodes ?? []).Where(n => n is not null).DistinctBy(n => n.Path).ToList();
         if (entries.Count == 0)
             return host.Localize("ui.mdWhatsNewEmpty");
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-whats-new-from-every-repo.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-whats-new-from-every-repo.md
@@ -1,0 +1,17 @@
+---
+Name: What's New now covers every repository
+Category: Feature
+Description: Release notes can be filed from any repository in the fleet, not only the platform one, so the feed stops under-reporting plugin- and content-side work.
+Icon: Sparkle
+Order: -20260828
+---
+
+# What's New now covers every repository
+
+Until now a release note could only be filed from the platform repository. Work that shipped from
+anywhere else — plugins, courses, content — had nowhere to put an entry, so those changes simply
+did not appear here. The feed looked complete while quietly under-reporting, and the gap widened
+every time more of the product moved out of the platform.
+
+Entries can now be written in whichever repository the change was made, and they all arrive in this
+one feed. What you read here should now reflect the whole product rather than one part of it.

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -45,6 +45,7 @@ public static class GraphConfigurationExtensions
                 // and SlideShowControl with its Blazor view (the pack emits the control).
                 .AddCommentType()
                 .AddRedirectType()
+                .AddWhatsNewType()
                 .AddTrackedChangeType()
                 .AddAccessAssignmentType()
                 .AddPartitionAccessPolicyType()

--- a/src/MeshWeaver.Graph/Configuration/WhatsNewNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/WhatsNewNodeType.cs
@@ -1,0 +1,41 @@
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The built-in <c>WhatsNew</c> node type — a release-note entry (#2539).
+///
+/// <para><b>Why it exists as a TYPE rather than a folder convention.</b> The What's New feed was a
+/// single <c>path:Doc/WhatsNew scope:children</c> listing, and that path lives only in the platform
+/// repository. A satellite — Plugins, Education, Reinsurance, SocialMedia, Memex — had no route to
+/// file an entry from its own PR, so a user-noticeable fix landing there was simply absent from the
+/// changelog. Keying the second listing lane on the node TYPE lets an entry live anywhere in any
+/// repo's tree and still reach the one feed, so authorship stays with the change.</para>
+///
+/// <para>🚨 Registering the type is not ceremony: node creation REFUSES an unregistered node type
+/// ("NodeType 'WhatsNew' is not registered"), so without this a satellite could not author an entry
+/// at all — which the test for the feature caught immediately.</para>
+///
+/// <para>The body is markdown and the front matter carries what the feed renders from
+/// (<c>Name</c>, <c>Category</c>, <c>Description</c>, <c>Icon</c>, <c>Order</c>) — the same shape
+/// the platform's own entries under <c>Doc/WhatsNew</c> use, which keep working unchanged through
+/// the other lane.</para>
+/// </summary>
+public static class WhatsNewNodeType
+{
+    /// <summary>The NodeType value identifying a release-note entry.</summary>
+    public const string NodeType = "WhatsNew";
+
+    /// <summary>Registers the built-in "WhatsNew" MeshNode on the mesh builder.</summary>
+    public static TBuilder AddWhatsNewType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        return builder;
+    }
+
+    /// <summary>Creates the MeshNode definition for the What's New entry node type.</summary>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "What's New entry",
+    };
+}

--- a/test/Memex.Portal.Shared.Test/WhatsNewSatelliteEntryTest.cs
+++ b/test/Memex.Portal.Shared.Test/WhatsNewSatelliteEntryTest.cs
@@ -1,0 +1,75 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Settings;
+using MeshWeaver.Data;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// A release note authored OUTSIDE this repository must reach the one What's New feed (#2539).
+///
+/// <para>The feed used to be a single <c>path:Doc/WhatsNew scope:children</c> listing, and that
+/// path exists only here — so a satellite repo (Plugins, Education, Reinsurance, SocialMedia,
+/// Memex) had no route to file an entry from its own PR, and a user-noticeable fix landing there
+/// was simply missing from the changelog. The failure is silent and it COMPOUNDS: every extraction
+/// moves more user-visible behaviour out of core, so the feed drifts toward being a platform-only
+/// changelog while reading as a complete one.</para>
+///
+/// <para>The contract a satellite writes against is exactly what this test performs: a node
+/// carrying <c>nodeType: WhatsNew</c> in its front matter, living anywhere in its own tree.</para>
+/// </summary>
+public class WhatsNewSatelliteEntryTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact]
+    public async Task An_entry_outside_Doc_reaches_the_feed()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var ns = $"SatelliteRepo{Guid.NewGuid():N}"[..20];
+
+        await meshService.CreateNode(new MeshNode("2026-08-28-a-satellite-fix", ns)
+        {
+            NodeType = WhatsNewSettingsTab.EntryNodeType,
+            Name = "A fix that shipped from a satellite repo",
+            State = MeshNodeState.Active,
+        }).Should().Within(30.Seconds()).Emit();
+
+        var listed = await Mesh
+            .GetQuery("whatsnew:test-listing", WhatsNewSettingsTab.ListingQueries)
+            .Where(nodes => nodes.Any(n =>
+                string.Equals(n.NodeType, WhatsNewSettingsTab.EntryNodeType, StringComparison.Ordinal)))
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+
+        listed.Should().Contain(
+            n => n.Name == "A fix that shipped from a satellite repo",
+            "an entry declaring nodeType:WhatsNew must reach the feed from any namespace — "
+            + "otherwise a satellite repo can only skip the entry, and the changelog silently "
+            + "becomes platform-only as more code leaves core");
+    }
+
+    /// <summary>
+    /// The platform's own 612 entries live under <c>Doc/WhatsNew</c> and carry no explicit node
+    /// type. Their lane must survive: this is a UNION, deliberately, not a migration.
+    /// </summary>
+    [Fact]
+    public void The_platform_lane_is_still_declared()
+    {
+        WhatsNewSettingsTab.ListingQueries.Should().Contain(
+            $"path:{WhatsNewSettingsTab.WhatsNewNamespace} scope:children",
+            "the 612 existing entries carry no nodeType — dropping this lane would empty the feed");
+        WhatsNewSettingsTab.ListingQueries.Should().Contain(
+            $"nodeType:{WhatsNewSettingsTab.EntryNodeType}",
+            "the satellite lane is what #2539 adds");
+    }
+}


### PR DESCRIPTION
Closes #2539. Implements the option you picked — **a partition per repo, merged into one feed**.

## The gap

The feed was a single `path:Doc/WhatsNew scope:children` listing, and that path exists **only in this repository**. A satellite — Plugins, Education, Reinsurance, SocialMedia, Memex — had no route to file an entry from its own PR, so a user-noticeable fix landing there was simply absent from the changelog. The author's only options were to skip the entry or open an unrequested cross-repo PR.

It compounds rather than holding steady: every extraction moves more user-visible behaviour out of core, so the feed acquires a systematic bias toward platform work **while still reading as a complete changelog**.

## The change

The listing is a union of two lanes (`GetQuery` takes several queries and unions their result sets, deduped by path):

| Lane | Covers |
|---|---|
| `path:Doc/WhatsNew scope:children` | the platform's **612** existing entries, untouched |
| `nodeType:WhatsNew` | an entry anywhere, in any repo |

A satellite writes `WhatsNew/<date>-<slug>.md` in its own tree with `nodeType: WhatsNew` in the front matter — one extra line, everything else identical — and it reaches the one feed. A union rather than a migration precisely so those 612 entries need no edit.

## What the test caught immediately

🚨 Registering the `WhatsNew` node type is **not** ceremony. Node creation *refuses* an unregistered type — `NodeType 'WhatsNew' is not registered` — so without registering it a satellite could not author an entry at all. My first draft omitted it and the test failed on its first run, which is exactly what a test is for.

## Red-proof

With the `nodeType` lane removed: the satellite entry never reaches the feed (the listing times out waiting for it) and the lane assertion fails. Both pass with it in place.

The `/pullrequest` skill now documents the one-line difference for satellite authors — a mechanism nobody knows about does not get used, and this one exists specifically to stop entries going missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)