### PR TITLE
fix(#2594): recycle-wait pings post under SYSTEM — ambient context never survives the hops

### DIFF
--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1407,18 +1407,16 @@ public static class PackageInstaller
                 return Observable.Return(Unit.Default);
             });
 
-        // 🚨 Impersonated PER PING, like every other installer post (see PublishContentAssets:
-        // ambient impersonation does not survive the pipeline's scheduler hops, and each Repeat
-        // re-subscription is its own post). Without it, a fresh-boot reconcile — which runs from a
-        // hosted-service chain with no ambient AccessContext — had EVERY ping refused by
-        // PostPipeline ("AccessContext must never be null for an application post"): a fail-level
-        // storm per retry until RootReadyTimeout, the wait degraded into a pure delay, and the
-        // install then proceeded against a hub that was still tearing down. An infrastructure
-        // probe posts under the SYSTEM identity at its call site, never off ambient context.
+        // 🚨 Impersonated PER PING (each Repeat re-subscription is its own post), because a
+        // fresh-boot reconcile runs from a hosted-service chain with no ambient AccessContext —
+        // without this, PostPipeline refused EVERY ping ("AccessContext must never be null for an
+        // application post"): a fail-level storm per retry until RootReadyTimeout, the wait
+        // degraded into a pure delay, and the install then proceeded against a hub that was still
+        // tearing down. RunAsSystem seals the scope at Subscribe (the identity-latch ratchet,
+        // #1790); an infrastructure probe posts under SYSTEM at its call site, never off ambient.
         IObservable<bool> Probe() =>
-            Observable.Using(
-                    () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
-                    _ => hub.Observe<PingResponse>(new PingRequest(), o => o.WithTarget(address)))
+            accessService.RunAsSystem(() =>
+                    hub.Observe<PingResponse>(new PingRequest(), o => o.WithTarget(address)))
                 .Take(1)
                 .Timeout(RootPingTimeout)
                 .Select(_ => true)

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1368,7 +1368,11 @@ public static class PackageInstaller
                     return Observable.Return(Unit.Default);
                 }
 
-                hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(rootPath!)));
+                // Impersonated for the same reason as the pings below: the recycle runs from the
+                // installer's chain, where no ambient AccessContext exists on a fresh boot.
+                var accessService = hub.ServiceProvider.GetService<AccessService>();
+                using (accessService?.ImpersonateAsSystem())
+                    hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(rootPath!)));
                 return WaitForRootReady(hub, rootPath!, logger);
             });
     }
@@ -1387,6 +1391,7 @@ public static class PackageInstaller
         IMessageHub hub, string rootPath, ILogger? logger)
     {
         var address = new Address(rootPath);
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
         return Observable.Defer(Probe)
             .Repeat()
             .Where(alive => alive)
@@ -1402,8 +1407,18 @@ public static class PackageInstaller
                 return Observable.Return(Unit.Default);
             });
 
+        // 🚨 Impersonated PER PING, like every other installer post (see PublishContentAssets:
+        // ambient impersonation does not survive the pipeline's scheduler hops, and each Repeat
+        // re-subscription is its own post). Without it, a fresh-boot reconcile — which runs from a
+        // hosted-service chain with no ambient AccessContext — had EVERY ping refused by
+        // PostPipeline ("AccessContext must never be null for an application post"): a fail-level
+        // storm per retry until RootReadyTimeout, the wait degraded into a pure delay, and the
+        // install then proceeded against a hub that was still tearing down. An infrastructure
+        // probe posts under the SYSTEM identity at its call site, never off ambient context.
         IObservable<bool> Probe() =>
-            hub.Observe<PingResponse>(new PingRequest(), o => o.WithTarget(address))
+            Observable.Using(
+                    () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
+                    _ => hub.Observe<PingResponse>(new PingRequest(), o => o.WithTarget(address)))
                 .Take(1)
                 .Timeout(RootPingTimeout)
                 .Select(_ => true)


### PR DESCRIPTION
Fixes #2594 (full RCA there): on a fresh boot the DefaultInstall reconcile has no ambient `AccessContext`, so every `WaitForRootReady` ping was refused by `PostPipeline` — a fail-level storm per retry, the recycle-wait degraded into a pure timeout, and installs proceeded against hubs still tearing down.

Per the file's own per-post doctrine (`PublishContentAssets`), the ping now impersonates SYSTEM per `Repeat` re-subscription (each is its own post), and `SettleRetypedRoot`'s `DisposeRequest` post is wrapped the same way — the identical `Observable.Using(ImpersonateAsSystem, …)` idiom the file already uses at its six other post sites.

Tested: `MeshWeaver.PluginCatalog.Test` 649/649 green. Live acceptance rides the post-#786 fresh-install verification (same run as #2584's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KJ5Lj4z9dWuv2ZKabLo4hr