### PR TITLE
Pooled I/O leaf now observes cancellation: script-completion's first-in-process reference build (#2480, #2578)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-script-completions-no-longer-stall-portal-shutdown.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-script-completions-no-longer-stall-portal-shutdown.md
@@ -1,0 +1,20 @@
+---
+Name: Script completions no longer stall portal shutdown
+Category: Fix
+Description: The first code-completion or script run in a portal's lifetime could hold up a restart for up to 30 seconds; it no longer does.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Script completions no longer stall portal shutdown
+
+The very first time a portal process ran a script cell or offered code completions in a
+script-flavored editor, it had to build a shared list of reference assemblies — a one-time cost
+that is normally quick, but occasionally ran long under memory pressure. That build used to run
+inline while holding a slot in the pool a shutdown needs to hand back cleanly, so on the rare
+occasion it was slow, a restart or redeploy could sit waiting on it for up to 30 seconds instead of
+completing promptly.
+
+The build now runs independently of any one request: a request waits for it but no longer blocks a
+shutdown from proceeding, even on that first, slower call. Restarts and redeploys are consistently
+quick regardless of when they land relative to the first script or completion request.

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeLanguageService.cs
@@ -55,8 +55,18 @@ internal sealed class MeshNodeLanguageService(
     // lifetime, so a single lazily-built project serves every request: each suggest forks the
     // immutable solution with the in-flight text, nothing is applied back, and concurrent
     // requests never contend. Bounded: one AdhocWorkspace total, not one per cell.
-    private readonly Lazy<ScriptWorkspace> _scriptWorkspace = new(
-        () => BuildScriptWorkspace(hub.ServiceProvider),
+    //
+    // 🚨 Task, not a bare value (issues #2480/#2578). Building it touches
+    // MeshScriptEnvironment.ReferencesAsync, whose FIRST-ever call in the process can be
+    // genuinely slow (materializing ~350 assemblies' metadata) — it used to run synchronously,
+    // inline, inside this leaf's Compile-pool gate, with no cancellation participation at all,
+    // so a silo/mesh teardown racing the first caller could not reclaim that gate permit within
+    // the drain budget. Every caller now races its OWN `ct` against this shared Task via
+    // Task.WaitAsync (see GetScriptCompletionsAsync/GetScriptDiagnosticsAsync) — the FIRST
+    // caller's own token never cancels the build (it is shared by every request against this
+    // mesh instance), it only governs how long THAT caller waits.
+    private readonly Lazy<Task<ScriptWorkspace>> _scriptWorkspace = new(
+        () => BuildScriptWorkspaceAsync(hub.ServiceProvider),
         LazyThreadSafetyMode.ExecutionAndPublication);
 
     // Path used as the script document's FilePath — never a real MeshNode path.
@@ -469,7 +479,7 @@ internal sealed class MeshNodeLanguageService(
     {
         var usage = usageIndex;
         var memory = CurrentMemory();
-        var script = _scriptWorkspace.Value;
+        var script = await _scriptWorkspace.Value.WaitAsync(ct).ConfigureAwait(false);
         var document = script.Workspace.CurrentSolution
             .WithDocumentText(script.DocumentId, SourceText.From(StripKernelDirectives(proposedCode)))
             .GetDocument(script.DocumentId);
@@ -484,7 +494,7 @@ internal sealed class MeshNodeLanguageService(
     private async Task<IReadOnlyList<DiagnosticInfo>> GetScriptDiagnosticsAsync(
         string proposedCode, CancellationToken ct)
     {
-        var script = _scriptWorkspace.Value;
+        var script = await _scriptWorkspace.Value.WaitAsync(ct).ConfigureAwait(false);
         var document = script.Workspace.CurrentSolution
             .WithDocumentText(script.DocumentId, SourceText.From(StripKernelDirectives(proposedCode)))
             .GetDocument(script.DocumentId);
@@ -781,12 +791,20 @@ internal sealed class MeshNodeLanguageService(
     /// compilation's usings, the process-shared reference set, the shared metadata resolver,
     /// and the script globals as the submission's host object — so <c>Mesh</c>, <c>Log</c>,
     /// <c>Ct</c> and <c>Inputs</c> complete as bare identifiers exactly as they run.
+    ///
+    /// <para>🚨 Awaits the shared reference snapshot with <see cref="CancellationToken.None"/> —
+    /// this build is cached (once) for every future request against THIS mesh instance's
+    /// <c>_scriptWorkspace</c>, so it must never be torn down by whichever caller happens to be
+    /// first; each caller's own cancellation is applied at the `_scriptWorkspace.Value.WaitAsync`
+    /// call site instead (see the field's doc comment).</para>
     /// </summary>
-    private static ScriptWorkspace BuildScriptWorkspace(IServiceProvider serviceProvider)
+    private static async Task<ScriptWorkspace> BuildScriptWorkspaceAsync(IServiceProvider serviceProvider)
     {
         var workspace = new AdhocWorkspace();
         var projectId = ProjectId.CreateNewId();
         var docId = DocumentId.CreateNewId(projectId);
+        var references = await Kernel.Hub.MeshScriptEnvironment
+            .ReferencesAsync(serviceProvider, CancellationToken.None).ConfigureAwait(false);
         var projectInfo = ProjectInfo
             .Create(
                 projectId,
@@ -799,7 +817,7 @@ internal sealed class MeshNodeLanguageService(
                         metadataReferenceResolver: Kernel.Hub.MeshScriptEnvironment.MetadataResolver)
                     .WithUsings(Kernel.Hub.MeshScriptEnvironment.Imports),
                 parseOptions: new CSharpParseOptions(kind: SourceCodeKind.Script),
-                metadataReferences: Kernel.Hub.MeshScriptEnvironment.References(serviceProvider),
+                metadataReferences: references,
                 isSubmission: true,
                 hostObjectType: Kernel.Hub.MeshScriptEnvironment.GlobalsType)
             .WithDocuments(

--- a/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
@@ -492,12 +492,11 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
     private async Task<Unit> EnsureInitializedAsync(CancellationToken ct)
     {
         if (initialized) return Unit.Default;
-        initialized = true;
 
         var defaultLogger = publicHub.ServiceProvider.GetRequiredService<ILoggerFactory>()
             .CreateLogger("MeshWeaver.Kernel.Script");
-        scriptLogger = new ScriptLogger(defaultLogger);
-        scriptGlobals = new MeshScriptGlobals { Mesh = publicHub, Log = scriptLogger };
+        var localScriptLogger = new ScriptLogger(defaultLogger);
+        var localScriptGlobals = new MeshScriptGlobals { Mesh = publicHub, Log = localScriptLogger };
 
         // Curated anchors + DI-contributed module assemblies + default imports all come
         // from MeshScriptEnvironment — the ONE description of the script environment,
@@ -507,9 +506,19 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
         // metadata block per reference PER SESSION (~350 refs ≈ 150-200 MiB of native
         // memory per kernel session, never reclaimed — the CI memory-pressure leak; see
         // KernelScriptReferences docs).
+        //
+        // 🚨 `initialized` flips to true ONLY after every step below has succeeded (Copilot
+        // review, PR #2598). It used to be set FIRST — harmless when the reference build was a
+        // synchronous call that either finished or threw synchronously right there, but this
+        // method is now `await`-based and genuinely cancellable, so a cancellation or a
+        // transient fault partway through used to leave `initialized == true` with
+        // `scriptOptions` still null FOREVER: the guard at the top would then skip every future
+        // submission's attempt to build it, permanently wedging the session. Local variables
+        // here (rather than writing straight into the instance fields) keep a failed attempt
+        // from leaving scriptLogger/scriptGlobals half-set either.
         var references = await MeshScriptEnvironment.ReferencesAsync(publicHub.ServiceProvider, ct)
             .ConfigureAwait(false);
-        scriptOptions = ScriptOptions.Default
+        var options = ScriptOptions.Default
             .WithReferences(references)
             // 🚨 Required for the sharing to be complete: the compilation resolves
             // the globals type's transitive closure via ResolveMissingAssembly —
@@ -518,6 +527,11 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
             .WithMetadataResolver(MeshScriptEnvironment.MetadataResolver)
             .WithImports(MeshScriptEnvironment.Imports)
             .WithEmitDebugInformation(true);
+
+        scriptLogger = localScriptLogger;
+        scriptGlobals = localScriptGlobals;
+        scriptOptions = options;
+        initialized = true;
         return Unit.Default;
     }
 

--- a/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelExecutor.cs
@@ -349,17 +349,17 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
         // No lock and no gate here: REPL ordering across submissions is owned by the serial
         // Concat pump (see `submissions`), which subscribes this observable only after the
         // previous submission completed. So Execute is just: init → resolve NuGet refs → run
-        // the Roslyn pass. SubscribeOn moves the WHOLE subscribe — including
-        // EnsureInitialized's AppDomain scan — onto the ThreadPool, so the executor action
-        // block is never blocked by a compile. (The Roslyn compile itself runs on the bounded
-        // Compile IoPool inside RunOnePass; NuGet restore on the Http pool.)
+        // the Roslyn pass. SubscribeOn moves the WHOLE subscribe onto the ThreadPool, so the
+        // executor action block is never blocked by a compile. EnsureInitializedAsync's
+        // AppDomain scan is ADDITIONALLY routed through the bounded Compile IoPool (issues
+        // #2480/#2578) — it used to run as a bare synchronous call here, off any pool, which
+        // meant it could neither be tracked nor cancelled by silo/mesh teardown; now it is the
+        // same tracked, drainable leaf shape as the Roslyn compile itself in RunOnePass.
         return Observable.Defer(() =>
-            {
-                EnsureInitialized();
-                return EnsureCellSurfaceReferences()
+                compilePool.Invoke(t => EnsureInitializedAsync(t))
+                    .SelectMany(_ => EnsureCellSurfaceReferences())
                     .SelectMany(_ => nugetPool.Invoke(t => ResolveNuGetReferencesAsync(code, t)))
-                    .SelectMany(cleaned => RunOnePass(cleaned, viewId, scriptOutputLogger, inputs, accessContext, ct));
-            })
+                    .SelectMany(cleaned => RunOnePass(cleaned, viewId, scriptOutputLogger, inputs, accessContext, ct)))
             .Catch<object?, Exception>(ex =>
             {
                 if (ex is OperationCanceledException) return Observable.Throw<object?>(ex);
@@ -479,10 +479,19 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
     /// Build script options once on first submission. Pulls the IMessageHub for
     /// the globals from the public hub (the parent), so scripts see the SAME hub
     /// external callers do — they can post messages, subscribe streams, etc.
+    ///
+    /// <para>🚨 Runs INSIDE the Compile IoPool leaf <see cref="Execute"/> wraps it in — never bare
+    /// on the ThreadPool as before (issues #2480/#2578). The reference materialization behind
+    /// <see cref="MeshScriptEnvironment.ReferencesAsync"/> can be genuinely slow the first time
+    /// any mesh in the process touches it, and used to hold no pool gate at all while doing so —
+    /// invisible to <c>IoPoolRegistry.DrainAll</c> and therefore never cancelled or joined by
+    /// teardown. Now the wait is a real, trackable, cancellable leaf; <paramref name="ct"/>
+    /// governs only how long THIS session waits, never the shared snapshot build itself (see
+    /// <see cref="KernelScriptReferences.GetReferencesAsync"/>).</para>
     /// </summary>
-    private void EnsureInitialized()
+    private async Task<Unit> EnsureInitializedAsync(CancellationToken ct)
     {
-        if (initialized) return;
+        if (initialized) return Unit.Default;
         initialized = true;
 
         var defaultLogger = publicHub.ServiceProvider.GetRequiredService<ILoggerFactory>()
@@ -498,8 +507,10 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
         // metadata block per reference PER SESSION (~350 refs ≈ 150-200 MiB of native
         // memory per kernel session, never reclaimed — the CI memory-pressure leak; see
         // KernelScriptReferences docs).
+        var references = await MeshScriptEnvironment.ReferencesAsync(publicHub.ServiceProvider, ct)
+            .ConfigureAwait(false);
         scriptOptions = ScriptOptions.Default
-            .WithReferences(MeshScriptEnvironment.References(publicHub.ServiceProvider))
+            .WithReferences(references)
             // 🚨 Required for the sharing to be complete: the compilation resolves
             // the globals type's transitive closure via ResolveMissingAssembly —
             // with the default resolver that re-materializes every assembly's
@@ -507,6 +518,7 @@ internal sealed class KernelExecutor(IMessageHub publicHub)
             .WithMetadataResolver(MeshScriptEnvironment.MetadataResolver)
             .WithImports(MeshScriptEnvironment.Imports)
             .WithEmitDebugInformation(true);
+        return Unit.Default;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Kernel.Hub/KernelScriptAssembly.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelScriptAssembly.cs
@@ -8,7 +8,7 @@ namespace MeshWeaver.Kernel.Hub;
 /// MeshNodes (export, import, NodeType compile, …) registers one
 /// <see cref="KernelScriptAssembly"/> per assembly that scripts need to reference.
 ///
-/// <para>The kernel's <see cref="KernelExecutor.EnsureInitialized"/> resolves all
+/// <para>The kernel's <see cref="KernelExecutor.EnsureInitializedAsync"/> resolves all
 /// instances via <c>IServiceProvider.GetServices&lt;KernelScriptAssembly&gt;</c>
 /// and adds each <see cref="Assembly"/> to the Roslyn script options. That way
 /// the script's <c>using MyNamespace;</c> directive resolves even if Roslyn's

--- a/src/MeshWeaver.Kernel.Hub/KernelScriptReferences.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelScriptReferences.cs
@@ -31,7 +31,7 @@ namespace MeshWeaver.Kernel.Hub;
 ///
 /// <para><b>The fix:</b> one <see cref="PortableExecutableReference"/> per assembly
 /// file, once per process, shared by every session — both for the declared
-/// reference set (<see cref="GetReferences"/>) and for resolver-driven resolution
+/// reference set (<see cref="GetReferencesAsync"/>) and for resolver-driven resolution
 /// (<see cref="SharedScriptMetadataResolver"/> wraps
 /// <see cref="ScriptMetadataResolver.Default"/> and memoizes per path). Roslyn
 /// shares the underlying <c>AssemblyMetadata</c> across compilations that use the
@@ -54,8 +54,15 @@ internal static class KernelScriptReferences
     private static readonly ConcurrentDictionary<string, PortableExecutableReference> Materialized =
         new(StringComparer.OrdinalIgnoreCase);
 
-    private static readonly Lazy<ImmutableArray<PortableExecutableReference>> SharedSnapshot =
-        new(CreateSharedSnapshot, LazyThreadSafetyMode.ExecutionAndPublication);
+    // 🚨 Task, not a bare value — see GetReferencesAsync. The materialization below is
+    // synchronous, uncancellable (no CancellationToken overload exists for
+    // MetadataReference.CreateFromFile) CPU/disk work over ~350 assemblies, run via Task.Run so
+    // it executes on its OWN detached ThreadPool work item, decoupled from whichever caller's
+    // pooled leaf happens to trigger the FIRST-ever build. A caller's own cancellation must never
+    // abort this — it is shared by every mesh in the process — so GetReferencesAsync races the
+    // CALLER's token against this shared Task with Task.WaitAsync, never against the work itself.
+    private static readonly Lazy<Task<ImmutableArray<PortableExecutableReference>>> SharedSnapshot =
+        new(() => Task.Run(CreateSharedSnapshot), LazyThreadSafetyMode.ExecutionAndPublication);
 
     private static ImmutableArray<PortableExecutableReference> CreateSharedSnapshot()
         => AppDomain.CurrentDomain.GetAssemblies()
@@ -165,12 +172,27 @@ internal static class KernelScriptReferences
     /// References for one kernel session: the process-shared snapshot plus shared
     /// references for any assembly in <paramref name="sessionAssemblies"/> (curated
     /// core set + DI-contributed module assemblies) that was loaded after the
-    /// snapshot was taken. The per-session cost is ~zero — everything resolves to
-    /// the same process-wide instances.
+    /// snapshot was taken. The per-session cost is ~zero once the snapshot is warm —
+    /// everything resolves to the same process-wide instances.
+    ///
+    /// <para>🚨 <paramref name="ct"/> governs only how long THIS caller waits — it is raced
+    /// against the shared snapshot Task via <c>Task.WaitAsync</c>, never used to cancel the
+    /// snapshot build itself. The build is a process-wide, cache-forever memo shared by every
+    /// mesh in the process (issues #2480 /
+    /// #2578: it used to run inline inside a per-request pooled leaf with no cancellation
+    /// participation at all — the FIRST caller in the process paid its full, sometimes
+    /// multi-second cold cost while holding that leaf's IIoPool gate permit, and a silo/mesh
+    /// teardown racing that first caller had no way to reclaim the permit within the drain
+    /// budget). Racing the WAIT (not the work) means: this caller's own pooled leaf settles
+    /// promptly on cancellation and releases its gate permit, while the shared build keeps
+    /// running to completion in the background for whichever mesh/request needs it next — safe,
+    /// because it never touches a collectible NodeType ALC or any one mesh's disposed DI scope
+    /// (<see cref="CreateSharedSnapshot"/> explicitly excludes collectible-ALC assemblies).</para>
     /// </summary>
-    public static ImmutableArray<MetadataReference> GetReferences(IEnumerable<Assembly> sessionAssemblies)
+    public static async Task<ImmutableArray<MetadataReference>> GetReferencesAsync(
+        IEnumerable<Assembly> sessionAssemblies, CancellationToken ct)
     {
-        var snapshot = SharedSnapshot.Value;
+        var snapshot = await SharedSnapshot.Value.WaitAsync(ct).ConfigureAwait(false);
         var result = ImmutableArray.CreateBuilder<MetadataReference>(snapshot.Length + 4);
         var seen = new HashSet<PortableExecutableReference>();
         foreach (var reference in snapshot)

--- a/src/MeshWeaver.Kernel.Hub/MeshScriptEnvironment.cs
+++ b/src/MeshWeaver.Kernel.Hub/MeshScriptEnvironment.cs
@@ -68,7 +68,7 @@ public static class MeshScriptEnvironment
     /// free — only its metadata reference has to be guaranteed here, immune to the process-wide
     /// snapshot freeze in <see cref="KernelScriptReferences"/>. De-duplication against the
     /// snapshot and the anchors happens by file path in
-    /// <see cref="KernelScriptReferences.GetReferences"/>.
+    /// <see cref="KernelScriptReferences.GetReferencesAsync"/>.
     /// </summary>
     public static IReadOnlyCollection<Assembly> SessionAssemblies(IServiceProvider serviceProvider)
     {
@@ -98,9 +98,15 @@ public static class MeshScriptEnvironment
     /// The full, process-shared metadata reference set for a script session — the shared
     /// snapshot of every referenceable loaded assembly plus the session anchors. Safe to
     /// hand to a Roslyn workspace: every instance is the one shared materialization.
+    ///
+    /// <para>🚨 <paramref name="ct"/> governs only how long the CALLER waits for the shared,
+    /// process-wide snapshot — never used to abort the snapshot build itself, which keeps
+    /// running for the next caller regardless of this one's cancellation. See
+    /// <see cref="KernelScriptReferences.GetReferencesAsync"/>.</para>
     /// </summary>
-    public static ImmutableArray<MetadataReference> References(IServiceProvider serviceProvider)
-        => KernelScriptReferences.GetReferences(SessionAssemblies(serviceProvider));
+    public static Task<ImmutableArray<MetadataReference>> ReferencesAsync(
+        IServiceProvider serviceProvider, CancellationToken ct)
+        => KernelScriptReferences.GetReferencesAsync(SessionAssemblies(serviceProvider), ct);
 
     /// <summary>
     /// Whether an assembly is TEST SCAFFOLDING and must therefore be kept out of the script

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Reactive;
 using System.Reactive.Linq;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Mesh.Threading;
 
@@ -18,6 +19,7 @@ public sealed class IoPoolRegistry : IDisposable
 {
     private readonly ConcurrentDictionary<string, IoPool> _pools = new(StringComparer.Ordinal);
     private readonly IoPoolOptions _options;
+    private readonly ILogger<IoPoolRegistry>? _logger;
     private int _disposing;
     private readonly System.Reactive.Subjects.AsyncSubject<int> _disposed = new();
 
@@ -37,9 +39,15 @@ public sealed class IoPoolRegistry : IDisposable
     /// Creates the registry with the given per-resource-class concurrency options.
     /// </summary>
     /// <param name="options">Concurrency caps per pool name; defaults are used when null.</param>
-    public IoPoolRegistry(IoPoolOptions? options = null)
+    /// <param name="logger">
+    /// Optional — resolved from DI when the mesh registers logging. Names the offending pool at
+    /// <see cref="DrainAll"/> time (issue #2480: the teardown report carried no pool name, exception,
+    /// or stack, so a fingerprint could never be turned into a direct pointer to the leaf).
+    /// </param>
+    public IoPoolRegistry(IoPoolOptions? options = null, ILogger<IoPoolRegistry>? logger = null)
     {
         _options = options ?? new IoPoolOptions();
+        _logger = logger;
     }
 
     /// <summary>
@@ -127,8 +135,16 @@ public sealed class IoPoolRegistry : IDisposable
     public int DrainAll()
     {
         var leaked = 0;
-        foreach (var pool in _pools.Values)
-            leaked += pool.Drain();
+        foreach (var kvp in _pools)
+        {
+            var residual = kvp.Value.Drain();
+            if (residual != 0)
+                _logger?.LogWarning(
+                    "IoPoolSiloTeardown: pool '{PoolName}' did not finish {Residual} leaf(es) within "
+                    + "the drain budget — a leaf ignored its cancellation token; fix the leaf, do not "
+                    + "widen the budget.", kvp.Key, residual);
+            leaked += residual;
+        }
         return leaked;
     }
 
@@ -143,7 +159,7 @@ public sealed class IoPoolRegistry : IDisposable
         // Dispose(): `using var pool = …` in an async method runs it on a ThreadPool thread, and
         // parking one there while the leaves it waits for need pool threads starves into a
         // deadlock on a small runner. The WAIT lives on Disposed, awaited asynchronously.
-        var pools = _pools.Values.ToArray();
+        var pools = _pools.ToArray();
         _pools.Clear();
         if (pools.Length == 0)
         {
@@ -152,17 +168,35 @@ public sealed class IoPoolRegistry : IDisposable
             return;
         }
 
+        // Per-pool attribution (issue #2480: the silo-teardown report named neither pool nor leaf).
+        // Logged the moment EACH pool's own Disposed fires — independent of the Zip below, and
+        // independent of whether the caller's own bounded wait (IoPoolSiloTeardown's 30 s Timeout
+        // on the aggregate) has already given up. A pool that unwinds AFTER that timeout still gets
+        // attributed here, which is strictly more than the aggregate -1 residual ever names.
+        foreach (var kvp in pools)
+        {
+            var name = kvp.Key;
+            kvp.Value.Disposed.Subscribe(residual =>
+            {
+                if (residual != 0)
+                    _logger?.LogWarning(
+                        "IoPoolSiloTeardown: pool '{PoolName}' left {Residual} leaf(es) still "
+                        + "running at dispose — a leaf ignored its cancellation token; fix the "
+                        + "leaf, do not widen the budget.", name, residual);
+            });
+        }
+
         // Zip: one emission once EVERY pool has reported, carrying the total residual. A pool whose
         // leaf never unwinds never reports, so this never fires — and the caller's bounded wait
         // surfaces that as the timeout it is, rather than a false all-clear.
-        Observable.Zip(pools.Select(pool => pool.Disposed))
+        Observable.Zip(pools.Select(kvp => kvp.Value.Disposed))
             .Select(residuals => residuals.Sum())
             .Take(1)
             .Subscribe(
                 total => { _disposed.OnNext(total); _disposed.OnCompleted(); },
                 _ => { _disposed.OnNext(0); _disposed.OnCompleted(); });
 
-        foreach (var pool in pools)
-            pool.Dispose();
+        foreach (var kvp in pools)
+            kvp.Value.Dispose();
     }
 }

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
@@ -139,8 +139,14 @@ public sealed class IoPoolRegistry : IDisposable
         {
             var residual = kvp.Value.Drain();
             if (residual != 0)
+                // 🚨 "IoPoolDrain", not "IoPoolSiloTeardown" (Copilot review, PR #2598): DrainAll()
+                // is the generic mesh-teardown phase 2 (MeshTeardownExtensions AND
+                // MonolithMeshTestBase.DisposeAsync both call it), not just the Orleans silo path —
+                // the earlier prefix mislabeled every non-silo residual as if it came from
+                // IoPoolSiloTeardown specifically. That class's own Dispose()/Disposed path below
+                // keeps the "IoPoolSiloTeardown" prefix; it is where that name is accurate.
                 _logger?.LogWarning(
-                    "IoPoolSiloTeardown: pool '{PoolName}' did not finish {Residual} leaf(es) within "
+                    "IoPoolDrain: pool '{PoolName}' did not finish {Residual} leaf(es) within "
                     + "the drain budget — a leaf ignored its cancellation token; fix the leaf, do not "
                     + "widen the budget.", kvp.Key, residual);
             leaked += residual;

--- a/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/KernelScriptMemoryLeakTest.cs
@@ -31,7 +31,7 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// with only a small managed delta. That signature = a small managed pin holding
 /// the script's <c>ScriptState</c> → <c>Compilation</c> → the ~300
 /// <c>AssemblyMetadata</c> native metadata blocks built by
-/// <c>KernelExecutor.EnsureInitialized</c> (one per loaded assembly).</para>
+/// <c>KernelExecutor.EnsureInitializedAsync</c> (one per loaded assembly).</para>
 ///
 /// <para>This probe runs one kernel script the same way MonolithKernelTest does,
 /// disposes the mesh AND its ServiceProvider, forces GC, and then BFS-walks the


### PR DESCRIPTION
## Summary

Fixes #2480 and #2578 — both describe the same defect class: a pooled I/O leaf that ignores its cancellation token, letting silo/mesh teardown dispose over live work.

**Root cause, confirmed against the real CI evidence** (attempt 1 of run [33152742916](https://github.com/Systemorph/MeshWeaver/actions/runs/33152742916), the actual failing run behind #2578 — not the passing re-run):

- `KernelScriptReferences.CreateSharedSnapshot()` materializes ~350 assemblies' Roslyn metadata (`MetadataReference.CreateFromFile` has no cancellable overload) — a genuinely slow, uncancellable, first-ever-per-process cost.
- It ran **inline**, inside a per-request pooled leaf, with **zero `CancellationToken` participation anywhere in the call chain** (`KernelScriptReferences.GetReferences` → `MeshScriptEnvironment.References` → `MeshNodeLanguageService.BuildScriptWorkspace` / `KernelExecutor.EnsureInitialized`).
- The FIRST caller in a given mesh/process pays this cost while holding that leaf's `IIoPool` gate permit. A silo/mesh teardown racing that first caller has no way to reclaim the permit inside `IoPool`'s 30 s drain budget — exactly the `"1 pooled I/O leaf(s) still running"` / `leakedIoLeaves=1` residual both issues report.
- The CI trace log (`_meshweaver-test-trace.log`, attempt 1) pins `MeshNodeLanguageServiceTest.ScriptCompletions_FilterByTypedPrefix_NotJustTheAlphabet` as the **first** script-completion call in its process (checked: no earlier test in that shard's process touches the script/kernel reference path — the many earlier `Compile*`/`NodeType*` tests use a separate, unrelated Roslyn reference path for NodeType compilation). Its dispose consumed the **entire** 30006 ms drain budget with **zero log output** in between — consistent only with a silent, uncancellable, still-running synchronous computation, not a hang that would leave a trace.
- `MeshNodeLanguageService` (used by the code editor's LSP-backed completions) and `KernelExecutor` (real script/kernel sessions) both resolve the **same shared, process-wide** `KernelScriptReferences.SharedSnapshot`, off the **same per-mesh `Compile` `IIoPool`** — so the same defect is reachable from a live prod portal's real AI/kernel usage, which is the structural link to #2480 (a `memex-cloud` pod, `IoPoolSiloTeardown`, no pool/leaf name in the log to confirm the exact call site — but the same shared, unguarded leaf is the only concrete match found).

## Fix (no band-aids — the leaf now genuinely observes its token, the drain budget is untouched)

- `KernelScriptReferences.SharedSnapshot` is now a detached `Task` (`Task.Run(CreateSharedSnapshot)`) instead of a bare synchronous `Lazy<T>` value. Every caller races **its own** cancellation token against that shared Task via `Task.WaitAsync(ct)` — never against the underlying work, which must keep running to completion for whichever mesh/session needs it next (it's a process-wide, cache-forever memo). This is the same "settle the bridge without aborting the shared work" shape the docs already prescribe for `delegate_to_agent`'s prior instance of this exact bug class.
- `MeshNodeLanguageService._scriptWorkspace` follows the same pattern (`Lazy<Task<ScriptWorkspace>>`); `GetScriptCompletionsAsync`/`GetScriptDiagnosticsAsync` now `await _scriptWorkspace.Value.WaitAsync(ct)`.
- `KernelExecutor.EnsureInitializedAsync` (renamed from `EnsureInitialized`) is additionally routed through the `compilePool` it previously bypassed entirely — it used to run as a bare synchronous call, untracked by any `IIoPool`, so it could be neither cancelled nor drained by teardown at all. It is now the same tracked, drainable leaf shape as the Roslyn compile in `RunOnePass`.
- `IoPoolRegistry` now logs the offending pool **by name** on a nonzero residual, on both drain paths (`DrainAll` — the test-base path; `Dispose`/`Disposed` — the actual `IoPoolSiloTeardown` prod path). Issue #2480 explicitly asked for this: *"The teardown report does not name the offending pool or leaf... worth including in the fix."*

## Verification

- `dotnet build -c Release -warnaserror --no-incremental` clean on every touched project (`MeshWeaver.Mesh.Contract`, `MeshWeaver.Kernel.Hub`, `MeshWeaver.Graph`) and their test-project dependent (`MeshWeaver.Hosting.Monolith.Test`, `Memex.Portal.Shared`).
- No regressions: `IoPoolTest` (23/23), `IoPoolSiloTeardownTest` (3/3), `NoStaticCollectionsTest` (2/2 — the field-type change to `SharedSnapshot`/`Materialized` doesn't trip the mutable-collection guard), full `MeshNodeLanguageServiceTest` class (24/24, including the originally-failing test), `MonolithKernelTest` (8/8 — real script execution through the now-pooled `EnsureInitializedAsync`), `WhatsNewEntryIntegrityTest` (1/1).
- Local stress-looping the specific failing test (15× under `DOTNET_PROCESSOR_COUNT=4`) never reproduced the race — consistent with both issues being single, CI-runner-specific occurrences. Rather than fabricate a synthetic repro, I pulled the actual failing CI run's attempt (not the passing re-run) as the authoritative red-proof and correlated it line-by-line against the code path above.

## Not fixed here

If any part of #2480's prod occurrence turns out to be a *different* leaf (the prod log carries no pool/leaf name), this fix still stands on its own evidence for #2578 and closes a real, provable defect reachable from prod's `MeshNodeLanguageService`/`KernelExecutor` paths — worth watching for recurrence given the new per-pool logging this PR adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)