### PR TITLE
Contents lists a document's PARTS, not its whole subtree

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-contents-lists-every-part.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-contents-lists-every-part.md
@@ -1,0 +1,17 @@
+---
+Name: A document's Contents lists every part again
+Category: Fix
+Description: The Contents index of a multi-part document showed only some of its parts, in no useful order, mixed in with material from inside them.
+Icon: Sparkle
+Order: -20260828
+---
+
+# A document's Contents lists every part again
+
+On a document made of several parts — a course with lessons, say — the Contents index was showing
+only some of them. The rest were pushed off the list by material from *inside* the parts: quizzes,
+solutions, exercises and their source. What remained appeared in no useful order, and the list ran
+out before the missing parts were reached, so scrolling did not help either.
+
+Contents now lists the parts of the document, in order, all of them. Nothing has become harder to
+reach: each entry still opens into its own contents, which is how you get to what is inside a part.

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -971,6 +971,24 @@ public static class MeshNodeLayoutAreas
         public string Placeholder { get; init; } = "Search... (use @ for references)";
     }
 
+    /// <summary>
+    /// Whether a catalog should query the whole descendant subtree, by render mode.
+    ///
+    /// <para>🚨 Only the NAMESPACE TREE needs it — that renderer reveals deeper levels lazily and
+    /// would otherwise stop at direct children. Every other mode shows ONE level, so a subtree
+    /// query buys nothing and costs correctness: the item limit is spent on descendants before the
+    /// level being displayed is complete.</para>
+    ///
+    /// <para>Measured on the 14-lesson <c>AdvancedBusinessRules</c> course, whose Contents index is
+    /// this catalog: the subtree query returned only <b>5 of the 14 lessons</b>, in no useful order,
+    /// interleaved with every <c>Quiz</c>, <c>MyExercises</c>, <c>Solution/</c> and <c>Exercise/</c>
+    /// node, and was STILL truncated. Scoped to children it returns all 14 in order, plus the three
+    /// real siblings — 17 rows, complete. Nothing about depth is lost: each card carries a
+    /// drill-down into its own Search area, which is how browsing was always meant to descend.</para>
+    /// </summary>
+    internal static bool DefaultIncludeSubtree(MeshSearchRenderMode mode)
+        => mode == MeshSearchRenderMode.NamespaceTree;
+
     /// <summary>Reads every catalog knob from the layout area's query string (see <see cref="CatalogOptions"/>).
     /// Booleans accept <c>true/1/yes/on</c> (and their negation by absence); ints must be positive.</summary>
     private static CatalogOptions ReadCatalogOptions(LayoutAreaHost host, MeshSearchRenderMode fallbackMode)
@@ -980,7 +998,17 @@ public static class MeshNodeLayoutAreas
         {
             Mode = mode,
             GroupByProperty = groupProp,
-            IncludeSubtree = ReadBool(host, "subtree", true),
+            // 🚨 The subtree is the NAMESPACE TREE's need, not every catalog's. Defaulting it on
+            // for all modes made the Contents index of a multi-part document unusable: on a
+            // 14-lesson course the query returned the whole descendant tree — every Quiz,
+            // MyExercises invite, Solution/ and Exercise/ node — and the item limit was spent
+            // before most of the lessons were reached. Measured on AdvancedBusinessRules: only
+            // 5 of 14 lessons appeared, in no particular order, and the result was still
+            // truncated. `scope:children` returns the 14 in order plus the three real siblings,
+            // 17 rows, complete. Depth is not lost — every card carries a drill-down to its own
+            // Search area (WithDrillDownArea below), which is how browsing was meant to descend.
+            // `?subtree=true` still opts back in.
+            IncludeSubtree = ReadBool(host, "subtree", DefaultIncludeSubtree(mode)),
             SearchTerm = host.GetQueryStringParamValue("q")?.Trim(),
             ShowSearchBox = ReadBool(host, "searchBar", true),
             ShowEmptyMessage = ReadBool(host, "emptyMessage", false),
@@ -1015,7 +1043,7 @@ public static class MeshNodeLayoutAreas
     /// <see cref="CatalogOptions"/>). The subtree default is what lets the namespace tree reveal
     /// deeper nodes (lazily, per level) instead of stopping at direct children.
     /// </summary>
-    private static MeshSearchControl BuildCatalog(string nodePath, CatalogOptions o)
+    internal static MeshSearchControl BuildCatalog(string nodePath, CatalogOptions o)
     {
         var scope = o.IncludeSubtree ? " scope:subtree" : "";
         var search = Controls.MeshSearch

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -1037,11 +1037,16 @@ public static class MeshNodeLayoutAreas
     /// <summary>
     /// Builds the node-content catalog (the shared body of the <see cref="Search"/> instance view and
     /// the legacy <c>Children</c> area): a <see cref="MeshSearchControl"/> over
-    /// <c>namespace:{nodePath} scope:subtree</c> (the whole descendant subtree, the default) — or
-    /// just <c>namespace:{nodePath}</c> (direct children) when <c>?subtree=false</c> — excluding
-    /// NodeType definitions. Every display knob comes from <paramref name="o"/> (see
-    /// <see cref="CatalogOptions"/>). The subtree default is what lets the namespace tree reveal
-    /// deeper nodes (lazily, per level) instead of stopping at direct children.
+    /// <c>namespace:{nodePath}</c> — the node's DIRECT CHILDREN — or over
+    /// <c>namespace:{nodePath} scope:subtree</c> (the whole descendant subtree) when the caller asks
+    /// for it, excluding NodeType definitions. Every display knob comes from <paramref name="o"/>
+    /// (see <see cref="CatalogOptions"/>).
+    ///
+    /// <para>🚨 The scope is decided by RENDER MODE, not by a blanket default — see
+    /// <see cref="DefaultIncludeSubtree"/>. Only the namespace tree takes the subtree, because it
+    /// alone reveals deeper levels lazily; every other mode renders one level, where a subtree query
+    /// cannot show more and merely spends the item limit on descendants. <c>?subtree=true</c>
+    /// overrides either way.</para>
     /// </summary>
     internal static MeshSearchControl BuildCatalog(string nodePath, CatalogOptions o)
     {

--- a/test/MeshWeaver.Graph.Test/MultiPartContentsIndexTest.cs
+++ b/test/MeshWeaver.Graph.Test/MultiPartContentsIndexTest.cs
@@ -1,0 +1,74 @@
+using MeshWeaver.Graph;
+using MeshWeaver.Layout;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The Contents index of a MULTI-PART document must list its parts — all of them, in order.
+///
+/// <para>🚨 It did not. The catalog behind that index queried the whole descendant subtree for
+/// every render mode, and the item limit was then spent on descendants before the level being
+/// displayed was complete. Measured on the 14-lesson <c>AdvancedBusinessRules</c> course:
+/// <b>5 of 14 lessons</b> appeared, in no useful order, interleaved with every <c>Quiz</c>,
+/// <c>MyExercises</c>, <c>Solution/</c> and <c>Exercise/</c> node — and the result was still
+/// truncated, so no amount of scrolling reached the missing nine.</para>
+///
+/// <para>The failure is silent in the worst way: an index that lists <i>something</i> looks like an
+/// index that works. A reader has no way to tell that nine parts of the document they are looking
+/// at are simply not on the page.</para>
+///
+/// <para>Only <see cref="MeshSearchRenderMode.NamespaceTree"/> needs the subtree — it reveals
+/// deeper levels lazily. Every other mode shows one level, and depth is reached by the drill-down
+/// link each card already carries.</para>
+/// </summary>
+public class MultiPartContentsIndexTest
+{
+    [Theory]
+    [InlineData(MeshSearchRenderMode.GraphNavigator)]   // the Search area's own default
+    [InlineData(MeshSearchRenderMode.Flat)]
+    [InlineData(MeshSearchRenderMode.Hierarchical)]
+    [InlineData(MeshSearchRenderMode.Grouped)]
+    public void A_one_level_catalog_lists_children_not_the_whole_subtree(MeshSearchRenderMode mode)
+    {
+        MeshNodeLayoutAreas.DefaultIncludeSubtree(mode).Should().BeFalse(
+            $"{mode} renders a single level, so a subtree query cannot show more — it only spends "
+            + "the item limit on descendants and starves the level being displayed");
+
+        var catalog = MeshNodeLayoutAreas.BuildCatalog(
+            "AdvancedBusinessRules",
+            new MeshNodeLayoutAreas.CatalogOptions
+            {
+                Mode = mode,
+                IncludeSubtree = MeshNodeLayoutAreas.DefaultIncludeSubtree(mode),
+            });
+
+        ((string?)catalog.HiddenQuery).Should().NotContain(
+            "scope:subtree",
+            "a 14-part course listed this way showed 5 parts and hid the other 9 behind a truncated "
+            + "subtree of quizzes, solutions and exercise sources");
+    }
+
+    /// <summary>
+    /// The namespace tree keeps the subtree — it is the one renderer that descends lazily, and
+    /// scoping it to children would stop it at the first level. This is why the fix is per-mode
+    /// rather than a blanket change.
+    /// </summary>
+    [Fact]
+    public void The_namespace_tree_still_gets_its_subtree()
+    {
+        MeshNodeLayoutAreas.DefaultIncludeSubtree(MeshSearchRenderMode.NamespaceTree).Should().BeTrue();
+
+        var tree = MeshNodeLayoutAreas.BuildCatalog(
+            "AdvancedBusinessRules",
+            new MeshNodeLayoutAreas.CatalogOptions
+            {
+                Mode = MeshSearchRenderMode.NamespaceTree,
+                IncludeSubtree = MeshNodeLayoutAreas.DefaultIncludeSubtree(MeshSearchRenderMode.NamespaceTree),
+            });
+
+        ((string?)tree.HiddenQuery).Should().Contain(
+            "scope:subtree",
+            "the namespace tree reveals deeper levels lazily and would stop at direct children without it");
+    }
+}


### PR DESCRIPTION
The Contents index of a multi-part document was showing only some of its parts.

## Measured, not inferred

The index is the node-content catalog, which queried `scope:subtree` for **every** render mode. On the 14-lesson `AdvancedBusinessRules` course:

| Query | Result |
|---|---|
| `namespace:AdvancedBusinessRules scope:subtree is:main is:content` | **5 of 14 lessons**, in no useful order, interleaved with every `Quiz`, `MyExercises`, `Solution/` and `Exercise/` node — and **still truncated** |
| `… scope:children is:main is:content` | **all 14 in order 01→14**, plus the three real siblings. 17 rows, complete |

The item limit was being spent on descendants before the level being displayed was complete, so the missing nine lessons were not reachable by scrolling either.

Note the parts are not separable by type: a solution node like `01-WhyRules/Solution/SpotThePlug` is itself `nodeType: Edu/Lesson`, so no type filter distinguishes a lesson from a lesson's solution. Scope is the thing that does.

## The fix

Only `NamespaceTree` needs the subtree — it reveals deeper levels lazily and would otherwise stop at direct children. Every other mode renders **one level**, so a subtree query cannot show more; it can only starve the level it is showing. The default is now per-mode (`DefaultIncludeSubtree`), and `?subtree=true` still opts back in.

Depth is not lost: each card already carries a drill-down into its own Search area (`WithDrillDownArea`), which is how browsing was always meant to descend.

## Why this was worth chasing

🚨 The failure is silent in the worst way: **an index that lists *something* looks like an index that works.** A reader has no signal that nine parts of the document in front of them are not on the page.

## Red-proof

With the always-subtree default restored, the four one-level modes (`GraphNavigator`, `Flat`, `Hierarchical`, `Grouped`) fail and `The_namespace_tree_still_gets_its_subtree` stays **green** — so the tests pin this specific change rather than all riding on one cause.

🤖 Generated with [Claude Code](https://claude.com/claude-code)