### PR TITLE
Fix #2469: MCP patch/update confirm the caller's own field, not any version bump

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-mcp-patch-confirms-your-own-field-not-just-any-write.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-mcp-patch-confirms-your-own-field-not-just-any-write.md
@@ -1,0 +1,19 @@
+---
+Name: MCP patch confirms your own field, not just any write
+Category: Fix
+Description: Patching a node that another process also writes to (like the auto-update setting) no longer reports success unless your specific change actually landed.
+Icon: Sparkle
+Order: -20260828
+---
+
+# MCP patch confirms your own field, not just any write
+
+Editing a node through an AI tool ("patch") used to confirm success as soon as the node's version
+number moved forward — even if that version bump came from a different write than the one you
+asked for. On a node that something else keeps updating in the background (the platform's
+auto-update setting, for example, which the system itself checks every few minutes), that meant a
+patch could answer "done" while your specific field never actually changed, with nothing to tell
+you otherwise.
+
+A patch now checks the field you actually asked to change, not just whether the node moved at all.
+If your change cannot be confirmed, the tool now says so instead of reporting a false success.

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -1037,6 +1037,62 @@ public class MeshOperations
             .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null));
 
     /// <summary>
+    /// Bounded wait for the CALLER'S OWN intended field values to be OBSERVABLE in the live
+    /// mirror — the Patch/Update analogue of <see cref="WaitForEditApplied"/>'s #1716 fix,
+    /// applied here for #2469. <see cref="WaitForReadYourWrites"/> alone is not a trustworthy
+    /// confirmation for Patch/Update: it only proves SOME version bump happened, and a concurrent
+    /// writer touching OTHER fields on the SAME node (e.g. <c>Admin/UpdatePolicy</c>'s self-update
+    /// poller ticking <c>checkedAt</c>/<c>latestAvailableTag</c> every few seconds) satisfies that
+    /// just as well as the caller's own write. A genuinely-refused write — a LATE
+    /// Conflict/AccessDenied NACK arriving after <c>UpdateRemote</c>'s optimistic emit, which is
+    /// only ever logged server-side (<c>LATE_NACK_TERMINAL</c>) and never propagated back to this
+    /// already-completed caller — could then still be reported as landed with a real version
+    /// delta shown. This checks the caller's OWN touched leaves specifically
+    /// (<see cref="FieldsLandedIn"/>), so it is neither fooled by, nor blind to, a concurrent
+    /// write elsewhere on the node. Also self-heals the legitimate no-op case (the caller's
+    /// values already match live): that is satisfied on the very first emission.
+    /// </summary>
+    private IObservable<MeshNode?> WaitForPatchApplied(string path, JsonObject expectedFields) =>
+        hub.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null
+                && JsonSerializer.SerializeToNode(n, hub.JsonSerializerOptions) is JsonObject live
+                && FieldsLandedIn(live, expectedFields))
+            .Take(1)
+            .Select(n => (MeshNode?)n)
+            .Timeout(TimeSpan.FromSeconds(5))
+            .Catch<MeshNode?, Exception>(_ => Observable.Return<MeshNode?>(null));
+
+    /// <summary>
+    /// True when every leaf in <paramref name="expected"/> (an RFC 7396-shaped delta — a nested
+    /// object recurses, a scalar/array/null is compared by value) matches the corresponding leaf
+    /// in <paramref name="live"/>. A <c>null</c> expected value (RFC 7396 "remove") matches a
+    /// live key that is absent OR explicitly null. Fields the caller did not touch are never
+    /// inspected, so a concurrent writer's changes elsewhere on the node can neither fail this
+    /// check nor satisfy it.
+    /// <para>Internal (not private): <c>InternalsVisibleTo</c> lets
+    /// <c>PatchLandedWriteCheckTest</c> pin this against the OLD version-only confirmation
+    /// directly and deterministically — see that test for why an integration-level timing
+    /// reproduction of the #2469 race is impractical in a single-silo test mesh (the per-path
+    /// write queue that gives <c>stream.Update</c> its ordering guarantee also prevents a second
+    /// writer from ever landing ahead of a still-unconfirmed one).</para>
+    /// </summary>
+    internal static bool FieldsLandedIn(JsonObject live, JsonObject expected)
+    {
+        foreach (var (key, expectedVal) in expected)
+        {
+            live.TryGetPropertyValue(key, out var liveVal);
+            if (expectedVal is JsonObject expectedObj)
+            {
+                if (liveVal is not JsonObject liveObj || !FieldsLandedIn(liveObj, expectedObj))
+                    return false;
+            }
+            else if (!JsonNode.DeepEquals(liveVal, expectedVal))
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
     /// Writes a full <see cref="MeshNode"/> to the node's own hub via
     /// <see cref="DataChangeRequest"/>. The target hub's data-change handler applies
     /// the update to its workspace (ticking the <c>MeshNodeReference</c> stream so
@@ -1626,18 +1682,33 @@ public class MeshOperations
                 var versionBefore = meshNode.Version;
                 var currentPath = meshNode.Path;
                 var nodeForCapture = meshNode;
+                // The caller's OWN intended field values (#2469 — see WaitForPatchApplied):
+                // restrict to the mutable surface (PatchableFields) so identity/audit fields
+                // (version, lastModified*, …) — which the OWNER re-stamps on apply and will
+                // therefore never match the caller's submitted snapshot — are never checked.
+                var nodeJson = JsonSerializer.SerializeToNode(nodeForCapture, hub.JsonSerializerOptions)
+                    as JsonObject ?? new JsonObject();
+                var expectedFields = new JsonObject();
+                foreach (var field in PatchableFields)
+                    if (nodeJson.TryGetPropertyValue(field, out var val))
+                        expectedFields[field] = val?.DeepClone();
                 perNode = perNode.Add(
                     ValidateContentWithSchema(nodeForCapture).SelectMany(validationError =>
                         validationError != null
                             ? Observable.Return(validationError)
                             : mesh.UpdateNode(nodeForCapture)
-                                // Read-your-writes barrier (see Patch): wait for the live
-                                // mirror to advance PAST the optimistic version before
-                                // returning, so a follow-up Get sees the reconciled update.
-                                .SelectMany(updated => WaitForReadYourWrites(currentPath, updated.Version)
-                                    .Select(confirmed =>
+                                // Gate the success string on the update PROVABLY landing — see
+                                // WaitForPatchApplied's #2469 note on Patch above; the same
+                                // late-NACK-after-optimistic-emit gap applies here.
+                                .SelectMany(_ => WaitForPatchApplied(currentPath, expectedFields)
+                                    .Select(after =>
                                     {
-                                        var after = confirmed ?? updated;
+                                        if (after is null)
+                                            return $"Error: the update to {currentPath} did not land "
+                                                + "within the confirmation window — a concurrent change "
+                                                + "may have conflicted with it, or the owner did not "
+                                                + "confirm the write in time. Get the node to see its "
+                                                + "current content and retry.";
                                         OnNodeChange?.Invoke(new NodeChangeEntry
                                         {
                                             Path = after.Path,
@@ -1750,6 +1821,14 @@ public class MeshOperations
                 // node so the polymorphic `$type` discriminator is present, so omitted
                 // keys are preserved and only the provided keys change. A null member
                 // deletes that key; arrays/scalars replace wholesale (RFC 7396).
+                // 🚨 Snapshot the CALLER'S OWN intended field values BEFORE the content merge
+                // below overwrites jsonObj["content"] with the full merged blob. WaitForPatchApplied
+                // (#2469) confirms the write landed by checking exactly these leaves against the
+                // live mirror — the caller's raw content sub-delta, not the merged snapshot (which
+                // also carries whatever unrelated fields — e.g. a poller's checkedAt — happened to
+                // be live at merge time, and would never match a busy node's live state again).
+                var expectedFields = jsonObj.DeepClone().AsObject();
+
                 if (jsonObj["content"] is JsonObject contentPatch)
                 {
                     var existingNodeJson = JsonSerializer.SerializeToNode(existing, hub.JsonSerializerOptions) as JsonObject;
@@ -1806,17 +1885,26 @@ public class MeshOperations
                     validationError != null
                         ? Observable.Return(validationError)
                         : mesh.UpdateNode(merged)
-                            // 🚨 Read-your-writes barrier. UpdateNode emits OPTIMISTICALLY —
-                            // the owner applies asynchronously and stamps a fresh, higher
-                            // Version on apply, so the emitted `updated` still carries the
-                            // pre-apply version. Without the wait, the immediately-following
-                            // Get races the propagation and reads the stale value. Wait
-                            // (bounded) for the live mirror to advance PAST versionBefore so
-                            // the reconciled update is observable before we return.
-                            .SelectMany(updated => WaitForReadYourWrites(resolvedPath, versionBefore)
-                                .Select(confirmed =>
+                            // 🚨 Gate the success string on the patch PROVABLY landing (#2469 —
+                            // mirrors EditContent's #1716 fix). UpdateNode/UpdateRemote emits
+                            // OPTIMISTICALLY after a short owner-response bound; a LATE
+                            // Conflict/AccessDenied NACK that arrives after that optimistic emit
+                            // is only ever LOGGED server-side (LATE_NACK_TERMINAL) — never
+                            // propagated back to this already-completed caller. The plain
+                            // WaitForReadYourWrites version-advance check cannot catch this on a
+                            // busy node: a concurrent unrelated writer (Admin/UpdatePolicy's
+                            // self-update poller, say) advances the version just as well as this
+                            // write would, so the tool could report "Patched:" — WITH a version
+                            // delta — while the caller's own field never changed. Verify the
+                            // caller's OWN touched leaves specifically instead.
+                            .SelectMany(_ => WaitForPatchApplied(resolvedPath, expectedFields)
+                                .Select(after =>
                                 {
-                                    var after = confirmed ?? updated;
+                                    if (after is null)
+                                        return $"Error: the patch to {resolvedPath} did not land within "
+                                            + "the confirmation window — a concurrent change may have "
+                                            + "conflicted with it, or the owner did not confirm the write "
+                                            + "in time. Get the node to see its current content and retry.";
                                     OnNodeChange?.Invoke(new NodeChangeEntry
                                     {
                                         Path = after.Path,

--- a/src/MeshWeaver.Mesh.Operations/MeshWeaver.Mesh.Operations.csproj
+++ b/src/MeshWeaver.Mesh.Operations/MeshWeaver.Mesh.Operations.csproj
@@ -20,9 +20,14 @@
   <ItemGroup>
     <!-- The same two suites MeshWeaver.AI granted before MeshOperations moved here (#2276): they
          cover the internal edit primitives (ApplyAnchoredEdit / IsEditApplied / MergePatch) and the
-         upload path directly, not through a tool surface. -->
+         upload path directly, not through a tool surface. Both suites left with the AI engine
+         (#2276, now in MeshWeaver.Plugins) — dangling here but harmless; kept so a re-added suite
+         of the same name needs no csproj change. -->
     <InternalsVisibleTo Include="MeshWeaver.AI.Test" />
     <InternalsVisibleTo Include="MeshWeaver.Threading.Test" />
+    <!-- #2469: pins FieldsLandedIn (the Patch/Update landed-write check) directly against a
+         hand-built fixture — same "internal primitive, not the tool surface" pattern as above. -->
+    <InternalsVisibleTo Include="Memex.Portal.Shared.Test" />
   </ItemGroup>
 
 </Project>

--- a/test/Memex.Portal.Shared.Test/PatchLandedWriteCheckTest.cs
+++ b/test/Memex.Portal.Shared.Test/PatchLandedWriteCheckTest.cs
@@ -1,0 +1,139 @@
+#pragma warning disable CS1591
+
+using System.Text.Json.Nodes;
+using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract (#2370)
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// #2469: "MCP patch reports success and does not land: Admin/UpdatePolicy refuses an admin write
+/// silently, and the version-transition suffix is the only tell."
+///
+/// <para><b>The mechanism, read directly out of the write path (MeshNodeStreamExtensions.cs):</b>
+/// <c>UpdateRemote</c> posts the caller's patch to the owning per-node hub and waits up to
+/// <c>UpdateResponseWaitBound</c> (2s) for its verdict. On a BUSY owner — exactly what
+/// <c>Admin/UpdatePolicy</c> is, ticked by the self-update poller every few seconds — that ack can
+/// arrive late. When it does, <c>UpdateRemote</c> emits the OPTIMISTIC (unconfirmed) snapshot and
+/// moves on; the real, LATE verdict — success or a genuine <c>Conflict</c> refusal — is only ever
+/// logged server-side (<c>LATE_ACK</c> / <c>LATE_NACK_TERMINAL</c>), never propagated back to a
+/// caller who already got an answer. <c>EditContent</c> was fixed for exactly this shape in #1716
+/// ("Gate the success string on the edit provably landing... instead of lying 'Edited:'"), but
+/// <c>Patch</c>/<c>Update</c> never got the same treatment — they confirmed via
+/// <c>WaitForReadYourWrites</c>, which only checks that SOME version bump happened on the node.
+/// That is not sufficient: a concurrent writer touching a DIFFERENT field (the poller's
+/// <c>checkedAt</c>/<c>latestAvailableTag</c>) bumps the version too, so the confirmation is
+/// satisfied whether or not the caller's OWN field ever changed.</para>
+///
+/// <para><b>Why this is a unit test on the internal check, not an end-to-end timing race.</b> The
+/// obvious integration reproduction — race a second writer against the operator's patch inside a
+/// <c>MonolithMeshTestBase</c> mesh — was attempted and does not reproduce reliably: MeshNode
+/// cross-hub writes to one path share ONE <c>IMeshNodeStreamCache</c>-owned write queue
+/// (silo-scoped, not per-caller), so a second write to the SAME path cannot even be POSTED until
+/// the first one's slot releases (on its ack, or the queue's own <c>QueueAdvanceBound</c>, 5s) —
+/// which is precisely the ordering guarantee that makes <c>stream.Update</c> safe. That guarantee
+/// also means a single-silo test can never get a second writer's change live BEFORE the first
+/// write's own confirmation check runs, so the exact production race (genuinely independent
+/// replicas / a real Postgres flush pushing the ack past 2s) is not reproducible fast and
+/// deterministically without a multi-silo cluster. The defect is not in doubt — it is read
+/// directly off the code above — so this test pins it precisely at the level it actually lives:
+/// the confirmation PREDICATE <c>Patch</c>/<c>Update</c> use to decide "did MY field land".
+/// </para>
+///
+/// <para>Fixture: the exact shape a busy <c>Admin/UpdatePolicy</c> produces — an operator wants
+/// <c>policy: "None"</c>, but at CONFIRMATION TIME the live node shows the poller's
+/// <c>checkedAt</c> has moved on (proving a real write occurred) while <c>policy</c> is still
+/// whatever it was before. The OLD check (<c>live.Version &gt; versionBefore</c>, inlined here
+/// exactly as <c>WaitForReadYourWrites</c> implements it) says "confirmed" — SetsPolicyAwayFrom
+/// wrongly. The fix, <see cref="MeshOperations.FieldsLandedIn"/>, does not.</para>
+/// </summary>
+public class PatchLandedWriteCheckTest
+{
+    private const long VersionBefore = 1492;
+
+    /// <summary>What Patch captures as the caller's own intent before content gets deep-merged —
+    /// see MeshOperations.Patch's <c>expectedFields</c> snapshot.</summary>
+    private static JsonObject ExpectedFields => JsonNode.Parse("""{"content":{"policy":"None"}}""")!.AsObject();
+
+    /// <summary>A live node where a DIFFERENT writer's field (checkedAt) advanced — proving SOME
+    /// write landed — while the caller's OWN field (policy) never changed.</summary>
+    private static JsonObject LiveWithOnlyThePollerHavingWritten => JsonNode.Parse("""
+        {
+          "version": 1493,
+          "content": {
+            "requireCiGreen": true,
+            "latestAvailableTag": "3.0.0-rc8.ci.6223",
+            "checkedAt": "2026-08-28T09:57:45.3029952+00:00"
+          }
+        }
+        """)!.AsObject();
+
+    /// <summary>A live node where the caller's OWN field genuinely landed too.</summary>
+    private static JsonObject LiveWithTheCallersOwnFieldLanded => JsonNode.Parse("""
+        {
+          "version": 1494,
+          "content": {
+            "policy": "None",
+            "requireCiGreen": true,
+            "latestAvailableTag": "3.0.0-rc8.ci.6223",
+            "checkedAt": "2026-08-28T09:57:45.3029952+00:00"
+          }
+        }
+        """)!.AsObject();
+
+    /// <summary>Inlines the OLD confirmation predicate exactly as <c>WaitForReadYourWrites</c>
+    /// implements it (MeshOperations.cs: <c>n.Version > versionBefore</c>) — the version-only check
+    /// this issue is about.</summary>
+    private static bool OldVersionOnlyCheckConfirms(JsonObject live, long versionBefore) =>
+        live["version"]!.GetValue<long>() > versionBefore;
+
+    [Fact]
+    public void OldCheck_ConfirmsOnAnUnrelatedWritersVersionBump_EvenThoughTheCallersFieldNeverLanded()
+    {
+        var live = LiveWithOnlyThePollerHavingWritten;
+
+        // This is the #2469 bug, pinned directly: the OLD criterion — the only one Patch/Update
+        // used before this fix — says "confirmed" purely because the POLLER'S write bumped the
+        // version. Nothing here required "policy" to be "None".
+        OldVersionOnlyCheckConfirms(live, VersionBefore).Should().BeTrue(
+            "a version-only check cannot tell the caller's own write apart from an unrelated one — "
+            + "this is exactly why Patch could answer 'Patched: ... (v1492 -> v1493)' while policy "
+            + "was never set");
+    }
+
+    [Fact]
+    public void FieldsLandedIn_RefusesToConfirm_WhenTheCallersOwnFieldNeverLanded()
+    {
+        var live = LiveWithOnlyThePollerHavingWritten;
+
+        // The fix: the SAME live node the old check wrongly confirmed on is correctly refused here,
+        // because the caller's OWN leaf ("content.policy") is absent, not "None".
+        MeshOperations.FieldsLandedIn(live, ExpectedFields).Should().BeFalse(
+            "the caller's own field must actually match before Patch/Update may report success — "
+            + "an unrelated writer's version bump must not be mistaken for it");
+    }
+
+    [Fact]
+    public void FieldsLandedIn_Confirms_WhenTheCallersOwnFieldGenuinelyLanded()
+    {
+        var live = LiveWithTheCallersOwnFieldLanded;
+
+        MeshOperations.FieldsLandedIn(live, ExpectedFields).Should().BeTrue(
+            "a write that genuinely landed the caller's own field must still be reported as success");
+    }
+
+    [Fact]
+    public void FieldsLandedIn_IgnoresFieldsTheCallerNeverTouched()
+    {
+        // The poller's own concurrent bookkeeping write: only checkedAt/latestAvailableTag change,
+        // policy is untouched — this must never be mistaken for a refusal of a change nobody asked
+        // for, and must never be mistaken for confirmation of one either.
+        var pollerOwnWrite = JsonNode.Parse("""
+            {"version": 1493, "content": {"checkedAt": "2026-08-28T10:00:00Z"}}
+            """)!.AsObject();
+        var pollerOwnExpectedFields = JsonNode.Parse(
+            """{"content":{"checkedAt":"2026-08-28T10:00:00Z"}}""")!.AsObject();
+
+        MeshOperations.FieldsLandedIn(pollerOwnWrite, pollerOwnExpectedFields).Should().BeTrue();
+    }
+}

--- a/test/Memex.Portal.Shared.Test/UpdatePolicyMcpPatchTest.cs
+++ b/test/Memex.Portal.Shared.Test/UpdatePolicyMcpPatchTest.cs
@@ -1,0 +1,261 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract (#2370)
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// #2469: an MCP <c>patch</c> to <c>Admin/UpdatePolicy</c> reported success
+/// (<c>"Patched: Admin/UpdatePolicy"</c>, no version-transition suffix) while the durable node
+/// stayed on its old <see cref="UpdatePolicyContent.Policy"/> — the operator's auto-update
+/// kill-switch never took effect. Reproduces the exact operator sequence against a REAL mesh:
+/// seed the node at the PLATFORM DEFAULT policy (<see cref="UpdatePolicyKind.Continuous"/> —
+/// also the enum's own default value, so it is OMITTED from JSON under this hub's
+/// <c>DefaultIgnoreCondition = WhenWritingDefault</c>), then run the exact MCP <c>patch</c> call
+/// an operator would issue to freeze auto-update, while the self-update poller concurrently
+/// writes its own bookkeeping fields (<c>checkedAt</c> / <c>latestAvailableTag</c>) on the SAME
+/// node — precisely what <see cref="Memex.Portal.Shared.SelfUpdate.SelfUpdateHostedService.RecordAvailable"/>
+/// does continuously in production.
+/// </summary>
+public class UpdatePolicyMcpPatchTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddUpdatePolicyType();
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    /// <summary>
+    /// The plain case: no concurrent writer at all. An admin patches
+    /// <c>Admin/UpdatePolicy</c>'s <c>policy</c> field away from its (platform- and enum-)
+    /// default. The tool's own reply must be trustworthy: if it says "Patched", the field must
+    /// actually have changed.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Patch_SetsPolicyAwayFromDefault_ActuallyLands()
+    {
+        await Seed();
+
+        var result = await new MeshOperations(Mesh)
+            .Patch(UpdatePolicyNodeType.NodePath, """{"content":{"policy":"None"}}""")
+            .FirstAsync().Timeout(Budget).ToTask(TestContext.Current.CancellationToken);
+
+        Output.WriteLine($"Patch tool returned: {result}");
+        result.Should().NotContain("Error:", "a real, applicable field change must not be refused");
+
+        var content = await ReadContentOnce();
+        content.Policy.Should().Be(UpdatePolicyKind.None,
+            "the tool reported success, so the write must actually have landed");
+    }
+
+    /// <summary>
+    /// The production shape: the self-update poller keeps ticking <c>checkedAt</c> /
+    /// <c>latestAvailableTag</c> on the SAME node (as System) while the operator's patch is in
+    /// flight — exactly the contention the issue names ("two fields, different writers, different
+    /// lifetimes, contending on one row").
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task Patch_SetsPolicyAwayFromDefault_ConcurrentWithPollerBookkeeping_ActuallyLands()
+    {
+        await Seed();
+
+        // Fire a handful of poller-shaped bookkeeping writes (as System) racing the operator's
+        // patch — mirrors SelfUpdateHostedService.RecordAvailable's write shape exactly.
+        var pollerTicks = Task.Run(async () =>
+        {
+            for (var i = 0; i < 10; i++)
+            {
+                await RecordAvailable($"3.0.0-ci.{i}");
+                await Task.Delay(10, TestContext.Current.CancellationToken);
+            }
+        }, TestContext.Current.CancellationToken);
+
+        var result = await new MeshOperations(Mesh)
+            .Patch(UpdatePolicyNodeType.NodePath, """{"content":{"policy":"None"}}""")
+            .FirstAsync().Timeout(Budget).ToTask(TestContext.Current.CancellationToken);
+
+        await pollerTicks;
+
+        Output.WriteLine($"Patch tool returned: {result}");
+        result.Should().NotContain("Error:", "a real, applicable field change must not be refused");
+
+        var content = await ReadContentOnce();
+        content.Policy.Should().Be(UpdatePolicyKind.None,
+            "the operator's write must survive concurrent poller bookkeeping on unrelated fields");
+    }
+
+    /// <summary>
+    /// A companion invariant check for #2469: <c>Patch</c>'s success string must be an honest
+    /// signal — if it does not say "Error:", the caller's OWN field must actually have changed.
+    /// Runs the operator's patch against a heavy REAL-concurrency write storm on the exact same
+    /// leaf (<c>policy</c>, seeded away from its enum default so base values are actually carried
+    /// and a genuine Conflict can fire) — this fast in-memory mesh usually resolves the race
+    /// within <c>UpdateRemote</c>'s 2s response bound, so it does not reliably discriminate
+    /// old/new code by itself (see <c>PatchLandedWriteCheckTest</c> for the deterministic,
+    /// timing-independent pin of the actual defect — the version-only confirmation this fix
+    /// replaces), but it does prove the fix holds under real contention, not just the quiet,
+    /// uncontended case the other tests in this file cover.
+    /// </summary>
+    [Fact(Timeout = 90000)]
+    public async Task Patch_SuccessString_IsHonest_UnderConcurrentContentionOnTheSameField()
+    {
+        // Seeded away from the enum default (Continuous) so "policy" is NOT omitted from JSON —
+        // ExtractBaseValues carries a real base for it, so a concurrent write to the SAME leaf
+        // produces a genuine Conflict refusal instead of the no-base "apply blindly" fallback.
+        await Seed(UpdatePolicyKind.Stable);
+
+        // A heavy concurrent storm on the SAME leaf ("policy", toggled between two OTHER values)
+        // — real concurrency (Task.WhenAll, not sequential awaits) so it genuinely backs up the
+        // owning hub's single-threaded action block. Started slightly ahead of, and kept running
+        // through, the operator's own patch call so that call's PatchDataRequest is likely queued
+        // behind a real backlog when the owner finally answers it.
+        using var stormCts = new CancellationTokenSource();
+        var storm = Task.WhenAll(Enumerable.Range(0, StormSize).Select(i => Task.Run(async () =>
+        {
+            try
+            {
+                await ToggleStormWriter(i % 2 == 0 ? UpdatePolicyKind.Continuous : UpdatePolicyKind.Stable);
+            }
+            catch (OperationCanceledException) { /* storm cancelled after the patch settles */ }
+            catch (Exception ex)
+            {
+                // Concurrent conflicts are EXPECTED and self-heal via the framework's own
+                // re-enqueue; only log so a genuine infra fault is still visible.
+                Output.WriteLine($"[storm] writer {i} faulted: {ex.GetType().Name}: {ex.Message}");
+            }
+        }, stormCts.Token)));
+
+        await Task.Delay(50, TestContext.Current.CancellationToken); // let the storm get ahead
+
+        var result = await new MeshOperations(Mesh)
+            .Patch(UpdatePolicyNodeType.NodePath, """{"content":{"policy":"None"}}""")
+            .FirstAsync().Timeout(Budget).ToTask(TestContext.Current.CancellationToken);
+
+        // Check the claim AT THE INSTANT it was made — before the storm is torn down and its
+        // remaining in-flight writes settle, which would let plenty of real time pass and give a
+        // premature "Patched:" every chance to become true after the fact instead of proving it
+        // was true when said.
+        var content = await ReadContentOnce();
+
+        await stormCts.CancelAsync();
+        await storm;
+
+        Output.WriteLine($"Patch tool returned: {result}");
+
+        if (!result.Contains("Error:", StringComparison.Ordinal))
+        {
+            content.Policy.Should().Be(UpdatePolicyKind.None,
+                "the tool did not report an error, so the caller's OWN field must actually have "
+                + $"landed — instead the tool said '{result}' while policy was '{content.Policy}' "
+                + "at that instant");
+        }
+    }
+
+    // ── helpers ──
+
+    /// <summary>Concurrent writers contending on the SAME leaf in the storm test — large enough
+    /// to genuinely back up the owning hub's single-threaded action block past the 2s
+    /// owner-response bound.</summary>
+    private const int StormSize = 250;
+
+    private Task Seed(UpdatePolicyKind policy = UpdatePolicyKind.Continuous)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var node = new MeshNode(UpdatePolicyNodeType.NodeId, UpdatePolicyNodeType.AdminPartition)
+        {
+            NodeType = UpdatePolicyNodeType.NodeType,
+            Name = "Update Policy",
+            State = MeshNodeState.Active,
+            // The default overload seeds at the PLATFORM default AND the enum's own default
+            // (Continuous = 0) — deliberately, so it is omitted from JSON under
+            // DefaultIgnoreCondition = WhenWritingDefault, exactly like the real
+            // Admin/UpdatePolicy node on a fresh install.
+            Content = new UpdatePolicyContent { Policy = policy },
+        };
+        return Observable.Create<MeshNode>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return meshService.CreateNode(node).Subscribe(observer);
+            })
+            .FirstAsync()
+            .Timeout(Budget)
+            .ToTask(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>One storm writer: flips <c>policy</c> to <paramref name="value"/> — the SAME leaf
+    /// the operator's patch targets, so a genuine base/live conflict is possible on either side.</summary>
+    private Task ToggleStormWriter(UpdatePolicyKind value)
+    {
+        var jsonOptions = Mesh.JsonSerializerOptions;
+        return Observable.Create<MeshNode>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return Mesh.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                        .Update(node =>
+                        {
+                            var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);
+                            return node with { Content = cur with { Policy = value } };
+                        })
+                        .Subscribe(observer);
+            })
+            .FirstAsync()
+            .Timeout(Budget)
+            .ToTask(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>Same write shape as <c>SelfUpdateHostedService.RecordAvailable</c> — touches only
+    /// the poller's bookkeeping fields, preserves Policy.</summary>
+    private Task RecordAvailable(string tag)
+    {
+        var jsonOptions = Mesh.JsonSerializerOptions;
+        return Observable.Create<MeshNode>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return Mesh.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                        .Update(node =>
+                        {
+                            var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);
+                            return node with
+                            {
+                                Content = cur with { LatestAvailableTag = tag, CheckedAt = DateTimeOffset.UtcNow },
+                            };
+                        })
+                        .Subscribe(observer);
+            })
+            .FirstAsync()
+            .Timeout(Budget)
+            .ToTask(TestContext.Current.CancellationToken);
+    }
+
+    /// <summary>A single authoritative read off the shared stream handle — the same primitive a
+    /// follow-up MCP <c>get</c> uses.</summary>
+    private Task<UpdatePolicyContent> ReadContentOnce() =>
+        Observable.Create<MeshNode>(observer =>
+            {
+                using (Access.ImpersonateAsSystem())
+                    return Mesh.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                        .Where(node => node is not null)
+                        .Subscribe(observer);
+            })
+            .Select(node => UpdatePolicyNodeType.Parse(node, Mesh.JsonSerializerOptions))
+            .FirstAsync()
+            .Timeout(Budget)
+            .ToTask(TestContext.Current.CancellationToken);
+}


### PR DESCRIPTION
## Summary

- `Patch`/`Update` confirmed a write via `WaitForReadYourWrites`, which only checks that the node's version advanced past what the caller started from — satisfied by **any** writer, not necessarily the caller's own change.
- On a busy node (`Admin/UpdatePolicy` is ticked by the self-update poller every few seconds), a genuinely refused write — a late `Conflict`/`AccessDenied` NACK arriving after `UpdateRemote`'s optimistic emit — is only ever logged server-side (`LATE_NACK_TERMINAL`), never propagated back to the caller. The tool could report `"Patched: {path}"` — sometimes even with a real version-transition suffix — while the caller's own field never changed.
- Root cause investigated directly against the live mesh: reproduced the exact "Patched" reply followed by a stale/inconsistent read on `Admin/UpdatePolicy`.
- Fix mirrors `EditContent`'s existing #1716 fix for the identical defect class: gate the success string on `WaitForPatchApplied`, which checks the caller's OWN touched leaves against the live mirror (`FieldsLandedIn`) instead of a bare version comparison. When the caller's field cannot be confirmed within the wait bound, the tool now returns an explicit `Error: ... did not land ...` message instead of silently claiming success.
- Applied consistently to both `Patch` (field-delta) and `Update` (full-node replace).

## Root cause

`MeshOperations.Patch`/`Update` (in `MeshWeaver.Mesh.Operations`) used `WaitForReadYourWrites(path, versionBefore)` — `n.Version > versionBefore` — as its only confirmation that a write landed. `UpdateRemote` (`MeshNodeStreamExtensions.cs`) posts the patch and waits up to `UpdateResponseWaitBound` (2s) for the owner's ack; on timeout it emits the OPTIMISTIC (unconfirmed) snapshot and moves on. The real, late verdict — success or a genuine refusal — arrives asynchronously and is only logged (`LATE_ACK` / `LATE_NACK_TERMINAL`), never surfaced to the already-completed caller. A version-only confirmation cannot distinguish "my own write landed" from "some other writer's write landed" — on `Admin/UpdatePolicy`, written continuously by the self-update poller's bookkeeping fields (`checkedAt`/`latestAvailableTag`), this made the false-success signature far more likely to manifest than on a quiet node.

## Test plan

- [x] `PatchLandedWriteCheckTest` — deterministic, timing-independent unit tests pinning the defect and the fix directly against a hand-built fixture matching the issue's exact reported shape (a poller-only version bump with the caller's own field unchanged). Reverting the fix makes these fail to **compile** (`FieldsLandedIn` doesn't exist), confirming the check is genuinely new.
- [x] `UpdatePolicyMcpPatchTest` — integration regression coverage against a real `MonolithMeshTestBase` mesh: plain patch, patch racing concurrent poller bookkeeping writes, and patch under a heavy real-concurrency write storm on the same field.
- [x] `dotnet build -c Release -warnaserror` clean for `MeshWeaver.Mesh.Operations` and `Memex.Portal.Shared.Test`.
- [x] All 7 tests pass in both Debug and Release.
- An integration-level TIMING reproduction (racing a second writer against the operator's patch) was attempted extensively but is not reliably reproducible in a single-silo `MonolithMeshTestBase` mesh: MeshNode cross-hub writes to one path share one `IMeshNodeStreamCache`-owned write queue (silo-scoped, not per-caller) that itself prevents a second writer from landing ahead of a still-unconfirmed one — exactly the ordering guarantee that makes `stream.Update` safe. This is documented in the test file's own comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)