### PR TITLE
fix: the Swiss-German voice model moves to MeshWeaver.Plugins — evicting the last pre-rewrite pin (#2593)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -453,7 +453,7 @@ memex/aspire/Memex.Portal.Distributed/wwwroot/app/
 # mounted at /models/model.bin (see deploy/whisper/docker-compose.yml).
 #
 # 🗄️ BACKUP OF RECORD — a GitHub RELEASE ASSET on this repo, which is exempt from the 100 MB blob
-# limit (2 GB/asset): tag `voice-model-swiss-german`, asset `ggml-swiss-german-turbo-q5_0.bin`
+# limit (2 GB/asset): tag `voice-model-swiss-german` on MeshWeaver.Plugins (moved 2026-08-28)
 # (574,041,195 bytes). Re-fetch it exactly as deploy/whisper/README.md documents:
-#   curl -fSL https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin -o deploy/whisper/models/model.bin
+#   gh release download voice-model-swiss-german --repo Systemorph/MeshWeaver.Plugins --pattern 'ggml-swiss-german-turbo-q5_0.bin' --output deploy/whisper/models/model.bin   (PRIVATE repo — gh auth required)
 deploy/whisper/models/

--- a/clients/voice-gateway/README.md
+++ b/clients/voice-gateway/README.md
@@ -51,8 +51,9 @@ Every leg is pluggable, so the gateway also runs **fully local** — no cloud in
 
 ```bash
 brew install whisper-cpp ollama
-mkdir -p ~/models/whisper && curl -fSL -o ~/models/whisper/ggml-swiss-german-turbo-q5_0.bin \
-  https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin
+# The model lives on the PRIVATE MeshWeaver.Plugins repo (moved 2026-08-28; it is a
+# Systemorph-tuned model, deliberately not world-downloadable). Requires `gh auth login`.
+mkdir -p ~/models/whisper && gh release download voice-model-swiss-german --repo Systemorph/MeshWeaver.Plugins --pattern 'ggml-swiss-german-turbo-q5_0.bin' --dir ~/models/whisper
 pip install -e .
 SATELLITE_HOST=… SATELLITE_PSK=… GATEWAY_HOST=<this Mac's LAN IP> ./run-local.sh
 ```

--- a/clients/voice-gateway/run-local.sh
+++ b/clients/voice-gateway/run-local.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # All-local run on a Mac: whisper.cpp STT + Ollama brain + macOS `say` TTS.
 # Prereqs: brew install whisper-cpp ollama; the Swiss German GGML in ~/models/whisper/
-# (from the voice-model-swiss-german release); an Ollama model pulled (default qwen3.6).
+# (voice-model-swiss-german release on the PRIVATE MeshWeaver.Plugins repo — gh auth); an Ollama model pulled (default qwen3.6).
 # Required env: SATELLITE_HOST, SATELLITE_PSK, GATEWAY_HOST (this Mac's LAN IP).
 set -e
 

--- a/deploy/whisper/README.md
+++ b/deploy/whisper/README.md
@@ -14,8 +14,8 @@ MAUI all reach one endpoint. The mesh side is `MeshWeaver.Speech` (`WhisperConta
 cd deploy/whisper
 # 1. Fetch the Swiss-German model (~547 MB) into ./models/ (same file the on-device client downloads):
 mkdir -p models
-curl -fSL https://github.com/Systemorph/MeshWeaver/releases/download/voice-model-swiss-german/ggml-swiss-german-turbo-q5_0.bin \
-     -o models/model.bin
+# Model on the PRIVATE MeshWeaver.Plugins repo (moved 2026-08-28) — requires gh auth.
+gh release download voice-model-swiss-german --repo Systemorph/MeshWeaver.Plugins --pattern 'ggml-swiss-german-turbo-q5_0.bin' --output models/model.bin
 # 2. Build + start the container:
 docker compose up --build -d
 # 3. Smoke-test with any WAV (16 kHz mono is ideal):


### PR DESCRIPTION
Closes #2593 (the code half; the release/tag deletion follows the merge).

## What

The `voice-model-swiss-german` release on this repo is the **last tag pinning the full pre-rewrite
history** (10,036 commits, `src/MeshWeaver.AI` included — 878 commits touching it remain reachable
through this one tag). Its 574MB asset was load-bearing, so the history prune deliberately left it.

The asset now lives on **MeshWeaver.Plugins** (`voice-model-swiss-german`, sha256 recorded in the
release notes). Plugins is **private — and that is a feature**: this is a Systemorph-tuned model,
and anonymous world-download was an accident of hosting, not a design.

All four consumers switch from anonymous `curl` to `gh release download`:
`clients/voice-gateway/README.md`, `deploy/whisper/README.md`, `.gitignore` (provenance comments),
`run-local.sh` (comment; it reads `$WHISPER_MODEL` from disk).

## Verified, not assumed

- The authenticated fetch **streams** (4.2MB in the first second of a probe, then cancelled).
- Zero references to the old core URL remain (`grep` clean).
- The asset on Plugins: `state: uploaded`, `size: 574,041,195` — byte-identical, checksum in the notes.

## After merge (maintainer-ordered, I execute)

1. Delete the core release + tag (ruleset window; the tag name is burned by release immutability
   either way — nothing will reuse it).
2. Fresh clones shed ~10k pre-rewrite commits (~118MB → ~85MB) and `src/MeshWeaver.AI` becomes
   unreachable from **every** ref.

🤖 Generated with [Claude Code](https://claude.com/claude-code)