### PR TITLE
Reframe MAUI-named tests to the renderer-agnostic contracts they actually pin (#2448)

### DIFF
--- a/test/MeshWeaver.Hosting.Monolith.Test/CircuitContextIsolationTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CircuitContextIsolationTest.cs
@@ -23,8 +23,8 @@ namespace MeshWeaver.Hosting.Monolith.Test;
 /// <para>The field is gone. <c>SetCircuitContext</c> now writes ONLY the AsyncLocal, so identity
 /// resolution fails CLOSED off the circuit's own call tree. The two legitimate "identity must
 /// survive every hop" cases are served by correctly-scoped APIs instead:
-/// <see cref="AccessService.SetHostIdentity"/> (a single-identity process — MAUI device client,
-/// xUnit host) and <see cref="AccessService.SetStandingIdentity"/> (per-hub owner injection).</para>
+/// <see cref="AccessService.SetHostIdentity"/> (a single-identity process — a native device
+/// client, the xUnit host) and <see cref="AccessService.SetStandingIdentity"/> (per-hub owner injection).</para>
 /// </summary>
 public class CircuitContextIsolationTest
 {
@@ -75,9 +75,9 @@ public class CircuitContextIsolationTest
     [Fact(Timeout = 20_000)]
     public async Task SetHostIdentity_SurvivesHops_ForSingleIdentityHosts()
     {
-        // The MAUI device client and the xUnit test host serve exactly one user and have no
+        // A native device client and the xUnit test host serve exactly one user and have no
         // circuit, so their standing identity legitimately survives every hop. This is the
-        // contract TestUsers.DevLogin and MauiProgram depend on.
+        // contract TestUsers.DevLogin depends on.
         var access = new AccessService();
         access.SetHostIdentity(new AccessContext { ObjectId = "device-user", Name = "Device User" });
 

--- a/test/MeshWeaver.Layout.Test/NativeRendererDataPathTest.cs
+++ b/test/MeshWeaver.Layout.Test/NativeRendererDataPathTest.cs
@@ -12,22 +12,25 @@ using MeshWeaver.Messaging;
 namespace MeshWeaver.Layout.Test;
 
 /// <summary>
-/// Data-path tests for the native MAUI view pack (<c>MeshWeaver.Maui</c>). The MAUI views can't be
-/// unit-tested headlessly (they need the MAUI runtime), but they render EXACTLY this Blazor-agnostic
-/// pipeline: <c>GetControlStream(area)</c> → a <see cref="UiControl"/> tree; a container's
-/// <c>IContainerControl.Areas</c> → per-child-area control streams; and each control's bound value. These
-/// tests pin that pipeline so a regression in what the views would render is caught in CI — no Xcode, no
-/// MAUI runtime. (The render mapping itself — control type → MAUI view — needs a maccatalyst test host.)
+/// Data-path tests for OUT-OF-PROCESS renderers (the React Native leaf pack, the gRPC/SignalR
+/// participants under <c>clients/</c>). Native views can't be unit-tested headlessly here, but every
+/// one of them renders EXACTLY this Blazor-agnostic pipeline — the contract
+/// <c>Doc/GUI/CrossRendererAuthoring</c> asks any renderer to hold to: <c>GetControlStream(area)</c> →
+/// a <see cref="UiControl"/> tree; a container's <c>IContainerControl.Areas</c> → per-child-area
+/// control streams; and each control's bound value. These tests pin that pipeline so a regression in
+/// what a native renderer would receive is caught in CI without any native test host.
+/// (Originally written against the retired <c>MeshWeaver.Maui</c> view pack; the pipeline under test
+/// is renderer-agnostic and outlives it.)
 /// </summary>
-public class MauiViewDataPathTest(ITestOutputHelper output) : HubTestBase(output)
+public class NativeRendererDataPathTest(ITestOutputHelper output) : HubTestBase(output)
 {
     private const string TreeView = nameof(TreeView);
 
     protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
         => base.ConfigureHost(configuration)
             .WithRoutes(r => r.RouteAddress(ClientType, (_, d) => d.Package()))
-            // A container (Stack) with three leaf controls — the shapes MeshWeaver.Maui's ContainerView +
-            // LabelView / MarkdownView / HtmlView render.
+            // A container (Stack) with leaf controls — the shapes an out-of-process renderer's
+            // container view + label / markdown / html views consume.
             .AddLayout(layout => layout.WithView(TreeView, (_, _) => Observable.Return<UiControl>(
                 Controls.Stack
                     .WithView(Controls.Label("Hello"), "Greeting")
@@ -44,19 +47,19 @@ public class MauiViewDataPathTest(ITestOutputHelper output) : HubTestBase(output
         => base.ConfigureClient(configuration).AddLayoutClient(d => d);
 
     [HubFact]
-    public async Task ContainerTreeAndLeaves_RenderForTheMauiPack()
+    public async Task ContainerTreeAndLeaves_ResolveThroughTheControlStreamPipeline()
     {
         var reference = new LayoutAreaReference(TreeView);
         var workspace = GetClient().GetWorkspace();
         var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(CreateHostAddress(), reference);
 
-        // 1. Root = a container — MauiControlRenderer maps any IContainerControl to ContainerView.
+        // 1. Root = a container — a renderer maps any IContainerControl to its container view.
         var root = await stream.GetControlStream(reference.Area!)
             .Where(c => c is not null)
             .Should().Within(5.Seconds()).Match(c => c is IContainerControl);
 
         var container = (IContainerControl)root!;
-        container.Areas.Should().HaveCount(7, "ContainerView iterates IContainerControl.Areas");
+        container.Areas.Should().HaveCount(7, "a container view iterates IContainerControl.Areas");
 
         // 2. Each child area resolves to its leaf control — exactly RenderArea(stream, named.Area) per child.
         var leaves = new List<UiControl>();
@@ -69,14 +72,14 @@ public class MauiViewDataPathTest(ITestOutputHelper output) : HubTestBase(output
             Output.WriteLine($"{named.Id}: {leaf!.GetType().Name}");
         }
 
-        // 3. The leaf control TYPES (→ MAUI views) and their bound VALUES (→ what Bind<object> sets).
+        // 3. The leaf control TYPES (→ native views) and their bound VALUES (→ what a renderer binds).
         leaves.OfType<LabelControl>().Should().ContainSingle()
             .Which.Data!.ToString().Should().Contain("Hello");
         leaves.OfType<MarkdownControl>().Should().ContainSingle()
             .Which.Markdown!.ToString().Should().Contain("Title");
         leaves.OfType<HtmlControl>().Should().ContainSingle()
             .Which.Data!.ToString().Should().Contain("hi");
-        // DataGridView consumes Columns + the rows in Data.
+        // A data-grid view consumes Columns + the rows in Data.
         leaves.OfType<DataGridControl>().Should().ContainSingle()
             .Which.Columns.Should().NotBeEmpty();
         // Wave-2 controls reach the views too.
@@ -84,7 +87,7 @@ public class MauiViewDataPathTest(ITestOutputHelper output) : HubTestBase(output
             .Which.Title!.ToString().Should().Contain("Home");
         leaves.OfType<BadgeControl>().Should().ContainSingle()
             .Which.Data!.ToString().Should().Contain("new");
-        // SelectView reads the selected value (Data); options drive the Picker items.
+        // A select view reads the selected value (Data); options drive its picker items.
         leaves.OfType<SelectControl>().Should().ContainSingle()
             .Which.Data!.ToString().Should().Contain("a");
     }

--- a/test/MeshWeaver.Markdown.Test/MarkdownAtAtOperatorTest.cs
+++ b/test/MeshWeaver.Markdown.Test/MarkdownAtAtOperatorTest.cs
@@ -6,19 +6,19 @@ using Xunit;
 namespace MeshWeaver.Markdown.Test;
 
 /// <summary>
-/// Dedicated test for the <c>@@</c> (inline layout-area embed) operator as rendered by the native MAUI
-/// client's <c>MarkdownView</c> (<c>src/MeshWeaver.Maui/MauiViewPack.cs</c>). That view replaced the old
-/// homebrew Label — which dumped raw markdown verbatim, so <c>@@</c> did nothing — with the OFFICIAL
-/// MeshWeaver Markdig pipeline: it builds <see cref="MarkdownExtensions.CreateMarkdownPipeline"/> (which
-/// wires the <see cref="LayoutAreaMarkdownExtension"/>) and converts markdown to HTML with
-/// <c>Markdig.Markdown.ToHtml(text, pipeline)</c>. This test runs that EXACT pipeline + call and pins the
-/// contract: a <c>@@path</c> block is RECOGNISED — it emits a layout-area element (per
+/// Dedicated test for the <c>@@</c> (inline layout-area embed) operator through the OFFICIAL
+/// MeshWeaver Markdig pipeline — the one every out-of-process markdown renderer must build:
+/// <see cref="MarkdownExtensions.CreateMarkdownPipeline"/> (which wires the
+/// <see cref="LayoutAreaMarkdownExtension"/>) followed by <c>Markdig.Markdown.ToHtml(text, pipeline)</c>.
+/// A renderer that substitutes its own pipeline dumps raw markdown verbatim, so <c>@@</c> does nothing —
+/// the bug the retired MAUI client's homebrew Label shipped with. This test runs that EXACT pipeline +
+/// call and pins the contract: a <c>@@path</c> block is RECOGNISED — it emits a layout-area element (per
 /// <see cref="LayoutAreaMarkdownRenderer"/>), NOT the literal text <c>@@path</c>.
 /// </summary>
-public class MauiMarkdownAtAtOperatorTest
+public class MarkdownAtAtOperatorTest
 {
-    /// <summary>The exact pipeline + render call the MAUI <c>MarkdownView.Render</c> makes.</summary>
-    private static string RenderLikeMaui(string markdown, string? nodePath = null)
+    /// <summary>The exact pipeline + render call an out-of-process markdown view makes.</summary>
+    private static string Render(string markdown, string? nodePath = null)
     {
         var pipeline = MarkdownExtensions.CreateMarkdownPipeline(collection: null, currentNodePath: nodePath);
         return Markdig.Markdown.ToHtml(markdown, pipeline);
@@ -29,7 +29,7 @@ public class MauiMarkdownAtAtOperatorTest
     {
         // @@ is a BLOCK-level operator (LayoutAreaMarkdownParser opens on a line beginning with '@'), so the
         // embed sits on its own line — the form a producing control emits for an inline area injection.
-        var html = RenderLikeMaui("@@MyNamespace/MyArea");
+        var html = Render("@@MyNamespace/MyArea");
 
         html.Should().Contain($"class='{LayoutAreaMarkdownRenderer.LayoutArea}'",
             "the @@ operator must render a layout-area element via LayoutAreaMarkdownRenderer");
@@ -43,8 +43,8 @@ public class MauiMarkdownAtAtOperatorTest
     public void AtAt_AbsoluteAreaVerb_CarriesAddressAndArea()
     {
         // The absolute keyword form resolves its own address/area even without a node path — the same shape
-        // the MarkdownViewLogic tests pin, proven here through the raw MAUI pipeline.
-        var html = RenderLikeMaui("@@/Acme/area/Search");
+        // the MarkdownViewLogic tests pin, proven here through the raw pipeline.
+        var html = Render("@@/Acme/area/Search");
 
         html.Should().Contain($"class='{LayoutAreaMarkdownRenderer.LayoutArea}'");
         html.Should().Contain($"data-{LayoutAreaMarkdownRenderer.Address}='Acme'");
@@ -58,7 +58,7 @@ public class MauiMarkdownAtAtOperatorTest
         // @@ embeds hide the embedded node's own header/comments/side menu by default. The flag rides
         // as a SEPARATE data-show-header attribute; data-raw-path stays a clean node path (it feeds
         // IMeshCatalog.ResolvePathAsync — a query there would double/break resolution).
-        var html = RenderLikeMaui("@@MyNamespace/MyArea");
+        var html = Render("@@MyNamespace/MyArea");
 
         html.Should().Contain($"data-{LayoutAreaMarkdownRenderer.RawPath}='MyNamespace/MyArea'",
             "the raw path must stay clean (no ?showHeader query) so it resolves as a node path");
@@ -69,7 +69,7 @@ public class MauiMarkdownAtAtOperatorTest
     [Fact]
     public void AtAt_Embed_AuthorOptsInToHeader_QueryStrippedFromRawPath()
     {
-        var html = RenderLikeMaui("@@MyNamespace/MyArea?showHeader=true");
+        var html = Render("@@MyNamespace/MyArea?showHeader=true");
 
         html.Should().Contain($"data-{LayoutAreaMarkdownRenderer.RawPath}='MyNamespace/MyArea'",
             "the ?showHeader flag is parsed out and carried separately, keeping the raw path clean");
@@ -82,7 +82,7 @@ public class MauiMarkdownAtAtOperatorTest
     [Fact]
     public void AtAt_Embed_ExplicitShowHeaderFalse_HidesAndCleansPath()
     {
-        var html = RenderLikeMaui("@@MyNamespace/MyArea?showHeader=false");
+        var html = Render("@@MyNamespace/MyArea?showHeader=false");
 
         html.Should().Contain($"data-{LayoutAreaMarkdownRenderer.RawPath}='MyNamespace/MyArea'");
         html.Should().Contain($"data-{LayoutAreaMarkdownRenderer.ShowHeader}='false'");
@@ -93,7 +93,7 @@ public class MauiMarkdownAtAtOperatorTest
     {
         // Contrast: a single @ is a hyperlink (ucr-link), NOT an inline area embed — proving the pipeline
         // distinguishes @@ (inline) from @ (link), so the @@ recognition above is meaningful.
-        var html = RenderLikeMaui("@MyNamespace/MyArea");
+        var html = Render("@MyNamespace/MyArea");
 
         html.Should().Contain($"class='{LayoutAreaMarkdownRenderer.UcrLink}'",
             "a single @ resolves to a UCR hyperlink");


### PR DESCRIPTION
Closes #2448 — the test-file half of the MAUI retirement residue.

## What

`e5fbf4546` retired the MAUI client and #2439 swept the guidance half. Two green test files survived claiming to cover the deleted `MeshWeaver.Maui` view pack. Both assert live, renderer-agnostic framework behaviour, so per the issue's own suggested resolution they are **reframed, not deleted** (deleting would lose real coverage; keeping them as-is keeps claiming coverage of a retired subject):

- `test/MeshWeaver.Layout.Test/MauiViewDataPathTest.cs` → `NativeRendererDataPathTest.cs` — pins the Blazor-agnostic control pipeline (`GetControlStream` → `UiControl` tree → `IContainerControl.Areas` → per-child streams → bound values), the contract `Doc/GUI/CrossRendererAuthoring` asks any out-of-process renderer to hold to. Method `ContainerTreeAndLeaves_RenderForTheMauiPack` → `ContainerTreeAndLeaves_ResolveThroughTheControlStreamPipeline`.
- `test/MeshWeaver.Markdown.Test/MauiMarkdownAtAtOperatorTest.cs` → `MarkdownAtAtOperatorTest.cs` — pins the official Markdig pipeline (`CreateMarkdownPipeline` + `LayoutAreaMarkdownExtension`) recognising `@@path` as a layout-area embed. Helper `RenderLikeMaui` → `Render`.
- `CircuitContextIsolationTest` comments no longer cite the deleted `MauiProgram` as a dependent of `SetHostIdentity`'s contract.

## Third piece (mesh, not tree)

The issue thread's third finding — the live `rbuergi/Skill/maui` node (`autoMount: true`, teaching the retired `memex/Memex.Client`) — has been **deleted from the mesh** and verified gone (`get` → Not found, `search path:rbuergi/Skill/maui` → 0 results). No repo change can reach it, so it was handled directly.

## Verification

- `dotnet build -c Release -warnaserror`: MeshWeaver.Layout.Test, MeshWeaver.Markdown.Test, MeshWeaver.Hosting.Monolith.Test — all 0 warnings / 0 errors.
- `dotnet test -c Release --no-build` filtered to the renamed classes: Markdown 6/6 passed, Layout 1/1 passed (fresh .trx both).

**What's New: skipped deliberately** — internal test hygiene, no user-visible change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)