### PR TITLE
Init faulting on a disposed DI scope is shutdown, not a FAILED hub (#2444)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-hub-init-scope-teardown.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-hub-init-scope-teardown.md
@@ -1,0 +1,20 @@
+---
+Name: Hubs no longer get stuck in a failed state when startup races shutdown
+Category: Fix
+Description: A hub initializing at the exact moment its process or parent was shutting down could be marked permanently failed, answering every request with an error until restart. That race is now recognized as a normal shutdown.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Hubs no longer get stuck in a failed state when startup races shutdown
+
+When a part of the mesh was starting up at the exact moment its host was being
+torn down — for example during a pod restart — it could observe the teardown
+mid-initialization and record itself as permanently failed instead of simply
+shutting down. Everything served at that address then answered with an error
+until it was recreated.
+
+That window is now recognized for what it is: a shutdown, not a failure. The
+affected hub winds down cleanly, error logs no longer report routine teardown
+as an initialization failure, and a genuine initialization fault still surfaces
+loudly exactly as before.

--- a/src/MeshWeaver.Messaging.Contract/ExceptionChain.cs
+++ b/src/MeshWeaver.Messaging.Contract/ExceptionChain.cs
@@ -1,0 +1,81 @@
+using System.Collections.Generic;
+
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// Classifies a failure by walking the exception GRAPH — not the chain.
+///
+/// <para>🚨 <c>for (var e = ex; e is not null; e = e.InnerException)</c> is the shape everyone
+/// writes and it is a TREE flattened to a line. <c>AggregateException.InnerException</c>
+/// yields <c>InnerExceptions[0]</c> only, so a fault that carries the interesting exception at any
+/// other index is invisible to it — and reactive pipelines produce exactly that: a
+/// <c>Merge</c>/<c>WhenAll</c> that saw a real error alongside a teardown hands back an aggregate
+/// whose ordering nobody controls. The classification then depends on which fault happened to
+/// arrive first, which is the definition of a race.</para>
+///
+/// <para>Both <see cref="HubDisposingException.IsHubDisposal"/> and MessageHub's scope-teardown
+/// classifier route through here so the two cannot drift: they answer different questions about
+/// the same graph, and a walker fixed in one place used to leave the other one wrong.</para>
+/// </summary>
+public static class ExceptionChain
+{
+    /// <summary>
+    /// Bound on how many exceptions one classification will look at.
+    ///
+    /// <para>🚨 This is a NODE budget, not a depth limit, and the difference is the whole point.
+    /// The obvious walker — a <c>for</c> loop over <c>InnerException</c> that also recurses into
+    /// <c>InnerExceptions</c> — visits the same chain once per position, because
+    /// <c>AggregateException.InnerException</c> IS <c>InnerExceptions[0]</c>. On a graph of nested
+    /// aggregates that is exponential: 200 of them pinned a core at 100% CPU indefinitely (caught
+    /// by <c>ExceptionChainTest.A_pathologically_deep_graph_terminates</c> while extracting this
+    /// walker). A depth cap does not help, since the blow-up is in BREADTH of re-walking, not
+    /// depth. The traversal below is iterative, visits each exception at most once, and stops at
+    /// this many — so its cost is linear in the graph and bounded regardless of shape.</para>
+    /// </summary>
+    private const int MaxNodes = 256;
+
+    /// <summary>True when <paramref name="exception"/> is — or carries, at any depth and through
+    /// any <see cref="AggregateException"/> branch — an exception of type
+    /// <typeparamref name="TException"/>.</summary>
+    public static bool Contains<TException>(Exception? exception)
+        where TException : Exception
+        => Contains(exception, static e => e is TException);
+
+    /// <summary>True when any exception in <paramref name="exception"/>'s graph satisfies
+    /// <paramref name="predicate"/>.</summary>
+    public static bool Contains(Exception? exception, Func<Exception, bool> predicate)
+    {
+        if (exception is null)
+            return false;
+
+        // Reference identity, because an exception graph is caller-supplied data: it can share
+        // nodes or be outright cyclic, and Equals on an exception is reference equality anyway.
+        var seen = new HashSet<Exception>(ReferenceEqualityComparer.Instance);
+        var pending = new Stack<Exception>();
+        pending.Push(exception);
+
+        while (pending.Count > 0 && seen.Count < MaxNodes)
+        {
+            var current = pending.Pop();
+            if (!seen.Add(current))
+                continue;   // already classified — a shared or cyclic edge, not new information
+
+            if (predicate(current))
+                return true;
+
+            if (current is AggregateException aggregate)
+            {
+                // InnerExceptions is the complete fan-out and its [0] IS InnerException, so
+                // pushing both would be the double-walk this method exists to avoid.
+                foreach (var inner in aggregate.InnerExceptions)
+                    pending.Push(inner);
+            }
+            else if (current.InnerException is { } inner)
+            {
+                pending.Push(inner);
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
+++ b/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
@@ -81,23 +81,6 @@ public sealed class HubDisposingException : ObjectDisposedException
     /// </summary>
     /// <param name="exception">The exception to classify; may be null.</param>
     /// <returns><c>true</c> when the failure is a hub-disposal race.</returns>
-    public static bool IsHubDisposal(Exception? exception) => IsHubDisposal(exception, depth: 0);
-
-    // depth caps the walk: an exception graph is caller-supplied data, and AggregateException
-    // fan-out makes the traversal a tree, not a chain. 16 is far beyond any real wrapping depth
-    // (the deepest observed is TargetInvocationException → HubDisposingException).
-    private static bool IsHubDisposal(Exception? exception, int depth)
-    {
-        if (depth > 16)
-            return false;
-        for (var e = exception; e is not null; e = e.InnerException)
-        {
-            if (e is HubDisposingException)
-                return true;
-            if (e is AggregateException agg
-                && agg.InnerExceptions.Any(inner => IsHubDisposal(inner, depth + 1)))
-                return true;
-        }
-        return false;
-    }
+    public static bool IsHubDisposal(Exception? exception)
+        => ExceptionChain.Contains<HubDisposingException>(exception);
 }

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -579,10 +579,12 @@ public sealed class MessageHub : IMessageHub
     /// </summary>
     private bool IsTerminatedByScopeTeardown(Exception exception)
     {
-        for (var e = exception; e is not null; e = e.InnerException)
-            if (e is ObjectDisposedException)
-                return IsServiceScopeDisposed();
-        return false;
+        // The graph, not the chain: an init fault that reaches here through a reactive Merge or a
+        // WhenAll arrives as an AggregateException whose ordering nobody controls, and walking only
+        // InnerException sees InnerExceptions[0] alone. Classifying a teardown by which fault
+        // happened to land first is a race, so this shares ONE walker with IsHubDisposal.
+        return ExceptionChain.Contains<ObjectDisposedException>(exception)
+               && IsServiceScopeDisposed();
     }
 
     /// <summary>Probes whether this hub's own DI scope still resolves (see

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -524,7 +524,21 @@ public sealed class MessageHub : IMessageHub
                 // same defect class as the CompileWatcher shutdown-as-fault reports. Terminate the
                 // init cleanly instead: no error log, no FAILED marker; still open the gate so any
                 // remaining lifecycle traffic (the disposal state machine) flows.
-                if (IsShuttingDown)
+                //
+                // 🚨 IsShuttingDown alone does NOT see every teardown (issue #2444). When the hub's
+                // DI scope is disposed OUT-OF-BAND — the host's root container torn down on a
+                // Host.StartAsync abort or pod shutdown, or an ancestor's Autofac scope disposing
+                // this hub's child scope — Autofac flips the scope's disposed flag BEFORE its
+                // disposer reaches the tracked hub instance (Disposable.Dispose sets the flag,
+                // THEN runs Dispose(true)). A BuildupAction resolving in that window observes
+                // ObjectDisposedException while IsShuttingDown is still false: no ancestor HUB
+                // Dispose ran, so no CloseCreation cascade froze the subtree. That was reported
+                // as "initialization failed → FAILED state" for a hub whose own Dispose was
+                // moments away — an Error-level log and FAILED residue for routine teardown
+                // (mesh/... data-source hubs during the 2026-08-26 host-start aborts). A disposed
+                // scope means this hub cannot live regardless — its own disposal is already queued
+                // in the same disposer, by construction — so classify it as the shutdown it is.
+                if (IsShuttingDown || IsTerminatedByScopeTeardown(ex))
                 {
                     logger.LogDebug(ex,
                         "Hub {Address} initialization ended by shutdown ({ExceptionType}) — recognized "
@@ -548,6 +562,42 @@ public sealed class MessageHub : IMessageHub
                 OpenGate(MessageHubConfiguration.InitializeGateName);
                 return Observable.Return(request.Failed($"Hub '{Address}' initialization failed — {reason}"));
             });
+    }
+
+    /// <summary>
+    /// True when an initialization fault is (or wraps) an <see cref="ObjectDisposedException"/> AND
+    /// this hub's own service scope no longer resolves — i.e. the DI scope backing this hub, one of
+    /// its parent scopes, or the host's root container has begun disposal (issue #2444). The probe
+    /// resolves this hub's own already-materialized <see cref="IMessageHub"/> registration: on a
+    /// live scope that is a cheap instance lookup with no side effects; on a disposing scope it
+    /// throws <see cref="ObjectDisposedException"/> — the positive signal that the
+    /// ObjectDisposedException the BuildupAction saw came from scope teardown, not from some
+    /// unrelated disposed dependency (which must still fault the init).
+    /// <para>A disposed scope is proof this hub is going away: the hub instance is a tracked
+    /// component of that same scope, so its <c>Dispose()</c> is already queued in the very disposer
+    /// that killed the scope. FAILED-state residue on it would outlive nothing.</para>
+    /// </summary>
+    private bool IsTerminatedByScopeTeardown(Exception exception)
+    {
+        for (var e = exception; e is not null; e = e.InnerException)
+            if (e is ObjectDisposedException)
+                return IsServiceScopeDisposed();
+        return false;
+    }
+
+    /// <summary>Probes whether this hub's own DI scope still resolves (see
+    /// <see cref="IsTerminatedByScopeTeardown"/>).</summary>
+    private bool IsServiceScopeDisposed()
+    {
+        try
+        {
+            ServiceProvider.GetService(typeof(IMessageHub));
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
     }
 
     /// <summary>

--- a/test/MeshWeaver.Messaging.Hub.Test/ExceptionChainTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/ExceptionChainTest.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Diagnostics;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// The classification walker shared by <see cref="HubDisposingException.IsHubDisposal"/> and
+/// MessageHub's scope-teardown classifier (review on #2604).
+///
+/// <para>🚨 The bug this pins is invisible to the obvious test. <c>AggregateException.InnerException</c>
+/// returns <c>InnerExceptions[0]</c>, so an <c>InnerException</c>-only walk finds a
+/// single-fault aggregate perfectly well and misses a multi-fault one — and which fault lands at
+/// index 0 is decided by whichever branch of a reactive <c>Merge</c> faulted first. A teardown
+/// racing a real error would then be classified as an init FAILURE some of the time and as
+/// shutdown the rest, from the same code path.</para>
+/// </summary>
+public class ExceptionChainTest
+{
+    private sealed class Marker : Exception;
+
+    [Fact]
+    public void A_chain_of_plain_wrappers_is_walked()
+        => Assert.True(ExceptionChain.Contains<Marker>(
+            new InvalidOperationException("outer", new InvalidOperationException("inner", new Marker()))));
+
+    /// <summary>The discriminator: the marker sits at index 1, where an InnerException-only walk
+    /// cannot reach it — InnerException would hand back the InvalidOperationException at index 0
+    /// and the walk would end there.</summary>
+    [Fact]
+    public void An_aggregate_carrying_the_marker_at_a_LATER_index_is_found()
+    {
+        var aggregate = new AggregateException(
+            new InvalidOperationException("the fault that happened to arrive first"),
+            new Marker());
+
+        Assert.Same(aggregate.InnerExceptions[0], aggregate.InnerException);   // the premise
+        Assert.True(ExceptionChain.Contains<Marker>(aggregate));
+    }
+
+    [Fact]
+    public void A_marker_nested_under_an_aggregate_under_a_wrapper_is_found()
+        => Assert.True(ExceptionChain.Contains<Marker>(
+            new InvalidOperationException("outer", new AggregateException(
+                new InvalidOperationException("first"),
+                new InvalidOperationException("second", new Marker())))));
+
+    [Fact]
+    public void An_absent_marker_is_absent()
+        => Assert.False(ExceptionChain.Contains<Marker>(
+            new AggregateException(new InvalidOperationException("a"), new InvalidOperationException("b"))));
+
+    [Fact]
+    public void Null_is_not_a_match() => Assert.False(ExceptionChain.Contains<Marker>(null));
+
+    /// <summary>
+    /// 🚨 An exception graph is caller-supplied data, so the walk must terminate on one that is
+    /// deep, shared or outright cyclic — cheaply, not merely eventually.
+    ///
+    /// <para>This test earned its keep on the first run: the walker extracted from
+    /// <c>IsHubDisposal</c> pinned a core at 100% CPU here, indefinitely. A <c>for</c> loop over
+    /// <c>InnerException</c> that ALSO recurses into <c>InnerExceptions</c> re-walks the same
+    /// chain once per position — <c>AggregateException.InnerException</c> IS
+    /// <c>InnerExceptions[0]</c> — so nested aggregates cost exponentially, and the depth cap did
+    /// not help because the blow-up is in re-walking, not depth. The bound is a wall-clock one on
+    /// purpose: a walker that returns the right answer in a minute is still a defect.</para>
+    /// </summary>
+    [Fact]
+    public void A_pathologically_deep_graph_terminates_QUICKLY()
+    {
+        Exception deep = new InvalidOperationException("floor");
+        for (var i = 0; i < 200; i++)
+            deep = new AggregateException(deep);
+
+        var started = Stopwatch.StartNew();
+        Assert.False(ExceptionChain.Contains<Marker>(deep));
+        Assert.True(started.Elapsed < TimeSpan.FromSeconds(1),
+            $"classification took {started.Elapsed} — a linear walk over 201 exceptions is "
+            + "microseconds; anything near a second means the graph is being re-walked");
+    }
+
+    /// <summary>A cyclic graph must terminate too — nothing stops a caller building one, and a
+    /// visited-set walk is what makes that a non-event rather than a hang.</summary>
+    [Fact]
+    public void A_CYCLIC_graph_terminates()
+    {
+        var a = new AggregateException(new InvalidOperationException("a"));
+        var cycle = new AggregateException(a, a, a);   // the same instance reached three ways
+
+        Assert.False(ExceptionChain.Contains<Marker>(cycle));
+    }
+
+    /// <summary>The two callers must keep answering their own question — the shared walker changed
+    /// how the graph is traversed, not what counts as a match.</summary>
+    [Fact]
+    public void IsHubDisposal_still_recognises_only_hub_disposal()
+    {
+        Assert.True(HubDisposingException.IsHubDisposal(
+            new AggregateException(new Marker(), new HubDisposingException(new Address("test", "1"), "what"))));
+        Assert.False(HubDisposingException.IsHubDisposal(new AggregateException(new Marker())));
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/ScopeDisposedDuringInitializationTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/ScopeDisposedDuringInitializationTest.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins the recognized-shutdown outcome for a hub whose initialization is terminated by an
+/// OUT-OF-BAND teardown of its DI scope (issue #2444) — the case
+/// <see cref="DisposeDuringInitializationTest"/> does NOT cover, because there the ancestor's
+/// <c>Dispose()</c> cascades <c>CloseCreation</c> first, so <see cref="IMessageHub.IsShuttingDown"/>
+/// is already true when the BuildupAction faults.
+///
+/// <para><b>The production sequence.</b> The host's root Autofac container (or an ancestor scope)
+/// is disposed directly — a <c>Host.StartAsync</c> abort, pod shutdown — without any HUB
+/// <c>Dispose()</c> having run. Autofac's <c>Disposable.Dispose()</c> flips the scope's disposed
+/// flag FIRST and only then runs the disposer over the tracked instances, so from that first
+/// instant every resolve throws <see cref="ObjectDisposedException"/> while the hub instance —
+/// itself a tracked component of the same scope, disposed later in the same sweep — still has
+/// <c>IsDisposing == false</c> and an unfrozen subtree. A BuildupAction resolving in that window
+/// (prod: <c>MeshDataSourceExtensions.SubscribeToOwnDeletion</c> resolving the workspace on a
+/// <c>mesh/…</c> data-source hub, 2026-08-23/26) faulted the init, and <c>HandleInitialize</c>'s
+/// <c>.Catch</c> — seeing <c>IsShuttingDown == false</c> — logged a fail-level "initialization
+/// failed … Hub is now in FAILED state." for a hub whose own disposal was already queued in the
+/// very disposer that killed the scope: routine teardown reported as an error, with FAILED
+/// residue.</para>
+///
+/// <para><b>The fix.</b> The catch now recognizes the window positively: when the fault chain
+/// carries an <see cref="ObjectDisposedException"/> AND the hub's own scope no longer resolves
+/// (probed against the hub's already-materialized <see cref="IMessageHub"/> registration), the
+/// init terminates as a recognized shutdown — Debug log, no
+/// <see cref="MessageHub.InitializationError"/>, gate opened so the imminent disposal traffic
+/// flows.</para>
+///
+/// <para><b>RED before the fix:</b> <c>InitializationError</c> records the
+/// <see cref="ObjectDisposedException"/> (FAILED state). <b>GREEN after:</b> it stays null.
+/// <see cref="InitializationErrorSurfacedTest"/> still pins the other side — a genuine fault on a
+/// hub whose scope is alive (including an <see cref="ObjectDisposedException"/> from an unrelated
+/// disposed dependency) must still enter the FAILED state.</para>
+/// </summary>
+public class ScopeDisposedDuringInitializationTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// Registered in the hub's OWN scope and resolved by the BuildupAction — i.e. created AFTER
+    /// the hub instance, so Autofac's reverse-creation-order disposer disposes it BEFORE the hub.
+    /// Its <see cref="Dispose"/> therefore runs exactly inside the incident window: the scope's
+    /// disposed flag is already set (every resolve throws), while the hub's <c>Dispose()</c> —
+    /// later in the same sweep — has not run (<c>IsShuttingDown</c> still false). The
+    /// <see cref="ReplaySubject{T}"/> emission is delivered synchronously on the disposing thread,
+    /// so the parked BuildupAction resumes and resolves strictly inside that window — the race is
+    /// pinned deterministically, no sleeps.
+    /// </summary>
+    private sealed class ScopeTeardownSentinel : IDisposable
+    {
+        public ReplaySubject<Unit> ScopeDisposing { get; } = new(1);
+
+        public void Dispose() => ScopeDisposing.OnNext(Unit.Default);
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task InitTerminatedByOutOfBandScopeDisposal_IsRecognizedShutdown_NoFailedState()
+    {
+        var host = GetHost();
+        var buildupParked = new ReplaySubject<Unit>(1);
+
+        var hub = host.GetHostedHub(
+            new Address("scope-teardown", Guid.NewGuid().ToString("N")),
+            c => c
+                // Plumbing fixture, no logged-in user — post as infrastructure, like the
+                // fixture's own hubs (see HubTestBase.ConfigureMesh).
+                .WithPostingIdentity(PostingIdentity.System)
+                .WithServices(s => s.AddSingleton<ScopeTeardownSentinel>())
+                .WithInitialization(h =>
+                {
+                    // Created here → tracked AFTER the hub instance → disposed BEFORE it.
+                    var sentinel = h.ServiceProvider.GetRequiredService<ScopeTeardownSentinel>();
+                    buildupParked.OnNext(Unit.Default);
+                    return sentinel.ScopeDisposing
+                        .Take(1)
+                        .Select(_ =>
+                        {
+                            // The scope's disposed flag is set, the hub's Dispose has not run:
+                            // this is the resolve the incident's BuildupAction performed, and it
+                            // throws ObjectDisposedException into HandleInitialize's .Catch with
+                            // IsShuttingDown == false.
+                            h.ServiceProvider.GetRequiredService<IMessageHub>();
+                            return Unit.Default;
+                        });
+                }));
+
+        hub.Should().NotBeNull();
+        await buildupParked.FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask();
+
+        // Out-of-band scope teardown — no hub Dispose(), no CloseCreation cascade: exactly the
+        // host-root-container disposal of a Host.StartAsync abort / pod shutdown. Disposing the
+        // hub's AutofacServiceProvider disposes the underlying lifetime scope, which flips the
+        // disposed flag, disposes the sentinel (waking the parked BuildupAction inside the
+        // window), and only then disposes the tracked hub instance.
+        ((IDisposable)hub!.ServiceProvider).Dispose();
+
+        await hub.DisposalCompleted.FirstAsync().Timeout(TimeSpan.FromSeconds(15)).ToTask();
+
+        ((MessageHub)hub).InitializationError.Should().BeNull(
+            "an init BuildupAction faulting on a DISPOSED scope is teardown racing initialization "
+            + "— the hub's own disposal is already queued in the same disposer, so it must "
+            + "terminate as a recognized shutdown outcome (no FAILED-state residue, no fail-level "
+            + "log), not as 'initialization failed'");
+    }
+}


### PR DESCRIPTION
Closes #2444 (incident `aaf0ffe1d2556dc6`).

## Root cause

`HandleInitialize`'s recognized-shutdown branch keys on `IsShuttingDown` — own `disposalStarted` OR the ancestor-Dispose `CloseCreation` cascade. An **out-of-band scope teardown** never trips either: when the host's root container is disposed (a `Host.StartAsync` abort, pod shutdown) or an ancestor Autofac scope disposes this hub's child scope, no hub `Dispose()` has run yet — Autofac's `Disposable.Dispose` flips the scope's disposed flag **before** its disposer reaches the tracked hub instance. A BuildupAction resolving inside that window (prod: `MeshDataSourceExtensions.SubscribeToOwnDeletion` resolving the workspace on `mesh/…` hubs) throws `ObjectDisposedException` while `IsShuttingDown` is still false → misclassified as init failure → permanent FAILED state + Error-level log for routine teardown. The 2026-08-26 occurrences line up to the second with #2443's `Host.StartAsync` aborts on the same pod.

## Fix — at the one seam every BuildupAction shares

The catch now also recognizes *fault chain carries `ObjectDisposedException` AND the hub's own scope no longer resolves* (probed by resolving the hub's own already-materialized `IMessageHub` registration — cheap on a live scope, throws ODE on a dead one) as a shutdown outcome: Debug log, no FAILED residue, gate opened so the imminent disposal flows. A disposed scope is proof the hub is going away — the hub instance is a tracked component of that same scope, so its `Dispose()` is already queued in the very disposer that killed the scope; no zombie is possible. An ODE from an **unrelated** disposed dependency (scope alive) still faults the init, and `InitializationErrorSurfacedTest` keeps pinning that side.

Not a per-call-site try/catch in `MeshDataSource` (that would be N band-aids for one classification defect), and no retry/re-resolve loop.

Relation to draft #2438 (scope *ownership*): complementary, not overlapping — #2438 has the parent close the child's scope strictly **after** `DisposalCompleted`, when no init can be in flight; this PR fixes the classification when a scope dies **out-of-band mid-init**.

## Deterministic repro

`ScopeDisposedDuringInitializationTest`: a sentinel `IDisposable` registered in the hub's own scope and resolved by the parked BuildupAction (created after the hub ⇒ reverse-creation-order disposal runs it **inside** the incident window: scope flag set, hub `Dispose` not yet run); its disposal wakes the BuildupAction synchronously on the disposing thread, whose resolve then throws exactly the incident's ODE with `IsShuttingDown == false`. No sleeps, no races.

- **RED without the fix** (verified by temporarily reverting the condition): `InitializationError` records the ODE — the exact incident.
- **GREEN with the fix**, and the companion `DisposeDuringInitializationTest` / `InitializationErrorSurfacedTest` stay green.

## Verification

- `dotnet build -c Release -warnaserror` (`--no-incremental` for the final src build): MeshWeaver.Messaging.Hub + test project, 0 warnings / 0 errors.
- Full `MeshWeaver.Messaging.Hub.Test` suite, Release: **306/306 passed** (1 m 18 s, fresh .trx).
- What's New entry included (Category: Fix); `WhatsNewEntryIntegrityTest` run against a rebuilt DLL verified to embed the new entry: passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)