### PR TITLE
Heal durable self-typed NodeType declaration rows at startup

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-user-directory-declaration-repair.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-user-directory-declaration-repair.md
@@ -1,0 +1,15 @@
+---
+Name: User lookups no longer trip over the User type definition
+Category: Fix
+Description: A leftover database row that made the "User" type definition answer user searches is now repaired automatically at startup, so identity lookups stop failing in bulk.
+Icon: Sparkle
+Order: -20260828
+---
+
+# User lookups no longer trip over the User type definition
+
+On long-lived installations, the built-in "User" type definition had once been saved to the
+database claiming to be a user itself. Every user lookup then received that definition row
+alongside real accounts, which degraded identity resolution (display name, time zone, language)
+and produced a steady stream of background errors. The platform now detects and corrects such
+rows automatically at startup, so the user directory returns only real accounts.

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -240,6 +240,17 @@ public static class GraphConfigurationExtensions
                 // CodeNodeSegmentNameValidator below.
                 services.AddScoped<INodeValidator, Security.NodeTypeDeclarationSelfTypingValidator>();
 
+                // The RETROACTIVE half of the same fix (#2425/#2506): the validator above only
+                // refuses NEW writes, and #2245 only fixed the STATIC registrations — a
+                // declaration row PERSISTED self-typed before either landed keeps answering its
+                // own instance query forever (prod: ~600 UserIdentityCache errors/hour on an
+                // image already carrying both). This startup pass retypes such durable rows at
+                // the storage seam (the serve path cannot reach them — the static claim shadows
+                // the row, #2534), using the validator's own predicate so guard and repair can
+                // never drift apart. One batched read per boot; writes nothing on a healthy
+                // store.
+                services.AddHostedService<Security.SelfTypedDeclarationDurableRepair>();
+
                 // Keeps the batch bake's "the union is every Code node" claim true BY
                 // CONSTRUCTION (issue #1235): a Code node named after a code-table routing
                 // segment (Source/Test) lands in the code table but has a namespace that

--- a/src/MeshWeaver.Graph/Security/NodeTypeDeclarationSelfTypingValidator.cs
+++ b/src/MeshWeaver.Graph/Security/NodeTypeDeclarationSelfTypingValidator.cs
@@ -49,8 +49,11 @@ namespace MeshWeaver.Graph.Security;
 ///
 /// <para>Bad-data TOLERANCE is unchanged: this guard never rejects a READ. An existing row that
 /// already carries the collision keeps loading (degraded, tolerated by
-/// <see cref="ObjectAsExtensions.As{T}"/>) until it is next written; only a NEW create/update that
-/// would (re)introduce the collision is refused.</para>
+/// <see cref="ObjectAsExtensions.As{T}"/>); only a NEW create/update that would (re)introduce the
+/// collision is refused. Rows PERSISTED with the collision before this guard existed are healed at
+/// startup by <see cref="SelfTypedDeclarationDurableRepair"/> (#2425/#2506) using
+/// <see cref="IsSelfTypedDeclaration"/> — the shared predicate that keeps the two halves exact
+/// mirrors.</para>
 /// </summary>
 public sealed class NodeTypeDeclarationSelfTypingValidator : INodeValidator
 {
@@ -69,21 +72,7 @@ public sealed class NodeTypeDeclarationSelfTypingValidator : INodeValidator
     {
         var node = context.Node;
 
-        // Nothing to judge unless the NodeType field claims to be an INSTANCE of something.
-        if (string.IsNullOrEmpty(node.NodeType)
-            || string.Equals(node.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal))
-            return Observable.Return(NodeValidationResult.Valid());
-
-        if (!IsNodeTypeDeclarationContent(node.Content))
-            return Observable.Return(NodeValidationResult.Valid());
-
-        // SELF-typing only: the NodeType field names THIS declaration. An instance references a
-        // type by the declaration's path (`nodeType:"Pack/Widget"`) or, for a built-in at the root,
-        // by its id (`nodeType:"User"`) — so those two are the ways a declaration can enrol itself
-        // in its own instance query. Naming an UNRELATED type is a different shape and is legal
-        // (see the class doc).
-        if (!string.Equals(node.NodeType, node.Path, StringComparison.OrdinalIgnoreCase)
-            && !string.Equals(node.NodeType, node.Id, StringComparison.OrdinalIgnoreCase))
+        if (!IsSelfTypedDeclaration(node))
             return Observable.Return(NodeValidationResult.Valid());
 
         return Observable.Return(NodeValidationResult.Invalid(
@@ -93,6 +82,39 @@ public sealed class NodeTypeDeclarationSelfTypingValidator : INodeValidator
             $"'nodeType:{node.NodeType}' query in the mesh. Set NodeType to " +
             $"'{MeshNode.NodeTypePath}', or leave it unset.",
             NodeRejectionReason.ValidationFailed));
+    }
+
+    /// <summary>
+    /// THE collision predicate, shared by the two halves of the fix: the write-boundary guard
+    /// (this validator, #2378) and the startup repair of rows persisted BEFORE the guard existed
+    /// (<see cref="SelfTypedDeclarationDurableRepair"/>, #2425/#2506). One definition, so what the
+    /// guard refuses and what the repair heals can never drift apart.
+    ///
+    /// <para>True when the node DECLARES a NodeType — its content is a
+    /// <see cref="Configuration.NodeTypeDefinition"/> — while its own
+    /// <see cref="MeshNode.NodeType"/> names ITSELF (its <see cref="MeshNode.Path"/> or
+    /// <see cref="MeshNode.Id"/>), i.e. the declaration is enrolled in its own instance query.
+    /// SELF-typing only: an instance references a type by the declaration's path
+    /// (<c>nodeType:"Pack/Widget"</c>) or, for a built-in at the root, by its id
+    /// (<c>nodeType:"User"</c>) — those two are the ways a declaration can collide with its own
+    /// instances. A declaration naming an UNRELATED type is a different, legal shape (see the
+    /// class doc: the UWDeepfield package root).</para>
+    /// </summary>
+    /// <param name="node">The node to classify.</param>
+    /// <returns><see langword="true"/> when the node is a declaration claiming to be an instance
+    /// of the type it declares.</returns>
+    public static bool IsSelfTypedDeclaration(MeshNode node)
+    {
+        // Nothing to judge unless the NodeType field claims to be an INSTANCE of something.
+        if (string.IsNullOrEmpty(node.NodeType)
+            || string.Equals(node.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal))
+            return false;
+
+        if (!IsNodeTypeDeclarationContent(node.Content))
+            return false;
+
+        return string.Equals(node.NodeType, node.Path, StringComparison.OrdinalIgnoreCase)
+            || string.Equals(node.NodeType, node.Id, StringComparison.OrdinalIgnoreCase);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Security/SelfTypedDeclarationDurableRepair.cs
+++ b/src/MeshWeaver.Graph/Security/SelfTypedDeclarationDurableRepair.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using System.Reactive.Disposables;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
@@ -51,14 +52,30 @@ namespace MeshWeaver.Graph.Security;
 /// <c>InstalledPackageRepairService</c> — a repair must never delay or fail startup; a skipped
 /// pass heals on the next boot.</para>
 /// </summary>
-/// <param name="hub">Hub supplying the service provider and serializer options.</param>
-public sealed class SelfTypedDeclarationDurableRepair(IMessageHub hub) : IHostedService
+public sealed class SelfTypedDeclarationDurableRepair : IHostedService
 {
-    private IDisposable? subscription;
+    // Both fields are RELEASED the moment they are no longer needed — the hub on StartAsync, the
+    // subscription when the one-shot sweep terminates. A hosted-service instance outlives the mesh
+    // it belongs to (test harnesses keep the started instances to stop them at teardown), so any
+    // field here that can reach the hub roots the entire DISPOSED hub graph across meshes —
+    // MeshHubDisposalLeakTest names exactly this chain (started-services list → this service →
+    // MessageHub) when either field is retained.
+    private IMessageHub? hub;
+    private SingleAssignmentDisposable? subscription;
+
+    /// <summary>Captures the hub — held only until <see cref="StartAsync"/> consumes it.</summary>
+    /// <param name="hub">Hub supplying the service provider and serializer options.</param>
+    public SelfTypedDeclarationDurableRepair(IMessageHub hub) => this.hub = hub;
 
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
+        // Take the hub ONCE and drop the field: everything below lives in locals and in the
+        // chain's closures, which are released when the sweep terminates (see the gate below).
+        var hub = Interlocked.Exchange(ref this.hub, null);
+        if (hub is null)
+            return Task.CompletedTask;
+
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger<SelfTypedDeclarationDurableRepair>();
         // A mesh without a storage adapter has no durable rows to heal.
@@ -77,8 +94,14 @@ public sealed class SelfTypedDeclarationDurableRepair(IMessageHub hub) : IHosted
             return Task.CompletedTask;
 
         // Subscribe-and-return per the IHostedService rule (AsynchronousCalls.md): the turn
-        // returns immediately and the work belongs to the observable chain.
-        subscription = storage.ReadMany(declarationPaths, options)
+        // returns immediately and the work belongs to the observable chain. The
+        // SingleAssignmentDisposable gate makes the retained state exactly the in-flight window:
+        // on a synchronously-completing store (in-memory) Finally nulls the field before the
+        // gate is even armed, and arming a disposed gate disposes the inner subscription on the
+        // spot — so a finished sweep leaves this instance referencing NOTHING.
+        var gate = new SingleAssignmentDisposable();
+        subscription = gate;
+        gate.Disposable = storage.ReadMany(declarationPaths, options)
             .Where(NodeTypeDeclarationSelfTypingValidator.IsSelfTypedDeclaration)
             .SelectMany(fossil => storage
                 .Write(fossil with
@@ -102,6 +125,10 @@ public sealed class SelfTypedDeclarationDurableRepair(IMessageHub hub) : IHosted
                         + "self-typed and will be retried on the next start", fossil.Path);
                     return Observable.Return<MeshNode?>(null);
                 }))
+            // A finished one-shot has nothing left to cancel, so it drops its own handle rather
+            // than keeping the sweep's closures (storage, options, and through them the hub)
+            // reachable from the host's IHostedService[] for the rest of the process.
+            .Finally(Release)
             .Subscribe(
                 _ => { },
                 ex => logger?.LogWarning(ex,
@@ -114,8 +141,11 @@ public sealed class SelfTypedDeclarationDurableRepair(IMessageHub hub) : IHosted
     /// <inheritdoc />
     public Task StopAsync(CancellationToken cancellationToken)
     {
-        subscription?.Dispose();
-        subscription = null;
+        Release();
         return Task.CompletedTask;
     }
+
+    /// <summary>Drops the sweep handle and, with it, everything the sweep closed over. Safe to
+    /// call twice — the sweep completing and the host stopping race by construction.</summary>
+    private void Release() => Interlocked.Exchange(ref subscription, null)?.Dispose();
 }

--- a/src/MeshWeaver.Graph/Security/SelfTypedDeclarationDurableRepair.cs
+++ b/src/MeshWeaver.Graph/Security/SelfTypedDeclarationDurableRepair.cs
@@ -1,0 +1,121 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Security;
+
+/// <summary>
+/// Heals, once at startup, the DURABLE rows that
+/// <see cref="NodeTypeDeclarationSelfTypingValidator"/> can only refuse going FORWARD: a NodeType
+/// declaration persisted with <see cref="MeshNode.NodeType"/> naming ITSELF — enrolled in its own
+/// instance query — is retyped to <see cref="MeshNode.NodeTypePath"/>, exactly the correction
+/// #2245 applied to the static registrations.
+///
+/// <para><b>Why the write guard and the static retype were not enough (#2425 / #2506).</b> The
+/// three built-in declarations (<c>User</c>, <c>VUser</c>, <c>Partition</c>) shipped self-typed
+/// and were PERSISTED that way on live stores. #2245 fixed the static registrations and #2378
+/// refuses any new write carrying the collision — but reads stay bad-data tolerant by design, so
+/// a row already persisted with <c>nodeType: "User"</c> keeps answering every
+/// <c>nodeType:User</c> query beside the real accounts, forever. On production that was ~600
+/// <c>As&lt;User&gt; for User: value is NodeTypeDefinition</c> errors per hour from
+/// <c>UserIdentityCache</c>, on an image that already contained both fixes: the defect had moved
+/// from the CODE into the DATA, and only a repair of the data closes it.</para>
+///
+/// <para><b>Why this is a STORAGE-layer write, not <c>GetMeshNodeStream(path).Update</c>.</b> A
+/// declaration path with a static claimant is served from the static registration
+/// (<c>MeshDataSource.WithMeshNodes</c> seeds the per-node hub via <c>WithInitialData</c>,
+/// bypassing persistence — the #2534 mechanism), so the durable row underneath is unreachable
+/// through the serve path: un-readable and un-writable via the one application-level mutation
+/// API. The row can only be corrected where it lives — the same seam
+/// <c>LegacyUserPartitionRepair</c> already writes on. The adapter's change feed still fires, so
+/// live <c>nodeType:</c> query subscriptions converge without a restart.</para>
+///
+/// <para><b>Scope.</b> Candidate paths are the statically-registered declarations
+/// (<see cref="Mesh.Services.StaticNodeProviderExtensions.EnumerateStaticNodes"/> filtered to
+/// <see cref="Configuration.NodeTypeDefinition"/> content) — the population that ever shipped
+/// self-typed, plus any future built-in. A durable row at such a path is rewritten ONLY when it
+/// matches <see cref="NodeTypeDeclarationSelfTypingValidator.IsSelfTypedDeclaration"/> — the
+/// exact predicate the write guard refuses, shared so the two can never drift. Everything else —
+/// already-correct declarations, real instances, package roots typed as an unrelated type — is
+/// left untouched, so on a healthy store this pass reads one batch and writes nothing.</para>
+///
+/// <para><b>Safe every boot.</b> One <see cref="IStorageAdapter.ReadMany"/> batch (the same
+/// multi-path probe the URL resolver runs constantly, so absent partitions answer "absent", never
+/// fault), zero writes when nothing matches, and idempotent when something does: the healed row no
+/// longer matches the predicate, and concurrent replicas retyping the same row write the same
+/// value under the monotonic-version guard. Fire-and-forget and failure-tolerant like
+/// <c>InstalledPackageRepairService</c> — a repair must never delay or fail startup; a skipped
+/// pass heals on the next boot.</para>
+/// </summary>
+/// <param name="hub">Hub supplying the service provider and serializer options.</param>
+public sealed class SelfTypedDeclarationDurableRepair(IMessageHub hub) : IHostedService
+{
+    private IDisposable? subscription;
+
+    /// <inheritdoc />
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger<SelfTypedDeclarationDurableRepair>();
+        // A mesh without a storage adapter has no durable rows to heal.
+        var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+        if (storage is null)
+            return Task.CompletedTask;
+
+        var options = hub.JsonSerializerOptions;
+        var declarationPaths = hub.ServiceProvider.EnumerateStaticNodes()
+            .Where(n => n.Content is Configuration.NodeTypeDefinition)
+            .Select(n => n.Path)
+            .Where(p => !string.IsNullOrEmpty(p))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        if (declarationPaths.Length == 0)
+            return Task.CompletedTask;
+
+        // Subscribe-and-return per the IHostedService rule (AsynchronousCalls.md): the turn
+        // returns immediately and the work belongs to the observable chain.
+        subscription = storage.ReadMany(declarationPaths, options)
+            .Where(NodeTypeDeclarationSelfTypingValidator.IsSelfTypedDeclaration)
+            .SelectMany(fossil => storage
+                .Write(fossil with
+                {
+                    NodeType = MeshNode.NodeTypePath,
+                    Version = MeshNode.NextVersion(fossil.Version),
+                    LastModified = DateTimeOffset.UtcNow,
+                }, options)
+                .Do(_ => logger?.LogInformation(
+                    "[SelfTypedDeclarationRepair] retyped durable declaration row '{Path}' from "
+                    + "nodeType '{Old}' to '{New}' — it was enrolled in its own instance query "
+                    + "(#2425/#2506)",
+                    fossil.Path, fossil.NodeType, MeshNode.NodeTypePath))
+                // Per-row tolerance: one path that cannot be written (a read-only claimant, a
+                // backend hiccup) must not stop the remaining rows from healing. Logged, and
+                // retried on the next boot — the fossil still matches the predicate.
+                .Catch<MeshNode?, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[SelfTypedDeclarationRepair] retyping '{Path}' failed; it stays "
+                        + "self-typed and will be retried on the next start", fossil.Path);
+                    return Observable.Return<MeshNode?>(null);
+                }))
+            .Subscribe(
+                _ => { },
+                ex => logger?.LogWarning(ex,
+                    "[SelfTypedDeclarationRepair] declaration sweep failed; durable self-typed "
+                    + "declaration rows (if any) stay unhealed until the next start"));
+
+        return Task.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        subscription?.Dispose();
+        subscription = null;
+        return Task.CompletedTask;
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfTypedDeclarationDurableRepairTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfTypedDeclarationDurableRepairTest.cs
@@ -1,0 +1,202 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.AspNetCore.Portal;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 A DURABLE self-typed declaration row must be HEALED at startup, not merely refused at the
+/// write boundary (#2425 / #2506).
+///
+/// <para>#2245 retyped the three shipped offenders (<c>User</c>, <c>VUser</c>, <c>Partition</c>)
+/// in their STATIC registrations, and #2378 added the write-boundary guard
+/// (<c>NodeTypeDeclarationSelfTypingValidator</c>) so no future write can
+/// reintroduce the collision. Neither touches a row that was PERSISTED before those fixes: on a
+/// store whose durable <c>User</c> row still carries <c>nodeType: "User"</c> with
+/// <see cref="NodeTypeDefinition"/> content, every <c>nodeType:User</c> query keeps returning the
+/// declaration beside the real accounts — ~600 <c>As&lt;User&gt; for User: value is
+/// NodeTypeDefinition</c> errors per hour on production, on an image that already contained both
+/// fixes. The row is unreachable through the serve path (the static claim shadows it, #2534), so
+/// only a storage-layer repair can correct it — which is what
+/// <c>SelfTypedDeclarationDurableRepair</c> does, once, at startup.</para>
+///
+/// <para>This class boots a mesh whose durable store ALREADY contains the fossil rows — seeded
+/// straight into the adapter before the mesh starts, exactly how production got them: written by
+/// code that predates the guard.</para>
+/// </summary>
+public class SelfTypedDeclarationDurableRepairTest : MonolithMeshTestBase
+{
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private static readonly JsonSerializerOptions SeedOptions = new();
+
+    private readonly InMemoryStorageAdapter persistence = new();
+
+    public SelfTypedDeclarationDurableRepairTest(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        // The pre-#2245 fossil: the durable `User` declaration claiming to BE a user. This is the
+        // exact row production still carries (path User, NodeTypeDefinition content,
+        // nodeType "User") — written long before the write-boundary guard existed.
+        persistence.SaveNodeSynchronously(MeshNode.FromPath("User") with
+        {
+            Name = "User",
+            NodeType = UserNodeType.NodeType, // "User" — the collision
+            Icon = "/static/NodeTypeIcons/person.svg",
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition
+            {
+                DefaultNamespace = "",
+                RestrictedToNamespaces = [""],
+                OwnsPartition = true
+            },
+            Version = 2,
+        }, SeedOptions);
+
+        // The VUser twin — same fossil class, second shipped offender. Pins that the repair is
+        // driven by the collision PREDICATE over every static declaration path, not by a
+        // hard-coded "User".
+        persistence.SaveNodeSynchronously(MeshNode.FromPath("VUser") with
+        {
+            Name = "VUser",
+            NodeType = VUserNodeType.NodeType, // "VUser"
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition(),
+            Version = 1,
+        }, SeedOptions);
+
+        // A CORRECTLY-typed durable declaration row: must not be gratuitously rewritten.
+        persistence.SaveNodeSynchronously(MeshNode.FromPath("Partition") with
+        {
+            Name = "Partition",
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition(),
+            Version = 5,
+        }, SeedOptions);
+
+        // A REAL user at a root path (the post-v10 layout): nodeType "User" with User content is
+        // an INSTANCE, not a declaration — the repair must leave it alone, and the directory must
+        // keep returning it.
+        persistence.SaveNodeSynchronously(MeshNode.FromPath("fossilprobe") with
+        {
+            Name = "Fossil Probe",
+            NodeType = UserNodeType.NodeType,
+            State = MeshNodeState.Active,
+            Content = new User { Email = "fossilprobe@meshweaver.io" },
+            Version = 1,
+        }, SeedOptions);
+
+        // Register the pre-seeded adapter FIRST: AddInMemoryPersistence(adapter) claims the
+        // IStorageAdapter slot and sets the core-services marker, so the base configuration's
+        // parameterless AddInMemoryPersistence() no-ops instead of registering a second store.
+        builder.ConfigureServices(services => services.AddInMemoryPersistence(persistence));
+        return base.ConfigureMesh(builder);
+    }
+
+    /// <summary>
+    /// The heal itself: at startup the fossil rows flip to <c>NodeType = "NodeType"</c> — content,
+    /// name and identity preserved, version minted forward — while an already-correct declaration
+    /// row and a real user instance are left untouched.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task FossilSelfTypedDeclarationRows_AreRetypedAtStartup()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+
+        var healedUser = await AwaitHealed(storage, "User", ct);
+        healedUser.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions).Should().NotBeNull(
+            "the repair retypes the row — it must not clobber the declaration content");
+        healedUser.Name.Should().Be("User");
+        healedUser.Version.Should().Be(3, "the retype is a forward-minted revision of the row");
+
+        var healedVUser = await AwaitHealed(storage, "VUser", ct);
+        healedVUser.Version.Should().Be(2);
+
+        var partition = await storage.ReadAsync("Partition", Mesh.JsonSerializerOptions, ct);
+        partition.Should().NotBeNull();
+        partition!.NodeType.Should().Be(MeshNode.NodeTypePath);
+        partition.Version.Should().Be(5,
+            "an already-correct declaration row must not be gratuitously rewritten on every boot");
+
+        var user = await storage.ReadAsync("fossilprobe", Mesh.JsonSerializerOptions, ct);
+        user.Should().NotBeNull();
+        user!.NodeType.Should().Be(UserNodeType.NodeType,
+            "a real user INSTANCE is not a declaration — the repair must never touch it");
+        user.Version.Should().Be(1);
+    }
+
+    /// <summary>
+    /// The consumer the incident was reported from (#2425/#2506): the portal's user directory
+    /// query (<see cref="UserIdentityCache.DirectoryQuery"/>, verbatim) no longer returns the
+    /// fossil declaration once the repair has run — every row it hands back reads as a
+    /// <see cref="User"/>, and the real account seeded beside the fossil is still there.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheUserDirectory_NoLongerReturnsTheFossilDeclaration()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+
+        // Gate on the heal, not on time — on an unhealed store this times out, which IS the
+        // failure being pinned.
+        await AwaitHealed(storage, "User", ct);
+
+        var rows = await MeshService.Query<MeshNode>(UserIdentityCache.DirectoryQuery)
+            .Where(c => c.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
+            .Select(c => c.Items)
+            .Where(items => items.Any(n =>
+                string.Equals(n.Path, "fossilprobe", StringComparison.OrdinalIgnoreCase)))
+            .FirstAsync()
+            .Timeout(60.Seconds())
+            .ToTask(ct);
+
+        rows.Should().NotContain(
+            n => string.Equals(n.Path, "User", StringComparison.OrdinalIgnoreCase),
+            "the healed declaration row no longer matches nodeType:User, so the user directory "
+            + "must stop returning it — every returned row is read as a User by "
+            + "UserIdentityCache.TryGetEmail, and the declaration produced one "
+            + "'As<User> for User: value is NodeTypeDefinition' error per row per snapshot");
+
+        var notUsers = rows
+            .Where(row => row.ContentAs<User>(Mesh.JsonSerializerOptions) is null)
+            .Select(row => $"{row.Path} (nodeType:{row.NodeType})")
+            .ToList();
+        notUsers.Should().BeEmpty("every row of the user directory must read as a User");
+    }
+
+    /// <summary>
+    /// Waits (bounded) for the durable row at <paramref name="path"/> to carry the corrected
+    /// <see cref="MeshNode.NodeTypePath"/> — the repair runs from a hosted service at startup, so
+    /// the wait is on the CONDITION, never a fixed sleep.
+    /// </summary>
+    private Task<MeshNode> AwaitHealed(IStorageAdapter storage, string path, CancellationToken ct)
+        => Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null
+                && string.Equals(n.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal))
+            .Select(n => n!)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask(ct);
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfTypedDeclarationRepairRetainsNothingTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfTypedDeclarationRepairRetainsNothingTest.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 A one-shot startup service must hold NOTHING once it has run — because the generic host
+/// keeps its <c>IHostedService[]</c> for the whole process lifetime.
+///
+/// <para><b>The measured leak.</b> <c>MeshHubDisposalLeakTest</c> failed on this PR's first CI
+/// run and its ClrMD GC-root analysis named the chain exactly:</para>
+/// <code>
+///   IHostedService[]
+///     -> MeshWeaver.Graph.Security.SelfTypedDeclarationDurableRepair
+///       -> MeshWeaver.Messaging.MessageHub  [Address=mesh/...]
+/// </code>
+/// <para>The repair held its hub in a field, so every mesh it was built for stayed reachable from
+/// that array after disposal. This ACCUMULATES: a process that builds many meshes — the test
+/// suite, a portal recycling silos — keeps every one of them alive.</para>
+///
+/// <para>🚨 <b>Why these tests exist rather than relying on the leak test.</b>
+/// <c>MeshHubDisposalLeakTest</c> is the outcome check, but its ClrMD snapshot-attach is
+/// unavailable on macOS, where it <c>Assert.SkipWhen</c>s as inconclusive (#674). So on every
+/// developer machine here the only signal is CI. These pin the MECHANISM — the two fields are
+/// released — deterministically and locally, so a future edit that reinstates the retention fails
+/// where it is written rather than three hours later on a Linux runner.</para>
+/// </summary>
+public class SelfTypedDeclarationRepairRetainsNothingTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private static object? Field(SelfTypedDeclarationDurableRepair repair, string name) =>
+        typeof(SelfTypedDeclarationDurableRepair)
+            .GetField(name, BindingFlags.Instance | BindingFlags.NonPublic)!
+            .GetValue(repair);
+
+    /// <summary>
+    /// The direct edge of the leak chain. Whatever the sweep does afterwards, the instance must
+    /// not still be pointing at the hub when <c>StartAsync</c> returns.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task StartAsync_RELEASES_theHub_soTheHostedServiceArrayCannotRootIt()
+    {
+        var repair = new SelfTypedDeclarationDurableRepair(Mesh);
+
+        Field(repair, "hub").Should().NotBeNull(
+            "the premise of this test is that the constructor holds the hub — if it stopped "
+            + "doing so, the assertion below would be proving nothing");
+
+        await repair.StartAsync(CancellationToken.None);
+
+        Field(repair, "hub").Should().BeNull(
+            "the host keeps IHostedService[] for the process lifetime, so a hub still referenced "
+            + "here outlives the mesh it belongs to — the exact chain ClrMD named");
+    }
+
+    /// <summary>
+    /// The release is an <c>Interlocked.Exchange</c>, which makes the pass one-shot: a second
+    /// start must be a no-op rather than run the sweep again on a hub it no longer has.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task StartAsync_IsOneShot_andTheSecondCallIsAnInertNoOp()
+    {
+        var repair = new SelfTypedDeclarationDurableRepair(Mesh);
+        await repair.StartAsync(CancellationToken.None);
+
+        var second = await Record.ExceptionAsync(() => repair.StartAsync(CancellationToken.None));
+
+        second.Should().BeNull("a second start has no hub and must simply return");
+        Field(repair, "hub").Should().BeNull("and it must not resurrect the field");
+    }
+
+    /// <summary>
+    /// The other field. A finished one-shot has nothing left to cancel, so it drops its own
+    /// handle — otherwise the sweep's closures (the storage adapter, and through it the hub)
+    /// stay reachable from <c>IHostedService[]</c> for the rest of the process.
+    ///
+    /// <para>Waits on the CONDITION, never a sleep: the sweep terminates on its own schedule, and
+    /// on a synchronously-completing store it is already released before this line runs.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task WhenTheSweepTerminates_theSubscriptionHandleIsDroppedToo()
+    {
+        var repair = new SelfTypedDeclarationDurableRepair(Mesh);
+        await repair.StartAsync(CancellationToken.None);
+
+        await Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .Select(_ => Field(repair, "subscription"))
+            .Where(s => s is null)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask();
+
+        Field(repair, "subscription").Should().BeNull(
+            "a finished sweep has nothing to cancel, so keeping the handle would keep its "
+            + "closures — and the hub behind them — reachable for the process lifetime");
+    }
+
+    /// <summary>Shutdown must tolerate a service the host never started — and the release runs on
+    /// both paths, so calling it twice has to be safe by construction.</summary>
+    [Fact(Timeout = 60_000)]
+    public async Task StopAsync_IsSafe_beforeAnyStart_andTwice()
+    {
+        var repair = new SelfTypedDeclarationDurableRepair(Mesh);
+
+        (await Record.ExceptionAsync(() => repair.StopAsync(CancellationToken.None)))
+            .Should().BeNull("a service the host never started has nothing to stop");
+
+        await repair.StartAsync(CancellationToken.None);
+        await repair.StopAsync(CancellationToken.None);
+
+        (await Record.ExceptionAsync(() => repair.StopAsync(CancellationToken.None)))
+            .Should().BeNull(
+                "the sweep completing and the host stopping race by construction, so the release "
+                + "path is reached twice in normal operation");
+    }
+}


### PR DESCRIPTION
Fixes #2425. Fixes #2506.

## The defect that survived two fixes

`UserIdentityCache` logged `As<User> for User: value is NodeTypeDefinition (MeshWeaver.Graph), not convertible` ~600 times/hour on memex.systemorph.com (and ~70/4h on memex.meshweaver.cloud) — on image `ci.6096`, which already carried BOTH prior fixes:

- **#2245** retyped the three self-typed built-in declarations (`User`, `VUser`, `Partition`) in their STATIC registrations (`NodeType = "NodeType"`), and
- **#2378** added `NodeTypeDeclarationSelfTypingValidator`, refusing any NEW write that re-introduces the collision.

Neither touches a row that was **persisted** self-typed before they landed. Verified live: `search nodeType:User` on prod still returns `{path: "User", nodeType: "User", version: 2, lastModified: 2026-06-02}` — the durable declaration fossil, answering the user-directory query beside real accounts. Reads are bad-data tolerant by design, and the row is unreachable through the serve path (the static claim shadows it — the #2534 mechanism), so "until it is next written" was **never**: the defect had moved from the code into the data, and no code-only guard could end it.

## The fix — heal the data, once, at startup

**`SelfTypedDeclarationDurableRepair`** (hosted service, registered by `AddGraph` beside the validator) runs once at startup, at the storage seam where `LegacyUserPartitionRepair` already writes (the only seam that can reach a static-shadowed row):

- one batched `IStorageAdapter.ReadMany` over the statically-registered declaration paths (the same multi-path probe the URL resolver runs constantly — absent partitions answer "absent", never fault: the PG routing adapter's reads catch 42P01 by contract);
- rewrites **exactly** the rows matching the write guard's own predicate — extracted as `NodeTypeDeclarationSelfTypingValidator.IsSelfTypedDeclaration` (public, shared), so what the guard refuses and what the repair heals can never drift apart;
- the rewrite is #2245's correction applied to the row: `NodeType = "NodeType"`, version minted forward, content/identity untouched;
- everything else is left alone — already-correct declarations, real user instances, package roots typed as an unrelated type (the UWDeepfield shape). A healthy store reads one batch and writes nothing;
- fire-and-forget and failure-tolerant like `InstalledPackageRepairService`: a skipped pass heals on the next boot; concurrent replicas write the same value under the monotonic-version guard.

The adapter change feed fires on the heal, so live `nodeType:User` subscriptions (`UserIdentityCache`'s directory query) converge without a restart.

## Repro test — red on main for the right reason

`SelfTypedDeclarationDurableRepairTest` boots a mesh over a store **already carrying the fossils** (seeded straight into the adapter before boot — exactly how production got them):

- `FossilSelfTypedDeclarationRows_AreRetypedAtStartup` — the `User` and `VUser` fossils flip to `NodeType = "NodeType"` (content preserved, version forward); an already-correct `Partition` declaration row and a real user instance are untouched.
- `TheUserDirectory_NoLongerReturnsTheFossilDeclaration` — `UserIdentityCache.DirectoryQuery` (verbatim) returns the real account and NOT the declaration; every returned row reads as a `User`.

On main both fail with `TimeoutException` waiting for a heal that never happens (`Failed: 2, Passed: 0`); with the fix, `Passed: 2` in <1s.

## Verification

- `MeshWeaver.Graph` and `MeshWeaver.Hosting.Monolith.Test` build clean `-c Release -warnaserror`.
- Adjacent guards stay green: `NodeTypeDeclarationSelfTypingValidatorTest` (9 — the predicate extraction is behavior-preserving), `NodeTypeDeclarationSelfTypingTest` (2), `WhatsNewEntryIntegrityTest`.
- What's New entry included (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)