### PR TITLE
DataContext's init watchdog is a subscription, not a Task-shaped timer race (#2528)

### DIFF
--- a/src/MeshWeaver.Data/DataContext.cs
+++ b/src/MeshWeaver.Data/DataContext.cs
@@ -1,5 +1,8 @@
 ﻿using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Data.Validation;
 using MeshWeaver.Domain;
@@ -440,110 +443,160 @@ public sealed record DataContext : IDisposable
         // prod wedge). Time-box it so a hang reaches the SAME terminal failed state
         // as a fault — mirroring MessageHub.HandleInitialize's .Timeout(StartupTimeout).
         //
-        // The delay is CANCELLED by Dispose(): a hub disposed mid-init (normal for
-        // transient probe hubs — $model-probe/$schema-probe live for one read) must not
-        // leave this watchdog armed to fire minutes post-mortem (issue #1122: the 120s
-        // timer fired 90s AFTER the probe hub was disposed and stamped a fail-level
-        // "TIMED OUT … FAILED state" on a hub that no longer existed).
-        watchdogCancellation = new CancellationTokenSource();
-        Task.WhenAny(allInit, Task.Delay(InitializationTimeout, watchdogCancellation.Token))
-            .ContinueWith(_ =>
+        // 🚨 The wait is a SUBSCRIPTION, never a Task-shaped timer race (#2528; the
+        // disposal twin is #2488). This replaced Task.WhenAny(allInit, Task.Delay(…))
+        // + ContinueWith + a watchdog CancellationTokenSource. Amb over three one-shot
+        // arms; whichever fires first settles the gate, and the outcome is read off
+        // allInit's ACTUAL state at settle time (same discrimination the old shape did):
+        //
+        //   1. init settled — allInit bridged Task→IObservable (the sanctioned
+        //      direction) and Materialize'd, so a FAULTED or CANCELED init still RUNS
+        //      the settle body instead of skipping past it to an error arm;
+        //   2. the time-box — Observable.Timer(InitializationTimeout). The bound itself
+        //      is deliberate and STAYS: deleting it re-opens the 2026-06-26 wedge above.
+        //      Its expiry fails FAST and LOUDLY (fail-level log + InitializationError +
+        //      rejection handler) — never "proceed as if initialized";
+        //   3. the disarm — fired by Dispose(). 🚨 Disarm means FIRE NOW, not
+        //      unsubscribe (an Amb arm, never a TakeUntil): the settle body must still
+        //      run so the gate gets its terminal ANSWER — returning without it strands
+        //      every deferred delivery (#1270) — while Hub.IsShuttingDown routes it to
+        //      the recognized-shutdown outcome that stamps no post-mortem FAILED
+        //      residue (#1122). The AsyncSubject replays its terminal, so a Dispose
+        //      that ran BEFORE this gate armed (a probe hub torn down in the same
+        //      breath it was built) settles immediately instead of waiting out the
+        //      full time-box — the old CTS shape armed a fresh, never-cancelled timer
+        //      in that ordering.
+        //
+        // Take(1): every arm yields exactly one value and the first unsubscribes the
+        // rest — the losing timer is disposed with its subscription, so nothing roots
+        // this context and the subscription need not be stored. ObserveOn: the settle
+        // body must not run inline on the last data source's completing thread (arm 1)
+        // nor on Dispose()'s teardown stack (arm 3) — the same hop the previous
+        // ContinueWith(TaskScheduler.Default) gave it.
+        var initSettled = allInit.ToObservable().Materialize().Take(1).Select(_ => Unit.Default);
+        var timeBox = Observable.Timer(InitializationTimeout).Select(_ => Unit.Default);
+        Observable.Amb(initSettled, timeBox, watchdogDisarm)
+            .Take(1)
+            .ObserveOn(TaskPoolScheduler.Default)
+            .Subscribe(
+                _ => SettleInitializationGate(allInit),
+                ex =>
+                {
+                    // Fluent error arm — a try/catch around Subscribe would see nothing
+                    // (the fault arrives later, on another thread). None of the three
+                    // arms can OnError (arm 1 is Materialize'd), so this is a
+                    // scheduler-level fault: log it AND still settle, because the one
+                    // unacceptable outcome is a gate that never gets its answer.
+                    logger.LogError(ex,
+                        "DataContext init watchdog stream faulted for {Address} — settling the gate anyway.",
+                        Hub.Address);
+                    SettleInitializationGate(allInit);
+                });
+    }
+
+    /// <summary>
+    /// The init watchdog's terminal body: discriminates shutdown / timed-out / faulted /
+    /// canceled / clean off <paramref name="allInit"/>'s state at settle time, records the
+    /// outcome, and always ANSWERS the gate (<see cref="IMessageHub.FailGate"/> on shutdown,
+    /// <see cref="IMessageHub.OpenGate"/> otherwise). Runs exactly once, whichever watchdog
+    /// arm fired first — see <see cref="OpenInitializationGate"/>.
+    /// </summary>
+    private void SettleInitializationGate(Task allInit)
+    {
+        // Recognized shutdown, NOT a failure: the hub was disposed (or its subtree
+        // frozen by an ancestor's disposal) while its data sources were still
+        // initializing. The disposal pipeline already answers all traffic
+        // (ErrorType.ShuttingDown); recording InitializationError / erroring the data
+        // streams / registering a rejection handler here would stamp fail-level FAILED
+        // residue onto a hub that is already gone.
+        if (Hub.IsShuttingDown)
+        {
+            logger.LogDebug(
+                "DataContext initialization for {Address} ended by hub disposal — recognized "
+                + "shutdown outcome, no failure state recorded.", Hub.Address);
+            // 🚨 …but "no failure state" must never mean "no answer". Returning here used
+            // to leave InitializationGateName SHUT FOREVER — shutdown is precisely the
+            // outcome after which nothing can ever open it — and every delivery already
+            // parked behind it (plus every one that arrives during the remaining teardown,
+            // which can be the full QuiesceTimeout) was stranded. The sender's
+            // hub.Observe(...) then heard nothing until an unrelated deadline expired: the
+            // 30 s per-message deferral timeout, or whenever the teardown finally reached
+            // messageService.Dispose(). Observed in production shape as a CreateNodeRequest
+            // recorded `DEFERRED gates=[DataContextInit]` at runLevel=Quiescing that never
+            // drained (issue #1270; the SkillAutocompleteTest teardown hang #1269 fixed at
+            // the CALLER — the gate itself still stranded anything that parked there).
+            //
+            // FailGate is the terminal ANSWER, not a timeout: shutdown is a KNOWN outcome,
+            // so every deferred caller gets a transient DeliveryFailure ("the address may
+            // reactivate; retry") immediately. It records no InitializationError, no
+            // fail-level log and no errored data streams — the post-mortem FAILED residue
+            // #1122 removed stays removed.
+            Hub.FailGate(InitializationGateName,
+                $"Hub '{Hub.Address}' is shutting down; its DataContext initialization ended "
+                + $"without opening '{InitializationGateName}', which can therefore never open. "
+                + "The address may reactivate (recycle / restart); retry to get the "
+                + "authoritative answer.");
+            return;
+        }
+
+        Exception? failure = null;
+        if (!allInit.IsCompleted)
+        {
+            failure = new TimeoutException(
+                $"Hub '{Hub.Address}' DataContext initialization did not complete within "
+                + $"{InitializationTimeout.TotalSeconds:F0}s — likely a stuck NodeType compile, "
+                + "or a data source that never initialised.");
+            logger.LogError(failure,
+                "DataContext initialization TIMED OUT for {Address}. Hub is now in FAILED state.", Hub.Address);
+        }
+        else if (allInit.IsFaulted)
+        {
+            failure = new InvalidOperationException(
+                $"Hub '{Hub.Address}' initialization failed", allInit.Exception);
+            logger.LogError(allInit.Exception,
+                "DataContext initialization failed for {Address}. Hub is now in FAILED state.", Hub.Address);
+        }
+        else if (allInit.IsCanceled)
+        {
+            logger.LogWarning("DataContext initialization was canceled for {Address}", Hub.Address);
+        }
+        else
+        {
+            logger.LogDebug("Finished initialization of DataContext for {Address}", Hub.Address);
+        }
+
+        if (failure is not null)
+        {
+            InitializationError = failure;
+
+            // Register a global rejection handler for all data requests: every
+            // subsequent request to this hub gets an immediate DeliveryFailure,
+            // so callers (and the MeshNodeStreamCache negative cache) get a
+            // TERMINAL answer and stop re-subscribing — never the 30s-defer loop.
+            RegisterInitializationFailureHandler(failure);
+
+            // Also propagate to existing data source streams.
+            foreach (var ds in DataSources)
             {
-                // Recognized shutdown, NOT a failure: the hub was disposed (or its subtree
-                // frozen by an ancestor's disposal) while its data sources were still
-                // initializing. The disposal pipeline already answers all traffic
-                // (ErrorType.ShuttingDown); recording InitializationError / erroring the data
-                // streams / registering a rejection handler here would stamp fail-level FAILED
-                // residue onto a hub that is already gone.
-                if (Hub.IsShuttingDown)
+                try
                 {
-                    logger.LogDebug(
-                        "DataContext initialization for {Address} ended by hub disposal — recognized "
-                        + "shutdown outcome, no failure state recorded.", Hub.Address);
-                    // 🚨 …but "no failure state" must never mean "no answer". Returning here used
-                    // to leave InitializationGateName SHUT FOREVER — shutdown is precisely the
-                    // outcome after which nothing can ever open it — and every delivery already
-                    // parked behind it (plus every one that arrives during the remaining teardown,
-                    // which can be the full QuiesceTimeout) was stranded. The sender's
-                    // hub.Observe(...) then heard nothing until an unrelated deadline expired: the
-                    // 30 s per-message deferral timeout, or whenever the teardown finally reached
-                    // messageService.Dispose(). Observed in production shape as a CreateNodeRequest
-                    // recorded `DEFERRED gates=[DataContextInit]` at runLevel=Quiescing that never
-                    // drained (issue #1270; the SkillAutocompleteTest teardown hang #1269 fixed at
-                    // the CALLER — the gate itself still stranded anything that parked there).
-                    //
-                    // FailGate is the terminal ANSWER, not a timeout: shutdown is a KNOWN outcome,
-                    // so every deferred caller gets a transient DeliveryFailure ("the address may
-                    // reactivate; retry") immediately. It records no InitializationError, no
-                    // fail-level log and no errored data streams — the post-mortem FAILED residue
-                    // #1122 removed stays removed.
-                    Hub.FailGate(InitializationGateName,
-                        $"Hub '{Hub.Address}' is shutting down; its DataContext initialization ended "
-                        + $"without opening '{InitializationGateName}', which can therefore never open. "
-                        + "The address may reactivate (recycle / restart); retry to get the "
-                        + "authoritative answer.");
-                    return;
+                    var stream = ds.GetStreamForPartition(null);
+                    stream?.OnError(failure);
                 }
+                catch (Exception ex)
+                {
+                    logger.LogDebug(ex, "Error propagating init failure to data source {Id}", ds.Id);
+                }
+            }
+        }
 
-                Exception? failure = null;
-                if (!allInit.IsCompleted)
-                {
-                    failure = new TimeoutException(
-                        $"Hub '{Hub.Address}' DataContext initialization did not complete within "
-                        + $"{InitializationTimeout.TotalSeconds:F0}s — likely a stuck NodeType compile, "
-                        + "or a data source that never initialised.");
-                    logger.LogError(failure,
-                        "DataContext initialization TIMED OUT for {Address}. Hub is now in FAILED state.", Hub.Address);
-                }
-                else if (allInit.IsFaulted)
-                {
-                    failure = new InvalidOperationException(
-                        $"Hub '{Hub.Address}' initialization failed", allInit.Exception);
-                    logger.LogError(allInit.Exception,
-                        "DataContext initialization failed for {Address}. Hub is now in FAILED state.", Hub.Address);
-                }
-                else if (allInit.IsCanceled)
-                {
-                    logger.LogWarning("DataContext initialization was canceled for {Address}", Hub.Address);
-                }
-                else
-                {
-                    logger.LogDebug("Finished initialization of DataContext for {Address}", Hub.Address);
-                }
-
-                if (failure is not null)
-                {
-                    InitializationError = failure;
-
-                    // Register a global rejection handler for all data requests: every
-                    // subsequent request to this hub gets an immediate DeliveryFailure,
-                    // so callers (and the MeshNodeStreamCache negative cache) get a
-                    // TERMINAL answer and stop re-subscribing — never the 30s-defer loop.
-                    RegisterInitializationFailureHandler(failure);
-
-                    // Also propagate to existing data source streams.
-                    foreach (var ds in DataSources)
-                    {
-                        try
-                        {
-                            var stream = ds.GetStreamForPartition(null);
-                            stream?.OnError(failure);
-                        }
-                        catch (Exception ex)
-                        {
-                            logger.LogDebug(ex, "Error propagating init failure to data source {Id}", ds.Id);
-                        }
-                    }
-                }
-
-                // Always open the gate so the hub can process messages.
-                // On failure/timeout, streams already have errors propagated and the
-                // rejection handler is registered; keeping the gate closed would hang
-                // the hub forever.
-                logger.LogDebug("DataContext: Opening {GateName} gate for {Address} (failed={Failed})",
-                    InitializationGateName, Hub.Address, failure is not null);
-                Hub.OpenGate(InitializationGateName);
-            }, TaskScheduler.Default);
+        // Always open the gate so the hub can process messages.
+        // On failure/timeout, streams already have errors propagated and the
+        // rejection handler is registered; keeping the gate closed would hang
+        // the hub forever.
+        logger.LogDebug("DataContext: Opening {GateName} gate for {Address} (failed={Failed})",
+            InitializationGateName, Hub.Address, failure is not null);
+        Hub.OpenGate(InitializationGateName);
     }
 
     /// <summary>
@@ -574,27 +627,26 @@ public sealed record DataContext : IDisposable
     public IEnumerable<Type> MappedTypes => DataSourcesByType.Keys;
     private readonly List<Task> tasks = new();
     private readonly List<WorkspaceReference> initialized = new();
-    // Cancels the init-watchdog Task.Delay armed in OpenInitializationGate. Assigned there
-    // (never at config time, so record with-ers copying this field pre-arm is harmless) and
-    // cancelled by Dispose so a hub disposed mid-init doesn't keep a live timer whose
-    // continuation would fire minutes after the hub is gone (issue #1122).
-    private CancellationTokenSource? watchdogCancellation;
+    // The init watchdog's DISARM arm (issue #1122): fired by Dispose so a hub disposed
+    // mid-init settles the gate NOW, through the recognized-shutdown branch that stamps no
+    // FAILED residue — instead of leaving a live timer whose continuation fires minutes
+    // after the hub is gone. An AsyncSubject replays its terminal to late subscribers, so a
+    // Dispose that runs BEFORE OpenInitializationGate arms the watchdog still disarms it.
+    // (Record with-ers copy the reference at config time; a DataContext is created per hub
+    // and only the final instance ever arms/disarms, so sharing across with-copies is
+    // harmless — same reasoning the CTS this replaced documented.)
+    private readonly AsyncSubject<Unit> watchdogDisarm = new();
     /// <summary>Disposes every configured data source and disarms the init watchdog.</summary>
     public void Dispose()
     {
         // Disarm the init watchdog FIRST: DataContext.Dispose only runs during hub teardown
         // (Workspace.Dispose), so from here on "init did not complete" is a shutdown outcome,
-        // not a timeout. Cancelling completes the Task.WhenAny immediately; its continuation
-        // observes Hub.IsShuttingDown and records nothing.
-        try
-        {
-            watchdogCancellation?.Cancel();
-            watchdogCancellation?.Dispose();
-        }
-        catch (ObjectDisposedException)
-        {
-            // Dispose raced a second Dispose call — the watchdog is already disarmed.
-        }
+        // not a timeout. Firing the arm settles the watchdog's Amb immediately; the settle
+        // body observes Hub.IsShuttingDown and records nothing (#1122) while still ANSWERING
+        // the gate (#1270). Idempotent: an AsyncSubject ignores notifications after its
+        // terminal, so a racing second Dispose is a no-op.
+        watchdogDisarm.OnNext(Unit.Default);
+        watchdogDisarm.OnCompleted();
 
         foreach (var dataSource in DataSourcesById.Values)
         {

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -1388,7 +1388,20 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                     // never Host.Version, so the init frame can't outrank later owned writes.
                     SetCurrent(hub, new ChangeItem<TStream>(init, StreamId, OwnerVersion()));
                     return System.Reactive.Unit.Default;
-                });
+                })
+                // 🚨 A faulted initial load must fault the STREAM, not only this hub's buildup.
+                // Without this hook the error stopped in HandleInitialize's .Catch: the hub
+                // entered its FAILED state, but SynchronizationGate stayed shut, RunLevel never
+                // reached Started, and Hub.Started never settled — so IDataSource.Initialized
+                // (Task.WhenAll over stream-hub Started tasks) HUNG and the owning DataContext
+                // could not tell a faulted init from a hung one until its time-box expired 120s
+                // later, reporting a TimeoutException instead of the real error. OnError routes
+                // the fault where the stream's other failure paths already go: it classifies
+                // (teardown stays quiet), faults the store, calls Hub.FailStartup (Initialized
+                // settles NOW, with the actual exception) and opens SynchronizationGate. The
+                // error still propagates to the buildup's .Catch, which records the hub-level
+                // FAILED state. Pinned by DataContextInitFaultedTest (#2528).
+                .Do(_ => { }, OnError);
         }
 
         // No custom initialization.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-reactive-init-watchdog.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-reactive-init-watchdog.md
@@ -1,0 +1,16 @@
+---
+Name: Data initialization watchdog is fully reactive
+Category: Fix
+Description: The data-initialization time-box now waits reactively on the real completion signal, so startup failures surface fast and precisely instead of racing a background timer.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Data initialization watchdog is fully reactive
+
+A hub whose data sources hang or fail during startup is now settled by a subscription to the
+actual completion signal rather than a background timer race. The behaviour a user sees is
+unchanged in the good cases and sharper in the bad ones: a hung initialization still trips the
+same time-box and answers requests immediately with a clear "did not complete within…"
+diagnostic, a failed initialization reports the specific error, and a page closed mid-startup no
+longer risks a stray timeout being logged minutes later.

--- a/test/MeshWeaver.Data.Test/DataContextInitWatchdogTest.cs
+++ b/test/MeshWeaver.Data.Test/DataContextInitWatchdogTest.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// Pins the TIMED-OUT outcome of the <see cref="DataContext"/> init watchdog — the branch the
+/// 2026-06-26 prod wedge bought (a hung init left the gate closed and every message deferred →
+/// NACKed → resubscribed, a path-resolution storm that GC-thrashed the portal).
+///
+/// <para>Together with its three siblings this fixes the watchdog's four terminal outcomes in
+/// place across the #2528 rewrite (the Task.WhenAny + Task.Delay + ContinueWith timer race became
+/// an Amb over init-settled / time-box / disarm — a subscription, per #2488):</para>
+/// <list type="bullet">
+/// <item><b>timed out</b> — THIS test: fail-level diagnostic, <see cref="DataContext.InitializationError"/>
+/// = <see cref="TimeoutException"/>, rejection handler answers fast, gate OPEN;</item>
+/// <item><b>faulted</b> — <see cref="DataContextInitFaultedTest"/>;</item>
+/// <item><b>shutdown (disarm)</b> — <c>DataContextDisposeDuringInitTest</c> (#1122: no post-mortem
+/// FAILED residue) and <c>DataContextShutdownGateAnswersDeferredTest</c> (#1270: FailGate still
+/// ANSWERS what parked behind the gate);</item>
+/// <item><b>clean</b> — every AddData round-trip test in this project (e.g.
+/// <c>DataContextIntegrationTest</c>): data flows ⇔ the gate opened cleanly.</item>
+/// </list>
+///
+/// <para><b>What a red here means.</b> A <see cref="TimeoutException"/> from the Observe below
+/// means the time-box never fired or the gate never got its answer — the exact silent-proceed /
+/// gate-shut-forever failure modes the reactive rewrite must not introduce.</para>
+/// </summary>
+public class DataContextInitTimeoutTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record HangingItem(string Id);
+
+    // NOT PingRequest: the DataContextInit gate deliberately exempts liveness pings
+    // (DataExtensions.WithInitializationGate), so only a real request parks behind it.
+    private record ProbeRequest : IRequest<ProbeResponse>;
+
+    private record ProbeResponse;
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => configuration
+            .WithTypes(typeof(ProbeRequest), typeof(ProbeResponse))
+            // The handler WOULD answer, so a pass can only come from the FAILED-state
+            // rejection — never from the request quietly being served after all.
+            .WithHandler<ProbeRequest>((hub, request) =>
+            {
+                hub.Post(new ProbeResponse(), o => o.ResponseFor(request));
+                return request.Processed();
+            })
+            .AddData(data => data
+                // Short bound so the terminal FAILED state is observed fast; prod is 120s.
+                .WithInitializationTimeout(TimeSpan.FromMilliseconds(1500))
+                .AddSource(src => src.WithType<HangingItem>(t => t
+                    .WithKey(i => i.Id)
+                    // An initial load that NEVER completes — the "stuck NodeType compile / data
+                    // source that never initialised" the time-box exists for.
+                    .WithInitialData(() => Observable.Never<IEnumerable<HangingItem>>()))));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => configuration.WithTypes(typeof(ProbeRequest), typeof(ProbeResponse));
+
+    [Fact(Timeout = 60000)]
+    public async Task HungInit_TripsTheTimeBox_FailsFastAndLoud_NeverSilentlyProceeds()
+    {
+        var host = GetHost();
+        var client = GetClient();
+
+        // The request parks behind the DataContextInit gate; the time-box fires at ~1.5s, the
+        // rejection handler answers it with a typed DeliveryFailure. 15s budget: far above the
+        // bound (so the graceful failure is observed), far below the 30s deferral timeout (so a
+        // gate left shut surfaces as this test's own TimeoutException and fails it).
+        var act = () => client
+            .Observe(new ProbeRequest(), o => o.WithTarget(host.Address))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(15)).ToTask();
+
+        var ex = (await act.Should().ThrowAsync<Exception>(
+            "a hub whose data-source init hung must answer requests with an error, not serve "
+            + "as if initialized and not hang")).Which;
+
+        ex.Should().NotBeOfType<TimeoutException>(
+            "the time-box must fail the hub FAST and terminally — this test timing out means "
+            + "the gate never got its answer, the wedge the time-box exists to prevent");
+        ex.ToString().Should().Contain("initialization failed",
+            "the rejection must say WHY the hub refuses, not read as a generic delivery error");
+        ex.ToString().Should().Contain("did not complete within",
+            "the timeout diagnostic must surface the time-box expiry, never silently proceed");
+
+        // The FAILED state is recorded where diagnostics (and the MeshNodeStreamCache negative
+        // cache) read it — a TimeoutException naming the budget and the likely causes.
+        var initError = host.GetWorkspace().DataContext.InitializationError;
+        initError.Should().BeOfType<TimeoutException>(
+            "a hung init reaches the SAME terminal failed state as a thrown one, via a "
+            + "TimeoutException that names the budget");
+    }
+}
+
+/// <summary>
+/// Pins the FAULTED outcome of the <see cref="DataContext"/> init watchdog: a data source whose
+/// initial load THROWS must drive the hub to the terminal FAILED state — error recorded, rejection
+/// handler answering fast, gate open — and the watchdog's init-settled arm must run the settle
+/// body for a faulted init exactly as for a clean one (the arm is Materialize'd; an OnError that
+/// skipped past the body to an error arm would leave the gate shut forever).
+/// See <see cref="DataContextInitTimeoutTest"/> for the outcome map.
+/// </summary>
+public class DataContextInitFaultedTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string InitFaultMarker = "boom during initial data load";
+
+    private record FaultyItem(string Id);
+
+    // NOT PingRequest — the gate exempts liveness pings; see DataContextInitTimeoutTest.
+    private record ProbeRequest : IRequest<ProbeResponse>;
+
+    private record ProbeResponse;
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => configuration
+            .WithTypes(typeof(ProbeRequest), typeof(ProbeResponse))
+            .WithHandler<ProbeRequest>((hub, request) =>
+            {
+                hub.Post(new ProbeResponse(), o => o.ResponseFor(request));
+                return request.Processed();
+            })
+            .AddData(data => data
+                .AddSource(src => src.WithType<FaultyItem>(t => t
+                    .WithKey(i => i.Id)
+                    // An initial load that FAULTS — the wedges-to-zero branch (fail fast →
+                    // reject subsequent requests) the watchdog has carried since before the
+                    // time-box.
+                    .WithInitialData(() =>
+                        Observable.Throw<IEnumerable<FaultyItem>>(
+                            new InvalidOperationException(InitFaultMarker))))));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => configuration.WithTypes(typeof(ProbeRequest), typeof(ProbeResponse));
+
+    [Fact(Timeout = 60000)]
+    public async Task FaultedInit_ReachesTerminalFailedState_AndAnswersFast()
+    {
+        var host = GetHost();
+        var client = GetClient();
+
+        var act = () => client
+            .Observe(new ProbeRequest(), o => o.WithTarget(host.Address))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(15)).ToTask();
+
+        var ex = (await act.Should().ThrowAsync<Exception>(
+            "a hub whose data-source init threw must answer requests with an error")).Which;
+
+        ex.Should().NotBeOfType<TimeoutException>(
+            "a faulted init must be answered FAST by the rejection handler — a timeout means "
+            + "the faulted arm skipped the settle body and left the gate shut");
+        ex.ToString().Should().Contain("initialization failed",
+            "the rejection must be reported as an initialization failure");
+
+        var initError = host.GetWorkspace().DataContext.InitializationError;
+        initError.Should().NotBeNull(
+            "the hub must expose the FAILED status marker after a faulted init");
+        initError!.ToString().Should().Contain(InitFaultMarker,
+            "the recorded failure must carry the SPECIFIC init fault for diagnosis");
+    }
+}


### PR DESCRIPTION
Closes #2528.

## What

`DataContext.OpenInitializationGate`'s watchdog was the banned timer-race shape: `Task.WhenAny(allInit, Task.Delay(InitializationTimeout, cts.Token)).ContinueWith(...)` plus a `CancellationTokenSource` disarm. The wait is now a subscription — `Observable.Amb` over three one-shot arms, `Take(1)`, `ObserveOn(TaskPoolScheduler.Default)` (the same off-thread hop the old `ContinueWith(TaskScheduler.Default)` gave the body), `Subscribe` with a fluent error arm:

1. **init settled** — `allInit.ToObservable().Materialize()` (Task→IObservable is the sanctioned bridge direction; Materialize so a FAULTED/CANCELED init still runs the settle body instead of skipping to an error arm);
2. **the time-box** — `Observable.Timer(InitializationTimeout)`. **The bound stays** (deleting it re-opens the 2026-06-26 path-resolution-storm wedge); its expiry fails fast and LOUD — fail-level log, `InitializationError = TimeoutException`, rejection handler — never "proceed as if initialized";
3. **the disarm** — an `AsyncSubject<Unit>` fired by `Dispose()`. Disarm means **fire now, not unsubscribe** (an Amb arm, never a `TakeUntil`): #1270's FailGate answer still runs, #1122's no-post-mortem-residue holds, and because the subject replays its terminal, a Dispose that lands *before* the gate arms now settles immediately (the old CTS shape armed a fresh, never-cancelled timer in that ordering).

The settle body is unchanged — the same four-way shutdown / timed-out / faulted / canceled / clean discrimination, read off `allInit`'s actual state, ending in `FailGate` (shutdown) or the unconditional `OpenGate`.

## Root cause found on the way: a FAULTED init was indistinguishable from a HUNG one

Writing #2528's requested faulted-init test exposed a pre-existing defect (verified red against `main`'s `DataContext` too): a data source whose initial load **throws** never faulted `IDataSource.Initialized`. The fault stopped in the stream hub's `HandleInitialize` catch — hub FAILED state, but `SynchronizationGate` stayed shut, `RunLevel` never reached `Started`, `Hub.Started` never settled — so the owning DataContext saw nothing until its **120 s time-box** expired, and then reported a `TimeoutException` instead of the real error.

Fix at the root: the Task-init arm of `SynchronizationStream.Initialize` routes its fault through the stream's own `OnError` — the path every other stream failure already takes — which classifies (teardown stays quiet), faults the store, calls `Hub.FailStartup` (so `Initialized` settles NOW with the actual exception) and opens `SynchronizationGate`. The error still propagates to the buildup's catch for the hub-level FAILED state. Consumed only by the data-source `CreateStream` path (`GenericUnpartitionedDataSource:621`), so the blast radius is exactly the path being fixed.

## Tests (the four terminal outcomes, per the issue)

- **hung** — `DataContextInitTimeoutTest`: time-box trips at the configured bound, request answered fast with "initialization failed … did not complete within", `InitializationError` is `TimeoutException`;
- **faulted** — `DataContextInitFaultedTest`: answers in milliseconds carrying the specific init error (**red on main**: 15 s timeout, the conflation above);
- **shutdown/disarm** — pre-existing `DataContextDisposeDuringInitTest` (#1122) and `DataContextShutdownGateAnswersDeferredTest` (#1270), both still green;
- **clean** — every AddData round-trip in the suites below.

## Verification

`-c Release -warnaserror` clean for `MeshWeaver.Data`, `MeshWeaver.Graph` and the three test projects. Full suites green locally: MeshWeaver.Data.Test **393/393**, MeshWeaver.Messaging.Hub.Test **305/305**, MeshWeaver.Persistence.Test **1023/1023**.

What's New: `Category: Fix` entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)