### PR TITLE
A revoked MCP back-connection token stops being handed out (#2302 finding 6)

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
@@ -41,6 +41,13 @@ internal sealed class McpBackConnectionService : IMcpBackConnection
     private readonly IOptions<McpConfiguration> mcpConfig;
     private readonly ILogger<McpBackConnectionService> logger;
 
+    /// <summary>
+    /// How long a cache-hit validation may take before the cached token is reused anyway. Short by
+    /// design: this is the hot path of every CLI spawn, and the check is an optimisation on
+    /// revocation latency, not a security boundary — a revoked token is still refused at /mcp.
+    /// </summary>
+    private static readonly TimeSpan ValidationBudget = TimeSpan.FromSeconds(2);
+
     // Instance (not static) — lifetime == the portal host. userId → raw mw_ token.
     private readonly ConcurrentDictionary<string, string> tokensByUser = new(StringComparer.Ordinal);
 
@@ -84,6 +91,13 @@ internal sealed class McpBackConnectionService : IMcpBackConnection
         // fresh (no cache), which is what makes checking it here meaningful rather than circular.
         if (tokensByUser.TryGetValue(userId, out var cached))
             return tokenService.Validate(cached)
+                // 🚨 Bounded well below ApiTokenService.ValidationReadTimeout (8 s by default).
+                // This runs on EVERY CLI spawn, so an unbounded check would let a brief store blip
+                // stall every spawn for the full validation window — trading the stale-token bug
+                // for a latency one. Expiring here lands in the Catch below and REUSES the cached
+                // token, which is the Unavailable semantics this class already applies: "we could
+                // not find out" is never "it was revoked".
+                .Timeout(ValidationBudget)
                 .SelectMany(verdict => verdict.Status switch
                 {
                     // 🚨 Only INVALID evicts. Unavailable must NOT: "we could not find out" is not

--- a/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/McpBackConnectionService.cs
@@ -21,8 +21,19 @@ namespace Memex.Portal.Shared.Authentication;
 ///
 /// <para>The per-user token is cached on this singleton's instance dictionary (NEVER static — it
 /// dies with the host) for the process lifetime; a fresh replica mints its own (the prior token
-/// stays valid). A revoked token surfaces as a 401 on the next MCP call, which the
-/// auth-on-exception path turns into a re-mint.</para>
+/// stays valid).</para>
+///
+/// <para>🚨 <b>A cached token is VALIDATED before it is reused</b>, and that is the only thing that
+/// makes a revocation take effect. This paragraph used to claim "a revoked token surfaces as a 401
+/// on the next MCP call, which the auth-on-exception path turns into a re-mint" — there was no such
+/// path (#2302 finding 6). Neither CLI client reports a subsequent <c>/mcp</c> 401 back to this
+/// service, so nothing evicted the entry and mesh access stayed broken until the process restarted.
+/// An <c>Invalidate(userId)</c> contract would not have helped for the same reason: there is no
+/// caller to invoke it. Validation reads the token node fresh, so asking here is meaningful.</para>
+///
+/// <para>Only an <b>Invalid</b> verdict evicts. <b>Unavailable</b> deliberately does not: "we could
+/// not find out" is not "it was revoked" (#637), and minting on a storage blip would fill the
+/// user's token list with orphans exactly when the mesh is already unwell.</para>
 /// </summary>
 internal sealed class McpBackConnectionService : IMcpBackConnection
 {
@@ -43,6 +54,20 @@ internal sealed class McpBackConnectionService : IMcpBackConnection
         this.logger = logger;
     }
 
+    /// <summary>
+    /// Drops a cached token the store has judged INVALID and mints a replacement, so a revocation
+    /// takes effect without a portal restart.
+    /// </summary>
+    private IObservable<McpConnectionInfo?> EvictAndMint(
+        string userId, string? userName, string? userEmail, string mcpUrl, string? reason)
+    {
+        tokensByUser.TryRemove(userId, out _);
+        logger.LogInformation(
+            "Cached MCP back-connection token for user {UserId} is no longer valid ({Reason}) — "
+            + "evicted and re-minting.", userId, reason ?? "no reason given");
+        return Mint(userId, userName, userEmail, mcpUrl);
+    }
+
     public IObservable<McpConnectionInfo?> EnsureForUser(string userId, string? userName = null, string? userEmail = null)
     {
         var baseUrl = mcpConfig.Value?.BaseUrl;
@@ -51,12 +76,47 @@ internal sealed class McpBackConnectionService : IMcpBackConnection
 
         var mcpUrl = $"{baseUrl!.TrimEnd('/')}{McpEndpointRoutes.PrimaryEndpoint}";
 
-        // Reuse the cached token (long-lived, no expiry) — cheap hot path, no mint.
+        // Reuse the cached token — but VALIDATE it first (#2302 finding 6). The cache had no
+        // eviction path at all: once a token was cached it was returned for the life of the
+        // process, so REVOKING it did not take effect. Neither CLI client reports a subsequent
+        // /mcp 401 back here, so an `Invalidate(userId)` contract would have been a method nobody
+        // ever calls — the revocation would still never land. Validation reads the token node
+        // fresh (no cache), which is what makes checking it here meaningful rather than circular.
         if (tokensByUser.TryGetValue(userId, out var cached))
-            return Observable.Return<McpConnectionInfo?>(new McpConnectionInfo(mcpUrl, cached));
+            return tokenService.Validate(cached)
+                .SelectMany(verdict => verdict.Status switch
+                {
+                    // 🚨 Only INVALID evicts. Unavailable must NOT: "we could not find out" is not
+                    // "it was revoked" (#637), and treating a storage blip as revocation would mint
+                    // a fresh token on every transient failure — filling the user's token list with
+                    // orphans and doing it precisely when the mesh is already unwell. A cached token
+                    // that is actually revoked simply fails at /mcp on that attempt, which is the
+                    // same outcome as today and is recoverable on the next call.
+                    TokenValidationStatus.Invalid => EvictAndMint(userId, userName, userEmail, mcpUrl, verdict.Reason),
+                    _ => Observable.Return<McpConnectionInfo?>(new McpConnectionInfo(mcpUrl, cached)),
+                })
+                .Catch((Exception ex) =>
+                {
+                    // Validation itself faulting is an availability failure, not a verdict: keep
+                    // serving the cached token rather than minting on every fault.
+                    logger.LogWarning(ex,
+                        "Could not validate the cached MCP back-connection token for user {UserId}; "
+                        + "reusing it. If it has been revoked the /mcp call will refuse it.", userId);
+                    return Observable.Return<McpConnectionInfo?>(new McpConnectionInfo(mcpUrl, cached));
+                });
 
-        // Cache miss → mint automatically. CreateToken self-elevates for the global index write;
-        // the user-scoped node is created under the calling user's AccessContext (active at spawn).
+        // Cache miss → mint automatically.
+        return Mint(userId, userName, userEmail, mcpUrl);
+    }
+
+    /// <summary>
+    /// Mints a back-connection token and caches it. CreateToken self-elevates for the global index
+    /// write; the user-scoped node is created under the calling user's AccessContext (active at
+    /// spawn).
+    /// </summary>
+    private IObservable<McpConnectionInfo?> Mint(
+        string userId, string? userName, string? userEmail, string mcpUrl)
+    {
         return tokenService
             .CreateToken(userId, userName ?? userId, userEmail ?? string.Empty,
                 label: "MCP back-connection (auto)", expiresAt: null)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-revoking-an-mcp-token-takes-effect.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-revoking-an-mcp-token-takes-effect.md
@@ -1,0 +1,18 @@
+---
+Name: Revoking an MCP token now takes effect
+Category: Fix
+Description: A revoked back-connection token kept being handed to the co-hosted CLI until the portal restarted.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Revoking an MCP token now takes effect
+
+The token that lets the co-hosted assistant reach your mesh was remembered for as long as the portal
+ran. If you revoked it, it kept being handed out anyway — the revocation only really took hold when
+the portal next restarted.
+
+Revoking now works immediately: the token is checked before it is reused, and a revoked one is
+replaced. If the check itself cannot be completed — the store is briefly unreachable, say — the
+existing token is kept rather than replaced, so a passing glitch does not quietly fill your token
+list with new ones.

--- a/test/Memex.Portal.Shared.Test/McpBackConnectionEvictionTest.cs
+++ b/test/Memex.Portal.Shared.Test/McpBackConnectionEvictionTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;

--- a/test/Memex.Portal.Shared.Test/McpBackConnectionEvictionTest.cs
+++ b/test/Memex.Portal.Shared.Test/McpBackConnectionEvictionTest.cs
@@ -8,7 +8,6 @@ using MeshWeaver.Data;
 using MeshWeaver.Hosting.AspNetCore;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Hosting.Monolith.TestBase;
-using MeshWeaver.Mesh.Services;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;

--- a/test/Memex.Portal.Shared.Test/McpBackConnectionEvictionTest.cs
+++ b/test/Memex.Portal.Shared.Test/McpBackConnectionEvictionTest.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.AspNetCore;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// A revoked MCP back-connection token must stop being handed out (#2302, finding 6).
+///
+/// <para>🚨 The cache had no eviction path at all: once a token was cached it was returned for the
+/// life of the process, so revoking it simply did not take effect — mesh access stayed broken until
+/// the portal restarted. The class comment claimed "a revoked token surfaces as a 401 on the next
+/// MCP call, which the auth-on-exception path turns into a re-mint"; no such path existed, and
+/// neither CLI client reports an <c>/mcp</c> 401 back here, so an <c>Invalidate(userId)</c>
+/// contract would have been a method with no caller. Validating before reuse is what makes the
+/// revocation land.</para>
+/// </summary>
+public class McpBackConnectionEvictionTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    // ApiTokenService is not a registered component in a bare test mesh — construct it the way
+    // ApiTokenServiceStaleReadTest does, with a short validation window so the revoked-token read
+    // settles quickly rather than waiting out the 8 s production default.
+    private ApiTokenService Tokens() => new(
+        Mesh.ServiceProvider.GetRequiredService<IMeshService>(),
+        Mesh,
+        Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>(),
+        Mesh.ServiceProvider.GetRequiredService<ILogger<ApiTokenService>>())
+    {
+        ValidationReadTimeout = TimeSpan.FromSeconds(2),
+    };
+
+    private McpBackConnectionService Service(ApiTokenService tokens) => new(
+        tokens,
+        Options.Create(new McpConfiguration { BaseUrl = "https://portal.example" }),
+        NullLogger<McpBackConnectionService>.Instance);
+
+    [Fact]
+    public async Task A_revoked_cached_token_is_evicted_and_replaced()
+    {
+        var tokens = Tokens();
+        var svc = Service(tokens);
+        var userId = $"mcpuser{Guid.NewGuid():N}"[..16];
+
+        var first = await svc.EnsureForUser(userId).FirstAsync().ToTask();
+        first.Should().NotBeNull("the first call mints a token");
+        var firstToken = first!.BearerToken;
+
+        // Cached: the same token comes back without minting a second one.
+        var cached = await svc.EnsureForUser(userId).FirstAsync().ToTask();
+        cached!.BearerToken.Should().Be(firstToken, "a valid cached token is reused — that is the hot path");
+
+        // Revoke it the way an operator would.
+        var mine = await tokens.GetTokensForUser(userId).FirstAsync().ToTask();
+        mine.Should().NotBeEmpty("the mint created a token node for this user");
+        (await tokens.RevokeToken(mine[0].NodePath).FirstAsync().ToTask())
+            .Should().BeTrue("revocation must succeed for this test to mean anything");
+
+        var afterRevoke = await svc.EnsureForUser(userId).FirstAsync().ToTask();
+
+        afterRevoke.Should().NotBeNull();
+        afterRevoke!.BearerToken.Should().NotBe(
+            firstToken,
+            "the revoked token must not be handed out again — before this fix the cache had no "
+            + "eviction path, so it was returned for the life of the process and revoking a "
+            + "back-connection token did nothing at all");
+    }
+}


### PR DESCRIPTION
Closes finding 6 of #2302.

## The gap

`McpBackConnectionService` cached `userId → raw token` in a dictionary with **no eviction path at all**. Once a token was cached it was returned for the life of the process, so **revoking it did not take effect** — mesh access stayed broken until the portal restarted.

## Why the obvious fix is the wrong one

The finding offers "an invalidation/retry contract **or** validate and evict before reuse". An `Invalidate(userId)` method would have been **a method with no caller**: neither CLI client reports a subsequent `/mcp` 401 back to this service, which is exactly why nothing evicted the entry in the first place. It would have looked like a fix and changed nothing.

So: **validate before reuse**. `ApiTokenService.Validate` reads the token node fresh (no cache), which is what makes asking here meaningful rather than circular.

## 🚨 Only INVALID evicts

`TokenValidationResult` is tri-state, and the distinction is load-bearing:

| verdict | action |
|---|---|
| `Valid` | reuse the cached token — the hot path is unchanged |
| `Invalid` | evict + re-mint — the revocation lands |
| `Unavailable` | **reuse** — "we could not find out" is not "it was revoked" (#637) |

Treating `Unavailable` as revocation would mint a fresh token on every storage blip, filling the user's token list with orphans **precisely when the mesh is already unwell**. A validation *fault* is handled the same way. If a token really is revoked, that attempt's `/mcp` call refuses it — no worse than today, and it recovers on the next call.

## The comment that hid this

The class doc claimed "a revoked token surfaces as a 401 on the next MCP call, which the auth-on-exception path turns into a re-mint". No such path existed. I corrected it in place rather than deleting it, because that sentence is *why the gap survived review* — it described a mechanism that was never built.

## Red-proof

Against main's code the test fails with the revoked token handed straight back:

> Did not expect value to be `"mw_jdaizLxj…"` because the revoked token must not be handed out again

## Note on #2302

This does **not** close the parent issue. Finding 5 (`OnboardingMiddleware`'s unanchored `scope:subtree`) is still open — I analysed it in a comment there: the fix is *not* the anchoring the finding suggests, because a user legitimately holds grants across partitions; the real defect is the mirror image, that a pathless cross-schema query excludes the admin schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)