### PR TITLE
fix: bounded transient-connect retry in the query fan-in (#2521)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-query-transient-retry.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-query-transient-retry.md
@@ -1,0 +1,15 @@
+---
+Name: Pages no longer fail on a brief database blip
+Category: Fix
+Description: Layout areas now retry a momentary database connection timeout instead of failing the render.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Pages no longer fail on a brief database blip
+
+Occasionally a page area would show a render error during a short burst while the rest of the
+portal kept working — the moment the database was briefly slow to accept a new connection. Queries
+behind page rendering now retry such momentary connection timeouts a few times with a short,
+increasing pause before giving up, so the page renders normally once the blip passes. Real errors
+are still reported immediately.

--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -415,6 +415,24 @@ public class MeshQuery : IMeshQueryCore
         if (observables.Count == 0)
             return Observable.Empty<QueryResultChange<T>>();
 
+        // 🚨 Bounded transient-connect retry, composed HERE — in the caller's reactive chain,
+        // OUTSIDE the adapters' capped IIoPool leaves (issue #2521: one timed-out Npgsql
+        // connector open failed the whole layout-area render; the provider observables are
+        // cold, so each resubscription re-runs the query through a fresh pool invoke). Only
+        // errors BEFORE the provider's first emission are retried, only for the transient
+        // connect/timeout class (TransientStorageFaults.IsTransientConnectFault); everything
+        // else — and the exhausted budget's LAST error — propagates unchanged.
+        var requestQuery = request.Query;
+        observables = observables
+            .Select(t => (t.Stream.RetryTransientConnect(
+                    onRetry: (ex, attempt, delay) => Logger?.LogWarning(ex,
+                        "Query provider {Provider} hit a transient storage connect fault on query "
+                        + "'{Query}' — retry {Attempt}/{Max} in {Delay}ms",
+                        t.Provider, requestQuery, attempt,
+                        TransientStorageFaults.DefaultMaxRetries, delay.TotalMilliseconds)),
+                t.Provider))
+            .ToList();
+
         if (observables.Count == 1)
         {
             // Single provider — still funnel Initial through ClipMergedInitial

--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -422,7 +422,10 @@ public class MeshQuery : IMeshQueryCore
         // errors BEFORE the provider's first emission are retried, only for the transient
         // connect/timeout class (TransientStorageFaults.IsTransientConnectFault); everything
         // else — and the exhausted budget's LAST error — propagates unchanged.
-        var requestQuery = request.Query;
+        // 🚨 EffectiveQueries, not Query: a multi-query request carries its text in Queries and
+        // leaves Query null, so logging Query would print an empty string in the one line an
+        // operator reads to find out WHICH query is failing to reach the database.
+        var requestQuery = string.Join(" | ", request.EffectiveQueries);
         observables = observables
             .Select(t => (t.Stream.RetryTransientConnect(
                     onRetry: (ex, attempt, delay) => Logger?.LogWarning(ex,

--- a/src/MeshWeaver.Hosting/Persistence/Query/TransientStorageFaults.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/TransientStorageFaults.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Data.Common;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
@@ -48,12 +49,18 @@ public static class TransientStorageFaults
     /// (<c>40001</c>/<c>40P01</c>): those belong to the layer that owns the statement (the
     /// adapters' own retry), not to the query fan-in.
     /// </summary>
-    private static readonly HashSet<string> TransientConnectSqlStates = new(StringComparer.Ordinal)
+    /// <para>🚨 <c>FrozenSet</c>, not <c>HashSet</c>, and not an allowlist entry on
+    /// <c>NoStaticCollectionsTest</c>. The rule bans a static COLLECTION because it is
+    /// process-wide state that survives mesh disposal; this is a constant, so the fix is to say
+    /// so in the TYPE rather than to argue for it in a list. A mutable type here would also be a
+    /// standing invitation for someone to write to it later, which is the failure the ban exists
+    /// to prevent — and it read as an exception to a rule that has none.</para>
+    private static readonly FrozenSet<string> TransientConnectSqlStates = new[]
     {
         "08000", "08001", "08003", "08004", "08006", // connection_exception family
         "57P01", "57P02", "57P03",                   // admin/crash shutdown, cannot_connect_now
         "53300", "53400",                            // too_many_connections, configuration_limit_exceeded
-    };
+    }.ToFrozenSet(StringComparer.Ordinal);
 
     /// <summary>
     /// True when <paramref name="ex"/> is a TRANSIENT database connect/timeout fault worth a

--- a/src/MeshWeaver.Hosting/Persistence/Query/TransientStorageFaults.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/TransientStorageFaults.cs
@@ -1,0 +1,162 @@
+using System.Data.Common;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+
+namespace MeshWeaver.Hosting.Persistence.Query;
+
+/// <summary>
+/// Classification + bounded reactive retry for TRANSIENT storage-connect faults surfacing on a
+/// query provider's observable (issue #2521: a single timed-out Npgsql connector open —
+/// <c>PoolingDataSource.OpenNewConnector → NpgsqlConnector.RawOpen → TimeoutException</c> —
+/// failed the entire layout-area render, in recurring bursts, while warm pooled connections kept
+/// serving).
+///
+/// <para><b>Why the retry lives HERE, in the caller's reactive chain.</b> The database adapters run
+/// their I/O leaves inside capped <c>IIoPool</c>s (<c>pg:{adapter}</c> / <c>pg-read:{adapter}</c>).
+/// A retry INSIDE such a leaf would hold the pooled slot across every backoff wait — stacking
+/// waiters inside the very pool whose cap is the serialization guarantee. Composing the retry on
+/// the provider's cold observable instead means each resubscription re-enters the pool from
+/// OUTSIDE: the failed attempt's slot is long released, and the backoff wait costs nothing but an
+/// <see cref="Observable.Timer(TimeSpan, IScheduler)"/>. Same shape as
+/// <c>MeshWeaver.Layout.AreaStreamRetry</c>: exponential backoff on a scheduler timer, a
+/// <c>shouldRetry</c> predicate selecting ONLY the transient class, and the LAST error surfaced to
+/// the consumer's <c>OnError</c> once the bound is spent — never an unbounded resubscribe (the
+/// 2026-06-14 storm), never a swallowed fault.</para>
+///
+/// <para><b>Why the predicate is typed on <see cref="DbException"/>.</b> The storage adapters live
+/// in provider packages (the plugins repo), so this assembly cannot name <c>NpgsqlException</c>.
+/// It does not need to: every ADO.NET driver derives its faults from the BCL
+/// <see cref="DbException"/>, which carries <see cref="DbException.SqlState"/> — enough to match
+/// exactly the transient connect/timeout class (client-side connect timeouts arrive as a
+/// <see cref="DbException"/> wrapping a <see cref="TimeoutException"/> /
+/// <see cref="System.Net.Sockets.SocketException"/>/<see cref="IOException"/>; server-side refusals
+/// carry a connection-class SQLSTATE). A real query/schema error (<c>42P01</c>, <c>23505</c>, a
+/// syntax error) is NOT matched and propagates unchanged, as does every non-database fault —
+/// retrying those would only mask a defect.</para>
+/// </summary>
+public static class TransientStorageFaults
+{
+    /// <summary>Maximum resubscriptions after the initial attempt before the fault is surfaced.</summary>
+    public const int DefaultMaxRetries = 3;
+
+    /// <summary>First backoff step; doubles each retry (250 → 500 → 1000 ms).</summary>
+    public static readonly TimeSpan DefaultBaseDelay = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// SQLSTATE classes meaning "the database could not be REACHED or is momentarily refusing
+    /// connections" — the transient connect class, deliberately WITHOUT the in-query races
+    /// (<c>40001</c>/<c>40P01</c>): those belong to the layer that owns the statement (the
+    /// adapters' own retry), not to the query fan-in.
+    /// </summary>
+    private static readonly HashSet<string> TransientConnectSqlStates = new(StringComparer.Ordinal)
+    {
+        "08000", "08001", "08003", "08004", "08006", // connection_exception family
+        "57P01", "57P02", "57P03",                   // admin/crash shutdown, cannot_connect_now
+        "53300", "53400",                            // too_many_connections, configuration_limit_exceeded
+    };
+
+    /// <summary>
+    /// True when <paramref name="ex"/> is a TRANSIENT database connect/timeout fault worth a
+    /// bounded retry: a <see cref="DbException"/> whose <see cref="DbException.SqlState"/> is in
+    /// the connection class, or one wrapping a network-level <see cref="TimeoutException"/> /
+    /// <see cref="System.Net.Sockets.SocketException"/> / <see cref="IOException"/> (the shape of
+    /// Npgsql's "Failed to connect … ---&gt; TimeoutException: Timeout during connection attempt").
+    /// A timeout WITHOUT a database exception in the chain is NOT matched — hub/request timeouts
+    /// have their own policy (<c>AreaErrorClassifier.IsTransientHubFailure</c>) and must not be
+    /// double-retried here.
+    /// </summary>
+    public static bool IsTransientConnectFault(Exception? ex)
+    {
+        var seenDbException = false;
+        for (var e = ex; e != null; e = e.InnerException)
+        {
+            switch (e)
+            {
+                case DbException db:
+                    var sqlState = db.SqlState;
+                    if (sqlState is not null && TransientConnectSqlStates.Contains(sqlState))
+                        return true;
+                    seenDbException = true;
+                    break;
+                // The network-level cause INSIDE a driver exception (drivers wrap the socket
+                // fault; the DbException is always the OUTER frame, so walking outer→inner
+                // seeing the DbException first is the invariant this flag encodes).
+                case TimeoutException or System.Net.Sockets.SocketException or IOException
+                    when seenDbException:
+                    return true;
+            }
+        }
+        return false;
+    }
+
+    /// <summary>
+    /// Wraps a COLD storage-backed observable so that an error accepted by
+    /// <paramref name="shouldRetry"/> arriving BEFORE the first emission resubscribes the source
+    /// after an exponentially growing, scheduler-driven delay — at most
+    /// <paramref name="maxRetries"/> times — then surfaces the last error. Non-retryable errors,
+    /// and any error after the stream has emitted, propagate immediately.
+    ///
+    /// <para><b>Why pre-first-emission only.</b> The providers' query observables are change
+    /// feeds: one Initial frame, then live deltas. The fault this heals is the initial SQL read
+    /// failing to obtain a connection — retrying THAT re-runs a read that produced nothing, which
+    /// is free. Resubscribing after the Initial has been delivered would mint a SECOND Initial
+    /// into a merge whose one-Initial-per-provider accounting has already closed; mid-stream
+    /// faults therefore keep their existing semantics (propagate to the consumer, whose own layers
+    /// — the area retry, the stream-cache breaker — own that recovery).</para>
+    /// </summary>
+    /// <param name="source">The cold provider observable; each resubscription re-runs the query.</param>
+    /// <param name="shouldRetry">Selects retryable errors; defaults to <see cref="IsTransientConnectFault"/>.</param>
+    /// <param name="maxRetries">Bounded retry budget; defaults to <see cref="DefaultMaxRetries"/>.</param>
+    /// <param name="baseDelay">First backoff step (doubles per retry); defaults to <see cref="DefaultBaseDelay"/>.</param>
+    /// <param name="scheduler">Backoff timer scheduler (inject a TestScheduler in tests).</param>
+    /// <param name="onRetry">Diagnostic hook invoked per scheduled retry: (error, attempt, delay).</param>
+    public static IObservable<T> RetryTransientConnect<T>(
+        this IObservable<T> source,
+        Func<Exception, bool>? shouldRetry = null,
+        int maxRetries = DefaultMaxRetries,
+        TimeSpan? baseDelay = null,
+        IScheduler? scheduler = null,
+        Action<Exception, int, TimeSpan>? onRetry = null)
+    {
+        ArgumentNullException.ThrowIfNull(source);
+        var accept = shouldRetry ?? IsTransientConnectFault;
+        var sched = scheduler ?? DefaultScheduler.Instance;
+        var stepMs = (baseDelay ?? DefaultBaseDelay).TotalMilliseconds;
+
+        return Observable.Defer(() =>
+        {
+            // Monotonic per consumer subscription, deliberately NOT reset per attempt: once
+            // anything has been delivered downstream, no later fault may trigger a resubscribe
+            // (see the pre-first-emission contract above).
+            var emitted = false;
+            return source
+                .Do(_ => emitted = true)
+                .RetryWhen(errors => errors
+                    .Scan(
+                        new RetryState(0, null, TimeSpan.Zero, false),
+                        (state, error) => Next(state, error, emitted, accept, maxRetries, stepMs))
+                    .SelectMany(state =>
+                    {
+                        if (state.GiveUp)
+                            return Observable.Throw<long>(state.Error!);
+                        onRetry?.Invoke(state.Error!, state.Attempt, state.Delay);
+                        return Observable.Timer(state.Delay, sched);
+                    }));
+        });
+    }
+
+    // The retry decision as a pure state transition (mirrors AreaStreamRetry) — testable as an
+    // assertion, not a timing observation.
+    private sealed record RetryState(int Attempt, Exception? Error, TimeSpan Delay, bool GiveUp);
+
+    private static RetryState Next(
+        RetryState state, Exception error, bool emitted,
+        Func<Exception, bool> shouldRetry, int maxRetries, double stepMs)
+    {
+        if (emitted || !shouldRetry(error) || state.Attempt >= maxRetries)
+            return new RetryState(state.Attempt, error, TimeSpan.Zero, true);
+        var attempt = state.Attempt + 1;
+        return new RetryState(
+            attempt, error, TimeSpan.FromMilliseconds(stepMs * (1L << (attempt - 1))), false);
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/MeshQueryTransientRetryTest.cs
+++ b/test/MeshWeaver.Hosting.Test/MeshQueryTransientRetryTest.cs
@@ -1,0 +1,282 @@
+using System;
+using System.Collections.Generic;
+using System.Data.Common;
+using System.Linq;
+using System.Net.Sockets;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Persistence.Query;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins the bounded transient-connect retry the query fan-in composes on every provider
+/// observable (issue #2521: a single timed-out Npgsql connector open —
+/// <c>PoolingDataSource.OpenNewConnector → RawOpen → TimeoutException</c> — failed the whole
+/// layout-area render; warm pooled connections kept working, so only renders needing a fresh
+/// connector died, in bursts). The contract, all on virtual time:
+/// <list type="bullet">
+///   <item>a transient connect fault BEFORE the first emission is retried a bounded number of
+///     times with exponential backoff, then the LAST error surfaces on OnError;</item>
+///   <item>a non-transient error fails fast — one subscription, no delay;</item>
+///   <item>an error AFTER the first emission propagates immediately (a resubscribe there would
+///     mint a second Initial into a merge whose per-provider accounting already closed);</item>
+///   <item>the classifier matches ONLY the transient connect/timeout class on the BCL
+///     <see cref="DbException"/> surface — core does not reference Npgsql.</item>
+/// </list>
+/// </summary>
+public class MeshQueryTransientRetryTest
+{
+    /// <summary>
+    /// Stand-in for a driver exception (NpgsqlException derives from <see cref="DbException"/>);
+    /// core never references the driver, so neither does this test.
+    /// </summary>
+    private sealed class FakeDbException(string message, Exception? inner = null, string? sqlState = null)
+        : DbException(message, inner)
+    {
+        public override string? SqlState { get; } = sqlState;
+    }
+
+    /// <summary>The #2521 incident shape: "Failed to connect …" wrapping a connect timeout.</summary>
+    private static DbException ConnectTimeout() =>
+        new FakeDbException("Failed to connect to 10.42.18.4:5432",
+            new TimeoutException("Timeout during connection attempt"));
+
+    // ————————————————————————— classifier
+
+    [Fact]
+    public void Classifier_MatchesOnlyTheTransientConnectClass()
+    {
+        // The incident shape and its network-level variants.
+        TransientStorageFaults.IsTransientConnectFault(ConnectTimeout()).Should().BeTrue();
+        TransientStorageFaults.IsTransientConnectFault(
+            new FakeDbException("connect", new SocketException())).Should().BeTrue();
+        TransientStorageFaults.IsTransientConnectFault(
+            new FakeDbException("connect", new System.IO.IOException("broken pipe"))).Should().BeTrue();
+        // Wrapped one level deeper (providers re-wrap driver faults).
+        TransientStorageFaults.IsTransientConnectFault(
+            new InvalidOperationException("query failed", ConnectTimeout())).Should().BeTrue();
+
+        // Server-side connection-class SQLSTATEs.
+        foreach (var state in new[] { "08000", "08006", "57P03", "53300" })
+            TransientStorageFaults.IsTransientConnectFault(
+                    new FakeDbException("server refusing", sqlState: state))
+                .Should().BeTrue($"SQLSTATE {state} is a transient connect refusal");
+
+        // Real query/schema errors are NOT transient — they must propagate.
+        TransientStorageFaults.IsTransientConnectFault(
+            new FakeDbException("undefined_table", sqlState: "42P01")).Should().BeFalse();
+        TransientStorageFaults.IsTransientConnectFault(
+            new FakeDbException("unique_violation", sqlState: "23505")).Should().BeFalse();
+        // In-query races belong to the layer owning the statement, not the query fan-in.
+        TransientStorageFaults.IsTransientConnectFault(
+            new FakeDbException("deadlock_detected", sqlState: "40P01")).Should().BeFalse();
+
+        // A timeout WITHOUT a database exception is a hub/request timeout — different policy.
+        TransientStorageFaults.IsTransientConnectFault(new TimeoutException()).Should().BeFalse();
+        TransientStorageFaults.IsTransientConnectFault(new OperationCanceledException()).Should().BeFalse();
+        TransientStorageFaults.IsTransientConnectFault(null).Should().BeFalse();
+    }
+
+    // ————————————————————————— retry chain (virtual time)
+
+    [Fact]
+    public void TransientFault_RetriesBoundedThenSurfacesLastError()
+    {
+        var scheduler = new TestScheduler();
+        var subscribeCount = 0;
+        var last = ConnectTimeout();
+        var source = Observable.Defer(() =>
+        {
+            subscribeCount++;
+            return Observable.Throw<int>(last, scheduler);
+        });
+
+        var observer = scheduler.CreateObserver<int>();
+        var retries = new List<(int Attempt, TimeSpan Delay)>();
+        source
+            .RetryTransientConnect(scheduler: scheduler,
+                onRetry: (_, attempt, delay) => retries.Add((attempt, delay)))
+            .Subscribe(observer);
+        scheduler.Start();
+
+        // 1 initial subscription + DefaultMaxRetries resubscriptions — bounded, never a spin.
+        subscribeCount.Should().Be(1 + TransientStorageFaults.DefaultMaxRetries);
+        // Exponential backoff: 250 → 500 → 1000 ms.
+        retries.Select(r => r.Delay.TotalMilliseconds).Should().Equal(250, 500, 1000);
+        // Terminal: the LAST error, surfaced — not swallowed, not replaced.
+        observer.Messages.Should().HaveCount(1);
+        observer.Messages[0].Value.Kind.Should().Be(NotificationKind.OnError);
+        observer.Messages[0].Value.Exception.Should().BeSameAs(last);
+    }
+
+    [Fact]
+    public void TransientFault_RecoveringWithinBudget_EmitsNormally()
+    {
+        var scheduler = new TestScheduler();
+        var subscribeCount = 0;
+        var source = Observable.Defer(() =>
+        {
+            subscribeCount++;
+            return subscribeCount < 3
+                ? Observable.Throw<int>(ConnectTimeout(), scheduler)
+                : Observable.Return(42, scheduler);
+        });
+
+        var observer = scheduler.CreateObserver<int>();
+        source.RetryTransientConnect(scheduler: scheduler).Subscribe(observer);
+        scheduler.Start();
+
+        subscribeCount.Should().Be(3);
+        observer.Messages.Should().HaveCount(2); // OnNext(42) + OnCompleted
+        observer.Messages[0].Value.Value.Should().Be(42);
+        observer.Messages[1].Value.Kind.Should().Be(NotificationKind.OnCompleted);
+    }
+
+    [Fact]
+    public void NonTransientError_FailsFast_NoRetry()
+    {
+        var scheduler = new TestScheduler();
+        var subscribeCount = 0;
+        var source = Observable.Defer(() =>
+        {
+            subscribeCount++;
+            return Observable.Throw<int>(new FakeDbException("undefined_table", sqlState: "42P01"), scheduler);
+        });
+
+        var observer = scheduler.CreateObserver<int>();
+        source.RetryTransientConnect(scheduler: scheduler).Subscribe(observer);
+        scheduler.Start();
+
+        subscribeCount.Should().Be(1);
+        observer.Messages.Should().HaveCount(1);
+        observer.Messages[0].Value.Kind.Should().Be(NotificationKind.OnError);
+    }
+
+    [Fact]
+    public void TransientFault_AfterFirstEmission_PropagatesWithoutResubscribe()
+    {
+        var scheduler = new TestScheduler();
+        var subscribeCount = 0;
+        // Emits once (the Initial), then dies with a transient fault — the live-feed shape.
+        var source = Observable.Defer(() =>
+        {
+            subscribeCount++;
+            return Observable.Return(1, scheduler)
+                .Concat(Observable.Throw<int>(ConnectTimeout(), scheduler));
+        });
+
+        var observer = scheduler.CreateObserver<int>();
+        source.RetryTransientConnect(scheduler: scheduler).Subscribe(observer);
+        scheduler.Start();
+
+        // No resubscribe: a second attempt would mint a second Initial into a closed merge.
+        subscribeCount.Should().Be(1);
+        observer.Messages.Should().HaveCount(2);
+        observer.Messages[0].Value.Value.Should().Be(1);
+        observer.Messages[1].Value.Kind.Should().Be(NotificationKind.OnError);
+    }
+
+    // ————————————————————————— through the MeshQuery fan-in (the actual caller)
+
+    private static readonly JsonSerializerOptions Options = new();
+
+    private sealed class FakeProvider(string name, Func<IObservable<QueryResultChange<MeshNode>>> factory)
+        : IMeshQueryProvider
+    {
+        public string Name => name;
+
+        public bool Matches(IReadOnlyList<string> queryNamespaces) => true;
+
+        public IObservable<QueryResultChange<T>> Query<T>(MeshQueryRequest request, JsonSerializerOptions options)
+            => (IObservable<QueryResultChange<T>>)factory();
+
+        public IObservable<IReadOnlyCollection<QueryResult>> Query(MeshQueryRequest request, JsonSerializerOptions options)
+            => Observable.Return((IReadOnlyCollection<QueryResult>)Array.Empty<QueryResult>());
+
+        public IObservable<IReadOnlyCollection<QueryResult>> Autocomplete(
+            string basePath, string prefix, JsonSerializerOptions options,
+            AutocompleteMode mode = AutocompleteMode.RelevanceFirst, int limit = 10,
+            string? contextPath = null, string? context = null)
+            => Observable.Return((IReadOnlyCollection<QueryResult>)Array.Empty<QueryResult>());
+
+        public IObservable<T?> Select<T>(string path, string property, JsonSerializerOptions options)
+            => Observable.Return<T?>(default);
+    }
+
+    private static QueryResultChange<MeshNode> Initial(params MeshNode[] nodes) => new()
+    {
+        ChangeType = QueryChangeType.Initial,
+        Items = nodes,
+        Timestamp = DateTimeOffset.UtcNow,
+    };
+
+    private static MeshNode Node(string path) => new(path.Split('/').Last(),
+        path.Contains('/') ? path[..path.LastIndexOf('/')] : null)
+    {
+        Name = path,
+        NodeType = "Markdown",
+        State = MeshNodeState.Active,
+    };
+
+    /// <summary>
+    /// The fault-injected end-to-end shape: a provider whose FIRST subscription dies with the
+    /// #2521 connect timeout and whose second succeeds — exactly what a blip during
+    /// <c>OpenNewConnector</c> looks like from the fan-in. The consumer must receive the Initial,
+    /// not the error (real scheduler; one 250 ms backoff).
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task MeshQuery_TransientConnectBlip_HealsWithinTheBoundedRetry()
+    {
+        var subscribeCount = 0;
+        var flaky = new FakeProvider("flaky", () => Observable.Defer(() =>
+            ++subscribeCount == 1
+                ? Observable.Throw<QueryResultChange<MeshNode>>(ConnectTimeout())
+                : Observable.Return(Initial(Node("a/one")))));
+
+        var query = new MeshQuery([flaky], hub: null!);
+
+        var change = await ((IMeshQueryCore)query)
+            .Query<MeshNode>(new MeshQueryRequest { Query = "nodeType:Markdown", Limit = 10 }, Options)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(10))
+            .ToTask();
+
+        subscribeCount.Should().Be(2, "the fan-in retries the transient connect fault once");
+        change.ChangeType.Should().Be(QueryChangeType.Initial);
+        change.Items.Select(n => n.Path).Should().Equal("a/one");
+    }
+
+    /// <summary>
+    /// A PERSISTENT outage exhausts the bound and the consumer sees the real error — the retry
+    /// must never convert a hard failure into silence or an empty result.
+    /// </summary>
+    [Fact(Timeout = 30_000)]
+    public async Task MeshQuery_PersistentConnectFailure_SurfacesTheErrorAfterTheBudget()
+    {
+        var subscribeCount = 0;
+        var down = new FakeProvider("down", () => Observable.Defer(() =>
+        {
+            subscribeCount++;
+            return Observable.Throw<QueryResultChange<MeshNode>>(ConnectTimeout());
+        }));
+
+        var query = new MeshQuery([down], hub: null!);
+
+        var act = () => ((IMeshQueryCore)query)
+            .Query<MeshNode>(new MeshQueryRequest { Query = "nodeType:Markdown", Limit = 10 }, Options)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(15))
+            .ToTask();
+
+        await act.Should().ThrowAsync<DbException>();
+        subscribeCount.Should().Be(1 + TransientStorageFaults.DefaultMaxRetries);
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/MeshWeaver.Hosting.Test.csproj
+++ b/test/MeshWeaver.Hosting.Test/MeshWeaver.Hosting.Test.csproj
@@ -12,5 +12,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" />
     <!-- PathResolutionCachePoisonTest stubs IMessageHub / IMeshQueryCore. -->
     <PackageReference Include="NSubstitute" />
+    <!-- MeshQueryTransientRetryTest drives the transient-connect retry backoff on virtual time. -->
+    <PackageReference Include="Microsoft.Reactive.Testing" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## What

Fixes #2521 — a single timed-out Npgsql connector open (`PoolingDataSource.OpenNewConnector → RawOpen → TimeoutException`) failed the whole layout-area render ("Rendering failed for area Overview/Lesson"), in recurring bursts across days and pods, while warm pooled connections kept serving.

## How

`MeshQuery.MergeProviderObservables` — the query fan-in every `Query<T>` / `IMeshQueryCore` consumer (layout areas included) flows through — now wraps each provider observable with a **bounded, pre-first-emission retry** (new `TransientStorageFaults`, the `AreaStreamRetry` shape):

- exponential backoff on `Observable.Timer` (250 → 500 → 1000 ms, max 3 retries), scheduler-injectable;
- a `shouldRetry` predicate matching **only** the transient connect/timeout class — a `DbException` wrapping a `TimeoutException`/`SocketException`/`IOException`, or a connection-class SQLSTATE (08xxx, 57P01–57P03, 53300, 53400). Classified on the BCL `DbException` surface: core does not reference Npgsql. Real query/schema errors (42P01, 23505), in-query races (40001/40P01), hub timeouts, and cancellations propagate unchanged;
- the **last error surfaces** on the consumer's OnError once the budget is spent — never swallowed, never an empty result;
- **pre-first-emission only**: retrying after the Initial would mint a second Initial into a merge whose per-provider accounting already closed; mid-stream faults keep their existing semantics.

Doctrine: the retry composes in the caller's reactive chain, **outside** the adapters' capped `IIoPool` leaves — the provider observables are cold, so each resubscription re-enters `pg:{adapter}`/`pg-read:{adapter}` from outside; no waiters stack inside the capped pool, and no `SemaphoreSlim`/`Task.Delay` anywhere.

## Tests

`MeshQueryTransientRetryTest` (test/MeshWeaver.Hosting.Test): classifier boundary pins; virtual-time (TestScheduler) retry-chain pins (bounded + backoff sequence + last-error surfaced, fail-fast on non-transient, no resubscribe after first emission); and fault-injected end-to-end through `MeshQuery` with a provider that dies once with the exact #2521 exception shape then succeeds (heals), plus a persistently-down provider (error surfaces after the budget). Full `MeshWeaver.Hosting.Test` suite green locally (252/252, Release).

What's New: `Category: Fix` entry included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)