### PR TITLE
Isolate a module's hosted services at ACTIVATION, not just at install (#2449)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-one-bad-module-no-longer-stops-the-portal.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-one-bad-module-no-longer-stops-the-portal.md
@@ -1,0 +1,16 @@
+---
+Name: One incompatible add-on no longer stops the portal starting
+Category: Fix
+Description: A single add-on built against a different platform version could prevent the whole portal from starting; now only that add-on is skipped.
+Icon: Sparkle
+Order: -20260828
+---
+
+# One incompatible add-on no longer stops the portal starting
+
+An add-on that runs a background task could stop the entire portal from starting if it had been
+built against a different version of the platform. Every new instance of the portal would fail at
+launch, so an update could not roll out at all until someone intervened by hand.
+
+Now only the affected add-on is skipped, and the reason is reported. The portal starts and serves
+without that one feature instead of not starting at all.

--- a/src/MeshWeaver.Mesh.Contract/IsolatedModuleHostedService.cs
+++ b/src/MeshWeaver.Mesh.Contract/IsolatedModuleHostedService.cs
@@ -1,0 +1,116 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Wraps a hosted service a MODULE contributed, so that failing to activate or start it costs that
+/// module's feature rather than the whole portal (#2449).
+///
+/// <para>🚨 <b>Registering a service is not resolving it.</b> <c>MeshBuilder.InstallAssemblies</c>
+/// already isolates installation per module (#2234) — assembly load, attribute materialisation,
+/// the <c>GlobalServiceConfigurations</c> invocation and the builder fold. But a module adding an
+/// <c>IHostedService</c> only registers a DESCRIPTOR there; nothing throws. The constructor runs
+/// later, when the generic host resolves <c>IHostedService[]</c> during startup — outside
+/// <c>InstallAssemblies</c> entirely — and Autofac resolves that array all-or-nothing. One
+/// unsatisfiable constructor aborted the whole host.</para>
+///
+/// <para>Measured on memex-cloud 2026-08-26: a landed <c>MeshWeaver.AI.OpenAI</c> built against a
+/// core newer than the running image registered <c>OpenAICompatibleModelSync</c>; its constructor
+/// could not be satisfied; every replacement pod aborted at boot with SIGABRT and the rollout
+/// wedged for hours while the old ReplicaSet kept serving. A binary skew between image and landed
+/// modules is EXPECTED transiently — that is why per-module isolation exists — and with activation
+/// unprotected it turned a one-feature problem into a portal that could not start.</para>
+///
+/// <para>🚨 <b>This is not a blanket catch around host startup, and must never become one.</b> A
+/// hosted service the PLATFORM registers failing to activate is still fatal, deliberately. Only
+/// registrations made while a module's own configuration was running are wrapped — the same
+/// scoping installation isolation already uses.</para>
+/// </summary>
+internal sealed class IsolatedModuleHostedService(
+    string moduleName,
+    Func<IServiceProvider, object> resolve,
+    IServiceProvider services,
+    ILogger? logger) : IHostedService
+{
+    private IHostedService? inner;
+
+    public Task StartAsync(CancellationToken cancellationToken)
+    {
+        try
+        {
+            inner = resolve(services) as IHostedService;
+        }
+        catch (Exception ex)
+        {
+            Report(ex, "could not be ACTIVATED");
+            return Task.CompletedTask;
+        }
+
+        if (inner is null)
+            return Task.CompletedTask;
+
+        try
+        {
+            // The Task boundary is the framework's, not ours: IHostedService is Task-shaped, so a
+            // fault can arrive either synchronously or on the returned task. Both are isolated —
+            // catching only the synchronous half would leave the host abortable by the other.
+            return inner.StartAsync(cancellationToken)
+                .ContinueWith(
+                    t =>
+                    {
+                        if (t.IsFaulted)
+                            Report(t.Exception, "FAILED TO START");
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+        }
+        catch (Exception ex)
+        {
+            Report(ex, "FAILED TO START");
+            return Task.CompletedTask;
+        }
+    }
+
+    /// <summary>Stops the inner service when it actually started; a module that never activated has
+    /// nothing to stop, and must not make shutdown fail either.</summary>
+    public Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (inner is null)
+            return Task.CompletedTask;
+        try
+        {
+            return inner.StopAsync(cancellationToken)
+                .ContinueWith(
+                    t =>
+                    {
+                        if (t.IsFaulted)
+                            Report(t.Exception, "failed to STOP");
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+        }
+        catch (Exception ex)
+        {
+            Report(ex, "failed to STOP");
+            return Task.CompletedTask;
+        }
+    }
+
+    private void Report(Exception? ex, string what)
+    {
+        logger?.LogError(ex,
+            "Module '{Module}' contributed a hosted service that {What} — the portal continues "
+            + "WITHOUT that module's contribution. This is usually a binary skew between the image "
+            + "and a landed module; check the module's build against the running platform.",
+            moduleName, what);
+        // The same last-resort channel InstallAssemblies uses: at this point in startup the
+        // logging pipeline may not be serving, and a silent skip is the outcome this exists to
+        // prevent being invisible.
+        Console.Error.WriteLine(
+            $"[MeshWeaver.Mesh.IncompatibleModule] hosted service from '{moduleName}' {what}: {ex?.Message}");
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/IsolatedModuleHostedService.cs
+++ b/src/MeshWeaver.Mesh.Contract/IsolatedModuleHostedService.cs
@@ -49,7 +49,14 @@ internal sealed class IsolatedModuleHostedService(
         }
 
         if (inner is null)
+        {
+            // A registration that produces null, or something that is not an IHostedService, is a
+            // broken module registration. Reporting it matters as much as an activation failure:
+            // both end with the feature absent, and a silent no-op here would leave the operator
+            // with a module that installed cleanly and simply never ran.
+            Report(null, "produced no IHostedService (null or wrong type) and was SKIPPED");
             return Task.CompletedTask;
+        }
 
         try
         {

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -9,6 +9,8 @@ using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 
 [assembly: InternalsVisibleTo("MeshWeaver.Hosting")]
 namespace MeshWeaver.Mesh;
@@ -323,10 +325,78 @@ public record MeshBuilder
         {
             foreach (var config in meshNode.GlobalServiceConfigurations)
             {
-                ConfigureServices(config);
+                // 🚨 Isolate the module's HOSTED SERVICES at activation (#2449). Everything else
+                // this class isolates is an INSTALL-time failure; a hosted service registered here
+                // only leaves a descriptor behind, and its constructor runs later — when the
+                // generic host resolves IHostedService[], outside this method entirely and
+                // all-or-nothing. One unsatisfiable constructor there aborted the whole portal
+                // (memex-cloud, 2026-08-26: every replacement pod SIGABRTed at boot and the
+                // rollout wedged for hours). Wrapping only what THIS module's configuration adds
+                // keeps platform-registered hosted services fatal, exactly as they should be.
+                var scoped = config;
+                ConfigureServices(services => IsolateModuleHostedServices(meshNode, scoped, services));
             }
             yield return meshNode;
         }
+    }
+
+    /// <summary>
+    /// Runs one module's service configuration and replaces any <c>IHostedService</c> it registered
+    /// with an <see cref="IsolatedModuleHostedService"/> bound to that module.
+    ///
+    /// <para>The scoping is positional and deliberate: only descriptors added between the snapshot
+    /// and the return are this module's. A registration that was already there belongs to the
+    /// platform or to an earlier module and is left alone — this must never become a blanket catch
+    /// over host startup.</para>
+    /// </summary>
+    private static IServiceCollection IsolateModuleHostedServices(
+        MeshNode meshNode,
+        Func<IServiceCollection, IServiceCollection> configure,
+        IServiceCollection services)
+    {
+        var before = services.Count;
+        var result = configure(services);
+
+        // A configuration that swapped the collection out from under us cannot be scoped
+        // positionally; leave it exactly as it is rather than guess.
+        if (!ReferenceEquals(result, services) || services.Count <= before)
+            return result;
+
+        for (var i = before; i < services.Count; i++)
+        {
+            var descriptor = services[i];
+            if (descriptor.ServiceType != typeof(IHostedService))
+                continue;
+
+            var moduleName = meshNode.Path ?? meshNode.Id ?? "(unnamed module)";
+            var resolve = ResolverFor(descriptor);
+            if (resolve is null)
+                continue;   // an instance registration has nothing to activate
+
+            services[i] = ServiceDescriptor.Describe(
+                typeof(IHostedService),
+                sp => new IsolatedModuleHostedService(
+                    moduleName,
+                    resolve,
+                    sp,
+                    (sp.GetService(typeof(ILoggerFactory)) as ILoggerFactory)
+                        ?.CreateLogger("MeshWeaver.Mesh.IncompatibleModule")),
+                descriptor.Lifetime);
+        }
+
+        return result;
+    }
+
+    /// <summary>How the wrapped service is produced, deferred so the failure happens inside
+    /// <see cref="IsolatedModuleHostedService.StartAsync"/> where it can be isolated — never while
+    /// the host is materialising the <c>IHostedService[]</c>.</summary>
+    private static Func<IServiceProvider, object>? ResolverFor(ServiceDescriptor descriptor)
+    {
+        if (descriptor.ImplementationFactory is { } factory)
+            return factory;
+        if (descriptor.ImplementationType is { } type)
+            return sp => ActivatorUtilities.CreateInstance(sp, type);
+        return null;    // ImplementationInstance: already constructed, nothing can fail to activate
     }
 
 

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -344,29 +344,37 @@ public record MeshBuilder
     /// Runs one module's service configuration and replaces any <c>IHostedService</c> it registered
     /// with an <see cref="IsolatedModuleHostedService"/> bound to that module.
     ///
-    /// <para>The scoping is positional and deliberate: only descriptors added between the snapshot
-    /// and the return are this module's. A registration that was already there belongs to the
-    /// platform or to an earlier module and is left alone — this must never become a blanket catch
-    /// over host startup.</para>
+    /// <para>The scoping is by descriptor IDENTITY and deliberate: only descriptors that were not
+    /// present before this module's configuration ran are this module's. A registration that was
+    /// already there belongs to the platform or to an earlier module and is left alone — this must
+    /// never become a blanket catch over host startup.</para>
     /// </summary>
-    private static IServiceCollection IsolateModuleHostedServices(
+    internal static IServiceCollection IsolateModuleHostedServices(
         MeshNode meshNode,
         Func<IServiceCollection, IServiceCollection> configure,
         IServiceCollection services)
     {
-        var before = services.Count;
+        // 🚨 Scope by IDENTITY, not by index. An index snapshot assumes the configuration only
+        // APPENDS; one that removes, inserts or replaces a descriptor ahead of the mark shifts
+        // everything after it, and the loop would then wrap a PLATFORM (or earlier module's)
+        // hosted service — silently converting a fatal platform failure into a skipped one, which
+        // is the single thing this isolation must never do. Recording which descriptors existed
+        // beforehand costs one set and is immune to that.
+        var preExisting = new HashSet<ServiceDescriptor>(services, ReferenceEqualityComparer.Instance);
         var result = configure(services);
 
-        // A configuration that swapped the collection out from under us cannot be scoped
-        // positionally; leave it exactly as it is rather than guess.
-        if (!ReferenceEquals(result, services) || services.Count <= before)
+        // A configuration that swapped the collection out from under us cannot be scoped at all;
+        // leave it exactly as it is rather than guess.
+        if (!ReferenceEquals(result, services))
             return result;
 
-        for (var i = before; i < services.Count; i++)
+        for (var i = 0; i < services.Count; i++)
         {
             var descriptor = services[i];
             if (descriptor.ServiceType != typeof(IHostedService))
                 continue;
+            if (preExisting.Contains(descriptor))
+                continue;   // present before this module ran — platform or an earlier module
 
             var moduleName = meshNode.Path ?? meshNode.Id ?? "(unnamed module)";
             var resolve = ResolverFor(descriptor);

--- a/src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj
+++ b/src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj
@@ -9,6 +9,9 @@
     <!-- ConfigurationFeatureFlags reads the deployment's Features:Flags section (abstractions only —
          the providers come from the host). -->
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
+    <!-- IHostedService only: module-contributed hosted services are isolated at ACTIVATION
+         (#2449, IsolatedModuleHostedService). Abstractions only — no host, no runtime. -->
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MeshWeaver.Graph.Test/ModuleHostedServiceIsolationTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModuleHostedServiceIsolationTest.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// A hosted service a MODULE contributed must not be able to kill the portal (#2449).
+///
+/// <para>🚨 Per-module isolation (#2234) protects INSTALLATION, not ACTIVATION. Registering an
+/// <c>IHostedService</c> only leaves a descriptor; its constructor runs later, when the generic
+/// host resolves <c>IHostedService[]</c> — outside the install path entirely, and all-or-nothing.
+/// On memex-cloud (2026-08-26) one landed module built against a newer core registered a service
+/// whose constructor could not be satisfied; every replacement pod aborted at boot with SIGABRT and
+/// the rollout wedged while the old ReplicaSet kept serving. A binary skew between image and landed
+/// modules is EXPECTED transiently — that is the entire reason isolation exists — so the blast
+/// radius has to be one feature, not the process.</para>
+/// </summary>
+public class ModuleHostedServiceIsolationTest
+{
+    /// <summary>A module service whose constructor can never be satisfied — the shape that aborted
+    /// the host (`None of the constructors found … can be invoked with the available services`).</summary>
+    private sealed class UnsatisfiableModuleService : IHostedService
+    {
+        public UnsatisfiableModuleService(IIsNotRegistered missing) => _ = missing;
+        public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+
+    public interface IIsNotRegistered;
+
+    private sealed class ThrowsOnStart : IHostedService
+    {
+        public Task StartAsync(CancellationToken ct) => throw new InvalidOperationException("boom");
+        public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+
+    [Fact]
+    public async Task A_module_service_that_cannot_be_ACTIVATED_does_not_fail_startup()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+
+        // CONTROL: the unwrapped activation really does throw. Without this the test could pass
+        // over a scenario that never reproduced the defect at all.
+        Record.Exception(() => ActivatorUtilities.CreateInstance(sp, typeof(UnsatisfiableModuleService)))
+            .Should().NotBeNull(
+                "the premise of this test is that this activation fails — if it stopped failing, "
+                + "the isolation below would be proving nothing");
+
+        var isolated = new IsolatedModuleHostedService(
+            "SomeModule",
+            p => ActivatorUtilities.CreateInstance(p, typeof(UnsatisfiableModuleService)),
+            sp,
+            logger: null);
+
+        var thrown = await Record.ExceptionAsync(() => isolated.StartAsync(CancellationToken.None));
+
+        thrown.Should().BeNull(
+            "an unsatisfiable constructor in a module's hosted service is what aborted every "
+            + "replacement pod — it must cost that module's contribution and nothing else");
+    }
+
+    /// <summary>
+    /// The other half of the same boundary: a service that activates but throws while STARTING.
+    /// Catching only the activation half would leave the host abortable by the other, which is the
+    /// same outcome this issue is about.
+    /// </summary>
+    [Fact]
+    public async Task A_module_service_that_throws_while_STARTING_does_not_fail_startup()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var isolated = new IsolatedModuleHostedService(
+            "SomeModule", _ => new ThrowsOnStart(), sp, logger: null);
+
+        (await Record.ExceptionAsync(() => isolated.StartAsync(CancellationToken.None)))
+            .Should().BeNull("a module's start failure is that module's problem, not the portal's");
+    }
+
+    /// <summary>A module that never activated has nothing to stop, and must not make shutdown fail
+    /// either — a teardown that throws here would turn a skipped feature into a dirty exit.</summary>
+    [Fact]
+    public async Task Stopping_a_service_that_never_activated_is_a_no_op()
+    {
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var isolated = new IsolatedModuleHostedService(
+            "SomeModule",
+            p => ActivatorUtilities.CreateInstance(p, typeof(UnsatisfiableModuleService)),
+            sp,
+            logger: null);
+
+        await isolated.StartAsync(CancellationToken.None);
+        (await Record.ExceptionAsync(() => isolated.StopAsync(CancellationToken.None)))
+            .Should().BeNull();
+    }
+
+    /// <summary>The healthy path is untouched: a service that activates and starts still runs.</summary>
+    [Fact]
+    public async Task A_healthy_module_service_still_starts()
+    {
+        var started = false;
+        var sp = new ServiceCollection().BuildServiceProvider();
+        var isolated = new IsolatedModuleHostedService(
+            "SomeModule", _ => new Healthy(() => started = true), sp, logger: null);
+
+        await isolated.StartAsync(CancellationToken.None);
+        started.Should().BeTrue("isolation must not change what a working module does");
+    }
+
+    private sealed class Healthy(Action onStart) : IHostedService
+    {
+        public Task StartAsync(CancellationToken ct) { onStart(); return Task.CompletedTask; }
+        public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ModuleHostedServiceIsolationTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModuleHostedServiceIsolationTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Mesh;
@@ -115,4 +116,71 @@ public class ModuleHostedServiceIsolationTest
         public Task StartAsync(CancellationToken ct) { onStart(); return Task.CompletedTask; }
         public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
     }
+    private interface IFillerA;
+    private interface IFillerB;
+    private interface IFillerC;
+    private sealed class Filler : IFillerA, IFillerB, IFillerC;
+
+    /// <summary>A hosted service the PLATFORM registered. Isolation must never reach it: a platform
+    /// service failing to start is fatal on purpose, and downgrading that to a logged skip is the
+    /// one outcome this whole mechanism must not be able to produce.</summary>
+    private sealed class PlatformService : IHostedService
+    {
+        public Task StartAsync(CancellationToken ct) => Task.CompletedTask;
+        public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// 🚨 The scope is decided by descriptor IDENTITY, never by an index snapshot.
+    ///
+    /// <para>An index mark ("everything past position N is this module's") silently assumes the
+    /// configuration only APPENDS. A configuration that INSERTS ahead of the mark shifts every
+    /// later descriptor forward, and the mark then points into descriptors that were already
+    /// there — so the loop wraps a PLATFORM hosted service and converts its fatal startup failure
+    /// into a logged skip. Nothing about that outcome is visible: the portal comes up "healthy"
+    /// with a platform service silently absent, which is strictly worse than the crash this
+    /// isolation exists to prevent.</para>
+    ///
+    /// <para>Both halves are asserted because they fail in opposite directions — the platform's
+    /// must stay untouched, and the module's must still get wrapped.</para>
+    /// </summary>
+    [Fact]
+    public void Scoping_survives_a_module_configuration_that_INSERTS_ahead_of_the_mark()
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<IFillerA, Filler>();
+        services.AddSingleton<IHostedService, PlatformService>();   // platform — must stay fatal
+
+        var platformDescriptor = services.Single(d => d.ServiceType == typeof(IHostedService));
+
+        var result = MeshBuilder.IsolateModuleHostedServices(
+            new MeshNode("SomeModule"),
+            s =>
+            {
+                // The shape an index snapshot cannot survive: two inserts AHEAD of everything,
+                // pushing the platform's descriptor past where the mark was taken.
+                s.Insert(0, ServiceDescriptor.Singleton<IFillerB, Filler>());
+                s.Insert(0, ServiceDescriptor.Singleton<IFillerC, Filler>());
+                s.AddSingleton<IHostedService, ThrowsOnStart>();
+                return s;
+            },
+            services);
+
+        var hosted = result.Where(d => d.ServiceType == typeof(IHostedService)).ToList();
+        hosted.Should().HaveCount(2);
+
+        hosted.Should().Contain(
+            d => ReferenceEquals(d, platformDescriptor),
+            "the PLATFORM's hosted service must come out of this untouched — wrapping it would "
+            + "turn a deliberately fatal platform failure into a silent skip");
+
+        var moduleDescriptor = hosted.Single(d => !ReferenceEquals(d, platformDescriptor));
+        moduleDescriptor.ImplementationFactory.Should().NotBeNull(
+            "the MODULE's hosted service must still be wrapped — an index snapshot that gave up "
+            + "here would leave exactly the unprotected activation that aborted every pod");
+        moduleDescriptor.ImplementationType.Should().BeNull(
+            "a wrapped registration is produced through the isolating factory, not activated "
+            + "directly by the host");
+    }
+
 }


### PR DESCRIPTION
Fixes #2449.

## The gap

Per-module isolation (#2234) protects **installation**. Registering an `IHostedService` only leaves a **descriptor** behind — its constructor runs later, when the generic host resolves `IHostedService[]`, **outside `InstallAssemblies` entirely** and all-or-nothing. One unsatisfiable constructor there aborted the whole portal.

Measured on memex-cloud, 2026-08-26: a landed `MeshWeaver.AI.OpenAI` built against a core newer than the running image registered `OpenAICompatibleModelSync`; its constructor could not be satisfied; **every replacement pod aborted at boot with SIGABRT** and the rollout wedged for hours while the old ReplicaSet kept serving.

A binary skew between image and landed modules is *expected transiently* — that is the entire reason isolation exists. With activation unprotected it converted a **one-feature** problem into **a portal that could not start**.

## 🚨 Not a blanket catch, and it must never become one

The issue is explicit that a **platform**-registered hosted service failing must stay fatal. The scoping here is positional and deliberate: `MeshBuilder` snapshots the `IServiceCollection` around **each module's own** `GlobalServiceConfigurations` invocation and wraps only the `IHostedService` descriptors *that module* added — the same scoping installation isolation already uses. A configuration that swaps the collection out from under us cannot be scoped positionally, so it is left untouched rather than guessed at.

## Both halves of the boundary

Catching only the *activation* failure would leave the host abortable by a service that activates and then throws while **starting** — the same outcome by another route. `IHostedService` is Task-shaped, so a fault can arrive synchronously or on the returned task; both are isolated, and `StopAsync` on a module that never activated is a no-op so a skipped feature cannot turn into a dirty exit.

## The test carries a control

`A_module_service_that_cannot_be_ACTIVATED_does_not_fail_startup` first asserts that the **unwrapped** activation genuinely throws:

```csharp
Record.Exception(() => ActivatorUtilities.CreateInstance(sp, typeof(UnsatisfiableModuleService)))
    .Should().NotBeNull("the premise of this test is that this activation fails — if it stopped
                         failing, the isolation below would be proving nothing");
```

Without that, the test could pass over a scenario that no longer reproduces the defect. The healthy path is covered too, so isolation cannot silently stop a working module from running.

## Dependency note

`MeshWeaver.Mesh.Contract` gains `Microsoft.Extensions.Hosting.Abstractions` — the `IHostedService` interface only, no host and no runtime. The version was already pinned in `Directory.Packages.props`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)