### PR TITLE
A release request is recognised by WHAT it asks for, not WHEN it was asked (#2544)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-one-change-one-rebuild.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-one-change-one-rebuild.md
@@ -1,0 +1,18 @@
+---
+Name: One change rebuilds a type once, not several times
+Category: Fix
+Description: A single edit or install could rebuild the same type several times over, interrupting anyone viewing a page built from it.
+Icon: Sparkle
+Order: -20260828
+---
+
+# One change rebuilds a type once, not several times
+
+A single change — saving an edit, pushing, installing a package — could rebuild the same type
+several times in a row. Each rebuild interrupted whatever was open: pages built from that type
+reloaded, and the "a newer build is available" prompt appeared again and again. A slide deck being
+presented could rebuild while it was on screen.
+
+Repeat rebuilds that would produce exactly the same result are now recognised as such and skipped.
+If the content really has changed in between, it still rebuilds — and asking for a rebuild
+explicitly always does one.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -584,7 +584,14 @@ internal static class NodeTypeCompilationHelpers
                     {
                         Content = def with
                         {
-                            CompilationStatus = CompilationStatus.Pending,
+                            CompilationStatus = CompilationStatus.Pending, 
+                            // 🚨 CLEAR the watcher's stamp (#2544). This flip does not come from
+                            // the release watcher and records no inputs, so leaving a previous
+                            // dispatch's token behind would let a later request be absorbed
+                            // against a compile nobody can vouch for — and if that compile fails,
+                            // the absorbed release request is simply lost. Null means "unstamped",
+                            // and the absorber parks on it exactly as it did before this change.
+                            DispatchedBuildInputs = null,
                         }
                     };
                 }).Subscribe(_ => { },
@@ -636,7 +643,7 @@ internal static class NodeTypeCompilationHelpers
                     if (def.CompilationStatus != CompilationStatus.Compiling) return curr;
                     return curr with
                     {
-                        Content = def with { CompilationStatus = CompilationStatus.Pending }
+                        Content = def with { CompilationStatus = CompilationStatus.Pending, DispatchedBuildInputs = null }
                     };
                 }).Subscribe(_ => { },
                     ex => logger?.LogWarning(ex,
@@ -758,7 +765,7 @@ internal static class NodeTypeCompilationHelpers
                     if (!HasStaleFrameworkBuild(def, guards)) return curr;
                     return curr with
                     {
-                        Content = def with { CompilationStatus = CompilationStatus.Pending }
+                        Content = def with { CompilationStatus = CompilationStatus.Pending, DispatchedBuildInputs = null }
                     };
                 }).Subscribe(_ => { },
                     ex => logger?.LogWarning(ex,
@@ -1490,9 +1497,9 @@ internal static class NodeTypeCompilationHelpers
                             // an UNSTAMPED in-flight compile (a direct Pending flip from one of the
                             // kickoff paths, which never sets the token) parks exactly as before —
                             // absorbing against an unknown input set would be a guess.
-                            var inFlightToken = BuildInputsToken(
+                            var requestedToken = BuildInputsToken(
                                 GuardsOf(hub).ModulesHash, def.CurrentSourceVersions);
-                            if (IsSatisfiedByInFlightCompile(def, inFlightToken))
+                            if (IsSatisfiedByInFlightCompile(def, requestedToken))
                             {
                                 logger?.LogInformation(
                                     "[ReleaseRequestWatcher] {HubPath}: release request absorbed — a "
@@ -1833,10 +1840,10 @@ internal static class NodeTypeCompilationHelpers
     ///   guess; park instead, exactly as before.</item>
     /// </list>
     /// </summary>
-    internal static bool IsSatisfiedByInFlightCompile(NodeTypeDefinition def, string inFlightToken)
+    internal static bool IsSatisfiedByInFlightCompile(NodeTypeDefinition def, string requestedToken)
         => !def.RequestedReleaseForce
            && def.DispatchedBuildInputs is { } dispatched
-           && string.Equals(dispatched, inFlightToken, StringComparison.Ordinal);
+           && string.Equals(dispatched, requestedToken, StringComparison.Ordinal);
 
     internal static string BuildInputsToken(
         string? modulesHash, IReadOnlyDictionary<string, long>? sources) =>
@@ -2005,7 +2012,8 @@ internal static class NodeTypeCompilationHelpers
                 // never writes back at all (process death mid-compile, the parked
                 // re-settle, a poisoned content read).
                 FailedBuildInputs = BuildInputsToken(modulesHash, d.CurrentSourceVersions),
-                CompilationStatus = CompilationStatus.Pending
+                CompilationStatus = CompilationStatus.Pending,
+                DispatchedBuildInputs = null
             }
         };
     }

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -1474,7 +1474,45 @@ internal static class NodeTypeCompilationHelpers
                         // compile with the user's latest edits.
                         if (def.CompilationStatus is CompilationStatus.Pending
                                                   or CompilationStatus.Compiling)
+                        {
+                            // 🚨 CONSUME a trigger the in-flight compile already satisfies (#2544).
+                            // Parking every such trigger is what turned one logical event into N
+                            // sequential compiles: the high-water is deliberately not advanced, so
+                            // the trigger re-fires on the FIRST COMPILE'S OWN terminal write-back —
+                            // the compile does not re-trigger itself, it is the clock that releases
+                            // the next queued one. Measured in production as pairs 65 ms apart and
+                            // seven compiles for one merge.
+                            //
+                            // When the in-flight compile was dispatched for exactly these inputs it
+                            // will produce byte-for-byte what this request asks for, so re-running
+                            // it buys nothing and costs an instance-hub invalidation plus a
+                            // "newer build available" adornment. Force still always compiles, and
+                            // an UNSTAMPED in-flight compile (a direct Pending flip from one of the
+                            // kickoff paths, which never sets the token) parks exactly as before —
+                            // absorbing against an unknown input set would be a guess.
+                            var inFlightToken = BuildInputsToken(
+                                GuardsOf(hub).ModulesHash, def.CurrentSourceVersions);
+                            if (IsSatisfiedByInFlightCompile(def, inFlightToken))
+                            {
+                                logger?.LogInformation(
+                                    "[ReleaseRequestWatcher] {HubPath}: release request absorbed — a "
+                                    + "compile is already in flight for these exact inputs, so it "
+                                    + "produces what this request asks for", hubPath);
+                                dispatchHighWater.Advance(triggerAt);
+                                return curr with
+                                {
+                                    Content = def with
+                                    {
+                                        LastReleaseRequestHandledAt =
+                                            def.LastReleaseRequestHandledAt is { } a && a > triggerAt
+                                                ? def.LastReleaseRequestHandledAt
+                                                : triggerAt,
+                                        RequestedReleaseBy = null,
+                                    }
+                                };
+                            }
                             return curr;
+                        }
                         // #1707 slice 3 — "if yes, we take it; if no, we generate": a release
                         // request arriving while the CURRENT state already holds a VALID build of
                         // the CURRENT sources (typically just ADOPTED from a prebuilt bundle by
@@ -1515,6 +1553,11 @@ internal static class NodeTypeCompilationHelpers
                             Content = def with
                             {
                                 CompilationStatus = CompilationStatus.Pending,
+                                // Stamp WHAT this dispatch is for, on the same commit that flips to
+                                // Pending, so a later trigger for the same inputs can be recognised
+                                // as already satisfied instead of queued behind it.
+                                DispatchedBuildInputs = BuildInputsToken(
+                                    GuardsOf(hub).ModulesHash, def.CurrentSourceVersions),
                                 // Stamp the CARRIED trigger value, never the
                                 // (possibly flapped-back) live value, and never
                                 // below the existing stamp — the on-node stamp is
@@ -1775,6 +1818,26 @@ internal static class NodeTypeCompilationHelpers
     /// WHICH input the standing verdict was formed under. The source set is folded to
     /// <c>count:sha256[0..16]</c> so the token stays a line rather than a kilobyte of paths.</para>
     /// </summary>
+    /// <summary>
+    /// Whether a release request is already satisfied by the compile currently in flight (#2544).
+    ///
+    /// <para>Three ways this is deliberately FALSE, each for its own reason:</para>
+    /// <list type="bullet">
+    ///   <item><c>RequestedReleaseForce</c> — the user's explicit escape hatch always compiles.</item>
+    ///   <item>A DIFFERENT token — the sources, framework or modules moved after the in-flight
+    ///   compile was dispatched, so it will NOT produce what this request asks for. Absorbing here
+    ///   would silently drop the user's latest edits.</item>
+    ///   <item>An UNSTAMPED in-flight compile (<c>DispatchedBuildInputs is null</c>) — several
+    ///   kickoff paths flip straight to Pending without going through the release watcher, so
+    ///   nothing recorded what they were built for. Absorbing against an unknown input set is a
+    ///   guess; park instead, exactly as before.</item>
+    /// </list>
+    /// </summary>
+    internal static bool IsSatisfiedByInFlightCompile(NodeTypeDefinition def, string inFlightToken)
+        => !def.RequestedReleaseForce
+           && def.DispatchedBuildInputs is { } dispatched
+           && string.Equals(dispatched, inFlightToken, StringComparison.Ordinal);
+
     internal static string BuildInputsToken(
         string? modulesHash, IReadOnlyDictionary<string, long>? sources) =>
         $"fw={FrameworkVersion};mod={modulesHash ?? "(none)"};src={SourceToken(sources)}";

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -685,8 +685,15 @@ public record NodeTypeDefinition
     public string? FailedBuildInputs { get; init; }
 
     /// <summary>
-    /// The build-inputs token the IN-FLIGHT compile was dispatched for, stamped on the same commit
-    /// that flips <see cref="CompilationStatus"/> to Pending (#2544).
+    /// The build-inputs token the in-flight compile was dispatched for, stamped by the RELEASE
+    /// WATCHER on the commit where it flips <see cref="CompilationStatus"/> to Pending (#2544).
+    ///
+    /// <para>🚨 <b>Null means "no watcher dispatch vouches for the compile in flight".</b> Several
+    /// kickoff paths — first build, recovery, framework-stale, the failed-verdict re-drive — flip
+    /// to Pending WITHOUT going through the watcher, and they now clear this field explicitly.
+    /// That is load-bearing rather than tidy: leaving a previous dispatch's token behind would let
+    /// a later request be absorbed against a compile nobody recorded the inputs of, and if that
+    /// compile fails the absorbed release request is simply lost.</para>
     ///
     /// <para>🚨 It exists so a release request can be recognised by WHAT it asks for, not by WHEN
     /// it was asked. <c>RequestedReleaseAt</c> is a fresh <c>UtcNow</c> on every write, so two

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -685,6 +685,25 @@ public record NodeTypeDefinition
     public string? FailedBuildInputs { get; init; }
 
     /// <summary>
+    /// The build-inputs token the IN-FLIGHT compile was dispatched for, stamped on the same commit
+    /// that flips <see cref="CompilationStatus"/> to Pending (#2544).
+    ///
+    /// <para>🚨 It exists so a release request can be recognised by WHAT it asks for, not by WHEN
+    /// it was asked. <c>RequestedReleaseAt</c> is a fresh <c>UtcNow</c> on every write, so two
+    /// requests for identical content are two distinct values that can never be seen as one. A
+    /// trigger arriving while the type is Pending/Compiling was therefore parked and re-fired by
+    /// the first compile's own terminal write-back — one logical event (a merge, a push, an
+    /// install wave) became N sequential Roslyn compiles of the same sources, each invalidating the
+    /// type's instance hubs and raising the "newer build available" adornment. Measured in
+    /// production: pairs 65 ms apart, three inside 2 s, and seven compiles for one merge.</para>
+    ///
+    /// <para>When this equals the token the current request resolves to, the in-flight compile will
+    /// produce byte-for-byte what the request asks for, so the request is CONSUMED rather than
+    /// queued. <c>RequestedReleaseForce</c> remains the user's escape hatch and always compiles.</para>
+    /// </summary>
+    public string? DispatchedBuildInputs { get; init; }
+
+    /// <summary>
     /// 🚨 Round-trip buffer for content members this compiled shape does not declare —
     /// schema evolution: a property written by a NEWER build, or one removed since the
     /// JSON was persisted. Without this, System.Text.Json silently DROPS such members on

--- a/test/MeshWeaver.Graph.Test/RecompileStormAbsorptionTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecompileStormAbsorptionTest.cs
@@ -1,0 +1,71 @@
+using MeshWeaver.Graph.Configuration;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// One logical event must cost ONE compile (#2544).
+///
+/// <para>🚨 A release request was identified by WHEN it was asked, never by WHAT it asks for:
+/// <c>RequestedReleaseAt</c> is a fresh <c>UtcNow</c> on every write, so two requests for identical
+/// content were two distinct values that could never be recognised as one. A trigger arriving while
+/// the type was Pending/Compiling was parked WITHOUT advancing the high-water — by design, so it
+/// would not be lost — and therefore re-fired on the first compile's own terminal write-back. The
+/// compile does not re-trigger itself; it is the CLOCK that releases the next queued trigger.</para>
+///
+/// <para>Measured in production on memex-cloud: compiles arriving in pairs 65 ms apart on
+/// <c>Training/Tour</c>, three inside 2 s on <c>Publish/Deck</c>, and SEVEN for one merge on
+/// <c>Store/Plugin</c> — each invalidating the type's instance hubs and raising the "newer build
+/// available" adornment. Reported from the user side as a slide deck that kept recompiling while
+/// being viewed.</para>
+/// </summary>
+public class RecompileStormAbsorptionTest
+{
+    private const string Token = "fw=sABC;mod=deadbeef;src=42";
+
+    private static NodeTypeDefinition Def(
+        string? dispatched, bool force = false) => new()
+    {
+        DispatchedBuildInputs = dispatched,
+        RequestedReleaseForce = force,
+    };
+
+    /// <summary>The whole point: a second request for the SAME inputs is absorbed, not queued.</summary>
+    [Fact]
+    public void A_request_for_the_inputs_already_compiling_is_absorbed()
+        => NodeTypeCompilationHelpers.IsSatisfiedByInFlightCompile(Def(Token), Token)
+            .Should().BeTrue(
+                "the in-flight compile produces byte-for-byte what this request asks for, so "
+                + "re-running it buys nothing and costs an instance-hub invalidation plus a "
+                + "'newer build available' adornment on every viewer");
+
+    /// <summary>
+    /// 🚨 Sources moved after the dispatch, so the in-flight compile will NOT produce what this
+    /// request asks for. Absorbing here would silently drop the user's latest edits — the one
+    /// failure worse than the storm this fixes.
+    /// </summary>
+    [Fact]
+    public void A_request_for_DIFFERENT_inputs_still_compiles()
+        => NodeTypeCompilationHelpers.IsSatisfiedByInFlightCompile(
+                Def("fw=sABC;mod=deadbeef;src=41"), Token)
+            .Should().BeFalse("the inputs changed — this request is not the one in flight");
+
+    /// <summary>Force is the user's explicit escape hatch and must survive the coalescing.</summary>
+    [Fact]
+    public void A_FORCED_request_always_compiles()
+        => NodeTypeCompilationHelpers.IsSatisfiedByInFlightCompile(Def(Token, force: true), Token)
+            .Should().BeFalse("RequestedReleaseForce is the escape hatch every UI and MCP path sets");
+
+    /// <summary>
+    /// An UNSTAMPED in-flight compile parks exactly as before. Several kickoff paths flip straight
+    /// to Pending without going through the release watcher, so nothing recorded what they were
+    /// built for — absorbing against an unknown input set would be a guess, and the safe answer is
+    /// the old behaviour.
+    /// </summary>
+    [Fact]
+    public void An_unstamped_in_flight_compile_is_never_absorbed_against()
+        => NodeTypeCompilationHelpers.IsSatisfiedByInFlightCompile(Def(dispatched: null), Token)
+            .Should().BeFalse(
+                "a direct Pending flip records no token; absorbing against an unknown input set "
+                + "would risk dropping a request the in-flight compile does not satisfy");
+}


### PR DESCRIPTION
Fixes #2544.

## The mechanism

`RequestedReleaseAt` mints a fresh `UtcNow` on every call, so **two requests for identical content are two distinct values that can never be recognised as one**. A trigger arriving while the type is `Pending`/`Compiling` fails the watcher's predicate, and the high-water is deliberately **not** advanced for it (correctly — it must not be lost). So it re-fires on the next settled emission, which is *the first compile's own `Ok` write-back*.

That is the part worth stating plainly: **the compile does not re-trigger itself — it is the clock that releases the next queued trigger.** Hence the pairs.

Measured in production: two compiles 65 ms apart on `Training/Tour`, three inside 2 s on `Publish/Deck`, **seven for one merge** on `Store/Plugin`. Every one invalidates the type's instance hubs and raises the "a newer build is available… Recycle" adornment — reported from the user side as a slide deck that kept recompiling while being presented.

## The fix

Dispatch becomes **content-keyed**. The commit that flips to `Pending` stamps `DispatchedBuildInputs` — the `(framework, modules, sources)` token that dispatch is for — so a later request resolving to the same token is **consumed** rather than queued: the in-flight compile will produce byte-for-byte what it asks for.

## 🚨 Three cases stay deliberately un-absorbed

Each has its own test, because each would be a different bug:

| case | why it must still compile |
|---|---|
| `RequestedReleaseForce` | the user's explicit escape hatch, set by every UI and MCP path |
| a **different** token | sources/framework/modules moved after dispatch — absorbing would **silently drop the user's latest edits**, which is worse than the storm |
| an **unstamped** in-flight compile | several kickoff paths flip straight to `Pending` without going through the watcher, so nothing recorded what they were built for; absorbing against an unknown input set is a guess |

## Verification

- **Red-proof discriminates**: forcing the predicate to `true` fails exactly those three guards and leaves the absorb case green.
- **Full `MeshWeaver.Graph.Test`: 1,689 passed, 0 failed** — the watcher itself is intact, which is the part a unit test cannot tell you.

## Scope

This is the coalescing half. The issue also notes `PackageUpdateReconciler` should take the claim `BuildProtocolDriver` already provides so one pod installs rather than all of them — that is a separate change and is not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)