### PR TITLE
An authorization refusal is terminal for an unattended install — classify, don't retry (#2536)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-a-commercial-package-no-longer-re-fails-every-boot.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-a-commercial-package-no-longer-re-fails-every-boot.md
@@ -1,0 +1,32 @@
+---
+Name: A commercial package no longer re-fails every boot
+Category: Fix
+Description: The unattended default install now records a commercial package as deliberately skipped, with the reason, instead of failing it at every restart with an error nobody could act on.
+Icon: ShieldCheckmark
+Order: -20260828
+---
+
+# A commercial package no longer re-fails every boot
+
+When a deployment's default-install set swept in a commercial package — one with a price or a
+sales contact — every restart tried to install it, was refused (correctly: an unattended boot has
+no one to pay or approve), logged the refusal as an **error**, recorded the package as FAILED, and
+promised "the next boot re-attempts it; that retry is the repair". For an authorization refusal
+that promise was false: no retry can conjure an approver, so the same errors re-appeared at every
+boot of every instance, forever.
+
+The installer now classifies that refusal for what it is — **terminal for an unattended
+installer** — before attempting anything:
+
+- The package is recorded as **skipped**, with its reason, on the install ledger
+  (`Plugins/_DefaultInstallLedger`) — one warning naming the packages and the remedy, instead of a
+  per-boot error with a stack trace per package.
+- Nothing re-attempts it. What changes the outcome is an event the next pass observes, not a
+  retry — a Global Admin installs the package from the catalog, or the package stops being
+  commercial. The classification is re-derived from the current catalog on every pass, so the
+  moment a package's terms change it installs with no further ceremony.
+- A genuine install *failure* (a timeout, a malformed package) keeps its existing behaviour:
+  recorded as FAILED and retried next boot, because there a retry really is the repair.
+
+If your instance should carry a commercial package, the ledger now tells you exactly that — and
+that installing it from the catalog as a Global Admin is the way to get it.

--- a/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceAutoRegistrationService.cs
@@ -704,11 +704,12 @@ public sealed class InstanceAutoRegistrationService(
     private IObservable<Unit> RecordSeeded(
         DefaultInstallLedger ledger, DefaultInstallSummary summary)
     {
-        // 🚨 A pass that attempted NOTHING knows nothing. A source listing that failed yields an
-        // empty summary, and treating that as "no package is missing" would erase the record of a
-        // genuinely missing one — the ledger would then be at its most optimistic exactly when the
-        // instance is least healthy.
-        if (summary.Packages.Count == 0)
+        // 🚨 A pass that attempted NOTHING and classified nothing knows nothing. A source listing
+        // that failed yields an empty summary, and treating that as "no package is missing" would
+        // erase the record of a genuinely missing one — the ledger would then be at its most
+        // optimistic exactly when the instance is least healthy. A skip-only pass, by contrast,
+        // DID read a listing (skips are derived from listed manifests), so it may write.
+        if (summary.Packages.Count == 0 && summary.Skipped.Count == 0)
             return Observable.Return(Unit.Default);
 
         var already = ledger.Seeded.ToImmutableHashSet(StringComparer.Ordinal);
@@ -720,7 +721,17 @@ public sealed class InstanceAutoRegistrationService(
             .OrderBy(x => x, StringComparer.Ordinal)
             .ToImmutableList();
 
-        if (delivered.Count == 0 && failures.SequenceEqual(ledger.Failed, StringComparer.Ordinal))
+        // Snapshot semantics, exactly like Failed (#2536): what THIS pass classified as outside
+        // the unattended lane's authority, deduplicated by package (records compare by value).
+        var skipped = summary.Skipped
+            .GroupBy(s => s.Package, StringComparer.Ordinal)
+            .Select(g => g.First())
+            .OrderBy(s => s.Package, StringComparer.Ordinal)
+            .ToImmutableList();
+
+        if (delivered.Count == 0
+            && failures.SequenceEqual(ledger.Failed, StringComparer.Ordinal)
+            && skipped.SequenceEqual(ledger.Skipped))
             return Observable.Return(Unit.Default);
 
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
@@ -745,6 +756,7 @@ public sealed class InstanceAutoRegistrationService(
             {
                 Seeded = already.Union(delivered).OrderBy(x => x, StringComparer.Ordinal).ToImmutableList(),
                 Failed = failures,
+                Skipped = skipped,
                 UpdatedAt = DateTimeOffset.UtcNow,
             },
         };
@@ -1176,19 +1188,67 @@ public sealed class InstanceAutoRegistrationService(
             .ToList();
     }
 
+    /// <summary>
+    /// Why the UNATTENDED default install must not even ATTEMPT <paramref name="package"/> — or
+    /// null when it may proceed. Pure.
+    ///
+    /// <para>🚨 <b>This is a CLASSIFICATION, not retry tuning (#2536).</b> A commercial package is
+    /// refused by <see cref="PackageEntitlement.Authorize"/> for want of an authorizing principal,
+    /// and on this lane that want is PERMANENT: no human can appear at boot to pay or approve.
+    /// Recording such a package as FAILED and re-attempting it at the next boot ("that retry is the
+    /// repair") was wrong twice — the retry could never succeed, and the per-boot <c>fail:</c>
+    /// advertised a defect where there is a standing decision. Such a package is recorded as
+    /// SKIPPED with this reason instead — durable on the ledger, never re-attempted as a repair.</para>
+    ///
+    /// <para>What changes the outcome is an EVENT the next pass observes, never a retry: a Global
+    /// Admin installs the package from the catalog (the lane with an authorizing principal), or the
+    /// package's own terms change — it stops being commercial. The classification is re-derived
+    /// from the CURRENT manifest on every pass, so it moves the moment its input does; nothing
+    /// polls the refused operation.</para>
+    /// </summary>
+    /// <param name="package">The selected candidate's manifest, as the catalog lists it now.</param>
+    /// <returns>The speaking skip reason, or null when the pass may install it.</returns>
+    internal static string? TerminalSkipReason(PackageManifest package) =>
+        package.IsCommercial() ? PackageEntitlement.Reason(package, null) : null;
+
     /// <summary>Installs the selected packages sequentially and folds their outcomes into one summary.</summary>
     private IObservable<DefaultInstallSummary> InstallAll(IReadOnlyList<InstallCandidate> candidates)
     {
         if (candidates.Count == 0)
             return Observable.Return(DefaultInstallSummary.Empty);
+
+        // The terminal skips FIRST — what this unattended pass must not even attempt (see
+        // TerminalSkipReason). They seed the aggregate so the ledger records them with their
+        // reasons, and they are reported ONCE, at Warning: actionable ("needs a Global Admin"),
+        // not a per-boot fail: with a stack trace (#2536).
+        var skipped = candidates
+            .Select(c => (c.Package.Id, Reason: TerminalSkipReason(c.Package)))
+            .Where(x => x.Reason is not null)
+            .Select(x => new DefaultInstallSkip(x.Id, x.Reason!))
+            .ToImmutableList();
+        var installable = skipped.Count == 0
+            ? candidates
+            : candidates.Where(c => TerminalSkipReason(c.Package) is null).ToList();
+        if (skipped.Count > 0)
+            logger.LogWarning(
+                "[DefaultInstall] {Count} declared package(s) require an authorization this "
+                + "unattended install can never obtain and are SKIPPED, not failed: [{Skipped}]. "
+                + "They are recorded with their reasons on {Ledger} and no boot re-attempts them — "
+                + "a Global Admin installing them from the catalog, or the package ceasing to be "
+                + "commercial, is what changes this.",
+                skipped.Count, string.Join(", ", skipped.Select(s => s.Package)), SeedLedgerPath);
+
+        var seed = DefaultInstallSummary.Empty with { Skipped = skipped };
+        if (installable.Count == 0)
+            return Observable.Return(seed);
         logger.LogInformation(
             "[DefaultInstall] {Count} package(s), in dependency order — {Packages}",
-            candidates.Count, string.Join(", ", candidates.Select(c => c.Package.Id)));
-        return candidates
+            installable.Count, string.Join(", ", installable.Select(c => c.Package.Id)));
+        return installable
             .Select(Install)
             .ToObservable()
             .Concat()
-            .Aggregate(DefaultInstallSummary.Empty, (acc, one) => acc.Add(one));
+            .Aggregate(seed, (acc, one) => acc.Add(one));
     }
 
     /// <summary>
@@ -1237,6 +1297,26 @@ public sealed class InstanceAutoRegistrationService(
                 UpToDate: result.Written > 0 ? 0 : 1,
                 Failed: 0,
                 Packages: [package.Id]))
+            // 🚨 The safety net behind TerminalSkipReason (#2536): a refusal that only becomes
+            // visible AT install time — commerciality stamped registry-side after listing, or a
+            // licence that requires an acceptance no boot-time principal can give — is STILL
+            // terminal for this lane. Record it as a SKIP carrying the refusal's own reason, never
+            // as a failure to retry: retrying an authorization refusal re-fails identically every
+            // boot, and what changes it is an event (an admin install, changed terms), not a retry.
+            .Catch((Exception exception) => exception
+                    is not PackageAuthorizationException and not LicenseAcceptanceRequiredException
+                ? Observable.Throw<DefaultInstallSummary>(exception)
+                : Observable.Defer(() =>
+                {
+                    logger.LogWarning(
+                        "[DefaultInstall] {Id} was refused and is SKIPPED, not failed — no boot "
+                        + "re-attempts it (recorded on {Ledger}): {Reason}",
+                        package.Id, SeedLedgerPath, exception.Message);
+                    return Observable.Return(DefaultInstallSummary.Empty with
+                    {
+                        Skipped = [new DefaultInstallSkip(package.Id, exception.Message)],
+                    });
+                }))
             .Catch((Exception exception) =>
             {
                 logger.LogError(exception,
@@ -1377,6 +1457,23 @@ public record DefaultInstallLedger
     /// </summary>
     public ImmutableList<string> Failed { get; init; } = ImmutableList<string>.Empty;
 
+    /// <summary>
+    /// The declared default packages the last pass deliberately did NOT act on, with the reason
+    /// each — the terminal-skip classification (#2536): an authorization the unattended lane can
+    /// never obtain. 🚨 NOT failures — a failure is retried next boot because a retry can repair
+    /// it; a skip is a standing decision no retry can change, so nothing re-attempts it and no
+    /// per-boot error is raised. What changes it is an event the next pass observes: a Global
+    /// Admin installs the package from the catalog, or its terms change (it stops being
+    /// commercial) — the classification is re-derived from the current manifest each pass.
+    ///
+    /// <para>A SNAPSHOT with the same semantics as <see cref="Failed"/>: an entry drops off the
+    /// moment the package stops being declared by default or stops being refusable. A skipped
+    /// package is never <see cref="Seeded"/> — so should it ever become free, the seed lane
+    /// installs it like any package it has not delivered yet.</para>
+    /// </summary>
+    public ImmutableList<DefaultInstallSkip> Skipped { get; init; } =
+        ImmutableList<DefaultInstallSkip>.Empty;
+
     /// <summary>When the ledger last changed.</summary>
     public DateTimeOffset UpdatedAt { get; init; }
 }
@@ -1406,6 +1503,19 @@ public readonly record struct DefaultInstallSummary(
     public ImmutableList<string> Failures { get; init; } = ImmutableList<string>.Empty;
 
     /// <summary>
+    /// The packages this pass deliberately did NOT attempt, with the reason each — the
+    /// terminal-skip classification (#2536): an authorization the unattended installer can never
+    /// obtain (a commercial package with no authorizing principal, a licence nobody is present to
+    /// accept). Distinct from <see cref="Failures"/> in every consequence: a failure was attempted,
+    /// errored, and is retried next boot (that retry is the repair); a skip is a standing decision,
+    /// re-derived from the current manifest each pass and never retried. A skip is counted in
+    /// neither <see cref="Failed"/> nor <see cref="Packages"/>, so it can neither be ledgered as
+    /// seeded nor reported as a failure.
+    /// </summary>
+    public ImmutableList<DefaultInstallSkip> Skipped { get; init; } =
+        ImmutableList<DefaultInstallSkip>.Empty;
+
+    /// <summary>
     /// The ids this pass actually DELIVERED — installed or already current. The ledger's input:
     /// what the seed may stop re-asserting.
     /// </summary>
@@ -1425,11 +1535,30 @@ public readonly record struct DefaultInstallSummary(
     {
         Failures = (Failures ?? ImmutableList<string>.Empty)
             .AddRange(other.Failures ?? ImmutableList<string>.Empty),
+        Skipped = (Skipped ?? ImmutableList<DefaultInstallSkip>.Empty)
+            .AddRange(other.Skipped ?? ImmutableList<DefaultInstallSkip>.Empty),
     };
 
     /// <inheritdoc />
     public override string ToString() =>
         $"{Installed} installed, {UpToDate} up to date, {Failed} failed "
         + $"[{string.Join(", ", Packages)}]"
-        + (Failures is { Count: > 0 } f ? $" — FAILED: [{string.Join(", ", f)}]" : "");
+        + (Failures is { Count: > 0 } f ? $" — FAILED: [{string.Join(", ", f)}]" : "")
+        + (Skipped is { Count: > 0 } s
+            ? $" — SKIPPED (authorization, not retried): [{string.Join(", ", s.Select(x => x.Package))}]"
+            : "");
 }
+
+/// <summary>
+/// One package the unattended default install deliberately does not act on, and why (#2536): the
+/// declared default set names it, but acting on it needs an authorization this lane can never hold
+/// — a commercial package with no authorizing principal, or a licence nobody is present to accept.
+///
+/// <para>Recorded on the <see cref="DefaultInstallLedger"/> so the standing decision is durable
+/// and diagnosable without grepping a boot log. It does NOT mean the package is absent: a Global
+/// Admin may well have installed it through the catalog — it means the unattended lane does not
+/// manage it (neither installs nor auto-updates it), which stays true either way.</para>
+/// </summary>
+/// <param name="Package">The package id.</param>
+/// <param name="Reason">The speaking refusal reason (see <see cref="PackageEntitlement.Reason"/>).</param>
+public sealed record DefaultInstallSkip(string Package, string Reason);

--- a/test/MeshWeaver.PluginCatalog.Test/DefaultInstallCommercialSkipTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/DefaultInstallCommercialSkipTest.cs
@@ -1,0 +1,203 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// 🚨 <b>#2536 — an authorization refusal is TERMINAL for an unattended installer, and must be a
+/// classification, not a retried failure.</b>
+///
+/// <para><b>What broke.</b> The default-install set on memex-cloud listed commercial packages
+/// (Claims, SST, Underwriting, …). <see cref="PackageEntitlement.Authorize"/> refused each one —
+/// correctly: the boot has no authorizing principal and no human can appear at boot to pay — but
+/// the sweep recorded every refusal as FAILED on <c>Plugins/_DefaultInstallLedger</c> and re-attempted
+/// it at the next boot, logging "that retry is the repair". For an authorization refusal that is
+/// false: every boot re-failed identically, at Error, with a stack trace, forever.</para>
+///
+/// <para><b>The fix under test.</b> A commercial package is classified BEFORE any attempt
+/// (<see cref="InstanceAutoRegistrationService.TerminalSkipReason"/>) and recorded as a terminal
+/// SKIP — named, with its reason, on the ledger — never as a failure. Nothing retries it; what
+/// changes the outcome is an EVENT the next pass observes: a Global Admin installs it from the
+/// catalog, or the package's own terms change. The last leg here IS that event — the manifest
+/// stops being commercial, and the very next pass installs the package with no ceremony.</para>
+///
+/// <para>Both directions are asserted, as in <see cref="DefaultInstallFailureLedgerTest"/>: the
+/// free package must be delivered and seeded (so the skip assertions cannot pass against a pass
+/// that did nothing), and the commercial ones must be skipped-with-reason, kept off both the
+/// seeded and the failed lists, and left un-attempted by later passes.</para>
+/// </summary>
+public class DefaultInstallCommercialSkipTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The name <c>InstanceAutoRegistrationService.Sources</c> gives a DI-registered source.</summary>
+    private const string SourceName = "registered-0";
+
+    private const string LedgerPath = PackageInstaller.InstalledPartition + "/_DefaultInstallLedger";
+
+    /// <summary>The catalog as the source serves it NOW — mutable so the entitlement-change leg
+    /// can flip a package's terms mid-test, exactly as a republished manifest would.</summary>
+    private IReadOnlyList<RepoFile> repo = CommercialRepo;
+
+    private string commit = "commit-2536-commercial";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddPluginCatalog()
+            .ConfigureServices(services => services
+                .AddSingleton<IPackageSource>(_ => new NodeRepoPackageSource(
+                    (_, _, _, _) => Observable.Return(new RepoSnapshot(commit, repo)),
+                    "https://github.com/acme/plugins"))
+                // The seed lane with a wildcard — the memex-cloud shape (`Plugins/*` sweeping in
+                // commercial packages). The pre-installed baseline is off so every selection here
+                // comes from the operator's pattern.
+                .AddSingleton(new PluginCatalogOptions
+                {
+                    InstallByDefault = [$"{SourceName}/*"],
+                    InstallPreInstalledPackages = false,
+                }));
+
+    private static RepoFile Index(string id, string extraContent) => new(
+        $"{id}/index.json",
+        $$"""{"$type":"MeshNode","id":"{{id}}","namespace":"","path":"{{id}}","mainNode":"{{id}}","name":"{{id}}","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"{{id}}.","minMeshVersion":"1.0.0"{{extraContent}} } }""");
+
+    private static RepoFile Page(string id) => new(
+        $"{id}/Page.json",
+        $$"""{"$type":"MeshNode","id":"Page","namespace":"{{id}}","path":"{{id}}/Page","mainNode":"{{id}}/Page","name":"Page","nodeType":"Markdown","state":"Active","content":"# {{id}}"}""");
+
+    private const string PaidTerms = ",\"price\":490,\"currency\":\"CHF\"";
+    private const string SalesTerms = ",\"contactEmail\":\"sales@acme.test\"";
+
+    /// <summary>Free installs; Paid (a price) and SalesOnly (a sales contact, no price — the
+    /// Claims/SST shape) are commercial in the two ways <see cref="PackageEntitlement.IsCommercial"/>
+    /// recognises.</summary>
+    private static readonly IReadOnlyList<RepoFile> CommercialRepo =
+    [
+        Index("Free", ""), Page("Free"),
+        Index("Paid", PaidTerms), Page("Paid"),
+        Index("SalesOnly", SalesTerms), Page("SalesOnly"),
+    ];
+
+    /// <summary>The same catalog after the vendor changes Paid's terms — the entitlement-change
+    /// EVENT: no price any more, so nothing is left to refuse.</summary>
+    private static readonly IReadOnlyList<RepoFile> FreedRepo =
+    [
+        Index("Free", ""), Page("Free"),
+        Index("Paid", ""), Page("Paid"),
+        Index("SalesOnly", SalesTerms), Page("SalesOnly"),
+    ];
+
+    [Fact]
+    public void TheClassifierIsPure_AndCountsBothCommercialShapes()
+    {
+        // Priced — positive (purchasable) and negative (coupon-only, the UWDeepfield shape).
+        InstanceAutoRegistrationService.TerminalSkipReason(
+                new PackageManifest { Id = "P", Price = 490m, Currency = "CHF" })
+            .Should().Contain("Global Admin").And.Contain("price 490");
+        InstanceAutoRegistrationService.TerminalSkipReason(
+                new PackageManifest { Id = "C", Price = -1m })
+            .Should().NotBeNull("a negative price means coupon-only, which is still commercial");
+        // Contact-sales — commercial WITHOUT a price (the Claims/SST shape).
+        InstanceAutoRegistrationService.TerminalSkipReason(
+                new PackageManifest { Id = "S", ContactEmail = "sales@acme.test" })
+            .Should().Contain("contact sales");
+        // Free — no price (or an explicit 0) and nobody to ask: nothing to skip.
+        InstanceAutoRegistrationService.TerminalSkipReason(new PackageManifest { Id = "F" })
+            .Should().BeNull();
+        InstanceAutoRegistrationService.TerminalSkipReason(
+                new PackageManifest { Id = "Z", Price = 0m })
+            .Should().BeNull("price 0 is explicitly free");
+    }
+
+    [Fact(Timeout = 180_000)]
+    public async Task ACommercialPackage_IsSkippedWithReason_NeverRetried_AndInstallsWhenItsTermsChange()
+    {
+        // PASS 1 — the boot pass (the hosted service's own AsyncSubject; no polling).
+        var first = await Installer().Completed
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(120)).ToTask();
+
+        Output.WriteLine($"pass 1: {first}");
+
+        // The refusal is a CLASSIFICATION: no failure is counted and nothing was attempted.
+        first.Failed.Should().Be(0,
+            "an authorization refusal is terminal for an unattended installer — reporting it as a "
+            + "failure is what made every boot re-fail identically (#2536)");
+        first.Delivered.Should().Contain("Free",
+            "the free package must actually install, or the skip assertions below prove nothing");
+        first.Packages.Should().NotContain("Paid").And.NotContain("SalesOnly",
+            "a terminally-skipped package is never ATTEMPTED — no install, no exception, no fail: line");
+        first.Skipped.Select(s => s.Package).OrderBy(x => x).Should().Equal("Paid", "SalesOnly");
+        first.Skipped.Should().OnlyContain(s => s.Reason.Contains("Global Admin"),
+            "the skip must carry the actionable reason — who can change the situation and how");
+
+        // THE LEDGER — the durable, diagnosable record.
+        var ledger = await ReadLedger();
+        ledger.Should().NotBeNull("the ledger must actually have been written");
+        ledger!.Seeded.Should().Contain("Free");
+        ledger.Seeded.Should().NotContain("Paid",
+            "a skipped package was never delivered, so seeding it would block the install that "
+            + "becomes possible when its terms change");
+        ledger.Failed.Should().BeEmpty(
+            "FAILED is for attempts a retry can repair; an authorization refusal is not one");
+        ledger.Skipped.Select(s => s.Package).OrderBy(x => x).Should().Equal("Paid", "SalesOnly");
+        ledger.Skipped.Should().OnlyContain(s => !string.IsNullOrWhiteSpace(s.Reason));
+
+        // PASS 2 — no retry. The skip is re-DERIVED (the manifest is still commercial), not re-attempted.
+        var second = await Installer().RunDefaultInstall()
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(120)).ToTask();
+
+        Output.WriteLine($"pass 2: {second}");
+
+        second.Packages.Should().BeEmpty(
+            "Free is seeded and the commercial two are skipped — a second boot attempts NOTHING, "
+            + "which is exactly the per-boot re-fail this change removes");
+        second.Failed.Should().Be(0);
+        second.Skipped.Select(s => s.Package).OrderBy(x => x).Should().Equal(
+            ["Paid", "SalesOnly"],
+            "the standing decision is re-derived each pass and stays visible on the ledger");
+
+        // THE EVENT — Paid's terms change: the vendor drops the price. This, not a retry, is what
+        // changes the outcome; the next pass sees the new manifest and simply installs.
+        repo = FreedRepo;
+        commit = "commit-2536-freed";
+
+        var third = await Installer().RunDefaultInstall()
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(120)).ToTask();
+
+        Output.WriteLine($"pass 3: {third}");
+
+        third.Delivered.Should().Contain("Paid",
+            "a package that stops being commercial installs on the very next pass — the skip is a "
+            + "classification of the CURRENT manifest, never a permanent ban");
+        third.Failed.Should().Be(0);
+        third.Skipped.Select(s => s.Package).Should().Equal(
+            ["SalesOnly"],
+            "the snapshot drops what is no longer refusable and keeps what still is");
+
+        var after = await ReadLedger();
+        after!.Seeded.Should().Contain("Paid").And.Contain("Free");
+        after.Skipped.Select(s => s.Package).Should().Equal(["SalesOnly"]);
+        after.Failed.Should().BeEmpty();
+    }
+
+    private InstanceAutoRegistrationService Installer() =>
+        Mesh.ServiceProvider.GetRequiredService<InstanceAutoRegistrationService>();
+
+    /// <summary>Authoritative single-node read straight off storage (never the lagging index).</summary>
+    private Task<DefaultInstallLedger?> ReadLedger() =>
+        Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>()
+            .Read(LedgerPath, Mesh.JsonSerializerOptions)
+            .Select(n => n?.ContentAs<DefaultInstallLedger>(Mesh.JsonSerializerOptions))
+            .Take(1).Timeout(TimeSpan.FromSeconds(30)).ToTask();
+}


### PR DESCRIPTION
The default-install sweep recorded a commercial package's refusal as FAILED
and re-attempted it at every boot, promising "that retry is the repair".
For an authorization refusal that promise is false: the boot has no
authorizing principal and no retry can conjure one, so every restart of
every instance whose default set swept in a commercial package (Claims,
SST, Underwriting, … on memex-cloud) re-failed identically at Error, with
a stack trace per package, forever.

The fix is classification, not retry tuning:

- TerminalSkipReason (pure) classifies a commercial candidate BEFORE any
  attempt; it is recorded as SKIPPED — named, with the speaking reason —
  on Plugins/_DefaultInstallLedger (new Skipped snapshot, same semantics
  as Failed), never as a failure, and never attempted. One Warning names
  the packages and the remedy.
- A refusal that only surfaces at install time (registry-side terms, a
  licence nobody is present to accept) is caught as the same class:
  PackageAuthorizationException and LicenseAcceptanceRequiredException
  become skips, not failures.
- Nothing re-attempts a skip. The entitlement change is the trigger: the
  classification is re-derived from the CURRENT manifest each pass, so a
  package that stops being commercial installs on the very next pass, and
  a Global Admin's catalog install (the lane with a principal) is never
  blocked. Genuine failures keep their retry — there the retry IS the
  repair (#2254).

DefaultInstallCommercialSkipTest pins all of it: skip-with-reason, zero
Failed, off the seeded ledger, un-attempted on the next pass, and the
freed-package leg proving the event-not-poll contract.

Closes #2536.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
