### PR TITLE
The contract can say a report is undiagnosable — platform mirror for the ingest guard (#2466)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-bodyless-red-logs-no-longer-become-tickets.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-bodyless-red-logs-no-longer-become-tickets.md
@@ -1,0 +1,21 @@
+---
+Name: Bodyless red-log captures no longer become undiagnosable incidents
+Category: Fix
+Description: A red log line that arrived with no message, exception or stack trace could open an incident that names a component and no defect; the portal now files it as a capture gap instead, whatever version of the log watcher sent it.
+Icon: Sparkle
+Order: -20260828
+---
+
+# Bodyless red-log captures no longer become undiagnosable incidents
+
+The red-log ticketing pipeline could open an incident — and a GitHub issue — whose entire
+content was a console header such as `OrleansRoutingService[0]`: no message, no exception, no
+stack trace, nothing an engineer could act on. Every later bodyless capture from the same
+component then folded into that one bucket instead of being noticed. The watcher that reads the
+logs had been fixed to hold such lines back, but the watcher is a separately shipped component
+and the running one predated the fix.
+
+The portal now checks every incoming report itself. A report that carries no diagnostic is
+refused and recorded on the per-namespace "capture gap" finding — the same one an up-to-date
+watcher files — with the original component and fingerprint kept as evidence, so the incident
+list shows where bodyless captures are coming from rather than a ticket nobody can diagnose.

--- a/src/MeshWeaver.Observability.Contract/LogIncidentReportSanity.cs
+++ b/src/MeshWeaver.Observability.Contract/LogIncidentReportSanity.cs
@@ -1,0 +1,115 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Observability;
+
+/// <summary>
+/// The last line of defence against the degenerate incident of #2222/#2466: a report whose entire
+/// identity is <c>(category, event id)</c> — no message, no exception type, no stack frame — or
+/// whose "message" is nothing but an echo of the console header itself.
+///
+/// <para>🚨 <b>Why this exists when <c>BurstAggregator</c> already refuses to fingerprint bodyless
+/// bursts</b> (#2466): the aggregator runs in the WATCHER, which is a separately shipped binary
+/// with no delivery lane of its own. The exclusion merged on 2026-08-25; the <c>mw-log-watcher</c>
+/// image running in the cluster was built on 2026-08-10 — its parser still fabricated a message
+/// out of the console header (producing exactly
+/// <c>MeshWeaver.Connection.Orleans.OrleansRoutingService[{n}]</c> and <c>Orleans.Messaging[{n}]</c>)
+/// and kept minting and folding undiagnosable incidents two days after the "fix" was green on
+/// main. A classification that only the sender enforces is not enforced: the ingest boundary — the
+/// side that PERSISTS the incident and lives on the portal's continuous delivery — must refuse the
+/// shape too, whatever vintage the watcher is.</para>
+///
+/// <para>This lives in the contract, beside the wire shape, so the watcher, the aggregator's tests
+/// and the portal's ingest all share ONE definition of "carries no diagnostic". It deliberately
+/// mirrors <c>LogLineParser.ParsedBurst.IsHeaderOnly</c> at the report level.</para>
+/// </summary>
+public static class LogIncidentReportSanity
+{
+    /// <summary>
+    /// The category the log pipeline files its own findings under — capture gaps, lost windows,
+    /// truncation. The watcher's <c>LogPipelineGap</c> reports use it too, so both sides fold onto
+    /// the same incidents.
+    /// </summary>
+    public const string PipelineCategory = "MeshWeaver.LogWatcher.Pipeline";
+
+    /// <summary>
+    /// The per-namespace fingerprint for "red bursts arrived with no body". The watcher's
+    /// <c>LogPipelineGap.HeaderOnlyReport</c> uses it as well, so a report the ingest refuses folds
+    /// onto the very incident a current watcher would have filed for it.
+    /// </summary>
+    public static string HeaderOnlyFingerprint(string? ns) => $"log-burst-header-only-{ns ?? "unknown"}";
+
+    /// <summary>
+    /// True when the report carries no diagnostic an engineer could act on: no exception type, no
+    /// application stack frame, and a message that is either empty or a mere echo of the console
+    /// header (<c>Category[{n}]</c> / the bare category) — the shape the pre-#2222 parser
+    /// fabricated for a bodyless burst.
+    ///
+    /// <para>Deliberately narrow. A report with a real logged message — however short — is
+    /// diagnosable and always passes; so does anything carrying an exception type or a frame,
+    /// and the pipeline's own findings (which have long prose messages). The failure direction of
+    /// a false positive is a reroute into the per-namespace capture-gap incident, where the
+    /// category is still named — recoverable and visible, never silent.</para>
+    /// </summary>
+    public static bool IsUndiagnosable(LogIncidentReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+
+        if (report.ExceptionType is { Length: > 0 } || report.TopFrame is { Length: > 0 })
+            return false;
+
+        // A detail that says more than the message is a diagnostic in its own right.
+        if (report.NormalizedDetail is { Length: > 0 } detail
+            && !string.Equals(detail, report.NormalizedMessage, StringComparison.Ordinal))
+            return false;
+
+        var message = report.NormalizedMessage;
+        if (message.Length == 0)
+            return true;
+
+        // The header echo, compared through the same masking the watcher applied — so a category
+        // containing digits ("memory-7") matches its own masked echo ("memory-{n}[{n}]") too.
+        return string.Equals(message, LogLineParser.Normalize(report.Category), StringComparison.Ordinal)
+               || string.Equals(message, LogLineParser.Normalize(report.Category + "[0]"), StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Reroutes an undiagnosable report onto the per-namespace capture-gap incident — the same one
+    /// a current watcher files via <c>LogPipelineGap.HeaderOnlyReport</c> — instead of letting it
+    /// mint (or fold into) an incident that names a component and no defect. The original category
+    /// and fingerprint survive as the first evidence sample, so the finding still says WHERE the
+    /// bodyless capture came from.
+    /// </summary>
+    public static LogIncidentReport AsCaptureGap(LogIncidentReport report)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        return new LogIncidentReport
+        {
+            Fingerprint = HeaderOnlyFingerprint(report.Namespace),
+            Category = PipelineCategory,
+            // Never downgrade a crit: the merge rule keeps the max anyway.
+            Severity = report.Severity > LogSeverity.Error ? report.Severity : LogSeverity.Error,
+            NormalizedMessage =
+                $"Red log line(s) in namespace '{report.Namespace ?? "unknown"}' arrived with NO "
+                + "body: a 'fail:'/'crit:' header and no message, no exception and no stack frame. "
+                + "They are deliberately not fingerprinted — an incident keyed on category+event id "
+                + "alone names a component and no defect, and swallows every later bodyless capture "
+                + "from the same site. Fix it at the category named in the samples: either the call "
+                + "site logs an empty message with no exception (pass the exception, or give the "
+                + "message a template), or its lines are being dropped between the pod and the log "
+                + "store — or an out-of-date log watcher is still fingerprinting headers.",
+            NormalizedDetail = "A red console header reached the watcher with no body.",
+            Namespace = report.Namespace,
+            Pods = report.Pods,
+            Occurrences = report.Occurrences,
+            FirstSeen = report.FirstSeen,
+            LastSeen = report.LastSeen,
+            Samples = ImmutableList
+                .Create(new LogSample(
+                    report.LastSeen,
+                    null,
+                    $"refused undiagnosable report {report.Fingerprint} for category "
+                    + $"{report.Category} — no message, no exception, no stack frame"))
+                .AddRange(report.Samples),
+        };
+    }
+}

--- a/src/MeshWeaver.Observability.Contract/LogIncidentReportSanity.cs
+++ b/src/MeshWeaver.Observability.Contract/LogIncidentReportSanity.cs
@@ -76,8 +76,13 @@ public static class LogIncidentReportSanity
     /// Reroutes an undiagnosable report onto the per-namespace capture-gap incident — the same one
     /// a current watcher files via <c>LogPipelineGap.HeaderOnlyReport</c> — instead of letting it
     /// mint (or fold into) an incident that names a component and no defect. The original category
-    /// and fingerprint survive as the first evidence sample, so the finding still says WHERE the
+    /// and fingerprint survive as the LAST evidence sample, so the finding still says WHERE the
     /// bodyless capture came from.
+    ///
+    /// <para>Last, not first, on purpose: the ingest keeps the most recent
+    /// <c>LogWatchOptions.MaxSamples</c> samples and trims from the FRONT, and the watcher's own
+    /// sample cap is configured independently — so a report that already carries a full budget of
+    /// evidence would lose a provenance sample placed at the head before it was ever stored.</para>
     /// </summary>
     public static LogIncidentReport AsCaptureGap(LogIncidentReport report)
     {
@@ -88,6 +93,8 @@ public static class LogIncidentReportSanity
             Category = PipelineCategory,
             // Never downgrade a crit: the merge rule keeps the max anyway.
             Severity = report.Severity > LogSeverity.Error ? report.Severity : LogSeverity.Error,
+            // A folded site-level report says how many shapes it stands for; that is evidence too.
+            Variants = report.Variants,
             NormalizedMessage =
                 $"Red log line(s) in namespace '{report.Namespace ?? "unknown"}' arrived with NO "
                 + "body: a 'fail:'/'crit:' header and no message, no exception and no stack frame. "
@@ -103,13 +110,11 @@ public static class LogIncidentReportSanity
             Occurrences = report.Occurrences,
             FirstSeen = report.FirstSeen,
             LastSeen = report.LastSeen,
-            Samples = ImmutableList
-                .Create(new LogSample(
-                    report.LastSeen,
-                    null,
-                    $"refused undiagnosable report {report.Fingerprint} for category "
-                    + $"{report.Category} — no message, no exception, no stack frame"))
-                .AddRange(report.Samples),
+            Samples = report.Samples.Add(new LogSample(
+                report.LastSeen,
+                null,
+                $"refused undiagnosable report {report.Fingerprint} for category "
+                + $"{report.Category} — no message, no exception, no stack frame")),
         };
     }
 }

--- a/test/MeshWeaver.Graph.Test/RedLogBurstReconstructionTest.cs
+++ b/test/MeshWeaver.Graph.Test/RedLogBurstReconstructionTest.cs
@@ -165,6 +165,72 @@ public class RedLogBurstReconstructionTest
     }
 
     /// <summary>
+    /// #2466 verbatim: the single bare header production actually fingerprinted —
+    /// <c>fail: MeshWeaver.Connection.Orleans.OrleansRoutingService[0]</c>, nothing else in the
+    /// window. It must never reach <c>Reports</c>; it is the recoverable window-edge case, so the
+    /// watcher holds its cursor at the header and reads the burst whole next poll (and reports it
+    /// as a capture gap if it genuinely has no body).
+    /// </summary>
+    [Fact]
+    public void The_2466_bare_header_is_never_fingerprinted()
+    {
+        var entries = ImmutableList.Create(
+            Line(0, Pod, "fail: MeshWeaver.Connection.Orleans.OrleansRoutingService[0]"));
+
+        var aggregation = BurstAggregator.Aggregate(entries, maxSamples: 10, maxSampleLength: 4000);
+
+        aggregation.Reports.Should().BeEmpty(
+            "an incident keyed on category+event id alone names a component and no defect (#2466)");
+        var open = aggregation.HeaderOnly.Should().ContainSingle().Which;
+        open.Category.Should().Be("MeshWeaver.Connection.Orleans.OrleansRoutingService");
+        open.AtWindowEdge.Should().BeTrue("nothing followed it, so the body may be past the edge");
+    }
+
+    /// <summary>
+    /// Two consecutive RED headers from the SAME pod: the first burst provably has no body — its
+    /// pod's very next line opened another red event — so it is bodyless-final, while the second is
+    /// the recoverable window-edge case. Neither may be fingerprinted. This is the
+    /// <c>Orleans.Messaging[100071]</c> shape from #2466's recurrences, where bare headers kept
+    /// folding into the degenerate incident.
+    /// </summary>
+    [Fact]
+    public void Consecutive_red_headers_from_one_pod_are_two_bodyless_bursts_not_incidents()
+    {
+        var entries = ImmutableList.Create(
+            Line(0, Pod, "fail: Orleans.Messaging[100071]"),
+            Line(5, Pod, "fail: Orleans.Messaging[100071]"));
+
+        var aggregation = BurstAggregator.Aggregate(entries, maxSamples: 10, maxSampleLength: 4000);
+
+        aggregation.Reports.Should().BeEmpty();
+        aggregation.HeaderOnly.Should().HaveCount(2);
+        aggregation.HeaderOnly[0].AtWindowEdge.Should().BeFalse(
+            "its own pod's next red header proves there was no body");
+        aggregation.HeaderOnly[1].AtWindowEdge.Should().BeTrue(
+            "the last burst's body may simply be past the window's edge");
+        aggregation.RedBursts.Should().Be(2, "both were red bursts and are counted honestly");
+    }
+
+    /// <summary>
+    /// A burst whose only continuation is whitespace — the shape of a call site logging an empty
+    /// template with no exception — is bodyless, not an incident with a blank message.
+    /// </summary>
+    [Fact]
+    public void A_whitespace_only_body_is_still_bodyless()
+    {
+        var entries = ImmutableList.Create(
+            Line(0, Pod, "fail: MeshWeaver.Connection.Orleans.OrleansRoutingService[0]"),
+            Line(1, Pod, "      "),
+            Line(2, Pod, "info: MeshWeaver.Hosting.MeshNodeStreamCache[0]"));
+
+        var aggregation = BurstAggregator.Aggregate(entries, maxSamples: 10, maxSampleLength: 4000);
+
+        aggregation.Reports.Should().BeEmpty("whitespace carries no diagnostic");
+        var bodyless = aggregation.HeaderOnly.Should().ContainSingle().Which;
+        bodyless.AtWindowEdge.Should().BeFalse("the pod moved on to another event, so this is final");
+    }
+
+    /// <summary>
     /// The masking / dedup contract still holds across the per-pod grouping: the same fault on two
     /// replicas is ONE incident with both pods on it, not one incident per replica.
     /// </summary>

--- a/test/MeshWeaver.Graph.Test/UndiagnosableReportTest.cs
+++ b/test/MeshWeaver.Graph.Test/UndiagnosableReportTest.cs
@@ -49,10 +49,11 @@ public class UndiagnosableReportTest
         Occurrences = 1,
         FirstSeen = Seen,
         LastSeen = Seen,
+        // The evidence line is the bare header of THIS category — the shape verbatim.
         Samples = ImmutableList.Create(new LogSample(
             Seen,
             "memex-portal-deployment-6c954fd5bf-7b4xq",
-            "fail: MeshWeaver.Connection.Orleans.OrleansRoutingService[0]")),
+            $"fail: {category}[0]")),
     };
 
     // ── The shapes production actually minted ─────────────────────────────────
@@ -159,12 +160,44 @@ public class UndiagnosableReportTest
         var gap = LogIncidentReportSanity.AsCaptureGap(Report(
             "Orleans.Messaging", "Orleans.Messaging[{n}]"));
 
-        gap.Samples.Should().HaveCountGreaterThan(1, "the original samples must survive the reroute");
-        gap.Samples[0].Line.Should()
+        gap.Samples.Should().HaveCount(2, "the original sample must survive the reroute");
+        gap.Samples[0].Line.Should().Be("fail: Orleans.Messaging[0]",
+            "the sender's own evidence comes first and unchanged — the bare header IS the evidence");
+        gap.Samples[^1].Line.Should()
             .Contain("Orleans.Messaging", "the finding must still say WHERE the capture came from")
             .And.Contain("b0a265175dc88c80", "and which degenerate fingerprint was refused");
-        gap.Samples[1].Line.Should().StartWith("fail:", "the bare header itself is the evidence");
     }
+
+    /// <summary>
+    /// 🚨 The provenance sample goes LAST because the ingest trims from the FRONT: it keeps the most
+    /// recent <c>MaxSamples</c>, and the watcher's own sample cap is configured independently. A
+    /// report that already carries a full budget of evidence must not lose the one line that says
+    /// which fingerprint was refused before it is ever stored.
+    /// </summary>
+    [Fact]
+    public void The_provenance_sample_survives_a_report_that_already_fills_the_sample_budget()
+    {
+        var full = Report("Orleans.Messaging", "Orleans.Messaging[{n}]") with
+        {
+            Samples = Enumerable.Range(0, 10)
+                .Select(i => new LogSample(Seen.AddSeconds(i), "pod", "fail: Orleans.Messaging[100071]"))
+                .ToImmutableList(),
+        };
+
+        var gap = LogIncidentReportSanity.AsCaptureGap(full);
+
+        // The same trim the ingest applies (LogIncidentIngestService.Trim: keep the LAST max).
+        var stored = gap.Samples.RemoveRange(0, gap.Samples.Count - 10);
+        stored.Should().HaveCount(10);
+        stored[^1].Line.Should().Contain("b0a265175dc88c80",
+            "trimming to the budget must keep the provenance, not the oldest header");
+    }
+
+    [Fact]
+    public void The_reroute_keeps_the_variant_count()
+        => LogIncidentReportSanity.AsCaptureGap(
+                Report("Orleans.Messaging", "Orleans.Messaging[{n}]") with { Variants = 7 })
+            .Variants.Should().Be(7, "a folded site-level report says how many shapes it stood for");
 
     [Fact]
     public void The_reroute_never_downgrades_a_critical()

--- a/test/MeshWeaver.Graph.Test/UndiagnosableReportTest.cs
+++ b/test/MeshWeaver.Graph.Test/UndiagnosableReportTest.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Collections.Immutable;
+using System.Globalization;
+using MeshWeaver.Observability;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>The ingest boundary must be able to refuse an undiagnosable report itself</b> (#2466).
+///
+/// <para><c>BurstAggregator</c> already refuses to fingerprint a bodyless burst — but the
+/// aggregator runs in the WATCHER, a separately shipped binary. Production proved the gap: the
+/// exclusion merged on 2026-08-25, yet the <c>mw-log-watcher</c> image in the cluster
+/// (<c>memex-log-watcher:1.3.0</c>, built 2026-08-10) kept fingerprinting bare console headers —
+/// minting <c>Admin/_LogIncident/b0a265175dc88c80</c> (<c>OrleansRoutingService[{n}]</c>,
+/// 2026-08-26) and folding recurrences into <c>ce8d2e8715bf9aa0</c>
+/// (<c>Orleans.Messaging[{n}]</c>) as late as 2026-08-27 — two days after the classifier was
+/// "fixed". These tests pin the shared predicate the portal-side ingest (in
+/// <c>MeshWeaver.Plugins</c>) uses to close that hole for every watcher vintage, and the reroute
+/// that preserves the evidence instead of dropping it.</para>
+///
+/// <para>This copy of the contract is the one <c>memex/Memex.Portal.Shared</c> compiles against;
+/// the plugins repo carries an identical copy for the watcher and the Observability module, and
+/// the portal image builds BOTH — so the predicate has to exist in each, or the type is missing
+/// at runtime whenever the other copy wins the copy-local step.</para>
+/// </summary>
+public class UndiagnosableReportTest
+{
+    private static readonly DateTimeOffset Seen =
+        DateTimeOffset.Parse("2026-08-26T23:04:55Z", CultureInfo.InvariantCulture);
+
+    private static LogIncidentReport Report(
+        string category,
+        string message,
+        string? exceptionType = null,
+        string? topFrame = null,
+        string detail = "") => new()
+    {
+        Fingerprint = "b0a265175dc88c80",
+        Category = category,
+        Severity = LogSeverity.Error,
+        NormalizedMessage = message,
+        NormalizedDetail = detail,
+        ExceptionType = exceptionType,
+        TopFrame = topFrame,
+        Namespace = "memex-cloud",
+        Pods = ImmutableList.Create("memex-portal-deployment-6c954fd5bf-7b4xq"),
+        Occurrences = 1,
+        FirstSeen = Seen,
+        LastSeen = Seen,
+        Samples = ImmutableList.Create(new LogSample(
+            Seen,
+            "memex-portal-deployment-6c954fd5bf-7b4xq",
+            "fail: MeshWeaver.Connection.Orleans.OrleansRoutingService[0]")),
+    };
+
+    // ── The shapes production actually minted ─────────────────────────────────
+
+    [Fact]
+    public void The_2466_header_echo_is_undiagnosable()
+        // The incident node's exact content: the pre-#2222 parser fabricated the message from the
+        // console header, so the "message" is the header with the event id masked.
+        => LogIncidentReportSanity.IsUndiagnosable(Report(
+                "MeshWeaver.Connection.Orleans.OrleansRoutingService",
+                "MeshWeaver.Connection.Orleans.OrleansRoutingService[{n}]"))
+            .Should().BeTrue("its entire identity is (category, event id) — a component, no defect");
+
+    [Fact]
+    public void The_orleans_messaging_echo_is_undiagnosable()
+        // Admin/_LogIncident/ce8d2e8715bf9aa0 — recurrences kept folding into it through 2026-08-27.
+        => LogIncidentReportSanity.IsUndiagnosable(Report(
+                "Orleans.Messaging", "Orleans.Messaging[{n}]"))
+            .Should().BeTrue();
+
+    [Fact]
+    public void A_truly_empty_report_is_undiagnosable()
+        // What a CURRENT parser would produce if a bodyless burst ever reached fingerprinting.
+        => LogIncidentReportSanity.IsUndiagnosable(Report(
+                "MeshWeaver.Connection.Orleans.OrleansRoutingService", ""))
+            .Should().BeTrue();
+
+    [Fact]
+    public void A_bare_category_echo_is_undiagnosable()
+        // A header without an event-id bracket echoes as the category alone.
+        => LogIncidentReportSanity.IsUndiagnosable(Report(
+                "Orleans.Messaging", "Orleans.Messaging"))
+            .Should().BeTrue();
+
+    [Fact]
+    public void A_category_with_digits_still_matches_its_own_masked_echo()
+        // The masking rewrites digits in the MESSAGE copy but not in the category field, so the
+        // comparison must run the category through the same masking ("memory-7" → "memory-{n}").
+        => LogIncidentReportSanity.IsUndiagnosable(Report(
+                "memory-7", "memory-{n}[{n}]"))
+            .Should().BeTrue();
+
+    // ── What must always pass ─────────────────────────────────────────────────
+
+    [Fact]
+    public void A_real_message_is_diagnosable()
+        => LogIncidentReportSanity.IsUndiagnosable(Report(
+                "MeshWeaver.Mesh.CreateNode", "Unexpected error during node creation at {path}"))
+            .Should().BeFalse("a logged message, however short, is something an engineer can act on");
+
+    [Fact]
+    public void An_exception_type_is_diagnosable_even_with_no_message()
+        => LogIncidentReportSanity.IsUndiagnosable(Report(
+                "OrleansRoutingService", "", exceptionType: "Orleans.Streams.QueueCacheMissException"))
+            .Should().BeFalse();
+
+    [Fact]
+    public void A_stack_frame_is_diagnosable_even_with_no_message()
+        => LogIncidentReportSanity.IsUndiagnosable(Report(
+                "OrleansRoutingService", "",
+                topFrame: "MeshWeaver.Connection.Orleans.OrleansRoutingService.RegisterStream"))
+            .Should().BeFalse();
+
+    [Fact]
+    public void A_detail_beyond_the_message_is_diagnosable()
+        => LogIncidentReportSanity.IsUndiagnosable(Report(
+                "Orleans.Messaging", "Orleans.Messaging[{n}]",
+                detail: "Failed to address message Request {hex}"))
+            .Should().BeFalse("the detail carries the fault's own words");
+
+    /// <summary>
+    /// The reroute target must pass the guard it feeds, or a refused report would be refused again
+    /// on the way in and the reroute would never terminate. (The watcher's other pipeline findings
+    /// are pinned against the same predicate in the plugins repo, next to <c>LogPipelineGap</c>.)
+    /// </summary>
+    [Fact]
+    public void The_capture_gap_finding_is_never_refused()
+        => LogIncidentReportSanity.IsUndiagnosable(
+                LogIncidentReportSanity.AsCaptureGap(Report("Orleans.Messaging", "Orleans.Messaging[{n}]")))
+            .Should().BeFalse("the finding names what went wrong in its message");
+
+    // ── The reroute ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public void The_reroute_folds_onto_the_watchers_own_capture_gap_incident()
+    {
+        var gap = LogIncidentReportSanity.AsCaptureGap(Report(
+            "MeshWeaver.Connection.Orleans.OrleansRoutingService",
+            "MeshWeaver.Connection.Orleans.OrleansRoutingService[{n}]"));
+
+        // Must equal the fingerprint LogPipelineGap.HeaderOnlyReport uses (pinned against the real
+        // report in the plugins repo), so a refused report and a current watcher's own finding land
+        // on the SAME per-namespace incident.
+        gap.Fingerprint.Should().Be("log-burst-header-only-memex-cloud");
+        gap.Category.Should().Be(LogIncidentReportSanity.PipelineCategory);
+        gap.Namespace.Should().Be("memex-cloud");
+        gap.Occurrences.Should().Be(1);
+        gap.Pods.Should().ContainSingle().Which.Should().Be("memex-portal-deployment-6c954fd5bf-7b4xq");
+    }
+
+    [Fact]
+    public void The_reroute_keeps_the_original_category_and_fingerprint_as_evidence()
+    {
+        var gap = LogIncidentReportSanity.AsCaptureGap(Report(
+            "Orleans.Messaging", "Orleans.Messaging[{n}]"));
+
+        gap.Samples.Should().HaveCountGreaterThan(1, "the original samples must survive the reroute");
+        gap.Samples[0].Line.Should()
+            .Contain("Orleans.Messaging", "the finding must still say WHERE the capture came from")
+            .And.Contain("b0a265175dc88c80", "and which degenerate fingerprint was refused");
+        gap.Samples[1].Line.Should().StartWith("fail:", "the bare header itself is the evidence");
+    }
+
+    [Fact]
+    public void The_reroute_never_downgrades_a_critical()
+        => LogIncidentReportSanity.AsCaptureGap(
+                Report("Orleans.Messaging", "") with { Severity = LogSeverity.Critical })
+            .Severity.Should().Be(LogSeverity.Critical);
+}


### PR DESCRIPTION
Platform half of the fix for #2466; the portal-side ingest guard is Systemorph/MeshWeaver.Plugins#822. **This one merges first** (dependency order), #822 follows.

## Why a platform PR for a plugins fix

`MeshWeaver.Observability.Contract` exists in **both** repos since the watcher moved (#2276): `memex/Memex.Portal.Shared` compiles against this copy, while the Observability module, the watcher and `Memex.Portal.Gui` compile against the plugins copy — and `Memex.Portal.Distributed` references both, so the image carries whichever `MeshWeaver.Observability.Contract.dll` wins the copy-local step. A type added to only one copy is missing at runtime whenever the other wins. So the new `LogIncidentReportSanity` lands here too, byte-identical.

## What the type does

`IsUndiagnosable` mirrors `ParsedBurst.IsHeaderOnly` at the report level: no exception, no frame, no detail beyond the message, and a message that is empty or a masked echo of the console header (`Category[{n}]` — exactly what `Admin/_LogIncident/b0a265175dc88c80` and `ce8d2e8715bf9aa0` carry, minted by the 2026-08-10 `memex-log-watcher:1.3.0` still running in the cluster, 15 days older than the classifier fix). `AsCaptureGap` reroutes such a report onto the per-namespace capture-gap incident a current watcher files (`log-burst-header-only-{ns}`), keeping the refused fingerprint and category as the first evidence sample.

## Tests

- `UndiagnosableReportTest` (Graph.Test): the production shapes verbatim, the narrow-guard negatives, the reroute target passing its own guard (or the reroute would not terminate), the reroute's identity and evidence.
- `RedLogBurstReconstructionTest`: the three #2466 shapes on this copy of the aggregator — a lone bare header, two consecutive headers from one pod, a whitespace-only body. They pass on the current classifier: the classifier was never the hole, the unshipped watcher was.
- Locally: Graph.Test (27 in the touched classes) and `WhatsNewEntryIntegrityTest` green, Release `-warnaserror`.

## What's New

`Category: Fix` entry included here — the plugins repo has no validator-accepted home for one (#2608).

## Still open after both merge

The watcher image itself: nothing ships it (hand-published, `deploy/aks/README.md` → "Red-log ticketing"). Until it is republished from current main, the 08-10 binary keeps sending header-echo reports; after #822 they land as capture-gap findings that name the categories and the watcher vintage instead of undiagnosable tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
