### PR TITLE
A local portal signs you in without a cloud identity provider

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -190,8 +190,12 @@ ensure_overlay() {
       -e "s|__AI_MASTER_KEY__|${ai_key}|g" \
       "$share/values.local.yaml" > "$OVERLAY"
   chmod 600 "$OVERLAY"
-  warn "Edit $OVERLAY to fill in your Entra ClientId/TenantId/ClientSecret (§9),"
-  warn "or uncomment Authentication__EnableDevLogin for a no-Azure login."
+  # 🚨 Dev login is the DEFAULT, and this line is what tells a developer so. It used to
+  # send them to Entra first — a tenant, an app registration, a redirect URI and a client
+  # secret on disk, all to sign in to their own machine. The only thing a fresh install
+  # needs is a username: DevLogin self-provisions it on first sign-in.
+  warn "Edit $OVERLAY and set Authentication__DevAdminUsers to your username (§9)."
+  warn "Entra is opt-in — uncomment the Microsoft lines only to test the OAuth flow itself."
 }
 
 # ---------------------------------------------------------------------------

--- a/deploy/homebrew/share/values.local.yaml
+++ b/deploy/homebrew/share/values.local.yaml
@@ -38,24 +38,38 @@ secrets:
     ConnectionStrings__memex: "Host=memex-postgres-service;Port=5432;Database=memex;Username=postgres;Password=__PG_PASSWORD__"
     # AI key-protection master key (encrypts stored provider keys). Generated once.
     Ai__KeyProtection__MasterKey: "__AI_MASTER_KEY__"
-    # Microsoft Entra client secret — see LocalColimaMac.md §9. Fill this in.
-    Authentication__Microsoft__ClientSecret: "<entra-client-secret>"
+    # Microsoft Entra client secret — ONLY needed if you opt into the Entra flow
+    # below (LocalColimaMac.md §9). Left commented so a local portal never asks a
+    # developer to put a real tenant secret on their disk to log into their own machine.
+    # Authentication__Microsoft__ClientSecret: "<entra-client-secret>"
     # OpenAI-compatible (Ollama) API key — any non-empty token; "ollama" per doc §10.
     OpenAICompatible__ApiKey: "ollama"
 
 config:
   memex_portal:
-    # ---- Auth: Microsoft Entra OAuth (LocalColimaMac.md §9) ------------------
-    # Fill ClientId / TenantId from your dedicated local-dev app registration.
-    # Register redirect URIs: https://memex.localhost:8443/signin-microsoft
-    #                     and https://memex.localhost/signin-microsoft
-    Authentication__Provider: "Microsoft"
-    Authentication__Microsoft__ClientId: "<entra-client-id>"
-    Authentication__Microsoft__TenantId: "<entra-tenant-id>"
-    # ---- No-Azure fallback ---------------------------------------------------
-    # If you have no Entra app yet, comment out the three Microsoft lines above
-    # and uncomment the next line to log in via the built-in dev login instead.
-    # Authentication__EnableDevLogin: "true"
+    # ---- Auth: the built-in developer login (the local default) ---------------
+    # A local portal signs you in WITHOUT a cloud identity provider. DevLogin
+    # self-provisions on first sign-in (DevAuthController -> UserOnboardingService),
+    # so a fresh machine needs no tenant, no app registration, no redirect URI and
+    # no client secret on disk.
+    #
+    # 🚨 These two are a PAIR. EnableDevLogin turns the login on; DevAdminUsers is
+    # the comma-separated list of ids granted platform admin when they sign in that
+    # way. One without the other is a portal you can log into and then administer
+    # nothing on — set both, or neither.
+    Authentication__EnableDevLogin: "true"
+    Authentication__DevAdminUsers: "<your-username>"
+    # ---- Opt-in: Microsoft Entra OAuth (LocalColimaMac.md §9) -----------------
+    # Only needed to exercise the ENTRA FLOW ITSELF locally — signing in for
+    # ordinary local work does not require it. Uncomment these plus the
+    # ClientSecret above, fill them from a dedicated local-dev app registration,
+    # and register the redirect URIs:
+    #   https://memex.localhost:8443/signin-microsoft
+    #   https://memex.localhost/signin-microsoft
+    # Note this also moves the sign-out path from /dev/logout to /auth/logout.
+    # Authentication__Provider: "Microsoft"
+    # Authentication__Microsoft__ClientId: "<entra-client-id>"
+    # Authentication__Microsoft__TenantId: "<entra-tenant-id>"
 
     # ---- Instance identity (tab title + favicon badge — LocalColimaMac.md §12)
     Portal__InstanceName: "Local"

--- a/test/MeshWeaver.Documentation.Test/LocalOverlayDefaultsToDevLoginTest.cs
+++ b/test/MeshWeaver.Documentation.Test/LocalOverlayDefaultsToDevLoginTest.cs
@@ -1,0 +1,94 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>A local portal must be signable-into without a cloud identity provider.</b>
+///
+/// <para><c>values.local.yaml</c> is the overlay <c>memex-local</c> seeds a fresh machine from, so
+/// whatever it defaults to IS the local developer experience. It used to default to Microsoft Entra
+/// and offer DevLogin as a commented fallback — meaning signing in to your own laptop required a
+/// tenant, a dedicated app registration, two registered redirect URIs, and a real client secret
+/// written to disk. DevLogin needs none of that: <c>DevAuthController</c> self-provisions the user
+/// on first sign-in.</para>
+///
+/// <para><b>The pair rule.</b> <c>EnableDevLogin</c> turns the login on; <c>DevAdminUsers</c> is who
+/// gets platform admin through it. Shipping one without the other yields a portal you can log into
+/// and then administer nothing on — the same defect <c>DevLoginConfigBindingTest</c> pins on the
+/// configmap side, here on the side that seeds the value in the first place.</para>
+///
+/// <para>Entra stays SUPPORTED and opt-in: exercising the OAuth flow locally is legitimate, and a
+/// real defect in exactly that path (a provider list written into the wrong options type) reached
+/// production. What this pins is the DEFAULT, not the capability.</para>
+/// </summary>
+public class LocalOverlayDefaultsToDevLoginTest
+{
+    private static string Overlay()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return File.ReadAllText(Path.Combine(
+            dir!.FullName, "deploy", "homebrew", "share", "values.local.yaml"));
+    }
+
+    /// <summary>Lines that are actually SET — a key named only in a comment configures nothing.</summary>
+    private static bool IsSet(string key) => Overlay()
+        .Split('\n')
+        .Select(l => l.Trim())
+        .Any(l => !l.StartsWith('#') && l.StartsWith(key + ":", StringComparison.Ordinal));
+
+    [Fact]
+    public void DevLoginIsOnByDefault()
+    {
+        Assert.True(IsSet("Authentication__EnableDevLogin"),
+            "a fresh local install must be able to sign in without a cloud identity provider");
+    }
+
+    /// <summary>
+    /// The other half of the pair. Without it the developer signs in successfully and then cannot
+    /// administer the portal they just created — which reads as a permissions bug, not a missing
+    /// setting.
+    /// </summary>
+    [Fact]
+    public void DevAdminUsersIsSetAlongsideIt()
+    {
+        Assert.True(IsSet("Authentication__DevAdminUsers"),
+            "EnableDevLogin and DevAdminUsers are a pair — set both, or neither");
+    }
+
+    /// <summary>
+    /// Entra must be OPT-IN. A set ClientId makes HasExternalProviders true, which puts the
+    /// Microsoft button on the login page and moves the sign-out path to /auth/logout — the whole
+    /// cloud-dependency this default exists to avoid.
+    /// </summary>
+    [Theory]
+    [InlineData("Authentication__Provider")]
+    [InlineData("Authentication__Microsoft__ClientId")]
+    [InlineData("Authentication__Microsoft__TenantId")]
+    [InlineData("Authentication__Microsoft__ClientSecret")]
+    public void EntraIsCommentedOut(string key)
+    {
+        Assert.False(IsSet(key),
+            $"{key} must stay commented — local sign-in may not require an Entra tenant");
+    }
+
+    /// <summary>
+    /// …but it must still be DOCUMENTED, or opting in becomes guesswork. Deleting the lines
+    /// outright would pass every assertion above while removing a capability that is legitimately
+    /// needed to test the OAuth flow locally.
+    /// </summary>
+    [Fact]
+    public void EntraRemainsDocumentedAsAnOptIn()
+    {
+        var text = Overlay();
+        Assert.Contains("Authentication__Microsoft__ClientId", text, StringComparison.Ordinal);
+        Assert.Contains("signin-microsoft", text, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## The problem

`values.local.yaml` is the overlay `memex-local` seeds a fresh machine from, so whatever it defaults
to **is** the local developer experience. It defaulted to Microsoft Entra, with DevLogin offered as
a commented fallback.

That meant signing in to your own laptop required a tenant, a dedicated app registration, two
registered redirect URIs, and a real client secret written to disk. The seed message reinforced it:

> *"Edit … to fill in your Entra ClientId/TenantId/ClientSecret, or uncomment
> `Authentication__EnableDevLogin` for a no-Azure login."*

DevLogin needs none of that — `DevAuthController` self-provisions the user on first sign-in, through
the same `UserOnboardingService` dual-write the Entra flow uses.

## The change

- **DevLogin is the default.** `EnableDevLogin` and `DevAdminUsers` are set; the seed message now
  asks for a username instead of an Azure app registration.
- **Entra becomes opt-in**, still documented, with its redirect URIs intact.

🚨 The template previously mentioned `EnableDevLogin` **only in a comment** and `DevAdminUsers`
**not at all**. They are a pair: one turns the login on, the other grants platform admin through it.
One without the other is a portal you can log into and then administer nothing on — which reads as a
permissions bug rather than a missing setting. Both are set now.

The opt-in block also notes the one behaviour that travels with it: `HasExternalProviders` flips the
sign-out path between `/dev/logout` and `/auth/logout`.

## Why not remove Entra support

Exercising the OAuth flow locally is legitimate — and a real defect in exactly that path (a provider
list written into the wrong one of two identical `AuthenticationOptions` types) reached **production**
this week. What changes here is the default, not the capability.

## Tests

`LocalOverlayDefaultsToDevLoginTest` pins the class, not the strings: dev login on, `DevAdminUsers`
beside it, each Entra key commented, and Entra still **documented** so opting in is not guesswork.
That last assertion is what stops "just delete the Microsoft lines" from passing — it would satisfy
every other check while removing a capability.

Against the old template: **6 failed, 1 passed** — the single pass being the documentation control,
which is correct there. With the change: **7/7**, and the full `MeshWeaver.Documentation.Test` suite
**97/97**. `bash -n` clean on `memex-local`.

## Note

This does not touch an existing `~/.memex-local/values.local.yaml` — it changes only what a fresh
install is seeded with.

## What's New

Skipped: local developer setup, no effect on a deployed portal.