### PR TITLE
docs: the existence-gate example compares mesh paths with StringComparison.Ordinal

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CqrsAndContentAccess.md
@@ -505,7 +505,10 @@ stream answers *what it says*:
 // the node is written, and a stale negative only means waiting a beat longer. select:path —
 // nothing here reads Content.
 hub.GetQuery($"usage:{parentPath}", $"path:{parentPath}/_Usage scope:children nodeType:TokenUsage select:path")
-    .Where(nodes => nodes.Any(n => string.Equals(n.Path, target, StringComparison.OrdinalIgnoreCase)))
+    // Ordinal, never OrdinalIgnoreCase: mesh paths are case-SENSITIVE. A case-insensitive match
+    // lets a DIFFERENT node satisfy the gate, and the point read below then opens on a path
+    // that does not exist — exactly the NotFound this gate exists to rule out.
+    .Where(nodes => nodes.Any(n => string.Equals(n.Path, target, StringComparison.Ordinal)))
     .Take(1)
     // CONTENT — the OWNER's authoritative stream, opened only now that the node demonstrably
     // exists, so it can neither NotFound nor trip the storm breaker. Live (no Take): later

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-existence-gate-is-case-sensitive.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-existence-gate-is-case-sensitive.md
@@ -1,0 +1,19 @@
+---
+Name: The existence-gate example compares mesh paths case-sensitively
+Category: Fix
+Description: The canonical "listing for existence, then the owner's stream for content" snippet in the CQRS guide matched paths case-insensitively, which let a different node open the gate for a point read that then could not exist; it now uses an ordinal comparison and says why.
+Icon: DocumentSearch
+Order: -20260828
+---
+
+# The existence-gate example compares mesh paths case-sensitively
+
+The CQRS and content-access guide shows how to read a node that may not exist yet: a children
+listing answers *whether it is there*, and only then is the owner's stream opened for *what it
+says*. The example gate matched the listed path with `StringComparison.OrdinalIgnoreCase`.
+
+Mesh paths are case-sensitive. A case-insensitive match lets a *different* node — one whose path
+differs only in case — satisfy the gate, and the point read that follows opens on a path that does
+not exist: exactly the `NotFound` the gate exists to rule out. The snippet was copied verbatim into a
+plugin and caught in review, so the guide now uses `StringComparison.Ordinal` and explains the
+reason inline.


### PR DESCRIPTION
Fixes #2613. The listing-then-stream snippet in `CqrsAndContentAccess.md` matched paths with `OrdinalIgnoreCase`; mesh paths are case-sensitive, so a different node could open the gate for a point read that then cannot exist. Now `Ordinal`, with the reason inline. Swept the other `OrdinalIgnoreCase` uses in `Documentation/Data`: portal-address prefix, URL prefixes and a provisioned-schema cache key — none is a mesh-path gate. Documentation project builds Release `-warnaserror` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)