### PR TITLE
fix(#2621): unset Microsoft tenant renders as 'organizations'; a blank tenant is unset

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -519,7 +519,12 @@ data:
          Modules__Required__N (#2104). */}}
   Authentication__DevAdminUsers: "{{ .Values.config.memex_portal.Authentication__DevAdminUsers | default "" }}"
   Authentication__Microsoft__ClientId: "{{ .Values.config.memex_portal.Authentication__Microsoft__ClientId | default "" }}"
-  Authentication__Microsoft__TenantId: "{{ .Values.config.memex_portal.Authentication__Microsoft__TenantId | default "" }}"
+  {{- /* 🚨 Never an EMPTY default here: an env var cannot be null, so "" reached the portal as a
+         tenant and the OIDC authority became login.microsoftonline.com//v2.0 — every Microsoft
+         sign-in 500-ed on memex-cloud (2026-08-28, #2621). The multi-tenant sign-in app the
+         onboarding doc prescribes uses `organizations`; an env that needs a single tenant sets
+         its id explicitly. */}}
+  Authentication__Microsoft__TenantId: "{{ .Values.config.memex_portal.Authentication__Microsoft__TenantId | default "organizations" }}"
   Authentication__Google__ClientId: "{{ .Values.config.memex_portal.Authentication__Google__ClientId | default "" }}"
   Authentication__LinkedIn__ClientId: "{{ .Values.config.memex_portal.Authentication__LinkedIn__ClientId | default "" }}"
   # Apple: ClientId is the Services ID; TeamId/KeyId identify the Sign in with Apple key

--- a/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
@@ -41,7 +41,12 @@ public sealed class EaGraphAuth(
         "https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send " +
         "https://graph.microsoft.com/Calendars.ReadWrite offline_access";
 
-    private string TenantId => configuration["Authentication:Microsoft:TenantId"] ?? "common";
+    // Whitespace counts as unset: a configMap / env var cannot carry null, only "", and "" is not
+    // a tenant (it yields the authority `login.microsoftonline.com//oauth2/v2.0` — #2621).
+    private string TenantId =>
+        configuration["Authentication:Microsoft:TenantId"] is { } t && !string.IsNullOrWhiteSpace(t)
+            ? t.Trim()
+            : "common";
     private string? ClientId => configuration["Authentication:Microsoft:ClientId"];
     private string? ClientSecret => configuration["Authentication:Microsoft:ClientSecret"];
     private string Authority => $"https://login.microsoftonline.com/{TenantId}/oauth2/v2.0";

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-microsoft-sign-in-empty-tenant.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-28-microsoft-sign-in-empty-tenant.md
@@ -1,0 +1,22 @@
+---
+Name: Microsoft sign-in no longer fails when the tenant is left unset
+Category: Fix
+Description: The Helm chart emitted an empty tenant id whenever an environment did not set one, and the portal read that empty string as a tenant — every Microsoft sign-in on such an environment failed with a server error. The chart now defaults to the multi-tenant `organizations` authority and the portal treats an empty tenant as unset.
+Icon: PersonKey
+Order: -20260828
+---
+
+# Microsoft sign-in no longer fails when the tenant is left unset
+
+An environment variable cannot be null, only empty. The portal chart rendered
+`Authentication__Microsoft__TenantId` with an empty default whenever an environment's values did not
+set one, and the sign-in handler took that empty string as the tenant. The OpenID Connect authority
+became `login.microsoftonline.com//v2.0`, its discovery document could never be fetched, and every
+Microsoft sign-in on that environment ended in a server error — deterministically, on the first
+request that touched the handler.
+
+Two changes close it. The chart defaults the tenant to `organizations`, the multi-tenant authority
+the onboarding guide prescribes; an environment that needs a single tenant still sets its id
+explicitly. And the portal now treats a blank tenant as unset (falling back to `common`) instead of
+building an authority out of it — the Graph sign-in helper in the platform and the Microsoft
+provider in the portal package alike.


### PR DESCRIPTION
Part 1 of 2 for #2621 (part 2: the portal handler in MeshWeaver.Plugins).

## Root cause
`deploy/helm/templates/memex-portal/config.yaml` rendered `Authentication__Microsoft__TenantId: "{{ … | default "" }}"`. memex-cloud's public overlay sets only the ClientId, so the pod's configMap carries the tenant as an **empty string** (verified on the live namespace: `len=0`; no inline `env:` on the deployment shadows it). `EaGraphAuth` (and the portal handler) used `?? "common"`, which does not see `""` as unset → authority `login.microsoftonline.com//v2.0` → `IDX20803` on every Microsoft sign-in.

## Fix
- chart: `default "organizations"` — the multi-tenant authority [OnboardingNewEnvironment](src/MeshWeaver.Documentation/Data/Architecture/OnboardingNewEnvironment.md) prescribes; a single-tenant env still sets its id. `helm template` renders `"organizations"` when unset.
- `EaGraphAuth.TenantId`: whitespace is unset → `common`.
- What's New (Fix).

`Memex.Portal.Shared` builds Release `-warnaserror` clean.

## Verification after the roll (not the configMap, not the chart)
`kubectl -n memex-cloud exec deploy/memex-portal-deployment -- printenv | grep Authentication__Microsoft__TenantId` must read `organizations`, then one Microsoft sign-in must reach the consent screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)