### PR TITLE
ci: the reusable gate and compile-check can compose external modules, like the bake already does

### DIFF
--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -57,6 +57,33 @@ on:
         required: false
         type: boolean
         default: false
+      module-artifacts:
+        description: >-
+          Artifact-name pattern (actions/download-artifact `pattern`) of module bundles UPLOADED
+          BY THIS RUN whose assemblies belong in the reference set.
+        required: false
+        type: string
+        default: ''
+      registry-modules:
+        description: >-
+          Package ids (whitespace-separated, e.g. `AI`) whose module bundle to fetch from
+          registry-url and add to the reference set — for a repo that BINDS a module's types but
+          does not build the module.
+
+          🚨 Since MeshWeaver#2276 the image is no longer the whole framework. `/app` ships no
+          MeshWeaver.AI, so `AiSettings`, `ThreadMessage`, `ThreadNodeType`,
+          `AgentPickerProjection`, `ModelProviderConfiguration` and the `IMessageHub.StartThread`
+          extension are simply ABSENT — and every NodeType binding them fails CS0246 / CS0103 /
+          CS1061. Those errors name the CONTENT, so they read as the repo breaking rather than as
+          a reference set that is missing a module.
+        required: false
+        type: string
+        default: ''
+      registry-url:
+        description: The registry serving module bundles for registry-modules.
+        required: false
+        type: string
+        default: ''
     secrets:
       acr-username:
         description: Registry user able to pull the image.
@@ -64,6 +91,9 @@ on:
       acr-password:
         description: Registry password for that user.
         required: true
+      registry-key:
+        description: An instance key (mwi_…) able to read the packages named in registry-modules.
+        required: false
 
 jobs:
   compile-check:
@@ -147,6 +177,47 @@ jobs:
           docker cp "$id:/app/." refs/ >/dev/null
           docker rm -v "$id" >/dev/null
           echo "framework assemblies: $(find refs -name 'MeshWeaver.*.dll' | wc -l)"
+      - name: Download this run's module-bundle artifacts
+        if: inputs.module-artifacts != ''
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ${{ inputs.module-artifacts }}
+          path: ${{ runner.temp }}/ref-bundles
+          merge-multiple: true
+      # 🚨 THE IMAGE IS NO LONGER THE WHOLE FRAMEWORK (#2276). A repo binding an external module's
+      # types must add that module's assemblies, or the gate compiles against a framework no mesh
+      # actually runs — and reports the gap as CONTENT errors.
+      - name: Add external modules to the reference set
+        if: inputs.module-artifacts != '' || inputs.registry-modules != ''
+        env:
+          REGISTRY_MODULES: ${{ inputs.registry-modules }}
+          REGISTRY_URL: ${{ inputs.registry-url }}
+          REGISTRY_KEY: ${{ secrets.registry-key }}
+        run: |
+          set -euo pipefail
+          BUNDLES="${RUNNER_TEMP:-/tmp}/ref-bundles"; mkdir -p "$BUNDLES"
+          for pkg in ${REGISTRY_MODULES:-}; do
+            idx=$(curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" "$REGISTRY_URL/api/plugins/bundles/index.json") \
+              || { echo "::error::registry index unreadable at $REGISTRY_URL (registry-modules: $pkg)"; exit 1; }
+            ver=$(jq -r --arg p "$pkg" '(.bundles // .Bundles // [])[] | select(((.plugin // .Plugin)|ascii_downcase)==($p|ascii_downcase)) | (.version // .Version)' <<<"$idx" | head -1)
+            [ -n "$ver" ] || { echo "::error::the registry at $REGISTRY_URL does not advertise package '$pkg' to this instance key."; exit 1; }
+            curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" -o "$BUNDLES/$pkg.bundle.zip" "$REGISTRY_URL/api/plugins/bundles/$pkg/$ver" \
+              || { echo "::error::download failed for $pkg@$ver from $REGISTRY_URL"; exit 1; }
+            echo "fetched $pkg@$ver from $REGISTRY_URL"
+          done
+          shopt -s nullglob
+          added=0
+          for b in "$BUNDLES"/*.nupkg "$BUNDLES"/*.zip; do
+            u="${RUNNER_TEMP:-/tmp}/refunpack-$(basename "$b")"; rm -rf "$u"; mkdir -p "$u"
+            unzip -o -q "$b" -d "$u"
+            [ -d "$u/meshweaver/modules" ] || { echo "::error::$(basename "$b"): no meshweaver/modules/ in the bundle"; exit 1; }
+            cp -R "$u"/meshweaver/modules/*.dll refs/ 2>/dev/null || true
+            added=$((added + 1))
+          done
+          # RED, not "nothing to do": silently falling back to the image-only set is exactly the
+          # state this input exists to leave.
+          [ "$added" -gt 0 ] || { echo "::error::external modules were requested but none were added — the artifact pattern matched nothing and no registry bundle was fetched."; exit 1; }
+          echo "reference set topped up from $added module bundle(s): $(find refs -name 'MeshWeaver.*.dll' | wc -l) assemblies"
       - name: Compile-check every NodeType
         working-directory: repo
         # --refs points at the assemblies unpacked from the platform image — a FLAT directory;

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -128,6 +128,28 @@ on:
         required: false
         type: string
         default: ''
+      module-artifacts:
+        description: >-
+          Artifact-name pattern (actions/download-artifact `pattern`) of module bundles UPLOADED
+          BY THIS RUN (each a *.module.nupkg) whose module DLLs the gate must compose with
+          `--module`. The mirror of the same input on node-repo-publish-bake.yml, and it exists
+          for the same reason: since MeshWeaver#2276 the tester image ships NO modules.
+        required: false
+        type: string
+        default: ''
+      registry-modules:
+        description: >-
+          Package ids (whitespace-separated, e.g. `AI`) whose module bundle to fetch from
+          registry-url and compose into the gate with `--module` — for a repo that consumes a
+          package's types but does not build its module. Requires registry-url + registry-key.
+
+          🚨 A repo whose content declares `Skill` or `Agent` nodes needs `AI` here. Those are
+          ENGINE NodeTypes served by MeshWeaver.AI, so without the module they are unregistered
+          and every such package fails at INSTALL with `NodeType(s) not registered: Skill` —
+          a CONTENT-shaped error with an INFRASTRUCTURE cause.
+        required: false
+        type: string
+        default: ''
       capture-coredumps:
         description: >-
           Run the tester with minidump-on-crash enabled and upload any dumps as a run artifact
@@ -447,6 +469,63 @@ jobs:
           token: ${{ steps.stage-token.outputs.token }}
           path: cross-repo-stage
           sparse-checkout: ${{ inputs.stage-modules }}
+      - name: Download this run's module-bundle artifacts
+        if: inputs.module-artifacts != ''
+        uses: actions/download-artifact@v7
+        with:
+          pattern: ${{ inputs.module-artifacts }}
+          path: ${{ runner.temp }}/ext-bundles
+          merge-multiple: true
+      # 🚨 EXTERNAL MODULES — the same composition node-repo-publish-bake.yml does, for the same
+      # reason (#2276: the tester image ships no modules) and by the same recipe, so the GATE and
+      # the BAKE cannot disagree about what a mesh contains.
+      #
+      # Without it the gate stands up a mesh missing whatever module the content binds, and the
+      # failure is CONTENT-shaped with an INFRASTRUCTURE cause — `NodeType(s) not registered:
+      # Skill` at install, or CS0246 at compile. Measured 2026-08-28 across every plugin repo at
+      # once, while bumping their pins past #2276: 17 packages failed to install in one run.
+      # Every failure below is RED and NAMED, because a gate that quietly ran without a module it
+      # needed is worse than one that did not run at all.
+      - name: "External modules: assemble what the gate must compose"
+        if: inputs.module-artifacts != '' || inputs.registry-modules != ''
+        env:
+          REGISTRY_MODULES: ${{ inputs.registry-modules }}
+          REGISTRY_URL: ${{ inputs.registry-url }}
+          REGISTRY_KEY: ${{ secrets.registry-key }}
+        run: |
+          set -euo pipefail
+          EXT="${RUNNER_TEMP:-/tmp}/ext-modules"; mkdir -p "$EXT"; chmod 777 "$EXT"
+          BUNDLES="${RUNNER_TEMP:-/tmp}/ext-bundles"; mkdir -p "$BUNDLES"
+          for pkg in ${REGISTRY_MODULES:-}; do
+            idx=$(curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" "$REGISTRY_URL/api/plugins/bundles/index.json") \
+              || { echo "::error::registry index unreadable at $REGISTRY_URL (registry-modules: $pkg)"; exit 1; }
+            ver=$(jq -r --arg p "$pkg" '(.bundles // .Bundles // [])[] | select(((.plugin // .Plugin)|ascii_downcase)==($p|ascii_downcase)) | (.version // .Version)' <<<"$idx" | head -1)
+            [ -n "$ver" ] || { echo "::error::the registry at $REGISTRY_URL does not advertise package '$pkg' to this instance key — check the key's grants, and that the upstream wave has published the bundle."; exit 1; }
+            curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" -o "$BUNDLES/$pkg.bundle.zip" "$REGISTRY_URL/api/plugins/bundles/$pkg/$ver" \
+              || { echo "::error::download failed for $pkg@$ver from $REGISTRY_URL"; exit 1; }
+            echo "fetched $pkg@$ver from $REGISTRY_URL"
+          done
+          shopt -s nullglob
+          MODULE_ARGS=""
+          for b in "$BUNDLES"/*.nupkg "$BUNDLES"/*.zip; do
+            u="${RUNNER_TEMP:-/tmp}/unpack-$(basename "$b")"; rm -rf "$u"; mkdir -p "$u"
+            unzip -o -q "$b" -d "$u"
+            name=""
+            [ -f "$u/meshweaver/manifest.json" ] && name=$(jq -r '.module.assemblyName // empty' "$u/meshweaver/manifest.json")
+            if [ -z "$name" ]; then
+              set -- "$u"/meshweaver/modules/*.dll
+              { [ $# -eq 1 ] && [ -f "$1" ]; } || { echo "::error::$(basename "$b"): cannot identify the module's entry assembly (no manifest module.assemblyName; meshweaver/modules/ holds $# dll(s))"; exit 1; }
+              name=$(basename "$1" .dll)
+            fi
+            test -f "$u/meshweaver/modules/$name.dll" || { echo "::error::$(basename "$b"): meshweaver/modules/$name.dll is missing from the bundle"; exit 1; }
+            mkdir -p "$EXT/$name"
+            cp -R "$u"/meshweaver/modules/. "$EXT/$name/"
+            MODULE_ARGS="$MODULE_ARGS --module /ext/$name/$name.dll"
+            echo "external module composed: $name ($(basename "$b"))"
+          done
+          [ -n "$MODULE_ARGS" ] || { echo "::error::external modules were requested but none were assembled — the artifact pattern matched nothing and no registry bundle was fetched."; exit 1; }
+          echo "EXT_MODULES_DIR=$EXT" >> "$GITHUB_ENV"
+          echo "EXT_MODULE_ARGS=$MODULE_ARGS" >> "$GITHUB_ENV"
       - name: Import + compile + render + run tests for each node repo
         env:
           TEST_IMAGE: ${{ inputs.test-image }}
@@ -544,16 +623,20 @@ jobs:
           # Reinsurance run 33091175986; the flag on the compile line had never been exercised).
           # The gate below stands the mesh up on the repo's own bundles PLUS the upstream seed —
           # that is where consuming a bake means something.
-          docker run --rm --init -v "$REPO_MOUNT:/repo" -v "$OWN_BAKE:/bake" "${DUMP_ARGS[@]}" \
+          EXT_V=()
+          [ -n "${EXT_MODULES_DIR:-}" ] && EXT_V=(-v "$EXT_MODULES_DIR:/ext")
+          # shellcheck disable=SC2086  # EXT_MODULE_ARGS is a flag list; word-splitting is the point
+          docker run --rm --init "${EXT_V[@]}" -v "$REPO_MOUNT:/repo" -v "$OWN_BAKE:/bake" "${DUMP_ARGS[@]}" \
             --entrypoint /app/mw-plugin-test "$IMAGE" compile /repo \
-            "${ALLOW_ARGS[@]}" \
+            "${ALLOW_ARGS[@]}" ${EXT_MODULE_ARGS:-} \
             --output /bake --source-sha "$GITHUB_SHA"
           [ -s "$OWN_BAKE/framework-mvid.txt" ] || { echo "::error::compile ran but wrote no bake identity — the bake stage regressed (or the image predates the compile verb; pin ≥ 77bc5f1)"; exit 1; }
           # Gate on the bake: own bundles AND the upstream seed together in one seed directory.
           if [ -n "${SEED_DIR:-}" ]; then cp "$SEED_DIR"/*.zip "$OWN_BAKE"/ 2>/dev/null || true; fi
-          docker run --rm --init -v "$REPO_MOUNT:/repo" -v "$OWN_BAKE:/seed:ro" "${DUMP_ARGS[@]}" \
+          # shellcheck disable=SC2086
+          docker run --rm --init "${EXT_V[@]}" -v "$REPO_MOUNT:/repo" -v "$OWN_BAKE:/seed:ro" "${DUMP_ARGS[@]}" \
             --entrypoint /app/mw-plugin-test "$IMAGE" /repo \
-            "${ALLOW_ARGS[@]}" --seed /seed
+            "${ALLOW_ARGS[@]}" ${EXT_MODULE_ARGS:-} --seed /seed
           echo "OWN_BAKE=$OWN_BAKE" >> "$GITHUB_ENV"
           echo "bake identity: $(cat "$OWN_BAKE/framework-mvid.txt") — $(ls "$OWN_BAKE"/*.zip | wc -l | tr -d ' ') bundle(s), gated on their own bytes"
       # 🚨 The dump is written by the CONTAINER, which runs as root, so the file lands owned by


### PR DESCRIPTION
Adds `module-artifacts` and `registry-modules` to `node-repo-gate.yml`, mirroring `node-repo-publish-bake.yml` exactly.

## Why

#2276 stopped the tester image shipping modules. #2541 gave the **bake** a way to hand them back (`--module`). The **gate** never got one — so every satellite gate stands its mesh up missing whatever module the content binds.

The failure is content-shaped with an infrastructure cause, which is what makes it expensive to diagnose:

```
Install of 'Store' failed: NodeType(s) not registered: Skill
Install of 'Voice' failed: NodeType(s) not registered: Agent
```

`Skill` and `Agent` are **engine** NodeTypes served by `MeshWeaver.AI`. Measured 2026-08-28 while bumping the plugin repos past #2276 — 17 packages failed to install in one run, in this shape, in every repo at once. The obvious reading is that the content broke.

## What

- two new optional inputs, documented with the `Skill`/`Agent` trap called out by name
- the bake's assembly step, verbatim, so gate and bake cannot disagree about what a mesh contains
- both docker runs (`compile` and the gate) take the `--module` list
- an empty assembly is **RED**, never a quiet pass — a gate that ran without a module it needed is worse than one that did not run

## Not a guard regression

`PlatformBakeLaneGuard.PlatformBake_NeverAdoptsAnotherBuildsBundles` polices *cross-run* adoption in workflows that run `publish-bake-bundles.sh`. This file runs no such script, and the download names no `run-id:`, so it can only see the current run's artifacts — the same same-run form #2628 already established for the bake.

## Follow-up

The satellites then set `registry-modules: AI` and re-pin their `uses:` to this merge. MeshWeaver.Plugins wires the equivalent inline (its gate is hand-rolled, not a caller) in Systemorph/MeshWeaver.Plugins#840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)