### PR TITLE
fix(#2621): a Microsoft tenant that cannot form an authority is refused at BOOT, by name

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
@@ -41,15 +41,15 @@ public sealed class EaGraphAuth(
         "https://graph.microsoft.com/Mail.ReadWrite https://graph.microsoft.com/Mail.Send " +
         "https://graph.microsoft.com/Calendars.ReadWrite offline_access";
 
-    // Whitespace counts as unset: a configMap / env var cannot carry null, only "", and "" is not
-    // a tenant (it yields the authority `login.microsoftonline.com//oauth2/v2.0` — #2621).
-    private string TenantId =>
-        configuration["Authentication:Microsoft:TenantId"] is { } t && !string.IsNullOrWhiteSpace(t)
-            ? t.Trim()
-            : "common";
+    // The tenant and the authority are composed by MicrosoftTenant, which treats blank as UNSET and
+    // refuses a value that cannot form a single authority segment — a configMap / env var cannot
+    // carry null, only "", and "" is not a tenant (it yields `login.microsoftonline.com//oauth2/
+    // v2.0`, the URL every memex-cloud sign-in 500-ed on — #2621). The same value is validated at
+    // boot by MemexConfiguration, so a malformed one is named at startup rather than here.
     private string? ClientId => configuration["Authentication:Microsoft:ClientId"];
     private string? ClientSecret => configuration["Authentication:Microsoft:ClientSecret"];
-    private string Authority => $"https://login.microsoftonline.com/{TenantId}/oauth2/v2.0";
+    private string Authority =>
+        MicrosoftTenant.Authority(configuration[MicrosoftTenant.ConfigurationKey], "oauth2/v2.0");
 
     /// <summary>True when the sign-in app credentials needed for the delegated flow are configured.</summary>
     /// <inheritdoc />

--- a/memex/Memex.Portal.Shared/Authentication/MicrosoftTenant.cs
+++ b/memex/Memex.Portal.Shared/Authentication/MicrosoftTenant.cs
@@ -1,0 +1,133 @@
+namespace Memex.Portal.Shared.Authentication;
+
+/// <summary>
+/// The one place a Microsoft (Entra) <b>authority</b> is composed from the configured tenant —
+/// <c>https://login.microsoftonline.com/{tenant}/{path}</c> — and the guard that refuses a tenant
+/// which cannot form one.
+///
+/// <para>🚨 <b>Why this exists (MeshWeaver#2621).</b> An environment variable or configMap entry
+/// cannot be null, only EMPTY, so <c>""</c> is the deployed shape of "unset". The portal chart
+/// rendered <c>Authentication__Microsoft__TenantId</c> with an empty default and the composition
+/// read that empty string AS the tenant: the authority became
+/// <c>login.microsoftonline.com//v2.0</c>, whose discovery document Entra will never serve
+/// (<c>IDX20803</c>). Every Microsoft sign-in on memex-cloud answered <b>500</b>, per request,
+/// deterministically — and the 500 named an unreachable URL rather than the configuration key an
+/// operator had to set.</para>
+///
+/// <para><b>Two rules, and they are deliberately different.</b></para>
+/// <list type="number">
+/// <item><description><b>Blank is UNSET, never a tenant.</b> Null, empty and whitespace all resolve
+/// to <see cref="Unset"/> — the same as no key at all. This must NOT refuse: an install that never
+/// wired Microsoft sign-in leaves the key blank, and aborting a portal because an optional
+/// integration is unconfigured is the #2510 failure (a guard that fails worse than the thing it
+/// guards).</description></item>
+/// <item><description><b>A present-but-malformed tenant is REFUSED, at startup.</b> A value that is
+/// not a single URL path segment cannot compose an authority at all, so no install is serving
+/// sign-in with one today — refusing it at boot cannot take a working portal down, and it converts
+/// the outage's per-request 500 into a named configuration error that says which key is
+/// wrong.</description></item>
+/// </list>
+///
+/// <para>Pure decision, no I/O and no container, so the boot-time guard is unit-testable without
+/// spinning a host — the same shape as <c>MemexConfiguration.ValidateContentStorageDurability</c>.
+/// The sign-in handler that actually 500-ed lives in the portal package
+/// (<c>MeshWeaver.Blazor.Portal.Authentication.AuthenticationBuilderExtensions</c>, plugins repo)
+/// and carries the same two rules at its registration; this covers every authority composed
+/// platform-side, starting with the Executive Assistant's delegated Graph flow.</para>
+/// </summary>
+public static class MicrosoftTenant
+{
+    /// <summary>The configuration key the tenant is read from, in binder form.</summary>
+    public const string ConfigurationKey = "Authentication:Microsoft:TenantId";
+
+    /// <summary>
+    /// The same key as an environment variable / configMap entry — the form an operator actually
+    /// sets, and the form that must appear in a refusal so the message is actionable in a pod.
+    /// </summary>
+    public const string EnvironmentKey = "Authentication__Microsoft__TenantId";
+
+    /// <summary>The Entra login host every authority is composed against.</summary>
+    public const string Host = "login.microsoftonline.com";
+
+    /// <summary>
+    /// The tenant an UNSET key resolves to: the multi-tenant <c>common</c> authority, which accepts
+    /// both work/school and personal accounts. An environment that needs a single tenant, or the
+    /// work/school-only <c>organizations</c> authority the onboarding guide prescribes, sets its
+    /// value explicitly.
+    /// </summary>
+    public const string Unset = "common";
+
+    /// <summary>
+    /// The tenant to compose an authority from: the configured value, trimmed, or
+    /// <see cref="Unset"/> when the key is absent or blank.
+    /// </summary>
+    /// <param name="configured">The raw configured value (<c>null</c> when the key is absent).</param>
+    /// <returns>A tenant that is guaranteed to form a single, non-empty authority segment.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// The value is present but is not a single URL path segment, so no authority can be composed
+    /// from it. The message names <see cref="EnvironmentKey"/> and the accepted values.
+    /// </exception>
+    public static string Resolve(string? configured)
+    {
+        // Blank is the deployed shape of "unset" — see rule 1 on the type.
+        if (string.IsNullOrWhiteSpace(configured))
+            return Unset;
+
+        var tenant = configured.Trim();
+        // A tenant id is a GUID, a verified domain (contoso.onmicrosoft.com), or one of the
+        // well-known multi-tenant aliases — all of which are a single path segment of letters,
+        // digits, '-', '.' and '_'. Anything else ('/', whitespace, '?', '#', ':') would either
+        // split the path or need escaping, and both compose a URL Entra never serves.
+        foreach (var c in tenant)
+            if (!char.IsAsciiLetterOrDigit(c) && c != '-' && c != '.' && c != '_')
+                throw new InvalidOperationException(Refusal(configured));
+
+        return tenant;
+    }
+
+    /// <summary>
+    /// Composes <c>https://login.microsoftonline.com/{tenant}/{path}</c> from the configured tenant.
+    /// </summary>
+    /// <param name="configured">The raw configured value (<c>null</c> when the key is absent).</param>
+    /// <param name="path">The authority path after the tenant, e.g. <c>v2.0</c> or <c>oauth2/v2.0</c>.</param>
+    /// <returns>An absolute authority with no empty segment.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// The configured tenant cannot form an authority — see <see cref="Resolve"/>.
+    /// </exception>
+    public static string Authority(string? configured, string path)
+    {
+        var authority = $"https://{Host}/{Resolve(configured)}/{path}";
+        // Belt and braces: the composed URL is re-read, so an EMPTY SEGMENT can never leave this
+        // method however the tenant rule above evolves. `//` in the path is the outage's exact
+        // signature, and it is cheaper to assert here than to recognise in a log at 13:50Z.
+        if (!Uri.TryCreate(authority, UriKind.Absolute, out var uri)
+            || uri.Host != Host
+            || uri.AbsolutePath.Contains("//", StringComparison.Ordinal)
+            || uri.AbsolutePath.EndsWith('/'))
+            throw new InvalidOperationException(Refusal(configured));
+        return authority;
+    }
+
+    /// <summary>
+    /// The BOOT-TIME guard: throws when the configured tenant cannot form an authority, so the
+    /// misconfiguration is named at startup instead of surfacing as a 500 on the first sign-in.
+    /// A blank or absent key is legitimate (it means "unset") and passes.
+    /// </summary>
+    /// <param name="configured">The raw configured value (<c>null</c> when the key is absent).</param>
+    /// <exception cref="InvalidOperationException">
+    /// The value is present but malformed; the message names the configuration key.
+    /// </exception>
+    public static void Validate(string? configured) => Authority(configured, "v2.0");
+
+    private static string Refusal(string? configured) =>
+        $"Microsoft sign-in misconfiguration (issue #2621): {EnvironmentKey} ('{configured}') is not a "
+        + "tenant. It has to be a single authority segment — an Entra tenant GUID, a verified domain "
+        + $"such as 'contoso.onmicrosoft.com', or one of '{Unset}' (work/school and personal), "
+        + "'organizations' (work/school only — what the onboarding guide prescribes for a public "
+        + $"portal) and 'consumers'. Composing https://{Host}/<tenant>/... from this value yields a "
+        + "URL Entra will never serve a discovery document for, so EVERY Microsoft sign-in would "
+        + $"answer 500 at the first request that touched the handler. Set {EnvironmentKey} to a valid "
+        + "tenant, or leave it unset (an unset key means the multi-tenant "
+        + $"'{Unset}' authority). Refusing to start so the misconfiguration surfaces now rather than "
+        + "on the first user who tries to sign in.";
+}

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -415,6 +415,13 @@ public static class MemexConfiguration
             // with an empty/relative BasePath resolves against the ephemeral container CWD (/app),
             // so uploaded collection files vanish on the next pod restart / grain teardown.
             ValidateContentStorageDurability(contentStorageConfig, isDevelopment);
+            // 🚨 Fail fast on a Microsoft tenant that cannot form an OIDC authority (#2621). An
+            // env var cannot be null, only empty, so a blank key legitimately means "unset" and
+            // passes; a value that is not a single authority segment composes
+            // login.microsoftonline.com//... — a URL Entra never serves — and used to surface as an
+            // unhandled 500 on the FIRST sign-in, naming the URL instead of the key to fix. Named
+            // here at boot instead.
+            MicrosoftTenant.Validate(configuration[MicrosoftTenant.ConfigurationKey]);
             if (contentStorageConfig != null)
             {
                 // Resolve relative path to absolute

--- a/test/Memex.Portal.Shared.Test/MicrosoftTenantAuthorityTest.cs
+++ b/test/Memex.Portal.Shared.Test/MicrosoftTenantAuthorityTest.cs
@@ -1,0 +1,121 @@
+using System;
+using Memex.Portal.Shared.Authentication;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>The platform-side regression guard for MeshWeaver#2621: every Microsoft sign-in on
+/// memex-cloud answered 500 because the tenant arrived as an EMPTY STRING.</b>
+///
+/// <para>An environment variable or configMap entry cannot be null, only empty — so <c>""</c> is
+/// the deployed shape of "unset". The chart rendered <c>Authentication__Microsoft__TenantId</c>
+/// with an empty default and the composition read that empty string as the tenant: the authority
+/// became <c>login.microsoftonline.com//v2.0</c>, its discovery document could never be fetched
+/// (<c>IDX20803</c>), and the failure surfaced as an unhandled <c>InvalidOperationException</c> on
+/// every request that touched the handler — never at startup, and never naming the key an operator
+/// had to set.</para>
+///
+/// <para>Both directions are pinned, because neither implies the other: a blank tenant is unset
+/// (so a portal that never wired Microsoft sign-in still starts — aborting on an unconfigured
+/// OPTIONAL integration is the #2510 failure), and a value that CANNOT form an authority is
+/// refused at boot with the key in the message, rather than composing a URL Entra never serves.
+/// The <c>//</c> that was the outage's signature can never leave the composer at all.</para>
+///
+/// <para>The sign-in handler that actually 500-ed lives in the portal package (plugins repo,
+/// <c>MicrosoftTenantBlankIsUnsetTest</c> pins it there). This pins the platform-side composer —
+/// <see cref="MicrosoftTenant"/>, used by the Executive Assistant's delegated Graph flow — and the
+/// boot-time guard <c>MemexConfiguration</c> runs on every portal host.</para>
+/// </summary>
+public class MicrosoftTenantAuthorityTest
+{
+    /// <summary>THE defect: the deployed shape of "unset" must never become a tenant.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("\t")]
+    [InlineData(null)]
+    public void ABlankTenantIsUnset(string? configured)
+    {
+        Assert.Equal(MicrosoftTenant.Unset, MicrosoftTenant.Resolve(configured));
+        Assert.Equal("https://login.microsoftonline.com/common/v2.0",
+            MicrosoftTenant.Authority(configured, "v2.0"));
+    }
+
+    /// <summary>
+    /// The outage's literal signature: whatever the tenant is, the composed authority never
+    /// carries an empty segment. This is the assertion that would have failed on 2026-08-28.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    [InlineData("organizations")]
+    public void TheAuthorityNeverCarriesAnEmptySegment(string? configured)
+    {
+        Assert.DoesNotContain("com//", MicrosoftTenant.Authority(configured, "v2.0"), StringComparison.Ordinal);
+        Assert.DoesNotContain("com//", MicrosoftTenant.Authority(configured, "oauth2/v2.0"), StringComparison.Ordinal);
+    }
+
+    /// <summary>The other direction: a real tenant composes its authority, whitespace-trimmed.</summary>
+    [Theory]
+    [InlineData("organizations", "https://login.microsoftonline.com/organizations/v2.0")]
+    [InlineData(" organizations ", "https://login.microsoftonline.com/organizations/v2.0")]
+    [InlineData("consumers", "https://login.microsoftonline.com/consumers/v2.0")]
+    [InlineData("contoso.onmicrosoft.com", "https://login.microsoftonline.com/contoso.onmicrosoft.com/v2.0")]
+    [InlineData("72f988bf-86f1-41af-91ab-2d7cd011db47",
+        "https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/v2.0")]
+    public void AnExplicitTenantFormsItsAuthority(string configured, string expected)
+    {
+        Assert.Equal(expected, MicrosoftTenant.Authority(configured, "v2.0"));
+    }
+
+    /// <summary>The Executive Assistant's delegated Graph flow composes the same way, one path deeper.</summary>
+    [Fact]
+    public void TheGraphAuthorityIsComposedFromTheSameTenant()
+    {
+        Assert.Equal("https://login.microsoftonline.com/organizations/oauth2/v2.0",
+            MicrosoftTenant.Authority("organizations", "oauth2/v2.0"));
+    }
+
+    /// <summary>
+    /// A value that is not a single authority segment is refused, and the refusal NAMES the
+    /// configuration key an operator has to set — the whole point of the guard.
+    /// </summary>
+    [Theory]
+    [InlineData("/")]
+    [InlineData("a/b")]
+    [InlineData("my tenant")]
+    [InlineData("../common")]
+    [InlineData("organizations?x=1")]
+    [InlineData("login.microsoftonline.com/organizations")]
+    public void AMalformedTenantIsRefusedByName(string configured)
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => MicrosoftTenant.Authority(configured, "v2.0"));
+        Assert.Contains(MicrosoftTenant.EnvironmentKey, ex.Message, StringComparison.Ordinal);
+        Assert.Contains(configured, ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The boot-time guard: it refuses a malformed tenant at STARTUP (where
+    /// <c>MemexConfiguration.ConfigureMemexMesh</c> calls it) and — just as importantly — passes an
+    /// unset one, so a portal that never wired Microsoft sign-in still starts.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData("organizations")]
+    public void ValidateAcceptsEveryUsableConfiguration(string? configured)
+    {
+        MicrosoftTenant.Validate(configured);
+    }
+
+    /// <summary>…and the same guard refuses the value that cannot work, naming the key.</summary>
+    [Fact]
+    public void ValidateRefusesAMalformedTenantAtStartup()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(() => MicrosoftTenant.Validate("a/b"));
+        Assert.Contains(MicrosoftTenant.EnvironmentKey, ex.Message, StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
Closes the **platform half** of #2621. (The sign-in handler itself and the chart default already landed — see *What was already fixed* below; this PR is what remains in core.)

## The failure mode

Every Microsoft sign-in on memex-cloud answered **500**. An environment variable or configMap entry **cannot be null, only empty**, so `""` is the deployed shape of "unset" — and the authority composition read that empty string *as the tenant*:

```
https://login.microsoftonline.com//v2.0/.well-known/openid-configuration
                                 ^^ the tenant segment
```

Entra never serves a discovery document for that URL (`IDX20803`), so it cannot self-heal, and the failure escaped as an unhandled `InvalidOperationException` through `OnboardingMiddleware.InvokeAsync` — **per request, naming an unreachable URL rather than the configuration key an operator had to set**. A configuration mistake was reported as a server error, five layers from its cause.

## What the guard does

`Memex.Portal.Shared.Authentication.MicrosoftTenant` becomes the one place an Entra authority is composed, and `MemexConfiguration.ConfigureMemexMesh` validates the configured value at **startup**, on every portal host (all three `Memex.Portal.*` hosts call it). Two rules, and they are deliberately different:

| configured value | verdict |
|---|---|
| absent, `""`, whitespace | **UNSET** → `common`, exactly as no key at all. Passes. |
| a GUID, a verified domain, `common` / `organizations` / `consumers` | composes its authority (trimmed) |
| anything that is not a single authority segment (`a/b`, `/`, `my tenant`, `../common`, …) | **refused at boot**, naming `Authentication__Microsoft__TenantId`, the offending value and the accepted ones |

**Blank must not refuse**, and that is the load-bearing half. An install that never wired Microsoft sign-in leaves the key blank; aborting a portal because an *optional* integration is unconfigured is the #2510 failure — a guard that fails worse than the thing it guards (`Email:TenantId` unset → `Hosting failed to start`). Conversely no install can be serving sign-in with a *malformed* tenant today, so refusing that one at boot cannot take a working portal down: it only moves the per-request 500 to a named configuration error at startup.

The composer also **re-reads the URL it built** and refuses an empty path segment, so the `//` that was the outage's signature can never leave it however the tenant rule evolves — cheaper to assert here than to recognise in a log at 13:50Z.

`EaGraphAuth` — the Executive Assistant's delegated Graph flow, and the last remaining `login.microsoftonline.com/{tenant}` composition platform-side (`memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs:52`) — now goes through the same composer. It had the blank→`common` fallback but no refusal of a malformed value and **no test in either direction**.

## Scope — this is the diagnosis, not the deployment config

This PR does **not** touch any deployment config, Helm values, ConfigMap or running cluster. It makes the misconfiguration *name itself at startup* instead of 500-ing at sign-in. The live `Authentication__Microsoft__TenantId` on memex-cloud still has to be set (the chart's `organizations` default lands on the next roll).

### What was already fixed, so this doesn't duplicate it

- `3993a55e9` (core) — the chart no longer emits an empty default; `EaGraphAuth` treats whitespace as unset; What's New entry.
- `eecbbb65` (MeshWeaver.Plugins) — `AddMicrosoftAuthentication`, the handler that actually 500-ed, with `MicrosoftTenantBlankIsUnsetTest`.

## Tests

`test/Memex.Portal.Shared.Test/MicrosoftTenantAuthorityTest.cs` — 25 cases pinning both directions: blank/absent is unset and composes no empty segment; GUID, domain, `organizations`, `consumers` compose theirs (whitespace-trimmed); six malformed values are refused **by name**; and the boot guard accepts every usable configuration while refusing the unusable one.

```
dotnet build test/Memex.Portal.Shared.Test   → 0 warnings, 0 errors (warnings-as-errors)
dotnet test  --filter MicrosoftTenantAuthorityTest   → Passed: 25, Failed: 0
dotnet test  --filter "…|Ea…"  (the EaGraphAuth callers too)  → Passed: 53, Failed: 0
```

**Non-vacuous:** reintroducing the original `?? "common"` (null-coalesce instead of `IsNullOrWhiteSpace`) fails **7 of the 25** cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)