### PR TITLE
Markdown: leave absolute and site-rooted image URLs alone instead of rebasing them onto api/content

### DIFF
--- a/src/MeshWeaver.Markdown/MarkdownExtensions.cs
+++ b/src/MeshWeaver.Markdown/MarkdownExtensions.cs
@@ -63,7 +63,7 @@ public static class MarkdownExtensions
             // emoji still work via unambiguous `:shortcode:` (`:smile:`, `:warning:`). Issue #402.
             .UseEmojiAndSmiley(enableSmileys: false)
             .UseYamlFrontMatter()
-            .Use(new ImgPathMarkdownExtension(path => ToContentHref(path, collection)))
+            .Use(new ImgPathMarkdownExtension(path => ResolveImageHref(path, collection)))
             .Use(new LinkUrlCleanupExtension(currentNodePath))
             .Use(new LayoutAreaMarkdownExtension(currentNodePath))
             .Use(new ExecutableCodeBlockExtension())
@@ -84,6 +84,29 @@ public static class MarkdownExtensions
     /// <returns>The content href string.</returns>
     public static string ToContentHref(string path, object? collection)
         => $"{ContentRoutePrefix}/{collection}/{path}";
+
+    /// <summary>
+    /// The href a markdown image renders with: a COLLECTION-RELATIVE path goes through the
+    /// access-controlled content route (<see cref="ToContentHref"/>); an ABSOLUTE URL
+    /// (<c>https://…</c>, <c>data:</c>, protocol-relative <c>//…</c>) or a SITE-ROOTED path
+    /// (<c>/api/og/…</c>, <c>/static/…</c>) is already an address and is left alone. Prefixing
+    /// those produced <c>api/content/{node}/https://media.licdn.com/…</c> for a LinkedIn profile
+    /// photo and <c>api/content/{node}//api/og/…</c> for an OG image — both 404, on every page that
+    /// embedded an external or portal-served picture (2026-08-29). Pure.
+    /// </summary>
+    public static string ResolveImageHref(string path, object? collection)
+        => IsAddressedAlready(path) ? path : ToContentHref(path, collection);
+
+    /// <summary>True for a URL that must not be rebased onto the content route: absolute
+    /// (scheme-qualified), protocol-relative, or rooted at the site. Pure.</summary>
+    public static bool IsAddressedAlready(string? url)
+    {
+        if (string.IsNullOrWhiteSpace(url))
+            return false;
+        var trimmed = url.TrimStart();
+        return trimmed.StartsWith('/')
+            || Uri.TryCreate(trimmed, UriKind.Absolute, out var uri) && !string.IsNullOrEmpty(uri.Scheme);
+    }
 
     /// <summary>
     /// The site-relative content route markdown images are rewritten onto. Mirrors

--- a/test/MeshWeaver.Markdown.Test/MarkdownImageHrefTest.cs
+++ b/test/MeshWeaver.Markdown.Test/MarkdownImageHrefTest.cs
@@ -1,0 +1,40 @@
+
+using Xunit;
+
+namespace MeshWeaver.Markdown.Test;
+
+/// <summary>
+/// Markdown images and the content route. A collection-relative image goes through the
+/// access-controlled <c>api/content/{collection}/{path}</c> route (issue #587); an image that is
+/// ALREADY an address — an external <c>https://</c> picture, a <c>data:</c> URI, a site-rooted
+/// <c>/api/og/…</c> — is left alone. The rewrite used to prefix everything, so a LinkedIn profile
+/// photo became <c>api/content/Profiles/…/https://media.licdn.com/…</c> and an OG card image
+/// <c>api/content/…//api/og/…</c>, both 404 (memex, 2026-08-29).
+/// </summary>
+public class MarkdownImageHrefTest
+{
+    [Theory]
+    [InlineData("photo.png", "api/content/Profiles/Roland/photo.png")]
+    [InlineData("images/hero.jpg", "api/content/Profiles/Roland/images/hero.jpg")]
+    [InlineData("https://media.licdn.com/dms/image/v2/abc/profile.jpg", "https://media.licdn.com/dms/image/v2/abc/profile.jpg")]
+    [InlineData("http://example.org/a.png", "http://example.org/a.png")]
+    [InlineData("//cdn.example.org/a.png", "//cdn.example.org/a.png")]
+    [InlineData("/api/og/OgCard/Doc", "/api/og/OgCard/Doc")]
+    [InlineData("/static/NodeTypeIcons/book.svg", "/static/NodeTypeIcons/book.svg")]
+    [InlineData("data:image/png;base64,iVBORw0KGgo=", "data:image/png;base64,iVBORw0KGgo=")]
+    public void ResolveImageHref_RebasesOnlyCollectionRelativePaths(string url, string expected)
+        => Assert.Equal(expected, MarkdownExtensions.ResolveImageHref(url, "Profiles/Roland"));
+
+    [Fact]
+    public void RenderedMarkdown_KeepsAbsoluteImages_AndRebasesRelativeOnes()
+    {
+        var html = Markdig.Markdown.ToHtml(
+            "![me](https://media.licdn.com/dms/image/v2/abc/profile.jpg) ![local](photo.png) ![og](/api/og/OgCard/Doc)",
+            MarkdownExtensions.CreateMarkdownPipeline("Profiles/Roland", "Profiles/Roland"));
+        Assert.Contains("src=\"https://media.licdn.com/dms/image/v2/abc/profile.jpg\"", html);
+        Assert.Contains("src=\"api/content/Profiles/Roland/photo.png\"", html);
+        Assert.Contains("src=\"/api/og/OgCard/Doc\"", html);
+        Assert.DoesNotContain("api/content/Profiles/Roland/https://", html);
+        Assert.DoesNotContain("api/content/Profiles/Roland//api", html);
+    }
+}


### PR DESCRIPTION
Every markdown image URL was prefixed with `api/content/{collection}/`, including ones that are already addresses. Measured on memex 2026-08-29 while walking every app as a signed-in user:

- `/api/content/Profiles/RolandLinkedIn/LinkedIn/https://media.licdn.com/dms/image/…` → 404 (LinkedIn profile photo)
- `/api/content/rbuergi/OgCard/Examples//api/og/OgCard` → 404 (OG card image)

`MarkdownExtensions.ResolveImageHref` now rebases only collection-relative paths; scheme-qualified, protocol-relative (`//…`) and site-rooted (`/…`) URLs pass through untouched. The access-controlled content route (issue #587) is unchanged for relative paths.

Tests: `MarkdownImageHrefTest` — a theory over the URL shapes plus a rendered-pipeline case asserting the `src` attributes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ETgRRMRVzYMg1WU4pMywed