### PR TITLE
fix(cd): a bake-only reconcile no longer blames promote for its own broken query

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -516,8 +516,13 @@ jobs:
           # instead of "healing" it back into a build every tick.
           IRRELEVANT='^clients/(react-native|voice-gateway)/'
           relevant=true
+          # `--detail` is load-bearing: WITHOUT it show-tags returns an array of plain STRINGS,
+          # so `[].name` matches nothing and newest_short is ALWAYS empty. Every gate log has read
+          # `Newest published set: <none>` for as long as this step has existed. It fails open
+          # (relevant stays true), so it never turned CD red — it only meant the image-irrelevant
+          # skip below could never fire. The batching probe above already passes --detail.
           newest_short=$(az acr repository show-tags -n meshweaver --repository memex-portal-ai \
-            --orderby time_desc --top 60 --query "[].name" -o tsv 2>/dev/null \
+            --orderby time_desc --detail --top 60 --query "[].name" -o tsv 2>/dev/null \
             | grep -E '^[0-9a-f]{7}$' | head -1 || true)
           if [ -n "$newest_short" ] && [ "$newest_short" != "$(printf '%s' "$SHA" | cut -c1-7)" ]; then
             base=$(gh api "repos/$GITHUB_REPOSITORY/commits/$newest_short" --jq .sha 2>/dev/null || true)

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1522,8 +1522,24 @@ jobs:
             echo "::error::portal-image produced no version and this is not a bake-only run — refusing to publish under an unknown release."
             exit 1
           fi
+          # 🚨 Two failure shapes live in this one read, and the second cost nine hours.
+          #
+          # `tags` is NULL on an untagged manifest — the orphaned per-platform children an index
+          # push leaves behind (16 of memex-portal-ai's 2101 manifests on 2026-08-29). jmespath's
+          # contains() THROWS on null instead of returning false, and the throw aborts the WHOLE
+          # query, so ONE orphan makes this unable to find any tag at all. `tags &&` short-circuits
+          # those rows out before contains() ever sees them.
+          #
+          # And do NOT swallow az's stderr. This read used to end `2>/dev/null || true`, which
+          # turned "the query crashed with an invalid-jmespath error" into "there is no version
+          # tag" — so the error below blamed promote, which was working perfectly: it had armed
+          # memex-portal-ai:<sha> → <version> on one digest, exactly as designed. Nine scheduled
+          # reconciles (2026-08-28 22:12Z → 08-29 05:26Z) died pointing at the healthy half of CD.
+          # An error that names a HEALTHY component as the culprit is worse than a silent failure;
+          # it is a silent failure with directions attached. Let az fail the step with its own
+          # message, so the next reader debugs the query and not promote.
           tags=$(az acr manifest list-metadata --registry meshweaver --name memex-portal-ai \
-                   --query "[?contains(tags, '${SHORT_SHA}')].tags[]" -o tsv 2>/dev/null || true)
+                   --query "[?tags && contains(tags, '${SHORT_SHA}')].tags[]" -o tsv)
           version=$(grep -E '^[0-9]+\.[0-9]+\.[0-9]+' <<<"$tags" | grep -vx "$SHORT_SHA" | head -1 || true)
           if [ -z "$version" ]; then
             echo "::error::memex-portal-ai:${SHORT_SHA} carries no version tag (tags on that digest: $(tr '\n' ' ' <<<"$tags")) — promote's Phase C never armed a release for this sha, so there is no release to make available. Fix promote; do not publish a marker for an invented version."


### PR DESCRIPTION
Core `main` CD was red on **nine consecutive scheduled reconciles** (2026-08-28 22:12Z → 08-29 05:26Z). The delivery itself was fine the whole time — what was broken is the reconcile's release-version read, and its error message sent readers at the wrong component.

## What was actually failing

Every red run failed on one step, `Resolve the release version this bake belongs to`:

```
memex-portal-ai:aaf95af carries no version tag (tags on that digest:  ) — promote's
Phase C never armed a release for this sha … Fix promote; do not publish a marker
for an invented version.
```

Two things are wrong with that sentence.

### 1. The error text accuses a healthy component

Promote **had** armed the release. Run [33210930983](https://github.com/Systemorph/MeshWeaver/actions/runs/33210930983) job `98987531545` pushed all three tags onto one digest:

```
memex-portal-ai:aaf95af   memex-portal-ai:main   memex-portal-ai:3.0.0-rc8.ci.6360
      → sha256:6c3abd508033db59865e8bedf68076bdb75b4c044e3fa1159c01eff98b2a1089
```

and the bake in that same run published, sealed and wrote `_releases/3.0.0-rc8.ci.6360 → identity s35f21e69e34d028fa49c70d79455a93d`. `aaf95af` was fully delivered at 21:23Z. Every later reconcile then told the reader that the one component doing its job was the one to fix.

**An error that names a healthy component as the culprit is worse than a silent failure — it is a silent failure with directions attached.** It cost nine hours in the wrong direction.

### 2. The swallow is the root cause; the query crash is only the trigger

```bash
tags=$(az acr manifest list-metadata --registry meshweaver --name memex-portal-ai \
         --query "[?contains(tags, '${SHORT_SHA}')].tags[]" -o tsv 2>/dev/null || true)
```

`tags` is **null** on an untagged manifest — the orphaned per-platform children an index push leaves behind. `memex-portal-ai` holds 2101 manifests, **16 of them untagged** (dated 08-16 → 08-22). jmespath's `contains()` *throws* on null rather than returning false, and the throw aborts the whole query:

```
ERROR: Invalid jmespath query supplied for `--query`: In function contains(),
invalid type for value: None, expected one of: ['array', 'string'], received: "null"
```

So one orphan makes the read find nothing. Then `2>/dev/null || true` converted *"the query crashed with an invalid-jmespath error"* into *"there is no version tag"* — and only because of that could the step reach the message blaming promote. **Removing the swallow is the more important half of this fix; the `tags &&` guard just stops the crash.**

## The fix (commit 62f4734)

- `[?tags && contains(tags, '${SHORT_SHA}')]` — `&&` short-circuits, so untagged rows never reach `contains()`.
- **`2>/dev/null || true` removed** — an az failure now fails the step with az's own message, so the next reader debugs the query rather than promote.

Verified against live ACR, all three paths:

| case | result |
|---|---|
| `aaf95af`, bake-only | `release version 3.0.0-rc8.ci.6360` — what the nine red runs should have printed |
| a sha with no version tag | exit 1, with the (now accurate) message |
| az itself fails | exit 1, carrying **az's own** error text — no longer masquerading as a missing tag |

## Second, separate defect (commit 9cae035)

`az acr repository show-tags` returns an array of plain **strings** unless `--detail` is passed, so the gate's `--query "[].name"` matched nothing and `newest_short` was **always** empty. Every gate log has read `Newest published set: <none>` for as long as that step has existed.

This is latent, not the outage: it fails open (`relevant` stays true), so it never turned CD red — it only meant the image-irrelevant skip could never fire. The batching probe 60 lines above already passes `--detail`; this one did not. Kept as its own commit for that reason.

Behaviour this restores, worth knowing: a push whose entire diff since the newest published set is under `clients/(react-native|voice-gateway)/` will now correctly skip the image build, which it never did before.

## Not caused by `aaf95afc3`

`aaf95afc3` (#2630, workflows-only) did not cause this. It is implicated only as the sha that happened to be main's tip when ACR returned HTTP 500 on two blob uploads (jobs `98980554453`, `98980554462` in run [33209932873](https://github.com/Systemorph/MeshWeaver/actions/runs/33209932873)) and then sat still. That 500 was transient and the 21:04Z reconcile healed it.

The real precondition is **main going quiet** — the first reconcile that finds a complete image set and nothing to build is the first one to take the bake-only path at all. Tracked separately in #2643, because the next merge to main masks it — and it already did: `origin/main` moved to `5f067884e` (#2634) mid-investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

