### PR TITLE
Join hub disposal before a harness proceeds — the SIGSEGV rule, plus a ratchet

### DIFF
--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1253,7 +1253,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     /// suite. The waits are sequential on purpose — a client that will not finish is named
     /// individually, which is what the trace file needs to be attributable.</para>
     /// </summary>
-    private async Task DisposeTestClients(string testName, Stopwatch sw)
+    private async Task DisposeTestClientsAsync(string testName, Stopwatch sw)
     {
         lock (_requestHubLock) _requestHub = null;
         IMessageHub[] snapshot;
@@ -1399,7 +1399,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // intermediate tests were already slow from the action-block
             // congestion). See ConcurrentRequests deadlock (commit 02dd88f37)
             // and the AI/Threading suite 6-min CI timeout.
-            await DisposeTestClients(testName, sw);
+            await DisposeTestClientsAsync(testName, sw);
             TestPhaseTrace(testName, "DISPOSE_SHARED_SKIP", sw.ElapsedMilliseconds);
             try { await base.DisposeAsync(); }
             catch (Exception ex)
@@ -1416,7 +1416,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
         // Non-shared path also benefits — Mesh.Dispose disposes all hosted hubs
         // including clients, but doing it via the tracked list is faster and
         // more deterministic (no race against the Mesh's own dispose).
-        await DisposeTestClients(testName, sw);
+        await DisposeTestClientsAsync(testName, sw);
 
         try
         {

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1236,7 +1236,24 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
         });
     }
 
-    private void DisposeTestClients(string testName, Stopwatch sw)
+    /// <summary>
+    /// Disposes every client hub this test created AND JOINS each one's teardown before returning.
+    ///
+    /// <para>🚨 The join is not tidiness. On the <see cref="SharesMeshAcrossTests"/> path this method
+    /// is the LAST thing that touches the mesh — <c>DisposeAsync</c> returns straight after it and
+    /// the next <c>[Fact]</c> begins — so a bare <c>Dispose()</c> here starts the client's teardown
+    /// (action-block drain, sync-stream unregistration, registrant callbacks) and then hands the
+    /// mesh to the next test while all of that is still running on other threads. The observed
+    /// result is a burst of <c>[SYNC_STREAM] Not setting … — stream is disposed</c> followed by a
+    /// use-after-dispose that takes the host down with exit 139, naming no test. On the non-shared
+    /// path the very next statements stop the hosted services and dispose the Mesh, which is the
+    /// same race one level up.</para>
+    ///
+    /// <para>Bounded per client and LOUD on expiry: a wedged client must fail visibly, not hang the
+    /// suite. The waits are sequential on purpose — a client that will not finish is named
+    /// individually, which is what the trace file needs to be attributable.</para>
+    /// </summary>
+    private async Task DisposeTestClients(string testName, Stopwatch sw)
     {
         lock (_requestHubLock) _requestHub = null;
         IMessageHub[] snapshot;
@@ -1250,12 +1267,9 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
         TestPhaseTrace(testName, "DISPOSE_CLIENTS_START", sw.ElapsedMilliseconds, $"count={snapshot.Length}");
         foreach (var client in snapshot)
         {
-            try { client.Dispose(); }
-            catch (Exception ex)
-            {
-                FileOutput.WriteLine(
-                    $"[DISPOSE] {testName}: client {client.Address} dispose failed: {ex.GetType().Name}: {ex.Message}");
-            }
+            await client.DisposeAndJoinAsync(
+                message => FileOutput.WriteLine($"[DISPOSE] {testName}: {message}"),
+                DisposeTimeout);
         }
         TestPhaseTrace(testName, "DISPOSE_CLIENTS_DONE", sw.ElapsedMilliseconds);
     }
@@ -1385,7 +1399,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // intermediate tests were already slow from the action-block
             // congestion). See ConcurrentRequests deadlock (commit 02dd88f37)
             // and the AI/Threading suite 6-min CI timeout.
-            DisposeTestClients(testName, sw);
+            await DisposeTestClients(testName, sw);
             TestPhaseTrace(testName, "DISPOSE_SHARED_SKIP", sw.ElapsedMilliseconds);
             try { await base.DisposeAsync(); }
             catch (Exception ex)
@@ -1402,7 +1416,7 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
         // Non-shared path also benefits — Mesh.Dispose disposes all hosted hubs
         // including clients, but doing it via the tracked list is faster and
         // more deterministic (no race against the Mesh's own dispose).
-        DisposeTestClients(testName, sw);
+        await DisposeTestClients(testName, sw);
 
         try
         {

--- a/src/MeshWeaver.Hosting.Orleans.TestBase/OrleansTestBase.cs
+++ b/src/MeshWeaver.Hosting.Orleans.TestBase/OrleansTestBase.cs
@@ -127,11 +127,17 @@ public abstract class OrleansTestBase<TSiloConfigurator>(ITestOutputHelper outpu
             snapshot = _clientsCreated.ToArray();
             _clientsCreated.Clear();
         }
+        // 🚨 JOIN each client's teardown before the cluster goes down. A bare Dispose() only STARTS
+        // it: the action-block drain, the routing-stream unregistration and the registrant callbacks
+        // all run afterwards, on other threads — and the very next statement hands the cluster to
+        // OrleansClusterDisposal, which stops the silos those callbacks are still talking to. The
+        // outcome is a use-after-dispose (grain calls onto a stopping silo, continuations resolving
+        // from a torn-down scope) that kills the host mid-run rather than failing a test. The
+        // previous `catch { /* best-effort */ }` also discarded a disposal fault entirely; it is now
+        // written to the test output (via FileOutput, which is safe to call after the test has been
+        // reported — a raw ITestOutputHelper throws there).
         foreach (var client in snapshot)
-        {
-            try { client.Dispose(); }
-            catch { /* best-effort */ }
-        }
+            await client.DisposeAndJoinAsync(FileOutput.WriteLine);
 
         OrleansClusterDisposal.DisposeInBackground(host);
         await base.DisposeAsync();

--- a/src/MeshWeaver.Hosting.Orleans.TestBase/SharedOrleansFixture.cs
+++ b/src/MeshWeaver.Hosting.Orleans.TestBase/SharedOrleansFixture.cs
@@ -290,10 +290,24 @@ public class SharedOrleansFixture : IAsyncLifetime
 
             foreach (var hub in hosted.Hubs.ToArray())
             {
-                if (hub.Address.ToString().StartsWith(pathPrefix, StringComparison.Ordinal))
-                {
-                    try { hub.Dispose(); } catch { /* swallow */ }
-                }
+                if (!hub.Address.ToString().StartsWith(pathPrefix, StringComparison.Ordinal))
+                    continue;
+                // 🚨 JOIN, don't just start it. This method's whole purpose is that the NEXT test
+                // does not inherit these hubs' state — and a bare Dispose() gives it exactly that,
+                // because disposal is a state machine that returns immediately and drains
+                // afterwards. Worse, these are SILO-SIDE hubs: their teardown deactivates the owning
+                // grain (MessageHubGrain), so returning early lets the next test's grain calls race
+                // a deactivation in flight on a hub it can still address. The wait is a synchronous
+                // block-join because this method has no async caller to suspend (it is invoked from
+                // synchronous per-test cleanup); it is bounded, and an expiry is written to the
+                // fixture's logger rather than swallowed the way `catch { }` used to swallow both a
+                // dispose fault and a hung teardown as one silence.
+                // Captured while the hub's scope is still alive — never resolve DI once disposal
+                // has begun (the same rule CleanupClientAsync above states).
+                var logger = SafeLogger(hub);
+                hub.DisposeAndJoin(
+                    message => logger?.LogError("Silo hub cleanup: {Message}", message),
+                    TimeSpan.FromSeconds(10));
             }
         }
     }

--- a/src/MeshWeaver.Messaging.Hub/HubDisposalJoin.cs
+++ b/src/MeshWeaver.Messaging.Hub/HubDisposalJoin.cs
@@ -1,3 +1,5 @@
+using System.Reactive;
+
 namespace MeshWeaver.Messaging;
 
 /// <summary>
@@ -30,11 +32,14 @@ namespace MeshWeaver.Messaging;
 /// swallowed. The budget exists to keep a wedged action block from hanging a whole suite — it is not
 /// a number to raise when it fires. A join that times out is a hub that is not finishing; find it.</para>
 ///
-/// <para>🚨 <b>No <c>Timeout</c> is composed into the signal</b>, in either overload — the bound is a
-/// <see cref="CancellationTokenSource"/> (async) or a <see cref="ManualResetEventSlim"/> wait (sync),
-/// and the subscription stays attached afterwards, so a fault arriving after the wait gave up is
-/// still reported instead of becoming the unobserved exception that xUnit v3 escalates to a
-/// Catastrophic failure (#2301/#2488, and <see cref="ReactiveCompletion"/>'s remarks).</para>
+/// <para>🚨 <b>No <c>Timeout</c> is composed into the signal</b>, in either form. Both go through
+/// <see cref="ReactiveCompletion.ObserveCompletion"/> — bounded by a
+/// <see cref="CancellationTokenSource"/> (async) or by <c>Task.Wait(TimeSpan)</c> (sync) — so the
+/// subscription stays attached after the wait gives up and a fault arriving later is still reported
+/// instead of becoming the unobserved exception that xUnit v3 escalates to a Catastrophic failure
+/// (#2301/#2488). It is also what makes the blocking form safe: the task is completed with
+/// <c>RunContinuationsAsynchronously</c>, so the signalling thread never carries on into the
+/// caller's code.</para>
 /// </summary>
 public static class HubDisposalJoin
 {
@@ -67,23 +72,55 @@ public static class HubDisposalJoin
 
         if (!TryDispose(hub, address, report)) return;
 
+        await hub.DisposalCompleted
+            .JoinDisposalAsync(address, report, budget, hub.GetPendingRequestDiagnostics)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Awaits a disposal-completion signal that something ELSE already started — a hub's
+    /// <see cref="IMessageHub.DisposalCompleted"/>, a
+    /// <see cref="HostedHubsCollection.DisposalCompleted"/>, any composed teardown signal — with the
+    /// same bound and the same loudness as <see cref="DisposeAndJoinAsync"/>. Split out so the join
+    /// itself is exercisable against a bare subject, which is how this repo pins signal behaviour
+    /// (see <c>DisposalWaitBridgeTest</c>'s remarks on why a real hub is the wrong instrument).
+    /// </summary>
+    /// <param name="disposalCompleted">The completion signal. Must terminate.</param>
+    /// <param name="description">How the thing being joined is named in a report — an address.</param>
+    /// <param name="report">Where a timeout, a fault or a late fault is SAID.</param>
+    /// <param name="timeout">The join budget; <see cref="DefaultJoinTimeout"/> when omitted.</param>
+    /// <param name="diagnostics">Optional in-flight snapshot, appended to a timeout report so it
+    /// says WHY. Evaluated only on expiry, and never allowed to throw out of teardown.</param>
+    /// <returns><c>true</c> if the signal terminated within the budget; <c>false</c> otherwise.</returns>
+    public static async Task<bool> JoinDisposalAsync(
+        this IObservable<Unit> disposalCompleted, string description, Action<string> report,
+        TimeSpan? timeout = null, Func<string?>? diagnostics = null)
+    {
+        ArgumentNullException.ThrowIfNull(disposalCompleted);
+        ArgumentNullException.ThrowIfNull(report);
+        report = Safely(report);
+        var budget = timeout ?? DefaultJoinTimeout;
+
         using var cts = new CancellationTokenSource(budget);
         try
         {
             // ConfigureAwait(false) on top of ObserveCompletion's RunContinuationsAsynchronously:
             // `await` captures TaskScheduler.Current absent a SynchronizationContext, so a teardown
             // entered from a hub scheduler would otherwise carry the rest of itself back onto one.
-            await hub.DisposalCompleted
-                .ObserveCompletion(LateFault(address, report), cts.Token)
+            await disposalCompleted
+                .ObserveCompletion(LateFault(description, report), cts.Token)
                 .ConfigureAwait(false);
+            return true;
         }
         catch (OperationCanceledException) when (cts.IsCancellationRequested)
         {
-            report(NotJoined(address, budget, hub));
+            report(NotJoined(description, budget, diagnostics));
+            return false;
         }
         catch (Exception ex)
         {
-            report($"[dispose-join] hub {address}: disposal FAULTED — {ex.GetType().Name}: {ex.Message}");
+            report(Faulted(description, ex));
+            return false;
         }
     }
 
@@ -109,37 +146,58 @@ public static class HubDisposalJoin
         var budget = timeout ?? DefaultJoinTimeout;
         var address = Describe(hub);
 
-        if (!TryDispose(hub, address, report)) return false;
+        return !TryDispose(hub, address, report)
+            ? false
+            : hub.DisposalCompleted.JoinDisposal(address, report, budget, hub.GetPendingRequestDiagnostics);
+    }
 
-        var joined = new ManualResetEventSlim(false);
-        var lateFault = LateFault(address, report);
-        var settled = 0;
+    /// <summary>
+    /// The block-joining twin of <see cref="JoinDisposalAsync"/>, for a signal something ELSE
+    /// already started. Same bound, same three distinguishable outcomes, same loudness.
+    /// </summary>
+    /// <param name="disposalCompleted">The completion signal. Must terminate.</param>
+    /// <param name="description">How the thing being joined is named in a report — an address.</param>
+    /// <param name="report">Where a timeout, a fault or a late fault is SAID.</param>
+    /// <param name="timeout">The join budget; <see cref="DefaultJoinTimeout"/> when omitted.</param>
+    /// <param name="diagnostics">Optional in-flight snapshot, appended to a timeout report.</param>
+    /// <returns><c>true</c> if the signal terminated within the budget; <c>false</c> otherwise.</returns>
+    public static bool JoinDisposal(
+        this IObservable<Unit> disposalCompleted, string description, Action<string> report,
+        TimeSpan? timeout = null, Func<string?>? diagnostics = null)
+    {
+        ArgumentNullException.ThrowIfNull(disposalCompleted);
+        ArgumentNullException.ThrowIfNull(report);
+        report = Safely(report);
+        var budget = timeout ?? DefaultJoinTimeout;
 
-        // 🚨 The subscription handle is deliberately dropped, exactly as ReactiveCompletion does:
-        // unsubscribing when the WAIT ends is what loses a fault that arrives afterwards. The
-        // observer is rooted by DisposalCompleted (a ReplaySubject) until the source terminates,
-        // which is the only moment after which no fault can still come.
-        hub.DisposalCompleted.Subscribe(
-            _ => { },
-            error =>
-            {
-                if (Interlocked.Exchange(ref settled, 1) == 0)
-                {
-                    report($"[dispose-join] hub {address}: disposal FAULTED — "
-                           + $"{error.GetType().Name}: {error.Message}");
-                    joined.Set();
-                }
-                else
-                {
-                    lateFault(error);
-                }
-            },
-            () => { Interlocked.Exchange(ref settled, 1); joined.Set(); });
+        // The SAME bridge the async overload uses, waited on synchronously. Going through
+        // ReactiveCompletion rather than hand-rolling an event is what keeps the two forms honest
+        // about the same outcomes, and it is what makes the block safe: the task is completed with
+        // RunContinuationsAsynchronously, so the signalling thread returns to its own business
+        // instead of running the rest of this method, and the error arm stays attached after the
+        // wait, so a fault arriving later is still SAID.
+        var joined = disposalCompleted.ObserveCompletion(LateFault(description, report));
 
-        if (joined.Wait(budget)) return true;
+        // 🚨 Task.Wait(TimeSpan), NOT .Result / .GetAwaiter().GetResult(): expiry comes back as
+        // FALSE rather than as an exception, so the three outcomes stay distinguishable — joined,
+        // faulted (the AggregateException below), budget expired. All three are reported and none
+        // escapes a teardown path as an exception nobody catches.
+        bool completed;
+        try
+        {
+            completed = joined.Wait(budget);
+        }
+        catch (AggregateException ex)
+        {
+            // A disposal FAULT. It settled the wait, so it never reached the late-fault arm and
+            // would otherwise be lost with the task.
+            report(Faulted(description, ex.GetBaseException()));
+            return false;
+        }
 
-        Interlocked.Exchange(ref settled, 1);
-        report(NotJoined(address, budget, hub));
+        if (completed) return true;
+
+        report(NotJoined(description, budget, diagnostics));
         return false;
     }
 
@@ -180,28 +238,34 @@ public static class HubDisposalJoin
         }
     }
 
-    private static Action<Exception> LateFault(string address, Action<string> report) =>
+    private static Action<Exception> LateFault(string description, Action<string> report) =>
         error => report(
-            $"[dispose-join] hub {address}: disposal faulted AFTER the join stopped waiting on it "
-            + $"— {error.GetType().Name}: {error.Message}. Reported rather than orphaned.");
+            $"[dispose-join] hub {description}: disposal faulted AFTER the join stopped waiting on "
+            + $"it — {error.GetType().Name}: {error.Message}. Reported rather than orphaned.");
 
-    private static string NotJoined(string address, TimeSpan budget, IMessageHub hub)
+    private static string Faulted(string description, Exception error) =>
+        $"[dispose-join] hub {description}: disposal FAULTED — "
+        + $"{error.GetType().Name}: {error.Message}";
+
+    private static string NotJoined(string description, TimeSpan budget, Func<string?>? diagnostics)
     {
-        var diagnostics = SafeDiagnostics(hub);
-        return $"[dispose-join] hub {address}: teardown did NOT complete within "
+        var detail = SafeDiagnostics(diagnostics);
+        return $"[dispose-join] hub {description}: teardown did NOT complete within "
                + $"{budget.TotalSeconds:F0}s. The caller is proceeding OVER live teardown — that is "
                + "the use-after-dispose that crashes the host, so find what on this hub's action "
                + "block is not finishing; do not widen the budget."
-               + (diagnostics is null ? string.Empty : "\n" + diagnostics);
+               + (detail is null ? string.Empty : "\n" + detail);
     }
 
     /// <summary>
-    /// The hub's own in-flight snapshot, so a timeout says WHY. Defensive: the hub is mid-teardown
-    /// and diagnostics must never be the thing that throws out of a teardown path.
+    /// The caller's in-flight snapshot, so a timeout says WHY. Defensive twice over: the snapshot is
+    /// taken from a hub that is mid-teardown, and reporting must never be the thing that throws out
+    /// of a teardown path.
     /// </summary>
-    private static string? SafeDiagnostics(IMessageHub hub)
+    private static string? SafeDiagnostics(Func<string?>? diagnostics)
     {
-        try { return hub.GetPendingRequestDiagnostics(); }
+        if (diagnostics is null) return null;
+        try { return diagnostics(); }
         catch (Exception ex) { return $"(diagnostics unavailable: {ex.GetType().Name})"; }
     }
 

--- a/src/MeshWeaver.Messaging.Hub/HubDisposalJoin.cs
+++ b/src/MeshWeaver.Messaging.Hub/HubDisposalJoin.cs
@@ -1,0 +1,213 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// Dispose a hub and JOIN its teardown — the one shape a test base, an xUnit fixture or a
+/// run harness may use, because all three go on to do something the hub's still-running
+/// teardown cannot survive.
+///
+/// <para><b>Why a bare <c>Dispose()</c> is a crash and not a leak.</b>
+/// <see cref="System.IDisposable.Dispose"/> on a hub STARTS the disposal state machine and returns
+/// immediately (<c>MessageHub.Dispose</c> says so in its own remarks); the action blocks drain, the
+/// hosted hubs tear down, the sync streams unregister and the registrants run — all afterwards, on
+/// other threads. A caller that disposes and then proceeds is running CONCURRENTLY with that. In a
+/// harness the very next thing is one of: disposing the service scope (a continuation resolves from
+/// a dead Autofac scope), unloading a collectible node ALC (a live thread dereferences freed
+/// metadata — a native use-after-unload <b>SIGSEGV</b>, exit 139), or returning to xUnit so the next
+/// test class starts on top of the previous one's live teardown. The observed signature is a burst
+/// of <c>[SYNC_STREAM] Not setting … — stream is disposed</c> and
+/// <c>resubscribe failed … TargetInvocationException</c> and then the process dies mid-run with no
+/// failing test named (MeshWeaver.Plugins run 33236823482, job 99060770662).</para>
+///
+/// <para><b>So the rule is:</b> in a teardown or run-boundary path, every hub disposal is followed
+/// by a JOIN on that hub's <see cref="IMessageHub.DisposalCompleted"/> before the caller proceeds.
+/// <c>MeshWeaver.Mesh.MeshTeardownExtensions</c> is the richer form for a MESH ROOT (it also
+/// cancels+joins the <c>IIoPool</c> leaves and quiesces the <c>AsyncDisposeQueue</c>); this type is
+/// the small form for every OTHER hub a harness owns — the per-test client hubs, a silo-side hosted
+/// hub, the gate runner's render client.</para>
+///
+/// <para><b>Bounded, and LOUD when the bound is hit.</b> A silent hang is not an improvement over a
+/// crash: both waits take a budget, and expiry is REPORTED through the caller's sink rather than
+/// swallowed. The budget exists to keep a wedged action block from hanging a whole suite — it is not
+/// a number to raise when it fires. A join that times out is a hub that is not finishing; find it.</para>
+///
+/// <para>🚨 <b>No <c>Timeout</c> is composed into the signal</b>, in either overload — the bound is a
+/// <see cref="CancellationTokenSource"/> (async) or a <see cref="ManualResetEventSlim"/> wait (sync),
+/// and the subscription stays attached afterwards, so a fault arriving after the wait gave up is
+/// still reported instead of becoming the unobserved exception that xUnit v3 escalates to a
+/// Catastrophic failure (#2301/#2488, and <see cref="ReactiveCompletion"/>'s remarks).</para>
+/// </summary>
+public static class HubDisposalJoin
+{
+    /// <summary>
+    /// The budget both joins default to, matching the dispose deadline the monolith test base
+    /// already enforces (<c>MonolithMeshTestBase.DisposeTimeout</c>).
+    /// </summary>
+    public static readonly TimeSpan DefaultJoinTimeout = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// Disposes <paramref name="hub"/> and awaits its <see cref="IMessageHub.DisposalCompleted"/>.
+    /// The form for an <c>async ValueTask DisposeAsync()</c> / <c>IAsyncLifetime</c> teardown: it
+    /// SUSPENDS the caller rather than parking its thread, so it cannot self-deadlock against the
+    /// hub's own scheduler.
+    /// </summary>
+    /// <param name="hub">The hub to dispose and join. A <c>null</c> is a no-op.</param>
+    /// <param name="report">
+    /// Where a dispose failure, a timeout or a late fault is SAID. Never <c>null</c> and never an
+    /// empty lambda — a discarded teardown fault is half of what this method exists to remove.
+    /// </param>
+    /// <param name="timeout">The join budget; <see cref="DefaultJoinTimeout"/> when omitted.</param>
+    public static async Task DisposeAndJoinAsync(
+        this IMessageHub? hub, Action<string> report, TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        if (hub is null) return;
+        report = Safely(report);
+        var budget = timeout ?? DefaultJoinTimeout;
+        var address = Describe(hub);
+
+        if (!TryDispose(hub, address, report)) return;
+
+        using var cts = new CancellationTokenSource(budget);
+        try
+        {
+            // ConfigureAwait(false) on top of ObserveCompletion's RunContinuationsAsynchronously:
+            // `await` captures TaskScheduler.Current absent a SynchronizationContext, so a teardown
+            // entered from a hub scheduler would otherwise carry the rest of itself back onto one.
+            await hub.DisposalCompleted
+                .ObserveCompletion(LateFault(address, report), cts.Token)
+                .ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cts.IsCancellationRequested)
+        {
+            report(NotJoined(address, budget, hub));
+        }
+        catch (Exception ex)
+        {
+            report($"[dispose-join] hub {address}: disposal FAULTED — {ex.GetType().Name}: {ex.Message}");
+        }
+    }
+
+    /// <summary>
+    /// Disposes <paramref name="hub"/> and BLOCK-JOINS its
+    /// <see cref="IMessageHub.DisposalCompleted"/>. The form for a genuinely synchronous run
+    /// boundary — a harness's <see cref="System.IDisposable.Dispose"/>, a tool's exit path — where
+    /// there is no <c>await</c>-able caller to suspend. This is the sanctioned exception to the
+    /// no-blocking rule and nothing else: never call it from hub- or view-reachable code, where
+    /// parking the calling thread on work that thread may itself have to run IS the deadlock.
+    /// </summary>
+    /// <param name="hub">The hub to dispose and join. A <c>null</c> is a no-op (returns <c>true</c>).</param>
+    /// <param name="report">Where a dispose failure, a timeout or a late fault is SAID.</param>
+    /// <param name="timeout">The join budget; <see cref="DefaultJoinTimeout"/> when omitted.</param>
+    /// <returns><c>true</c> if teardown finished within the budget; <c>false</c> if it did not —
+    /// the caller has been told through <paramref name="report"/> either way.</returns>
+    public static bool DisposeAndJoin(
+        this IMessageHub? hub, Action<string> report, TimeSpan? timeout = null)
+    {
+        ArgumentNullException.ThrowIfNull(report);
+        if (hub is null) return true;
+        report = Safely(report);
+        var budget = timeout ?? DefaultJoinTimeout;
+        var address = Describe(hub);
+
+        if (!TryDispose(hub, address, report)) return false;
+
+        var joined = new ManualResetEventSlim(false);
+        var lateFault = LateFault(address, report);
+        var settled = 0;
+
+        // 🚨 The subscription handle is deliberately dropped, exactly as ReactiveCompletion does:
+        // unsubscribing when the WAIT ends is what loses a fault that arrives afterwards. The
+        // observer is rooted by DisposalCompleted (a ReplaySubject) until the source terminates,
+        // which is the only moment after which no fault can still come.
+        hub.DisposalCompleted.Subscribe(
+            _ => { },
+            error =>
+            {
+                if (Interlocked.Exchange(ref settled, 1) == 0)
+                {
+                    report($"[dispose-join] hub {address}: disposal FAULTED — "
+                           + $"{error.GetType().Name}: {error.Message}");
+                    joined.Set();
+                }
+                else
+                {
+                    lateFault(error);
+                }
+            },
+            () => { Interlocked.Exchange(ref settled, 1); joined.Set(); });
+
+        if (joined.Wait(budget)) return true;
+
+        Interlocked.Exchange(ref settled, 1);
+        report(NotJoined(address, budget, hub));
+        return false;
+    }
+
+    /// <summary>
+    /// Wraps the caller's sink so it can never be the thing that fails a teardown. Reporters here
+    /// are usually loggers or an xUnit output helper, and BOTH throw once their scope is gone — an
+    /// <c>ITestOutputHelper</c> after the test has been reported, an <c>ILogger</c> whose provider
+    /// went down with the service scope. Propagating that would raise an exception on whatever
+    /// thread signalled disposal, which is the failure this whole type exists to prevent. The
+    /// information is kept on <see cref="System.Diagnostics.Trace"/> instead of being lost, exactly
+    /// as <see cref="ReactiveCompletion"/> does for its own late-fault reporter.
+    /// </summary>
+    private static Action<string> Safely(Action<string> report) =>
+        message =>
+        {
+            try { report(message); }
+            catch (Exception reporterFailure)
+            {
+                System.Diagnostics.Trace.TraceError(
+                    "HubDisposalJoin: the report sink threw ({0}: {1}) while reporting: {2}",
+                    reporterFailure.GetType().Name, reporterFailure.Message, message);
+            }
+        };
+
+    private static bool TryDispose(IMessageHub hub, string address, Action<string> report)
+    {
+        try
+        {
+            hub.Dispose();
+            return true;
+        }
+        catch (Exception ex)
+        {
+            // Nothing was started, so nothing can be joined — say so and let the caller continue.
+            report($"[dispose-join] hub {address}: Dispose() threw {ex.GetType().Name}: {ex.Message} "
+                   + "— teardown was NOT joined.");
+            return false;
+        }
+    }
+
+    private static Action<Exception> LateFault(string address, Action<string> report) =>
+        error => report(
+            $"[dispose-join] hub {address}: disposal faulted AFTER the join stopped waiting on it "
+            + $"— {error.GetType().Name}: {error.Message}. Reported rather than orphaned.");
+
+    private static string NotJoined(string address, TimeSpan budget, IMessageHub hub)
+    {
+        var diagnostics = SafeDiagnostics(hub);
+        return $"[dispose-join] hub {address}: teardown did NOT complete within "
+               + $"{budget.TotalSeconds:F0}s. The caller is proceeding OVER live teardown — that is "
+               + "the use-after-dispose that crashes the host, so find what on this hub's action "
+               + "block is not finishing; do not widen the budget."
+               + (diagnostics is null ? string.Empty : "\n" + diagnostics);
+    }
+
+    /// <summary>
+    /// The hub's own in-flight snapshot, so a timeout says WHY. Defensive: the hub is mid-teardown
+    /// and diagnostics must never be the thing that throws out of a teardown path.
+    /// </summary>
+    private static string? SafeDiagnostics(IMessageHub hub)
+    {
+        try { return hub.GetPendingRequestDiagnostics(); }
+        catch (Exception ex) { return $"(diagnostics unavailable: {ex.GetType().Name})"; }
+    }
+
+    private static string Describe(IMessageHub hub)
+    {
+        try { return hub.Address.ToString() ?? "<unknown>"; }
+        catch (Exception ex) { return $"<address unavailable: {ex.GetType().Name}>"; }
+    }
+}

--- a/src/MeshWeaver.Messaging.Hub/HubDisposalJoin.cs
+++ b/src/MeshWeaver.Messaging.Hub/HubDisposalJoin.cs
@@ -146,9 +146,9 @@ public static class HubDisposalJoin
         var budget = timeout ?? DefaultJoinTimeout;
         var address = Describe(hub);
 
-        return !TryDispose(hub, address, report)
-            ? false
-            : hub.DisposalCompleted.JoinDisposal(address, report, budget, hub.GetPendingRequestDiagnostics);
+        return TryDispose(hub, address, report)
+               && hub.DisposalCompleted.JoinDisposal(
+                   address, report, budget, hub.GetPendingRequestDiagnostics);
     }
 
     /// <summary>

--- a/test/HubDisposalJoinSites.allow
+++ b/test/HubDisposalJoinSites.allow
@@ -1,0 +1,62 @@
+# HubDisposalJoinSites.allow — the un-joined-disposal ratchet.
+#
+# 🚨 THIS FILE IS EMPTY AND MUST STAY EMPTY.
+#
+# Each line WOULD be a harness file (a test base, an xUnit fixture, a tool) that disposes a hub
+# without joining its teardown:
+#
+#     hub.Dispose();          // …and then the caller proceeds
+#
+# `IMessageHub.Dispose()` STARTS the disposal state machine and returns. The action blocks drain,
+# the hosted hubs tear down, the sync streams unregister and the registrants run afterwards, on
+# other threads. A harness that proceeds past that is running concurrently with it — and the next
+# thing a harness always does is one of the three that live teardown cannot survive: dispose the
+# service scope (a continuation resolves from a dead Autofac scope), unload a collectible node ALC
+# (a live thread dereferences freed metadata), or return to xUnit so the next test class starts on
+# top of the previous one's teardown.
+#
+# The failure is not a red test. It is a DEAD PROCESS: MeshWeaver.Plugins run 33236823482, job
+# 99060770662 — the plugin gate exited 139 mid-run while installing packages, right after a burst of
+# `[SYNC_STREAM] Not setting … — stream is disposed` and
+# `Stream …: resubscribe failed … TargetInvocationException`. The gate's FINAL teardown already
+# joined the mesh. What did not join was the render CLIENT, disposed two statements earlier — which
+# is why the file reads as disciplined right up until you check which hub the join names.
+#
+# TO FIX A SITE:  await hub.DisposeAndJoinAsync(report)   — an async teardown (DisposeAsync,
+#                     IAsyncLifetime). SUSPENDS the caller instead of parking its thread, so it
+#                     cannot self-deadlock against the hub's own scheduler.
+#                 hub.DisposeAndJoin(report)              — a genuinely synchronous run boundary
+#                     (a harness's IDisposable.Dispose, a tool's exit path). The sanctioned
+#                     block-join, and nothing else: never from hub- or view-reachable code.
+#                 mesh.TeardownAsync(timeout) / mesh.WaitForDisposalAndIoDrainAsync(...)
+#                     — a MESH ROOT, which additionally needs the IIoPool leaves cancelled+joined
+#                     and the AsyncDisposeQueue quiesced.
+#                 Both helpers are BOUNDED and both SAY it when the bound is hit. A silent hang is
+#                 not an improvement over a crash — and a budget that fires is a hub that is not
+#                 finishing, not a number to raise.
+#
+# WHAT THE SEEDING PASS FOUND (2026-08-29). The covered surface held exactly FOUR un-joined sites,
+# and all four are fixed in the change that added this file — so it is seeded EMPTY, on purpose:
+#
+#   * src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs — DisposeTestClients. On the
+#     ShareMeshAcrossTests path this is the LAST thing that touches the mesh before DisposeAsync
+#     returns and the next [Fact] begins.
+#   * src/MeshWeaver.Hosting.Orleans.TestBase/OrleansTestBase.cs — DisposeAsync. The next statement
+#     hands the cluster to OrleansClusterDisposal, stopping the silos those teardowns still talk to.
+#     Its `catch { /* best-effort */ }` also discarded disposal faults outright.
+#   * src/MeshWeaver.Hosting.Orleans.TestBase/SharedOrleansFixture.cs — CleanupSiloHubsWithPrefix.
+#     Silo-side hubs whose teardown deactivates the owning grain; returning early lets the next
+#     test race a deactivation in flight.
+#   * tools/MeshWeaver.PluginTester/PluginGateRunner.cs — the render client (see the incident above).
+#
+# 🚨 THIS LIST MAY ONLY SHRINK, and it is already at zero. Adding a line is NOT a fix, and
+# HubDisposalJoinRatchetGuard.TotalBudget (0) fails the PR that tries.
+#
+# Scope: src/*.TestBase, src/*.Fixture, tools/, and fixtures under test/. Product code is
+# deliberately OUT — a SynchronizationStream unsubscribing its sync hub, Workspace evicting a client
+# subscription, OrleansRoutingService releasing a pod claim: nothing there is about to tear down the
+# scope or exit, and blocking a hub thread to watch a disposal finish would be the deadlock the
+# reactive rule forbids. Test BODIES are out for the same reason from the other side: their base
+# class joins the mesh, and the mesh's disposal joins its hosted hubs.
+#
+# format: <path>	<count>

--- a/test/MeshWeaver.Documentation.Test/HubDisposalJoinRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/HubDisposalJoinRatchetGuard.cs
@@ -1,0 +1,368 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance ratchet for the un-joined-disposal defect class: in a TEST BASE, an xUnit FIXTURE or
+/// a RUN HARNESS, a hub may not be disposed without joining its teardown before the caller
+/// proceeds.
+///
+/// <para><b>Why this is a crash and not a leak.</b> <c>IMessageHub.Dispose()</c> STARTS the disposal
+/// state machine and returns immediately — the action blocks drain, the hosted hubs tear down, the
+/// sync streams unregister and the registrants run AFTERWARDS, on other threads. A harness that
+/// disposes and proceeds is running concurrently with all of that, and the very next thing it does
+/// is always one of the three that live teardown cannot survive: dispose the service scope (a
+/// continuation resolves from a dead Autofac scope), unload a collectible node ALC (a live thread
+/// dereferences freed metadata — a native use-after-unload <b>SIGSEGV</b>), or return to xUnit so the
+/// next test class starts on top of the previous one's teardown.</para>
+///
+/// <para><b>What it looks like when it fires.</b> Not a failing test — a dead process. MeshWeaver.Plugins
+/// run 33236823482, job 99060770662: the plugin gate exited <b>139</b> mid-run while installing
+/// packages, immediately after a burst of <c>[SYNC_STREAM] Not setting … — stream is disposed</c> and
+/// <c>Stream …: resubscribe failed … TargetInvocationException</c>. The gate's FINAL teardown already
+/// joined the mesh; what did not join was the render CLIENT disposed two statements earlier. That is
+/// the shape this guard exists to stop reappearing: the join is present nearby, on a different hub,
+/// which is why a reviewer reads the file and sees discipline.</para>
+///
+/// <para><b>The fix at a site</b> is <c>MeshWeaver.Messaging.HubDisposalJoin</c>:
+/// <c>await hub.DisposeAndJoinAsync(report)</c> from an <c>async</c> teardown (it SUSPENDS the caller
+/// rather than parking its thread, so it cannot self-deadlock against the hub's own scheduler), or
+/// <c>hub.DisposeAndJoin(report)</c> at a genuinely synchronous run boundary. Both are bounded and
+/// both SAY it when the bound is hit — a silent hang is not an improvement over a crash. For a MESH
+/// ROOT prefer <c>MeshTeardownExtensions.TeardownAsync</c> / <c>WaitForDisposalAndIoDrainAsync</c>,
+/// which additionally cancel+join the <c>IIoPool</c> leaves and quiesce the
+/// <c>AsyncDisposeQueue</c>.</para>
+///
+/// <para><b>Why the allow file is EMPTY, and must stay that way.</b> Every site in the covered
+/// surface was fixed in the change that added this guard — there were exactly four
+/// (<c>MonolithMeshTestBase.DisposeTestClients</c>, <c>OrleansTestBase.DisposeAsync</c>,
+/// <c>SharedOrleansFixture.CleanupSiloHubsWithPrefix</c>, <c>PluginGateRunner</c>'s render client).
+/// An allow file seeded with today's debt makes the debt permanent, so this one starts at zero and
+/// may only ever be at zero: <b>adding a line to it is not a fix</b>, and the total budget below is
+/// nought.</para>
+///
+/// <para><b>Scope, and why it is not "everywhere".</b> Product code disposes hubs on purpose and
+/// does NOT join — a <c>SynchronizationStream</c> unsubscribing its sync hub, <c>Workspace</c>
+/// evicting a client subscription, <c>OrleansRoutingService</c> releasing a pod claim,
+/// <c>Activity</c> dropping its hosted hub. Those are live-system disposals: nothing is about to
+/// tear the scope down or exit, the disposal's own state machine finishes on its own, and blocking a
+/// hub thread to watch it finish would be the deadlock this repo's reactive rule forbids. The defect
+/// is specific to a caller that PROCEEDS PAST the disposal into teardown or exit, which is what a
+/// test base, a fixture and a run harness all do by definition. Test BODIES under <c>test/</c> are
+/// also excluded: their base class joins the mesh in <c>DisposeAsync</c>, and the mesh's own
+/// disposal joins its hosted hubs — a per-test client disposed inside a <c>[Fact]</c> is therefore
+/// bounded by the class teardown rather than by process exit.</para>
+/// </summary>
+public class HubDisposalJoinRatchetGuard(ITestOutputHelper output)
+{
+    /// <summary>
+    /// The seeded inventory's size — <b>zero</b>. Per-file entries would stop a new site in a file
+    /// that already carries the shape; this stops the list as a WHOLE from growing, including by
+    /// the trick of adding a new file's line. It may only ever go down, and it is already at the
+    /// floor.
+    /// </summary>
+    private const int TotalBudget = 0;
+
+    private const string AllowFileName = "HubDisposalJoinSites.allow";
+
+    /// <summary>
+    /// The roots walked before <see cref="IsHarnessFile"/> narrows them. Kept wide so a harness
+    /// added in a new project is seen; the predicate, not the walk, is what defines the surface.
+    /// </summary>
+    private static readonly string[] ScannedRoots = ["src", "test", "tools"];
+
+    /// <summary>
+    /// A <c>.Dispose()</c> call, capturing the whole receiver chain (<c>reg.Hub</c>, <c>kv.Value.Stream.Hub</c>)
+    /// so the join can be attributed to the SAME hub — the miss that let the plugin gate's client
+    /// read as joined because the MESH's join happened to sit two statements below it.
+    /// </summary>
+    private static readonly Regex DisposeCall = new(
+        @"(?<![A-Za-z0-9_])((?:[A-Za-z_]\w*)(?:\s*\??\.\s*[A-Za-z_]\w*)*)\s*\??\.\s*Dispose\s*\(\s*\)",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// 🚨 <b>LOAD-BEARING.</b> A receiver is treated as a hub when its last identifier ENDS in one of
+    /// these — <c>hub</c>, <c>Hub</c>, <c>meshHub</c>, <c>podHub</c>, <c>Mesh</c>, <c>client</c>,
+    /// <c>Client</c>. A hub variable named after none of them is invisible to this guard, which is
+    /// how a whole family of sites goes uncounted (the identity-scope ratchet learned the same
+    /// lesson the hard way: 19 sites across 10 files hid behind a helper name that was not on its
+    /// list). Extend this in the same change that introduces the naming.
+    ///
+    /// <para>The match is anchored so it cannot fire on a PLURAL (<c>hostedHubs</c>, a
+    /// <c>HostedHubsCollection</c> with its own collective join) or on an unrelated word ending in
+    /// the same letters (<c>clientHost</c> is an <c>IHost</c>, <c>_portalProcess</c> is a
+    /// <see cref="System.Diagnostics.Process"/>).</para>
+    /// </summary>
+    private static readonly Regex HubReceiver = new(
+        @"(?:^|[a-z0-9_])(?:[Hh]ub|[Mm]esh|[Cc]lient)$", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Joins that must name the hub being joined — <c>hub.DisposalCompleted</c>,
+    /// <c>Mesh.DisposeAndJoin(…)</c>, <c>reg.Hub.TeardownAsync(…)</c>. Anchoring on the receiver is
+    /// the whole point: an unanchored search reads a NEIGHBOURING hub's join as this one's.
+    /// </summary>
+    private static readonly string[] AnchoredJoins =
+    [
+        "DisposalCompleted", "DisposeAndJoin", "DisposeAndJoinAsync",
+        "WaitForDisposalAndIoDrainAsync", "TeardownAsync",
+    ];
+
+    /// <summary>
+    /// 🚨 <b>LOAD-BEARING, and deliberately tiny.</b> Named indirections that join the hub the
+    /// enclosing method owns without naming it at the call site. <c>WaitWithProgressAsync</c> is
+    /// <c>MonolithMeshTestBase</c>'s own private wait on <c>Mesh.DisposalCompleted</c> with a
+    /// progress dump. Every entry here is a hole the guard cannot see through, so add one only when
+    /// the indirection genuinely joins, and prefer renaming the helper to contain
+    /// <c>DisposeAndJoin</c> over growing this list.
+    /// </summary>
+    private static readonly string[] UnanchoredJoins = ["WaitWithProgressAsync"];
+
+    /// <summary>
+    /// How far after the disposal a join may appear, in NON-BLANK lines of masked code. Counting
+    /// code lines rather than physical ones is what lets a site stay clear through the long
+    /// explanatory comment blocks this repo writes between the two statements
+    /// (<c>SharedOrleansFixture.CleanupClientAsync</c> puts 14 lines of remark between its
+    /// <c>Dispose()</c> and its <c>DisposalCompleted</c>).
+    /// </summary>
+    private const int JoinWindow = 15;
+
+    [Fact]
+    public void NoHarnessDisposesAHubWithoutJoiningItsTeardown()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var allowed = SourceScan.ReadAllowFile(Path.Combine(root, "test", AllowFileName), AllowFileName);
+        var found = Scan(root, out var bare);
+
+        var failures = new List<string>();
+
+        foreach (var (file, count) in found.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            if (!allowed.TryGetValue(file, out var budget))
+                failures.Add(
+                    $"  NEW SITE   {file} ({count}) — the hub(s) disposed here are never joined. "
+                    + "Use `await hub.DisposeAndJoinAsync(report)` (async teardown) or "
+                    + "`hub.DisposeAndJoin(report)` (synchronous run boundary); for a mesh root use "
+                    + "MeshTeardownExtensions. Do NOT add a line to " + AllowFileName + ".");
+            else if (count > budget)
+                failures.Add(
+                    $"  MORE       {file} ({count} > {budget} allowed) — an un-joined disposal was "
+                    + "ADDED to a file that already carries the shape.");
+        }
+
+        var total = allowed.Values.Sum();
+        if (total > TotalBudget)
+            failures.Add(
+                $"  TOTAL      {total} allowances > {TotalBudget} budgeted — the inventory GREW. "
+                + "Adding a line to " + AllowFileName + " is not a fix.");
+
+        foreach (var (file, budget) in allowed.OrderBy(kv => kv.Key, StringComparer.Ordinal))
+        {
+            var count = found.GetValueOrDefault(file, 0);
+            if (count < budget)
+                output.WriteLine(
+                    $"STALE (please tidy): {file} — {count} found, {budget} allowed. "
+                    + $"{(count == 0 ? "Delete the line" : $"Lower it to {count}")} and lower "
+                    + $"TotalBudget by {budget - count}.");
+        }
+
+        Assert.True(failures.Count == 0,
+            "A harness that disposes a hub and proceeds without joining its teardown runs the rest "
+            + "of teardown CONCURRENTLY with the hub's own — and then disposes the scope, unloads a "
+            + "node ALC, or hands the mesh to the next test. The result is a use-after-dispose that "
+            + "kills the process (SIGSEGV / exit 139) mid-run, naming no test: exactly "
+            + "MeshWeaver.Plugins run 33236823482. Join the disposal.\n"
+            + string.Join("\n", failures)
+            + (bare.Count == 0 ? string.Empty : "\n\nSites:\n  " + string.Join("\n  ", bare)));
+    }
+
+    /// <summary>
+    /// Non-vacuity, part 1 — the CLASSIFIER, proven on synthetic source rather than on the tree.
+    /// A ratchet whose allow file is empty passes just as happily when its scanner has stopped
+    /// matching anything at all, so the discriminating behaviour is asserted directly: the bare
+    /// shape must be flagged, the joined shape must not, and the join must be attributed to the
+    /// hub it names rather than to whichever hub happens to be joined nearby.
+    /// </summary>
+    [Fact]
+    public void TheClassifierTellsAJoinedDisposalFromABareOne()
+    {
+        const string bare = "void T() { client.Dispose(); Log(\"done\"); }";
+        Assert.Equal(1, CountUnjoined(bare));
+
+        const string joined = "void T() { client.Dispose(); client.DisposalCompleted.Wait(); }";
+        Assert.Equal(0, CountUnjoined(joined));
+
+        const string viaHelper = "void T() { client.DisposeAndJoin(Report); }";
+        Assert.Equal(0, CountUnjoined(viaHelper));
+
+        // The plugin-gate miss, verbatim in shape: the client is disposed, the MESH is joined two
+        // statements later. An unanchored scan reads this as clean; it is the bug.
+        const string neighboursJoin =
+            "void T() { Client.Dispose(); Mesh.Dispose(); Mesh.DisposalCompleted.Wait(); }";
+        Assert.Equal(1, CountUnjoined(neighboursJoin));
+
+        // A dotted receiver is one site, joined through the same chain.
+        const string dotted = "void T() { reg.Hub.Dispose(); reg.Hub.DisposalCompleted.Wait(); }";
+        Assert.Equal(0, CountUnjoined(dotted));
+
+        // Not hubs: a collection with its own collective join, an IHost, a Process.
+        const string notHubs =
+            "void T() { hostedHubs.Dispose(); clientHost.Dispose(); _portalProcess.Dispose(); }";
+        Assert.Equal(0, CountUnjoined(notHubs));
+
+        // Prose quoting the shape is not a call site — this file and the allow file both do it.
+        const string prose = "void T() { /* client.Dispose(); with no join */ Log(\"x\"); }";
+        Assert.Equal(0, CountUnjoined(prose));
+    }
+
+    /// <summary>
+    /// Non-vacuity, part 2 — the WALK. The classifier can be perfect and the guard still gate
+    /// nothing if <see cref="IsHarnessFile"/> selects no files or <see cref="SourceScan"/> stops
+    /// finding them. The four harness sites the fixing change converted are all JOINED now, so the
+    /// only honest evidence the surface is still being read is that the scan sees hub disposals in
+    /// it at all.
+    /// </summary>
+    [Fact]
+    public void TheScannerStillSeesTheHarnessSurface()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var harnessFiles = SourceScan.SourceFiles(root, ScannedRoots)
+            .Select(f => SourceScan.Relative(root, f))
+            .Where(IsHarnessFile)
+            .ToList();
+
+        Assert.True(harnessFiles.Count >= 10,
+            "IsHarnessFile selected " + harnessFiles.Count + " files — the covered surface has "
+            + "collapsed (a project renamed away from *.TestBase / *.Fixture, or tools/ moved), so "
+            + "the ratchet above is gating nothing. Fix the predicate, do not delete the check.");
+
+        var teardowns = harnessFiles
+            .Select(rel =>
+            {
+                var text = File.ReadAllText(Path.Combine(root, rel));
+                var code = SourceScan.MaskCommentsAndStrings(text);
+                return (rel, sites: Sites(text), helper: HelperCalls.Matches(code).Count);
+            })
+            .Where(x => x.sites.Count > 0 || x.helper > 0)
+            .ToList();
+
+        // 🚨 The count includes helper calls ON PURPOSE, and that is not padding. Counting only
+        // literal `.Dispose()` would make this assertion FALL as sites get converted to
+        // DisposeAndJoin — a gate that goes red for doing exactly what the gate asks, which is the
+        // shape that teaches people to stop shrinking a ratchet. Every hub teardown in the surface
+        // is one of the two spellings, so the total is stable under fixing and only grows.
+        var total = teardowns.Sum(x => x.sites.Count + x.helper);
+        Assert.True(total >= 6,
+            $"The scan found {total} hub teardowns across the whole harness surface (expected at "
+            + "least 6). Either every harness stopped owning hubs — which would be news — or the "
+            + "DisposeCall / HubReceiver / HelperCalls patterns no longer match this codebase, in "
+            + "which case the empty allow file is proving nothing.");
+
+        foreach (var (rel, sites, helper) in teardowns.OrderBy(x => x.rel, StringComparer.Ordinal))
+            output.WriteLine(
+                $"{rel}: {sites.Count(s => s.Joined)} joined / {sites.Count} bare-form disposals, "
+                + $"{helper} via DisposeAndJoin");
+    }
+
+    /// <summary>The helper spellings, for the surface census above — not for the ratchet itself.</summary>
+    private static readonly Regex HelperCalls = new(
+        @"\.DisposeAndJoin(?:Async)?\s*\(", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The covered surface. 🚨 LOAD-BEARING: a test base, an xUnit fixture or a run harness is
+    /// exactly a place where the caller proceeds past a disposal into teardown or process exit.
+    /// </summary>
+    private static bool IsHarnessFile(string relative)
+    {
+        var parts = relative.Split('/');
+        if (parts.Length < 2) return false;
+        return parts[0] switch
+        {
+            // Every tool is a run harness: it boots a mesh, does a job and exits.
+            "tools" => true,
+            // The shared test bases and the fixture library they are built on.
+            "src" => parts[1].EndsWith(".TestBase", StringComparison.Ordinal)
+                     || parts[1].Contains(".Fixture", StringComparison.Ordinal),
+            // Fixtures only — test BODIES are bounded by their base class's join (see the remarks).
+            "test" => parts[1].Contains(".Fixture", StringComparison.Ordinal)
+                      || parts[^1].Contains("Fixture", StringComparison.Ordinal),
+            _ => false,
+        };
+    }
+
+    private static Dictionary<string, int> Scan(string root, out List<string> bare)
+    {
+        var sites = new List<string>();
+        var counts = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        foreach (var file in SourceScan.SourceFiles(root, ScannedRoots))
+        {
+            var relative = SourceScan.Relative(root, file);
+            if (!IsHarnessFile(relative)) continue;
+
+            string text;
+            try { text = File.ReadAllText(file); }
+            catch (IOException) { continue; } // a file a concurrent build is writing is not evidence
+
+            var unjoined = Sites(text).Where(s => !s.Joined).ToList();
+            if (unjoined.Count == 0) continue;
+
+            counts[relative] = unjoined.Count;
+            sites.AddRange(unjoined.Select(s => $"{relative}:{s.Line}  {s.Receiver}.Dispose()"));
+        }
+
+        bare = sites;
+        return counts;
+    }
+
+    private static int CountUnjoined(string text) => Sites(text).Count(s => !s.Joined);
+
+    /// <summary>
+    /// Every hub disposal in <paramref name="text"/>, each marked joined or not. Comments and string
+    /// literals are masked first, so prose quoting the shape — which this repo's remarks do
+    /// constantly — is not counted as a call site.
+    /// </summary>
+    private static List<(int Line, string Receiver, bool Joined)> Sites(string text)
+    {
+        var result = new List<(int, string, bool)>();
+        if (!text.Contains(".Dispose(", StringComparison.Ordinal)) return result;
+
+        var code = SourceScan.MaskCommentsAndStrings(text);
+        var lines = code.Split('\n');
+
+        foreach (Match match in DisposeCall.Matches(code))
+        {
+            var chain = Whitespace.Replace(match.Groups[1].Value, string.Empty);
+            var tail = chain.Split('.')[^1];
+            if (!HubReceiver.IsMatch(tail)) continue;
+
+            var line = code.Take(match.Index).Count(c => c == '\n') + 1;
+            result.Add((line, chain, IsJoined(lines, line, chain, tail)));
+        }
+
+        return result;
+    }
+
+    private static bool IsJoined(string[] lines, int line, string chain, string tail)
+    {
+        var window = new List<string>();
+        for (var i = line - 1; i < lines.Length && window.Count < JoinWindow; i++)
+            if (lines[i].Trim().Length > 0)
+                window.Add(lines[i]);
+
+        var text = string.Join('\n', window);
+        if (UnanchoredJoins.Any(j => text.Contains(j, StringComparison.Ordinal)))
+            return true;
+
+        var dense = Whitespace.Replace(text, string.Empty);
+        return AnchoredJoins.Any(j =>
+            dense.Contains(tail + "." + j, StringComparison.Ordinal)
+            || dense.Contains(chain + "." + j, StringComparison.Ordinal));
+    }
+
+    private static readonly Regex Whitespace = new(@"\s+", RegexOptions.Compiled);
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/HubDisposalJoinTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/HubDisposalJoinTest.cs
@@ -1,0 +1,241 @@
+using System;
+using System.Collections.Concurrent;
+using System.Reactive;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// <see cref="HubDisposalJoin"/>, pinned. The type exists because a harness that disposes a hub and
+/// PROCEEDS runs the rest of its teardown concurrently with the hub's — and then disposes the scope,
+/// unloads a node ALC, or hands the mesh to the next test. That is a use-after-dispose, and it kills
+/// the process (SIGSEGV / exit 139) rather than failing a test.
+///
+/// <para>Three outcomes have to stay DISTINGUISHABLE, because a harness that cannot tell them apart
+/// is exactly what the old <c>catch { /* best-effort */ }</c> sites were: joined, faulted, and
+/// budget-expired. Each is asserted here, plus the two ways this could quietly become useless — a
+/// reporter that throws taking teardown down with it, and a late fault with nowhere to go.</para>
+///
+/// <para>These tests drive a bare <see cref="Subject{T}"/> rather than a real hub, for the same
+/// reason <c>DisposalWaitBridgeTest</c> gives: it makes the timing and the terminating notification
+/// controllable, and a real hub cannot be made to produce a disposal that never completes — which is
+/// the case the BUDGET exists for.</para>
+/// </summary>
+public class HubDisposalJoinTest
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromMilliseconds(250);
+
+    // ── joined ────────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Async_ReturnsOnlyAfterTheSignalTerminates()
+    {
+        var signal = new Subject<Unit>();
+        var reports = new ConcurrentQueue<string>();
+
+        var join = signal.JoinDisposalAsync("hub/1", reports.Enqueue, TimeSpan.FromSeconds(10));
+        Assert.False(join.IsCompleted, "the join settled before the signal did — it is not joining anything");
+
+        signal.OnNext(Unit.Default);
+        signal.OnCompleted();
+
+        Assert.True(await join);
+        Assert.Empty(reports);
+    }
+
+    [Fact]
+    public async Task Sync_BlocksUntilTheSignalTerminates()
+    {
+        var signal = new Subject<Unit>();
+        var reports = new ConcurrentQueue<string>();
+
+        // The blocking form is driven from ANOTHER thread and the signal is terminated from this
+        // one, so "it waited" is observable rather than assumed.
+        var joiner = Task.Run(() =>
+            signal.JoinDisposal("hub/1", reports.Enqueue, TimeSpan.FromSeconds(10)));
+
+        // A Subject is cold until subscribed, so publish the terminal notification only once the
+        // joiner is actually listening — otherwise it goes into the void and the test measures the
+        // budget instead of the join.
+        Assert.True(SpinWait.SpinUntil(() => signal.HasObservers, TimeSpan.FromSeconds(5)),
+            "the synchronous join never subscribed to the signal");
+        Assert.False(joiner.IsCompleted, "the join returned before the signal terminated");
+
+        signal.OnCompleted();
+
+        Assert.True(await joiner.WaitAsync(TimeSpan.FromSeconds(10)));
+        Assert.Empty(reports);
+    }
+
+    /// <summary>
+    /// A signal that has ALREADY terminated joins immediately. This is the everyday case for a hub:
+    /// <c>MessageHub.disposalCompleted</c> is a <c>ReplaySubject(1)</c>, so a hub that finished
+    /// disposing before the join was written replays its completion rather than hanging for the
+    /// whole budget.
+    /// </summary>
+    [Fact]
+    public async Task AnAlreadyCompletedSignalJoinsImmediately()
+    {
+        var replay = new ReplaySubject<Unit>(1);
+        replay.OnNext(Unit.Default);
+        replay.OnCompleted();
+
+        Assert.True(await replay.JoinDisposalAsync("hub/1", _ => { }, Budget));
+        Assert.True(replay.JoinDisposal("hub/1", _ => { }, Budget));
+    }
+
+    // ── budget expired ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The case the whole design turns on. A disposal that never finishes must NOT hang the
+    /// harness (a silent hang is not an improvement over a crash) and must NOT pass silently either.
+    /// It returns false, and the report NAMES the failure and refuses to recommend a bigger budget.
+    /// </summary>
+    [Fact]
+    public async Task Async_TimesOutLoudlyRatherThanHanging()
+    {
+        var neverCompletes = new Subject<Unit>();
+        var reports = new ConcurrentQueue<string>();
+
+        Assert.False(await neverCompletes.JoinDisposalAsync(
+            "hub/wedged", reports.Enqueue, Budget, () => "pending: SubscribeRequest 42s"));
+
+        var report = Assert.Single(reports);
+        Assert.Contains("hub/wedged", report, StringComparison.Ordinal);
+        Assert.Contains("did NOT complete", report, StringComparison.Ordinal);
+        Assert.Contains("do not widen the budget", report, StringComparison.Ordinal);
+        Assert.Contains("pending: SubscribeRequest 42s", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sync_TimesOutLoudlyRatherThanHanging()
+    {
+        var neverCompletes = new Subject<Unit>();
+        var reports = new ConcurrentQueue<string>();
+
+        Assert.False(neverCompletes.JoinDisposal("hub/wedged", reports.Enqueue, Budget));
+
+        var report = Assert.Single(reports);
+        Assert.Contains("did NOT complete", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Diagnostics are a courtesy, never a hazard: a snapshot taken from a half-disposed hub can
+    /// throw, and reporting must not be the thing that fails a teardown.
+    /// </summary>
+    [Fact]
+    public async Task AThrowingDiagnosticsSnapshotIsAbsorbedIntoTheReport()
+    {
+        var reports = new ConcurrentQueue<string>();
+
+        Assert.False(await new Subject<Unit>().JoinDisposalAsync(
+            "hub/1", reports.Enqueue, Budget,
+            () => throw new ObjectDisposedException("scope")));
+
+        Assert.Contains("diagnostics unavailable: ObjectDisposedException",
+            Assert.Single(reports), StringComparison.Ordinal);
+    }
+
+    // ── faulted ───────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A disposal FAULT is an answer, not a silence. The old shape at these sites — a bare
+    /// <c>catch { }</c>, or a <c>.Catch(...)</c> spliced into the signal — rendered it as success.
+    /// </summary>
+    [Fact]
+    public async Task Async_ReportsAFaultedDisposalAndDoesNotThrow()
+    {
+        var signal = new Subject<Unit>();
+        var reports = new ConcurrentQueue<string>();
+
+        var join = signal.JoinDisposalAsync("hub/1", reports.Enqueue, TimeSpan.FromSeconds(10));
+        signal.OnError(new InvalidOperationException("action block faulted"));
+
+        Assert.False(await join);
+        var report = Assert.Single(reports);
+        Assert.Contains("FAULTED", report, StringComparison.Ordinal);
+        Assert.Contains("action block faulted", report, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Sync_ReportsAFaultedDisposalAndDoesNotThrow()
+    {
+        var replay = new ReplaySubject<Unit>(1);
+        replay.OnError(new InvalidOperationException("action block faulted"));
+
+        var reports = new ConcurrentQueue<string>();
+        Assert.False(replay.JoinDisposal("hub/1", reports.Enqueue, Budget));
+
+        var report = Assert.Single(reports);
+        Assert.Contains("FAULTED", report, StringComparison.Ordinal);
+        Assert.Contains("action block faulted", report, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The half a <see cref="Task"/> cannot represent: a fault that lands AFTER the wait gave up.
+    /// Unobserved, it surfaces on the finalizer as an <c>UnobservedTaskException</c>, which xUnit v3
+    /// escalates to a Catastrophic failure that poisons the NEXT test class (#2301). The
+    /// subscription therefore outlives the wait, and the fault is reported instead.
+    /// </summary>
+    [Fact]
+    public async Task ALateFaultIsStillReported()
+    {
+        var neverCompletes = new Subject<Unit>();
+        var reports = new ConcurrentQueue<string>();
+
+        Assert.False(await neverCompletes.JoinDisposalAsync("hub/1", reports.Enqueue, Budget));
+        Assert.Single(reports); // the timeout
+
+        neverCompletes.OnError(new InvalidOperationException("arrived after the budget"));
+
+        Assert.Equal(2, reports.Count);
+        Assert.Contains(reports, r =>
+            r.Contains("faulted AFTER the join stopped waiting", StringComparison.Ordinal)
+            && r.Contains("arrived after the budget", StringComparison.Ordinal));
+    }
+
+    // ── the reporter itself ───────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A reporter that throws must not become the failure. These sinks are loggers and xUnit output
+    /// helpers, and BOTH throw once their scope is gone — an <c>ITestOutputHelper</c> after the test
+    /// has been reported, an <c>ILogger</c> whose provider went down with the service scope. Letting
+    /// that propagate would raise an exception on whatever thread signalled disposal, which is the
+    /// failure this type exists to prevent.
+    /// </summary>
+    [Fact]
+    public async Task AThrowingReportSinkNeverFailsTheTeardown()
+    {
+        static void Explode(string _) => throw new ObjectDisposedException("ITestOutputHelper");
+
+        Assert.False(await new Subject<Unit>().JoinDisposalAsync("hub/1", Explode, Budget));
+        Assert.False(new Subject<Unit>().JoinDisposal("hub/1", Explode, Budget));
+    }
+
+    // ── the hub-facing overloads ──────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A null hub is a no-op in both forms — a teardown that has nothing to dispose must not have to
+    /// guard the call site, because a guard is where the join gets dropped.
+    /// </summary>
+    [Fact]
+    public async Task ANullHubIsANoOp()
+    {
+        await ((IMessageHub?)null).DisposeAndJoinAsync(_ => Assert.Fail("nothing to report"));
+        Assert.True(((IMessageHub?)null).DisposeAndJoin(_ => Assert.Fail("nothing to report")));
+    }
+
+    [Fact]
+    public void ANullReportSinkIsRefusedRatherThanDefaultedToSilence()
+    {
+        // The one argument that must never be optional: a join whose outcome goes nowhere is the
+        // `catch { }` these call sites are being moved OFF.
+        Assert.Throws<ArgumentNullException>(
+            () => new Subject<Unit>().JoinDisposal("hub/1", null!, Budget));
+        Assert.Throws<ArgumentNullException>(
+            () => ((IMessageHub?)null).DisposeAndJoin(null!));
+    }
+}

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -838,32 +838,28 @@ public static class PluginGateRunner
                     output.WriteLine($"[teardown] hosted service stop failed: {ex.Message}");
                 }
             }
-            try
-            {
-                Client.Dispose();
-            }
-            catch (Exception ex)
-            {
-                output.WriteLine($"[teardown] client dispose failed: {ex.Message}");
-            }
-            try
-            {
-                Mesh.Dispose();
-                // Block-join at the run boundary: teardown = synchronous dispose that joins.
-                Mesh.DisposalCompleted
-                    .FirstOrDefaultAsync()
-                    .Timeout(TimeSpan.FromSeconds(30))
-                    .Catch((TimeoutException _) =>
-                    {
-                        output.WriteLine("[teardown] mesh disposal did not complete within 30s");
-                        return Observable.Return(Unit.Default);
-                    })
-                    .Wait();
-            }
-            catch (Exception ex)
-            {
-                output.WriteLine($"[teardown] mesh dispose failed: {ex.Message}");
-            }
+            // 🚨 The CLIENT is block-joined too, not merely disposed. It was the one hub in this
+            // teardown that only had its disposal STARTED: the next statements dispose the Mesh and
+            // then the whole container, so the client's still-draining action block, its
+            // routing-stream unregistration and its sync-stream registrants ran against services
+            // being torn down underneath them. That is the burst of
+            // `[SYNC_STREAM] Not setting … — stream is disposed` + `resubscribe failed …
+            // TargetInvocationException` immediately before the gate died with exit 139 mid-run
+            // (MeshWeaver.Plugins run 33236823482, job 99060770662) — a use-after-dispose, not the
+            // final teardown, which already joined.
+            Client.DisposeAndJoin(
+                message => output.WriteLine($"[teardown] {message}"),
+                TimeSpan.FromSeconds(30));
+            // Block-join at the run boundary: teardown = synchronous dispose that joins.
+            //
+            // This used to splice `.Timeout(30s).Catch(...)` INTO the signal, which races the thing
+            // being waited for and leaves a fault arriving afterwards with no observer — the
+            // unobserved exception ReactiveCompletion's remarks describe (#2301/#2488). The bound is
+            // now outside the signal and the subscription outlives it, so a late disposal fault is
+            // still SAID.
+            Mesh.DisposeAndJoin(
+                message => output.WriteLine($"[teardown] {message}"),
+                TimeSpan.FromSeconds(30));
             try
             {
                 ServiceProvider.GetRequiredService<IoPoolRegistry>().DrainAll();


### PR DESCRIPTION
## The failure mode: SIGSEGV mid-run, from use-after-dispose

`IMessageHub.Dispose()` **starts** the disposal state machine and returns. The action blocks drain, the hosted hubs tear down, the sync streams unregister and the registrants run **afterwards, on other threads**. A test base, an xUnit fixture or a run harness that disposes and then proceeds is running concurrently with all of that — and the next thing a harness always does is one of the three that live teardown cannot survive:

* dispose the service scope — a continuation resolves from a dead Autofac scope;
* unload a collectible node ALC — a live thread dereferences freed metadata, a native use-after-unload **SIGSEGV**;
* return to xUnit, so the next test class starts on top of the previous one's teardown.

The result is not a red test. It is a dead process, naming nothing. **MeshWeaver.Plugins run 33236823482, job 99060770662**: the plugin gate exited **139** mid-run while installing packages, immediately after a burst of `[SYNC_STREAM] Not setting … — stream is disposed` and `Stream …: resubscribe failed … TargetInvocationException`.

The instructive part is *where* it was. The gate's **final** teardown already joined the mesh correctly. What did not join was the render **client**, disposed two statements earlier. The file reads as disciplined right up until you check which hub the join actually names.

## The rule

> In a teardown or run-boundary path, every hub disposal joins **that hub's** `DisposalCompleted` before the caller proceeds.

`MeshWeaver.Messaging.HubDisposalJoin` (new) is the small form for every hub a harness owns:

| | |
|---|---|
| `await hub.DisposeAndJoinAsync(report, timeout?)` | an async teardown (`DisposeAsync`, `IAsyncLifetime`). **Suspends** the caller rather than parking its thread, so it cannot self-deadlock against the hub's own scheduler. |
| `hub.DisposeAndJoin(report, timeout?)` | a genuinely synchronous run boundary — a harness's `IDisposable.Dispose`, a tool's exit path. The sanctioned block-join, and nothing else; never from hub- or view-reachable code. |

`MeshTeardownExtensions.TeardownAsync` / `WaitForDisposalAndIoDrainAsync` stay the richer form for a **mesh root** (they also cancel+join the `IIoPool` leaves and quiesce the `AsyncDisposeQueue`).

Both new helpers are **bounded** and both **say it** when the bound is hit — a silent hang is not an improvement over a crash, and a budget that fires is a hub that is not finishing, not a number to raise. Neither splices a `Timeout` into the signal: the bound is a `CancellationTokenSource` (async) or a `ManualResetEventSlim` wait (sync), and the subscription stays attached afterwards, so a fault arriving after the wait gave up is still reported instead of becoming the unobserved exception xUnit v3 escalates to a Catastrophic failure (#2301/#2488). The report sink is wrapped so a logger or `ITestOutputHelper` whose scope is already gone cannot become the thing that fails a teardown.

## Enumeration — every hub disposal in the covered surface

The surface is `src/*.TestBase`, `src/*.Fixture`, `tools/`, and fixtures under `test/`. Receiver-anchored scan (the join must name the hub being disposed):

| site | joined before? | verdict |
|---|---|---|
| `src/MeshWeaver.Fixture/HubTestBase.cs:182` `Mesh.Dispose()` | ✅ `Mesh.WaitForDisposalAndIoDrainAsync` | already correct |
| `src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs:1445` `Mesh.Dispose()` | ✅ `WaitWithProgressAsync` (its own wait on `Mesh.DisposalCompleted`) | already correct |
| `src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs:1253` `client.Dispose()` | ❌ | **FIXED** |
| `src/MeshWeaver.Hosting.Orleans.TestBase/OrleansTestBase.cs:132` `client.Dispose()` | ❌ | **FIXED** |
| `src/MeshWeaver.Hosting.Orleans.TestBase/SharedOrleansFixture.cs:211` `reg.Hub.Dispose()` | ✅ `reg.Hub.DisposalCompleted.ObserveCompletion` | already correct |
| `src/MeshWeaver.Hosting.Orleans.TestBase/SharedOrleansFixture.cs:295` `hub.Dispose()` | ❌ | **FIXED** |
| `tools/MeshWeaver.PluginTester/PluginGateRunner.cs:843` `Client.Dispose()` | ❌ | **FIXED** — the incident above |
| `tools/MeshWeaver.PluginTester/PluginGateRunner.cs:851` `Mesh.Dispose()` | ✅ (spliced `.Timeout`) | moved onto the helper |

**Can the process/test exit before teardown finishes?** Yes at all four:

* **`MonolithMeshTestBase.DisposeTestClients`** — on the `SharesMeshAcrossTests` path this is the *last* thing that touches the mesh: `DisposeAsync` returns straight after it and the next `[Fact]` begins on a mesh whose client teardowns are still draining. On the non-shared path the very next statements stop the hosted services and dispose the Mesh, which is the same race one level up. Now `async Task` and joins each client, bounded by the existing `DisposeTimeout`, reporting through `FileOutput` (safe after the test has been reported; a raw `ITestOutputHelper` throws there).
* **`OrleansTestBase.DisposeAsync`** — the next statement hands the cluster to `OrleansClusterDisposal.DisposeInBackground`, stopping the silos those client teardowns are still talking to. Its `catch { /* best-effort */ }` also discarded disposal faults outright; they are now written out.
* **`SharedOrleansFixture.CleanupSiloHubsWithPrefix`** — silo-side hosted hubs whose teardown deactivates the owning grain (`MessageHubGrain`); returning early lets the next test's grain calls race a deactivation in flight on a hub it can still address. Synchronous block-join (10s), reported through a logger captured **before** disposal began.
* **`PluginGateRunner.GateMesh.Dispose`** — its own doc comment already claimed "dispose the hubs and JOIN their disposal" (plural); the client half was never implemented. The mesh half moved onto the same helper, dropping the `.Timeout(30s).Catch(...)` spliced into the signal.

### Deliberately out of scope

**Product code.** 15 hub disposals across `src/` (`SynchronizationStream` unsubscribing its sync hub, `Workspace` evicting a client subscription, `OrleansRoutingService` releasing a pod claim, `Activity` dropping its hosted hub, `MeshOperations`' probe hub, …). Every one is a *live-system* disposal: nothing is about to tear the scope down or exit, the state machine finishes on its own, and blocking a hub thread to watch it would be the deadlock the reactive rule forbids.

**Test bodies under `test/`.** A per-test client disposed inside a `[Fact]` is bounded by the class teardown: the base class joins the mesh in `DisposeAsync`, and the mesh's disposal joins its hosted hubs collectively. 10 such sites exist; none can outlive the class.

## The ratchet

`test/MeshWeaver.Documentation.Test/HubDisposalJoinRatchetGuard.cs` + `test/HubDisposalJoinSites.allow`, in the idiom this repo already uses (`BlockingBridgeInTestRatchetGuard`, `ImpersonationScopeSiteRatchetGuard`) and sharing their `SourceScan` masker so prose quoting the shape is not counted as a call site.

**The allow file is seeded EMPTY**, and `TotalBudget = 0`. There was no debt left to seed it with — all four sites are fixed here — and an allow list seeded with today's debt makes the debt permanent. Adding a line to it fails the PR.

Two design points worth the review:

* **The join must NAME the hub being joined.** An unanchored scan reads a *neighbouring* hub's join as this one's — which is exactly the plugin-gate miss. `AnchoredJoins` are matched as `<receiver>.<marker>`, against the full dotted chain (`reg.Hub.DisposalCompleted`) as well as the tail.
* **Two marker lists are documented as LOAD-BEARING**: `HubReceiver` (a hub variable named after none of `hub`/`mesh`/`client` is invisible — the identity-scope ratchet learned this the hard way) and `UnanchoredJoins` (today exactly one entry, `WaitWithProgressAsync`, `MonolithMeshTestBase`'s private wait on `Mesh.DisposalCompleted`).

### Mutation evidence — the guard is not vacuous

Three mutations, each run against the built guard, then restored:

**1. Revert the plugin gate's client to the un-joined shape** → red:

```
NEW SITE   tools/MeshWeaver.PluginTester/PluginGateRunner.cs (1) — the hub(s) disposed here are never joined.
Sites:
  tools/MeshWeaver.PluginTester/PluginGateRunner.cs:852  Client.Dispose()
Failed!  - Failed: 1, Passed: 2
```

**2. Reconstruct the EXACT pre-fix file** — bare `Client.Dispose()` with the *mesh's* `Mesh.DisposalCompleted…Wait()` two statements below it, i.e. the state that shipped and crashed → still red, and it flags **only** the client, not the correctly-joined mesh below it. This is the receiver-anchoring proof:

```
Sites:
  tools/MeshWeaver.PluginTester/PluginGateRunner.cs:852  Client.Dispose()
Failed!  - Failed: 1, Passed: 2
```

**3. Revert `OrleansTestBase.DisposeAsync`** to `try { client.Dispose(); } catch { }` → red:

```
NEW SITE   src/MeshWeaver.Hosting.Orleans.TestBase/OrleansTestBase.cs (1)
Sites:
  src/MeshWeaver.Hosting.Orleans.TestBase/OrleansTestBase.cs:141  client.Dispose()
Failed!  - Failed: 1, Passed: 2
```

**Restored → `Passed! - Failed: 0, Passed: 3`.**

Two further non-vacuity facts are pinned *as tests*, so they cannot rot silently:

* `TheClassifierTellsAJoinedDisposalFromABareOne` proves the discrimination on **synthetic** source (bare vs. joined vs. via-helper vs. the neighbour's-join trap vs. dotted receiver vs. non-hubs `hostedHubs`/`clientHost`/`_portalProcess` vs. a commented occurrence) — independent of the tree, so it stays meaningful once every real site is clean.
* `TheScannerStillSeesTheHarnessSurface` proves the **walk** still selects files (≥10) and still sees hub teardowns in them (≥6). It counts `DisposeAndJoin` calls **as well as** literal `.Dispose()` on purpose: counting only the literal form would make the assertion *fall* as sites get converted — a gate that goes red for doing what the gate asks is how a ratchet gets deleted.

## Tests actually run

All on this branch, built first (full solution restore+compile, 0 warnings / 0 errors under warnings-as-errors):

| suite | result |
|---|---|
| `MeshWeaver.Documentation.Test` (holds the new guard) | **100 passed** |
| `MeshWeaver.Messaging.Hub.Test` (the helper's home assembly; the disposal suites) | **317 passed** |
| `MeshWeaver.Hosting.Orleans.Test` (`OrleansTestBase` + `SharedOrleansFixture`) | **177 passed** |
| `MeshWeaver.Content.Test` (exercises the `ShareMeshAcrossTests` path) | **223 passed, 1 skipped** |
| `MeshWeaver.PluginTester.Test` (the gate harness) | **96 passed** |
| `MeshWeaver.NodeOperations.Test` (`MonolithMeshTestBase`) | **76 passed** |
| `MeshWeaver.AccessControl.Test` (`MonolithMeshTestBase`) | **29 passed** |
| `MeshWeaver.Hosting.Monolith.Test` (158 files on `MonolithMeshTestBase`) | started locally — result posted as a comment below |

Not run locally: the remaining ~30 suites, the E2E/portal projects, and anything needing external infrastructure. CI covers those.

## 🚨 Do not merge yet

`main` CD is red for an unrelated reason (a promote/image issue on `aaf95afc3`, owned by another worker). This PR is prepared and green on its own gates; the maintainer decides when it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
