### PR TITLE
fix(#2633): retry a transient stream-attach instead of latching a hub into "cross-process routing DISABLED"

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -986,52 +986,53 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     internal Func<int, TimeSpan> AttachBackoff { get; set; } = SubscribeAttachBackoff;
 
     /// <summary>
-    /// Runs <paramref name="attach"/>, re-attempting it while it fails TRANSIENTLY and the budget
-    /// holds — the retry-with-fresh-resolve shape <c>RoutingGrain.DeliverToGrainObservable</c>
-    /// already applies to the DELIVERY leg, applied here to the SUBSCRIBE leg (issue #2633).
+    /// The attach, re-attempted while it fails TRANSIENTLY and the budget holds (issue #2633).
     ///
-    /// <para>🚨 <b>What this must not become.</b> It is bounded (<paramref name="maxRetries"/>), it
-    /// is loud (<paramref name="onTransientRetry"/> fires on every re-attempt), it never swallows
-    /// the terminal exception — the last one is rethrown to the caller's own failure branch — and it
-    /// never retries a cancellation. A permanent failure is still permanent.</para>
+    /// <para>Deliberately the SAME reactive shape as <see cref="AttachPodHub"/> forty lines below
+    /// and as <c>RoutingGrain.DeliverToGrainObservable</c> — <c>Defer</c> keeps
+    /// <paramref name="attach"/> COLD, so every <c>RetryWhen</c> re-subscribe re-invokes it from
+    /// scratch (a fresh <c>GetStream</c> and a fresh <c>SubscribeAsync</c>, hence a fresh grain
+    /// resolution rather than a reference minted while the directory was mid-handoff). One
+    /// retry-with-fresh-resolve idiom for the subscribe leg and the delivery leg, so a transient
+    /// rejection is handled identically whichever leg meets it.</para>
     ///
-    /// <para><paramref name="backoff"/> is a seam so the policy is testable with no wall clock.</para>
+    /// <para>🚨 <b>What this must not become.</b> Bounded (<paramref name="maxRetries"/>), loud
+    /// (<paramref name="onTransientRetry"/> fires on every re-attempt), and never swallowing: the
+    /// last exception is rethrown to the caller's own failure branch. A permanent failure is still
+    /// permanent, and anything <paramref name="isTransient"/> rejects gives up on the FIRST
+    /// attempt.</para>
+    ///
+    /// <para><paramref name="backoff"/> and <paramref name="scheduler"/> are seams so the policy is
+    /// testable with no wall clock.</para>
     /// </summary>
     /// <typeparam name="T">The attach result (the Orleans subscription handle).</typeparam>
     /// <param name="attach">The attach attempt; re-invoked from scratch on every retry.</param>
     /// <param name="isTransient">Predicate deciding whether another attempt is worth making.</param>
     /// <param name="onTransientRetry">Called with the failure, the 1-based attempt number and the wait.</param>
-    /// <param name="ct">Cancels the wait and stops the budget.</param>
     /// <param name="maxRetries">Number of RE-attempts after the first (so attempts = this + 1).</param>
     /// <param name="backoff">Wait before the attempt following a zero-based failed attempt index.</param>
-    /// <returns>The attach result, or the last exception rethrown once the budget is exhausted.</returns>
-    internal static async Task<T> AttachWithBoundedRetryAsync<T>(
+    /// <param name="scheduler">Scheduler for the backoff timer.</param>
+    /// <returns>A cold observable emitting the attach result, or erroring with the last exception.</returns>
+    internal static IObservable<T> AttachWithBoundedRetry<T>(
         Func<Task<T>> attach,
         Func<Exception, bool> isTransient,
         Action<Exception, int, TimeSpan> onTransientRetry,
-        CancellationToken ct,
         int maxRetries = SubscribeAttachRetries,
-        Func<int, TimeSpan>? backoff = null)
+        Func<int, TimeSpan>? backoff = null,
+        IScheduler? scheduler = null)
     {
         var delay = backoff ?? SubscribeAttachBackoff;
-        for (var attempt = 0; ; attempt++)
-        {
-            TimeSpan wait;
-            try
-            {
-                return await attach().ConfigureAwait(false);
-            }
-            catch (Exception ex) when (
-                attempt < maxRetries
-                && !ct.IsCancellationRequested
-                && ex is not OperationCanceledException
-                && isTransient(ex))
-            {
-                wait = delay(attempt);
-                onTransientRetry(ex, attempt + 1, wait);
-            }
-            await Task.Delay(wait, ct).ConfigureAwait(false);
-        }
+        return Observable.Defer(() => attach().ToObservable())
+            .RetryWhen(errors => errors
+                .Select((ex, i) => (Exception: ex, Attempt: i))
+                .SelectMany(t =>
+                {
+                    if (t.Attempt >= maxRetries || !isTransient(t.Exception))
+                        return Observable.Throw<long>(t.Exception);
+                    var wait = delay(t.Attempt);
+                    onTransientRetry(t.Exception, t.Attempt + 1, wait);
+                    return Observable.Timer(wait, scheduler ?? Scheduler.Default);
+                }));
     }
 
     // Attaches the Orleans memory-stream subscription for <paramref name="address"/> once the
@@ -1073,7 +1074,7 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             // inconsistency between the two legs was the whole defect.
             //
             // Bounded, loud, and still terminal: see AttachWithBoundedRetryAsync.
-            var handle = await AttachWithBoundedRetryAsync(
+            var handle = await AttachWithBoundedRetry(
                 AttachSubscriptionAsync,
                 IsTransientFailure,
                 (ex, attempt, wait) =>
@@ -1089,8 +1090,13 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                         + "the grain directory is unstable, which every rolling deploy produces; retrying in {Delay}ms",
                         StreamProviders.Memory, address, attempt, SubscribeAttachRetries + 1, wait.TotalMilliseconds);
                 },
-                ct,
-                backoff: AttachBackoff).ConfigureAwait(false);
+                backoff: AttachBackoff)
+                // The enclosing method is async by construction — RegisterStream stores the Task so
+                // teardown can await the handle it produced and unsubscribe it. ToTask(ct) is the one
+                // bridge, and it is where cancellation lands: a teardown that cancels mid-budget
+                // surfaces as OperationCanceledException into the catch below, exactly as the
+                // pre-#2633 single attempt did.
+                .ToTask(ct).ConfigureAwait(false);
 
             OrleansRouteTrace.Write($"OrleansRoutingService.SubscribeAsync OK addr={address}");
             logger.LogDebug("Orleans '{Provider}' stream subscription attached for {Address}",

--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -1073,7 +1073,7 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             // — RoutingGrain.DeliverToGrainWithRetry retries this identical exception class. That
             // inconsistency between the two legs was the whole defect.
             //
-            // Bounded, loud, and still terminal: see AttachWithBoundedRetryAsync.
+            // Bounded, loud, and still terminal: see AttachWithBoundedRetry.
             var handle = await AttachWithBoundedRetry(
                 AttachSubscriptionAsync,
                 IsTransientFailure,

--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -540,7 +540,14 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         }
     }
 
-    private static bool IsTransientFailure(Exception ex)
+    /// <summary>
+    /// A failure worth another attempt: a transport-level blip, an Orleans rejection, or the grain
+    /// directory mid-handoff. Mirrors <c>RoutingGrain.IsTransientFailure</c>; <c>internal</c> so a
+    /// test can pin the PREMISE of the attach retry (issue #2633) rather than only its effect.
+    /// </summary>
+    /// <param name="ex">The exception a cluster call faulted with.</param>
+    /// <returns><c>true</c> when re-attempting is worthwhile.</returns>
+    internal static bool IsTransientFailure(Exception ex)
     {
         return ex is SocketException
             or HttpRequestException
@@ -946,6 +953,87 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     // and that must surface as a Critical, never a silent hang (wedges-to-zero).
     private static readonly TimeSpan StreamingReadinessTimeout = TimeSpan.FromSeconds(120);
 
+    /// <summary>
+    /// How many times the stream ATTACH is re-attempted after a TRANSIENT failure — issue #2633.
+    ///
+    /// <para>🚨 <b>Bounded and loud, never a poll.</b> This is not the readiness gate above (that is
+    /// deterministic ordering); it covers the seconds AFTER the gate opens, in which the subscribe's
+    /// own grain-directory lookup can be refused because cluster membership is mid-handoff. Five
+    /// attempts across <see cref="SubscribeAttachBackoff"/> spend ≈7.75 s — comfortably longer than
+    /// the ~0.5–0.9 s reconnect Orleans' own <c>ConnectionManager</c> promises in the very message
+    /// it fails with, and far short of the caller-visible budgets that sit above this.</para>
+    ///
+    /// <para>Everything <see cref="IsTransientFailure"/> does NOT recognise still gives up on the
+    /// first attempt, and an exhausted budget still ends in the same <c>LogCritical</c> +
+    /// <c>null</c>: a permanent failure must still fail.</para>
+    /// </summary>
+    internal const int SubscribeAttachRetries = 5;
+
+    /// <summary>
+    /// Backoff between stream-attach attempts: 250 ms doubling to a 4 s ceiling.
+    /// </summary>
+    /// <param name="attempt">Zero-based index of the attempt that just failed.</param>
+    /// <returns>How long to wait before the next attempt.</returns>
+    internal static TimeSpan SubscribeAttachBackoff(int attempt) =>
+        TimeSpan.FromMilliseconds(Math.Min(250 * Math.Pow(2, attempt), 4_000));
+
+    /// <summary>
+    /// Test seam (<c>InternalsVisibleTo</c>): the backoff the stream-attach retry uses. Instance
+    /// state, never static — a unit test collapses it to zero so the POLICY (how many attempts, and
+    /// that a non-transient failure gets exactly one) is assertable without a wall clock, while
+    /// production keeps <see cref="SubscribeAttachBackoff"/>.
+    /// </summary>
+    internal Func<int, TimeSpan> AttachBackoff { get; set; } = SubscribeAttachBackoff;
+
+    /// <summary>
+    /// Runs <paramref name="attach"/>, re-attempting it while it fails TRANSIENTLY and the budget
+    /// holds — the retry-with-fresh-resolve shape <c>RoutingGrain.DeliverToGrainObservable</c>
+    /// already applies to the DELIVERY leg, applied here to the SUBSCRIBE leg (issue #2633).
+    ///
+    /// <para>🚨 <b>What this must not become.</b> It is bounded (<paramref name="maxRetries"/>), it
+    /// is loud (<paramref name="onTransientRetry"/> fires on every re-attempt), it never swallows
+    /// the terminal exception — the last one is rethrown to the caller's own failure branch — and it
+    /// never retries a cancellation. A permanent failure is still permanent.</para>
+    ///
+    /// <para><paramref name="backoff"/> is a seam so the policy is testable with no wall clock.</para>
+    /// </summary>
+    /// <typeparam name="T">The attach result (the Orleans subscription handle).</typeparam>
+    /// <param name="attach">The attach attempt; re-invoked from scratch on every retry.</param>
+    /// <param name="isTransient">Predicate deciding whether another attempt is worth making.</param>
+    /// <param name="onTransientRetry">Called with the failure, the 1-based attempt number and the wait.</param>
+    /// <param name="ct">Cancels the wait and stops the budget.</param>
+    /// <param name="maxRetries">Number of RE-attempts after the first (so attempts = this + 1).</param>
+    /// <param name="backoff">Wait before the attempt following a zero-based failed attempt index.</param>
+    /// <returns>The attach result, or the last exception rethrown once the budget is exhausted.</returns>
+    internal static async Task<T> AttachWithBoundedRetryAsync<T>(
+        Func<Task<T>> attach,
+        Func<Exception, bool> isTransient,
+        Action<Exception, int, TimeSpan> onTransientRetry,
+        CancellationToken ct,
+        int maxRetries = SubscribeAttachRetries,
+        Func<int, TimeSpan>? backoff = null)
+    {
+        var delay = backoff ?? SubscribeAttachBackoff;
+        for (var attempt = 0; ; attempt++)
+        {
+            TimeSpan wait;
+            try
+            {
+                return await attach().ConfigureAwait(false);
+            }
+            catch (Exception ex) when (
+                attempt < maxRetries
+                && !ct.IsCancellationRequested
+                && ex is not OperationCanceledException
+                && isTransient(ex))
+            {
+                wait = delay(attempt);
+                onTransientRetry(ex, attempt + 1, wait);
+            }
+            await Task.Delay(wait, ct).ConfigureAwait(false);
+        }
+    }
+
     // Attaches the Orleans memory-stream subscription for <paramref name="address"/> once the
     // Orleans lifecycle reports streaming usable — a deterministic ordering gate on
     // OrleansStreamingReadiness (ServiceLifecycleStage.Active), NOT a retry loop. Touching
@@ -967,48 +1055,91 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                 .ToTask(ct)
                 .ConfigureAwait(false);
 
-            var stream = GetStreamProvider(StreamProviders.Memory)
-                .GetStream<IMessageDelivery>(address.ToString());
-            var handle = await stream.SubscribeAsync((v, _) =>
-            {
-                OrleansRouteTrace.Write($"OrleansRoutingService.STREAM_CALLBACK addr={address} msg={v.Message?.GetType().Name} id={v.Id}");
-                // Orleans stream handlers must return Task; the AsyncDelivery callback is a cold
-                // IObservable — Subscribe to run the delivery (the hub queues it), then signal Orleans
-                // the message was accepted. 🚨 onError is mandatory: we return Task.CompletedTask below,
-                // so Orleans considers the item accepted and nothing retries — a faulted delivery here
-                // IS a lost message and must be loud, never an unobserved rethrow.
-                callback.Invoke(v, CancellationToken.None).Subscribe(
-                    _ => { },
-                    ex =>
-                    {
-                        logger.LogError(ex,
-                            "Delivery callback faulted for {MessageType} ({Id}) on stream {Address} — message dropped",
-                            v.Message?.GetType().Name, v.Id, address);
-                        OrleansRouteTrace.Write(
-                            $"OrleansRoutingService.STREAM_CALLBACK FAULTED addr={address} msg={v.Message?.GetType().Name} id={v.Id} ex={ex.Message}");
-                    });
-                return Task.CompletedTask;
-            },
-            ex =>
-            {
-                // 🚨 The transport TELLING us it lost/failed delivery must never be silent
-                // (issue #1081 — a dropped frame on this stream leaves a mirror tracking its
-                // owner at a permanent deficit; the protocol-level BasedOnVersion chain heals
-                // it, but the loss itself must be attributable). Orleans reports pulling-agent
-                // faults and cache-pressure data loss (DataNotAvailableException) through this
-                // callback; without it the default handler swallows the signal.
-                logger.LogError(ex,
-                    "Orleans '{Provider}' stream for {Address} reported a delivery error — frames may have been lost; mirrors recover via the BasedOnVersion resync chain",
-                    StreamProviders.Memory, address);
-                OrleansRouteTrace.Write(
-                    $"OrleansRoutingService.STREAM_ONERROR addr={address} ex={ex.Message}");
-                return Task.CompletedTask;
-            }).ConfigureAwait(false);
+            // 🚨 THE ATTACH IS RETRIED, THE GATE IS NOT — issue #2633.
+            //
+            // Everything below this line runs AFTER the ordering gate has opened, and it is a
+            // CLUSTER call: SubscribeAsync resolves the stream's PubSubRendezvousGrain through
+            // Orleans' grain directory, which is exactly the component that is unstable while
+            // membership changes. Every rolling deploy produces that window and it is over in
+            // seconds — Orleans' own ConnectionManager says so in the message it fails with
+            // ("Unable to connect to S… , will retry after 582.6889ms").
+            //
+            // This used to be a single attempt inside the catch-all below, so one such rejection
+            // LATCHED the hub into "cross-process routing DISABLED" for the rest of its life:
+            // nothing re-attempted, and the loss persisted until the hub re-registered (a circuit
+            // reconnect, or a pod restart). Six per-user losses across three ReplicaSet generations
+            // on memex-cloud, every one of them a transient the delivery leg would have ridden out
+            // — RoutingGrain.DeliverToGrainWithRetry retries this identical exception class. That
+            // inconsistency between the two legs was the whole defect.
+            //
+            // Bounded, loud, and still terminal: see AttachWithBoundedRetryAsync.
+            var handle = await AttachWithBoundedRetryAsync(
+                AttachSubscriptionAsync,
+                IsTransientFailure,
+                (ex, attempt, wait) =>
+                {
+                    OrleansRouteTrace.Write(
+                        $"OrleansRoutingService.SubscribeAsync RETRY addr={address} attempt={attempt} delayMs={wait.TotalMilliseconds} ex={ex.Message}");
+                    // Warning, not Debug: the retry itself is expected during a roll, but a hub whose
+                    // cross-process routing is momentarily unattached is exactly what the Critical
+                    // below used to be the only evidence of. Losing that evidence entirely would trade
+                    // one silent failure for another.
+                    logger.LogWarning(ex,
+                        "Orleans '{Provider}' stream subscription for {Address} could not be attached (attempt {Attempt}/{Max}) — "
+                        + "the grain directory is unstable, which every rolling deploy produces; retrying in {Delay}ms",
+                        StreamProviders.Memory, address, attempt, SubscribeAttachRetries + 1, wait.TotalMilliseconds);
+                },
+                ct,
+                backoff: AttachBackoff).ConfigureAwait(false);
 
             OrleansRouteTrace.Write($"OrleansRoutingService.SubscribeAsync OK addr={address}");
             logger.LogDebug("Orleans '{Provider}' stream subscription attached for {Address}",
                 StreamProviders.Memory, address);
             return handle;
+
+            // The attach ITSELF, re-invoked from scratch on every retry: a fresh GetStream and a
+            // fresh SubscribeAsync, so Orleans re-resolves the rendezvous grain rather than
+            // re-using a reference minted while the directory was mid-handoff. The two handler
+            // lambdas are unchanged from the former single-attempt path.
+            Task<StreamSubscriptionHandle<IMessageDelivery>> AttachSubscriptionAsync() =>
+                GetStreamProvider(StreamProviders.Memory)
+                    .GetStream<IMessageDelivery>(address.ToString())
+                    .SubscribeAsync((v, _) =>
+                    {
+                        OrleansRouteTrace.Write($"OrleansRoutingService.STREAM_CALLBACK addr={address} msg={v.Message?.GetType().Name} id={v.Id}");
+                        // Orleans stream handlers must return Task; the AsyncDelivery callback is a cold
+                        // IObservable — Subscribe to run the delivery (the hub queues it), then signal
+                        // Orleans the message was accepted. 🚨 onError is mandatory: we return
+                        // Task.CompletedTask below, so Orleans considers the item accepted and nothing
+                        // retries — a faulted delivery here IS a lost message and must be loud, never an
+                        // unobserved rethrow.
+                        callback.Invoke(v, CancellationToken.None).Subscribe(
+                            _ => { },
+                            ex =>
+                            {
+                                logger.LogError(ex,
+                                    "Delivery callback faulted for {MessageType} ({Id}) on stream {Address} — message dropped",
+                                    v.Message?.GetType().Name, v.Id, address);
+                                OrleansRouteTrace.Write(
+                                    $"OrleansRoutingService.STREAM_CALLBACK FAULTED addr={address} msg={v.Message?.GetType().Name} id={v.Id} ex={ex.Message}");
+                            });
+                        return Task.CompletedTask;
+                    },
+                    ex =>
+                    {
+                        // 🚨 The transport TELLING us it lost/failed delivery must never be silent
+                        // (issue #1081 — a dropped frame on this stream leaves a mirror tracking its
+                        // owner at a permanent deficit; the protocol-level BasedOnVersion chain heals
+                        // it, but the loss itself must be attributable). Orleans reports pulling-agent
+                        // faults and cache-pressure data loss (DataNotAvailableException) through this
+                        // callback; without it the default handler swallows the signal.
+                        logger.LogError(ex,
+                            "Orleans '{Provider}' stream for {Address} reported a delivery error — frames may have been lost; mirrors recover via the BasedOnVersion resync chain",
+                            StreamProviders.Memory, address);
+                        OrleansRouteTrace.Write(
+                            $"OrleansRoutingService.STREAM_ONERROR addr={address} ex={ex.Message}");
+                        return Task.CompletedTask;
+                    });
         }
         catch (OperationCanceledException) when (ct.IsCancellationRequested)
         {
@@ -1023,6 +1154,12 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             // unobserved exception, no retry into a broken state). The local route registered
             // above stays live, so in-process delivery keeps working; only this hub's
             // cross-process routing is degraded — never a silent silo wedge.
+            //
+            // 🚨 Reaching here is now a REAL give-up, and that is the point of #2633: a transient
+            // directory rejection has already been re-attempted SubscribeAttachRetries times (each
+            // one a Warning naming the attempt), so this Critical no longer fires for a condition
+            // that was over in half a second. A permanent failure still lands here, still latches,
+            // and still says so.
             OrleansRouteTrace.Write($"OrleansRoutingService.SubscribeAsync FAILED addr={address} ex={ex.Message}");
             logger.LogCritical(ex,
                 "Orleans '{Provider}' stream subscription could not be attached for {Address} — cross-process routing for this hub is DISABLED (in-process routing remains active)",

--- a/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
@@ -164,8 +164,18 @@ manufactured by every deploy. Two residual silent-loss windows remain:
 1. **The queue grain is still in RAM.** `MemoryStreamQueueGrain` holds enqueued-but-not-yet-pulled
    messages, and it dies with its silo. This is a narrow race at the moment of departure, not a
    permanent black hole — but it is silent.
-2. **A genuinely absent subscriber.** A hub whose subscription attach failed, or which is torn down
-   between publish and pull, still absorbs the message without a `DeliveryFailure`.
+2. **A genuinely absent subscriber.** A hub which is torn down between publish and pull still
+   absorbs the message without a `DeliveryFailure`.
+
+   > 🚨 **The "attach failed" half of this residual is narrower since #2633.** It used to be much
+   > wider than it reads: `OrleansRoutingService.SubscribeWhenStreamingReadyAsync` made a SINGLE
+   > attach attempt, and the subscribe's own grain-directory lookup is refused whenever cluster
+   > membership is mid-handoff — i.e. on every rolling deploy. One such rejection latched that hub
+   > into *"cross-process routing DISABLED"* permanently, so "a hub whose subscription attach
+   > failed" was not a race at all but a standing condition, until the hub re-registered. The attach
+   > is now retried on a bounded, loud budget against the same `IsTransientFailure` the delivery leg
+   > uses, so what remains here is the genuine race plus a genuinely permanent attach failure — both
+   > of which still say so at `Critical`.
 
 > 🚨 **Both of those residuals now live on a FALLBACK path, and that changes who should pay for
 > them.** Since the transport swap ([Pod-Hub Delivery](/Doc/Architecture/PodHubDeliveryRollPlan))

--- a/test/MeshWeaver.Hosting.Orleans.Test/StreamAttachTransientRetryTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/StreamAttachTransientRetryTest.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans;
+using Orleans.Runtime;
+using Orleans.Streams;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #2633 — a TRANSIENT stream-attach failure must not permanently disable a hub's
+/// cross-process routing.</b>
+///
+/// <para><c>OrleansRoutingService.SubscribeWhenStreamingReadyAsync</c> attaches the hub's Orleans
+/// memory-stream subscription once the #1129 readiness gate opens. Everything after that gate is a
+/// CLUSTER call — <c>SubscribeAsync</c> resolves the stream's <c>PubSubRendezvousGrain</c> through
+/// Orleans' grain directory — and the grain directory is precisely what is unstable while cluster
+/// membership changes. Every rolling deploy produces that window, and Orleans' own
+/// <c>ConnectionManager</c> says in the very message it fails with that it will reconnect within
+/// ~0.5–0.9 s.</para>
+///
+/// <para><b>The defect.</b> The attach was a SINGLE attempt inside a catch-all, so one such
+/// rejection latched the hub into <i>"cross-process routing for this hub is DISABLED"</i> for the
+/// rest of its life — nothing re-attempted, and the loss persisted until the hub re-registered (a
+/// circuit reconnect or a pod restart). Six per-user losses across three ReplicaSet generations on
+/// memex-cloud, every one of them an <see cref="OrleansMessageRejectionException"/> that the
+/// DELIVERY leg already classifies transient and retries
+/// (<c>RoutingGrain.DeliverToGrainWithRetry</c>). The inconsistency between the two legs was the
+/// whole defect.</para>
+///
+/// <para><b>What these tests pin, in both directions.</b> A transient attach failure is
+/// re-attempted up to <c>SubscribeAttachRetries</c> times; a NON-transient one still gives up on
+/// the first attempt (a permanent failure must still fail). Reaching the stream provider IS the
+/// observable, so no cluster and no <c>IAsyncStream</c> fake is needed — and the backoff is
+/// collapsed to zero through the instance seam, so neither case waits on a wall clock.</para>
+///
+/// <para><b>Fails on unfixed code:</b> <see cref="TransientAttachFailure_IsRetried_UpToTheBudget"/>
+/// observes exactly ONE attempt instead of six.</para>
+/// </summary>
+public class StreamAttachTransientRetryTest
+{
+    /// <summary>
+    /// Reaching <see cref="GetStream{T}"/> is the assertion: it counts attach attempts and throws
+    /// the exception the test is about. The throw keeps the fake minimal — the attach-SUCCESS path
+    /// is covered by the real-cluster routing tests.
+    /// </summary>
+    private sealed class ThrowingStreamProvider(Func<Exception> failure) : IStreamProvider
+    {
+        private int getStreamCalls;
+        public int GetStreamCalls => Volatile.Read(ref getStreamCalls);
+        public string Name => StreamProviders.Memory;
+        public bool IsRewindable => false;
+
+        public IAsyncStream<T> GetStream<T>(StreamId streamId)
+        {
+            Interlocked.Increment(ref getStreamCalls);
+            throw failure();
+        }
+    }
+
+    /// <summary>
+    /// The production shape, in the real class: Orleans refuses to address the subscribe because
+    /// its grain directory is mid-handoff, and the message is quoted verbatim from the #2633
+    /// incident. <c>OrleansRoutingService.IsTransientFailure</c> already matches this TYPE — it
+    /// simply was not consulted on this leg.
+    ///
+    /// <para>Constructed reflectively because Orleans keeps this exception's constructors
+    /// <c>internal</c>: a hand-rolled stand-in would test the classifier against a type production
+    /// never produces. <see cref="TheFakeIsTheProductionException"/> is the guard that keeps this
+    /// honest — if an Orleans upgrade moves the constructor, that test fails by name instead of this
+    /// one silently degrading.</para>
+    /// </summary>
+    private static Exception DirectoryRejection() =>
+        (Exception)Activator.CreateInstance(
+            typeof(OrleansMessageRejectionException),
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic,
+            binder: null,
+            args:
+            [
+                "Exception while sending message: Orleans.Runtime.Messaging.ConnectionFailedException: "
+                + "Unable to connect to S10.244.4.150:11111:146475119, will retry after 582.6889ms"
+            ],
+            culture: null)!;
+
+    /// <summary>
+    /// Guard for the reflection above: the exception the retry tests are driven with must BE the
+    /// production type AND must be the thing the classifier calls transient. Without this, a
+    /// constructor that moved would leave the retry tests passing against nothing.
+    /// </summary>
+    [Fact]
+    public void TheFakeIsTheProductionException()
+    {
+        var ex = DirectoryRejection();
+
+        ex.Should().BeOfType<OrleansMessageRejectionException>(
+            "the retry is gated on IsTransientFailure, which matches this exception by TYPE");
+        OrleansRoutingService.IsTransientFailure(ex).Should().BeTrue(
+            "if this ever goes false the attach retry below is inert and the tests prove nothing");
+    }
+
+    private static async Task<int> AttachAttemptsAsync(Func<Exception> failure)
+    {
+        var provider = new ThrowingStreamProvider(failure);
+        var readiness = new OrleansStreamingReadiness();
+        var services = new ServiceCollection();
+        services.AddSingleton(readiness);
+        services.AddKeyedSingleton<IStreamProvider>(StreamProviders.Memory, provider);
+        await using var sp = services.BuildServiceProvider();
+
+        // grainFactory is deliberately null — RegisterStream never places grains, so reaching one
+        // would throw and fail the test (the same probe technique as the readiness-gate test).
+        using var routing = new OrleansRoutingService(
+            null!, sp, NullLogger<OrleansRoutingService>.Instance)
+        {
+            // Instance seam, not static state: the POLICY is what is under test, not the clock.
+            AttachBackoff = _ => TimeSpan.Zero
+        };
+
+        using var registration = routing.RegisterStream(
+            AddressExtensions.CreateMeshAddress($"attach-retry-{Guid.NewGuid():N}"),
+            (d, _) => Observable.Return(d));
+
+        // Open the gate exactly the way Orleans does: the lifecycle observer's OnStart at Active.
+        await ((ILifecycleObserver)readiness).OnStart(CancellationToken.None);
+
+        // Poll until the attempt count STOPS moving — the attach runs detached, so there is no
+        // completion signal to await from here. Two consecutive equal readings after the first
+        // attempt has landed is the settled state; bounded so a regression fails rather than hangs.
+        var last = -1;
+        for (var i = 0; i < 200; i++)
+        {
+            await Task.Delay(25);
+            var now = provider.GetStreamCalls;
+            if (now > 0 && now == last)
+                return now;
+            last = now;
+        }
+
+        throw new TimeoutException(
+            $"the attach never settled — last observed attempt count {provider.GetStreamCalls}");
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. On unfixed code this observes exactly 1 — the single attempt that latched
+    /// the hub into "cross-process routing DISABLED" — instead of the full bounded budget.
+    /// </summary>
+    [Fact]
+    public async Task TransientAttachFailure_IsRetried_UpToTheBudget()
+    {
+        var attempts = await AttachAttemptsAsync(DirectoryRejection);
+
+        attempts.Should().Be(
+            OrleansRoutingService.SubscribeAttachRetries + 1,
+            "a grain-directory rejection is TRANSIENT — Orleans' own message says it reconnects in "
+            + "under a second — and the delivery leg already retries this exact exception class. "
+            + "One attempt is what latched a hub into permanently disabled cross-process routing "
+            + "on every rolling deploy (#2633)");
+    }
+
+    /// <summary>
+    /// The other direction, and the one that keeps the retry honest: a fault that is not transient
+    /// must NOT be re-attempted. A retry budget spent on a permanent failure is six times the log
+    /// noise and six times the delay before the hub's outbound gate opens, for the same outcome.
+    /// </summary>
+    [Fact]
+    public async Task NonTransientAttachFailure_StillGivesUpOnTheFirstAttempt()
+    {
+        var attempts = await AttachAttemptsAsync(
+            () => new NotSupportedException("attach probe — a permanent failure must still fail"));
+
+        attempts.Should().Be(1,
+            "everything IsTransientFailure does not recognise is permanent, and a permanent "
+            + "failure must still fail — loudly, once, on the first attempt");
+    }
+
+    /// <summary>
+    /// The policy itself, with no host at all: bounded, growing, and capped. This is what stops the
+    /// retry from becoming the unbounded loop the codebase forbids.
+    /// </summary>
+    [Fact]
+    public void AttachBackoff_IsBoundedAndCapped()
+    {
+        OrleansRoutingService.SubscribeAttachRetries.Should().BeInRange(1, 10,
+            "a retry budget must be small enough to stay inside the caller-visible budgets above it");
+
+        var waits = Enumerable.Range(0, OrleansRoutingService.SubscribeAttachRetries)
+            .Select(OrleansRoutingService.SubscribeAttachBackoff)
+            .ToArray();
+
+        waits.Should().BeInAscendingOrder("backoff must grow, or it is a busy loop with a sleep in it");
+        waits.Should().OnlyContain(w => w <= TimeSpan.FromSeconds(4),
+            "the backoff is capped so the total budget stays predictable");
+        waits.Sum(w => w.TotalSeconds).Should().BeLessThan(30,
+            "the whole budget must finish well inside the 120 s readiness gate that precedes it and "
+            + "the 60 s request budgets that sit above it");
+    }
+}


### PR DESCRIPTION
Closes nothing by itself — linking, not closing: #2633.

## The defect

`OrleansRoutingService.SubscribeWhenStreamingReadyAsync` attaches a hub's Orleans memory-stream subscription once the #1129 readiness gate opens. Everything **past** that gate is a cluster call: `SubscribeAsync` resolves the stream's `PubSubRendezvousGrain` through Orleans' grain directory, which is precisely the component that is unstable while cluster membership changes.

The attach was a **single attempt inside a catch-all**, so one such rejection latched the hub into

```
crit: Orleans 'Memory' stream subscription could not be attached for portal/… —
      cross-process routing for this hub is DISABLED (in-process routing remains active)
```

…for the rest of that hub's life. Nothing re-attempted; the loss persisted until the hub re-registered (a circuit reconnect, or a pod restart). Six per-user losses across three ReplicaSet generations on `memex-cloud`, every one of them an `OrleansMessageRejectionException` whose inner text is Orleans' own *"Unable to connect to S… , **will retry after 582.6889ms**"*.

The same exception class is already classified transient and retried on the **delivery** leg (`RoutingGrain.DeliverToGrainWithRetry` → `IsTransientFailure`). The subscribe leg had no equivalent. That inconsistency is the defect.

## The fix

The attach runs through a new `AttachWithBoundedRetryAsync`:

- **Bounded** — 5 re-attempts, backoff 250 ms doubling to a 4 s cap (≈7.75 s total). Comfortably longer than the sub-second reconnect Orleans promises; far short of the 120 s readiness gate that precedes it and the 60 s request budgets above it.
- **Loud** — every retry logs a `Warning` naming the attempt number and the wait. The evidence that a hub was momentarily unattached is not lost, it is just no longer a `Critical` for a condition that was over in half a second.
- **Still terminal** — anything `IsTransientFailure` does not recognise gives up on the **first** attempt, and an exhausted budget still ends in the same `LogCritical` + `null` + latched disable. A permanent failure still fails.
- Each retry re-invokes the attach **from scratch** (fresh `GetStream`, fresh `SubscribeAsync`), so Orleans re-resolves the rendezvous grain rather than re-using a reference minted mid-handoff.

No change to the readiness gate itself, to the outbound `subscriptionReady` gate, or to the delivery handlers.

## Tests — `StreamAttachTransientRetryTest`

Deterministic, no cluster: reaching the stream provider **is** the observable, and the backoff is collapsed to zero through an instance seam (`AttachBackoff`, never static state).

| test | asserts |
|---|---|
| `TransientAttachFailure_IsRetried_UpToTheBudget` | 6 attempts (1 + `SubscribeAttachRetries`) |
| `NonTransientAttachFailure_StillGivesUpOnTheFirstAttempt` | exactly 1 attempt — a permanent failure must still fail |
| `TheFakeIsTheProductionException` | the driver **is** `OrleansMessageRejectionException` and **is** what `IsTransientFailure` matches — without this the retry tests could pass against nothing |
| `AttachBackoff_IsBoundedAndCapped` | the budget is small, growing, capped, and finishes well inside the enclosing budgets |

### Failing on unfixed code

Run with the retry budget forced to the pre-fix single attempt (`maxRetries: 0`):

```
[FAIL] StreamAttachTransientRetryTest.TransientAttachFailure_IsRetried_UpToTheBudget
  Expected value to be 6 because a grain-directory rejection is TRANSIENT … but found 1.
Failed!  - Failed: 1, Passed: 3, Total: 4
```

With the fix in place:

```
Passed!  - Failed: 0, Passed: 13, Total: 13
```

(13 = this file plus `OrleansStreamingReadinessGateTest` and `OrleansDirectoryInstabilityClassificationTest`, run together to confirm the #1129 gate's "attaches exactly once" assertion still holds — it does, because its probe throws a *non-transient* `NotSupportedException`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)