### PR TITLE
fix(#2636, #2637): an install that CLAIMS mail it cannot send is refused at BOOT, by key

### DIFF
--- a/memex/Memex.Portal.Shared/Email/EmailConfigurationGuard.cs
+++ b/memex/Memex.Portal.Shared/Email/EmailConfigurationGuard.cs
@@ -1,0 +1,172 @@
+using System.Collections.Immutable;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Configuration;
+
+namespace Memex.Portal.Shared.Email;
+
+/// <summary>
+/// The BOOT-TIME guard for the <c>Email</c> section: an install that CLAIMS mail
+/// (<c>Email:Enabled=true</c>) and cannot possibly deliver it is refused at startup, by key
+/// (MeshWeaver#2636, #2637).
+///
+/// <para>🚨 <b>The defect this closes.</b> On memex the section was half-set — enabled, with
+/// <c>Email:TenantId</c> and <c>Email:ClientId</c> unset — and the portal came up perfectly
+/// healthy with mail DARK. <see cref="EmailDeliveryGuard"/> did its job (the watchers refused, so
+/// nothing was ever falsely stamped <c>Sent</c>), but a single <c>Error</c> line in a pod log is
+/// not a signal anyone reads: <c>/health</c> was 200, the site served, and every invitation,
+/// notification and document share queued as <c>New</c> and stayed there. The install said mail
+/// was on and dropped every message. That is the failure — not the missing key, which is
+/// ordinary, but the fact that nothing surfaced it.</para>
+///
+/// <para><b>Two rules, and they are deliberately different</b> — the same distinction
+/// <see cref="Authentication.MicrosoftTenant"/> encodes for the OIDC tenant (#2621), and it is the
+/// whole of this guard:</para>
+/// <list type="number">
+/// <item><description><b>Absent or <c>Email:Enabled=false</c> = the integration was NEVER
+/// configured, and it must NOT refuse.</b> A blank section is exactly what "no mail on this
+/// install" looks like — it is every local dev run, every test host, every deployment that never
+/// wanted mail — and aborting a portal because an OPTIONAL integration is unconfigured is the
+/// #2510 failure verbatim (a guard that fails worse than the thing it guards). Nothing here is
+/// even looked at in that case.</description></item>
+/// <item><description><b><c>Email:Enabled=true</c> with the section INCOMPLETE = a real
+/// misconfiguration, refused at startup, naming the exact keys.</b> Someone MEANT to enable mail.
+/// An install in this state is not sending anything today, so refusing it cannot take a working
+/// portal's mail down — it converts a silent drop into a named configuration error at boot, which
+/// is the one thing an operator can act on.</description></item>
+/// </list>
+///
+/// <para>🚨 <b>Why this does NOT re-open #2510.</b> #2510 was not "email configuration stopped the
+/// host" in the abstract; it was <c>EmailDeliveryGuard</c> ACTIVATING the Graph sender from
+/// <c>IHostedService.StartAsync</c>, whose <c>ClientSecretCredential</c> constructor threw
+/// <c>ArgumentException: Invalid tenant id provided</c> → <c>Hosting failed to start</c> — an
+/// unactionable message, from a container resolution, that named Azure's validator instead of the
+/// key to set. Two properties keep that fixed and are not negotiable here:
+/// <list type="bullet">
+/// <item><description>this verdict is reached from <b>inert configuration data only</b> — no
+/// container, no credential object, no I/O — so it cannot throw for any reason other than the one
+/// it is reporting; and</description></item>
+/// <item><description>the <b>unconfigured</b> install (blank/disabled) is never refused.</description></item>
+/// </list>
+/// What changes is only the SEVERITY of the enabled-but-incomplete case: from a log line nobody
+/// reads to a named startup refusal. <see cref="EmailDeliveryGuard"/> stays exactly as it is — it
+/// still refuses the watchers on hosts that never call this guard (LocalMesh, test hosts, any host
+/// not going through <c>ConfigureMemexMesh</c>), and it is still what guarantees queued mail is
+/// never stamped <c>Sent</c>.</para>
+///
+/// <para>Pure decision, no I/O and no container, so it is unit-testable without spinning a host —
+/// the same shape as <c>MemexConfiguration.ValidateContentStorageDurability</c> and
+/// <see cref="Authentication.MicrosoftTenant"/>.</para>
+///
+/// <para>Scope is OUTBOUND, deliberately. The inbound channel (<c>Email:InboundEnabled</c>,
+/// <c>Email:WebhookBaseUrl</c>, <c>Email:SubscriptionClientState</c>) has the same shape but no
+/// incident behind it, and widening a boot-time refusal past the failure it is fixing is how a
+/// guard acquires a blast radius nobody signed off on.</para>
+/// </summary>
+public static class EmailConfigurationGuard
+{
+    /// <summary>The configuration section this guard reads, in binder form.</summary>
+    public const string SectionName = EmailOptions.SectionName;
+
+    /// <summary>The switch that turns a blank section into a CLAIM, in binder form.</summary>
+    public const string EnabledKey = $"{SectionName}:{nameof(EmailOptions.Enabled)}";
+
+    /// <summary>The mailbox the system path sends AS — required by both credential flows.</summary>
+    public const string MailboxAddressKey = $"{SectionName}:{nameof(EmailOptions.MailboxAddress)}";
+
+    /// <summary>The alternative to the client-secret flow, named in every refusal as a way out.</summary>
+    public const string UseManagedIdentityKey = $"{SectionName}:{nameof(EmailOptions.UseManagedIdentity)}";
+
+    /// <summary>
+    /// A binder key (<c>Email:TenantId</c>) as the environment-variable / configMap entry an
+    /// operator actually sets (<c>Email__TenantId</c>).
+    ///
+    /// <para>Both forms appear in every refusal on purpose. The binder form is what the code, the
+    /// docs and <see cref="EmailOptions.MissingCredentialKeys"/> speak; the environment form is
+    /// what is typed into a Helm value, a configMap or a <c>kubectl set env</c>, and an operator
+    /// reading a pod log has no reason to know the two are the same key. Naming only one of them
+    /// is how a message that looks actionable still costs a search.</para>
+    /// </summary>
+    public static string EnvironmentKey(string binderKey)
+        => binderKey.Replace(":", "__", StringComparison.Ordinal);
+
+    /// <summary>
+    /// The keys this install CLAIMS mail with and has not set — empty when there is nothing to
+    /// refuse, which includes every disabled or absent section.
+    ///
+    /// <para>The credential half is delegated to <see cref="EmailOptions.MissingCredentialKeys"/>
+    /// rather than re-derived, so "which keys does the selected flow need" has exactly ONE
+    /// definition; a second copy here would be free to drift from the one the watchers and the
+    /// no-op sender already report. Managed identity carries no credential keys at all.</para>
+    ///
+    /// <para><see cref="EmailOptions.MailboxAddress"/> is added on top because it is required by
+    /// BOTH flows and by no credential: the system send path is
+    /// <c>/users/{MailboxAddress}/sendMail</c>, so a blank value composes a Graph request for no
+    /// mailbox. It is not a credential, which is why it is not in
+    /// <see cref="EmailOptions.MissingCredentialKeys"/> — but it is just as certainly the
+    /// difference between an install that sends and one that silently does not.</para>
+    /// </summary>
+    /// <param name="options">The bound <c>Email</c> section (<c>null</c> when absent).</param>
+    public static ImmutableArray<string> MissingRequiredKeys(EmailOptions? options)
+    {
+        // Rule 1: absent or disabled is a COMPLETE, supported configuration. Nothing is missing
+        // from a section that never claimed anything.
+        if (options is not { Enabled: true })
+            return ImmutableArray<string>.Empty;
+
+        var missing = ImmutableArray.CreateBuilder<string>(4);
+        if (string.IsNullOrWhiteSpace(options.MailboxAddress))
+            missing.Add(MailboxAddressKey);
+        missing.AddRange(options.MissingCredentialKeys());
+        return missing.ToImmutable();
+    }
+
+    /// <summary>
+    /// The boot-time guard: throws when this install claims mail it cannot send, so the
+    /// misconfiguration is named at startup instead of surfacing as mail that never arrives. An
+    /// absent or disabled section passes.
+    /// </summary>
+    /// <param name="options">The bound <c>Email</c> section (<c>null</c> when absent).</param>
+    /// <exception cref="InvalidOperationException">
+    /// <c>Email:Enabled=true</c> and a required key is unset; the message names every missing key
+    /// in both the binder and the environment-variable form.
+    /// </exception>
+    public static void Validate(EmailOptions? options)
+    {
+        var missing = MissingRequiredKeys(options);
+        if (!missing.IsEmpty)
+            throw new InvalidOperationException(Refusal(missing));
+    }
+
+    /// <summary>
+    /// The call-site form: binds the <c>Email</c> section exactly as the portal composition does
+    /// (<c>GetSection(...).Get&lt;EmailOptions&gt;()</c>) and validates it. An absent section binds
+    /// to <c>null</c> and passes.
+    /// </summary>
+    /// <param name="configuration">The host configuration.</param>
+    public static void Validate(IConfiguration configuration)
+        => Validate(configuration.GetSection(SectionName).Get<EmailOptions>());
+
+    /// <summary>
+    /// The refusal wording. Names every missing key in both forms, and every way OUT of the
+    /// refusal — complete the client-secret flow, switch to managed identity, or turn the
+    /// integration off — because "your configuration is incomplete" without a supported way to
+    /// disable it is an instruction to guess.
+    /// </summary>
+    /// <param name="missing">The keys from <see cref="MissingRequiredKeys"/>; never empty.</param>
+    internal static string Refusal(ImmutableArray<string> missing)
+    {
+        var named = string.Join(", ", missing.Select(k => $"{k} ({EnvironmentKey(k)})"));
+        return $"Email misconfiguration (issues #2636, #2637): {EnabledKey}=true "
+            + $"({EnvironmentKey(EnabledKey)}=true), but the {SectionName} section is INCOMPLETE — "
+            + $"{named} {(missing.Length == 1 ? "is" : "are")} not set, so this install cannot send "
+            + "mail at all. It would accept every invitation, notification and document share and "
+            + "then DROP it: the mail queues as New and stays there, the portal serves normally, "
+            + "/health stays 200, and nothing on any screen says mail is dark. Set the keys named "
+            + $"above, or set {UseManagedIdentityKey}=true "
+            + $"({EnvironmentKey(UseManagedIdentityKey)}=true) and grant the managed identity the "
+            + $"Mail.Send app role, or turn the integration off with {EnabledKey}=false "
+            + $"({EnvironmentKey(EnabledKey)}=false) — a disabled section is a complete, supported "
+            + "configuration and starts normally. Refusing to start so the misconfiguration "
+            + "surfaces now rather than as mail that never arrives.";
+    }
+}

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -422,6 +422,15 @@ public static class MemexConfiguration
             // unhandled 500 on the FIRST sign-in, naming the URL instead of the key to fix. Named
             // here at boot instead.
             MicrosoftTenant.Validate(configuration[MicrosoftTenant.ConfigurationKey]);
+            // 🚨 Fail fast on an install that CLAIMS mail it cannot send (#2636, #2637):
+            // Email:Enabled=true with the section incomplete. Same two rules as the tenant guard
+            // above — a blank/disabled section is "never configured" and passes (aborting on an
+            // unconfigured optional integration is the #2510 failure), while enabled-but-incomplete
+            // is a real misconfiguration and is named here. On memex it produced a portal that
+            // served perfectly, reported mail as ON, and dropped every invitation and notification
+            // into a queue nobody watches. Inert configuration data only — nothing is resolved and
+            // no credential is constructed, which is the property #2510 turned on.
+            EmailConfigurationGuard.Validate(configuration);
             if (contentStorageConfig != null)
             {
                 // Resolve relative path to absolute

--- a/src/MeshWeaver.Documentation/Data/Architecture/SendingEmail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SendingEmail.md
@@ -138,6 +138,44 @@ point the queued `New` mail goes out by itself, with no data repair and nothing 
 That is the whole reason refusing beats succeeding quietly: mail stamped `Sent` that was never sent
 is indistinguishable from mail that really was sent, and no restart recovers it (#2023).
 
+### 🚨 An INCOMPLETE section refuses at STARTUP, by key (#2636, #2637)
+
+The watcher refusal above is correct and stays. It is also, on its own, **invisible**: its whole
+output is one `Error` line per host start. On memex the `Email` section sat half-set — enabled, with
+`Email:TenantId` and `Email:ClientId` unset — and the portal came up perfectly healthy with mail
+dark. `/health` was 200, the site served, and every invitation, notification and document share
+queued as `New` and stayed there until a human noticed mail had not arrived.
+
+So `MemexConfiguration.ConfigureMemexMesh` now runs `EmailConfigurationGuard.Validate(configuration)`
+at boot, beside `ValidateContentStorageDurability` and `MicrosoftTenant.Validate`. **Two rules, and
+they are deliberately different:**
+
+| The `Email` section is… | Verdict | Why |
+|---|---|---|
+| **absent, or `Email:Enabled=false`** | **starts** — never refused, however blank | Blank is what "no mail on this install" looks like: every local dev run, every test host, every deployment that never wanted mail. Aborting a portal for an unconfigured OPTIONAL integration is #2510 verbatim. |
+| **`Email:Enabled=true` and complete** (either flow) | **starts** | Nothing to refuse. Managed identity needs no credential keys at all. |
+| **`Email:Enabled=true` and INCOMPLETE** | **refuses at startup**, naming every missing key in **both** forms — `Email:TenantId` *and* `Email__TenantId` | Someone MEANT to enable mail. Such an install sends nothing today, so refusing cannot take working mail down — it converts a silent drop into a named configuration error an operator can act on. |
+
+Required when enabled: `Email:MailboxAddress` (both flows — the system send path is
+`/users/{MailboxAddress}/sendMail`), plus `Email:TenantId`, `Email:ClientId`, `Email:ClientSecret`
+for the client-secret flow, or nothing further for `Email:UseManagedIdentity=true`. The credential
+half is `EmailOptions.MissingCredentialKeys()` — the same answer the watchers and `NoOpEmailSender`
+report, deliberately not a second copy. Scope is OUTBOUND; the inbound keys
+(`Email:InboundEnabled`, `Email:WebhookBaseUrl`, `Email:SubscriptionClientState`) are not guarded.
+
+> 🚨 **This does NOT re-open #2510.** That incident was `EmailDeliveryGuard` *activating* the Graph
+> sender from `IHostedService.StartAsync`, whose `ClientSecretCredential` constructor threw
+> `ArgumentException: Invalid tenant id provided` → `Hosting failed to start` — an unactionable
+> message from a container resolution. This verdict is reached from **inert configuration data
+> only**: no container, no credential object, no I/O, so it cannot throw for any reason other than
+> the one it reports. And the **unconfigured** install still starts. What changed is only the
+> severity of the enabled-but-incomplete case, from a log line nobody reads to a named refusal.
+
+⚠️ **Operationally**: an install that is enabled-but-incomplete TODAY will refuse to start once it
+rolls onto a build carrying this guard. Complete the section, or set `Email__Enabled=false`, **before**
+that roll. That is the intended trade — a portal that says mail is on and drops every message is the
+defect this replaces.
+
 🚨 **The order the two questions are asked in is load-bearing** (#2510). The guard runs inside
 `IHostedService.StartAsync`, where a throw aborts the **host**, not a feature. It therefore asks the
 configuration *first*, from data that cannot throw, and only a completely-configured install goes on

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-email-config-cannot-block-startup.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-27-email-config-cannot-block-startup.md
@@ -18,3 +18,8 @@ starts and serves normally; mail alone is switched off, with an error naming the
 Anything already queued stays visibly unsent, and goes out by itself once the keys are set and the portal
 restarts — mail settings are read at startup, so completing them takes effect on the next roll. Nothing
 is ever marked as delivered when it was not.
+
+**Since 2026-08-29** this is refined rather than reversed: an installation that never wanted mail — a
+blank or absent mail section — still starts exactly as described above, but one that *switches mail on*
+without finishing its settings is now stopped at startup and told which settings are missing, instead
+of serving with mail silently dark. See *A portal that says mail is on now proves it at startup*.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-29-mail-enabled-but-unconfigured-is-named-at-startup.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-29-mail-enabled-but-unconfigured-is-named-at-startup.md
@@ -1,0 +1,23 @@
+---
+Name: A portal that says mail is on now proves it at startup
+Category: Fix
+Description: Switching mail on without finishing its settings is reported by name when the portal starts, instead of quietly delivering nothing.
+Icon: Sparkle
+Order: -20260829
+---
+
+# A portal that says mail is on now proves it at startup
+
+Mail could be switched on (`Email:Enabled=true`) with its settings half-filled in, and everything
+looked fine: the portal started, every page served, the health check was green — and not one message
+went out. Invitations, notifications and shared documents piled up unsent, with nothing on any screen
+to say so. The only sign was a single line in a server log.
+
+Now the portal checks that claim when it starts. If mail is switched on but a setting it needs is
+missing, the portal refuses to start and says exactly which ones — in both the form the documentation
+uses (`Email:TenantId`) and the form an operator actually sets (`Email__TenantId`) — along with every
+way out: fill them in, switch to a managed identity, or turn mail off.
+
+Turning mail **off** is still a complete, supported answer, and an installation that never wanted mail
+is untouched: a blank or absent mail section starts exactly as before. Only an installation that
+*claims* mail it cannot send is stopped, and it was never sending anything to begin with.

--- a/test/Memex.Portal.Shared.Test/EmailStartupConfigurationGuardTest.cs
+++ b/test/Memex.Portal.Shared.Test/EmailStartupConfigurationGuardTest.cs
@@ -1,0 +1,396 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Memex.Portal.Shared.Email;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>The regression guard for MeshWeaver#2636 / #2637: the memex portal said mail was ON and
+/// dropped every message.</b>
+///
+/// <para><c>Email:Enabled=true</c> with <c>Email:TenantId</c> and <c>Email:ClientId</c> unset. The
+/// portal started, served, answered <c>/health</c> 200 — and <c>OutboundEmailSender</c> and
+/// <c>InvitationEmailSender</c> both refused to start, so every invitation, notification and
+/// document share queued as <c>New</c> and stayed there. <see cref="EmailDeliveryGuard"/> did
+/// exactly its job (nothing was ever falsely stamped <c>Sent</c>), but its whole output is one
+/// <c>Error</c> line per host start, and a log line nobody reads is not a signal. The install was
+/// half-configured for as long as it took a human to notice mail had not arrived.</para>
+///
+/// <para><b>Both directions are pinned, and neither implies the other.</b> A guard that refuses
+/// everything satisfies half of this file and would abort every local dev run and every deployment
+/// that never wanted mail — which is #2510, the incident where a half-configured OPTIONAL
+/// integration took the whole host down. A guard that refuses nothing satisfies the other half and
+/// is the bug being fixed. So:</para>
+/// <list type="number">
+/// <item><description><b>Absent / <c>Enabled=false</c> starts.</b> Blank is what "no mail on this
+/// install" looks like; it is never a misconfiguration.</description></item>
+/// <item><description><b><c>Enabled=true</c> and complete starts</b> — both credential flows.</description></item>
+/// <item><description><b><c>Enabled=true</c> and incomplete REFUSES</b>, naming every missing key
+/// in the binder form the docs use AND the <c>__</c> form an operator actually
+/// sets.</description></item>
+/// </list>
+///
+/// <para>Every case is a pure call on inert configuration data — no host, no container, no
+/// credential object. That is not test convenience: it is the property #2510 bought (the verdict
+/// must be unable to throw for any reason other than the one it reports), and a test that needed a
+/// host to reach it would not be pinning it.</para>
+/// </summary>
+public class EmailStartupConfigurationGuardTest
+{
+    /// <summary>The memex install from the two incident tickets: switched on, the client secret
+    /// present (the refusal named only the other two), tenant and client id unset.</summary>
+    private static EmailOptions TheIncident() => new()
+    {
+        Enabled = true,
+        MailboxAddress = "memex@example.test",
+        ClientSecret = "secret",
+        // TenantId / ClientId deliberately unset — this is the half-configured deployment.
+    };
+
+    private static EmailOptions Complete() => new()
+    {
+        Enabled = true,
+        MailboxAddress = "memex@example.test",
+        TenantId = "72f988bf-86f1-41af-91ab-2d7cd011db47",
+        ClientId = "client",
+        ClientSecret = "secret",
+    };
+
+    // ───────────── rule 1: never configured must NOT refuse (this is the #2510 half) ─────────────
+
+    /// <summary>
+    /// 🚨 The case that protects against #2510, stated at its weakest point: NOTHING configured at
+    /// all. An absent section binds to <c>null</c>, and a null section is not a claim — it is every
+    /// local dev run, every test host and every deployment that never wanted mail. Refusing it
+    /// would abort hosts that are working perfectly.
+    /// </summary>
+    [Fact]
+    public void AnAbsentEmailSection_IsNeverRefused()
+    {
+        EmailConfigurationGuard.Validate((EmailOptions?)null);
+        Assert.Empty(EmailConfigurationGuard.MissingRequiredKeys(null));
+    }
+
+    /// <summary>
+    /// <c>Email:Enabled=false</c> is a COMPLETE, supported configuration however blank the rest of
+    /// the section is — that is precisely what the switch means, and the host registers
+    /// <c>NoOpEmailSender</c> for it. Asserted over the shapes a real deployment leaves behind: all
+    /// blank, half-filled (someone started wiring it and turned it off), and fully filled but
+    /// switched off (mail deliberately parked).
+    /// </summary>
+    [Theory]
+    [InlineData("", "", "", "")]
+    [InlineData("memex@example.test", "", "", "secret")]
+    [InlineData("memex@example.test", "tenant", "client", "secret")]
+    public void ADisabledEmailSection_IsNeverRefused_HoweverBlankOrFullItIs(
+        string mailbox, string tenantId, string clientId, string clientSecret)
+    {
+        var options = new EmailOptions
+        {
+            Enabled = false,
+            MailboxAddress = mailbox,
+            TenantId = tenantId,
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+        };
+
+        EmailConfigurationGuard.Validate(options);
+        Assert.Empty(EmailConfigurationGuard.MissingRequiredKeys(options));
+    }
+
+    /// <summary>
+    /// The same rule through the seam the portal actually uses — the bound configuration, not a
+    /// hand-built record. An environment that never set a single <c>Email__*</c> variable must pass
+    /// the boot guard, and so must one that explicitly switched mail off.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("false")]
+    [InlineData("False")]
+    public void ConfigurationWithNoEmailClaim_PassesTheBootGuard(string? enabled)
+    {
+        var settings = new Dictionary<string, string?>
+        {
+            ["Graph:Storage:Type"] = "FileSystem",
+        };
+        if (enabled is not null)
+            settings["Email__Enabled"] = enabled;
+
+        EmailConfigurationGuard.Validate(Configuration(settings));
+    }
+
+    // ───────────── rule 2: enabled + incomplete REFUSES, by name ─────────────
+
+    /// <summary>
+    /// 🚨 The incident itself: enabled, client secret set, tenant and client id unset. Refused, and
+    /// the refusal names BOTH missing keys in BOTH forms — the binder form the documentation and
+    /// the code speak, and the <c>__</c> form that goes into a Helm value or a configMap. It must
+    /// NOT name the key that is set: a refusal that lists everything tells an operator nothing.
+    /// </summary>
+    [Fact]
+    public void TheIncidentConfiguration_IsRefusedAtStartup_NamingBothMissingKeysInBothForms()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => EmailConfigurationGuard.Validate(TheIncident()));
+
+        Assert.Contains("Email:TenantId", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Email__TenantId", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Email:ClientId", ex.Message, StringComparison.Ordinal);
+        Assert.Contains("Email__ClientId", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Email:ClientSecret", ex.Message, StringComparison.Ordinal);
+        Assert.DoesNotContain("Email__ClientSecret", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Each required key on its own, so the guard is proven to name THE key that is missing rather
+    /// than a fixed list that happens to contain it. Every one of these is an install that would
+    /// start, claim mail, and silently deliver nothing.
+    ///
+    /// <para><c>Email:MailboxAddress</c> is in this set although it is not a credential: the system
+    /// send path is <c>/users/{MailboxAddress}/sendMail</c>, so a blank value composes a Graph
+    /// request for no mailbox at all. It is required by BOTH flows, which is why it is checked here
+    /// rather than in <see cref="EmailOptions.MissingCredentialKeys"/>.</para>
+    /// </summary>
+    [Theory]
+    [InlineData("Email:MailboxAddress")]
+    [InlineData("Email:TenantId")]
+    [InlineData("Email:ClientId")]
+    [InlineData("Email:ClientSecret")]
+    public void EachRequiredKey_RefusesOnItsOwn_AndTheRefusalNamesThatKey(string key)
+    {
+        var options = Blank(Complete(), key);
+
+        var missing = EmailConfigurationGuard.MissingRequiredKeys(options);
+        Assert.Equal(new[] { key }, missing.ToArray());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => EmailConfigurationGuard.Validate(options));
+        Assert.Contains(key, ex.Message, StringComparison.Ordinal);
+        Assert.Contains(EmailConfigurationGuard.EnvironmentKey(key), ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Whitespace is unset. A Helm value templated from an empty secret arrives as <c>" "</c>, and
+    /// Azure's own validator rejects it exactly like <c>""</c> — so a guard that accepted it would
+    /// wave through the very install it exists to catch.
+    /// </summary>
+    [Theory]
+    [InlineData(" ")]
+    [InlineData("\t")]
+    [InlineData("\n  ")]
+    public void AWhitespaceValueIsUnset(string blank)
+    {
+        Assert.Equal(
+            new[] { "Email:TenantId" },
+            EmailConfigurationGuard.MissingRequiredKeys(Complete() with { TenantId = blank }).ToArray());
+    }
+
+    /// <summary>
+    /// Enabled and nothing else: every required key of the selected (default, client-secret) flow
+    /// is named at once, so one restart tells the operator the whole job rather than one key per
+    /// roll.
+    /// </summary>
+    [Fact]
+    public void EnabledWithNothingElse_NamesEveryRequiredKeyAtOnce()
+    {
+        var missing = EmailConfigurationGuard.MissingRequiredKeys(new EmailOptions { Enabled = true });
+
+        Assert.Equal(
+            new[] { "Email:MailboxAddress", "Email:TenantId", "Email:ClientId", "Email:ClientSecret" },
+            missing.ToArray());
+    }
+
+    /// <summary>
+    /// Managed identity carries no credential keys — <c>DefaultAzureCredential</c> takes no tenant
+    /// id — but it still sends AS a mailbox. So a managed-identity install missing only the mailbox
+    /// is refused for that key ALONE: naming tenant/client/secret here would send an operator to
+    /// set three keys their flow does not use, which is a confidently wrong answer.
+    /// </summary>
+    [Fact]
+    public void ManagedIdentity_IsRefusedOnlyForTheMailbox_NeverForCredentialKeysItDoesNotUse()
+    {
+        var options = new EmailOptions { Enabled = true, UseManagedIdentity = true };
+
+        Assert.Equal(
+            new[] { "Email:MailboxAddress" },
+            EmailConfigurationGuard.MissingRequiredKeys(options).ToArray());
+
+        var ex = Assert.Throws<InvalidOperationException>(() => EmailConfigurationGuard.Validate(options));
+        Assert.DoesNotContain("Email:TenantId", ex.Message, StringComparison.Ordinal);
+    }
+
+    // ───────────── rule 3: enabled + complete starts ─────────────
+
+    /// <summary>
+    /// The control that stops every case above from being satisfied by a guard that refuses
+    /// everything: a completely configured install passes, on BOTH flows. Managed identity is the
+    /// production deployment shape — a false refusal here would stop mail on every install that
+    /// works today.
+    /// </summary>
+    [Fact]
+    public void ACompleteConfiguration_Starts_OnEitherCredentialFlow()
+    {
+        EmailConfigurationGuard.Validate(Complete());
+        Assert.Empty(EmailConfigurationGuard.MissingRequiredKeys(Complete()));
+
+        var managedIdentity = new EmailOptions
+        {
+            Enabled = true,
+            UseManagedIdentity = true,
+            MailboxAddress = "memex@example.test",
+        };
+        EmailConfigurationGuard.Validate(managedIdentity);
+        Assert.Empty(EmailConfigurationGuard.MissingRequiredKeys(managedIdentity));
+    }
+
+    /// <summary>
+    /// …and through the bound configuration, written the way an operator writes it: as
+    /// <c>Email__*</c> environment entries. This is the shape the fix is asking a maintainer to
+    /// produce, so it is worth asserting that it is actually accepted.
+    /// </summary>
+    [Fact]
+    public void ACompleteConfigurationInEnvironmentVariableForm_PassesTheBootGuard()
+    {
+        EmailConfigurationGuard.Validate(Configuration(new Dictionary<string, string?>
+        {
+            ["Email__Enabled"] = "true",
+            ["Email__MailboxAddress"] = "memex@example.test",
+            ["Email__TenantId"] = "72f988bf-86f1-41af-91ab-2d7cd011db47",
+            ["Email__ClientId"] = "client",
+            ["Email__ClientSecret"] = "secret",
+        }));
+    }
+
+    // ───────────── the message, and the one definition of "what does this flow need" ─────────────
+
+    /// <summary>
+    /// A refusal that only says what is wrong is half a message. This one has to carry every way
+    /// OUT: complete the client-secret flow, switch to managed identity, or turn the integration
+    /// off — the last of which matters most, because an operator who does not want mail on this
+    /// install must not have to guess that <c>Email:Enabled=false</c> is a supported answer.
+    /// </summary>
+    [Fact]
+    public void TheRefusalNamesEveryWayOut()
+    {
+        var message = EmailConfigurationGuard.Refusal(EmailConfigurationGuard.MissingRequiredKeys(TheIncident()));
+
+        Assert.Contains("Email:UseManagedIdentity=true", message, StringComparison.Ordinal);
+        Assert.Contains("Email__UseManagedIdentity=true", message, StringComparison.Ordinal);
+        Assert.Contains("Email:Enabled=false", message, StringComparison.Ordinal);
+        Assert.Contains("Email__Enabled=false", message, StringComparison.Ordinal);
+        Assert.Contains("#2636", message, StringComparison.Ordinal);
+    }
+
+    /// <summary>The binder → environment mapping, pinned: every level separator becomes <c>__</c>.</summary>
+    [Theory]
+    [InlineData("Email:TenantId", "Email__TenantId")]
+    [InlineData("Email:Enabled", "Email__Enabled")]
+    [InlineData("Email:MailboxAddress", "Email__MailboxAddress")]
+    public void TheEnvironmentFormOfAKey(string binder, string environment)
+        => Assert.Equal(environment, EmailConfigurationGuard.EnvironmentKey(binder));
+
+    /// <summary>
+    /// 🚨 ONE definition of "which credential keys does the selected flow need". This guard
+    /// delegates that half to <see cref="EmailOptions.MissingCredentialKeys"/> — the same answer
+    /// <see cref="EmailDeliveryGuard"/> and <c>NoOpEmailSender</c> report — instead of re-deriving
+    /// it. A second copy would be free to drift, and the two would then tell the same operator
+    /// different stories about the same install.
+    /// </summary>
+    [Theory]
+    [InlineData(false, "", "", "")]
+    [InlineData(false, "t", "", "s")]
+    [InlineData(false, "t", "c", "s")]
+    [InlineData(true, "", "", "")]
+    public void TheCredentialHalfIsTheSameAnswerTheWatchersGive(
+        bool useManagedIdentity, string tenantId, string clientId, string clientSecret)
+    {
+        var options = new EmailOptions
+        {
+            Enabled = true,
+            MailboxAddress = "memex@example.test",
+            UseManagedIdentity = useManagedIdentity,
+            TenantId = tenantId,
+            ClientId = clientId,
+            ClientSecret = clientSecret,
+        };
+
+        Assert.Equal(
+            EmailDeliveryGuard.MissingConfiguration(options).ToArray(),
+            EmailConfigurationGuard.MissingRequiredKeys(options).ToArray());
+    }
+
+    // ───────────── the guard is WIRED, not merely present ─────────────
+
+    /// <summary>
+    /// 🚨 The case that stops all of the above from being dead code: the guard has to run on the
+    /// portal boot path. <c>ConfigureMemexMesh</c> is what both hosts (Monolith and Distributed,
+    /// plugins repo) call, and it is where <c>ValidateContentStorageDurability</c> and
+    /// <c>MicrosoftTenant.Validate</c> already sit.
+    ///
+    /// <para>A pure function nobody calls refuses nothing, and its unit tests stay green forever —
+    /// which is exactly how this class of guard rots.</para>
+    /// </summary>
+    [Fact]
+    public void TheBootPathRefusesAHalfConfiguredEmailSection()
+    {
+        var ex = Assert.Throws<InvalidOperationException>(
+            () => ConfigureMemexMeshWith(new Dictionary<string, string?>
+            {
+                ["Email:Enabled"] = "true",
+                ["Email:MailboxAddress"] = "memex@example.test",
+                ["Email:ClientSecret"] = "secret",
+            }));
+
+        Assert.Contains("Email__TenantId", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// …and the boot path is unaffected by an install that never configured mail. Same call, no
+    /// <c>Email</c> section at all — the #2510 direction, asserted where it would actually happen.
+    /// </summary>
+    [Fact]
+    public void TheBootPathIsUnaffectedByAnInstallThatNeverConfiguredMail()
+        => ConfigureMemexMeshWith(new Dictionary<string, string?>());
+
+    // ───────────── fixtures ─────────────
+
+    private static IConfiguration Configuration(Dictionary<string, string?> settings)
+        => new ConfigurationBuilder().AddInMemoryCollection(settings).Build();
+
+    /// <summary>Runs the real portal boot configuration over an in-memory configuration, with the
+    /// minimum storage answer that gets past the awaiting-setup short-circuit.</summary>
+    private static void ConfigureMemexMeshWith(Dictionary<string, string?> settings)
+    {
+        var temp = Directory.CreateTempSubdirectory("mw-2636-").FullName;
+        try
+        {
+            settings["Graph:Storage:Type"] = "FileSystem";
+            settings["Graph:Storage:BasePath"] = temp;
+            settings["Modules:Root"] = temp;
+
+            new MeshBuilder(configure => configure(new ServiceCollection()), new Address("mesh", "test"))
+                .ConfigureMemexMesh(Configuration(settings));
+        }
+        finally
+        {
+            try { Directory.Delete(temp, recursive: true); }
+            catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        }
+    }
+
+    /// <summary>The complete section with exactly one key blanked — "this deployment set everything
+    /// but that one".</summary>
+    private static EmailOptions Blank(EmailOptions options, string key) => key switch
+    {
+        "Email:MailboxAddress" => options with { MailboxAddress = "" },
+        "Email:TenantId" => options with { TenantId = "" },
+        "Email:ClientId" => options with { ClientId = "" },
+        "Email:ClientSecret" => options with { ClientSecret = "" },
+        _ => throw new ArgumentOutOfRangeException(nameof(key), key, "not a required Email key"),
+    };
+}


### PR DESCRIPTION
Fixes the outbound-email outage reported in Systemorph/MeshWeaver#2636 and Systemorph/MeshWeaver#2637 — **two views of one failure, one fix**. Both tickets are the same memex install at the same host start: `Email:Enabled=true` with `Email:TenantId` and `Email:ClientId` unset, seen once through `OutboundEmailSender` and once through `InvitationEmailSender`. Same fingerprint pod, same minute.

## The defect

Not the missing key — that is ordinary. **Nothing surfaced it.**

The portal came up perfectly healthy with mail dark: `/health` 200, every page served, and every invitation, notification and document share queued as `New` and stayed there. `EmailDeliveryGuard` did exactly its job — the watchers refused, so nothing was ever falsely stamped `Sent` (#2023) — but its entire output is **one `Error` line per host start**, and a log line nobody reads is not a signal. The install said mail was on and dropped every message, for as long as it took a human to notice mail had not arrived.

## The fix — the established shape, not a new one

`EmailConfigurationGuard` (`memex/Memex.Portal.Shared/Email/`) is a pure startup decision — no container, no credential object, no I/O — called from `MemexConfiguration.ConfigureMemexMesh` beside `ValidateContentStorageDurability` (#435) and `MicrosoftTenant.Validate` (#2634). **Two rules, and they are deliberately different** — the same distinction the OIDC tenant guard encodes:

| The `Email` section is… | Verdict | Why |
|---|---|---|
| **absent, or `Email:Enabled=false`** | **starts** — never refused, however blank or however full | Blank is what "no mail on this install" looks like: every local dev run, every test host, every deployment that never wanted mail. Aborting a portal for an unconfigured **optional** integration is Systemorph/MeshWeaver#2510 verbatim. |
| **`Email:Enabled=true` and complete** (either flow) | **starts** | Nothing to refuse. Managed identity needs no credential keys at all. |
| **`Email:Enabled=true` and INCOMPLETE** | **refuses at startup**, naming every missing key | Someone *meant* to enable mail. Such an install sends nothing today, so refusing cannot take working mail down — it converts a silent drop into a named configuration error an operator can act on. |

The refusal names each key in **both** forms — `Email:TenantId` (binder, what the docs and the code speak) **and** `Email__TenantId` (what an operator actually types into a Helm value, a configMap or `kubectl set env`) — plus every way out: complete the flow, `Email:UseManagedIdentity=true`, or `Email:Enabled=false`.

### 🚨 This does NOT re-open Systemorph/MeshWeaver#2510

Systemorph/MeshWeaver#2510 was not "email configuration stopped the host" in the abstract. It was `EmailDeliveryGuard` **activating** the Graph sender from `IHostedService.StartAsync`, whose `ClientSecretCredential` constructor threw `ArgumentException: Invalid tenant id provided` → `Hosting failed to start` — an unactionable message, from a container resolution, naming Azure's validator instead of the key to set. Two properties keep that fixed and are asserted here:

- the verdict is reached from **inert configuration data only**, so it cannot throw for any reason other than the one it reports; and
- the **unconfigured** install (blank/disabled) is never refused.

What changes is only the *severity* of the enabled-but-incomplete case: from a log line nobody reads to a named startup refusal. **`EmailDeliveryGuard` is untouched** — it still refuses the watchers on hosts that never call this guard (LocalMesh, test hosts, anything not going through `ConfigureMemexMesh`), and it is still what guarantees queued mail is never stamped `Sent`. All 8 of its Systemorph/MeshWeaver#2510/#2023 pins stay green.

### One definition, not a second copy

The credential half delegates to `EmailOptions.MissingCredentialKeys()` — the same answer `EmailDeliveryGuard` and `NoOpEmailSender` already report — rather than re-deriving it, so "which keys does the selected flow need" keeps exactly one definition and the two can never tell the same operator different stories. `Email:MailboxAddress` is added on top because it is required by **both** flows and by no credential: the system send path is `/users/{MailboxAddress}/sendMail`, so a blank value composes a Graph request for no mailbox. Scope is **outbound**; the inbound keys are deliberately not guarded (same shape, no incident, and widening a boot-time refusal past the failure it fixes is how a guard acquires a blast radius nobody signed off on).

## Which repo, and why

**Core (`Systemorph/MeshWeaver`)**, not `MeshWeaver.Plugins`. The portal *hosts* did move to the plugins repo, but everything this touches stayed here: `ConfigureMemexMesh` (`memex/Memex.Portal.Shared/MemexConfiguration.cs`) is the single boot path **both** hosts call — `Memex.Portal.Monolith/Program.cs:70` and `Memex.Portal.Distributed/Program.cs:372`, both via `$(MeshWeaverRoot)/memex/Memex.Portal.Shared` — and `EmailOptions`, `EmailDeliveryGuard`, `NoOpEmailSender`, both watchers and their tests all live here too. Landing it here gives one guard for both hosts, next to the code it is about and next to the two precedents it copies. Nothing in the plugins repo changes; there is no signature change to `ConfigureMemexMesh`.

## Tests — `test/Memex.Portal.Shared.Test/EmailStartupConfigurationGuardTest.cs`

**29 cases. Against the unfixed code (guard neutered to pre-fix behaviour — nothing refuses at startup): `Failed: 13, Passed: 16`.** With the fix: **29/29 green**. The 16 that already passed are the "must not refuse" direction — the Systemorph/MeshWeaver#2510 protection — which is exactly what stops the fix from being satisfied by a guard that refuses everything.

| Direction | Cases |
|---|---|
| **Never configured must NOT refuse** (#2510) | absent section (`null`); `Enabled=false` over three real shapes (all blank / half-filled / fully filled but switched off); bound configuration with no `Email__*` at all and with `Email__Enabled` `false`/`False` |
| **Enabled + incomplete REFUSES, by name** | the incident shape (tenant + client id missing, secret set) — names both in both forms and **not** the key that is set; each of the 4 required keys blanked on its own; whitespace-is-unset ×3; enabled-with-nothing-else names all four at once; managed identity refused for the mailbox **alone**, never for credential keys its flow does not use |
| **Enabled + complete starts** | both credential flows; a complete section written in `Email__*` environment form |
| **Message quality** | every way out named (`UseManagedIdentity`, `Enabled=false`, both forms); binder→environment mapping |
| **One definition** | the credential half agrees with `EmailDeliveryGuard.MissingConfiguration` across 4 flow shapes |
| **The guard is WIRED, not merely present** | the real `ConfigureMemexMesh` boot path refuses a half-configured section, and is unaffected by an install that never configured mail — a pure function nobody calls refuses nothing, and its unit tests stay green forever |

Full suites: `Memex.Portal.Shared.Test` **454/454**, `MeshWeaver.Documentation.Test` **97/97**. Build clean, 0 warnings (warnings-as-errors).

## ⚠️ What this does NOT do — the maintainer's half

**This does not restore mail on memex.** It converts a silent drop into a named startup error; the `Email__*` values are deployment configuration and are deliberately untouched here — exactly as Systemorph/MeshWeaver#2634 left the OIDC tenant to the deployment. No Helm values, no ConfigMap, no cluster change is in this diff. The default chart already ships `Email__Enabled: "false"`, so only the memex overlay is affected.

🚨 **Ordering matters, and it is a live-install decision, which is why this is not self-merged.** An install that is enabled-but-incomplete **today** will refuse to start once it rolls onto a build carrying this guard. On memex, set `Email__TenantId` + `Email__ClientId` (the secret is already set — the refusal named only the other two), **or** `Email__UseManagedIdentity=true` with the `Mail.Send` app role, **or** `Email__Enabled=false` — **before** the image carrying this merges and rolls. Once the keys land and the portal restarts, the queued `New` mail drains by itself, with no data repair and nothing to re-queue.

That trade is the intent, not a side effect: a portal that says mail is enabled and drops every message is the defect this replaces.

## Docs

`Doc/Architecture/SendingEmail` gains a *"An INCOMPLETE section refuses at STARTUP, by key"* section (the verdict table, the required keys, why Systemorph/MeshWeaver#2510 stays fixed, and the roll-ordering warning). A What's New entry ships for 2026-08-29, and the 2026-08-27 Systemorph/MeshWeaver#2510 entry is qualified so the feed does not carry two adjacent notes saying opposite things.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
