### PR TITLE
fix(#2638): routing that runs after the Autofac root scope is disposed fails as a lifecycle transition, not a terminal defect

### DIFF
--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -93,6 +93,28 @@ internal class RoutingGrain(
     private readonly DeadTargetRefusalLog nackLog = new(DeadTargetRefusalLog.DefaultWindow);
 
     /// <summary>
+    /// Probes whether this process's DI container still resolves — the positive half of
+    /// <see cref="IsScopeTeardown"/> (issue #2638). On a live container this is a cheap lookup of an
+    /// already-materialised singleton with no side effects; once the host has disposed its root
+    /// <c>LifetimeScope</c> it throws, which is the signal.
+    ///
+    /// <para>Mirrors <c>MessageHub.IsServiceScopeDisposed</c> deliberately: one shape, one meaning,
+    /// so a routing turn and a hub init classify the same teardown the same way.</para>
+    /// </summary>
+    private bool IsServiceScopeDisposed()
+    {
+        try
+        {
+            meshHub.ServiceProvider.GetService(typeof(IMessageHub));
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>
     /// Routes dispatched but not yet terminated. This is the back-pressure signal that used to be
     /// INVISIBLE: before #1028 the only evidence a route had stopped making progress was Orleans'
     /// own <c>NonReentrancyQueueSize</c> growing into the hundreds inside a "Response did not
@@ -450,8 +472,13 @@ internal class RoutingGrain(
             // 🚨 CLASSIFY — this line read ErrorType.Failed unconditionally. See
             // ClassifyDeliveryException: a silo leaving mid-roll and a directory mid-handoff are
             // TRANSIENT, and telling the sender otherwise tears down mirrors that would have resumed.
-            var errorType = ClassifyDeliveryException(ex);
-            logger.LogError(ex,
+            var errorType = ClassifyDeliveryException(ex, IsServiceScopeDisposed);
+            // 🚨 A container that is already gone is not an incident to page on — it is this process
+            // exiting, and the delivery it could not carry is being retried against a live pod by a
+            // sender that now (correctly) reads ShuttingDown. Error there filed #2638 for a pod that
+            // was merely finishing; the failure is still reported, at the level it deserves.
+            var level = errorType == ErrorType.ShuttingDown ? LogLevel.Information : LogLevel.Error;
+            logger.Log(level, ex,
                 "[ROUTE] Directed delivery to pod hub {Address} failed — surfacing {ErrorType} DeliveryFailure to sender {Sender}",
                 addressPath, errorType, delivery.Sender);
             PostFailureToSender($"Delivery to '{addressPath}' failed: {ex.Message}", errorType);
@@ -700,7 +727,12 @@ internal class RoutingGrain(
                         grainKey, addressPath, delivery.Id, PostFailureToSender, logger,
                         resolveActivationError: activationFailures is null
                             ? null
-                            : activationFailures.TryGet);
+                            : activationFailures.TryGet,
+                        // Issue #2638: a grain call whose PROXY could not be built because this
+                        // process's container is already disposed is a lifecycle transition, not a
+                        // terminal defect. Without the probe it NACK'd the sender as permanently
+                        // Failed and tore down its recovery machinery.
+                        scopeDisposed: IsServiceScopeDisposed);
                     return Unit.Default;
                 })
                 .Catch<Unit, Exception>(ex =>
@@ -883,6 +915,17 @@ internal class RoutingGrain(
                 RoutingGrainTrace.Write(IsPodHubNotHere(ex)
                     ? $"RoutingGrain.RouteMessage FAILURE_POD_HUB_NOT_HERE id={delivery.Id} sender={delivery.Sender}"
                     : $"RoutingGrain.RouteMessage FAILURE_POD_HUB_FAULT id={delivery.Id} sender={delivery.Sender} ex={ex.Message}");
+                // 🚨 ONE DEAD CONTAINER, NOT TWO FAILED TRANSPORTS — issue #2638. The stream publish
+                // resolves its own services through the SAME disposed root scope the directed call
+                // just died on, so attempting it can only produce the identical
+                // ObjectDisposedException and an AggregateException that names one fault twice.
+                // Prod logged exactly that, at Error, for a pod that was merely exiting. Fail clean
+                // instead: say once, at Information, that the NACK could not be carried because this
+                // process is gone. The sender still waits out its budget — nothing running inside a
+                // dead container can prevent that — but it is a bounded wait against a stated cause
+                // rather than an incident.
+                if (IsScopeTeardown(ex, IsServiceScopeDisposed))
+                    return LogUndeliverableNackAfterTeardown(ex);
                 return PublishFailureOverStream()
                     .Catch<Unit, Exception>(streamEx => LogUndeliverableNack(
                         new AggregateException(
@@ -939,6 +982,10 @@ internal class RoutingGrain(
                         {
                             RoutingGrainTrace.Write(
                                 $"RoutingGrain.RouteMessage FAILURE_DELIVER_GRAIN_FAULT id={delivery.Id} sender={delivery.Sender} ex={grainEx.Message}");
+                            // Same as the pod-hub arm above (#2638): a disposed container is one
+                            // cause, and the stream publish would only restate it.
+                            if (IsScopeTeardown(grainEx, IsServiceScopeDisposed))
+                                return LogUndeliverableNackAfterTeardown(grainEx);
                             return PublishFailureOverStream()
                                 .Catch<Unit, Exception>(streamEx => LogUndeliverableNack(
                                     new AggregateException(
@@ -993,6 +1040,32 @@ internal class RoutingGrain(
                     RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_OK_UNCONFIRMED id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
                     return Unit.Default;
                 });
+        }
+
+        // This process's DI container is already disposed (issue #2638), so NO transport in it can
+        // carry anything — the second one would fail identically and the AggregateException would
+        // name one cause twice. Say it once, name the cause, and stop: Information, because a
+        // process finishing its shutdown is not a defect, and the windowing is shared with the two
+        // Error shapes below so one dead sender still earns one line per window across all three.
+        IObservable<Unit> LogUndeliverableNackAfterTeardown(Exception ex)
+        {
+            RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_DELIVER_AFTER_TEARDOWN id={delivery.Id} ex={ex.Message}");
+            if (nackLog.ShouldReport(senderPath, out var suppressedNacks))
+                logger.LogInformation(ex,
+                    "[ROUTE] Cannot deliver the {ErrorType} DeliveryFailure for {DeliveryId} to sender {Sender}: "
+                    + "this process's service container is already disposed, so neither transport can be "
+                    + "constructed — the stream publish was NOT attempted, because it resolves through the "
+                    + "same disposed scope. The sender will wait out its own request budget — the original "
+                    + "failure was: {FailureMessage}. {Suppressed} earlier undeliverable NACK(s) to this "
+                    + "sender since the last such line were logged at Debug.",
+                    errorType, delivery.Id, delivery.Sender, failureMessage, suppressedNacks);
+            else
+                logger.LogDebug(ex,
+                    "[ROUTE] Cannot deliver the {ErrorType} DeliveryFailure for {DeliveryId} to sender {Sender} "
+                    + "(container disposed); windowed — see the Information line for this sender. "
+                    + "Original failure: {FailureMessage}",
+                    errorType, delivery.Id, delivery.Sender, failureMessage);
+            return Observable.Return(Unit.Default);
         }
 
         // The owning silo threw, went away mid-call, or the placement could not be made. There is
@@ -1164,7 +1237,8 @@ internal class RoutingGrain(
         int maxRetries = 6,
         Func<int, TimeSpan>? backoff = null,
         IScheduler? scheduler = null,
-        Func<string, string?>? resolveActivationError = null)
+        Func<string, string?>? resolveActivationError = null,
+        Func<bool>? scopeDisposed = null)
     {
         return DeliverToGrainObservable(grainCall, grainKey, deliveryId, logger, maxRetries, backoff, scheduler)
             .Subscribe(
@@ -1242,7 +1316,7 @@ internal class RoutingGrain(
                     var detail = string.IsNullOrEmpty(activationError) ? ex.Message : activationError;
                     // 🚨 CLASSIFY — this line read ErrorType.Failed unconditionally, which is the same
                     // defect #2346/#2451 removed from the result arm above and left standing here.
-                    var errorType = ClassifyDeliveryException(ex);
+                    var errorType = ClassifyDeliveryException(ex, scopeDisposed);
                     logger.LogWarning(ex,
                         "[ROUTE] Grain {GrainKey} delivery failed after transient retries (or a non-transient fault) → NACK sender as {ErrorType}: {Detail}",
                         grainKey, errorType, detail);
@@ -1342,10 +1416,51 @@ internal class RoutingGrain(
     /// </summary>
     /// <param name="ex">The exception the delivery attempt faulted with.</param>
     /// <returns>The <see cref="ErrorType"/> the sender's NACK should carry.</returns>
-    internal static ErrorType ClassifyDeliveryException(Exception ex) =>
-        OrleansRoutingService.IsDirectoryUnstable(ex) || IsShutdownShaped(ex)
+    /// <param name="scopeDisposed">Probe for "this process's DI container is gone" — see
+    /// <see cref="IsScopeTeardown"/>. Null (the default) keeps the pre-#2638 answer for callers that
+    /// have no container to probe, such as a pure classification test.</param>
+    internal static ErrorType ClassifyDeliveryException(Exception ex, Func<bool>? scopeDisposed = null) =>
+        OrleansRoutingService.IsDirectoryUnstable(ex)
+        || IsShutdownShaped(ex)
+        || IsScopeTeardown(ex, scopeDisposed)
             ? ErrorType.ShuttingDown
             : ErrorType.Failed;
+
+    /// <summary>
+    /// 🚨 <b>The routing turn is executing after the process's DI container was disposed — issue
+    /// #2638.</b> Orleans builds a grain proxy by resolving its codec provider from the container
+    /// (<c>OrleansGeneratedCodeHelper.GetService</c> → <c>AutofacServiceProvider.GetService</c>), so
+    /// once the silo host has disposed its root <c>LifetimeScope</c> every remaining delivery — and
+    /// every NACK about one — faults with Autofac's <c>ObjectDisposedException</c> before it reaches
+    /// a transport at all.
+    ///
+    /// <para><b>Why this must not stay terminal.</b> It is a lifecycle transition by construction —
+    /// the container is disposed exactly once, at the end of host shutdown, and the target hub comes
+    /// back on the surviving pod seconds later. Reported as <see cref="ErrorType.Failed"/> it tears
+    /// down every consumer with recovery machinery of its own (<c>SynchronizationStream</c>'s
+    /// resubscribe latch, <c>MeshNodeStreamCache</c>'s transient-owner rule), which is exactly the
+    /// damage #2346/#2357 removed for the directory-unstable and silo-departing shapes and left
+    /// standing for this one. Prod (memex, 2026-08-29) NACK'd a live <c>Planning</c> delivery as
+    /// terminal for it.</para>
+    ///
+    /// <para>🚨 <b>The type test alone is NOT the signal, and that is deliberate</b> — the same
+    /// argument <c>MessageHub.IsTerminatedByScopeTeardown</c> makes for #2444. An unrelated disposed
+    /// dependency also throws <see cref="ObjectDisposedException"/> and IS a genuine defect; only a
+    /// probe that finds the CONTAINER itself no longer resolving turns the type test into a positive
+    /// statement about teardown. Without a probe this answers <c>false</c> and nothing changes.</para>
+    ///
+    /// <para>The walk is <see cref="ExceptionChain"/>'s — the exception GRAPH, not the
+    /// <c>InnerException</c> line — because this arrives through Rx <c>Catch</c> arms and
+    /// <c>PostFailure</c>'s two-transport <see cref="AggregateException"/>, where which fault sits at
+    /// index 0 is a race.</para>
+    /// </summary>
+    /// <param name="ex">The exception the delivery (or its NACK) faulted with.</param>
+    /// <param name="scopeDisposed">Probe: does this process's DI container still resolve?</param>
+    /// <returns><c>true</c> when the fault is the process's container going away.</returns>
+    internal static bool IsScopeTeardown(Exception ex, Func<bool>? scopeDisposed) =>
+        scopeDisposed is not null
+        && ExceptionChain.Contains<ObjectDisposedException>(ex)
+        && scopeDisposed();
 
     /// <summary>
     /// The silo hosting the target is going away — an expected lifecycle event during every roll,

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingAfterScopeTeardownTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingAfterScopeTeardownTest.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Concurrency;
+using System.Threading.Tasks;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #2638 — routing work that executes after the process's Autofac root scope is
+/// disposed must fail as the LIFECYCLE TRANSITION it is, not as a terminal defect.</b>
+///
+/// <para><b>The mechanism.</b> Orleans builds a grain proxy by resolving its codec provider out of
+/// the DI container (<c>OrleansGeneratedCodeHelper.GetService</c> →
+/// <c>AutofacServiceProvider.GetService</c>). Once the silo host has disposed its root
+/// <c>LifetimeScope</c>, every remaining delivery — and every NACK about one — faults with Autofac's
+/// <see cref="ObjectDisposedException"/> before it reaches a transport at all. Prod (memex,
+/// 2026-08-29) carried that exception TWICE in one <see cref="AggregateException"/>: the directed
+/// pod-hub call and the stream publish, both dying on the same dead container, reported at Error for
+/// a pod that was merely exiting.</para>
+///
+/// <para><b>Two defects, both pinned here.</b></para>
+/// <list type="number">
+/// <item>The delivery this NACK was about was classified <see cref="ErrorType.Failed"/> — TERMINAL.
+/// Consumers with recovery machinery of their own (<c>SynchronizationStream</c>'s resubscribe latch,
+/// <c>MeshNodeStreamCache</c>'s transient-owner rule) RIDE OUT <see cref="ErrorType.ShuttingDown"/>
+/// and TEAR DOWN on a terminal verdict, so a routine pod exit permanently killed live mirrors that
+/// would have resumed against the surviving pod seconds later. That is the identical damage
+/// #2346/#2357 removed for the directory-unstable and silo-departing shapes and left standing for
+/// this one.</item>
+/// <item>The second transport was attempted even though it resolves through the SAME disposed
+/// scope, so the failure could only ever be the first one restated.</item>
+/// </list>
+///
+/// <para><b>The probe is the point, and the negative control below is what proves it.</b> An
+/// <see cref="ObjectDisposedException"/> from an unrelated disposed dependency is a genuine defect
+/// and must stay terminal; only a probe finding the CONTAINER itself gone turns the type test into a
+/// statement about teardown. Same shape as <c>MessageHub.IsTerminatedByScopeTeardown</c> (#2444).</para>
+///
+/// <para>Pure — the classifier and the retry primitive are <c>internal static</c>, the exception
+/// text is quoted verbatim from the production log, and the container probe is a delegate. No
+/// cluster, no host, no clock.</para>
+/// </summary>
+public class RoutingAfterScopeTeardownTest
+{
+    private static readonly Func<int, TimeSpan> NoBackoff = _ => TimeSpan.Zero;
+
+    /// <summary>
+    /// Verbatim from Autofac's <c>LifetimeScope.ThrowDisposedException()</c>, as it reached
+    /// <c>RoutingGrain.PostFailure</c> in the #2638 incident.
+    /// </summary>
+    private const string ScopeDisposedText =
+        "Instances cannot be resolved and nested lifetimes cannot be created from this LifetimeScope "
+        + "as it (or one of its parent scopes) has already been disposed.";
+
+    private static Exception ScopeDisposed() => new ObjectDisposedException(ScopeDisposedText, (Exception?)null);
+
+    /// <summary>The prod NACK shape: the same fault carried twice, once per transport.</summary>
+    private static Exception BothTransportsOnTheDeadContainer() =>
+        new AggregateException(
+            "Neither the directed pod-hub call nor the stream publish could carry the NACK.",
+            ScopeDisposed(), ScopeDisposed());
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. Pre-fix this answers <see cref="ErrorType.Failed"/> — terminal — for a
+    /// process that is simply exiting.
+    /// </summary>
+    [Fact]
+    public void DisposedContainer_ClassifiesAsShuttingDown()
+    {
+        RoutingGrain.ClassifyDeliveryException(ScopeDisposed(), scopeDisposed: () => true)
+            .Should().Be(ErrorType.ShuttingDown,
+                "the container is disposed exactly once, at the end of host shutdown, and the target "
+                + "hub comes back on the surviving pod — a terminal verdict tears down every consumer "
+                + "that would have resumed (#2638, same damage as #2346/#2357)");
+    }
+
+    /// <summary>
+    /// The graph, not the chain: the NACK leg hands the classifier an
+    /// <see cref="AggregateException"/> whose ordering nobody controls.
+    /// </summary>
+    [Fact]
+    public void DisposedContainer_IsSeenThroughAnAggregate()
+    {
+        RoutingGrain.ClassifyDeliveryException(BothTransportsOnTheDeadContainer(), scopeDisposed: () => true)
+            .Should().Be(ErrorType.ShuttingDown,
+                "classification must not depend on which fault happened to land at index 0");
+    }
+
+    /// <summary>
+    /// 🚨 NEGATIVE CONTROL — and the reason the probe exists at all. A disposed dependency while the
+    /// container is ALIVE is a real defect and must stay terminal; widening the rule to the bare type
+    /// test would silently reclassify those as "ride it out and resubscribe", which is the
+    /// resubscribe-storm shape <c>ClassifyDeliveryException</c> is explicitly narrower than
+    /// <c>IsTransientFailure</c> to avoid.
+    /// </summary>
+    [Fact]
+    public void DisposedDependency_WhileTheContainerLives_StaysTerminal()
+    {
+        RoutingGrain.ClassifyDeliveryException(
+                new ObjectDisposedException("SomeCache"), scopeDisposed: () => false)
+            .Should().Be(ErrorType.Failed,
+                "only the CONTAINER being gone is a lifecycle transition — an unrelated disposed "
+                + "object is a defect and must be reported as one");
+
+        RoutingGrain.ClassifyDeliveryException(new ObjectDisposedException("SomeCache"))
+            .Should().Be(ErrorType.Failed,
+                "with no probe supplied the answer must be exactly the pre-#2638 one");
+    }
+
+    /// <summary>
+    /// Nothing else moved: the two shapes #2346/#2357 already classified must keep their verdict,
+    /// and a genuine defect must keep its terminal one.
+    /// </summary>
+    [Fact]
+    public void TheOtherClassificationsAreUnchanged()
+    {
+        RoutingGrain.ClassifyDeliveryException(
+                new global::Orleans.Runtime.SiloUnavailableException("the silo went away"), () => false)
+            .Should().Be(ErrorType.ShuttingDown, "#2357's silo-departing shape is untouched");
+
+        RoutingGrain.ClassifyDeliveryException(new InvalidOperationException("a real defect"), () => true)
+            .Should().Be(ErrorType.Failed,
+                "the probe must not turn EVERY failure during shutdown into a ride-it-out — only the "
+                + "ones that actually carry an ObjectDisposedException");
+    }
+
+    /// <summary>
+    /// End to end through the delivery leg: a grain call whose PROXY cannot be built because the
+    /// container is gone must NACK the sender as <see cref="ErrorType.ShuttingDown"/>, and must not
+    /// burn its transient-retry budget on a container that cannot come back.
+    /// </summary>
+    [Fact]
+    public async Task DeliveryOnADeadContainer_NacksTheSenderAsShuttingDown_WithoutRetrying()
+    {
+        var nacks = new List<(string Message, ErrorType Type)>();
+        var attempts = 0;
+
+        RoutingGrain.DeliverToGrainWithRetry(
+            grainCall: () =>
+            {
+                attempts++;
+                // Synchronous throw, exactly as GrainFactory.GetGrain<T> does when the codec
+                // provider cannot be resolved from the disposed root scope.
+                throw ScopeDisposed();
+            },
+            grainKey: "messagehub/Planning",
+            addressPath: "Planning",
+            deliveryId: "d-2638",
+            postFailureToSender: (m, t) => nacks.Add((m, t)),
+            logger: NullLogger.Instance,
+            backoff: NoBackoff,
+            scheduler: Scheduler.Immediate,
+            scopeDisposed: () => true);
+
+        await Task.Yield();
+
+        attempts.Should().Be(1,
+            "a disposed container is not transient — retrying inside a process whose DI is gone is "
+            + "six guaranteed failures and six log lines for the same outcome");
+        var nack = nacks.Should().ContainSingle().Subject;
+        nack.Type.Should().Be(ErrorType.ShuttingDown,
+            "prod NACK'd exactly this as terminal ('Delivery to Planning failed: Instances cannot be "
+            + "resolved …'), tearing down the sender's recovery machinery (#2638)");
+        nack.Message.Should().Contain("Planning");
+    }
+}


### PR DESCRIPTION
Linking, not closing: #2638.

## The mechanism

Orleans builds a grain proxy by resolving its codec provider out of the DI container (`OrleansGeneratedCodeHelper.GetService` → `AutofacServiceProvider.GetService`). Once the silo host has disposed its root Autofac `LifetimeScope`, every remaining delivery — **and every NACK about one** — faults with Autofac's `ObjectDisposedException` before it reaches a transport at all.

Prod (memex, 2026-08-29) therefore logged, at `Error`, an `AggregateException` carrying **the same fault twice**:

```
[ROUTE] Cannot deliver the Failed DeliveryFailure for … to sender cache/…: BOTH transports failed …
        the original failure was: Delivery to 'Planning' failed: Instances cannot be resolved and
        nested lifetimes cannot be created from this LifetimeScope …
```

## Two defects, both fixed

**1. The classification was terminal.** `Delivery to 'Planning' failed: Instances cannot be resolved …` was NACK'd as `ErrorType.Failed`. Consumers with recovery machinery of their own — `SynchronizationStream`'s resubscribe latch, `MeshNodeStreamCache`'s transient-owner rule — **ride out** `ErrorType.ShuttingDown` and **tear down** on a terminal verdict. So a routine pod exit permanently killed live mirrors that would have resumed against the surviving pod seconds later. That is the identical damage #2346/#2357 removed for the directory-unstable and silo-departing shapes, and left standing for this one.

`ClassifyDeliveryException` now recognises it — **gated on a probe of the container itself**, never on the bare `ObjectDisposedException` type test:

```csharp
internal static bool IsScopeTeardown(Exception ex, Func<bool>? scopeDisposed) =>
    scopeDisposed is not null
    && ExceptionChain.Contains<ObjectDisposedException>(ex)
    && scopeDisposed();
```

The probe is the same shape `MessageHub.IsTerminatedByScopeTeardown` uses for #2444, and it is what keeps an *unrelated* disposed dependency — a genuine defect — terminal. With no probe supplied the answer is exactly the pre-fix one. The walk is `ExceptionChain`'s graph walk, because this arrives through Rx `Catch` arms and a two-transport `AggregateException` where which fault sits at index 0 is a race.

**2. The second transport was attempted on the same dead container.** `PostFailure`'s stream fallback resolves through the very scope the directed call just died on, so it could only restate the first fault. When the first transport dies on a disposed container the fallback is now **skipped**, and the outcome is stated **once, at Information**, naming the cause — a process finishing its shutdown is not an incident to page on. The refusal is still logged, still windowed by the same `nackLog`, and still tells the reader the sender will wait out its budget.

The sender still waits out that budget — nothing running inside a dead container can prevent that — but it is now a bounded wait against a stated cause, and the verdict it eventually reads is one its recovery machinery can act on.

## Tests — `RoutingAfterScopeTeardownTest`

Pure: the classifier and the retry primitive are `internal static`, the exception text is verbatim from the production log, the container probe is a delegate. No cluster, no host, no clock.

| test | asserts |
|---|---|
| `DisposedContainer_ClassifiesAsShuttingDown` | the verdict flips from terminal to ride-it-out |
| `DisposedContainer_IsSeenThroughAnAggregate` | the prod NACK shape (one fault, twice) is seen regardless of index |
| `DisposedDependency_WhileTheContainerLives_StaysTerminal` | **negative control** — the probe is what makes this a teardown statement; without it, and for a live container, the verdict stays `Failed` |
| `TheOtherClassificationsAreUnchanged` | #2357's `SiloUnavailableException` still `ShuttingDown`; a real defect during shutdown still `Failed` |
| `DeliveryOnADeadContainer_NacksTheSenderAsShuttingDown_WithoutRetrying` | end to end through `DeliverToGrainWithRetry`: one attempt (a dead container is not transient), NACK carries `ShuttingDown` |

### Non-vacuity, by mutation

The tests cannot be compiled against unfixed code — the fix adds the probe parameter they pass — so non-vacuity is proven the way #2635 asks for: `IsScopeTeardown` forced to the pre-fix answer (`false &&`), which is exactly what the classifier could see before.

```
[FAIL] DisposedContainer_IsSeenThroughAnAggregate
   Expected value to be ShuttingDown … but found Failed.
[FAIL] DisposedContainer_ClassifiesAsShuttingDown
   Expected value to be ShuttingDown … but found Failed.
[FAIL] DeliveryOnADeadContainer_NacksTheSenderAsShuttingDown_WithoutRetrying
   Expected value to be ShuttingDown … but found Failed.
Failed!  - Failed: 3, Passed: 2, Total: 5
```

The two that still pass are the negative controls — correctly, since they assert the unchanged behaviour.

With the mutation reverted, this file plus every neighbouring routing/classification suite:

```
Passed!  - Failed: 0, Passed: 52, Total: 52
```

(`RoutingAfterScopeTeardownTest`, `RoutingGrainFailureClassificationTest`, `OrleansDirectoryInstabilityClassificationTest`, `RoutedFailureClassificationTest`, `RoutingGrainDeliveryRetryTest`, `RoutingGrainPodHubDeliveryRetryTest`, `RoutingFailureTakesTheLocalRouteTest`, `DeadTargetRefusalWindowTest`, `RoutingGrainStreamPostBoundTest`.)

## What this deliberately does NOT do

The issue's own root-cause framing — *"the silo shutdown sequence disposes the service provider before routing work is quiesced"* — is carried at **medium** confidence, and quiescing routing before container disposal is a change to the host stop sequence, not to the router. This PR makes the window fail **clean and correctly classified**; it does not close the window. See my comment on #2638 for the precise open question.

## Not related to #2644

#2644 (issue #2635) joins `DisposalCompleted` in **test harnesses**; this is the production silo-shutdown path. No file overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)