### PR TITLE
fix(#2322): stop reporting the router's 60s guard for the transport's own 30s timeout

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OrleansStreamPubSubDurability.md
@@ -176,6 +176,20 @@ manufactured by every deploy. Two residual silent-loss windows remain:
 > a different (classification) fix, written up in the roll plan's "What the swap traded" section.
 > Size the pre-release-package decision on the stream tickets alone.
 
+> 🚨 **…and that decision has since been MADE, in the other direction — do not evaluate the
+> pre-release package.** Maintainer direction, 2026-08-27 (recorded on #2320 and #2322):
+> *"we can essentially use mesh nodes for durable streams"*. So the answer to both stream-leg
+> residuals is **not** `Microsoft.Orleans.Streaming.AdoNet` as a second named provider; it is a
+> node-backed stream, on primitives the platform already operates: node content is PG-backed and
+> versioned, `GetMeshNodeStream(path)` is the change feed, the owning hub's action block gives
+> ordered serialised writes, and a late subscriber gets current state rather than a missed edge.
+> There is then no queue grain to lose (#2322) and no producer to register (#2320).
+>
+> The paragraph above is kept because its SIZING is still correct — these are fallback-path tickets.
+> Only its implied next step is superseded. And the design has one hard constraint attached from
+> #2426: the subscriber lifetime must be **derived** (expiry, or eviction on a genuinely terminal
+> `NotFound`), never dependent on an `UnsubscribeRequest` a restarting portal never sends.
+
 Plus one deployment-shaped residual: **the `AzureTables` / Azure Container Apps route still runs a
 memory PubSubStore**, and it is a multi-silo shape. Anyone taking that route to production must pass
 a durable `configurePubSubStore` (Azure Table or Blob grain storage under the name `PubSubStore`)

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -1103,25 +1103,62 @@ internal class RoutingGrain(
         TimeSpan timeout,
         IScheduler? scheduler)
         => Observable.Defer(() => post().ToObservable())
-            .Timeout(timeout, scheduler ?? Scheduler.Default)
+            // 🚨 THE GUARD MUST BE DISTINGUISHABLE FROM WHAT IT GUARDS — issue #2322.
+            //
+            // The bare `.Timeout(timeout, scheduler)` overload raises a plain TimeoutException, and
+            // so does the thing it is bounding: the post's only await is a grain call to
+            // IMemoryStreamQueueGrain.Enqueue, which Orleans bounds at its own 30 s ResponseTimeout.
+            // Two different facts, one type — so the Catch below could not tell them apart and
+            // printed the GUARD's value for both. Prod therefore said "did not complete within
+            // 00:01:00" about a leg that had died, and reported promptly, at ~30 s, naming the
+            // wedged queue-grain activation. That wrong number sent a triage looking for a double
+            // publish and 30 s of avoidable latency; there is neither.
+            //
+            // The `other` overload lets the guard raise its OWN exception, so the two are
+            // distinguishable by type instead of by hope. It still derives from TimeoutException, so
+            // every classifier above this line (IsTransientFailure, ClassifyDeliveryException) reads
+            // it exactly as before.
+            .Timeout(timeout,
+                Observable.Throw<Unit>(new StreamPostGuardTimeoutException(addressPath, timeout)),
+                scheduler ?? Scheduler.Default)
             .Do(_ => RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM_OK id={deliveryId}"))
             .Catch<Unit, Exception>(ex =>
             {
                 RoutingGrainTrace.Write($"RoutingGrain.RouteMessage MEMORY_STREAM_FAULT id={deliveryId} ex={ex.Message}");
-                if (ex is TimeoutException)
-                    // The post never completed. Its ONLY await is a grain call Orleans already bounds
-                    // at 30 s, so this is not slowness — the leg is dead. Loud, because a delivery that
-                    // neither lands nor reports is exactly the silent hang #1028 was made of.
+                string reason;
+                if (ex is StreamPostGuardTimeoutException)
+                {
+                    // OUR bound fired: the post never completed AND never faulted. Its only await is
+                    // a grain call Orleans already bounds at 30 s, so reaching this is not slowness —
+                    // the leg is dead somewhere the transport's own bound cannot see. Loud, because a
+                    // delivery that neither lands nor reports is exactly the silent hang #1028 was
+                    // made of.
                     logger.LogError(ex,
-                        "[ROUTE] Stream-routed forward to {Address} did not complete within {Timeout} — the post is not going to land; surfacing DeliveryFailure to sender {Sender}",
+                        "[ROUTE] Stream-routed forward to {Address} did not complete within {Timeout} and never "
+                        + "faulted — the post is not going to land; surfacing DeliveryFailure to sender {Sender}",
                         addressPath, timeout, sender);
+                    reason = $"the post did not complete within {timeout}";
+                }
+                else if (ex is TimeoutException)
+                {
+                    // The TRANSPORT's own bound fired, INSIDE our guard — Orleans' 30 s response
+                    // timeout on IMemoryStreamQueueGrain.Enqueue. Its message names the real budget,
+                    // the queue-grain activation and the correlation id, which is the whole
+                    // diagnostic; the guard's value would say nothing true about it. Error, not
+                    // Warning: an unresponsive queue grain is not self-limiting (#2322).
+                    logger.LogError(ex,
+                        "[ROUTE] Stream-routed forward to {Address} faulted on the transport's OWN timeout, "
+                        + "inside this router's {Timeout} guard — surfacing DeliveryFailure to sender {Sender}: {Detail}",
+                        addressPath, timeout, sender, ex.Message);
+                    reason = ex.Message;
+                }
                 else
+                {
                     logger.LogWarning(ex,
                         "[ROUTE] Stream-routed forward to {Address} faulted — surfacing DeliveryFailure to sender {Sender}",
                         addressPath, sender);
-                var reason = ex is TimeoutException
-                    ? $"the post did not complete within {timeout}"
-                    : ex.Message;
+                    reason = ex.Message;
+                }
                 postFailureToSender($"Stream-routed delivery to '{addressPath}' failed: {reason}", ErrorType.Failed);
                 return Observable.Return(Unit.Default);
             });

--- a/src/MeshWeaver.Hosting.Orleans/StreamPostGuardTimeoutException.cs
+++ b/src/MeshWeaver.Hosting.Orleans/StreamPostGuardTimeoutException.cs
@@ -1,0 +1,38 @@
+namespace MeshWeaver.Hosting.Orleans;
+
+/// <summary>
+/// 🚨 <b>The router's OWN bound on a memory-stream post fired — issue #2322.</b> Raised by
+/// <c>RoutingGrain.PostToStreamCore</c>'s Rx guard, and by nothing else.
+///
+/// <para><b>Why it needs a type of its own.</b> The guard bounds a post whose only await is a grain
+/// call to <c>IMemoryStreamQueueGrain.Enqueue</c>, which Orleans already bounds at its own 30 s
+/// <c>ResponseTimeout</c> — so the leg can produce a <see cref="TimeoutException"/> for two
+/// completely different reasons: <i>the transport gave up</i>, or <i>the post never completed at
+/// all</i>. The bare <c>Observable.Timeout(dueTime, scheduler)</c> overload raises the same plain
+/// <see cref="TimeoutException"/> as the first case, so the catch arm could not tell them apart and
+/// printed the GUARD's budget for both. Production consequently reported <i>"did not complete within
+/// 00:01:00"</i> about a leg that had in fact died and reported promptly, at ~30 s, naming the
+/// wedged <c>memorystreamqueue</c> activation — a wrong number that sent triage looking for a double
+/// publish and 30 s of avoidable latency, neither of which existed.</para>
+///
+/// <para>🚨 <b>It stays a <see cref="TimeoutException"/> deliberately.</b> Every classifier above
+/// this leg (<c>RoutingGrain.IsTransientFailure</c>,
+/// <c>OrleansRoutingService.IsTransientFailure</c>, <c>ClassifyDeliveryException</c>) matches
+/// <see cref="TimeoutException"/> by type; narrowing that would silently change how a
+/// never-completing post is retried and reported. This carries only the DIAGNOSTIC distinction.</para>
+/// </summary>
+/// <param name="addressPath">The destination whose post did not complete.</param>
+/// <param name="budget">The router's own bound, i.e. the budget that was exceeded.</param>
+internal sealed class StreamPostGuardTimeoutException(string addressPath, TimeSpan budget)
+    : TimeoutException(
+        $"The stream-routed post to '{addressPath}' neither completed nor faulted within the router's "
+        + $"own {budget} bound. The post's only await is an Orleans grain call which Orleans bounds at "
+        + "its 30s ResponseTimeout, so exceeding this bound means the leg is dead somewhere that "
+        + "bound cannot see.")
+{
+    /// <summary>The destination whose post did not complete.</summary>
+    public string AddressPath { get; } = addressPath;
+
+    /// <summary>The router's own bound — never the transport's.</summary>
+    public TimeSpan Budget { get; } = budget;
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/StreamPostTimeoutAttributionTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/StreamPostTimeoutAttributionTest.cs
@@ -1,0 +1,176 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #2322 — the router must not report its OWN budget for a failure the TRANSPORT
+/// reported.</b>
+///
+/// <para>The memory-stream leg's only await is a grain call to
+/// <c>IMemoryStreamQueueGrain.Enqueue</c>, which Orleans bounds at its own 30 s
+/// <c>ResponseTimeout</c>. <c>RoutingGrain.PostToStreamCore</c> wraps that in a 60 s Rx guard using
+/// the bare <c>Observable.Timeout(dueTime, scheduler)</c> overload — which raises the same plain
+/// <see cref="TimeoutException"/> the transport does. So the catch arm could not tell the two apart
+/// and printed the GUARD's value for both.</para>
+///
+/// <para>Production consequently logged, twice, for a wedged <c>memorystreamqueue</c>
+/// activation:</para>
+/// <code>
+/// [ROUTE] Stream-routed forward to cache/… did not complete within 00:01:00 …
+/// System.TimeoutException: Response did not arrive on time in 00:00:30 for message: Request
+///   […] Orleans.Providers.IMemoryStreamQueueGrain.Enqueue(…)
+/// </code>
+///
+/// <para>Both numbers are in the same record and they disagree. The leg died at ~30 s and reported
+/// PROMPTLY — <c>post().ToObservable()</c> is the Task overload, so a faulted post propagates the
+/// instant the task faults and the Rx guard never fired at all. The sentence is simply false, and
+/// the same wrong number rides to the sender in the <c>DeliveryFailure</c>'s reason string. That is
+/// what sent the original triage looking for a double publish and "30 s of avoidable latency",
+/// neither of which exists.</para>
+///
+/// <para>The cure is a guard exception with a type of its own, so "our bound" and "the transport's
+/// bound" are distinguishable by construction rather than by hope. It still derives from
+/// <see cref="TimeoutException"/>, so every classifier above this leg reads it exactly as before —
+/// which <see cref="TheGuardsExceptionIsStillATimeoutException"/> pins.</para>
+///
+/// <para>Deterministic — <see cref="TestScheduler"/> for the guard, no cluster, no wall clock.</para>
+/// </summary>
+public class StreamPostTimeoutAttributionTest
+{
+    private static readonly TimeSpan Guard = TimeSpan.FromSeconds(60);
+    private static readonly Address Sender = new("client", "sender-1");
+    private const string Address = "cache/cLhEcQcDAUa-W9zPmBOQWw";
+
+    /// <summary>Verbatim from the #2322 production log — Orleans' own 30 s response timeout.</summary>
+    private const string OrleansEnqueueTimeoutText =
+        "Response did not arrive on time in 00:00:30 for message: Request "
+        + "[S10.244.4.207:11111:146709268 sys.client/hosted-10.244.4.207:11111@146709268]->"
+        + "[S10.244.2.28:11111:146709309 memorystreamqueue/be8eb06fb48875590000000000000000] "
+        + "Orleans.Providers.IMemoryStreamQueueGrain.Enqueue(Orleans.Providers.MemoryMessageData) "
+        + "#59B543F946E76231.";
+
+    private sealed class RecordingLogger : ILogger
+    {
+        private readonly List<(LogLevel Level, string Message)> records = [];
+        public IReadOnlyList<(LogLevel Level, string Message)> Records => records;
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+            => records.Add((logLevel, formatter(state, exception)));
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+
+    private static IMessageDelivery Delivery(string id) =>
+        new MessageDelivery<RawJson>(
+            Sender, new Address("cache", "cLhEcQcDAUa-W9zPmBOQWw"), new RawJson("{\"$type\":\"Ping\"}"),
+            JsonSerializerOptions.Default) with
+        { Id = id };
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. The transport's OWN timeout must be reported as the transport's — with its
+    /// message, which names the real budget, the wedged queue-grain activation and the correlation
+    /// id. Pre-fix, both the log line and the sender's NACK claimed the router's 60 s guard.
+    /// </summary>
+    [Fact]
+    public async Task TransportTimeout_IsNotReportedAsTheRoutersOwnBudget()
+    {
+        var logger = new RecordingLogger();
+        var nacks = new List<(string Message, ErrorType Type)>();
+
+        await RoutingGrain.PostToStream(
+                delivery: Delivery("d-2322"),
+                post: () => Task.FromException(new TimeoutException(OrleansEnqueueTimeoutText)),
+                addressPath: Address,
+                sender: Sender,
+                postFailureToSender: (m, t) => nacks.Add((m, t)),
+                logger: logger,
+                timeout: Guard)
+            .ToTask();
+
+        var line = logger.Records.Should().ContainSingle().Subject;
+        line.Message.Should().NotContain("did not complete within 00:01:00",
+            "the leg did NOT run for 60 s — it faulted promptly at Orleans' own 30 s bound, and "
+            + "post().ToObservable() propagates a faulted task the instant it faults. Printing the "
+            + "guard's value here is what sent triage looking for a double publish (#2322)");
+        line.Message.Should().Contain("00:00:30",
+            "the transport's own message names the real budget, the wedged memorystreamqueue "
+            + "activation and the correlation id — that IS the diagnostic");
+
+        var nack = nacks.Should().ContainSingle().Subject;
+        nack.Type.Should().Be(ErrorType.Failed, "the classification is unchanged");
+        nack.Message.Should().NotContain("00:01:00",
+            "the sender's DeliveryFailure carried the same wrong number as the log line");
+        nack.Message.Should().Contain("00:00:30");
+    }
+
+    /// <summary>
+    /// The other direction, unchanged: when the router's OWN guard fires — the post neither
+    /// completes nor faults — it must still say so, with ITS budget. This is the #1028 contract and
+    /// it must not be traded away while fixing the attribution.
+    /// </summary>
+    [Fact]
+    public void GuardTimeout_StillReportsTheRoutersBudget_AndStillNacks()
+    {
+        var never = new TaskCompletionSource();
+        var logger = new RecordingLogger();
+        var nacks = new List<(string Message, ErrorType Type)>();
+        var scheduler = new TestScheduler();
+        var terminated = false;
+
+        RoutingGrain.PostToStream(
+                delivery: Delivery("d-guard"),
+                post: () => never.Task,
+                addressPath: Address,
+                sender: Sender,
+                postFailureToSender: (m, t) => nacks.Add((m, t)),
+                logger: logger,
+                timeout: Guard,
+                scheduler: scheduler)
+            .Subscribe(_ => { }, () => terminated = true);
+
+        scheduler.AdvanceBy(Guard.Ticks + 1);
+
+        terminated.Should().BeTrue("the leg must always terminate — #1028");
+        logger.Records.Should().ContainSingle().Which
+            .Message.Should().Contain("00:01:00",
+                "when the ROUTER's bound is what fired, the router's budget is the true number");
+        nacks.Should().ContainSingle().Which
+            .Message.Should().Contain("did not complete within 00:01:00");
+    }
+
+    /// <summary>
+    /// 🚨 The guard's exception must stay a <see cref="TimeoutException"/>. Every classifier above
+    /// this leg matches that type — narrowing it would silently change how a never-completing post
+    /// is retried and reported, which is a behaviour change hiding inside a diagnostic fix.
+    /// </summary>
+    [Fact]
+    public void TheGuardsExceptionIsStillATimeoutException()
+    {
+        var ex = new StreamPostGuardTimeoutException(Address, Guard);
+
+        ex.Should().BeAssignableTo<TimeoutException>();
+        RoutingGrain.IsTransientFailure(ex).Should().BeTrue(
+            "the router's transient classifier matched a guard timeout before this change and must "
+            + "still match it");
+        RoutingGrain.ClassifyDeliveryException(ex).Should().Be(ErrorType.Failed,
+            "a bare TimeoutException stays TERMINAL by design — a target that did not answer across "
+            + "the whole budget is plausibly wedged, and telling a consumer to resubscribe is the "
+            + "2026-06-08 storm shape");
+        ex.Budget.Should().Be(Guard);
+        ex.AddressPath.Should().Be(Address);
+    }
+}


### PR DESCRIPTION
Linking, not closing: #2322. This lands the one item that issue's own triage settled as actionable, and deliberately does **not** claim to fix the wedged queue grain — see *What is left* below.

## The defect

`RoutingGrain.PostToStreamCore` bounds the memory-stream post with a 60 s Rx guard using the bare `Observable.Timeout(dueTime, scheduler)` overload — which raises **the same plain `TimeoutException` the thing it is guarding raises**. The post's only await is a grain call to `IMemoryStreamQueueGrain.Enqueue`, which Orleans bounds at its own 30 s `ResponseTimeout`. So the catch arm could not tell *"our bound fired"* from *"the transport gave up"*, and printed the guard's value for both.

Production, for a wedged `memorystreamqueue` activation:

```
[ROUTE] Stream-routed forward to cache/… did not complete within 00:01:00 …
System.TimeoutException: Response did not arrive on time in 00:00:30 for message: Request
  […] Orleans.Providers.IMemoryStreamQueueGrain.Enqueue(…) #59B543F946E76231.
```

Two numbers in one record, disagreeing. The leg died at ~30 s and reported **promptly** — `post().ToObservable()` is the `Task` overload, so a faulted post propagates the instant the task faults and the Rx guard never fired at all. The sentence is simply false, and the **same wrong number rides to the sender** in the `DeliveryFailure`'s reason string.

That is what sent the original triage looking for a double publish and *"30 s of avoidable latency"* — neither of which exists.

## The fix

The guard raises **its own** exception through the `Timeout(dueTime, other, scheduler)` overload, so the two facts are distinguishable **by type** rather than by hope:

- **`StreamPostGuardTimeoutException`** → the router's bound fired: the post neither completed nor faulted. Keeps the #1028 wording and the router's budget, which is the true number for that case.
- **any other `TimeoutException`** → the transport's own bound fired inside ours. Logged with **its** message, which names the real budget, the wedged queue-grain activation and the correlation id — that *is* the diagnostic — and at `Error`, because an unresponsive queue grain is not self-limiting.

🚨 It still derives from `TimeoutException`. Every classifier above this leg (`RoutingGrain.IsTransientFailure`, `OrleansRoutingService.IsTransientFailure`, `ClassifyDeliveryException`) matches that type; narrowing it would be a behaviour change hiding inside a diagnostic fix. `TheGuardsExceptionIsStillATimeoutException` pins exactly that.

## Tests — `StreamPostTimeoutAttributionTest`

Deterministic: `TestScheduler` for the guard, the Orleans timeout text quoted verbatim from the #2322 log, no cluster and no wall clock.

| test | asserts |
|---|---|
| `TransportTimeout_IsNotReportedAsTheRoutersOwnBudget` | the log line and the sender's NACK carry `00:00:30`, never `00:01:00` |
| `GuardTimeout_StillReportsTheRoutersBudget_AndStillNacks` | the #1028 contract is untouched — a never-completing post still terminates, still says `00:01:00`, still NACKs |
| `TheGuardsExceptionIsStillATimeoutException` | classification is byte-identical to before |

### Failing on unfixed code

Run against `origin/main`'s `RoutingGrain.cs` (this test compiles unchanged against it):

```
[FAIL] StreamPostTimeoutAttributionTest.TransportTimeout_IsNotReportedAsTheRoutersOwnBudget
  Did not expect "[ROUTE] Stream-routed forward to cache/cLhEcQcDAUa-W9zPmBOQWw did not complete
  within 00:01:00 — the post is not going to land; surfacing DeliveryFailure to sender
  client/sender-1" to contain "did not complete within 00:01:00" …
Failed!  - Failed: 1, Passed: 2, Total: 3
```

The reproduced line is the production line, character for character. With the fix:

```
Passed!  - Failed: 0, Passed: 14, Total: 14
```

(this file plus `RoutingGrainStreamPostBoundTest` and `OversizedStreamMessageRefusedTest`, the two suites that own the rest of this leg's contract.)

## What is left on #2322, and why it is not here

The wedged `MemoryStreamQueueGrain` itself. That residual is **not** a router defect — the enqueue leg is Orleans-internal, the queue grain lives in RAM, and the maintainer's 2026-08-27 direction on that ticket was explicit: **do not add a durable stream provider; the durable stream should be a mesh node.** That is design work, not a patch to this leg, and guessing at it here would be worse than leaving it stated. Detailed in my comment on the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)