### PR TITLE
fix(gate): a timeout and a lost status write are not compile failures (#2454, #2463)

### DIFF
--- a/src/MeshWeaver.PluginCatalog/ComboVerification.cs
+++ b/src/MeshWeaver.PluginCatalog/ComboVerification.cs
@@ -199,11 +199,34 @@ public enum GateRunOutcome
     /// <summary>The check passed.</summary>
     Passed,
 
-    /// <summary>The check failed.</summary>
+    /// <summary>
+    /// The check produced a NEGATIVE verdict — a compiler diagnostic, an error control, a red
+    /// test. A CONTENT failure: the reader fixes the source.
+    /// </summary>
     Failed,
 
     /// <summary>The check does not apply (e.g. the type declares no Tests area).</summary>
     Skipped,
+
+    /// <summary>
+    /// NO VERDICT: the check never produced an answer within its budget (a timeout, a wedge). It
+    /// fails the run — an unjudged check is not a passing one — but it is NOT a diagnostic, and a
+    /// consumer must not report it as one.
+    ///
+    /// <para>🚨 Appended, never inserted: the members before it keep their ordinals, so a report
+    /// written by an older tester still deserializes correctly. Introduced with #2454/#2463, where
+    /// a 300s "no terminal compile status" timeout was reported as <see cref="Failed"/> and
+    /// annotated as a public-API break on a PR that contained no C# at all.</para>
+    /// </summary>
+    Inconclusive,
+
+    /// <summary>
+    /// The WORK SUCCEEDED and the mesh failed to RECORD it — the run consumed a bake that carries
+    /// this type's assembly, so the compile is proven by bytes, and only the mesh-side status
+    /// write was lost (a <c>MergeGuard</c> stale/reordered refusal, a hub disposed with the write
+    /// in flight). INFRASTRUCTURE, never content.
+    /// </summary>
+    Unrecorded,
 }
 
 /// <summary>
@@ -280,10 +303,18 @@ public sealed record GateRunNodeType
     /// <summary>The Tests verdict detail (the pass/fail summary, or the red rows).</summary>
     public string? TestsDetail { get; init; }
 
-    /// <summary>True when no check failed.</summary>
+    /// <summary>
+    /// True when no check failed. 🚨 Every non-passing, non-skipped outcome fails — never
+    /// <c>!= Failed</c>, which silently admits each member added after
+    /// <see cref="GateRunOutcome.Failed"/> and would have made a run that judged NOTHING report as
+    /// a clean pass to the combo verifier.
+    /// </summary>
     [JsonIgnore]
-    public bool Success =>
-        Compile != GateRunOutcome.Failed
-        && Render != GateRunOutcome.Failed
-        && Tests != GateRunOutcome.Failed;
+    public bool Success => !Fails(Compile) && !Fails(Render) && !Fails(Tests);
+
+    /// <summary>Whether <paramref name="outcome"/> fails the run.</summary>
+    private static bool Fails(GateRunOutcome outcome) =>
+        outcome is GateRunOutcome.Failed
+            or GateRunOutcome.Inconclusive
+            or GateRunOutcome.Unrecorded;
 }

--- a/src/MeshWeaver.PluginCatalog/InstanceComboVerifier.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceComboVerifier.cs
@@ -314,8 +314,18 @@ public sealed class InstanceComboVerifier
         return ComboVerdictKind.Green;
     }
 
-    /// <summary>The breadth-complete failure lines of one package: install, idempotence, and every
-    /// failed per-NodeType check with its diagnostics.</summary>
+    /// <summary>
+    /// The breadth-complete failure lines of one package: install, idempotence, and every failed
+    /// per-NodeType check with its diagnostics.
+    ///
+    /// <para>🚨 Each line says WHICH KIND of not-passing it is. A <see cref="GateRunOutcome"/>
+    /// that is <see cref="GateRunOutcome.Inconclusive"/> or <see cref="GateRunOutcome.Unrecorded"/>
+    /// must not be rendered as "compile failed" — that is #2454/#2463 reproduced one process
+    /// boundary out, in the text a human reads off the combo verdict. And the test must be
+    /// <see cref="Fails"/>, not <c>== Failed</c>: an equality test would have DROPPED both new
+    /// members from the failure list, so a run that judged nothing would report a package with an
+    /// empty failure list beside a non-zero exit code.</para>
+    /// </summary>
     private static ImmutableList<string> FailuresOf(GateRunPackage package)
     {
         var failures = ImmutableList.CreateBuilder<string>();
@@ -325,17 +335,35 @@ public sealed class InstanceComboVerifier
             failures.Add($"idempotence: {package.IdempotenceError}");
         foreach (var type in package.NodeTypes)
         {
-            if (type.Compile == GateRunOutcome.Failed)
-                failures.Add($"{type.Path}: compile failed"
+            if (Fails(type.Compile))
+                failures.Add($"{type.Path}: compile {Verb(type.Compile)}"
                              + (type.CompilationStatus is null ? "" : $" ({type.CompilationStatus})")
                              + Detail(type.CompileDetail));
-            if (type.Render == GateRunOutcome.Failed)
-                failures.Add($"{type.Path}: render failed{Detail(type.RenderDetail)}");
-            if (type.Tests == GateRunOutcome.Failed)
-                failures.Add($"{type.Path}: tests failed{Detail(type.TestsDetail)}");
+            if (Fails(type.Render))
+                failures.Add($"{type.Path}: render {Verb(type.Render)}{Detail(type.RenderDetail)}");
+            if (Fails(type.Tests))
+                failures.Add($"{type.Path}: tests {Verb(type.Tests)}{Detail(type.TestsDetail)}");
         }
         return failures.ToImmutable();
     }
+
+    /// <summary>Whether an outcome fails the run — every state that is neither a pass nor a
+    /// deliberate skip.</summary>
+    private static bool Fails(GateRunOutcome outcome) =>
+        outcome is GateRunOutcome.Failed
+            or GateRunOutcome.Inconclusive
+            or GateRunOutcome.Unrecorded;
+
+    /// <summary>How the failure line NAMES the outcome — a verdict, a missing verdict, or a lost
+    /// record.</summary>
+    private static string Verb(GateRunOutcome outcome) => outcome switch
+    {
+        GateRunOutcome.Inconclusive =>
+            "produced NO VERDICT (a timeout or a wedge in the mesh — not a diagnostic)",
+        GateRunOutcome.Unrecorded =>
+            "SUCCEEDED but the mesh did not record it (infrastructure, not the content)",
+        _ => "failed",
+    };
 
     private static string Detail(string? detail) =>
         string.IsNullOrWhiteSpace(detail) ? "" : $" — {detail}";

--- a/test/MeshWeaver.PluginTester.Test/GateNamesTheRealCauseTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/GateNamesTheRealCauseTest.cs
@@ -1,0 +1,273 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using MeshWeaver.PluginCatalog;
+using MeshWeaver.PluginTester;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// 🚨 THE GATE MUST NAME THE REAL CAUSE — the regression suite for Systemorph/MeshWeaver#2454 and
+/// #2463, which are ONE defect with two triggers.
+///
+/// <para>Both begin at the same observation, in the same <c>Catch((TimeoutException _) =&gt; …)</c>:
+/// the mesh wrote no terminal compile status inside the per-type budget. That observation was
+/// scored <c>compile = Failed</c>, which is the single most expensive kind of wrong a report here
+/// can be — it names a component that is not broken, so every reader spends their time in the one
+/// place the cause provably is not:</para>
+///
+/// <list type="bullet">
+///   <item><b>#2454</b> — <c>RolePlay/Story</c>: <c>no terminal compile status within 300s</c>
+///     after the install raced its own hub disposal. The required check annotated it <i>"a public
+///     API change here broke plugin node source"</i> on a PR whose entire diff was one markdown
+///     line, a test-data ledger and one test-list row. Nothing in it was C#.</item>
+///   <item><b>#2463</b> — <c>RolePlay/Scenery</c>: the SAME run's log had already recorded
+///     <c>ok RolePlay/Scenery</c> and baked four assemblies with no mesh involved, then
+///     <c>MergeGuard</c> refused the adoption stamp as a stale/reordered cross-hub write and
+///     <c>CompileWatcher</c> logged <c>the write did not converge</c>. The gate read the absent
+///     status as <c>compile=FAILED</c>, reddened main and held a production rollout ~11 hours.</item>
+/// </list>
+///
+/// <para>Every assertion below is TWO-SIDED, in the tradition of <see cref="GateSummaryTest"/>: the
+/// line must name the cause that applies AND must not name one that does not. A one-sided "it
+/// failed" assertion passes just as happily against the defect.</para>
+/// </summary>
+public class GateNamesTheRealCauseTest
+{
+    private const string TypePath = "RolePlay/Scenery";
+
+    private static NodeTypeResult Type(CheckOutcome compile, string? detail) =>
+        new(TypePath, "RolePlay")
+        {
+            Compile = compile,
+            CompileDetail = detail,
+            Render = CheckOutcome.Skipped,
+            Tests = CheckOutcome.Skipped,
+        };
+
+    private static GateReport Report(NodeTypeResult type) =>
+        new([new PackageResult("RolePlay") { NodeCount = 42, NodeTypes = [type] }]);
+
+    private static string Summarize(GateReport report, GateVerdict? verdict = null)
+    {
+        var output = new StringWriter();
+        report.WriteSummary(output, verdict);
+        return output.ToString();
+    }
+
+    private static string VerdictLine(string summary) =>
+        summary.ReplaceLineEndings("\n").Split('\n')
+            .Single(l => l.StartsWith(GateReport.FailedPrefix, StringComparison.Ordinal));
+
+    /// <summary>A bake seed that declares assemblies for <paramref name="declared"/> — the
+    /// evidence half of the classification, built with the seeder's own comparer.</summary>
+    private static BakeSeed Seed(params string[] declared) =>
+        new("/bake", "sdeadbeef", ImmutableArray.Create("/bake/RolePlay.zip"),
+            declared.ToImmutableSortedSet(StringComparer.OrdinalIgnoreCase));
+
+    // ── 1. the classification: which of the three outcomes the observation earns ──────────────
+
+    /// <summary>
+    /// #2463 exactly: the run CONSUMED a bake that carries this type's assembly, so the compile is
+    /// proven by bytes the compiler stage emitted with no mesh involved. The only thing missing is
+    /// the mesh's own status write, and the verdict must say so.
+    /// </summary>
+    [Fact]
+    public void BakeCarriesTheAssembly_TheStatusWriteIsWhatWasLost_NotTheCompile()
+    {
+        var result = PluginGateRunner.NoTerminalCompileStatus(
+            Type(CheckOutcome.Skipped, null), TypePath, Seed(TypePath), TimeSpan.FromSeconds(300));
+
+        result.Compile.Should().Be(CheckOutcome.Unrecorded,
+            "the bake proves the compile succeeded — what did not happen is the status write");
+        result.Compile.Should().NotBe(CheckOutcome.Failed,
+            "reporting a compile failure for a compile that produced bytes is #2463");
+        result.CompileDetail.Should().Contain("COMPILE SUCCEEDED");
+        result.CompileDetail.Should().Contain("STATUS WRITE");
+        result.CompileDetail.Should().Contain("INFRASTRUCTURE, not the plugin source");
+    }
+
+    /// <summary>
+    /// The comparer must be the SEEDER's (OrdinalIgnoreCase). A stricter one here would answer "no
+    /// evidence" for an assembly <c>ShippedPrebuiltBundles.SeedForTypes</c> had happily adopted
+    /// under a case difference — and the gate would then blame the compile after all.
+    /// </summary>
+    [Fact]
+    public void TheBakeEvidenceIsMatchedWithTheSeedersOwnComparer()
+    {
+        var result = PluginGateRunner.NoTerminalCompileStatus(
+            Type(CheckOutcome.Skipped, null), "roleplay/scenery", Seed(TypePath),
+            TimeSpan.FromSeconds(300));
+
+        result.Compile.Should().Be(CheckOutcome.Unrecorded);
+    }
+
+    /// <summary>
+    /// #2454's honest floor: with no bake evidence the gate does NOT know that the compile
+    /// succeeded, so it must not say so — but it equally must not say the compile FAILED. "I did
+    /// not get an answer" is its own outcome, and the detail sends the reader to the mesh.
+    /// </summary>
+    [Fact]
+    public void WithNoBakeEvidence_ItIsNoVerdict_NeverACompileFailure()
+    {
+        var result = PluginGateRunner.NoTerminalCompileStatus(
+            Type(CheckOutcome.Skipped, null), TypePath, seed: null, TimeSpan.FromSeconds(300));
+
+        result.Compile.Should().Be(CheckOutcome.Inconclusive);
+        result.Compile.Should().NotBe(CheckOutcome.Failed);
+        result.CompileDetail.Should().Contain("no terminal compile status within 300s");
+        result.CompileDetail.Should().Contain("TIMEOUT, not a compiler diagnostic");
+        result.CompileDetail.Should().NotContain("COMPILE SUCCEEDED",
+            "with no bake there is no evidence the compile succeeded either");
+    }
+
+    /// <summary>A seed that covers OTHER types is not evidence about this one.</summary>
+    [Fact]
+    public void ABakeThatDoesNotCoverThisType_IsNotEvidenceAboutIt()
+    {
+        var result = PluginGateRunner.NoTerminalCompileStatus(
+            Type(CheckOutcome.Skipped, null), TypePath, Seed("RolePlay/Story"),
+            TimeSpan.FromSeconds(300));
+
+        result.Compile.Should().Be(CheckOutcome.Inconclusive);
+        result.CompileDetail.Should().Contain("declares no assembly for this type");
+    }
+
+    // ── 2. the verdict LINE — the one line CI lifts verbatim ──────────────────────────────────
+
+    /// <summary>
+    /// The #2463 headline. <c>compile: RolePlay/Scenery</c> is the sentence that cost 11 hours; the
+    /// line must instead name the status write and say the work succeeded.
+    /// </summary>
+    [Fact]
+    public void TheHeadline_ForALostStatusWrite_DoesNotSayTheCompileFailed()
+    {
+        var line = VerdictLine(Summarize(Report(Type(
+            CheckOutcome.Unrecorded, "the COMPILE SUCCEEDED … MergeGuard refused the write"))));
+
+        line.Should().Contain("compile-status-unrecorded: RolePlay/Scenery");
+        line.Should().Contain("the work SUCCEEDED and the mesh did not record it");
+        line.Should().NotContain("compile: RolePlay/Scenery",
+            "that is the sentence that sends the reader to diff public API that is fine (#2463)");
+    }
+
+    /// <summary>
+    /// The #2454 headline. A timeout is "I did not get an answer", and the line must say which of
+    /// the two it is so nobody reads it as a diagnostic.
+    /// </summary>
+    [Fact]
+    public void TheHeadline_ForATimeout_SaysNoVerdict_AndPointsAtTheMesh()
+    {
+        var line = VerdictLine(Summarize(Report(Type(
+            CheckOutcome.Inconclusive, "no terminal compile status within 300s"))));
+
+        line.Should().Contain("compile-no-verdict: RolePlay/Scenery");
+        line.Should().Contain("NOT a compiler diagnostic");
+        line.Should().Contain("investigate the mesh, not the source");
+        line.Should().NotContain("compile: RolePlay/Scenery");
+    }
+
+    /// <summary>
+    /// A REAL compile error must be unchanged — the fix must not blur the one case where "fix the
+    /// source" IS the right instruction, and it must lead when both kinds are present.
+    /// </summary>
+    [Fact]
+    public void ARealCompileError_StillReadsExactlyAsBefore_AndLeads()
+    {
+        var report = new GateReport(
+        [
+            new PackageResult("RolePlay")
+            {
+                NodeCount = 42,
+                NodeTypes =
+                [
+                    Type(CheckOutcome.Inconclusive, "no terminal compile status within 300s"),
+                    new NodeTypeResult("RolePlay/Story", "RolePlay")
+                    {
+                        Compile = CheckOutcome.Failed,
+                        CompileDetail = "CS0246: type or namespace not found",
+                        Render = CheckOutcome.Skipped,
+                        Tests = CheckOutcome.Skipped,
+                    },
+                ],
+            },
+        ]);
+
+        var line = VerdictLine(Summarize(report));
+
+        line.Should().Contain("compile: RolePlay/Story");
+        line.Should().Contain("compile-no-verdict: RolePlay/Scenery");
+        line.IndexOf("compile: RolePlay/Story", StringComparison.Ordinal)
+            .Should().BeLessThan(line.IndexOf("compile-no-verdict", StringComparison.Ordinal),
+                "the actionable verdict leads; the non-verdict follows");
+    }
+
+    // ── 3. the two halves of the gate must agree about what failed ────────────────────────────
+
+    /// <summary>
+    /// 🚨 The failure ENUMERATION and the SUCCESS predicate are two independent readers of the same
+    /// outcome, and a `== Failed` test in either makes them disagree: the run exits non-zero while
+    /// the headline says "no failing check was recorded" and the ratchet calls every listed entry
+    /// stale. A gate whose halves contradict each other is worse than one that names a wrong cause.
+    /// </summary>
+    [Theory]
+    [InlineData(CheckOutcome.Inconclusive)]
+    [InlineData(CheckOutcome.Unrecorded)]
+    public void ANonVerdictFailsTheRun_AndIsEnumeratedAsAFailure(CheckOutcome outcome)
+    {
+        var report = Report(Type(outcome, "detail"));
+
+        report.Success.Should().BeFalse("a check that produced no verdict has not passed");
+        report.ExitCode.Should().Be(1);
+        GateVerdict.Headline(report).Should().NotBe("no failing check was recorded");
+
+        var verdict = GateVerdict.Evaluate(report, GateAllowlist.Empty);
+        verdict.NewFailures.Should().ContainSingle()
+            .Which.Outcome.Should().Be(outcome);
+        verdict.Success.Should().BeFalse();
+    }
+
+    /// <summary>
+    /// The known-debt ratchet keys on the CHECK NAME, not the kind — an entry that tolerates
+    /// <c>RolePlay/Scenery compile</c> keeps tolerating it however the check failed to pass, and
+    /// the entry is neither stale (the check did not pass) nor a new failure.
+    /// </summary>
+    [Fact]
+    public void TheRatchetStillKeysOnTheCheckName()
+    {
+        var report = Report(Type(CheckOutcome.Unrecorded, "detail"));
+        var verdict = GateVerdict.Evaluate(
+            report, GateAllowlist.Parse(["RolePlay/Scenery compile"]));
+
+        verdict.NewFailures.Should().BeEmpty();
+        verdict.KnownDebt.Should().ContainSingle();
+        verdict.Stale.Should().BeEmpty("the check did not pass, so the entry is not stale");
+    }
+
+    // ── 4. the wire contract — the collapse must not be reintroduced at the process boundary ──
+
+    /// <summary>
+    /// The combo verifier runs OUTSIDE the candidate image and reads this report as JSON. Both new
+    /// outcomes must survive with their identity: mapping them to <c>Skipped</c> (the old
+    /// catch-all) would tell the verifier "the check does not apply" about a check that failed.
+    /// </summary>
+    [Theory]
+    [InlineData(CheckOutcome.Inconclusive, GateRunOutcome.Inconclusive)]
+    [InlineData(CheckOutcome.Unrecorded, GateRunOutcome.Unrecorded)]
+    public void TheNonVerdictsSurviveTheWireRoundTrip(CheckOutcome local, GateRunOutcome wire)
+    {
+        var json = JsonSerializer.Serialize(
+            Report(Type(local, "detail")).ToRunReport(), InstanceComboAssembler.Json);
+        var read = JsonSerializer.Deserialize<GateRunReport>(json, InstanceComboAssembler.Json)!;
+
+        var type = read.Packages.Single().NodeTypes.Single();
+        type.Compile.Should().Be(wire);
+        type.Success.Should().BeFalse("a non-verdict is not a pass on the wire either");
+        read.Packages.Single().Success.Should().BeFalse();
+    }
+}

--- a/tools/MeshWeaver.PluginTester/GateAllowlist.cs
+++ b/tools/MeshWeaver.PluginTester/GateAllowlist.cs
@@ -153,7 +153,27 @@ public sealed record AllowEntry(string Scope, string Check)
 }
 
 /// <summary>One observed failure: where, which check, and the detail text.</summary>
-public sealed record GateFailure(string Scope, string Check, string Detail);
+/// <param name="Scope">The package id or NodeType path the failure is on.</param>
+/// <param name="Check">The check name — install / idempotence / compile / render / tests. This is
+/// the RATCHET key: an allow entry names this, so it must stay the bare check name whatever kind
+/// of not-passing <see cref="GateFailure.Outcome"/> is (a listed debt is tolerated whether the
+/// check failed or produced no verdict).</param>
+/// <param name="Detail">The failure detail text.</param>
+public sealed record GateFailure(string Scope, string Check, string Detail)
+{
+    /// <summary>
+    /// WHICH KIND of not-passing this is — a negative verdict, no verdict at all, or a lost
+    /// record. It steers the HEADLINE only; the ratchet keys on <see cref="Check"/>.
+    ///
+    /// <para>🚨 An init-only PROPERTY, not a primary-constructor parameter: adding a defaulted
+    /// parameter to a public record's primary ctor is a binary-breaking change that
+    /// <c>scripts/check-record-signatures.py</c> refuses (the same rule
+    /// <see cref="AllowEntry.Intermittent"/> records). Defaults to
+    /// <see cref="CheckOutcome.Failed"/> so an existing construction keeps meaning exactly what it
+    /// meant.</para>
+    /// </summary>
+    public CheckOutcome Outcome { get; init; } = CheckOutcome.Failed;
+}
 
 /// <summary>
 /// The run's verdict once the allowlist is applied: which failures are NEW (fail the run), which
@@ -237,15 +257,26 @@ public sealed record GateVerdict(
         var failures = verdict is not null
             ? verdict.NewFailures
             : Failures(report).ToList();
+        // 🚨 Grouped by (check, KIND OF NOT-PASSING), never by check alone. This is the whole of
+        // #2454/#2463 in one loop: `compile: RolePlay/Story` for a 300s timeout, and for a compile
+        // whose bytes the same run had already baked, is a sentence that sends every reader to
+        // diff plugin source and framework signatures that are fine. The three states get three
+        // labels, and each non-verdict carries the clause that says where to look instead.
         foreach (var check in CheckOrder)
+        foreach (var outcome in OutcomeOrder)
         {
             var scopes = failures
-                .Where(f => string.Equals(f.Check, check, StringComparison.OrdinalIgnoreCase))
+                .Where(f => string.Equals(f.Check, check, StringComparison.OrdinalIgnoreCase)
+                            && f.Outcome == outcome)
                 .Select(f => f.Scope)
                 .Distinct(StringComparer.Ordinal)
                 .ToList();
-            if (scopes.Count > 0)
-                parts.Add($"{check}: {string.Join(", ", scopes)}");
+            if (scopes.Count == 0)
+                continue;
+            var part = $"{CheckOutcomes.Label(check, outcome)}: {string.Join(", ", scopes)}";
+            parts.Add(CheckOutcomes.Guidance(outcome) is { } guidance
+                ? $"{part} ({guidance})"
+                : part);
         }
 
         if (verdict is { Stale.Count: > 0 })
@@ -260,6 +291,13 @@ public sealed record GateVerdict(
     private static readonly string[] CheckOrder =
         ["install", "idempotence", "compile", "render", "tests"];
 
+    /// <summary>
+    /// The not-passing kinds, most-conclusive first — so a run carrying a REAL compile error and a
+    /// separate timeout leads with the error, which is the one the reader can act on directly.
+    /// </summary>
+    private static readonly CheckOutcome[] OutcomeOrder =
+        [CheckOutcome.Failed, CheckOutcome.Unrecorded, CheckOutcome.Inconclusive];
+
     private static string FirstLine(string text) =>
         text.ReplaceLineEndings("\n").Split('\n')[0];
 
@@ -273,12 +311,21 @@ public sealed record GateVerdict(
                 yield return new GateFailure(package.Id, "idempotence", package.IdempotenceError);
             foreach (var type in package.NodeTypes)
             {
-                if (type.Compile == CheckOutcome.Failed)
-                    yield return new GateFailure(type.Path, "compile", type.CompileDetail ?? "");
-                if (type.Render == CheckOutcome.Failed)
-                    yield return new GateFailure(type.Path, "render", type.RenderDetail ?? "");
-                if (type.Tests == CheckOutcome.Failed)
-                    yield return new GateFailure(type.Path, "tests", type.TestsDetail ?? "");
+                // 🚨 .Fails(), never `== Failed`. An equality test here would have DROPPED every
+                // Inconclusive / Unrecorded outcome from the failure set — so the run would exit
+                // non-zero (NodeTypeResult.Success is false) while Headline reported "no failing
+                // check was recorded", and the allowlist would call every listed entry stale. A
+                // gate whose two halves disagree about what failed is worse than one that names
+                // the wrong cause.
+                if (type.Compile.Fails())
+                    yield return new GateFailure(type.Path, "compile", type.CompileDetail ?? "")
+                        { Outcome = type.Compile };
+                if (type.Render.Fails())
+                    yield return new GateFailure(type.Path, "render", type.RenderDetail ?? "")
+                        { Outcome = type.Render };
+                if (type.Tests.Fails())
+                    yield return new GateFailure(type.Path, "tests", type.TestsDetail ?? "")
+                        { Outcome = type.Tests };
             }
         }
     }

--- a/tools/MeshWeaver.PluginTester/GateReport.cs
+++ b/tools/MeshWeaver.PluginTester/GateReport.cs
@@ -4,17 +4,125 @@ using MeshWeaver.PluginCatalog;
 
 namespace MeshWeaver.PluginTester;
 
-/// <summary>Outcome of one gate check (compile / render / Tests area) on one NodeType.</summary>
+/// <summary>
+/// Outcome of one gate check (compile / render / Tests area) on one NodeType.
+///
+/// <para>🚨 <b>Three ways for a check not to pass, and they have DIFFERENT OWNERS.</b> They were
+/// one member (<see cref="Failed"/>) until #2454/#2463, and collapsing them is the most expensive
+/// reporting defect this gate can have: a verdict that names the wrong component sends the reader
+/// to the one place the cause provably is not.</para>
+///
+/// <list type="table">
+///   <item><term><see cref="Failed"/></term><description>the check produced a NEGATIVE verdict —
+///     the compiler emitted diagnostics, the area rendered an error, a test went red. <b>Fix the
+///     source.</b></description></item>
+///   <item><term><see cref="Inconclusive"/></term><description>the check produced NO verdict —
+///     nothing answered within the budget. "I did not get an answer" is not "the answer was no".
+///     <b>Investigate the mesh, not the source.</b></description></item>
+///   <item><term><see cref="Unrecorded"/></term><description>the WORK succeeded and the mesh
+///     failed to RECORD it — the bake this run consumed carries the type's assembly, so the
+///     compile is proven, and only the status write was lost. <b>Fix the writer; the content is
+///     fine.</b></description></item>
+/// </list>
+///
+/// <para>Modelled on <c>MeshWeaver.Hosting.PreWarmStatus</c>, which already separates
+/// <c>CompileError</c> from <c>TimedOut</c> / <c>NoSources</c> / <c>UpstreamUnevaluated</c> for
+/// exactly this reason — "I don't know" propagates as "I don't know" there rather than becoming a
+/// verdict. This is the same distinction at the CI gate.</para>
+///
+/// <para>🚨 All three still FAIL the run. A gate that cannot judge must not look like a gate that
+/// passed (the node-repo CI policy's invariants #3/#4), and neither non-verdict is evidence the
+/// content is good. What changes is WHICH CAUSE IS NAMED — see
+/// <c>GateVerdict.Headline</c>.</para>
+/// </summary>
 public enum CheckOutcome
 {
     /// <summary>The check passed.</summary>
     Passed,
 
-    /// <summary>The check failed — the gate exits non-zero.</summary>
+    /// <summary>
+    /// The check produced a NEGATIVE verdict: the compiler emitted diagnostics, the area rendered
+    /// an error control, a test row went red. This is a CONTENT failure — the gate exits non-zero
+    /// and the reader fixes the source.
+    /// </summary>
     Failed,
 
     /// <summary>The check does not apply (e.g. the type declares no Tests area).</summary>
     Skipped,
+
+    /// <summary>
+    /// NO VERDICT: the check never produced an answer within its budget — the mesh wrote no
+    /// terminal compile status, an area never emitted. The gate exits non-zero (an unjudged check
+    /// is not a passing one) but the failure is a TIMEOUT or a WEDGE, not a diagnostic: nothing
+    /// reported an error and no source was found wanting.
+    ///
+    /// <para>🚨 Reported under its own headline label so a CI annotation cannot send the reader to
+    /// diff the PR's source. #2454: a PR whose entire diff was one markdown line, a test ledger
+    /// and a test-list row was annotated <i>"a public API change here broke plugin node
+    /// source"</i> — the gate had observed <c>no terminal compile status within 300s</c> and
+    /// scored it <see cref="Failed"/>.</para>
+    /// </summary>
+    Inconclusive,
+
+    /// <summary>
+    /// The WORK SUCCEEDED and the mesh failed to RECORD it. Reachable only on a run that CONSUMES
+    /// a bake (<see cref="GateOptions.Seed"/>): the bake declares an assembly for this type, so
+    /// the compile is PROVEN by bytes on disk, and what is missing is the mesh-side status write.
+    ///
+    /// <para>🚨 This is INFRASTRUCTURE, never content. #2463: the compiler logged
+    /// <c>ok RolePlay/Scenery</c> and baked four assemblies; six minutes later <c>MergeGuard</c>
+    /// refused the adoption stamp as a stale/reordered cross-hub write, <c>CompileWatcher</c> said
+    /// <c>the write did not converge</c> in as many words — and the gate reported
+    /// <c>compile=FAILED</c>, turning main red and holding a production rollout for ~11 hours on a
+    /// compile that had never failed. Same shape in #2454, where the owning hub was disposed with
+    /// a <c>CreateOrUpdateNodeRequest</c> still in flight.</para>
+    ///
+    /// <para>It still fails the run: the type never settled, so the gate could judge neither its
+    /// render nor its <c>Tests</c> area, and a green here would be a claim about checks that never
+    /// ran. Making it PASS would be a separate, deliberate policy change — it needs the render and
+    /// Tests halves to run against the adopted bytes first.</para>
+    /// </summary>
+    Unrecorded,
+}
+
+/// <summary>Outcome classification helpers shared by the report and the verdict.</summary>
+public static class CheckOutcomes
+{
+    /// <summary>
+    /// Whether <paramref name="outcome"/> fails the gate. Every non-verdict fails: a check that
+    /// produced no answer is not a check that passed. 🚨 Never write <c>!= Failed</c> — that is
+    /// the test that made <see cref="CheckOutcome.Inconclusive"/> and
+    /// <see cref="CheckOutcome.Unrecorded"/> silently green when they were introduced.
+    /// </summary>
+    public static bool Fails(this CheckOutcome outcome) =>
+        outcome is CheckOutcome.Failed or CheckOutcome.Inconclusive or CheckOutcome.Unrecorded;
+
+    /// <summary>
+    /// The headline label for a failing <paramref name="outcome"/> on <paramref name="check"/>:
+    /// the bare check name for a real verdict, a distinct token for each non-verdict — so the ONE
+    /// line CI lifts cannot say "compile" about a compile that succeeded.
+    /// </summary>
+    public static string Label(string check, CheckOutcome outcome) => outcome switch
+    {
+        CheckOutcome.Inconclusive => $"{check}-no-verdict",
+        CheckOutcome.Unrecorded => $"{check}-status-unrecorded",
+        _ => check,
+    };
+
+    /// <summary>
+    /// The one clause that tells the reader WHERE TO LOOK, appended once per non-verdict kind in
+    /// the headline. Null for a real verdict — the check name already says it.
+    /// </summary>
+    public static string? Guidance(CheckOutcome outcome) => outcome switch
+    {
+        CheckOutcome.Inconclusive =>
+            "no result was observed — a timeout or a wedge in the mesh, NOT a compiler "
+            + "diagnostic; investigate the mesh, not the source",
+        CheckOutcome.Unrecorded =>
+            "the work SUCCEEDED and the mesh did not record it — infrastructure, not the "
+            + "content; fix the writer",
+        _ => null,
+    };
 }
 
 /// <summary>The gate results for one NodeType node of a package.</summary>
@@ -53,11 +161,15 @@ public sealed record NodeTypeResult(string Path, string Package)
     /// </summary>
     public string? TestsHost { get; init; }
 
-    /// <summary>True when no gate check failed.</summary>
+    /// <summary>
+    /// True when no gate check failed. 🚨 Reads <see cref="CheckOutcomes.Fails"/>, never
+    /// <c>!= Failed</c>: a check that produced NO verdict
+    /// (<see cref="CheckOutcome.Inconclusive"/> / <see cref="CheckOutcome.Unrecorded"/>) has not
+    /// passed either, and an inequality test against one member silently admits every member
+    /// added after it.
+    /// </summary>
     public bool Success =>
-        Compile != CheckOutcome.Failed
-        && Render != CheckOutcome.Failed
-        && Tests != CheckOutcome.Failed;
+        !Compile.Fails() && !Render.Fails() && !Tests.Fails();
 }
 
 /// <summary>The gate results for one installed package.</summary>
@@ -153,10 +265,18 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
             .ToImmutableList(),
     };
 
+    /// <summary>
+    /// Maps a local outcome onto the wire contract. 🚨 EXHAUSTIVE by construction — a new member
+    /// must be given a wire spelling here, never fall into a catch-all. The previous
+    /// <c>_ =&gt; Skipped</c> would have reported both non-verdicts to the combo verifier as
+    /// "the check does not apply", which is the same collapse one process boundary further out.
+    /// </summary>
     private static GateRunOutcome Map(CheckOutcome outcome) => outcome switch
     {
         CheckOutcome.Passed => GateRunOutcome.Passed,
         CheckOutcome.Failed => GateRunOutcome.Failed,
+        CheckOutcome.Inconclusive => GateRunOutcome.Inconclusive,
+        CheckOutcome.Unrecorded => GateRunOutcome.Unrecorded,
         _ => GateRunOutcome.Skipped,
     };
 
@@ -239,20 +359,29 @@ public sealed record GateReport(IReadOnlyList<PackageResult> Packages)
             (package.InstallError is null || verdict.IsKnownDebt(package.Id, "install"))
             && (package.IdempotenceError is null || verdict.IsKnownDebt(package.Id, "idempotence"))
             && package.NodeTypes.All(t =>
-                (t.Compile != CheckOutcome.Failed || verdict.IsKnownDebt(t.Path, "compile"))
-                && (t.Render != CheckOutcome.Failed || verdict.IsKnownDebt(t.Path, "render"))
-                && (t.Tests != CheckOutcome.Failed || verdict.IsKnownDebt(t.Path, "tests")));
+                (!t.Compile.Fails() || verdict.IsKnownDebt(t.Path, "compile"))
+                && (!t.Render.Fails() || verdict.IsKnownDebt(t.Path, "render"))
+                && (!t.Tests.Fails() || verdict.IsKnownDebt(t.Path, "tests")));
         return allKnown ? "DEBT" : "FAIL";
     }
 
     private static string Debt(GateVerdict? verdict, string scope, string check) =>
         verdict is not null && verdict.IsKnownDebt(scope, check) ? " [known-debt]" : "";
 
+    /// <summary>
+    /// The per-type summary token. 🚨 The three not-passing states print DIFFERENTLY — this line
+    /// is what a human scans, and <c>compile=FAILED</c> for a compile that succeeded is the whole
+    /// defect (#2454/#2463).
+    /// </summary>
     private static string Describe(CheckOutcome outcome, string? detail = null) =>
         outcome switch
         {
             CheckOutcome.Passed => detail is null ? "ok" : detail,
             CheckOutcome.Failed => detail is null ? "FAILED" : $"FAILED({detail})",
+            CheckOutcome.Inconclusive =>
+                detail is null ? "NO-VERDICT" : $"NO-VERDICT({detail})",
+            CheckOutcome.Unrecorded =>
+                detail is null ? "UNRECORDED" : $"UNRECORDED({detail})",
             _ => "skipped",
         };
 

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -411,8 +411,13 @@ public static class PluginGateRunner
     {
         var result = new NodeTypeResult(type.Path, type.Package);
         return AwaitCompile(harness, options, type, result)
-            .SelectMany(afterCompile => afterCompile.Compile == CheckOutcome.Failed
-                // A broken compile already fails the gate — rendering it would only add noise.
+            // 🚨 .Fails(), never `== Failed`: a type whose compile produced NO verdict
+            // (Inconclusive/Unrecorded) has no settled build either, so rendering it would add a
+            // second, more confusing failure on top of the first. An equality test against one
+            // member silently admits every member added after it.
+            .SelectMany(afterCompile => afterCompile.Compile.Fails()
+                // A compile that did not pass already fails the gate — rendering it would only
+                // add noise.
                 ? Observable.Return(afterCompile with
                 {
                     Render = CheckOutcome.Skipped,
@@ -453,12 +458,72 @@ public static class PluginGateRunner
                         : def.CompilationError,
                 };
             })
-            .Catch((TimeoutException _) => Observable.Return(result with
+            // 🚨 A TIMEOUT IS NOT A COMPILE FAILURE. It used to be scored one, and the cost was
+            // paid twice: #2454 (a PR of one markdown line, a test ledger and a test-list row,
+            // annotated as a public-API break) and #2463 (main red and a production rollout held
+            // ~11 hours on a compile the same run's own log had recorded as `ok`).
+            .Catch((TimeoutException _) => Observable.Return(
+                NoTerminalCompileStatus(result, type.Path, options.Seed, options.CompileTimeout)));
+    }
+
+    /// <summary>
+    /// Classifies "the mesh never wrote a terminal compile status within the budget" — the ONE
+    /// observation behind both #2454 and #2463 — into the outcome whose reader can act on it.
+    /// Pure, so the classification is unit-testable without a mesh.
+    ///
+    /// <para>The discriminator is EVIDENCE, not a guess: on a run that CONSUMES a bake
+    /// (<see cref="GateOptions.Seed"/>), a bundle carrying an assembly for this exact NodeType is
+    /// proof the compile SUCCEEDED — the compiler stage emitted those bytes with no mesh involved
+    /// at all ("<c>mw-compiler compile … (no mesh)</c>"). So when the bake declares the type and
+    /// the mesh still reported nothing, the compile is not in question and the STATUS WRITE is
+    /// what was lost: <see cref="CheckOutcome.Unrecorded"/>. Without that evidence the honest
+    /// answer is narrower — nothing answered, and the gate does not know why:
+    /// <see cref="CheckOutcome.Inconclusive"/>.</para>
+    ///
+    /// <para>🚨 <b>Both still fail the run</b>, and the detail says why in the reader's own terms.
+    /// This is deliberately NOT "the bake said ok, so pass": the type never settled, so its render
+    /// and <c>Tests</c> checks never ran, and reporting green would assert checks that did not
+    /// happen — the failure shape the whole gate exists to refuse.</para>
+    /// </summary>
+    /// <param name="result">The result so far for this type.</param>
+    /// <param name="typePath">The NodeType path, matched against the bake's declared assemblies
+    /// with the seeder's own OrdinalIgnoreCase comparer (<see cref="BakeSeed.DeclaredTypePaths"/>)
+    /// — a stricter comparer here would report "no evidence" for bytes the seeder had happily
+    /// adopted under a case difference.</param>
+    /// <param name="seed">The bake this run consumed, or null on a self-producing run.</param>
+    /// <param name="budget">The elapsed per-type compile budget, named in the detail.</param>
+    internal static NodeTypeResult NoTerminalCompileStatus(
+        NodeTypeResult result, string typePath, BakeSeed? seed, TimeSpan budget)
+    {
+        var seconds = $"{budget.TotalSeconds:F0}s";
+        if (seed is not null && seed.DeclaredTypePaths.Contains(typePath))
+            return result with
             {
-                Compile = CheckOutcome.Failed,
-                CompileDetail = $"no terminal compile status within " +
-                                $"{options.CompileTimeout.TotalSeconds:F0}s",
-            }));
+                Compile = CheckOutcome.Unrecorded,
+                CompileDetail =
+                    $"the COMPILE SUCCEEDED — the bake this run consumed ('{seed.Directory}') "
+                    + "carries an assembly for this type, produced by the compiler stage with no "
+                    + $"mesh involved — but no terminal compile status was written within {seconds}. "
+                    + "The mesh lost the STATUS WRITE (a MergeGuard stale/reordered refusal on the "
+                    + "cross-hub compile-state fields, or the owning hub disposed with its "
+                    + "CreateOrUpdateNodeRequest still in flight). This is INFRASTRUCTURE, not the "
+                    + "plugin source: do not diff the content or the framework's public API. "
+                    + "Systemorph/MeshWeaver#2463, #2454.",
+            };
+        return result with
+        {
+            Compile = CheckOutcome.Inconclusive,
+            CompileDetail =
+                $"no terminal compile status within {seconds} — the gate observed NO compile "
+                + "result. This is a TIMEOUT, not a compiler diagnostic: nothing reported an "
+                + "error and no source was judged. Investigate the mesh (a wedged hub, a lost or "
+                + "refused status write, an install racing its own teardown), not the plugin "
+                + "source. Systemorph/MeshWeaver#2454."
+                + (seed is null
+                    ? ""
+                    : $" (The bake in '{seed.Directory}' declares no assembly for this type, so "
+                      + "there is no evidence here that the compile itself succeeded.)"),
+        };
     }
 
     private static IObservable<NodeTypeResult> RenderGate(


### PR DESCRIPTION
Fixes the reporting half of #2454 and #2463 — **one defect, two triggers**, so one PR.

## They are the same code path

Both issues begin at the same observation, in the same `Catch((TimeoutException _) => …)` inside `PluginGateRunner.AwaitCompile`: *the mesh wrote no terminal compile status within the per-type budget.* That observation was scored `compile = Failed`, which is the most expensive kind of wrong a gate report can be — it names a component that is not broken, so the reader spends their time in the one place the cause provably is not.

| issue | what actually happened | what the gate said |
|---|---|---|
| **#2454** `RolePlay/Story` | the install raced its own hub disposal; `CreateOrUpdateNodeRequest` outstanding at teardown | `compile=FAILED` → *"a public API change here broke plugin node source"*, on a PR whose entire diff was one markdown line, a test-data ledger and one test-list row |
| **#2463** `RolePlay/Scenery` | the same run had already logged `ok RolePlay/Scenery` and baked 4 assemblies **with no mesh involved**; then `MergeGuard` refused the adoption stamp and `CompileWatcher` logged *"the write did not converge"* | `compile=FAILED` → main red, a production rollout held ~11 h on a compile that never failed |

## The fix: three outcomes, three owners

`CheckOutcome` gains two members, modelled on `MeshWeaver.Hosting.PreWarmStatus` — which already keeps `CompileError` apart from `TimedOut` / `NoSources` / `UpstreamUnevaluated` precisely so *"I don't know" propagates as "I don't know"* rather than becoming a verdict.

| outcome | means | the reader should |
|---|---|---|
| `Failed` | the compiler answered *no* | fix the source |
| `Inconclusive` | nothing answered | investigate the mesh, not the source |
| `Unrecorded` | the work **succeeded**, the mesh did not **record** it | fix the writer; the content is fine |

**The discriminator is evidence, not a guess.** On a run that CONSUMES a bake (`--seed`), a bundle carrying an assembly for this exact NodeType is *proof* the compile succeeded — the compiler stage emitted those bytes with no mesh at all (`mw-compiler compile … (no mesh)`). That is #2463's own suggested direction #1, taken as far as it can honestly go. Matched with the seeder's own `OrdinalIgnoreCase` comparer, so a case difference the seeder would have adopted under cannot become "no evidence".

## 🚨 All three still FAIL the run — deliberately

A gate that cannot judge must not look like a gate that passed (the node-repo CI policy's invariants #3/#4), and neither non-verdict is evidence the content is good: the type never settled, so its render and `Tests` checks never ran, and green would assert checks that did not happen.

**What changes is which cause is named.** The one line CI lifts verbatim:

```
before:  GATE FAILED — compile: RolePlay/Scenery
after:   GATE FAILED — compile-status-unrecorded: RolePlay/Scenery (the work SUCCEEDED
         and the mesh did not record it — infrastructure, not the content; fix the writer)

before:  GATE FAILED — compile: RolePlay/Story
after:   GATE FAILED — compile-no-verdict: RolePlay/Story (no result was observed — a
         timeout or a wedge in the mesh, NOT a compiler diagnostic; investigate the mesh,
         not the source)
```

A real compile error is byte-identical to before, and **leads** when both kinds are present.

Making `Unrecorded` *pass* would be a separate, deliberate policy change — it needs the render and `Tests` halves to run against the adopted bytes first. Called out in the doc comment rather than smuggled in here.

## The `== Failed` sweep

Every reader of an outcome now goes through `CheckOutcomes.Fails()`. This is not tidiness: an equality test against one member silently admits every member added after it, and there were four such sites.

- `GateVerdict.Failures` — an `== Failed` there **dropped both new members from the failure enumeration**, so the run would exit non-zero (`NodeTypeResult.Success` is false) while `Headline` reported *"no failing check was recorded"* and the ratchet called every listed entry stale. A gate whose two halves disagree about what failed is worse than one that names a wrong cause.
- `GateReport.Map` is now **exhaustive**: the old `_ => Skipped` catch-all would have told the combo verifier *"the check does not apply"* about a check that failed — the same collapse, one process boundary further out.
- `InstanceComboVerifier.FailuresOf` names the kind in its failure lines.

`GateRunOutcome` gains the two members by **appending**, so a report written by an older tester still deserializes correctly.

The known-debt ratchet still keys on the **bare check name**, so an existing `Scope compile` entry keeps tolerating its scope's compile however it failed to pass, and is not reported stale.

## Tests — 12, all failing against the previous behaviour

`test/MeshWeaver.PluginTester.Test/GateNamesTheRealCauseTest.cs`. Every assertion is two-sided (the line must name the cause that applies AND must not name one that does not), in the tradition of `GateSummaryTest`.

Run against the previous behaviour (the fix reverted in `NoTerminalCompileStatus`, `CheckOutcomes.Fails/Label/Guidance` and `Map`, with the enum members kept so the tests compile):

```
Failed  TheNonVerdictsSurviveTheWireRoundTrip(local: Unrecorded, wire: Unrecorded)
        Expected value to be Unrecorded, but found Skipped.
Failed  TheNonVerdictsSurviveTheWireRoundTrip(local: Inconclusive, wire: Inconclusive)
        Expected value to be Inconclusive, but found Skipped.
Failed  ANonVerdictFailsTheRun_AndIsEnumeratedAsAFailure(outcome: Unrecorded)
        Expected value to be false because a check that produced no verdict has not passed, but found True.
Failed  ANonVerdictFailsTheRun_AndIsEnumeratedAsAFailure(outcome: Inconclusive)
        Expected value to be false because a check that produced no verdict has not passed, but found True.
Failed  TheHeadline_ForATimeout_SaysNoVerdict_AndPointsAtTheMesh
Failed  TheBakeEvidenceIsMatchedWithTheSeedersOwnComparer
        Expected value to be Unrecorded, but found Failed.
Failed  ARealCompileError_StillReadsExactlyAsBefore_AndLeads
        Expected "GATE FAILED — compile: RolePlay/Story" to contain "compile-no-verdict: RolePlay/Scenery".
Failed  TheHeadline_ForALostStatusWrite_DoesNotSayTheCompileFailed
Failed  WithNoBakeEvidence_ItIsNoVerdict_NeverACompileFailure
        Expected value to be Inconclusive, but found Failed.
Failed  BakeCarriesTheAssembly_TheStatusWriteIsWhatWasLost_NotTheCompile
        Expected value to be Unrecorded because the bake proves the compile succeeded —
        what did not happen is the status write, but found Failed.
Failed  ABakeThatDoesNotCoverThisType_IsNotEvidenceAboutIt
        Expected value to be Inconclusive, but found Failed.
Failed  TheRatchetStillKeysOnTheCheckName
        Expected collection to contain a single item, but found 0.

Failed!  - Failed: 12, Passed: 0, Skipped: 0, Total: 12
```

With the fix in place: `MeshWeaver.PluginTester.Test` **108/108 green**, `MeshWeaver.PluginCatalog.Test` `InstanceComboVerifier*` **11/11 green**, `scripts/check-record-signatures.py --base origin/main` and `scripts/check-type-forwards.py --base origin/main` clean.

## What this does NOT fix

The underlying races. #2454's hub-disposal race and #2463's `MergeGuard`-refused adoption stamp are still there, and both issues stay open for them — this PR makes them **legible** rather than misattributed. #2471 (a portal serving stale bytes while reporting `Ok`) is a different shape and gets its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
