### PR TITLE
perf(menu): read the menu catalog with the storm-safe existence query, not a point probe

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/MenuPresentationOverlay.cs
+++ b/src/MeshWeaver.Graph/Configuration/MenuPresentationOverlay.cs
@@ -22,6 +22,11 @@ namespace MeshWeaver.Graph.Configuration;
 /// </summary>
 internal static class MenuPresentationOverlay
 {
+    /// <summary>
+    /// The projection a catalog read needs. <c>content</c> is named deliberately: a <c>select:</c>
+    /// that omits it yields a node whose <c>Content</c> is silently null, which would read as
+    /// "no catalog" for a catalog that exists.
+    /// </summary>
     internal const string CatalogProjection = "select:path,id,namespace,name,nodeType,content";
 
     /// <summary>
@@ -63,11 +68,6 @@ internal static class MenuPresentationOverlay
     /// renders its compiled presentation until someone chooses to override it. Seeding a copy of the
     /// compiled presentation would instead freeze it, and silently outrank every later change to it.
     /// </para>
-    /// </summary>
-    /// <summary>
-    /// The projection a catalog read needs. <c>content</c> is named deliberately: a <c>select:</c>
-    /// that omits it yields a node whose <c>Content</c> is silently null, which would read as
-    /// "no catalog" for a catalog that exists.
     /// </summary>
     public static IObservable<MenuPresentation?> CatalogStream(
         IWorkspace workspace, JsonSerializerOptions options, string context, ILogger? logger)

--- a/src/MeshWeaver.Graph/Configuration/MenuPresentationOverlay.cs
+++ b/src/MeshWeaver.Graph/Configuration/MenuPresentationOverlay.cs
@@ -22,6 +22,34 @@ namespace MeshWeaver.Graph.Configuration;
 /// </summary>
 internal static class MenuPresentationOverlay
 {
+    internal const string CatalogProjection = "select:path,id,namespace,name,nodeType,content";
+
+    /// <summary>
+    /// The synced-query id for <paramref name="context"/>'s catalog — <c>{type}|{path}</c>, the same
+    /// convention <c>UpdatePolicyNodeType</c> and <c>NotificationSettingsNodeType</c> register under,
+    /// so a future seeding path can share this registration instead of opening a second synced query
+    /// for the same node. Stable per context and never composed per call, so the process-wide query
+    /// cache holds ONE upstream per menu context for the life of the process — see
+    /// <see cref="CatalogQuery"/> for why that matters here.
+    /// </summary>
+    internal static string CatalogQueryId(string context)
+        => $"{nameof(MenuPresentation)}|{MenuPresentation.PathFor(context)}";
+
+    /// <summary>
+    /// The catalog read for <paramref name="context"/>: an EXACT, partition-anchored read of the one
+    /// node at <see cref="MenuPresentation.PathFor"/>.
+    ///
+    /// <para>Anchored by construction — <c>path:Admin/Menu/{context}</c> carries a concrete first
+    /// segment, so every backend routes it to the <c>admin</c> partition alone rather than fanning
+    /// out. (A <c>namespace:Admin</c>-shaped read could not: <c>admin</c> is deliberately excluded
+    /// from cross-schema search, so a path is the only way in.) It is deliberately NOT filtered by
+    /// <c>nodeType:</c> — <c>MenuPresentation</c> is a registered CONTENT type, not a NodeType, so
+    /// the node's own <c>nodeType</c> is whatever its author chose; the path is already unique and
+    /// <c>ContentAs&lt;MenuPresentation&gt;</c> is what decides whether it is a catalog.</para>
+    /// </summary>
+    internal static string CatalogQuery(string context)
+        => $"path:{MenuPresentation.PathFor(context)} {CatalogProjection}";
+
     /// <summary>
     /// The catalog for <paramref name="context"/> as a live stream, or a stream of <c>null</c> when
     /// there is none. Fail-safe in every direction: a missing node, an unreadable partition, a
@@ -36,17 +64,55 @@ internal static class MenuPresentationOverlay
     /// compiled presentation would instead freeze it, and silently outrank every later change to it.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// The projection a catalog read needs. <c>content</c> is named deliberately: a <c>select:</c>
+    /// that omits it yields a node whose <c>Content</c> is silently null, which would read as
+    /// "no catalog" for a catalog that exists.
+    /// </summary>
     public static IObservable<MenuPresentation?> CatalogStream(
         IWorkspace workspace, JsonSerializerOptions options, string context, ILogger? logger)
     {
         var path = MenuPresentation.PathFor(context);
         try
         {
-            return workspace.GetMeshNodeStream(path)
+            // 🚨 A synced QUERY (empty-on-absent), never a GetMeshNodeStream point-read — and the
+            // reason is the sentence three paragraphs up: there is deliberately no seeded catalog,
+            // so ABSENT IS THE NORMAL STATE for every context on almost every mesh. A point-read of
+            // a node that does not exist is not free and not quiet: it resolves through the router,
+            // finds nothing, and answers NotFound — one `[ROUTE] NotFound: No node found at
+            // 'Admin/Menu/{context}'` warning plus a DeliveryFailure NACK per probe, damped only by
+            // the stream cache's negative-cache window, which expires and re-probes forever.
+            //
+            // And the probe rate is not once per circuit. RenderMenus is a GLOBAL predicate
+            // renderer (`WithRenderer(_ => true, …)`), so it runs on EVERY area render, and it
+            // installs this stream with ReplaceDisposable — dispose the old subscription, open a
+            // new one — once per menu CONTEXT per render. Contexts are data-driven
+            // (UiContributionCatalog), so installing a plugin that declares a TopBar menu adds one
+            // more permanently-missing routed lookup to every area render on the mesh. Issue #2640
+            // names these misses directly.
+            //
+            // This is not a new rule, it is an existing one applied where it was missed.
+            // PlatformUpdateStatus.Observe states it outright: "Absence is detected with the
+            // storm-safe existence GetQuery (empty-on-absent) — NEVER a point GetMeshNodeStream
+            // probe of a maybe-absent path, which NotFound-resubscribe-storms". That surface reads
+            // its maybe-absent node at most a few times a day; this one read its maybe-absent node
+            // once per context per area render.
+            //
+            // A query answers "no rows" for an absent node — no NotFound, no NACK, no negative
+            // cache — and `GetQuery` caches its upstream process-wide under a stable id with
+            // Replay(1)+AutoConnect(1), so the per-render re-subscribe lands on a warm replay
+            // instead of re-probing. Liveness is unchanged, which is the point: it is still a
+            // synced query fed by the change feed, so an admin creating Admin/Menu/Node updates
+            // every open menu with no recycle — the "seconds, no build, no rollout" contract in
+            // Doc/Architecture/MenuAsData. Same substitution, and the same rationale, as
+            // NotificationService.ReadSettings and NotificationSettingsNodeType.EnsureExists.
+            return workspace.GetQuery(CatalogQueryId(context), CatalogQuery(context))
                 // ContentAs is the bad-data-tolerant read: a stale/unknown $type degrades to a raw
                 // JsonElement and is recovered here, and an unrecoverable one logs LOUD and returns
                 // null — so a corrupt catalog names itself in the log and the menu keeps rendering.
-                .Select(node => node.ContentAs<MenuPresentation>(options, logger))
+                .Select(nodes => nodes
+                    .Select(node => node.ContentAs<MenuPresentation>(options, logger))
+                    .FirstOrDefault(catalog => catalog is not null))
                 .Catch<MenuPresentation?, Exception>(ex =>
                 {
                     logger?.LogDebug(ex,
@@ -58,8 +124,9 @@ internal static class MenuPresentationOverlay
         }
         catch (Exception ex)
         {
-            // GetMeshNodeStream throws synchronously on hubs with no MeshDataSource (scratch hubs,
-            // startup, mid-dispose) — same guard the default provider uses.
+            // GetQuery resolves IMeshNodeStreamCache eagerly and throws synchronously on hubs that
+            // have none (scratch hubs, startup, mid-dispose) — the same guard the point-read needed
+            // for the same class of caller, and the same one the default provider uses.
             logger?.LogDebug(ex, "Menu catalog unavailable for context '{Context}'", context);
             return Observable.Return<MenuPresentation?>(null);
         }

--- a/test/MeshWeaver.Graph.Test/MenuPresentationOverlayTest.cs
+++ b/test/MeshWeaver.Graph.Test/MenuPresentationOverlayTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
+using System.IO;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -218,5 +219,131 @@ public class MenuPresentationOverlayTest
         Assert.Equal("Admin/Menu/Mesh", MenuPresentation.PathFor("Mesh"));
         // The unnamed root $Menu slot must not silently share the Node dropdown's catalog.
         Assert.Equal("Admin/Menu/Default", MenuPresentation.PathFor(""));
+    }
+
+    // ── The catalog READ: storm-safe and anchored (#2640) ────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The catalog read must be a <c>path:</c> QUERY, not a point read.
+    ///
+    /// <para>There is deliberately no seeded catalog, so ABSENT is the normal state for every
+    /// context on almost every mesh — and <c>RenderMenus</c> is a global predicate renderer
+    /// (<c>WithRenderer(_ =&gt; true, …)</c>) that reinstalls this stream once per context on EVERY
+    /// area render. A point <c>GetMeshNodeStream</c> probe of a maybe-absent path answers NotFound:
+    /// one <c>[ROUTE] NotFound</c> warning plus a DeliveryFailure NACK per probe, damped only by a
+    /// negative-cache window that expires and re-probes forever. <c>PlatformUpdateStatus.Observe</c>
+    /// states the rule outright — "storm-safe existence GetQuery (empty-on-absent) — NEVER a point
+    /// GetMeshNodeStream probe of a maybe-absent path".</para>
+    ///
+    /// <para>This asserts the QUERY STRING because that is the part a caller can get wrong silently:
+    /// the shape decides both the storm behaviour and the partition routing.</para>
+    /// </summary>
+    [Fact]
+    public void CatalogQuery_IsAnExactPathRead_SoAnAbsentCatalogIsNoRowsRatherThanNotFound()
+    {
+        var query = MenuPresentationOverlay.CatalogQuery("Node");
+
+        Assert.StartsWith("path:Admin/Menu/Node", query);
+        // Default scope for a `path:` query is Exact — no scope token means the one node, which is
+        // what an existence check wants. An explicit widening here would read siblings too.
+        Assert.DoesNotContain("scope:", query);
+    }
+
+    /// <summary>
+    /// The read must stay ANCHORED to the Admin partition. It is anchored by its first path segment,
+    /// which is the ONLY way in: <c>admin</c> is deliberately excluded from cross-schema search, so a
+    /// <c>namespace:</c>-shaped read would fan out over every partition AND still miss the catalog.
+    /// </summary>
+    [Fact]
+    public void CatalogQuery_IsAnchoredToTheAdminPartition_ByPathNotNamespace()
+    {
+        foreach (var context in new[] { "Node", "Mesh", "AI", "" })
+        {
+            var query = MenuPresentationOverlay.CatalogQuery(context);
+            var firstSegment = query["path:".Length..].Split(' ')[0].Split('/')[0];
+            Assert.Equal(MenuPresentation.CatalogPartition, firstSegment);
+            Assert.DoesNotContain("namespace:", query);
+        }
+    }
+
+    /// <summary>
+    /// The projection must NAME <c>content</c>. A <c>select:</c> that omits it yields a node whose
+    /// <c>Content</c> is silently null, so a catalog that exists would read as "no catalog" and the
+    /// overlay would quietly stop applying — the failure this whole class exists to make visible.
+    /// </summary>
+    [Fact]
+    public void CatalogQuery_ProjectsContent_OrAnExistingCatalogReadsAsAbsent()
+    {
+        Assert.Contains("select:", MenuPresentationOverlay.CatalogQuery("Node"));
+        Assert.Contains("content", MenuPresentationOverlay.CatalogProjection);
+    }
+
+    /// <summary>
+    /// The synced-query id is STABLE per context and distinct across contexts. Both halves matter:
+    /// an id composed per call would open a new upstream on every area render (defeating the cache
+    /// that makes the per-render re-subscribe cheap), and a shared id would serve the Node
+    /// dropdown's catalog to the Mesh dropdown.
+    /// </summary>
+    [Fact]
+    public void CatalogQueryId_IsStablePerContext_AndDistinctAcrossContexts()
+    {
+        Assert.Equal(MenuPresentationOverlay.CatalogQueryId("Node"), MenuPresentationOverlay.CatalogQueryId("Node"));
+        Assert.NotEqual(MenuPresentationOverlay.CatalogQueryId("Node"), MenuPresentationOverlay.CatalogQueryId("Mesh"));
+        // The unnamed context resolves through PathFor, so it cannot collide with "Node" either.
+        Assert.NotEqual(MenuPresentationOverlay.CatalogQueryId(""), MenuPresentationOverlay.CatalogQueryId("Node"));
+    }
+
+    /// <summary>
+    /// 🚨 The guard that pins the PRIMITIVE, because the string tests above cannot see it: a
+    /// point read and a query produce the same catalog when the node exists, and differ only when
+    /// it does NOT — which here is the normal state.
+    ///
+    /// <para>The rule is already written down, in <c>PlatformUpdateStatus.Observe</c>: "Absence is
+    /// detected with the storm-safe existence <c>GetQuery</c> (empty-on-absent) — NEVER a point
+    /// <c>GetMeshNodeStream</c> probe of a maybe-absent path, which NotFound-resubscribe-storms."
+    /// This overlay broke it on a far hotter path than the one that rule was written for:
+    /// <c>RenderMenus</c> is a global predicate renderer, so it reinstalled the probe once per menu
+    /// context on EVERY area render, and each probe of the deliberately-absent catalog cost a
+    /// <c>[ROUTE] NotFound</c> warning and a DeliveryFailure NACK.</para>
+    ///
+    /// <para>A source guard rather than a behavioural assertion is deliberate: reproducing the
+    /// difference needs a live hub, a routing grain and an absent node, and a test that heavy would
+    /// be the first one silenced. This one fails the moment the primitive is swapped back, which is
+    /// the only regression that matters. If the file is restructured, re-point it — do not delete
+    /// it because it went red.</para>
+    /// </summary>
+    [Fact]
+    public void CatalogStream_UsesTheStormSafeExistenceQuery_NeverAPointReadOfAMaybeAbsentPath()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            FindRepoRoot(), "src", "MeshWeaver.Graph", "Configuration", "MenuPresentationOverlay.cs"));
+
+        // The body must reach the catalog through the synced query surface…
+        Assert.Contains("GetQuery(CatalogQueryId(context), CatalogQuery(context))", source);
+
+        // …and must not point-probe it. Mentions inside comments are how the rule explains itself,
+        // so only CODE lines are considered.
+        var pointReads = source
+            .Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => !line.StartsWith("//") && !line.StartsWith("///") && !line.StartsWith("*"))
+            .Where(line => line.Contains("GetMeshNodeStream"))
+            .ToList();
+
+        Assert.True(pointReads.Count == 0,
+            "MenuPresentationOverlay must not point-read Admin/Menu/{context}: the catalog is absent "
+            + "by design and RenderMenus reinstalls this stream on every area render, so a point read "
+            + "is a permanent NotFound-resubscribe storm (#2640). Found: "
+            + string.Join(" | ", pointReads));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+            ?? throw new InvalidOperationException(
+                "Could not locate the repo root (MeshWeaver.slnx) from " + AppContext.BaseDirectory);
     }
 }


### PR DESCRIPTION
Addresses the `Admin/Menu/{X}` half of #2640 — deliberately NOT a closing reference; the rest of that issue's enumeration is unaffected by this change.

## The defect

`MenuPresentationOverlay.CatalogStream` point-read `Admin/Menu/{context}` with `GetMeshNodeStream`. That node is absent **by design**, as the same file says four lines above the call:

> There is deliberately NO seeded catalog. "No entry for this area" is the normal resting state, not drift to be repaired.

A point read of a node that does not exist is neither free nor quiet. It resolves through `PathResolutionService` → `RoutingGrain.BuildGrainRoute`, finds nothing, and answers NotFound — one `[ROUTE] NotFound: No node found at 'Admin/Menu/{context}'` warning plus a DeliveryFailure NACK per probe. `PathResolutionService` deliberately caches **no** negative resolution (`if (resolution is null) return;`), so the only damping is `MeshNodeStreamCache`'s storm breaker, whose window expires (2s → 4s → … → 5min) and re-probes for the life of the process.

**And it is not once per circuit.** `RenderMenus` is a global predicate renderer:

```csharp
.AddLayout(layout => layout.WithRenderer(_ => true, RenderMenus));
```

Its own comment says so — *"RenderMenus is a GLOBAL predicate renderer (`WithRenderer(_ => true, …)`), so it runs on EVERY area render"* — and it installs this stream with `ReplaceDisposable`, i.e. dispose the old subscription and open a new one, **once per menu CONTEXT per area render**. Contexts are data-driven (`UiContributionCatalog.Current`, read at render time), so installing a plugin that declares a TopBar menu adds one more permanently-missing routed lookup to every area render on the mesh. #2640 counts these misses directly.

## The rule this broke is already written down

`PlatformUpdateStatus.Observe`, in this repo:

> Absence is detected with the storm-safe existence `GetQuery` (empty-on-absent) — **NEVER a point `GetMeshNodeStream` probe of a maybe-absent path**, which NotFound-resubscribe-storms on an install that never wired self-update.

`NotificationService.ReadSettings` states the same thing for the same shape, and names the same precedents (`NotificationSettingsNodeType.EnsureExists`, the AiSettings/UpdatePolicy nodes). So this is an **existing rule applied where it was missed**, not a new one — and it was missed on a far hotter path than the one the rule was written for: About-page-a-few-times-a-day versus once-per-context-per-area-render.

## The change

`CatalogStream` reads through the synced query surface instead:

```csharp
workspace.GetQuery(CatalogQueryId(context), CatalogQuery(context))
```

with `CatalogQuery(context)` = `path:Admin/Menu/{context} select:path,id,namespace,name,nodeType,content` and `CatalogQueryId(context)` = `MenuPresentation|Admin/Menu/{context}` — the `{type}|{path}` convention `UpdatePolicyNodeType` and `NotificationSettingsNodeType` already register under, so a future seeding path shares this registration rather than opening a second synced query for the same node.

Four properties, each load-bearing:

- **Empty-on-absent.** A query answers "no rows"; no NotFound, no NACK, no negative-cache window to expire.
- **Still anchored, and anchored the only way that works.** `path:Admin/…` routes by first segment to the `admin` schema. A `namespace:`-shaped read could not substitute: `admin` is deliberately excluded from cross-schema search, so that form would fan out over every partition **and still miss the catalog**.
- **One upstream per context, for the process.** `GetQuery` caches under the stable id with `Replay(1).AutoConnect(1)`, so the per-render re-subscribe lands on a warm replay. This is the "resolve the menu keys once, not per render" in @rbuergi's design comment on #2640, at silo scope rather than circuit scope.
- **Liveness unchanged**, which is the point. It is still a synced query fed by the change feed, so an admin creating `Admin/Menu/Node` updates every open menu with no recycle — the "Seconds, no build, no image, no rollout" contract in `Doc/Architecture/MenuAsData`.

Deliberately **not** filtered by `nodeType:` — `MenuPresentation` is a registered CONTENT type (`.WithTypes(…)`), not a NodeType, so the node's own `nodeType` is whatever its author chose. The path is already unique and `ContentAs<MenuPresentation>` is what decides whether it is a catalog. Adding a `nodeType:` filter would silently drop a legitimately-authored catalog.

Access is unchanged in both directions: the point read was gated by `MeshNodeStreamCache.ProbeEffectivePermissions`, and `GetQuery` reads upstream as System with `WrapWithPerUserRls` re-applying `CheckPermission(path, Read)` per subscriber. A viewer without Read on `Admin/Menu/{X}` sees no overlay either way.

## Tests

Five new cases in `MenuPresentationOverlayTest` (19 in the class, all green):

- `CatalogQuery_IsAnExactPathRead_SoAnAbsentCatalogIsNoRowsRatherThanNotFound`
- `CatalogQuery_IsAnchoredToTheAdminPartition_ByPathNotNamespace`
- `CatalogQuery_ProjectsContent_OrAnExistingCatalogReadsAsAbsent`
- `CatalogQueryId_IsStablePerContext_AndDistinctAcrossContexts`
- `CatalogStream_UsesTheStormSafeExistenceQuery_NeverAPointReadOfAMaybeAbsentPath`

The last one is a **source guard**, and the choice is deliberate: the string tests cannot see the thing that actually changed, because a point read and a query produce the same catalog when the node exists and differ only when it does **not** — which here is the normal state. Reproducing that behaviourally needs a live hub, a routing grain and an absent node, and a test that heavy is the first one silenced. The guard fails the moment the primitive is swapped back, which is the only regression that matters; it ignores comment lines, so the rule can keep explaining itself in prose.

**Mutation-verified**: restoring `workspace.GetMeshNodeStream(path)` in the body fails exactly that guard (1 of 19) and nothing else — which is also the honest reading of the other four, since they pin the query shape rather than the primitive.

Full `MeshWeaver.Graph.Test` green: **1717 passed, 0 failed**.

## What this does not claim

I cannot measure the saving. What is measured is the mechanism — a global predicate renderer, `ReplaceDisposable` per context per area render, a path that resolves to nothing, and a resolver that caches no negative — and that the repo already forbids this exact combination by name. The DB cost of one probe was modest (a pinned single-schema read against `admin`); the removed cost is mostly the routed round trip, the warning volume and the NACKs, so **do not expect this alone to move Postgres CPU**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
