### PR TITLE
Fix #2631: let an upsert move a node's MainNode, without demoting satellites

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/SatelliteNodePatterns.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/SatelliteNodePatterns.md
@@ -139,6 +139,26 @@ workspace.GetMeshNodeStream(path)
 
 > **Never serialize manually.** Let the framework's polymorphic converter emit the `$type` discriminators; hand-rolled `JsonSerializer.SerializeToElement(...)` of a node's content produces a payload the deserializer can reject.
 
+### Moving a node's `MainNode`
+
+`MainNode` is what makes a node a satellite at all, so re-pointing it is re-parenting, not an ordinary field edit. It is writable through both mutation paths, with one asymmetry worth knowing:
+
+```csharp
+// Re-parent to another node — works through either path.
+workspace.GetMeshNodeStream(path).Update(n => n with { MainNode = newOwnerPath });
+hub.CreateOrUpdateNode(node with { MainNode = newOwnerPath });   // since #2631
+```
+
+🚨 **A full-instance upsert can move `MainNode` anywhere EXCEPT back onto the node's own path.** `MeshNode.MainNode` is not nullable — it is initialised to the node's own path — so "the writer never touched it" and "the writer set it to this node itself" are the *same value on the wire*. The upsert therefore applies it only when `MeshNode.HasExplicitMainNode` holds, i.e. when it names something other than the node itself; any other rule would silently promote every satellite an upsert touched into a main node (`is:main` is SQL `n.main_node = n.path`), dropping it out of its owner's listings and re-scoping its grants, which project at `COALESCE(main_node, namespace)`.
+
+To turn a satellite back INTO a main node, say so explicitly through the stream — that path carries the intent, and so does `patch`, which can see the key was present:
+
+```csharp
+workspace.GetMeshNodeStream(path).Update(n => n with { MainNode = n.Path });
+```
+
+Before #2631 an upsert could not move `MainNode` at all: `IsNoOpUpsert` did not compare it, so a write whose only change was `MainNode` was skipped and reported as a successful no-op.
+
 ---
 
 ## Thread + ThreadMessage Pattern

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -4220,8 +4220,11 @@ public static class MeshExtensions
     /// True when applying <paramref name="sourceNode"/> onto <paramref name="existing"/> via
     /// <see cref="UpdateAccordingToSourceNode"/> would change nothing but the churn stamps
     /// (LastModified/Version) — the write can then be skipped entirely. MUST mirror that merge
-    /// field-for-field (same null-keeps-state convention); a field added there without a compare
-    /// here would silently stop landing on unchanged-otherwise nodes. Content compares
+    /// field-for-field (same null-keeps-state convention, except <see cref="MeshNode.MainNode"/>,
+    /// whose "was it set?" test is <see cref="MeshNode.HasExplicitMainNode"/> because it is
+    /// non-nullable);
+    /// a field added there without a compare here would silently stop landing on
+    /// unchanged-otherwise nodes — which is precisely what #2631 was. Content compares
     /// structurally through the hub's serializer (bridging typed content against the persisted
     /// <see cref="JsonElement"/> representation); any doubt — a serialization failure, a mixed
     /// shape — reports "changed", which merely takes today's write path. Conservative by
@@ -4243,7 +4246,15 @@ public static class MeshExtensions
             || (sourceNode.Description ?? existing.Description) != existing.Description
             || (sourceNode.Order ?? existing.Order) != existing.Order
             || (sourceNode.State == default ? existing.State : sourceNode.State) != existing.State
-            || (sourceNode.PreRenderedHtml ?? existing.PreRenderedHtml) != existing.PreRenderedHtml)
+            || (sourceNode.PreRenderedHtml ?? existing.PreRenderedHtml) != existing.PreRenderedHtml
+            // 🚨 MainNode's "was it set?" test is MeshNode.HasExplicitMainNode, NOT a null check
+            // — the field is non-nullable and defaults to the node's own path, so read that
+            // property's remarks before touching this line. Missing entirely until #2631: an
+            // upsert whose only change was MainNode was reported as a successful no-op and moved
+            // nothing (MeshWeaver.Plugins #839's RefreshAppTiles sweep: "1390 of 1443 record(s)
+            // refreshed" with not one mainNode changed).
+            || (sourceNode.HasExplicitMainNode ? sourceNode.MainNode : existing.MainNode)
+                != existing.MainNode)
             return false;
         var excludeApplied = sourceNode.ExcludeFromContext ?? existing.ExcludeFromContext;
         if (!ReferenceEquals(excludeApplied, existing.ExcludeFromContext)
@@ -4272,7 +4283,9 @@ public static class MeshExtensions
     /// upsert. Copies every writable field from <paramref name="sourceNode"/>
     /// onto <paramref name="state"/>; preserves <paramref name="state"/>'s
     /// identity (Id, Path, CreatedDate, CreatedBy, Version) and stamps a
-    /// fresh LastModified. Falls back to <paramref name="sourceNode"/> when
+    /// fresh LastModified. <see cref="MeshNode.MainNode"/> is writable too, but
+    /// only when the source names one other than its own path — see
+    /// <see cref="MeshNode.HasExplicitMainNode"/>. Falls back to <paramref name="sourceNode"/> when
     /// <paramref name="state"/> is null (defensive — the create path
     /// dispatches CreateNodeRequest before reaching this lambda, so state
     /// should always be non-null here).
@@ -4299,6 +4312,14 @@ public static class MeshExtensions
             Content = sourceNode.Content ?? state.Content,
             State = sourceNode.State == default ? state.State : sourceNode.State,
             PreRenderedHtml = sourceNode.PreRenderedHtml ?? state.PreRenderedHtml,
+            // 🚨 NOT the null-keeps-state idiom: MainNode is non-nullable and defaults to the
+            // node's OWN path, so an untouched source is indistinguishable from one deliberately
+            // set to self, and copying it blindly would demote every satellite an upsert touches
+            // to a main node. MeshNode.HasExplicitMainNode carries the rule and its one
+            // limitation. (NormalizeSatelliteMainNode and the AccessAssignment scope guard both
+            // run on the incoming node BEFORE this merge, so what arrives here is already
+            // normalised and validated — until #2631 that validated value was then thrown away.)
+            MainNode = sourceNode.HasExplicitMainNode ? sourceNode.MainNode : state.MainNode,
             LastModified = DateTimeOffset.UtcNow,
         };
     }

--- a/src/MeshWeaver.Mesh.Contract/MeshNode.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNode.cs
@@ -96,6 +96,59 @@ public record MeshNode([property: Key] string Id, [property: Editable(false)] st
     public string MainNode { get; init; } = string.IsNullOrEmpty(Namespace) ? Id : $"{Namespace}/{Id}";
 
     /// <summary>
+    /// This node names a <see cref="MainNode"/> the writer chose DELIBERATELY — i.e. one that is
+    /// not simply the node's own <see cref="Path"/>. THE definition of "the caller meant this", so
+    /// every merge that has to decide whether to move a stored MainNode asks it here rather than
+    /// re-deriving a subtly different rule.
+    ///
+    /// <para>🚨 <b>Why the question needs asking at all.</b> <see cref="MainNode"/> is NOT nullable:
+    /// it is initialised to this node's own path, so on the wire "the writer never touched it" and
+    /// "the writer set it to this node itself" are the SAME value. A full-instance upsert therefore
+    /// cannot use the null-keeps-state idiom every other field uses — a plain
+    /// <c>source.MainNode ?? stored.MainNode</c> would copy a self-pointing default over every
+    /// stored value, and <c>MainNode == Path</c> is exactly what makes a node a MAIN node
+    /// (<c>is:main</c> is SQL <c>n.main_node = n.path</c>; <see cref="Satellite"/> points it at the
+    /// primary). Every satellite an upsert touched would be silently promoted to a main node,
+    /// dropping it out of its owner's listings and re-scoping its grants, which project at
+    /// <c>COALESCE(main_node, namespace)</c>. That is why the field was simply LEFT OUT of the
+    /// upsert merge — a fix whose cure was worse than the disease (#2631).</para>
+    ///
+    /// <para><b>The residual limitation, stated plainly:</b> a full-instance write can move a
+    /// MainNode anywhere EXCEPT back onto the node's own path — it cannot turn a satellite back
+    /// INTO a main node, because that intent is indistinguishable from the untouched default.
+    /// Nothing needs it today: every writer that assigns a self-path (<c>PackageInstaller</c>'s
+    /// partition rebase, <c>GitHubSyncService</c>'s import rebase) is restating the default for a
+    /// node that already holds it. A caller that genuinely means it uses
+    /// <c>GetMeshNodeStream(path).Update(n =&gt; n with { MainNode = n.Path })</c> — which is also
+    /// what the <c>patch</c> verb does, since it can see the key was PRESENT
+    /// (<c>jsonObj.ContainsKey("mainNode")</c>), a signal a full instance does not carry.</para>
+    ///
+    /// <para>Allocation-free: <see cref="Path"/> is a computed interpolation, so it is compared
+    /// segment-wise rather than materialised — this runs on every upsert in the mesh.</para>
+    /// </summary>
+    [JsonIgnore, NotMapped]
+    public bool HasExplicitMainNode
+    {
+        get
+        {
+            var mainNode = MainNode;
+            // Defensive: MainNode is declared non-nullable, but a deserialized `"mainNode": null`
+            // arrives as null. Unset → keep the stored value, exactly like the other fields.
+            if (mainNode is null)
+                return false;
+            var ns = Namespace;
+            if (string.IsNullOrEmpty(ns))
+                return !string.Equals(mainNode, Id, StringComparison.Ordinal);
+            // "{ns}/{Id}" without building it. The length test runs FIRST, so the indexer below is
+            // in range by construction.
+            return mainNode.Length != ns.Length + 1 + Id.Length
+                   || mainNode[ns.Length] != '/'
+                   || !mainNode.AsSpan(0, ns.Length).SequenceEqual(ns.AsSpan())
+                   || !mainNode.AsSpan(ns.Length + 1).SequenceEqual(Id.AsSpan());
+        }
+    }
+
+    /// <summary>
     /// A SATELLITE of the node at <paramref name="mainNode"/>: created with <see cref="MainNode"/>
     /// already pointing at its primary, which is what the doc on <see cref="MainNode"/> promises and
     /// what every listing relies on to keep satellites out of a node's contents (the catalog's

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -2066,6 +2066,7 @@ public static class PackageInstaller
 
     // The node's scalar fields, applying the incoming's non-null values over the current (mirrors
     // UpdateAccordingToSourceNode) — unchanged? The churn fields (LastModified/Version) are ignored.
+    // MainNode is the one field that is NOT null-keeps-state; see the comment on its line.
     private static bool ScalarsUnchanged(MeshNode current, MeshNode incoming) =>
         (incoming.Name ?? current.Name) == current.Name
         && (incoming.NodeType ?? current.NodeType) == current.NodeType
@@ -2073,7 +2074,15 @@ public static class PackageInstaller
         && (incoming.Category ?? current.Category) == current.Category
         && (incoming.State == default ? current.State : incoming.State) == current.State
         && (incoming.PreRenderedHtml ?? current.PreRenderedHtml) == current.PreRenderedHtml
-        && (incoming.Order ?? current.Order) == current.Order;
+        && (incoming.Order ?? current.Order) == current.Order
+        // 🚨 MainNode's "was it set?" test is MeshNode.HasExplicitMainNode, NOT a null check — the
+        // field is non-nullable and defaults to the node's own path, so a plain `?? current` would
+        // read every untouched source as "re-parent to self" and demote every satellite. Missing
+        // here as well as in the merge until #2631, which is why an install could never move one:
+        // this gate skipped the write before the upsert was even asked (a package's _Access grant
+        // carries an AUTHORED mainNode, preserved by ParseNodeRepoFile, and re-scoping it landed
+        // nowhere).
+        && (incoming.HasExplicitMainNode ? incoming.MainNode : current.MainNode) == current.MainNode;
 
     // Content serialized with the hub options ($type discriminators), then CANONICALIZED — object
     // keys sorted recursively — so the comparison is order-insensitive. It must be: on a

--- a/test/MeshWeaver.Hosting.Monolith.Test/CreateOrUpdateNodeRequestTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CreateOrUpdateNodeRequestTest.cs
@@ -334,6 +334,243 @@ public class CreateOrUpdateNodeRequestTest(ITestOutputHelper output)
             "an operational member ABSENT on the live node stays absent — the writer's value never seeds it");
     }
 
+    // ══════════════════════════════════════════════════════════════════════════════════════════
+    //  MainNode — issue #2631
+    //
+    //  MeshNode.MainNode is NOT nullable: it defaults to the node's own path, so "unset" and "set
+    //  to self" are the same value on the wire. That is why the merge simply LEFT IT OUT — and why
+    //  an upsert could never move one, while `GetMeshNodeStream(path).Update` could. The rule is
+    //  MeshNode.HasExplicitMainNode: apply the source's MainNode only when it names something
+    //  other than the node itself. The two directions are pinned separately below, because the
+    //  naive fix (`source.MainNode ?? state.MainNode`) passes the first and DEMOTES EVERY
+    //  SATELLITE on the second.
+    // ══════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 #2631 — the bug. An upsert whose ONLY difference from the stored node is MainNode was
+    /// skipped as a no-op (<c>IsNoOpUpsert</c> never compared the field) and, had it taken the
+    /// write path, dropped anyway (<c>UpdateAccordingToSourceNode</c> kept the stored value). The
+    /// caller got <c>Success = true</c> and nothing moved: MeshWeaver.Plugins #839's
+    /// <c>RefreshAppTiles</c> sweep reported "1390 of 1443 record(s) refreshed" on memex with not
+    /// one <c>mainNode</c> changed.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Upsert_ChangingOnlyMainNode_IsApplied_NotSkippedAsANoOp()
+    {
+        var id = $"upsert-mainnode-move-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+        var target = $"{TestPartition}/click-target-{Guid.NewGuid():N}";
+
+        // A perfectly ordinary MAIN node — MainNode defaults to its own path.
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "Tile",
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = "# tile" },
+            State = MeshNodeState.Active,
+        }).Should().Emit();
+
+        // Everything identical EXCEPT MainNode: the whole point of the test.
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(
+                new MeshNode(id, TestPartition)
+                {
+                    Name = "Tile",
+                    NodeType = "Markdown",
+                    Content = new MarkdownContent { Content = "# tile" },
+                    State = MeshNodeState.Active,
+                    MainNode = target,
+                }))
+            .Select(d => d.Message)
+            .Should().Emit();
+
+        resp.Success.Should().BeTrue(resp.Error ?? "");
+        resp.Log!.Messages.Any(m => m.Message.Contains("no-op", StringComparison.OrdinalIgnoreCase))
+            .Should().BeFalse(
+                "MainNode is a real change — reporting it as a skipped no-op is exactly #2631");
+
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var after = await ReadStable(storage, path, n => n.MainNode == target);
+        after.MainNode.Should().Be(target,
+            "an upsert that names a different MainNode must move it — the sweep in "
+            + "MeshWeaver.Plugins #839 reported success and moved nothing");
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION GUARD, and the reason the fix is not <c>source.MainNode ?? state.MainNode</c>.
+    /// MainNode is non-nullable and defaults to the node's OWN path, so a writer that never touched
+    /// it still sends a self-pointing value. Copying that blindly turns every SATELLITE the upsert
+    /// touches into a main node (<c>is:main</c> is SQL <c>n.main_node = n.path</c>) — dropping it
+    /// out of its owner's listings and re-scoping its grants, which project at
+    /// <c>COALESCE(main_node, namespace)</c>. Here the upsert carries a genuine change (Name), so
+    /// it takes the WRITE path: the merge itself must preserve the stored MainNode.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Upsert_WithDefaultSelfMainNode_PreservesAStoredSatelliteMainNode()
+    {
+        var id = $"upsert-satellite-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+        var owner = $"{TestPartition}/owner-{Guid.NewGuid():N}";
+
+        // A satellite: MainNode points at its primary, not at itself.
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "Before",
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = "# satellite" },
+            State = MeshNodeState.Active,
+            MainNode = owner,
+        }).Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        (await ReadStable(storage, path)).MainNode.Should().Be(owner, "seed precondition");
+
+        // A writer that never thought about MainNode — so the source carries the SELF-PATH default.
+        var source = new MeshNode(id, TestPartition)
+        {
+            Name = "After",
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = "# satellite" },
+            State = MeshNodeState.Active,
+        };
+        source.MainNode.Should().Be(path, "precondition: an untouched MainNode IS the node's path");
+        source.HasExplicitMainNode.Should().BeFalse(
+            "the self-path default must never read as a deliberate re-parenting");
+
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(source))
+            .Select(d => d.Message)
+            .Should().Emit();
+        resp.Success.Should().BeTrue(resp.Error ?? "");
+
+        var after = await ReadStable(storage, path, n => n.Name == "After");
+        after.Name.Should().Be("After", "the real change must still land");
+        after.MainNode.Should().Be(owner,
+            "an untouched MainNode must NOT demote a satellite to a main node — a `?? state` "
+            + "merge would silently do exactly that on every upsert");
+    }
+
+    /// <summary>
+    /// The same guard on the COMPARE side: with nothing else changed either, the self-path default
+    /// must not read as a change, so the whole upsert is still skipped — no Version mint, no
+    /// LastModified re-stamp — and the satellite's MainNode is untouched.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Upsert_WithDefaultSelfMainNode_OnASatellite_IsStillANoOp()
+    {
+        var id = $"upsert-satellite-noop-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+        var owner = $"{TestPartition}/owner-{Guid.NewGuid():N}";
+
+        MeshNode Node(string? mainNode) => mainNode is null
+            ? new MeshNode(id, TestPartition)
+            {
+                Name = "Same",
+                NodeType = "Markdown",
+                Content = new MarkdownContent { Content = "# same" },
+                State = MeshNodeState.Active,
+            }
+            : new MeshNode(id, TestPartition)
+            {
+                Name = "Same",
+                NodeType = "Markdown",
+                Content = new MarkdownContent { Content = "# same" },
+                State = MeshNodeState.Active,
+                MainNode = mainNode,
+            };
+
+        await NodeFactory.CreateNode(Node(owner)).Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var before = await ReadStable(storage, path);
+        before.MainNode.Should().Be(owner, "seed precondition");
+
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(Node(null)))
+            .Select(d => d.Message)
+            .Should().Emit();
+        resp.Success.Should().BeTrue(resp.Error ?? "");
+        resp.Log!.Messages.Any(m => m.Message.Contains("no-op", StringComparison.OrdinalIgnoreCase))
+            .Should().BeTrue(
+                "the self-path default is not a change — comparing it raw would make EVERY "
+                + "re-import of every satellite take the write path");
+
+        var after = await ReadStable(storage, path);
+        after.Version.Should().Be(before.Version, "no change → no Version mint");
+        after.LastModified.Should().Be(before.LastModified, "no change → no LastModified re-stamp");
+        after.MainNode.Should().Be(owner, "and the satellite is still a satellite");
+    }
+
+    /// <summary>
+    /// The no-op guard must keep holding once MainNode is part of the comparison: an upsert that
+    /// restates the SAME explicit MainNode changes nothing and must not churn the node.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Upsert_RestatingTheSameExplicitMainNode_IsStillANoOp()
+    {
+        var id = $"upsert-mainnode-noop-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+        var owner = $"{TestPartition}/owner-{Guid.NewGuid():N}";
+
+        MeshNode Node() => new(id, TestPartition)
+        {
+            Name = "Same",
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = "# identical" },
+            State = MeshNodeState.Active,
+            MainNode = owner,
+        };
+
+        await NodeFactory.CreateNode(Node()).Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var before = await ReadStable(storage, path);
+
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(Node()))
+            .Select(d => d.Message)
+            .Should().Emit();
+        resp.Success.Should().BeTrue(resp.Error ?? "");
+        resp.Log!.Messages.Any(m => m.Message.Contains("no-op", StringComparison.OrdinalIgnoreCase))
+            .Should().BeTrue("an identical upsert must still be skipped");
+
+        var after = await ReadStable(storage, path);
+        after.Version.Should().Be(before.Version, "an identical upsert must not mint a Version");
+        after.LastModified.Should().Be(before.LastModified,
+            "an identical upsert must not re-stamp LastModified");
+        after.MainNode.Should().Be(owner);
+    }
+
+    /// <summary>
+    /// A MAIN node stays a main node across an ordinary upsert: <c>MainNode == Path</c> is what
+    /// <c>is:main</c> filters on, so a merge that got this wrong would drop the node out of its
+    /// partition's own listings.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task Upsert_OnAMainNode_KeepsItAMainNode()
+    {
+        var id = $"upsert-mainnode-stable-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "Before",
+            NodeType = "Markdown",
+            Content = new MarkdownContent { Content = "# main" },
+            State = MeshNodeState.Active,
+        }).Should().Emit();
+
+        var resp = await ObserveNodeOperation(new CreateOrUpdateNodeRequest(
+                new MeshNode(id, TestPartition)
+                {
+                    Name = "After",
+                    NodeType = "Markdown",
+                    Content = new MarkdownContent { Content = "# main" },
+                    State = MeshNodeState.Active,
+                }))
+            .Select(d => d.Message)
+            .Should().Emit();
+        resp.Success.Should().BeTrue(resp.Error ?? "");
+
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var after = await ReadStable(storage, path, n => n.Name == "After");
+        after.MainNode.Should().Be(path, "MainNode == Path is what makes this a MAIN node");
+        after.MainNode.Should().Be(after.Path);
+    }
+
     // Reads until the persisted node satisfies the predicate AND its Version is unchanged across
     // 4 consecutive samples (~1.2s quiet — past the 200ms persist debounce), so enrichment/debounce
     // trails can't masquerade as churn.


### PR DESCRIPTION
Fixes #2631.

## Confirmed first

Both sites are in `src/MeshWeaver.Mesh.Contract/MeshExtensions.cs`, and each one alone is enough to lose the write:

- **`IsNoOpUpsert`** compared Name / NodeType / Icon / Category / Description / Order / State / PreRenderedHtml / ExcludeFromContext / Content — never `MainNode`. An upsert whose only change was MainNode was skipped and reported as a successful no-op.
- **`UpdateAccordingToSourceNode`** built `state with { … }` from that same list, so even on the write path the stored `MainNode` was kept.

There is a **third** site, which I found while confirming the two and which makes the fix complete rather than half: **`PackageInstaller.ScalarsUnchanged`** is an explicit, documented mirror of the merge's field list ("mirrors `UpdateAccordingToSourceNode`") and it gates the write *before* the upsert is ever asked. Without it a node-repo install still could not move a MainNode — and a package's `_Access` grant carries an **authored** `mainNode` that `ParseNodeRepoFile` deliberately preserves, so re-scoping one landed nowhere.

## The trap — why the obvious fix is worse than the bug

`MeshNode.MainNode` is **not nullable**:

```csharp
public string MainNode { get; init; } = string.IsNullOrEmpty(Namespace) ? Id : $"{Namespace}/{Id}";
```

It defaults to the node's **own path**, so on the wire *"the writer never touched it"* and *"the writer set it to this node itself"* are the same value. The `?? state.X` idiom every other field uses would therefore copy a self-pointing default over every stored value — and `MainNode == Path` is exactly what makes a node a **main** node (`is:main` is SQL `n.main_node = n.path`; `MeshNode.Satellite(id, mainNode)` points it at the primary). Every satellite an upsert touched would be silently promoted to a main node, dropping it out of its owner's listings and re-scoping its grants, which project at `COALESCE(main_node, namespace)`.

That is not theoretical: **the naive fix fails two of the tests in this PR** (see the mutation run below).

## The rule

`MeshNode.HasExplicitMainNode` — apply the source's `MainNode` only when it names something other than the node itself.

I kept the self-path rule rather than inventing a different signal, because the alternatives are worse here:

- **Key presence** is the *ideal* signal and is what `patch` already uses (`MeshOperations`: `jsonObj.ContainsKey("mainNode") ? partial.MainNode : existing.MainNode`) — but `CreateOrUpdateNodeRequest` carries a whole `MeshNode` instance, not a JSON object, so the information does not exist on this path. (`Patch`-mode upserts are still rejected up front.)
- **Making `MainNode` nullable** would express it exactly, and touches the wire shape, the DB mapping and ~60 assignment sites. Not worth it for this.

One definition, three consumers (merge, no-op compare, installer mirror) — the codebase's own rule about a classification having exactly one home. It lives on `MeshNode` because it is a fact about that field's default, is `[JsonIgnore, NotMapped]`, and is **allocation-free**: `Path` is a computed interpolation, so it is compared segment-wise instead of materialised. Both methods are on every upsert's hot path.

Two things the fix quietly improves: `NormalizeSatelliteMainNode` and `AccessAssignmentGuard.IsScopeInvalid` both already ran on the incoming node *before* the merge — so what arrives is normalised and scope-validated, and until now that validated value was then thrown away.

## The residual limitation, stated plainly

**An upsert can move a MainNode anywhere except back onto the node's own path** — it cannot turn a satellite back *into* a main node, because that intent is indistinguishable from the untouched default. This is documented on `HasExplicitMainNode`, not left implicit.

I grepped for callers that would need it. Every writer that assigns a self-path is *restating the default for a node that already holds it*:

| site | what it does |
|---|---|
| `PackageInstaller.cs:3205` | partition rebase → `MainNode = $"{rebasedNs}/{id}"` |
| `GitHubSyncService.cs:707` | import rebase → `MainNode = $"{rebasedNs}/{id}"` |
| `GitHubSyncService.cs:700` | space root → `MainNode = spaceId` (root, `Namespace = ""`) |

None of them is trying to *demote-then-promote* anything; a caller that genuinely means it uses `GetMeshNodeStream(path).Update(n => n with { MainNode = n.Path })`, which is the path `patch` already takes.

## Tests — `CreateOrUpdateNodeRequestTest`, and the split is the point

| # | test | on **unfixed** code | with the fix | under the **naive `?? state`** mutation |
|---|---|---|---|---|
| 1 | `Upsert_ChangingOnlyMainNode_IsApplied_NotSkippedAsANoOp` | ❌ **FAIL** — the bug | ✅ | ✅ |
| 2 | `Upsert_WithDefaultSelfMainNode_PreservesAStoredSatelliteMainNode` (write path) | ✅ | ✅ | ❌ **FAIL** — satellite demoted |
| 3 | `Upsert_WithDefaultSelfMainNode_OnASatellite_IsStillANoOp` (compare path) | ✅ | ✅ | ❌ **FAIL** — spurious write + demotion |
| 4 | `Upsert_RestatingTheSameExplicitMainNode_IsStillANoOp` | ✅ | ✅ | ✅ |
| 5 | `Upsert_OnAMainNode_KeepsItAMainNode` | ✅ | ✅ | ✅ |

Measured runs of the class (11 tests: 6 pre-existing + 5 new):

- **unfixed source, new tests present → `Failed: 1, Passed: 10`** — only #1, which is the issue.
- fixed → `Failed: 0, Passed: 11`.
- naive `source.MainNode ?? state.MainNode` mutation → `Failed: 2, Passed: 9` — #2 and #3.

That third row is what makes #2 and #3 non-vacuous: they are green before *and* after, and the only thing that turns them red is the wrong fix.

## Wider suites

- `MeshWeaver.PluginCatalog.Test` — **653 passed, 0 failed** (covers the installer idempotence pins that `ScalarsUnchanged` gates).
- `MeshWeaver.Hosting.Monolith.Test` — **757 passed, 0 failed** (760, 3 skipped).
  A first full run of the same code showed 2 failures — `WorkspaceCacheEvictionTest.NewSubscriber_AfterRecreate_GetsFreshSnapshot` and `SilentReadNackTest.GetMeshNode_WhenOwnerIsDisposedMidRead_RecoversOnTheReProbe`. Both are hub-lifecycle timing tests (cache eviction after recreate; owner disposed mid-read) that a scalar-field merge cannot reach; both pass in isolation on the pre-change baseline, and **the re-run of the identical tree is fully green**, so they are load flakes rather than anything this diff caused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

Also documents the rule and its limitation in `Doc/Architecture/SatelliteNodePatterns` — the "Updating Node Content" section covered content edits and said nothing about re-parenting.

