### PR TITLE
ci: gate the shell CI itself runs — main-cd.yml was exercised by no PR check

### DIFF
--- a/.github/scripts/assert-bake-consumption.sh
+++ b/.github/scripts/assert-bake-consumption.sh
@@ -48,7 +48,7 @@ no prebuilt assemblies adopted
 PHRASES
 
 # ── 3. The gate CONSUMED the bake ───────────────────────────────────────────────────────────────
-seed_line="$(grep -m1 -- '^seed: adopted ' "$GATE_LOG" 2>/dev/null || true)"
+seed_line="$(grep -m1 -- '^seed: adopted ' "$GATE_LOG" || true)"
 [ -n "$seed_line" ] \
   || fail "$LABEL: the gate ran green but printed no 'seed:' line — it was given no bake to consume, so it judged a private recompile instead of the bytes the bake shipped."
 

--- a/.github/scripts/check-workflow-shell.py
+++ b/.github/scripts/check-workflow-shell.py
@@ -1,0 +1,633 @@
+#!/usr/bin/env python3
+"""Gate the shell that CI itself runs.
+
+WHY THIS EXISTS
+---------------
+`main-cd.yml` is 2000 lines of shell that decides what gets built, published and rolled to
+the fleet — and until this script, NOTHING opened it. It fires on `workflow_run`, `schedule`
+and `workflow_dispatch`; never on `pull_request`. So an edit to it merged on the strength of
+being valid YAML, and the first execution was in production, on a schedule, at 03:00.
+
+What that cost, measured (MeshWeaver#2642, written up in #2643):
+
+    tags=$(az acr manifest list-metadata ... \
+             --query "[?contains(tags, '${SHORT_SHA}')].tags[]" -o tsv 2>/dev/null || true)
+
+`tags` is NULL on the orphaned per-platform manifests an index push leaves behind (16 of
+memex-portal-ai's 2101). jmespath's `contains()` THROWS on null rather than returning false,
+and the throw aborts the WHOLE query — so one orphan made the read unable to find any tag.
+`2>/dev/null || true` then turned "the query crashed" into "there is no version tag", and the
+step blamed a component that was working perfectly. Nine consecutive scheduled runs, ~33
+hours, and the step had never once succeeded in its life.
+
+THE THREE CHECKS, and what each is honestly worth
+-------------------------------------------------
+  shellcheck  Extract every `run:` block from every workflow and shellcheck it. This would
+              NOT have caught the bug above. It is here because it is nearly free and it
+              catches a real class (quoting, dead variables, broken tests) — and because the
+              only thing standing between a workflow `run:` and production is review.
+
+  swallow     THE bug class above: a command substitution whose value is CAPTURED and then
+              read as authoritative, with BOTH its stderr sent to /dev/null AND its exit
+              status swallowed. That combination converts "the call failed" into "the answer
+              is empty" and leaves no trace anywhere — not in the log, not in the exit code.
+              Only captured substitutions are flagged: `cp … 2>/dev/null || true` collecting
+              diagnostics is a different act, because nothing reads its output.
+
+  jmespath    The specific throw: an `az --query` filter that calls contains()/starts_with()/
+              ends_with()/length() on a field that can be null. Checked by EXECUTION, not by
+              regex — the real jmespath engine az uses, over a fixture that mirrors the live
+              registry (a null-field row beside a populated one). No Azure, no credentials.
+
+THE ALLOW FILE (.github/workflow-shell.allow) is a one-way ratchet
+-----------------------------------------------------------------
+Every entry needs a `#` reason on the line(s) above it, an entry that matches nothing FAILS
+(so the list can only shrink), and a reasonless entry FAILS. Seeded with the seven
+fail-open/best-effort sites that already existed; adding to it is a diagnosis, not a fix.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+
+# ── what is scanned ─────────────────────────────────────────────────────────────────────────
+WORKFLOW_GLOBS = [".github/workflows/*.yml", ".github/workflows/*.yaml"]
+SHELL_GLOBS = [".github/scripts/*.sh"]
+
+# shellcheck severity. Matches the level the operator-scripts gate already runs at
+# (hosting-operator.yml), so one repo does not carry two different bars for the same tool.
+SHELLCHECK_SEVERITY = "warning"
+
+# A `${{ … }}` expression is not shell. Substituting a LITERAL for it makes shellcheck
+# "helpfully" report every `[ "${{ github.event_name }}" = "push" ]` as a constant expression
+# (11 such findings, plus 3 SC2157 and 2 SC2043, on this repo — all pure artefacts of the
+# substitution). Substituting a VARIABLE reference is faithful: the value is unknown at
+# check time, which is exactly what a GitHub expression is. That drops the corpus from
+# 16 artefacts to 0, and leaves the 2 findings that are real.
+GHA_EXPR = re.compile(r"\$\{\{[^}]*\}\}")
+GHA_PLACEHOLDER = "$_GHA_EXPR"
+
+# jmespath functions that RAISE on a null argument instead of returning a falsy answer.
+NULL_INTOLERANT_FUNCS = ("contains", "starts_with", "ends_with", "length")
+
+STDERR_SWALLOW = re.compile(r"2\s*>\s*/dev/null|&>\s*/dev/null|>\s*/dev/null\s+2\s*>\s*&\s*1|2\s*>\s*&\s*-")
+# The failure path must yield a value INDISTINGUISHABLE from a successful-but-empty call:
+# `|| true`, `|| :`, `|| echo` with nothing, `|| echo ""`, `|| printf ''`.
+#
+# 🚨 `|| echo unknown` / `|| echo parse-error` is deliberately NOT flagged, and the distinction is
+# the whole point of the rule rather than a softening of it. A named sentinel is the CORRECT
+# handling of this class: the caller can tell "the call failed" from "the answer is no", and the
+# repo already does this in seven places. Flagging it would punish the fix and teach people to
+# reach for `|| true` instead. What #2642 shipped was the other kind — an empty string that reads
+# exactly like a real, authoritative "there is no version tag".
+EXIT_SWALLOW = re.compile(
+    r"""(?x)
+    \|\|\s*
+    (?: true\b
+      | :\s* (?: [;)&|]|$ )
+      | echo\s* (?: ""|'' )? \s* (?: [;)&|]|$ )
+      | printf\s+ (?: ""|'' ) \s* (?: [;)&|]|$ )
+    )
+    """
+)
+# A capture: an assignment from a command substitution, or a process substitution feeding a
+# redirect (`done < <(…)`), or a here-string. In every case something downstream READS the
+# value and acts on it.
+CAPTURE = re.compile(
+    r"""(?x)
+    (?: (?:^|;|\||&&|\|\||\bthen\b|\bdo\b|\{)\s*
+        (?:local\s+|export\s+|declare\s+(?:-\w+\s+)?|readonly\s+|typeset\s+)?
+        [A-Za-z_][A-Za-z0-9_]*\s*=\s*"?\$\(          # VAR=$( … )   /   VAR="$( … )"
+    )
+  | (?: <\s*<\(  )                                    # done < <( … )
+  | (?: <<<\s*"?\$\( )                                # <<< "$( … )"
+    """
+)
+
+
+@dataclass
+class Finding:
+    check: str          # shellcheck | swallow | jmespath
+    path: str
+    line: int
+    code: str           # the offending source, normalized
+    message: str
+
+    @property
+    def key(self) -> str:
+        """Stable identity for the allow file: check + file + hash of the normalized code.
+
+        Deliberately NOT the line number — a gate whose allow file goes stale every time
+        someone adds a comment above the line teaches people to regenerate it, not to read
+        it. Deliberately DOES include the code — changing the line re-opens the question.
+        """
+        h = hashlib.sha256(self.code.encode()).hexdigest()[:12]
+        return f"{self.check} {self.path} {h}"
+
+
+# ── logical lines ───────────────────────────────────────────────────────────────────────────
+def logical_lines(script: str) -> list[tuple[int, str]]:
+    """Join backslash continuations and unbalanced `$(` so a multi-line az call is ONE line.
+
+    The bug this gate exists for spans three physical lines: the command on the first, the
+    `--query` on the third, and `2>/dev/null || true` at the very end. A line-at-a-time
+    scanner sees none of it.
+    """
+    out: list[tuple[int, str]] = []
+    buf: list[str] = []
+    start = 0
+    depth = 0
+    for i, raw in enumerate(script.split("\n"), start=1):
+        if not buf:
+            start = i
+        buf.append(raw)
+        joined = " ".join(s.rstrip("\\").strip() if s.rstrip().endswith("\\") else s for s in buf)
+        # Count only substitution parens, ignoring anything inside single quotes.
+        stripped = re.sub(r"'[^']*'", "", joined)
+        depth = stripped.count("$(") + stripped.count("<(") - stripped.count(")")
+        if raw.rstrip().endswith("\\") or depth > 0:
+            continue
+        out.append((start, joined))
+        buf = []
+    if buf:
+        out.append((start, " ".join(buf)))
+    return out
+
+
+# ── workflow parsing ────────────────────────────────────────────────────────────────────────
+def run_blocks(path: Path) -> list[dict]:
+    """Every `run:` scalar in a workflow, with the file line its body starts on."""
+    import yaml
+
+    node = yaml.compose(path.read_text())
+    found: list[dict] = []
+
+    def walk(n, step_name=None):
+        if isinstance(n, yaml.MappingNode):
+            keys = {k.value: v for k, v in n.value if isinstance(k, yaml.ScalarNode)}
+            nm = keys["name"].value if isinstance(keys.get("name"), yaml.ScalarNode) else step_name
+            run = keys.get("run")
+            if isinstance(run, yaml.ScalarNode):
+                found.append(
+                    dict(
+                        # start_mark of a block scalar points at the `|`/`>` line; the body
+                        # begins on the next one.
+                        line=run.start_mark.line + 2,
+                        name=nm,
+                        body=run.value,
+                    )
+                )
+            for _, v in n.value:
+                walk(v, nm)
+        elif isinstance(n, yaml.SequenceNode):
+            for v in n.value:
+                walk(v, step_name)
+
+    walk(node)
+    return found
+
+
+def sources(root: Path) -> list[tuple[str, int, str, str | None]]:
+    """(path, first-line-of-body, shell text, step-name) for everything this gate reads."""
+    out = []
+    for g in WORKFLOW_GLOBS:
+        for p in sorted(root.glob(g)):
+            rel = str(p.relative_to(root))
+            for blk in run_blocks(p):
+                out.append((rel, blk["line"], blk["body"], blk["name"]))
+    for g in SHELL_GLOBS:
+        for p in sorted(root.glob(g)):
+            out.append((str(p.relative_to(root)), 1, p.read_text(), None))
+    return out
+
+
+# ── check 1: shellcheck ─────────────────────────────────────────────────────────────────────
+def check_shellcheck(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for rel, base, body, step in sources(root):
+        if not rel.startswith(".github/workflows/"):
+            continue  # .sh files on disk are shellchecked where they live, not re-extracted
+        neutral = GHA_EXPR.sub(GHA_PLACEHOLDER, body)
+        # Two prologue lines: the shebang, and a definition so the placeholder is a real
+        # variable rather than an "undefined" finding of its own.
+        script = "#!/usr/bin/env bash\n_GHA_EXPR=x\n" + neutral
+        proc = subprocess.run(
+            ["shellcheck", "-f", "gcc", "-s", "bash", "-S", SHELLCHECK_SEVERITY, "-"],
+            input=script, capture_output=True, text=True,
+        )
+        lines = neutral.split("\n")
+        for out_line in proc.stdout.splitlines():
+            m = re.match(r"-:(\d+):(\d+): (\w+): (.*) \[(SC\d+)\]", out_line)
+            if not m:
+                continue
+            off = int(m.group(1)) - 3  # minus the two prologue lines, minus 1-based
+            code = lines[off].strip() if 0 <= off < len(lines) else ""
+            findings.append(
+                Finding(
+                    "shellcheck", rel, base + off, f"{m.group(5)} {code}",
+                    f"{m.group(5)} ({m.group(3)}) in step {step!r}: {m.group(4)}",
+                )
+            )
+    return findings
+
+
+# ── check 2: the swallowed exit ─────────────────────────────────────────────────────────────
+def check_swallow(root: Path) -> list[Finding]:
+    findings: list[Finding] = []
+    for rel, base, body, step in sources(root):
+        for off, line in logical_lines(body):
+            code = " ".join(line.split())
+            if code.lstrip().startswith("#"):
+                continue
+            if not CAPTURE.search(line):
+                continue
+            if not (STDERR_SWALLOW.search(line) and EXIT_SWALLOW.search(line)):
+                continue
+            findings.append(
+                Finding(
+                    "swallow", rel, base + off - 1, code,
+                    "a CAPTURED command substitution swallows both stderr and the exit status "
+                    f"(step {step!r}) — a failed call becomes an empty answer with no trace. "
+                    "Either let it fail (drop `|| true`), or keep the stderr so the log says why "
+                    "it was empty. If the empty answer is genuinely a designed fail-open, put it "
+                    "in .github/workflow-shell.allow with the reason.",
+                )
+            )
+    return findings
+
+
+# ── check 3: jmespath null-tolerance, by EXECUTION ──────────────────────────────────────────
+QUERY_ARG = re.compile(r"--query(?:\s+|=)(\"[^\"]*\"|'[^']*'|[^\s]+)")
+SHELL_VAR = re.compile(r"\$\{[A-Za-z_][A-Za-z0-9_]*(?::-[^}]*)?\}|\$[A-Za-z_][A-Za-z0-9_]*")
+
+
+def check_jmespath(root: Path) -> list[Finding]:
+    import jmespath
+    from jmespath.exceptions import JMESPathError
+
+    findings: list[Finding] = []
+    for rel, base, body, step in sources(root):
+        neutral = GHA_EXPR.sub("GHAEXPR", body)
+        for off, line in logical_lines(neutral):
+            for m in QUERY_ARG.finditer(line):
+                raw = m.group(1)
+                if raw[:1] in "\"'" and raw[-1:] == raw[:1]:
+                    raw = raw[1:-1]
+                expr = SHELL_VAR.sub("SHELLVAR", raw)
+                if not any(f + "(" in expr for f in NULL_INTOLERANT_FUNCS):
+                    continue  # a query with no throwing function cannot throw on null
+                try:
+                    parsed = jmespath.compile(expr)
+                except JMESPathError as e:
+                    findings.append(
+                        Finding("jmespath", rel, base + off - 1, expr,
+                                f"is not a valid jmespath expression ({e}) — az would exit "
+                                "non-zero every time this ran."))
+                    continue
+
+                fields = sorted(_fields(parsed.parsed))
+                if not fields:
+                    continue
+                full = [{f: "meshweaver-fixture" for f in fields}] * 2
+                # The live shape: one row whose fields are null (the untagged manifests an
+                # index push orphans) sitting beside a populated one.
+                nulled = [{f: None for f in fields}, {f: "meshweaver-fixture" for f in fields}]
+                try:
+                    parsed.search(full)
+                except JMESPathError as e:
+                    findings.append(
+                        Finding("jmespath", rel, base + off - 1, expr,
+                                f"could not be verified — the derived fixture {full[0]!r} does "
+                                f"not fit it ({e}). Refusing to report a pass on no evidence; "
+                                "give this query a hand-written fixture or allow-list it."))
+                    continue
+                try:
+                    parsed.search(nulled)
+                except JMESPathError as e:
+                    findings.append(
+                        Finding("jmespath", rel, base + off - 1, expr,
+                                f"THROWS on a row whose field is null ({e}). jmespath aborts the "
+                                "WHOLE query on that throw, so one such row makes this read find "
+                                "nothing at all — and az exits non-zero. Guard the field: "
+                                "`[?field && contains(field, …)]`. (MeshWeaver#2642.)"))
+    return findings
+
+
+def _fields(node) -> set[str]:
+    out: set[str] = set()
+    if isinstance(node, dict):
+        if node.get("type") == "field":
+            out.add(node["value"])
+        for c in node.get("children") or []:
+            out |= _fields(c)
+        v = node.get("value")
+        if isinstance(v, (dict, list)):
+            out |= _fields(v)
+    elif isinstance(node, list):
+        for c in node:
+            out |= _fields(c)
+    return out
+
+
+# ── the allow file ──────────────────────────────────────────────────────────────────────────
+def read_allow(path: Path) -> tuple[dict[str, str], list[str]]:
+    """Returns {key: reason} and a list of format errors.
+
+    An entry with no `#` reason directly above it is a format ERROR, not a silent pass: the
+    whole point of the list is that every waiver was diagnosed by a person.
+    """
+    entries: dict[str, str] = {}
+    errors: list[str] = []
+    if not path.exists():
+        return entries, errors
+    reason: list[str] = []
+    for n, raw in enumerate(path.read_text().split("\n"), start=1):
+        line = raw.strip()
+        if not line:
+            reason = []
+            continue
+        if line.startswith("#"):
+            reason.append(line.lstrip("#").strip())
+            continue
+        parts = line.split()
+        if len(parts) != 3:
+            errors.append(f"{path}:{n}: expected `<check> <path> <hash>`, got {line!r}")
+            reason = []
+            continue
+        text = " ".join(r for r in reason if r)
+        if not text:
+            errors.append(
+                f"{path}:{n}: `{line}` has no reason. Put the diagnosis in `#` comment lines "
+                "directly above it — an undiagnosed waiver is how debt becomes permanent.")
+        entries[line] = text
+        reason = []
+    return entries, errors
+
+
+# ── self-test ───────────────────────────────────────────────────────────────────────────────
+SELF_TEST_WORKFLOW = """\
+name: fixture
+on: [push]
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: The pre-2642 read
+        run: |
+          set -uo pipefail
+          tags=$(az acr manifest list-metadata --registry meshweaver --name memex-portal-ai \\
+                   --query "[?contains(tags, '${SHORT_SHA}')].tags[]" -o tsv 2>/dev/null || true)
+          echo "$tags"
+"""
+
+SELF_TEST_FIXED = """\
+name: fixture
+on: [push]
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: The post-2642 read
+        run: |
+          set -uo pipefail
+          tags=$(az acr manifest list-metadata --registry meshweaver --name memex-portal-ai \\
+                   --query "[?tags && contains(tags, '${SHORT_SHA}')].tags[]" -o tsv)
+          echo "$tags"
+"""
+
+SELF_TEST_BEST_EFFORT = r"""name: fixture
+on: [push]
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Collect diagnostics
+        run: |
+          cp -r probe-logs diagnostics/ 2>/dev/null || true
+          find . -name '*.trx' -exec cp {} out/ \; 2>/dev/null || true
+"""
+
+SELF_TEST_SHELL_BUG = """\
+name: fixture
+on: [push]
+jobs:
+  j:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dead variable
+        run: |
+          UNUSED_HERE=(--seed /seed)
+          echo ok
+"""
+
+
+def self_test(root: Path) -> int:
+    """Prove each check is non-vacuous: it must FIRE on the defect and stay SILENT on the fix.
+
+    Mirrors `affected-modules.py --self-test` in MeshWeaver.Plugins. A gate whose self-test
+    only asserts the happy path proves nothing — every case below has both halves.
+    """
+    failures: list[str] = []
+
+    def case(name: str, ok: bool, detail: str = "") -> None:
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}" + (f"  — {detail}" if detail and not ok else ""))
+        if not ok:
+            failures.append(name)
+
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        (tmp / ".github" / "workflows").mkdir(parents=True)
+        (tmp / ".github" / "scripts").mkdir(parents=True)
+        wf = tmp / ".github" / "workflows" / "fixture.yml"
+
+        # ── swallow: the exact regression, and the exact fix ────────────────────────────
+        wf.write_text(SELF_TEST_WORKFLOW)
+        got = check_swallow(tmp)
+        case("swallow FIRES on the pre-#2642 `2>/dev/null || true` capture", len(got) == 1,
+             f"got {len(got)}: {[f.code for f in got]}")
+
+        wf.write_text(SELF_TEST_FIXED)
+        got = check_swallow(tmp)
+        case("swallow is SILENT on the #2642 fix", len(got) == 0, f"got {[f.code for f in got]}")
+
+        # A swallow whose output nobody reads is a different act, and must not be flagged —
+        # otherwise the allow file fills with diagnostics-collection noise and stops meaning
+        # anything.
+        wf.write_text(SELF_TEST_BEST_EFFORT)
+        got = check_swallow(tmp)
+        case("swallow is SILENT on best-effort cp/find (nothing reads the output)",
+             len(got) == 0, f"got {[f.code for f in got]}")
+
+        # ── shellcheck ─────────────────────────────────────────────────────────────────
+        wf.write_text(SELF_TEST_SHELL_BUG)
+        got = check_shellcheck(tmp)
+        case("shellcheck FIRES on a dead variable",
+             len(got) == 1 and "SC2034" in got[0].message, f"got {[f.message for f in got]}")
+
+        wf.write_text(SELF_TEST_FIXED)
+        got = check_shellcheck(tmp)
+        case("shellcheck is SILENT on the #2642 fix", len(got) == 0, f"got {[f.message for f in got]}")
+
+        # A `${{ … }}` expression must not be turned into a constant — that artefact alone
+        # produced 16 false findings on this repo, which is more than enough to make a gate
+        # unusable and then allow-listed into uselessness.
+        wf.write_text(
+            "name: f\non: [push]\njobs:\n  j:\n    runs-on: ubuntu-latest\n    steps:\n"
+            '      - run: |\n          if [ "${{ github.event_name }}" = "push" ]; then echo hi; fi\n'
+        )
+        got = check_shellcheck(tmp)
+        case("shellcheck does not misread a ${{ }} expression as a constant",
+             len(got) == 0, f"got {[f.message for f in got]}")
+
+        # ── jmespath: THE fixture — a manifest list with an untagged row ────────────────
+        wf.write_text(SELF_TEST_WORKFLOW)
+        got = check_jmespath(tmp)
+        case("jmespath FIRES on contains() over an unguarded field", len(got) == 1,
+             f"got {[f.message for f in got]}")
+
+        wf.write_text(SELF_TEST_FIXED)
+        got = check_jmespath(tmp)
+        case("jmespath is SILENT on the `tags && contains(tags, …)` guard", len(got) == 0,
+             f"got {[f.message for f in got]}")
+
+        # Belt and braces: prove the property directly against a fixture shaped like the
+        # live registry, so the check above is not merely agreeing with itself.
+        import jmespath
+        from jmespath.exceptions import JMESPathError
+
+        manifests = (
+            [{"digest": f"sha256:{i:064x}", "tags": None} for i in range(16)]      # index orphans
+            + [{"digest": "sha256:6c3ab", "tags": ["aaf95af", "main", "3.0.0-rc8.ci.6360"]}]
+        )
+        threw = False
+        try:
+            jmespath.compile("[?contains(tags, 'aaf95af')].tags[]").search(manifests)
+        except JMESPathError:
+            threw = True
+        case("fixture: the unguarded query really does throw on 16 untagged manifests", threw)
+
+        guarded = jmespath.compile("[?tags && contains(tags, 'aaf95af')].tags[]").search(manifests)
+        case("fixture: the guarded query recovers 3.0.0-rc8.ci.6360",
+             guarded == ["aaf95af", "main", "3.0.0-rc8.ci.6360"], f"got {guarded!r}")
+
+        # ── allow-file mechanics ───────────────────────────────────────────────────────
+        allow = tmp / "allow"
+        allow.write_text("# a reason\nswallow .github/workflows/fixture.yml deadbeefcafe\n")
+        entries, errs = read_allow(allow)
+        case("allow: an entry with a reason parses", entries and not errs, f"{entries} {errs}")
+
+        allow.write_text("swallow .github/workflows/fixture.yml deadbeefcafe\n")
+        _, errs = read_allow(allow)
+        case("allow: a REASONLESS entry is an error", len(errs) == 1, f"got {errs}")
+
+        allow.write_text("# reason\nnonsense\n")
+        _, errs = read_allow(allow)
+        case("allow: a malformed entry is an error", len(errs) == 1, f"got {errs}")
+
+        # The ratchet: an entry that no longer matches anything must FAIL, so the list can
+        # only ever shrink.
+        wf.write_text(SELF_TEST_FIXED)
+        # Captured: this case DELIBERATELY produces the gate's failure output, and a raw
+        # `::error::` from a passing job would put a spurious annotation on a green run.
+        import contextlib, io
+        sink = io.StringIO()
+        with contextlib.redirect_stdout(sink):
+            rc = run(tmp, allow_path=Path(td) / "stale.allow", write_stale=True)
+        case("allow: a STALE entry fails the gate (the list may only shrink)",
+             rc != 0 and "may only shrink" in sink.getvalue(), f"exit {rc}: {sink.getvalue()}")
+
+    print()
+    if failures:
+        print(f"::error::self-test FAILED: {len(failures)} case(s) — {', '.join(failures)}")
+        return 1
+    print("self-test: all cases passed")
+    return 0
+
+
+# ── driver ──────────────────────────────────────────────────────────────────────────────────
+def run(root: Path, allow_path: Path, write_stale: bool = False) -> int:
+    if write_stale:
+        allow_path.write_text("# stale on purpose (self-test)\nswallow nowhere.yml 000000000000\n")
+
+    entries, errors = read_allow(allow_path)
+    for e in errors:
+        print(f"::error::{e}")
+
+    findings = check_shellcheck(root) + check_swallow(root) + check_jmespath(root)
+
+    used: set[str] = set()
+    live: list[Finding] = []
+    for f in findings:
+        if f.key in entries:
+            used.add(f.key)
+            continue
+        live.append(f)
+
+    stale = sorted(set(entries) - used)
+
+    for f in live:
+        print(f"::error file={f.path},line={f.line}::[{f.check}] {f.message}")
+        print(f"    {f.path}:{f.line}")
+        print(f"        {f.code}")
+        print(f"    If this is deliberate, add to {allow_path.name} WITH the reason:")
+        print(f"        # <why this failure must not fail the step>")
+        print(f"        {f.key}")
+        print()
+
+    for k in stale:
+        print(f"::error::{allow_path.name} entry `{k}` no longer matches anything. "
+              "Delete it — this list is a one-way ratchet and may only shrink.")
+
+    ok = not live and not stale and not errors
+    print(f"{len(findings)} finding(s): {len(live)} live, {len(used)} allow-listed, "
+          f"{len(stale)} stale entr(ies), {len(errors)} allow-file error(s)")
+    return 0 if ok else 1
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--root", default=".", help="repository root")
+    ap.add_argument("--allow", default=".github/workflow-shell.allow")
+    ap.add_argument("--self-test", action="store_true",
+                    help="prove every check fires on its defect and stays silent on its fix")
+    args = ap.parse_args()
+
+    # 🚨 The tools are ASSERTED, never assumed. shellcheck ships on hosted runners and
+    # jmespath is a pip install; either one missing must turn this RED. A gate that quietly
+    # degrades to "the checks it could run" is a gate that reports a tick for work it did
+    # not do — and GitHub renders that tick identically to a real one.
+    missing = []
+    if not shutil.which("shellcheck"):
+        missing.append("shellcheck — apt-get install shellcheck")
+    try:
+        import yaml  # noqa: F401
+    except ImportError:
+        missing.append("PyYAML — pip install pyyaml")
+    try:
+        import jmespath  # noqa: F401
+    except ImportError:
+        missing.append("jmespath — pip install jmespath (the same engine the azure-cli uses)")
+    if missing:
+        print("::error::the workflow-shell gate cannot run — provide:")
+        for m in missing:
+            print(f"  • {m}")
+        return 1
+
+    root = Path(args.root).resolve()
+    if args.self_test:
+        return self_test(root)
+    return run(root, root / args.allow)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/test-cd-steps.py
+++ b/.github/scripts/test-cd-steps.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""EXECUTE main-cd's pure-shell decision steps against fixtures. No Azure, no cluster, no secret.
+
+WHY
+---
+`main-cd.yml` runs on `workflow_run`, `schedule` and `workflow_dispatch` — never on
+`pull_request`. So the first execution of an edit to it is in production, on a schedule, and
+its decision steps are exactly the ones whose verdict everyone downstream believes.
+
+The release-version recovery step is the worked example, and it is the reason this file exists:
+it had NEVER ONCE SUCCEEDED in its life. Nine consecutive scheduled reconciles (2026-08-28
+22:12Z → 08-29 05:26Z, ~33 h) died in it, and every one of them accused promote — a component
+that was working perfectly. MeshWeaver#2642 fixed it; this executes it.
+
+HOW IT STAYS HONEST
+-------------------
+* The step is EXTRACTED FROM THE WORKFLOW by its `id:`, never copied here. A copy passes while
+  the real thing rots.
+* If the step cannot be found, or has grown a `${{ }}` expression this harness cannot supply, or
+  has stopped calling the command being stubbed, the harness FAILS RED. It never reports a pass
+  for a step it did not run — that is the same "a skipped gate ticks like a passed one" defect the
+  thing being tested was full of.
+* `az` is stubbed with a script that answers from a fixture using REAL jmespath — the same engine
+  the azure-cli uses — so the null-throw is reproduced rather than asserted about.
+
+THE FIXTURE is the live registry's shape on the day of the incident: 2101 manifests in
+`memex-portal-ai`, 16 of them UNTAGGED (`tags: null` — the orphaned per-platform children an
+index push leaves behind), and one digest carrying `aaf95af`, `main` and `3.0.0-rc8.ci.6360`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+WORKFLOW = ".github/workflows/main-cd.yml"
+STEP_ID = "release"
+
+SHORT_SHA = "aaf95af"
+VERSION = "3.0.0-rc8.ci.6360"
+
+# ── the stub `az` ───────────────────────────────────────────────────────────────────────────
+# Reproduces the three behaviours that matter: a successful jmespath query, a query that THROWS
+# on a null field (az's own message, exit 1), and a call that fails for an unrelated reason
+# (auth). Nothing else about `az` is modelled, and the harness asserts the step still calls the
+# subcommand being stubbed, so a step that grew a second az call cannot pass on this one.
+AZ_STUB = r'''#!/usr/bin/env python3
+import json, os, sys
+import jmespath
+from jmespath.exceptions import JMESPathError
+
+if os.environ.get("AZ_FAIL"):
+    sys.stderr.write("ERROR: Please run 'az login' to setup account.\n")
+    sys.exit(1)
+
+argv = sys.argv[1:]
+if argv[:3] != ["acr", "manifest", "list-metadata"]:
+    sys.stderr.write(f"stub az: unmodelled invocation {argv!r}\n")
+    sys.exit(97)
+
+query = None
+for i, a in enumerate(argv):
+    if a == "--query":
+        query = argv[i + 1]
+if query is None:
+    sys.stderr.write("stub az: no --query\n")
+    sys.exit(97)
+
+data = json.load(open(os.environ["AZ_FIXTURE"]))
+try:
+    result = jmespath.compile(query).search(data)
+except JMESPathError as e:
+    # az surfaces a jmespath failure verbatim on stderr and exits non-zero.
+    sys.stderr.write(f"{e}\n")
+    sys.exit(1)
+
+for row in result or []:
+    print(row)
+'''
+
+
+def fixture(tagged: bool) -> list[dict]:
+    """memex-portal-ai as it stood on 2026-08-29: 2101 manifests, 16 with `tags: null`."""
+    rows: list[dict] = [{"digest": f"sha256:{i:064x}", "tags": None} for i in range(16)]
+    rows += [{"digest": f"sha256:{i:064x}", "tags": [f"ci.{i}"]} for i in range(16, 2100)]
+    rows.append(
+        {
+            "digest": "sha256:6c3abd508033db59865e8bedf68076bdb75b4c044e3fa1159c01eff98b2a1089",
+            # Phase A tags the short sha; Phase C arms the release on the SAME digest.
+            "tags": [SHORT_SHA, "main", VERSION] if tagged else [SHORT_SHA, "main"],
+        }
+    )
+    return rows
+
+
+# ── extraction ──────────────────────────────────────────────────────────────────────────────
+def extract_step(root: Path, step_id: str) -> str:
+    import yaml
+
+    doc = yaml.safe_load((root / WORKFLOW).read_text())
+    for job in (doc.get("jobs") or {}).values():
+        for step in job.get("steps") or []:
+            if isinstance(step, dict) and step.get("id") == step_id:
+                body = step.get("run")
+                if not body:
+                    die(f"step id `{step_id}` in {WORKFLOW} has no `run:` — nothing to execute.")
+                if "${{" in body:
+                    die(
+                        f"step id `{step_id}`'s `run:` now contains a ${{{{ }}}} expression, which "
+                        "this harness cannot supply. It is refusing to execute a body it would "
+                        "have to rewrite — pass the value through `env:` instead (every input it "
+                        "takes today already is)."
+                    )
+                return body
+    die(
+        f"no step with `id: {step_id}` in {WORKFLOW}. It was renamed, moved or deleted — and this "
+        "harness will not report a pass for a step it could not find. Re-point STEP_ID."
+    )
+
+
+def die(msg: str):
+    print(f"::error::{msg}")
+    sys.exit(1)
+
+
+# ── running one case ────────────────────────────────────────────────────────────────────────
+def run_step(body: str, env: dict[str, str], rows: list[dict] | None, az_fail: bool = False):
+    with tempfile.TemporaryDirectory() as td:
+        tmp = Path(td)
+        binp = tmp / "bin"
+        binp.mkdir()
+        (binp / "az").write_text(AZ_STUB)
+        (binp / "az").chmod(0o755)
+        fx = tmp / "fixture.json"
+        fx.write_text(json.dumps(rows if rows is not None else []))
+        out = tmp / "github_output"
+        out.touch()
+
+        e = dict(os.environ)
+        e["PATH"] = f"{binp}:{e['PATH']}"
+        e["AZ_FIXTURE"] = str(fx)
+        e["GITHUB_OUTPUT"] = str(out)
+        if az_fail:
+            e["AZ_FAIL"] = "1"
+        else:
+            e.pop("AZ_FAIL", None)
+        e.update(env)
+
+        p = subprocess.run(["bash", "-c", body], env=e, capture_output=True, text=True)
+        return p.returncode, p.stdout + p.stderr, out.read_text()
+
+
+def main() -> int:
+    root = Path(os.environ.get("GITHUB_WORKSPACE", ".")).resolve()
+    try:
+        import jmespath  # noqa: F401
+        import yaml  # noqa: F401
+    except ImportError as exc:
+        die(f"this harness cannot run — {exc}. pip install jmespath pyyaml.")
+
+    body = extract_step(root, STEP_ID)
+    # A stub is only evidence about the call it stubs. If the step stopped making that call, the
+    # cases below would all pass while testing nothing.
+    if "az acr manifest list-metadata" not in body:
+        die(
+            f"step `{STEP_ID}` no longer calls `az acr manifest list-metadata` — the stub these "
+            "cases rely on is no longer the seam under test, so every case below would pass "
+            "vacuously. Update the harness with the step."
+        )
+
+    failures: list[str] = []
+
+    def case(name: str, ok: bool, detail: str = ""):
+        print(f"  {'PASS' if ok else 'FAIL'}  {name}")
+        if not ok:
+            print(f"        {detail}")
+            failures.append(name)
+
+    base = {"RELEASE_VERSION": "", "BAKE_ONLY": "true", "SHORT_SHA": SHORT_SHA}
+
+    # 1 ── A full run: portal-image minted the version, so nothing is read back.
+    rc, log, outputs = run_step(body, {**base, "RELEASE_VERSION": "3.0.0-rc9.ci.1"}, fixture(True))
+    case("a minted version passes straight through",
+         rc == 0 and "version=3.0.0-rc9.ci.1" in outputs, f"rc={rc} out={outputs!r} log={log}")
+
+    # 2 ── THE CASE THAT HAD NEVER SUCCEEDED. Bake-only reconcile, and the repository holds 16
+    #      untagged manifests whose `tags` is null. Before #2642 the query threw on the first of
+    #      them, jmespath aborted the WHOLE query, az exited non-zero, `2>/dev/null || true`
+    #      turned that into an empty tag list, and the step blamed promote.
+    rc, log, outputs = run_step(body, base, fixture(True))
+    case("a bake-only reconcile recovers the version DESPITE 16 untagged manifests",
+         rc == 0 and f"version={VERSION}" in outputs, f"rc={rc} out={outputs!r} log={log}")
+
+    # 3 ── The genuine "promote never armed it" case must still be loud, and must still say so.
+    rc, log, outputs = run_step(body, base, fixture(False))
+    case("a digest with no version tag is still a loud, accurate stop",
+         rc != 0 and "carries no version tag" in log, f"rc={rc} log={log}")
+
+    # 4 ── 🚨 THE REGRESSION GUARD. When az itself fails, the step must fail with az's message —
+    #      it must NOT convert the failure into "there is no version tag" and blame promote.
+    #      Reintroduce `2>/dev/null || true` on that read and this case goes red: `tags` becomes
+    #      empty, `version` becomes empty, and the step prints the promote accusation.
+    rc, log, outputs = run_step(body, base, fixture(True), az_fail=True)
+    case("a FAILING az fails the step", rc != 0, f"rc={rc} log={log}")
+    case("a FAILING az is never reported as promote's fault",
+         "Fix promote" not in log and "carries no version tag" not in log,
+         f"the step blamed a healthy component for its own failed call:\n{log}")
+    case("a FAILING az surfaces az's own message", "az login" in log, f"log={log}")
+
+    # 5 ── A non-bake-only run with no version is a refusal, not a read.
+    rc, log, outputs = run_step(body, {**base, "BAKE_ONLY": "false"}, fixture(True))
+    case("no version on a non-bake-only run refuses rather than guessing",
+         rc != 0 and "unknown release" in log, f"rc={rc} log={log}")
+
+    print()
+    if failures:
+        print(f"::error::{len(failures)} case(s) failed: {', '.join(failures)}")
+        return 1
+    print(f"all cases passed against {WORKFLOW} step `{STEP_ID}` (extracted, not copied)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflow-shell.allow
+++ b/.github/workflow-shell.allow
@@ -1,0 +1,26 @@
+# ── Waivers for .github/scripts/check-workflow-shell.py ─────────────────────────────────────────
+#
+# A ONE-WAY RATCHET. Every entry needs its diagnosis in the `#` lines directly above it (a
+# reasonless entry FAILS the gate), and an entry that no longer matches anything FAILS too — so
+# this list can only ever shrink. Adding a line is a diagnosis, not a fix.
+#
+# 🚨 It is seeded with ONE entry, and that is deliberate. The first run of this gate found 22
+# findings; 21 of them were REMEDIED in the same change rather than waived, because for a
+# genuinely-intended fail-open the remedy costs nothing: dropping `2>/dev/null` leaves the control
+# flow byte-for-byte identical and restores the evidence. That is precisely what would have turned
+# MeshWeaver#2642 from a 33-hour misdiagnosis into a 10-minute one — az's own
+# "In function contains(), invalid type for value: None" would have been printed directly above the
+# step's confident, wrong conclusion that promote had never armed a release.
+#
+# Format:  <check> <path> <hash>       (the gate prints the exact line to paste)
+
+# publish-bake-bundles.sh: the ABSENCE of $DEST/$SOURCE_MARKER is a NORMAL, expected state — a
+# publication sealed before source-marker recording existed simply has no such file, and this
+# script's whole job at that point is to notice that and republish. So `az storage file download`
+# failing here is the ordinary path, not an incident, and it runs once per module per publish (~40
+# times a run). Letting its stderr through would print an Azure "ResourceNotFound" storm on every
+# healthy re-publish, which is how a log stops being read. The empty answer is also NOT taken as
+# authoritative: the next two lines test it against $SOURCE_SHA and fall through to republishing
+# when it does not match, so a genuine credential failure degrades to "publish again", never to
+# "already published; skipping".
+swallow .github/scripts/publish-bake-bundles.sh 67fc06cddcb7

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -324,7 +324,7 @@ jobs:
         #
         # Marker leaf is `<epoch>` (legacy) or `<epoch>-<run_id>` (carries provenance,
         # #1491). Both are accepted; sorting is on the epoch field only.
-        newest=$(git ls-remote origin "refs/ci-green/$tree/*" 2>/dev/null \
+        newest=$(git ls-remote origin "refs/ci-green/$tree/*" \
                  | awk '{print $2}' \
                  | grep -E "^refs/ci-green/$tree/[0-9]+(-[0-9]+)?$" \
                  | sed 's|.*/||' | sort -t- -k1,1n | tail -1 || true)
@@ -1529,7 +1529,7 @@ jobs:
         status=0
         bash .github/scripts/bake-then-gate.sh "$TESTER" "$STAGE" "$BAKE/doc" \
           .github/doc-gate.allow "$GITHUB_SHA" "${RUNNER_TEMP:-/tmp}/doc-gate" || status=$?
-        verdict="$(grep -m1 -- '^GATE FAILED' "$log" 2>/dev/null || true)"
+        verdict="$(grep -m1 -- '^GATE FAILED' "$log" || true)"
         # ── Second stage: the samples trees — the "12k lines of C# no build ever type-checks"
         # from AGENTS.md. Same tester, same mechanics; .github/samples-gate.allow is its own
         # one-way debt ratchet (a listed entry that starts passing fails the run until removed).
@@ -1539,7 +1539,7 @@ jobs:
         sstatus=0
         bash .github/scripts/bake-then-gate.sh "$TESTER" "$SSTAGE" "$BAKE/samples" \
           .github/samples-gate.allow "$GITHUB_SHA" "${RUNNER_TEMP:-/tmp}/samples-gate" || sstatus=$?
-        sverdict="$(grep -m1 -- '^GATE FAILED' "$slog" 2>/dev/null || true)"
+        sverdict="$(grep -m1 -- '^GATE FAILED' "$slog" || true)"
         combined="$(printf '%s\n%s' "$verdict" "$sverdict" | grep . | head -1 || true)"
         {
           echo "failure<<GATE_EOF"
@@ -1631,6 +1631,75 @@ jobs:
     - name: Check dependency licences
       run: python3 .github/scripts/check-licenses.py --report
 
+  workflow-shell:
+    name: "CI's own shell"
+    # 🚨 THE GAP THIS CLOSES: `main-cd.yml` is 2000 lines of shell that decides what is built,
+    # published and rolled to the fleet — and NOTHING opened it. It fires on `workflow_run`,
+    # `schedule` and `workflow_dispatch`; never on `pull_request`. So an edit to it merged on the
+    # strength of being valid YAML, and its first execution was in production, on a cron.
+    #
+    # What that cost, measured (#2642, trap written up in #2643): a bake-only reconcile carried
+    #
+    #     tags=$(az acr manifest list-metadata … \
+    #              --query "[?contains(tags, '${SHORT_SHA}')].tags[]" -o tsv 2>/dev/null || true)
+    #
+    # `contains(null, …)` THROWS on the 16 untagged manifests in that repository, jmespath aborts
+    # the whole query, az exits non-zero, `2>/dev/null || true` swallows it — and the step then
+    # accused a HEALTHY component: "promote's Phase C never armed a release for this sha".
+    # NINE consecutive scheduled runs, ~33 hours, and the step had never once succeeded in its
+    # life. An error that names the wrong culprit is worse than a silent failure; it is a silent
+    # failure with directions attached.
+    #
+    # 🛡️ NO SKIP-TRAPDOOR. Every input is in this repository — no secret, no cluster, no registry
+    # — so there is no condition under which this may decline to run and still render a tick:
+    #   * no `needs:`, so nothing upstream can skip it (not even the green-tree reuse path — this
+    #     job is seconds, and the reuse optimisation exists for a 70-runner-minute suite);
+    #   * no input-shaped `if:`, because GitHub renders a skipped job with the same tick as a
+    #     passed one;
+    #   * no path filter, which is that same defect from the other side (an unrelated PR would
+    #     "pass" by not running);
+    #   * no `continue-on-error`;
+    #   * the tools it needs are ASSERTED, and a missing one fails RED rather than quietly
+    #     reducing the gate to the checks it happened to be able to run.
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+    - uses: actions/checkout@v7
+      with: { fetch-depth: 1 }
+
+    # jmespath is PINNED, and the pin is the fidelity claim: it is the engine the azure-cli
+    # itself evaluates `--query` with, so "this query throws on a null field" is reproduced here
+    # rather than asserted about. A venv keeps it off the runner's externally-managed python.
+    - name: Assert the tools this gate needs
+      run: |
+        set -euo pipefail
+        command -v shellcheck >/dev/null || { echo "::error::shellcheck is not on this runner"; exit 1; }
+        shellcheck --version | head -2
+        python3 -m venv "$RUNNER_TEMP/wfshell"
+        "$RUNNER_TEMP/wfshell/bin/pip" install --quiet --disable-pip-version-check \
+          'jmespath==1.0.1' 'PyYAML==6.0.2'
+        echo "$RUNNER_TEMP/wfshell/bin" >> "$GITHUB_PATH"
+
+    # 🚨 Run the self-test FIRST, and let it fail the job. An unproven gate is no gate: every
+    # check below must be shown to FIRE on its defect and stay SILENT on its fix before its
+    # verdict on the real tree means anything. (Same posture as `affected-modules.py --self-test`
+    # in MeshWeaver.Plugins.)
+    - name: "Prove the gate is non-vacuous (self-test)"
+      run: python3 .github/scripts/check-workflow-shell.py --self-test
+
+    - name: "Gate the shell CI itself runs"
+      run: python3 .github/scripts/check-workflow-shell.py
+
+    # Deliverable that needs no credential: EXECUTE main-cd's release-version recovery — the step
+    # that never once succeeded — against a fixture shaped like the live registry (2101 manifests,
+    # 16 of them untagged). The step is EXTRACTED from main-cd.yml by its `id:`, never copied, and
+    # the harness fails red if it cannot find it or if the step stopped making the call being
+    # stubbed. A copy passes while the real thing rots.
+    - name: "Execute main-cd's decision steps against fixtures"
+      run: python3 .github/scripts/test-cd-steps.py
+      env:
+        GITHUB_WORKSPACE: ${{ github.workspace }}
+
   collect-results:
     name: "Consolidate test results"
     # plugin-gate is a NEEDS so this required check cannot go green while the plugins are
@@ -1641,6 +1710,11 @@ jobs:
     # clients-gate is a NEEDS on the same principle as plugin-gate/doc-gate/licence-gate: a red
     # Clients workflow can stop ALL image publication (#1568), so it must be able to fail the
     # repo's only required status check.
+    # workflow-shell is a NEEDS on the same principle, applied to CI's own shell: main-cd.yml is
+    # not exercised by ANY pull-request check, so until #2642 an edit to the pipeline that decides
+    # what ships merged on YAML validity alone — and one such edit spent nine scheduled runs and
+    # ~33 hours blaming a healthy component for its own swallowed crash. A gate on that shell that
+    # could go red while the PR merged anyway would be decorative in exactly the same way.
     # record-signatures is a NEEDS on the same principle, and it is the one that had been
     # missing: it carries BOTH binary-compatibility gates (public record primary constructors,
     # and public types moving assembly without a TypeForwardedTo). #2283 moved four public types
@@ -1648,7 +1722,7 @@ jobs:
     # (#2370) — a module's IL binds a NAME, so no source build can see it. The gate for exactly
     # that now exists and is proven live, but until this line it could go RED while the PR merged
     # anyway. A gate whose verdict nothing reads is decorative.
-    needs: [precheck, build, test, doc-gate, licence-gate, clients-gate, record-signatures]
+    needs: [precheck, build, test, doc-gate, licence-gate, clients-gate, record-signatures, workflow-shell]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -1903,7 +1977,7 @@ jobs:
           if [ $(( now - epoch )) -gt "${CI_GREEN_PRUNE_SECONDS}" ]; then
             refspecs+=(":$ref")
           fi
-        done < <(git ls-remote origin 'refs/ci-green/*' 'refs/ci-executed/*' 2>/dev/null || true)
+        done < <(git ls-remote origin 'refs/ci-green/*' 'refs/ci-executed/*' || true)
         if [ "${#refspecs[@]}" -eq 0 ]; then
           echo "No stale markers to prune."
           exit 0
@@ -1956,6 +2030,14 @@ jobs:
     # 🚨 `needs:` alone is NOT enough under `if: always()` — same lesson as the steps above.
     # This is the merge gate #1555 did not have: its Portal-next job was red, naming the exact
     # build main-cd would later run, and it was advisory.
+    - name: Fail if CI's own shell gate failed
+      # `!= 'success'` rather than `== 'failure'`: a gate that was skipped or cancelled has
+      # produced no verdict, and "no verdict" must never read as "passed".
+      if: needs.workflow-shell.result != 'success'
+      run: |
+        echo "::error::The 'CI's own shell' gate concluded '${{ needs.workflow-shell.result }}' — see that job. It shellchecks every workflow \`run:\` block, refuses a captured command substitution that swallows BOTH stderr and its exit status (the #2642 shape: a failed call becomes an empty answer that is then read as authoritative), refuses an az \`--query\` that throws on a null field, and EXECUTES main-cd's release-version recovery against a fixture. main-cd.yml is exercised by no other check on this PR."
+        exit 1
+
     - name: Fail if the clients gate failed
       if: needs.clients-gate.result != 'success'
       run: |
@@ -1977,7 +2059,7 @@ jobs:
       continue-on-error: true
       run: |
         set -uo pipefail
-        last=$(git ls-remote origin 'refs/ci-executed/main/*' 2>/dev/null \
+        last=$(git ls-remote origin 'refs/ci-executed/main/*' \
                | sed -E 's|^([0-9a-f]+)[[:space:]]+refs/ci-executed/main/([0-9]+)(-([0-9]+))?$|\2 \1 \4|' \
                | grep -E '^[0-9]+ ' | sort -n | tail -1 || true)
         {

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -447,6 +447,17 @@ jobs:
       # 🚨 FAILS OPEN: if the registry cannot be read, the age reports 999999 and the merge
       # publishes — a broken batching probe must cost at most one extra image build, never a
       # missed publish. Unset/empty var = publish every merge (the historical behavior).
+      #
+      # 🚨 …but fail-open is a CONTROL-FLOW decision, and it never justified `2>/dev/null`.
+      # `|| true` alone delivers the whole fail-open; the stderr swallow only deleted the
+      # evidence of WHY the probe was empty, which is precisely how #2642's sibling read spent
+      # nine scheduled runs blaming a healthy component for its own crashed query. Keep the
+      # `|| true`; never put the redirect back. `.github/scripts/check-workflow-shell.py` now
+      # fails the PR on that combination.
+      #
+      # The `name &&` guard in the query is the same lesson one layer down: jmespath's
+      # `contains()` THROWS on a null field and the throw aborts the WHOLE query, so a single
+      # untagged row would make this probe permanently blind. Costs nothing when name is set.
       - name: "Age of the newest published set (batching probe)"
         id: freshness
         if: steps.target.outputs.reason == 'push' && vars.CD_BATCH_WINDOW_MINUTES != ''
@@ -454,14 +465,14 @@ jobs:
           set -uo pipefail
           newest=$(az acr repository show-tags -n meshweaver --repository memex-portal-ai \
             --orderby time_desc --detail --top 20 \
-            --query "[?contains(name, 'ci.')] | [0].lastUpdateTime" -o tsv 2>/dev/null || true)
+            --query "[?name && contains(name, 'ci.')] | [0].lastUpdateTime" -o tsv || true)
           # Fail-open must survive EVERY failure shape, including a timestamp `date -d` cannot
           # parse: an error inside arithmetic expansion is fatal to the shell, which would fail
           # this step — and the gate job with it — CLOSED. So the epoch parse is guarded on its
           # own line and age_min only computed from a verified number (Copilot review, #1691).
           age_min=999999
           if [ -n "$newest" ]; then
-            epoch=$(date -u -d "$newest" +%s 2>/dev/null || true)
+            epoch=$(date -u -d "$newest" +%s || true)
             case "$epoch" in
               ''|*[!0-9]*) echo "::warning::Batching probe could not parse '$newest' — failing OPEN (this merge publishes)." ;;
               *) age_min=$(( ( $(date -u +%s) - epoch ) / 60 )) ;;
@@ -522,12 +533,12 @@ jobs:
           # (relevant stays true), so it never turned CD red — it only meant the image-irrelevant
           # skip below could never fire. The batching probe above already passes --detail.
           newest_short=$(az acr repository show-tags -n meshweaver --repository memex-portal-ai \
-            --orderby time_desc --detail --top 60 --query "[].name" -o tsv 2>/dev/null \
+            --orderby time_desc --detail --top 60 --query "[].name" -o tsv \
             | grep -E '^[0-9a-f]{7}$' | head -1 || true)
           if [ -n "$newest_short" ] && [ "$newest_short" != "$(printf '%s' "$SHA" | cut -c1-7)" ]; then
-            base=$(gh api "repos/$GITHUB_REPOSITORY/commits/$newest_short" --jq .sha 2>/dev/null || true)
+            base=$(gh api "repos/$GITHUB_REPOSITORY/commits/$newest_short" --jq .sha || true)
             if [ -n "$base" ]; then
-              files=$(gh api "repos/$GITHUB_REPOSITORY/compare/$base...$SHA" --jq '.files[].filename' 2>/dev/null || true)
+              files=$(gh api "repos/$GITHUB_REPOSITORY/compare/$base...$SHA" --jq '.files[].filename' || true)
               if [ -n "$files" ] && ! printf '%s\n' "$files" | grep -qvE "$IRRELEVANT"; then
                 relevant=false
               fi
@@ -1924,7 +1935,7 @@ jobs:
           # hole and it must stay loud. So the discriminator is tip-ness, not colour.
           if [ "$REASON" = "push" ] && [ "$PUBLISH" != "true" ] && [ "$GREEN" != "true" ] \
              && [ "${CONCLUSION#*/}" = "cancelled" ]; then
-            TIP=$(gh api "repos/${{ github.repository }}/commits/main" --jq '.sha' 2>/dev/null || echo "")
+            TIP=$(gh api "repos/${{ github.repository }}/commits/main" --jq '.sha' || echo "")
             if [ -z "$TIP" ]; then
               # \U0001f6a8 Say what is true, not what is convenient. Tip-ness was NOT established, so
               # claiming it (either way) would be the same sin this step exists to correct: a

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -601,14 +601,11 @@ jobs:
           # Step 2 of the plugin build contract: hand the tester the upstream seed, mounted
           # read-only. The tester checks it BEFORE the mesh boots (BakeSeed.Read — a seed it
           # cannot consume is a usage error, exit 2, never a green gate) and REFUSES a run that
-          # compiled a type the seed declared (BakeSeedConsumer.Shortfall).
-          SEED_ARGS=()
-          if [ -n "${SEED_DIR:-}" ]; then
-            SEED_MOUNT=(-v "$SEED_DIR:/seed:ro")
-            SEED_ARGS=(--seed /seed)
-          else
-            SEED_MOUNT=()
-          fi
+          # compiled a type the seed declared (BakeSeedConsumer.Shortfall). That mount happens on
+          # the GATE call below, not here: `compile` takes no --seed, and the gate is given
+          # $OWN_BAKE — into which the upstream zips are copied — as /seed.
+          # (SEED_ARGS/SEED_MOUNT arrays used to be built at this point and passed to neither
+          # docker run. shellcheck's SC2034 on them is what surfaced the leftover.)
           # ── BUILD ONCE, TEST WHAT WAS BUILT (Doc/Architecture/PluginBuildContract, step 3 → 4).
           # The gate used to compile in-mesh and DISCARD the result; publish-bake then compiled the
           # identical source again on merge. Now: `compile` (mesh-free, the producer) writes this


### PR DESCRIPTION
## The gap

`main-cd.yml` fires on `workflow_run`, `schedule` and `workflow_dispatch` — **never on `pull_request`**. So 2000 lines of shell that decide what is built, published and rolled to the fleet merged on the strength of being valid YAML, and the first execution of any edit to it was in production, on a cron.

#2642 is what that costs. A bake-only reconcile carried

```
tags=$(az acr manifest list-metadata … \
         --query "[?contains(tags, '${SHORT_SHA}')].tags[]" -o tsv 2>/dev/null || true)
```

`contains(null, …)` throws on the 16 untagged manifests in that repository, jmespath aborts the **whole** query, `az` exits non-zero, `2>/dev/null || true` swallows it — and the step then accused a **healthy** component: *"promote's Phase C never armed a release for this sha"*. Nine consecutive scheduled runs, ~33 hours, and **the step had never once succeeded in its life**. #2643 writes the trap up (this PR does not fix the idle-main trap that issue tracks).

## What I built — all three, in that order of confidence

### 1. shellcheck over every workflow's `run:` blocks

Extracted from the YAML and checked at `-S warning`, the same bar `hosting-operator.yml` already runs at for the operator scripts on disk (different target, so this complements rather than duplicates it).

It would **not** have caught the bug above; it is here because it is nearly free and catches a real class.

The one design decision that made it viable: `${{ … }}` is neutralised with a **variable**, not a literal. A literal makes shellcheck report every `[ "${{ github.event_name }}" = "push" ]` as a constant expression — that was **16 of the 16** findings on this tree, all artefacts. With a variable placeholder, the whole corpus of **209 run blocks yielded exactly 2 findings, and both were real**: `SEED_ARGS` and `SEED_MOUNT` in `node-repo-gate.yml` are built and passed to neither `docker run`. Removed rather than waived.

### 2. The swallowed non-zero exit — the class that actually bit

Flagged: a **captured** command substitution (assignment, `< <(…)`, `<<< "$(…)"`) whose stderr goes to `/dev/null` **and** whose failure yields a value indistinguishable from a successful-but-empty call (`|| true`, `|| :`, `|| echo ""`).

Two deliberate exclusions, each of which is the rule rather than a softening of it:

* **`cp … 2>/dev/null || true` collecting diagnostics is not flagged** — nothing reads its output, so a failure is not converted into a wrong answer.
* **`|| echo unknown` / `|| echo parse-error` is not flagged.** A named sentinel is the *correct* handling of this class — the caller can tell "the call failed" from "the answer is no", and this repo already does that in seven places. Flagging it would punish the fix and teach people to reach for `|| true`.

**The allow file is seeded with ONE entry, not with today's debt.** The first run found 22 findings; **21 were remedied in this PR**, because for a genuinely-intended fail-open the remedy costs nothing: dropping `2>/dev/null` leaves the control flow **byte-for-byte identical** and restores the evidence. That alone would have made #2642 a ten-minute diagnosis — az's own `In function contains(), invalid type for value: None` would have printed directly above the step's confident, wrong conclusion.

The single waiver is `publish-bake-bundles.sh`'s source-marker read, where the file's *absence is the normal state*, it runs ~40× per publish, and the empty answer is not taken as authoritative (it is tested against `$SOURCE_SHA` and falls through to republishing). The list is a one-way ratchet: an entry with no `#` reason **fails**, and an entry that matches nothing **fails**.

### 3. A smoke that EXECUTES main-cd's decision step against fixtures — no ACR, no Azure, no cluster

`test-cd-steps.py` **extracts** the release-version-recovery step from `main-cd.yml` by its `id:` (never a copy — a copy passes while the real thing rots), runs it under `bash` with a stub `az` that answers from a fixture using **real jmespath, the engine the azure-cli uses**, and asserts seven outcomes.

The fixture is the live registry's shape on the day of the incident: **2101 manifests, 16 of them untagged (`tags: null`)**, one digest carrying `aaf95af` / `main` / `3.0.0-rc8.ci.6360`.

The load-bearing case is the regression guard: **when `az` itself fails, the step must fail with az's message and must never report it as promote's fault.**

Anti-vacuity is enforced, not hoped for — the harness fails **red** if the step is renamed/moved (proved: `::error::no step with id: release …`), if it grows a `${{ }}` this harness cannot supply, or if it stops calling the stubbed command (proved: `::error::step release no longer calls az acr manifest list-metadata … every case below would pass vacuously`).

## Mutation evidence

Baseline: gate `exit=0` (`1 finding: 0 live, 1 allow-listed, 0 stale`), smoke `exit=0` (7/7).

| Mutation | `check-workflow-shell.py` | `test-cd-steps.py` |
|---|---|---|
| **A** — restore `2>/dev/null \|\| true` on the az read | **exit 1** — `[swallow] … main-cd.yml:1546` | **exit 1** — 2 cases red |
| **B** — drop the `tags &&` null guard | **exit 1** — `[jmespath] THROWS on a row whose field is null (In function contains(), invalid type for value: None …)` | **exit 1** — 2 cases red |
| **C** — the exact pre-#2642 line (both defects) | **exit 1** — 2 live findings, one of each check | **exit 1** — 3 cases red |
| **D** — rename the step's `id:` | — | **exit 1**, refuses to pass vacuously |
| **E** — step stops calling the stubbed command | — | **exit 1**, refuses to pass vacuously |
| restore | **exit 0** | **exit 0**, 7/7 |

Mutation C reproduces the production symptom exactly:

```
  FAIL  a bake-only reconcile recovers the version DESPITE 16 untagged manifests
  FAIL  a FAILING az is never reported as promote's fault
        the step blamed a healthy component for its own failed call:
        ::error::memex-portal-ai:aaf95af carries no version tag (tags on that digest:  ) —
        promote's Phase C never armed a release for this sha … Fix promote
```

That is the message that ran nine times over 33 hours.

Both scripts also carry `--self-test` (14 + 7 cases), run as the job's **first** step, each proving its check FIRES on the defect and stays SILENT on the fix — including that the `${{ }}` placeholder does not manufacture the 16 artefacts, and that the allow file's reason requirement and shrink-only ratchet both work.

## How it is wired, and why it cannot go grey

A new `workflow-shell` job in `dotnet-test.yml`, which `collect-results` — **the repo's only required status check** — now `needs`, with an explicit `!= 'success'` fail step (the `licence-gate` / `clients-gate` precedent). A gate whose verdict nothing reads is decorative.

Every input is in this repository — no secret, no cluster, no registry — so there is no condition under which it may decline to run and still render a tick:

* **no `needs:`** (not even the green-tree reuse path — this job is seconds; the reuse optimisation exists for a 70-runner-minute suite);
* **no input-shaped `if:`**, because GitHub renders a skipped job with the same tick as a passed one;
* **no path filter**, which is that same defect from the other side (an unrelated PR would "pass" by not running);
* **no `continue-on-error`**;
* **tools asserted** — a missing `shellcheck` or `jmespath` fails RED rather than quietly reducing the gate to whatever it could run. `jmespath==1.0.1` is pinned in a venv, and the pin *is* the fidelity claim.

## Verified in CI

[Run 33239711573 → *CI's own shell*](https://github.com/Systemorph/MeshWeaver/actions/runs/33239711573) — green, with all three steps executed: 14/14 self-test cases, `1 finding(s): 0 live, 1 allow-listed, 0 stale`, and 7/7 smoke cases against the extracted step.

One honest caveat surfaced by that run: the hosted runner carries **ShellCheck 0.9.0** while this was developed against 0.11.0, and the finding set is identical on both. A runner-image bump that brings a newer ShellCheck could therefore surface new findings on unrelated PRs — the same exposure `hosting-operator.yml`'s shellcheck job already carries, and the reason the assert step prints `shellcheck --version` into the log.

## What I deliberately did NOT do

* **`deploy/aks/operator/bin/*` and `deploy/homebrew/bin/memex-local` are out of scope.** Measured: 22 more sites match the swallow rule there. Diagnosing 22 waivers in scripts I would be guessing about is exactly how an allow file becomes a rubber stamp. `hosting-operator.yml` already shellchecks those files; extending the swallow rule to them is a separate, honest change.
* **No `actionlint`.** It would add workflow-level expression/`needs` checking, but it is a third-party binary needing a pinned digest, and the brief's #1 is specifically the `run:` blocks — which 60 lines of extraction cover with no new supply-chain surface. Worth revisiting deliberately.
* **`main-cd.yml` still does not run on `pull_request`**, and should not — it publishes. This gate is the substitute: the parts of it that are decidable without credentials are now decided on every PR.

## Files

* `.github/scripts/check-workflow-shell.py` — the three checks + `--self-test`
* `.github/scripts/test-cd-steps.py` — executes main-cd's decision step against fixtures
* `.github/workflow-shell.allow` — one entry, with its diagnosis
* `.github/workflows/dotnet-test.yml` — the `workflow-shell` job, wired into the required check (+5 swallow remedies)
* `.github/workflows/main-cd.yml` — 6 swallow remedies + the `name &&` null guard on the batching probe's query (the same defect as #2642, one step earlier, still live)
* `.github/workflows/node-repo-gate.yml` — the two dead arrays shellcheck found
* `.github/scripts/assert-bake-consumption.sh` — 1 swallow remedy

Related: #2643 (the idle-main trap — not fixed here), #2642 (the incident this gates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
