### PR TITLE
fix(graph): make "compiled Ok" checkable against the bytes actually served (#2471)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-29-a-page-now-tells-you-when-it-is-running-old-code.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-29-a-page-now-tells-you-when-it-is-running-old-code.md
@@ -1,0 +1,32 @@
+---
+Name: A page now tells you when it is running old code
+Category: Fix
+Description: If a page is executing a different build from the one its type reports, it now says so — instead of showing you old content under a green "compiled" status.
+Icon: Sparkle
+Order: -20260829
+---
+
+# A page now tells you when it is running old code
+
+A page could show you the previous version of itself while every status in the portal said the
+newest one had been compiled successfully. Recycling the page, recycling its type, and pressing
+Compile all reported success and changed nothing, so a fix that had been published and verified was
+indistinguishable from one that had not.
+
+The reason nothing noticed is that the portal was comparing the wrong thing. It checked *where* a
+build was stored, and the storage location does not change when a type is rebuilt without its
+version moving — so the location matched perfectly while the code behind it differed. Every warning
+built on that comparison was silent by construction, including the "a newer build is available"
+banner, and every recycle re-loaded the same copy it already had.
+
+Pages now compare the **identity of the code they are actually executing** against the identity the
+type records for its latest build. When they differ:
+
+* the page carries a banner saying it is not running the published build — and deliberately does
+  **not** offer a recycle link, because recycling does not fix this state;
+* the portal logs it as an error, naming both builds;
+* `get_diagnostics` names the build its `Ok` is about, and no longer claims the assembly "is
+  loaded" — it reports what it knows, which is that the build succeeded.
+
+This makes the situation visible and loud. It does not yet get the page onto the new code by itself;
+if you see the banner, report it.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -2111,6 +2111,15 @@ internal static class NodeTypeCompilationHelpers
             // without a store so legacy consumers keep the AssemblyLocation path.
             LatestAssemblyCollection = result.Collection ?? def.LatestAssemblyCollection,
             LatestAssemblyPath = result.ContentPath ?? def.LatestAssemblyPath,
+            // 🚨 The IDENTITY of the bytes, beside their ADDRESS (#2471). The path is a store key
+            // whose contents a pod resolves through its own local cache, so a path comparison
+            // cannot tell "this instance is on the published build" from "this instance is on a
+            // stale local copy at the same key" — which is why every recycle was inert while a
+            // portal served old code under a green Ok. Read from the emitted assembly (metadata
+            // only, nothing loaded); a producer with no readable file leaves the previous stamp
+            // alone rather than erasing it, exactly as the other assembly fields do.
+            LatestAssemblyMvid =
+                ServedBuildIdentity.OfFile(result.AssemblyLocation) ?? def.LatestAssemblyMvid,
             // The framework the assembly bound against — HasUsableBuild compares this to the
             // live FrameworkVersion so a MeshWeaver redeploy forces a recompile instead of
             // loading an ABI-stale DLL.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeContractHandler.cs
@@ -244,6 +244,14 @@ internal static class NodeTypeContractHandler
                                     // populate them (Null store).
                                     LatestAssemblyCollection = response.Collection ?? def.LatestAssemblyCollection,
                                     LatestAssemblyPath = response.ContentPath ?? def.LatestAssemblyPath,
+                                    // The bytes' identity beside their address (#2471). This
+                                    // handler RACES ApplyCompileSuccess (see the LastCompiledVersion
+                                    // note below), so it has to stamp the same shape — a success
+                                    // write that omitted the MVID would leave whichever writer won
+                                    // deciding whether the served build is checkable at all.
+                                    LatestAssemblyMvid =
+                                        ServedBuildIdentity.OfFile(response.AssemblyLocation)
+                                        ?? def.LatestAssemblyMvid,
                                     // 🚨 The version the BYTES are stored under — never curr.Version.
                                     // LastCompiledVersion is one half of the IAssemblyStore key
                                     // (nodeTypePath, version); the response echoes that key's version

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -415,6 +415,32 @@ public record NodeTypeDefinition
     public string? LatestAssemblyPath { get; init; }
 
     /// <summary>
+    /// 🚨 <b>The MVID of the bytes the last successful build PRODUCED — the identity a served
+    /// assembly can be checked against.</b> Lower-case hex, no separators; null on a node stamped
+    /// before this field existed, or by a producer that had no bytes to read.
+    ///
+    /// <para><see cref="LatestAssemblyPath"/> is an ADDRESS, not an identity. The store key is
+    /// <c>(nodeTypePath, <see cref="LastCompiledVersion"/>)</c>, a recompile of an
+    /// already-<c>Ok</c> type does not rewrite this node, and each pod resolves those bytes through
+    /// its own local cache — so the path can match perfectly while the bytes behind it differ per
+    /// replica. Every staleness check that compared paths was therefore structurally unable to see
+    /// the state in Systemorph/MeshWeaver#2471: a portal serving stale compiled code while
+    /// reporting <c>Ok</c>, surviving two NodeType recycles, four instance recycles and a forced
+    /// compile, with the <c>$Banner</c> stale-build adornment empty throughout.</para>
+    ///
+    /// <para>An MVID is minted per emitted assembly, so it answers the question the path cannot:
+    /// <i>are these the bytes this node is talking about?</i> Written by every success stamp
+    /// (<c>NodeTypeCompilationHelpers.ApplyCompileSuccess</c>, the adoption path in
+    /// <c>PrebuiltAssemblySeeder</c>, and <c>NodeTypeContractHandler</c>'s write-back) and read at
+    /// bind time by <c>NodeTypeEnrichmentHelpers</c>; see <see cref="ServedBuildIdentity"/>.</para>
+    ///
+    /// <para>🚨 Null is "I do not know", never "mismatch" — see
+    /// <see cref="ServedBuildIdentity.Mismatch"/>. A detector that fired on every legacy node's
+    /// first boot would be turned off before it ever caught anything.</para>
+    /// </summary>
+    public string? LatestAssemblyMvid { get; init; }
+
+    /// <summary>
     /// Free-form release notes captured next to the "Create Release" button on
     /// the Configuration view. Auto-saved through the same form-debounce path
     /// every other editable field uses (no manual read-on-click). Surfaced on

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1173,11 +1173,19 @@ internal static class NodeTypeEnrichmentHelpers
                     // WithStaleAssemblySelfHeal for why the gate is the published assembly path
                     // and not the node version.
                     var boundAssembly = def.LatestAssemblyPath;
+                    // 🚨 The IDENTITY of the bytes about to be bound, read ONCE per activation
+                    // (metadata only, nothing loaded) — the half the path cannot supply, and the
+                    // only thing that makes "compiled Ok" checkable against what is served (#2471).
+                    // Taken here rather than inside the watcher because the mismatch is true AT
+                    // BIND TIME: there is no later publication to wait for, which is exactly why a
+                    // publication-driven watcher stayed silent while memex served old code.
+                    var boundMvid = ServedBuildIdentity.OfFile(localPath);
 
                     if (compilationService is null)
                         return Observable.Return(WithStaleAssemblySelfHeal(
                             ApplyEntry(node, localPath, hubConfig: null, nodeType, meshConfiguration),
-                            meshHub, nodeType, boundAssembly, meshConfiguration, logger));
+                            meshHub, nodeType, boundAssembly, meshConfiguration, logger,
+                            def.LatestAssemblyMvid, boundMvid));
 
                     return compilationService.GetConfigurationsFromExistingAssembly(localPath!, nodeType)
                         .Take(1)
@@ -1191,7 +1199,8 @@ internal static class NodeTypeEnrichmentHelpers
                                 ApplyEntry(
                                     node, localPath, matching?.HubConfiguration,
                                     nodeType, meshConfiguration),
-                                meshHub, nodeType, boundAssembly, meshConfiguration, logger);
+                                meshHub, nodeType, boundAssembly, meshConfiguration, logger,
+                                def.LatestAssemblyMvid, boundMvid);
                         })
                         .Catch<MeshNode, Exception>(ex =>
                         {
@@ -1204,7 +1213,8 @@ internal static class NodeTypeEnrichmentHelpers
                                 nodeType, ex.GetType().Name, node.Path);
                             return Observable.Return(WithStaleAssemblySelfHeal(
                                 ApplyEntry(node, localPath, hubConfig: null, nodeType, meshConfiguration),
-                                meshHub, nodeType, boundAssembly, meshConfiguration, logger));
+                                meshHub, nodeType, boundAssembly, meshConfiguration, logger,
+                                def.LatestAssemblyMvid, boundMvid));
                         });
                 });
         }
@@ -1727,13 +1737,28 @@ internal static class NodeTypeEnrichmentHelpers
     /// </param>
     /// <param name="meshConfiguration">Used only for the null-config carve-out above.</param>
     /// <param name="logger">Best-effort diagnostics.</param>
+    /// <param name="publishedAssemblyMvid">
+    /// <see cref="NodeTypeDefinition.LatestAssemblyMvid"/> — the identity of the bytes the type
+    /// says it published. Null on a node stamped before that field existed.
+    /// </param>
+    /// <param name="boundAssemblyMvid">
+    /// 🚨 The MVID of the bytes this instance ACTUALLY BOUND, read from the local file
+    /// (<see cref="ServedBuildIdentity.OfFile"/>). This is the half the path comparison above
+    /// cannot supply: the store key is <c>(nodeTypePath, LastCompiledVersion)</c> and each pod
+    /// resolves it through its own local cache, so an instance can sit on a DIFFERENT build at the
+    /// SAME path — the #2471 state, in which the node reads <c>Ok</c>, the banner stayed empty, and
+    /// six recycles changed nothing. Null when the file could not be read; a null on either side is
+    /// "unknown" and never fires.
+    /// </param>
     internal static MeshNode WithStaleAssemblySelfHeal(
         MeshNode bound,
         IMessageHub meshHub,
         string nodeType,
         string? boundAssemblyPath,
         MeshConfiguration meshConfiguration,
-        ILogger? logger)
+        ILogger? logger,
+        string? publishedAssemblyMvid = null,
+        string? boundAssemblyMvid = null)
     {
         // Nothing published to compare against, or nothing that would compose a configuration:
         // leave the node exactly as it is.
@@ -1763,10 +1788,35 @@ internal static class NodeTypeEnrichmentHelpers
                         // seeded null so an instance on the current build shows nothing at all.
                         // Set() owns its disposal ("Disposed with the hub" — IMessageHub.Set), so
                         // no separate RegisterForDisposal for the subject.
-                        instanceHub.Set(new BehaviorSubject<StaleBuildOffer?>(null));
+                        // 🚨 SEEDED WITH THE VERDICT, not unconditionally null (#2471). If the
+                        // bytes this instance just bound are not the bytes the type says it
+                        // published, that is true AT BIND TIME — there is no later publication to
+                        // wait for, which is exactly why the watcher below (which only ever fires
+                        // on an incoming emission) stayed silent through 30+ minutes and six
+                        // recycles while memex served old code under a green Ok. The comparison is
+                        // taken once, here, and it is what makes the claim CHECKABLE at all.
+                        var served = ServedBuildIdentity.Mismatch(
+                            publishedAssemblyMvid, boundAssemblyMvid, nodeType);
+                        if (served is not null)
+                            // LogError, not Warning: a portal serving a build nobody published is
+                            // an integrity failure, and the whole cost of #2471 was that NOTHING
+                            // said so — every surface reported success.
+                            logger?.LogError(
+                                "Served build is NOT the published build for instance "
+                                + "'{InstancePath}': {Detail}", instanceHub.Address, served);
+                        instanceHub.Set(new BehaviorSubject<StaleBuildOffer?>(
+                            served is null
+                                ? null
+                                : new StaleBuildOffer(nodeType, boundAssemblyPath, boundAssemblyPath)
+                                {
+                                    Kind = StaleBuildKind.ServedBuildIsNotPublished,
+                                    PublishedAssemblyMvid = publishedAssemblyMvid,
+                                    BoundAssemblyMvid = boundAssemblyMvid,
+                                }));
                         instanceHub.RegisterForDisposal(ArmStaleAssemblySelfHeal(
                             meshHub.GetWorkspace().GetMeshNodeStream(nodeType),
                             instanceHub, nodeType, boundAssemblyPath, logger,
+                            boundAssemblyMvid: boundAssemblyMvid,
                             guards: NodeTypeCompilationHelpers.GuardsOf(meshHub),
                             // Deployment policy, resolved off the MESH hub's configuration: a
                             // production portal opts into convergence (auto-recycle), everything
@@ -1805,7 +1855,8 @@ internal static class NodeTypeEnrichmentHelpers
         ILogger? logger,
         IScheduler? scheduler = null,
         NodeTypeCompilationHelpers.BuildGuards? guards = null,
-        bool autoRecycle = false)
+        bool autoRecycle = false,
+        string? boundAssemblyMvid = null)
         // 🚨 ContentAs, never `is NodeTypeDefinition` (#1669): the type node reaches this stream
         // in UN-MATERIALIZED JSON shape whenever the publication just crossed a sync stream — the
         // normal shape for exactly the emission this watcher exists to catch. A CLR type test is
@@ -1819,10 +1870,18 @@ internal static class NodeTypeEnrichmentHelpers
             // (a second ContentAs would also duplicate its degraded-content warning logs).
             .Select(t => (Node: t,
                 Def: t?.ContentAs<NodeTypeDefinition>(instanceHub.JsonSerializerOptions, logger)))
+            // 🚨 EITHER identity may differ, and the second one is the whole of #2471. A PATH is a
+            // store key — (nodeTypePath, LastCompiledVersion), resolved per pod through a local
+            // cache — so a republication at the SAME key with different bytes is invisible to the
+            // path test, and that is the state in which a portal served stale code while reporting
+            // Ok through six recycles. The MVID test is added, never substituted: a legacy node
+            // carries no published MVID and must keep healing on the path exactly as before.
             .Where(x => x.Def is { } d
                 && NodeTypeCompilationHelpers.HasUsableBuild(x.Node!, d, guards)
                 && !string.IsNullOrEmpty(d.LatestAssemblyPath)
-                && !string.Equals(d.LatestAssemblyPath, boundAssemblyPath, StringComparison.Ordinal))
+                && (!string.Equals(d.LatestAssemblyPath, boundAssemblyPath, StringComparison.Ordinal)
+                    || ServedBuildIdentity.Mismatch(
+                        d.LatestAssemblyMvid, boundAssemblyMvid, nodeType) is not null))
             // 🚨 Wait for the type to stop publishing — see AssemblySettleWindow. An install
             // publishes twice (type, then its Source/) while instances are being read, and
             // recycling on each one disposes hubs mid-read.
@@ -1832,6 +1891,23 @@ internal static class NodeTypeEnrichmentHelpers
                 x =>
                 {
                     var published = x.Def?.LatestAssemblyPath;
+                    // 🚨 A SAME-PATH difference is not a build to converge ON, it is a build
+                    // MISMATCH to report (#2471). The path is a store key; if it did not move, a
+                    // recycle re-resolves the same key from the same local cache and lands on the
+                    // same bytes — which is precisely what was measured on memex six times over
+                    // while every surface reported success. So the auto-recycle branch below is
+                    // skipped here: converging on nothing would consume the Take(1) and leave the
+                    // instance in the same state with its one shot spent, and the banner never
+                    // shown.
+                    var samePath = string.Equals(
+                        published, boundAssemblyPath, StringComparison.Ordinal);
+                    if (samePath)
+                        logger?.LogError(
+                            "Served build is NOT the published build for instance '{InstancePath}': "
+                            + "{Detail}", instanceHub.Address,
+                            ServedBuildIdentity.Mismatch(
+                                x.Def?.LatestAssemblyMvid, boundAssemblyMvid, nodeType));
+
                     // 🚨 The DEPLOYMENT decides between the two terminal behaviours
                     // (AutoRecycleConfigKey):
                     //
@@ -1843,7 +1919,7 @@ internal static class NodeTypeEnrichmentHelpers
                     // and an unrelated node write costs nothing. Without it, prod after a package
                     // update is a mixture of old and new assemblies for as long as viewers do not
                     // click (the 2026-08-25 Store outage).
-                    if (autoRecycle)
+                    if (autoRecycle && !samePath)
                     {
                         logger?.LogInformation(
                             "Stale-build convergence: NodeType '{NodeType}' published a new build ('{Published}' supersedes '{Bound}') — auto-recycling instance '{InstancePath}' ({ConfigKey}=true)",
@@ -1865,8 +1941,19 @@ internal static class NodeTypeEnrichmentHelpers
                     // assembly indefinitely — safe, since that build worked, but "published" no
                     // longer implies "every instance is running it"; a deployment whose invariant
                     // is convergence opts into the branch above instead.
+                    // 🚨 The KIND follows which identity moved. A republication at the SAME path
+                    // whose bytes differ is not "a newer build is available, recycle to pick it
+                    // up" — the recycle re-binds the same local copy — so it must not be offered
+                    // as one (#2471). Only a genuine path advance earns the recycle link.
                     instanceHub.Get<BehaviorSubject<StaleBuildOffer?>>()
-                        ?.OnNext(new StaleBuildOffer(nodeType, published, boundAssemblyPath));
+                        ?.OnNext(new StaleBuildOffer(nodeType, published, boundAssemblyPath)
+                        {
+                            Kind = samePath
+                                ? StaleBuildKind.ServedBuildIsNotPublished
+                                : StaleBuildKind.NewerBuildAvailable,
+                            PublishedAssemblyMvid = x.Def?.LatestAssemblyMvid,
+                            BoundAssemblyMvid = boundAssemblyMvid,
+                        });
                 },
                 ex => logger?.LogWarning(ex,
                     "Stale-assembly self-heal watcher for NodeType '{NodeType}' (instance '{InstancePath}') faulted — falling back to manual Recycle",

--- a/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
@@ -342,6 +342,14 @@ public static class PrebuiltAssemblySeeder
                                     LastCompiledVersion = version,
                                     LatestAssemblyCollection = location.Collection,
                                     LatestAssemblyPath = location.ContentPath,
+                                    // The adopted bytes' own identity (#2471), read from the image
+                                    // in hand — no file, no load. An adopted build is exactly the
+                                    // case where a path says least: several pods adopt the same
+                                    // bundle under the same key, and a replica that later serves a
+                                    // different build is invisible to a path comparison.
+                                    LatestAssemblyMvid =
+                                        ServedBuildIdentity.OfBytes(assemblyBytes)
+                                        ?? def.LatestAssemblyMvid,
                                     CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
                                     // The adopted build retires any standing FAILURE verdict, so
                                     // the inputs it was formed from go with it (#1793) — exactly as

--- a/src/MeshWeaver.Graph/Configuration/ServedBuildIdentity.cs
+++ b/src/MeshWeaver.Graph/Configuration/ServedBuildIdentity.cs
@@ -1,0 +1,125 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// 🚨 <b>The MVID of the bytes — so "compiled Ok" can be CHECKED instead of believed.</b>
+///
+/// <para>A portal can serve STALE compiled code while reporting <c>Ok</c>/compiled, and survive
+/// every remedy the product offers: recycle the NodeType, recycle the instance, press Compile —
+/// each reports success and changes nothing, and <c>get_diagnostics</c> keeps saying <c>Ok</c>
+/// (Systemorph/MeshWeaver#2471; memex, 2026-08-26, over 30+ minutes and six recycles). A claim of
+/// <c>Ok</c> that is not backed by the bytes actually being served is a <b>lie with a green
+/// tick</b>, which is strictly worse than an error: a merged, published, correct fix becomes
+/// indistinguishable from one that is live, and the only honest check left is rendering the screen
+/// and counting what comes back — exactly what a compile status is supposed to save you from.</para>
+///
+/// <para><b>Why the existing check cannot see it.</b> The stale-build watcher compares
+/// <see cref="NodeTypeDefinition.LatestAssemblyPath"/> against the path an instance bound. A PATH is
+/// not an identity: the store key is <c>(nodeTypePath, LastCompiledVersion)</c>, a recompile of an
+/// already-<c>Ok</c> type does not rewrite its node, and a pod resolves those bytes through its own
+/// local cache — so the path can match perfectly while the bytes behind it differ per replica. That
+/// is why a recycle is inert: it re-binds the same path from the same local copy.</para>
+///
+/// <para><b>The MVID is the identity.</b> A module version id is minted per emitted assembly, so two
+/// builds of the same sources have different MVIDs and the same bytes always have the same one.
+/// Recording it beside the path turns "which build is this?" from a guess into a comparison —
+/// the same move the platform already makes with <c>framework-mvid.txt</c> beside a bake and the
+/// <c>_complete</c> sentinel beside a publication: <b>a postcondition is asserted, never hoped
+/// for.</b></para>
+///
+/// <para>🚨 <b>Metadata only — nothing is loaded.</b> Reading through <see cref="PEReader"/> costs a
+/// file open and a table lookup, takes no ALC, and cannot run the assembly's initializers. Loading
+/// it to ask for <c>ManifestModule.ModuleVersionId</c> would pin bytes this process may be about to
+/// replace, which is how an assembly-cache leak starts.</para>
+///
+/// <para>Every reader here DEGRADES TO NULL rather than throwing: an unreadable or absent file is
+/// "I do not know", and <see cref="Mismatch"/> treats "I do not know" as no evidence — never as a
+/// mismatch. A detector that faults an activation would be a worse defect than the one it detects.</para>
+/// </summary>
+public static class ServedBuildIdentity
+{
+    /// <summary>
+    /// The MVID of the assembly at <paramref name="path"/>, lower-case hex without separators
+    /// (the <c>"N"</c> format the framework identity already uses), or null when the file is
+    /// absent, unreadable, or not a managed PE.
+    /// </summary>
+    public static string? OfFile(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path))
+            return null;
+        try
+        {
+            using var stream = File.OpenRead(path);
+            return Read(stream);
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException
+                                       or InvalidOperationException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The MVID of an in-memory assembly image — the shape a bundle adoption has in hand, where no
+    /// file exists yet. Null when <paramref name="assembly"/> is empty or not a managed PE.
+    /// </summary>
+    public static string? OfBytes(byte[]? assembly)
+    {
+        if (assembly is null || assembly.Length == 0)
+            return null;
+        try
+        {
+            using var stream = new MemoryStream(assembly, writable: false);
+            return Read(stream);
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException
+                                       or InvalidOperationException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// The one-line account of a served build that is NOT the published one, or null when there is
+    /// no evidence of a mismatch.
+    ///
+    /// <para>🚨 <b>Null on ANY unknown, deliberately.</b> A node stamped before this field existed
+    /// carries no published MVID, and a producer without a store carries no path to read a served
+    /// one; treating either absence as a mismatch would fire the banner on every legacy node on the
+    /// first boot after this ships — a detector that cries wolf is uninstalled within the day, and
+    /// then the real signal is gone too. Absence of a "yes" is not a "no": it is silence, and
+    /// silence is reported by <see cref="Unverifiable"/> instead.</para>
+    /// </summary>
+    /// <param name="publishedMvid">The MVID the NodeType records for the build it published.</param>
+    /// <param name="servedMvid">The MVID of the bytes this instance actually bound.</param>
+    /// <param name="nodeType">The NodeType path, named in the message.</param>
+    public static string? Mismatch(string? publishedMvid, string? servedMvid, string nodeType)
+        => string.IsNullOrEmpty(publishedMvid)
+           || string.IsNullOrEmpty(servedMvid)
+           || string.Equals(publishedMvid, servedMvid, StringComparison.OrdinalIgnoreCase)
+            ? null
+            : $"'{nodeType}' reports a compiled build with MVID {publishedMvid}, but the bytes this "
+              + $"instance bound are MVID {servedMvid}. The node's status is therefore NOT evidence "
+              + "about what is being served: this hub is executing a DIFFERENT build from the one "
+              + "the type published. A recycle re-binds the same local copy and will not change it "
+              + "(Systemorph/MeshWeaver#2471).";
+
+    /// <summary>
+    /// Whether the comparison could not be taken at all — one side unknown. Distinct from "they
+    /// match": a caller that reports coverage must be able to say how many types it could not
+    /// check, or an all-green count over an all-unknown fleet reads as proof.
+    /// </summary>
+    public static bool Unverifiable(string? publishedMvid, string? servedMvid) =>
+        string.IsNullOrEmpty(publishedMvid) || string.IsNullOrEmpty(servedMvid);
+
+    private static string? Read(Stream stream)
+    {
+        using var pe = new PEReader(stream);
+        if (!pe.HasMetadata)
+            return null;
+        var md = pe.GetMetadataReader();
+        return md.GetGuid(md.GetModuleDefinition().Mvid).ToString("N");
+    }
+}

--- a/src/MeshWeaver.Graph/Configuration/StaleBuildBanner.cs
+++ b/src/MeshWeaver.Graph/Configuration/StaleBuildBanner.cs
@@ -9,9 +9,32 @@ using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Graph.Configuration;
 
+/// <summary>What the banner is ABOUT — two states that look alike and need opposite advice.</summary>
+public enum StaleBuildKind
+{
+    /// <summary>
+    /// The type has PUBLISHED a newer build and this instance is still on the previous one. Fully
+    /// functional, and a recycle picks the new one up — so the banner is an offer.
+    /// </summary>
+    NewerBuildAvailable,
+
+    /// <summary>
+    /// 🚨 The bytes this instance is EXECUTING are not the bytes the type says it published — the
+    /// served assembly's MVID differs from <see cref="NodeTypeDefinition.LatestAssemblyMvid"/>.
+    ///
+    /// <para>This is NOT an offer, and the difference matters to the reader: the node's
+    /// <c>Ok</c> is not evidence about what is being served, and a recycle re-binds the same local
+    /// copy, so pressing the button changes nothing. Systemorph/MeshWeaver#2471 — measured on memex
+    /// 2026-08-26 across two NodeType recycles, four instance recycles and a forced compile, with
+    /// this very adornment empty throughout because a PATH comparison cannot see it.</para>
+    /// </summary>
+    ServedBuildIsNotPublished,
+}
+
 /// <summary>
 /// The OFFER a per-instance hub publishes when its NodeType has compiled a build newer than the
-/// assembly this instance actually bound. Held on the instance hub (see
+/// assembly this instance actually bound — or, since #2471, when the bytes it is EXECUTING are not
+/// the bytes the type claims to have published at all. Held on the instance hub (see
 /// <see cref="StaleBuildBanner"/>) and rendered as a banner ABOVE the instance's real content.
 /// </summary>
 /// <param name="NodeType">The NodeType path that published the newer build.</param>
@@ -20,7 +43,23 @@ namespace MeshWeaver.Graph.Configuration;
 public sealed record StaleBuildOffer(
     string NodeType,
     string? PublishedAssemblyPath,
-    string? BoundAssemblyPath);
+    string? BoundAssemblyPath)
+{
+    /// <summary>
+    /// Which of the two states this is. 🚨 An init-only PROPERTY, never a primary-constructor
+    /// parameter: adding a defaulted parameter to a public record's primary ctor is
+    /// binary-breaking and <c>scripts/check-record-signatures.py</c> refuses it. Defaults to
+    /// <see cref="StaleBuildKind.NewerBuildAvailable"/>, so an existing construction keeps meaning
+    /// exactly what it meant.
+    /// </summary>
+    public StaleBuildKind Kind { get; init; } = StaleBuildKind.NewerBuildAvailable;
+
+    /// <summary>The MVID the NodeType records for the build it published; null when unknown.</summary>
+    public string? PublishedAssemblyMvid { get; init; }
+
+    /// <summary>The MVID of the bytes this instance actually bound; null when unknown.</summary>
+    public string? BoundAssemblyMvid { get; init; }
+}
 
 /// <summary>
 /// Renders "a newer build of this type is available — recycle to pick it up" as an ADORNMENT above
@@ -123,6 +162,14 @@ public static class StaleBuildBanner
     {
         if (offer is null)
             return Controls.Stack;
+
+        // 🚨 A served-build MISMATCH gets NO recycle link, and that omission is the message
+        // (#2471). Recycling re-binds the same local copy of the same store key, so offering the
+        // button here would hand the viewer the exact remedy that was measured to report success
+        // and change nothing — six times over, on memex. The banner's job in that state is to say
+        // the status is not evidence, not to suggest a cure it does not have.
+        if (offer.Kind == StaleBuildKind.ServedBuildIsNotPublished)
+            return Controls.Markdown(host.Localize("ui.mdServedBuildIsNotPublished"));
 
         var recycleHref = MeshNodeLayoutAreas.BuildUrl(nodePath, MeshNodeLayoutAreas.RecycleArea);
         return Controls.Markdown(

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -3811,7 +3811,10 @@ public class MeshOperations
                 : null,
             startedAt: status == CompilationStatus.Compiling ? def.LastCompileStartedAt : null,
             lastCompiledAt: status == CompilationStatus.Ok ? def.LastCompileSucceededAt : null,
-            hub.JsonSerializerOptions);
+            hub.JsonSerializerOptions,
+            // WHICH build the Ok is about (#2471) — the identity a caller can compare against the
+            // bytes an instance is actually serving.
+            def.LatestAssemblyMvid);
     }
 
     /// <summary>
@@ -4205,7 +4208,7 @@ public class MeshOperations
 
     /// <summary>
     /// Pure JSON formatter for <see cref="Compile"/>'s ALREADY-IN-FLIGHT answer (#576).
-    /// Lives on its own — like <see cref="FormatDiagnostics"/> — so a unit test can lock in
+    /// Lives on its own — like <c>FormatDiagnostics</c> — so a unit test can lock in
     /// the exact wording, because the wording is the whole point: the caller must learn
     /// (a) that a compile IS running, (b) that this call did NOT start a second one, and
     /// (c) WHERE to watch the running one. The previous answer (a 60s wait then
@@ -4255,6 +4258,32 @@ public class MeshOperations
         DateTimeOffset? startedAt,
         DateTimeOffset? lastCompiledAt,
         JsonSerializerOptions options)
+        => FormatDiagnostics(
+            status, nodeTypePath, error, startedAt, lastCompiledAt, options,
+            publishedAssemblyMvid: null);
+
+    /// <summary>
+    /// 🚨 <b>The overload that reports WHICH BUILD the status is about</b> (#2471).
+    ///
+    /// <para>An OVERLOAD, never an added optional parameter: a defaulted parameter replaces the
+    /// signature, so a module compiled against the old arity calls a method the new assembly does
+    /// not have — the abort this repo's <c>check-record-signatures.py</c> exists to refuse, in a
+    /// method rather than a record.</para>
+    /// </summary>
+    /// <param name="publishedAssemblyMvid">
+    /// <see cref="Graph.Configuration.NodeTypeDefinition.LatestAssemblyMvid"/> — the identity of
+    /// the bytes the last successful build produced. Null when unknown (a node stamped before the
+    /// field existed, or a producer with no readable assembly), in which case the reply is
+    /// unchanged.
+    /// </param>
+    public static string FormatDiagnostics(
+        CompilationStatus status,
+        string nodeTypePath,
+        string? error,
+        DateTimeOffset? startedAt,
+        DateTimeOffset? lastCompiledAt,
+        JsonSerializerOptions options,
+        string? publishedAssemblyMvid)
     {
         switch (status)
         {
@@ -4286,14 +4315,36 @@ public class MeshOperations
                     },
                     options);
             case CompilationStatus.Ok:
+                // 🚨 THIS REPLY USED TO OVERCLAIM, and the overclaim is #2471. "…and is loaded"
+                // asserts something this formatter has no evidence for: it reads the NODE's record,
+                // and a portal can serve a DIFFERENT build than the one that record describes — a
+                // path is a store key each pod resolves through its own local cache. On memex
+                // 2026-08-26 this said Ok while the page rendered the previous build, through two
+                // NodeType recycles, four instance recycles and a forced compile. A claim of Ok
+                // that is not backed by the bytes being served is a lie with a green tick, which
+                // is strictly worse than an error.
+                //
+                // So the reply now says exactly what it knows (the compile succeeded), NAMES the
+                // build it is about (mvid), and points at the one check that is actually about the
+                // served bytes. Do not restore the "is loaded" clause.
                 return JsonSerializer.Serialize(
                     new
                     {
                         status = "Ok",
                         nodeTypePath,
                         lastCompiledAt,
+                        mvid = publishedAssemblyMvid,
                         message = "Compile SUCCEEDED at " + lastCompiledAt?.ToString("u")
-                            + ". The NodeType assembly was built without errors and is loaded."
+                            + ". The NodeType assembly was built without errors"
+                            + (publishedAssemblyMvid is null
+                                ? "."
+                                : " (mvid " + publishedAssemblyMvid + ").")
+                            + " 🚨 This describes the BUILD, not what any hub is currently "
+                            + "executing: an instance can serve an older assembly at the same "
+                            + "store key. If a change is missing from a rendered page, the "
+                            + "$Banner adornment on that instance is the check (it fires when the "
+                            + "served build's mvid differs from this one) — a green status here is "
+                            + "not evidence."
                     },
                     options);
             case CompilationStatus.Unavailable:

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -634,6 +634,7 @@
   "ui.mdNodeToUpdateMissing": "**Fehler:** Zu aktualisierender MeshNode nicht gefunden.",
   "ui.mdRecyclingHub": "**Hub wird recycelt…** Weiterleitung folgt gleich.",
   "ui.mdStaleBuildAvailable": "**F\u00fcr diesen Typ liegt ein neuerer Build vor.** Diese Seite f\u00fchrt noch den zuvor kompilierten aus.",
+  "ui.mdServedBuildIsNotPublished": "**Diese Seite f\u00fchrt nicht den Build aus, den dieser Typ ver\u00f6ffentlicht hat.** Der Knoten meldet einen kompilierten Build, dessen Bytes von den ausgef\u00fchrten abweichen; sein Status sagt daher nichts \u00fcber das Sichtbare aus. Ein Recycle bindet dieselbe lokale Kopie erneut und \u00e4ndert nichts \u2014 bitte melden.",
   "ui.recycleConfirmTitle": "Diesen Hub neu starten?",
   "ui.recycleConfirmBody": "Der Hub des Knotens wird beendet und beim n\u00e4chsten Aufruf neu aufgebaut \u2014 dabei \u00fcbernimmt er den zuletzt kompilierten Build. Es wird nichts gel\u00f6scht und kein Inhalt ge\u00e4ndert.",
   "ui.recycleFailed": "Der Hub unter '{0}' hat nach dem angeforderten Neustart noch nicht wieder geantwortet: {1}",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -634,6 +634,7 @@
   "ui.mdNodeToUpdateMissing": "**Error:** Could not find MeshNode to update.",
   "ui.mdRecyclingHub": "**Recycling hub…** redirecting in a moment.",
   "ui.mdStaleBuildAvailable": "**A newer build of this type is available.** This page is still running the previously compiled one.",
+  "ui.mdServedBuildIsNotPublished": "**This page is NOT running the build this type published.** The node reports a compiled build whose bytes differ from the ones this page is executing, so its status says nothing about what you are seeing. A recycle re-binds the same local copy and will not change it \u2014 report this.",
   "ui.recycleConfirmTitle": "Recycle this hub?",
   "ui.recycleConfirmBody": "The node's hub is torn down and rebuilt on the next visit, picking up the latest compiled build. Nothing is deleted and no content changes.",
   "ui.recycleFailed": "The hub at '{0}' has not answered again yet after the recycle was requested: {1}",

--- a/test/MeshWeaver.Graph.Test/ServedBuildIsVerifiableTest.cs
+++ b/test/MeshWeaver.Graph.Test/ServedBuildIsVerifiableTest.cs
@@ -1,0 +1,320 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.Reactive.Testing;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>A portal must not be able to serve one build while reporting another</b> —
+/// Systemorph/MeshWeaver#2471.
+///
+/// <para>Measured on memex, 2026-08-26: the source node carried the change, <c>get_diagnostics</c>
+/// said <c>Ok</c>/compiled, and the rendered <c>Tests</c> area produced the OLD suite. It survived
+/// two NodeType recycles, four instance recycles and a forced compile over 30+ minutes, and the
+/// <c>$Banner</c> stale-build adornment — the one adornment whose entire job is to say "you are
+/// looking at an old build" — was EMPTY throughout.</para>
+///
+/// <para><b>Why the adornment could not fire, and why no recycle helped.</b> The watcher compared
+/// <see cref="NodeTypeDefinition.LatestAssemblyPath"/> against the path the instance bound. A path
+/// is a STORE KEY — <c>(nodeTypePath, LastCompiledVersion)</c> — which each pod resolves through
+/// its own local cache, and a recompile of an already-<c>Ok</c> type does not advance the node's
+/// version. So the key can be identical on both sides while the bytes behind it differ, and a
+/// recycle simply re-resolves the same key from the same local copy. A path comparison is
+/// structurally incapable of observing this state, and every remedy built on it is inert by
+/// construction.</para>
+///
+/// <para><b>What makes the claim checkable.</b> An assembly's MVID is minted per emission, so it
+/// answers the question the path cannot: <i>are these the bytes this node is talking about?</i>
+/// Recording it on the node and reading it off the bound file turns "compiled Ok" from something
+/// believed into something COMPARED — the same postcondition-not-hope move the platform already
+/// makes with <c>framework-mvid.txt</c> beside a bake and the <c>_complete</c> sentinel beside a
+/// publication.</para>
+/// </summary>
+public class ServedBuildIsVerifiableTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string NodeTypePath = "TestData/ServedBuildType";
+    private const string InstancePath = "TestData/ServedBuildType/instance1";
+    private const string BoundAssembly = "TestData_ServedBuildType/v10-abc-111111111111.dll";
+    private const string BoundMvid = "1111111111111111111111111111111a";
+    private const string PublishedMvid = "2222222222222222222222222222222b";
+
+    // ── the pure identity surface ─────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The MVID read from the file must be the assembly's REAL one — otherwise the whole detector
+    /// compares two numbers it made up. Ground truth is the loaded assembly's own
+    /// <see cref="Module.ModuleVersionId"/>; the reader must reach the same value WITHOUT loading.
+    /// </summary>
+    [Fact]
+    public void OfFile_ReadsTheAssemblysRealMvid_WithoutLoadingIt()
+    {
+        var assembly = typeof(ServedBuildIdentity).Assembly;
+
+        ServedBuildIdentity.OfFile(assembly.Location)
+            .Should().Be(assembly.ManifestModule.ModuleVersionId.ToString("N"));
+    }
+
+    /// <summary>Two different assemblies have two different identities — the property the whole
+    /// comparison rests on. A reader that returned a constant would pass every "it reads something"
+    /// assertion and detect nothing.</summary>
+    [Fact]
+    public void OfFile_DistinguishesTwoDifferentAssemblies()
+    {
+        var mine = ServedBuildIdentity.OfFile(typeof(ServedBuildIdentity).Assembly.Location);
+        var bcl = ServedBuildIdentity.OfFile(typeof(object).Assembly.Location);
+
+        mine.Should().NotBeNullOrEmpty();
+        bcl.Should().NotBeNullOrEmpty();
+        mine.Should().NotBe(bcl);
+    }
+
+    /// <summary>
+    /// The same bytes through the in-memory reader (the shape a bundle adoption has in hand — no
+    /// file exists yet) must agree with the file reader, or an adopted build would be stamped with
+    /// an identity nothing else computes.
+    /// </summary>
+    [Fact]
+    public void OfBytes_AgreesWithOfFile()
+    {
+        var path = typeof(ServedBuildIdentity).Assembly.Location;
+
+        ServedBuildIdentity.OfBytes(File.ReadAllBytes(path))
+            .Should().Be(ServedBuildIdentity.OfFile(path));
+    }
+
+    /// <summary>
+    /// 🚨 A DETECTOR MUST NEVER FAULT AN ACTIVATION. It runs on the hot path of every per-instance
+    /// hub binding, so an absent, unreadable or non-managed file has to degrade to "I do not know"
+    /// — a throw here would turn a reporting improvement into an outage.
+    /// </summary>
+    [Fact]
+    public void EveryUnreadableInputDegradesToNull_NeverAThrow()
+    {
+        var notAnAssembly = Path.Combine(Path.GetTempPath(),
+            $"served-build-{Guid.NewGuid():N}.dll");
+        File.WriteAllText(notAnAssembly, "this is not a PE file");
+        try
+        {
+            ServedBuildIdentity.OfFile(null).Should().BeNull();
+            ServedBuildIdentity.OfFile("").Should().BeNull();
+            ServedBuildIdentity.OfFile("/does/not/exist.dll").Should().BeNull();
+            ServedBuildIdentity.OfFile(notAnAssembly).Should().BeNull();
+            ServedBuildIdentity.OfBytes(null).Should().BeNull();
+            ServedBuildIdentity.OfBytes([]).Should().BeNull();
+            ServedBuildIdentity.OfBytes([1, 2, 3]).Should().BeNull();
+        }
+        finally
+        {
+            File.Delete(notAnAssembly);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 UNKNOWN IS NOT A MISMATCH. Every node stamped before <c>LatestAssemblyMvid</c> existed
+    /// carries a null on one side; treating that as evidence would fire the banner on every legacy
+    /// node on the first boot after this ships, and a detector that cries wolf is switched off
+    /// within the day — taking the real signal with it.
+    /// </summary>
+    [Theory]
+    [InlineData(null, null)]
+    [InlineData(PublishedMvid, null)]
+    [InlineData(null, BoundMvid)]
+    [InlineData("", BoundMvid)]
+    [InlineData(PublishedMvid, "")]
+    [InlineData(PublishedMvid, PublishedMvid)]
+    public void Mismatch_IsNullWheneverThereIsNoEvidenceOfOne(string? published, string? served)
+    {
+        ServedBuildIdentity.Mismatch(published, served, NodeTypePath).Should().BeNull();
+        if (published is null or "" || served is null or "")
+            ServedBuildIdentity.Unverifiable(published, served).Should().BeTrue(
+                "a comparison that could not be taken must be reportable as such, or an all-green "
+                + "count over an all-unknown fleet reads as proof");
+    }
+
+    /// <summary>
+    /// …and when both sides ARE known and differ, the message must name both builds and say the
+    /// thing the reader most needs: the node's status is not evidence, and a recycle will not help.
+    /// </summary>
+    [Fact]
+    public void Mismatch_NamesBothBuilds_AndSaysARecycleWillNotHelp()
+    {
+        var detail = ServedBuildIdentity.Mismatch(PublishedMvid, BoundMvid, NodeTypePath);
+
+        detail.Should().NotBeNull();
+        detail.Should().Contain(PublishedMvid);
+        detail.Should().Contain(BoundMvid);
+        detail.Should().Contain(NodeTypePath);
+        detail.Should().Contain("NOT evidence");
+        detail.Should().Contain("A recycle re-binds the same local copy");
+    }
+
+    // ── the watcher: the state a PATH comparison cannot see ───────────────────────────────────
+
+    private IMessageHub BuildHub() =>
+        Mesh.GetHostedHub(new Address(InstancePath), c => c.WithTypes(typeof(NodeTypeDefinition)));
+
+    private (IMessageHub Hub, List<StaleBuildOffer?> Offers, IObservable<bool> Disposed) BuildInstanceHub()
+    {
+        var hub = BuildHub();
+        var subject = new BehaviorSubject<StaleBuildOffer?>(null);
+        hub.Set(subject);
+        var observed = new List<StaleBuildOffer?>();
+        subject.Subscribe(observed.Add);
+        var disposed = new ReplaySubject<bool>(1);
+        hub.RegisterForDisposal(_ =>
+        {
+            disposed.OnNext(true);
+            disposed.OnCompleted();
+        });
+        return (hub, observed, disposed);
+    }
+
+    private static MeshNode TypeNode(long version, string assemblyPath, string? mvid) =>
+        new MeshNode("ServedBuildType", "TestData")
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Version = version,
+            Content = new NodeTypeDefinition
+            {
+                CompilationStatus = CompilationStatus.Ok,
+                LatestAssemblyCollection = "assemblies",
+                LatestAssemblyPath = assemblyPath,
+                LatestAssemblyMvid = mvid,
+                CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
+            }
+        };
+
+    private static void Settle(TestScheduler scheduler) =>
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(30).Ticks);
+
+    private static async Task<bool> DisposedWithinAsync(IObservable<bool> disposed, TimeSpan window)
+    {
+        try { return await disposed.FirstAsync().Timeout(window).ToTask(); }
+        catch (TimeoutException) { return false; }
+    }
+
+    /// <summary>
+    /// 🚨 THE #2471 SIGNAL: the type republishes at the SAME assembly path with DIFFERENT bytes.
+    /// The path comparison sees nothing — this emission is byte-for-byte the "unrelated node write"
+    /// the anti-bounce rule deliberately ignores — so before this the banner stayed empty exactly
+    /// when it was needed.
+    /// </summary>
+    [Fact]
+    public void SameAssemblyPath_DifferentBytes_IsOffered_AsAServedBuildMismatch()
+    {
+        var (hub, offers, _) = BuildInstanceHub();
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler,
+            boundAssemblyMvid: BoundMvid);
+
+        // The instance's OWN build republished — same path, same bytes. Still silent.
+        typeStream.OnNext(TypeNode(version: 11, BoundAssembly, BoundMvid));
+        Settle(scheduler);
+        offers.Should().NotContain(o => o != null,
+            "republishing the very bytes this instance is running is not a mismatch");
+
+        // Same store key, DIFFERENT bytes behind it.
+        typeStream.OnNext(TypeNode(version: 12, BoundAssembly, PublishedMvid));
+        Settle(scheduler);
+
+        var offer = offers.LastOrDefault(o => o is not null);
+        offer.Should().NotBeNull(
+            "the served bytes are not the published bytes — the one state $Banner exists for");
+        offer!.Kind.Should().Be(StaleBuildKind.ServedBuildIsNotPublished);
+        offer.PublishedAssemblyMvid.Should().Be(PublishedMvid);
+        offer.BoundAssemblyMvid.Should().Be(BoundMvid);
+    }
+
+    /// <summary>
+    /// 🚨 …and it must NOT be auto-recycled, even on a portal that opted into convergence. The
+    /// path did not move, so the recycle re-resolves the same store key from the same local cache
+    /// and lands on the same bytes — which is precisely what was measured six times over. Worse,
+    /// the watcher is <c>Take(1)</c>: spending that one shot on a recycle that changes nothing
+    /// leaves the instance in the same state with no banner and nothing left to fire.
+    /// </summary>
+    [Fact]
+    public async Task ASameKeyMismatch_IsNeverAutoRecycled_EvenWhenConvergenceIsOn()
+    {
+        var (hub, offers, disposed) = BuildInstanceHub();
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler,
+            autoRecycle: true, boundAssemblyMvid: BoundMvid);
+
+        typeStream.OnNext(TypeNode(version: 12, BoundAssembly, PublishedMvid));
+        Settle(scheduler);
+
+        (await DisposedWithinAsync(disposed, TimeSpan.FromMilliseconds(300))).Should().BeFalse(
+            "recycling re-binds the same local copy of the same store key — it is not convergence");
+        offers.LastOrDefault(o => o is not null).Should().NotBeNull(
+            "the banner is what the viewer gets instead, and it must not be swallowed by the "
+            + "auto-recycle branch");
+    }
+
+    /// <summary>
+    /// The unchanged half, guarded: a genuine PATH advance is still an OFFER — a newer build the
+    /// user can take with a recycle — and still converges when the deployment asked for it. The
+    /// #2471 detection is ADDED to the watcher, never substituted for what it already did.
+    /// </summary>
+    [Fact]
+    public async Task ARealNewBuild_IsStillAnOffer_AndStillConverges()
+    {
+        var (offerHub, offers, offerDisposed) = BuildInstanceHub();
+        var offerStream = new Subject<MeshNode>();
+        var offerScheduler = new TestScheduler();
+        using var offerWatcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
+            offerStream, offerHub, NodeTypePath, BoundAssembly, logger: null, offerScheduler,
+            boundAssemblyMvid: BoundMvid);
+
+        offerStream.OnNext(TypeNode(
+            version: 12, "TestData_ServedBuildType/v12-abc-222222222222.dll", PublishedMvid));
+        Settle(offerScheduler);
+
+        var offer = offers.LastOrDefault(o => o is not null);
+        offer.Should().NotBeNull();
+        offer!.Kind.Should().Be(StaleBuildKind.NewerBuildAvailable,
+            "a new build at a new key IS takeable with a recycle — that offer must not be "
+            + "downgraded into the #2471 message, which tells the user the button will not help");
+        (await DisposedWithinAsync(offerDisposed, TimeSpan.FromMilliseconds(300)))
+            .Should().BeFalse("the default is an offer, never a self-recycle");
+    }
+
+    /// <summary>
+    /// A node stamped before <c>LatestAssemblyMvid</c> existed carries a null published identity.
+    /// Every such instance must behave EXACTLY as it did before this change — silent on a same-path
+    /// republication — or the first boot after this ships banners the whole mesh.
+    /// </summary>
+    [Fact]
+    public void ALegacyNodeWithNoRecordedMvid_BehavesExactlyAsBefore()
+    {
+        var (hub, offers, _) = BuildInstanceHub();
+        var typeStream = new Subject<MeshNode>();
+        var scheduler = new TestScheduler();
+        using var watcher = NodeTypeEnrichmentHelpers.ArmStaleAssemblySelfHeal(
+            typeStream, hub, NodeTypePath, BoundAssembly, logger: null, scheduler,
+            boundAssemblyMvid: BoundMvid);
+
+        for (var version = 11; version <= 20; version++)
+            typeStream.OnNext(TypeNode(version, BoundAssembly, mvid: null));
+        Settle(scheduler);
+
+        offers.Should().NotContain(o => o != null,
+            "unknown is not a mismatch — a null published mvid must never fire the banner");
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/DiagnosticsDescribesTheBuildNotTheServeTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/DiagnosticsDescribesTheBuildNotTheServeTest.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Text.Json;
+using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract (#2370)
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 <b><c>get_diagnostics</c> must describe the BUILD, never claim what is being SERVED</b> —
+/// Systemorph/MeshWeaver#2471.
+///
+/// <para>The <c>Ok</c> reply used to end <i>"The NodeType assembly was built without errors <b>and
+/// is loaded</b>."</i> The first half is what this formatter knows: it reads the node's record. The
+/// second half is a claim about a hub's runtime state that nothing in the read establishes — and on
+/// memex, 2026-08-26, it was FALSE for over 30 minutes while the portal served the previous build
+/// through two NodeType recycles, four instance recycles and a forced compile.</para>
+///
+/// <para>That is the worst shape a diagnostic can take: a success signal that is not measuring the
+/// thing it names. It makes a merged, published, correct fix indistinguishable from one that is
+/// live, and it silently invalidates "I fixed it and verified the compile is green" for every fix
+/// on the portal. The same family as an MCP write reporting <c>Patched:</c> without landing (#2469)
+/// and a cancelled CI run reading as a settled red one (#2470).</para>
+///
+/// <para>Pure formatter assertions — no mesh, no hub. The wording IS the contract here, exactly as
+/// the <c>"Compile SUCCEEDED"</c> pin above it has always been.</para>
+/// </summary>
+public class DiagnosticsDescribesTheBuildNotTheServeTest
+{
+    private const string TypePath = "ReinsuranceDemo/Walkthrough";
+    private const string Mvid = "0123456789abcdef0123456789abcdef";
+
+    private static readonly DateTimeOffset CompiledAt =
+        new(2026, 8, 26, 23, 4, 54, TimeSpan.Zero);
+
+    private static string Ok(string? mvid) => MeshOperations.FormatDiagnostics(
+        CompilationStatus.Ok, TypePath, error: null, startedAt: null,
+        lastCompiledAt: CompiledAt, JsonSerializerOptions.Default, publishedAssemblyMvid: mvid);
+
+    /// <summary>
+    /// The claim that is not backed by anything must be gone. A reader acting on "is loaded" stops
+    /// looking — which is why the #2471 session spent 30 minutes recycling instead of comparing
+    /// builds.
+    /// </summary>
+    [Fact]
+    public void TheOkReply_NoLongerClaimsTheAssemblyIsLoaded()
+    {
+        var reply = Ok(Mvid);
+
+        reply.Should().NotContain("is loaded",
+            "the formatter reads the NODE's record; whether any hub is executing those bytes is "
+            + "not knowable from it, and asserting it is the #2471 lie with a green tick");
+        reply.Should().Contain("Compile SUCCEEDED at",
+            "the half it DOES know must still be stated as plainly as before");
+        reply.Should().Contain("built without errors");
+    }
+
+    /// <summary>
+    /// …and it must say WHICH build, so the claim can be checked rather than believed. Without the
+    /// identity in the reply there is nothing for a caller to compare the served bytes against, and
+    /// "verify by rendering the screen and counting what comes back" stays the only honest check.
+    /// </summary>
+    [Fact]
+    public void TheOkReply_NamesTheBuildItIsAbout_AndPointsAtTheCheckThatIsAboutTheServedBytes()
+    {
+        var reply = Ok(Mvid);
+
+        reply.Should().Contain(Mvid, "the reply must name the build the status is about");
+        reply.Should().Contain("\"mvid\"",
+            "as a FIELD, not only inside prose — a caller compares it, it does not read it");
+        reply.Should().Contain("not what any hub is currently executing");
+        reply.Should().Contain("$Banner",
+            "the reader is pointed at the one check that IS about the served bytes");
+    }
+
+    /// <summary>
+    /// A node stamped before the identity existed still answers, unchanged in substance: no
+    /// fabricated mvid, and still no "is loaded". Degrading to silence about the identity is
+    /// correct; degrading back to the overclaim would not be.
+    /// </summary>
+    [Fact]
+    public void WithNoRecordedIdentity_ItStaysHonestRatherThanReverting()
+    {
+        var reply = Ok(null);
+
+        reply.Should().Contain("Compile SUCCEEDED at");
+        reply.Should().NotContain("is loaded");
+        reply.Should().Contain("not what any hub is currently executing");
+    }
+
+    /// <summary>
+    /// The pre-existing 6-argument overload must keep working and keep meaning what it meant — it
+    /// is a public entry point, and an added optional parameter (rather than this overload) would
+    /// be the binary break <c>scripts/check-record-signatures.py</c> exists to refuse, one shape
+    /// over.
+    /// </summary>
+    [Fact]
+    public void TheOriginalOverloadStillCompilesAndAnswers()
+    {
+        var reply = MeshOperations.FormatDiagnostics(
+            CompilationStatus.Ok, TypePath, error: null, startedAt: null,
+            lastCompiledAt: CompiledAt, JsonSerializerOptions.Default);
+
+        reply.Should().Contain("Compile SUCCEEDED at");
+        reply.Should().NotContain("is loaded");
+    }
+
+    /// <summary>The Error branch is untouched — the one case where "fix the source" IS the right
+    /// instruction must not be blurred by this change.</summary>
+    [Fact]
+    public void TheErrorReplyIsUnchanged()
+    {
+        var reply = MeshOperations.FormatDiagnostics(
+            CompilationStatus.Error, TypePath, error: "CS0246: not found", startedAt: null,
+            lastCompiledAt: null, JsonSerializerOptions.Default, publishedAssemblyMvid: Mvid);
+
+        reply.Should().Contain("Compile FAILED");
+        reply.Should().Contain("CS0246: not found");
+    }
+}


### PR DESCRIPTION
Lands the **detection** half of #2471 — a portal serving stale compiled code while reporting `Ok`.

## Why nothing could see it, and why no remedy worked

Measured on `memex`, 2026-08-26: the source node carried the change, `get_diagnostics` said `Ok`/compiled, and `ReinsuranceDemo/Walkthrough`'s in-node `Tests` area still rendered the **old** suite — through **two NodeType recycles, four instance recycles and a forced compile**, over 30+ minutes, with the **`$Banner` stale-build adornment empty throughout**.

That is not a coincidence of timing. Every staleness check in the platform compared `NodeTypeDefinition.LatestAssemblyPath` against the path the instance bound. **A path is a store key**, `(nodeTypePath, LastCompiledVersion)`, and:

- each pod resolves those bytes through **its own local cache**;
- a recompile of an already-`Ok` type **does not advance the node's version**.

So the key can be identical on both sides while the bytes behind it differ per replica — and a recycle simply re-resolves the same key from the same local copy. **A path comparison is structurally incapable of observing this state, and every remedy built on one is inert by construction.** The banner was not broken; it was blind.

This is the worst class of defect in the codebase: a claim of `Ok` that is not backed by the bytes being served is **a lie with a green tick**, strictly worse than an error. A merged, published, correct fix becomes indistinguishable from one that is live.

## What makes the claim checkable

An assembly's **MVID** is minted per emission, so it answers the question the path cannot: *are these the bytes this node is talking about?* Recording it on the node and reading it off the bound file turns "compiled Ok" from something believed into something **compared** — the same postcondition-not-hope move the platform already makes with `framework-mvid.txt` beside a bake and the `_complete` sentinel beside a publication.

- **`ServedBuildIdentity`** (new) — MVID from a file or from bytes. **Metadata only, nothing loaded**: loading to ask for `ManifestModule.ModuleVersionId` would pin bytes this process may be about to replace. Every reader degrades to `null` rather than throwing — it runs on the hot path of every per-instance hub binding, and a detector that faults an activation is a worse defect than the one it detects.
- **`NodeTypeDefinition.LatestAssemblyMvid`** — stamped by **all three** success writers: `ApplyCompileSuccess` (the one stamp shape), the adoption path in `PrebuiltAssemblySeeder` (from the image in hand), and `NodeTypeContractHandler`'s write-back, which *races* the first and therefore has to stamp the same shape.
- **`EnrichWithNodeType`** reads the bound file's MVID **once per activation** and hands both identities down. 🚨 The mismatch is true **at bind time** — there is no later publication to wait for, which is exactly why a publication-driven watcher stayed silent — so the offer is **seeded with the verdict** rather than with `null`, and logged at **`LogError`**, not Warning: a portal serving a build nobody published is an integrity failure, and the entire cost of #2471 was that *nothing said so*.
- **The watcher fires on either identity.** Added, never substituted: a legacy node with no recorded MVID keeps healing on the path exactly as before.

## The two states need opposite advice

`StaleBuildKind` separates them, and the difference is load-bearing:

| state | banner says | recycle link? | auto-recycle? |
|---|---|---|---|
| `NewerBuildAvailable` (path advanced) | "a newer build is available" | yes — unchanged | yes, under `AutoRecycle`, unchanged |
| `ServedBuildIsNotPublished` (same key, different bytes) | "this page is NOT running the build this type published … a recycle will not change it" | **no** | **never** |

Offering the recycle button in the second state would hand the viewer the exact remedy that was measured to report success and change nothing, six times over. And the watcher is `Take(1)`: spending that one shot on a recycle that converges on nothing leaves the instance in the same state with no banner and nothing left to fire.

## `get_diagnostics` stops overclaiming

The `Ok` reply ended *"The NodeType assembly was built without errors **and is loaded**."* The first half is what the formatter knows — it reads the node's record. The second is a claim about a hub's runtime state that nothing in the read establishes, and it was **false for 30 minutes** while the portal served the previous build. It now states only what it knows, **names the build** (`mvid` as a field, so a caller can compare rather than read), and points at the check that *is* about the served bytes.

Added as an **overload**, never an optional parameter — a defaulted parameter replaces the signature, which is the binary break `scripts/check-record-signatures.py` exists to refuse, one shape over. Same reason `StaleBuildOffer`'s new fields are init-only properties.

## Tests

11 new (`ServedBuildIsVerifiableTest`, `DiagnosticsDescribesTheBuildNotTheServeTest`). Six have a before/after and **all six fail against the previous behaviour** (the fix reverted in the watcher's `Where`, the offer's `Kind`, the auto-recycle guard and the `Ok` message):

```
Failed  ServedBuildIsVerifiableTest.SameAssemblyPath_DifferentBytes_IsOffered_AsAServedBuildMismatch
        Expected value not to be <null> because the served bytes are not the published bytes
        — the one state $Banner exists for.
Failed  ServedBuildIsVerifiableTest.ASameKeyMismatch_IsNeverAutoRecycled_EvenWhenConvergenceIsOn
        Expected value not to be <null> because the banner is what the viewer gets instead,
        and it must not be swallowed by the auto-recycle branch.
Failed  DiagnosticsDescribesTheBuildNotTheServeTest.TheOkReply_NoLongerClaimsTheAssemblyIsLoaded
        Did not expect "… The NodeType assembly was built without errors and is loaded." to
        contain "is loaded".
Failed  DiagnosticsDescribesTheBuildNotTheServeTest.TheOkReply_NamesTheBuildItIsAbout_…
        Expected "… built without errors and is loaded." to contain "0123456789abcdef…"
        because the reply must name the build the status is about.
Failed  DiagnosticsDescribesTheBuildNotTheServeTest.WithNoRecordedIdentity_ItStaysHonestRatherThanReverting
Failed  DiagnosticsDescribesTheBuildNotTheServeTest.TheOriginalOverloadStillCompilesAndAnswers
```

The other five pin the new primitive itself and have no unfixed counterpart — the type does not exist on `main`. They are not decoration: `OfFile_ReadsTheAssemblysRealMvid_WithoutLoadingIt` checks the reader against `Module.ModuleVersionId` (a reader returning a constant would pass every "it reads something" assertion and detect nothing), and `Mismatch_IsNullWheneverThereIsNoEvidenceOfOne` + `ALegacyNodeWithNoRecordedMvid_BehavesExactlyAsBefore` pin the property that keeps this from bannering the whole mesh on its first boot.

Green: `MeshWeaver.Graph.Test` **1727/1727**; `MeshWeaver.Hosting.Monolith.Test` (Diagnostics/StaleBuild/SelfHeal/Prebuilt/BatchBake/CompilePark/CodeEditRecompile) **47/47**; `MeshWeaver.Messaging.Hub.Test` Localization **56/56**; full solution builds clean; `check-record-signatures.py` and `check-type-forwards.py` clean against `origin/main`.

## 🚨 What this does NOT do — the rest of #2471

**This is detection, not convergence.** After it, the stale state is *loud* — an `Error` log naming both builds, a banner on the page, and an `mvid` in `get_diagnostics` a caller can compare — instead of silent under a green tick. What remains:

1. **Making it converge.** Nothing here gets a wedged instance onto the published bytes; the honest banner says the recycle will not help, and it is right. The cure is upstream, in how the local assembly copy is keyed and invalidated — the store key `(nodeTypePath, LastCompiledVersion)` is not unique per build, which is the actual root cause and a change to the resolution path, not the reporting path.
2. **The mechanism behind the memex sighting is still unproven.** #2471's own comment records replicas straddling two framework identities, each considering the other's build stale and re-stamping the node, and is explicit that this is *"a mechanism consistent with the evidence, not a measurement of it"*. This PR gives that measurement its instrument (the same node read through two pods should now disagree, loudly) but does not take it.
3. **Coverage is per-instance, on activation.** There is no fleet-wide sweep answering "how many types is this portal serving a different build for". `ServedBuildIdentity.Unverifiable` exists so such a sweep can report what it could not check — an all-green count over an all-unknown fleet must not read as proof — but nothing calls it yet.
4. **Legacy nodes are unverifiable until their next successful build**, by design (unknown is not a mismatch).

Leaving #2471 open for 1–3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
