### PR TITLE
fix(self-update): a check that finds nothing must SAY so, and a dead event channel must not freeze an install (#2553, #2494)

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1795,7 +1795,7 @@ jobs:
           issue=$(gh issue list --repo "$GITHUB_REPOSITORY" --label ci-failure --state open \
             --limit 1 --json number --jq '.[0].number // empty')
           [ -n "$issue" ] || exit 0
-          gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body "✅ **Healed \`${{ needs.gate.outputs.short_sha }}\`** ([run]($RUN_URL)) — main's HEAD now has the complete image set (portal \`${{ needs.portal-image.outputs.version }}\`), verified against ACR. Installs pick it up on their next 6 h self-update poll. Close this issue if nothing else is outstanding."
+          gh issue comment "$issue" --repo "$GITHUB_REPOSITORY" --body "✅ **Healed \`${{ needs.gate.outputs.short_sha }}\`** ([run]($RUN_URL)) — main's HEAD now has the complete image set (portal \`${{ needs.portal-image.outputs.version }}\`), verified against ACR. Installs pick it up on the build-completion event, or within one safety-net check interval if that event never reaches them (#2494). Close this issue if nothing else is outstanding."
 
   # ───────────────────────────── FAILURE ALERTING ────────────────────────────
   # A red CD after a green merge is otherwise INVISIBLE (nobody watches the Actions tab), and the

--- a/deploy/aks/SELF-UPDATE.md
+++ b/deploy/aks/SELF-UPDATE.md
@@ -10,11 +10,15 @@ merge to main ─▶ "Build and Test" (green) ─▶ images job builds+pushes  m
         ┌─────────────────────────────────────────────────────────────────────┼──────────────── … every install in the world
         ▼                                   ▼                                   ▼
    memex install                       prod install                      external install
-   SelfUpdateHostedService polls ACR (its OWN workload identity) every 6h, per its OWN Admin/UpdatePolicy,
+   SelfUpdateHostedService lists ACR (its OWN workload identity), per its OWN Admin/UpdatePolicy,
    and PATCHes its OWN portal+migration Deployments via its OWN in-cluster ServiceAccount token.
-   Where the GitHub webhook is wired, a green build of SelfUpdate:BuildTriggerRepository (default
-   Systemorph/MeshWeaver) additionally triggers ONE immediate check via the BuildCompletion node —
-   the poll stays as the fallback for installs without the webhook.
+   The check is EVENT-DRIVEN: one pass at startup, then one per BuildCompletion record written by
+   the GitHub webhook for the platform or ANY module this environment deploys.
+   🚨 …plus a SAFETY NET (SelfUpdate__SafetyNetCheckInterval, default 1h — #2494). Not the old
+   poll: it cannot roll anything MinRollInterval would refuse. It exists because every joint of
+   the event chain (webhook registration → WebhookInbox target → HMAC secret) fails SILENTLY, and
+   an install whose event channel is dead is otherwise indistinguishable from one that is up to
+   date — healthy pods, no errors, and a check that simply never runs.
 ```
 
 **Why** — prod must not know about the (potentially many) installs, and a central CI service principal
@@ -22,7 +26,12 @@ with per-cluster Azure RBAC cannot scale to clusters prod doesn't manage. (It wa
 break on 2026-06-29: the CD SP lacked `Microsoft.ContainerService/managedClusters/commandResults/read`,
 so every `az aks command invoke` deploy leg failed.) Pull-based removes that failure class entirely.
 
-Code: `memex/Memex.Portal.Shared/SelfUpdate/` — `SelfUpdateHostedService` (poller), `AcrTagLister`
+Every check reports exactly one verdict — logged, and stamped on `Admin/UpdatePolicy`
+(`LastCheckedAt`/`LastCheckVerdict`/`LastCheckTrigger`) so it survives a deployment that never set
+this service's log level. "Checked and found nothing" and "never checked" are different facts;
+until #2553 they produced identical evidence, which is how memex sat three builds behind for 7 h.
+
+Code: `memex/Memex.Portal.Shared/SelfUpdate/` — `SelfUpdateHostedService` (the checker), `AcrTagLister`
 (ACR via AAD→ACR token exchange), `VersionSelect` (which tag), `KubernetesDeploymentUpdater` (in-cluster
 PATCH). Wired by `AddSelfUpdate()` in `MemexConfiguration.cs`.
 

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -286,9 +286,19 @@ config:
     # ---- Platform self-update cadence --------------------------------------
     # The check is EVENT-DRIVEN (#1773): one pass at startup, then a check per
     # published build of the platform or of any module this environment deploys.
-    # There is no polling interval any more — SelfUpdate__PollInterval was renamed
-    # and this key sat here inert, reading like a live daily throttle while binding
-    # to nothing (#1778).
+    # SelfUpdate__PollInterval is gone — it was renamed and this key sat here inert,
+    # reading like a live daily throttle while binding to nothing (#1778).
+    #
+    # 🚨 There IS a SAFETY NET, and it is not the old poll (#2494). Every event
+    # reaches an install across a chain nothing re-verifies — a GitHub webhook, a
+    # WebhookInbox allowlist slot, an HMAC secret that must match byte-for-byte —
+    # and every joint of it fails SILENTLY. An install whose event channel is dead
+    # is indistinguishable from one that is up to date: healthy pods, no errors, a
+    # check that simply never runs. memex sat three builds behind for 7 h exactly
+    # so. SelfUpdate__SafetyNetCheckInterval (default 1h; empty or 0 disables)
+    # bounds how long that can hide. It cannot change the ROLL cadence — a
+    # safety-net check passes through the floor below like any other — so it only
+    # ever shortens DISCOVERY.
     #
     # What this number now sets is the floor between two AUTOMATIC rolls. It is a
     # RESTART budget, not a delivery speed: a roll restarts the pod and drops every
@@ -309,6 +319,13 @@ config:
     # newest image immediately (the startup pass), and `gh workflow run
     # main-cd.yml --ref main` bypasses the batch window.
     SelfUpdate__MinRollInterval: "01:00:00"
+    # The SAFETY NET (#2494): the longest this install may go without ASKING. It is
+    # not the old poll — it cannot roll anything the floor above would refuse; it
+    # only bounds how long a silently-broken event channel can keep an install
+    # behind while looking perfectly healthy. "00:00:00" disables it, which is a
+    # deliberate choice to make an install's freshness depend entirely on a chain
+    # of configuration that fails without saying so.
+    SelfUpdate__SafetyNetCheckInterval: "01:00:00"
     # Converge instances onto every newly published NodeType build (MeshWeaver#2192).
     # A prod portal's invariant is "after an update, everything serves the new build" —
     # leaving the banner default meant every publication wave stacked one more rooted

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -295,10 +295,12 @@ config:
     # and every joint of it fails SILENTLY. An install whose event channel is dead
     # is indistinguishable from one that is up to date: healthy pods, no errors, a
     # check that simply never runs. memex sat three builds behind for 7 h exactly
-    # so. SelfUpdate__SafetyNetCheckInterval (default 1h; empty or 0 disables)
-    # bounds how long that can hide. It cannot change the ROLL cadence — a
-    # safety-net check passes through the floor below like any other — so it only
-    # ever shortens DISCOVERY.
+    # so. SelfUpdate__SafetyNetCheckInterval bounds how long that can hide. It
+    # cannot change the ROLL cadence — a safety-net check passes through the floor
+    # below like any other — so it only ever shortens DISCOVERY.
+    # 🚨 "00:00:00" disables it; NEVER "". Like MinRollInterval this binds to a
+    # TimeSpan, and an empty string aborts the host in the configuration binder
+    # (the chart renders a real default for exactly that reason).
     #
     # What this number now sets is the floor between two AUTOMATIC rolls. It is a
     # RESTART budget, not a delivery speed: a roll restarts the pod and drops every

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -316,6 +316,9 @@ data:
   # exactly how the 2026-08-23 memex operator-enablement deploy wedged. A typed key needs a real
   # default; "empty = inert" is only true for strings.
   SelfUpdate__MinRollInterval: "{{ .Values.config.memex_portal.SelfUpdate__MinRollInterval | default "01:00:00" }}"
+  # #2494's safety net. Same typed-key rule as the line above: a real default, never "" — this
+  # binds to a TimeSpan and an empty string aborts the host in the configuration binder.
+  SelfUpdate__SafetyNetCheckInterval: "{{ .Values.config.memex_portal.SelfUpdate__SafetyNetCheckInterval | default "01:00:00" }}"
   WebhookInbox__Targets__0: "{{ .Values.config.memex_portal.WebhookInbox__Targets__0 | default "" }}"
   # 🚨 #2235: a SECOND slot, because index 0 is not this template's alone to give. memex-cloud
   # hand-set WebhookInbox__Targets__0=Store/Payments directly on the Deployment (kubectl set env,

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -1,5 +1,6 @@
 using Microsoft.Extensions.Configuration;
 using System.Reactive.Disposables;
+using System.Threading;
 using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Concurrency;
@@ -44,6 +45,15 @@ public class SelfUpdateHostedService : IHostedService
     private readonly IIoPool _http;
     private IDisposable? _subscription;
 
+    /// <summary>
+    /// How many build-completion events this process has observed. The ONLY evidence that the event
+    /// channel is alive, and it exists solely to make the dead-channel report in
+    /// <see cref="ReportCheck"/> possible — nothing else can distinguish "nothing published" from
+    /// "something published and nothing told us". Mutable instance state, read with
+    /// <see cref="Volatile"/> because the watch and the check run on different pool threads.
+    /// </summary>
+    private int _buildEventsSeen;
+
     public SelfUpdateHostedService(
         IMessageHub hub,
         IAcrTagLister acr,
@@ -65,66 +75,88 @@ public class SelfUpdateHostedService : IHostedService
     public Task StartAsync(CancellationToken cancellationToken)
     {
         _logger?.LogInformation(
-            "[SelfUpdate] starting (event-driven; one startup pass, then a check per build-completion event); version={Version}, registry={Registry}/{Repo}, canPatch={CanPatch}, retryInterval={Interval}.",
+            "[SelfUpdate] starting (event-driven, with a {SafetyNet} safety net); version={Version}, "
+            + "registry={Registry}/{Repo}, canPatch={CanPatch}, retryInterval={Interval}.",
+            _options.SafetyNetCheckInterval > TimeSpan.Zero
+                ? _options.SafetyNetCheckInterval.ToString()
+                : "disabled",
             ShippedReleaseSeed.InstalledPlatformVersion, _options.Registry, _options.PortalRepository,
             _updater.CanPatch, _options.RetryInterval);
 
-        // 🚨 EVENT-DRIVEN, and the event source is deliberately OUTSIDE the policy stream.
+        // 🚨 EVENT-DRIVEN WITH A SAFETY NET, and the event source is deliberately OUTSIDE the
+        // policy stream.
         //
-        // Exactly ONE pass at startup — to catch publications missed while this install was down —
-        // and after that a check per build completion, of the platform OR of any module the
-        // environment deploys. There is no recurring interval: a timer that re-asks a question
-        // nothing has answered is the shape this codebase treats as a band-aid, and the
-        // availability gate already defers a roll whose artifacts are not ready. What makes
-        // deferral safe without a timer is that the NEXT publication is itself an event, so a
-        // deferred roll is re-decided the moment its missing artifact appears.
+        // The fast path is unchanged and is still the design: one pass at startup (to catch
+        // publications missed while this install was down), then a check per build completion of
+        // the platform OR of any module the environment deploys. Nothing beats an event for
+        // latency, and a timer that re-asks a question nothing has answered is a band-aid.
+        //
+        // 🚨 What the event-ONLY shape got wrong is its failure mode, and it cost a week of prod
+        // (#2494/#2553). Every event reaches this install across a chain of configuration that
+        // nothing re-verifies — a GitHub webhook registration, a `WebhookInbox` allowlist slot, an
+        // HMAC secret that must be byte-identical on both ends — and every joint of it fails
+        // SILENTLY: an unlisted inbox target answers 404 exactly like a wrong URL, a mismatched
+        // secret still answers 2xx and drops the delivery. An install whose event channel is dead
+        // therefore looks EXACTLY like an install that is up to date: healthy pods, no errors, and
+        // a check that simply never runs. memex sat three builds behind for 7 h in that state with
+        // nothing in the product able to say so.
+        //
+        // So the safety net is not the removed poll returning. A poll DRIVES the update; this
+        // BOUNDS how long a broken driver can hide, and it cannot change the roll cadence at all —
+        // a safety-net check passes through MinRollInterval like any other. See
+        // SelfUpdateOptions.SafetyNetCheckInterval.
         //
         // 🚨 The policy is STATE, not a driver — WithLatestFrom, never Switch. Under Switch every
         // policy emission re-subscribed the watch, which RE-BASELINED it: a publication landing in
         // that window was read as "current state" rather than as a new build and silently swallowed.
-        // The recurring interval used to cover that; with the interval gone it would be a lost
-        // update with nothing to recover it. One long-lived watch, the latest policy read at
-        // decision time, is what closes it. (CreatePolicySource emits the default exactly once
-        // before the first live read, so the startup pass always has a policy to run under.)
+        // One long-lived watch, the latest policy read at decision time, is what closes it.
+        // (CreatePolicySource emits the default exactly once before the first live read, so the
+        // startup pass always has a policy to run under.)
         // The policy is shared STATE with a replayed latest value, connected for the lifetime of the
         // service. Replay(1)+Connect rather than RefCount: a RefCount would drop to zero between the
-        // Take(1) below and the WithLatestFrom re-subscribe, re-running the seed and re-baselining
-        // everything downstream — the very class of bug this restructure exists to remove.
+        // Take(1) below and the re-subscribe, re-running the seed and re-baselining everything
+        // downstream — the very class of bug this restructure exists to remove.
         var policy = CreatePolicySource().Replay(1);
 
         // 🚨 The first check waits for a policy to exist. CreatePolicySource emits the default only
         // AFTER its async seed, so a startup pass composed with WithLatestFrom alone fires before
         // any policy is available and is silently dropped — no first check at all. Take(1) gates the
-        // trigger stream on that first emission; every LATER policy change is picked up by
-        // WithLatestFrom without re-subscribing the watch.
-        // Three trigger sources, no timer among them:
+        // trigger stream on that first emission; every LATER policy change is picked up without
+        // re-subscribing the watch.
+        // Four trigger sources:
         //   • the one startup pass,
         //   • a build completion from the platform or ANY module the environment deploys,
         //   • an admin CHANGING the policy — enabling updates must not wait for the next
         //     publication, which could be weeks away. DistinctUntilChanged so a re-emission of the
         //     same policy is not a trigger, and Skip(1) so the replayed CURRENT policy is not one
-        //     either (the startup pass already covers it).
+        //     either (the startup pass already covers it),
+        //   • the safety net, so a dead event channel is bounded rather than permanent.
         var checks = policy
             .Take(1)
             .SelectMany(_ => Observable.Merge(
-                Observable.Return(-1L),
-                BuildCompletionTicks(),
-                policy.DistinctUntilChanged(content => content.Policy).Skip(1).Select(_ => -3L)))
+                Observable.Return(SelfUpdateTrigger.Startup),
+                BuildCompletionTicks().Do(_ => Interlocked.Increment(ref _buildEventsSeen)),
+                SafetyNetTicks(),
+                policy.DistinctUntilChanged(content => content.Policy).Skip(1)
+                    .Select(_ => SelfUpdateTrigger.PolicyChange)))
             // 🚨 Read the CURRENT policy at decision time — never WithLatestFrom. That operator only
             // pairs once its secondary has produced, and the startup trigger fires synchronously on
             // subscribe, so whether the first check survives came down to Rx's internal subscribe
             // ordering: it silently dropped the startup pass. policy is Replay(1), so Take(1) yields
             // the latest value immediately and deterministically.
-            .SelectMany(_ => policy.Take(1))
-            .Where(content => content.Policy != UpdatePolicyKind.None)   // None => never update
-            .SelectMany(content => RunOnce(content)
-                .Catch((Exception ex) =>
-                {
-                    // wedges-to-zero: a check error (ACR outage, k8s 403) logs and the watch stays
-                    // live. No outer .Retry — that would be a resubscribe storm.
-                    _logger?.LogWarning(ex, "[SelfUpdate] check failed (policy={Policy}).", content.Policy);
-                    return Observable.Empty<Unit>();
-                }))
+            .SelectMany(trigger => policy.Take(1).Select(content => (trigger, content)))
+            .SelectMany(check => RunOnce(check.content)
+                // wedges-to-zero: a check error (ACR outage, k8s 403) is a VERDICT, not a silence,
+                // and the watch stays live. No outer .Retry — that would be a resubscribe storm.
+                .Catch((Exception ex) => Observable.Return(SelfUpdateVerdict.CheckFailed(ex)))
+                // 🚨 THE POSTCONDITION, asserted rather than hoped for. Every branch of RunOnce
+                // names its outcome, so this should be unreachable — and that is exactly why it is
+                // here. The defect this whole restructure fixes was two bare `Where` clauses that
+                // dropped a check on the floor, and the only thing that stops a third one being
+                // added is making "produced nothing" itself an outcome that gets reported.
+                .DefaultIfEmpty(SelfUpdateVerdict.NoOutcome())
+                .Take(1)
+                .SelectMany(verdict => ReportCheck(check.trigger, verdict)))
             .SubscribeOn(TaskPoolScheduler.Default)
             .Subscribe(
                 _ => { },
@@ -133,6 +165,83 @@ public class SelfUpdateHostedService : IHostedService
         _subscription = new CompositeDisposable(checks, policy.Connect());
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// The safety net (#2494): a bounded liveness floor on the CHECK, never on the roll.
+    ///
+    /// <para>Off entirely when <see cref="SelfUpdateOptions.SafetyNetCheckInterval"/> is zero or
+    /// negative, which is the shape a deployment that genuinely wants event-only can opt into
+    /// — deliberately, in configuration, where it is visible.</para>
+    ///
+    /// <para>Virtual for the same reason the other three seams are: a test must be able to drive
+    /// the safety-net path without waiting out an hour.</para>
+    /// </summary>
+    protected virtual IObservable<SelfUpdateTrigger> SafetyNetTicks() =>
+        _options.SafetyNetCheckInterval <= TimeSpan.Zero
+            ? Observable.Never<SelfUpdateTrigger>()
+            : Observable.Interval(_options.SafetyNetCheckInterval)
+                .Select(_ => SelfUpdateTrigger.SafetyNet);
+
+    /// <summary>
+    /// 🚨 Reports the outcome of ONE check — the single reporting site, and the thing whose absence
+    /// #2553 measured as "ZERO SelfUpdate log lines in 6.7 h while three builds behind".
+    ///
+    /// <para>It reports TWICE, to two audiences with different failure modes:</para>
+    /// <list type="number">
+    /// <item>a LOG line, one per check, naming the trigger and the verdict; and</item>
+    /// <item>a durable stamp on <c>Admin/UpdatePolicy</c>
+    /// (<see cref="UpdatePolicyContent.LastCheckedAt"/> / <c>LastCheckVerdict</c> /
+    /// <c>LastCheckTrigger</c>).</item>
+    /// </list>
+    ///
+    /// <para>Both, because the log alone was not enough and the reason is instructive: every line
+    /// this service had to say was <c>LogInformation</c>, the portal image caps its whole logger
+    /// prefix at <c>Warning</c>, and no deployment had added the category. So the mechanism was
+    /// working exactly as designed and reporting into a void — the one thing an operator could
+    /// read, the Updates tab, showed "No newer version detected yet" because that is what an
+    /// install that has never checked and an install that checked and found nothing both look
+    /// like. A node write does not depend on a log level anyone remembered to set.</para>
+    ///
+    /// <para>🚨 THE DEAD-EVENT-CHANNEL REPORT is the one line that goes to Warning: a check woken
+    /// by the SAFETY NET, on an install that has seen no build-completion event at all, that
+    /// nevertheless FOUND a newer release. Each clause matters. "No events yet" alone is not
+    /// alarming — an install whose modules rarely build legitimately sees none for days — and
+    /// warning on it would train people to ignore the line. "A release was waiting and nothing
+    /// told us" is the #2494 symptom exactly, and it is only ever observable from here.</para>
+    ///
+    /// <para>Bookkeeping, never a gate (#1020): the stamp is best-effort and a failed write is a
+    /// warning that names itself, never something that can abort a check or hold a roll.</para>
+    /// </summary>
+    private IObservable<Unit> ReportCheck(SelfUpdateTrigger trigger, SelfUpdateVerdict verdict) =>
+        Observable.Defer(() =>
+        {
+            var eventChannelSilent = trigger == SelfUpdateTrigger.SafetyNet
+                && Volatile.Read(ref _buildEventsSeen) == 0
+                && verdict.FoundNewerRelease;
+
+            if (eventChannelSilent)
+                _logger?.LogWarning(
+                    "[SelfUpdate] check ({Trigger}): {Verdict} 🚨 This install has received NO "
+                    + "build-completion event since it started, yet a newer release was waiting — "
+                    + "only the safety net found it. The event channel (GitHub webhook → "
+                    + "WebhookInbox target → Admin/_Build) is not reaching this instance; every "
+                    + "joint of it fails silently, so check them rather than this service.",
+                    trigger, verdict.Message);
+            else if (verdict.Outcome is SelfUpdateOutcome.NoOutcome
+                     or SelfUpdateOutcome.CheckFailed)
+                _logger?.LogWarning("[SelfUpdate] check ({Trigger}): {Verdict}", trigger, verdict.Message);
+            else
+                _logger?.LogInformation("[SelfUpdate] check ({Trigger}): {Verdict}", trigger, verdict.Message);
+
+            return RecordCheck(trigger, verdict)
+                .Catch((Exception ex) =>
+                {
+                    _logger?.LogWarning(ex,
+                        "[SelfUpdate] could not record the check verdict on {Node}; the check itself "
+                        + "still ran and its verdict is above.", UpdatePolicyNodeType.NodePath);
+                    return Observable.Return(Unit.Default);
+                });
+        });
 
     public Task StopAsync(CancellationToken cancellationToken)
     {
@@ -197,7 +306,7 @@ public class SelfUpdateHostedService : IHostedService
     /// and <see cref="RunOnce"/> still lists ACR itself, so a spurious tick costs one cheap tag
     /// list and can never cause a wrong roll.
     /// </summary>
-    protected virtual IObservable<long> BuildCompletionTicks() =>
+    protected virtual IObservable<SelfUpdateTrigger> BuildCompletionTicks() =>
         Observable
             .Defer(() => NewBuildEventsAcross(_hub
                 .GetQuery($"SelfUpdate.BuildTrigger:{_hub.Address}",
@@ -209,7 +318,7 @@ public class SelfUpdateHostedService : IHostedService
                     // GitHubSyncConfig satellites in ordinary partitions ARE returned unscoped.)
                     BuildCompletion.WatchQuery)))
             .Throttle(_options.EventCoalesceWindow)
-            .Select(_ => -2L)
+            .Select(_ => SelfUpdateTrigger.BuildCompletion)
             .RetryWhen(ResubscribeAfterRetryInterval("build-completion watch"));
 
     /// <summary>
@@ -276,9 +385,25 @@ public class SelfUpdateHostedService : IHostedService
         });
 
     /// <summary>One evaluation: list tags → pick target per policy → gate target &gt; current →
-    /// record availability → (if armed) patch the workloads.</summary>
-    private IObservable<Unit> RunOnce(UpdatePolicyContent policy) =>
-        _http.Invoke(ct => _acr.ListTagsAsync(_options.PortalRepository, ct))
+    /// record availability → (if armed) patch the workloads.
+    ///
+    /// <para>🚨 Returns a <see cref="SelfUpdateVerdict"/>, not <c>Unit</c>, and that is the whole
+    /// #2553 fix rather than a style change. As <c>IObservable&lt;Unit&gt;</c> this method had two
+    /// ways to complete having said NOTHING — a policy of <c>None</c> and "no candidate is newer"
+    /// were both bare Rx <c>Where</c> clauses upstream — and an empty completion is
+    /// indistinguishable from a check that never ran. Every exit now names its outcome, so the
+    /// caller has something to log and something to record.</para></summary>
+    private IObservable<SelfUpdateVerdict> RunOnce(UpdatePolicyContent policy)
+    {
+        // 🚨 `None` means never update, and it used to be a `Where` in the trigger pipeline: the
+        // single most silent path in the service. An install deliberately pinned by an
+        // administrator and an install whose updater is broken produced byte-identical evidence
+        // (none), which is the exact confusion #2553 was filed about. It is a DECISION, so it says
+        // so — and it still costs no ACR call.
+        if (policy.Policy == UpdatePolicyKind.None)
+            return Observable.Return(SelfUpdateVerdict.UpdatesDisabled());
+
+        return _http.Invoke(ct => _acr.ListTagsAsync(_options.PortalRepository, ct))
             // 🚨 The BEST ROLLABLE release, not merely the newest one. A target is only rollable if a
             // sealed content bake exists for the identity that exact image resolves to, and picking
             // the newest tag and stopping means one unbaked release freezes the instance FOREVER:
@@ -291,32 +416,46 @@ public class SelfUpdateHostedService : IHostedService
             // never backwards (IsNewer), still never into a boot storm (unsealed candidates are
             // SKIPPED, not forced) — but a not-yet-baked head no longer blocks the releases behind
             // it, and an instance always advances to the best release that can actually serve.
-            .Select(tags => VersionSelect
-                .PickTargets(tags, policy.Policy, policy.RequireCiGreen)
-                .Where(tag => VersionSelect.IsNewer(tag, ShippedReleaseSeed.InstalledPlatformVersion))
-                .ToArray())
-            .SelectMany(FirstRollable)
-            .Where(target => !string.IsNullOrEmpty(target))
-            .SelectMany(target => RecordAvailable(target!)
-                // 🚨 BOOKKEEPING, NOT A GATE (#1020). RecordAvailable writes two cosmetic fields
-                // (LatestAvailableTag / CheckedAt) that drive the admin tab; the ROLL-FORWARD does not
-                // depend on them. Chaining Apply after it with .SelectMany made a failed status write
-                // abort the update: in production the Admin/UpdatePolicy node hub was unreachable (its
-                // SubscribeRequest never answered — the silo's routing was wedged), every 6 h tick
-                // timed out after 30 s in this write, and the portal sat 37 h on a stale image while
-                // the poller kept ticking and the ACR check kept succeeding. The update it would not
-                // apply is exactly what recovers a degraded pod, so the write must never gate it:
-                // surface the fault (never swallow it — the warning names the tag and the node) and
-                // carry on to Apply, which touches only ACR + the k8s API and works while the mesh
-                // is degraded. Concat, not Merge — the record still lands FIRST when it succeeds.
-                .Catch((Exception ex) =>
-                {
-                    _logger?.LogWarning(ex,
-                        "[SelfUpdate] could not record available tag {Tag} on {Node}; applying the update anyway.",
-                        target, UpdatePolicyNodeType.NodePath);
-                    return Observable.Return(Unit.Default);
-                })
-                .Concat(GateThenApply(target!)));
+            .Select(tags => (
+                Listed: tags.Count,
+                Candidates: VersionSelect
+                    .PickTargets(tags, policy.Policy, policy.RequireCiGreen)
+                    .Where(tag => VersionSelect.IsNewer(tag, ShippedReleaseSeed.InstalledPlatformVersion))
+                    .ToArray()))
+            .SelectMany(listing => listing.Candidates.Length == 0
+                // 🚨 "We asked and the answer was no" — the OTHER formerly-silent exit, and the one
+                // that made a stalled install unfalsifiable from outside. This is the normal, happy
+                // outcome of most checks, and it has to be SAID: it is the only thing that
+                // distinguishes a healthy up-to-date install from one whose checker is dead.
+                ? Observable.Return(SelfUpdateVerdict.NoNewerRelease(
+                    listing.Listed, ShippedReleaseSeed.InstalledPlatformVersion))
+                : FirstRollable(listing.Candidates)
+                    .SelectMany(target => RecordAvailable(target!)
+                        // 🚨 BOOKKEEPING, NOT A GATE (#1020). RecordAvailable writes two cosmetic fields
+                        // (LatestAvailableTag / CheckedAt) that drive the admin tab; the ROLL-FORWARD does not
+                        // depend on them. Chaining Apply after it with .SelectMany made a failed status write
+                        // abort the update: in production the Admin/UpdatePolicy node hub was unreachable (its
+                        // SubscribeRequest never answered — the silo's routing was wedged), every 6 h tick
+                        // timed out after 30 s in this write, and the portal sat 37 h on a stale image while
+                        // the poller kept ticking and the ACR check kept succeeding. The update it would not
+                        // apply is exactly what recovers a degraded pod, so the write must never gate it:
+                        // surface the fault (never swallow it — the warning names the tag and the node) and
+                        // carry on to Apply, which touches only ACR + the k8s API and works while the mesh
+                        // is degraded. Concat, not Merge — the record still lands FIRST when it succeeds.
+                        .Catch((Exception ex) =>
+                        {
+                            _logger?.LogWarning(ex,
+                                "[SelfUpdate] could not record available tag {Tag} on {Node}; applying the update anyway.",
+                                target, UpdatePolicyNodeType.NodePath);
+                            return Observable.Return(Unit.Default);
+                        })
+                        // IgnoreElements keeps the record's own emissions out of the verdict
+                        // stream while preserving Concat's ordering — the record still lands FIRST,
+                        // and the Select below is unreachable by construction.
+                        .IgnoreElements()
+                        .Select(_ => SelfUpdateVerdict.NoOutcome())
+                        .Concat(GateThenApply(target!))));
+    }
 
     /// <summary>
     /// 🚨 <b>The release-availability gate (#1754), the last thing between a newer tag and a roll.</b>
@@ -377,7 +516,7 @@ public class SelfUpdateHostedService : IHostedService
             .Catch((Exception _) => Observable.Return<string?>(candidates[0]));
     }
 
-    private IObservable<Unit> GateThenApply(string target) =>
+    private IObservable<SelfUpdateVerdict> GateThenApply(string target) =>
         Observable.Defer(() =>
         {
             var gate = ResolveAvailabilityGate();
@@ -396,13 +535,16 @@ public class SelfUpdateHostedService : IHostedService
                         // Clearing is unconditional: a previous hold that no longer applies must
                         // disappear from the admin tab the moment it is resolved.
                         return RecordHold(target, null).Catch(HoldWriteFailed(target))
+                            .IgnoreElements()
+                            .Select(_ => SelfUpdateVerdict.NoOutcome())
                             .Concat(Apply(target));
                     }
 
-                    _logger?.LogInformation(
-                        "[SelfUpdate] HOLDING update to {Tag} (staying on {Current}) — {Reason}",
-                        target, ShippedReleaseSeed.InstalledPlatformVersion, verdict.HoldReason);
-                    return RecordHold(target, verdict).Catch(HoldWriteFailed(target));
+                    return RecordHold(target, verdict).Catch(HoldWriteFailed(target))
+                        .IgnoreElements()
+                        .Select(_ => SelfUpdateVerdict.NoOutcome())
+                        .Concat(Observable.Return(
+                            SelfUpdateVerdict.Held(target, verdict.HoldReason)));
                 });
         });
 
@@ -434,7 +576,7 @@ public class SelfUpdateHostedService : IHostedService
     /// set it in configuration, where it is visible, and the roll proceeds while saying so at
     /// Warning on every tick. It can never waive a gate that DID run.</para>
     /// </summary>
-    private IObservable<Unit> GateNotWired(string target) =>
+    private IObservable<SelfUpdateVerdict> GateNotWired(string target) =>
         Observable.Defer(() =>
         {
             // 🚨 "CANNOT VERIFY" AND "VERIFIED AS NOTHING TO VERIFY" ARE DIFFERENT STATES, and only
@@ -458,7 +600,10 @@ public class SelfUpdateHostedService : IHostedService
                     target, notApplicable);
                 // Clearing is unconditional, exactly as on the verdict path: a previous hold that
                 // no longer applies must disappear from the admin tab the moment it is resolved.
-                return RecordHold(target, null).Catch(HoldWriteFailed(target)).Concat(Apply(target));
+                return RecordHold(target, null).Catch(HoldWriteFailed(target))
+                    .IgnoreElements()
+                    .Select(_ => SelfUpdateVerdict.NoOutcome())
+                    .Concat(Apply(target));
             }
 
             if (_options.AllowUnverifiedRoll)
@@ -484,7 +629,10 @@ public class SelfUpdateHostedService : IHostedService
                 "[SelfUpdate] HOLDING update to {Tag} (staying on {Current}) — {Reason}",
                 target, ShippedReleaseSeed.InstalledPlatformVersion, verdict.HoldReason);
 
-            return RecordHold(target, verdict).Catch(HoldWriteFailed(target));
+            return RecordHold(target, verdict).Catch(HoldWriteFailed(target))
+                .IgnoreElements()
+                .Select(_ => SelfUpdateVerdict.NoOutcome())
+                .Concat(Observable.Return(SelfUpdateVerdict.Held(target, verdict.HoldReason)));
         });
 
     /// <summary>
@@ -562,16 +710,11 @@ public class SelfUpdateHostedService : IHostedService
     /// ONLY trace a stalled install left — it read like a registry problem while the registry was
     /// fine. Deferred so the announcement runs per subscription (per tick), not at composition.
     /// </summary>
-    private IObservable<Unit> Apply(string target) =>
+    private IObservable<SelfUpdateVerdict> Apply(string target) =>
         Observable.Defer(() =>
         {
             if (!_updater.CanPatch)
-            {
-                _logger?.LogInformation(
-                    "[SelfUpdate] update available: {Tag} (detect-and-notify — this install does not self-patch).",
-                    target);
-                return Observable.Return(Unit.Default);
-            }
+                return Observable.Return(SelfUpdateVerdict.DetectOnly(target));
 
             // 🚨 The pacing floor. A roll is a POD RESTART, so without it publication frequency is
             // restart frequency and every restart drops the live circuits of everyone using the
@@ -585,33 +728,58 @@ public class SelfUpdateHostedService : IHostedService
             // in the AKS implementation, and its answer cannot change the decision when the floor is
             // zero. Skipping it removes an API call and a failure point from the happy path.
             if (_options.MinRollInterval <= TimeSpan.Zero)
-            {
-                _logger?.LogInformation(
-                    "[SelfUpdate] applying update {Tag} (was {Current}; no roll floor configured).",
-                    target, ShippedReleaseSeed.InstalledPlatformVersion);
-                return _http.Invoke(ct => _updater.PatchToVersionAsync(target, ct));
-            }
+                return _http.Invoke(ct => _updater.PatchToVersionAsync(target, ct))
+                    .Select(_ => SelfUpdateVerdict.Applied(
+                        target, ShippedReleaseSeed.InstalledPlatformVersion, null));
 
             return _http.Invoke(ct => _updater.LastRolledAtAsync(ct)).SelectMany(lastRolledAt =>
             {
                 var since = lastRolledAt is null ? (TimeSpan?)null : DateTimeOffset.UtcNow - lastRolledAt.Value;
                 if (since is { } elapsed && elapsed < _options.MinRollInterval)
-                {
-                    _logger?.LogInformation(
-                        "[SelfUpdate] {Tag} is available but this install rolled {Elapsed} ago, inside the "
-                        + "{Floor} floor — deferring. The next publication re-decides it; "
-                        + "`kubectl rollout restart` applies it now.",
-                        target, elapsed, _options.MinRollInterval);
-                    return Observable.Return(Unit.Default);
-                }
+                    return Observable.Return(
+                        SelfUpdateVerdict.Deferred(target, elapsed, _options.MinRollInterval));
 
-                _logger?.LogInformation(
-                    "[SelfUpdate] applying update {Tag} (was {Current}; last rolled {Last}).",
-                    target, ShippedReleaseSeed.InstalledPlatformVersion,
-                    lastRolledAt?.ToString("O") ?? "never");
-                return _http.Invoke(ct => _updater.PatchToVersionAsync(target, ct));
+                return _http.Invoke(ct => _updater.PatchToVersionAsync(target, ct))
+                    .Select(_ => SelfUpdateVerdict.Applied(
+                        target, ShippedReleaseSeed.InstalledPlatformVersion, lastRolledAt));
             });
         });
+
+    /// <summary>
+    /// Stamps the outcome of one check on the policy node, as System — the durable half of
+    /// <see cref="ReportCheck"/>, and the one that survives a deployment forgetting to set a log
+    /// level. Virtual so a test can fault it and prove the check itself is unaffected.
+    ///
+    /// <para>🚨 It cannot feed itself. The check trigger reads
+    /// <c>policy.DistinctUntilChanged(c =&gt; c.Policy)</c> and the policy source itself is
+    /// <c>DistinctUntilChanged((Policy, RequireCiGreen))</c>, so a write that touches only these
+    /// three bookkeeping fields emits nothing downstream and can never schedule another check —
+    /// the reconcile-feeds-itself write storm (#223) is structurally excluded rather than avoided
+    /// by convention.</para>
+    /// </summary>
+    protected virtual IObservable<Unit> RecordCheck(SelfUpdateTrigger trigger, SelfUpdateVerdict verdict)
+    {
+        var accessService = _hub.ServiceProvider.GetService<AccessService>();
+        var jsonOptions = _hub.JsonSerializerOptions;
+        // RunAsSystem, never `Observable.Using(AccessContextScope.AsSystem, …)` — see
+        // RecordHold below (#1444/#1790).
+        return accessService.RunAsSystem(
+            () => _hub.GetWorkspace().GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+                .Update(node =>
+                {
+                    var cur = UpdatePolicyNodeType.ParseContent(node.Content, jsonOptions);
+                    return node with
+                    {
+                        Content = cur with
+                        {
+                            LastCheckedAt = DateTimeOffset.UtcNow,
+                            LastCheckVerdict = verdict.Message,
+                            LastCheckTrigger = trigger.ToString(),
+                        },
+                    };
+                })
+                .Select(_ => Unit.Default));
+    }
 
     /// <summary>Record the newest available tag on the policy node (as System). Drives the admin tab
     /// and the detect-and-notify path. Touches only the bookkeeping fields; preserves Policy.

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateVerdict.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateVerdict.cs
@@ -1,0 +1,140 @@
+namespace Memex.Portal.Shared.SelfUpdate;
+
+/// <summary>What woke a self-update check. Named, because "why did this run" is half of what makes
+/// a check's outcome readable — and because a check that only ever runs on the SAFETY NET is the
+/// signature of a dead event channel (#2494), which is invisible unless the trigger is recorded.</summary>
+public enum SelfUpdateTrigger
+{
+    /// <summary>The single pass at startup, catching publications missed while this install was down.</summary>
+    Startup,
+
+    /// <summary>A <c>BuildCompletion</c> record moved — the platform or any module this environment
+    /// deploys published. The intended primary driver.</summary>
+    BuildCompletion,
+
+    /// <summary>An admin changed <c>Admin/UpdatePolicy</c>. Enabling updates must not wait for the
+    /// next publication.</summary>
+    PolicyChange,
+
+    /// <summary>The safety net (<see cref="MeshWeaver.Hosting.SelfUpdate.SelfUpdateOptions.SafetyNetCheckInterval"/>).
+    /// Nothing told this install anything; it asked anyway.</summary>
+    SafetyNet,
+}
+
+/// <summary>The outcome of exactly one self-update check.</summary>
+public enum SelfUpdateOutcome
+{
+    /// <summary>🚨 The structural backstop: the check pipeline terminated without producing an
+    /// outcome at all. It should be unreachable — every branch below is exhaustive — and it exists
+    /// precisely so that a future filter added to the pipeline cannot re-create the silence this
+    /// enum was introduced to remove. Reported at Warning, naming itself.</summary>
+    NoOutcome,
+
+    /// <summary><c>Admin/UpdatePolicy</c> says <c>None</c>: this install never updates. A DECISION,
+    /// and previously the single most silent path in the service — a bare Rx <c>Where</c> that
+    /// discarded the check with no log line and no record.</summary>
+    UpdatesDisabled,
+
+    /// <summary>The registry was listed and holds nothing newer than the installed version.
+    /// 🚨 The other formerly-silent path, and the one that matters most: "we asked and the answer
+    /// was no" is a completely different fact from "nothing ever asked", and until this outcome
+    /// existed the two were indistinguishable from outside the process.</summary>
+    NoNewerRelease,
+
+    /// <summary>A newer release exists and the release-availability gate refused it.</summary>
+    Held,
+
+    /// <summary>A newer release exists and the roll floor deferred it.</summary>
+    Deferred,
+
+    /// <summary>A newer release exists and this install does not self-patch (detect-and-notify).</summary>
+    DetectOnly,
+
+    /// <summary>A newer release exists and the workloads were patched to it.</summary>
+    Applied,
+
+    /// <summary>The check itself faulted (ACR outage, k8s 403, …). The watch stays live.</summary>
+    CheckFailed,
+}
+
+/// <summary>
+/// The outcome of ONE self-update check — the value that makes "this install checked and found
+/// nothing" distinguishable from "this install never checked".
+///
+/// <para>🚨 <b>Why this type exists (#2553).</b> memex sat three builds behind for 6.7 h having
+/// emitted ZERO self-update log lines, and there was no way to tell from outside the process which
+/// of three states it was in: the check never ran, the check ran and decided nothing was newer, or
+/// the check ran and everything it had to say was filtered out by the log configuration. The
+/// service reported an outcome on some paths and returned <c>Unit</c> on others, so "silence" was a
+/// legitimate result — two Rx <c>Where</c> clauses (policy <c>None</c>, and no candidate newer than
+/// the installed version) discarded a whole check with nothing written anywhere.</para>
+///
+/// <para>Making the check's return type a VERDICT rather than <c>Unit</c> is what removes that
+/// possibility: every branch has to name its outcome, the reporting site is single, and a pipeline
+/// that somehow produces nothing is itself reported as <see cref="SelfUpdateOutcome.NoOutcome"/>.
+/// The verdict is then both LOGGED and RECORDED on the policy node, because a log line depends on a
+/// per-category log level that a deployment may simply not have set — which is exactly what
+/// happened — while a node write does not.</para>
+///
+/// <para>Pure: no hub, no logger, no Rx. The messages are pinned by unit tests.</para>
+/// </summary>
+/// <param name="Outcome">Which of the exhaustive outcomes this check reached.</param>
+/// <param name="Message">The one-sentence verdict, ready to log and to store.</param>
+/// <param name="Tag">The release the verdict is about, when there is one.</param>
+public sealed record SelfUpdateVerdict(SelfUpdateOutcome Outcome, string Message, string? Tag = null)
+{
+    /// <summary>
+    /// True when the check established that a newer release EXISTS — whatever then happened to it.
+    ///
+    /// <para>This is the discriminator the dead-event-channel report needs. "The safety net woke us
+    /// and no build event has ever arrived" is not on its own alarming: an install whose modules
+    /// rarely build legitimately sees no events for days. "The safety net woke us, no build event
+    /// has ever arrived, AND there was a newer release waiting" is the #2494 symptom exactly —
+    /// something published and nothing told this install about it.</para>
+    /// </summary>
+    public bool FoundNewerRelease => Outcome is SelfUpdateOutcome.Held or SelfUpdateOutcome.Deferred
+        or SelfUpdateOutcome.DetectOnly or SelfUpdateOutcome.Applied;
+
+    /// <summary>The policy says never update.</summary>
+    public static SelfUpdateVerdict UpdatesDisabled() => new(
+        SelfUpdateOutcome.UpdatesDisabled,
+        "updates are disabled on this install (Admin/UpdatePolicy = None); the registry was not listed.");
+
+    /// <summary>The registry was listed and holds nothing newer.</summary>
+    public static SelfUpdateVerdict NoNewerRelease(int tagsListed, string installed) => new(
+        SelfUpdateOutcome.NoNewerRelease,
+        $"no newer release: {tagsListed} tag(s) listed, none newer than the installed {installed}.");
+
+    /// <summary>A newer release exists and the availability gate refused it.</summary>
+    public static SelfUpdateVerdict Held(string tag, string? reason) => new(
+        SelfUpdateOutcome.Held,
+        $"HOLDING {tag} — {reason ?? "no reason recorded"}", tag);
+
+    /// <summary>A newer release exists and the roll floor deferred it.</summary>
+    public static SelfUpdateVerdict Deferred(string tag, TimeSpan elapsed, TimeSpan floor) => new(
+        SelfUpdateOutcome.Deferred,
+        $"{tag} is available but this install rolled {elapsed} ago, inside the {floor} floor — "
+        + "deferring. The next publication (or the next safety-net check) re-decides it.", tag);
+
+    /// <summary>A newer release exists and this install does not self-patch.</summary>
+    public static SelfUpdateVerdict DetectOnly(string tag) => new(
+        SelfUpdateOutcome.DetectOnly,
+        $"update available: {tag} (detect-and-notify — this install does not self-patch).", tag);
+
+    /// <summary>The workloads were patched.</summary>
+    public static SelfUpdateVerdict Applied(string tag, string installed, DateTimeOffset? lastRolledAt) => new(
+        SelfUpdateOutcome.Applied,
+        $"applied update {tag} (was {installed}; last rolled {lastRolledAt?.ToString("O") ?? "never"}).",
+        tag);
+
+    /// <summary>The check faulted.</summary>
+    public static SelfUpdateVerdict CheckFailed(Exception ex) => new(
+        SelfUpdateOutcome.CheckFailed,
+        $"check FAILED: {ex.GetType().Name}: {ex.Message}");
+
+    /// <summary>🚨 The pipeline produced no verdict — a defect in this service, reported as one.</summary>
+    public static SelfUpdateVerdict NoOutcome() => new(
+        SelfUpdateOutcome.NoOutcome,
+        "the check produced NO outcome — a filter in the self-update pipeline swallowed it. "
+        + "This is a defect in SelfUpdateHostedService, not a state of this install.");
+}

--- a/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/UpdatePolicyNodeType.cs
@@ -52,6 +52,35 @@ public record UpdatePolicyContent
     public DateTimeOffset? CheckedAt { get; init; }
 
     /// <summary>
+    /// 🚨 When this install last COMPLETED an update check — whatever the check concluded.
+    ///
+    /// <para>Distinct from <see cref="CheckedAt"/>, and the difference is the defect it closes
+    /// (#2553). <see cref="CheckedAt"/> is stamped beside <see cref="LatestAvailableTag"/>, so it
+    /// only ever advances on a check that FOUND something newer. An install that checks hourly and
+    /// finds nothing therefore has no record of ever having checked — indistinguishable from an
+    /// install whose checker is dead, which is precisely the state memex was in for 7 h while its
+    /// Updates tab read "No newer version detected yet."</para>
+    ///
+    /// <para>Written by the poller on EVERY check, on every outcome path, as a best-effort
+    /// bookkeeping write that can never gate the roll (#1020). Not user-editable.</para>
+    /// </summary>
+    [Browsable(false)]
+    public DateTimeOffset? LastCheckedAt { get; init; }
+
+    /// <summary>The one-sentence verdict of the check <see cref="LastCheckedAt"/> stamps — see
+    /// <c>SelfUpdateVerdict</c>. Durable on purpose: a log line depends on a per-category log level
+    /// that a deployment may simply not have set (and had not), a node write does not. Not
+    /// user-editable.</summary>
+    [Browsable(false)]
+    public string? LastCheckVerdict { get; init; }
+
+    /// <summary>What woke that check — <c>Startup</c>, <c>BuildCompletion</c>, <c>PolicyChange</c>
+    /// or <c>SafetyNet</c>. An install whose checks are ONLY ever <c>SafetyNet</c> has a dead event
+    /// channel, and that is not visible from anything else. Not user-editable.</summary>
+    [Browsable(false)]
+    public string? LastCheckTrigger { get; init; }
+
+    /// <summary>
     /// Combo-verification verdicts per candidate tag — what the Candidate Release Protocol's
     /// instance gate found when it ran this instance's module set inside a candidate image
     /// (<c>mw-combo-verify</c>). Written via

--- a/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/UpdatePolicySettingsTab.cs
@@ -168,8 +168,19 @@ public static class UpdatePolicySettingsTab
     internal static string StatusMarkdown(
         UpdatePolicyContent content, Func<string, object?[], string> localize, string? zoneId = null)
     {
+        // 🚨 "No newer version detected yet" is a CLAIM, and until #2553 this surface made it
+        // without evidence. An install that has checked hourly and found nothing and an install
+        // whose checker has not run since the pod started produce the identical empty
+        // LatestAvailableTag — and the second is the one that matters, because it is how memex sat
+        // three builds behind for 7 h while this line reassured whoever read it. The two are now
+        // different sentences, and the honest one comes first: without a completed check there is
+        // nothing to report but the absence of a check.
         if (string.IsNullOrEmpty(content.LatestAvailableTag))
-            return localize("ui.updateNoNewerVersion", []);
+            return content.LastCheckedAt is { } checkedAt
+                ? localize("ui.updateNoNewerVersion", [])
+                    + " " + localize("ui.updateCheckedAt",
+                        [DisplayTimeExtensions.ToDisplayTime(checkedAt, zoneId).ToString("yyyy-MM-dd HH:mm")])
+                : localize("ui.updateNeverChecked", []);
 
         var tag = content.LatestAvailableTag!;
         var available = localize("ui.updateLatestAvailable", [tag])

--- a/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
+++ b/src/MeshWeaver.Hosting/SelfUpdate/SelfUpdateOptions.cs
@@ -65,6 +65,33 @@ public record SelfUpdateOptions
     public TimeSpan MinRollInterval { get; init; } = TimeSpan.FromHours(1);
 
     /// <summary>
+    /// 🚨 The SAFETY NET: the longest this install may go without ASKING whether a newer release
+    /// exists. Zero or negative disables it.
+    ///
+    /// <para>The check is event-driven, and that is still the design: a build completion wakes it in
+    /// seconds, which no interval can match. What the event-only shape got wrong is its failure
+    /// mode. Every event reaches this install over a chain of configuration nobody re-verifies — a
+    /// GitHub webhook, a <c>WebhookInbox</c> allowlist slot, an HMAC secret that must be
+    /// byte-identical on both sides — and EVERY joint of that chain fails SILENTLY. An install
+    /// whose event channel is dead is byte-identical, from outside and from its own logs, to an
+    /// install that is perfectly up to date: healthy pods, no errors, and a check that simply never
+    /// runs. memex sat three builds behind for 7 h in exactly that state (#2494, #2553), and
+    /// nothing in the product could have told anyone.</para>
+    ///
+    /// <para>🚨 So this is NOT the recurring poll this service deliberately removed, and the
+    /// distinction is the whole point: a poll DRIVES the update, a safety net BOUNDS how long a
+    /// broken driver can hide. Events stay the fast path and decide the latency; this decides the
+    /// worst case. It is also, by construction, unable to change the ROLL cadence — a safety-net
+    /// check is gated by <see cref="MinRollInterval"/> exactly like an event-driven one, so it can
+    /// only ever discover a release sooner, never roll more often.</para>
+    ///
+    /// <para>Default one hour: the same value as <see cref="MinRollInterval"/>, so the safety net
+    /// can never propose a roll the floor would refuse anyway, and the same cadence as CD's own
+    /// reconcile tick. The cost is one ACR tag list per hour per install.</para>
+    /// </summary>
+    public TimeSpan SafetyNetCheckInterval { get; init; } = TimeSpan.FromHours(1);
+
+    /// <summary>
     /// How long a burst of build-completion events is coalesced before one check runs.
     ///
     /// <para>Several repositories publishing at once (a platform release plus its satellites

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -554,6 +554,7 @@
   "ui.connectOAuth": "Mit dem Login der Gegenstelle verbinden (OAuth)",
   "ui.applyUpdateNow": "Verfügbares Update jetzt anwenden",
   "ui.updateNoNewerVersion": "_Noch keine neuere Version erkannt._",
+  "ui.updateNeverChecked": "_Diese Installation hat noch keine Update-Prüfung abgeschlossen — diese Anzeige besagt also nicht, dass es keine neuere Version gibt. Bleibt das so, läuft die Update-Prüfung nicht._",
   "ui.updateLatestAvailable": "**Neueste verfügbare Version:** `{0}`",
   "ui.updateCheckedAt": "_(geprüft {0})_",
   "ui.updateVerifiedGreen": "✅ Gegen die Module dieser Instanz verifiziert: alle {0} Modul(e) kompilieren und testen grün gegen diesen Build.",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -554,6 +554,7 @@
   "ui.connectOAuth": "Connect with the remote's login (OAuth)",
   "ui.applyUpdateNow": "Apply available update now",
   "ui.updateNoNewerVersion": "_No newer version detected yet._",
+  "ui.updateNeverChecked": "_This install has not completed an update check yet — so nothing here says a newer version does not exist. If this persists, the update checker is not running._",
   "ui.updateLatestAvailable": "**Latest available:** `{0}`",
   "ui.updateCheckedAt": "_(checked {0})_",
   "ui.updateVerifiedGreen": "✅ Verified against this instance's modules: all {0} module(s) compile and test green against this build.",

--- a/test/Memex.Portal.Shared.Test/ComboVerdictRecordingTest.cs
+++ b/test/Memex.Portal.Shared.Test/ComboVerdictRecordingTest.cs
@@ -225,11 +225,36 @@ public class ComboVerdictRecordingTest(ITestOutputHelper output) : MonolithMeshT
         markdown.Should().NotContain("ui.updateBlocked");
     }
 
+    /// <summary>
+    /// 🚨 #2553. This test used to assert that an empty <c>LatestAvailableTag</c> renders "no newer
+    /// version detected" — pinning a CLAIM the surface has no evidence for. An install that checked
+    /// and found nothing and an install whose checker never ran both reach this branch, and the
+    /// second is the one that matters: it is how memex sat three builds behind for 7 h while this
+    /// line reassured whoever read it. Without a completed check there is nothing to report but the
+    /// absence of a check.
+    /// </summary>
     [Fact]
-    public void StatusMarkdown_NoTagAtAll_SaysNothingDetected()
+    public void StatusMarkdown_NoTagAndNoCheckEverCompleted_SaysNoCheckHasRun()
     {
         UpdatePolicySettingsTab.StatusMarkdown(new UpdatePolicyContent(), EchoLocalizer)
-            .Should().Be("ui.updateNoNewerVersion[]");
+            .Should().Be("ui.updateNeverChecked[]");
+    }
+
+    /// <summary>The other half of the same branch, and the reason it may not be collapsed back into
+    /// one sentence: a check that RAN and found nothing is genuine good news, and it says when.</summary>
+    [Fact]
+    public void StatusMarkdown_NoTagButACheckDidRun_SaysNothingNewerAndWhen()
+    {
+        var content = new UpdatePolicyContent
+        {
+            LastCheckedAt = new DateTimeOffset(2026, 8, 29, 7, 30, 0, TimeSpan.Zero),
+            LastCheckVerdict = "no newer release: 12 tag(s) listed, none newer than the installed 3.0.0.",
+        };
+
+        var markdown = UpdatePolicySettingsTab.StatusMarkdown(content, EchoLocalizer);
+
+        markdown.Should().Contain("ui.updateNoNewerVersion[]");
+        markdown.Should().Contain("ui.updateCheckedAt[2026-08-29 07:30]");
     }
 
     // ── helpers ──

--- a/test/Memex.Portal.Shared.Test/SelfUpdateVerdictTest.cs
+++ b/test/Memex.Portal.Shared.Test/SelfUpdateVerdictTest.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Linq;
+using Memex.Portal.Shared.SelfUpdate;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The pure half of #2553: the verdict a self-update check reports. No hub, no logger, no Rx —
+/// these are the judgements the reporting site depends on, and they are worth pinning here rather
+/// than re-deriving them inside an integration test that also has to stand up a mesh.
+/// </summary>
+public class SelfUpdateVerdictTest
+{
+    /// <summary>
+    /// 🚨 The load-bearing discriminator. The dead-event-channel warning fires only when a
+    /// safety-net check FOUND a release nobody announced, and this predicate is what "found" means.
+    /// Get it wrong in the permissive direction and every quiet install warns hourly until people
+    /// stop reading the line; get it wrong in the strict direction and the one report that would
+    /// have named #2494 never fires.
+    /// </summary>
+    [Theory]
+    [InlineData(SelfUpdateOutcome.Applied, true)]
+    [InlineData(SelfUpdateOutcome.Held, true)]
+    [InlineData(SelfUpdateOutcome.Deferred, true)]
+    [InlineData(SelfUpdateOutcome.DetectOnly, true)]
+    [InlineData(SelfUpdateOutcome.NoNewerRelease, false)]
+    [InlineData(SelfUpdateOutcome.UpdatesDisabled, false)]
+    [InlineData(SelfUpdateOutcome.CheckFailed, false)]
+    [InlineData(SelfUpdateOutcome.NoOutcome, false)]
+    public void FoundNewerRelease_IsTrueExactlyWhenAReleaseWasWaiting(
+        SelfUpdateOutcome outcome, bool expected)
+        => Assert.Equal(expected, new SelfUpdateVerdict(outcome, "…").FoundNewerRelease);
+
+    /// <summary>
+    /// Every outcome must be reachable through a factory. An enum member with no constructor is a
+    /// state the service can never report, which is the same silence one level up.
+    /// </summary>
+    [Fact]
+    public void EveryOutcome_HasAFactoryThatProducesIt()
+    {
+        SelfUpdateVerdict[] all =
+        [
+            SelfUpdateVerdict.UpdatesDisabled(),
+            SelfUpdateVerdict.NoNewerRelease(7, "3.0.0"),
+            SelfUpdateVerdict.Held("3.0.1", "no sealed bake"),
+            SelfUpdateVerdict.Deferred("3.0.1", TimeSpan.FromMinutes(5), TimeSpan.FromHours(1)),
+            SelfUpdateVerdict.DetectOnly("3.0.1"),
+            SelfUpdateVerdict.Applied("3.0.1", "3.0.0", null),
+            SelfUpdateVerdict.CheckFailed(new InvalidOperationException("boom")),
+            SelfUpdateVerdict.NoOutcome(),
+        ];
+
+        Assert.Equal(
+            Enum.GetValues<SelfUpdateOutcome>().OrderBy(o => o),
+            all.Select(v => v.Outcome).OrderBy(o => o));
+        Assert.All(all, v => Assert.False(string.IsNullOrWhiteSpace(v.Message)));
+    }
+
+    /// <summary>
+    /// 🚨 "Nothing newer" has to say WHAT IT LOOKED AT. "No newer release" alone is the sentence a
+    /// broken checker would also produce; naming the number of tags listed and the installed
+    /// version is what makes it evidence rather than a reassurance.
+    /// </summary>
+    [Fact]
+    public void NoNewerRelease_NamesWhatItActuallyLookedAt()
+    {
+        var verdict = SelfUpdateVerdict.NoNewerRelease(12, "3.0.0-rc8.ci.6183");
+
+        Assert.Contains("12 tag(s) listed", verdict.Message, StringComparison.Ordinal);
+        Assert.Contains("3.0.0-rc8.ci.6183", verdict.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>A hold with no recorded reason must still read as a hold, never as an empty
+    /// sentence — a null reason is exactly the case an operator most needs to see.</summary>
+    [Fact]
+    public void AHoldWithNoReason_StillNamesTheTagAndTheHold()
+    {
+        var verdict = SelfUpdateVerdict.Held("3.0.1", null);
+
+        Assert.Equal(SelfUpdateOutcome.Held, verdict.Outcome);
+        Assert.Contains("HOLDING 3.0.1", verdict.Message, StringComparison.Ordinal);
+        Assert.Equal("3.0.1", verdict.Tag);
+    }
+
+    /// <summary>The structural backstop names itself as a defect in the service, not as a state of
+    /// the install — otherwise it would be read as one more thing about the deployment.</summary>
+    [Fact]
+    public void NoOutcome_BlamesTheService_NotTheInstall()
+    {
+        var verdict = SelfUpdateVerdict.NoOutcome();
+
+        Assert.Contains("SelfUpdateHostedService", verdict.Message, StringComparison.Ordinal);
+        Assert.False(verdict.FoundNewerRelease);
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateCheckVerdictTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateCheckVerdictTest.cs
@@ -1,0 +1,305 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.SelfUpdate;
+using MeshWeaver.Data;
+using MeshWeaver.GitSync;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.SelfUpdate;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 <b>#2553 — "memex self-update is silent: 3 builds behind, roll floor satisfied 5 h ago, and
+/// ZERO SelfUpdate log lines in 6.7 h", and #2494 — "self-update is EVENT-DRIVEN (no poll)".</b>
+///
+/// <para>Both issues are the same defect seen from two ends: a self-update check could complete
+/// having reported NOTHING, and the check could stop happening at all without reporting that
+/// either. An install three builds behind and an install perfectly up to date produced identical
+/// evidence — healthy pods, no errors, an Updates tab reading "No newer version detected yet" —
+/// so nobody could tell them apart, and the fleet sat behind for a week.</para>
+///
+/// <para>These tests assert the DELIVERY, never a return value. A verdict object that nothing
+/// emits is worth exactly as much as the silence it replaced, so every case here asserts either a
+/// log line that actually reached a logger or a field that actually landed on the policy node.</para>
+/// </summary>
+public class SelfUpdateCheckVerdictTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddUpdatePolicyType().AddGitHubSyncTypes();
+
+    private const string NewerTag = "3.0.0";
+
+    /// <summary>Every line the service emitted, with its level — the DELIVERY under test.</summary>
+    private sealed class CapturingLogger : ILogger<SelfUpdateHostedService>
+    {
+        private readonly ConcurrentQueue<(LogLevel Level, string Message)> _lines = new();
+        private readonly ReplaySubject<(LogLevel Level, string Message)> _emitted = new();
+
+        public IObservable<(LogLevel Level, string Message)> Emitted => _emitted;
+        public IReadOnlyList<(LogLevel Level, string Message)> Lines => _lines.ToArray();
+
+        /// <summary>Only the once-per-check verdict lines — never the startup banner.</summary>
+        public IReadOnlyList<(LogLevel Level, string Message)> Checks =>
+            _lines.Where(l => l.Message.Contains("[SelfUpdate] check (", StringComparison.Ordinal)).ToArray();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var line = (logLevel, formatter(state, exception));
+            _lines.Enqueue(line);
+            _emitted.OnNext(line);
+        }
+    }
+
+    /// <summary>Counts every registry listing, so "did this install ask again?" is measurable.</summary>
+    private sealed class CountingTagLister(params string[] tags) : IAcrTagLister
+    {
+        private int _calls;
+        private readonly ReplaySubject<int> _listed = new();
+
+        public int Calls => Volatile.Read(ref _calls);
+        public IObservable<int> Listed => _listed;
+
+        public Task<IReadOnlyList<string>> ListTagsAsync(string repository, CancellationToken ct)
+        {
+            _listed.OnNext(Interlocked.Increment(ref _calls));
+            return Task.FromResult<IReadOnlyList<string>>(tags);
+        }
+    }
+
+    private sealed class PatchingUpdater : IDeploymentUpdater
+    {
+        public bool CanPatch => true;
+        public Task<DateTimeOffset?> LastRolledAtAsync(CancellationToken ct) =>
+            Task.FromResult<DateTimeOffset?>(null);
+        public Task PatchToVersionAsync(string versionTag, CancellationToken ct) => Task.CompletedTask;
+    }
+
+    private static SelfUpdateOptions Options(
+        UpdatePolicyKind policy = UpdatePolicyKind.Continuous, TimeSpan? safetyNet = null) => new()
+        {
+            RetryInterval = TimeSpan.FromMilliseconds(500),
+            EventCoalesceWindow = TimeSpan.FromMilliseconds(50),
+            MinRollInterval = TimeSpan.Zero,
+            DefaultPolicy = policy,
+            // Short enough for a test; production's default is an hour. Delete this initializer to
+            // compile the file against pre-fix code — the option does not exist there, which is the
+            // defect #2494 reports.
+            SafetyNetCheckInterval = safetyNet ?? TimeSpan.FromHours(1),
+        };
+
+    private SelfUpdateHostedService NewService(
+        CapturingLogger logger, IAcrTagLister acr, IDeploymentUpdater updater, SelfUpdateOptions options) =>
+        new(Mesh, acr, updater, options, logger);
+
+    /// <summary>
+    /// Runs the startup pass and waits for the FIRST check verdict to be reported — a positive
+    /// signal, never a fixed delay.
+    /// </summary>
+    private async Task<CapturingLogger> RunOneCheckAsync(
+        IAcrTagLister acr, IDeploymentUpdater updater, SelfUpdateOptions options)
+    {
+        var logger = new CapturingLogger();
+        var service = NewService(logger, acr, updater, options);
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            await logger.Emitted
+                .Where(l => l.Message.Contains("[SelfUpdate] check (", StringComparison.Ordinal))
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(TestContext.Current.CancellationToken);
+            return logger;
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 THE CASE THE WHOLE ISSUE IS ABOUT. A check that finds nothing newer is the normal, happy
+    /// outcome of most checks — and it used to be a bare Rx <c>Where</c>, so it produced no log
+    /// line, no node write, nothing. "We asked and the answer was no" and "nothing ever asked" were
+    /// therefore the same observation from outside the process, which is exactly why memex could sit
+    /// three builds behind while looking healthy.
+    ///
+    /// <para>Fails on pre-fix code with zero check lines.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ACheckThatFindsNothingNewer_SaysSoAnyway()
+    {
+        var logger = await RunOneCheckAsync(new CountingTagLister(), new PatchingUpdater(), Options());
+
+        logger.Checks.Should().ContainSingle(
+            "a check must report exactly one verdict — the absence of a line is what made a stalled "
+            + "install indistinguishable from a current one");
+        logger.Checks[0].Message.Should().Contain("no newer release");
+        logger.Checks[0].Message.Should().Contain("Startup");
+    }
+
+    /// <summary>
+    /// The other formerly-silent exit: <c>Admin/UpdatePolicy = None</c>. It is a DECISION an
+    /// administrator took, and it deserves to look different from a broken updater — it used to be
+    /// the single most silent path in the service, a <c>Where</c> in the trigger pipeline that
+    /// discarded the check before anything could observe it.
+    ///
+    /// <para>Fails on pre-fix code with zero check lines.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task APolicyOfNone_IsADecisionThatReportsItself()
+    {
+        var acr = new CountingTagLister(NewerTag);
+        var logger = await RunOneCheckAsync(
+            acr, new PatchingUpdater(), Options(policy: UpdatePolicyKind.None));
+
+        logger.Checks.Should().ContainSingle();
+        logger.Checks[0].Message.Should().Contain("updates are disabled");
+        acr.Calls.Should().Be(0, "a policy of None still costs no registry call");
+    }
+
+    /// <summary>
+    /// The DURABLE half, and the one that survives a deployment forgetting a log level — which is
+    /// what actually happened: every line this service had to say was <c>LogInformation</c>, the
+    /// portal image caps its whole logger prefix at <c>Warning</c>, and no deployment had added the
+    /// category. So a log-only fix would have shipped straight back into the same void.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task EveryCheck_StampsItsVerdictOnThePolicyNode()
+    {
+        await RunOneCheckAsync(new CountingTagLister(), new PatchingUpdater(), Options());
+
+        var content = await Mesh.GetWorkspace()
+            .GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+            .Select(node => UpdatePolicyNodeType.ParseContent(node.Content, Mesh.JsonSerializerOptions))
+            .Where(c => c.LastCheckedAt is not null)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+
+        content.LastCheckVerdict.Should().Contain("no newer release");
+        content.LastCheckTrigger.Should().Be(nameof(SelfUpdateTrigger.Startup));
+    }
+
+    /// <summary>
+    /// 🚨 #2494 — <b>the delivery fix.</b> With no build-completion event and no policy change,
+    /// pre-fix code checks exactly ONCE (the startup pass) and then never again for the life of the
+    /// pod. That is the state prod was in: the event channel was misconfigured, every joint of it
+    /// failed silently, and an install that had stopped checking was indistinguishable from one
+    /// with nothing to do.
+    ///
+    /// <para>The safety net is not the removed poll returning — it cannot change the roll cadence
+    /// (a safety-net check passes through <see cref="SelfUpdateOptions.MinRollInterval"/> like any
+    /// other). It bounds how long a broken driver can hide.</para>
+    ///
+    /// <para>Fails on pre-fix code: the lister is called once and stays there.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task WithNoBuildEventAtAll_TheInstallStillChecksAgain()
+    {
+        var acr = new CountingTagLister();
+        var logger = new CapturingLogger();
+        var service = NewService(logger, acr, new PatchingUpdater(),
+            Options(safetyNet: TimeSpan.FromMilliseconds(300)));
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            // A positive signal: a REPORTED check whose trigger is the safety net. Nothing
+            // published and nothing changed the policy, so that is the only thing that can produce
+            // it. Waiting on the verdict rather than on the listing also removes the race between
+            // the two — the registry call happens first, the report follows.
+            await logger.Emitted
+                .Where(l => l.Message.Contains("[SelfUpdate] check (", StringComparison.Ordinal)
+                    && l.Message.Contains(nameof(SelfUpdateTrigger.SafetyNet), StringComparison.Ordinal))
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+
+        acr.Calls.Should().BeGreaterThanOrEqualTo(2,
+            "the startup pass is one listing; a second one can only have come from the safety net");
+        logger.Checks.Should().Contain(
+            l => l.Message.Contains(nameof(SelfUpdateTrigger.SafetyNet), StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// 🚨 #2494 — <b>the diagnosis fix, and the only place in the product that can make it.</b>
+    /// Three facts have to coincide before "your event channel is dead" is a fair thing to say:
+    /// the check was woken by the safety net, this install has seen no build-completion event at
+    /// all, AND a newer release was in fact waiting. Each clause matters — "no events yet" alone is
+    /// routine on an install whose modules rarely build, and warning about it would train people to
+    /// ignore the line that means something.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ASafetyNetCheckThatFindsAReleaseNobodyAnnounced_WarnsAboutTheEventChannel()
+    {
+        var logger = new CapturingLogger();
+        var service = NewService(logger, new CountingTagLister(NewerTag), new PatchingUpdater(),
+            Options(safetyNet: TimeSpan.FromMilliseconds(300)));
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            var warning = await logger.Emitted
+                .Where(l => l.Level == LogLevel.Warning
+                    && l.Message.Contains("NO build-completion event", StringComparison.Ordinal))
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(TestContext.Current.CancellationToken);
+
+            warning.Message.Should().Contain("WebhookInbox",
+                "the report must name the chain to check, not this service");
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
+    /// <summary>
+    /// The control for the test above: a check woken by a real build completion must NOT warn about
+    /// the event channel, however many releases it finds. A report that fires on the healthy path
+    /// is noise, and noise is what taught everyone to ignore the last one.
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task ABuildCompletionDrivenCheck_NeverWarnsAboutTheEventChannel()
+    {
+        var logger = new CapturingLogger();
+        var service = NewService(logger, new CountingTagLister(NewerTag), new PatchingUpdater(),
+            // Safety net off: the ONLY stimulus in this test is a real event.
+            Options(safetyNet: TimeSpan.Zero));
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            await SelfUpdateEventDriver.PublishBuildAsync(Mesh, "MeshWeaver", 4242);
+            await logger.Emitted
+                .Where(l => l.Message.Contains(nameof(SelfUpdateTrigger.BuildCompletion), StringComparison.Ordinal))
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .ToTask(TestContext.Current.CancellationToken);
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+
+        logger.Lines.Should().NotContain(
+            l => l.Message.Contains("NO build-completion event", StringComparison.Ordinal));
+    }
+}


### PR DESCRIPTION
Fixes the two halves of the same defect: a self-update check could complete having reported **nothing**, and the check could stop happening at all without reporting that either. An install three builds behind and an install perfectly up to date produced **identical evidence** — healthy pods, no errors, an Updates tab reading *"No newer version detected yet"* — which is why memex sat 7 h and 3 builds behind while every signal said it was fine.

Refs #2553, #2494. Neither issue is closed by this PR: both carry a deployment half that is not mine to do (below).

## #2553 — every check reports exactly one verdict

`RunOnce` returned `IObservable<Unit>`, so **completing with no emission was a legitimate result**. Two paths did exactly that, and they are the two most common outcomes a healthy install has:

```csharp
.Where(content => content.Policy != UpdatePolicyKind.None)   // ← policy None: whole check discarded
.Where(target => !string.IsNullOrEmpty(target))              // ← nothing newer: whole check discarded
```

* `RunOnce` now returns a **`SelfUpdateVerdict`**. Every branch names its outcome, so "we asked and the answer was no" is a different observation from "nothing ever asked".
* **The postcondition is asserted, not hoped for** — following the `framework-mvid.txt` / `_complete` precedent. `DefaultIfEmpty(SelfUpdateVerdict.NoOutcome())` means a pipeline that somehow produces nothing reports *that*, at Warning, naming itself as a defect in this service. A future filter cannot re-create the silence.
* The verdict is **logged AND stamped on `Admin/UpdatePolicy`** (`LastCheckedAt` / `LastCheckVerdict` / `LastCheckTrigger`). Both, and the reason is the measured one: every line this service had to say was `LogInformation`, and the portal image's `appsettings.json` caps its logger prefix at `Warning` with no entry for this category (see "Deployment half" below). A log-only fix would have shipped straight back into the same void.
* **The Updates tab stops asserting a fact it never established.** `StatusMarkdown` returned `ui.updateNoNewerVersion` whenever `LatestAvailableTag` was empty — which is also the state of an install that has never checked. Those are now two different sentences.

The bookkeeping write cannot feed itself: the trigger reads `policy.DistinctUntilChanged(c => c.Policy)` and the source is `DistinctUntilChanged((Policy, RequireCiGreen))`, so a write touching only these three fields emits nothing downstream — the #223 write-storm shape is structurally excluded rather than avoided by convention.

## #2494 — a bounded safety net, and the first report that can name a dead channel

`SelfUpdate:SafetyNetCheckInterval` (default `01:00:00`, `00:00:00` disables), rendered by the chart and declared in `values.aks.yaml`.

**This is not the removed poll returning.** A poll *drives* the update; this *bounds how long a broken driver can hide*. It passes through `MinRollInterval` like any other check, so it can only ever shorten **discovery** — never change the roll cadence. Events stay the fast path and still decide the latency.

The justification is the failure mode, not the latency: every event reaches an install across a chain nothing re-verifies — a GitHub webhook registration, a `WebhookInbox` allowlist slot, an HMAC secret that must match byte-for-byte — and **every joint of it fails silently** (an unlisted target answers 404 exactly like a wrong URL; a mismatched secret still answers 2xx and drops the delivery).

And the diagnosis half: a safety-net check that **finds a release** on an install that has seen **no build-completion event at all** warns and names the chain to check. All three clauses matter — "no events yet" alone is routine on an install whose modules rarely build, and warning on it would train people to ignore the line that means something. `ABuildCompletionDrivenCheck_NeverWarnsAboutTheEventChannel` is the control.

## Tests — run against unfixed code FIRST

`SelfUpdateCheckVerdictTest` (6 tests) asserts the **delivery**: a log line that reached a logger, or a field that landed on the node. Never a return value — asserting the thing that already lied is worthless.

Against `origin/main` (`ecef6dbd9`) in a clean worktree, with only the two edits needed to compile there (`SafetyNetCheckInterval` and the `SelfUpdateTrigger` enum do not exist yet; the node-stamp test was dropped for the same reason):

```
ACheckThatFindsNothingNewer_SaysSoAnyway                                  [FAIL] 30s TimeoutException
APolicyOfNone_IsADecisionThatReportsItself                                [FAIL] 30s TimeoutException
WithNoBuildEventAtAll_TheInstallStillChecksAgain                          [FAIL] 30s TimeoutException
ASafetyNetCheckThatFindsAReleaseNobodyAnnounced_WarnsAboutTheEventChannel [FAIL] 30s TimeoutException
ABuildCompletionDrivenCheck_NeverWarnsAboutTheEventChannel                [FAIL] 30s TimeoutException
```

Five of five time out waiting for a verdict line that pre-fix code never emits — which is the issue, reproduced.

On this branch:

```
SelfUpdateCheckVerdictTest           6/6 pass
All *SelfUpdate* (Hosting.Monolith) 28/28 pass
Memex.Portal.Shared.Test           426/426 pass   (+ SelfUpdateVerdictTest, 12 pure tests)
MeshWeaver.Documentation.Test       97/97 pass
deploy/aks/scripts/check-values-are-read.sh — 120 keys, all read
```

`ComboVerdictRecordingTest.StatusMarkdown_NoTagAtAll_SaysNothingDetected` was **replaced**, not adjusted: it pinned the claim that has no evidence behind it. It is now two tests, one per fact.

## 🚨 The deployment half — not in this PR, and not mine to do

1. **`Memex.Portal.Shared.SelfUpdate` has no log-level entry.** `MeshWeaver.Plugins/src/Memex.Portal.Distributed/appsettings.json` sets `"Memex": "Warning"` and explicitly surfaces the sibling `Memex.Portal.Shared.ShippedReleaseSeedHostedService` at Information — but nothing for this service. **That is the direct cause of #2553's "ZERO SelfUpdate log lines"**: the mechanism was working and reporting into a void. The node stamp above makes the verdict readable without it; the entry is still worth adding, in that repo.
2. **`memex` lists zero webhook targets** (`WebhookInbox__Targets__0/1` both `""`, per #2494's last comment). This PR bounds the damage; it does not fix the channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
