### PR TITLE
Key the permission-probe cache by the CONTEXT it evaluated, not just (path, user)

### DIFF
--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -227,7 +227,49 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     // Lazy<T>(ThreadSafety.ExecutionAndPublication) guarantees the factory
     // runs at most once per key, even when multiple GetOrAdd calls race.
     private readonly ConcurrentDictionary<string, Lazy<Entry>> _streams = new();
-    private readonly ConcurrentDictionary<(string Path, string UserId), AccessEntry> _access = new();
+    private readonly ConcurrentDictionary<AccessCacheKey, AccessEntry> _access = new();
+
+    /// <summary>
+    /// The key of the permission-probe cache below.
+    ///
+    /// <para>🚨 <b>It carries every <see cref="AccessContext"/> dimension the evaluation READS,
+    /// not just the identity.</b> <c>PermissionEvaluator.GetEffectivePermissions</c> is not a
+    /// function of <c>(path, userId)</c> alone: it also reads <see cref="AccessContext.IsApiToken"/>
+    /// and the token's claim roles (the API-token capability clamp, which zeroes the WHOLE
+    /// permission set when a bearer context lacks <c>Api</c>), and <see cref="AccessContext.IsHub"/>
+    /// (the hub-credential early return). Keying on <c>(path, userId)</c> alone made two contexts
+    /// for the SAME person share one verdict, and the cache is a process-wide singleton, so the
+    /// two surfaces really do meet in it:</para>
+    ///
+    /// <list type="bullet">
+    /// <item><b>Too permissive (a capability bypass).</b> A portal read caches the unclamped
+    /// permissions; an MCP/bearer read of the same node within the TTL takes that entry and
+    /// never runs the API-token clamp at all — the token is admitted to the API surface the
+    /// clamp exists to keep it off.</item>
+    /// <item><b>Too restrictive (the reported symptom).</b> A bearer read the clamp zeroed caches
+    /// <c>Permission.None</c>; the same user's PORTAL read within the TTL then fails with
+    /// "lacks Read permission", on a node they are plainly granted.</item>
+    /// </list>
+    ///
+    /// <para>Both directions are wrong ANSWERS rather than errors, which is why nothing logged
+    /// and neither surface could be trusted to reproduce the other's result.</para>
+    /// </summary>
+    internal readonly record struct AccessCacheKey(
+        string Path, string UserId, bool IsApiToken, bool IsHub, string ClaimRoles);
+
+    /// <summary>
+    /// Builds the probe key for a context. <paramref name="context"/>'s claim roles are folded in
+    /// ORDER-INDEPENDENTLY (they are a set) so two equivalent tokens still share an entry, while
+    /// two tokens whose claims genuinely differ — one carrying <c>Api</c>, one not — never do.
+    /// </summary>
+    internal static AccessCacheKey BuildAccessCacheKey(string path, AccessContext context) =>
+        new(path,
+            context.ObjectId,
+            context.IsApiToken,
+            context.IsHub,
+            context.Roles is null || context.Roles.Count == 0
+                ? string.Empty
+                : string.Join('\u001f', context.Roles.OrderBy(r => r, StringComparer.Ordinal)));
 
     // 🚨 Idle release of read entries — the read-side counterpart of the write
     // cache's (_updateQueues) sliding expiration. Window/interval come from
@@ -722,7 +764,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
             logger.LogDebug(ex, "MeshNodeStreamCache: error disposing update-queue cache");
         }
 
-        // 3. Permission probe cache — drop the cached (path,user)⇒Permission
+        // 3. Permission probe cache — drop the cached (path,user,context)⇒Permission
         //    entries so nothing roots the disposed mesh's identities.
         _access.Clear();
 
@@ -1536,7 +1578,7 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     /// </summary>
     private IObservable<Permission> ProbeEffectivePermissions(string path, AccessContext captured)
     {
-        var key = (Path: path, UserId: captured.ObjectId);
+        var key = BuildAccessCacheKey(path, captured);
         return Observable.Defer(() =>
         {
             // TTL cache hit ⇒ short-circuit the evaluation.

--- a/test/MeshWeaver.Hosting.Test/PermissionProbeCacheKeyTests.cs
+++ b/test/MeshWeaver.Hosting.Test/PermissionProbeCacheKeyTests.cs
@@ -1,0 +1,137 @@
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Regression tests for the permission-probe cache key
+/// (<c>MeshNodeStreamCache.BuildAccessCacheKey</c>) — MeshWeaver.SocialMedia#92, reported as
+/// "MCP token cannot read Profiles nodes although the portal renders them for the same user".
+///
+/// <para><b>The mechanism.</b> <c>PermissionEvaluator.GetEffectivePermissions</c> is NOT a
+/// function of <c>(path, userId)</c>. It also reads the caller's <see cref="AccessContext"/>:
+/// <see cref="AccessContext.IsApiToken"/> together with the token's claim roles drive the
+/// API-token capability clamp (which zeroes the WHOLE permission set — not merely the
+/// <c>Api</c> bit — when a bearer context lacks <c>Api</c>), and <see cref="AccessContext.IsHub"/>
+/// drives the hub-credential early return. The probe cache in front of it was keyed by
+/// <c>(path, userId)</c> alone, and <c>IMeshNodeStreamCache</c> is a process-wide SINGLETON, so a
+/// person's browser session and their MCP token really do meet in one entry.</para>
+///
+/// <para><b>Both directions are wrong ANSWERS, not errors</b> — which is why nothing logged and
+/// neither surface reproduced the other's result:</para>
+/// <list type="bullet">
+/// <item><b>Too permissive — a capability bypass.</b> A portal read caches the unclamped
+/// permissions; a bearer read of the same node inside the TTL takes that entry and never runs
+/// the clamp at all, admitting a token to the API surface the clamp exists to keep it off.</item>
+/// <item><b>Too restrictive — the reported symptom.</b> A bearer read the clamp zeroed caches
+/// <c>Permission.None</c>; the same user's PORTAL read inside the TTL is then refused with
+/// "lacks Read permission" on a node they are plainly granted.</item>
+/// </list>
+///
+/// <para>These tests pin the invariant the key must satisfy: <b>it carries every context
+/// dimension the evaluation reads, and nothing else</b> — differing where the verdict can
+/// differ, and still SHARING an entry where it cannot, or the fix would simply disable the
+/// cache.</para>
+/// </summary>
+public class PermissionProbeCacheKeyTests
+{
+    private const string Path = "Profiles/RobertLinkedIn";
+
+    private static AccessContext Carson() => new()
+    {
+        ObjectId = "carson",
+        Name = "Carson",
+        Roles = ["Viewer"],
+    };
+
+    [Fact]
+    public void A_bearer_context_and_a_portal_context_never_share_an_entry()
+    {
+        var portal = Carson();
+        var bearer = Carson() with { IsApiToken = true };
+
+        Assert.NotEqual(
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, portal),
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, bearer));
+    }
+
+    [Fact]
+    public void A_hub_credential_never_shares_an_entry_with_a_user_context()
+    {
+        var user = Carson();
+        var hub = Carson() with { IsHub = true };
+
+        Assert.NotEqual(
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, user),
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, hub));
+    }
+
+    /// <summary>
+    /// Two tokens for the SAME person whose claims differ are two different capabilities — one
+    /// may carry <c>Api</c> and the other not — so one token's verdict must never be served to
+    /// the other.
+    /// </summary>
+    [Fact]
+    public void Two_tokens_with_different_claim_roles_never_share_an_entry()
+    {
+        var withViewer = Carson() with { IsApiToken = true, Roles = ["Viewer"] };
+        var withNothing = Carson() with { IsApiToken = true, Roles = [] };
+
+        Assert.NotEqual(
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, withViewer),
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, withNothing));
+    }
+
+    /// <summary>
+    /// …but claims are a SET. Two tokens carrying the same roles in a different order are the
+    /// same capability and must still share the entry — otherwise the fix quietly turns the
+    /// probe cache off for every multi-role token, which is a latency regression on the read
+    /// path rather than a security fix.
+    /// </summary>
+    [Fact]
+    public void Claim_role_ORDER_does_not_split_the_cache()
+    {
+        var a = Carson() with { IsApiToken = true, Roles = ["Viewer", "Editor"] };
+        var b = Carson() with { IsApiToken = true, Roles = ["Editor", "Viewer"] };
+
+        Assert.Equal(
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, a),
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, b));
+    }
+
+    /// <summary>The cache must still WORK: an identical context on the same path is one entry.</summary>
+    [Fact]
+    public void An_identical_context_shares_its_entry()
+    {
+        Assert.Equal(
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, Carson()),
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, Carson()));
+    }
+
+    [Fact]
+    public void The_path_and_the_user_still_separate_entries()
+    {
+        var carson = Carson();
+        Assert.NotEqual(
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, carson),
+            MeshNodeStreamCache.BuildAccessCacheKey("Profiles/RolandLinkedIn", carson));
+        Assert.NotEqual(
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, carson),
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, carson with { ObjectId = "rbuergi" }));
+    }
+
+    /// <summary>
+    /// Fields the evaluation does NOT read must not split the cache — a key that varied with,
+    /// say, the display name would be correct-but-useless, and this test is what keeps the key
+    /// honest as <see cref="AccessContext"/> grows.
+    /// </summary>
+    [Fact]
+    public void Irrelevant_context_fields_do_not_split_the_cache()
+    {
+        var carson = Carson();
+        Assert.Equal(
+            MeshNodeStreamCache.BuildAccessCacheKey(Path, carson),
+            MeshNodeStreamCache.BuildAccessCacheKey(
+                Path, carson with { Name = "Carson N.", Email = "carson@example.com" }));
+    }
+}


### PR DESCRIPTION
Found while investigating [MeshWeaver.SocialMedia#92](https://github.com/Systemorph/MeshWeaver.SocialMedia/issues/92) — *"MCP token cannot read Profiles nodes although the portal renders them for the same user"*.

## The defect

`PermissionEvaluator.GetEffectivePermissions` is **not** a function of `(path, userId)`. It also reads the caller's `AccessContext`:

- **`IsApiToken`** + the token's **claim roles** drive the API-token capability clamp (`PermissionEvaluator.cs`, the `IsApiToken` branch), which sets `p = Permission.None` — zeroing the **whole** permission set, not merely the `Api` bit — when a bearer context lacks `Api`;
- **`IsHub`** drives the hub-credential early return.

`MeshNodeStreamCache.ProbeEffectivePermissions` cached that result under `(path, userId)` **alone**. And `IMeshNodeStreamCache` is a process-wide **singleton** (`PersistenceExtensions.cs`: `TryAddSingleton`), so a person's browser session and their MCP token genuinely meet in the same entry for the `AccessTtl` (30 s) window.

The comment directly above the cache already notes that the evaluation depends on the captured context — *"so claim-based (Bearer-token) roles on `AccessContext.Roles` resolve"* — while the key ignores it.

## Both directions are wrong ANSWERS, not errors

That is why nothing logged, and why neither surface could reproduce the other's result:

| Direction | What happens |
|---|---|
| **Too permissive — a capability bypass** | A portal read caches the *unclamped* permissions. A bearer read of the same node inside the TTL takes that entry and **never runs the clamp at all**, admitting a token to the API surface the clamp exists to keep it off. |
| **Too restrictive — the reported symptom** | A bearer read the clamp zeroed caches `Permission.None`. The same user's **portal** read inside the TTL is then refused with `lacks Read permission` on a node they are plainly granted. |

## The fix

The key now carries every context dimension the evaluation reads — **and nothing else**, so the cache stays useful rather than being quietly disabled:

- claim roles are folded **order-independently** (they are a set), so two equivalent tokens still share an entry;
- fields the evaluator never reads (name, email) do not split entries.

## Tests

7 new cases in `PermissionProbeCacheKeyTests`, and they are **proven non-vacuous**: restoring the pre-fix `(path, userId)` key fails **exactly the 3** that pin the context dimensions, while the **4** that pin *"the cache must still work / must not over-split"* pass in both states — which is the shape you want, since a fix that merely disabled the cache would also make the first three pass.

| Suite | Result |
|---|---|
| `MeshWeaver.Hosting.Test` | 259/259 ✓ |
| `MeshWeaver.AccessControl.Test` | 29/29 ✓ |
| `MeshWeaver.Hosting.Monolith.Test` (access + permission filter) | 29/29 ✓ |

## ⚠️ Scope — please read before closing anything

This is a real defect on the reported code path, but it is **probably not the whole of SocialMedia#92**: a 30-second TTL cannot explain a denial that persisted for a week. That issue stays open. Two live reads are still needed to attribute the sustained denial, and I could not make them (the `memex`/`systemorph` MCP servers have failed DNS all session):

1. **`get @Profiles/_Policy` and `@Profiles/RobertLinkedIn/_Policy`** — does either set `api: false`? A policy that caps `Api` out makes `p` lack the `Api` bit, and the clamp then zeroes the entire set for *every* MCP token on that subtree, permanently. That would be a sustained, non-cache explanation with exactly this symptom.
2. **carson's API-token `Roles` claim snapshot** — `ClaimsCarryApi` is the clamp's only escape hatch, and the claim is snapshotted at token-creation time, so a token minted before a role change can be permanently short.

What the investigation *did* settle, against the issue's own stated theory: **the MCP path does not "evaluate only the node's own scope"**. Both surfaces provably go through the same evaluator, and it folds the full ancestor chain (`GetScopeHierarchy` → `ComputeRoleState`, `Inherited ∪ Local, deny overrides`). So @rbuergi's reading on the issue is right — the portal is correct and the denial is the bug — and the remaining suspects are the two above plus this cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)