### PR TITLE
fix(modules): a recorded module version is a claim about the disk, not the disk (#2417)

### DIFF
--- a/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
+++ b/src/MeshWeaver.PluginCatalog/CatalogLayoutAreas.cs
@@ -635,9 +635,23 @@ public static class CatalogLayoutAreas
                     && string.Equals(record.ModuleVersion, pkg.ModuleVersion, StringComparison.Ordinal))
                 {
                     logger?.LogInformation(
-                        "Package {Id} is up to date (module {ModuleVersion}); nothing to sync.",
+                        "Package {Id} content is up to date (module {ModuleVersion}); nothing to sync.",
                         pkg.Id, pkg.ModuleVersion);
-                    return Observable.Return(new InstallResult(0, 0));
+                    // 🚨 #2417 — WithModule, and the missing wrapper here is half of why a package
+                    // could record as installed with no binary anywhere. This early return is a
+                    // CONTENT verdict: the manifest hash the record was stamped from equals the
+                    // one the source serves, so no node needs to travel. It says nothing whatever
+                    // about the module — and by returning unwrapped (the other two exits below are
+                    // both WithModule'd) it made the content answer stand in for the module
+                    // answer. Once a moduleVersion was stamped, no install and no reconcile would
+                    // ever ask about the binary again, on any deployment.
+                    //
+                    // The module lane costs nothing when there is nothing to ask: WithModule is
+                    // the identity for a package declaring no module or a source that serves no
+                    // bundles, and AdoptModule absorbs every failure into a logged zero — its
+                    // presence-aware ModuleUpdateDecision answers SkipUpToDate for the normal
+                    // case, in which nothing travels either.
+                    return WithModule(Observable.Return(new InstallResult(0, 0)));
                 }
                 if (record?.InstalledFiles is not { Count: > 0 })
                     return Full();

--- a/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
@@ -95,12 +95,32 @@ public static class ModuleUpdateDecision
     /// <param name="policyDecline">Why the deployment's update policy declines unattended landing,
     /// or null when it allows it (<see cref="IModuleUpdatePolicy"/>; null when no policy is
     /// registered — the platform default is auto-update).</param>
+    /// <param name="landedBytesPresent">
+    /// 🚨 Whether the entry's landed assembly is actually ON DISK — production passes
+    /// <see cref="ModuleActivationBoot.LandedModuleDllExists"/> bound to the module root, the same
+    /// resolution rule boot itself uses, so there is never a second notion of "landed".
+    ///
+    /// <para>Required, not optional-defaulting-to-true, and #2417 is why. Until this parameter
+    /// existed the "already landed" branch below was decided from the entry's recorded VERSION
+    /// alone — a string in a sidecar — and the bytes were never stat'd. That made every way a
+    /// landed binary can go missing PERMANENT and SILENT on every deployment: a recreated
+    /// <c>Modules:Root</c> volume, a half-completed landing, a generation directory collected out
+    /// from under its entry. The record said "module X at version V", the disk said nothing, and
+    /// no reconcile would ever look again. A default of <c>true</c> would keep exactly that
+    /// answer as the one a careless caller gets.</para>
+    ///
+    /// <para>Three other surfaces already diagnose this state and all three say "re-install"
+    /// (<see cref="ModuleActivationStatus"/>, <c>RequiredModuleStatus.StoreReason</c>,
+    /// <see cref="ModuleActivationBoot"/>'s skip reason). Nothing on the install path acted on it.
+    /// This is that action.</para>
+    /// </param>
     public static ModuleUpdateVerdict Decide(
         string? bundleVersion,
         string? bundleMinMeshVersion,
         Func<string?, string?> platformGate,
         ModuleActivationEntry? landed,
-        string? policyDecline)
+        string? policyDecline,
+        Func<ModuleActivationEntry, bool> landedBytesPresent)
     {
         if (string.IsNullOrWhiteSpace(bundleVersion))
             return new(ModuleUpdateAction.SkipNoBundle,
@@ -122,12 +142,23 @@ public static class ModuleUpdateDecision
             ? NuGetVersionComparer.Instance.Compare(bundleVersion, landed.Version)
             : (int?)null;
 
-        // Already landed at the served version: nothing travels. The version alone keys this —
-        // landed bytes stay loadable across platform builds (simple-name binding), so there is no
-        // "re-land the same version for a new build" case.
+        // Already landed at the served version: nothing travels — PROVIDED the bytes are there.
+        // The version alone still keys the no-op (landed bytes stay loadable across platform
+        // builds, simple-name binding, so there is no "re-land the same version for a new build"
+        // case) — but a version is a claim about the disk, not the disk.
+        //
+        // 🚨 #2417: this branch used to end here, and that single missing question is what made
+        // the whole lane SELF-SEALING. A recorded version with no assembly behind it answered
+        // "up to date" forever, on every deployment and every reconcile, while the package was in
+        // fact half-installed. Note the ordering: SkipUninstalled above still wins, because a
+        // disabled entry with no bytes is a completed uninstall, not damage to repair.
         if (landedComparison == 0)
-            return new(ModuleUpdateAction.SkipUpToDate,
-                $"version {bundleVersion} is already landed");
+            return landedBytesPresent(landed!)
+                ? new(ModuleUpdateAction.SkipUpToDate, $"version {bundleVersion} is already landed")
+                : new(ModuleUpdateAction.Land,
+                    $"version {bundleVersion} is recorded as landed but its assembly is ABSENT — "
+                    + "the landing never completed or its bytes were lost; re-landing (no restart "
+                    + "would have fixed it, and nothing else would ever have looked again)");
 
         // Never roll BACK unattended: a registry serving an older version than what is landed is a
         // deliberate operator situation (a pinned rollback, a lagging registry), and silently

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -299,9 +299,15 @@ public sealed class PluginBundleClient
                         var entry = activation.Entries.FirstOrDefault(e =>
                             string.Equals(e.Name, moduleName, StringComparison.OrdinalIgnoreCase));
 
+                        // 🚨 #2417 — the presence probe, bound to the landing service's OWN base
+                        // directory and resolved by ModuleActivationBoot, which is the same rule
+                        // boot uses. Never MeshBuilder.ResolveModulePath: its app-closure fallback
+                        // would find a same-named platform DLL and report a landed module that was
+                        // never landed here.
                         var verdict = ModuleUpdateDecision.Decide(
                             bundle?.Version, bundle?.MinMeshVersion,
-                            ModulePlatformFloor.DeclineReason, entry, declined);
+                            ModulePlatformFloor.DeclineReason, entry, declined,
+                            e => ModuleActivationBoot.LandedModuleDllExists(landing.BaseDirectory, e));
 
                         if (verdict.Action != ModuleUpdateAction.Land)
                         {

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleLaneAfterContentUpToDateTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleLaneAfterContentUpToDateTest.cs
@@ -1,0 +1,160 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// 🚨 <b>#2417 — "a local install can never land a module binary: 26 of 28 module packages record
+/// as installed but no binary lands".</b>
+///
+/// <para>The install orchestrator's content short-circuit compares the install record's
+/// <c>ModuleVersion</c> — a hash of the package's <c>manifest.lock</c> — against the one the source
+/// serves, and returns <c>InstallResult(0,0)</c> when they match. That is a correct and valuable
+/// CONTENT optimisation: no node needs to travel.</para>
+///
+/// <para>What made it self-sealing is that the early return was the ONE exit of that method not
+/// wrapped in <c>WithModule</c>. So the content answer stood in for the module answer, and once a
+/// <c>moduleVersion</c> was stamped, no install and no reconcile would ever ask about the binary
+/// again — on any deployment, not only a local one. A recreated volume, a half-completed landing,
+/// or a package installed while no bundle source was configured were all permanent and silent.</para>
+///
+/// <para>This test asserts the DELIVERY — that the module lane was actually ENTERED — rather than
+/// the <c>InstallResult</c>, which reports <c>(0,0)</c> either way and is precisely the value that
+/// was already lying.</para>
+/// </summary>
+public class ModuleLaneAfterContentUpToDateTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static readonly LogSink Sink = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddGraph()
+            .AddPluginCatalog()
+            .ConfigureServices(services =>
+                services.AddSingleton<ILoggerProvider>(new SinkProvider(Sink)));
+
+    private const string ModuleHash = "aaaaaaaaaaaaaaa1";
+    private const string ModuleName = "Acme.Gizmo";
+
+    private static readonly IReadOnlyList<PackageFile> Files =
+    [
+        new("Gizmo/index.json",
+            """{"$type":"MeshNode","id":"Gizmo","namespace":"","path":"Gizmo","mainNode":"Gizmo","name":"Gizmo Plugin","nodeType":"Space","state":"Active","content":{"$type":"PluginManifest","description":"A gizmo plugin.","minMeshVersion":"1.0.0"}}"""),
+        new("Gizmo/Notes.md", "# Notes"),
+        new("Gizmo/manifest.lock",
+            $$$"""{"schema":"mw-manifest/1","module":"Gizmo","moduleVersion":"{{{ModuleHash}}}","sourceCommit":"c1","files":{"Gizmo/index.json":"h-root-1","Gizmo/Notes.md":"h-notes-1"}}"""),
+    ];
+
+    /// <summary>The package DECLARES a compiled module — the whole point; a package without one has
+    /// no module lane to skip.</summary>
+    private static PackageManifest Pkg() => new()
+    {
+        Id = "Gizmo",
+        Name = "Gizmo Plugin",
+        Kind = PackageKind.NodeRepo,
+        TargetPartition = "Gizmo",
+        SourceFolder = "Gizmo",
+        Version = "commit-1",
+        ModuleVersion = ModuleHash,
+        Module = ModuleName,
+    };
+
+    private sealed class LogSink
+    {
+        private readonly ConcurrentQueue<string> _lines = new();
+        public void Add(string category, string message) => _lines.Enqueue($"{category}|{message}");
+        public IReadOnlyList<string> Lines => _lines.ToArray();
+        public IReadOnlyList<string> From(string category) =>
+            _lines.Where(l => l.StartsWith(category + "|", StringComparison.Ordinal)).ToArray();
+    }
+
+    private sealed class SinkProvider(LogSink sink) : ILoggerProvider
+    {
+        public ILogger CreateLogger(string categoryName) => new SinkLogger(sink, categoryName);
+        public void Dispose() { }
+
+        private sealed class SinkLogger(LogSink sink, string category) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter) =>
+                sink.Add(category, formatter(state, exception));
+        }
+    }
+
+    /// <summary>
+    /// A source that serves the files (so the first install works) and carries a bundle client (so
+    /// the module lane is reachable). The client points at a closed local port: this test asks
+    /// only whether the lane was ENTERED, and every failure past that point is absorbed by
+    /// <c>AdoptModule</c> into a logged zero by design.
+    /// </summary>
+    private sealed class RecordingSource(IReadOnlyList<PackageFile> files) : IPackageSource
+    {
+        public readonly List<IReadOnlyCollection<string>?> Fetches = [];
+
+        public IObservable<IReadOnlyList<PackageManifest>> ListPackages(string gitRef) =>
+            Observable.Return<IReadOnlyList<PackageManifest>>([]);
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef)
+        {
+            Fetches.Add(null);
+            return Observable.Return(files);
+        }
+
+        public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(
+            PackageManifest package, string gitRef, IReadOnlyCollection<string>? paths)
+        {
+            Fetches.Add(paths);
+            var wanted = paths is null ? null : new HashSet<string>(paths, StringComparer.Ordinal);
+            return Observable.Return<IReadOnlyList<PackageFile>>(
+                wanted is null ? files : files.Where(f => wanted.Contains(f.RelativePath)).ToList());
+        }
+    }
+
+    [Fact(Timeout = 180_000)]
+    public async Task ContentUpToDate_StillAsksTheModuleLane()
+    {
+        // ── The install that stamps the record. Any source shape does; what matters is that the
+        //    record ends up carrying this moduleVersion.
+        await PackageInstaller.Install(Mesh, Pkg(), Files, "commit-1").FirstAsync().ToTask();
+
+        // ── Now install again, from a REGISTRY source that can serve bundles, at the SAME content
+        //    version. Pre-fix this returns (0,0) without a single module question being asked.
+        var registry = new RegistryPackageSource(Mesh, "http://127.0.0.1:1")
+        {
+            Bundles = new PluginBundleClient(Mesh, "http://127.0.0.1:1"),
+        };
+        var source = new RecordingSource(Files);
+
+        var result = await CatalogLayoutAreas
+            .InstallOrUpdate(Mesh, registry, "commit-1", Pkg(), logger: null)
+            .FirstAsync()
+            .ToTask(TestContext.Current.CancellationToken);
+
+        result.Written.Should().Be(0, "the CONTENT is up to date — nothing should be re-fetched");
+        source.Fetches.Should().BeEmpty("the content short-circuit must survive this change intact");
+
+        // 🚨 The delivery: PluginBundleClient was reached at all. WHAT it then decided is not this
+        // test's business (there is no registry behind that port, so it will report a miss and
+        // absorb it into a logged zero, exactly as designed) — that the question was ASKED is.
+        var bundleLines = Sink.From("MeshWeaver.PluginCatalog.PluginBundleClient");
+        bundleLines.Should().NotBeEmpty(
+            "an up-to-date CONTENT hash says nothing about whether the module's binary is on disk; "
+            + "letting it stand in for the module answer is what made a missing binary permanent");
+        bundleLines.Should().Contain(l => l.Contains(ModuleName, StringComparison.Ordinal));
+    }
+}

--- a/test/MeshWeaver.PluginCatalog.Test/ModuleUpdateDecisionTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ModuleUpdateDecisionTest.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using System;
 using Xunit;
 
 namespace MeshWeaver.PluginCatalog.Test;
@@ -33,11 +34,23 @@ public class ModuleUpdateDecisionTest
         Enabled = enabled,
     };
 
+    /// <summary>
+    /// 🚨 The presence probe (#2417). Production binds this to
+    /// <c>ModuleActivationBoot.LandedModuleDllExists</c>; here it is a constant, so every case
+    /// below has to STATE whether the bytes are on disk. That statement is the point: the
+    /// "already landed" rule was decided from a version string alone, and a version string is a
+    /// claim about the disk rather than the disk.
+    /// </summary>
+    private static bool BytesPresent(ModuleActivationEntry _) => true;
+
+    /// <summary>The state #2417 is about: the sidecar records the module, the assembly is gone.</summary>
+    private static bool BytesGone(ModuleActivationEntry _) => false;
+
     [Fact]
     public void ANewerBundleWhoseFloorIsSatisfied_Lands()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            "1.3.0", "3.0.0", Gate, Landed("1.2.0"), policyDecline: null);
+            "1.3.0", "3.0.0", Gate, Landed("1.2.0"), policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
     }
@@ -50,7 +63,7 @@ public class ModuleUpdateDecisionTest
         // installs ex post as long as this platform satisfies its declared floor. Under MVID
         // equality this exact case — "install GRPC ex post through the Store" — was impossible.
         var verdict = ModuleUpdateDecision.Decide(
-            "1.3.0", "1.0.0", Gate, landed: null, policyDecline: null);
+            "1.3.0", "1.0.0", Gate, landed: null, policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
     }
@@ -59,7 +72,7 @@ public class ModuleUpdateDecisionTest
     public void ABundleWithNoDeclaredFloor_Lands_AbsenceIsNoConstraint()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            "1.3.0", bundleMinMeshVersion: null, Gate, Landed("1.2.0"), policyDecline: null);
+            "1.3.0", bundleMinMeshVersion: null, Gate, Landed("1.2.0"), policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
     }
@@ -68,7 +81,7 @@ public class ModuleUpdateDecisionTest
     public void TheSameLandedVersion_SkipsWithoutAnyDownloadDecision()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            "1.2.0", "3.0.0", Gate, Landed("1.2.0"), policyDecline: null);
+            "1.2.0", "3.0.0", Gate, Landed("1.2.0"), policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
     }
@@ -80,9 +93,9 @@ public class ModuleUpdateDecisionTest
         // equality must go through the SAME comparer as the downgrade check — string equality
         // would read this as an update and re-land the module on every reconcile, forever.
         Assert.Equal(ModuleUpdateAction.SkipUpToDate,
-            ModuleUpdateDecision.Decide("1.2", "3.0.0", Gate, Landed("1.2.0"), null).Action);
+            ModuleUpdateDecision.Decide("1.2", "3.0.0", Gate, Landed("1.2.0"), null, BytesPresent).Action);
         Assert.Equal(ModuleUpdateAction.SkipUpToDate,
-            ModuleUpdateDecision.Decide("1.2.0", "3.0.0", Gate, Landed("1.2"), null).Action);
+            ModuleUpdateDecision.Decide("1.2.0", "3.0.0", Gate, Landed("1.2"), null, BytesPresent).Action);
     }
 
     [Fact]
@@ -93,7 +106,7 @@ public class ModuleUpdateDecisionTest
         // skip is silent-with-log, and the SAME reconcile lands the bundle once the platform has
         // moved past the floor.
         var verdict = ModuleUpdateDecision.Decide(
-            "1.3.0", "9.0.0", Gate, Landed("1.2.0"), policyDecline: null);
+            "1.3.0", "9.0.0", Gate, Landed("1.2.0"), policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.SkipPlatformBelowFloor, verdict.Action);
         Assert.Contains("9.0.0", verdict.Reason!);
@@ -106,7 +119,7 @@ public class ModuleUpdateDecisionTest
         // Covers the heal path too: a package installed before the module lane existed has content
         // but no landed module — the reconcile is what brings the binary half in.
         var verdict = ModuleUpdateDecision.Decide(
-            "1.2.0", "3.0.0", Gate, landed: null, policyDecline: null);
+            "1.2.0", "3.0.0", Gate, landed: null, policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
     }
@@ -115,7 +128,7 @@ public class ModuleUpdateDecisionTest
     public void AnOlderBundleThanWhatIsLanded_NeverRollsBackUnattended()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            "1.1.0", "3.0.0", Gate, Landed("1.2.0"), policyDecline: null);
+            "1.1.0", "3.0.0", Gate, Landed("1.2.0"), policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.SkipOlder, verdict.Action);
     }
@@ -127,7 +140,7 @@ public class ModuleUpdateDecisionTest
         // registry version as a rollback and silently never update (the exact defect class
         // NuGetVersionComparer exists for).
         var verdict = ModuleUpdateDecision.Decide(
-            "1.10.0", "3.0.0", Gate, Landed("1.9.0"), policyDecline: null);
+            "1.10.0", "3.0.0", Gate, Landed("1.9.0"), policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
     }
@@ -140,7 +153,7 @@ public class ModuleUpdateDecisionTest
         // which every other test passes: auto-update is the DEFAULT, opting out is the choice.
         var verdict = ModuleUpdateDecision.Decide(
             "1.3.0", "3.0.0", Gate, Landed("1.2.0"),
-            policyDecline: "the deployment's update policy is Stable");
+            policyDecline: "the deployment's update policy is Stable", BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.SkipPolicy, verdict.Action);
         Assert.Contains("Stable", verdict.Reason!);
@@ -153,7 +166,7 @@ public class ModuleUpdateDecisionTest
         // policy is the LAST gate, so its skips always mean "an update was withheld".
         var verdict = ModuleUpdateDecision.Decide(
             "1.2.0", "3.0.0", Gate, Landed("1.2.0"),
-            policyDecline: "the deployment's update policy is Stable");
+            policyDecline: "the deployment's update policy is Stable", BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
     }
@@ -166,7 +179,7 @@ public class ModuleUpdateDecisionTest
         // default-install config), and the module is part of what they asked for.
         var verdict = ModuleUpdateDecision.Decide(
             "1.2.0", "3.0.0", Gate, landed: null,
-            policyDecline: "the deployment's update policy is Stable");
+            policyDecline: "the deployment's update policy is Stable", BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
     }
@@ -175,7 +188,7 @@ public class ModuleUpdateDecisionTest
     public void AnUninstalledModule_IsNeverReinstalledByTheReconcile()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            "1.3.0", "3.0.0", Gate, Landed("1.2.0", enabled: false), policyDecline: null);
+            "1.3.0", "3.0.0", Gate, Landed("1.2.0", enabled: false), policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.SkipUninstalled, verdict.Action);
     }
@@ -184,9 +197,96 @@ public class ModuleUpdateDecisionTest
     public void ARegistryListingNoBundle_SkipsQuietly()
     {
         var verdict = ModuleUpdateDecision.Decide(
-            bundleVersion: null, "3.0.0", Gate, Landed("1.2.0"), policyDecline: null);
+            bundleVersion: null, "3.0.0", Gate, Landed("1.2.0"), policyDecline: null, BytesPresent);
 
         Assert.Equal(ModuleUpdateAction.SkipNoBundle, verdict.Action);
+    }
+
+    /// <summary>
+    /// 🚨 <b>#2417 — the self-sealing state, and the whole reason this parameter exists.</b>
+    ///
+    /// <para>A record saying "module X at version V" with no assembly behind it answered
+    /// <c>SkipUpToDate</c> — forever, on every deployment, on every reconcile. Nothing else in the
+    /// system would ever look again: the version comparison is the only gate the healing lane has,
+    /// and it was satisfied. So every way a landed binary can go missing — a recreated
+    /// <c>Modules:Root</c> volume, a half-completed landing, a generation directory collected out
+    /// from under its entry — was PERMANENT and produced a cheerful "up to date" line.</para>
+    ///
+    /// <para>Fails on pre-fix code, which has no way to be told the bytes are gone and answers
+    /// <c>SkipUpToDate</c>.</para>
+    /// </summary>
+    [Fact]
+    public void ARecordedLandingWhoseAssemblyIsGone_Lands_NeverSkipsAsUpToDate()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", "3.0.0", Gate, Landed("1.3.0"), policyDecline: null, BytesGone);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+        Assert.Contains("ABSENT", verdict.Reason, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The control, and it is not a formality: if a present assembly ever started re-landing, the
+    /// reconcile would re-download every module on every boot forever. "Up to date" must still be
+    /// reachable — the fix narrows the skip, it does not remove it.
+    /// </summary>
+    [Fact]
+    public void ARecordedLandingWhoseAssemblyIsThere_StillSkipsAsUpToDate()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", "3.0.0", Gate, Landed("1.3.0"), policyDecline: null, BytesPresent);
+
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
+    }
+
+    /// <summary>
+    /// 🚨 A DELIBERATE UNINSTALL IS NOT DAMAGE. A disabled entry has no assembly on disk by
+    /// construction, so the presence probe would say "gone" for every uninstalled module — and a
+    /// repair that re-installs what an operator removed is worse than the defect it fixes. The
+    /// uninstall check sits ABOVE the presence question for exactly this reason, and this test is
+    /// what stops a later reordering from turning the repair into a resurrection.
+    /// </summary>
+    [Fact]
+    public void AnUninstalledModuleWithNoAssembly_StaysUninstalled_TheProbeDoesNotResurrectIt()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", "3.0.0", Gate, Landed("1.3.0", enabled: false), policyDecline: null, BytesGone);
+
+        Assert.Equal(ModuleUpdateAction.SkipUninstalled, verdict.Action);
+    }
+
+    /// <summary>
+    /// A missing assembly is a REPAIR, not an upgrade, so the unattended-update policy must not
+    /// hold it — the same reasoning that already exempts a first landing: it completes an install
+    /// the operator's own surfaces sanctioned, and gating it ships a package whose binary half
+    /// never arrives. (The policy check runs after the version comparison, so a re-land decided
+    /// here never reaches it.)
+    /// </summary>
+    [Fact]
+    public void ARepairOfAMissingAssembly_IsNotHeldByTheUnattendedPolicy()
+    {
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", "3.0.0", Gate, Landed("1.3.0"),
+            policyDecline: "this deployment declines unattended landings", BytesGone);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+    }
+
+    /// <summary>
+    /// The probe must never be consulted for an entry that does not exist — there is nothing to
+    /// stat, and a caller binding it to a filesystem read would be handed a null. A never-landed
+    /// module lands on its own rule.
+    /// </summary>
+    [Fact]
+    public void ANeverLandedModule_DecidesWithoutAskingTheProbe()
+    {
+        var asked = false;
+        var verdict = ModuleUpdateDecision.Decide(
+            "1.3.0", "3.0.0", Gate, landed: null, policyDecline: null,
+            _ => { asked = true; return true; });
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+        Assert.False(asked, "there is no entry to probe, so nothing may be stat'd");
     }
 }
 


### PR DESCRIPTION
An install record saying *"module X at version V"* with no assembly behind it answered **"up to date" — forever**, on every deployment and every reconcile. Nothing would ever look again.

Refs #2417. It does **not** close it: the local-build lane the issue also asks for is deliberately out of scope (below).

## The shape

This is #2235's shape one layer down — *reports success, delivers nothing* — and the report is a version string in a record. `PackageManifest.ModuleVersion`'s own doc says equality means *"nothing to sync"*; that is true of the **content**, and it was being read as true of the **binary**.

Two gates in series made the state self-sealing, and **fixing either alone repairs nothing**:

### Gate A — `CatalogLayoutAreas.InstallOrUpdateCore`

The content short-circuit was the **one exit of that method not wrapped in `WithModule`** — the other two both are. So the content answer stood in for the module answer:

```csharp
if (record is not null && string.Equals(record.ModuleVersion, pkg.ModuleVersion, StringComparison.Ordinal))
{
    logger?.LogInformation("Package {Id} is up to date (module {ModuleVersion}); nothing to sync.", …);
    return Observable.Return(new InstallResult(0, 0));   // ← not WithModule'd
}
```

Now wrapped. It costs nothing when there is nothing to ask: `WithModule` is the identity for a package declaring no module or a source serving no bundles, and `AdoptModule` absorbs every failure into a logged zero, so this can never fail an install. The content optimisation itself is untouched — no file is re-fetched.

### Gate B — `ModuleUpdateDecision.Decide`

"Already landed" was decided from the entry's recorded **version string** alone. The bytes were never stat'd, so the healing lane (`RegistryUpdateReconciler.ReconcileModules` → `AdoptModule`, which runs on every boot) recovered only the case where *no activation entry existed at all*.

`Decide` now takes a required `Func<ModuleActivationEntry, bool> landedBytesPresent` — production binds `ModuleActivationBoot.LandedModuleDllExists`, the same resolution rule boot itself uses, so there is never a second notion of "landed". A version match with absent bytes is a `Land` naming the reason.

**Required, not optional-defaulting-to-`true`.** A default of `true` keeps the blind answer as the one a careless caller gets, which is the shape this codebase refuses. The 17 existing tests each now state their presence assumption, which is the point. (Checked: `Decide` has no caller outside `PluginBundleClient` and the tests, in either repo.)

Ordering inside `Decide` is unchanged and load-bearing: `SkipUninstalled` still runs **above** the presence question, because a disabled entry has no assembly by construction and a repair that re-installs what an operator removed is worse than the defect. `AnUninstalledModuleWithNoAssembly_StaysUninstalled_TheProbeDoesNotResurrectIt` pins it.

## Tests — run against unfixed code FIRST

Both assert the **delivery**. `InstallResult` reports `(0,0)` either way and is exactly the value that was already lying, so neither test looks at it as evidence.

Against `origin/main` (`ecef6dbd9`) in a clean worktree:

```
ModuleLaneAfterContentUpToDateTest.ContentUpToDate_StillAsksTheModuleLane                [FAIL]
  Expected collection not to be empty because an up-to-date CONTENT hash says nothing
  about whether the module's binary is on disk …          ← PluginBundleClient never reached

ModuleUpdateDecision: ARecordedLandingWhoseAssemblyIsGone_Lands_NeverSkipsAsUpToDate     [FAIL]
  Expected: Land
  Actual:   SkipUpToDate
```

(The pure case had to be re-expressed against the pre-fix signature to compile there — pre-fix `Decide` has no way to be *told* the bytes are gone, which is the defect.)

`ContentUpToDate_StillAsksTheModuleLane` asserts that `PluginBundleClient` was **entered at all**, via an injected `ILoggerProvider`. What it then decides is not the test's business — there is no registry behind the port it is given, and the miss is absorbed by design; that the question was *asked* is the whole point.

On this branch:

```
MeshWeaver.PluginCatalog.Test   659/659 pass  (5m48s)
  incl. ModuleUpdateDecisionTest + ModulePlatformFloorTest  25/25 (17 existing + 5 new + control)
```

The two tests that pinned the old short-circuit — `IncrementalUpdateTest.…SkipsWhenUpToDate` and `BuildCompletionSubscriptionTest.AGreenBuildThatChangedNothingInTheModuleFetchesNothing` — still pass unchanged: their packages declare no `Module`, so `WithModule` is the identity for them, which is the invariant worth keeping.

## 🚨 Deliberately NOT in scope

**The local-build lane** (#2417's option 1: build the module projects from the checkout the install already mounts and hand the bundle to the instance that is its own registry). That is a new lane, not a defect fix, and `WithModule`'s guard — *"only a registry source can serve a bundle; a git source has repo files and no bake behind it"* — is a correct statement about source capability, not a bug.

What this PR closes is the **ordering constraint the issue itself names**: *"it needs (1) addressed or it will no-op on any install whose records are already stamped."* Until the up-to-date test is presence-aware, any local lane built on top would silently do nothing. It also fixes the half that is **not** local-only — the same blindness affects every deployment that ever loses a module binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
