### PR TITLE
i18n: two model-stream failure strings the clients need (Plugins#855)

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -1040,5 +1040,7 @@
   "presentation.unmarkedTitle": "Wieder sichtbar",
   "presentation.unmarkedBody": "Das wird im Präsentationsmodus nicht mehr ausgeblendet.",
   "presentation.signInRequiredTitle": "Anmeldung erforderlich",
-  "presentation.signInRequiredBody": "Der Präsentationsmodus ist eine persönliche Einstellung — dafür musst du angemeldet sein."
+  "presentation.signInRequiredBody": "Der Präsentationsmodus ist eine persönliche Einstellung — dafür musst du angemeldet sein.",
+  "chat.modelStreamStalled": "Das Sprachmodell \u201e{0}\u201c hat aufgeh\u00f6rt zu antworten: Die Verbindung blieb offen, es kamen aber keine weiteren Daten an, daher wurde die Runde abgebrochen. Das ist eine St\u00f6rung beim Modell-Endpunkt und kein Problem der Anfrage \u2014 bitte erneut senden oder ein anderes Modell w\u00e4hlen.",
+  "chat.modelStreamFaulted": "Das Sprachmodell \u201e{0}\u201c hat seine Antwort mit einem Provider-Fehler beendet. Das ist eine St\u00f6rung beim vorgelagerten Modell-Provider und kein Problem der Anfrage \u2014 bitte erneut senden oder ein anderes Modell w\u00e4hlen."
 }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -1040,5 +1040,7 @@
   "presentation.unmarkedTitle": "Shown again",
   "presentation.unmarkedBody": "This is no longer hidden while presentation mode is on.",
   "presentation.signInRequiredTitle": "Sign-in required",
-  "presentation.signInRequiredBody": "Presentation mode is a personal setting, so you have to be signed in to use it."
+  "presentation.signInRequiredBody": "Presentation mode is a personal setting, so you have to be signed in to use it.",
+  "chat.modelStreamStalled": "The language model '{0}' stopped responding: the connection stayed open but no further data arrived, so the round was aborted. This is an upstream stall at the model endpoint, not a problem with your request \u2014 submit again to retry, or pick a different model.",
+  "chat.modelStreamFaulted": "The language model '{0}' ended its response with a provider error. This is a fault at the upstream model provider, not a problem with your request \u2014 submit again to retry, or pick a different model."
 }


### PR DESCRIPTION
Adds `chat.modelStreamStalled` and `chat.modelStreamFaulted` to `strings.en.json` and `strings.de.json`.

## Why here, and why first

Systemorph/MeshWeaver.Plugins#855 adds a guard that fails a chat round when the model endpoint **stalls mid-stream** or **ends with a provider error**, and tells the user which happened. Today that round just ends with nothing.

The strings must land in **core** before the client mirror, because the server catalog is the single place a string is authored and the clients' copies are checked against it:

```
FAIL src/i18n/localize.test.ts > catalog drift guard > strings.en.json is identical to the server catalog
AssertionError: expected [ …(1043) ] to deeply equal [ …(1041) ]
```

That is #855 red right now — two client keys with no server counterpart. This PR is the other half; #855 rebases onto it.

## The messages

Both distinguish an **upstream** fault from a bad request, and say what to do — which is the point of the guard:

> The language model `{0}` stopped responding: the connection stayed open but no further data arrived, so the round was aborted. This is an upstream stall at the model endpoint, not a problem with your request — submit again to retry, or pick a different model.

> The language model `{0}` ended its response with a provider error. This is a fault at the upstream model provider, not a problem with your request — submit again to retry, or pick a different model.

German supplied for both.

## Minimal diff, deliberately

Appended textually with ASCII escaping to match each file's existing convention — **4 lines changed per file, nothing else**. A first pass round-tripped the JSON with `ensure_ascii=False` and silently rewrote existing `\uXXXX` escapes as literal characters across unrelated entries (`approval.noDocument`, four `ui.update*`). Reverted; a catalog diff should show only what it adds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)