### PR TITLE
fix(#890): the canary's "pristine" control shared the one file it had to exclude

### DIFF
--- a/src/MeshWeaver.Compiler/EmitPipeline.cs
+++ b/src/MeshWeaver.Compiler/EmitPipeline.cs
@@ -177,7 +177,8 @@ public static class EmitPipeline
     ///
     /// <para><b>Leg 2 — pristine references.</b> Run only when leg 1 fails: the SAME source
     /// against a freshly created, minimal reference set that has never been handed to Roslyn
-    /// before and is shared with nothing. This is the discriminator, and it exists because
+    /// before and is shared with nothing — see the mapping note below for what "nothing" had to
+    /// be widened to mean. This is the discriminator, and it exists because
     /// Roslyn's own source settles who can supply the null. The NRE's guard
     /// (<c>NamedTypeSymbolAdapter.AsNestedTypeDefinitionImpl</c>) admits a type only when
     /// <c>ContainingModule == moduleBeingBuilt.SourceModule</c> — so the symbol whose
@@ -191,8 +192,9 @@ public static class EmitPipeline
     ///   <item><c>canary=DIVERGENT</c> — neither emits, but they died in DIFFERENT frames. The
     ///     two legs run identical source, so two different faults are not evidence of one
     ///     process-wide fault; both sites are named and the below-Roslyn claim is withheld.</item>
-    ///   <item><c>canary=BELOW-ROSLYN</c> — neither emits, IN THE SAME FRAME: brand-new references and freshly
-    ///     parsed source still cannot emit, so nothing about the reference set explains it. The
+    ///   <item><c>canary=BELOW-ROSLYN</c> — neither emits, IN THE SAME FRAME: freshly parsed source
+    ///     and an IMAGE-BACKED CoreLib (sharing neither the reference instances nor their file
+    ///     mappings) still cannot emit, so nothing about the reference set explains it. The
     ///     broken state is under Roslyn (CLR heap / JIT / GC) and no reference-set change can fix
     ///     it. Roslyn keeps no cross-emit state — the metadata writer's indices are per-emit, its
     ///     object pools hold only scratch buffers, and <c>AssemblyMetadata.CachedSymbols</c> is a
@@ -202,6 +204,25 @@ public static class EmitPipeline
     ///     folded into BELOW-ROSLYN: a probe that answers its scariest branch on its own
     ///     inability would send triage after a CLR heap bug nothing observed.</item>
     /// </list></para>
+    ///
+    /// <para>🚨 <b>The control must not share the one file both sets must map.</b> Leg 2 built its
+    /// CoreLib with <c>MetadataReference.CreateFromFile(typeof(object).Assembly.Location)</c> —
+    /// and <see cref="CompileReferences"/> maps <b>that same path</b>, both from
+    /// <c>TRUSTED_PLATFORM_ASSEMBLIES</c> and again as an explicit
+    /// <c>typeof(object).Assembly</c> addition. Distinct <c>PortableExecutableReference</c>
+    /// instances, yes — but the same on-disk image, hence the same mmap and the same OS page-cache
+    /// pages. Every compilation must reference CoreLib, so that overlap is unavoidable *by
+    /// construction*: the "pristine" leg shared with the poisoned set precisely the one input no
+    /// compile can omit. A fault in those mapped metadata pages (a torn or evicted page on the
+    /// runner's overlayfs, a bad mapping) therefore killed BOTH legs in the SAME frame and was
+    /// reported as <c>BELOW-ROSLYN</c> — *"nothing about the reference set explains this … capture
+    /// a core dump"* — which is the most expensive answer this probe can give, handed out on
+    /// evidence that never excluded the mapping. Nine CI occurrences (2026-08-23 → 08-28) all
+    /// returned that verdict unanimously, and it steered #890's triage away from the reference set
+    /// on a distinction the probe had not actually drawn. Leg 2 now uses
+    /// <c>CreateFromImage(File.ReadAllBytes(...))</c>: fresh managed bytes, no mapping shared with
+    /// anything. This is the same defect as the message-vs-site one below, one layer down — a
+    /// control is only a control for what it does not share.</para>
     ///
     /// <para>🚨 It cannot fail into the fault path it is diagnosing: every outcome — including
     /// the canary throwing — returns a STRING. A diagnostic that throws while diagnosing would
@@ -231,20 +252,7 @@ public static class EmitPipeline
         // branch on its own inability, sending triage after a CLR heap bug that nothing observed.
         // A diagnostic that cannot report "I could not run" is the same defect as a gate that
         // passes when its input is missing.
-        string? pristineUnavailable = null;
-        IReadOnlyList<MetadataReference> pristineRefs = [];
-        try
-        {
-            var coreLib = typeof(object).Assembly.Location;
-            if (string.IsNullOrEmpty(coreLib) || !File.Exists(coreLib))
-                pristineUnavailable = "no on-disk System.Private.CoreLib to reference";
-            else
-                pristineRefs = [MetadataReference.CreateFromFile(coreLib)];
-        }
-        catch (Exception buildError)
-        {
-            pristineUnavailable = $"{buildError.GetType().Name}: {buildError.Message}";
-        }
+        var pristineRefs = TryBuildPristineControl(out var pristineUnavailable);
 
         if (pristineUnavailable is not null)
             return $"canary=INCONCLUSIVE shared:{shared} pristine:UNAVAILABLE({pristineUnavailable}) "
@@ -252,6 +260,54 @@ public static class EmitPipeline
                 + "BUILT, so this says nothing about whether the reference set is the cause";
 
         return Verdict(shared, EmitCanary(() => pristineRefs));
+    }
+
+    /// <summary>
+    /// Test seam: run ONE canary leg against a given reference set and return its outcome token.
+    /// Lets <c>EmitCanaryControlTest</c> assert that the control can still emit — a control that
+    /// cannot compile would retire the discriminator silently, turning every occurrence into
+    /// INCONCLUSIVE with nothing going red.
+    /// </summary>
+    internal static string EmitCanaryForTest(IReadOnlyList<MetadataReference> references)
+        => EmitCanary(() => references);
+
+    /// <summary>
+    /// Builds leg 2's control reference set: CoreLib, and nothing else.
+    ///
+    /// <para>🚨 <b>Image-backed, never file-backed</b> — the whole point of the control is that it
+    /// shares nothing with the reference set under suspicion, and
+    /// <c>CreateFromFile(typeof(object).Assembly.Location)</c> shared the single file
+    /// <see cref="CompileReferences.Default"/> is guaranteed to map. Reading the bytes and using
+    /// <c>CreateFromImage</c> gives a reference backed by a fresh managed array: no mmap, no
+    /// shared page-cache pages, no shared <c>AssemblyMetadata</c>. Extracted so the invariant is
+    /// assertable — <c>EmitCanaryControlTest</c> pins that the control carries no
+    /// <c>FilePath</c> while the shared set does map that same file, which is exactly the overlap
+    /// that made <c>BELOW-ROSLYN</c> unearned.</para>
+    ///
+    /// <para>Never throws: a failure to build the control is a SEPARATE verdict
+    /// (<c>INCONCLUSIVE</c>), never folded into <c>BELOW-ROSLYN</c>. Cost is one ~15 MB read, only
+    /// ever on an already-failing path.</para>
+    /// </summary>
+    /// <param name="unavailable">Why the control could not be built, or <c>null</c> on success.</param>
+    internal static IReadOnlyList<MetadataReference> TryBuildPristineControl(out string? unavailable)
+    {
+        unavailable = null;
+        try
+        {
+            var coreLib = typeof(object).Assembly.Location;
+            if (string.IsNullOrEmpty(coreLib) || !File.Exists(coreLib))
+            {
+                unavailable = "no on-disk System.Private.CoreLib to reference";
+                return [];
+            }
+
+            return [MetadataReference.CreateFromImage(File.ReadAllBytes(coreLib))];
+        }
+        catch (Exception buildError)
+        {
+            unavailable = $"{buildError.GetType().Name}: {buildError.Message}";
+            return [];
+        }
     }
 
     /// <summary>
@@ -277,9 +333,12 @@ public static class EmitPipeline
     {
         if (pristine.StartsWith("OK", StringComparison.Ordinal))
             return $"canary=REFERENCES shared:{shared} pristine:{pristine} — the same source emits fine "
-                + "against BRAND-NEW references but fails against the shared set ⇒ the poison "
-                + "travels with the MetadataReference instances / the Roslyn symbols cached on "
-                + "them (reference-set scoping is the right axis)";
+                + "against an IMAGE-BACKED CoreLib but fails against the shared set ⇒ the poison "
+                + "travels with the shared reference state: either the MetadataReference instances "
+                + "and the Roslyn symbols cached on them, or the mmap'd on-disk images they map "
+                + "(the control shares neither). Scope the reference set per mesh to separate the "
+                + "two — and if the shared set's CoreLib is implicated, suspect the file mapping, "
+                + "not the instance";
 
         var sharedSite = SiteOf(shared);
         var pristineSite = SiteOf(pristine);
@@ -295,11 +354,14 @@ public static class EmitPipeline
                 + "whichever site is not the emit itself";
 
         return $"canary=BELOW-ROSLYN shared:{shared} pristine:{pristine} — a trivial compilation "
-            + "with BRAND-NEW references and freshly parsed source cannot emit either, and BOTH "
-            + $"legs died in the same frame ({sharedSite}) ⇒ nothing about the reference set "
-            + "explains this; the broken state is below Roslyn (CLR heap / JIT / GC), so no "
-            + "reference-set change can fix it — capture a core dump and re-run with tiering "
-            + "disabled";
+            + "with freshly parsed source and an IMAGE-BACKED CoreLib (fresh managed bytes, "
+            + "sharing neither the MetadataReference instances nor the mmap'd images of the "
+            + $"shared set) cannot emit either, and BOTH legs died in the same frame ({sharedSite}) "
+            + "⇒ nothing about the reference set OR its file mappings explains this; the "
+            + "broken state is below Roslyn (CLR heap / JIT / GC), so no reference-set change can "
+            + "fix it — capture a core dump and re-run with tiering disabled. RESIDUAL: both legs "
+            + "still run on the one CLR, so this does not separate a corrupted heap from a "
+            + "miscompiled Roslyn method — compare the dump's faulting address against #613";
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -213,9 +213,9 @@ public record PreWarmOutcome(string TypePath, PreWarmStatus Status, string? Deta
 ///
 /// <para><b>Best-effort — never blocks, never wedges.</b> It runs on a background
 /// subscription after the silo is up (<c>ApplicationStarted</c>), bounds concurrency with
-/// a reactive <c>Merge(maxConcurrency)</c> (Roslyn itself is already serialized on the
-/// Compile IoPool, so this only caps how many activations are in flight), and gives each
-/// type a generous per-type budget. A type that fails to compile, times out, or faults is
+/// a reactive <c>Merge(maxConcurrency)</c> — which is the ONLY bound on how many Roslyn emits
+/// run at once, so do not widen it on the belief that something below serializes them (see the
+/// #890 correction on the sweep default) — and gives each type a generous per-type budget. A type that fails to compile, times out, or faults is
 /// LOGGED and skipped — it does not block the others and it is NOT gated on. If any type
 /// is still compiling when a user arrives, Part 2
 /// (<see cref="NodeTypeEnrichmentHelpers.WaitForCompileSettled"/>) makes that activation
@@ -236,12 +236,21 @@ public static class DynamicTypePreWarmer
     /// measurably harmful): on 2026-07-28 04:05 four compiles were triggered on memex in quick
     /// succession — nothing to do with this warmer, but the identical load shape — and within
     /// minutes SIX plugin roots (Claims, Edu, Underwriting, Chess, Publish, Training) fell to the
-    /// "did not settle" overlay and needed a scale-to-zero to recover. The compiles already
-    /// serialize on the Compile IoPool, so concurrency bought nothing except simultaneous cold
-    /// ACTIVATIONS — the expensive part (109ms/0ms discovery for the same NodeType shape on a fresh
+    /// "did not settle" overlay and needed a scale-to-zero to recover. Concurrency bought
+    /// nothing except simultaneous cold ACTIVATIONS — the expensive part (109ms/0ms discovery for the same NodeType shape on a fresh
     /// mesh, versus 45.20s on memex — issue #686). A dependency ORDER cannot be honoured while its
     /// members run in parallel either, so the sweep is now strictly sequential and the knob is
     /// gone rather than left lying about what it does.</para>
+    ///
+    /// <para>🚨 <b>Correction (#890).</b> Two comments here used to assert that "Roslyn itself is
+    /// already serialized on the Compile IoPool". It is not, and never was. The Compile pool gates
+    /// only the NuGet-restore leaf; <c>MeshNodeCompilationService.OnThreadPool</c> deliberately
+    /// runs the compile on a bare <c>Task.Run</c> — its own comment says "NOT the IoPool … no gate,
+    /// no re-entrancy" — precisely because that pool's semaphore deadlocked the compile against
+    /// itself. So concurrent Roslyn emits over the process-wide
+    /// <c>CompileReferences.Default</c> reference instances ARE reachable. That is a live axis in
+    /// #890, and a false claim of serialization sitting in the one place a reader would check is
+    /// how an axis gets ruled out without ever being tested.</para>
     /// </summary>
     /// <remarks>
     /// 🚨 This is the SERVING-pod default, and on a big mesh it — not Roslyn — is the bake's

--- a/test/MeshWeaver.Graph.Test/EmitCanaryControlTest.cs
+++ b/test/MeshWeaver.Graph.Test/EmitCanaryControlTest.cs
@@ -1,0 +1,89 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using MeshWeaver.Compiler;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The emit canary's leg 2 is a CONTROL, and a control is only a control for what it does not
+/// share with the thing it is exonerating (#890).
+///
+/// <para><b>The bug this pins.</b> Leg 2 built its reference set with
+/// <c>MetadataReference.CreateFromFile(typeof(object).Assembly.Location)</c> and the verdict then
+/// claimed the shared reference set was excluded — *"nothing about the reference set explains
+/// this; the broken state is below Roslyn (CLR heap / JIT / GC) … capture a core dump"*. But
+/// <see cref="CompileReferences.Default"/> maps that SAME file, twice over (from
+/// <c>TRUSTED_PLATFORM_ASSEMBLIES</c> and again as an explicit <c>typeof(object).Assembly</c>
+/// addition). Different <c>PortableExecutableReference</c> instances, same on-disk image, same
+/// mmap, same page-cache pages. Since every compilation must reference CoreLib, the overlap was
+/// unavoidable by construction: the control shared with the suspect precisely the one input no
+/// compile can omit, so a fault in those mapped metadata pages killed both legs in the same frame
+/// and was reported as the most expensive verdict the probe can give.</para>
+///
+/// <para>Nine CI occurrences between 2026-08-23 and 2026-08-28 returned <c>BELOW-ROSLYN</c>
+/// unanimously, and that verdict steered triage away from the reference set on a distinction the
+/// probe had never actually drawn.</para>
+/// </summary>
+public class EmitCanaryControlTest
+{
+    /// <summary>
+    /// 🚨 The regression this file exists for. Stated as the two halves that must BOTH hold:
+    /// the shared set really does map CoreLib from disk (so the old overlap was real, not
+    /// hypothetical), and the control really is not file-backed (so the overlap is now gone).
+    /// Asserting only the second half would pass just as well if <see cref="CompileReferences"/>
+    /// had stopped mapping CoreLib, which would make this test vacuous.
+    /// </summary>
+    [Fact]
+    public void TheControl_SharesNoFileMapping_WithTheSharedReferenceSet()
+    {
+        var coreLib = typeof(object).Assembly.Location;
+        coreLib.Should().NotBeNullOrEmpty("the premise of the whole test is an on-disk CoreLib");
+
+        var sharedFilePaths = CompileReferences.Default
+            .OfType<PortableExecutableReference>()
+            .Select(r => r.FilePath)
+            .Where(p => !string.IsNullOrEmpty(p))
+            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+
+        sharedFilePaths.Should().Contain(coreLib,
+            "the shared set maps CoreLib from disk — that is WHY a file-backed control was not a "
+            + "control, and if this ever stops holding the rest of this test proves nothing");
+
+        var control = EmitCanary_Control(out var unavailable);
+        unavailable.Should().BeNull("the control must be buildable on any host with an on-disk CoreLib");
+
+        control.Should().ContainSingle("the control is deliberately minimal — CoreLib and nothing else");
+        control.Single().Should().BeAssignableTo<PortableExecutableReference>();
+        var only = (PortableExecutableReference)control.Single();
+
+        only.FilePath.Should().BeNull(
+            "an image-backed reference carries no file path — that IS the property that makes it a "
+            + "control: no mmap and no page-cache pages shared with the set under suspicion");
+
+        sharedFilePaths.Should().NotContain(only.FilePath ?? "\0",
+            "and therefore it cannot appear in the shared set's mapped files");
+    }
+
+    /// <summary>
+    /// A control that cannot compile is not a control — it would turn every occurrence into a
+    /// permanent INCONCLUSIVE and silently retire the discriminator. Pins that CoreLib alone is
+    /// still sufficient for the canary source AFTER the switch to image-backed bytes.
+    /// </summary>
+    [Fact]
+    public void TheControl_CanStillEmitTheCanarySource()
+    {
+        var control = EmitCanary_Control(out var unavailable);
+        unavailable.Should().BeNull();
+
+        var outcome = EmitPipeline.EmitCanaryForTest(control);
+
+        outcome.Should().StartWith("OK",
+            "on a healthy process the control MUST emit — if CoreLib alone no longer satisfies the "
+            + "canary source, every future occurrence reports INCONCLUSIVE and #890's "
+            + "discriminator is gone without anything going red");
+    }
+
+    private static IReadOnlyList<MetadataReference> EmitCanary_Control(out string? unavailable)
+        => EmitPipeline.TryBuildPristineControl(out unavailable);
+}


### PR DESCRIPTION
## The problem

#890's triage rests on one verdict string, and the probe was not entitled to it.

**MEASURED** — a sweep of all 1200 `MeshWeaver Build and Test` runs from 2026-08-22 to 2026-08-29, reading `[FAIL]` lines out of **every attempt** of every failed run (376 run/attempt pairs, 290 shard logs):

- The emit canary fired **9 times**.
- It returned **`canary=BELOW-ROSLYN` 9 times out of 9**, every one at the identical frame `NamedTypeSymbol.Microsoft.Cci.ITypeDefinitionMember.get_ContainingTypeDefinition`.
- Those 9 events blamed **37 distinct test names** and account for **14.6% of all test-failure occurrences** in the window — see the ranking on #1384.

That verdict reads: *"nothing about the reference set explains this; the broken state is below Roslyn (CLR heap / JIT / GC), so no reference-set change can fix it — capture a core dump."* It is the most expensive answer this probe can give, and it closed the reference-set axis.

## The defect

Leg 2 built its control with `MetadataReference.CreateFromFile(typeof(object).Assembly.Location)`.

`CompileReferences.GetDefaultReferences()` maps **that same path** — once from `TRUSTED_PLATFORM_ASSEMBLIES`, and again as an explicit `typeof(object).Assembly` addition.

Distinct `PortableExecutableReference` instances, yes. Same on-disk image, same mmap, same OS page-cache pages. And since **every** compilation must reference CoreLib, the overlap was unavoidable *by construction*: the "pristine" control shared with the poisoned set precisely the one input no compile can omit.

So a fault in those mapped metadata pages — a torn or evicted page on the runner's overlayfs, a bad mapping — kills **both** legs in the **same frame**, and the probe reports `BELOW-ROSLYN`. The strong claim, on evidence that never excluded the mapping.

This is the same defect the file already documents one layer up (deciding the verdict on a message rather than a throw site), one layer down. **A control is only a control for what it does not share.**

## The fix

- Leg 2 uses `CreateFromImage(File.ReadAllBytes(coreLib))` — fresh managed bytes, no mmap, no page-cache pages, no `AssemblyMetadata` shared with anything.
- Construction extracted to `TryBuildPristineControl` so the invariant is **assertable** rather than a comment. Build failure still lands as `INCONCLUSIVE`, never folded into `BELOW-ROSLYN`.
- Cost: one ~15 MB read, only ever on an already-failing path.
- The three verdict texts now say what they have actually excluded. `BELOW-ROSLYN` names its residual (both legs still run on the one CLR, so it does not separate a corrupted heap from a miscompiled Roslyn method — compare against #613). `REFERENCES` widens from "the instances" to "the instances **or their file mappings**", because those are now two different things and the control separates them.

## Non-vacuity — measured in both directions

`TheControl_SharesNoFileMapping_WithTheSharedReferenceSet` asserts **both halves**: that the shared set really does map CoreLib from disk (so the overlap was real, not hypothetical — asserting only the second half would pass just as well if `CompileReferences` had stopped mapping CoreLib), and that the control now carries no `FilePath`.

Reverting **only the one line** back to `CreateFromFile` reds it, naming the shared file:

```
Expected value to be <null> because an image-backed reference carries no file path
... but found "/Users/roland/.dotnet/shared/Microsoft.NETCore.App/10.0.9/System.Private.CoreLib.dll"
```

Restored → green.

`TheControl_CanStillEmitTheCanarySource` guards the other direction: a control that cannot compile would retire the discriminator **silently**, turning every future occurrence into `INCONCLUSIVE` with nothing going red.

Full `MeshWeaver.Graph.Test`: **1714 passed, 0 failed.**

## Also: a false claim about the axis under investigation

`DynamicTypePreWarmer` asserted **twice** that *"Roslyn itself is already serialized on the Compile IoPool"*.

It is not, and never was. That pool gates only the NuGet-restore leaf, and `MeshNodeCompilationService.OnThreadPool` deliberately uses a bare `Task.Run` — its own comment says *"NOT the IoPool … no gate, no re-entrancy"* — precisely because the pool's semaphore deadlocked the compile against itself. **Concurrent Roslyn emits over the process-wide `CompileReferences.Default` instances ARE reachable.**

A false claim of serialization sitting in the one place a reader would check is how an axis gets ruled out without ever being tested. Corrected, with the reason.

## What this does and does not do

It **does not fix the NRE.** It removes a false exclusion from the instrument that exists to find it. The reference-set axis is back in the search space, and the next occurrence's verdict will mean what it says.

Refs #890, #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)