### PR TITLE
TestTeardownExceptionSuppressor names the wrong event (comment-only)

### DIFF
--- a/src/MeshWeaver.Fixture/TestTeardownExceptionSuppressor.cs
+++ b/src/MeshWeaver.Fixture/TestTeardownExceptionSuppressor.cs
@@ -3,15 +3,36 @@ using System.Runtime.CompilerServices;
 namespace MeshWeaver.Fixture;
 
 /// <summary>
-/// Process-wide suppressor for the two BENIGN test-teardown races that otherwise
-/// escape as unobserved task exceptions and get escalated by xUnit v3 to a
-/// "Catastrophic failure" — which aborts the whole test assembly/collection
-/// (no per-test trx, every test in it reported failed) even though each test
-/// passes in isolation. This module initializer runs once per test-process for
-/// EVERY project that references <c>MeshWeaver.Fixture</c> (i.e. all of them via
-/// the test base classes), so the suppression is no longer Orleans-only — the
-/// <c>MeshWeaver.Hosting.Orleans.Test</c>-local suppressor only protected one
-/// project, leaving e.g. Security.Test to abort under CI load.
+/// Process-wide observer for the two BENIGN test-teardown races, so an unobserved task exception
+/// of either shape is marked observed rather than left to whatever policy the host has. This
+/// module initializer runs once per test-process for EVERY project that references
+/// <c>MeshWeaver.Fixture</c> (i.e. all of them via the test base classes) — the
+/// <c>MeshWeaver.Hosting.Orleans.Test</c>-local suppressor it replaced protected only one project.
+///
+/// <para>🚨 <b>This class does NOT stop a "Catastrophic failure", and this doc used to say it did.</b>
+/// The claim ("escape as unobserved task exceptions and get escalated by xUnit v3") is wrong, and it
+/// is the kind of wrong that costs an afternoon: it names the wrong EVENT, so anyone chasing a
+/// green-but-exit-1 shard starts by reading this file and concludes the suppressor "ran too late".
+/// Measured twice, 2026-08-29 — by disassembling the shipped runners, and by two probes inside
+/// <c>MeshWeaver.AI.Test</c>:</para>
+/// <list type="bullet">
+///   <item><b>xunit.v3 3.2.2 never hooks <see cref="TaskScheduler.UnobservedTaskException"/></b> —
+///   zero references in the shipped binaries — and .NET Core does not escalate unobserved task
+///   exceptions (<c>ThrowUnobservedTaskExceptions</c> is set nowhere in either repo). A deliberately
+///   unobserved <see cref="ObjectDisposedException"/> of the disposed-<c>LifetimeScope</c> shape
+///   makes a suite exit <b>0</b> and print nothing at all.</item>
+///   <item>The channel that reds a green shard is <see cref="AppDomain.UnhandledException"/>, hooked
+///   by <c>Xunit.Runner.InProc.SystemConsole.ConsoleRunner</c>, which writes
+///   <c>ErrorMessage.FromException</c> — <b>message only, no stack</b> — then lets the run finish and
+///   exits 2. A raw <c>new Thread(… throw …)</c> reproduces the whole signature exactly:
+///   <c>Passed! - Failed: 0</c> AND exit 1.</item>
+/// </list>
+/// <para>So this class is inert against that failure mode by construction, and cannot be "fixed" to
+/// cover it — <c>SetObserved()</c> has nothing to say about an unhandled thread exception. The
+/// class that DOES cover it is <see cref="TeardownStragglerCapturer"/> in this same assembly, whose
+/// own doc reached this conclusion independently; it records the full stack the runner omits. It is
+/// kept rather than deleted because observing a benign unobserved exception is still correct
+/// hygiene and is cheap, and because a future runner may reinstate the escalation.</para>
 ///
 /// <para>The two benign races, both "a message/continuation runs AFTER the test's
 /// scope is gone":</para>


### PR DESCRIPTION
Comment-only. No behaviour change.

The summary on `TestTeardownExceptionSuppressor` said the benign teardown races *"escape as unobserved task exceptions and get escalated by xUnit v3 to a 'Catastrophic failure'"*. **Neither half is true for xunit.v3 3.2.2**, and this is the first file anyone opens when a shard reports `Passed! - Failed: 0` **and** exit 1 — so naming the wrong event sends the reader hunting a registration-order bug that does not exist.

Measured twice on 2026-08-29 — by disassembling the shipped runners, and by two probes inside `MeshWeaver.AI.Test`:

| | |
|---|---|
| xunit.v3 3.2.2 references to `TaskScheduler.UnobservedTaskException` | **zero**; `ThrowUnobservedTaskExceptions` set nowhere in either repo |
| a deliberately **unobserved** `ObjectDisposedException` (disposed-`LifetimeScope` shape) | **exit 0, nothing printed** |
| a raw `new Thread(… throw …)` of the same exception | the whole CI signature: `[FATAL ERROR]` + `Catastrophic failure`, process survives, `Passed! - Failed: 0`, **exit 1** |

The real channel is `AppDomain.UnhandledException`, hooked by `Xunit.Runner.InProc.SystemConsole.ConsoleRunner`, which writes `ErrorMessage.FromException` — **message only, no stack** — then `finishEvent.Wait()` → `Environment.Exit(2)`.

So this class is **inert against that failure mode by construction** and cannot be extended to cover it: `SetObserved()` has nothing to say about an unhandled thread exception. `TeardownStragglerCapturer`, in this same assembly, already documents the correct mechanism and records the stack the runner omits — two files in one assembly contradicting each other is the drift that misdirects the next reader, so the summary now points at it.

**Kept rather than deleted**: observing a benign unobserved exception is still correct hygiene, it is cheap, and a future runner may reinstate the escalation. Removing it is a maintainer call, not a side effect of a doc correction.

Found while fixing the same failure in Systemorph/MeshWeaver.Plugins#871.

Refs #2638

🤖 Generated with [Claude Code](https://claude.com/claude-code)