### PR TITLE
fix(#2616): a teardown residual that names no pool is not a diagnostic

### DIFF
--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1054,11 +1054,11 @@ public static class MeshDataSourceExtensions
     ///   recycled). Nothing else is going to tell us it is safe and the mesh may run for months, so
     ///   unload NOW — deferring would leak this ALC for the process lifetime, which is exactly the
     ///   late-project CI OOM / GC-stall this hook was added to fix. No mesh-wide teardown is in
-    ///   progress, so no <see cref="IoPoolRegistry.DrainAll"/> is pending behind us.</item>
+    ///   progress, so no <see cref="IoPoolRegistry.DrainAll()"/> is pending behind us.</item>
     /// <item><b>The mesh is tearing down.</b> This callback runs from <c>MessageHub.DisposeImpl</c>,
     ///   i.e. STRICTLY BEFORE <see cref="IMessageHub.DisposalCompleted"/> — but the pooled
     ///   layout-render leaves that execute this node's compiled types are cancelled and JOINED only
-    ///   by <see cref="IoPoolRegistry.DrainAll"/>, which every teardown orchestrator runs AFTER
+    ///   by <see cref="IoPoolRegistry.DrainAll()"/>, which every teardown orchestrator runs AFTER
     ///   <c>DisposalCompleted</c> (<c>MeshTeardownExtensions.WaitForDisposalAndIoDrainAsync</c>,
     ///   <c>MonolithMeshTestBase</c>, <c>HubTestBase</c>). Unloading here therefore frees the
     ///   LoaderAllocator out from under a leaf still inside <c>IoPool.SubscribeThroughPool</c>, and
@@ -1097,7 +1097,7 @@ public static class MeshDataSourceExtensions
     /// <see cref="UnloadNodeAssemblyContexts"/>, and for the same reason: releasing the last lease
     /// is what runs the deferred <c>Unload</c>, so doing it inline from
     /// <c>MessageHub.DisposeImpl</c> would free the LoaderAllocator before
-    /// <see cref="IoPoolRegistry.DrainAll"/> has joined the pooled leaves still running that
+    /// <see cref="IoPoolRegistry.DrainAll()"/> has joined the pooled leaves still running that
     /// assembly's code (issue #613 — AccessViolation → SIGABRT). Mesh alive ⇒ release now, so a
     /// long-lived process reclaims the ALC as soon as its last user is gone. Mesh tearing down ⇒
     /// hand it to <see cref="MeshTeardownSignal"/>, which fires after every drain phase.

--- a/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/src/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1477,9 +1477,19 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // unload (the teardown use-after-unload SIGSEGV). A live change-feed leaf never
             // completes on its own, so a WAIT-only drain would time out and let the scope
             // dispose under it; DrainAll() cancels the leaf so it stops, then joins.
-            var leakedIoLeaves = ioPools?.DrainAll() ?? 0;
+            // 🚨 The residual must NAME ITS POOL, and it must do so through TestPhaseTrace rather
+            // than an ILogger. IoPoolRegistry.DrainAll already logs a warning naming the pool, and
+            // that warning is structurally invisible here: the mesh's log sink stops capturing at
+            // Mesh.Dispose(), so of 294 dispose windows in the #2616 shard-2 trx, ZERO carry an
+            // ILogger line at any level. TestPhaseTrace writes the file CI keeps and is the only
+            // thing that survives both dispose and an exit=124 host kill. Without the name a
+            // residual reads as an anonymous "1" — which is how #2578 and #2616 both ended with
+            // nothing to act on. (Query=1 and Compile=1 are different bugs.)
+            IReadOnlyList<IoPoolRegistry.PoolResidual> residualByPool = [];
+            var leakedIoLeaves = ioPools is null ? 0 : ioPools.DrainAll(out residualByPool);
             TestPhaseTrace(testName, "DISPOSE_IOPOOL_DRAIN_DONE", sw.ElapsedMilliseconds,
-                $"leakedIoLeaves={leakedIoLeaves}");
+                $"leakedIoLeaves={leakedIoLeaves}"
+                + (residualByPool.Count > 0 ? $" pools=[{string.Join(", ", residualByPool)}]" : ""));
             // After all the sync stuff is disposed (and everyone has enqueued their async
             // cleanup), quiesce the async dispose queue before the scope closes below.
             var asyncDisposeClean = asyncDisposeQueue is null

--- a/src/MeshWeaver.Mesh.Contract/MeshTeardownExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshTeardownExtensions.cs
@@ -23,7 +23,7 @@ namespace MeshWeaver.Mesh;
 ///   <see cref="IMessageHub.DisposalCompleted"/> fires), and</item>
 /// <item>I/O offloaded onto the ThreadPool through <see cref="IIoPool"/> — which
 ///   runs independently of the action block and is NOT tracked by
-///   <see cref="IMessageHub.DisposalCompleted"/>. <see cref="IoPoolRegistry.DrainAll"/>
+///   <see cref="IMessageHub.DisposalCompleted"/>. <see cref="IoPoolRegistry.DrainAll()"/>
 ///   cancels + joins that I/O — a live change-feed leaf never completes on its own, so a
 ///   wait-without-cancel would time out and let the scope dispose under it.</item>
 /// </list>
@@ -127,7 +127,7 @@ public static class MeshTeardownExtensions
     ///   disposal: action blocks + message round-trips. Resources enqueue their async
     ///   cleanup onto the <see cref="AsyncDisposeQueue"/> during this phase.</item>
     /// <item>cancel + join the offloaded ThreadPool I/O the action block doesn't cover
-    ///   (<see cref="IoPoolRegistry.DrainAll"/>).</item>
+    ///   (<see cref="IoPoolRegistry.DrainAll()"/>).</item>
     /// <item>after all the sync stuff is disposed, give the
     ///   <see cref="AsyncDisposeQueue"/> a bounded quiesce budget to finish
     ///   (<see cref="AsyncDisposeQueue.DrainAsync"/>), then the caller closes the scope.</item>
@@ -221,7 +221,8 @@ public static class MeshTeardownExtensions
         //     leaf still runs → its ThreadPool thread dereferences a collectible node ALC's freed
         //     metadata after unload → native use-after-unload SIGSEGV. DrainAll() cancels every leaf
         //     so it stops, then joins — no ToTask, no wait-without-cancel.
-        var leakedIoLeaves = ioPools?.DrainAll() ?? 0;
+        IReadOnlyList<IoPoolRegistry.PoolResidual> residualByPool = [];
+        var leakedIoLeaves = ioPools is null ? 0 : ioPools.DrainAll(out residualByPool);
 
         // (3) After all the sync stuff is disposed (and everyone has enqueued their
         //     async cleanup), quiesce the async dispose queue before the scope closes.
@@ -234,6 +235,7 @@ public static class MeshTeardownExtensions
         //     tells it when that guarantee could NOT be kept.
         var report = new TeardownReport(leakedIoLeaves, asyncDisposeClean)
         {
+            ResidualByPool = residualByPool,
             DisposalFault = disposalFault,
             ActivitiesQuiesced = activitiesQuiesced
         };

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
@@ -41,7 +41,7 @@ public sealed class IoPoolRegistry : IDisposable
     /// <param name="options">Concurrency caps per pool name; defaults are used when null.</param>
     /// <param name="logger">
     /// Optional — resolved from DI when the mesh registers logging. Names the offending pool at
-    /// <see cref="DrainAll"/> time (issue #2480: the teardown report carried no pool name, exception,
+    /// <see cref="DrainAll()"/> time (issue #2480: the teardown report carried no pool name, exception,
     /// or stack, so a fingerprint could never be turned into a direct pointer to the leaf).
     /// </param>
     public IoPoolRegistry(IoPoolOptions? options = null, ILogger<IoPoolRegistry>? logger = null)
@@ -132,12 +132,38 @@ public sealed class IoPoolRegistry : IDisposable
     /// (see <see cref="IoPool.Drain"/>). <c>0</c> means the join is real and the caller may proceed
     /// to scope disposal / ALC unload. Non-zero means live work survives teardown — surface it.
     /// </returns>
-    public int DrainAll()
+    public int DrainAll() => DrainAll(out _);
+
+    /// <summary>
+    /// <see cref="DrainAll()"/>, but also handing back WHICH pool leaked and how much.
+    ///
+    /// <para>🚨 <b>Why the ILogger warning was not enough.</b> The residual warning added for
+    /// #2480 goes to <see cref="ILogger"/>, and <c>DrainAll</c> runs during mesh teardown — after
+    /// the mesh's log sink has stopped capturing. Measured on the #2616 shard-2 trx: of <b>294</b>
+    /// <c>Mesh.Dispose() invoking</c> windows, <b>zero</b> contain a single ILogger line at any
+    /// level, while the same trx carries 84 <c>[Warning] [SynchronizationStream]</c> and 76
+    /// <c>[Warning] [RoutingServiceBase]</c> records from BEFORE dispose. So the one diagnostic
+    /// written to name the offending pool is structurally invisible in exactly the window it
+    /// exists for: two occurrences of the drain flake (#2578, #2616) and the leaf is still an
+    /// anonymous <c>"1"</c>.</para>
+    ///
+    /// <para>The residual therefore has to travel back as a RETURN VALUE, so the caller can put it
+    /// somewhere that survives dispose — <c>TestPhaseTrace</c> in the test base, the
+    /// <c>TeardownReport</c> in production. A diagnostic that can only be read where nobody is
+    /// listening is the same defect as no diagnostic at all.</para>
+    /// </summary>
+    /// <param name="byPool">
+    /// One entry per pool that did NOT fully unwind, in drain order. Empty on a clean drain.
+    /// </param>
+    public int DrainAll(out IReadOnlyList<PoolResidual> byPool)
     {
         var leaked = 0;
+        var residuals = new List<PoolResidual>();
         foreach (var kvp in _pools)
         {
             var residual = kvp.Value.Drain();
+            if (residual != 0)
+                residuals.Add(new PoolResidual(kvp.Key, residual));
             if (residual != 0)
                 // 🚨 "IoPoolDrain", not "IoPoolSiloTeardown" (Copilot review, PR #2598): DrainAll()
                 // is the generic mesh-teardown phase 2 (MeshTeardownExtensions AND
@@ -151,7 +177,19 @@ public sealed class IoPoolRegistry : IDisposable
                     + "widen the budget.", kvp.Key, residual);
             leaked += residual;
         }
+        byPool = residuals;
         return leaked;
+    }
+
+    /// <summary>
+    /// One pool's unfinished-leaf count from <see cref="DrainAll(out IReadOnlyList{PoolResidual})"/>.
+    /// <see cref="ToString"/> is the wire format the teardown traces embed, so a residual reads as
+    /// <c>Query=1</c> rather than as a bare <c>1</c>.
+    /// </summary>
+    public readonly record struct PoolResidual(string Pool, int Residual)
+    {
+        /// <inheritdoc />
+        public override string ToString() => $"{Pool}={Residual}";
     }
 
     /// <summary>Disposes every created pool and clears the registry; called when the mesh is torn down.</summary>

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolSubscribeScheduler.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolSubscribeScheduler.cs
@@ -5,7 +5,7 @@ namespace MeshWeaver.Mesh.Threading;
 /// <summary>
 /// The <see cref="IPooledSubscribeScheduler"/> implementation: routes a subscribe through the
 /// mesh-scoped, teardown-drainable <see cref="IoPoolNames.Layout"/> pool so
-/// <see cref="IoPoolRegistry.DrainAll"/> cancel+joins it before the service scope disposes and any
+/// <see cref="IoPoolRegistry.DrainAll()"/> cancel+joins it before the service scope disposes and any
 /// collectible NodeType <c>AssemblyLoadContext</c> unloads. Registered as a mesh singleton in
 /// <c>AddIoPools</c>; resolved by <c>LayoutAreaHost</c> (which lives BELOW <c>MeshWeaver.Mesh.Contract</c>
 /// in the dependency graph and therefore cannot reference <see cref="IoPoolRegistry"/> directly — it

--- a/src/MeshWeaver.Mesh.Contract/Threading/MeshTeardownSignal.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/MeshTeardownSignal.cs
@@ -20,6 +20,17 @@ namespace MeshWeaver.Mesh.Threading;
 public sealed record TeardownReport(int LeakedIoLeaves, bool AsyncDisposeClean)
 {
     /// <summary>
+    /// WHICH pools did not finish, and by how much — empty on a clean drain.
+    ///
+    /// <para>🚨 <see cref="LeakedIoLeaves"/> alone is a bare count, and a bare count is not
+    /// actionable: <c>Query=1</c> and <c>Compile=1</c> are different bugs with different owners.
+    /// The registry already logs the name, but <c>DrainAll</c> runs after the mesh's log sink has
+    /// stopped capturing, so that warning cannot be read in the window it describes (#2616).
+    /// Carrying it on the report puts it somewhere a subscriber can still see.</para>
+    /// </summary>
+    public IReadOnlyList<IoPoolRegistry.PoolResidual> ResidualByPool { get; init; } = [];
+
+    /// <summary>
     /// The exception the hub's <c>DisposalCompleted</c> reported instead of a completion, or
     /// <c>null</c> when disposal finished normally.
     ///

--- a/test/MeshWeaver.Hosting.Test/IoPoolResidualNamesItsPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolResidualNamesItsPoolTest.cs
@@ -1,0 +1,99 @@
+using MeshWeaver.Mesh.Threading;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// A teardown residual has to say WHICH pool did not finish, through a channel that still works
+/// during teardown (#2578, #2616).
+///
+/// <para><b>The bug this pins.</b> <see cref="IoPoolRegistry.DrainAll()"/> returned a bare total,
+/// and named the offending pool only in an <c>ILogger</c> warning. But <c>DrainAll</c> runs after
+/// <c>Mesh.Dispose()</c>, and the mesh's log sink has stopped capturing by then — measured on the
+/// #2616 shard-2 trx, of <b>294</b> <c>Mesh.Dispose() invoking</c> windows, <b>zero</b> carry an
+/// ILogger line at any level, while the same trx holds 84 <c>[Warning] [SynchronizationStream]</c>
+/// records from before dispose. So the one diagnostic written to name the pool was structurally
+/// invisible in exactly the window it existed for.</para>
+///
+/// <para>The visible consequence: two occurrences of the same drain flake (#2578 on 2026-08-28
+/// 07:46Z, #2616 at 12:32Z the same day) both reported
+/// <c>DISPOSE_DONE teardown DIRTY — 1 pooled I/O leaf(s) still running</c> and nothing more. An
+/// anonymous <c>1</c> is not actionable: <c>Query=1</c> and <c>Compile=1</c> are different bugs
+/// with different owners, and <see cref="IoPool.Drain"/> can produce a residual from three
+/// distinct causes. The residual therefore travels back as a RETURN VALUE, so the caller can put
+/// it where it survives — <c>TestPhaseTrace</c> in the test base, <c>TeardownReport</c> in
+/// production.</para>
+/// </summary>
+public class IoPoolResidualNamesItsPoolTest
+{
+    /// <summary>
+    /// 🚨 The regression this file exists for. A leaf that ignores its cancellation token must be
+    /// reported AS BELONGING TO ITS POOL, not merely counted.
+    ///
+    /// <para>Deliberately slow (~30 s): a residual is by definition a leaf that outlives
+    /// <c>IoPool.Drain</c>'s budget, so the only way to observe one is to let the budget expire.
+    /// That is the cost of pinning the diagnostic rather than trusting it — and the budget is a
+    /// contract, so shortening it for the test would be testing something else.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task DrainAll_reportsTheResidual_againstTheNameOfThePoolThatLeaked()
+    {
+        using var registry = new IoPoolRegistry();
+        var pool = registry.Get(IoPoolNames.Query);
+
+        using var entered = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        pool.InvokeBlocking(_ =>
+        {
+            entered.Set();
+            // Deliberately ignores the token and outlives IoPool's drain budget — that IS the
+            // condition a residual reports.
+            release.Wait(TimeSpan.FromMinutes(2));
+            return 0;
+        }).Subscribe(_ => { }, _ => { });
+
+        entered.Wait(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken)
+            .Should().BeTrue("the leaf must actually be running before the drain starts");
+
+        var total = 0;
+        IReadOnlyList<IoPoolRegistry.PoolResidual> byPool = [];
+        var drain = Task.Run(() => total = registry.DrainAll(out byPool),
+            TestContext.Current.CancellationToken);
+
+        await drain.WaitAsync(TimeSpan.FromSeconds(120), TestContext.Current.CancellationToken);
+        release.Set();
+
+        total.Should().BeGreaterThan(0,
+            "the leaf ignored its token and outlived the budget — that is a residual");
+
+        byPool.Should().ContainSingle(
+            "exactly one pool leaked, and the caller needs to know WHICH — a bare total is what "
+            + "made #2578 and #2616 unactionable twice over");
+        byPool[0].Pool.Should().Be(IoPoolNames.Query,
+            "the residual must carry the leaking pool's NAME: Query=1 and Compile=1 are different "
+            + "bugs with different owners");
+        byPool[0].Residual.Should().BeGreaterThan(0);
+        byPool[0].ToString().Should().Be($"{IoPoolNames.Query}={byPool[0].Residual}",
+            "this is the wire format the teardown traces embed, so it is part of the contract");
+    }
+
+    /// <summary>
+    /// The other direction: a clean drain must report NOTHING, so a reader can trust the absence
+    /// of a pool name. A diagnostic that names a pool on every healthy teardown would be ignored
+    /// within a day.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void DrainAll_reportsNoPool_whenEveryLeafUnwound()
+    {
+        using var registry = new IoPoolRegistry();
+        var pool = registry.Get(IoPoolNames.Query);
+
+        pool.InvokeBlocking(_ => 0).Subscribe(_ => { }, _ => { });
+
+        var total = registry.DrainAll(out var byPool);
+
+        total.Should().Be(0, "the leaf finished — the join is real");
+        byPool.Should().BeEmpty("a clean drain names no pool");
+    }
+}


### PR DESCRIPTION
## The problem

The same drain failure has now been filed **twice** — #2578 (2026-08-28 07:46Z) and #2616 (12:32Z the same day) — and both times the entire evidence was:

```
DISPOSE_IOPOOL_DRAIN_DONE elapsed=30045ms leakedIoLeaves=1
DISPOSE_DONE teardown DIRTY — 1 pooled I/O leaf(s) still running
```

An anonymous `1`.

`IoPoolRegistry.DrainAll` **already** names the pool — #2480 asked for exactly that, and #2598 added it. But it names it through `ILogger`, and `DrainAll` runs *after* `Mesh.Dispose()`.

**MEASURED:** of **294** `Mesh.Dispose() invoking` windows in the #2616 shard-2 trx, **zero** carry an `ILogger` line at any level — while the same trx holds 84 `[Warning] [SynchronizationStream]` and 76 `[Warning] [RoutingServiceBase]` records from *before* dispose. The mesh's log sink stops capturing at dispose, so the one diagnostic written to name the offending pool is **structurally invisible in precisely the window it exists for.**

Same defect class as a gate that passes when its input is missing: the instrument reports into a channel nobody can read, so its silence looks like health.

## Why the name is the whole deliverable

`Query=1` and `Compile=1` are different bugs with different owners. And `IoPool.Drain` can produce a residual from **three distinct causes**:

| | |
|---|---|
| `cancelResidual` | a teardown callback that never returned |
| `gateResidual` | an async leaf that ignored its token |
| `blockingResidual` | a blocking leaf still executing |

All three currently reduce to the same integer, so triage cannot even pick a starting point. #2616's leaf is still unidentified two occurrences later for exactly this reason.

## The fix

`DrainAll` gains an overload returning per-pool residuals, and both callers put them somewhere that survives dispose:

- **`MonolithMeshTestBase`** → `TestPhaseTrace`, the file CI keeps and the only thing that survives an `exit=124` host kill. The trace now reads `leakedIoLeaves=1 pools=[Query=1]`.
- **`MeshTeardownExtensions`** → `TeardownReport.ResidualByPool`, for production subscribers.

The parameterless `DrainAll()` is kept and delegates, so **no caller changes**, and the `ILogger` warning stays where it *is* useful (a live silo, where the sink is running).

## Non-vacuity

- `DrainAll_reportsTheResidual_againstTheNameOfThePoolThatLeaked` parks a leaf that ignores its cancellation token and asserts the residual comes back as `Query=1`, including the `ToString` wire format the traces embed.
- Its mirror, `DrainAll_reportsNoPool_whenEveryLeafUnwound`, asserts a clean drain names **nothing** — a diagnostic that fires on every healthy teardown is ignored within a day.

Both green. The first is deliberately ~30 s: a residual is *by definition* a leaf that outlives the drain budget, so the only way to observe one is to let the budget expire — and shortening the budget for the test would be testing something else. `IoPoolTest`: 23 passed, 0 failed.

## What this does and does not do

It **does not fix the leaking leaf.** It makes the third occurrence name it — which is what #2480 asked for and what has not actually been delivered yet.

Separately, the premise in #2616's title is refuted: see my comment there. The failure predates #2598 by ~4 h (#2578, same test, same exception, same 30 s), so it is a recurrence, not a regression from that PR.

Refs #2616, #2578, #2480, #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)