### PR TITLE
An outbound forward stops going out as "Re: Fwd: …" (#2656)

### DIFF
--- a/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
@@ -165,20 +165,36 @@ public sealed class OutboundEmailSender(
     /// left the building as <c>Re: Fwd: Quote for 200 seats</c>, which tells the recipient the
     /// opposite of what happened.</para>
     ///
-    /// <para>The markers are the same set <c>EmailInboundProcessor.ThreadKey</c> strips when it
-    /// normalises a subject into a conversation key — the two ends of the same conversation should
-    /// agree about what a reply/forward prefix looks like. Only the LEADING marker matters: this
-    /// decides whether to add one, not what the subject means.</para>
+    /// <para>Only the LEADING marker matters: this decides whether to ADD one, not what the subject
+    /// means. "Question about the RE: header" is not a reply.</para>
+    ///
+    /// <para>🚨 <b>The marker set is a deliberate SECOND COPY of the one
+    /// <c>EmailInboundProcessor.ThreadKey</c> strips</b>, and the duplication cannot be removed from
+    /// here today. That processor is in the <c>MeshWeaver.Mail.MicrosoftGraph</c> MODULE, in the
+    /// plugins repository, which depends on this one — the reference cannot run the other way, so a
+    /// shared constant would have to live in the mesh CONTRACT. Putting it there is a new framework
+    /// API, and a module may not call an API newer than the newest RELEASED framework without
+    /// raising its <c>minMeshVersion</c> floor; so "de-duplicate it" today means shipping a floor
+    /// bump for a list of natural-language prefixes that changes about never. The copies are
+    /// therefore left standing and each NAMES the other, so whoever edits one is told where the twin
+    /// is. Fold them into the contract when a floor bump is being paid for anyway.</para>
     /// </summary>
-    /// <param name="subject">The subject as queued.</param>
+    /// <param name="subject">The subject as queued; null is treated as empty.</param>
     /// <returns>The subject to send.</returns>
     internal static string OutboundSubject(string? subject)
     {
-        var trimmed = (subject ?? "").TrimStart();
-        return ReplyOrForwardPrefix.IsMatch(trimmed) ? subject! : $"Re: {subject}";
+        // One normalisation, not two: the pattern's own `^\s*` handles the leading whitespace, so
+        // trimming here as well would be a second answer to the same question — and returning the
+        // TRIMMED string would silently rewrite a subject this method was only asked to classify.
+        var queued = subject ?? "";
+        return ReplyOrForwardPrefix.IsMatch(queued) ? queued : $"Re: {queued}";
     }
 
-    /// <summary>Leading reply/forward markers, several languages — the set <c>ThreadKey</c> strips.</summary>
+    /// <summary>
+    /// Leading reply/forward markers, several languages. 🚨 Twin of the pattern in
+    /// <c>EmailInboundProcessor.ThreadKey</c> (plugins repo) — change both; see
+    /// <see cref="OutboundSubject"/> for why they cannot be one.
+    /// </summary>
     private static readonly Regex ReplyOrForwardPrefix = new(
         @"^\s*(re|fwd|fw|aw|wg|tr|rv|sv|vs|antw|antwort|rif)(\s*\[\d+\])?\s*:",
         RegexOptions.IgnoreCase | RegexOptions.Compiled);

--- a/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Text.RegularExpressions;
 using System.Text.Json;
 using MeshWeaver.Hosting.AspNetCore.Portal;
 using MeshWeaver.Graph.Configuration;
@@ -113,12 +114,7 @@ public sealed class OutboundEmailSender(
                     .Select(n => EmailOf(n, jsonOptions)),
                 writeStatus: (node, current, status) =>
                     SetStatus(node, current, status, meshService, accessService),
-                send: email =>
-                {
-                    var subject = email.Subject.StartsWith("Re:", StringComparison.OrdinalIgnoreCase)
-                        ? email.Subject : $"Re: {email.Subject}";
-                    return emailSender.SendEmail(email.To!, subject, email.Body);
-                },
+                send: email => emailSender.SendEmail(email.To!, OutboundSubject(email.Subject), email.Body),
                 logger: logger);
             subscriptions.Add(sendQueue);
 
@@ -156,6 +152,36 @@ public sealed class OutboundEmailSender(
             logger?.LogWarning(ex, "OutboundEmailSender: failed to start watching outbound mail");
         }
     }
+
+    /// <summary>
+    /// The subject an outbound mail is sent with: a reply marker is added only when the subject
+    /// does not already carry one.
+    ///
+    /// <para>🚨 <b>"Already carries one" is not just <c>Re:</c>.</b> The check used to be
+    /// <c>StartsWith("Re:")</c>, which is right for the case this lane was built for — the Email
+    /// Router's reply, whose subject the agent writes as <c>Re: &lt;original&gt;</c> anyway — and
+    /// wrong for every outbound mail that is not a reply. A FORWARD is the one that made it visible
+    /// (Systemorph/MeshWeaver#2656): the inbox lane queues <c>Fwd: Quote for 200 seats</c> and it
+    /// left the building as <c>Re: Fwd: Quote for 200 seats</c>, which tells the recipient the
+    /// opposite of what happened.</para>
+    ///
+    /// <para>The markers are the same set <c>EmailInboundProcessor.ThreadKey</c> strips when it
+    /// normalises a subject into a conversation key — the two ends of the same conversation should
+    /// agree about what a reply/forward prefix looks like. Only the LEADING marker matters: this
+    /// decides whether to add one, not what the subject means.</para>
+    /// </summary>
+    /// <param name="subject">The subject as queued.</param>
+    /// <returns>The subject to send.</returns>
+    internal static string OutboundSubject(string? subject)
+    {
+        var trimmed = (subject ?? "").TrimStart();
+        return ReplyOrForwardPrefix.IsMatch(trimmed) ? subject! : $"Re: {subject}";
+    }
+
+    /// <summary>Leading reply/forward markers, several languages — the set <c>ThreadKey</c> strips.</summary>
+    private static readonly Regex ReplyOrForwardPrefix = new(
+        @"^\s*(re|fwd|fw|aw|wg|tr|rv|sv|vs|antw|antwort|rif)(\s*\[\d+\])?\s*:",
+        RegexOptions.IgnoreCase | RegexOptions.Compiled);
 
     private static IObservable<MeshNode> SetStatus(
         MeshNode node, MeshWeaver.Mesh.Email current, EmailStatus to,

--- a/src/MeshWeaver.Documentation/Data/Architecture/EmailIngestionAndNotifications.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/EmailIngestionAndNotifications.md
@@ -63,7 +63,7 @@ whether the agent acts on the sender's behalf.
 
 Key properties:
 
-- **At most once, because Graph delivers at least once.** A `created` change notification is
+- **Processed once, because Graph delivers at least once.** Delivery stays at-least-once — that is the transport's contract and nothing here changes it; what the lane guarantees is that the second and later deliveries of one message have no EFFECT. A `created` change notification is
   re-delivered after a retry, after a duplicate subscription, and after a portal restart that raced
   the 202. Two claims make that harmless, and they land *before* any thread is created:
   the Email node's **id is derived from the message id**, so the create-only

--- a/src/MeshWeaver.Documentation/Data/Architecture/EmailIngestionAndNotifications.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/EmailIngestionAndNotifications.md
@@ -44,39 +44,60 @@ inbound mail ──▶ Graph subscription ──▶ POST /api/email (webhook)
                                    EmailInboundProcessor.Route
                                               │
                   ┌───────────────────────────┴───────────────────────────┐
-            sender is a known Memex user                        sender is NOT a user
+            sender is a known Memex user                        sender is anyone else
                   │                                                        │
-   create Email node {recipient}/_Email/{id}                 create Email node Admin/Inbox/{id}
-   find-or-create conversation thread                        notify admins (in-app)
-   append "process this email" (references the              (surfaced in the Admin ▸ Inbox menu)
-   Email by PATH — body is not duplicated)
-   the Email Router agent runs as that user,
-   does the work, emits an Outbound Email reply
+   Email node {recipient}/_Email/{id}                         Email node Admin/Inbox/{id}
+                  └───────────────────────────┬───────────────────────────┘
+                                              ▼
+                        claim ▸ find-or-start a thread ON the Email node
+                            ({emailPath}/_Thread/{id}, Email as MainNode)
+                                              ▼
+                        the Email Router agent works it, and either replies
+                        (an Outbound Email node) or forwards it to info@
 ```
+
+**This is the mail instance of one pattern the platform runs three times** — a red log becomes a
+`LogIncident` and a triage thread, a ticket becomes a thread, a delivered message becomes a thread.
+Both mail lanes are the same code; the difference is only *whose* partition the mail lands in and
+whether the agent acts on the sender's behalf.
 
 Key properties:
 
-- **One conversation = one thread.** Each inbound email is matched to its conversation by *normalized
-  subject* (strip `Re:/Fwd:/AW:/WG:/…` repeatedly → a stable `ThreadKey`) using the **vector index** over
-  the sender's `_Email` namespace, confirmed by `ThreadKey` equality. Match → append to the existing
-  thread; no match → start a new one. Replies with accumulating `Re:`/`Fwd:` land in the same thread.
-- **The agent acts on the sender's behalf** (runs with their identity), treats the first line as the
-  likely instruction, infers intent with `Search` if absent, and **cuts slop** (forwarding banners, quoted
-  history, signatures). See the [Email Router agent](/Agent/EmailRouter).
+- **At most once, because Graph delivers at least once.** A `created` change notification is
+  re-delivered after a retry, after a duplicate subscription, and after a portal restart that raced
+  the 202. Two claims make that harmless, and they land *before* any thread is created:
+  the Email node's **id is derived from the message id**, so the create-only
+  `CreateNodeRequest` — answered from persistence — refuses a redelivery; and the artefact is flipped
+  **`New → Read` inside the update lambda**, on the node's serialised write queue, so of two workers
+  racing one artefact exactly one proceeds. A failed round puts the mail back to `New` and leaves it
+  UNREAD in the mailbox, which is the signal a person actually sees.
+- **One conversation = one thread.** Candidates come from an exact query on the stored `ThreadKey` —
+  the normalized subject with any number of `Re:/Fwd:/AW:/WG:/…` layers stripped — and among them
+  Graph's **`ConversationId` decides**, so two mails that merely share a subject are never merged.
+- **The agent acts on the sender's behalf ONLY in the user lane** (it runs with their identity). On
+  `Admin/Inbox` the sender has no account and no authority: the job there is triage. See the
+  [Email Router agent](/Agent/EmailRouter).
 - **The reply is emailed back** by creating an **Outbound `Email`** node (see §4) — the agent never sends
-  mail directly.
+  mail directly. **Forwarding** to the team's `info@` (`Email:Inbound:ForwardAddress`) writes the same
+  kind of node, with an id derived from the mail being forwarded, so asking twice forwards once.
 - **Everything is a MeshNode.** Every inbound and outbound mail is persisted as an `Email` node, so the
   whole exchange is queryable, access-controlled, and visible in the UI.
 
 ### Moving parts (code)
 
+Everything inbound rides the **`MeshWeaver.Mail.MicrosoftGraph` module** (Systemorph/MeshWeaver.Plugins
+`src/`), because the Graph SDK is 43 MB a deployment that sends no mail should not carry. Only the
+outbound drain and the no-op fallback are compiled into the portal.
+
 | Concern | Type |
 |---|---|
-| Reactive Graph client (read message, mark read, manage subscription) | `Memex.Portal.Shared.Email.GraphMail` |
-| Webhook endpoint (`/api/email`) — validation echo + notification batch | `EmailWebhookController` |
-| Keeps the Graph subscription alive (create on `ApplicationStarted`, renew every 24 h) | `GraphSubscriptionService` |
-| Sender → user match, find-or-create thread, slop-free seed message | `EmailInboundProcessor` |
-| Outbound: drains `Email` nodes with `Direction=Outbound, Status=New` and sends them | `OutboundEmailSender` |
+| Reactive Graph client (read message, mark read, manage subscription) | `GraphMail` *(module)* |
+| Webhook endpoint (`/api/email`) — validation echo + notification batch | `EmailWebhookEndpoints` *(module)* |
+| Keeps the Graph subscription alive (create on `ApplicationStarted`, renew every 24 h) | `GraphSubscriptionService` *(module)* |
+| Claim, route, find-or-start the thread, notify | `EmailInboundProcessor` *(module)* |
+| The deterministic ids the claims rest on | `InboundMailIdentity` *(module)* |
+| Forward a shared-inbox mail to `info@` | `InboxForward` / the `MemexInbox` agent tool *(module)* |
+| Outbound: drains `Email` nodes with `Direction=Outbound, Status=New` and sends them | `OutboundEmailSender` *(portal)* |
 
 > **Startup ordering matters.** Both hosted services defer their work to
 > `IHostApplicationLifetime.ApplicationStarted`: the Graph subscription can only be created once Kestrel

--- a/test/Memex.Portal.Shared.Test/OutboundSubjectTest.cs
+++ b/test/Memex.Portal.Shared.Test/OutboundSubjectTest.cs
@@ -1,0 +1,56 @@
+using Memex.Portal.Shared.Email;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The subject an outbound mail leaves with.
+///
+/// <para>The rule is "add a reply marker unless one is already there", and the whole defect was in
+/// what counts as already there. <c>StartsWith("Re:")</c> is right for the case this lane was built
+/// for — the Email Router's reply, whose subject the agent writes as <c>Re: &lt;original&gt;</c> —
+/// and wrong for every outbound mail that is not a reply. The forward action of
+/// Systemorph/MeshWeaver#2656 is what made it visible: the inbox lane queues
+/// <c>Fwd: Quote for 200 seats</c> and it went out as <c>Re: Fwd: Quote for 200 seats</c>, telling
+/// the recipient the opposite of what happened.</para>
+/// </summary>
+public class OutboundSubjectTest
+{
+    [Theory]
+    [InlineData("Re: Project status")]
+    [InlineData("RE: Project status")]
+    [InlineData("re: Project status")]
+    [InlineData("Re[2]: Project status")]
+    [InlineData("AW: Project status")]              // German reply
+    public void ASubjectThatIsAlreadyAReply_IsSentUnchanged(string subject)
+        => OutboundEmailSender.OutboundSubject(subject).Should().Be(subject);
+
+    [Theory]
+    [InlineData("Fwd: Quote for 200 seats")]
+    [InlineData("FW: Quote for 200 seats")]
+    [InlineData("WG: Quote for 200 seats")]         // German forward
+    [InlineData("  Fwd: Quote for 200 seats")]      // whatever the mail client left in front
+    public void ASubjectThatIsAlreadyAForward_IsNotTurnedIntoAReply(string subject)
+        => OutboundEmailSender.OutboundSubject(subject).Should().Be(subject,
+            "a forward that arrives as \"Re: Fwd: …\" tells the recipient the opposite of what "
+            + "happened to it");
+
+    [Fact]
+    public void APlainSubject_StillGetsTheReplyMarker()
+        => OutboundEmailSender.OutboundSubject("Project status")
+            .Should().Be("Re: Project status",
+                "the agent-reply case this lane was built for is unchanged");
+
+    [Fact]
+    public void AMarkerInTheMIDDLE_IsNotAPrefix()
+        => OutboundEmailSender.OutboundSubject("Question about the RE: header")
+            .Should().Be("Re: Question about the RE: header",
+                "only a LEADING marker says the subject is already a reply or a forward");
+
+    [Fact]
+    public void AnEmptyOrNullSubject_DoesNotThrow()
+    {
+        OutboundEmailSender.OutboundSubject("").Should().Be("Re: ");
+        OutboundEmailSender.OutboundSubject(null).Should().Be("Re: ");
+    }
+}


### PR DESCRIPTION
Follow-up to #2656 (implemented in Systemorph/MeshWeaver.Plugins#873). Independent of it — that PR
does not compile against this one.

## The defect

`OutboundEmailSender` adds a reply marker unless the subject already has one, and "already has one"
was `StartsWith("Re:")`:

```csharp
var subject = email.Subject.StartsWith("Re:", StringComparison.OrdinalIgnoreCase)
    ? email.Subject : $"Re: {email.Subject}";
```

That is right for the case this lane was built for — the Email Router's reply, whose subject the
agent writes as `Re: <original>` anyway — and wrong for every outbound mail that is **not** a reply.
The forward action of #2656 is what made it visible: the inbox lane queues
`Fwd: Quote for 200 seats` and it leaves the building as `Re: Fwd: Quote for 200 seats`, which tells
the recipient the opposite of what happened to their mail.

## The fix

The check now recognises the same leading reply/forward markers `EmailInboundProcessor.ThreadKey`
strips when it normalises a subject into a conversation key — the two ends of one conversation should
agree about what a marker looks like. Only a **leading** marker counts: this decides whether to add
one, not what the subject means, so `"Question about the RE: header"` still gets its `Re:`.

Extracted as `OutboundSubject`, so the rule is a pure function with its own test rather than a lambda
inside a hosted service.

## Non-vacuity, measured

`OutboundSubjectTest` — 12 cases. Reverting the implementation to `StartsWith("Re:")` turns **6 of
the 12** red (every forward marker, in both languages, plus the leading-whitespace case). The whole
`Memex.Portal.Shared.Test` suite is 437/437 green with the fix in place.

## Also

`Doc/Architecture/EmailIngestionAndNotifications` is brought up to date. It still described the
non-user lane as "notify admins (in-app)" with no agent — which #2656 changes — and its moving-parts
table still named `Memex.Portal.Shared.Email.GraphMail` and `EmailWebhookController`, both of which
moved into the `MeshWeaver.Mail.MicrosoftGraph` module with #2276. The doc now also states the
at-least-once delivery contract and the two claims that make the lane idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)