### PR TITLE
CI: a PR builds only what it changed; a publish or a release-follow builds everything

### DIFF
--- a/.github/scripts/node-repo-pack-verify.py
+++ b/.github/scripts/node-repo-pack-verify.py
@@ -62,7 +62,8 @@ def read_receipts(directory: Path) -> tuple[dict[str, dict], list[str]]:
 
 
 def verify(expected: list[str], receipts: dict[str, dict], broken: list[str],
-           pack_result: str, receipts_dir_exists: bool) -> tuple[int, list[str], list[str]]:
+           pack_result: str, receipts_dir_exists: bool,
+           scope: str = "") -> tuple[int, list[str], list[str]]:
     """(exit code, error lines, note lines)."""
     errors: list[str] = []
     notes: list[str] = []
@@ -72,6 +73,17 @@ def verify(expected: list[str], receipts: dict[str, dict], broken: list[str],
     if broken:
         errors.append(f"{len(broken)} receipt file(s) could not be read as a receipt: "
                       + ", ".join(broken))
+
+    # 🚨 "BUILD EVERYTHING" AND "EVERYTHING IS NOTHING" CANNOT BOTH BE TRUE. A `full` scope with
+    # an empty expectation is an internal contradiction, and the shape it takes is a green tick
+    # over a lane that built nothing — a bad --root, an empty matrix input, a tree that could not
+    # be listed. The selector refuses it now; this is the second lock, because the two are
+    # computed in different jobs and only one of them has to be wrong.
+    if scope == "full" and not want:
+        return 1, [f"the scope is '{scope}' but the selection is EMPTY — 'build everything' and "
+                   "'everything is nothing' cannot both be true. Something upstream (a --root "
+                   "that is not the checkout, an empty matrix input) produced a contradiction, "
+                   "and nothing was built."], []
 
     if not want:
         # An empty selection is legitimate (a diff reaching no package and no module project) —
@@ -134,9 +146,9 @@ def self_test() -> int:
         if not ok:
             failures.append(name)
 
-    def run(directory: Path, expected: list[str], result: str = "success"):
+    def run(directory: Path, expected: list[str], result: str = "success", scope: str = ""):
         receipts, broken = read_receipts(directory)
-        return verify(expected, receipts, broken, result, directory.is_dir())
+        return verify(expected, receipts, broken, result, directory.is_dir(), scope)
 
     with tempfile.TemporaryDirectory() as tmp:
         d = Path(tmp) / "receipts"
@@ -199,6 +211,17 @@ def self_test() -> int:
         code, errors, notes = run(empty, [], "skipped")
         check("zero selected + zero receipts + a skipped job ⇒ pass, and says so",
               code == 0 and bool(notes), f"{errors}")
+        code, errors, notes = run(empty, [], "success")
+        check("zero selected + zero receipts + a job GitHub reported success ⇒ pass",
+              code == 0 and bool(notes), f"{errors}")
+        # 🚨 The contradiction lock. Without the scope, this is indistinguishable from the case
+        # above — which is why the count alone was not enough.
+        code, errors, _ = run(empty, [], "skipped", scope="full")
+        check("scope=FULL with an empty selection ⇒ fail (a contradiction, not a scope)",
+              code == 1 and any("cannot both be true" in e for e in errors), f"{errors}")
+        code, errors, _ = run(empty, [], "skipped", scope="narrowed")
+        check("…while scope=narrowed with an empty selection stays legitimate",
+              code == 0, f"{errors}")
         (empty / "MeshWeaver.AI.json").write_text(json.dumps({"module": "MeshWeaver.AI"}),
                                                   encoding="utf-8")
         code, errors, _ = run(empty, [], "skipped")
@@ -212,7 +235,8 @@ def self_test() -> int:
               "skipped module bundle.")
         return 1
     print("\n✓ node-repo-pack-verify self-test: 2 green-run assertions, 7 mutations that must go "
-          "red, 2 empty-selection cases — all green.")
+          "red, and 5 empty-selection cases including the scope=full contradiction lock — all "
+          "green.")
     return 0
 
 
@@ -223,6 +247,9 @@ def main() -> int:
     p.add_argument("--receipts", default="", help="directory the receipt artifacts were merged into")
     p.add_argument("--pack-result", default="", dest="pack_result",
                    help="the pack job's aggregated result (needs.pack.result)")
+    p.add_argument("--scope", default="",
+                   help="the selection's own scope (full|narrowed). A 'full' scope with an empty "
+                        "selection is a contradiction and is refused.")
     p.add_argument("--self-test", action="store_true", dest="self_test")
     args = p.parse_args()
     if args.self_test:
@@ -233,7 +260,8 @@ def main() -> int:
     directory = Path(args.receipts)
     expected = [m for m in args.expected.split() if m]
     receipts, broken = read_receipts(directory)
-    code, errors, notes = verify(expected, receipts, broken, args.pack_result, directory.is_dir())
+    code, errors, notes = verify(expected, receipts, broken, args.pack_result,
+                                 directory.is_dir(), args.scope)
 
     for note in notes:
         print(f"✓ {note}")

--- a/.github/scripts/node-repo-pack-verify.py
+++ b/.github/scripts/node-repo-pack-verify.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""node-repo-pack-verify.py — assert that EXACTLY the selected module bundles were built.
+
+    "we can estimate the required count and validate it"
+
+A dynamic matrix cannot be a fixed list of required status checks: the per-module contexts appear
+and disappear with the diff, so requiring one means requiring a context that will legitimately
+never report. That is not a detail — it is the same trap as an `if:` on a gate, and it is how a
+gate ends up not required at all and PRs merge past it.
+
+The answer is to make the SELECTION itself checkable: `node-repo-scope.py` computes how many
+bundles must be built, every pack job drops a RECEIPT, and this script — one final job, one
+STABLE context, present on every run whatever the diff — asserts the two agree and names the
+discrepancy. That is CI invariant #4 (a final job that fails iff a real gate skipped for an unsafe
+reason) applied to a matrix that is allowed to change size, and it is what makes narrowing safe to
+require.
+
+🚨 THE FAILURE IT EXISTS TO CATCH IS A SKIP. GitHub renders a skipped matrix leg with the same
+tick as a passed one, so "this module was never packed" and "this module packed fine" look
+identical on the checks wall. A receipt is positive evidence; its absence is the finding.
+
+    node-repo-pack-verify.py --expected "MeshWeaver.AI MeshWeaver.Mcp" \\
+                             --receipts "$RUNNER_TEMP/receipts" --pack-result success
+    node-repo-pack-verify.py --self-test
+
+EXIT 0 only when: every expected module has a well-formed receipt, no unexpected receipt exists,
+and the pack job's own result agrees with the expectation (an empty selection is the ONLY case in
+which the pack job may be `skipped`).
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+
+def read_receipts(directory: Path) -> tuple[dict[str, dict], list[str]]:
+    """{module → receipt} plus the files that could not be read as one."""
+    found: dict[str, dict] = {}
+    broken: list[str] = []
+    if not directory.is_dir():
+        return found, broken
+    for path in sorted(directory.rglob("*.json")):
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            broken.append(path.name)
+            continue
+        module = doc.get("module") if isinstance(doc, dict) else None
+        if not isinstance(module, str) or not module:
+            broken.append(path.name)
+            continue
+        # The receipt must be self-describing: a file called X.json claiming to be module Y means
+        # the matrix and the artifact names have drifted, and the count would then prove nothing.
+        if path.stem != module:
+            broken.append(f"{path.name} (claims module '{module}')")
+            continue
+        found[module] = doc
+    return found, broken
+
+
+def verify(expected: list[str], receipts: dict[str, dict], broken: list[str],
+           pack_result: str, receipts_dir_exists: bool) -> tuple[int, list[str], list[str]]:
+    """(exit code, error lines, note lines)."""
+    errors: list[str] = []
+    notes: list[str] = []
+    got = set(receipts)
+    want = set(expected)
+
+    if broken:
+        errors.append(f"{len(broken)} receipt file(s) could not be read as a receipt: "
+                      + ", ".join(broken))
+
+    if not want:
+        # An empty selection is legitimate (a diff reaching no package and no module project) —
+        # GitHub skips a job whose matrix is empty. What must NOT happen is a bundle being built
+        # that the selection did not name.
+        if pack_result not in ("skipped", "success"):
+            errors.append(f"the selection named ZERO module bundles, but the pack job reported "
+                          f"'{pack_result}' — a job that should not have run did something.")
+        if got:
+            errors.append("the selection named ZERO module bundles, yet receipts arrived for: "
+                          + ", ".join(sorted(got)))
+        if not errors:
+            notes.append("no module bundle is reachable from this diff — nothing was packed, and "
+                         "nothing was expected to be.")
+        return (1 if errors else 0), errors, notes
+
+    # 🚨 The skip. `needs.pack.result == 'skipped'` with a NON-empty selection means the whole
+    # fan-out silently did not happen — the exact shape that renders green.
+    if pack_result == "skipped":
+        errors.append(f"the selection named {len(want)} module bundle(s) and the pack job did NOT "
+                      f"RUN AT ALL (result: skipped). A skipped job renders with the same tick as "
+                      f"a passed one; nothing was built and nothing would have said so.")
+    elif pack_result != "success":
+        errors.append(f"the pack job reported '{pack_result}' — read that job for the real "
+                      f"failure; the receipt accounting below is a consequence, not the cause.")
+
+    if not receipts_dir_exists:
+        errors.append("no receipt directory arrived at all — every pack job failed before its "
+                      "receipt, or the artifact names drifted from the matrix.")
+
+    missing = sorted(want - got)
+    extra = sorted(got - want)
+    if missing:
+        errors.append(f"{len(missing)} selected module bundle(s) produced NO receipt — they were "
+                      f"never built: " + ", ".join(missing))
+    if extra:
+        errors.append(f"{len(extra)} receipt(s) arrived for module(s) the selection did not name — "
+                      f"the matrix and the selection disagree: " + ", ".join(extra))
+
+    if not errors:
+        published = sorted(m for m, r in receipts.items() if r.get("published") is True)
+        notes.append(f"{len(want)} of {len(want)} selected module bundle(s) built"
+                     + (f"; {len(published)} published to the registry" if published
+                        else "; nothing published (not a trunk/release run)"))
+    return (1 if errors else 0), errors, notes
+
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────────
+# 🚨 A COUNT GATE THAT CANNOT FAIL IS A TICK, NOT A GATE. Every case below is a MUTATION of a
+# green run — remove a receipt, add one, skip the job, corrupt a file — and each must turn red and
+# NAME what it found. Without these, "the count matched" would be an assertion nobody has ever
+# seen fail.
+
+def self_test() -> int:
+    import tempfile
+    failures: list[str] = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        print(f"  {'✓' if ok else '✗'} {name}{'' if ok else ': ' + detail}")
+        if not ok:
+            failures.append(name)
+
+    def run(directory: Path, expected: list[str], result: str = "success"):
+        receipts, broken = read_receipts(directory)
+        return verify(expected, receipts, broken, result, directory.is_dir())
+
+    with tempfile.TemporaryDirectory() as tmp:
+        d = Path(tmp) / "receipts"
+        d.mkdir()
+        three = ["MeshWeaver.AI", "MeshWeaver.Mcp", "MeshWeaver.Teams"]
+        for m in three:
+            (d / f"{m}.json").write_text(json.dumps(
+                {"package": m.split(".")[-1], "module": m, "version": "1.2.3",
+                 "published": False}), encoding="utf-8")
+
+        print("the green run this gate is a mutation of:")
+        code, errors, notes = run(d, three)
+        check("every selected bundle has a receipt ⇒ pass", code == 0, f"{errors}")
+        check("and it SAYS what it verified", bool(notes), f"{notes}")
+
+        print("mutations — each must turn RED and name what it found:")
+        removed = d / "MeshWeaver.Mcp.json"
+        keep = removed.read_text(encoding="utf-8")
+        removed.unlink()
+        code, errors, _ = run(d, three)
+        check("a pack job that SKIPPED (its receipt is gone) fails, naming the module",
+              code == 1 and any("MeshWeaver.Mcp" in e and "NO receipt" in e for e in errors),
+              f"{errors}")
+        removed.write_text(keep, encoding="utf-8")
+
+        (d / "MeshWeaver.Ghost.json").write_text(json.dumps(
+            {"package": "Ghost", "module": "MeshWeaver.Ghost"}), encoding="utf-8")
+        code, errors, _ = run(d, three)
+        check("a bundle built that the selection did NOT name fails, naming it",
+              code == 1 and any("MeshWeaver.Ghost" in e and "did not name" in e for e in errors),
+              f"{errors}")
+        (d / "MeshWeaver.Ghost.json").unlink()
+
+        code, errors, _ = run(d, three, "skipped")
+        check("a NON-EMPTY selection whose pack job never ran fails loudly",
+              code == 1 and any("did NOT" in e and "RUN AT ALL" in e for e in errors), f"{errors}")
+        code, errors, _ = run(d, three, "failure")
+        check("a failed pack job is reported as the CAUSE, not as a count discrepancy",
+              code == 1 and any("read that job" in e for e in errors), f"{errors}")
+
+        (d / "MeshWeaver.AI.json").write_text("{ not json", encoding="utf-8")
+        code, errors, _ = run(d, three)
+        check("a corrupt receipt is not a receipt (and the module then reads as unbuilt)",
+              code == 1 and any("could not be read" in e for e in errors), f"{errors}")
+        (d / "MeshWeaver.AI.json").write_text(json.dumps(
+            {"module": "MeshWeaver.SomethingElse"}), encoding="utf-8")
+        code, errors, _ = run(d, three)
+        check("a receipt whose filename and module disagree is refused",
+              code == 1 and any("claims module" in e for e in errors), f"{errors}")
+        (d / "MeshWeaver.AI.json").write_text(json.dumps(
+            {"package": "AI", "module": "MeshWeaver.AI", "published": True}), encoding="utf-8")
+
+        code, errors, _ = run(Path(tmp) / "nowhere", three)
+        check("no receipts at all is a FAILURE, never a pass",
+              code == 1 and any("no receipt directory" in e for e in errors), f"{errors}")
+
+        print("the legitimate empty selection — and its own mutation:")
+        empty = Path(tmp) / "empty"
+        empty.mkdir()
+        code, errors, notes = run(empty, [], "skipped")
+        check("zero selected + zero receipts + a skipped job ⇒ pass, and says so",
+              code == 0 and bool(notes), f"{errors}")
+        (empty / "MeshWeaver.AI.json").write_text(json.dumps({"module": "MeshWeaver.AI"}),
+                                                  encoding="utf-8")
+        code, errors, _ = run(empty, [], "skipped")
+        check("zero selected but a bundle WAS built ⇒ fail",
+              code == 1 and any("ZERO" in e and "receipts arrived" in e for e in errors),
+              f"{errors}")
+
+    if failures:
+        print(f"\n::error title=node-repo-pack-verify self-test failed::{len(failures)} case(s) — "
+              "this gate is the only thing standing between a narrowed matrix and a silently "
+              "skipped module bundle.")
+        return 1
+    print("\n✓ node-repo-pack-verify self-test: 2 green-run assertions, 7 mutations that must go "
+          "red, 2 empty-selection cases — all green.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--expected", default="",
+                   help="space-separated module names the selection named")
+    p.add_argument("--receipts", default="", help="directory the receipt artifacts were merged into")
+    p.add_argument("--pack-result", default="", dest="pack_result",
+                   help="the pack job's aggregated result (needs.pack.result)")
+    p.add_argument("--self-test", action="store_true", dest="self_test")
+    args = p.parse_args()
+    if args.self_test:
+        return self_test()
+    if not args.receipts or not args.pack_result:
+        p.error("--receipts and --pack-result are required")
+
+    directory = Path(args.receipts)
+    expected = [m for m in args.expected.split() if m]
+    receipts, broken = read_receipts(directory)
+    code, errors, notes = verify(expected, receipts, broken, args.pack_result, directory.is_dir())
+
+    for note in notes:
+        print(f"✓ {note}")
+    for error in errors:
+        print(f"::error title=Module bundles incomplete::{error}")
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+            fh.write(f"### {'✅' if code == 0 else '❌'} Module bundles complete\n\n")
+            fh.write(f"selection named **{len(expected)}**, receipts arrived for "
+                     f"**{len(receipts)}** (pack job: `{args.pack_result}`)\n\n")
+            for line in notes + errors:
+                fh.write(f"- {line}\n")
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -187,8 +187,11 @@ def project_hits(root: Path, entries: list[str], changed: list[str], say) -> dic
 # ── classification ───────────────────────────────────────────────────────────────────────────
 
 def node_packages(root: Path) -> set[str]:
+    # "meshweaver" is CI's checkout of Systemorph/MeshWeaver — gen-manifests.py skips it for the
+    # same reason. The select job keeps the two trees apart anyway; this is the belt to that brace,
+    # because the day core grows a root index.json is the day the framework becomes a plugin.
     skip = {".git", ".github", ".claude", ".worktrees", "scripts", "src", "test", "docs", "e2e",
-            "app", "clients", "legacy"}
+            "app", "clients", "legacy", "meshweaver"}
     try:
         return {d.name for d in root.iterdir()
                 if d.is_dir() and d.name not in skip and (d / "index.json").exists()}

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -1,0 +1,595 @@
+#!/usr/bin/env python3
+"""node-repo-scope.py — decide what a plugin repo's CI must actually REBUILD.
+
+    "in plugins we only re-run concerned modules ⇒ we can estimate the required count and
+     validate it"  ·  "all plugins should only re-build what changed"  ·  "there is always a
+     notion of 'full rebuild' when the platform updates"  ·  "unify all MeshWeaver.* repos"
+
+TWO LANES ask this question, with the same rule and the same fallbacks, so they share one script:
+
+  --for modules   `node-repo-module-pack.yml` fans out ONE JOB per mixed package. That fan-out was
+                  the caller's literal list, every entry on every event: MeshWeaver.Plugins ran 29
+                  module builds on every push of every PR, whether the diff touched one module's
+                  C# or a course's markdown.
+  --for packages  `plugin-publish.yml` packs EVERY node package in one job — 53 in
+                  MeshWeaver.Plugins, `Store` alone being 17 compilation units. It is the COMPILE
+                  GATE over ~12k lines of in-mesh NodeType C# against the newest RELEASED
+                  framework (a different compiler input from `compile-check.py --image`), and it
+                  publishes nothing on a PR because that lane is `dry-run` by design.
+
+🚨 THE BIAS IS THE DESIGN, and it is copied from bake-scope.sh deliberately. Narrowing a build is
+the shape that produces a SILENT under-build, and the evidence of the miss is the absence of
+evidence. So every uncertainty below — an event without a meaningful diff, a missing selector, a
+git failure, a file that reaches the tooling, a matrix entry built from outside this checkout —
+resolves to a FULL run, out loud, NAMING which one.
+
+═══ WHY ONLY `pull_request` / `merge_group` NARROW ═══
+
+**A platform update is always FULL.** A module is built against a platform PIN; when the platform
+releases, the pin moves and every module must be rebuilt AND republished or every portal reads
+`FrameworkDeclined (built against <old>, live <new>)` and adopts nothing (MeshWeaver#2088). The
+release-follow triggers — `repository_dispatch` and the `schedule` poll — therefore never narrow.
+The same argument makes the pack lane exhaustive against a MOVING FLOOR: a package that did not
+change can stop compiling when the published framework advances, which is the whole reason that
+gate exists.
+
+**A `push` is always FULL, and that is deliberate rather than unfinished.**
+  * modules — the baseline a publishing run must diff against is its own PUBLICATION, never
+    `github.event.before`, which silently under-builds after ANY run that did not publish
+    (cancelled, superseded, red, re-run). The bake HAS such a marker (`source-commit.txt` sealed
+    beside its bundles; bake-scope.sh reads it). THE MODULE LANE HAS NONE: the registry is keyed
+    `{package}@{version}` from `manifest.lock`, and that version identifies only the CONTENT half
+    — a `src/`-only change repacks the same version with different bytes, so "the registry already
+    serves this version" is NOT evidence the published bundle matches HEAD. (That is the same
+    blind spot Plugins #878 records on the delivery side.) Until this lane stamps a source commit
+    into what it publishes, a push packs everything.
+  * packages — `plugin-publish.yml`'s header spells out why there is no changed-plugin detection
+    on the publish path: the derived PATCH is the change detector, and a hand-written diff would
+    be a second detector free to disagree, whose failure mode is a plugin that silently never
+    ships. That argument is about PUBLISHING. On a `pull_request` nothing is published at all, so
+    it does not apply — and the unnarrowed `push` keeps the trunk exhaustive.
+
+So the whole win sits on `pull_request` / `merge_group`, which is exactly where the cost is: a PR
+pushes many times, a trunk commit lands once.
+
+═══ WHAT MAKES A MODULE ENTRY REACHABLE — two halves, because a bundle has two ═══
+
+  * the CONTENT half — `{package}/manifest.lock`'s version and `{package}/index.json`'s
+    `content.module` + `content.minMeshVersion`, which the lane asserts. The reachable set is the
+    caller's own AFFECTED closure: `scripts/affected-modules.py`, the ONE answer this repo family
+    already uses for the mesh gate and the bake, INVOKED here rather than reimplemented.
+  * the COMPILED half — the module's project, its transitive in-repo `ProjectReference`s, and the
+    sibling `.Test` project the lane runs, with the same closure. `affected-modules.py` cannot see
+    this: it answers ALL modules for any `src/` path. `scripts/project-closure.py` in the caller
+    owns it, and is likewise INVOKED, because at least three consumers must agree on that graph
+    (this narrowing, the Plugins #878 version gate, and anything else asking "what does this
+    csproj depend on here").
+
+USAGE
+    node-repo-scope.py --for modules  --modules @matrix.json --event pull_request --base-ref main
+    node-repo-scope.py --for packages --event schedule
+    node-repo-scope.py --self-test
+
+OUTPUT — JSON on stdout, the human report on stderr, plus $GITHUB_OUTPUT / $GITHUB_STEP_SUMMARY.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# 🚨 EXACTLY scripts/affected-modules.py's NOOP_DIRS, verbatim — the top-level dirs a change in
+# which can reach no build at all. It is copied rather than widened on purpose: every entry NOT in
+# this set falls through to a FULL run, so ADDING one here silently un-builds something. `clients/`
+# is deliberately absent (the established selector treats it as ALL, and a client asset can be
+# embedded by a host), as are editor dirs — a repo that wants them exempt changes the selector
+# both lanes already share, so the two answers cannot drift.
+NOOP_DIRS = {"legacy", "e2e", "docs", "app", ".claude", ".worktrees"}
+
+SELECTOR = "scripts/affected-modules.py"        # the caller's NODE graph
+PROJECTS = "scripts/project-closure.py"          # the caller's PROJECT graph
+
+# Events whose diff means anything. Everything else runs the full set, each for its own reason.
+NARROWABLE = {"pull_request", "pull_request_target", "merge_group"}
+
+FULL_REASONS = {
+    "modules": {
+        "push": "a push PUBLISHES, and the only sound baseline is its own publication — which the "
+                "module lane does not record (the registry is keyed {package}@{version}, and a "
+                "version identifies only the CONTENT half, so a src/-only change repacks the same "
+                "version with different bytes). Diffing github.event.before instead would silently "
+                "skip every module whose commit belonged to a cancelled, superseded or red run. "
+                "Packing every module.",
+        "repository_dispatch": "a framework-release dispatch moves the platform pin every module is "
+                               "built against — every bundle must be rebuilt and republished or "
+                               "every portal reads FrameworkDeclined and adopts nothing "
+                               "(MeshWeaver#2088). The git diff is irrelevant.",
+        "schedule": "the release poll is how this repo learns the platform released; every module "
+                    "must be rebuilt and republished against the new framework identity "
+                    "(MeshWeaver#2088), so the git diff is irrelevant.",
+        "workflow_dispatch": "a manual dispatch has no diff to narrow by — packing every module.",
+    },
+    "packages": {
+        "push": "the publish path's change detector is the DERIVED VERSION, not a diff "
+                "(plugin-publish.yml's header): a second detector free to disagree would let a "
+                "plugin silently never ship. Packing every plugin.",
+        "repository_dispatch": "the published framework moved — this gate's value is being "
+                               "EXHAUSTIVE against that floor, because a package that did not "
+                               "change can still stop compiling. Packing every plugin.",
+        "schedule": "the released-framework floor moves without this repo changing, and a package "
+                    "that did not change can still stop compiling against it. Packing every plugin.",
+        "workflow_dispatch": "a manual dispatch has no diff to narrow by — packing every plugin.",
+    },
+}
+
+
+# ── the caller's two graphs, invoked (never reimplemented) ───────────────────────────────────
+
+def _invoke(root: Path, script: str, argv: list[str], say) -> dict | None:
+    path = root / script
+    if not path.is_file():
+        return None
+    try:
+        proc = subprocess.run([sys.executable, str(path), *argv],
+                              cwd=root, capture_output=True, text=True, timeout=600)
+    except (OSError, subprocess.SubprocessError) as exc:
+        say(f"    {script}: {exc}")
+        return None
+    if proc.returncode != 0:
+        say("    " + (proc.stderr.strip()[-2000:] or f"{script} exited {proc.returncode}"))
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        say(f"    {script}: answer is not JSON")
+        return None
+
+
+def affected_packages(root: Path, changed: list[str], say) -> set[str] | None:
+    """The caller's affected closure over the given paths. None ⇒ cannot narrow.
+
+    🚨 Its refusals stay load-bearing: a non-zero exit, an unparseable answer, or `runAll` is taken
+    as "cannot narrow", never as "nothing affected". It refuses an empty diff for the same reason.
+    """
+    # A temp file, never a path inside the checkout: this script runs against a tree CI is about
+    # to diff, and a stray file in it is a changed file.
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as fh:
+        fh.write("\n".join(changed) + "\n")
+        listing = Path(fh.name)
+    try:
+        answer = _invoke(root, SELECTOR, ["--changed", str(listing), "--json"], say)
+    finally:
+        listing.unlink(missing_ok=True)
+    if answer is None or answer.get("runAll") is not False:
+        return None
+    affected = answer.get("affected")
+    return set(affected) if isinstance(affected, list) else None
+
+
+def project_hits(root: Path, entries: list[str], changed: list[str], say) -> dict | None:
+    """{entry → the changed project dirs its build+test closure contains} + `unclassified`."""
+    with tempfile.NamedTemporaryFile("w", suffix=".txt", delete=False) as fh:
+        fh.write("\n".join(changed) + "\n")
+        listing = Path(fh.name)
+    argv = ["--hits", "--changed", str(listing), "--json"]
+    for e in entries:
+        argv += ["--entry", e]
+    try:
+        return _invoke(root, PROJECTS, argv, say)
+    finally:
+        listing.unlink(missing_ok=True)
+
+
+# ── classification ───────────────────────────────────────────────────────────────────────────
+
+def node_packages(root: Path) -> set[str]:
+    skip = {".git", ".github", ".claude", ".worktrees", "scripts", "src", "test", "docs", "e2e",
+            "app", "clients", "legacy"}
+    try:
+        return {d.name for d in root.iterdir()
+                if d.is_dir() and d.name not in skip and (d / "index.json").exists()}
+    except OSError:
+        return set()
+
+
+def changed_files(root: Path, diff_range: str, say) -> list[str] | None:
+    proc = subprocess.run(["git", "diff", "--name-only", diff_range],
+                          cwd=root, capture_output=True, text=True, timeout=120)
+    if proc.returncode != 0:
+        say("    " + proc.stderr.strip()[-2000:])
+        return None
+    return [line for line in proc.stdout.splitlines() if line.strip()]
+
+
+# ── the decision ─────────────────────────────────────────────────────────────────────────────
+
+def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: str | None,
+           override: list[str] | None, say) -> dict:
+    all_packages = sorted(node_packages(root))
+    universe = ([e["module"] for e in entries] if lane == "modules" else all_packages)
+
+    def full(reason: str) -> dict:
+        return {"lane": lane, "scope": "full", "reason": reason,
+                "modules": entries if lane == "modules" else [],
+                "packages": all_packages if lane == "packages" else [],
+                "count": len(universe), "selected": sorted(universe), "skipped": [], "why": {}}
+
+    if event not in NARROWABLE:
+        return full(FULL_REASONS[lane].get(
+            event, f"event '{event}' has no meaningful content diff — running the full set."))
+    if not universe:
+        return full("there is nothing to select from — running the full set.")
+    if not (root / SELECTOR).is_file():
+        return full(f"the caller repo ships no {SELECTOR}, so the affected closure cannot be "
+                    "computed — running the full set.")
+
+    if override is not None:
+        files = [f for f in override if f.strip()]
+    else:
+        got = changed_files(root, diff_range or "", say)
+        if got is None:
+            return full(f"git diff --name-only {diff_range} failed (see above) — the changed set "
+                        "is unknown, so the full set runs.")
+        files = got
+    # 🚨 A CI diff is never empty; an empty one is a broken range (an unfetched base). Answering
+    # "nothing to do" to it would skip the whole lane under a green tick.
+    if not files:
+        return full(f"the diff for '{diff_range or '--changed'}' came back EMPTY — a CI diff is "
+                    "never empty, so this is a broken range (is the base ref fetched?), not "
+                    "'nothing to do'. Running the full set.")
+
+    packages = node_packages(root)
+    node_files: list[str] = []
+    src_files: list[str] = []
+    global_files: list[str] = []
+    report: list[str] = []
+    for f in files:
+        top = f.split("/", 1)[0]
+        if "/" in f and top in packages:
+            node_files.append(f)
+            report.append(f"  {f}  → node package {top}")
+        elif "/" in f and top in NOOP_DIRS:
+            report.append(f"  {f}  → (reaches nothing this lane builds — {top}/)")
+        elif f.startswith("src/") and f.count("/") >= 2 and lane == "modules":
+            src_files.append(f)
+        else:
+            global_files.append(f)
+            report.append(f"  {f}  → EVERYTHING (tooling / repo-root / unknown scope)")
+    for line in report:
+        say(line)
+
+    if global_files:
+        return full(f"{len(global_files)} changed file(s) reach the tooling/global scope — first: "
+                    f"{global_files[0]}. Running the full set.")
+
+    affected: set[str] = set()
+    if node_files:
+        answer = affected_packages(root, node_files, say)
+        if answer is None:
+            return full(f"{SELECTOR} could not narrow the node-package closure (it refused, "
+                        "answered ALL, or could not be parsed) — running the full set.")
+        affected = answer
+
+    if lane == "packages":
+        chosen = sorted(affected & set(all_packages))
+        return {"lane": lane, "scope": "narrowed",
+                "reason": f"{len(chosen)} of {len(all_packages)} plugin(s) are reachable from this "
+                          f"diff ({len(files)} file(s)).",
+                "modules": [], "packages": chosen, "count": len(chosen), "selected": chosen,
+                "skipped": sorted(set(all_packages) - set(chosen)),
+                "why": {p: "in the affected closure" for p in chosen}}
+
+    # ── the modules lane also needs the COMPILED half ──
+    # An entry built from outside this checkout (a platform-hosted transition entry) can never be
+    # shown unaffected by this repo's diff.
+    external = [e for e in entries if not e.get("project", "").startswith("src/")]
+    if external:
+        return full(f"matrix entry '{external[0].get('module')}' builds "
+                    f"{external[0].get('project')}, which is outside this checkout's src/ — its "
+                    "reachability cannot be decided from this diff. Packing every module.")
+
+    hits: dict[str, list[str]] = {e["project"]: [] for e in entries}
+    if src_files:
+        answer = project_hits(root, sorted(hits), src_files, say)
+        if answer is None:
+            return full(f"the caller repo's {PROJECTS} could not answer the compiled-half closure "
+                        f"for {len(src_files)} src/ file(s) — packing every module.")
+        unclassified = answer.get("unclassified") or []
+        if unclassified:
+            return full(f"{len(unclassified)} changed path(s) under src/ belong to no project — "
+                        f"first: {unclassified[0]}. Such a file (Directory.Build.props, "
+                        "platform-shipped.txt, a renamed project) can change what EVERY project "
+                        "builds. Packing every module.")
+        got = answer.get("entries")
+        if not isinstance(got, dict) or set(got) != set(hits):
+            return full(f"{PROJECTS} answered for {len(got or {})} of {len(hits)} entries — "
+                        "packing every module.")
+        hits = {k: list(v) for k, v in got.items()}
+        for f in src_files:
+            say(f"  {f}  → src/")
+
+    selected: list[dict] = []
+    why: dict[str, str] = {}
+    for e in entries:
+        reasons = []
+        if e["package"] in affected:
+            reasons.append(f"node package `{e['package']}` is in the affected closure")
+        if hits.get(e["project"]):
+            reasons.append("compiled closure reaches " + ", ".join(f"`{p}`"
+                                                                   for p in hits[e["project"]]))
+        if reasons:
+            why[e["module"]] = "; ".join(reasons)
+            selected.append(e)
+
+    chosen = {e["module"] for e in selected}
+    return {"lane": lane, "scope": "narrowed",
+            "reason": f"{len(selected)} of {len(entries)} module bundle(s) are reachable from this "
+                      f"diff ({len(files)} file(s)).",
+            "modules": selected, "packages": [], "count": len(selected),
+            "selected": sorted(chosen), "skipped": sorted(set(universe) - chosen), "why": why}
+
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────────
+# 🚨 THIS SCRIPT DECIDES WHAT DOES NOT GET BUILT, so it owes its own proof that it can say no AND
+# that every fallback still falls back. The fixture is a miniature plugin repo: two node packages
+# (Beta ← Alpha, a dependent edge), a five-project src/ graph whose entry reaches a shared library
+# and whose sibling .Test reaches a project the entry does not, and a two-entry matrix.
+
+_ENTRY_A = {"package": "Alpha", "module": "Acme.Alpha",
+            "project": "src/Acme.Alpha/Acme.Alpha.csproj"}
+_ENTRY_B = {"package": "Beta", "module": "Acme.Beta",
+            "project": "src/Acme.Beta/Acme.Beta.csproj"}
+_MATRIX = [_ENTRY_A, _ENTRY_B]
+
+# The fixture project graph the stub answers from — entry closures already resolved, so the stub
+# is obviously a fixture rather than a second implementation of the real graph.
+_STUB_PROJECTS = (
+    "import json,sys\n"
+    "CLOSURE={'src/Acme.Alpha/Acme.Alpha.csproj':"
+    "{'src/Acme.Alpha','src/Acme.Shared','src/Acme.Alpha.Test','src/Acme.Kit'},"
+    "'src/Acme.Beta/Acme.Beta.csproj':{'src/Acme.Beta'}}\n"
+    "KNOWN={p for c in CLOSURE.values() for p in c}\n"
+    "a=sys.argv\n"
+    "entries=[a[i+1] for i,v in enumerate(a) if v=='--entry']\n"
+    "paths=[l for l in open(a[a.index('--changed')+1]).read().splitlines() if l]\n"
+    "own=lambda f: next((k for k in KNOWN if f==k or f.startswith(k+'/')), None)\n"
+    "hit={own(f) for f in paths if own(f)}\n"
+    "unc=sorted(f for f in paths if f.startswith('src/') and not own(f))\n"
+    "json.dump({'projects':sorted(KNOWN),'changedProjects':sorted(hit),'unclassified':unc,"
+    "'entries':{e:sorted(CLOSURE.get(e,set())&hit) for e in entries}},sys.stdout)\n")
+
+_STUB_SELECTOR = (
+    "import json,sys\n"
+    "paths=[l for l in open(sys.argv[sys.argv.index('--changed')+1]).read().splitlines() if l]\n"
+    "pk=sorted({p.split('/')[0] for p in paths})\n"
+    # Alpha is Beta's dependent in the fixture graph, exactly as a `requires` edge would make it.
+    "aff=sorted(set(pk)|({'Alpha'} if 'Beta' in pk else set()))\n"
+    "json.dump({'runAll':False,'affected':aff,'mount':aff,'skipped':[],'support':[]},sys.stdout)\n")
+
+
+def _csproj(refs: list[str]) -> str:
+    return "<Project><ItemGroup>%s</ItemGroup></Project>\n" % "".join(
+        f'<ProjectReference Include="{r}" />' for r in refs)
+
+
+def _fixture(root: Path) -> None:
+    (root / "scripts").mkdir(parents=True, exist_ok=True)
+    (root / "scripts" / "affected-modules.py").write_text(_STUB_SELECTOR, encoding="utf-8")
+    # 🚨 A CONTRACT STUB, deliberately — not a copy of the caller's project-closure.py. What this
+    # script depends on is that file's CONTRACT (exit code + `entries`/`unclassified` JSON), and
+    # that is what the fixture varies; the graph's own semantics (transitive edges, the .Test hop,
+    # $(MeshWeaverRoot) not being an edge) are pinned by its own --self-test, in the repo that owns
+    # it. Copying it here would be the second implementation this whole design exists to avoid.
+    (root / "scripts" / "project-closure.py").write_text(_STUB_PROJECTS, encoding="utf-8")
+    for pkg in ("Alpha", "Beta", "Gamma"):
+        (root / pkg).mkdir(exist_ok=True)
+        (root / pkg / "index.json").write_text('{"id":"%s"}\n' % pkg, encoding="utf-8")
+    for name, refs in (
+            ("Acme.Alpha", ["../Acme.Shared/Acme.Shared.csproj"]),
+            ("Acme.Alpha.Test", ["../Acme.Alpha/Acme.Alpha.csproj",
+                                 "../Acme.Kit/Acme.Kit.csproj"]),
+            ("Acme.Beta", []), ("Acme.Shared", []), ("Acme.Kit", [])):
+        d = root / "src" / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{name}.csproj").write_text(_csproj(refs), encoding="utf-8")
+    (root / "src" / "Directory.Build.props").write_text("<Project />\n", encoding="utf-8")
+    (root / "docs").mkdir(exist_ok=True)
+    (root / "README.md").write_text("x\n", encoding="utf-8")
+
+
+def _run(root: Path, lane: str, event: str, changed: list[str] | None) -> dict:
+    argv = [sys.executable, str(Path(__file__).resolve()), "--for", lane,
+            "--root", str(root), "--event", event]
+    if lane == "modules":
+        argv += ["--modules", json.dumps(_MATRIX)]
+    if changed is not None:
+        argv += ["--changed-list", ",".join(changed)]
+    proc = subprocess.run(argv, capture_output=True, text=True, timeout=600)
+    if proc.returncode != 0:
+        raise SystemExit(f"self-test harness: exit {proc.returncode}\n{proc.stderr}")
+    return json.loads(proc.stdout)
+
+
+def self_test() -> int:
+    import tempfile
+    failures: list[str] = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        print(f"  {'✓' if ok else '✗'} {name}{'' if ok else ': ' + detail}")
+        if not ok:
+            failures.append(name)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _fixture(root)
+
+        print("FULL-run fallbacks — the bias that makes narrowing safe (both lanes):")
+        for lane, n in (("modules", 2), ("packages", 3)):
+            for event, label in (
+                    ("push", "a push has no sound publication baseline / is the publish path"),
+                    ("repository_dispatch", "a framework release rebuilds everything"),
+                    ("schedule", "the release poll rebuilds everything"),
+                    ("workflow_dispatch", "a manual dispatch has no diff"),
+                    ("issue_comment", "an unrecognised event")):
+                got = _run(root, lane, event, ["Alpha/index.json"])
+                check(f"[{lane}] {label} ({event})",
+                      got["scope"] == "full" and got["count"] == n,
+                      f"scope={got['scope']} count={got['count']}")
+            for label, changed in (
+                    ("a repo-ROOT file ⇒ ALL", ["README.md"]),
+                    (".github/ (the workflow itself) ⇒ ALL", [".github/workflows/ci.yml"]),
+                    ("scripts/ (the gates) ⇒ ALL", ["scripts/gen-manifests.py"]),
+                    ("an UNKNOWN top-level dir (a deleted package) ⇒ ALL", ["Gone/index.json"]),
+                    ("an EMPTY diff is a broken range, never 'nothing to do'", [])):
+                got = _run(root, lane, "pull_request", changed)
+                check(f"[{lane}] {label}", got["scope"] == "full" and got["count"] == n,
+                      f"scope={got['scope']} count={got['count']} — {got['reason']}")
+        for label, changed in (
+                ("src/<file> outside any project (Directory.Build.props) ⇒ ALL",
+                 ["src/Directory.Build.props"]),
+                ("src/<dir> holding no csproj ⇒ ALL", ["src/Loose/notes.txt"]),
+                ("a project that no longer exists (renamed/deleted) ⇒ ALL",
+                 ["src/Acme.Gone/Gone.cs"])):
+            got = _run(root, "modules", "pull_request", changed)
+            check(f"[modules] {label}", got["scope"] == "full" and got["count"] == 2,
+                  f"scope={got['scope']} — {got['reason']}")
+
+        print("narrowed — the CONTENT half (the caller's affected closure, invoked not copied):")
+        got = _run(root, "modules", "pull_request", ["Alpha/index.json"])
+        check("[modules] a node package selects its own bundle and no other",
+              got["selected"] == ["Acme.Alpha"], f"{got['selected']}")
+        got = _run(root, "modules", "pull_request", ["Beta/Board.json"])
+        check("[modules] a node package's DEPENDENT is selected too",
+              got["selected"] == ["Acme.Alpha", "Acme.Beta"], f"{got['selected']}")
+        got = _run(root, "packages", "pull_request", ["Beta/Board.json"])
+        check("[packages] the pack lane narrows to the same closure",
+              got["packages"] == ["Alpha", "Beta"] and got["skipped"] == ["Gamma"],
+              f"{got['packages']} skipped={got['skipped']}")
+
+        print("narrowed — the COMPILED half (the graph affected-modules.py answers ALL for):")
+        for label, changed, expect in (
+                ("a module's own project selects only that module", ["src/Acme.Beta/T.cs"],
+                 ["Acme.Beta"]),
+                ("a shared library selects every module whose closure references it",
+                 ["src/Acme.Shared/S.cs"], ["Acme.Alpha"]),
+                ("the sibling .Test project the lane RUNS is in the closure",
+                 ["src/Acme.Alpha.Test/T.cs"], ["Acme.Alpha"]),
+                ("a project reached only THROUGH the .Test project still selects",
+                 ["src/Acme.Kit/K.cs"], ["Acme.Alpha"]),
+                ("both halves union", ["src/Acme.Beta/T.cs", "Alpha/index.json"],
+                 ["Acme.Alpha", "Acme.Beta"])):
+            got = _run(root, "modules", "pull_request", changed)
+            check(f"[modules] {label}",
+                  got["scope"] == "narrowed" and got["selected"] == expect, f"{got['selected']}")
+
+        print("the legitimate EMPTY answer — explicit, never a missing input:")
+        for lane in ("modules", "packages"):
+            got = _run(root, lane, "pull_request", ["docs/guide.md"])
+            check(f"[{lane}] a diff reaching nothing selects ZERO, and says so",
+                  got["scope"] == "narrowed" and got["count"] == 0 and got["skipped"],
+                  f"scope={got['scope']} count={got['count']}")
+
+        print("the caller's graphs are load-bearing — every failure of theirs is a FULL run:")
+        selector = root / "scripts" / "affected-modules.py"
+        for label, body in (
+                ("a selector that REFUSES", "import sys; sys.exit(1)\n"),
+                ("a selector answering runAll", "import json,sys; json.dump({'runAll':True},sys.stdout)\n"),
+                ("an unparseable selector answer", "not json\n")):
+            selector.write_text(body, encoding="utf-8")
+            got = _run(root, "modules", "pull_request", ["Alpha/index.json"])
+            check(f"[modules] {label} ⇒ ALL", got["scope"] == "full" and got["count"] == 2,
+                  f"scope={got['scope']}")
+        selector.unlink()
+        got = _run(root, "modules", "pull_request", ["Alpha/index.json"])
+        check("[modules] no selector in the caller repo ⇒ ALL",
+              got["scope"] == "full" and got["count"] == 2, f"scope={got['scope']}")
+        selector.write_text(_STUB_SELECTOR, encoding="utf-8")
+        (root / "scripts" / "project-closure.py").unlink()
+        got = _run(root, "modules", "pull_request", ["src/Acme.Beta/T.cs"])
+        check("[modules] no project-closure.py in the caller repo ⇒ ALL",
+              got["scope"] == "full" and got["count"] == 2, f"scope={got['scope']}")
+
+    if failures:
+        print(f"\n::error title=node-repo-scope self-test failed::{len(failures)} case(s) — this "
+              "script decides what is NOT rebuilt; a fallback that stops falling back is a stale "
+              "assembly the registry keeps serving, or an in-mesh compile break that reaches main.")
+        return 1
+    print("\n✓ node-repo-scope self-test: 23 full-run fallbacks, 8 narrowing assertions, "
+          "2 explicit-empty answers, 5 caller-graph refusals — all green.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--for", dest="lane", choices=("modules", "packages"))
+    p.add_argument("--modules", help="the module matrix as JSON, or @file (--for modules)")
+    p.add_argument("--root", default=".", help="the caller repo checkout")
+    p.add_argument("--event", default="", help="the triggering GitHub event name")
+    p.add_argument("--base-ref", default="", dest="base_ref",
+                   help="the PR base branch — the diff is origin/<base-ref>...HEAD")
+    p.add_argument("--changed-list", default=None, dest="changed_list",
+                   help="comma-separated changed paths instead of a git diff (tests only)")
+    p.add_argument("--self-test", action="store_true", dest="self_test")
+    args = p.parse_args()
+    if args.self_test:
+        return self_test()
+    if not args.lane:
+        p.error("--for {modules,packages} is required")
+
+    entries: list[dict] = []
+    if args.lane == "modules":
+        if not args.modules:
+            p.error("--for modules needs --modules")
+        raw = (Path(args.modules[1:]).read_text(encoding="utf-8")
+               if args.modules.startswith("@") else args.modules)
+        entries = json.loads(raw)
+        if not isinstance(entries, list):
+            sys.exit("✗ --modules must be a JSON array of {package, module, project}")
+        for e in entries:
+            if not isinstance(e, dict) or not {"package", "module", "project"} <= set(e):
+                sys.exit(f"✗ matrix entry missing package/module/project: {e!r}")
+
+    root = Path(args.root).resolve()
+    say = lambda *a: print(*a, file=sys.stderr)  # noqa: E731
+    changed = None if args.changed_list is None else [c for c in args.changed_list.split(",") if c]
+    answer = decide(root, args.lane, entries, args.event,
+                    f"origin/{args.base_ref}...HEAD" if args.base_ref else None, changed, say)
+
+    say("")
+    say(f"scope: {answer['scope']} — {answer['reason']}")
+    for name, reason in sorted(answer.get("why", {}).items()):
+        say(f"  ▸ {name}: {reason}")
+    if answer["skipped"]:
+        say(f"not built ({len(answer['skipped'])}): {', '.join(answer['skipped'])}")
+
+    if os.environ.get("GITHUB_OUTPUT"):
+        with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+            fh.write(f"scope={answer['scope']}\n")
+            fh.write(f"count={answer['count']}\n")
+            fh.write("modules=" + json.dumps(answer["modules"]) + "\n")
+            fh.write("packages=" + " ".join(answer["packages"]) + "\n")
+            fh.write("selected=" + " ".join(answer["selected"]) + "\n")
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        total = answer["count"] + len(answer["skipped"])
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+            fh.write(f"### {'🧱' if answer['scope'] == 'full' else '🎯'} "
+                     f"{answer['lane']}: {answer['scope']} — {answer['count']} of {total}\n\n"
+                     f"{answer['reason']}\n\n")
+            if answer["scope"] == "narrowed":
+                if answer["why"]:
+                    fh.write("| built | why |\n|---|---|\n")
+                    for name, reason in sorted(answer["why"].items()):
+                        fh.write(f"| `{name}` | {reason} |\n")
+                if answer["skipped"]:
+                    fh.write(f"\n**Not built:** `{'`, `'.join(answer['skipped'])}`\n")
+
+    print(json.dumps(answer, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -77,24 +77,33 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
-# 🚨 EXACTLY scripts/affected-modules.py's NOOP_DIRS, verbatim — the top-level dirs a change in
-# which can reach no build at all. It is copied rather than widened on purpose: every entry NOT in
-# this set falls through to a FULL run, so ADDING one here silently un-builds something. `clients/`
-# is deliberately absent (the established selector treats it as ALL, and a client asset can be
-# embedded by a host), as are editor dirs — a repo that wants them exempt changes the selector
-# both lanes already share, so the two answers cannot drift.
-NOOP_DIRS = {"legacy", "e2e", "docs", "app", ".claude", ".worktrees"}
+# 🚨 scripts/affected-modules.py's NOOP_DIRS, and it must stay EQUAL to it — the top-level dirs a
+# change in which can reach no build at all. Every entry NOT in this set falls through to a FULL
+# run, so adding one silently un-builds something and dropping one merely costs a full run.
+# `clients/` is deliberately absent (the established selector treats it as ALL, and a client asset
+# can be embedded by a host).
+#
+# 🚨 A HAND COPY IS NOT A GUARANTEE, and this one drifted on its first day: `WhatsNew` was missing,
+# so a note-only PR ran the entire fleet's module suite — the exact case affected-modules.py added
+# it for. `assert_noop_dirs_match()` below now READS the caller's set and refuses to narrow when
+# the two disagree, so the next drift is a full run with a named reason instead of a silent one.
+NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees"}
 
 SELECTOR = "scripts/affected-modules.py"        # the caller's NODE graph
 PROJECTS = "scripts/project-closure.py"          # the caller's PROJECT graph
 
 # Events whose diff means anything. Everything else runs the full set, each for its own reason.
-NARROWABLE = {"pull_request", "pull_request_target", "merge_group"}
+# 🚨 `pull_request_target` is deliberately ABSENT. With the default checkout it runs at the BASE
+# tip, so `origin/<base>...HEAD` is empty and it could only ever take the empty-diff fallback — and
+# the day someone adds `ref: github.event.pull_request.head.sha` it would start narrowing on
+# fork-controlled content. A lane that cannot narrow should not claim it can.
+NARROWABLE = {"pull_request", "merge_group"}
 
 FULL_REASONS = {
     "modules": {
@@ -187,16 +196,45 @@ def project_hits(root: Path, entries: list[str], changed: list[str], say) -> dic
 # ── classification ───────────────────────────────────────────────────────────────────────────
 
 def node_packages(root: Path) -> set[str]:
+    """Top-level dirs carrying an index.json — the caller's node packages.
+
+    🚨 An OSError here is NOT caught. "I could not read the tree" must never become "the tree is
+    empty": a swallowed error made this function return an empty set, `full()` then answered
+    scope=full with count=0, and both lanes reported SUCCESS having built nothing — a green tick
+    over a compile gate that compiled zero packages. Letting it raise exits non-zero and fails the
+    job, which is the loud version of the same fact.
+    """
     # "meshweaver" is CI's checkout of Systemorph/MeshWeaver — gen-manifests.py skips it for the
     # same reason. The select job keeps the two trees apart anyway; this is the belt to that brace,
     # because the day core grows a root index.json is the day the framework becomes a plugin.
     skip = {".git", ".github", ".claude", ".worktrees", "scripts", "src", "test", "docs", "e2e",
             "app", "clients", "legacy", "meshweaver"}
+    return {d.name for d in root.iterdir()
+            if d.is_dir() and d.name not in skip and (d / "index.json").exists()}
+
+
+def assert_noop_dirs_match(root: Path) -> str | None:
+    """None when the caller's NOOP_DIRS equals ours; otherwise why we must not narrow.
+
+    Read out of the caller's source rather than imported: affected-modules.py is a CLI, and
+    importing it would run its argparse. A set literal on one line is what it has always been; if
+    that ever stops parsing, the honest answer is "cannot verify" — which is also a full run.
+    """
     try:
-        return {d.name for d in root.iterdir()
-                if d.is_dir() and d.name not in skip and (d / "index.json").exists()}
-    except OSError:
-        return set()
+        text = (root / SELECTOR).read_text(encoding="utf-8")
+    except OSError as exc:
+        return f"{SELECTOR} could not be read ({exc})"
+    match = re.search(r"^NOOP_DIRS\s*=\s*\{([^}]*)\}", text, re.M)
+    if not match:
+        return f"{SELECTOR} has no single-line NOOP_DIRS literal to compare against"
+    theirs = set(re.findall(r"[\"']([^\"']+)[\"']", match.group(1)))
+    if theirs != NOOP_DIRS:
+        only_theirs = ", ".join(sorted(theirs - NOOP_DIRS)) or "(none)"
+        only_ours = ", ".join(sorted(NOOP_DIRS - theirs)) or "(none)"
+        return (f"this script's NOOP_DIRS has drifted from {SELECTOR}'s — only theirs: "
+                f"{only_theirs}; only ours: {only_ours}. The two must classify a top-level dir "
+                "identically or the lanes disagree about what a change reaches")
+    return None
 
 
 def changed_files(root: Path, diff_range: str, say) -> list[str] | None:
@@ -219,7 +257,7 @@ def changed_files(root: Path, diff_range: str, say) -> list[str] | None:
 # ── the decision ─────────────────────────────────────────────────────────────────────────────
 
 def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: str | None,
-           override: list[str] | None, say) -> dict:
+           override: list[str] | None, say, publishing: bool = False) -> dict:
     all_packages = sorted(node_packages(root))
     universe = ([e["module"] for e in entries] if lane == "modules" else all_packages)
 
@@ -229,14 +267,34 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
                 "packages": all_packages if lane == "packages" else [],
                 "count": len(universe), "selected": sorted(universe), "skipped": [], "why": {}}
 
+    def refuse(reason: str) -> dict:
+        return {"lane": lane, "scope": "refuse", "reason": reason, "modules": [], "packages": [],
+                "count": 0, "selected": [], "skipped": [], "why": {}}
+
+    # 🚨 THE ANSWER "BUILD EVERYTHING, AND EVERYTHING IS NOTHING" IS NOT AN ANSWER. `full` with a
+    # count of 0 is an internal contradiction, and it is REACHABLE: a --root that does not match
+    # the checkout path, a matrix input of `[]`, a tree that could not be listed. Every consumer
+    # keys on the count alone, so it sailed through as a green tick over a lane that built nothing
+    # — the precise failure this script exists to prevent. It is a refusal, not a scope.
+    if not universe:
+        return refuse(
+            f"there is nothing to select from: {'the modules input is empty' if lane == 'modules' else f'no node package was found under {root}'}. "
+            "'Build everything' and 'everything is nothing' cannot both be true, so this is a "
+            "broken input (a --root that does not match the checkout?), not a scope.")
+
+    if publishing:
+        return full("this run PUBLISHES, and a publishing run is never narrowed — the derived "
+                    "version is the change detector on that path, and a diff that misses a unit "
+                    "means that unit silently never ships.")
     if event not in NARROWABLE:
         return full(FULL_REASONS[lane].get(
             event, f"event '{event}' has no meaningful content diff — running the full set."))
-    if not universe:
-        return full("there is nothing to select from — running the full set.")
     if not (root / SELECTOR).is_file():
         return full(f"the caller repo ships no {SELECTOR}, so the affected closure cannot be "
                     "computed — running the full set.")
+    drift = assert_noop_dirs_match(root)
+    if drift is not None:
+        return full(f"{drift} — running the full set.")
 
     if override is not None:
         files = [f for f in override if f.strip()]
@@ -298,11 +356,30 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
     # ── the modules lane also needs the COMPILED half ──
     # An entry built from outside this checkout (a platform-hosted transition entry) can never be
     # shown unaffected by this repo's diff.
-    external = [e for e in entries if not e.get("project", "").startswith("src/")]
-    if external:
-        return full(f"matrix entry '{external[0].get('module')}' builds "
-                    f"{external[0].get('project')}, which is outside this checkout's src/ — its "
-                    "reachability cannot be decided from this diff. Packing every module.")
+    # 🚨 EVERY ENTRY MUST BE REACHABLE IN PRINCIPLE BEFORE ANY OF THEM IS RULED OUT, and this
+    # check is UNCONDITIONAL — not behind `if src_files`, or a diff that touches no src/ path
+    # would never look at the entry list at all.
+    #
+    # A stale entry (a renamed csproj, a package that no longer exists) used to be caught on the
+    # first PR, because every PR built every entry and went red immediately. Narrowed, it is
+    # simply never selected: the closure cannot reach a project that is not there, so the entry
+    # goes quiet and the failure defers to the next `push` on main — which is exactly where this
+    # repo's policy says the cost must not land. Two direct filesystem facts, no graph needed.
+    for e in entries:
+        project = e.get("project", "")
+        if not project.startswith("src/"):
+            return full(f"matrix entry '{e.get('module')}' builds {project}, which is outside "
+                        "this checkout's src/ — its reachability cannot be decided from this "
+                        "diff. Packing every module.")
+        if not (root / project).is_file():
+            return full(f"matrix entry '{e.get('module')}' names {project}, which does not exist "
+                        "in this checkout — the matrix and the tree have drifted, and a narrowed "
+                        "run would simply never select it. Packing every module, so the entry "
+                        "fails on THIS pull request rather than on the next push to main.")
+        if e.get("package") not in all_packages:
+            return full(f"matrix entry '{e.get('module')}' names package '{e.get('package')}', "
+                        "which is not a node package in this checkout (no index.json) — the "
+                        "matrix and the tree have drifted. Packing every module.")
 
     hits: dict[str, list[str]] = {e["project"]: [] for e in entries}
     if src_files:
@@ -375,7 +452,10 @@ _STUB_PROJECTS = (
     "json.dump({'projects':sorted(KNOWN),'changedProjects':sorted(hit),'unclassified':unc,"
     "'entries':{e:sorted(CLOSURE.get(e,set())&hit) for e in entries}},sys.stdout)\n")
 
+# 🚨 The stub carries a NOOP_DIRS literal because the real selector does and this script now
+# READS it — a fixture without one would make every case take the drift fallback.
 _STUB_SELECTOR = (
+    'NOOP_DIRS = {"legacy", "e2e", "docs", "WhatsNew", "app", ".claude", ".worktrees"}\n'
     "import json,sys\n"
     "paths=[l for l in open(sys.argv[sys.argv.index('--changed')+1]).read().splitlines() if l]\n"
     "pk=sorted({p.split('/')[0] for p in paths})\n"
@@ -417,14 +497,21 @@ def _fixture(root: Path) -> None:
     (root / "README.md").write_text("x\n", encoding="utf-8")
 
 
-def _run(root: Path, lane: str, event: str, changed: list[str] | None) -> dict:
+def _raw(root: Path, lane: str, event: str, changed: list[str] | None,
+         matrix: list[dict] | None = None, extra: list[str] | None = None):
     argv = [sys.executable, str(Path(__file__).resolve()), "--for", lane,
             "--root", str(root), "--event", event]
     if lane == "modules":
-        argv += ["--modules", json.dumps(_MATRIX)]
+        argv += ["--modules", json.dumps(_MATRIX if matrix is None else matrix)]
     if changed is not None:
         argv += ["--changed-list", ",".join(changed)]
-    proc = subprocess.run(argv, capture_output=True, text=True, timeout=600)
+    argv += extra or []
+    return subprocess.run(argv, capture_output=True, text=True, timeout=600)
+
+
+def _run(root: Path, lane: str, event: str, changed: list[str] | None,
+         matrix: list[dict] | None = None, extra: list[str] | None = None) -> dict:
+    proc = _raw(root, lane, event, changed, matrix, extra)
     if proc.returncode != 0:
         raise SystemExit(f"self-test harness: exit {proc.returncode}\n{proc.stderr}")
     return json.loads(proc.stdout)
@@ -433,8 +520,11 @@ def _run(root: Path, lane: str, event: str, changed: list[str] | None) -> dict:
 def self_test() -> int:
     import tempfile
     failures: list[str] = []
+    ran = 0
 
     def check(name: str, ok: bool, detail: str = "") -> None:
+        nonlocal ran
+        ran += 1
         print(f"  {'✓' if ok else '✗'} {name}{'' if ok else ': ' + detail}")
         if not ok:
             failures.append(name)
@@ -465,10 +555,14 @@ def self_test() -> int:
                 check(f"[{lane}] {label}", got["scope"] == "full" and got["count"] == n,
                       f"scope={got['scope']} count={got['count']} — {got['reason']}")
         for label, changed in (
-                ("src/<file> outside any project (Directory.Build.props) ⇒ ALL",
-                 ["src/Directory.Build.props"]),
-                ("src/<dir> holding no csproj ⇒ ALL", ["src/Loose/notes.txt"]),
-                ("a project that no longer exists (renamed/deleted) ⇒ ALL",
+                # 🚨 This one does NOT go through `unclassified`: `src/Directory.Build.props` has a
+                # single slash, so it never reaches the project graph at all — it is the
+                # TWO-SLASH GUARD that sends it to the global scope. Labelled for what it pins,
+                # because it was labelled for what the case below pins and neither was tested.
+                ("a file directly under src/ (one slash: Directory.Build.props) ⇒ ALL, without "
+                 "ever consulting the project graph", ["src/Directory.Build.props"]),
+                ("src/<dir> holding no csproj ⇒ ALL (via `unclassified`)", ["src/Loose/notes.txt"]),
+                ("a project that no longer exists (renamed/deleted) ⇒ ALL (via `unclassified`)",
                  ["src/Acme.Gone/Gone.cs"])):
             got = _run(root, "modules", "pull_request", changed)
             check(f"[modules] {label}", got["scope"] == "full" and got["count"] == 2,
@@ -546,6 +640,56 @@ def self_test() -> int:
               got["scope"] == "narrowed" and got["selected"] == ["Acme.Beta"],
               f"scope={got['scope']} selected={got['selected']}")
 
+        print("REFUSALS — 'build everything' and 'everything is nothing' cannot both be true:")
+        # 🚨 The bug this pins shipped as a GREEN TICK: an empty universe took the `full` branch,
+        # which set count = len(universe) = 0, and every consumer keys on the count alone — so
+        # both lanes reported success having built nothing. It is a broken input, not a scope.
+        proc = _raw(root, "modules", "pull_request", ["Alpha/index.json"], matrix=[])
+        check("an EMPTY matrix input is refused (exit 2), never answered as full/0",
+              proc.returncode == 2 and "nothing to select from" in proc.stderr,
+              f"exit={proc.returncode}")
+        proc = _raw(root, "packages", "pull_request", ["Alpha/index.json"],
+                    extra=["--root", str(root / "no-such-dir")])
+        check("a --root that is not the checkout is refused, never answered as full/0",
+              proc.returncode != 0 and '"count": 0' not in proc.stdout,
+              f"exit={proc.returncode} stdout={proc.stdout[:120]}")
+
+        print("a PUBLISHING run never narrows, whatever the event:")
+        got = _run(root, "packages", "pull_request", ["Alpha/index.json"], extra=["--publishing"])
+        check("--publishing forces FULL even on a pull_request",
+              got["scope"] == "full" and got["count"] == 3 and "PUBLISHES" in got["reason"],
+              f"scope={got['scope']} count={got['count']}")
+
+        print("a stale matrix entry must fail on THIS PR, not on the next push to main:")
+        ghost = _MATRIX + [{"package": "Alpha", "module": "Acme.Ghost",
+                            "project": "src/Acme.Ghost/Acme.Ghost.csproj"}]
+        got = _run(root, "modules", "pull_request", ["src/Acme.Beta/T.cs"], matrix=ghost)
+        check("an entry whose csproj does not exist ⇒ ALL (it could never be selected)",
+              got["scope"] == "full" and "does not exist" in got["reason"], f"{got['reason'][:90]}")
+        nopkg = _MATRIX + [{"package": "NoSuchPkg", "module": "Acme.Nope",
+                            "project": "src/Acme.Beta/Acme.Beta.csproj"}]
+        got = _run(root, "modules", "pull_request", ["src/Acme.Beta/T.cs"], matrix=nopkg)
+        check("an entry naming a package with no index.json ⇒ ALL",
+              got["scope"] == "full" and "not a node package" in got["reason"],
+              f"{got['reason'][:90]}")
+        # 🚨 UNCONDITIONAL: a diff touching no src/ path must still look at the entry list.
+        got = _run(root, "modules", "pull_request", ["Alpha/index.json"], matrix=ghost)
+        check("…and it is checked even when the diff touches NO src/ path",
+              got["scope"] == "full" and "does not exist" in got["reason"], f"{got['reason'][:90]}")
+
+        print("the NOOP_DIRS copy cannot drift from the caller's unnoticed:")
+        selector_src = (root / "scripts" / "affected-modules.py").read_text(encoding="utf-8")
+        (root / "scripts" / "affected-modules.py").write_text(
+            'NOOP_DIRS = {"legacy", "e2e"}\n' + selector_src, encoding="utf-8")
+        got = _run(root, "modules", "pull_request", ["Alpha/index.json"])
+        check("a NOOP_DIRS that disagrees with the caller's ⇒ ALL, naming both sides",
+              got["scope"] == "full" and "drifted" in got["reason"], f"{got['reason'][:100]}")
+        (root / "scripts" / "affected-modules.py").write_text(selector_src, encoding="utf-8")
+        got = _run(root, "modules", "pull_request", ["WhatsNew/note.md"])
+        check("WhatsNew/ is a NOOP dir — a note-only PR builds NOTHING, not everything",
+              got["scope"] == "narrowed" and got["count"] == 0,
+              f"scope={got['scope']} count={got['count']}")
+
         print("the caller's graphs are load-bearing — every failure of theirs is a FULL run:")
         selector = root / "scripts" / "affected-modules.py"
         for label, body in (
@@ -561,7 +705,20 @@ def self_test() -> int:
         check("[modules] no selector in the caller repo ⇒ ALL",
               got["scope"] == "full" and got["count"] == 2, f"scope={got['scope']}")
         selector.write_text(_STUB_SELECTOR, encoding="utf-8")
-        (root / "scripts" / "project-closure.py").unlink()
+        projects = root / "scripts" / "project-closure.py"
+        graph_src = projects.read_text(encoding="utf-8")
+        for label, body in (
+                ("a project graph that REFUSES", "import sys; sys.exit(1)\n"),
+                ("an unparseable project-graph answer", "not json\n"),
+                ("a project graph that answers for FEWER entries than were asked about",
+                 "import json,sys; json.dump({'entries':{},'unclassified':[],"
+                 "'projects':[],'changedProjects':[]},sys.stdout)\n")):
+            projects.write_text(body, encoding="utf-8")
+            got = _run(root, "modules", "pull_request", ["src/Acme.Beta/T.cs"])
+            check(f"[modules] {label} ⇒ ALL", got["scope"] == "full" and got["count"] == 2,
+                  f"scope={got['scope']} — {got['reason'][:80]}")
+        projects.write_text(graph_src, encoding="utf-8")
+        projects.unlink()
         got = _run(root, "modules", "pull_request", ["src/Acme.Beta/T.cs"])
         check("[modules] no project-closure.py in the caller repo ⇒ ALL",
               got["scope"] == "full" and got["count"] == 2, f"scope={got['scope']}")
@@ -571,9 +728,11 @@ def self_test() -> int:
               "script decides what is NOT rebuilt; a fallback that stops falling back is a stale "
               "assembly the registry keeps serving, or an in-mesh compile break that reaches main.")
         return 1
-    print("\n✓ node-repo-scope self-test: 23 full-run fallbacks, 9 narrowing assertions (the "
-          "last over a REAL git range — a rename must select the end it LEFT), 2 explicit-empty "
-          "answers, 5 caller-graph refusals — all green.")
+    print(f"\n✓ node-repo-scope self-test: {ran} cases green — full-run fallbacks, "
+          "narrowing assertions (one over a REAL git range: a rename must select the end it "
+          "LEFT), two explicit-empty answers, the two REFUSALS that must never render as "
+          "'full, count 0', the stale-matrix-entry guard, the NOOP_DIRS drift guard, the "
+          "publishing guard, and every caller-graph failure mode.")
     return 0
 
 
@@ -587,6 +746,10 @@ def main() -> int:
                    help="the PR base branch — the diff is origin/<base-ref>...HEAD")
     p.add_argument("--changed-list", default=None, dest="changed_list",
                    help="comma-separated changed paths instead of a git diff (tests only)")
+    p.add_argument("--publishing", action="store_true",
+                   help="this run hands its output to a registry or feed — never narrow. The "
+                        "publish path's change detector is the derived version, and a diff that "
+                        "misses a unit means that unit silently never ships.")
     p.add_argument("--self-test", action="store_true", dest="self_test")
     args = p.parse_args()
     if args.self_test:
@@ -611,7 +774,18 @@ def main() -> int:
     say = lambda *a: print(*a, file=sys.stderr)  # noqa: E731
     changed = None if args.changed_list is None else [c for c in args.changed_list.split(",") if c]
     answer = decide(root, args.lane, entries, args.event,
-                    f"origin/{args.base_ref}...HEAD" if args.base_ref else None, changed, say)
+                    f"origin/{args.base_ref}...HEAD" if args.base_ref else None, changed, say,
+                    publishing=args.publishing)
+
+    # 🚨 A refusal is a BROKEN INPUT, not a scope: exit non-zero so the step fails and the job
+    # goes red. Emitting it as an answer is how "build everything, and everything is nothing"
+    # became a green tick in the first place.
+    if answer["scope"] == "refuse":
+        print(f"::error title=Cannot decide the build scope::{answer['reason']}", file=sys.stderr)
+        if os.environ.get("GITHUB_STEP_SUMMARY"):
+            with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+                fh.write(f"### ⛔ Cannot decide the build scope\n\n{answer['reason']}\n\n")
+        return 2
 
     say("")
     say(f"scope: {answer['scope']} — {answer['reason']}")

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -267,6 +267,7 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
             report.append(f"  {f}  → (reaches nothing this lane builds — {top}/)")
         elif f.startswith("src/") and f.count("/") >= 2 and lane == "modules":
             src_files.append(f)
+            report.append(f"  {f}  → src/ (which project decides, below)")
         else:
             global_files.append(f)
             report.append(f"  {f}  → EVERYTHING (tooling / repo-root / unknown scope)")
@@ -320,8 +321,6 @@ def decide(root: Path, lane: str, entries: list[dict], event: str, diff_range: s
             return full(f"{PROJECTS} answered for {len(got or {})} of {len(hits)} entries — "
                         "packing every module.")
         hits = {k: list(v) for k, v in got.items()}
-        for f in src_files:
-            say(f"  {f}  → src/")
 
     selected: list[dict] = []
     why: dict[str, str] = {}

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -200,7 +200,15 @@ def node_packages(root: Path) -> set[str]:
 
 
 def changed_files(root: Path, diff_range: str, say) -> list[str] | None:
-    proc = subprocess.run(["git", "diff", "--name-only", diff_range],
+    """The changed paths, with renames DECOMPOSED into a delete and an add.
+
+    🚨 `--no-renames` is selection logic, not a formatting flag. Git detects renames by default and
+    `--name-only` then prints only the DESTINATION — so a file moved from one module (or one
+    csproj) to another names only the module it arrived in, and the one it LEFT is never selected,
+    even though its build changed. Under-selection is the failure mode this whole script is biased
+    against; decomposing the rename makes both ends appear.
+    """
+    proc = subprocess.run(["git", "diff", "--no-renames", "--name-only", diff_range],
                           cwd=root, capture_output=True, text=True, timeout=120)
     if proc.returncode != 0:
         say("    " + proc.stderr.strip()[-2000:])
@@ -355,7 +363,10 @@ _STUB_PROJECTS = (
     "CLOSURE={'src/Acme.Alpha/Acme.Alpha.csproj':"
     "{'src/Acme.Alpha','src/Acme.Shared','src/Acme.Alpha.Test','src/Acme.Kit'},"
     "'src/Acme.Beta/Acme.Beta.csproj':{'src/Acme.Beta'}}\n"
-    "KNOWN={p for c in CLOSURE.values() for p in c}\n"
+    # Acme.Other is a KNOWN project in NO entry's closure — so a path in it is classified (not
+    # `unclassified`, which would force a full run) and yet selects nothing. That is what makes
+    # the rename case able to tell "both ends" from "destination only".
+    "KNOWN={p for c in CLOSURE.values() for p in c}|{'src/Acme.Other'}\n"
     "a=sys.argv\n"
     "entries=[a[i+1] for i,v in enumerate(a) if v=='--entry']\n"
     "paths=[l for l in open(a[a.index('--changed')+1]).read().splitlines() if l]\n"
@@ -395,7 +406,10 @@ def _fixture(root: Path) -> None:
             ("Acme.Alpha", ["../Acme.Shared/Acme.Shared.csproj"]),
             ("Acme.Alpha.Test", ["../Acme.Alpha/Acme.Alpha.csproj",
                                  "../Acme.Kit/Acme.Kit.csproj"]),
-            ("Acme.Beta", []), ("Acme.Shared", []), ("Acme.Kit", [])):
+            ("Acme.Beta", []), ("Acme.Shared", []), ("Acme.Kit", []),
+            # referenced by NO matrix entry — the destination of the rename case below, chosen so
+            # that "both ends" and "destination only" give DIFFERENT answers.
+            ("Acme.Other", [])):
         d = root / "src" / name
         d.mkdir(parents=True, exist_ok=True)
         (d / f"{name}.csproj").write_text(_csproj(refs), encoding="utf-8")
@@ -496,6 +510,43 @@ def self_test() -> int:
                   got["scope"] == "narrowed" and got["count"] == 0 and got["skipped"],
                   f"scope={got['scope']} count={got['count']}")
 
+        print("renames are DECOMPOSED — the module a file LEFT is selected too:")
+        # A real git fixture, because this case is about what `git diff` prints: with git's
+        # default rename detection `--name-only` names only the destination, and the source
+        # project silently drops out of the selection.
+        import subprocess as sp
+        git = lambda *a: sp.run(["git", *a], cwd=root, capture_output=True, text=True)
+        # 🚨 Three things make this assertion non-vacuous, and each was needed:
+        #   * the moved file exists ON THE BASE — otherwise the diff is a plain add and rename
+        #     detection has nothing to collapse;
+        #   * it moves OUT of a project a matrix entry builds INTO one no entry references, so
+        #     "both ends" (['Acme.Beta']) and "destination only" ([]) differ;
+        #   * a real `origin` remote, because the range this script takes is origin/<base>...HEAD.
+        # Verified by reverting --no-renames: this case then reports [] and goes red.
+        (root / "src" / "Acme.Beta" / "Moved.cs").write_text(
+            "// long enough that git is certain it is the same file\n" * 8, encoding="utf-8")
+        git("init", "-q", ".")
+        git("config", "user.email", "t@t")
+        git("config", "user.name", "t")
+        git("add", "-A")
+        git("commit", "-qm", "base")
+        git("branch", "-M", "main")
+        git("remote", "add", "origin", str(root))
+        git("fetch", "-q", "origin")
+        git("checkout", "-q", "-b", "move")
+        (root / "src" / "Acme.Beta" / "Moved.cs").rename(
+            root / "src" / "Acme.Other" / "Moved.cs")
+        git("add", "-A")
+        git("commit", "-qm", "move it")
+        proc = sp.run([sys.executable, str(Path(__file__).resolve()), "--for", "modules",
+                       "--root", str(root), "--event", "pull_request", "--base-ref", "main",
+                       "--modules", json.dumps(_MATRIX)], capture_output=True, text=True)
+        got = (json.loads(proc.stdout) if proc.returncode == 0
+               else {"scope": f"<exit {proc.returncode}>", "selected": []})
+        check("a file moved between projects selects the module it LEFT, not only the destination",
+              got["scope"] == "narrowed" and got["selected"] == ["Acme.Beta"],
+              f"scope={got['scope']} selected={got['selected']}")
+
         print("the caller's graphs are load-bearing — every failure of theirs is a FULL run:")
         selector = root / "scripts" / "affected-modules.py"
         for label, body in (
@@ -521,8 +572,9 @@ def self_test() -> int:
               "script decides what is NOT rebuilt; a fallback that stops falling back is a stale "
               "assembly the registry keeps serving, or an in-mesh compile break that reaches main.")
         return 1
-    print("\n✓ node-repo-scope self-test: 23 full-run fallbacks, 8 narrowing assertions, "
-          "2 explicit-empty answers, 5 caller-graph refusals — all green.")
+    print("\n✓ node-repo-scope self-test: 23 full-run fallbacks, 9 narrowing assertions (the "
+          "last over a REAL git range — a rename must select the end it LEFT), 2 explicit-empty "
+          "answers, 5 caller-graph refusals — all green.")
     return 0
 
 

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -163,9 +163,16 @@ jobs:
           MODULES: ${{ inputs.modules }}
           EVENT: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
+          # A merge_group run carries no `base_ref`; its base is on the event payload. Dormant
+          # today (no repo here has a queue) and kept correct so enabling one narrows rather than
+          # silently falling back to the full set.
+          QUEUE_BASE_REF: ${{ github.event.merge_group.base_ref }}
         run: |
           set -euo pipefail
           printf '%s' "$MODULES" > "$RUNNER_TEMP/matrix.json"
+          if [ -z "${BASE_REF:-}" ] && [ -n "${QUEUE_BASE_REF:-}" ]; then
+            BASE_REF="${QUEUE_BASE_REF#refs/heads/}"
+          fi
           if [ -n "${BASE_REF:-}" ]; then
             git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           fi
@@ -182,7 +189,10 @@ jobs:
     # run". What makes it safe is that `verify` below runs UNCONDITIONALLY and asserts the pairing
     # — a zero count with receipts, or a non-zero count with a skipped pack job, is RED. Never
     # replace it with a condition that asks whether an input or a secret happens to be set.
-    if: needs.select.outputs.count != '0'
+    # (`select.result` too, not just the count: a FAILED select emits no count at all, and
+    # `'' != '0'` is true — the matrix would then fail to evaluate instead of the verify job
+    # naming the real cause.)
+    if: needs.select.result == 'success' && needs.select.outputs.count != '0'
     strategy:
       # One module's failure must not hide the rest — a sweep wants every verdict in one run.
       fail-fast: false

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -434,9 +434,22 @@ jobs:
           PACK_RESULT: ${{ needs.pack.result }}
           SCOPE: ${{ needs.select.outputs.scope }}
           COUNT: ${{ needs.select.outputs.count }}
+          DECLARED: ${{ inputs.modules }}
         run: |
           set -euo pipefail
           echo "scope=$SCOPE, selection named $COUNT module bundle(s); pack job: $PACK_RESULT"
+          # 🚨 An INDEPENDENT recount, because the count and the selection come from the same
+          # call and therefore agree by construction — they cannot catch a selection that is
+          # simply wrong. This one has a second source: on a FULL scope the answer must be every
+          # entry the CALLER declared, counted here from `inputs.modules` rather than from
+          # anything `select` produced.
+          declared=$(jq 'length' <<< "$DECLARED")
+          if [ "$SCOPE" = "full" ] && [ "$COUNT" != "$declared" ]; then
+            echo "::error title=Module bundles incomplete::the scope is FULL, so every one of the \
+          $declared declared module(s) must be packed — but the selection named $COUNT. The \
+          selection and the caller's matrix disagree."
+            exit 1
+          fi
           # 🚨 `select` itself failing must not read as "nothing was selected" — that would turn a
           # broken selector into a green wall with an empty matrix behind it.
           if [ "${{ needs.select.result }}" != "success" ]; then
@@ -448,4 +461,5 @@ jobs:
           python3 meshweaver/.github/scripts/node-repo-pack-verify.py \
             --expected "$EXPECTED" \
             --receipts "$RUNNER_TEMP/receipts" \
-            --pack-result "$PACK_RESULT"
+            --pack-result "$PACK_RESULT" \
+            --scope "$SCOPE"

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -131,8 +131,15 @@ jobs:
       selected: ${{ steps.scope.outputs.selected }}
       scope: ${{ steps.scope.outputs.scope }}
     steps:
+      # 🚨 The caller goes in its OWN directory, not the workspace root. Node packages are
+      # discovered as "top-level dirs carrying an index.json", and the platform checkout below
+      # lands INSIDE the workspace — clone core to the root beside the caller's content and the
+      # selector is one `index.json` away from treating the framework as a plugin of this repo.
+      # gen-manifests.py already carries "meshweaver" in its SKIP set for exactly this reason;
+      # keeping the two trees apart is the version that cannot rot.
       - uses: actions/checkout@v7
         with:
+          path: repo
           # 🚨 The diff is taken against the PR base, so the base commits must be present. A
           # shallow clone would make every range unresolvable — which the scope script turns into
           # a FULL pack rather than an empty one, but silently paying for 29 jobs is not the plan.
@@ -174,10 +181,11 @@ jobs:
             BASE_REF="${QUEUE_BASE_REF#refs/heads/}"
           fi
           if [ -n "${BASE_REF:-}" ]; then
-            git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+            git -C repo fetch --no-tags origin \
+              "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           fi
           python3 meshweaver/.github/scripts/node-repo-scope.py \
-            --for modules --root . --modules "@$RUNNER_TEMP/matrix.json" \
+            --for modules --root repo --modules "@$RUNNER_TEMP/matrix.json" \
             --event "$EVENT" --base-ref "${BASE_REF:-}" > "$RUNNER_TEMP/scope.json"
 
   pack:

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -48,6 +48,30 @@ name: node-repo module pack
 #             || github.event_name == 'schedule' }}
 #     secrets: { publish-token: ${{ secrets.PLUGIN_REGISTRY_PUBLISH_TOKEN }} }
 #
+# ─────────────────────────── Narrowing (the `select` job) ───────────────────────────
+# 🚨 "in plugins we only re-run concerned modules ⇒ we can estimate the required count and
+# validate it" · "all plugins should only re-build what changed" · "there is always a notion of
+# 'full rebuild' when the platform updates".
+#
+# The matrix is no longer the caller's literal list on every event: `select` runs
+# .github/scripts/node-repo-scope.py over the diff and hands `pack` the entries it can reach.
+# MeshWeaver.Plugins ran 29 module builds on every push of every PR, whichever file moved.
+#
+# 🚨 ONLY `pull_request` / `merge_group` NARROW. A push, a framework-release dispatch, the release
+# poll and a manual dispatch all pack the FULL set — a module is built against a platform pin, and
+# when that pin moves every bundle must be rebuilt and republished or every portal reads
+# FrameworkDeclined and adopts nothing (#2088). The scope script names which fallback it took, in
+# the log and in the job summary; every uncertainty resolves to FULL.
+#
+# 🚨 AND THE COUNT IS ASSERTED. A dynamic matrix cannot be a fixed list of required contexts — the
+# per-module contexts come and go with the diff — so the SELECTION is what gets checked instead:
+# every pack job drops a receipt, and `verify` (one stable context, present on every run) fails if
+# the receipts and the selection disagree. That is invariant #4 for a matrix allowed to change
+# size, and it is the only reason a narrowed matrix is safe to require.
+#
+# A caller that ships neither scripts/affected-modules.py nor scripts/project-closure.py is simply
+# not narrowable: the scope script says FULL and says why. Nothing to opt into, nothing to skip.
+#
 # Republishing is SAFE to repeat, which is why the schedule may simply publish rather than
 # first proving something changed: the registry is keyed by `{package}@{version}` from
 # `manifest.lock`, so a rebuild of an unchanged version overwrites the same slot with equivalent
@@ -95,14 +119,75 @@ on:
         required: false
 
 jobs:
+  # ─────────────────────── WHICH BUNDLES THIS DIFF CAN REACH ───────────────────────
+  # One place decides, out loud. It never skips a gate: its two answers are "pack these" and
+  # "pack everything", and it takes the second whenever it cannot be sure of the first.
+  select:
+    name: Select the affected bundles
+    runs-on: ubuntu-latest
+    outputs:
+      modules: ${{ steps.scope.outputs.modules }}
+      count: ${{ steps.scope.outputs.count }}
+      selected: ${{ steps.scope.outputs.selected }}
+      scope: ${{ steps.scope.outputs.scope }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # 🚨 The diff is taken against the PR base, so the base commits must be present. A
+          # shallow clone would make every range unresolvable — which the scope script turns into
+          # a FULL pack rather than an empty one, but silently paying for 29 jobs is not the plan.
+          fetch-depth: 0
+      # The scope script is the PLATFORM's (one implementation, every repo), read from the same
+      # checkout the pack jobs make at platform-ref — so a workflow newer than the checkout can
+      # never call a script the checkout does not have (run 33073476996's exact failure).
+      - name: Check out Systemorph/MeshWeaver at the pinned ref
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.platform-ref }}
+          path: meshweaver
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      # 🚨 The selection logic owes its own proof that it can say no AND that every fallback still
+      # falls back. It runs here, on every run, next to the answer it produces — a selector whose
+      # self-test is only run by someone remembering to is a selector nobody checks.
+      - name: The selection can say no (self-test)
+        run: |
+          set -euo pipefail
+          python3 meshweaver/.github/scripts/node-repo-scope.py --self-test
+          python3 meshweaver/.github/scripts/node-repo-pack-verify.py --self-test
+      - name: Decide which module bundles this diff can reach
+        id: scope
+        env:
+          MODULES: ${{ inputs.modules }}
+          EVENT: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          printf '%s' "$MODULES" > "$RUNNER_TEMP/matrix.json"
+          if [ -n "${BASE_REF:-}" ]; then
+            git fetch --no-tags origin "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          fi
+          python3 meshweaver/.github/scripts/node-repo-scope.py \
+            --for modules --root . --modules "@$RUNNER_TEMP/matrix.json" \
+            --event "$EVENT" --base-ref "${BASE_REF:-}" > "$RUNNER_TEMP/scope.json"
+
   pack:
     name: Module bundle (${{ matrix.entry.module }})
+    needs: select
     runs-on: ubuntu-latest
+    # 🚨 This is a MODE SWITCH on the selection's own output, not a skip-trapdoor: GitHub refuses
+    # a matrix with no vectors, so an empty selection has to express itself as "this job does not
+    # run". What makes it safe is that `verify` below runs UNCONDITIONALLY and asserts the pairing
+    # — a zero count with receipts, or a non-zero count with a skipped pack job, is RED. Never
+    # replace it with a condition that asks whether an input or a secret happens to be set.
+    if: needs.select.outputs.count != '0'
     strategy:
       # One module's failure must not hide the rest — a sweep wants every verdict in one run.
       fail-fast: false
       matrix:
-        entry: ${{ fromJson(inputs.modules) }}
+        entry: ${{ fromJson(needs.select.outputs.modules) }}
     steps:
       - uses: actions/checkout@v7
       - name: Check out Systemorph/MeshWeaver at the pinned ref
@@ -266,3 +351,83 @@ jobs:
             2*) echo "$MODULE@$VERSION is now served by $REGISTRY" ;;
             *)  echo "::error::registry refused $MODULE@$VERSION (HTTP $code)"; exit 1 ;;
           esac
+
+      # ─────────────────────────── THE RECEIPT ───────────────────────────
+      # 🚨 POSITIVE EVIDENCE THAT THIS LEG RAN. A skipped matrix leg renders with the same tick as
+      # a passed one, so "this module was never packed" and "this module packed fine" are
+      # indistinguishable on the checks wall — and a matrix whose size depends on a diff makes
+      # that failure mode reachable rather than theoretical. `verify` counts these against the
+      # selection and names whatever is missing. It is the LAST step on purpose: a receipt means
+      # the whole leg, publish included, got here.
+      - name: Drop the receipt
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/receipts"
+          jq -n --arg p "${{ matrix.entry.package }}" --arg m "${{ matrix.entry.module }}" \
+                --arg v "${{ steps.identity.outputs.version }}" \
+                --argjson pub '${{ inputs.publish }}' \
+             '{package:$p, module:$m, version:$v, published:$pub}' \
+             > "$RUNNER_TEMP/receipts/${{ matrix.entry.module }}.json"
+          cat "$RUNNER_TEMP/receipts/${{ matrix.entry.module }}.json"
+      - name: Upload the receipt
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-pack-receipt-${{ matrix.entry.module }}
+          path: ${{ runner.temp }}/receipts/*.json
+          if-no-files-found: error
+
+  # ═══════════════ THE COUNT GATE — one STABLE context, on every run ═══════════════
+  # 🚨 A dynamic matrix cannot be a fixed list of required status checks: the per-module contexts
+  # appear and disappear with the diff, so requiring one means requiring a context that will
+  # legitimately never report — which is how a gate ends up not required at all and PRs merge past
+  # it. This job is the answer: it is present on EVERY run whatever the diff, so it is the one
+  # context a repo's protection should require for this lane, and it asserts that exactly the
+  # selected bundles were built.
+  #
+  # `if: always()` because the failure it exists to catch is a SKIP, and a job that skips when the
+  # thing it watches skipped watches nothing.
+  verify:
+    name: All selected bundles built
+    needs: [select, pack]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out Systemorph/MeshWeaver at the pinned ref
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.platform-ref }}
+          path: meshweaver
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+      # Absent receipts are the finding, so a download that matches nothing must NOT fail here —
+      # it must reach the verifier, which says which module is missing. That is the whole point.
+      - name: Collect the receipts
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          pattern: module-pack-receipt-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/receipts
+      - name: Exactly the selected bundles were built
+        env:
+          EXPECTED: ${{ needs.select.outputs.selected }}
+          PACK_RESULT: ${{ needs.pack.result }}
+          SCOPE: ${{ needs.select.outputs.scope }}
+          COUNT: ${{ needs.select.outputs.count }}
+        run: |
+          set -euo pipefail
+          echo "scope=$SCOPE, selection named $COUNT module bundle(s); pack job: $PACK_RESULT"
+          # 🚨 `select` itself failing must not read as "nothing was selected" — that would turn a
+          # broken selector into a green wall with an empty matrix behind it.
+          if [ "${{ needs.select.result }}" != "success" ]; then
+            echo "::error title=Module bundles incomplete::the selection job reported \
+          '${{ needs.select.result }}' — no module bundle was chosen, so none was built. Read that \
+          job; nothing below can be trusted."
+            exit 1
+          fi
+          python3 meshweaver/.github/scripts/node-repo-pack-verify.py \
+            --expected "$EXPECTED" \
+            --receipts "$RUNNER_TEMP/receipts" \
+            --pack-result "$PACK_RESULT"

--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -73,7 +73,13 @@ on:
         required: true
         type: string
       meshweaver-ref:
-        description: Ref of Systemorph/MeshWeaver to build the plugin-build tool from.
+        description: >
+          Ref of Systemorph/MeshWeaver to build the plugin-build tool from — and, since the
+          narrowing landed, to read .github/scripts/node-repo-scope.py from. 🚨 PIN IT TO A COMMIT
+          THAT HAS BOTH: a caller using this workflow at a ref NEWER than its `meshweaver-ref`
+          calls a script that checkout does not have, and the run dies in the scope step instead
+          of anywhere that names the cause (run 33073476996's exact failure, one lane over). The
+          default keeps the two in step; if you pin one, pin both.
         required: false
         default: main
         type: string

--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -167,8 +167,15 @@ jobs:
             git -C plugins fetch --no-tags origin \
               "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
           fi
+          # 🚨 `--publishing` when this run PUSHES, whatever the event. `merge_group` is a
+          # narrowable event, and the push step below is gated only on `dry-run` — so a caller
+          # with a merge queue and `dry-run: false` would have published a narrowed subset,
+          # contradicting the very argument this lane's header makes about the version being the
+          # change detector on the publish path. Belt on the reusable side, where it cannot be
+          # forgotten by a caller.
           python3 meshweaver/.github/scripts/node-repo-scope.py \
             --for packages --root plugins \
+            ${{ inputs.dry-run && ' ' || '--publishing' }} \
             --event "$EVENT" --base-ref "${BASE_REF:-}" > "$RUNNER_TEMP/scope.json"
 
       - name: Build the tool
@@ -185,6 +192,22 @@ jobs:
           failed=()
           packed=0
           echo "scope=$SCOPE — the selection names $EXPECTED plugin(s)"
+          # 🚨 An INDEPENDENT recount. `$EXPECTED` and `$SELECTED` come from the same call and
+          # agree by construction, so on their own they can only catch a lost output — never a
+          # selection that is simply wrong. On a FULL scope there IS a second source: the tree.
+          if [ "$SCOPE" = "full" ]; then
+            onDisk=$(find plugins -mindepth 2 -maxdepth 2 -name index.json | wc -l | tr -d " ")
+            if [ "$onDisk" != "$EXPECTED" ]; then
+              echo "::error title=Pack count does not match the tree::the scope is FULL, so every \
+          plugin in the checkout must be packed — the tree holds $onDisk and the selection named \
+          $EXPECTED."
+              exit 1
+            fi
+            echo "full scope cross-checked against the tree: $onDisk plugin(s)"
+          fi
+          # The loop word-splits $SELECTED deliberately; globbing is NOT wanted, and it is the one
+          # way `seen` could exceed the count for a reason that is not a real discrepancy.
+          set -f
           for name in $SELECTED; do
             plugin="plugins/$name"
             # 🚨 NOT `|| continue`. The old loop globbed the tree and skipped anything without an
@@ -209,7 +232,14 @@ jobs:
             fi
             echo "::endgroup::"
           done
+          set +f
           echo "packed $packed plugin(s) of $EXPECTED selected"
+          # Written BEFORE the failure branches: a red run is the one whose summary matters.
+          {
+            echo "### 📦 Packed $packed of $EXPECTED selected plugin(s) — scope \`$SCOPE\`"
+            echo ""
+            echo "\`${SELECTED:-(nothing)}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
           # ══════════════ THE COUNT GATE ══════════════
           # 🚨 "we can estimate the required count and validate it." A loop over a list that came
           # out empty, short, or mis-parsed packs less than it should and exits 0 — a green tick
@@ -228,11 +258,6 @@ jobs:
             echo "::error::packing failed for: ${failed[*]} — nothing was pushed"
             exit 1
           fi
-          {
-            echo "### 📦 Packed $packed of $EXPECTED selected plugin(s) — scope \`$SCOPE\`"
-            echo ""
-            echo "\`$SELECTED\`"
-          } >> "$GITHUB_STEP_SUMMARY"
 
       # Reached only when EVERY plugin packed. A content-only plugin produces no package and that
       # is a success, so an empty directory is not an error — but it must be SAID, or "published

--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -178,7 +178,6 @@ jobs:
           mkdir -p "$RUNNER_TEMP/nupkgs"
           failed=()
           packed=0
-          attempted=0
           echo "scope=$SCOPE — the selection names $EXPECTED plugin(s)"
           for name in $SELECTED; do
             plugin="plugins/$name"
@@ -191,7 +190,6 @@ jobs:
               failed+=("$name")
               continue
             fi
-            attempted=$((attempted + 1))
             echo "::group::$name"
             if dotnet run --project meshweaver/src/MeshWeaver.Plugin.Build -c Release --no-build -- \
                  "$plugin" \

--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -151,8 +151,12 @@ jobs:
         env:
           EVENT: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
+          QUEUE_BASE_REF: ${{ github.event.merge_group.base_ref }}
         run: |
           set -euo pipefail
+          if [ -z "${BASE_REF:-}" ] && [ -n "${QUEUE_BASE_REF:-}" ]; then
+            BASE_REF="${QUEUE_BASE_REF#refs/heads/}"
+          fi
           if [ -n "${BASE_REF:-}" ]; then
             git -C plugins fetch --no-tags origin \
               "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"

--- a/.github/workflows/plugin-publish.yml
+++ b/.github/workflows/plugin-publish.yml
@@ -8,6 +8,9 @@ name: Plugin Publish
 # See Doc/Architecture/PluginPackaging.
 #
 # ═══════════════════ WHY EVERY PLUGIN, EVERY MERGE ═══════════════════
+# 🚨 Read this heading literally: EVERY MERGE. A `pull_request` run narrows (see the next block);
+# a push, a dispatch and a schedule do not, and the paragraph below is the reason.
+#
 # There is no changed-plugin detection here, and that is deliberate rather than lazy. A module's
 # PATCH is DERIVED by gen-manifests.py from its content hash: the version changes when, and only
 # when, the tree changes. So publishing every plugin with `--skip-duplicate` publishes exactly the
@@ -18,6 +21,32 @@ name: Plugin Publish
 # mode is silent: a plugin the diff misses simply never ships, at a version nobody notices is
 # absent until an install resolves the old content.
 #
+# ═════════════════ …AND WHY A PULL REQUEST IS DIFFERENT ═════════════════
+# "all plugins should only re-build what changed."
+#
+# The argument above is about PUBLISHING: a diff that misses a plugin means that plugin silently
+# never ships. On a `pull_request` NOTHING is published — for MeshWeaver.Plugins the whole lane is
+# `dry-run: true` by design — so the failure mode the version-as-change-detector protects against
+# cannot occur. What a PR run buys is the COMPILE GATE: it is the only thing that type-checks
+# in-mesh NodeType C# against the newest RELEASED framework, which is a different compiler input
+# from `compile-check.py --image`.
+#
+# That gate still has to be exhaustive against a MOVING FLOOR — a package that did not change can
+# stop compiling when the published framework advances. But the floor moves relative to the trunk,
+# not relative to a PR base, and the unnarrowed `push` re-packs every plugin on every merge. So:
+#
+#   pull_request / merge_group → the affected closure (changed plugins + every dependent)
+#   push, dispatch, schedule   → EVERY plugin, exhaustively
+#
+# …which is the same rule the module lane runs (node-repo-module-pack.yml), computed by the same
+# script (.github/scripts/node-repo-scope.py), whose every uncertainty resolves to the full set and
+# says which fallback it took. Measured on MeshWeaver.Plugins: 53 packages packed per run, `Store`
+# alone 17 compilation units; a PR touching one plugin now packs one.
+#
+# 🚨 The count is ASSERTED, not assumed: the loop below counts what it actually packed and fails if
+# that is not exactly what the selection named. A pack loop that silently iterated an empty list
+# would otherwise be a green tick over a gate that ran on nothing.
+
 # ══════════════════ WHAT THE PACK-THEN-PUSH ORDER BUYS ══════════════════
 # Every plugin is PACKED before any is PUSHED, so a BUILD failure ships nothing. That is the whole
 # guarantee, and it is worth being precise about, because it is weaker than the image pipeline's.
@@ -89,6 +118,10 @@ jobs:
         uses: actions/checkout@v7
         with:
           path: plugins
+          # 🚨 The affected closure diffs against the PR base — a shallow clone makes that range
+          # unresolvable, which the scope script turns into a full pack rather than an empty one,
+          # but paying for 53 packs silently is not the plan.
+          fetch-depth: 0
 
       - name: Checkout MeshWeaver (for the plugin-build tool)
         uses: actions/checkout@v7
@@ -102,18 +135,59 @@ jobs:
         with:
           dotnet-version: '10.x'
 
+      - uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      # ─────────────────── WHICH PLUGINS THIS RUN MUST PACK ───────────────────
+      # One script, shared with the module lane, biased to FULL: a push/dispatch/schedule, a
+      # tooling change, a refusal from the caller's own selector, or an empty diff all resolve to
+      # every plugin, naming which fallback was taken in the log and the job summary.
+      - name: The selection can say no (self-test)
+        run: python3 meshweaver/.github/scripts/node-repo-scope.py --self-test
+
+      - name: Decide which plugins this run must pack
+        id: scope
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          if [ -n "${BASE_REF:-}" ]; then
+            git -C plugins fetch --no-tags origin \
+              "+refs/heads/$BASE_REF:refs/remotes/origin/$BASE_REF"
+          fi
+          python3 meshweaver/.github/scripts/node-repo-scope.py \
+            --for packages --root plugins \
+            --event "$EVENT" --base-ref "${BASE_REF:-}" > "$RUNNER_TEMP/scope.json"
+
       - name: Build the tool
         run: dotnet build meshweaver/src/MeshWeaver.Plugin.Build/MeshWeaver.Plugin.Build.csproj -c Release
 
-      - name: Pack every plugin
+      - name: Pack the selected plugins
+        env:
+          SELECTED: ${{ steps.scope.outputs.packages }}
+          EXPECTED: ${{ steps.scope.outputs.count }}
+          SCOPE: ${{ steps.scope.outputs.scope }}
         run: |
           set -uo pipefail
           mkdir -p "$RUNNER_TEMP/nupkgs"
           failed=()
           packed=0
-          for plugin in plugins/*/; do
-            [ -f "$plugin/index.json" ] || continue
-            name=$(basename "$plugin")
+          attempted=0
+          echo "scope=$SCOPE — the selection names $EXPECTED plugin(s)"
+          for name in $SELECTED; do
+            plugin="plugins/$name"
+            # 🚨 NOT `|| continue`. The old loop globbed the tree and skipped anything without an
+            # index.json, which is correct for a glob and wrong for a selection: a named plugin
+            # that cannot be packed must be a failure, or the count below would silently agree
+            # with a shorter run.
+            if [ ! -f "$plugin/index.json" ]; then
+              echo "::error::the selection named '$name' but $plugin/index.json does not exist"
+              failed+=("$name")
+              continue
+            fi
+            attempted=$((attempted + 1))
             echo "::group::$name"
             if dotnet run --project meshweaver/src/MeshWeaver.Plugin.Build -c Release --no-build -- \
                  "$plugin" \
@@ -127,11 +201,30 @@ jobs:
             fi
             echo "::endgroup::"
           done
-          echo "packed $packed plugin(s)"
+          echo "packed $packed plugin(s) of $EXPECTED selected"
+          # ══════════════ THE COUNT GATE ══════════════
+          # 🚨 "we can estimate the required count and validate it." A loop over a list that came
+          # out empty, short, or mis-parsed packs less than it should and exits 0 — a green tick
+          # over a compile gate that compiled nothing. The estimate is the selection; this is the
+          # validation, and it runs before the failure report so a miscount is never masked by a
+          # genuine build failure.
+          seen=$((packed + ${#failed[@]}))
+          if [ "$seen" != "$EXPECTED" ]; then
+            echo "::error title=Pack count does not match the selection::the selection named \
+          $EXPECTED plugin(s) and this loop reached $seen. Nothing here may silently pack less \
+          than was selected — a compile gate that ran on fewer packages than it reported is the \
+          failure this check exists for. Selected: $SELECTED"
+            exit 1
+          fi
           if [ ${#failed[@]} -gt 0 ]; then
             echo "::error::packing failed for: ${failed[*]} — nothing was pushed"
             exit 1
           fi
+          {
+            echo "### 📦 Packed $packed of $EXPECTED selected plugin(s) — scope \`$SCOPE\`"
+            echo ""
+            echo "\`$SELECTED\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       # Reached only when EVERY plugin packed. A content-only plugin produces no package and that
       # is a success, so an empty directory is not an error — but it must be SAID, or "published


### PR DESCRIPTION
## The measurement

Two lanes fanned out over the whole repo on every push of every PR. Measured on `MeshWeaver.Plugins` this morning, they were **29 of the 31 queued runs** on that repo, while two clean, zero-failure PRs sat on six pending checks each:

| lane | what it did per run | cost |
|---|---|---|
| `Plugin Catalog CI` → `modules` → `node-repo-module-pack.yml` | a **hardcoded literal 29-entry matrix**, on every event | 29 jobs per PR push |
| `Publish Plugin Packages` → `plugin-publish.yml` | `for plugin in plugins/*/` | **53 packages** in one job (`Store` alone = 17 compilation units) |

`scripts/affected-modules.py` already computed a closure — and was wired only to the mesh gate and the bake.

## What this changes

Both lanes now ask one script, `.github/scripts/node-repo-scope.py`, what the diff can reach.

**Only `pull_request` / `merge_group` narrow.** `push`, `repository_dispatch`, `schedule` and `workflow_dispatch` build the FULL set — a module is built against a platform PIN, and when that pin moves every bundle must be rebuilt and republished or every portal reads `FrameworkDeclined` and adopts nothing (#2088). The pack lane's value is that same property from the compile side: a package that did not change can stop compiling when the published framework advances.

**`push` is full for a second, separate reason.** The baseline a *publishing* run must diff against is its own publication, never `github.event.before` (which silently under-builds after any cancelled, superseded, red or re-run commit). `bake-scope.sh` has that marker — `source-commit.txt`, sealed beside the bundles. **The module lane has none**: the registry is keyed `{package}@{version}` from `manifest.lock`, and that version identifies only the CONTENT half, so a `src/`-only change repacks the same version with different bytes. Narrowing a push needs that marker first; noted in the script.

## Two halves, because a bundle has two

- **content** — the caller's own affected closure, `scripts/affected-modules.py`, **invoked rather than reimplemented**.
- **compiled** — the caller's `scripts/project-closure.py`: the csproj, its transitive in-repo `ProjectReference`s, and the sibling `.Test` project this lane runs. `affected-modules.py` cannot answer this — it says ALL modules for any `src/` path, which is right for the mesh gate and useless for a matrix whose entries ARE projects.

Both graphs live in the CALLER repo because the edges are the caller's content — the split `bake-scope.sh` already uses. A repo shipping neither is simply not narrowable: the scope script answers FULL and says why. Nothing to opt into, nothing that can silently skip.

`project-closure.py` is deliberately a **shared** answer, not a private helper: Systemorph/MeshWeaver.Plugins#878 (a mixed package's `src/`-only change moves no version, so the rebuilt bundle is shelved and no existing portal ever asks for it) needs the same graph for its version gate.

## The count is asserted — and it is the context to require

🚨 A narrowed fan-out **cannot** be a required status check: the per-module contexts appear and disappear with the diff, so requiring one means requiring a context that will legitimately never report — which is how a lane ends up with no required gate at all.

So the SELECTION is what gets checked. Every pack leg drops a receipt as its **last** step; a new final job — **`All selected bundles built`**, present on every run whatever the diff, `if: always()` — fails when the receipts and the selection disagree: a selected bundle with no receipt, a receipt nobody selected, a non-empty selection whose pack job never ran, a failed or failing `select`. The pack lane asserts the same thing inline.

## Evidence

Both new scripts carry `--self-test` and **both run it in CI, in the job that produces the answer**:

- `node-repo-scope.py --self-test` — 23 full-run fallbacks, 8 narrowing assertions, 2 explicit-empty answers, 5 caller-graph refusals.
- `node-repo-pack-verify.py --self-test` — 2 green-run assertions and **7 mutations of that green run** (remove a receipt, add an unexpected one, skip the pack job, fail it, corrupt a receipt, mismatch its name, lose the whole directory) that must each turn red *and name what they found*, plus 2 empty-selection cases.

Measured narrowing on `MeshWeaver.Plugins`' real 29-entry matrix, over real git ranges:

| changed path | before | after |
|---|---|---|
| `src/MeshWeaver.OgCard/OgCard.cs` | 29 | **2** (OgCard, and Export whose `.Test` references it) |
| `src/MeshWeaver.Markdown.Export.Test/**` | 29 | **1** |
| `src/MeshWeaver.AI/**` | 29 | 15 |
| `src/MeshWeaver.Blazor/**` | 29 | 13 |
| `Chess/index.json` | 29 | **0** |
| `AI/index.json` | 29 | 2 |
| `Store/Plugin/Source/**` | 29 | 29 — Store really is a universal dependency |
| `src/Directory.Packages.props`, `.github/**`, `scripts/**`, a repo-root file | 29 | 29, with the fallback **named** in the log and the job summary |

## Blast radius

- `node-repo-module-pack.yml` — called by `MeshWeaver.Plugins` (`@main`, 29 entries) and `MeshWeaver.SocialMedia` (pinned at `89f8862`, so unaffected until its pins are bumped together).
- `plugin-publish.yml` — called by `MeshWeaver.Plugins` only (`@main`).
- No other satellite calls either lane; each falls back to FULL if it ships neither graph.

**Required contexts:** neither repo requires any module-bundle context today (measured: `MeshWeaver.Plugins` requires `Validate node repos`, `Compile every NodeType (vs core)`, `Compile + render node repos (MeshWeaver from ACR)`; SocialMedia the same three, path-prefixed). So nothing breaks. The follow-up ask is that `Module bundles / All selected bundles built` be **added** — that is a branch-protection edit and therefore the maintainer's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
