### PR TITLE
One page for module versioning, and every AGENTS.md points at it

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,6 +125,8 @@ All docs are embedded in `src/MeshWeaver.Documentation/` and served under `Doc/`
 
 📘 **The full manual — what you author, what the build derives, the `src/` blind spot, and the closure boundary — is [Module Versioning](src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md) (`get Doc/Architecture/ModuleVersioning`). Read it before bumping anything.**
 
+🚦 **Before trusting a green wall or debugging a red: [Reading CI Signals](src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md) (`get Doc/Architecture/ReadingCiSignals`) — `SKIPPED` and *absent* required contexts count as SATISFIED, a red on a non-required check does not block, and the i18n mirror reds every Plugins PR until it lands. A required context counts only when it reads literally `=SUCCESS`.**
+
 ## 🌍🌍🌍 ALWAYS think about internationalization — every user-visible string, every time
 
 **Before you write ANY text a user will read, stop and ask: "how does this render for a German viewer?"** This is part of writing the feature, not a follow-up ticket. The portal ships English + German; **a hard-coded UI string is a bug** — buttons, labels, tooltips, `aria-label`s, placeholders, page titles, empty states, validation messages, toasts, dialog copy, menu entries, settings tabs, notification text and errors alike.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,8 @@ All docs are embedded in `src/MeshWeaver.Documentation/` and served under `Doc/`
 
 **Hub-handler test hangs or a message disappears:** read [DebuggingMessageFlow.md](src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md) first — never rerun a hung test "to see". **`type 'X' is not registered in this hub's TypeRegistry`:** the fix is `WithType(typeof(X), nameof(X))` on the receiving hub. **Use `hub.Observe(...)`, not `RegisterCallback`/`AwaitResponse`** — those overloads are `[Obsolete]` and deadlock.
 
+📘 **The full manual — what you author, what the build derives, the `src/` blind spot, and the closure boundary — is [Module Versioning](src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md) (`get Doc/Architecture/ModuleVersioning`). Read it before bumping anything.**
+
 ## 🌍🌍🌍 ALWAYS think about internationalization — every user-visible string, every time
 
 **Before you write ANY text a user will read, stop and ask: "how does this render for a German viewer?"** This is part of writing the feature, not a follow-up ticket. The portal ships English + German; **a hard-coded UI string is a bug** — buttons, labels, tooltips, `aria-label`s, placeholders, page titles, empty states, validation messages, toasts, dialog copy, menu entries, settings tabs, notification text and errors alike.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
@@ -1,0 +1,151 @@
+---
+Name: Module Versioning
+Category: Architecture
+Description: How a package's version is decided — what you author, what the build derives, why an unchanged version means "delivered to nobody", and the one blind spot that made twelve packages undeliverable.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v6m0 8v6M4.9 4.9l4.2 4.2m5.8 5.8l4.2 4.2M2 12h6m8 0h6M4.9 19.1l4.2-4.2m5.8-5.8l4.2-4.2"/></svg>
+---
+
+# Module Versioning
+
+**A package's version is not decoration. It is the ONLY thing that decides whether anything you
+built reaches a portal that already has an older copy.** Get it wrong and the pipeline stays green,
+the bytes reach the shelf, and no installation ever asks for them.
+
+This page is the authoring reference for that number. For the *node* revision counter — a different
+number entirely — see [MeshNode Versioning](MeshNodeVersioning). For what a module IS and how a
+deployment activates one, see [Modules](Modules).
+
+## The three numbers, and who owns each
+
+| number | lives in | owned by |
+|---|---|---|
+| **MAJOR.MINOR** — the series | the package root's `index.json` → `content.version` | **you**, by hand |
+| **PATCH** | `manifest.lock` → `version` | **the build** (`gen-manifests.py`), never you |
+| **`moduleVersion`** — a content hash | `manifest.lock` | the build. Unordered; nothing can pin against it |
+
+You author a series. The build derives the patch against the last published release and settles it
+on `main` in `tag-modules`, so a branch never races the trunk for a number.
+
+- **Bump the MINOR for a feature. Bump the MAJOR for a break.** That is the whole authoring rule.
+- 🚨 **Never hand-edit the PATCH.** It is derived. A hand-set patch is a claim about a tree you did
+  not measure.
+- 🚨 **Never commit a node's `version` field.** That is `MeshNode.Version`, the owner's persistence
+  clock — not authorable content. A committed counter collides with the durable row on a fresh
+  mesh, `MonotonicWriteGuard` refuses the write, and the symptom surfaces four causal steps away as
+  *"never reached compilationStatus Ok"*. Strip `version`, `lastModified` and `lastModifiedBy` from
+  anything you copy out of a live mesh.
+- 🚨 **A published version describes exactly one tree, forever.** `tag-modules.py` refuses to move
+  an existing tag onto different content. Bump; never re-cut.
+
+## Why an unchanged version means "delivered to nobody"
+
+Module delivery is keyed on **SemVer and nothing else**. Two independent gates close on an unchanged
+version, and neither looks at the bytes:
+
+- `ModuleUpdateDecision` — `landedComparison == 0` → `SkipUpToDate`. The verdict is taken **before
+  any download**, and the fetch carries no `If-None-Match`, so there is no byte-level fallback.
+- `CatalogLayoutAreas` — the manual **Update** button returns `InstallResult(0, 0)` on
+  `ModuleVersion` equality, **before** the module half is even composed. The human override does not
+  override.
+
+CI still rebuilds the assembly and POSTs it to `bundles/<Package>?version=<unchanged>`. The shelf is
+correct. Nobody requests it. **A fresh install gets the new code; every existing portal keeps the old
+one forever** — and the repo, CI and the registry all look green. This is
+[MERGED is not delivered](DeployingPluginChanges) one layer down.
+
+## 🚨 The blind spot: `src/` and mixed packages
+
+A **mixed package** declares `content.module` and ships an assembly built from `src/`.
+
+`gen-manifests.py` enumerates packages with `plugin_dirs()`, which skips a fixed set:
+
+```python
+SKIP = {"src", "test", "scripts", "tools", "e2e", "app", "clients", "meshweaver", ...}
+```
+
+That skip is deliberate and correct for *enumeration* — `src/` is not a package, and skipping it is
+what keeps this gate independent of step order and of `validate-repos.py`. **Do not "fix" this by
+deleting `"src"` from `SKIP`.** That changes what `moduleVersion` means for every package.
+
+The defect was narrower: for a mixed package, the module's own source under `src/` was **never hashed
+into `moduleVersion`** — so a change confined to `src/` moved **no version, by construction**, and was
+therefore built, shelved and delivered to nobody.
+
+Measured on 2026-08-29: **12 of 29 mixed packages** were in exactly that state. The worst was the AI
+engine itself — `AI/manifest.lock` on `main` was byte-identical to the tag `AI/v1.0.0`
+(`version 1.0.0`, `moduleVersion be7ff235b95fb8e4`) across **205 changed `src/` files**. Since
+`MeshWeaver.AI` left the portal image, the module bundle is its only delivery channel, and
+`Agent/` + `Skill/` content ships as embedded resources inside that assembly — so an edit to a
+built-in agent reached nobody, silently.
+
+**The fix belongs in the derivation, not in a checklist.** For a package declaring
+`content.module`, the hash must cover what actually ships in that bundle, so a `src/`-only change
+moves the hash, moves the derived patch, and is delivered. Nothing to remember.
+
+### What "what actually ships" means — the closure is narrower than the reference graph
+
+Do not hash the whole dependency network. A bundle's contents are decided by `DepsClosure.Derive`,
+which walks the module's own `deps.json` from its direct references and **stops at `MeshWeaver.*`
+nodes** — those are never bundled, because a bundled copy would shadow the one in `/app`. Diamonds
+ride deliberately: `/app` wins in the default load context while the platform carries a copy, and
+the module's copy takes over when the platform sheds it, which is what lets platform slim-downs
+land with no re-land coordination.
+
+So for a mixed package the hash should cover:
+
+| | in the hash? | why |
+|---|---|---|
+| the module project's own sources | **yes** | they are the assembly |
+| the module's `.csproj` | **yes** | it pins package versions, and a NuGet bump changes the shipped bundle |
+| non-`MeshWeaver.*` transitive deps | **yes**, by resolved version | they are bundled alongside the module |
+| `MeshWeaver.*` project references | **no** | never bundled — they ship in their own bundles or come from `/app`, so changing one does not change this module's bytes |
+
+That last row is the one worth stating out loud: **a change to `MeshWeaver.AI` does not require
+bumping `MeshWeaver.AI.OpenAI`.** Modules bind platform types by simple assembly name, so the
+dependent's bytes are unchanged; `MeshWeaver.AI` ships its own bundle at its own version. Bumping
+every dependent would be busywork that also destroys the signal in the version number.
+
+The ProjectReference walker for this already exists — see `scripts/check-surface-manifest.py`
+(`assembly names reachable from start through ProjectReference`) and the floor rule in
+`scripts/check-module-floors.py`. Reuse one of those rather than writing a fourth.
+
+> **If you are reading this while that derivation is still landing:** bump `content.version`'s MINOR
+> by hand for any `src/`-only change to a mixed package, and say in the PR that you did so and why.
+
+## Full rebuild when the platform updates
+
+A module is built against a platform pin. **When the platform releases, the pin moves and EVERY
+module must be rebuilt and republished** — not only the ones whose source changed — or every portal
+reads `FrameworkDeclined (built against <old>, live <new>)` and adopts nothing.
+
+So the two lanes differ deliberately:
+
+| trigger | scope |
+|---|---|
+| `pull_request` | the **affected** closure |
+| `push` to `main` | the **affected** closure, baselined on the PUBLICATION (`source-commit.txt`), never `github.event.before` |
+| `repository_dispatch` / `schedule` (release-follow) | **everything** |
+
+## Before you open the PR
+
+```bash
+python3 scripts/gen-manifests.py           # after ANY change to a package folder
+python3 scripts/gen-manifests.py --check   # what CI runs on your branch
+```
+
+`--check` is a **PR** gate and is entirely local: it asserts your lock describes *your* tree.
+`--check-versions` is **main-only** — a branch is never asked to win a race against the trunk.
+
+**The question to ask before merging is not "is it green" but "will anyone receive it":**
+
+1. Did I change a package's node content? → the hash moves, the patch is derived. Nothing to do.
+2. Did I change only `src/` of a mixed package? → confirm `manifest.lock` actually moved. If it did
+   not, the change reaches nobody.
+3. Is this a feature or a break? → bump the MINOR or the MAJOR in `index.json` by hand.
+4. Am I tempted to edit the patch, or to re-cut an existing tag? → no.
+
+## Related
+
+[Modules](Modules) · [MeshNode Versioning](MeshNodeVersioning) ·
+[Plugin Packaging](PluginPackaging) · [Deploying Plugin Changes](DeployingPluginChanges) ·
+[Plugin Registry](PluginRegistry) · [Plugin Update on Green Build](PluginUpdateOnGreenBuild)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -1,0 +1,120 @@
+---
+Name: Reading CI Signals
+Category: Architecture
+Description: What a check's colour actually means — why SKIPPED and ABSENT count as satisfied, why a red on a non-required check does not block, and the i18n mirror that reds every downstream PR until it lands.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-4l-3 9L9 3l-3 9H2"/></svg>
+---
+
+# Reading CI Signals
+
+**A check's colour is not its authority.** Every rule here was learned by getting it wrong in
+production or in a merge, several of them on the same day. They are cheap to apply and expensive to
+rediscover.
+
+## 🚨 The one sentence
+
+**The absence of a red is not evidence of green.**
+
+`SKIPPED`, `CANCELLED`, `NEUTRAL`, an empty conclusion, and *a required context that never
+appeared at all* are all "not FAILURE" — and **GitHub counts a skipped or absent required context as
+SATISFIED**. A PR can therefore merge through a required gate that never ran, with a full wall of
+ticks.
+
+Measured: **Plugins #862** merged with
+
+```
+Validate node repos:                     SUCCESS
+Compile every NodeType (vs core):        SKIPPED     <- required
+Compile + render node repos (from ACR):  SKIPPED     <- required
+Module bundle (MeshWeaver.AI):           FAILURE
+```
+
+Branch protection was satisfied and auto-merge fired. The compile gate carries **no `if:`** — it is
+deliberately unconditional — and it skipped anyway. So *"it skipped, therefore skipping was safe"*
+is not an inference you may make.
+
+**The rule:** a required context counts only when its conclusion is literally `SUCCESS`.
+
+```bash
+gh pr view <N> --repo <repo> --json statusCheckRollup \
+  --jq '[.statusCheckRollup[]? | select(.name | IN("<required>","<contexts>","<here>"))
+         | "\(.name)=\(.conclusion)"]'
+```
+Every required name must be **present** and read `=SUCCESS`. Count them — a missing row is a fail,
+not an absence.
+
+## Required ≠ meaningful, in both directions
+
+Two independent facts, and confusing them costs time in both directions:
+
+| | |
+|---|---|
+| **Required, and red** | blocks the merge |
+| **Required, and skipped/absent** | **does not block** — GitHub treats it as satisfied |
+| **Not required, and red** | does **not** block — but it is still evidence, and may be a real defect |
+| **Not required, and it is the job your diff changes** | do not arm auto-merge: the PR can land *before* that job finishes, putting a broken gate on `main` where it renders as a green tick |
+
+**Measure protection per repo; never trust a table, including this one.** And check *both* mechanisms:
+classic branch protection **and rulesets** — `GET /repos/{owner}/{repo}/branches/main/protection`
+answers `404 Branch not protected` for a repo governed by a ruleset, which reads as "no protection
+at all" and is wrong.
+
+```bash
+gh api repos/<owner>/<repo>/branches/main/protection --jq '.required_status_checks.contexts'
+gh api repos/<owner>/<repo>/rulesets --jq '.[]|"\(.id) \(.name) \(.enforcement)"'
+gh api repos/<owner>/<repo>/rulesets/<id> \
+  --jq '.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[]?.context'
+```
+
+A **dynamic matrix cannot be a required context** — the shard names change. Require a single
+**collector** job that `needs:` every shard and fails if any did not succeed (core does this with
+`Consolidate test results`). Requiring shard names by hand orphans a required context the moment the
+shard count changes, and it then waits forever.
+
+## The same trap in the tools you write to watch CI
+
+Two bugs that make a monitor lie, both hit in one session:
+
+- **`jq`'s `//` does not fall through on `""`.** Only `null` and `false` trigger it, and an empty
+  string is truthy — so `.conclusion // .status` yields `""` for a queued check, and "not yet run"
+  becomes indistinguishable from "no failure".
+- **An empty or partial rollup is vacuously green.** "No failures and nothing incomplete" is *true*
+  of a PR with zero checks. Decide readiness by asserting the **required set is present and
+  SUCCESS**, never by the absence of failures.
+
+## 🌍 The i18n mirror — deal with it routinely, not as an incident
+
+Core owns `src/MeshWeaver.Messaging.Hub/Localization/strings.{en,de}.json`. MeshWeaver.Plugins
+mirrors them at `clients/react/src/i18n/strings.{en,de}.json`, and its `RN app + web clients` job
+asserts the mirror matches core `main`.
+
+**So the moment a core catalog change merges, EVERY open Plugins PR goes red on that job,
+regardless of its diff, until the mirror lands.** Measured 2026-08-29: eleven PRs red at once, on
+diffs that could not reach the RN app — a lockfile override, a Store C# change. The guard is
+correct; the gap between the two merges is the problem.
+
+**The routine — do this every time, not as a fix afterwards:**
+
+1. Adding a key to core's catalog? **Open the Plugins mirror PR in the same session**, and land it
+   immediately after the core PR merges. Core must go first: the guard compares against core, so a
+   mirror that leads *is* the drift it exists to catch.
+2. 🚨 **Never patch the mirror on the individual red branches.** That creates competing edits to the
+   same two files and a conflict for the real mirroring PR. **One landing clears them all**; the
+   others need only a re-run, no code change.
+3. Recognise it instantly: **a diff that provably cannot reach the RN app is failing the RN job.**
+   Do not debug the PR — compare the catalogs:
+
+```bash
+git -C <core>    grep -c '<newKey>' origin/main -- 'src/MeshWeaver.Messaging.Hub/Localization/strings.en.json'
+git -C <plugins> grep -c '<newKey>' origin/main -- clients/react/src/i18n/strings.en.json
+```
+Core `1` / Plugins `0` is this, every time.
+
+Note the RN job is **not** a required context in Plugins, so this reds PRs without blocking them —
+which is its own hazard: eleven PRs red on a known-benign check is exactly the noise a *real*
+failure hides in.
+
+## Related
+
+[Module Versioning](ModuleVersioning) · [Modules](Modules) ·
+[Deploying Plugin Changes](DeployingPluginChanges)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -110,6 +110,20 @@ git -C <plugins> grep -c '<newKey>' origin/main -- clients/react/src/i18n/string
 ```
 Core `1` / Plugins `0` is this, every time.
 
+🚨 **The guard asserts the mirror is IDENTICAL to the whole server catalog — not that particular
+keys exist.** So a mirror PR that copies "the keys that broke it" is still red, one key short, and
+looks like the fix failing:
+
+```
+FAIL  catalog drift guard > strings.en.json is identical to the server catalog
+AssertionError: expected [ 'about.buildCommit', …(1043) ] to deeply equal [ …(1044) ]
+```
+
+Mirror by **diffing the key sets**, never by copying the keys you happened to notice — a second,
+unrelated key added to core in the meantime is exactly what you will miss. And insert at the
+**text level**: re-serialising the JSON rewrites unrelated `\uXXXX` escapes across the whole file
+and buries the real change.
+
 Note the RN job is **not** a required context in Plugins, so this reds PRs without blocking them —
 which is its own hazard: eleven PRs red on a known-benign check is exactly the noise a *real*
 failure hides in.


### PR DESCRIPTION
The versioning rules were spread across five `AGENTS.md` files, three issues and nobody's head. This adds `Doc/Architecture/ModuleVersioning` as the single page, and points each repo at it (satellite `AGENTS.md` edits follow in their own PRs).

## What it carries that we were missing

**Module delivery is keyed on SemVer and nothing else**, and two gates close on an unchanged version *before any bytes are fetched*:

- `ModuleUpdateDecision` → `SkipUpToDate`, decided before the download, with no `If-None-Match`.
- `CatalogLayoutAreas` → the manual **Update** button returns `InstallResult(0,0)` before the module half is composed. The human override does not override.

So a version that does not move means the assembly is **built, shelved, and requested by nobody**. Fresh installs get it; existing portals never do; repo, CI and registry all look green.

**Measured 2026-08-29: 12 of 29 mixed packages were in exactly that state**, because a mixed package's own `src/` was never hashed into `moduleVersion`. Worst was the engine itself:

```
main         version: 1.0.0   moduleVersion: be7ff235b95fb8e4
AI/v1.0.0    version: 1.0.0   moduleVersion: be7ff235b95fb8e4
```

byte-identical across **205 changed `src/` files**.

## The closure boundary — narrower than "the dependency graph"

`DepsClosure.Derive` stops at `MeshWeaver.*` nodes because those are never bundled (a bundled copy would shadow `/app`). So **a change to `MeshWeaver.AI` does NOT require bumping `MeshWeaver.AI.OpenAI`** — the dependent binds by assembly name and ships its own bundle. Bumping every dependent would be busywork that also destroys the signal in the version number.

What *should* be hashed: the module project's own sources, its `.csproj` (it pins package versions, and a NuGet bump changes the shipped bundle), and its non-`MeshWeaver.*` transitive deps by resolved version.

The page points at the existing ProjectReference walkers (`check-surface-manifest.py`, `check-module-floors.py`) rather than inviting a fourth implementation.

## Scope

Documentation only — no behaviour change. The derivation fix itself is tracked in MeshWeaver.Plugins#878; until it lands, the page says plainly to bump `content.version` by hand for a `src/`-only change to a mixed package and to say so in the PR.