### PR TITLE
fix(gate): a bake shortfall names the assembly that declined

### DIFF
--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmerHostedService.cs
@@ -671,7 +671,7 @@ public static class PreWarmServiceCollectionExtensions
 
 /// <summary>
 /// The hosting-layer <see cref="IPrebuiltAssemblyConsumer"/>: adoption for a specific type set
-/// over the deployment's bundle sources — see <see cref="ShippedPrebuiltBundles.SeedForTypes"/>.
+/// over the deployment's bundle sources — see <see cref="ShippedPrebuiltBundles.SeedForTypes(IMessageHub, System.Collections.Generic.IReadOnlyCollection{string}, Microsoft.Extensions.Logging.ILogger, string, string)"/>.
 /// </summary>
 internal sealed class PrebuiltAssemblyConsumer(
     IMessageHub mesh,

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -195,7 +195,8 @@ public static class ShippedPrebuiltBundles
     /// </summary>
     public static IObservable<int> SeedForTypes(
         IMessageHub mesh, IReadOnlyCollection<string> typePaths, ILogger? logger,
-        string? imageDirectory = null, string? publishedRoot = null)
+        string? imageDirectory = null, string? publishedRoot = null,
+        Action<string>? onCovered = null)
         => Observable.Defer(() =>
         {
             if (typePaths.Count == 0)
@@ -217,13 +218,13 @@ public static class ShippedPrebuiltBundles
                         .EnumerateFiles(imageDir, "*.zip", SearchOption.TopDirectoryOnly)
                         .OrderBy(f => f, StringComparer.Ordinal)
                         .ToList(),
-                    logger, paths),
+                    logger, paths, onCovered),
             };
             if (!string.IsNullOrWhiteSpace(publishedRoot))
             {
                 var identityDir = Path.Combine(publishedRoot, PrebuiltAssemblySeeder.LiveFrameworkMvid);
                 seeds.Add(SeedBundles(mesh, identityDir,
-                    () => CompletePublishedBundlesOf(identityDir, logger), logger, paths));
+                    () => CompletePublishedBundlesOf(identityDir, logger), logger, paths, onCovered));
             }
             return seeds.Concat().Aggregate(0, (total, adopted) => total + adopted);
         });
@@ -276,7 +277,7 @@ public static class ShippedPrebuiltBundles
     /// caller already knows which types it is consuming for (#1707 slice 3).</summary>
     private static IObservable<int> SeedBundles(
         IMessageHub mesh, string dir, Func<List<string>> enumerateBundles, ILogger? logger,
-        ImmutableHashSet<string>? typePathFilter = null)
+        ImmutableHashSet<string>? typePathFilter = null, Action<string>? onCovered = null)
         => Observable.Defer(() =>
         {
             if (!Directory.Exists(dir))
@@ -351,7 +352,7 @@ public static class ShippedPrebuiltBundles
                             return snapshot
                                 .SelectMany(existing => bundles
                                     .Select(bundle => SeedBundle(
-                                        mesh, pool, store, bundle, existing, logger))
+                                        mesh, pool, store, bundle, existing, logger, onCovered))
                                     .Concat()
                                     .Aggregate(default(SeedTally), (total, one) => total + one)
                                     .Do(tally =>
@@ -420,7 +421,8 @@ public static class ShippedPrebuiltBundles
         IAssemblyStore store,
         string bundlePath,
         TypeSnapshot snapshot,
-        ILogger? logger)
+        ILogger? logger,
+        Action<string>? onCovered = null)
         => pool
             .InvokeBlocking(_ => Plugin.Packaging.BundleReader.ReadManifest(bundlePath))
             .SelectMany(manifest =>
@@ -491,6 +493,13 @@ public static class ShippedPrebuiltBundles
                             .Select(c => c.Entry.NodePath)
                             .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
                         var alreadyCurrent = checks.Count - deviating.Count;
+                        // An already-current entry is COVERED — the store holds its bytes under the
+                        // record the mesh already carries. It counts toward Covered, so it must be
+                        // witnessed here too, or the shortfall would name a type that is fine.
+                        if (onCovered is not null)
+                            foreach (var check in checks)
+                                if (check.Current)
+                                    onCovered(check.Entry.NodePath);
 
                         if (deviating.IsEmpty)
                         {
@@ -507,7 +516,7 @@ public static class ShippedPrebuiltBundles
                                 .ReadFile(bundlePath, deviating))
                             .SelectMany(payload => SeedPayloads(
                                 mesh, bundlePath, manifest.FrameworkMvid,
-                                payload.Assemblies, alreadyCurrent, logger));
+                                payload.Assemblies, alreadyCurrent, logger, onCovered));
                     });
             })
             .Catch<SeedTally, Exception>(ex =>
@@ -584,12 +593,18 @@ public static class ShippedPrebuiltBundles
         string? frameworkMvid,
         IReadOnlyList<Plugin.Packaging.BundleReader.Payload> assemblies,
         int alreadyCurrent,
-        ILogger? logger)
+        ILogger? logger,
+        Action<string>? onCovered = null)
         => assemblies
             .Select(a => PrebuiltAssemblySeeder
                 .Seed(mesh, a.NodePath, a.Assembly, a.Pdb, frameworkMvid, logger, a.Dependencies)
                 .Take(1)
                 .Timeout(SeedBudget)
+                .Do(adopted =>
+                {
+                    if (adopted)
+                        onCovered?.Invoke(a.NodePath);
+                })
                 .Catch<bool, Exception>(ex =>
                 {
                     logger?.LogWarning(ex,

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -195,8 +195,32 @@ public static class ShippedPrebuiltBundles
     /// </summary>
     public static IObservable<int> SeedForTypes(
         IMessageHub mesh, IReadOnlyCollection<string> typePaths, ILogger? logger,
-        string? imageDirectory = null, string? publishedRoot = null,
-        Action<string>? onCovered = null)
+        string? imageDirectory = null, string? publishedRoot = null)
+        => SeedForTypes(mesh, typePaths, logger, imageDirectory, publishedRoot, onCovered: null);
+
+    /// <summary>
+    /// <see cref="SeedForTypes(IMessageHub, IReadOnlyCollection{string}, ILogger, string, string)"/>
+    /// with a per-path witness: <paramref name="onCovered"/> is invoked once for every NodeType
+    /// path this pass BACKED — adopted now, or already current — from the seeder's own pool
+    /// threads, so an implementation must be thread-safe.
+    ///
+    /// <para>🚨 A separate overload rather than one more optional parameter, and every argument
+    /// here is REQUIRED. C# bakes a call's full argument list into the CALL SITE, so widening the
+    /// shipped signature with an optional parameter is a BINARY break: an assembly compiled
+    /// against the old surface still calls the 5-argument form and would fail with
+    /// <c>MissingMethodException</c> at runtime — which in this framework means a prebuilt bundle
+    /// adopted from an earlier build, exactly the artifact this method exists to serve. Leaving
+    /// the overlapping parameters required is what keeps <c>SeedForTypes(mesh, paths, logger)</c>
+    /// from becoming ambiguous between the two.</para>
+    ///
+    /// <para>The count it emits is unchanged and still authoritative; the witness only says WHICH
+    /// paths are behind that count, which is the question a bake shortfall raises
+    /// (<c>BakeSeedConsumer.Shortfall</c>).</para>
+    /// </summary>
+    public static IObservable<int> SeedForTypes(
+        IMessageHub mesh, IReadOnlyCollection<string> typePaths, ILogger? logger,
+        string? imageDirectory, string? publishedRoot,
+        Action<string>? onCovered)
         => Observable.Defer(() =>
         {
             if (typePaths.Count == 0)
@@ -264,7 +288,7 @@ public static class ShippedPrebuiltBundles
     ///
     /// <para>An EMPTY <see cref="Nodes"/> map means "no record snapshot available", and the
     /// deviation check then answers "deviates" for everything — the install/push caller
-    /// (<see cref="SeedForTypes"/>) supplies paths rather than a query, and it is called precisely
+    /// (<see cref="SeedForTypes(IMessageHub, System.Collections.Generic.IReadOnlyCollection{string}, Microsoft.Extensions.Logging.ILogger, string, string)"/>) supplies paths rather than a query, and it is called precisely
     /// when content just changed, so re-adopting is the right answer there anyway.</para>
     /// </summary>
     private sealed record TypeSnapshot(

--- a/test/MeshWeaver.PluginTester.Test/BakeShortfallNamesTheTypeTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeShortfallNamesTheTypeTest.cs
@@ -1,0 +1,93 @@
+using System.Collections.Immutable;
+using System.Linq;
+using MeshWeaver.PluginTester;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// The bake-consumption verdict must NAME what declined.
+///
+/// <para>🚨 The shape this pins was measured on <c>MeshWeaver.Crm</c>: the gate reported "adopted 86
+/// of 87 baked assembly(ies) — 1 were DECLINED" and pointed the operator at the per-assembly reason
+/// "logged by PrebuiltAssemblySeeder". That reason is logged at <b>Information</b> and the gate mesh
+/// runs at <b>Warning</b>, so the log it named contained nothing: <c>main</c> sat red from
+/// 2026-08-28 21:54 for ~12 hours with every per-type verdict green and no way to tell which of 87
+/// assemblies was the problem. A verdict that cannot be acted on is not a verdict.</para>
+///
+/// <para>The consumer now witnesses each path the seeder BACKS, so the difference is exact rather
+/// than a count. These pin the arithmetic and the naming, without a mesh.</para>
+/// </summary>
+public class BakeShortfallNamesTheTypeTest
+{
+    private static ImmutableSortedSet<string> Set(params string[] paths) =>
+        ImmutableSortedSet.Create(System.StringComparer.OrdinalIgnoreCase, paths);
+
+    [Fact]
+    public void Names_the_declined_type_rather_than_only_counting_it()
+    {
+        var declared = Set("Crm/Board", "Crm/Client", "Store/Plugin");
+        var verdict = BakeSeedConsumer.DescribeShortfall(
+            declared,
+            requested: declared,
+            covered: Set("Crm/Board", "Store/Plugin"),
+            adopted: 2,
+            directory: "/bake");
+
+        Assert.NotNull(verdict);
+        Assert.Contains("DECLINED: Crm/Client", verdict);
+        Assert.Contains("adopted 2 of 3", verdict);
+        // The types that were fine must not be named as declined.
+        Assert.DoesNotContain("DECLINED: Crm/Board", verdict);
+    }
+
+    [Fact]
+    public void Silent_when_everything_declared_and_requested_was_backed()
+    {
+        var declared = Set("Crm/Board", "Crm/Client");
+        Assert.Null(BakeSeedConsumer.DescribeShortfall(
+            declared, requested: declared, covered: declared, adopted: 2, directory: "/bake"));
+    }
+
+    [Fact]
+    public void A_type_the_run_never_installed_is_not_a_shortfall()
+    {
+        // The bake may carry types this run does not install; only the intersection is owed.
+        var verdict = BakeSeedConsumer.DescribeShortfall(
+            declared: Set("Crm/Board", "Other/Type"),
+            requested: Set("Crm/Board"),
+            covered: Set("Crm/Board"),
+            adopted: 1,
+            directory: "/bake");
+        Assert.Null(verdict);
+    }
+
+    [Fact]
+    public void No_overlap_at_all_still_reports_the_staging_error()
+    {
+        var verdict = BakeSeedConsumer.DescribeShortfall(
+            declared: Set("Crm/Board"),
+            requested: Set("Something/Else"),
+            covered: Set(),
+            adopted: 0,
+            directory: "/bake");
+        Assert.NotNull(verdict);
+        Assert.Contains("NONE of which this run installed", verdict);
+    }
+
+    [Fact]
+    public void Counting_alone_could_not_distinguish_these_two_runs()
+    {
+        // Both runs adopted 2 of 3. Only the witnessed set says WHICH one is missing — the whole
+        // point of the change, and precisely what a count-based verdict conflated.
+        var declared = Set("A/One", "B/Two", "C/Three");
+        var missingB = BakeSeedConsumer.DescribeShortfall(
+            declared, declared, Set("A/One", "C/Three"), adopted: 2, directory: "/bake");
+        var missingC = BakeSeedConsumer.DescribeShortfall(
+            declared, declared, Set("A/One", "B/Two"), adopted: 2, directory: "/bake");
+
+        Assert.Contains("DECLINED: B/Two", missingB);
+        Assert.Contains("DECLINED: C/Three", missingC);
+        Assert.NotEqual(missingB, missingC);
+    }
+}

--- a/tools/MeshWeaver.PluginTester/BakeSeed.cs
+++ b/tools/MeshWeaver.PluginTester/BakeSeed.cs
@@ -124,7 +124,7 @@ public sealed record BakeSeed(
 /// The gate's <see cref="IPrebuiltAssemblyConsumer"/>: adoption restricted to ONE bake directory,
 /// with the accounting the gate's postcondition needs.
 ///
-/// <para>🚨 It delegates to <see cref="ShippedPrebuiltBundles.SeedForTypes"/> — the SAME consumption
+/// <para>🚨 It delegates to <see cref="ShippedPrebuiltBundles.SeedForTypes(MeshWeaver.Messaging.IMessageHub, System.Collections.Generic.IReadOnlyCollection{string}, Microsoft.Extensions.Logging.ILogger, string, string)"/> — the SAME consumption
 /// implementation a portal runs — rather than re-reading the bundles itself. A gate that proved a
 /// bake adoptable through a second, gate-only reader would prove nothing about the reader that
 /// actually runs in production; the framework gate, the per-type dependency-record gate and the
@@ -258,8 +258,9 @@ public sealed class BakeSeedConsumer(
             + "not judge the bytes the bake shipped for them. DECLINED: "
             + $"{string.Join(", ", missing.Take(20))}"
             + (missing.Count > 20 ? ", …" : "")
-            + ". The per-assembly reason is logged by PrebuiltAssemblySeeder at Information "
-            + "(framework identity, or the per-type dependency record); the gate logs at Warning, "
-            + "so raise its level to read it.";
+            + ". The per-assembly reason (framework identity, the per-type dependency record, or a "
+            + $"payload the bundle's manifest names but does not carry) is logged above under the "
+            + $"'{LogCategory}' category, which the gate raises to Information whenever it consumes "
+            + "a bake; outside the gate, enable that category to read it.";
     }
 }

--- a/tools/MeshWeaver.PluginTester/BakeSeed.cs
+++ b/tools/MeshWeaver.PluginTester/BakeSeed.cs
@@ -145,10 +145,18 @@ public sealed class BakeSeedConsumer(
     Func<IMessageHub> mesh,
     BakeSeed seed) : IPrebuiltAssemblyConsumer
 {
+    /// <summary>The logger category every adoption line rides — named once so the gate can raise
+    /// exactly this category to Information and nothing else (see GateMesh.Create).</summary>
+    public const string LogCategory = "bake-seed";
+
     private readonly object gate = new();
     // Same comparer as BakeSeed.DeclaredTypePaths and as the seeder's own path set — the three
     // are intersected to reach a verdict and must agree on what "the same node path" means.
     private ImmutableSortedSet<string> requested =
+        ImmutableSortedSet.Create<string>(StringComparer.OrdinalIgnoreCase);
+    // The paths the seeder actually BACKED, witnessed one by one as it backs them. A count alone
+    // cannot answer "which one declined", and that is the only question a shortfall raises.
+    private ImmutableSortedSet<string> covered =
         ImmutableSortedSet.Create<string>(StringComparer.OrdinalIgnoreCase);
     private int adopted;
 
@@ -161,6 +169,13 @@ public sealed class BakeSeedConsumer(
     /// <summary>Assemblies adopted from the bake across the whole run.</summary>
     public int Adopted => Volatile.Read(ref adopted);
 
+    /// <summary>Every NodeType path the seeder BACKED from this bake — adopted now or already
+    /// current. The witness behind <see cref="Shortfall"/>'s named verdict.</summary>
+    public ImmutableSortedSet<string> Covered
+    {
+        get { lock (gate) return covered; }
+    }
+
     /// <summary>The bake this consumer serves.</summary>
     public BakeSeed Seed => seed;
 
@@ -171,7 +186,7 @@ public sealed class BakeSeedConsumer(
             lock (gate)
                 requested = requested.Union(typePaths);
             var hub = mesh();
-            var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("bake-seed");
+            var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(LogCategory);
             return ShippedPrebuiltBundles
                 .SeedForTypes(hub, typePaths, logger, imageDirectory: seed.Directory,
                     // The gate consumes exactly the bake it was pointed at. Null here falls back to
@@ -179,7 +194,12 @@ public sealed class BakeSeedConsumer(
                     // is empty by construction (its IConfiguration is a bare ConfigurationBuilder)
                     // — so there is only ever one source and "the gate adopted N" stays
                     // attributable to the bake under test.
-                    publishedRoot: null)
+                    publishedRoot: null,
+                    // Witnessed per path, on the seeder's own pool threads — hence the lock.
+                    onCovered: path =>
+                    {
+                        lock (gate) covered = covered.Add(path);
+                    })
                 .Do(count => Interlocked.Add(ref adopted, count));
         });
 
@@ -193,28 +213,53 @@ public sealed class BakeSeedConsumer(
     /// entire consuming half could silently stop working and every run would stay green. That is
     /// the same shape as a skipped CI job wearing a passing tick.</para>
     /// </summary>
-    public string? Shortfall()
+    public string? Shortfall() =>
+        DescribeShortfall(seed.DeclaredTypePaths, Requested, Covered, Adopted, seed.Directory);
+
+    /// <summary>
+    /// <see cref="Shortfall"/>'s verdict as a PURE function of the four facts it rests on, so the
+    /// accounting can be pinned without standing up a mesh (the same seam
+    /// <c>PrebuiltAssemblySeeder.DeclineReason</c> exposes for the same reason).
+    /// </summary>
+    /// <param name="declared">Every path the bake carries bytes for.</param>
+    /// <param name="requested">Every path the install asked the consumer about.</param>
+    /// <param name="covered">Every path the seeder actually backed.</param>
+    /// <param name="adopted">The seeder's own count, reported as-is.</param>
+    /// <param name="directory">The bake directory, for the no-overlap message.</param>
+    public static string? DescribeShortfall(
+        ImmutableSortedSet<string> declared,
+        ImmutableSortedSet<string> requested,
+        ImmutableSortedSet<string> covered,
+        int adopted,
+        string directory)
     {
-        var expected = seed.DeclaredTypePaths.Intersect(Requested);
+        var expected = declared.Intersect(requested);
         if (expected.Count == 0)
-            return seed.DeclaredTypePaths.Count == 0
+            return declared.Count == 0
                 ? null
-                : $"the bake in '{seed.Directory}' declares assemblies for "
-                  + $"{seed.DeclaredTypePaths.Count} NodeType(s), NONE of which this run installed "
+                : $"the bake in '{directory}' declares assemblies for "
+                  + $"{declared.Count} NodeType(s), NONE of which this run installed "
                   + "— the gate judged none of the baked bytes. Bake and gate must be staged from "
                   + "the same tree (declared: "
-                  + $"{string.Join(", ", seed.DeclaredTypePaths.Take(5))}"
-                  + (seed.DeclaredTypePaths.Count > 5 ? ", …" : "") + ").";
-        if (Adopted >= expected.Count)
+                  + $"{string.Join(", ", declared.Take(5))}"
+                  + (declared.Count > 5 ? ", …" : "") + ").";
+        var missing = expected.Except(covered);
+        if (missing.Count == 0)
             return null;
-        // WHICH assembly was declined is not knowable here — ShippedPrebuiltBundles reports a
-        // count, and the per-assembly reason goes to the log where it belongs. So name the SET the
-        // shortfall is inside rather than inventing a per-path verdict this consumer never saw.
-        return $"the gate adopted {Adopted} of {expected.Count} baked assembly(ies) for the types "
-            + $"it installed — {expected.Count - Adopted} were DECLINED and compiled locally, so "
-            + "the gate did not judge the bytes the bake shipped for them. The per-assembly reason "
-            + "is logged by PrebuiltAssemblySeeder (framework identity, or the per-type dependency "
-            + $"record). The bake covered: {string.Join(", ", expected.Take(20))}"
-            + (expected.Count > 20 ? ", …" : "") + ".";
+        // 🚨 NAME them. This used to say WHICH assembly declined "is not knowable here", because
+        // the seeder reported only a COUNT; it now witnesses every path it backs, so the single
+        // question a shortfall raises is answered in the verdict itself. That matters because the
+        // per-assembly reason it deferred to is logged at Information and THE GATE MESH RUNS AT
+        // WARNING — the pointer led to lines the gate never writes, which is why a 1-of-87
+        // shortfall was undiagnosable from a CI log (MeshWeaver.Crm main, red from 2026-08-28
+        // 21:54 for ~12 h with every per-type verdict green). A verdict carries its own evidence.
+        return $"the gate adopted {adopted} of {expected.Count} baked assembly(ies) for the types "
+            + $"it installed — {missing.Count} were DECLINED and compiled locally, so the gate did "
+            + "not judge the bytes the bake shipped for them. DECLINED: "
+            + $"{string.Join(", ", missing.Take(20))}"
+            + (missing.Count > 20 ? ", …" : "")
+            + ". The per-assembly reason is logged by PrebuiltAssemblySeeder at Information "
+            + "(framework identity, or the per-type dependency record); the gate logs at Warning, "
+            + "so raise its level to read it.";
     }
 }

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -676,6 +676,19 @@ public static class PluginGateRunner
                 // Warning volume is a handful of lines per run — the trace levels are still opt-in
                 // through MW_LOG_LEVEL.
                 logging.AddSimpleConsole(o => { o.SingleLine = true; o.TimestampFormat = "HH:mm:ss.fff "; });
+                // 🚨 The bake-consumption category is raised to Information whenever a bake is
+                // being consumed — the same argument as the always-attach fix above, one seam
+                // over. A bake shortfall is a RED verdict, and every reason an assembly is
+                // declined (framework identity, the per-type dependency record, a payload the
+                // bundle's manifest names but does not carry) is logged at Information by
+                // ShippedPrebuiltBundles / PrebuiltAssemblySeeder. At the gate's default Warning
+                // those lines are never written, so the verdict pointed at evidence that did not
+                // exist: MeshWeaver.Crm main sat red from 2026-08-28 21:54 for ~12 hours on
+                // "adopted 86 of 87 … 1 were DECLINED" with every per-type verdict green and no
+                // way to tell which assembly, or why, from the job log. The volume is one line
+                // per bundle (34 on that run) — the trace levels stay opt-in via MW_LOG_LEVEL.
+                if (seed is not null)
+                    logging.AddFilter(BakeSeedConsumer.LogCategory, LogLevel.Information);
                 foreach (var category in (Environment.GetEnvironmentVariable("MW_LOG_CATEGORIES") ?? "")
                          .Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries))
                     logging.AddFilter(category, minLevel);


### PR DESCRIPTION
## The failure this makes diagnosable

`MeshWeaver.Crm`'s `main` has been red since **2026-08-28 21:54** — 23 consecutive runs — on one line:

```
seed: adopted 86 of 87 baked assembly(ies) for the 87 installed NodeType(s)
FATAL: bake consumption: … 1 were DECLINED and compiled locally
GATE FAILED
```

Every per-type verdict in that same run is green (`Crm/Board: compile=Ok render=ok tests=ok`, 12/12 types, 8/8 tests). So the only question the verdict raises is **which** of 87 assemblies declined, and **why**. Neither was answerable:

1. **The verdict could not name it.** `BakeSeedConsumer` counted adoptions and compared counts, and said so in a comment — *"WHICH assembly was declined is not knowable here"* — deferring to "the per-assembly reason is logged by `PrebuiltAssemblySeeder`".
2. **That log does not exist.** Those reasons are logged at **Information**; the gate mesh runs at **Warning**. The CI log for that run contains **zero** `ShippedPrebuiltBundles` lines. The verdict pointed at evidence the gate never writes.

A red gate that carries no way to diagnose itself is the same shape as the always-attach-the-provider fix one seam over (2026-08-10, "the run therefore carried zero evidence of WHY").

## The fix — both halves, at the root

- **The seeder witnesses each path it backs.** `SeedForTypes(…, Action<string>? onCovered = null)` — optional and additive; every existing caller keeps today's behaviour and the `IPrebuiltAssemblyConsumer` interface is untouched. Both routes to Covered report: adopted in `SeedPayloads`, already-current in `SeedBundle`.
- **`Shortfall()` is now `expected.Except(covered)`** and prints `DECLINED: <paths>`. This is *strictly more correct* than the count it replaces: `Adopted` sums per-call totals, so a path covered under two packages inflated it and could mask a genuinely missing one. A set cannot.
- **The gate raises exactly the `bake-seed` category to Information while consuming a bake** — one line per bundle (34 on that run) — so the reason is in the log the verdict names. `MW_LOG_LEVEL` still governs the trace levels.

The verdict logic moves into a pure `DescribeShortfall(declared, requested, covered, adopted, directory)`, so the accounting is pinned without standing up a mesh — the same seam `PrebuiltAssemblySeeder.DeclineReason` exposes for the same reason.

## Scope — what this does and does not do

This makes the Crm failure **diagnosable**; it does not by itself explain which assembly declines there. The next gate run on this build prints the name, and the reason lands beside it. I did not guess at the underlying decline: a faithful local repro needs the sealed upstream publication and the external AI module artifact, and inventing a cause from a count would have been the band-aid.

⚠️ **Behaviour change worth reviewing:** the set-based check is stricter than the count. If any repo's gate is currently passing *because* double-counted coverage masked a real gap, this will turn it red — correctly, and now with the name attached.

## How it was tested

- **5 new tests** — naming the declined type; the no-overlap staging message; a bake carrying types the run never installs (not a shortfall); and that two runs with **identical counts but different missing paths** now produce different verdicts, the exact case a count conflated.
- **113/113** `MeshWeaver.PluginTester.Test`, including the bake→gate round-trips that exercise the instrumented adoption path (`TheGateRunsOnTheBakedBytes_AndCompilesNothingItWasHandedABakeFor`, `GateInstallsUpstreamPackages`, `BakeEquivalence`).
- **10/10** `ShippedPrebuiltBundlesTest`.
- Release + `-warnaserror` clean on all three touched projects.

**What's New:** skipped — CI/gate tooling only, no user-visible effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wt457V2hiV4YkEmcNFNt4N