### PR TITLE
chart: template Email__Inbound__ForwardAddress (Memex#144 is blocked on it)

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -660,3 +660,8 @@ data:
   Email__InboundEnabled: "{{ .Values.config.memex_portal.Email__InboundEnabled | default "false" }}"
   Email__WebhookBaseUrl: "{{ .Values.config.memex_portal.Email__WebhookBaseUrl | default "" }}"
   Email__SubscriptionClientState: "{{ .Values.config.memex_portal.Email__SubscriptionClientState | default "" }}"
+  # Where the inbound triage lane's Forward action sends a mail (MeshWeaver #2656). Binds
+  # InboundMailOptions.ForwardAddress (Email:Inbound:ForwardAddress). Empty is the default and
+  # makes the action report itself UNAVAILABLE rather than silently drop a message — so this
+  # key is what turns Forward on, and an untemplated key here would ship the feature inert.
+  Email__Inbound__ForwardAddress: "{{ .Values.config.memex_portal.Email__Inbound__ForwardAddress | default "" }}"


### PR DESCRIPTION
Memex#144 sets `Email__Inbound__ForwardAddress: info@systemorph.com` for #2656's inbound triage lane. Its `config-key-coverage` gate **correctly refused it**:

```
config-key-coverage: declared 238 key(s); 2 new rendered-nowhere; 0 stale allow-list entries
  [memex-cloud] values.memexcloud.public.yaml (declared 79) -> rendered-nowhere 2
```

**The configMap only emits keys it templates**, so an overlay key the chart does not know is *silently dropped* — it looks configured and never reaches the pod. This PR templates it.

That matters more than usual here: `InboundMailOptions.ForwardAddress` defaults to empty, which makes the Forward action **report itself unavailable** rather than drop a message. So this key is exactly what turns the feature on — the worst possible one to lose quietly. Without this, #2656 would have shipped inert and looked configured.

**Not the same as the existing `Email__InboundEnabled`:** that binds `EmailOptions.InboundEnabled` (`Email:InboundEnabled`); this binds the `Email:Inbound:*` options object. Both are correct as written, which is why the doubled underscore looks odd but is right.

### The second rendered-nowhere key

The other one is `Email__NoReplyAddress`, which the chart itself documents as dead — *"the old key Email__NoReplyAddress no longer binds"* — yet memex-cloud's overlay still sets it. That half belongs in Memex#144 (remove the dead key), not here.

Credit where due: this is the gate working exactly as designed. It caught a key that would have been configured and inert, before it shipped.