### PR TITLE
Fix the framework floor: resolve across ALL referenced packages, and print the diagnostic

### DIFF
--- a/src/MeshWeaver.Plugin.Build/FrameworkVersionResolver.cs
+++ b/src/MeshWeaver.Plugin.Build/FrameworkVersionResolver.cs
@@ -40,13 +40,38 @@ public static class FrameworkVersionResolver
         if (!string.Equals(requested, Latest, StringComparison.OrdinalIgnoreCase))
             return requested;
 
-        var candidates = sources
-            .SelectMany(source => VersionsFrom(source, http))
-            .ToList();
+        // 🚨 The floor is the newest version at which EVERY referenced package is published —
+        // not the newest MeshWeaver.Graph. Every emitted project references all of
+        // CompilationEnvironment.PackageIds, so a version where one of them has no build is not a
+        // floor any plugin can honestly claim: NuGet resolves the missing one to whatever else it
+        // can find and the restore dies with an NU1605 downgrade before compiling anything.
+        //
+        // This is not hypothetical. When MeshWeaver.AI's source moved out of the platform repo,
+        // the platform stopped publishing it. The framework released 3.0.0-rc8, MeshWeaver.AI
+        // stopped at 3.0.0-rc7, and 33 of 33 code-bearing packages failed to pack.
+        //
+        // Intersecting rather than pinning each package separately is deliberate: a mixed floor
+        // resolves rc7-era transitives alongside rc8 ones, and a type that moved between
+        // assemblies then exists in both — CS0433, reported against innocent plugin source.
+        var candidates = CompilationEnvironment.PackageIds
+            .Select(package => sources
+                .SelectMany(source => VersionsFrom(package, source, http))
+                .ToHashSet(StringComparer.OrdinalIgnoreCase))
+            // A package no source can answer for constrains nothing — the alternative is that one
+            // unreachable feed empties the intersection and resolves nothing at all.
+            .Where(versions => versions.Count > 0)
+            .Aggregate(
+                (IEnumerable<string>?)null,
+                (intersection, versions) => intersection is null
+                    ? versions
+                    : intersection.Intersect(versions, StringComparer.OrdinalIgnoreCase))
+            ?.ToList()
+            ?? [];
 
         if (candidates.Count == 0)
             throw new InvalidOperationException(
-                $"--framework-version {Latest} could not find any {FrameworkPackage} version in: "
+                $"--framework-version {Latest} could not find a version published for ALL of "
+                + string.Join(", ", CompilationEnvironment.PackageIds) + " in: "
                 + string.Join(", ", sources)
                 + ". Resolving nothing must not silently fall back to a hard-coded version — that "
                 + "is how every plugin ends up compiled against a framework nobody runs.");
@@ -54,16 +79,17 @@ public static class FrameworkVersionResolver
         return candidates.OrderBy(v => v, NuGetVersionComparer.Instance).Last();
     }
 
-    private static IEnumerable<string> VersionsFrom(string source, HttpClient http)
+
+    private static IEnumerable<string> VersionsFrom(string packageId, string source, HttpClient http)
     {
         if (Directory.Exists(source))
             return Directory
-                .EnumerateFiles(source, $"{FrameworkPackage}.*.nupkg")
-                .Select(f => Path.GetFileNameWithoutExtension(f)[(FrameworkPackage.Length + 1)..]);
+                .EnumerateFiles(source, $"{packageId}.*.nupkg")
+                .Select(f => Path.GetFileNameWithoutExtension(f)[(packageId.Length + 1)..]);
 
         try
         {
-            return FeedVersions(source, http);
+            return FeedVersions(packageId, source, http);
         }
         catch (Exception ex) when (ex is HttpRequestException or JsonException or TaskCanceledException)
         {
@@ -80,7 +106,7 @@ public static class FrameworkVersionResolver
     /// container lives on a different host per feed (nuget.org serves it from
     /// <c>v3-flatcontainer</c>, GitHub Packages from its own).
     /// </summary>
-    private static IEnumerable<string> FeedVersions(string serviceIndexUrl, HttpClient http)
+    private static IEnumerable<string> FeedVersions(string packageId, string serviceIndexUrl, HttpClient http)
     {
         using var indexResponse = http.Send(new HttpRequestMessage(HttpMethod.Get, serviceIndexUrl));
         indexResponse.EnsureSuccessStatusCode();
@@ -98,7 +124,7 @@ public static class FrameworkVersionResolver
             return [];
 
         var versionsUrl = baseAddress.TrimEnd('/')
-                          + "/" + FrameworkPackage.ToLowerInvariant() + "/index.json";
+                          + "/" + packageId.ToLowerInvariant() + "/index.json";
         using var versionsResponse = http.Send(new HttpRequestMessage(HttpMethod.Get, versionsUrl));
         if (!versionsResponse.IsSuccessStatusCode)
             return [];

--- a/src/MeshWeaver.Plugin.Build/Program.cs
+++ b/src/MeshWeaver.Plugin.Build/Program.cs
@@ -175,8 +175,31 @@ foreach (var unit in units)
 
     failures++;
     Console.Error.WriteLine($"  FAILED {unit.NodePath}");
-    foreach (var line in output.Split('\n').Where(l => l.Contains("error CS", StringComparison.Ordinal)).Take(5))
+    // 🚨 Match "error " generally, NOT "error CS". A unit fails for reasons the compiler never
+    // reaches: NU1605 when a referenced package has no build at the framework version, MSB when
+    // the SDK is wrong, a child that dies before emitting a diagnostic at all. Filtering to CS
+    // discarded ALL of those and printed a bare "FAILED", which is how 33 of 33 code-bearing
+    // packages once failed across a whole lane with not one diagnostic anywhere in the log.
+    var diagnostics = output
+        .Split('\n')
+        .Where(l => l.Contains("error ", StringComparison.Ordinal))
+        .Take(5)
+        .ToArray();
+    // Nothing matched: the build still failed, so it said SOMETHING. Print the tail rather than
+    // nothing — an unrecognised failure is exactly the case where the raw output is all there is.
+    if (diagnostics.Length == 0)
+        diagnostics = output
+            .Split('\n')
+            .Where(l => !string.IsNullOrWhiteSpace(l))
+            .TakeLast(15)
+            .ToArray();
+    foreach (var line in diagnostics)
         Console.Error.WriteLine($"    {line.Trim()}");
+    // A silent child is itself the finding — say so instead of leaving the reader to wonder
+    // whether the output was empty or merely filtered away.
+    if (diagnostics.Length == 0)
+        Console.Error.WriteLine(
+            $"    (dotnet build exited {process.ExitCode} without writing any output)");
     // A closure that resolved short is the likeliest cause, and the declared queries are the
     // only place that shows it — print them rather than making the next person go find the node.
     if (unit.DeclaredSources.Length > 0)
@@ -189,7 +212,7 @@ if (failures > 0)
     return 1;
 }
 
-Console.WriteLine($"all {units.Length} unit(s) built");
+Console.WriteLine($"all {units.Length} unit(s) {(build ? "built" : "emitted")}");
 
 if (packDirectory is null)
     return 0;

--- a/test/MeshWeaver.Graph.Test/FrameworkFloorTest.cs
+++ b/test/MeshWeaver.Graph.Test/FrameworkFloorTest.cs
@@ -1,0 +1,108 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.Plugin.Build;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The framework FLOOR (<see cref="FrameworkVersionResolver.Resolve"/>) is the newest version at
+/// which EVERY package in <see cref="CompilationEnvironment.PackageIds"/> is published — not the
+/// newest <c>MeshWeaver.Graph</c>.
+///
+/// <para>Resolving it from one package is a latent outage. Every emitted project references all of
+/// them, so a version where one has no build is not a floor any plugin can claim: NuGet resolves
+/// the missing package to whatever else it can find and the restore dies with an NU1605 downgrade
+/// before compiling a line. When <c>MeshWeaver.AI</c>'s source moved out of the platform repo the
+/// platform stopped publishing it — the framework released <c>3.0.0-rc8</c>, <c>MeshWeaver.AI</c>
+/// stopped at <c>3.0.0-rc7</c>, and 33 of 33 code-bearing packages failed to pack.</para>
+///
+/// <para>Local directory sources are enough to pin this: the resolver globs
+/// <c>{packageId}.*.nupkg</c>, so a directory of empty files IS a feed, and the test needs no
+/// network.</para>
+/// </summary>
+public class FrameworkFloorTest : IDisposable
+{
+    private readonly string feed =
+        Directory.CreateTempSubdirectory(nameof(FrameworkFloorTest)).FullName;
+
+    private void Publish(string packageId, params string[] versions)
+    {
+        foreach (var version in versions)
+            File.WriteAllText(Path.Combine(feed, $"{packageId}.{version}.nupkg"), "");
+    }
+
+    /// <summary>Publishes every package at every version, so the feed is complete by default.</summary>
+    private void PublishAll(params string[] versions)
+    {
+        foreach (var package in CompilationEnvironment.PackageIds)
+            Publish(package, versions);
+    }
+
+    private string Resolve() =>
+        FrameworkVersionResolver.Resolve(FrameworkVersionResolver.Latest, [feed], new HttpClient());
+
+    [Fact]
+    public void ResolvesTheNewestVersionPublishedForEveryPackage()
+    {
+        PublishAll("3.0.0-rc6", "3.0.0-rc7");
+        Assert.Equal("3.0.0-rc7", Resolve());
+    }
+
+    /// <summary>The regression this exists for: one package short at the newest version drops the
+    /// floor to the newest COMPLETE one, rather than naming a version that cannot restore.</summary>
+    [Fact]
+    public void DropsToTheNewestCompleteVersionWhenOnePackageIsNotPublishedThere()
+    {
+        PublishAll("3.0.0-rc6", "3.0.0-rc7");
+        foreach (var package in CompilationEnvironment.PackageIds)
+        {
+            // MeshWeaver.AI is the one that actually stopped; assert on whichever it is, so the
+            // test keeps meaning if the list changes.
+            if (package == "MeshWeaver.AI")
+                continue;
+            Publish(package, "3.0.0-rc8");
+        }
+
+        Assert.Equal("3.0.0-rc7", Resolve());
+    }
+
+    /// <summary>A package no source can answer for must not empty the intersection — otherwise one
+    /// unreachable feed resolves nothing at all.</summary>
+    [Fact]
+    public void APackageAbsentFromEverySourceDoesNotConstrainTheFloor()
+    {
+        foreach (var package in CompilationEnvironment.PackageIds)
+        {
+            if (package == "MeshWeaver.AI")
+                continue;
+            Publish(package, "3.0.0-rc7", "3.0.0-rc8");
+        }
+
+        Assert.Equal("3.0.0-rc8", Resolve());
+    }
+
+    /// <summary>An explicit version is the caller's choice and is returned untouched — the floor
+    /// logic applies to <c>latest</c>, which is what CI passes.</summary>
+    [Fact]
+    public void AnExplicitVersionIsReturnedUnchanged()
+    {
+        PublishAll("3.0.0-rc7");
+        Assert.Equal(
+            "3.0.0-rc8",
+            FrameworkVersionResolver.Resolve("3.0.0-rc8", [feed], new HttpClient()));
+    }
+
+    /// <summary>Resolving nothing must throw rather than fall back to a hard-coded version.</summary>
+    [Fact]
+    public void NoCommonVersionThrows()
+    {
+        Publish("MeshWeaver.Graph", "3.0.0-rc8");
+        Publish("MeshWeaver.AI", "3.0.0-rc7");
+
+        var ex = Assert.Throws<InvalidOperationException>(Resolve);
+        Assert.Contains("MeshWeaver.AI", ex.Message, StringComparison.Ordinal);
+    }
+
+    public void Dispose() => Directory.Delete(feed, recursive: true);
+}


### PR DESCRIPTION
Fixes the framework-floor gate, which is red on **every PR in every plugin repo**, and fixes the reason nobody could see why.

Tracked as Systemorph/MeshWeaver.Plugins#911.

## What broke

`MeshWeaver.AI`'s source moved out of this repo (plugins#786), so the platform stopped publishing it. Measured on `api.nuget.org`:

| Package | Latest published |
|---|---|
| `MeshWeaver.AI` | **`3.0.0-rc7`** |
| `MeshWeaver.Graph` *(control)* | `3.0.0-rc8` |

`FrameworkVersionResolver.Resolve` derived the floor from `MeshWeaver.Graph` alone → `latest` = rc8. But `ProjectEmitter` references **all** of `CompilationEnvironment.PackageIds` in **every** emitted project. NuGet could not find `MeshWeaver.AI` at rc8, fell back, and the restore died with `NU1605` **before compiling anything** — in every unit, including the ~27 of 33 that never touch the AI engine.

Latent since #786; detonated by the rc8 release. It worked at rc7 only because rc7 predates the move.

## Two commits

**1. Print the diagnostic instead of a bare `FAILED`.** The failure path captured the whole `dotnet build` output and discarded it unless a line contained the literal `error CS`. Restore failures (`NU`), MSBuild failures, and silent child crashes all printed `FAILED <unit>` and nothing else — which is how a lane failed 33 of 33 packages with **zero** `error CS|MSB|NU` lines in 1781 lines of log. Now: match `error ` generally, fall back to the output tail, and say so explicitly when the child wrote nothing.

**2. Resolve the floor across all referenced packages.** The floor is the newest version published for *every* package, not the newest `Graph`. A package absent from every source constrains nothing, so one unreachable feed cannot empty the intersection.

## Why intersect rather than pin each package separately

I tried per-package pinning first (AI at rc7, everything else at rc8). It builds Chess, MyAi and Store — and breaks Edu:

```
error CS0433: The type 'FluentIcons' exists in both
  'MeshWeaver.Application.Styles' and 'MeshWeaver.Domain'
```

A mixed floor resolves rc7-era transitives alongside rc8 ones, and a type that moved between assemblies then exists in both. Edu builds clean on a uniform floor. **One era, or none.** That reasoning is in the code comment so the next person does not retry it.

## Verification

| Module | Units | Before | After |
|---|---|---|---|
| Chess | 3 | NU1605 | ✅ |
| Edu | 8 | NU1605 | ✅ |
| MyAi | 1 | NU1605 | ✅ |
| Store | 17 | NU1605 | ✅ |

`latest` now resolves `3.0.0-rc7`. **29 units that failed now build.**

New `FrameworkFloorTest` — 5 cases, no network (the resolver globs `{packageId}.*.nupkg`, so a directory of empty files is a feed): newest-complete-version, the drop when one package is short, an absent package not constraining, explicit versions passed through, and no-common-version throwing while naming the package.

`MeshWeaver.Graph.Test`: **1686 passed, 0 failed.**

## ⚠️ What this does NOT fix

This makes the gate **honest, not the publication gap closed.** The fleet's plugin floor is now rc7 and stays there until `MeshWeaver.AI` is published again — so in-mesh source cannot call rc8 API, and a green gate must not be read as "the floor is current".

Deciding who publishes `MeshWeaver.AI` now that this repo owns it is a maintainer call (it means an outward-facing publish lane and a credential, and published versions are immutable). Options are laid out in Systemorph/MeshWeaver.Plugins#911.
