### PR TITLE
fix(operator): teardown leaves the storage and most of the secrets behind

### DIFF
--- a/deploy/aks/operator/bin/hosting-kv-purge
+++ b/deploy/aks/operator/bin/hosting-kv-purge
@@ -8,20 +8,34 @@
 # without it a restored database is a pile of undecryptable `enc:` values. A purge would convert a
 # reversible mistake into permanent data loss, so this step deliberately cannot make one.
 #
-# 🚨 It refuses an EMPTY prefix. With no prefix every name below resolves to the FLEET-WIDE secret
+# 🚨 It refuses an EMPTY prefix. With no prefix every name resolves to the FLEET-WIDE secret
 # (`Ai-KeyProtection-MasterKey` is memex's own), so tearing down one instance would delete the
 # control instance's envelope key. That is the single most destructive typo available here.
+#
+# 🚨 IT ENUMERATES, it does not guess. This used to delete a hard-coded TWO suffixes
+# (Ai-KeyProtection-MasterKey, PluginCatalog-RegistryToken). Real instances carry more — atioz held
+# five (2026-08-29: + Anthropic-ApiKey, Authentication-Microsoft-ClientSecret, Email-ClientSecret,
+# GitHub-OAuth-ClientSecret) — so a "successful" teardown left three live credentials in the vault
+# for an instance that no longer existed. Which secrets an instance owns depends on the providers
+# it configured, so no fixed list can be right; the vault is the only accurate inventory.
+#
+# 🚨 ENUMERATING BY PREFIX NEEDS AN AMBIGUITY GUARD, because one instance's prefix can be a prefix
+# of another's. Today's fleet is safe by luck, not design: `memex-` does not match `memexcloud-`
+# only because the sixth character is `c` and not `-`. A future `memex-dev` WOULD be swallowed by a
+# `memex` teardown. Pass every other instance's prefix as --sibling-prefix and this refuses rather
+# than guessing; with none passed it still runs, and this comment is the record of that residual risk.
 
 source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
 # shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
 HOSTING_CMD="hosting-kv-purge"
 
-vault="" prefix="" namespace=""
+vault="" prefix="" namespace="" siblings=""
 while [ $# -gt 0 ]; do
   case "$1" in
-    --vault)     vault="${2:-}";     shift 2 ;;
-    --prefix)    prefix="${2:-}";    shift 2 ;;
-    --namespace) namespace="${2:-}"; shift 2 ;;
+    --vault)          vault="${2:-}";     shift 2 ;;
+    --prefix)         prefix="${2:-}";    shift 2 ;;
+    --namespace)      namespace="${2:-}"; shift 2 ;;
+    --sibling-prefix) siblings="${siblings} ${2:-}"; shift 2 ;;
     *) hosting::die "unknown argument '$1'" ;;
   esac
 done
@@ -34,21 +48,36 @@ hosting::safe_name namespace "$namespace"
 [ -n "$prefix" ] || hosting::die "refusing to purge with an EMPTY --prefix: every per-instance secret name would resolve to the fleet-wide one, so this would delete the CONTROL instance's Ai-KeyProtection-MasterKey rather than the torn-down instance's. A deployment record without keyVaultSecretPrefix should not reach this step."
 hosting::safe_name prefix "$prefix"
 
-SUFFIXES="Ai-KeyProtection-MasterKey PluginCatalog-RegistryToken"
+# Refuse before deleting anything if another instance's prefix lives UNDER ours: every secret of
+# theirs would match our enumeration and be deleted by their neighbour's teardown.
+for sib in $siblings; do
+  [ -n "$sib" ] || continue
+  case "$sib" in
+    "$prefix") ;;                       # ourselves, when the caller passes the whole fleet
+    "$prefix"*) hosting::die "prefix '${prefix}' is a prefix of sibling instance prefix '${sib}' — enumerating by '${prefix}' would delete ${sib} secrets too. Rename one instance's keyVaultSecretPrefix so neither contains the other." ;;
+  esac
+done
 
-deleted=0 absent=0
-for suffix in $SUFFIXES; do
-  name="${prefix}${suffix}"
-  if ! az keyvault secret show --vault-name "$vault" --name "$name" --query id -o tsv >/dev/null 2>&1; then
-    hosting::log "absent  ${name}"
-    absent=$((absent + 1))
-    continue
-  fi
+# The vault is the inventory. --query does the prefix match server-side so a huge vault does not
+# come back over the wire just to be filtered here.
+names="$(hosting::read az keyvault secret list --vault-name "$vault" \
+    --query "[?starts_with(name, '${prefix}')].name" -o tsv 2>/dev/null)" \
+  || hosting::die "could not list secrets in vault ${vault}"
+names="$(printf '%s\n' "$names" | grep -v '^[[:space:]]*$' || true)"
+
+if [ -z "$names" ]; then
+  hosting::log "vault ${vault}: no secret starts with '${prefix}' — nothing to purge"
+  hosting::say kv_deleted 0
+  exit 0
+fi
+
+deleted=0
+for name in $names; do
   hosting::log "delete  ${name} (soft-delete — recoverable for the vault's retention window)"
   hosting::do az keyvault secret delete --vault-name "$vault" --name "$name" --output none \
     || hosting::die "could not delete ${name} from vault ${vault}"
   deleted=$((deleted + 1))
 done
 
-hosting::log "vault ${vault}: ${deleted} soft-deleted, ${absent} already absent"
+hosting::log "vault ${vault}: ${deleted} secret(s) soft-deleted"
 hosting::say kv_deleted "$deleted"

--- a/deploy/aks/operator/bin/hosting-pv-purge
+++ b/deploy/aks/operator/bin/hosting-pv-purge
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# hosting-pv-purge --namespace <ns> [--expect <n>]
+#
+# Delete the PersistentVolumes an instance left behind, AND the Azure Files shares behind them.
+#
+# 🚨 WHY THIS EXISTS: deleting the namespace does NOT delete the storage. The fleet's PVs are
+# provisioned `reclaimPolicy: Retain`, so `kubectl delete namespace` deletes the PVCs and leaves
+# every PV `Released` with its Azure Files share fully intact and fully billed. Teardown therefore
+# LOOKED complete while the instance's entire file content survived — 128Gi across four shares in
+# the atioz case (2026-08-29), found only by listing PVs after the namespace was already gone.
+# "The namespace is deleted" is not "the data is deleted", and Retain is the reason.
+#
+# 🚨 THE RETAIN POLICY IS DELIBERATE AND STAYS. It is what makes a mistaken teardown recoverable
+# up to this point. This command is the ONE place allowed to convert that retention into deletion,
+# which is why every guard below is here rather than in the caller.
+#
+# 🚨 IT REFUSES A BOUND VOLUME. A `Bound` PV means something is still using it — the namespace was
+# not deleted, or the volume is shared with another instance. Deleting the share under a running
+# pod corrupts it silently rather than failing. Only `Released`/`Available`/`Failed` are purged.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-pv-purge"
+
+namespace="" expect=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace) namespace="${2:-}"; shift 2 ;;
+    --expect)    expect="${2:-}";    shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag namespace "$namespace"
+# 🚨 An empty or wildcard namespace would select EVERY PV in the cluster — every instance's
+# storage, plus the control instance's. Same class of typo as an empty --prefix in
+# hosting-kv-purge, with a worse blast radius because there is no soft-delete behind it.
+hosting::safe_name namespace "$namespace"
+
+# Claimed-by-namespace is the ONLY selector. Not a name prefix: PV names are provisioner-generated
+# GUIDs (`pvc-<uuid>`) that carry no instance identity at all, so a name-based match would either
+# miss everything or match another instance's volume by accident.
+pvs="$(hosting::read kubectl get pv \
+  -o jsonpath="{range .items[?(@.spec.claimRef.namespace=='${namespace}')]}{.metadata.name}{'\n'}{end}" \
+  2>/dev/null)" || hosting::die "could not list PersistentVolumes — is the operator's ClusterRole missing 'persistentvolumes'?"
+
+pvs="$(printf '%s\n' "$pvs" | grep -v '^[[:space:]]*$' || true)"
+
+if [ -z "$pvs" ]; then
+  # Not an error: a teardown re-run, or an instance whose volumes were already removed. Saying so
+  # explicitly matters because "found nothing" and "did nothing" must not look identical in the log.
+  hosting::log "no PersistentVolume is claimed by namespace ${namespace} — nothing to purge"
+  hosting::say pv_deleted 0
+  hosting::say shares_deleted 0
+  exit 0
+fi
+
+count="$(printf '%s\n' "$pvs" | wc -l | tr -d ' ')"
+hosting::log "namespace ${namespace}: ${count} PersistentVolume(s) to purge"
+
+# An expectation is optional, but when the caller states one a mismatch stops the run: purging
+# fewer volumes than the record describes means the selector is wrong, and the ones it did not
+# match are exactly the ones that would be left behind again.
+if [ -n "$expect" ]; then
+  [ "$count" = "$expect" ] \
+    || hosting::die "expected ${expect} volume(s) for namespace ${namespace} but found ${count} — refusing to purge a set that does not match the deployment record. Reconcile the record or the cluster before retrying."
+fi
+
+pv_deleted=0 shares_deleted=0
+for pv in $pvs; do
+  phase="$(hosting::read kubectl get pv "$pv" -o jsonpath='{.status.phase}' 2>/dev/null)"
+  case "$phase" in
+    Released|Available|Failed) ;;
+    Bound) hosting::die "PersistentVolume ${pv} is still Bound (namespace ${namespace}) — something is still using it. Delete the namespace first; refusing to delete storage out from under a running pod." ;;
+    *)     hosting::die "PersistentVolume ${pv} is in unexpected phase '${phase}' — refusing." ;;
+  esac
+
+  policy="$(hosting::read kubectl get pv "$pv" -o jsonpath='{.spec.persistentVolumeReclaimPolicy}' 2>/dev/null)"
+  size="$(hosting::read kubectl get pv "$pv" -o jsonpath='{.spec.capacity.storage}' 2>/dev/null)"
+
+  # Prefer the explicit attributes; fall back to the volumeHandle, whose shape the Azure Files CSI
+  # driver defines as <resourceGroup>#<storageAccount>#<shareName>###<namespace>.
+  share="$(hosting::read kubectl get pv "$pv" -o jsonpath='{.spec.csi.volumeAttributes.shareName}' 2>/dev/null)"
+  account="$(hosting::read kubectl get pv "$pv" -o jsonpath='{.spec.csi.volumeAttributes.storageAccount}' 2>/dev/null)"
+  handle="$(hosting::read kubectl get pv "$pv" -o jsonpath='{.spec.csi.volumeHandle}' 2>/dev/null)"
+  handle_rg="$(printf '%s' "$handle" | cut -d'#' -f1)"
+  [ -n "$account" ] || account="$(printf '%s' "$handle" | cut -d'#' -f2)"
+  [ -n "$share" ]   || share="$(printf '%s' "$handle" | cut -d'#' -f3)"
+
+  if [ -z "$share" ] || [ -z "$account" ]; then
+    # A PV this command cannot resolve to a share is NOT skipped quietly: leaving it is the very
+    # bug this exists to fix, and deleting the PV object alone would strand the share invisibly.
+    hosting::die "cannot resolve the Azure Files share for ${pv} (volumeHandle='${handle}') — refusing to delete the PV object, which would strand its share with no remaining reference to find it by."
+  fi
+
+  hosting::log "purge   ${pv}  ${size}  share=${share}  account=${account}  (reclaim=${policy}, phase=${phase})"
+
+  # The share first, then the PV object. This order is deliberate: the PV is the only record that
+  # ties a GUID-named share to the instance that owned it, so deleting it first would turn a
+  # failure here into an orphan nobody can attribute.
+  hosting::do az storage share-rm delete \
+      --storage-account "$account" --name "$share" \
+      ${handle_rg:+--resource-group "$handle_rg"} --yes --output none \
+    || hosting::die "could not delete Azure Files share ${share} on ${account}"
+  shares_deleted=$((shares_deleted + 1))
+
+  hosting::do kubectl delete pv "$pv" --wait=true \
+    || hosting::die "deleted share ${share} but could not delete PersistentVolume ${pv} — the object is now dangling and must be removed by hand"
+  pv_deleted=$((pv_deleted + 1))
+done
+
+hosting::log "namespace ${namespace}: ${pv_deleted} volume(s) and ${shares_deleted} share(s) deleted"
+hosting::say pv_deleted "$pv_deleted"
+hosting::say shares_deleted "$shares_deleted"

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -60,9 +60,23 @@ emits() {
   case "$out" in *"$line"*) ok "$what" ;; *) bad "$what" "no '${line}' in: ${out}" ;; esac
 }
 
+# Assert a command did NOT stop at a specific guard. It may still fail for want of az/kubectl —
+# what matters is that the named refusal is not the reason, i.e. execution got past that guard.
+not_refused_by_guard() {
+  local what="$1" phrase="$2"; shift 2
+  local out
+  out="$("$@" 2>&1)"
+  case "$out" in
+    *"$phrase"*) bad "$what" "stopped at the guard it should have passed: ${out}" ;;
+    *) ok "$what" ;;
+  esac
+}
+
 echo "── argument handling ─────────────────────────────────────────────"
 refuses "kv-ensure needs --vault"          "missing required flag --vault"      hosting-kv-ensure --namespace n
 refuses "kv-purge needs --vault"           "missing required flag --vault"      hosting-kv-purge --namespace n
+refuses "pv-purge needs --namespace"       "missing required flag --namespace"  hosting-pv-purge
+refuses "pv-purge rejects unknown flags"   "unknown argument"                   hosting-pv-purge --namespace n --nope 1
 refuses "dns needs a mode"                 "must be 'upsert' or 'delete'"       hosting-dns --zone z --host h
 refuses "redirect needs a mode"            "must be 'suspend' or 'restore'"     hosting-redirect --namespace n
 refuses "deploy needs --release"           "missing required flag --release"    hosting-deploy --namespace n --database d
@@ -73,6 +87,15 @@ echo
 echo "── the refusals that stand in front of something destructive ─────"
 refuses "kv-purge refuses an EMPTY prefix" "refusing to purge with an EMPTY --prefix" \
   hosting-kv-purge --vault V --prefix "" --namespace n
+# The ambiguity guard: one instance's prefix living UNDER another's means a teardown of the outer
+# one enumerates and deletes the inner one's secrets. Runs before any az call, so it is testable here.
+refuses "kv-purge refuses a sibling prefix under its own" "is a prefix of sibling instance prefix" \
+  hosting-kv-purge --vault V --prefix memex- --namespace n --sibling-prefix memex-dev-
+# A sibling that merely SHARES leading characters is not ambiguous and must NOT refuse — this is
+# today's real fleet (memex- vs memexcloud-), and a guard that refused it would block every
+# memex teardown. Reaches az, which is absent here, so assert only that it got PAST the guard.
+not_refused_by_guard "kv-purge allows memex- beside memexcloud-" "is a prefix of sibling" \
+  hosting-kv-purge --vault V --prefix memex- --namespace n --sibling-prefix memexcloud-
 refuses "dns refuses a host outside its zone" "is not inside zone" \
   env AZ_DNS_RESOURCE_GROUP=rg hosting-dns upsert --zone example.com --host evil.other.com --target 1.2.3.4
 refuses "dns refuses a non-IPv4 target"    "is not an IPv4 address" \
@@ -88,6 +111,8 @@ echo
 echo "── command injection cannot ride in on a name ────────────────────"
 refuses_hard "namespace with a shell metacharacter" "is not a plain name" \
   hosting-kv-ensure --vault V --namespace 'n; rm -rf /'
+refuses_hard "pv-purge namespace with a metacharacter" "is not a plain name" \
+  hosting-pv-purge --namespace 'n; kubectl delete pv --all'
 refuses_hard "database with a backtick"             "is not a plain name" \
   env HOSTING_DRY_RUN=true hosting-verify-restore --database 'd`whoami`' --server s
 refuses_hard "host with a space"                    "is not a hostname" \


### PR DESCRIPTION
Two gaps in the teardown, both found by inspecting what atioz ACTUALLY left on the estate after being decommissioned today — not by reading the plan.

## 1. Nothing ever deleted the volumes

The fleet's PVs are `reclaimPolicy: Retain`, so `kubectl delete namespace` deletes the PVCs and leaves every PV `Released` with its Azure Files share intact and billed. atioz left **128Gi across four shares**, found only by listing PVs after the namespace was gone.

New `bin/hosting-pv-purge --namespace <ns> [--expect <n>]`: selects by `claimRef.namespace` (never by name — PV names are provisioner GUIDs), deletes the share **before** the PV object (the PV is the only record tying a GUID share to its instance), refuses a still-`Bound` volume, refuses a PV whose share it cannot resolve, refuses an unsafe namespace. Retain stays; this is the one place allowed to convert it into deletion.

## 2. kv-purge deleted a hard-coded two suffixes

atioz held **five** `atioz-*` secrets; a "successful" teardown would have left three live credentials in the vault. Now enumerates by prefix — the vault is the only accurate inventory. Adds a `--sibling-prefix` ambiguity guard: today `memex-` misses `memexcloud-` only by luck (6th char). Soft-delete only, unchanged.

## Tests

5 new cases, 34 passing — including the negative control that `memex-` beside `memexcloud-` must NOT refuse.

Companion: MeshWeaver.Plugins `feat/teardown-purges-volumes` adds the plan step + in-mesh test. Memex #145 stamps atioz decommissioned and renames memex's prefix to `memexsystemorph-`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)