### PR TITLE
fix(layout): a catalog flag switched OFF must survive the wire

### DIFF
--- a/src/MeshWeaver.Layout/Catalog/CatalogTypes.cs
+++ b/src/MeshWeaver.Layout/Catalog/CatalogTypes.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace MeshWeaver.Layout.Catalog;
 
 /// <summary>
@@ -26,6 +28,13 @@ public record SectionConfig
     /// <summary>
     /// Whether to show item counts in section headers (default true).
     /// </summary>
+    // 🚨 Serialized ALWAYS, never "when not default". The hub writes with
+    // WhenWritingDefault, which compares against the CLR default (false) — not against this
+    // property's initializer (true). So `true` went over the wire and `false` was DROPPED, and the
+    // reader then re-applied the initializer: an explicit "off" arrived as "on", and these flags
+    // could not be turned off at all. Measured 2026-08-29 on MeshWeaver.Crm's activity feed, which
+    // asked for newest-first and silently rendered oldest-first.
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public bool ShowCounts { get; init; } = true;
 
     /// <summary>
@@ -44,6 +53,13 @@ public record SectionConfig
     /// <summary>
     /// Whether sections can be collapsed/expanded (default true).
     /// </summary>
+    // 🚨 Serialized ALWAYS, never "when not default". The hub writes with
+    // WhenWritingDefault, which compares against the CLR default (false) — not against this
+    // property's initializer (true). So `true` went over the wire and `false` was DROPPED, and the
+    // reader then re-applied the initializer: an explicit "off" arrived as "on", and these flags
+    // could not be turned off at all. Measured 2026-08-29 on MeshWeaver.Crm's activity feed, which
+    // asked for newest-first and silently rendered oldest-first.
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public bool Collapsible { get; init; } = true;
 
     /// <summary>
@@ -68,6 +84,13 @@ public record SortConfig
     /// <summary>
     /// Whether to sort in ascending order (default true).
     /// </summary>
+    // 🚨 Serialized ALWAYS, never "when not default". The hub writes with
+    // WhenWritingDefault, which compares against the CLR default (false) — not against this
+    // property's initializer (true). So `true` went over the wire and `false` was DROPPED, and the
+    // reader then re-applied the initializer: an explicit "off" arrived as "on", and these flags
+    // could not be turned off at all. Measured 2026-08-29 on MeshWeaver.Crm's activity feed, which
+    // asked for newest-first and silently rendered oldest-first.
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public bool Ascending { get; init; } = true;
 
     /// <summary>
@@ -78,6 +101,13 @@ public record SortConfig
     /// <summary>
     /// Whether secondary sort is ascending (default true).
     /// </summary>
+    // 🚨 Serialized ALWAYS, never "when not default". The hub writes with
+    // WhenWritingDefault, which compares against the CLR default (false) — not against this
+    // property's initializer (true). So `true` went over the wire and `false` was DROPPED, and the
+    // reader then re-applied the initializer: an explicit "off" arrived as "on", and these flags
+    // could not be turned off at all. Measured 2026-08-29 on MeshWeaver.Crm's activity feed, which
+    // asked for newest-first and silently rendered oldest-first.
+    [JsonIgnore(Condition = JsonIgnoreCondition.Never)]
     public bool ThenByAscending { get; init; } = true;
 }
 

--- a/test/MeshWeaver.Layout.Test/CatalogConfigFlagsSurviveTheWireTest.cs
+++ b/test/MeshWeaver.Layout.Test/CatalogConfigFlagsSurviveTheWireTest.cs
@@ -1,0 +1,62 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using MeshWeaver.Layout.Catalog;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// The catalog config flags default to <c>true</c> in C# but to <c>false</c> in the CLR, and the hub
+/// serializes with <see cref="JsonIgnoreCondition.WhenWritingDefault"/> — which compares against the
+/// CLR default. So an explicit <c>false</c> was DROPPED and the reader re-applied the initializer:
+/// the flags could be turned on, never off.
+///
+/// <para>Measured 2026-08-29 on MeshWeaver.Crm's activity feed: it asked for
+/// <c>Ascending = false</c> (newest first) and the payload carried no <c>ascending</c> at all, so
+/// the portal rendered oldest-first. Nothing errored — the intent simply evaporated between the two
+/// sides.</para>
+/// </summary>
+public class CatalogConfigFlagsSurviveTheWireTest
+{
+    // The hub's shape: default-valued members are not written.
+    private static readonly JsonSerializerOptions HubLike = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingDefault,
+    };
+
+    [Fact]
+    public void SortConfig_descending_survives_a_round_trip()
+    {
+        var sort = new SortConfig { SortByProperty = "date", Ascending = false, ThenByAscending = false };
+
+        var json = JsonSerializer.Serialize(sort, HubLike);
+        Assert.Contains("\"ascending\":false", json);
+        Assert.Contains("\"thenByAscending\":false", json);
+
+        Assert.False(JsonSerializer.Deserialize<SortConfig>(json, HubLike)!.Ascending);
+    }
+
+    [Fact]
+    public void SectionConfig_off_switches_survive_a_round_trip()
+    {
+        var sections = new SectionConfig { ShowCounts = false, Collapsible = false };
+
+        var json = JsonSerializer.Serialize(sections, HubLike);
+        Assert.Contains("\"showCounts\":false", json);
+        Assert.Contains("\"collapsible\":false", json);
+
+        var read = JsonSerializer.Deserialize<SectionConfig>(json, HubLike)!;
+        Assert.False(read.ShowCounts);
+        Assert.False(read.Collapsible);
+    }
+
+    [Fact]
+    public void The_true_case_and_the_defaults_are_unchanged()
+    {
+        Assert.True(JsonSerializer.Deserialize<SortConfig>(
+            JsonSerializer.Serialize(new SortConfig { Ascending = true }, HubLike), HubLike)!.Ascending);
+
+        // An absent flag still reads as the documented default — nothing about existing payloads moves.
+        Assert.True(JsonSerializer.Deserialize<SortConfig>("""{"sortByProperty":"name"}""", HubLike)!.Ascending);
+    }
+}


### PR DESCRIPTION
## The defect

`SortConfig.Ascending`, `SortConfig.ThenByAscending`, `SectionConfig.ShowCounts` and `SectionConfig.Collapsible` all default to **`true` in C#** but to **`false` in the CLR**. The hub serializes with `WhenWritingDefault`, which compares against the *CLR* default — so `true` was written, `false` was **dropped**, and the reader re-applied the initializer.

**None of these four flags could be turned off.** An explicit "off" arrived as "on", silently.

## How it surfaced

MeshWeaver.Crm's new activity feed asks for `Ascending = false` (newest first). The rendered payload on the portal:

```json
"sorting":{"$type":"SortConfig","sortByProperty":"date","thenByAscending":true}
```

No `ascending` key at all — so the feed rendered **oldest first**. Compare the sibling view that asks for `true`, where it survives:

```json
"sorting":{"$type":"SortConfig","sortByProperty":"nextStepDate","ascending":true,...}
```

Nothing errored; the intent evaporated between the two sides. Same silent shape as the documented "enum member numbered 0 is never stored" trap, one layer up.

## The fix

`[JsonIgnore(Condition = JsonIgnoreCondition.Never)]` on the four properties, so the value is always written whatever it is.

- No type or signature change → nothing source- or binary-breaking.
- An **absent** flag still reads as the documented default, so existing payloads are unaffected.

## How it was tested

Round-trip through a hub-shaped serializer (`DefaultIgnoreCondition = WhenWritingDefault`), asserting the `false` case reaches the client *and* that the `true`/default cases are unchanged.

Verified the tests actually catch it rather than assuming:

```
attributes removed  → Failed: 2, Passed: 1
attributes restored → Passed: 3
```

Release + `-warnaserror` clean on `MeshWeaver.Layout`.

**What's New:** skipped — a serialization fix with no standalone user-facing story; the visible effect ships with the consumer that needed it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wt457V2hiV4YkEmcNFNt4N