### PR TITLE
Push the release wave to dependent repos (event-driven) instead of waiting to be polled

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1694,6 +1694,29 @@ jobs:
   # the watcher drops every delivery as unverifiable and this job still goes green. That is the
   # residual #2235 tracks; its close condition is observing a `repository_dispatch` run on the
   # satellites plus the MW_IMAGE_DIGEST bump PRs — never a green tick here.
+  # ────────────────── PUSH THE RELEASE WAVE (repository_dispatch) ──────────────────
+  # 🚨 The block above says a dispatch job here "never will be" added, for two reasons that were
+  # true when it was written and are not now: there was no credential in the release path, and no
+  # subscriber list that would not drift. Both are answered:
+  #   • `DEPENDENT_DISPATCH_APP_ID` / `_PRIVATE_KEY` were provisioned 2026-08-19 and, until this,
+  #     were referenced by NOTHING in this repo.
+  #   • there is no list — the subscribers are the repos the App is INSTALLED on, read at run time.
+  #     Adding a repo to the wave is installing the App on it.
+  # memex's broadcast stays; this does not replace it. The two are independent paths to the same
+  # event, and the failure that motivated this is that a wave depending on ONE hop through a mesh
+  # is a wave that stops when that hop is unreachable — which is not observable from here.
+  notify-dependents:
+    name: "Push the release wave to dependent repos"
+    needs: [preflight, gate, portal-image, plugin-test-image, promote]
+    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
+    uses: ./.github/workflows/notify-dependents.yml
+    with:
+      version: ${{ needs.plugin-test-image.outputs.version }}
+      reason: platform
+    secrets:
+      app-id: ${{ secrets.DEPENDENT_DISPATCH_APP_ID }}
+      private-key: ${{ secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
+
   notify-platform-update:
     name: "Notify platform-update registry"
     # `preflight` is what guarantees URL + SECRET exist, so nothing in this job checks for them.

--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -1,0 +1,125 @@
+name: Notify dependent repos
+
+# 🚨 THE RELEASE WAVE IS PUSHED, NOT POLLED.
+#
+# A package is built against a PINNED platform, so when the platform releases, every plugin repo
+# must rebuild and republish or its portals read `FrameworkDeclined (built against <old>, live
+# <new>)` and adopt nothing. Until now that wave was only PULLED: each repo's `schedule` run noticed
+# the release at its next poll, up to an interval late, and `main-cd.yml` said in prose that a
+# GitHub→GitHub dispatch "never will be" added here.
+#
+# Both reasons that gave are now stale:
+#   • "no credential in the release path" — `DEPENDENT_DISPATCH_APP_ID` / `_PRIVATE_KEY` were
+#     provisioned on 2026-08-19 and, until this workflow, were referenced by NOTHING.
+#   • "no hand-maintained list here" — there is none. The subscriber set is the set of repositories
+#     the App is INSTALLED on, read at run time from `GET /installation/repositories`. Adding a repo
+#     to the wave is installing the App on it; there is no list in this file to drift.
+#
+# The `schedule` poll in each repo stays as the fallback, so a lost dispatch costs one delayed wave
+# rather than a missed one. What changes is that the normal case is now seconds, not an interval.
+#
+# 🚨 THIS JOB FAILS RED WHEN IT NOTIFIES NOBODY. Its predecessor printed "NOT CONFIGURED" and went
+# green for its entire life, which is why nothing was ever notified and nobody noticed. A fan-out
+# that reaches zero repositories is indistinguishable from a fan-out that never ran, so it is an
+# error here — the one shape this whole file exists to prevent.
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: 'The released version, passed to each subscriber as client_payload.version'
+        required: true
+        type: string
+      reason:
+        description: 'What released — "platform" (images) or "packages" (NuGet)'
+        required: true
+        type: string
+    secrets:
+      app-id:
+        required: true
+      private-key:
+        required: true
+
+jobs:
+  notify:
+    name: Notify dependent repos
+    runs-on: ubuntu-latest
+    steps:
+      # Invariant #2: assert the inputs and fail RED naming what is missing, rather than skipping.
+      - name: Assert the dispatch credential is configured
+        env:
+          APP_ID: ${{ secrets.app-id }}
+          PRIVATE_KEY: ${{ secrets.private-key }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "$APP_ID" ]      || missing+=("secrets.DEPENDENT_DISPATCH_APP_ID")
+          [ -n "$PRIVATE_KEY" ] || missing+=("secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY")
+          # 🚨 `needs.<skipped-job>.outputs.*` is the EMPTY STRING, not an error. A CD run once
+          # published and then died on exactly that (#2496). An empty version here would fan a
+          # release event carrying no version out to the whole fleet, so refuse instead.
+          [ -n "$VERSION" ]     || missing+=("inputs.version (empty — did the job producing it skip?)")
+          if [ ${#missing[@]} -gt 0 ]; then
+            printf '::error::%s is not set — the release wave cannot be pushed and every plugin repo would wait for its next schedule poll.\n' "${missing[@]}"
+            exit 1
+          fi
+
+      - name: Mint an installation token for the subscriber repos
+        id: token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.app-id }}
+          private-key: ${{ secrets.private-key }}
+          owner: Systemorph
+          # No `repositories:` — the token spans every repo the App is installed on, which IS the
+          # subscriber set. `contents: read` is not enough: repository_dispatch needs write.
+          permission-contents: write
+
+      - name: Fan the release out to every subscriber
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+          VERSION: ${{ inputs.version }}
+          REASON: ${{ inputs.reason }}
+        run: |
+          set -euo pipefail
+
+          # The subscriber set, read at run time. Not a variable, not a literal in this file.
+          repos=$(gh api --paginate /installation/repositories \
+                    --jq '.repositories[].full_name' | sort -u)
+
+          if [ -z "$repos" ]; then
+            echo "::error::the dispatch App is installed on NO repositories, so this release"
+            echo "::error::notified nobody. Install it on the plugin repos — a fan-out that reaches"
+            echo "::error::zero subscribers is exactly the silent no-op this job replaced."
+            exit 1
+          fi
+
+          echo "Subscribers ($(echo "$repos" | wc -l | tr -d ' ')):"
+          echo "$repos" | sed 's/^/  /'
+
+          # 🚨 Every failure is COLLECTED, never fatal on the first one. A wave that stops at the
+          # first unreachable repo leaves the rest of the fleet stale for an interval, and the
+          # partial state is invisible. Notify everyone, then report.
+          failed=""
+          for repo in $repos; do
+            if gh api -X POST "/repos/$repo/dispatches" \
+                 -f "event_type=meshweaver-framework-released" \
+                 -F "client_payload[version]=$VERSION" \
+                 -F "client_payload[reason]=$REASON" 2>dispatch.err; then
+              echo "  dispatched → $repo"
+            else
+              # A repo with no `repository_dispatch:` receiver still ACCEPTS the POST (204) and
+              # simply runs nothing, so a failure here is a real problem — permissions, or the repo
+              # is gone — and must be named rather than counted.
+              echo "::warning::dispatch FAILED → $repo: $(tr -d '\n' < dispatch.err)"
+              failed="$failed $repo"
+            fi
+          done
+
+          if [ -n "$failed" ]; then
+            echo "::error::the release wave did not reach:$failed"
+            echo "::error::Those repos will rebuild at their next schedule poll instead of now."
+            exit 1
+          fi
+          echo "release $VERSION ($REASON) pushed to every subscriber"

--- a/.github/workflows/release-packages.yml
+++ b/.github/workflows/release-packages.yml
@@ -12,6 +12,9 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    # The tag IS the version; the fan-out below carries it to every subscriber.
+    outputs:
+      version: ${{ steps.extract_version.outputs.version }}
 
     steps:
     - name: Checkout code
@@ -24,7 +27,14 @@ jobs:
 
     - name: Extract version from tag
       id: extract_version
-      run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+      # 🚨 Both, deliberately: $GITHUB_ENV is read by the later steps in THIS job, and
+      # $GITHUB_OUTPUT is the only one a dependent job can see. Writing only the former is how a
+      # downstream job silently receives the empty string.
+      run: |
+        set -euo pipefail
+        version="${GITHUB_REF#refs/tags/v}"
+        echo "VERSION=$version" >> "$GITHUB_ENV"
+        echo "version=$version" >> "$GITHUB_OUTPUT"
       
     - name: Restore workloads
       run: dotnet workload restore
@@ -67,3 +77,21 @@ jobs:
 
     - name: Publish compiler tool to nuget.org
       run: dotnet nuget push ./tool-nupkgs/MeshWeaver.Compiler.Cli.*.nupkg --source https://api.nuget.org/v3/index.json --api-key ${{ secrets.NUGET_PAT }} --skip-duplicate
+
+  # 🚨 PACKAGES ARE HALF OF WHAT A PLUGIN REPO PINS. The images move on a platform release and the
+  # NuGet packages move here, and a plugin repo compiles its in-mesh source against the newest
+  # PUBLISHED package set — so a package release that nobody is told about leaves every plugin repo
+  # building against the previous one until its next schedule poll.
+  #
+  # Same fan-out as main-cd's, same credential, same "fails RED when it notifies nobody" rule.
+  notify-dependents:
+    name: "Push the package release to dependent repos"
+    needs: publish
+    if: needs.publish.result == 'success'
+    uses: ./.github/workflows/notify-dependents.yml
+    with:
+      version: ${{ needs.publish.outputs.version }}
+      reason: packages
+    secrets:
+      app-id: ${{ secrets.DEPENDENT_DISPATCH_APP_ID }}
+      private-key: ${{ secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Makes the release wave **event-driven** — pushed to every dependent repo the moment the platform releases, instead of each repo noticing at its next `schedule` poll.

## Why this is not "another poll optimisation"

A plugin repo compiles against a **pinned** platform. When the platform releases — images from `main-cd`, NuGet packages from a `v*` tag — every plugin repo must rebuild and republish, or its portals read `FrameworkDeclined (built against <old>, live <new>)` and adopt nothing. Until now that wave only travelled by pull.

## The two objections in `main-cd.yml`, answered

That file states a dispatch job here *"never will be"* added. Both reasons were true when written:

| Objection | Status |
|---|---|
| "no credential in the release path" | **`DEPENDENT_DISPATCH_APP_ID` / `_PRIVATE_KEY` were provisioned 2026-08-19** and, until this PR, referenced by **nothing** in this repo. `grep -rn DEPENDENT_DISPATCH .github/` returned zero hits. |
| "no hand-maintained list HERE" | **There is no list.** Subscribers are the repos the App is *installed on*, read at run time from `GET /installation/repositories`. Adding a repo to the wave is installing the App on it. |

This does **not** replace memex's broadcast; the two are independent paths to the same event. The reason for a second is that a wave depending on one hop through a mesh stops whenever that hop is unreachable — and that is not observable from here. The `schedule` poll stays as the fallback, so a lost dispatch costs one delayed wave rather than a missed one.

## Failure modes this refuses to repeat

**It fails RED when it notifies nobody.** Its predecessor printed `NOT CONFIGURED` and went green for its entire life — which is exactly why nothing was ever notified and nobody noticed. A fan-out reaching zero repositories is indistinguishable from one that never ran.

**Per-repo failures are collected, not fatal on the first.** A wave that stops at the first unreachable repo leaves the rest of the fleet stale, with the partial state invisible.

**An empty version is refused.** `needs.<skipped-job>.outputs.*` is the empty string, not an error, and a CD run already died on precisely that (#2496). Relatedly, `release-packages.yml` wrote its version only to `$GITHUB_ENV`, which a *dependent job cannot read* — it now writes `$GITHUB_OUTPUT` too, since that silent `""` is the same defect one layer down.

## Verified

Receivers already exist and agree on the event name — `types: [meshweaver-framework-released]` in MeshWeaver.Plugins, SocialMedia, Reinsurance, Education and Crm. **MeshWeaver.Manufacturing has no `repository_dispatch` receiver at all** and will need one added separately to be part of "every repo".

Both workflows parse (`yaml.safe_load`).

⚠️ **This changes the delivery pipeline's behaviour, so it is a maintainer call to merge**, not something I should land on my own judgement. Two things also need checking before it can work end to end: that the App is installed on every plugin repo, and that its installation token may write `repository_dispatch` there.

Companion work: the ordered rebuild that each notified repo should then perform is Systemorph/MeshWeaver.Plugins#925 — a package may not rebuild until every package it requires has republished at the new version.
