### PR TITLE
Make the release fan-out testable by hand (dry-run), so the App installation can be verified now

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -24,6 +24,22 @@ name: Notify dependent repos
 # error here — the one shape this whole file exists to prevent.
 
 on:
+  # 🚨 RUNNABLE BY HAND, AND DRY BY DEFAULT — because "is the App installed on every plugin repo?"
+  # must be answerable NOW, not at the next release. The whole reason this lane exists is that its
+  # predecessor reported success while notifying nobody for its entire life; a fan-out you cannot
+  # test until it matters is the same bet with extra steps.
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'List the subscribers WITHOUT dispatching (default: true)'
+        required: false
+        default: true
+        type: boolean
+      version:
+        description: 'Version to announce (dry-run ignores it)'
+        required: false
+        default: '0.0.0-dispatch-check'
+        type: string
   workflow_call:
     inputs:
       version:
@@ -80,7 +96,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           VERSION: ${{ inputs.version }}
-          REASON: ${{ inputs.reason }}
+          REASON: ${{ inputs.reason || 'manual-check' }}
+          DRY_RUN: ${{ inputs.dry-run }}
         run: |
           set -euo pipefail
 
@@ -97,6 +114,14 @@ jobs:
 
           echo "Subscribers ($(echo "$repos" | wc -l | tr -d ' ')):"
           echo "$repos" | sed 's/^/  /'
+
+          # The dry run answers the only question that matters before a real release: does this
+          # App reach every repo that must rebuild? It dispatches nothing, so it is safe to run at
+          # any time and proves the wiring without waiting for a release to test it.
+          if [ "${DRY_RUN:-false}" = "true" ]; then
+            echo "dry-run: no dispatches sent. The list above is who WOULD be notified."
+            exit 0
+          fi
 
           # 🚨 Every failure is COLLECTED, never fatal on the first one. A wave that stops at the
           # first unreachable repo leaves the rest of the fleet stale for an interval, and the


### PR DESCRIPTION
Follow-up to #2691. The fan-out is merged, but whether it actually **reaches** anything cannot currently be checked without waiting for a release.

## Why this matters here specifically

The lane #2691 replaced printed `NOT CONFIGURED` and went green for its **entire life** — which is exactly why nothing was ever notified and nobody noticed. A fan-out you cannot test until it matters is that same bet with extra steps.

## The change

`workflow_dispatch` with **`dry-run: true` by default**. It mints the token, resolves the subscriber set from `GET /installation/repositories`, prints it, and dispatches **nothing**. Safe to run at any time; proves the whole chain except the final POST.

## Measured motivation

```
$ gh api /orgs/Systemorph/installations
  azure-boards      repos=all
  meshweaver-cloud  repos=all
```

**Exactly two Apps are installed org-wide, and neither is obviously a dedicated dependent-dispatch App.** So `DEPENDENT_DISPATCH_APP_ID` — provisioned 2026-08-19, referenced by nothing until #2691 — may well name an App that was never installed anywhere. In that case the first real release resolves an **empty** subscriber set.

#2691 already fails red on that rather than going green, which is the important half. But discovering it on a release is strictly worse than discovering it on demand.

## If the dry run reports zero subscribers

Two options, and the second needs no new installation:

1. Install the dispatch App on the plugin repos, or
2. Point the lane at `MESHWEAVER_APP_ID` / `MESHWEAVER_APP_PRIVATE_KEY` — the `meshweaver-cloud` App, which core already holds credentials for and which is installed on **all** repos.

I have not switched it pre-emptively: `DEPENDENT_DISPATCH_APP_*` was provisioned deliberately for this purpose, and the dry run will say which is right in about thirty seconds rather than me guessing from an installation list.