### PR TITLE
ci: the release wave is a GitHub Actions trigger — platform + plugins built together, dependents dispatched, packages cascade

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -253,6 +253,9 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
           PLATFORM_WEBHOOK_URL: ${{ vars.PLATFORM_WEBHOOK_URL }}
           PLATFORM_WEBHOOK_SECRET: ${{ secrets.PLATFORM_WEBHOOK_SECRET }}
+          DEPENDENT_DISPATCH_APP_ID: ${{ secrets.DEPENDENT_DISPATCH_APP_ID }}
+          DEPENDENT_DISPATCH_APP_PRIVATE_KEY: ${{ secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
+          BAKE_PUBLISH_TARGETS: ${{ vars.BAKE_PUBLISH_TARGETS }}
         run: |
           missing=()
           [ -n "$AZURE_CLIENT_ID" ]       || missing+=("secrets.AZURE_CLIENT_ID           OIDC app registration for azure/login")
@@ -260,6 +263,9 @@ jobs:
           [ -n "$AZURE_SUBSCRIPTION_ID" ] || missing+=("secrets.AZURE_SUBSCRIPTION_ID     the subscription holding ACR meshweaver")
           [ -n "$PLATFORM_WEBHOOK_URL" ]  || missing+=("vars.PLATFORM_WEBHOOK_URL         the control instance's inbox, e.g. https://<instance>/api/hooks/Hosting/PlatformBuilds — WITHOUT it no release event ever reaches the mesh, so the framework-release broadcast to the node repos never fires and every satellite falls back to its schedule poll")
           [ -n "$PLATFORM_WEBHOOK_SECRET" ] || missing+=("secrets.PLATFORM_WEBHOOK_SECRET  the shared HMAC the inbox watcher verifies X-Hub-Signature-256 against. It must be BYTE-IDENTICAL to the control instance's Hosting:PlatformWebhookSecret (Key Vault -> Hosting-PlatformWebhookSecret, see deploy/aks/envs/example/secretproviderclass.yaml); a mismatch is INVISIBLE from here — the POST still answers 2xx and the watcher silently drops every delivery as unverifiable")
+          [ -n "$DEPENDENT_DISPATCH_APP_ID" ]          || missing+=("secrets.DEPENDENT_DISPATCH_APP_ID          GitHub App installed on every node repo (Contents: Read + Write) — the release wave's sender")
+          [ -n "$DEPENDENT_DISPATCH_APP_PRIVATE_KEY" ] || missing+=("secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY that App's private key, PEM")
+          [ -n "$BAKE_PUBLISH_TARGETS" ]               || missing+=("vars.BAKE_PUBLISH_TARGETS                  the portals' storage shares the Plugins publication is sealed to (<account>/<share>…)")
           if [ ${#missing[@]} -gt 0 ]; then
             echo "::error::CD cannot deliver a release event — provision the following, then re-run:"
             for m in "${missing[@]}"; do echo "  • $m"; done
@@ -1624,7 +1630,14 @@ jobs:
   # 🚨 Provisioning note (#1755): a subscriber whose own upstreams are not yet published EXITS
   # without building and is re-woken by its upstream's `meshweaver-upstream-published` event, so
   # ────────────────── NO DEPENDENT DISPATCH *FROM HERE*: memex broadcasts (2026-08-23) ──────────
-  # There is deliberately no job here that dispatches to the node repos, and there never will be —
+  # 🚨 SUPERSEDED 2026-08-29 — the paragraph below is kept as the record of a design that never
+  # delivered (#2235: the mesh broadcast's subscriber set was empty on every deploy, and #777: the
+  # inbox watcher that would have run the pin updater is armed on an on-demand hub). The maintainer's
+  # decision: "it should be github actions trigger — no in mesh baking — plugins is top level, built
+  # with platform — on platform update ⇒ update all". The dispatch now happens HERE, in the
+  # `dispatch-dependents` job below, after `plugins-bake` has sealed the Plugins publication for
+  # this run's identity; the mesh notify below stays for the portals' own self-update only.
+  # (Historical, superseded:) There is deliberately no job here that dispatches to the node repos —
   # but the wave is now BROADCAST, not only pulled. The broadcast happens ONE HOP AWAY, in memex,
   # and this workflow already feeds it: the `notify-platform-update` job below signs a POST telling
   # the registry mesh "a new platform build exists". memex, on that fact, fans a
@@ -1794,6 +1807,169 @@ jobs:
   #
   # The assertion itself lives in .github/scripts/check-image-set.sh because `gate` asks the SAME
   # question to decide whether HEAD needs reconciling; the two must never disagree.
+  # ────────────────── PLUGINS: BUILT WITH THE PLATFORM ──────────────────
+  # "plugins is top level — built with platform" (maintainer, 2026-08-29). Plugins is NOT a
+  # subscriber that gets told to rebuild: its module bundles and its NodeType publication for the
+  # identity this run mints are produced HERE, from the same plugins-repo commit the portal image
+  # was built from, and sealed to the portals' storage before any dependent is dispatched. That is
+  # what makes "downstream must check that all dependencies are present" satisfiable — when a
+  # satellite wakes, the upstream it consumes is already sealed for the identity it is told to
+  # bake against. Both legs are the platform's reusable workflows pointed at the Plugins checkout
+  # (content-repository); a node repo calling them with no content-repository behaves as before.
+  plugins-modules:
+    name: "Plugins: pack the module bundles the bake composes"
+    needs: [preflight, gate, promote]
+    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/node-repo-module-pack.yml
+    with:
+      content-repository: Systemorph/MeshWeaver.Plugins
+      content-ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
+      platform-ref: ${{ needs.gate.outputs.sha }}
+      # The compose set the bake needs (the same two Plugins' own ci.yml passes as
+      # module-artifacts); the rest of the catalog is content, baked below.
+      modules: >-
+        [{"package": "AI", "module": "MeshWeaver.AI", "project": "src/MeshWeaver.AI/MeshWeaver.AI.csproj"},
+         {"package": "Essentials", "module": "MeshWeaver.Markdown.Collaboration", "project": "src/MeshWeaver.Markdown.Collaboration/MeshWeaver.Markdown.Collaboration.csproj"}]
+      # Registry module PACKAGES are content-versioned and published by Plugins' own lane when a
+      # package changes; a platform release changes no package content. The bundles packed here
+      # are the bake's inputs (artifacts), nothing more.
+      publish: false
+
+  plugins-bake-image:
+    name: "Plugins: resolve this run's tester image digest"
+    needs: [preflight, gate, plugin-test-image, promote]
+    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    outputs:
+      digest: ${{ steps.digest.outputs.digest }}
+      image: ${{ steps.digest.outputs.image }}
+    steps:
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: ACR login
+        run: az acr login --name meshweaver
+      - name: Resolve the promoted tester image's digest
+        id: digest
+        env:
+          VERSION: ${{ needs.plugin-test-image.outputs.version }}
+        run: |
+          set -euo pipefail
+          [ -n "${VERSION:-}" ] || { echo "::error::plugin-test-image produced no version — cannot name the image the Plugins bake must target"; exit 1; }
+          ref="meshweaver.azurecr.io/mw-plugin-test:${VERSION}"
+          digest=$(docker buildx imagetools inspect "$ref" --format '{{json .Manifest.Digest}}' | tr -d '"')
+          case "$digest" in sha256:*) ;; *) echo "::error::could not resolve a digest for $ref (got '$digest') — the promoted set is not readable"; exit 1 ;; esac
+          echo "digest=$digest" >> "$GITHUB_OUTPUT"
+          echo "image=meshweaver.azurecr.io/mw-plugin-test@$digest" >> "$GITHUB_OUTPUT"
+          echo "plugins bake target: $ref = $digest"
+
+  plugins-bake:
+    name: "Plugins: bake + seal the publication for this identity"
+    needs: [preflight, gate, plugin-test-image, promote, plugins-modules, plugins-bake-image]
+    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success'
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/node-repo-publish-bake.yml
+    with:
+      content-repository: Systemorph/MeshWeaver.Plugins
+      content-ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
+      bake-source: plugins
+      module-artifacts: module-bundle-MeshWeaver.{AI,Markdown.Collaboration}
+      test-image: meshweaver.azurecr.io/mw-plugin-test:${{ needs.plugin-test-image.outputs.version }}
+      image-digest: ${{ needs.plugins-bake-image.outputs.digest }}
+      bake-publish-targets: ${{ vars.BAKE_PUBLISH_TARGETS }}
+      platform-ref: ${{ needs.gate.outputs.sha }}
+      # Plugins is a ROOT: no upstream to wait for. And it does NOT dispatch its own dependents —
+      # on a platform release the job below wakes every repo once; a second, package-shaped wave
+      # from here would wake the same satellites twice for the same identity.
+      upstream-sources: ''
+      dispatch-dependents: false
+    secrets:
+      # No acr-* secrets: the platform holds none, and the reusable bake pulls the image through
+      # the same OIDC identity that publishes to storage (its 'oidc' registry mode).
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+  # ────────────────── DISPATCH DEPENDENTS: "on platform update ⇒ update all" ──────────────────
+  # Fires ONLY after the Plugins publication is sealed for this identity. Every repo the dispatch
+  # App is installed on, except this one and Plugins (built above, not a subscriber), receives
+  # `meshweaver-framework-released`; their CI already answers it by baking against the released
+  # image and refusing unless every upstream is sealed. Package-only publishes take the other
+  # path — the reusable bake's own `dispatch-dependents` job sends `meshweaver-upstream-published`
+  # to dependents only, and recurses.
+  #
+  # 🚨 No hand-maintained subscriber list and no skip-trapdoor: the set IS the App's installation
+  # (install the App on a repo = subscribe it), preflight asserts the credential RED, an empty set
+  # is RED, and a failed dispatch is RED naming the repo. A release that told nobody is not delivered.
+  dispatch-dependents:
+    name: "Dispatch meshweaver-framework-released to every dependent repo"
+    needs: [preflight, gate, plugin-test-image, promote, plugins-bake, plugins-bake-image]
+    if: needs.gate.outputs.publish == 'true' && needs.promote.result == 'success' && needs.plugins-bake.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: Mint an installation token for the dependents
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.DEPENDENT_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+      - name: Dispatch to every installed repo (except the platform and Plugins)
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          SHA: ${{ needs.gate.outputs.sha }}
+          VERSION: ${{ needs.plugin-test-image.outputs.version }}
+          IMAGE: ${{ needs.plugins-bake-image.outputs.image }}
+          DIGEST: ${{ needs.plugins-bake-image.outputs.digest }}
+          SELF: ${{ github.repository }}
+          PLUGINS: Systemorph/MeshWeaver.Plugins
+        run: |
+          set -euo pipefail
+          repos=$(gh api --paginate /installation/repositories --jq '.repositories[].full_name')
+          [ -n "$repos" ] || { echo "::error::the dispatch App is installed on NO repository — nobody is subscribed. Install DEPENDENT_DISPATCH's App on the node repos."; exit 1; }
+          payload=$(jq -cn --arg sha "$SHA" --arg v "$VERSION" --arg i "$IMAGE" --arg d "$DIGEST" \
+            '{sha:$sha, version:$v, image:$i, digest:$d, source:"platform", chain:["platform","plugins"]}')
+          dispatched=(); failed=()
+          for repo in $repos; do
+            case "$repo" in "$SELF"|"$PLUGINS") continue ;; esac
+            code=$(curl -sS -o /tmp/resp -w '%{http_code}' -X POST \
+              -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$repo/dispatches" \
+              -d "$(jq -cn --argjson p "$payload" '{event_type:"meshweaver-framework-released", client_payload:$p}')") || code=000
+            case "$code" in
+              2*) dispatched+=("$repo") ;;
+              *)  failed+=("$repo (HTTP $code: $(head -c 200 /tmp/resp | tr '\n' ' '))") ;;
+            esac
+          done
+          if [ ${#dispatched[@]} -eq 0 ] && [ ${#failed[@]} -eq 0 ]; then
+            echo "::error::the App is installed only on $SELF / $PLUGINS — no dependent to dispatch. Install it on the node repos."; exit 1
+          fi
+          {
+            echo "### 📣 Platform ${VERSION} (${SHA:0:9}) released — dependents dispatched"
+            echo "- image: \`$IMAGE\`"
+            for r in "${dispatched[@]}"; do echo "- ✅ $r"; done
+            for r in "${failed[@]}";     do echo "- ❌ $r"; done
+          } >> "$GITHUB_STEP_SUMMARY"
+          for r in "${dispatched[@]}"; do echo "dispatched: $r"; done
+          if [ ${#failed[@]} -gt 0 ]; then
+            for r in "${failed[@]}"; do echo "::error::dispatch failed: $r"; done
+            exit 1
+          fi
+
   verify-images:
     name: "Verify every image shipped"
     needs: [gate, portal-image, migration-image, plugin-test-image, promote]
@@ -1869,7 +2045,8 @@ jobs:
     # 🚨 Every delivery leg is a NEED, not just [gate, promote]. The verdict cannot assert that a
     # publish actually happened while it can only see two of the nine jobs that make it happen.
     needs: [preflight, gate, portal-image, migration-image, plugin-test-image, promote,
-            publish-bake, notify-platform-update, verify-images]
+            publish-bake, notify-platform-update, verify-images,
+            plugins-modules, plugins-bake-image, plugins-bake, dispatch-dependents]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -2006,6 +2183,10 @@ jobs:
             publish-bake=${{ needs.publish-bake.result }}
             notify-platform-update=${{ needs.notify-platform-update.result }}
             verify-images=${{ needs.verify-images.result }}
+            plugins-modules=${{ needs.plugins-modules.result }}
+            plugins-bake-image=${{ needs.plugins-bake-image.result }}
+            plugins-bake=${{ needs.plugins-bake.result }}
+            dispatch-dependents=${{ needs.dispatch-dependents.result }}
         run: |
           set -euo pipefail
           bad=""

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -123,6 +123,19 @@ on:
         description: The registry that will serve these bundles onward.
         type: string
         default: https://memex.meshweaver.cloud
+      content-repository:
+        description: >-
+          The repository whose packages are packed. Empty = the caller (today's behaviour). The
+          platform's CD sets it to Systemorph/MeshWeaver.Plugins: Plugins is built WITH the
+          platform, so its module bundles for a new framework identity come out of the same run.
+        required: false
+        type: string
+        default: ''
+      content-ref:
+        description: The ref of content-repository to pack. Empty = the caller's own commit.
+        required: false
+        type: string
+        default: ''
     secrets:
       publish-token:
         description: The registry's Plugins:Registry:PublishToken. Required when publish is true.
@@ -149,6 +162,8 @@ jobs:
       # keeping the two trees apart is the version that cannot rot.
       - uses: actions/checkout@v7
         with:
+          repository: ${{ inputs.content-repository || github.repository }}
+          ref: ${{ inputs.content-ref || github.sha }}
           path: repo
           # 🚨 The diff is taken against the PR base, so the base commits must be present. A
           # shallow clone would make every range unresolvable — which the scope script turns into
@@ -219,6 +234,9 @@ jobs:
         entry: ${{ fromJson(needs.select.outputs.modules) }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.content-repository || github.repository }}
+          ref: ${{ inputs.content-ref || github.sha }}
       - name: Check out Systemorph/MeshWeaver at the pinned ref
         uses: actions/checkout@v7
         with:

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1026,9 +1026,16 @@ jobs:
           dispatched=(); skipped=(); failed=()
           for repo in $repos; do
             if [ "$repo" = "$SELF" ]; then continue; fi
-            ci=$(gh api "repos/$repo/contents/.github/workflows/ci.yml" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
-            if [ -z "$ci" ]; then skipped+=("$repo (no .github/workflows/ci.yml)"); continue; fi
-            own=$(printf '%s\n' "$ci" | grep -E '^[[:space:]]*bake-source:' | head -1 | sed -E 's/^[[:space:]]*bake-source:[[:space:]]*//; s/["'"'"']//g; s/[[:space:]]+$//')
+            # A missing ci.yml is a designed skip (404, said so); ANY other failure to read it is
+            # RED — a transient API error must never read as "this repo has no CI", because that
+            # is exactly a dependent silently left out of the wave.
+            err="$RUNNER_TEMP/ci-read.err"
+            if ! resp=$(gh api "repos/$repo/contents/.github/workflows/ci.yml" 2>"$err"); then
+              if grep -q "HTTP 404" "$err"; then skipped+=("$repo (no .github/workflows/ci.yml)"); continue; fi
+              failed+=("$repo (could not read its ci.yml: $(tr '\n' ' ' <"$err" | head -c 200))"); continue
+            fi
+            ci=$(jq -r '.content' <<<"$resp" | base64 -d)
+            own=$(printf '%s\n' "$ci" | sed -nE 's/^[[:space:]]*bake-source:[[:space:]]*//p' | head -1 | sed -E 's/["'"'"']//g; s/[[:space:]]+$//')
             if [ -n "$own" ] && jq -e --arg o "$own" 'index($o) != null' <<<"$chain" >/dev/null; then
               skipped+=("$repo (its source '$own' is already in the chain — cycle guard)"); continue
             fi

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -249,13 +249,43 @@ on:
         required: false
         type: string
         default: ''
+      content-repository:
+        description: >-
+          The repository whose node content is baked. Empty = the caller (every node repo baking
+          its own content — today's behaviour). The platform's CD sets it to
+          Systemorph/MeshWeaver.Plugins: Plugins is built WITH the platform, not as a subscriber,
+          so its publication for a new framework identity is sealed in the same run that mints
+          the identity, before any dependent is told to rebuild.
+        required: false
+        type: string
+        default: ''
+      content-ref:
+        description: The ref of content-repository to bake. Empty = the caller's own commit.
+        required: false
+        type: string
+        default: ''
+      dispatch-dependents:
+        description: >-
+          After a SUCCESSFUL publish, send `repository_dispatch: meshweaver-upstream-published` to
+          every repo the dispatch App is installed on whose ci.yml declares this bake-source as an
+          upstream (`upstream-sources:` / `upstream-seed:`). That is the package-publish half of
+          the rebuild wave: "otherwise only dependent packages — then publish package built and
+          cascade recursively". Each receiver bakes against the SAME image (client_payload.image),
+          publishes, and emits the same event for its own source; the payload carries the chain of
+          sources so a cycle can never loop. Needs the dispatch-app-* secrets, asserted RED.
+        required: false
+        type: boolean
+        default: false
     secrets:
       acr-username:
-        description: Registry user able to pull the test image.
-        required: true
+        description: >-
+          Registry user able to pull the test image. OPTIONAL since the platform's own CD calls
+          this workflow: leave both acr-* secrets empty and the image pull authenticates through
+          the azure-* OIDC identity instead (`az acr login`), which then needs AcrPull.
+        required: false
       acr-password:
-        description: Registry password for that user.
-        required: true
+        description: Registry password for that user (see acr-username).
+        required: false
       azure-client-id:
         description: >-
           Client id of an Azure identity holding "Storage File Data Privileged Contributor" on
@@ -283,12 +313,27 @@ on:
           Instance key (mwi_…) able to read the packages named in registry-modules from
           registry-url. Needed only when registry-modules is set.
         required: false
+      dispatch-app-id:
+        description: >-
+          App id of a GitHub App installed on every repo that may depend on this one, with
+          Contents: Read (to read their ci.yml) and Contents: Write (repository_dispatch).
+          Required when dispatch-dependents is true; asserted RED, never skipped.
+        required: false
+      dispatch-app-private-key:
+        description: Private key (PEM) of that App.
+        required: false
 
 jobs:
   publish-bake:
     name: Bake + publish NodeType assemblies to portal storage
     runs-on: ubuntu-latest
     timeout-minutes: ${{ inputs.timeout-minutes }}
+    outputs:
+      # Read by dispatch-dependents below: a run that baked NOTHING (already sealed) publishes
+      # nothing and therefore wakes nobody.
+      published: ${{ steps.publish.outputs.published }}
+      image: ${{ steps.image.outputs.ref }}
+      identity: ${{ steps.identity.outputs.identity }}
     permissions:
       contents: read
       id-token: write     # azure/login OIDC — no long-lived storage secret in any node repo
@@ -303,6 +348,8 @@ jobs:
           AZURE_SUBSCRIPTION_ID: ${{ secrets.azure-subscription-id }}
           ACR_USERNAME: ${{ secrets.acr-username }}
           ACR_PASSWORD: ${{ secrets.acr-password }}
+          # Half a basic credential is a misconfiguration, not OIDC mode.
+          ACR_MODE: ${{ (secrets.acr-username != '' && secrets.acr-password != '') && 'basic' || ((secrets.acr-username == '' && secrets.acr-password == '') && 'oidc' || 'half') }}
           STAGE_APP_ID: ${{ secrets.stage-repo-app-id }}
           STAGE_APP_KEY: ${{ secrets.stage-repo-app-private-key }}
           BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
@@ -318,8 +365,11 @@ jobs:
           [ -n "${AZURE_CLIENT_ID:-}" ]        || missing+=("azure-client-id (secret) — client id of an Azure identity holding 'Storage File Data Privileged Contributor' on the portals' storage account, with a federated credential for repo:${GITHUB_REPOSITORY}:ref:refs/heads/main")
           [ -n "${AZURE_TENANT_ID:-}" ]        || missing+=("azure-tenant-id (secret) — tenant of that identity")
           [ -n "${AZURE_SUBSCRIPTION_ID:-}" ]  || missing+=("azure-subscription-id (secret) — subscription of the storage account")
-          [ -n "${ACR_USERNAME:-}" ]           || missing+=("acr-username (secret) — registry user able to pull the test image")
-          [ -n "${ACR_PASSWORD:-}" ]           || missing+=("acr-password (secret) — registry password for that user")
+          case "${ACR_MODE:-}" in
+            basic) ;;                       # user + password present
+            oidc)  ;;                       # both empty: az acr login under the azure-* identity (asserted below)
+            *) missing+=("acr-username + acr-password (secrets) — set BOTH for a basic registry login, or NEITHER to pull through the azure-* OIDC identity; one without the other is neither") ;;
+          esac
           [ -n "${BAKE_PUBLISH_TARGETS:-}" ]   || missing+=("bake-publish-targets (input, from the caller's repo VARIABLE) — the portals' Azure Files targets, whitespace-separated <account>/<share>[/<base-path>]")
           if [ -n "${STAGE_MODULES:-}" ]; then
             stage_missing=0
@@ -369,7 +419,18 @@ jobs:
       # expressions treat the NUMBER 0 as falsy, so `inputs.x && 0 || 1` yields 1 in both branches.
       - uses: actions/checkout@v7
         with:
+          # Empty inputs fall through to the caller's own repo + commit — byte-identical to the
+          # default checkout for every node repo; only the platform's CD points these elsewhere.
+          repository: ${{ inputs.content-repository || github.repository }}
+          ref: ${{ inputs.content-ref || github.sha }}
           fetch-depth: ${{ inputs.narrow-by-affected && '0' || '1' }}
+      # 🚨 The CONTENT commit, not $GITHUB_SHA. They differ exactly when content-repository is set
+      # (the platform baking Plugins), and the publication records the content's commit — the
+      # bake-scope baseline is compared against it on the next run, so stamping the caller's sha
+      # would make every narrowed bake fall back to a full one.
+      - name: Resolve the content commit
+        id: content
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - name: Resolve the bake image
         id: image
         env:
@@ -377,9 +438,18 @@ jobs:
           IMAGE_DIGEST: ${{ inputs.image-digest }}
           RELEASED_VERSION: ${{ github.event.client_payload.version }}
           RELEASED_SHA: ${{ github.event.client_payload.sha }}
+          UPSTREAM_IMAGE: ${{ github.event.client_payload.image }}
+          UPSTREAM_SOURCE: ${{ github.event.client_payload.source }}
         run: |
           set -euo pipefail
-          if [ "${{ github.event_name }}" = "repository_dispatch" ] && [ -n "${RELEASED_VERSION:-}" ]; then
+          if [ "${{ github.event.action }}" = "meshweaver-upstream-published" ]; then
+            # A dependency republished for an identity: bake against THAT image, so this repo's
+            # publication lands under the same identity its upstream just sealed. Never the pin
+            # and never the tag — either could name a different framework than the upstream's.
+            [ -n "${UPSTREAM_IMAGE:-}" ] || { echo "::error::meshweaver-upstream-published payload carries no client_payload.image — cannot know which framework the upstream '${UPSTREAM_SOURCE:-?}' was sealed for."; exit 1; }
+            echo "ref=${UPSTREAM_IMAGE}" >> "$GITHUB_OUTPUT"
+            echo "woken by upstream '${UPSTREAM_SOURCE:-?}' publishing; baking against its image ${UPSTREAM_IMAGE}"
+          elif [ "${{ github.event_name }}" = "repository_dispatch" ] && [ -n "${RELEASED_VERSION:-}" ]; then
             # The release's own identity tag (main-cd promote, phase A). A framework-release
             # dispatch without a resolvable image is a platform CD contract break — fail loudly
             # below, never fall back to the pinned digest (that would publish the OLD identity and
@@ -412,7 +482,33 @@ jobs:
             echo "::error::image-digest is empty and allow-unpinned is not set — pin a digest (reproducible) or opt in to following the tag."
             exit 1
           fi
+      - name: Registry login mode
+        id: acr
+        env:
+          ACR_MODE: ${{ (secrets.acr-username != '' && secrets.acr-password != '') && 'basic' || ((secrets.acr-username == '' && secrets.acr-password == '') && 'oidc' || 'half') }}
+        run: |
+          set -euo pipefail
+          case "$ACR_MODE" in
+            basic|oidc) echo "mode=$ACR_MODE" >> "$GITHUB_OUTPUT"; echo "registry login: $ACR_MODE" ;;
+            *) echo "::error::acr-username and acr-password must BOTH be set (basic) or BOTH be empty (OIDC via the azure-* identity) — one without the other is a misconfiguration, not a mode."; exit 1 ;;
+          esac
+      - name: Azure login (OIDC) for the image pull
+        if: steps.acr.outputs.mode == 'oidc'
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.azure-client-id }}
+          tenant-id: ${{ secrets.azure-tenant-id }}
+          subscription-id: ${{ secrets.azure-subscription-id }}
+      - name: Log in to the image registry (OIDC)
+        if: steps.acr.outputs.mode == 'oidc'
+        env:
+          TEST_IMAGE: ${{ inputs.test-image }}
+        run: |
+          set -euo pipefail
+          host="${TEST_IMAGE%%/*}"
+          az acr login --name "${host%%.*}" || { echo "::error::az acr login to ${host} failed under the OIDC identity — it needs AcrPull on that registry."; exit 1; }
       - name: Log in to the image registry
+        if: steps.acr.outputs.mode == 'basic'
         env:
           TEST_IMAGE: ${{ inputs.test-image }}
         run: |
@@ -736,7 +832,7 @@ jobs:
           docker run --rm --init "${EXT_V[@]}" -v "$REPO_MOUNT:/repo" -v "$BAKE:/bake" \
             --entrypoint /app/mw-plugin-test "${{ steps.image.outputs.ref }}" compile /repo \
             "${ALLOW_ARGS[@]}" ${EXT_MODULE_ARGS:-} \
-            --output /bake --source-sha "$GITHUB_SHA"
+            --output /bake --source-sha "${{ steps.content.outputs.sha }}"
 
           # ══ 2. THE GATE — a mesh, CONSUMING the bake above ═════════════════════════════════
           # Strictly stronger than the fused form as a gate: fused, the mesh rendered and ran
@@ -807,6 +903,7 @@ jobs:
           "${{ steps.identity.outputs.identity }}"
           "${{ inputs.bake-source }}"
       - name: Publish bundles to every portal target
+        id: publish
         if: steps.scope.outputs.scope != 'none'
         env:
           BAKE_PUBLISH_TARGETS: ${{ inputs.bake-publish-targets }}
@@ -817,7 +914,8 @@ jobs:
         # design).
         run: |
           set -euo pipefail
-          mw-platform/.github/scripts/publish-bake-bundles.sh "$BAKE_DIR" "${{ inputs.bake-source }}" "$GITHUB_SHA"
+          mw-platform/.github/scripts/publish-bake-bundles.sh "$BAKE_DIR" "${{ inputs.bake-source }}" "${{ steps.content.outputs.sha }}"
+          echo "published=true" >> "$GITHUB_OUTPUT"
           {
             echo "### 📦 CI bake published"
             echo "- identity: \`$(cat "$BAKE_DIR/framework-mvid.txt")\`"
@@ -847,6 +945,116 @@ jobs:
         run: |
           set -euo pipefail
           echo "no bake, no publish: $REASON"
-          echo "published baseline: $BASELINE   head: $GITHUB_SHA   identity: ${{ steps.identity.outputs.identity }}"
+          echo "published baseline: $BASELINE   head: ${{ steps.content.outputs.sha }}   identity: ${{ steps.identity.outputs.identity }}"
           echo "This is a VERIFIED outcome, not a skipped gate: the sealed publication was read from"
           echo "every target in BAKE_PUBLISH_TARGETS and compared against this commit's content."
+
+  # ────────────────── DISPATCH DEPENDENTS (the package-publish half of the wave) ──────────────────
+  # "otherwise only dependent packages — then publish package built and cascade recursively"
+  # (maintainer, 2026-08-29). A platform release rebuilds EVERYTHING (the platform's CD sends
+  # meshweaver-framework-released to every installed repo); a package publish wakes ONLY the repos
+  # that declare this source as an upstream, against the SAME image, and each of those emits the
+  # same event for its own source after it publishes — recursion by construction, terminated by the
+  # chain carried in the payload.
+  #
+  # Dependents are DISCOVERED, never listed: every repo the dispatch App is installed on is asked
+  # for its .github/workflows/ci.yml, and a repo depends on this source iff that file declares it
+  # under `upstream-sources:` or `upstream-seed:`. Installing the App on a new node repo is the
+  # whole subscription. A repo with no ci.yml, or one that does not name this source, is skipped
+  # and SAID so — silence is not a skip.
+  #
+  # 🚨 A failed dispatch is RED, not a warning. "The next own push re-bakes it" is precisely the
+  # silent-drift shape the maintainer is removing; a dependent that was not told is a dependent
+  # that is out of date, and this job's summary must say which one.
+  dispatch-dependents:
+    name: Dispatch dependents (meshweaver-upstream-published)
+    needs: publish-bake
+    if: >-
+      inputs.dispatch-dependents && needs.publish-bake.result == 'success'
+      && needs.publish-bake.outputs.published == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: "Preflight: the dispatch credential must be provisioned"
+        env:
+          APP_ID: ${{ secrets.dispatch-app-id }}
+          APP_KEY: ${{ secrets.dispatch-app-private-key }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${APP_ID:-}" ]  || missing+=("dispatch-app-id (secret) — a GitHub App installed on every dependent repo, Contents: Read + Write")
+          [ -n "${APP_KEY:-}" ] || missing+=("dispatch-app-private-key (secret) — that App's private key, PEM")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::dispatch-dependents is on but its credential is not provisioned — a publish that wakes nobody is silent drift:"
+            for m in "${missing[@]}"; do echo "  • $m"; done
+            exit 1
+          fi
+      - name: Mint an installation token for the dependents
+        id: app
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.dispatch-app-id }}
+          private-key: ${{ secrets.dispatch-app-private-key }}
+          owner: ${{ github.repository_owner }}
+      - name: Dispatch to every installed repo that declares this source as an upstream
+        env:
+          GH_TOKEN: ${{ steps.app.outputs.token }}
+          SOURCE: ${{ inputs.bake-source }}
+          IMAGE: ${{ needs.publish-bake.outputs.image }}
+          IDENTITY: ${{ needs.publish-bake.outputs.identity }}
+          CHAIN_IN: ${{ toJSON(github.event.client_payload.chain) }}
+          RELEASED_VERSION: ${{ github.event.client_payload.version }}
+          RELEASED_SHA: ${{ github.event.client_payload.sha }}
+          SELF: ${{ inputs.content-repository || github.repository }}
+        run: |
+          set -euo pipefail
+          # The chain: every source that led here, plus this one. A repo whose own bake-source is
+          # already in it is never dispatched — that is the cycle guard, and it needs no registry.
+          chain=$(jq -cn --argjson in "${CHAIN_IN:-null}" --arg s "$SOURCE" '(if ($in|type)=="array" then $in else [] end) + [$s]')
+          echo "source=$SOURCE image=$IMAGE identity=${IDENTITY:-?} chain=$chain"
+          repos=$(gh api --paginate /installation/repositories --jq '.repositories[].full_name')
+          [ -n "$repos" ] || { echo "::error::the dispatch App is installed on NO repository — nothing can subscribe. Install it on the dependent repos."; exit 1; }
+          # A receiver's own gate wants the bare digest (its image-digest input); the bake wants
+          # the full reference. Carry both — the digest is the part after '@' when the image was
+          # resolved by digest, empty when it was a tag (then the receiver resolves it itself).
+          digest=""; case "$IMAGE" in *@sha256:*) digest="${IMAGE#*@}" ;; esac
+          payload=$(jq -cn --arg s "$SOURCE" --arg i "$IMAGE" --arg d "$digest" --arg id "${IDENTITY:-}" --argjson c "$chain" \
+            --arg v "${RELEASED_VERSION:-}" --arg sha "${RELEASED_SHA:-}" \
+            '{source:$s, image:$i, digest:$d, identity:$id, chain:$c, version:$v, sha:$sha}')
+          dispatched=(); skipped=(); failed=()
+          for repo in $repos; do
+            if [ "$repo" = "$SELF" ]; then continue; fi
+            ci=$(gh api "repos/$repo/contents/.github/workflows/ci.yml" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+            if [ -z "$ci" ]; then skipped+=("$repo (no .github/workflows/ci.yml)"); continue; fi
+            own=$(printf '%s\n' "$ci" | grep -E '^[[:space:]]*bake-source:' | head -1 | sed -E 's/^[[:space:]]*bake-source:[[:space:]]*//; s/["'"'"']//g; s/[[:space:]]+$//')
+            if [ -n "$own" ] && jq -e --arg o "$own" 'index($o) != null' <<<"$chain" >/dev/null; then
+              skipped+=("$repo (its source '$own' is already in the chain — cycle guard)"); continue
+            fi
+            if ! printf '%s\n' "$ci" | grep -Eq "^[[:space:]]*(upstream-sources|upstream-seed):[[:space:]]*.*(^|[[:space:],\"'])${SOURCE}([[:space:],\"']|$)"; then
+              skipped+=("$repo (does not declare upstream '$SOURCE')"); continue
+            fi
+            code=$(curl -sS -o /tmp/resp -w '%{http_code}' -X POST \
+              -H "Authorization: Bearer $GH_TOKEN" -H "Accept: application/vnd.github+json" \
+              "https://api.github.com/repos/$repo/dispatches" \
+              -d "$(jq -cn --argjson p "$payload" '{event_type:"meshweaver-upstream-published", client_payload:$p}')") || code=000
+            case "$code" in
+              2*) dispatched+=("$repo") ;;
+              *)  failed+=("$repo (HTTP $code: $(head -c 200 /tmp/resp | tr '\n' ' '))") ;;
+            esac
+          done
+          {
+            echo "### 📣 upstream '$SOURCE' published — dependents dispatched"
+            echo "- image: \`$IMAGE\`  identity: \`${IDENTITY:-?}\`  chain: \`$chain\`"
+            for r in "${dispatched[@]}"; do echo "- ✅ $r"; done
+            for r in "${skipped[@]}";    do echo "- ⏭️ $r"; done
+            for r in "${failed[@]}";     do echo "- ❌ $r"; done
+          } >> "$GITHUB_STEP_SUMMARY"
+          for r in "${dispatched[@]}"; do echo "dispatched: $r"; done
+          for r in "${skipped[@]}";    do echo "skipped:    $r"; done
+          if [ ${#failed[@]} -gt 0 ]; then
+            for r in "${failed[@]}"; do echo "::error::dispatch failed: $r"; done
+            exit 1
+          fi
+          echo "dependents dispatched: ${#dispatched[@]}"

--- a/test/MeshWeaver.Documentation.Test/PlatformReleaseNotifyGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PlatformReleaseNotifyGuard.cs
@@ -150,21 +150,42 @@ public class PlatformReleaseNotifyGuard
     }
 
     /// <summary>
-    /// 🚨 No hand-maintained subscriber list, and no satellite write credential, may creep back
-    /// into the release path. The subscriber set lives in the Hosting fleet registry on the control
-    /// instance; the platform holds no write access to any node repo and signs one POST instead.
-    /// `BAKE_SUBSCRIBER_REPOS` was the previous attempt — it was never provisioned, printed
-    /// "NOT CONFIGURED" for its whole life, and survived as a repo variable holding one stale repo
-    /// name long after the design moved on.
+    /// 🚨 The dependents ARE dispatched from here (maintainer, 2026-08-29: "it should be github actions
+    /// trigger — no in mesh baking — on platform update ⇒ update all"), and the way it is done is
+    /// what this guard pins, because both previous designs failed in the same silent shape:
+    /// <c>BAKE_SUBSCRIBER_REPOS</c> + a stored PAT printed "NOT CONFIGURED" for its whole life, and
+    /// the mesh broadcast that replaced it dispatched to an empty subscriber set on every deploy
+    /// (#2235). So: no hand-maintained list (the set is the dispatch App's installation, read at
+    /// run time), no stored token (an App installation token minted per run), the credential asserted
+    /// RED in preflight, and the job itself a delivery leg the verdict requires — never a skip.
     /// </summary>
     [Fact]
-    public void TheReleasePathHoldsNoSubscriberListAndNoSatelliteCredential()
+    public void TheDispatchIsDiscoveredAppCredentialedAndAssertedRed()
     {
         var body = Body();
-
         Assert.DoesNotContain("BAKE_SUBSCRIBER_REPOS", body, StringComparison.Ordinal);
         Assert.DoesNotContain("DEPENDENT_DISPATCH_TOKEN", body, StringComparison.Ordinal);
-        Assert.DoesNotContain("/dispatches", body, StringComparison.Ordinal);
+
+        var job = JobBlock(body, "dispatch-dependents:");
+        Assert.Contains("actions/create-github-app-token", job, StringComparison.Ordinal);
+        Assert.Contains("secrets.DEPENDENT_DISPATCH_APP_ID", job, StringComparison.Ordinal);
+        Assert.Contains("secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY", job, StringComparison.Ordinal);
+        Assert.Contains("/installation/repositories", job, StringComparison.Ordinal);
+        Assert.Contains("meshweaver-framework-released", job, StringComparison.Ordinal);
+        Assert.DoesNotContain("continue-on-error", job, StringComparison.Ordinal);
+        Assert.DoesNotContain("::warning", job, StringComparison.Ordinal);
+        Assert.Contains("exit 1", job, StringComparison.Ordinal);
+        // Plugins is built WITH the platform (plugins-bake), never told to rebuild — and the wave
+        // fires only after that publication is sealed.
+        Assert.Contains("needs.plugins-bake.result == 'success'", job, StringComparison.Ordinal);
+
+        var preflight = SectionAfter(JobBlock(body, "preflight:"), "missing=()");
+        Assert.Contains("DEPENDENT_DISPATCH_APP_ID", preflight, StringComparison.Ordinal);
+        Assert.Contains("DEPENDENT_DISPATCH_APP_PRIVATE_KEY", preflight, StringComparison.Ordinal);
+
+        var legs = SectionAfter(JobBlock(body, "delivery-verdict:"), "LEGS: >-");
+        Assert.Contains("dispatch-dependents=", legs, StringComparison.Ordinal);
+        Assert.Contains("plugins-bake=", legs, StringComparison.Ordinal);
     }
 
     // ── helpers ──────────────────────────────────────────────────────────────

--- a/test/MeshWeaver.Documentation.Test/UpstreamBuildGateGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/UpstreamBuildGateGuard.cs
@@ -97,24 +97,44 @@ public class UpstreamBuildGateGuard
     }
 
     /// <summary>
-    /// 🚨 The wave is PULLED, and no credential may creep back in.
-    ///
-    /// <para>This workflow used to POST <c>meshweaver-upstream-published</c> to a declared list of
-    /// dependent repos, using a token with write access to each. Both are gone: a publication is a
-    /// FACT about the registry, and a dependent repo's scheduled run reads memex for the released
-    /// image and rebuilds if it must.</para>
-    ///
-    /// <para>Pinned because the tempting fix, when a satellite is found a release behind, is to add
-    /// the token back — which reintroduces a cross-repo write credential AND a hand-maintained
-    /// second copy of a graph memex already holds, whose missing entry fails silently.</para>
+    /// 🚨 A package publish wakes ONLY the repos that depend on it — "otherwise only dependent
+    /// packages — then publish package built and cascade recursively" (maintainer, 2026-08-29) —
+    /// and the way it does so is pinned, because the previous version of this cascade POSTed to a
+    /// declared list with a stored token and was removed for exactly that: a hand-maintained second
+    /// copy of a graph whose missing entry fails silently. Now: opt-in (<c>dispatch-dependents</c>),
+    /// dependents DISCOVERED from the installed repos' own <c>upstream-sources</c>/<c>upstream-seed</c>
+    /// declarations, an App token minted per run (no stored PAT), the credential asserted RED, a
+    /// failed dispatch RED naming the repo, and the source chain carried so a cycle cannot loop.
     /// </summary>
     [Fact]
-    public void ThereIsNoDependentDispatch_AndNoCredentialForOne()
+    public void TheCascadeIsOptInDiscoveredAppCredentialedAndRed()
     {
         var body = Body();
-
         Assert.DoesNotContain("dependent-dispatch-token", body, StringComparison.Ordinal);
-        Assert.DoesNotContain("meshweaver-upstream-published", body, StringComparison.Ordinal);
-        Assert.DoesNotContain("/dispatches", body, StringComparison.Ordinal);
+
+        var job = JobBlock(body, "dispatch-dependents:");
+        Assert.Contains("inputs.dispatch-dependents", job, StringComparison.Ordinal);
+        Assert.Contains("needs.publish-bake.outputs.published == 'true'", job, StringComparison.Ordinal);
+        Assert.Contains("actions/create-github-app-token", job, StringComparison.Ordinal);
+        Assert.Contains("secrets.dispatch-app-id", job, StringComparison.Ordinal);
+        Assert.Contains("/installation/repositories", job, StringComparison.Ordinal);
+        Assert.Contains("upstream-sources|upstream-seed", job, StringComparison.Ordinal);
+        Assert.Contains("meshweaver-upstream-published", job, StringComparison.Ordinal);
+        Assert.Contains("chain", job, StringComparison.Ordinal);
+        Assert.DoesNotContain("continue-on-error", job, StringComparison.Ordinal);
+        Assert.DoesNotContain("::warning", job, StringComparison.Ordinal);
+        Assert.Contains("exit 1", job, StringComparison.Ordinal);
+    }
+
+    /// <summary>Everything from a job's key to the next job key at the same indent.</summary>
+    private static string JobBlock(string body, string jobKey)
+    {
+        var start = body.IndexOf("\n  " + jobKey, StringComparison.Ordinal);
+        Assert.True(start >= 0, $"job '{jobKey}' is gone from {Workflow} — it has been removed or "
+                                + "renamed, which no other check would catch.");
+        var next = body.IndexOf("\n  ", start + jobKey.Length + 3, StringComparison.Ordinal);
+        while (next >= 0 && next + 3 < body.Length && body[next + 3] == ' ')
+            next = body.IndexOf("\n  ", next + 1, StringComparison.Ordinal);
+        return next < 0 ? body[start..] : body[start..next];
     }
 }


### PR DESCRIPTION
Implements the maintainer's directives on the cross-repo rebuild wave (2026-08-29): **GitHub Actions trigger, no in-mesh hop; Plugins built with the platform; platform update ⇒ update all; package publish ⇒ dependent packages only, cascading recursively; downstream refuses unless every upstream is present.**

## Why now
Measured today: **47 signed platform-build events unconsumed** in `Hosting/PlatformBuilds/_Inbox` (Plugins#777 — the watcher lives on an on-demand hub), the mesh broadcaster's subscriber set empty on every deploy (#2235), and every pin bump in every node repo done by hand. The wave has never fired.

## `main-cd.yml`
- **`plugins-modules` → `plugins-bake-image` → `plugins-bake`**: the platform run packs the Plugins compose set and bakes + seals the Plugins publication for *this run's* identity from the same plugins-repo commit the portal image used. Plugins is built with the platform, not told to rebuild.
- **`dispatch-dependents`**: after the seal, `repository_dispatch: meshweaver-framework-released` to every repo the `DEPENDENT_DISPATCH` App is installed on, except core and Plugins. Install the App = subscribe. Preflight asserts the App secrets + `BAKE_PUBLISH_TARGETS` **RED**; empty set RED; failed dispatch RED naming the repo; the delivery verdict requires all four legs.
- The "never from here" prose is marked superseded, citing #2235/#777.

## `node-repo-publish-bake.yml` (reusable)
- `content-repository`/`content-ref` (default = caller; every node repo unchanged). Publication stamped with the **content** commit.
- Registry login **`oidc` mode**: `acr-*` optional; both empty ⇒ `az acr login` under the `azure-*` identity; one without the other is RED.
- `Resolve the bake image` takes `client_payload.image` on `meshweaver-upstream-published` — a dependent bakes against the **same** image its upstream sealed for.
- **`dispatch-dependents`** job (opt-in): after a successful publish, `meshweaver-upstream-published` to every installed repo whose `ci.yml` declares this `bake-source` under `upstream-sources:`/`upstream-seed:`. Discovered, not listed; payload carries the source chain — cycle guard; a run that baked nothing wakes nobody.

## `node-repo-module-pack.yml`
- `content-repository`/`content-ref` on both checkouts.

## Follow-ups (separate PRs, referencing this merge)
- Satellites (Crm/Reinsurance/SocialMedia/Education): `on:` gains `meshweaver-upstream-published`; bake-target takes `client_payload.digest`; `dispatch-dependents: true` with `MESHWEAVER_APP_*`.
- Plugins: `dispatch-dependents: true` on its `publish-bake` so a package publish cascades.
- Then the end-to-end test the maintainer asked for: a change in a central package, and every downstream rebuilds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)