### PR TITLE
The dispatch dry run could never run — workflow_call secrets are empty on workflow_dispatch

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -64,8 +64,13 @@ jobs:
       # Invariant #2: assert the inputs and fail RED naming what is missing, rather than skipping.
       - name: Assert the dispatch credential is configured
         env:
-          APP_ID: ${{ secrets.app-id }}
-          PRIVATE_KEY: ${{ secrets.private-key }}
+          # 🚨 `secrets.app-id` is a workflow_call secret: on a manual workflow_dispatch there is
+          # no caller passing it, so it resolves to the EMPTY STRING and the assertion below
+          # correctly refuses. Fall back to the repo secret for the dispatch path — without this
+          # the dry run can never run, which would make the one tool for checking the fan-out
+          # untestable itself.
+          APP_ID: ${{ secrets.app-id || secrets.DEPENDENT_DISPATCH_APP_ID }}
+          PRIVATE_KEY: ${{ secrets.private-key || secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
           VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
@@ -85,8 +90,8 @@ jobs:
         id: token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.app-id }}
-          private-key: ${{ secrets.private-key }}
+          app-id: ${{ secrets.app-id || secrets.DEPENDENT_DISPATCH_APP_ID }}
+          private-key: ${{ secrets.private-key || secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
           owner: Systemorph
           # No `repositories:` — the token spans every repo the App is installed on, which IS the
           # subscriber set. `contents: read` is not enough: repository_dispatch needs write.


### PR DESCRIPTION
#2694 added a manual dry run so "is the dispatch App installed everywhere?" could be answered on demand. **It could never run.**

`secrets.app-id` and `secrets.private-key` are `workflow_call` inputs. On a manual `workflow_dispatch` there is no caller passing them, so both resolve to the **empty string** and the credential assertion refuses.

Observed on run [`33274129955`](https://github.com/Systemorph/MeshWeaver/actions/runs/33274129955) — the first dry run after #2694 merged — failing at *"Assert the dispatch credential is configured"* while `DEPENDENT_DISPATCH_APP_ID` is set on the repo.

The assertion was right; the reason was wrong. Nothing was misconfigured — the dispatch path simply could not see the secrets.

## Fix

Fall back to the repo secret when the workflow_call one is absent:

```yaml
app-id:      ${{ secrets.app-id     || secrets.DEPENDENT_DISPATCH_APP_ID }}
private-key: ${{ secrets.private-key || secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
```

The assertion itself is unchanged. With the fallback in place a red there now means the credential **really is absent**, rather than merely invisible on this path.

## Why this was worth catching rather than working around

The dry run is the one tool for checking whether the fan-out reaches anything. A checking tool that cannot itself be run is the same failure it exists to prevent — its predecessor printed `NOT CONFIGURED` and went green for its entire life. I would rather it fail loudly for a real reason than be quietly untestable.

Once this lands, the dry run answers the open question directly: it prints the repositories the App is installed on, or fails naming an empty set.