### PR TITLE
Subscription is declared, not inherited from the App's installation list (33 → 5)

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -106,14 +106,33 @@ jobs:
         run: |
           set -euo pipefail
 
-          # The subscriber set, read at run time. Not a variable, not a literal in this file.
-          repos=$(gh api --paginate /installation/repositories \
-                    --jq '.repositories[].full_name' | sort -u)
+          # 🚨 INSTALLATION IS NOT SUBSCRIPTION. The App is installed org-wide for OTHER reasons
+          # (GitSync), so its installation list is 33 repositories — customer and solution repos
+          # included. Measured on the first dry run (run 33275415742): 33 installed, and exactly
+          # FIVE declare a `meshweaver-framework-released` receiver. Dispatching to the other 28
+          # is not harmful — a repo with no receiver runs nothing — but it is wrong, unreviewable,
+          # and it makes "who is subscribed?" unanswerable from the release side.
+          #
+          # So subscription is DISCOVERED: a repo is a subscriber iff its ci.yml declares the
+          # event. Still no hand-maintained list — adding a receiver to a repo subscribes it, which
+          # is the same property the installation list was reached for, minus the over-reach.
+          installed=$(gh api --paginate /installation/repositories \
+                        --jq '.repositories[].full_name' | sort -u)
+          repos=""
+          for candidate in $installed; do
+            if gh api "repos/$candidate/contents/.github/workflows/ci.yml" --jq '.content' 2>/dev/null \
+                 | base64 -d 2>/dev/null | grep -q 'meshweaver-framework-released'; then
+              repos="$repos$candidate"$'\n'
+            fi
+          done
+          repos=$(printf '%s' "$repos" | sed '/^$/d' | sort -u)
+          echo "installed: $(echo "$installed" | wc -l | tr -d ' ')  declaring a receiver: $(echo "$repos" | sed '/^$/d' | wc -l | tr -d ' ')"
 
           if [ -z "$repos" ]; then
-            echo "::error::the dispatch App is installed on NO repositories, so this release"
-            echo "::error::notified nobody. Install it on the plugin repos — a fan-out that reaches"
-            echo "::error::zero subscribers is exactly the silent no-op this job replaced."
+            echo "::error::NO repository declares a meshweaver-framework-released receiver, so this"
+            echo "::error::release notified nobody. Either the App lost access, or every receiver was"
+            echo "::error::removed. A fan-out reaching zero subscribers is exactly the silent no-op"
+            echo "::error::this job replaced, so it is an error rather than a quiet success."
             exit 1
           fi
 


### PR DESCRIPTION
The first dry run after #2699 answered the question it was built for, and the answer was not the assumed one.

```
Input 'repositories' is not set. Creating token for all repositories owned by Systemorph.
Subscribers (33):
  Systemorph/AgenticEngineering
  Systemorph/CreditReRate
  Systemorph/DFV-IFRS17
  Systemorph/Documentation
  Systemorph/EmployeePlanning
  Systemorph/IFRS17CalculationEngine
  Systemorph/ILS
  Systemorph/Loom
  …
```

**The App is installed — on 33 repositories**, org-wide, for GitSync. Of those, exactly **five** declare a `meshweaver-framework-released` receiver:

```
MeshWeaver.Plugins   MeshWeaver.Reinsurance   MeshWeaver.SocialMedia
MeshWeaver.Education MeshWeaver.Crm
```

(Manufacturing joins when its receiver lands — Systemorph/MeshWeaver.Manufacturing#28.)

## The flaw

I used the App's installation scope as the subscriber set, on the reasoning that "installing the App **is** subscribing" and therefore nothing needs a hand-maintained list. The first half was wrong: the App is installed for **other** reasons, so installation over-reaches badly — a release would fan out to customer and solution repositories that have nothing to do with the platform wave.

Not *harmful* — a repo with no receiver runs nothing — but wrong in a way that matters: it makes **"who is subscribed?" unanswerable from the release side**, which is precisely the property this lane exists to provide.

## The fix

Subscription is **discovered**: a repo is a subscriber iff its `ci.yml` declares the event. That keeps what the installation list was reached for — no hand-maintained list, adding a receiver subscribes a repo — without the over-reach.

The empty-set error is kept and reworded: it now means *"no repository declares a receiver"* — a real fault (the App lost access, or every receiver was removed) rather than *"the App is installed nowhere"*, which was never going to be true.

## Note

This is exactly what the dry run was added for. Finding it on a real release, **after** fanning out to 33 repositories, would have been considerably worse — and it would have looked like a success, because 28 of them would have silently done nothing.