### PR TITLE
Fetch workflow files raw — base64 -d is not portable and failed CLOSED (33 → 0 subscribers)

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -120,8 +120,15 @@ jobs:
                         --jq '.repositories[].full_name' | sort -u)
           repos=""
           for candidate in $installed; do
-            if gh api "repos/$candidate/contents/.github/workflows/ci.yml" --jq '.content' 2>/dev/null \
-                 | base64 -d 2>/dev/null | grep -q 'meshweaver-framework-released'; then
+            # 🚨 RAW, not base64. `--jq '.content' | base64 -d` works on macOS and FAILS on the
+            # GNU coreutils base64 the runner has: GitHub wraps the payload in newlines, which GNU
+            # rejects as invalid input unless --ignore-garbage. Every probe then fails silently and
+            # EVERY repo looks like a non-subscriber — measured on run 33276934253:
+            # "installed: 33  declaring a receiver: 0", against 5 when the same check is run
+            # locally. The Accept header returns the file directly and has no such trap.
+            if gh api "repos/$candidate/contents/.github/workflows/ci.yml" \
+                 -H "Accept: application/vnd.github.raw" 2>/dev/null \
+                 | grep -q 'meshweaver-framework-released'; then
               repos="$repos$candidate"$'\n'
             fi
           done


### PR DESCRIPTION
The receiver discovery in #2703 probed each repo with:

```bash
gh api ... --jq '.content' | base64 -d | grep -q 'meshweaver-framework-released'
```

**That works on macOS and fails on the runner.** GitHub wraps the base64 payload in newlines; GNU coreutils `base64 -d` rejects them as invalid input unless `--ignore-garbage`, while the BSD version ignores them. Every probe failed, so every repository looked like a non-subscriber.

Measured on run [`33276934253`](https://github.com/Systemorph/MeshWeaver/actions/runs/33276934253), the first dry run after #2703:

```
installed: 33  declaring a receiver: 0
```

against **5** when the identical check runs locally.

## What this nearly cost

Had it shipped unnoticed, the fan-out would have notified **nobody** — exactly the failure its predecessor had, reintroduced by the change intended to make targeting correct.

It did not ship unnoticed for two reasons, both deliberate: the **dry run exists**, and the **empty set is an error**. The job failed loudly rather than reporting a successful release wave to zero repositories.

## Fix

`-H "Accept: application/vnd.github.raw"` returns the file directly — no encoding step to be non-portable about.

## The generalisable part

🚨 **A probe that decides membership must fail OPEN or fail LOUD — never fail closed and quiet.**

This one failed closed: *"cannot read the file"* and *"the file does not declare the event"* were indistinguishable, and both produced "not a subscriber". The empty-set guard is what turned a silent wrong answer into a red job, which is the only reason this is a PR and not an incident.