### PR TITLE
ci(gates): a gate composes the modules its upstream was sealed against — the seal carries them, the registry serves them, no fallback (#2698)

### DIFF
--- a/.github/scripts/compose-sealed-modules.sh
+++ b/.github/scripts/compose-sealed-modules.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# compose-sealed-modules.sh — take a gate's module bundles FROM THE SEALED PUBLICATION it seeds,
+# never from the registry's package endpoint.
+#
+#   compose-sealed-modules.sh --identity <framework-identity> --packages "AI Essentials" \
+#       --upstreams "plugins [socialmedia …]" --out <dir> \
+#       ( --registry-url <url> --registry-key <mwi_…> | --storage-target <account>/<share>[/<base>] )
+#
+# 🚨 WHY THIS EXISTS (MeshWeaver#2698, 2026-08-29/30). A publication is sealed against the exact
+# module bytes its bake composed (`--module`). The registry's package endpoint
+# (`/api/plugins/bundles/<pkg>/<version>`) serves whatever the module's OWN lane published last,
+# under a content version that does not move when a rebuild changes the bytes. A gate that seeds
+# publication X but composes modules from the registry therefore judges NodeType assemblies built
+# against one MeshWeaver.AI while running another — and the boot seeder rightly DECLINES every one
+# of them ("dependency record mismatch — built against mvid:…, live is mvid:…"). That decline was
+# fleet-wide on 2026-08-29: every satellite red, no diff in any of them.
+#
+# The publication is the unit of consistency. Since MeshWeaver#2707 a sealed publication carries the
+# bundles it composed under `modules/` with its own `_index`, and the registry serves them at
+# `…/prebuilt/<identity>/<source>/modules[/<bundle>]`. A gate pinned to identity X takes module
+# bytes sealed FOR X — from the first upstream (in the order given) whose seal lists the package.
+#
+# 🚨 NO FALLBACK. An upstream with no seal for this identity, a seal that predates module sealing
+# (no `modules/_index` — republish it under a core that carries #2707), or a package no upstream
+# sealed, all fail RED naming the identity. Falling back to the registry would reproduce today's
+# decline under a green tick — the exact shape a gate must never take.
+set -euo pipefail
+
+identity="" packages="" upstreams="" out="" registry_url="" registry_key="" storage_target=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --identity)       identity="${2:-}";       shift 2 ;;
+    --packages)       packages="${2:-}";       shift 2 ;;
+    --upstreams)      upstreams="${2:-}";      shift 2 ;;
+    --out)            out="${2:-}";            shift 2 ;;
+    --registry-url)   registry_url="${2:-}";   shift 2 ;;
+    --registry-key)   registry_key="${2:-}";   shift 2 ;;
+    --storage-target) storage_target="${2:-}"; shift 2 ;;
+    *) echo "::error::compose-sealed-modules.sh: unknown argument '$1'"; exit 2 ;;
+  esac
+done
+
+for required in identity packages upstreams out; do
+  [ -n "${!required}" ] || { echo "::error::compose-sealed-modules.sh: --${required} is required"; exit 2; }
+done
+if [ -n "$registry_url" ]; then
+  [ -n "$registry_key" ] || { echo "::error::compose-sealed-modules.sh: --registry-url needs --registry-key"; exit 2; }
+elif [ -z "$storage_target" ]; then
+  echo "::error::compose-sealed-modules.sh: pass --registry-url/--registry-key or --storage-target"; exit 2
+fi
+case "$identity" in */*|*..*|"") echo "::error::compose-sealed-modules.sh: identity '$identity' is not a bare name"; exit 2 ;; esac
+
+mkdir -p "$out"
+work=$(mktemp -d); trap 'rm -rf "$work"' EXIT
+
+# ── one upstream's sealed module set (an index), or a RED reason ──────────────────────────────
+# Prints the listed bundle names, one per line. Exit 1 with ::error when the upstream has no seal
+# for this identity or the seal predates module sealing — both are stop conditions, not misses.
+sealed_modules_of() { # <source>
+  local src="$1"
+  case "$src" in */*|*..*|"") echo "::error::upstream '$src' is not a bare source name"; return 1 ;; esac
+  if [ -n "$registry_url" ]; then
+    local base="${registry_url%/}/api/plugins/bundles/prebuilt/$identity/$src"
+    local code
+    code=$(curl -sS -o "$work/$src.modules.json" -w '%{http_code}' -H "Authorization: Bearer $registry_key" "$base/modules")
+    case "$code" in
+      200) ;;
+      404)
+        echo "::error::upstream '$src' answers 404 for the module set of identity $identity at $base/modules: $(tr -d '\n' < "$work/$src.modules.json" | head -c 300)"
+        echo "::error::Either '$src' has no SEALED publication for this identity, or its publication predates module sealing (no modules/_index) — republish '$src' under a core that carries MeshWeaver#2707. Not composing from the registry instead: that is the decline this exists to end."
+        return 1 ;;
+      401|403)
+        echo "::error::the registry refused registry-key for '$src' ($code) — the instance needs a whole-source grant '$src/*'."; return 1 ;;
+      *)
+        echo "::error::registry answered $code for $base/modules — refusing."; return 1 ;;
+    esac
+    jq -e '.modules | type == "array"' "$work/$src.modules.json" > /dev/null 2>&1 \
+      || { echo "::error::$base/modules answered 200 but not a module-set index (starts: $(head -c 80 "$work/$src.modules.json" | tr -d '\n\r')…)"; return 1; }
+    jq -r '.modules[]' "$work/$src.modules.json"
+  else
+    local account="${storage_target%%/*}" rest="${storage_target#*/}"
+    local share="${rest%%/*}" base=""
+    case "$rest" in */*) base="${rest#*/}" ;; esac
+    local dir="${base:+$base/}prebuilt-bundles/$identity/$src"
+    local sealed
+    sealed=$(az storage file exists --account-name "$account" --share-name "$share" \
+      --path "$dir/_complete" --auth-mode login --backup-intent --query exists -o tsv --only-show-errors 2>/dev/null || echo unknown)
+    [ "$sealed" = "true" ] || { echo "::error::upstream '$src' has no SEALED publication under $account/$share/$dir for identity $identity (exists=$sealed)."; return 1; }
+    if ! az storage file download --account-name "$account" --share-name "$share" \
+         --path "$dir/modules/_index" --dest "$work/$src.modules.index" \
+         --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1; then
+      echo "::error::upstream '$src' is sealed under $account/$share/$dir but carries no modules/_index — the publication predates module sealing; republish '$src' under a core that carries MeshWeaver#2707."
+      return 1
+    fi
+    grep -v '^[[:space:]]*$' "$work/$src.modules.index" || true
+  fi
+}
+
+fetch_module() { # <source> <bundle-name> <dest>
+  local src="$1" name="$2" dest="$3"
+  if [ -n "$registry_url" ]; then
+    curl -sSf -H "Authorization: Bearer $registry_key" -o "$dest" \
+      "${registry_url%/}/api/plugins/bundles/prebuilt/$identity/$src/modules/$name" \
+      || { echo "::error::could not fetch sealed module $name of '$src' for identity $identity"; return 1; }
+  else
+    local account="${storage_target%%/*}" rest="${storage_target#*/}"
+    local share="${rest%%/*}" base=""
+    case "$rest" in */*) base="${rest#*/}" ;; esac
+    az storage file download --account-name "$account" --share-name "$share" \
+      --path "${base:+$base/}prebuilt-bundles/$identity/$src/modules/$name" --dest "$dest" \
+      --auth-mode login --backup-intent --only-show-errors > /dev/null \
+      || { echo "::error::could not download sealed module $name of '$src' for identity $identity"; return 1; }
+  fi
+}
+
+# Read every upstream's module set ONCE, in the order given; the first seal listing a package wins.
+# A seal that cannot be read stops the run — see sealed_modules_of.
+for src in $upstreams; do
+  sealed_modules_of "$src" > "$work/$src.list"
+  echo "upstream '$src' sealed $(grep -c '[^[:space:]]' "$work/$src.list" || true) module bundle(s) for identity $identity"
+done
+
+composed=0
+for pkg in $packages; do
+  wanted="$(printf '%s' "$pkg" | tr '[:upper:]' '[:lower:]').module.nupkg"
+  found=""
+  for src in $upstreams; do
+    name=$(awk -v w="$wanted" 'tolower($0) == w { print; exit }' "$work/$src.list")
+    if [ -n "$name" ]; then
+      fetch_module "$src" "$name" "$out/$name"
+      echo "composed $pkg from the sealed publication of '$src' for identity $identity ($name)"
+      found="$src"; break
+    fi
+  done
+  if [ -z "$found" ]; then
+    echo "::error::no sealed upstream publication ($upstreams) for identity $identity carries module package '$pkg' (looked for $wanted). The upstream that owns it must compose it in its bake (module-artifacts / registry-modules) so its seal carries it; composing it from the registry here would be the decline this replaces."
+    exit 1
+  fi
+  composed=$((composed + 1))
+done
+echo "composed=$composed"

--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -137,6 +137,19 @@ SENTINEL_LOCAL_DIR=$(mktemp -d)
 trap 'rm -rf "$SENTINEL_LOCAL_DIR"' EXIT
 SENTINEL_LOCAL="$SENTINEL_LOCAL_DIR/$SENTINEL"
 for zip in "${BUNDLES[@]}"; do basename "$zip"; done | sort > "$SENTINEL_LOCAL"
+# 🚨 THE MODULE SET (MeshWeaver#2698). A publication is sealed against the exact module bytes its
+# bake composed; a consumer pinned to this identity must compose THOSE, not the registry's
+# package endpoint (which serves the module's own lane's last build under an unmoved version). So
+# the composed bundles travel with the publication under modules/, listed in modules/_index —
+# written before the top-level sentinel, so "sealed" implies "module set present". A bake dir
+# with no modules/ composed nothing and seals an EMPTY index: a reader can then tell "nothing
+# composed" from "predates module sealing" (no index at all), and the latter is republished.
+MODULES_DIR_NAME="modules"
+MODULES_INDEX="_index"
+MODULES=("$BAKE_DIR/$MODULES_DIR_NAME"/*.module.nupkg)
+MODULES_INDEX_LOCAL="$SENTINEL_LOCAL_DIR/$MODULES_INDEX"
+: > "$MODULES_INDEX_LOCAL"
+for m in "${MODULES[@]}"; do basename "$m"; done | sort > "$MODULES_INDEX_LOCAL"
 
 # The CONTENT identity marker: which source commit this publication was baked from. It is NOT
 # part of the reader's contract (SeedPublishedRoot seeds only what the sentinel lists; extra
@@ -219,6 +232,19 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
       --auth-mode login --backup-intent --only-show-errors > /dev/null
     echo "published: $account/$share/$dest/$(basename "$zip")"
   done
+  # The module set: every bundle, then its index — both strictly before the sentinel.
+  ensure_directory "$account" "$share" "$dest/$MODULES_DIR_NAME"
+  local m
+  for m in "${MODULES[@]}"; do
+    az storage file upload --account-name "$account" --share-name "$share" \
+      --path "$dest/$MODULES_DIR_NAME/$(basename "$m")" --source "$m" \
+      --auth-mode login --backup-intent --only-show-errors > /dev/null
+    echo "published module: $account/$share/$dest/$MODULES_DIR_NAME/$(basename "$m")"
+  done
+  az storage file upload --account-name "$account" --share-name "$share" \
+    --path "$dest/$MODULES_DIR_NAME" --source "$MODULES_INDEX_LOCAL" \
+    --auth-mode login --backup-intent --only-show-errors > /dev/null
+  echo "module set: $account/$share/$dest/$MODULES_DIR_NAME/$MODULES_INDEX (${#MODULES[@]} bundle(s))"
   # 🚨 Both marker uploads pass the DIRECTORY as --path on purpose — the CLI appends the source
   # basename. An extensionless "$dest/$SENTINEL" --path would be silently re-interpreted as a
   # DIRECTORY and fail ParentNotFound (see the SENTINEL_LOCAL comment above).
@@ -337,6 +363,20 @@ for target in $BAKE_PUBLISH_TARGETS; do
       --path "$DEST/$SOURCE_MARKER" --dest "$SENTINEL_LOCAL_DIR/remote-$SOURCE_MARKER" \
       --auth-mode login --backup-intent --only-show-errors > /dev/null 2>&1 \
       && tr -d '[:space:]' < "$SENTINEL_LOCAL_DIR/remote-$SOURCE_MARKER" || echo "")
+    # A publication sealed before module sealing existed has no modules/_index. Under the current
+    # contract that publication is INCOMPLETE — a consumer cannot compose from it — so it is
+    # republished even when the content is unchanged. This is what converges the fleet (#2698):
+    # the next bake of each source re-seals it WITH its module set, and nothing is done by hand.
+    module_set=$(az storage file exists --account-name "$ACCOUNT" --share-name "$SHARE" \
+      --path "$DEST/$MODULES_DIR_NAME/$MODULES_INDEX" --auth-mode login --backup-intent --query exists -o tsv \
+      --only-show-errors 2>/dev/null || echo unknown)
+    if [ "$module_set" != "true" ]; then
+      echo "sealed publication under $DEST carries no $MODULES_DIR_NAME/$MODULES_INDEX (exists=$module_set) — it predates module sealing; republishing WITH the module set."
+      echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s))"
+      publish_one_target "$ACCOUNT" "$SHARE" "$DEST" true
+      PUBLISHED=$((PUBLISHED + 1))
+      continue
+    fi
     if [ -n "${SOURCE_SHA:-}" ] && [ "$published_sha" = "$SOURCE_SHA" ]; then
       echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication of THIS content under $DEST (sentinel present, source $published_sha) — already published; skipping."
       continue
@@ -350,7 +390,7 @@ for target in $BAKE_PUBLISH_TARGETS; do
     resealing=true
     echo "sealed publication under $DEST is from source '${published_sha:-<unrecorded>}' but this bake is from '$SOURCE_SHA' — republishing."
   fi
-  echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s))"
+  echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s))"
   publish_one_target "$ACCOUNT" "$SHARE" "$DEST" "$resealing"
   PUBLISHED=$((PUBLISHED + 1))
 done

--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -84,6 +84,19 @@ on:
         required: false
         type: string
         default: ''
+      upstream-seed:
+        description: >-
+          The upstream source(s) whose SEALED publication for this image's framework identity
+          supplies the registry-modules bundles (e.g. `plugins`). 🚨 With this set, module bytes
+          come from the seal — the ones the upstream's NodeType assemblies were built against —
+          never from the registry's package endpoint (MeshWeaver#2698: the registry serves the
+          module's own lane's last build under an unmoved version, so a gate composing it judges
+          assemblies built against one MeshWeaver.AI while holding another). No fallback: an
+          upstream with no seal, or a seal without a module set, fails RED naming the identity.
+          Without it, registry-modules are taken from the registry and the log says so loudly.
+        required: false
+        type: string
+        default: ''
     secrets:
       acr-username:
         description: Registry user able to pull the image.
@@ -154,9 +167,11 @@ jobs:
           echo "::error::docker login to ${TEST_IMAGE%%/*} failed after 3 connection-level attempts."
           exit 1
       - name: Take the framework assemblies from the platform image
+        id: image
         env:
           TEST_IMAGE: ${{ inputs.test-image }}
           IMAGE_DIGEST: ${{ inputs.image-digest }}
+          UPSTREAM_SEED: ${{ inputs.upstream-seed }}
         # The image already CONTAINS the built framework — the same assemblies the mesh loads at
         # run time. Copying them out costs seconds, and checking Source against what actually
         # ships is the question this gate exists to answer.
@@ -177,6 +192,14 @@ jobs:
           docker cp "$id:/app/." refs/ >/dev/null
           docker rm -v "$id" >/dev/null
           echo "framework assemblies: $(find refs -name 'MeshWeaver.*.dll' | wc -l)"
+          # The identity that addresses an upstream's sealed publication — only when one is seeded.
+          if [ -n "${UPSTREAM_SEED:-}" ]; then
+            line=$(docker run --rm --init --entrypoint /app/mw-plugin-test "$IMAGE" --print-framework-identity)
+            identity="${line#*identity=}"; identity="${identity%% *}"
+            [ -n "$identity" ] || { echo "::error::could not resolve a framework identity from $IMAGE (got: '$line') — cannot address the upstream publication for upstream-seed."; exit 1; }
+            echo "identity=$identity" >> "$GITHUB_OUTPUT"
+            echo "this check resolves framework identity $identity; registry-modules come from the seal of: $UPSTREAM_SEED"
+          fi
       - name: Download this run's module-bundle artifacts
         if: inputs.module-artifacts != ''
         uses: actions/download-artifact@v7
@@ -193,18 +216,40 @@ jobs:
           REGISTRY_MODULES: ${{ inputs.registry-modules }}
           REGISTRY_URL: ${{ inputs.registry-url }}
           REGISTRY_KEY: ${{ secrets.registry-key }}
+          SEAL_UPSTREAMS: ${{ inputs.upstream-seed }}
+          IDENTITY: ${{ steps.image.outputs.identity }}
+          JOB_WORKFLOW_SHA: ${{ github.job_workflow_sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           BUNDLES="${RUNNER_TEMP:-/tmp}/ref-bundles"; mkdir -p "$BUNDLES"
-          for pkg in ${REGISTRY_MODULES:-}; do
-            idx=$(curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" "$REGISTRY_URL/api/plugins/bundles/index.json") \
-              || { echo "::error::registry index unreadable at $REGISTRY_URL (registry-modules: $pkg)"; exit 1; }
-            ver=$(jq -r --arg p "$pkg" '(.bundles // .Bundles // [])[] | select(((.plugin // .Plugin)|ascii_downcase)==($p|ascii_downcase)) | (.version // .Version)' <<<"$idx" | head -1)
-            [ -n "$ver" ] || { echo "::error::the registry at $REGISTRY_URL does not advertise package '$pkg' to this instance key."; exit 1; }
-            curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" -o "$BUNDLES/$pkg.bundle.zip" "$REGISTRY_URL/api/plugins/bundles/$pkg/$ver" \
-              || { echo "::error::download failed for $pkg@$ver from $REGISTRY_URL"; exit 1; }
-            echo "fetched $pkg@$ver from $REGISTRY_URL"
-          done
+          if [ -n "${REGISTRY_MODULES:-}" ]; then
+            if [ -n "${SEAL_UPSTREAMS:-}" ]; then
+              # 🚨 The publication is the unit of consistency (MeshWeaver#2698): module bytes come
+              # from the SEALED upstream publication for this identity, never the registry's
+              # package endpoint. No fallback — a missing seal or module set is RED in the script.
+              # The compose script at THIS workflow's own commit (github.job_workflow_sha) — never a floating
+              # ref, so a node repo pinned to a reusable sha gets the script that sha was written with.
+              SCRIPT="${RUNNER_TEMP:-/tmp}/compose-sealed-modules.sh"
+              gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-sealed-modules.sh?ref=${JOB_WORKFLOW_SHA}" --jq .content | base64 -d > "$SCRIPT" \
+                || { echo "::error::could not fetch compose-sealed-modules.sh at ${JOB_WORKFLOW_SHA} from Systemorph/MeshWeaver"; exit 1; }
+              chmod +x "$SCRIPT"
+              [ -n "${REGISTRY_URL:-}" ] || { echo "::error::upstream-seed is set but registry-url is empty — the compile check reads sealed module sets from the registry."; exit 1; }
+              "$SCRIPT" --identity "$IDENTITY" --packages "$REGISTRY_MODULES" --upstreams "$SEAL_UPSTREAMS" --out "$BUNDLES" \
+                --registry-url "$REGISTRY_URL" --registry-key "$REGISTRY_KEY"
+            else
+              echo "::notice::composing registry-modules ($REGISTRY_MODULES) from the REGISTRY's package endpoint: this repo declares no upstream seed, so there is no sealed publication to take module bytes from. These bytes are whatever the module's own lane published last — a bake-consumption decline against a publication that composed different ones is expected, and is the reason to declare the upstream (upstream-seed / upstream-sources) instead."
+            for pkg in ${REGISTRY_MODULES:-}; do
+              idx=$(curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" "$REGISTRY_URL/api/plugins/bundles/index.json") \
+                || { echo "::error::registry index unreadable at $REGISTRY_URL (registry-modules: $pkg)"; exit 1; }
+              ver=$(jq -r --arg p "$pkg" '(.bundles // .Bundles // [])[] | select(((.plugin // .Plugin)|ascii_downcase)==($p|ascii_downcase)) | (.version // .Version)' <<<"$idx" | head -1)
+              [ -n "$ver" ] || { echo "::error::the registry at $REGISTRY_URL does not advertise package '$pkg' to this instance key."; exit 1; }
+              curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" -o "$BUNDLES/$pkg.bundle.zip" "$REGISTRY_URL/api/plugins/bundles/$pkg/$ver" \
+                || { echo "::error::download failed for $pkg@$ver from $REGISTRY_URL"; exit 1; }
+              echo "fetched $pkg@$ver from $REGISTRY_URL"
+            done
+            fi
+          fi
           shopt -s nullglob
           added=0
           for b in "$BUNDLES"/*.nupkg "$BUNDLES"/*.zip; do

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -492,19 +492,46 @@ jobs:
           REGISTRY_MODULES: ${{ inputs.registry-modules }}
           REGISTRY_URL: ${{ inputs.registry-url }}
           REGISTRY_KEY: ${{ secrets.registry-key }}
+          SEAL_UPSTREAMS: ${{ inputs.upstream-seed }}
+          IDENTITY: ${{ steps.seed-identity.outputs.identity }}
+          TARGETS: ${{ inputs.bake-publish-targets }}
+          JOB_WORKFLOW_SHA: ${{ github.job_workflow_sha }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           EXT="${RUNNER_TEMP:-/tmp}/ext-modules"; mkdir -p "$EXT"; chmod 777 "$EXT"
           BUNDLES="${RUNNER_TEMP:-/tmp}/ext-bundles"; mkdir -p "$BUNDLES"
-          for pkg in ${REGISTRY_MODULES:-}; do
-            idx=$(curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" "$REGISTRY_URL/api/plugins/bundles/index.json") \
-              || { echo "::error::registry index unreadable at $REGISTRY_URL (registry-modules: $pkg)"; exit 1; }
-            ver=$(jq -r --arg p "$pkg" '(.bundles // .Bundles // [])[] | select(((.plugin // .Plugin)|ascii_downcase)==($p|ascii_downcase)) | (.version // .Version)' <<<"$idx" | head -1)
-            [ -n "$ver" ] || { echo "::error::the registry at $REGISTRY_URL does not advertise package '$pkg' to this instance key — check the key's grants, and that the upstream wave has published the bundle."; exit 1; }
-            curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" -o "$BUNDLES/$pkg.bundle.zip" "$REGISTRY_URL/api/plugins/bundles/$pkg/$ver" \
-              || { echo "::error::download failed for $pkg@$ver from $REGISTRY_URL"; exit 1; }
-            echo "fetched $pkg@$ver from $REGISTRY_URL"
-          done
+          if [ -n "${REGISTRY_MODULES:-}" ]; then
+            if [ -n "${SEAL_UPSTREAMS:-}" ]; then
+              # 🚨 The publication is the unit of consistency (MeshWeaver#2698): module bytes come
+              # from the SEALED upstream publication for this identity, never the registry's
+              # package endpoint. No fallback — a missing seal or module set is RED in the script.
+              # The compose script at THIS workflow's own commit (github.job_workflow_sha) — never a floating
+              # ref, so a node repo pinned to a reusable sha gets the script that sha was written with.
+              SCRIPT="${RUNNER_TEMP:-/tmp}/compose-sealed-modules.sh"
+              gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-sealed-modules.sh?ref=${JOB_WORKFLOW_SHA}" --jq .content | base64 -d > "$SCRIPT" \
+                || { echo "::error::could not fetch compose-sealed-modules.sh at ${JOB_WORKFLOW_SHA} from Systemorph/MeshWeaver"; exit 1; }
+              chmod +x "$SCRIPT"
+              if [ -n "${REGISTRY_URL:-}" ]; then
+                "$SCRIPT" --identity "$IDENTITY" --packages "$REGISTRY_MODULES" --upstreams "$SEAL_UPSTREAMS" --out "$BUNDLES" \
+                  --registry-url "$REGISTRY_URL" --registry-key "$REGISTRY_KEY"
+              else
+                "$SCRIPT" --identity "$IDENTITY" --packages "$REGISTRY_MODULES" --upstreams "$SEAL_UPSTREAMS" --out "$BUNDLES" \
+                  --storage-target "$(printf '%s\n' $TARGETS | head -1)"
+              fi
+            else
+              echo "::notice::composing registry-modules ($REGISTRY_MODULES) from the REGISTRY's package endpoint: this repo declares no upstream seed, so there is no sealed publication to take module bytes from. These bytes are whatever the module's own lane published last — a bake-consumption decline against a publication that composed different ones is expected, and is the reason to declare the upstream (upstream-seed / upstream-sources) instead."
+            for pkg in ${REGISTRY_MODULES:-}; do
+              idx=$(curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" "$REGISTRY_URL/api/plugins/bundles/index.json") \
+                || { echo "::error::registry index unreadable at $REGISTRY_URL (registry-modules: $pkg)"; exit 1; }
+              ver=$(jq -r --arg p "$pkg" '(.bundles // .Bundles // [])[] | select(((.plugin // .Plugin)|ascii_downcase)==($p|ascii_downcase)) | (.version // .Version)' <<<"$idx" | head -1)
+              [ -n "$ver" ] || { echo "::error::the registry at $REGISTRY_URL does not advertise package '$pkg' to this instance key — check the key's grants, and that the upstream wave has published the bundle."; exit 1; }
+              curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" -o "$BUNDLES/$pkg.bundle.zip" "$REGISTRY_URL/api/plugins/bundles/$pkg/$ver" \
+                || { echo "::error::download failed for $pkg@$ver from $REGISTRY_URL"; exit 1; }
+              echo "fetched $pkg@$ver from $REGISTRY_URL"
+            done
+            fi
+          fi
           shopt -s nullglob
           MODULE_ARGS=""
           for b in "$BUNDLES"/*.nupkg "$BUNDLES"/*.zip; do

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -761,19 +761,33 @@ jobs:
           REGISTRY_MODULES: ${{ inputs.registry-modules }}
           REGISTRY_URL: ${{ inputs.registry-url }}
           REGISTRY_KEY: ${{ secrets.registry-key }}
+          SEAL_UPSTREAMS: ${{ inputs.upstream-sources }}
+          IDENTITY: ${{ steps.identity.outputs.identity }}
         run: |
           set -euo pipefail
           EXT="${RUNNER_TEMP:-/tmp}/ext-modules"; mkdir -p "$EXT"; chmod 777 "$EXT"
           BUNDLES="${RUNNER_TEMP:-/tmp}/ext-bundles"; mkdir -p "$BUNDLES"
-          for pkg in ${REGISTRY_MODULES:-}; do
-            idx=$(curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" "$REGISTRY_URL/api/plugins/bundles/index.json") \
-              || { echo "::error::registry index unreadable at $REGISTRY_URL (registry-modules: $pkg)"; exit 1; }
-            ver=$(jq -r --arg p "$pkg" '(.bundles // .Bundles // [])[] | select(((.plugin // .Plugin)|ascii_downcase)==($p|ascii_downcase)) | (.version // .Version)' <<<"$idx" | head -1)
-            [ -n "$ver" ] || { echo "::error::the registry at $REGISTRY_URL does not advertise package '$pkg' to this instance key — check the key's grants, and that the upstream wave has published the bundle."; exit 1; }
-            curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" -o "$BUNDLES/$pkg.bundle.zip" "$REGISTRY_URL/api/plugins/bundles/$pkg/$ver" \
-              || { echo "::error::download failed for $pkg@$ver from $REGISTRY_URL"; exit 1; }
-            echo "fetched $pkg@$ver from $REGISTRY_URL"
-          done
+          if [ -n "${REGISTRY_MODULES:-}" ]; then
+            if [ -n "${SEAL_UPSTREAMS:-}" ]; then
+              # 🚨 The publication is the unit of consistency (MeshWeaver#2698): module bytes come
+              # from the SEALED upstream publication for this identity, never the registry's
+              # package endpoint. No fallback — a missing seal or module set is RED in the script.
+              [ -n "${REGISTRY_URL:-}" ] || { echo "::error::upstream-sources is set but registry-url is empty — the bake reads sealed module sets from the registry."; exit 1; }
+              mw-platform-gate/.github/scripts/compose-sealed-modules.sh --identity "$IDENTITY" --packages "$REGISTRY_MODULES" \
+                --upstreams "$SEAL_UPSTREAMS" --out "$BUNDLES" --registry-url "$REGISTRY_URL" --registry-key "$REGISTRY_KEY"
+            else
+              echo "::notice::composing registry-modules ($REGISTRY_MODULES) from the REGISTRY's package endpoint: this repo declares no upstream seed, so there is no sealed publication to take module bytes from. These bytes are whatever the module's own lane published last — a bake-consumption decline against a publication that composed different ones is expected, and is the reason to declare the upstream (upstream-seed / upstream-sources) instead."
+            for pkg in ${REGISTRY_MODULES:-}; do
+              idx=$(curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" "$REGISTRY_URL/api/plugins/bundles/index.json") \
+                || { echo "::error::registry index unreadable at $REGISTRY_URL (registry-modules: $pkg)"; exit 1; }
+              ver=$(jq -r --arg p "$pkg" '(.bundles // .Bundles // [])[] | select(((.plugin // .Plugin)|ascii_downcase)==($p|ascii_downcase)) | (.version // .Version)' <<<"$idx" | head -1)
+              [ -n "$ver" ] || { echo "::error::the registry at $REGISTRY_URL does not advertise package '$pkg' to this instance key — check the key's grants, and that the upstream wave has published the bundle."; exit 1; }
+              curl -fsS -H "Authorization: Bearer $REGISTRY_KEY" -o "$BUNDLES/$pkg.bundle.zip" "$REGISTRY_URL/api/plugins/bundles/$pkg/$ver" \
+                || { echo "::error::download failed for $pkg@$ver from $REGISTRY_URL"; exit 1; }
+              echo "fetched $pkg@$ver from $REGISTRY_URL"
+            done
+            fi
+          fi
           shopt -s nullglob
           MODULE_ARGS=""
           for b in "$BUNDLES"/*.nupkg "$BUNDLES"/*.zip; do
@@ -791,10 +805,24 @@ jobs:
             cp -R "$u"/meshweaver/modules/. "$EXT/$name/"
             MODULE_ARGS="$MODULE_ARGS --module /ext/$name/$name.dll"
             echo "external module composed: $name ($(basename "$b"))"
+            # 🚨 The bytes this bake composes are the bytes its publication SEALS (modules/<pkg>.module.nupkg,
+            # MeshWeaver#2698): a consumer pinned to this identity composes exactly these, never the
+            # registry's. Keyed by PACKAGE id, which is what a consumer asks for (registry-modules).
+            pkg=""
+            case "$(basename "$b")" in
+              MeshWeaver.Plugin.*.module.nupkg) pkg=$(basename "$b" | sed -E 's/^MeshWeaver\.Plugin\.([^.]+)\..*$/\1/') ;;   # this run's module-pack artifact
+              *.bundle.zip)                     pkg=$(basename "$b" .bundle.zip) ;;                                        # the registry's package endpoint
+              *.module.nupkg)                   pkg=$(basename "$b" .module.nupkg) ;;                                      # an upstream's sealed module set
+            esac
+            [ -n "$pkg" ] || { echo "::error::$(basename "$b"): cannot derive the package id this bundle seals under — expected MeshWeaver.Plugin.<pkg>.<version>.module.nupkg, <pkg>.bundle.zip or <pkg>.module.nupkg"; exit 1; }
+            SEAL="${RUNNER_TEMP:-/tmp}/seal-modules"; mkdir -p "$SEAL"
+            cp "$b" "$SEAL/$(printf '%s' "$pkg" | tr '[:upper:]' '[:lower:]').module.nupkg"
+            echo "sealing $name as module package '$pkg'"
           done
           [ -n "$MODULE_ARGS" ] || { echo "::error::external modules were requested but none were assembled — the artifact pattern matched nothing and no registry bundle was fetched."; exit 1; }
           echo "EXT_MODULES_DIR=$EXT" >> "$GITHUB_ENV"
           echo "EXT_MODULE_ARGS=$MODULE_ARGS" >> "$GITHUB_ENV"
+          echo "SEAL_MODULES_DIR=${RUNNER_TEMP:-/tmp}/seal-modules" >> "$GITHUB_ENV"
       - name: Bake (compiler --output), then gate a mesh against it (--seed)
         # scope=none means the decision above VERIFIED that this exact content is already sealed
         # for this framework identity at every target — a positive finding, logged with both
@@ -882,6 +910,14 @@ jobs:
             --entrypoint /app/mw-plugin-test "${{ steps.image.outputs.ref }}" /repo \
             "${ALLOW_ARGS[@]}" ${EXT_MODULE_ARGS:-} \
             --seed /bake
+          # The module set this bake composed travels WITH the publication (publish-bake-bundles.sh
+          # writes modules/_index from it). A bake that composed nothing seals an empty set — a
+          # consumer can tell "composed nothing" from "predates module sealing".
+          mkdir -p "$BAKE/modules"
+          if [ -n "${SEAL_MODULES_DIR:-}" ] && [ -d "$SEAL_MODULES_DIR" ]; then
+            cp "$SEAL_MODULES_DIR"/*.module.nupkg "$BAKE/modules/"
+            echo "module set to seal: $(ls "$BAKE/modules" | tr '\n' ' ')"
+          fi
           # Postcondition, not a hope: a green tester that wrote no identity is a bake-stage
           # regression (or an image predating --bake-output support).
           if [ ! -s "$BAKE/framework-mvid.txt" ]; then

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -808,13 +808,16 @@ jobs:
             # 🚨 The bytes this bake composes are the bytes its publication SEALS (modules/<pkg>.module.nupkg,
             # MeshWeaver#2698): a consumer pinned to this identity composes exactly these, never the
             # registry's. Keyed by PACKAGE id, which is what a consumer asks for (registry-modules).
+            # The package id is the manifest's `plugin` (ModulePackCommand writes it); the file name
+            # is only the fallback for a hand-built bundle, and then the VERSION is stripped from the
+            # right so a package id that itself contains dots (Markdown.Collaboration) survives.
             pkg=""
-            case "$(basename "$b")" in
-              MeshWeaver.Plugin.*.module.nupkg) pkg=$(basename "$b" | sed -E 's/^MeshWeaver\.Plugin\.([^.]+)\..*$/\1/') ;;   # this run's module-pack artifact
-              *.bundle.zip)                     pkg=$(basename "$b" .bundle.zip) ;;                                        # the registry's package endpoint
-              *.module.nupkg)                   pkg=$(basename "$b" .module.nupkg) ;;                                      # an upstream's sealed module set
-            esac
-            [ -n "$pkg" ] || { echo "::error::$(basename "$b"): cannot derive the package id this bundle seals under — expected MeshWeaver.Plugin.<pkg>.<version>.module.nupkg, <pkg>.bundle.zip or <pkg>.module.nupkg"; exit 1; }
+            [ -f "$u/meshweaver/manifest.json" ] && pkg=$(jq -r '.plugin // empty' "$u/meshweaver/manifest.json")
+            if [ -z "$pkg" ]; then
+              stem="$(basename "$b")"; stem="${stem%.module.nupkg}"; stem="${stem%.bundle.zip}"; stem="${stem#MeshWeaver.Plugin.}"
+              pkg=$(printf '%s' "$stem" | sed -E 's/\.[0-9]+(\.[0-9]+)*([-+][0-9A-Za-z.+-]*)?$//')
+            fi
+            [ -n "$pkg" ] || { echo "::error::$(basename "$b"): cannot derive the package id this bundle seals under — no manifest plugin id, and the file name is not MeshWeaver.Plugin.<pkg>.<version>.module.nupkg / <pkg>.bundle.zip / <pkg>.module.nupkg"; exit 1; }
             SEAL="${RUNNER_TEMP:-/tmp}/seal-modules"; mkdir -p "$SEAL"
             cp "$b" "$SEAL/$(printf '%s' "$pkg" | tr '[:upper:]' '[:lower:]').module.nupkg"
             echo "sealing $name as module package '$pkg'"

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -184,6 +184,15 @@ public static class PluginBundleEndpoints
         group.MapGet($"/{PrebuiltSegment}/{{identity}}/{{source}}/{{bundle}}",
             (HttpContext http, string identity, string source, string bundle) =>
                 PrebuiltBundle(http, identity, source, bundle, Caller(http)));
+        // The module set a publication was sealed against (MeshWeaver#2698) — a consumer pinned to
+        // this identity composes THESE bytes, never the package endpoint's. The literal segment wins
+        // over {bundle} above, so a NodeType bundle named "modules" is not served here.
+        group.MapGet($"/{PrebuiltSegment}/{{identity}}/{{source}}/{PublishedBundleCatalogue.ModulesDirectoryName}",
+            (HttpContext http, string identity, string source) =>
+                PrebuiltModuleSet(http, identity, source, Caller(http)));
+        group.MapGet($"/{PrebuiltSegment}/{{identity}}/{{source}}/{PublishedBundleCatalogue.ModulesDirectoryName}/{{bundle}}",
+            (HttpContext http, string identity, string source, string bundle) =>
+                PrebuiltModule(http, identity, source, bundle, Caller(http)));
     }
 
     /// <summary>The sealed publication's bundle names, or 404 when none is sealed for that
@@ -214,6 +223,46 @@ public static class PluginBundleEndpoints
         if (sealed_ is null || !sealed_.Contains(bundle, StringComparer.OrdinalIgnoreCase))
             return NoSuchBundle();
         var path = Path.Combine(directory!, bundle);
+        return Results.File(path, "application/zip", fileDownloadName: bundle);
+    }
+
+    /// <summary>The module bundles the sealed publication composed — its NodeType assemblies'
+    /// dependency records point at exactly these bytes. 404 with the reason when the publication
+    /// is torn, or predates module sealing (republish it); an EMPTY list when the bake composed
+    /// nothing. Same grant as the bundle index: a whole-source grant on the source.</summary>
+    private static IResult PrebuiltModuleSet(
+        HttpContext http, string identity, string source, AuthenticatedInstance? caller)
+    {
+        if (PrebuiltDecision(http, identity, source, caller) is { } refused)
+            return refused;
+        var directory = PrebuiltDirectory(http, identity, source);
+        var reading = directory is null
+            ? new ModuleSetReading(null, "no sealed publication")
+            : PublishedBundleCatalogue.SealedModulesOf(directory, Log(http));
+        if (reading.Modules is null)
+            return Results.Json(
+                new { error = $"{reading.Refusal} — source '{source}', framework identity '{identity}'" },
+                statusCode: StatusCodes.Status404NotFound);
+        return Results.Json(new { identity, source, modules = reading.Modules });
+    }
+
+    /// <summary>One sealed module bundle's bytes. A name the module index does not list is 404
+    /// even if the file exists — an unlisted file is not part of the sealed set.</summary>
+    private static IResult PrebuiltModule(
+        HttpContext http, string identity, string source, string bundle, AuthenticatedInstance? caller)
+    {
+        if (PrebuiltDecision(http, identity, source, caller) is { } refused)
+            return refused;
+        if (!IsBareName(bundle))
+            return Results.Json(new { error = "bundle must be a bare name" },
+                statusCode: StatusCodes.Status400BadRequest);
+        var directory = PrebuiltDirectory(http, identity, source);
+        var reading = directory is null
+            ? new ModuleSetReading(null, "no sealed publication")
+            : PublishedBundleCatalogue.SealedModulesOf(directory, Log(http));
+        if (reading.Modules is null || !reading.Modules.Contains(bundle, StringComparer.OrdinalIgnoreCase))
+            return NoSuchBundle();
+        var path = Path.Combine(directory!, PublishedBundleCatalogue.ModulesDirectoryName, bundle);
         return Results.File(path, "application/zip", fileDownloadName: bundle);
     }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CiContentBake.md
@@ -117,6 +117,40 @@ Two refusals guard it, because both failures are otherwise invisible:
   an adopted type renders and tests exactly like a compiled one — so "the consuming half silently
   stopped working" cannot be noticed unless it is a verdict.
 
+### 🚨 The seal carries the modules it composed — a gate composes from the seal, never the registry
+
+A bake composes external modules with `--module` (this run's module-pack artifacts, or an
+upstream's) and seals its NodeType assemblies against **those bytes**: every dependency record
+names the module's MVID. The registry's *package* endpoint (`/api/plugins/bundles/<pkg>/<version>`)
+serves something else — the module's own lane's last build, under a content version that does not
+move when a rebuild changes the bytes. A gate that seeded publication X but composed its modules from
+the registry therefore ran assemblies built against one `MeshWeaver.AI` while holding another, and
+the boot seeder rightly declined every one: `dependency record mismatch — built against mvid:…, live
+is mvid:…`. On 2026-08-29 that was every satellite, red at once, with no diff in any of them (#2698).
+
+**The publication is the unit of consistency.** Since #2707:
+
+- `publish-bake-bundles.sh` seals the composed bundles WITH the publication —
+  `prebuilt-bundles/<identity>/<source>/modules/<pkg>.module.nupkg`, listed in `modules/_index`,
+  written strictly before `_complete`. A bake that composed nothing seals an **empty** index, so a
+  reader can tell "composed nothing" from "predates module sealing"; a sealed publication with no
+  index is republished on the source's next bake even when its content is unchanged — that is what
+  converges the fleet without anyone re-baking by hand.
+- The registry serves the set: `GET …/prebuilt/<identity>/<source>/modules` (the index's list, 404
+  *saying* "predates module sealing" for an old seal) and `…/modules/<bundle>` (listed names only).
+- `compose-sealed-modules.sh` — called by `node-repo-gate.yml`, `node-repo-compile-check.yml` and
+  `node-repo-publish-bake.yml` whenever the repo declares an upstream (`upstream-seed` /
+  `upstream-sources`) — takes each `registry-modules` package from the first upstream whose seal
+  lists it. **No fallback**: an upstream with no seal for the identity, a seal without a module set,
+  or a package no upstream sealed is RED naming the identity. Falling back to the registry would
+  reproduce the decline under a green tick. A repo that declares **no** upstream still composes from
+  the registry, and the log says so in a `::notice::` — those bytes are the module lane's, and a
+  decline against a publication that composed different ones is the reason to declare the upstream.
+
+The registry's package endpoint remains the **runtime** surface — a portal installing `AI@1.2`
+gets whatever the module lane published — which is why the platform's own wave seals its module
+bundles without publishing them as packages.
+
 ### 🚨 An adoption used to lose a race with the first-build kickoff
 
 Adopting a prebuilt assembly writes the NodeType's node, and that write goes through the type's OWN

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginBuildContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginBuildContract.md
@@ -238,7 +238,9 @@ between a GitHub secret and an Entra credential that no query can join.
 **The mechanism: the registry SERVES publications, so the gate never touches Azure.** The portal
 already mounts `/data/prebuilt-bundles`, and the bundle route already has a GET side (`FetchIndex`,
 `ModuleFetchCommand`). Add `GET /api/plugins/bundles/prebuilt/<framework-identity>/<source>/` under
-the same authenticator, requiring `fetch:<source>` on the presenting principal. `upstream-seed` then
+the same authenticator, requiring `fetch:<source>` on the presenting principal — and, beside it,
+`…/<source>/modules` (the module bundles that publication was sealed against, #2698) so a gate
+composes the bytes its upstream's assemblies were built with, never the package endpoint's. `upstream-seed` then
 presents its run's OIDC token — `ACTIONS_ID_TOKEN_REQUEST_TOKEN`, available to any job with
 `id-token: write` — and receives the sealed publication. PR or push is a claim the rule reads, not
 a credential someone had to remember to create.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-gate-composes-the-modules-its-upstream-was-sealed-against.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-gate-composes-the-modules-its-upstream-was-sealed-against.md
@@ -1,0 +1,31 @@
+---
+Name: A gate composes the modules its upstream was sealed against
+Category: Fix
+Description: Every node repository's gate went red at once on "dependency record mismatch" because it composed AI and Collaboration from the registry while its upstream's assemblies were sealed against a different build of them. A publication now carries the module bundles it composed, the registry serves them, and gates take them from there — never the package endpoint.
+Icon: LinkMultiple
+Order: -20260830
+---
+
+# A gate composes the modules its upstream was sealed against
+
+A node repository's gate installs the packages it depends on from a *sealed publication* — the
+assemblies its upstream baked for exactly the platform image the gate runs. Those assemblies record
+which build of each module they were compiled against. The gate, however, fetched the modules
+themselves — `AI`, `Essentials` — from the registry's package endpoint, which serves whatever the
+module's own lane published last, under a version number that does not change when a rebuild
+changes the bytes.
+
+The moment those two disagreed, every gate in the fleet declined every prebuilt assembly it
+installed (`dependency record mismatch — built against mvid:…, live is mvid:…`), compiled the
+sources itself instead, and then failed its own postcondition for having judged bytes that will not
+ship. Reinsurance, SocialMedia, Crm, Manufacturing and Education were red at the same time, and
+none of them had changed anything.
+
+A publication now travels with the module bundles its bake composed, listed in their own index that
+is written before the seal. The registry serves that set beside the publication's bundles, and a
+gate that declares its upstream takes each module from the first upstream whose seal lists it. There
+is deliberately no fallback: an upstream with no seal for the identity, a seal from before this
+change, or a module no upstream sealed fails red naming what to republish — the registry's bytes
+would reproduce the same mismatch under a green tick. A publication sealed before this change is
+republished with its module set on the source's next bake, so the fleet converges without anyone
+re-baking by hand.

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -228,7 +228,71 @@ public static class PublishedBundleCatalogue
             .Select(d => Path.GetFileName(d)!)
             .ToHashSet(StringComparer.OrdinalIgnoreCase);
     }
+
+    /// <summary>The sub-directory of a sealed publication holding the module bundles its bake
+    /// composed, and the index that lists them. Mirrored in
+    /// <c>.github/scripts/publish-bake-bundles.sh</c> and <c>compose-sealed-modules.sh</c>.</summary>
+    public const string ModulesDirectoryName = "modules";
+
+    /// <summary>The module set's own listing — written strictly before the publication's
+    /// <c>_complete</c>, so a sealed publication either carries its module set or predates
+    /// module sealing altogether.</summary>
+    public const string ModulesIndexFileName = "_index";
+
+    /// <summary>
+    /// 🚨 The module bundles one source's SEALED publication composed — the exact bytes its
+    /// NodeType assemblies were built against (MeshWeaver#2698). A consumer pinned to this
+    /// identity must compose THESE; the registry's package endpoint serves the module's own
+    /// lane's last build under an unmoved version, and a gate that composed it judged assemblies
+    /// built against one <c>MeshWeaver.AI</c> while holding another — the boot seeder declined
+    /// every one ("dependency record mismatch"), fleet-wide, with no diff in any repo.
+    ///
+    /// <para><see cref="ModuleSetReading.Modules"/> is <c>null</c> with a
+    /// <see cref="ModuleSetReading.Refusal"/> when the publication is torn (no seal, or a listed
+    /// bundle absent — the same rule as <see cref="SealedBundlesOf"/>), when it PREDATES module
+    /// sealing (no <c>modules/_index</c>: republish the source, which
+    /// <c>publish-bake-bundles.sh</c> does on its next run), or when the index names a bundle
+    /// that is absent or not a bare name. It is EMPTY, not null, when the bake composed nothing —
+    /// a reader can tell "composed nothing" from "predates module sealing".</para>
+    /// </summary>
+    public static ModuleSetReading SealedModulesOf(string sourceDirectory, ILogger? logger = null)
+    {
+        if (CompleteBundlesOf(sourceDirectory, logger) is null)
+            return new(null, "no sealed publication");
+        var directory = Path.Combine(sourceDirectory, ModulesDirectoryName);
+        var index = Path.Combine(directory, ModulesIndexFileName);
+        if (!File.Exists(index))
+        {
+            logger?.LogInformation(
+                "ReleaseAvailability: {SourceDirectory} is sealed but carries no {Modules}/{Index} — "
+                + "it predates module sealing, so a consumer cannot compose from it until it is republished",
+                sourceDirectory, ModulesDirectoryName, ModulesIndexFileName);
+            return new(null,
+                $"the publication is sealed but carries no module set ({ModulesDirectoryName}/{ModulesIndexFileName}) — "
+                + "it predates module sealing; republish the source under a platform that seals module sets");
+        }
+        var listed = File.ReadAllLines(index)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .ToList();
+        var bad = listed.FirstOrDefault(name =>
+            name.IndexOfAny(['/', '\\', ':']) >= 0 || name == "." || name == ".."
+            || !File.Exists(Path.Combine(directory, name)));
+        if (bad is not null)
+        {
+            logger?.LogInformation(
+                "ReleaseAvailability: {SourceDirectory} lists module bundle '{Bundle}' that is absent "
+                + "or not a bare name — the module set is torn, so a consumer cannot compose from it",
+                sourceDirectory, bad);
+            return new(null, $"the module set is torn: '{bad}' is listed in {ModulesDirectoryName}/{ModulesIndexFileName} but absent (or not a bare name)");
+        }
+        return new(listed, null);
+    }
 }
+
+/// <summary>One reading of a sealed publication's module set: the listed bundle names, or
+/// <c>null</c> with the reason a consumer must not compose from it.</summary>
+public sealed record ModuleSetReading(IReadOnlyList<string>? Modules, string? Refusal);
 
 /// <summary>One reading of the catalogue: what the target release turned out to be, and what was
 /// published for it.</summary>

--- a/test/Memex.Portal.Shared.Test/PrebuiltPublicationTest.cs
+++ b/test/Memex.Portal.Shared.Test/PrebuiltPublicationTest.cs
@@ -95,6 +95,83 @@ public class PrebuiltPublicationTest(ITestOutputHelper output) : MonolithMeshTes
         }
     }
 
+    /// <summary>
+    /// 🚨 MeshWeaver#2698: a gate pinned to an identity composes the module bytes the publication
+    /// was SEALED against, from the publication — never the registry's package endpoint, whose
+    /// bytes are the module's own lane's last build. The registry therefore serves a sealed
+    /// publication's module set beside its bundles: exactly the index's list (an unlisted file is
+    /// not part of the set), 404 with a reason for a publication that predates module sealing
+    /// (so a consumer fails RED naming the republish instead of composing something else), and an
+    /// EMPTY set for a bake that composed nothing — distinguishable from "predates".
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ServesTheSealedModuleSet_AndRefusesAPublicationThatPredatesIt()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-prebuilt-modules-" + Guid.NewGuid().ToString("N"));
+        var dir = Path.Combine(root, Identity, Source);
+        var modules = Path.Combine(dir, PublishedBundleCatalogue.ModulesDirectoryName);
+        Directory.CreateDirectory(modules);
+        try
+        {
+            WriteBundle(Path.Combine(dir, "Store.zip"), "Store");
+            File.WriteAllText(Path.Combine(dir, ShippedPrebuiltBundles.CompletionSentinelFileName), "Store.zip\n");
+            WriteBundle(Path.Combine(modules, "ai.module.nupkg"), "AI");
+            WriteBundle(Path.Combine(modules, "orphan.module.nupkg"), "Orphan");     // on disk, NOT in the set
+            File.WriteAllText(Path.Combine(modules, PublishedBundleCatalogue.ModulesIndexFileName), "ai.module.nupkg\n");
+
+            var legacy = Path.Combine(root, Identity, "legacy");                       // sealed BEFORE module sealing
+            Directory.CreateDirectory(legacy);
+            WriteBundle(Path.Combine(legacy, "L.zip"), "L");
+            File.WriteAllText(Path.Combine(legacy, ShippedPrebuiltBundles.CompletionSentinelFileName), "L.zip\n");
+
+            var bare = Path.Combine(root, Identity, "bare");                           // sealed, composed nothing
+            Directory.CreateDirectory(Path.Combine(bare, PublishedBundleCatalogue.ModulesDirectoryName));
+            WriteBundle(Path.Combine(bare, "B.zip"), "B");
+            File.WriteAllText(Path.Combine(bare, ShippedPrebuiltBundles.CompletionSentinelFileName), "B.zip\n");
+            File.WriteAllText(Path.Combine(bare, PublishedBundleCatalogue.ModulesDirectoryName, PublishedBundleCatalogue.ModulesIndexFileName), "");
+
+            var key = await RegisterInstance("module-reader", $"{Source}/*", "legacy/*", "bare/*");
+            var ungrantedKey = await RegisterInstance("module-stranger");
+            await using var app = await StartHost(root);
+
+            // 1. the set is the index's list — the orphan on disk is not in it
+            var index = await Get(app, $"/api/plugins/bundles/prebuilt/{Identity}/{Source}/modules", key);
+            Assert.Equal(HttpStatusCode.OK, index.StatusCode);
+            var body = await index.Content.ReadAsStringAsync();
+            Assert.Contains("ai.module.nupkg", body);
+            Assert.DoesNotContain("orphan", body);
+            var ai = await Get(app, $"/api/plugins/bundles/prebuilt/{Identity}/{Source}/modules/ai.module.nupkg", key);
+            Assert.Equal(HttpStatusCode.OK, ai.StatusCode);
+            Assert.True((await ai.Content.ReadAsByteArrayAsync()).Length > 0);
+            var orphan = await Get(app, $"/api/plugins/bundles/prebuilt/{Identity}/{Source}/modules/orphan.module.nupkg", key);
+            Assert.Equal(HttpStatusCode.NotFound, orphan.StatusCode);
+
+            // 2. the NodeType bundle index is untouched by the module set (and "modules" is not a bundle)
+            var bundles = await Get(app, $"/api/plugins/bundles/prebuilt/{Identity}/{Source}", key);
+            Assert.Contains("Store.zip", await bundles.Content.ReadAsStringAsync());
+
+            // 3. a publication that predates module sealing → 404 that SAYS so, never an empty set
+            var predates = await Get(app, $"/api/plugins/bundles/prebuilt/{Identity}/legacy/modules", key);
+            Assert.Equal(HttpStatusCode.NotFound, predates.StatusCode);
+            Assert.Contains("predates module sealing", await predates.Content.ReadAsStringAsync());
+
+            // 4. a bake that composed nothing → 200 with an EMPTY set
+            var empty = await Get(app, $"/api/plugins/bundles/prebuilt/{Identity}/bare/modules", key);
+            Assert.Equal(HttpStatusCode.OK, empty.StatusCode);
+            Assert.Contains("\"modules\":[]", (await empty.Content.ReadAsStringAsync()).Replace(" ", ""));
+
+            // 5. no grant → 403; a walking name → refused before any disk read
+            var refused = await Get(app, $"/api/plugins/bundles/prebuilt/{Identity}/{Source}/modules", ungrantedKey);
+            Assert.Equal(HttpStatusCode.Forbidden, refused.StatusCode);
+            var walk = await Get(app, $"/api/plugins/bundles/prebuilt/{Identity}/{Source}/modules/..%2FStore.zip", key);
+            Assert.NotEqual(HttpStatusCode.OK, walk.StatusCode);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
     private static void WriteBundle(string path, string plugin)
     {
         using var zip = ZipFile.Open(path, ZipArchiveMode.Create);


### PR DESCRIPTION
## The defect (#2698, fleet-wide 2026-08-29)

Every satellite gate declined every prebuilt assembly it installed — `dependency record mismatch — 'MeshWeaver.AI' built against mvid:900d42…, live is mvid:d61fd1…` (same for `Markdown.Collaboration`) — compiled locally, then failed its own consumption postcondition. No diff in any repo. Cause: the gate seeds the **plugins publication** for its identity but composed `registry-modules: AI Essentials` from the registry's **package** endpoint, which serves the module lane's last build under an unmoved version. Two builds, one version string. Agreed with the Plugins session: the publication is the unit of consistency; the package endpoint is the runtime/install surface.

## What this does

**Producer — the seal carries its modules.** `publish-bake-bundles.sh` uploads the bundles the bake composed under `modules/<pkg>.module.nupkg` + `modules/_index`, strictly before `_complete`. Empty index = composed nothing. A sealed publication with **no** index predates module sealing and is **republished on the source's next bake even when content is unchanged** — the fleet converges by itself. `node-repo-publish-bake.yml` keys the bundles by package id (from this run's artifact `MeshWeaver.Plugin.<pkg>.<v>.module.nupkg`, the registry's `<pkg>.bundle.zip`, or an upstream's `<pkg>.module.nupkg`).

**Registry — serves the set.** `GET …/prebuilt/{identity}/{source}/modules` (the index's list; 404 whose message says *predates module sealing* for an old seal; `[]` for a bake that composed nothing) and `…/modules/{bundle}` (listed names only, bare names only). `PublishedBundleCatalogue.SealedModulesOf` is the single rule, same torn-publication semantics as `SealedBundlesOf`.

**Consumers — compose from the seal, never the registry.** New `.github/scripts/compose-sealed-modules.sh`: for each `registry-modules` package, the first upstream (in order) whose seal for this identity lists it. **No fallback** — an upstream with no seal, a seal without a module set, or a package no upstream sealed is RED naming the identity and the republish. Wired into `node-repo-gate.yml` (`upstream-seed`), `node-repo-publish-bake.yml` (`upstream-sources`, script from its `mw-platform-gate` checkout) and `node-repo-compile-check.yml` (new `upstream-seed` input + identity resolution). Gate/compile-check fetch the script at `github.job_workflow_sha`, so a satellite pinned to a reusable sha runs the script that sha was written with. A repo declaring **no** upstream still composes from the registry, and the log says so in a `::notice::`.

## Verified locally
- `PrebuiltPublicationTest` 2/2 incl. new `ServesTheSealedModuleSet_AndRefusesAPublicationThatPredatesIt` (index = listed set; unlisted file 404; pre-sealing publication 404 *saying so*; empty set 200 `[]`; no grant 403; walking name refused).
- `Memex.Portal.Shared.Test` and `MeshWeaver.Documentation.Test` build `-c Release -warnaserror`, 0 errors; guards + `DocumentationLinkIntegrityTest` 11/11; `check-workflow-shell.py` 0 live; `bash -n` on both scripts.

## Rollout
1. This merges → the next bake of each source (Plugins first) re-seals its publication with its module set.
2. Satellites: pass `upstream-seed: plugins` to `node-repo-compile-check.yml` (new input; the gate call already has it) and bump the `uses:` pins — I do that in the open wave PRs.
3. The platform wave's `plugins-bake` keeps `publish: false`: sealing ≠ publishing packages; the runtime install surface stays the package endpoint (Plugins #931/#907 `{package}@{version}+{identity}` lane).

🤖 Generated with [Claude Code](https://claude.com/claude-code)