### PR TITLE
One place decides how long a test waits (#2700)

### DIFF
--- a/src/MeshWeaver.Fixture/TestTimeouts.cs
+++ b/src/MeshWeaver.Fixture/TestTimeouts.cs
@@ -1,0 +1,87 @@
+namespace MeshWeaver.Fixture;
+
+/// <summary>
+/// The one place a test waiting time is decided.
+///
+/// <para>🚨 <b>A convergence has no deadline of its own.</b> A reconnect-and-drain, a projection
+/// settling, a cancellation restarting pending rounds — none of these promises to finish in N
+/// seconds. Every bound on one is a guess about how fast the machine is, and a guess written as a
+/// literal is a guess that cannot be revisited.</para>
+///
+/// <para>The literal that was written is <c>30 s</c>, roughly 2,679 times across the two
+/// repositories. On 2026-08-29 six failures landed at 30–33 s in a single evening, in different
+/// tests, different suites and different repos — because the same guess had been copied everywhere
+/// and CI is slower than the laptop it was made on. There is a documented ~1.7× CI/local ratio,
+/// so a 30 s local bound leaves about 18 s of CI headroom, and under runner contention that is
+/// gone.</para>
+///
+/// <para>🚨 <b>The inner bound must be strictly less than the outer one, and that is why both live
+/// here.</b> 24 files carry <c>[Fact(Timeout = 30000)]</c> AND a 30 s internal wait: xunit kills
+/// the test at the exact moment the wait would have expired, so the assertion never fires and the
+/// failure is reported as an anonymous timeout instead of naming what did not converge. Scaling
+/// only the inner bound changes nothing in precisely the files that need it. Deriving both from
+/// one factor keeps the ordering by construction rather than by whoever writes the next test
+/// remembering it.</para>
+/// </summary>
+public static class TestTimeouts
+{
+    /// <summary>Local baseline for one convergence wait. Every other value is derived from it.</summary>
+    private static readonly TimeSpan LocalConvergence = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// How much slower CI is assumed to be. Overridable with <c>MW_TEST_TIMEOUT_FACTOR</c> so the
+    /// number can be tuned against evidence — a shared bound is only an improvement on a literal
+    /// if it can actually be changed in one place.
+    /// </summary>
+    private const double DefaultCiFactor = 3.0;
+
+    /// <summary>
+    /// True on a CI runner. Both variables are checked: <c>CI</c> is the convention, and
+    /// <c>GITHUB_ACTIONS</c> is what this fleet's runners actually set.
+    /// </summary>
+    public static bool IsContinuousIntegration =>
+        !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("CI"))
+        || !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("GITHUB_ACTIONS"));
+
+    private static double Factor
+    {
+        get
+        {
+            if (!IsContinuousIntegration)
+                return 1.0;
+            var raw = Environment.GetEnvironmentVariable("MW_TEST_TIMEOUT_FACTOR");
+            // A malformed override must not silently become 1.0 — that would quietly restore the
+            // very bound this type exists to widen. Fall back to the default instead.
+            return double.TryParse(raw, out var parsed) && parsed > 0 ? parsed : DefaultCiFactor;
+        }
+    }
+
+    /// <summary>
+    /// How long to wait for a convergence that has no deadline of its own. Use this instead of
+    /// writing a literal.
+    /// </summary>
+    public static TimeSpan Convergence => LocalConvergence * Factor;
+
+    /// <summary>
+    /// The value for <c>[Fact(Timeout = …)]</c>, in milliseconds — deliberately LARGER than
+    /// <see cref="Convergence"/> so an inner wait can lose first and report what it was waiting
+    /// for. A test whose xunit timeout equals its internal wait can only ever fail anonymously.
+    /// </summary>
+    public static int TestMilliseconds => (int)(Convergence * OuterMargin).TotalMilliseconds;
+
+    /// <summary>
+    /// The gap between the inner and outer bound. 2× is deliberate rather than tight: the outer
+    /// bound exists to stop a WEDGE, not to police a slow convergence, so it should be nowhere
+    /// near the inner one.
+    /// </summary>
+    private const double OuterMargin = 2.0;
+
+    /// <summary>A convergence expected to be quick — a local projection, a cached read.</summary>
+    public static TimeSpan Quick => Convergence / 3;
+
+    /// <summary>
+    /// A convergence crossing a silo or a real network hop, where the platform's own request
+    /// timeout (60 s) is the thing being waited on rather than a local settle.
+    /// </summary>
+    public static TimeSpan CrossSilo => Convergence * 2;
+}

--- a/test/MeshWeaver.Graph.Test/TestTimeoutsTest.cs
+++ b/test/MeshWeaver.Graph.Test/TestTimeoutsTest.cs
@@ -1,0 +1,103 @@
+#pragma warning disable CS1591
+
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// <see cref="TestTimeouts"/> exists so a waiting time is decided in one place instead of written
+/// out as a literal ~2,679 times. These pin the two properties that make it an improvement rather
+/// than a rename.
+/// </summary>
+public class TestTimeoutsTest
+{
+    /// <summary>
+    /// 🚨 THE INVARIANT. 24 files carry `[Fact(Timeout = 30000)]` AND a 30 s internal wait, so
+    /// xunit kills the test at the exact moment the wait expires: the assertion never fires and
+    /// the failure is an anonymous timeout instead of naming what did not converge. The outer
+    /// bound must therefore be strictly greater than the inner one — at EVERY scale factor, since
+    /// a rule that holds only locally is one CI run away from being useless.
+    /// </summary>
+    [Theory]
+    [InlineData(null)]      // local
+    [InlineData("1")]
+    [InlineData("3")]
+    [InlineData("10")]
+    public void TheOuterBoundAlwaysExceedsTheInner(string? factor)
+    {
+        using var _ = new EnvironmentVariable("GITHUB_ACTIONS", factor is null ? null : "true");
+        using var __ = new EnvironmentVariable("MW_TEST_TIMEOUT_FACTOR", factor);
+
+        Assert.True(
+            TestTimeouts.TestMilliseconds > TestTimeouts.Convergence.TotalMilliseconds,
+            $"the [Fact(Timeout)] value ({TestTimeouts.TestMilliseconds} ms) must exceed the "
+            + $"convergence wait ({TestTimeouts.Convergence.TotalMilliseconds} ms), or an inner "
+            + "wait can never lose first and the failure cannot say what it was waiting for.");
+    }
+
+    /// <summary>The ordering of the three convergence scales holds wherever it runs.</summary>
+    [Fact]
+    public void TheScalesAreOrdered()
+    {
+        Assert.True(TestTimeouts.Quick < TestTimeouts.Convergence);
+        Assert.True(TestTimeouts.Convergence < TestTimeouts.CrossSilo);
+    }
+
+    /// <summary>CI is slower than the machine the 30 s literal was chosen on; that is the point.</summary>
+    [Fact]
+    public void CiWaitsLongerThanLocal()
+    {
+        TimeSpan local, ci;
+        using (var _ = new EnvironmentVariable("CI", null))
+        using (var __ = new EnvironmentVariable("GITHUB_ACTIONS", null))
+            local = TestTimeouts.Convergence;
+        using (var _ = new EnvironmentVariable("GITHUB_ACTIONS", "true"))
+        using (var __ = new EnvironmentVariable("MW_TEST_TIMEOUT_FACTOR", null))
+            ci = TestTimeouts.Convergence;
+
+        Assert.True(ci > local, $"CI ({ci}) must wait longer than local ({local}).");
+    }
+
+    /// <summary>
+    /// 🚨 A malformed override must NOT silently become 1.0 — that would quietly restore the exact
+    /// bound this type exists to widen, and it would do so only on CI, where nobody would see it.
+    /// </summary>
+    [Theory]
+    [InlineData("not-a-number")]
+    [InlineData("")]
+    [InlineData("0")]
+    [InlineData("-2")]
+    public void AMalformedFactorFallsBackToTheDefaultRatherThanToOne(string bad)
+    {
+        using var _ = new EnvironmentVariable("GITHUB_ACTIONS", "true");
+        using var __ = new EnvironmentVariable("MW_TEST_TIMEOUT_FACTOR", bad);
+
+        TimeSpan local;
+        using (var ___ = new EnvironmentVariable("GITHUB_ACTIONS", null))
+        using (var ____ = new EnvironmentVariable("CI", null))
+            local = TestTimeouts.Convergence;
+
+        using var _____ = new EnvironmentVariable("GITHUB_ACTIONS", "true");
+        Assert.True(
+            TestTimeouts.Convergence > local,
+            $"a malformed MW_TEST_TIMEOUT_FACTOR ('{bad}') must not collapse the CI bound back to "
+            + "the local one — that restores the defect silently, and only on CI.");
+    }
+
+    /// <summary>Sets an environment variable for a scope and restores whatever was there.</summary>
+    private sealed class EnvironmentVariable : IDisposable
+    {
+        private readonly string name;
+        private readonly string? previous;
+
+        public EnvironmentVariable(string name, string? value)
+        {
+            this.name = name;
+            previous = Environment.GetEnvironmentVariable(name);
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        public void Dispose() => Environment.SetEnvironmentVariable(name, previous);
+    }
+}


### PR DESCRIPTION
Toward #2700. This is the **providing half** — the type. The migration of the tests that flake follows in the Plugins repo once this is available to them.

## Why a literal was the wrong shape

A convergence has no deadline of its own — a reconnect-and-drain, a projection settling, a cancellation restarting pending rounds. Every bound on one is a guess about machine speed, and **a guess written as a literal cannot be revisited**.

The guess was 30 s, written out **~2,679 times** across the two repos. On 2026-08-29, six failures landed at 30–33 s in one evening, in different tests, suites and repositories. There is a documented **~1.7× CI/local ratio**, so 30 s locally leaves ~18 s of CI headroom — and under contention that is gone.

## Why raising the literal would not have been enough

🚨 **24 files carry `[Fact(Timeout = 30000)]` *and* a 30 s internal wait.** xunit kills the test at the exact moment the wait expires, so the assertion never fires and the failure is an anonymous timeout instead of a message naming what did not converge.

Scaling only the inner bound changes nothing in precisely the files that need it most. So this type exposes **both**, derived from one factor with the outer strictly greater — pinned by a `Theory` at 1×, 3× and 10× rather than left to whoever writes the next test to remember.

## Details worth reviewing

- `MW_TEST_TIMEOUT_FACTOR` makes the CI factor tunable — a shared bound is only better than a literal if it can be changed in one place against evidence.
- A **malformed override falls back to the default, not to 1.0**. Collapsing silently to the old bound, on CI only, is the defect being fixed; there is a test for each malformed shape.
- `Quick` / `Convergence` / `CrossSilo` cover the three scales already in use, so migration is a rename rather than a judgement call per site.

**10 tests, all green.**

## Sequencing

This is the **providing** half of a cross-repo pair, so it lands **first** — the reverse of a deletion, where the removing half lands last (MeshWeaver.Plugins#2689 is about exactly that ordering).

The four tests named by the flake issues — #909, #912, #913, #929 — are all in the Plugins repo. `MeshWeaver.AI.Test` and `MeshWeaver.InstanceSync.Test` already reference `MeshWeaver.Fixture`; `MeshWeaver.Threading.Test` will need the reference added.

**This PR retires no flake issue by itself.** It makes retiring them a rename instead of 2,679 judgement calls.