### PR TITLE
ci(publish): publish every reachable target, then fail naming the unreachable ones — a dead share no longer starves the live ones

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -262,9 +262,18 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
   echo "sealed: $account/$share/$dest/$SENTINEL (${#BUNDLES[@]} bundle(s), source ${SOURCE_SHA:-unknown})"
 }
 
-PUBLISHED=0
-MARKERS=0
-for target in $BAKE_PUBLISH_TARGETS; do
+# 🚨 PER-TARGET ISOLATION (Plugins #2682, 2026-08-30). Each target is published in its OWN subshell:
+# a failure — an unreadable marker, a share that no longer exists, an upload that dies — fails THAT
+# target and the loop moves on, so a dead entry in BAKE_PUBLISH_TARGETS can no longer starve the
+# live ones. It is NOT a skip: every failed target is named at the end and the script exits 1. For
+# three days every Plugins main bake sealed the two live shares and then died on the third (a torn-
+# down instance's share, gone from the storage account) — whether anything sealed was ordering luck.
+# The refusals inside stay exactly as strict (an unreadable marker is still not an absent one); only
+# their blast radius shrinks from "the whole publication" to "this target".
+OUTCOMES="$SENTINEL_LOCAL_DIR/outcomes"
+: > "$OUTCOMES"
+publish_to_target() { # <target> — called in a SUBSHELL by the loop below: `exit 1` fails this target only
+  local target="$1"
   ACCOUNT="${target%%/*}"
   REST="${target#*/}"
   SHARE="${REST%%/*}"
@@ -281,7 +290,7 @@ for target in $BAKE_PUBLISH_TARGETS; do
   # by `set -e`, deliberately: a silently missing marker holds everything.
   if [ -n "${RELEASE_MARKER_LOCAL:-}" ]; then
     publish_release_marker "$ACCOUNT" "$SHARE" "$BASE"
-    MARKERS=$((MARKERS + 1))
+    echo marker >> "$OUTCOMES"
   fi
   DEST="${BASE:+$BASE/}prebuilt-bundles/$IDENTITY/$SOURCE"
   # "Rebuild only when we need to" applies to the publish too (#1660 WS3), but the key is
@@ -374,25 +383,41 @@ for target in $BAKE_PUBLISH_TARGETS; do
       echo "sealed publication under $DEST carries no $MODULES_DIR_NAME/$MODULES_INDEX (exists=$module_set) — it predates module sealing; republishing WITH the module set."
       echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s))"
       publish_one_target "$ACCOUNT" "$SHARE" "$DEST" true
-      PUBLISHED=$((PUBLISHED + 1))
-      continue
+      echo published >> "$OUTCOMES"
+      return 0
     fi
     if [ -n "${SOURCE_SHA:-}" ] && [ "$published_sha" = "$SOURCE_SHA" ]; then
       echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication of THIS content under $DEST (sentinel present, source $published_sha) — already published; skipping."
-      continue
+      return 0
     fi
     if [ -z "${SOURCE_SHA:-}" ]; then
       # No content identity given (framework-repo producer): the framework identity IS the
       # content key, so a sealed directory is already this publication.
       echo "::notice::$ACCOUNT/$SHARE holds a COMPLETE publication under $DEST ($SENTINEL present) — surface unchanged, bake already published; skipping."
-      continue
+      return 0
     fi
     resealing=true
     echo "sealed publication under $DEST is from source '${published_sha:-<unrecorded>}' but this bake is from '$SOURCE_SHA' — republishing."
   fi
   echo "→ $ACCOUNT/$SHARE: $DEST (${#BUNDLES[@]} bundle(s), ${#MODULES[@]} module(s))"
   publish_one_target "$ACCOUNT" "$SHARE" "$DEST" "$resealing"
-  PUBLISHED=$((PUBLISHED + 1))
+  echo published >> "$OUTCOMES"
+}
+
+FAILED=()
+for target in $BAKE_PUBLISH_TARGETS; do
+  if ( publish_to_target "$target" ); then
+    :
+  else
+    FAILED+=("$target")
+    echo "::error::target $target FAILED (see above) — continuing with the remaining targets so a dead target cannot starve the live ones"
+  fi
 done
+PUBLISHED=$(awk '/^published$/ { c++ } END { print c + 0 }' "$OUTCOMES")
+MARKERS=$(awk '/^marker$/ { c++ } END { print c + 0 }' "$OUTCOMES")
+if [ "${#FAILED[@]}" -gt 0 ]; then
+  echo "::error::bake publication FAILED on ${#FAILED[@]} of $(printf '%s\n' $BAKE_PUBLISH_TARGETS | wc -l | tr -d ' ') target(s): ${FAILED[*]} — identity=$IDENTITY source=$SOURCE. Every OTHER target above was published and sealed; these were not. A target that no longer exists (a torn-down instance's share) belongs OUT of BAKE_PUBLISH_TARGETS — remove it, never route around it."
+  exit 1
+fi
 
 echo "bake published: identity=$IDENTITY arch=$BAKE_ARCHITECTURE source=$SOURCE source-sha=${SOURCE_SHA:-unknown} bundles=${#BUNDLES[@]} targets-published=$PUBLISHED release=${RELEASE_VERSION:-none} release-markers=$MARKERS"

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-one-dead-publish-target-no-longer-starves-the-live-ones.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-one-dead-publish-target-no-longer-starves-the-live-ones.md
@@ -1,0 +1,23 @@
+---
+Name: One dead publish target no longer starves the live ones
+Category: Fix
+Description: A bake publishes its sealed assemblies to every portal's storage in turn, and a single target that could not be read — a share that no longer existed — stopped the run before the targets after it were written. Each target is now published on its own; the run still fails, naming exactly the targets it could not reach.
+Icon: ArrowSplit
+Order: -20260830
+---
+
+# One dead publish target no longer starves the live ones
+
+When a node repository bakes its NodeType assemblies, the sealed result is published to every
+portal's storage share listed for the fleet, one after the other. That loop stopped at the first
+target it could not read: a share that had been deleted with a torn-down instance still appeared
+in the list, its marker probe answered nothing, and the script — correctly refusing to treat an
+unreadable marker as an absent one — exited there. Whether the targets *after* it were published
+depended on where in the list the dead entry sat; for three days every bake sealed the two live
+shares and then went red on the third, which read as a broken bake rather than a stale list.
+
+Every target is now published in isolation. A target that cannot be read fails on its own, the
+remaining targets are still published and sealed, and the run ends red naming exactly the targets
+it did not reach. The refusals themselves are unchanged — an unreadable marker is still not an
+absent one — only their blast radius shrank from the whole publication to one target. A target that
+no longer exists belongs out of the list, and the message says so.


### PR DESCRIPTION
## Why
`publish-bake-bundles.sh` publishes to each `BAKE_PUBLISH_TARGETS` entry in turn and exited on the first target it could not read. A torn-down instance's share (atioz, `pvc-9e341c82…`, no longer on the storage account) sat third in the list in all seven repos; for three days every Plugins main bake sealed the two live shares and then died on it — whether anything sealed at all was ordering luck (Plugins #2682). The dead entry itself is already removed from the variable in all seven repos; this makes the script's blast radius per-target so the shape cannot recur.

## What
- Each target is published in its own subshell (`( publish_to_target "$target" )`); `exit 1` inside fails that target only. Failures are collected; the script exits 1 at the end **naming every failed target**, after every reachable target was published and sealed.
- Every refusal inside is unchanged (an unreadable marker is still not an absent one; the arch/seal/module-set checks are untouched) — only their blast radius shrinks. Not a skip-trapdoor: a failed target is always RED.
- Counters move to an outcomes file (a subshell cannot update the parent's variables); the EXIT trap is not inherited by `( )`, verified.

## Verified
Fake `az` on PATH (logs calls; the share `dead` answers nothing to the marker probe): targets `live1 dead live2` → `live1` and `live2` each get modules + `_index` + `_complete`, `dead` fails with the original refusal text, exit 1 with `FAILED on 1 of 3 target(s): acct/dead`; `live1 live2` → exit 0, `targets-published=2`. `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)