### PR TITLE
node-repo-module-pack: 'the bundle exists' is its own claim — bundles-built output, tests after the bundle

### DIFF
--- a/.github/scripts/node-repo-pack-verify.py
+++ b/.github/scripts/node-repo-pack-verify.py
@@ -165,6 +165,37 @@ def verify(expected: list[str], receipts: dict[str, dict], broken: list[str],
     return (1 if errors else 0), errors, notes
 
 
+def read_markers(directory: Path) -> set[str]:
+    """The modules with a well-formed built marker (`module-built-<module>` artifacts, merged)."""
+    found: set[str] = set()
+    if not directory.is_dir():
+        return found
+    for path in sorted(directory.rglob("*.json")):
+        try:
+            doc = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            continue
+        module = doc.get("module") if isinstance(doc, dict) else None
+        if isinstance(module, str) and module and path.stem == module:
+            found.add(module)
+    return found
+
+
+def bundles_built(expected: list[str], built: set[str], declared: set[str] | None) -> tuple[bool, str]:
+    """(every selected bundle exists as an artifact, one line saying so). Independent of the
+    receipts and of the pack job's result on purpose: this is the claim a caller's gate depends on
+    when it only COMPOSES the bundles, and a red suite or a failed hand-over must not turn it
+    false. A sibling call's markers are set aside the same way as its receipts."""
+    want = set(expected)
+    if declared is not None:
+        built = {m for m in built if m in declared}
+    missing = sorted(want - built)
+    if missing:
+        return False, (f"bundles-built: false — {len(missing)} of {len(want)} selected bundle(s) "
+                       f"never became an artifact: " + ", ".join(missing))
+    return True, f"bundles-built: true — {len(want)} of {len(want)} selected bundle(s) exist as artifacts"
+
+
 def parse_declared(text: str) -> set[str] | None:
     """The caller's `modules:` input as it reaches the workflow — a JSON list of entries carrying
     `module`, a JSON list of names, or a whitespace-separated list. Empty ⇒ None (no filter)."""
@@ -290,6 +321,27 @@ def self_test() -> int:
         check("no receipts at all is a FAILURE, never a pass",
               code == 1 and any("no receipt directory" in e for e in errors), f"{errors}")
 
+        print("the built markers — 'the bundle exists' stays true through a red suite:")
+        b = Path(tmp) / "built"
+        b.mkdir()
+        for m in three:
+            (b / f"{m}.json").write_text(json.dumps({"module": m}), encoding="utf-8")
+        ok, line = bundles_built(three, read_markers(b), None)
+        check("every selected bundle has a marker ⇒ bundles-built true", ok and "true" in line, line)
+        code, errors, _ = run(d, three, "failure")
+        ok, _ = bundles_built(three, read_markers(b), None)
+        check("…and a FAILED pack job (its suite went red) keeps bundles-built TRUE while the "
+              "lane itself still fails", ok and code == 1, f"{errors}")
+        (b / "MeshWeaver.Mcp.json").unlink()
+        ok, line = bundles_built(three, read_markers(b), None)
+        check("a selected bundle with NO marker ⇒ bundles-built false, naming it",
+              not ok and "MeshWeaver.Mcp" in line, line)
+        (b / "MeshWeaver.Ghost.json").write_text(json.dumps({"module": "MeshWeaver.Ghost"}), encoding="utf-8")
+        ok, _ = bundles_built(["MeshWeaver.AI", "MeshWeaver.Teams"], read_markers(b), set(three))
+        check("a sibling call's marker is set aside like its receipt", ok)
+        ok, _ = bundles_built([], set(), None)
+        check("an empty selection has every bundle it needs ⇒ true", ok)
+
         print("the legitimate empty selection — and its own mutation:")
         empty = Path(tmp) / "empty"
         empty.mkdir()
@@ -320,7 +372,7 @@ def self_test() -> int:
               "skipped module bundle.")
         return 1
     print("\n✓ node-repo-pack-verify self-test: 2 green-run assertions, 10 mutations that must go "
-          "red, the two sibling-call receipts (well-formed and corrupt) that must NOT, and 5 empty-selection cases including the "
+          "red, the two sibling-call receipts (well-formed and corrupt) that must NOT, 5 built-marker cases, and 5 empty-selection cases including the "
           "scope=full contradiction lock — all green.")
     return 0
 
@@ -339,6 +391,11 @@ def main() -> int:
                    help="the caller's own `modules:` input (JSON entries or names). Receipts for "
                         "modules outside it belong to a sibling call in the same run and are set "
                         "aside, not counted. Empty ⇒ every receipt is this call's.")
+    p.add_argument("--built", default="",
+                   help="directory the module-built-* markers were merged into; with --github-output, "
+                        "writes bundles_built=true|false — the receipt-independent 'bundle exists' claim")
+    p.add_argument("--github-output", default="", dest="github_output",
+                   help="the $GITHUB_OUTPUT file to append bundles_built to")
     p.add_argument("--self-test", action="store_true", dest="self_test")
     args = p.parse_args()
     if args.self_test:
@@ -352,6 +409,13 @@ def main() -> int:
     code, errors, notes = verify(expected, receipts, broken, args.pack_result,
                                  directory.is_dir(), args.scope, parse_declared(args.declared))
 
+    ok, line = bundles_built(expected, read_markers(Path(args.built)) if args.built else set(),
+                             parse_declared(args.declared))
+    if args.built:
+        notes.append(line)
+        if args.github_output:
+            with open(args.github_output, "a", encoding="utf-8") as fh:
+                fh.write(f"bundles_built={'true' if ok else 'false'}\n")
     for note in notes:
         print(f"✓ {note}")
     for error in errors:

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -176,6 +176,17 @@ on:
       content-app-private-key:
         description: Private key (PEM) of that App.
         required: false
+    outputs:
+      bundles-built:
+        description: >
+          "true" when EVERY selected module bundle exists as an artifact — the module-built-<module>
+          markers, dropped right after the bundle upload and BEFORE the tests. This is the claim a
+          caller's gate should depend on when it only COMPOSES the bundles: a red suite in this call
+          must not read as "bundle missing" there (Plugins #937 — one AI flake turned both required
+          gates red). The lane's own stable context (`All selected bundles built`) still asserts the
+          receipts AND the pack job's result, so a failed suite keeps the lane red wherever the lane
+          itself is required.
+        value: ${{ jobs.verify.outputs.bundles-built }}
 
 jobs:
   # ─────────────────────── WHICH BUNDLES THIS DIFF CAN REACH ───────────────────────
@@ -411,26 +422,6 @@ jobs:
           -p:Version=${{ steps.identity.outputs.version }}
           ${REFS:+-p:MeshWeaverRefs=$REFS}
 
-      # 🚨 Only when THIS diff reaches the module (or on a full run): a floor-only entry — built
-      # because the caller's gates compose it — carries test=false from the selection, and its
-      # suite is skipped rather than answering a question nobody asked. The AI engine's suite
-      # (~13 min, 1,600 tests) ran on every PR that never touched AI until 2026-08-29.
-      - name: Run the module's tests, when it ships any
-        if: ${{ matrix.entry.test != false }}
-        env:
-          PROJECT: ${{ matrix.entry.project }}
-        run: |
-          set -euo pipefail
-          # A module's tests relocate WITH it (the Approvals precedent). Conventional sibling:
-          # src/<Module>.Test. Absent is fine; present and red is not.
-          tests="$(dirname "$PROJECT").Test"
-          if [ -d "$tests" ]; then
-            dotnet test "$tests" -c Release -warnaserror \
-              -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver
-          else
-            echo "no test project at $tests — nothing to run"
-          fi
-
       # Publish materializes the module's PACKAGE dependencies beside the entry DLL — the SDK's
       # own answer to the runtime closure (framework-trimmed packages excluded, everything else
       # included), which the pack step's --deps-closure derivation selects from. A
@@ -513,6 +504,49 @@ jobs:
           path: ${{ runner.temp }}/bundles/*.module.nupkg
           if-no-files-found: error
 
+      # ───────────── THE BUILT MARKER — "the bundle exists", and nothing more ─────────────
+      # Dropped the moment the bundle artifact is up, BEFORE the tests and the hand-over, so a
+      # caller whose gates only COMPOSE this bundle can depend on the workflow's `bundles-built`
+      # output instead of this job's result: a red suite here must not read as "bundle missing"
+      # there. The receipt further down stays LAST — it still means the whole leg, tests and
+      # publish included, got here.
+      - name: Drop the built marker
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/built"
+          jq -n --arg p "${{ matrix.entry.package }}" --arg m "${{ matrix.entry.module }}" \
+                --arg v "${{ steps.identity.outputs.version }}" \
+             '{package:$p, module:$m, version:$v}' \
+             > "$RUNNER_TEMP/built/${{ matrix.entry.module }}.json"
+      - name: Upload the built marker
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-built-${{ matrix.entry.module }}
+          path: ${{ runner.temp }}/built/*.json
+          if-no-files-found: error
+
+      # 🚨 Only when THIS diff reaches the module (or on a full run): a floor-only entry — built
+      # because the caller's gates compose it — carries test=false from the selection, and its
+      # suite is skipped rather than answering a question nobody asked. The AI engine's suite
+      # (~13 min, 1,600 tests) ran on every PR that never touched AI until 2026-08-29.
+      # Runs AFTER the bundle artifact and its built marker exist and BEFORE the hand-over: a
+      # failing suite never publishes — and never un-builds.
+      - name: Run the module's tests, when it ships any
+        if: ${{ matrix.entry.test != false }}
+        env:
+          PROJECT: ${{ matrix.entry.project }}
+        run: |
+          set -euo pipefail
+          # A module's tests relocate WITH it (the Approvals precedent). Conventional sibling:
+          # src/<Module>.Test. Absent is fine; present and red is not.
+          tests="$(dirname "$PROJECT").Test"
+          if [ -d "$tests" ]; then
+            dotnet test "$tests" -c Release -warnaserror \
+              -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver
+          else
+            echo "no test project at $tests — nothing to run"
+          fi
+
       # 🚨 The hand-over. Without it a module that has LEFT the platform repo is packed, versioned,
       # inspected — and reaches nobody, because a registry serves only bytes it holds. A missing
       # token here FAILS the job rather than skipping quietly: "published nothing" and "published
@@ -583,6 +617,8 @@ jobs:
     needs: [select, pack]
     if: always()
     runs-on: ubuntu-latest
+    outputs:
+      bundles-built: ${{ steps.verify.outputs.bundles_built }}
     steps:
       - name: Check out Systemorph/MeshWeaver at the pinned ref
         uses: actions/checkout@v7
@@ -602,7 +638,15 @@ jobs:
           pattern: module-pack-receipt-*
           merge-multiple: true
           path: ${{ runner.temp }}/receipts
+      - name: Collect the built markers
+        uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          pattern: module-built-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/built
       - name: Exactly the selected bundles were built
+        id: verify
         env:
           EXPECTED: ${{ needs.select.outputs.selected }}
           PACK_RESULT: ${{ needs.pack.result }}
@@ -622,6 +666,7 @@ jobs:
             echo "::error title=Module bundles incomplete::the scope is FULL, so every one of the \
           $declared declared module(s) must be packed — but the selection named $COUNT. The \
           selection and the caller's matrix disagree."
+            echo "bundles_built=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
           # 🚨 `select` itself failing must not read as "nothing was selected" — that would turn a
@@ -630,6 +675,7 @@ jobs:
             echo "::error title=Module bundles incomplete::the selection job reported \
           '${{ needs.select.result }}' — no module bundle was chosen, so none was built. Read that \
           job; nothing below can be trusted."
+            echo "bundles_built=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
           # 🚨 `--declared`: artifacts are RUN-wide, so when a repo calls this workflow twice in
@@ -640,4 +686,6 @@ jobs:
             --receipts "$RUNNER_TEMP/receipts" \
             --pack-result "$PACK_RESULT" \
             --scope "$SCOPE" \
-            --declared "$DECLARED"
+            --declared "$DECLARED" \
+            --built "$RUNNER_TEMP/built" \
+            --github-output "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Why
A caller whose gates only **compose** a module bundle (Plugins' two required gates take the AI + Markdown.Collaboration bundles from the floor module-pack call, #932) had to depend on that call's **result**, which also carries the module's test suite — so one AI flake turned both required gates red (Plugins #937: `PreInstalledPackageInstallTest` on main run 33279529511, `ThreadSubmissionIntegrationTest` on run 33280461137).

## What
- `pack`: drops a `module-built-<module>` marker right after the bundle artifact is uploaded; the module's tests now run **after** that (still before the registry hand-over — a failing suite never publishes, and never un-builds). The receipt stays LAST and keeps its meaning (the whole leg got here).
- `verify` (`All selected bundles built`): collects the markers, writes `bundles_built=true|false` (every selected module has a marker — independent of receipts and of the pack result), exposed as the reusable's `outputs.bundles-built`. Early exits (scope contradiction, select failed) answer `false`. The job's own verdict is unchanged: receipts complete AND pack result — a red suite keeps the lane's stable context red wherever the lane is required.
- Guard: a pack job that produced no bundle drops no marker → `false` → nothing satisfies a caller's edge with an empty artifact.

Caller side (Plugins #932 follow-up): the gates' guard keys on `needs.modules-floor.outputs.bundles-built == 'true'` instead of `needs.modules-floor.result`.

## Self-test
`node-repo-pack-verify.py --self-test`: bundles-built true with a FAILED pack job; false naming a module with no marker; a sibling call's marker set aside like its receipt; empty selection ⇒ true. YAML parses; `outputs: [bundles-built]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)