### PR TITLE
ci(gate): upload the tester's stdout as a per-commit artifact — a caller's own ratchets can read the shared gate's log

### DIFF
--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -38,6 +38,14 @@ name: Node repo gate (reusable)
 
 on:
   workflow_call:
+    outputs:
+      gate-log-artifact:
+        description: >-
+          The name of the artifact holding the tester's stdout (gate-log-<sha>) — EMPTY when the gate
+          ran nothing (a PR whose diff reaches no module content). A caller's own ratchet keys on
+          this: present ⇒ download and read it, and fail on a missing or truncated log; empty ⇒
+          there was no gate run to ratchet, which the gate's own log states.
+        value: ${{ jobs.test-repos.outputs.gate-log-artifact }}
     inputs:
       test-image:
         description: The mw-plugin-test image reference (the caller's vars.MW_TEST_IMAGE).
@@ -194,6 +202,8 @@ on:
 jobs:
   test-repos:
     name: Compile + render node repos (MeshWeaver from ACR)
+    outputs:
+      gate-log-artifact: ${{ steps.gate.outputs.artifact }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -554,6 +564,7 @@ jobs:
           echo "EXT_MODULES_DIR=$EXT" >> "$GITHUB_ENV"
           echo "EXT_MODULE_ARGS=$MODULE_ARGS" >> "$GITHUB_ENV"
       - name: Import + compile + render + run tests for each node repo
+        id: gate
         env:
           TEST_IMAGE: ${{ inputs.test-image }}
           IMAGE_DIGEST: ${{ inputs.image-digest }}
@@ -667,6 +678,7 @@ jobs:
             --entrypoint /app/mw-plugin-test "$IMAGE" /repo \
             "${ALLOW_ARGS[@]}" ${EXT_MODULE_ARGS:-} --seed /seed | tee "$GATE_LOG"
           echo "GATE_LOG=$GATE_LOG" >> "$GITHUB_ENV"
+          echo "artifact=gate-log-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
           echo "OWN_BAKE=$OWN_BAKE" >> "$GITHUB_ENV"
           echo "bake identity: $(cat "$OWN_BAKE/framework-mvid.txt") — $(ls "$OWN_BAKE"/*.zip | wc -l | tr -d ' ') bundle(s), gated on their own bytes"
       # 🚨 The dump is written by the CONTAINER, which runs as root, so the file lands owned by

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -674,11 +674,22 @@ jobs:
           # file back through outputs, so it is uploaded as an artifact below. `pipefail` keeps the
           # TESTER's exit code — tee's success never masks a red gate.
           GATE_LOG="${RUNNER_TEMP:-/tmp}/gate.log"
+          # 🚨 Exported BEFORE the tester runs: under `set -e` a red gate would exit this script before
+          # a later export, and the always() upload would then skip on an empty GATE_LOG — the log
+          # missing exactly when a caller's ratchet needs the `GATE FAILED` line. The tester's exit
+          # code is carried past `tee` explicitly and re-raised after, so a red gate is still red.
+          echo "GATE_LOG=$GATE_LOG" >> "$GITHUB_ENV"
+          echo "artifact=gate-log-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          set +e
           docker run --rm --init "${EXT_V[@]}" -v "$REPO_MOUNT:/repo" -v "$OWN_BAKE:/seed:ro" "${DUMP_ARGS[@]}" \
             --entrypoint /app/mw-plugin-test "$IMAGE" /repo \
             "${ALLOW_ARGS[@]}" ${EXT_MODULE_ARGS:-} --seed /seed | tee "$GATE_LOG"
-          echo "GATE_LOG=$GATE_LOG" >> "$GITHUB_ENV"
-          echo "artifact=gate-log-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          rc=${PIPESTATUS[0]}
+          set -e
+          if [ "$rc" -ne 0 ]; then
+            echo "::error::the gate exited $rc — the verdict is above and in the gate-log-${GITHUB_SHA} artifact"
+            exit "$rc"
+          fi
           echo "OWN_BAKE=$OWN_BAKE" >> "$GITHUB_ENV"
           echo "bake identity: $(cat "$OWN_BAKE/framework-mvid.txt") — $(ls "$OWN_BAKE"/*.zip | wc -l | tr -d ' ') bundle(s), gated on their own bytes"
       # 🚨 The dump is written by the CONTAINER, which runs as root, so the file lands owned by

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -658,9 +658,15 @@ jobs:
           # Gate on the bake: own bundles AND the upstream seed together in one seed directory.
           if [ -n "${SEED_DIR:-}" ]; then cp "$SEED_DIR"/*.zip "$OWN_BAKE"/ 2>/dev/null || true; fi
           # shellcheck disable=SC2086
+          # The tester's stdout is ALSO the gate log a caller's own ratchets read (MeshWeaver.Manufacturing's
+          # Tests-area ratchet, `check-test-suites.py --gate-log`). A reusable workflow cannot hand a
+          # file back through outputs, so it is uploaded as an artifact below. `pipefail` keeps the
+          # TESTER's exit code — tee's success never masks a red gate.
+          GATE_LOG="${RUNNER_TEMP:-/tmp}/gate.log"
           docker run --rm --init "${EXT_V[@]}" -v "$REPO_MOUNT:/repo" -v "$OWN_BAKE:/seed:ro" "${DUMP_ARGS[@]}" \
             --entrypoint /app/mw-plugin-test "$IMAGE" /repo \
-            "${ALLOW_ARGS[@]}" ${EXT_MODULE_ARGS:-} --seed /seed
+            "${ALLOW_ARGS[@]}" ${EXT_MODULE_ARGS:-} --seed /seed | tee "$GATE_LOG"
+          echo "GATE_LOG=$GATE_LOG" >> "$GITHUB_ENV"
           echo "OWN_BAKE=$OWN_BAKE" >> "$GITHUB_ENV"
           echo "bake identity: $(cat "$OWN_BAKE/framework-mvid.txt") — $(ls "$OWN_BAKE"/*.zip | wc -l | tr -d ' ') bundle(s), gated on their own bytes"
       # 🚨 The dump is written by the CONTAINER, which runs as root, so the file lands owned by
@@ -679,6 +685,18 @@ jobs:
       # `if: always()` because the only runs with a dump are the ones where the gate FAILED.
       # The bake this gate produced — publish-bake reuses it on merge (bake-run-id) so the same
       # source is never compiled twice. Short retention: it is an intermediate, not a publication.
+      # 🚨 always(), and RED if the log is missing while the gate ran: a caller's ratchet that finds no
+      # artifact must fail on "no log", never pass on "nothing to check" — the same rule the gate
+      # itself applies to a truncated log. Named per commit so a merge-group ref cannot pick up a
+      # sibling run's log.
+      - name: Upload the gate log (the tester's stdout) for the caller's own ratchets
+        if: always() && env.GATE_LOG != ''
+        uses: actions/upload-artifact@v7
+        with:
+          name: gate-log-${{ github.sha }}
+          path: ${{ env.GATE_LOG }}
+          retention-days: 3
+          if-no-files-found: error
       - name: Upload this run's bake for publish-bake to reuse
         if: always() && env.OWN_BAKE != ''
         uses: actions/upload-artifact@v7

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-the-shared-gate-hands-its-log-back.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-the-shared-gate-hands-its-log-back.md
@@ -1,0 +1,20 @@
+---
+Name: The shared gate hands its log back
+Category: Feature
+Description: A node repository that adopts the platform's shared gate can now keep its own ratchets — the tester's full output is uploaded as a per-commit artifact, so a repo-local check such as Manufacturing's Tests-area ratchet reads the same verdict lines it read from its hand-rolled job.
+Icon: DocumentArrowRight
+Order: -20260830
+---
+
+# The shared gate hands its log back
+
+The platform's shared gate (`node-repo-gate.yml`) runs the tester inside a reusable workflow, and a
+reusable workflow can hand back outputs but not files. A repository with its own ratchet over the
+tester's verdict lines — Manufacturing's *Tests-area ratchet*, which turns `tests=skipped` into
+debt that must be listed or fixed — therefore could not adopt the shared gate without losing that
+check, which is exactly how a wholesale adoption silently drops a repo's own guard.
+
+The gate now uploads the tester's complete stdout as a per-commit artifact, always, and fails if
+the gate ran but wrote no log. A repository's own job downloads it and runs whatever ratchet it
+keeps, reading the same lines it read before. Nothing changes for repositories that keep no such
+check.


### PR DESCRIPTION
## Why
`node-repo-gate.yml` runs the tester inside a reusable workflow, which can hand back outputs but not files. MeshWeaver.Manufacturing keeps a **Tests-area ratchet** (`check-test-suites.py --gate-log`) over the tester's verdict lines — its own invariant 6 records that adopting the shared gate would silently drop it. That ratchet is the reason Manufacturing still hand-rolls its gate, which in turn is why it composes no AI module and fails `NodeType(s) not registered: Agent, Skill` on a post-#2276 image.

## What
- The tester's stdout is `tee`'d to `$RUNNER_TEMP/gate.log` (`set -o pipefail` keeps the **tester's** exit code — verified: `( …; exit 3 ) | tee` exits 3).
- Uploaded as artifact `gate-log-<sha>` with `if: always()` and `if-no-files-found: error` — a gate that ran and wrote no log is RED, never "nothing to check".
- No behaviour change for callers that keep no ratchet.

Next: Manufacturing adopts the shared gate (`upstream-seed: plugins`, `registry-modules: AI`) and its ratchet job downloads this artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)