### PR TITLE
ci(gates): the compose script's refusals reach the log, and its ref is an input — job_workflow_sha is empty inside a called reusable

### DIFF
--- a/.github/scripts/compose-sealed-modules.sh
+++ b/.github/scripts/compose-sealed-modules.sh
@@ -54,10 +54,13 @@ mkdir -p "$out"
 work=$(mktemp -d); trap 'rm -rf "$work"' EXIT
 
 # ── one upstream's sealed module set (an index), or a RED reason ──────────────────────────────
-# Prints the listed bundle names, one per line. Exit 1 with ::error when the upstream has no seal
-# for this identity or the seal predates module sealing — both are stop conditions, not misses.
-sealed_modules_of() { # <source>
-  local src="$1"
+# Writes the listed bundle names, one per line, into <list-file>. Exit 1 with ::error when the
+# upstream has no seal for this identity or the seal predates module sealing — both are stop
+# conditions, not misses. 🚨 The list goes to a FILE, never stdout: the first version returned it
+# on stdout and the caller captured it, so every ::error this function printed vanished into the
+# list file and a red gate showed nothing but "exit code 1" (Manufacturing run 33283588300).
+sealed_modules_of() { # <source> <list-file>
+  local src="$1" list="$2"
   case "$src" in */*|*..*|"") echo "::error::upstream '$src' is not a bare source name"; return 1 ;; esac
   if [ -n "$registry_url" ]; then
     local base="${registry_url%/}/api/plugins/bundles/prebuilt/$identity/$src"
@@ -76,7 +79,7 @@ sealed_modules_of() { # <source>
     esac
     jq -e '.modules | type == "array"' "$work/$src.modules.json" > /dev/null 2>&1 \
       || { echo "::error::$base/modules answered 200 but not a module-set index (starts: $(head -c 80 "$work/$src.modules.json" | tr -d '\n\r')…)"; return 1; }
-    jq -r '.modules[]' "$work/$src.modules.json"
+    jq -r '.modules[]' "$work/$src.modules.json" > "$list"
   else
     local account="${storage_target%%/*}" rest="${storage_target#*/}"
     local share="${rest%%/*}" base=""
@@ -92,7 +95,7 @@ sealed_modules_of() { # <source>
       echo "::error::upstream '$src' is sealed under $account/$share/$dir but carries no modules/_index — the publication predates module sealing; republish '$src' under a core that carries MeshWeaver#2707."
       return 1
     fi
-    grep -v '^[[:space:]]*$' "$work/$src.modules.index" || true
+    grep -v '^[[:space:]]*$' "$work/$src.modules.index" > "$list" || true
   fi
 }
 
@@ -116,7 +119,7 @@ fetch_module() { # <source> <bundle-name> <dest>
 # Read every upstream's module set ONCE, in the order given; the first seal listing a package wins.
 # A seal that cannot be read stops the run — see sealed_modules_of.
 for src in $upstreams; do
-  sealed_modules_of "$src" > "$work/$src.list"
+  sealed_modules_of "$src" "$work/$src.list"
   echo "upstream '$src' sealed $(grep -c '[^[:space:]]' "$work/$src.list" || true) module bundle(s) for identity $identity"
 done
 

--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -84,6 +84,15 @@ on:
         required: false
         type: string
         default: ''
+      platform-ref:
+        description: >-
+          The Systemorph/MeshWeaver ref whose .github/scripts this gate runs (compose-sealed-modules.sh).
+          Default main; pin it to the same sha as the `uses:` line for a reproducible run.
+          (`github.job_workflow_sha` is EMPTY inside a reusable called from another repo — measured
+          2026-08-30 — so the script's ref is an input, never inferred.)
+        required: false
+        type: string
+        default: main
       upstream-seed:
         description: >-
           The upstream source(s) whose SEALED publication for this image's framework identity
@@ -218,7 +227,7 @@ jobs:
           REGISTRY_KEY: ${{ secrets.registry-key }}
           SEAL_UPSTREAMS: ${{ inputs.upstream-seed }}
           IDENTITY: ${{ steps.image.outputs.identity }}
-          JOB_WORKFLOW_SHA: ${{ github.job_workflow_sha }}
+          PLATFORM_REF: ${{ inputs.platform-ref }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -228,11 +237,14 @@ jobs:
               # 🚨 The publication is the unit of consistency (MeshWeaver#2698): module bytes come
               # from the SEALED upstream publication for this identity, never the registry's
               # package endpoint. No fallback — a missing seal or module set is RED in the script.
-              # The compose script at THIS workflow's own commit (github.job_workflow_sha) — never a floating
-              # ref, so a node repo pinned to a reusable sha gets the script that sha was written with.
+              # The compose script at inputs.platform-ref (default main; pin it beside the `uses:` sha for a
+              # reproducible run). NOT github.job_workflow_sha: it is empty inside a reusable called from
+              # another repository, so a fetch keyed on it silently read main while claiming a pin.
               SCRIPT="${RUNNER_TEMP:-/tmp}/compose-sealed-modules.sh"
-              gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-sealed-modules.sh?ref=${JOB_WORKFLOW_SHA}" --jq .content | base64 -d > "$SCRIPT" \
-                || { echo "::error::could not fetch compose-sealed-modules.sh at ${JOB_WORKFLOW_SHA} from Systemorph/MeshWeaver"; exit 1; }
+              [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the compose script has no ref to be fetched at"; exit 1; }
+              gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-sealed-modules.sh?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$SCRIPT" \
+                || { echo "::error::could not fetch compose-sealed-modules.sh at ${PLATFORM_REF} from Systemorph/MeshWeaver"; exit 1; }
+              head -c 2 "$SCRIPT" | grep -q '#!' || { echo "::error::the fetched compose-sealed-modules.sh at ${PLATFORM_REF} is not a script (starts: $(head -c 40 "$SCRIPT" | tr -d '\n'))"; exit 1; }
               chmod +x "$SCRIPT"
               [ -n "${REGISTRY_URL:-}" ] || { echo "::error::upstream-seed is set but registry-url is empty — the compile check reads sealed module sets from the registry."; exit 1; }
               "$SCRIPT" --identity "$IDENTITY" --packages "$REGISTRY_MODULES" --upstreams "$SEAL_UPSTREAMS" --out "$BUNDLES" \

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -158,6 +158,15 @@ on:
         required: false
         type: string
         default: ''
+      platform-ref:
+        description: >-
+          The Systemorph/MeshWeaver ref whose .github/scripts this gate runs (compose-sealed-modules.sh).
+          Default main; pin it to the same sha as the `uses:` line for a reproducible run.
+          (`github.job_workflow_sha` is EMPTY inside a reusable called from another repo — measured
+          2026-08-30 — so the script's ref is an input, never inferred.)
+        required: false
+        type: string
+        default: main
       capture-coredumps:
         description: >-
           Run the tester with minidump-on-crash enabled and upload any dumps as a run artifact
@@ -505,7 +514,7 @@ jobs:
           SEAL_UPSTREAMS: ${{ inputs.upstream-seed }}
           IDENTITY: ${{ steps.seed-identity.outputs.identity }}
           TARGETS: ${{ inputs.bake-publish-targets }}
-          JOB_WORKFLOW_SHA: ${{ github.job_workflow_sha }}
+          PLATFORM_REF: ${{ inputs.platform-ref }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -516,11 +525,14 @@ jobs:
               # 🚨 The publication is the unit of consistency (MeshWeaver#2698): module bytes come
               # from the SEALED upstream publication for this identity, never the registry's
               # package endpoint. No fallback — a missing seal or module set is RED in the script.
-              # The compose script at THIS workflow's own commit (github.job_workflow_sha) — never a floating
-              # ref, so a node repo pinned to a reusable sha gets the script that sha was written with.
+              # The compose script at inputs.platform-ref (default main; pin it beside the `uses:` sha for a
+              # reproducible run). NOT github.job_workflow_sha: it is empty inside a reusable called from
+              # another repository, so a fetch keyed on it silently read main while claiming a pin.
               SCRIPT="${RUNNER_TEMP:-/tmp}/compose-sealed-modules.sh"
-              gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-sealed-modules.sh?ref=${JOB_WORKFLOW_SHA}" --jq .content | base64 -d > "$SCRIPT" \
-                || { echo "::error::could not fetch compose-sealed-modules.sh at ${JOB_WORKFLOW_SHA} from Systemorph/MeshWeaver"; exit 1; }
+              [ -n "${PLATFORM_REF:-}" ] || { echo "::error::platform-ref is empty — the compose script has no ref to be fetched at"; exit 1; }
+              gh api "repos/Systemorph/MeshWeaver/contents/.github/scripts/compose-sealed-modules.sh?ref=${PLATFORM_REF}" --jq .content | base64 -d > "$SCRIPT" \
+                || { echo "::error::could not fetch compose-sealed-modules.sh at ${PLATFORM_REF} from Systemorph/MeshWeaver"; exit 1; }
+              head -c 2 "$SCRIPT" | grep -q '#!' || { echo "::error::the fetched compose-sealed-modules.sh at ${PLATFORM_REF} is not a script (starts: $(head -c 40 "$SCRIPT" | tr -d '\n'))"; exit 1; }
               chmod +x "$SCRIPT"
               if [ -n "${REGISTRY_URL:-}" ]; then
                 "$SCRIPT" --identity "$IDENTITY" --packages "$REGISTRY_MODULES" --upstreams "$SEAL_UPSTREAMS" --out "$BUNDLES" \


### PR DESCRIPTION
Follow-up to #2707, from its first satellite run (Manufacturing run 33283588300, attempt 2):

1. **Refusals were invisible.** `compose-sealed-modules.sh` returned each upstream's module list on stdout and the caller captured it into a file — so the `::error` lines it printed on a 404 seal / missing module set went into the list file, and the gate showed only `Process completed with exit code 1`. The list is now written to a file argument; every message stays on stdout. Verified with a fake `curl` answering 404: the log now carries both `::error` lines naming the identity and the republish.
2. **`github.job_workflow_sha` is empty inside a reusable called from another repo** (measured: `JOB_WORKFLOW_SHA:` blank in the step env), so the script fetch read `main` while claiming a pin. `node-repo-gate.yml` and `node-repo-compile-check.yml` gain `platform-ref` (default `main`; pin beside the `uses:` sha for reproducibility), assert it non-empty, and refuse a fetched file that is not a script.

No caller input changes required (default `main`). `check-workflow-shell.py`: 0 live; `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)