### PR TITLE
ci(publish): refuse to seal an EMPTY module set when the workflow composed modules — a caller pinned before #2707 must bump, not seal a lie

### DIFF
--- a/.github/scripts/publish-bake-bundles.sh
+++ b/.github/scripts/publish-bake-bundles.sh
@@ -147,9 +147,20 @@ for zip in "${BUNDLES[@]}"; do basename "$zip"; done | sort > "$SENTINEL_LOCAL"
 MODULES_DIR_NAME="modules"
 MODULES_INDEX="_index"
 MODULES=("$BAKE_DIR/$MODULES_DIR_NAME"/*.module.nupkg)
+# 🚨 A workflow that COMPOSED modules must have STAGED them. EXT_MODULES_DIR is exported by the
+# reusable bake's assemble step (before and after #2707 alike); an empty staging dir beside it
+# means the CALLING WORKFLOW predates module sealing while this script does not — a version skew
+# (the workflow pinned by `uses:`, the script fetched at platform-ref). Plugins run 33284306805
+# (2026-08-30) sealed exactly that: an EMPTY set that the new contract reads as "composed nothing",
+# so every consumer was told the seal carries no AI. RED, naming the pin to bump — never a seal
+# that claims completeness for bytes it did not carry.
+if [ -n "${EXT_MODULES_DIR:-}" ] && [ "${#MODULES[@]}" -eq 0 ]; then
+  echo "::error::this bake composed external modules ($(ls "$EXT_MODULES_DIR" 2>/dev/null | tr '\n' ' ')) but staged none under $BAKE_DIR/$MODULES_DIR_NAME/ — the calling workflow predates module sealing (MeshWeaver#2707) while this script does not. Bump the caller's node-repo-publish-bake.yml pin to a core commit at or after 4584ca3c5. Refusing to seal an empty module set that would claim completeness."
+  exit 1
+fi
 MODULES_INDEX_LOCAL="$SENTINEL_LOCAL_DIR/$MODULES_INDEX"
 : > "$MODULES_INDEX_LOCAL"
-for m in "${MODULES[@]}"; do basename "$m"; done | sort > "$MODULES_INDEX_LOCAL"
+for m in ${MODULES[@]+"${MODULES[@]}"}; do basename "$m"; done | sort > "$MODULES_INDEX_LOCAL"
 
 # The CONTENT identity marker: which source commit this publication was baked from. It is NOT
 # part of the reader's contract (SeedPublishedRoot seeds only what the sentinel lists; extra
@@ -235,7 +246,7 @@ publish_one_target() { # <account> <share> <dest-dir> <resealing>
   # The module set: every bundle, then its index — both strictly before the sentinel.
   ensure_directory "$account" "$share" "$dest/$MODULES_DIR_NAME"
   local m
-  for m in "${MODULES[@]}"; do
+  for m in ${MODULES[@]+"${MODULES[@]}"}; do
     az storage file upload --account-name "$account" --share-name "$share" \
       --path "$dest/$MODULES_DIR_NAME/$(basename "$m")" --source "$m" \
       --auth-mode login --backup-intent --only-show-errors > /dev/null


### PR DESCRIPTION
## What happened
Plugins main run 33284306805 called `node-repo-publish-bake.yml@3a5dfe451` (pre-#2707: its assemble step has no seal-copy) while fetching `publish-bake-bundles.sh` from `platform-ref: main` (post-#2707). It composed `MeshWeaver.AI` + `MeshWeaver.Markdown.Collaboration`, staged nothing under `$BAKE/modules/`, and sealed `modules/_index` with **0 bundles** — which the new contract reads as "composed nothing". Every satellite gate seeding that publication is now told the seal carries no `AI`. Workflow pinned by `uses:` + script fetched by ref = a version skew the script can detect.

## What this does
- `EXT_MODULES_DIR` is exported by the assemble step before and after #2707 alike. Set **and** nothing staged ⇒ the publish is RED, naming the pin to bump (`node-repo-publish-bake.yml@` ≥ `4584ca3c5`). Never a seal that claims completeness for bytes it did not carry.
- A caller that composed nothing (no `EXT_MODULES_DIR`) still seals an empty set green — node-only repos with no upstream are unaffected.
- Empty-array expansions made bash-3.2-safe so the script runs under a local shim.

## Verified with a fake `az`
1. composed (`EXT_MODULES_DIR` set), nothing staged → exit 1 with the pin-bump message
2. composed and staged → `module set: … (1 bundle(s))`, exit 0
3. nothing composed, nothing staged → `module set: … (0 bundle(s))`, exit 0

Plugins is bumping its pins to `94d18f9cb` in parallel; the first main push after that re-seals `s770d75c…` with both bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)