### PR TITLE
Two catalog keys were declared twice, and every existing check ran on the survivor

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -1044,7 +1044,5 @@
   "presentation.unmarkedTitle": "Wieder sichtbar",
   "presentation.unmarkedBody": "Das wird im Präsentationsmodus nicht mehr ausgeblendet.",
   "presentation.signInRequiredTitle": "Anmeldung erforderlich",
-  "presentation.signInRequiredBody": "Der Präsentationsmodus ist eine persönliche Einstellung — dafür musst du angemeldet sein.",
-  "chat.modelStreamStalled": "Das Sprachmodell \u201e{0}\u201c hat aufgeh\u00f6rt zu antworten: Die Verbindung blieb offen, es kamen aber keine weiteren Daten an, daher wurde die Runde abgebrochen. Das ist eine St\u00f6rung beim Modell-Endpunkt und kein Problem der Anfrage \u2014 bitte erneut senden oder ein anderes Modell w\u00e4hlen.",
-  "chat.modelStreamFaulted": "Das Sprachmodell \u201e{0}\u201c hat seine Antwort mit einem Provider-Fehler beendet. Das ist eine St\u00f6rung beim vorgelagerten Modell-Provider und kein Problem der Anfrage \u2014 bitte erneut senden oder ein anderes Modell w\u00e4hlen."
+  "presentation.signInRequiredBody": "Der Präsentationsmodus ist eine persönliche Einstellung — dafür musst du angemeldet sein."
 }

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -1044,7 +1044,5 @@
   "presentation.unmarkedTitle": "Shown again",
   "presentation.unmarkedBody": "This is no longer hidden while presentation mode is on.",
   "presentation.signInRequiredTitle": "Sign-in required",
-  "presentation.signInRequiredBody": "Presentation mode is a personal setting, so you have to be signed in to use it.",
-  "chat.modelStreamStalled": "The language model '{0}' stopped responding: the connection stayed open but no further data arrived, so the round was aborted. This is an upstream stall at the model endpoint, not a problem with your request \u2014 submit again to retry, or pick a different model.",
-  "chat.modelStreamFaulted": "The language model '{0}' ended its response with a provider error. This is a fault at the upstream model provider, not a problem with your request \u2014 submit again to retry, or pick a different model."
+  "presentation.signInRequiredBody": "Presentation mode is a personal setting, so you have to be signed in to use it."
 }

--- a/test/MeshWeaver.Messaging.Hub.Test/LocalizationTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/LocalizationTest.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
+using System.Text.Json;
 using Xunit;
 
 namespace MeshWeaver.Messaging.Hub.Test;
@@ -44,6 +45,44 @@ public class LocalizationTest
         missing.Should().BeEmpty(
             "every key in strings.en.json needs a translation in strings.{0}.json; missing: {1}",
             locale, string.Join(", ", missing));
+    }
+
+    /// <summary>
+    /// 🚨 No catalog may declare a key TWICE — and this must read the RAW resource, because every
+    /// other assertion in this file runs on the LOADED catalog, where a duplicate is already gone.
+    ///
+    /// <para><see cref="LocalizationCatalog"/> loads with <c>builder[property.Name] = …</c>, a
+    /// dictionary assignment, so a repeated key silently overwrites and the collapsed catalog looks
+    /// perfect. Completeness, orphan and plural-pair checks all pass over the survivor. That is
+    /// exactly how <c>chat.modelStreamFaulted</c> and <c>chat.modelStreamStalled</c> came to be
+    /// declared twice in BOTH strings.en.json and strings.de.json — 1048 raw pairs collapsing to
+    /// 1046 — with nothing red for two commits.</para>
+    ///
+    /// <para>It was harmless only by luck: the two copies happened to carry equal text, one written
+    /// with literal characters and one <c>\u</c>-escaped. Had they differed, the winner would have
+    /// been decided by parser order, and editing the copy a reader happened to find would have
+    /// changed nothing at all — the "two homes drift" failure, inside a single file.</para>
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(AllLocales))]
+    public void NoCatalogDeclaresAKeyTwice(string locale)
+    {
+        var resourceName = $"MeshWeaver.Messaging.Localization.strings.{locale}.json";
+        using var stream = typeof(LocalizationCatalog).Assembly.GetManifestResourceStream(resourceName);
+        stream.Should().NotBeNull($"{resourceName} must be embedded");
+
+        using var document = JsonDocument.Parse(stream!);
+        var duplicates = document.RootElement.EnumerateObject()
+            .GroupBy(p => p.Name, StringComparer.Ordinal)
+            .Where(g => g.Count() > 1)
+            .Select(g => $"{g.Key} (x{g.Count()})")
+            .OrderBy(x => x, StringComparer.Ordinal)
+            .ToArray();
+
+        duplicates.Should().BeEmpty(
+            "strings.{0}.json declares {1} key(s) more than once; a duplicate is resolved by parser "
+            + "order and editing one copy leaves the other standing: {2}",
+            locale, duplicates.Length, string.Join(", ", duplicates));
     }
 
     /// <summary>
@@ -305,4 +344,8 @@ public class LocalizationTest
         => Locales.Supported
             .Where(l => l != Locales.Default)
             .Select(l => new object[] { l });
+
+    /// <summary>Every shipped catalog, English included — the duplicate check applies to all.</summary>
+    public static IEnumerable<object[]> AllLocales()
+        => Locales.Supported.Select(l => new object[] { l });
 }


### PR DESCRIPTION
`strings.en.json` and `strings.de.json` each declared **`chat.modelStreamFaulted`** and
**`chat.modelStreamStalled` twice** — 1048 raw pairs collapsing to 1046 — once with literal
characters and once `\u`-escaped, from the two commits that added them (`262eb506a`, then
`579e7eaaf`).

## Why nothing caught it

`LocalizationCatalog.Load` builds with `builder[property.Name] = …`, a **dictionary assignment**, so
a repeated key silently overwrites. Every assertion in `LocalizationTest` then runs on the collapsed
catalog, where the duplicate is already gone — completeness, orphan and plural-pair checks all pass
over the survivor and report a perfect file.

**The condition is invisible to every check that reads the catalog the way production does.** That
is the whole reason it survived two commits with nothing red.

It was harmless *only by luck*: the two copies happened to carry equal text. Had they differed, the
winner would have been decided by parser order, and editing whichever copy a reader happened to find
would have changed nothing at all — the "two homes drift" failure, inside a single file.

## The fix

Drop the later declaration of each key, keeping the literal-character form that matches the
surrounding file. Both catalogs go 1048 → 1046 raw pairs, `en`/`de` parity intact, both stream
strings retained and rendering correctly.

The diff also re-terminates the now-last entry (`presentation.signInRequiredBody`), since the
duplicates were the final two lines — worth noting because a naive line-delete leaves a trailing
comma and invalid JSON. I did exactly that on the first attempt and it was caught by re-parsing
before writing.

## The guard

`LocalizationTest.NoCatalogDeclaresAKeyTwice` reads the **raw embedded resource** and groups
`EnumerateObject()` by name — deliberately *not* the loaded catalog, which is precisely where the
evidence is destroyed. Runs for every shipped locale, English included.

Proven in both directions rather than trusting a green:

| tree | result |
|---|---|
| the duplicated catalogs | **Failed 2, Passed 0** — *"strings.en.json declares 2 key(s) more than once"* |
| this branch | 58/58 green |

Release, `-warnaserror` clean.

## Provenance

Found while verifying #2632 (separately fixed by Plugins#855, and now closed). Nothing here is a
defect in that fix — the duplicate arrived because the same two strings were added by two commits,
one of which re-encoded them.