### PR TITLE
ci(cd): the build fact names the whole promoted set — tester, portal and migration digests from this run's version tag

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1766,9 +1766,19 @@ jobs:
           az acr login --name meshweaver
           # The digest of mw-plugin-test:main — the exact pin (MW_IMAGE_DIGEST) the plugin repos
           # compile against. Resolved HERE so the mesh side needs no registry credential.
-          DIGEST=$(docker buildx imagetools inspect meshweaver.azurecr.io/mw-plugin-test:main --format '{{json .Manifest.Digest}}' | tr -d '"')
-          [ -n "$DIGEST" ] || { echo "::error::could not resolve mw-plugin-test:main digest — the release event would name a pin that does not exist"; exit 1; }
-          BODY=$(printf '{"event":"platform-build","repo":"%s","sha":"%s","version":"%s","image":"meshweaver.azurecr.io/mw-plugin-test","digest":"%s"}' "$GITHUB_REPOSITORY" "$SHA" "$V_PLUGIN" "$DIGEST")
+          # 🚨 Resolved from THIS run's version tag, never `:main` — `main` moves the moment another run
+          # promotes, so a fact read a minute later could name a set this run did not build. The
+          # promote job tags every image of the set with the version, so the three digests below are
+          # the ONE set the receivers should pin together (Plugins #944: the PlatformPinUpdater moves
+          # the tester AND the portal pin from one fact).
+          resolve() { docker buildx imagetools inspect "meshweaver.azurecr.io/$1:$V_PLUGIN" --format '{{json .Manifest.Digest}}' | tr -d '"'; }
+          DIGEST=$(resolve mw-plugin-test)
+          [ -n "$DIGEST" ] || { echo "::error::could not resolve mw-plugin-test:$V_PLUGIN digest — the release event would name a pin that does not exist"; exit 1; }
+          PORTAL_DIGEST=$(resolve memex-portal-ai)
+          [ -n "$PORTAL_DIGEST" ] || { echo "::error::could not resolve memex-portal-ai:$V_PLUGIN digest — the release event would name a portal pin that does not exist"; exit 1; }
+          MIGRATION_DIGEST=$(resolve memex-migration)
+          [ -n "$MIGRATION_DIGEST" ] || { echo "::error::could not resolve memex-migration:$V_PLUGIN digest — the release event would name a migration pin that does not exist"; exit 1; }
+          BODY=$(printf '{"event":"platform-build","repo":"%s","sha":"%s","version":"%s","image":"meshweaver.azurecr.io/mw-plugin-test","digest":"%s","portalImage":"meshweaver.azurecr.io/memex-portal-ai","portalDigest":"%s","migrationImage":"meshweaver.azurecr.io/memex-migration","migrationDigest":"%s"}' "$GITHUB_REPOSITORY" "$SHA" "$V_PLUGIN" "$DIGEST" "$PORTAL_DIGEST" "$MIGRATION_DIGEST")
           SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | sed 's/^.*= /sha256=/')
           # `|| code=000` is not defensive noise: `run:` is `bash -e`, so a curl that fails at the
           # TRANSPORT level (DNS, TLS, connection refused) would kill the step before the verdict

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1771,13 +1771,22 @@ jobs:
           # promote job tags every image of the set with the version, so the three digests below are
           # the ONE set the receivers should pin together (Plugins #944: the PlatformPinUpdater moves
           # the tester AND the portal pin from one fact).
-          resolve() { docker buildx imagetools inspect "meshweaver.azurecr.io/$1:$V_PLUGIN" --format '{{json .Manifest.Digest}}' | tr -d '"'; }
+          # resolve <repo> → the manifest-list digest, or EMPTY. The `if` keeps a failing inspect from
+          # ending the step under `set -e` before the guard below can name WHICH image is missing;
+          # the inspect's own stderr still reaches the log. The guard then checks the SHAPE, not just
+          # non-emptiness — a fact naming something that is not a sha256: digest is worse than none.
+          resolve() {
+            local d
+            if d=$(docker buildx imagetools inspect "meshweaver.azurecr.io/$1:$V_PLUGIN" --format '{{json .Manifest.Digest}}'); then
+              printf '%s' "$d" | tr -d '"'
+            fi
+          }
           DIGEST=$(resolve mw-plugin-test)
-          [ -n "$DIGEST" ] || { echo "::error::could not resolve mw-plugin-test:$V_PLUGIN digest — the release event would name a pin that does not exist"; exit 1; }
+          case "$DIGEST" in sha256:*) ;; *) echo "::error::could not resolve mw-plugin-test:$V_PLUGIN to a digest (got '$DIGEST') — the release event would name a pin that does not exist"; exit 1 ;; esac
           PORTAL_DIGEST=$(resolve memex-portal-ai)
-          [ -n "$PORTAL_DIGEST" ] || { echo "::error::could not resolve memex-portal-ai:$V_PLUGIN digest — the release event would name a portal pin that does not exist"; exit 1; }
+          case "$PORTAL_DIGEST" in sha256:*) ;; *) echo "::error::could not resolve memex-portal-ai:$V_PLUGIN to a digest (got '$PORTAL_DIGEST') — the release event would name a portal pin that does not exist"; exit 1 ;; esac
           MIGRATION_DIGEST=$(resolve memex-migration)
-          [ -n "$MIGRATION_DIGEST" ] || { echo "::error::could not resolve memex-migration:$V_PLUGIN digest — the release event would name a migration pin that does not exist"; exit 1; }
+          case "$MIGRATION_DIGEST" in sha256:*) ;; *) echo "::error::could not resolve memex-migration:$V_PLUGIN to a digest (got '$MIGRATION_DIGEST') — the release event would name a migration pin that does not exist"; exit 1 ;; esac
           BODY=$(printf '{"event":"platform-build","repo":"%s","sha":"%s","version":"%s","image":"meshweaver.azurecr.io/mw-plugin-test","digest":"%s","portalImage":"meshweaver.azurecr.io/memex-portal-ai","portalDigest":"%s","migrationImage":"meshweaver.azurecr.io/memex-migration","migrationDigest":"%s"}' "$GITHUB_REPOSITORY" "$SHA" "$V_PLUGIN" "$DIGEST" "$PORTAL_DIGEST" "$MIGRATION_DIGEST")
           SIG=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$SECRET" -hex | sed 's/^.*= /sha256=/')
           # `|| code=000` is not defensive noise: `run:` is `bash -e`, so a curl that fails at the


### PR DESCRIPTION
## Why
Plugins' `PlatformPinUpdater` moves only `MW_IMAGE_DIGEST`. With Plugins #940 (module lane compiles against the portal image) the portal pin (`MW_PORTAL_IMAGE_DIGEST` + the `platform-image-digest` literals) must move with it — Plugins #944 — which needs the CD build fact to carry the promoted portal digest. This is the core half.

## What
`Sign and POST the build fact` now resolves three digests from **this run's version tag** (`<image>:<version>`, the tag the promote job writes for the set) — never `:main`, which moves the moment another run promotes:
- `image`/`digest` — `mw-plugin-test` (as before, but race-free)
- `portalImage`/`portalDigest` — `memex-portal-ai`
- `migrationImage`/`migrationDigest` — `memex-migration`

Each unresolved digest is RED (`::error` + `exit 1`, the guard's pairing holds: 6/6). Backward compatible: the inbox watcher's `ParseBuild` reads known fields with `TryGetProperty` and ignores the rest.

## Verified
`PlatformReleaseNotifyGuard` + `UpstreamBuildGateGuard` + shell guards 10/10 (Release `-warnaserror`, 0 errors); `check-workflow-shell.py` 0 live; body shape checked with `jq`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)