### PR TITLE
fix(#2641): heal the self-typed User declaration inside the partition its instance query is pinned to

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-user-directory-fossil-healed-in-auth-partition.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-user-directory-fossil-healed-in-auth-partition.md
@@ -1,0 +1,19 @@
+---
+Name: The stray "User" entry in the user directory is now healed where it actually lives
+Category: Fix
+Description: The startup repair that removes the self-typed User declaration from the user directory now finds it inside the Auth partition, so the "As<User> … value is NodeTypeDefinition" error flood stops on stores where the earlier repair changed nothing.
+Icon: Sparkle
+Order: -20260830
+---
+
+# The stray "User" entry in the user directory is now healed where it actually lives
+
+A leftover row from an early platform version made the `User` type definition look like a user account,
+so the user directory kept reading it as a person and logged an error on every refresh — hundreds of
+times an hour. A repair that retypes that row at startup already shipped, yet on some portals the errors
+never stopped: the repair looked for the row under its own path, while on those stores the row sits in
+the Auth partition, which is exactly where the user directory finds it.
+
+The repair now also looks inside the partition each definition's own instance query is routed to, and
+fixes the row there. It also reports, at every start, how many rows it read and retyped — so "nothing
+found" is a number in the log, never silence.

--- a/src/MeshWeaver.Graph/Security/NodeTypeDeclarationSelfTypingValidator.cs
+++ b/src/MeshWeaver.Graph/Security/NodeTypeDeclarationSelfTypingValidator.cs
@@ -121,9 +121,15 @@ public sealed class NodeTypeDeclarationSelfTypingValidator : INodeValidator
     /// True when <paramref name="content"/> is a <see cref="Configuration.NodeTypeDefinition"/> —
     /// already typed (in-process content), or degraded to the raw JSON a cross-hub write can arrive
     /// as (the same discriminator shape <c>ContentDiscriminatorValidator</c> reads for its own
-    /// <c>$type</c> probe).
+    /// <c>$type</c> probe). Public because it is also the CANDIDATE test of
+    /// <see cref="SelfTypedDeclarationDurableRepair"/>: what counts as "declares a NodeType" must
+    /// be one definition for the guard, the repair's predicate and the repair's candidate set —
+    /// a bare <c>is NodeTypeDefinition</c> on a candidate would silently drop a declaration whose
+    /// content arrived untyped (AGENTS.md: never cast an object payload).
     /// </summary>
-    private static bool IsNodeTypeDeclarationContent(object? content) => content switch
+    /// <param name="content">The node content to classify.</param>
+    /// <returns><see langword="true"/> when the content declares a NodeType.</returns>
+    public static bool IsNodeTypeDeclarationContent(object? content) => content switch
     {
         Configuration.NodeTypeDefinition => true,
         JsonElement je when je.ValueKind == JsonValueKind.Object

--- a/src/MeshWeaver.Graph/Security/SelfTypedDeclarationDurableRepair.cs
+++ b/src/MeshWeaver.Graph/Security/SelfTypedDeclarationDurableRepair.cs
@@ -162,6 +162,19 @@ public sealed class SelfTypedDeclarationDurableRepair : IHostedService
         // on a synchronously-completing store (in-memory) Finally nulls the field before the
         // gate is even armed, and arming a disposed gate disposes the inner subscription on the
         // spot — so a finished sweep leaves this instance referencing NOTHING.
+        // The one line every boot ends with, whichever way the sweep terminates — the
+        // "nothing found" outcome is a count of zero here, never an absent line.
+        void Summarize(string outcome) => logger?.LogInformation(
+            "[SelfTypedDeclarationRepair] sweep {Outcome}: {Count} declaration path(s) [{Paths}] "
+            + "by path routing and inside pinned partition(s) [{Partitions}]: {Read} durable "
+            + "row(s) read, {Retyped} self-typed row(s) retyped",
+            outcome,
+            declarationPaths.Length,
+            string.Join(", ", declarationPaths),
+            string.Join(", ", pinned.Select(p =>
+                $"{p.Definition.Namespace}←{string.Join("|", p.Paths)}")),
+            stats.Read, stats.Retyped);
+
         var gate = new SingleAssignmentDisposable();
         subscription = gate;
         gate.Disposable = lanes
@@ -173,18 +186,17 @@ public sealed class SelfTypedDeclarationDurableRepair : IHostedService
             .Finally(Release)
             .Subscribe(
                 _ => { },
-                ex => logger?.LogWarning(ex,
-                    "[SelfTypedDeclarationRepair] declaration sweep failed; durable self-typed "
-                    + "declaration rows (if any) stay unhealed until the next start"),
-                () => logger?.LogInformation(
-                    "[SelfTypedDeclarationRepair] swept {Count} declaration path(s) [{Paths}] by "
-                    + "path routing and inside pinned partition(s) [{Partitions}]: {Read} durable "
-                    + "row(s) read, {Retyped} self-typed row(s) retyped",
-                    declarationPaths.Length,
-                    string.Join(", ", declarationPaths),
-                    string.Join(", ", pinned.Select(p =>
-                        $"{p.Definition.Namespace}←{string.Join("|", p.Paths)}")),
-                    stats.Read, stats.Retyped));
+                ex =>
+                {
+                    // Unreachable by construction — every lane isolates its own fault (see
+                    // Sweep) — but a fault that does escape must still end with the summary,
+                    // or the sweep would be silent about what it had probed before it died.
+                    logger?.LogWarning(ex,
+                        "[SelfTypedDeclarationRepair] declaration sweep failed; durable "
+                        + "self-typed declaration rows (if any) stay unhealed until the next start");
+                    Summarize("faulted");
+                },
+                () => Summarize("completed"));
 
         return Task.CompletedTask;
     }
@@ -193,7 +205,9 @@ public sealed class SelfTypedDeclarationDurableRepair : IHostedService
     /// One lane of the sweep: every durable row <paramref name="source"/> yields is counted,
     /// filtered with the shared collision predicate, and — when it is a fossil — retyped through
     /// <paramref name="target"/>, the adapter it was read from, so the write lands where the row
-    /// is.
+    /// is. A lane whose READ faults (a backend that cannot answer for one partition) is logged and
+    /// ends empty, so the lanes after it still run — the sweep is per-lane tolerant for the same
+    /// reason it is per-row tolerant: one failing seam must not leave every other row unhealed.
     /// </summary>
     private static IObservable<MeshNode?> Sweep(
         IObservable<MeshNode> source,
@@ -230,7 +244,16 @@ public sealed class SelfTypedDeclarationDurableRepair : IHostedService
                         "[SelfTypedDeclarationRepair] retyping '{Path}' ({Lane}) failed; it stays "
                         + "self-typed and will be retried on the next start", fossil.Path, lane);
                     return Observable.Return<MeshNode?>(null);
-                }));
+                }))
+            // Per-lane tolerance: a read that faults ends THIS lane, not the sweep. Logged, and
+            // retried on the next boot — whatever it would have found still matches the predicate.
+            .Catch<MeshNode?, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[SelfTypedDeclarationRepair] reading declaration rows by {Lane} failed; any "
+                    + "self-typed row there stays unhealed until the next start", lane);
+                return Observable.Empty<MeshNode?>();
+            });
 
     /// <summary>
     /// The partitions the candidate declarations' OWN instance queries are pinned to, each with

--- a/src/MeshWeaver.Graph/Security/SelfTypedDeclarationDurableRepair.cs
+++ b/src/MeshWeaver.Graph/Security/SelfTypedDeclarationDurableRepair.cs
@@ -1,5 +1,7 @@
 using System.Reactive.Linq;
 using System.Reactive.Disposables;
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
@@ -35,20 +37,49 @@ namespace MeshWeaver.Graph.Security;
 /// <c>LegacyUserPartitionRepair</c> already writes on. The adapter's change feed still fires, so
 /// live <c>nodeType:</c> query subscriptions converge without a restart.</para>
 ///
-/// <para><b>Scope.</b> Candidate paths are the statically-registered declarations
-/// (<see cref="Mesh.Services.StaticNodeProviderExtensions.EnumerateStaticNodes"/> filtered to
-/// <see cref="Configuration.NodeTypeDefinition"/> content) — the population that ever shipped
-/// self-typed, plus any future built-in. A durable row at such a path is rewritten ONLY when it
-/// matches <see cref="NodeTypeDeclarationSelfTypingValidator.IsSelfTypedDeclaration"/> — the
-/// exact predicate the write guard refuses, shared so the two can never drift. Everything else —
-/// already-correct declarations, real instances, package roots typed as an unrelated type — is
-/// left untouched, so on a healthy store this pass reads one batch and writes nothing.</para>
+/// <para><b>🚨 Where the row LIVES is where its instance query LOOKS — not where its path routes
+/// (#2641).</b> The first version of this sweep read the declaration paths through the ordinary
+/// path-routed <see cref="IStorageAdapter.ReadMany"/>, and on memex-cloud that healed nothing while
+/// the errors kept coming at the same ~600/h: <c>User</c>'s first segment routes to the partition
+/// <c>user</c>, which the V27 migration renamed to <c>auth</c> (and V31 dropped when a stray one
+/// reappeared), so the path-routed probe answered "absent" — the tolerated 42P01 — and the sweep
+/// wrote nothing and, worse, LOGGED nothing. The fossil is in the <c>auth</c> schema, and that is
+/// precisely where every consumer finds it: <c>UserNodeType</c> pins the path-less
+/// <c>nodeType:User</c> query to the <c>Auth</c> partition via a
+/// <see cref="QueryRoutingRule"/>. The collision this repair exists to remove is "the declaration
+/// answers its own instance query", so the row that matters is the one THAT query reaches. The
+/// sweep therefore runs two lanes per declaration: the path-routed read (a row filed under its
+/// own first segment), and — when the declaration's instance query is pinned to a partition by
+/// the mesh's routing rules — a read of the same path INSIDE that partition, through each writable
+/// <see cref="IPartitionStorageProvider"/>'s partition-scoped adapter
+/// (<see cref="IPartitionStorageProvider.CreateAdapterForTable"/>, the seam the partition-storage
+/// hubs address a schema through regardless of the path's first segment). A fossil found in
+/// either lane is retyped through the adapter that found it, so the write lands in the schema the
+/// row is in. The lanes run in sequence, each re-reading, so a row both lanes can see (a shared
+/// in-memory store) is healed once and read as already-correct by the next.</para>
 ///
-/// <para><b>Safe every boot.</b> One <see cref="IStorageAdapter.ReadMany"/> batch (the same
-/// multi-path probe the URL resolver runs constantly, so absent partitions answer "absent", never
-/// fault), zero writes when nothing matches, and idempotent when something does: the healed row no
-/// longer matches the predicate, and concurrent replicas retyping the same row write the same
-/// value under the monotonic-version guard. Fire-and-forget and failure-tolerant like
+/// <para><b>Scope.</b> Candidate paths are the statically-registered declarations
+/// (<see cref="Mesh.Services.StaticNodeProviderExtensions.EnumerateStaticNodes"/> filtered with
+/// <see cref="NodeTypeDeclarationSelfTypingValidator.IsNodeTypeDeclarationContent"/>, so a
+/// candidate whose content arrived untyped is not silently dropped) — the population that ever
+/// shipped self-typed, plus any future built-in. A durable row at such a path is rewritten ONLY
+/// when it matches <see cref="NodeTypeDeclarationSelfTypingValidator.IsSelfTypedDeclaration"/> —
+/// the exact predicate the write guard refuses, shared so the two can never drift. Everything
+/// else — already-correct declarations, real instances, package roots typed as an unrelated type
+/// — is left untouched, so on a healthy store this pass reads a few rows and writes nothing.</para>
+///
+/// <para><b>Never silent.</b> The sweep's three outcomes — healed, tried-and-failed, nothing found
+/// — used to be distinguishable only by the ABSENCE of a line for the third, which is how #2641
+/// ran undiagnosed on an image that carried the repair. Every pass now ends with one Information
+/// line naming the candidate paths, the pinned partitions it probed, and how many rows it read
+/// and retyped, so "the repair never considered the row" reads as a count of zero, not as
+/// silence.</para>
+///
+/// <para><b>Safe every boot.</b> A few batched reads (the same probes the URL resolver and the
+/// partition hubs run constantly, so absent partitions answer "absent", never fault), zero writes
+/// when nothing matches, and idempotent when something does: the healed row no longer matches the
+/// predicate, and concurrent replicas retyping the same row write the same value under the
+/// backend's version-conditional upsert (#971). Fire-and-forget and failure-tolerant like
 /// <c>InstalledPackageRepairService</c> — a repair must never delay or fail startup; a skipped
 /// pass heals on the next boot.</para>
 /// </summary>
@@ -84,14 +115,46 @@ public sealed class SelfTypedDeclarationDurableRepair : IHostedService
             return Task.CompletedTask;
 
         var options = hub.JsonSerializerOptions;
-        var declarationPaths = hub.ServiceProvider.EnumerateStaticNodes()
-            .Where(n => n.Content is Configuration.NodeTypeDefinition)
+        var staticNodes = hub.ServiceProvider.EnumerateStaticNodes().ToList();
+        var declarationPaths = staticNodes
+            .Where(n => NodeTypeDeclarationSelfTypingValidator.IsNodeTypeDeclarationContent(n.Content))
             .Select(n => n.Path)
             .Where(p => !string.IsNullOrEmpty(p))
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .ToArray();
         if (declarationPaths.Length == 0)
+        {
+            logger?.LogInformation(
+                "[SelfTypedDeclarationRepair] no statically-registered NodeType declaration on "
+                + "this hub — nothing to sweep");
             return Task.CompletedTask;
+        }
+
+        var pinned = PinnedPartitions(
+            hub.ServiceProvider.GetService<MeshConfiguration>(), staticNodes, declarationPaths, options);
+        var providers = hub.ServiceProvider.GetServices<IPartitionStorageProvider>()
+            .Where(p => !p.IsReadOnly)
+            .ToList();
+        var stats = new SweepStats();
+
+        // Lane 1: the path-routed read — a fossil filed under its own first segment.
+        var lanes = new List<IObservable<MeshNode?>>
+        {
+            Sweep(storage.ReadMany(declarationPaths, options), storage, "path routing", options, stats, logger),
+        };
+        // Lane 2: one read per (pinned partition, writable provider) — a fossil filed in the
+        // partition its instance query is pinned to, addressed through the provider's
+        // partition-scoped adapter so the read (and the retype) land in that schema.
+        foreach (var (definition, paths) in pinned)
+        {
+            foreach (var provider in providers)
+            {
+                var scoped = provider.CreateAdapterForTable(definition, definition.Table);
+                lanes.Add(Sweep(
+                    scoped.ReadMany(paths, options), scoped,
+                    $"partition '{definition.Namespace}' via {provider.Name}", options, stats, logger));
+            }
+        }
 
         // Subscribe-and-return per the IHostedService rule (AsynchronousCalls.md): the turn
         // returns immediately and the work belongs to the observable chain. The
@@ -101,30 +164,9 @@ public sealed class SelfTypedDeclarationDurableRepair : IHostedService
         // spot — so a finished sweep leaves this instance referencing NOTHING.
         var gate = new SingleAssignmentDisposable();
         subscription = gate;
-        gate.Disposable = storage.ReadMany(declarationPaths, options)
-            .Where(NodeTypeDeclarationSelfTypingValidator.IsSelfTypedDeclaration)
-            .SelectMany(fossil => storage
-                .Write(fossil with
-                {
-                    NodeType = MeshNode.NodeTypePath,
-                    Version = MeshNode.NextVersion(fossil.Version),
-                    LastModified = DateTimeOffset.UtcNow,
-                }, options)
-                .Do(_ => logger?.LogInformation(
-                    "[SelfTypedDeclarationRepair] retyped durable declaration row '{Path}' from "
-                    + "nodeType '{Old}' to '{New}' — it was enrolled in its own instance query "
-                    + "(#2425/#2506)",
-                    fossil.Path, fossil.NodeType, MeshNode.NodeTypePath))
-                // Per-row tolerance: one path that cannot be written (a read-only claimant, a
-                // backend hiccup) must not stop the remaining rows from healing. Logged, and
-                // retried on the next boot — the fossil still matches the predicate.
-                .Catch<MeshNode?, Exception>(ex =>
-                {
-                    logger?.LogWarning(ex,
-                        "[SelfTypedDeclarationRepair] retyping '{Path}' failed; it stays "
-                        + "self-typed and will be retried on the next start", fossil.Path);
-                    return Observable.Return<MeshNode?>(null);
-                }))
+        gate.Disposable = lanes
+            // Sequential, not merged: a later lane must observe an earlier lane's heal.
+            .Concat()
             // A finished one-shot has nothing left to cancel, so it drops its own handle rather
             // than keeping the sweep's closures (storage, options, and through them the hub)
             // reachable from the host's IHostedService[] for the rest of the process.
@@ -133,9 +175,132 @@ public sealed class SelfTypedDeclarationDurableRepair : IHostedService
                 _ => { },
                 ex => logger?.LogWarning(ex,
                     "[SelfTypedDeclarationRepair] declaration sweep failed; durable self-typed "
-                    + "declaration rows (if any) stay unhealed until the next start"));
+                    + "declaration rows (if any) stay unhealed until the next start"),
+                () => logger?.LogInformation(
+                    "[SelfTypedDeclarationRepair] swept {Count} declaration path(s) [{Paths}] by "
+                    + "path routing and inside pinned partition(s) [{Partitions}]: {Read} durable "
+                    + "row(s) read, {Retyped} self-typed row(s) retyped",
+                    declarationPaths.Length,
+                    string.Join(", ", declarationPaths),
+                    string.Join(", ", pinned.Select(p =>
+                        $"{p.Definition.Namespace}←{string.Join("|", p.Paths)}")),
+                    stats.Read, stats.Retyped));
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// One lane of the sweep: every durable row <paramref name="source"/> yields is counted,
+    /// filtered with the shared collision predicate, and — when it is a fossil — retyped through
+    /// <paramref name="target"/>, the adapter it was read from, so the write lands where the row
+    /// is.
+    /// </summary>
+    private static IObservable<MeshNode?> Sweep(
+        IObservable<MeshNode> source,
+        IStorageAdapter target,
+        string lane,
+        JsonSerializerOptions options,
+        SweepStats stats,
+        ILogger? logger)
+        => source
+            .Do(_ => stats.CountRead())
+            .Where(NodeTypeDeclarationSelfTypingValidator.IsSelfTypedDeclaration)
+            .SelectMany(fossil => target
+                .Write(fossil with
+                {
+                    NodeType = MeshNode.NodeTypePath,
+                    Version = MeshNode.NextVersion(fossil.Version),
+                    LastModified = DateTimeOffset.UtcNow,
+                }, options)
+                .Do(_ =>
+                {
+                    stats.CountRetyped();
+                    logger?.LogInformation(
+                        "[SelfTypedDeclarationRepair] retyped durable declaration row '{Path}' "
+                        + "from nodeType '{Old}' to '{New}' ({Lane}) — it was enrolled in its own "
+                        + "instance query (#2425/#2506/#2641)",
+                        fossil.Path, fossil.NodeType, MeshNode.NodeTypePath, lane);
+                })
+                // Per-row tolerance: one path that cannot be written (a read-only claimant, a
+                // backend hiccup) must not stop the remaining rows from healing. Logged, and
+                // retried on the next boot — the fossil still matches the predicate.
+                .Catch<MeshNode?, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[SelfTypedDeclarationRepair] retyping '{Path}' ({Lane}) failed; it stays "
+                        + "self-typed and will be retried on the next start", fossil.Path, lane);
+                    return Observable.Return<MeshNode?>(null);
+                }));
+
+    /// <summary>
+    /// The partitions the candidate declarations' OWN instance queries are pinned to, each with
+    /// the declaration paths whose <c>nodeType:{path}</c> query the mesh's
+    /// <see cref="QueryRoutingRule"/>s route there — resolved exactly as the query pipeline
+    /// resolves them (<see cref="MeshConfiguration.ResolveRoutingHints"/> over a path-less
+    /// <c>nodeType:</c> comparison, the shape <c>UserIdentityCache.DirectoryQuery</c> has). The
+    /// <see cref="PartitionDefinition"/> is the statically-registered one
+    /// (<c>DefaultPartitionProvider</c>: <c>Auth</c> → schema <c>auth</c>) when there is one, else
+    /// the default first-segment shape the routers synthesise.
+    /// </summary>
+    private static IReadOnlyList<(PartitionDefinition Definition, string[] Paths)> PinnedPartitions(
+        MeshConfiguration? configuration,
+        IReadOnlyList<MeshNode> staticNodes,
+        string[] declarationPaths,
+        JsonSerializerOptions options)
+    {
+        if (configuration is null || configuration.QueryRoutingRules.Count == 0)
+            return [];
+
+        var pathsByPartition = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
+        foreach (var path in declarationPaths)
+        {
+            var instanceQuery = new ParsedQuery(
+                new QueryComparison(new QueryCondition("nodeType", QueryOperator.Equal, [path])),
+                TextSearch: null);
+            var partition = configuration.ResolveRoutingHints(instanceQuery).Partition;
+            if (string.IsNullOrEmpty(partition))
+                continue;
+            if (!pathsByPartition.TryGetValue(partition, out var paths))
+                pathsByPartition[partition] = paths = [];
+            paths.Add(path);
+        }
+        if (pathsByPartition.Count == 0)
+            return [];
+
+        var registered = staticNodes
+            .Where(n => string.Equals(n.NodeType, PartitionNodeType.NodeType, StringComparison.Ordinal))
+            .Select(n => n.ContentAs<PartitionDefinition>(options))
+            .Where(d => d is not null && !string.IsNullOrEmpty(d.Namespace))
+            .Select(d => d!)
+            .ToList();
+
+        return pathsByPartition
+            .Select(kv => (
+                Definition: registered.FirstOrDefault(d =>
+                    string.Equals(d.Namespace, kv.Key, StringComparison.OrdinalIgnoreCase))
+                    ?? new PartitionDefinition
+                    {
+                        Namespace = kv.Key,
+                        Schema = kv.Key.ToLowerInvariant(),
+                        TableMappings = PartitionDefinition.DefaultSegmentTableMappings(),
+                        NodeTypeTableMappings = PartitionDefinition.DefaultNodeTypeTableMappings(),
+                    },
+                Paths: kv.Value.ToArray()))
+            .ToList();
+    }
+
+    /// <summary>Counters for the end-of-sweep summary line; incremented from the sequential
+    /// chain, guarded anyway because a backend may emit from its own pool thread.</summary>
+    private sealed class SweepStats
+    {
+        private int read;
+        private int retyped;
+
+        public int Read => Volatile.Read(ref read);
+        public int Retyped => Volatile.Read(ref retyped);
+
+        public void CountRead() => Interlocked.Increment(ref read);
+        public void CountRetyped() => Interlocked.Increment(ref retyped);
     }
 
     /// <inheritdoc />

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfTypedDeclarationPinnedPartitionRepairTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfTypedDeclarationPinnedPartitionRepairTest.cs
@@ -1,0 +1,169 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 The durable self-typed <c>User</c> declaration must be healed WHERE ITS INSTANCE QUERY FINDS
+/// IT, not only where its path routes (#2641).
+///
+/// <para><c>SelfTypedDeclarationDurableRepairTest</c> pins the repair on a store where the fossil
+/// sits under its own path. memex-cloud is not that store. There, <c>User</c>'s first segment routes
+/// to the partition <c>user</c> — which the V27 migration renamed to <c>auth</c> — so a path-routed
+/// read of <c>User</c> answers "absent" (the tolerated 42P01) while the row itself sits in the
+/// <c>auth</c> schema, exactly where <c>UserNodeType</c> pins every path-less <c>nodeType:User</c>
+/// query. Live evidence on the image that carried #2605: <c>search nodeType:User</c> returned the
+/// fossil (nodeType <c>User</c>, version 2), <c>search nodeType:User path:User</c> returned nothing
+/// (a path switches the Auth pin off), and the repair's boot log carried neither a "retyped" nor a
+/// "failed" line — it had read nothing, written nothing and said nothing.</para>
+///
+/// <para>This class models that store with the in-memory partition stack: a wildcard catch-all plus
+/// one specific provider for the <c>Auth</c> partition whose PATH-ROUTED adapter only answers for
+/// paths inside <c>Auth/…</c> (what the Postgres path router does with a first segment) and whose
+/// PARTITION-SCOPED adapter (<see cref="IPartitionStorageProvider.CreateAdapterForTable"/>, what the
+/// partition-storage hubs address a schema through) exposes the whole store. The fossil is seeded
+/// into that store — reachable through the partition, invisible to the path.</para>
+/// </summary>
+public class SelfTypedDeclarationPinnedPartitionRepairTest : MonolithMeshTestBase
+{
+    private static readonly JsonSerializerOptions SeedOptions = new();
+
+    /// <summary>The <c>auth</c> schema: rows live here by PARTITION, whatever their path says.</summary>
+    private readonly InMemoryStorageAdapter authStore = new();
+
+    public SelfTypedDeclarationPinnedPartitionRepairTest(ITestOutputHelper output) : base(output)
+    {
+    }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        // The production fossil, verbatim: path User, namespace "", nodeType "User",
+        // NodeTypeDefinition content, version 2 — written into the legacy `user` schema by a
+        // first-segment route that no longer exists, carried into `auth` by the V27 rename.
+        authStore.SaveNodeSynchronously(MeshNode.FromPath("User") with
+        {
+            Name = "User",
+            NodeType = UserNodeType.NodeType, // "User" — the collision
+            Icon = "/static/NodeTypeIcons/person.svg",
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition
+            {
+                DefaultNamespace = "",
+                RestrictedToNamespaces = [""],
+                OwnsPartition = true
+            },
+            Version = 2,
+        }, SeedOptions);
+
+        // A real account, mirrored into auth by the V27 trigger the way every user's root row is
+        // (prod: `rbuergi`, nodeType User, version 7). Same partition, same nodeType, NOT a
+        // declaration — the repair must leave it exactly as it found it.
+        authStore.SaveNodeSynchronously(MeshNode.FromPath("mirroredprobe") with
+        {
+            Name = "Mirrored Probe",
+            NodeType = UserNodeType.NodeType,
+            State = MeshNodeState.Active,
+            Content = new User { Email = "mirroredprobe@meshweaver.io" },
+            Version = 7,
+        }, SeedOptions);
+
+        // Registered FIRST so the base's parameterless AddInMemoryPersistence() sees the
+        // IStorageAdapter slot taken and the core-services marker set, and no-ops.
+        builder.ConfigureServices(services =>
+        {
+            services.AddPartitionedInMemoryPersistence();
+            services.AddSingleton<IPartitionStorageProvider>(new AuthPartitionStorageProvider(authStore));
+            return services;
+        });
+        return base.ConfigureMesh(builder);
+    }
+
+    /// <summary>
+    /// The heal lands in the partition the fossil is in: the <c>auth</c> row flips to
+    /// <c>NodeType = "NodeType"</c> with content, name and identity preserved and the version
+    /// minted forward; no copy is conjured under the path route; the mirrored real account beside
+    /// it is untouched. On the pre-#2641 sweep this times out — the path-routed read never sees
+    /// the row.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task FossilInThePinnedPartition_UnreachableByPath_IsRetypedWhereItsInstanceQueryLooks()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        var healed = await AwaitHealed(authStore, "User", ct);
+        healed.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions).Should().NotBeNull(
+            "the repair retypes the row — it must not clobber the declaration content");
+        healed.Name.Should().Be("User");
+        healed.Version.Should().Be(3, "the retype is a forward-minted revision of the row");
+
+        var pathRouted = Mesh.ServiceProvider.GetRequiredService<InMemoryStorageAdapter>();
+        var strayCopy = await pathRouted.ReadAsync("User", Mesh.JsonSerializerOptions, ct);
+        strayCopy.Should().BeNull(
+            "the retype must be written through the adapter that FOUND the fossil — a write "
+            + "routed by path would land a second User row in the wildcard store and leave the "
+            + "auth row self-typed");
+
+        var mirrored = await authStore.ReadAsync("mirroredprobe", Mesh.JsonSerializerOptions, ct);
+        mirrored.Should().NotBeNull();
+        mirrored!.NodeType.Should().Be(UserNodeType.NodeType,
+            "a real user INSTANCE in the same partition is not a declaration — the repair must never touch it");
+        mirrored.Version.Should().Be(7);
+    }
+
+    /// <summary>
+    /// Waits (bounded) for the durable row at <paramref name="path"/> in <paramref name="storage"/>
+    /// to carry the corrected <see cref="MeshNode.NodeTypePath"/> — the repair runs from a hosted
+    /// service at startup, so the wait is on the CONDITION, never a fixed sleep.
+    /// </summary>
+    private Task<MeshNode> AwaitHealed(IStorageAdapter storage, string path, CancellationToken ct)
+        => Observable.Interval(TimeSpan.FromMilliseconds(50))
+            .StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null
+                && string.Equals(n.NodeType, MeshNode.NodeTypePath, StringComparison.Ordinal))
+            .Select(n => n!)
+            .FirstAsync()
+            .Timeout(30.Seconds())
+            .ToTask(ct);
+
+    /// <summary>
+    /// The <c>Auth</c> partition as Postgres shapes it. Path-routed traffic reaches the store only
+    /// for paths INSIDE the partition (<c>Auth</c>, <c>Auth/…</c>) — a first segment maps to a
+    /// schema and nothing else does — while the partition-scoped adapter addresses the store
+    /// directly, whatever the path's first segment. A row filed here under the path <c>User</c> is
+    /// therefore reachable through the partition and invisible to the path — the #2641 shape.
+    /// </summary>
+    private sealed class AuthPartitionStorageProvider(InMemoryStorageAdapter store) : IPartitionStorageProvider
+    {
+        public string Name => "Auth(test)";
+        public bool IsReadOnly => false;
+        /// <summary>Durable-backend precedence, like Postgres — asked before the in-memory catch-all.</summary>
+        public int Priority => 100;
+
+        public IStorageAdapter Adapter { get; } = new PathFilteringStorageAdapter(store, path =>
+            string.Equals(path, "Auth", StringComparison.OrdinalIgnoreCase)
+            || path.StartsWith("Auth/", StringComparison.OrdinalIgnoreCase));
+
+        public PartitionDefinition? PartitionDefinition { get; } = new()
+        {
+            Namespace = "Auth",
+            Schema = "auth",
+        };
+
+        public IStorageAdapter CreateAdapterForTable(PartitionDefinition def, string table) => store;
+    }
+}


### PR DESCRIPTION
## The `UserIdentityCache` half of #2641 — branch 3, and the mechanism

`SelfTypedDeclarationDurableRepair` (#2605) never considered the fossil `User` row on memex-cloud: it read the declaration paths through the ordinary **path-routed** `IStorageAdapter.ReadMany`, and `User`'s first segment routes to the partition `user` — which the V27 migration renamed to `auth` (V31 dropped the stray one that reappeared). The path-routed probe therefore answered "absent" (the tolerated `42P01`), the sweep wrote nothing, and — because "nothing found" had no log line — said nothing.

The row lives in the **`auth` schema**, which is exactly where every consumer finds it: `UserNodeType` pins the path-less `nodeType:User` query (verbatim `UserIdentityCache.DirectoryQuery`) to the `Auth` partition via a `QueryRoutingRule`. The collision the repair exists to remove is "the declaration answers its own instance query", so the row that matters is the one *that query* reaches — not the one the path route reaches.

### Live evidence (memex-cloud, image carrying #2605)

| probe | result |
|---|---|
| `search nodeType:User` | `{path:"User", nodeType:"User", version:2, lastModified:2026-06-02}` + the real accounts — the fossil, via the Auth pin |
| `search nodeType:User path:User` | **0 rows** — with a path the Auth pin is off, first-segment routing goes to `user`, absent |
| `search path:User` | only the static registration (`nodeType:"NodeType"`) |
| boot log | neither `retyped durable declaration row 'User'` nor `retyping 'User' failed` |

### The fix (`src/MeshWeaver.Graph/Security/SelfTypedDeclarationDurableRepair.cs`)

The sweep now runs two lanes per candidate declaration, in sequence:

1. the existing path-routed read;
2. when the declaration's **own instance query** (`nodeType:{path}`) is pinned to a partition by `MeshConfiguration.ResolveRoutingHints` — the same resolution the query pipeline performs — a read of the same path **inside that partition**, through each writable `IPartitionStorageProvider`'s partition-scoped adapter (`CreateAdapterForTable`, the seam the partition-storage hubs address a schema through regardless of the path's first segment). A fossil found there is retyped **through the adapter that found it**, so the write lands in the schema the row is in.

Also:
- the candidate filter uses `NodeTypeDeclarationSelfTypingValidator.IsNodeTypeDeclarationContent` (now public) instead of a bare `is NodeTypeDefinition`, so the guard, the predicate and the candidate set share one definition of "declares a NodeType";
- **never silent again**: every pass ends with one Information line naming the candidate paths, the pinned partitions it probed, and how many rows it read / retyped — the third outcome the issue comment enumerated is now a count of zero, not an absence.

### Deterministic repro — `SelfTypedDeclarationPinnedPartitionRepairTest`

Models the production store with the in-memory partition stack: a wildcard catch-all plus a specific `Auth` provider whose *path-routed* adapter only answers for `Auth/…` (what the Postgres path router does with a first segment) and whose *partition-scoped* adapter exposes the whole store. The fossil is seeded into that store — reachable through the partition, invisible to the path.

- **Unfixed sweep** (both `src/` files reverted, rebuilt): **fails** — `System.TimeoutException` after 30 s, the `auth` row never leaves `nodeType: "User"` (the path-routed read never sees it)
- **Fixed sweep**: passes — the `auth` row flips to `NodeType = "NodeType"`, version 2 → 3, content preserved; no stray copy is written under the path route; the mirrored real account beside it is untouched.

Existing `SelfTypedDeclarationDurableRepairTest` (2), `SelfTypedDeclarationRepairRetainsNothingTest` (4) and `NodeTypeDeclarationSelfTypingValidatorTest` (9) all pass. Built `MeshWeaver.Graph`, `MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.Graph.Test` with `-c Release -warnaserror`: `0 Error(s)`.

### Not in this PR

- The frame-loss / circuit-churn half of #2641 (the amplifier) — untouched.
- The retype through the partition-scoped adapter bypasses the in-process `MonotonicWriteGuard`/`VersionWriting` decorators (they wrap only the path-routed root adapter); the backend's own version-conditional upsert (#971) still guards the row.

What's New: `src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-user-directory-fossil-healed-in-auth-partition.md` (Category: Fix).

Refs #2641
