### PR TITLE
fix(#2638): hold the silo stop until accepted routing work has landed

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-departing-pod-lets-accepted-messages-land.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-departing-pod-lets-accepted-messages-land.md
@@ -1,0 +1,23 @@
+---
+Name: A departing pod lets accepted messages land before it leaves
+Category: Fix
+Description: During a rolling deploy, a message the departing pod had already accepted for routing now lands — or is answered — before that pod stops, instead of being lost to a full reply timeout.
+Icon: Sparkle
+Order: -20260830
+---
+
+# A departing pod lets accepted messages land before it leaves
+
+When a pod stopped — every rolling deploy does this — it could stop *over* messages it had already
+accepted for delivery. The message had left the sender and was on its way; the pod then shut its
+grains down, closed its transport, and disposed its service container while that delivery was still
+running. The delivery could only fail at that point, and the failure notice it tried to send back
+failed for the same reason, so the sender simply waited out its full reply budget and, in the worst
+case, gave up on a subscription that would have come back on the surviving pod seconds later. Each
+roll re-created the window.
+
+The pod now holds its own shutdown, as the very first thing it does, until every delivery it has
+accepted has either landed or been answered — while its hubs, its transport and its container are
+all still alive. On a healthy pod that takes milliseconds. A delivery that genuinely will not
+finish is reported by name after a bounded wait, and shutdown proceeds; it no longer hides behind a
+timeout on the sender's side.

--- a/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
+++ b/src/MeshWeaver.Hosting.Orleans/OrleansServerRegistryExtensions.cs
@@ -174,6 +174,16 @@ public static class OrleansServerRegistryExtensions
         // at process exit (#613). Subscribed at stage First ⇒ stops LAST, so grains keep their
         // full chance to flush before the terminal drain. See IoPoolSiloTeardown.
         services.AddIoPoolSiloTeardown();
+        // 🚨 Let ACCEPTED routing work LAND before the silo stops (issue #2638). RoutingGrain's
+        // turn is O(1), so Orleans' grain deactivation never waits on a route; the leg runs on
+        // the routing pool but holds its permit only for the subscribe; and the per-node delivery
+        // plus every NACK were detached from even that. The silo stop therefore ran — grains
+        // deactivated, transport stopped, mesh drained, container disposed — over legs that were
+        // still executing, and their tails died resolving grain proxies from a disposed Autofac
+        // scope. RoutingQuiescence counts that work; its participant holds the silo stop at stage
+        // Active (BEFORE membership announces ShuttingDown and BEFORE any grain deactivates) until
+        // the count is zero, bounded, so each leg lands or is NACK'd over a live transport.
+        services.AddRoutingQuiescence();
         // The root mesh hub's cross-silo REPLY stream (core#694 layer 2) — see
         // RootMeshHubReplyStreamService for the full story.
         services.AddRootMeshHubReplyStream();

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -66,6 +66,15 @@ internal class RoutingGrain(
     private readonly OrleansRoutingService? localRoutes =
         meshHub.ServiceProvider.GetService<IRoutingService>() as OrleansRoutingService;
 
+    // 🚨 Issue #2638. The mesh-scoped gauge the SILO STOP holds on: every leg this grain dispatches
+    // and every NACK it carries is tracked from dispatch to termination, and
+    // RoutingQuiescenceSiloParticipant will not let the silo deactivate a grain until the count is
+    // zero. Resolved from the mesh hub's provider like the failure registry, so grain and participant
+    // read the SAME instance across this grain's own activations (a StatelessWorker is recycled; its
+    // legs are not). Null on a host that did not register it — then nothing is held, as before.
+    private readonly RoutingQuiescence? quiescence =
+        meshHub.ServiceProvider.GetService<RoutingQuiescence>();
+
     /// <summary>
     /// Per-destination FIFO for the stream-routed branch. Instance field — its lifetime is this
     /// activation's, and it holds an entry only while a destination has work in flight.
@@ -242,10 +251,17 @@ internal class RoutingGrain(
         if (meshConfig.StreamRoutedAddressTypes.Contains(address.Type))
         {
             ReportSaturation(Interlocked.Increment(ref inFlightRoutes), addressPath);
+            // Claimed at ENQUEUE like the in-flight slot — a leg queued behind another leg is work
+            // this silo has accepted and must let land before it stops (#2638).
+            var slot = quiescence?.Track();
             orderedDispatcher.Enqueue(
                 addressPath,
                 BuildPodHubRoute(delivery, address, addressPath, streamProvider, grainFactory),
-                () => ReportDrained(Interlocked.Decrement(ref inFlightRoutes)));
+                () =>
+                {
+                    ReportDrained(Interlocked.Decrement(ref inFlightRoutes));
+                    slot?.Dispose();
+                });
         }
         else
             Dispatch(BuildGrainRoute(delivery, address, addressPath, streamProvider, grainFactory),
@@ -262,8 +278,13 @@ internal class RoutingGrain(
     private void Dispatch(IObservable<Unit> route, string addressPath, string deliveryId)
     {
         ReportSaturation(Interlocked.Increment(ref inFlightRoutes), addressPath);
+        var slot = quiescence?.Track();
         routingPool.SubscribeThroughPool(route)
-            .Finally(() => ReportDrained(Interlocked.Decrement(ref inFlightRoutes)))
+            .Finally(() =>
+            {
+                ReportDrained(Interlocked.Decrement(ref inFlightRoutes));
+                slot?.Dispose();
+            })
             .Subscribe(
                 _ => { },
                 ex => logger.LogError(ex,
@@ -692,7 +713,15 @@ internal class RoutingGrain(
             return pathResolver.ResolveRoute(addressPath)
                 .Take(1)
                 .Timeout(ResolveTimeout)
-                .Select(resolution =>
+                // 🚨 SelectMany, not Select — the delivery is PART OF THE LEG (issue #2638). It used
+                // to be subscribed inside a Select with its subscription discarded, so the leg
+                // "terminated" the instant path resolution emitted while the grain call, its ≤6
+                // retry timers and its NACK ran on detached, untracked, undrainable continuations —
+                // the tail that executed after the host had disposed its container in prod. Now the
+                // leg terminates when the delivery has LANDED or been NACK'd: the in-flight slot,
+                // the RoutingQuiescence gauge the silo stop holds on, and the pool drain all see the
+                // whole thing.
+                .SelectMany(resolution =>
                 {
                     var grainKey = resolution?.Prefix ?? addressPath;
                     RoutingGrainTrace.Write($"RoutingGrain.RouteMessage RESOLVE_EMIT id={delivery.Id} addr={addressPath} grainKey={grainKey} prefix={resolution?.Prefix ?? "(null)"} remainder={resolution?.Remainder ?? "(null)"}");
@@ -709,7 +738,7 @@ internal class RoutingGrain(
                         logger.LogWarning("[ROUTE] NotFound: {FailureMessage}", failureMessage);
                         RoutingGrainTrace.Write($"RoutingGrain.RouteMessage NOT_FOUND id={delivery.Id} addr={addressPath} sender={delivery.Sender}");
                         PostFailureToSender(failureMessage, ErrorType.NotFound);
-                        return Unit.Default;
+                        return Observable.Return(Unit.Default);
                     }
 
                     logger.LogDebug("[ROUTE] Delivering {MessageType} to grain {GrainKey}", delivery.Message?.GetType().Name ?? "(null)", grainKey);
@@ -722,7 +751,7 @@ internal class RoutingGrain(
                     // hubs aren't stream-registered — those return at the StreamRoutedAddressTypes check above),
                     // so the SubscribeRequest never got a response, the cache hub timed out after 60 s, and the
                     // node wedged on "Subscribing to {path}…" until a portal restart (prod 2026-06-24).
-                    DeliverToGrainWithRetry(
+                    return DeliverToGrainRoute(
                         () => grainFactory.GetGrain<IMessageHubGrain>(grainKey).DeliverMessage(delivery),
                         grainKey, addressPath, delivery.Id, PostFailureToSender, logger,
                         resolveActivationError: activationFailures is null
@@ -733,7 +762,6 @@ internal class RoutingGrain(
                         // terminal defect. Without the probe it NACK'd the sender as permanently
                         // Failed and tore down its recovery machinery.
                         scopeDisposed: IsServiceScopeDisposed);
-                    return Unit.Default;
                 })
                 .Catch<Unit, Exception>(ex =>
                 {
@@ -827,12 +855,9 @@ internal class RoutingGrain(
         if (localRoute is not null)
         {
             RoutingGrainTrace.Write($"RoutingGrain.RouteMessage FAILURE_LOCAL_ROUTE id={delivery.Id} sender={delivery.Sender} errorType={errorType}");
-            localRoute.Invoke(failureDelivery, CancellationToken.None)
-                .Subscribe(
-                    _ => { },
-                    ex => logger.LogWarning(ex,
-                        "[ROUTE] Failed to deliver {ErrorType} failure to co-hosted sender {Sender} over its local route",
-                        errorType, delivery.Sender));
+            SubscribeNack(
+                localRoute.Invoke(failureDelivery, CancellationToken.None).Select(_ => Unit.Default),
+                "over its local route");
             return;
         }
 
@@ -936,11 +961,35 @@ internal class RoutingGrain(
 
         // The NACK is fire-and-forget by nature — there is no NACK for a NACK — so the one thing a
         // subscriber owes is that a fault reaching here is never swallowed.
-        void SubscribeNack(IObservable<Unit> nack) =>
-            nack.Subscribe(
-                _ => { },
-                ex => logger.LogWarning(ex,
-                    "[ROUTE] Failed to deliver {ErrorType} failure to sender {Sender}", errorType, delivery.Sender));
+        //
+        // 🚨 …and it is ROUTING WORK, tracked like a leg (issue #2638). A NACK used to be a bare
+        // detached Subscribe: nothing counted it, nothing drained it, and the prod incident IS a
+        // NACK executing after the host had disposed its container. Through the routing pool it is
+        // terminated by IoPoolSiloTeardown's drain like every leg, and through the RoutingQuiescence
+        // gauge the silo stop holds until it has been carried — over a transport that still exists.
+        void SubscribeNack(IObservable<Unit> nack, string transport = "")
+        {
+            var slot = quiescence?.Track();
+            routingPool.SubscribeThroughPool(nack)
+                .Finally(() => slot?.Dispose())
+                .Subscribe(
+                    _ => { },
+                    ex =>
+                    {
+                        // The pool has been drained: this process is past the point where anything
+                        // can carry a NACK, and the drain says so by refusing the subscribe. Expected
+                        // teardown, not a fault — the hold ran out or the stop was non-graceful, and
+                        // RoutingQuiescence already reported the residual at Error.
+                        if (ex is OperationCanceledException)
+                            logger.LogDebug(
+                                "[ROUTE] {ErrorType} failure to sender {Sender} not carried {Transport}: the routing pool is drained (silo stopping)",
+                                errorType, delivery.Sender, transport);
+                        else
+                            logger.LogWarning(ex,
+                                "[ROUTE] Failed to deliver {ErrorType} failure to sender {Sender} {Transport}",
+                                errorType, delivery.Sender, transport);
+                    });
+        }
 
         // The NACK leg for a GRAIN-hosted sender (a per-node hub): resolve the sender's path the
         // same way the forward leg would, and when it names a real node, deliver the NACK as the
@@ -1276,9 +1325,43 @@ internal class RoutingGrain(
         IScheduler? scheduler = null,
         Func<string, string?>? resolveActivationError = null,
         Func<bool>? scopeDisposed = null)
+        => DeliverToGrainRoute(
+                grainCall, grainKey, addressPath, deliveryId, postFailureToSender, logger,
+                maxRetries, backoff, scheduler, resolveActivationError, scopeDisposed)
+            .Subscribe(
+                _ => { },
+                ex => logger.LogError(ex,
+                    "[ROUTE] Grain {GrainKey} delivery leg faulted past its own NACK arm ({DeliveryId})",
+                    grainKey, deliveryId));
+
+    /// <summary>
+    /// The delivery as ONE COLD LEG — the grain call with its transient retry, the result arm
+    /// (a <c>Failed</c> result NACKs the sender with the verdict the owning hub recorded) and the
+    /// fault arm (classified, then NACK'd) — emitting exactly one <see cref="Unit"/> and completing
+    /// once the delivery has LANDED or been NACK'd. Never faults past its NACK arm by design; the
+    /// subscriber's error arm exists so that a NACK that itself throws is still reported.
+    ///
+    /// <para>🚨 <b>Issue #2638 — a leg, not a detached side effect.</b> <see cref="BuildGrainRoute"/>
+    /// composes this INTO the route observable, so the route's in-flight slot, the
+    /// <see cref="RoutingQuiescence"/> gauge the silo stop holds on, and the routing pool's drain
+    /// all cover the delivery, its ≤6 retry timers and its NACK. <see cref="DeliverToGrainWithRetry"/>
+    /// is the fire-and-forget subscription of the same leg, kept for the pure tests that drive it.</para>
+    /// </summary>
+    internal static IObservable<Unit> DeliverToGrainRoute(
+        Func<Task<IMessageDelivery>> grainCall,
+        string grainKey,
+        string addressPath,
+        string deliveryId,
+        Action<string, ErrorType> postFailureToSender,
+        ILogger logger,
+        int maxRetries = 6,
+        Func<int, TimeSpan>? backoff = null,
+        IScheduler? scheduler = null,
+        Func<string, string?>? resolveActivationError = null,
+        Func<bool>? scopeDisposed = null)
     {
         return DeliverToGrainObservable(grainCall, grainKey, deliveryId, logger, maxRetries, backoff, scheduler)
-            .Subscribe(
+            .Do(
                 result =>
                 {
                     RoutingGrainTrace.Write($"RoutingGrain.RouteMessage GRAIN_CALL_OK id={deliveryId} grainKey={grainKey} state={result.State}");
@@ -1338,7 +1421,9 @@ internal class RoutingGrain(
                             grainKey, failMsg, failureErrorType);
                         postFailureToSender(failMsg, failureErrorType);
                     }
-                },
+                })
+            .Select(_ => Unit.Default)
+            .Catch<Unit, Exception>(
                 ex =>
                 {
                     RoutingGrainTrace.Write($"RoutingGrain.RouteMessage GRAIN_CALL_FAULT id={deliveryId} grainKey={grainKey} ex={ex.Message}");
@@ -1358,6 +1443,7 @@ internal class RoutingGrain(
                         "[ROUTE] Grain {GrainKey} delivery failed after transient retries (or a non-transient fault) → NACK sender as {ErrorType}: {Detail}",
                         grainKey, errorType, detail);
                     postFailureToSender($"Delivery to '{addressPath}' failed: {detail}", errorType);
+                    return Observable.Return(Unit.Default);
                 });
     }
 

--- a/src/MeshWeaver.Hosting.Orleans/RoutingQuiescence.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingQuiescence.cs
@@ -1,0 +1,304 @@
+using System.Diagnostics;
+using System.Reactive;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Orleans.Runtime;
+
+namespace MeshWeaver.Hosting.Orleans;
+
+/// <summary>
+/// Counts the routing work this silo has ACCEPTED and not yet LANDED — every route leg
+/// <see cref="RoutingGrain"/> dispatched off its turn, and every <c>DeliveryFailure</c> NACK it
+/// is carrying — so the silo stop can hold until that work has terminated
+/// (<see cref="RoutingQuiescenceSiloParticipant"/>). Issue #2638.
+///
+/// <para><b>Why nothing else measures this.</b> <c>RoutingGrain.RouteMessage</c> does O(1) work
+/// and returns <c>Forwarded</c> (issue #1028), so from Orleans' point of view the routing grain
+/// never has a request in flight: <c>Catalog.DeactivateAllActivations</c> deactivates it
+/// instantly, and the <c>DeactivationTimeout</c> it waits on in-flight requests with never
+/// applies. The leg itself runs on the routing <c>IIoPool</c>, but
+/// <c>SubscribeThroughPool</c> holds its permit for the SUBSCRIBE window only — so
+/// <c>IoPoolSiloTeardown</c>'s join at the end of the silo stop sees nothing once the leg has
+/// continued past its subscribe (the same gap <see cref="MeshWeaver.Mesh.ActivityTracker"/>
+/// closes for activities). And the per-node grain delivery used to be DETACHED from the leg
+/// entirely — subscribed inside a <c>Select</c> with its subscription discarded — so its retry
+/// timers and its NACK ran under no drain at all. The prod incident is exactly that tail
+/// executing after the host had disposed its Autofac root: <c>GetGrain</c> resolving a codec
+/// provider from a dead <c>LifetimeScope</c>.</para>
+///
+/// <para><b>Hold, do not cancel.</b> A message already accepted for routing must still land
+/// (<c>OrleansRoutingService.GrainWhileRunning</c> documents why the drain is deliberately
+/// ungated). The hold sits at <see cref="ServiceLifecycleStage.Active"/> — BEFORE membership
+/// announces <c>ShuttingDown</c> and BEFORE the catalog deactivates a single grain — so a leg
+/// finishes against live local hubs, a live transport and a live container, and its NACK, if it
+/// needs one, is carried while there is still something to carry it. Bounded: a leg that cannot
+/// land inside the budget is reported as the defect it is, and the silo proceeds.</para>
+///
+/// <para>Same reactive shape as <see cref="MeshWeaver.Mesh.ActivityTracker"/>: deltas in, running
+/// count out, serialised by QUEUEING onto one scheduler — no lock, no <c>Interlocked</c>, no
+/// async gate. Instance state owned by the mesh (never <c>static</c>).</para>
+/// </summary>
+public sealed class RoutingQuiescence : IDisposable
+{
+    private readonly Subject<int> deltas = new();
+    private readonly EventLoopScheduler scheduler = new();
+    private readonly IConnectableObservable<int> counts;
+    private readonly IDisposable connection;
+    private int disposed;
+
+    /// <summary>Initializes a new instance of the <see cref="RoutingQuiescence"/> class.</summary>
+    public RoutingQuiescence()
+    {
+        // Replay(1) so a late subscriber (the silo stop) sees the CURRENT count immediately rather
+        // than waiting for the next change — a stop on an idle silo must not wait at all.
+        counts = deltas
+            .ObserveOn(scheduler)
+            .Scan(0, (running, delta) => running + delta)
+            .StartWith(0)
+            .Replay(1);
+        connection = counts.Connect();
+    }
+
+    /// <summary>
+    /// Live count of routing work in flight, starting with the current value. Emits on every
+    /// dispatch and every termination, so a consumer waits for zero without polling.
+    /// </summary>
+    public IObservable<int> InFlightChanges => counts;
+
+    /// <summary>
+    /// Completes once no routing work is in flight. Emits immediately when the silo is already idle.
+    /// </summary>
+    public IObservable<Unit> WhenIdle =>
+        counts.Where(running => running == 0).Take(1).Select(_ => Unit.Default);
+
+    /// <summary>
+    /// Registers one piece of routing work as in flight. Dispose the returned handle when it
+    /// TERMINATES — landed, NACK'd, or faulted — never when it was merely dispatched. A double
+    /// dispose does not double-decrement.
+    /// </summary>
+    public IDisposable Track()
+    {
+        Push(1);
+        return Disposable.Create(() => Push(-1));
+    }
+
+    // 🚨 Tolerant of a straggler AFTER the mesh is gone. This singleton is disposed with the
+    // container, and the one thing left that can still call Track()/release on it is precisely a
+    // routing tail that outlived everything — the #2638 shape. There is nothing to count it
+    // against any more, and the alternative (a disposed Subject throwing ObjectDisposedException
+    // out of a Finally) would turn a leg's own bookkeeping into a second fault. The Subject is
+    // never disposed for the same reason: with the connection gone it has no observers, so a late
+    // push is a no-op rather than a throw.
+    private void Push(int delta)
+    {
+        if (Volatile.Read(ref disposed) != 0)
+            return;
+        deltas.OnNext(delta);
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+            return;
+        connection.Dispose();
+        scheduler.Dispose();
+    }
+}
+
+/// <summary>
+/// Holds the silo stop, at <see cref="ServiceLifecycleStage.Active"/>, until the routing work
+/// this silo accepted has terminated — see <see cref="RoutingQuiescence"/> for what is counted
+/// and why nothing else drains it. Issue #2638.
+///
+/// <para><b>Stage, and why it is the FIRST thing the stop does.</b> Orleans stops observers in
+/// DESCENDING stage order, and <see cref="ServiceLifecycleStage.Active"/> is the highest stage a
+/// running silo has started, so this runs before <c>MembershipAgent</c> announces
+/// <c>ShuttingDown</c> (<see cref="ServiceLifecycleStage.BecomeActive"/>), before
+/// <c>Catalog.DeactivateAllActivations</c> (<see cref="ServiceLifecycleStage.GrainDeactivation"/>),
+/// before the message centre stops accepting application messages
+/// (<see cref="ServiceLifecycleStage.RuntimeServices"/>) and long before the host disposes its
+/// root container. Every leg therefore finishes against exactly what it was dispatched against:
+/// live local hubs, a live transport, a live DI container. Held any later, a leg could only be
+/// re-placed on another silo (after grain deactivation), or fail (after the transport stopped) —
+/// and a NACK attempted after the container is gone is the very incident.</para>
+///
+/// <para><b>What makes the wait converge.</b> The host fires
+/// <c>IHostApplicationLifetime.ApplicationStopping</c> BEFORE it stops any hosted service, and the
+/// silo is a hosted service — so by the time this runs, <c>OrleansRoutingService.DeliverMessage</c>
+/// already refuses new dispatches as <c>ShuttingDown</c>. The count is monotone non-increasing
+/// from here, and on a healthy silo it reaches zero in milliseconds; only a leg that is genuinely
+/// not terminating burns the budget, and that is the defect the residual line names.</para>
+///
+/// <para><b>No deadlock.</b> The wait belongs to the silo lifecycle's own thread-pool task and
+/// parks nothing a leg needs: legs run on pool and thread-pool threads, their grain calls are
+/// answered by a scheduler that is still fully running, their NACKs land on hubs that are still
+/// alive. The Task handed to Orleans is a subscription bridged ONCE at the boundary, exactly like
+/// <c>IoPoolSiloTeardown.OnStop</c>. A non-graceful stop (the token already cancelled — Orleans'
+/// own <c>OnActiveStop</c> returns immediately on that) holds nothing.</para>
+/// </summary>
+public sealed class RoutingQuiescenceSiloParticipant
+    : ILifecycleParticipant<ISiloLifecycle>, ILifecycleObserver
+{
+    /// <summary>
+    /// The hold budget. Matches <c>MeshTeardownHostedService</c> and <c>IoPoolSiloTeardown</c>:
+    /// a leg's own bounds are of this order (<c>RoutingGrain.ResolveTimeout</c> is 30 s), so a leg
+    /// still in flight at expiry is one that would not have landed in time anyway.
+    /// </summary>
+    internal static readonly TimeSpan DefaultBudget = TimeSpan.FromSeconds(30);
+
+    private readonly RoutingQuiescence quiescence;
+    private readonly ILogger<RoutingQuiescenceSiloParticipant> logger;
+    private readonly TimeSpan budget;
+
+    /// <summary>Creates the participant with the production budget.</summary>
+    /// <param name="quiescence">The mesh-scoped routing gauge the stop holds on.</param>
+    /// <param name="logger">Logger for the hold's outcome lines.</param>
+    public RoutingQuiescenceSiloParticipant(
+        RoutingQuiescence quiescence,
+        ILogger<RoutingQuiescenceSiloParticipant> logger)
+        : this(quiescence, logger, DefaultBudget)
+    {
+    }
+
+    /// <summary>Test seam: the same participant with an explicit budget.</summary>
+    internal RoutingQuiescenceSiloParticipant(
+        RoutingQuiescence quiescence,
+        ILogger<RoutingQuiescenceSiloParticipant> logger,
+        TimeSpan budget)
+    {
+        this.quiescence = quiescence;
+        this.logger = logger;
+        this.budget = budget;
+    }
+
+    /// <inheritdoc />
+    public void Participate(ISiloLifecycle observer) =>
+        // Active ⇒ the LAST stage to start and the FIRST to stop (Orleans stops in descending
+        // stage order). See the type remarks for why it must be this early.
+        observer.Subscribe(nameof(RoutingQuiescenceSiloParticipant), ServiceLifecycleStage.Active, this);
+
+    Task ILifecycleObserver.OnStart(CancellationToken cancellationToken) => Task.CompletedTask;
+
+    // 🚨 NOT `async`, and nothing here awaits — the composition is handed back as ONE Task at the
+    // boundary Orleans demands, and the completion arrives on whichever thread the last leg
+    // unwinds on. Same argument, same shape, as IoPoolSiloTeardown.OnStop.
+    //
+    // 🚨 Bridged with ReactiveCompletion.ObserveCompletion, never `.ToTask()`. The gauge signals
+    // idle on its own event-loop thread; `.ToTask()` would resume Orleans' LifecycleSubject.OnStop
+    // INLINE there, and every lower stage's synchronous prologue — membership, the catalog, the
+    // pool drain — would then run on the one thread the gauge needs to count anything at all.
+    // ObserveCompletion completes with RunContinuationsAsynchronously, so the silo stop continues
+    // on the thread pool and the gauge's thread goes straight back to counting.
+    Task ILifecycleObserver.OnStop(CancellationToken cancellationToken)
+    {
+        if (cancellationToken.IsCancellationRequested)
+        {
+            // A non-graceful stop: Orleans' own Active-stage stop returns immediately on this, and
+            // so does the hold. Whatever is in flight is reported, not waited for.
+            return quiescence.InFlightChanges
+                .Take(1)
+                .Do(inFlight =>
+                {
+                    if (inFlight != 0)
+                        logger.LogWarning(
+                            "RoutingQuiescence: the silo is stopping NON-gracefully with {InFlight} route "
+                            + "leg(s) in flight — not holding; they will be abandoned by the pool drain.",
+                            inFlight);
+                })
+                .Select(_ => Unit.Default)
+                .ObserveCompletion(ReportLateFault);
+        }
+
+        var started = Stopwatch.GetTimestamp();
+        return quiescence.InFlightChanges
+            .Take(1)
+            .SelectMany(inFlight =>
+            {
+                if (inFlight == 0)
+                {
+                    logger.LogInformation(
+                        "RoutingQuiescence: no routing work in flight — the silo may deactivate its grains");
+                    return Observable.Return(Unit.Default);
+                }
+
+                logger.LogInformation(
+                    "RoutingQuiescence: holding the silo stop while {InFlight} route leg(s) land "
+                    + "(budget {Budget}) — before membership announces ShuttingDown and before any "
+                    + "grain deactivates, so each lands or is NACK'd over a live transport",
+                    inFlight, budget);
+
+                var landed = quiescence.WhenIdle
+                    .Do(_ => logger.LogInformation(
+                        "RoutingQuiescence: routing work landed after {Elapsed} ms — the silo may deactivate its grains",
+                        Stopwatch.GetElapsedTime(started).TotalMilliseconds))
+                    .Timeout(budget)
+                    // Expiry is DATA, not silence: read the residual off the gauge and name it. The
+                    // silo proceeds — a stop that never releases is worse than one that releases
+                    // loudly — and the leg that would not land is the defect to fix. Never widen
+                    // the budget.
+                    .Catch<Unit, TimeoutException>(_ => quiescence.InFlightChanges
+                        .Take(1)
+                        .Do(residual => logger.LogError(
+                            "RoutingQuiescence: {Residual} route leg(s) did not land within {Budget} — "
+                            + "the silo is proceeding to deactivate its grains over them. Each will now "
+                            + "fail on its own bound against a stopping transport, and its NACK may be "
+                            + "undeliverable. A leg that cannot land in {Budget} is stuck; find it, do "
+                            + "not widen the budget.",
+                            residual, budget, budget))
+                        .Select(_ => Unit.Default));
+
+                // The host's own shutdown budget can expire mid-hold (HostOptions.ShutdownTimeout).
+                // Orleans keeps stopping through stages on a cancelled token and so must this: a
+                // registration on the token is the reactive bridge, and Amb takes whichever ends
+                // the hold first.
+                var hostGaveUp = Observable.Create<Unit>(observer =>
+                        cancellationToken.Register(() => observer.OnNext(Unit.Default)))
+                    .Take(1)
+                    .SelectMany(_ => quiescence.InFlightChanges.Take(1))
+                    .Do(residual => logger.LogWarning(
+                        "RoutingQuiescence: the host's shutdown budget expired with {Residual} route "
+                        + "leg(s) still in flight after {Elapsed} ms — releasing the silo stop over them.",
+                        residual, Stopwatch.GetElapsedTime(started).TotalMilliseconds))
+                    .Select(_ => Unit.Default);
+
+                return landed.Amb(hostGaveUp);
+            })
+            .FirstAsync()
+            .ObserveCompletion(ReportLateFault);
+    }
+
+    // The gauge is a replayed Scan over a Subject — it cannot fault after emitting — so this arm
+    // exists for the contract, not for a case anyone expects; if it ever fires, say so.
+    private void ReportLateFault(Exception ex) =>
+        logger.LogError(ex,
+            "RoutingQuiescence: the routing gauge faulted AFTER the silo stop had stopped waiting on it");
+}
+
+/// <summary>DI wiring for <see cref="RoutingQuiescence"/> and its silo lifecycle participant.</summary>
+public static class RoutingQuiescenceExtensions
+{
+    /// <summary>
+    /// Registers the mesh-scoped <see cref="RoutingQuiescence"/> gauge and the silo lifecycle
+    /// participant that holds the silo stop on it (issue #2638). Idempotent. On an Orleans CLIENT
+    /// host the participant is registered but never enumerated — a client has no silo lifecycle —
+    /// so the registration is inert there, exactly like <c>IoPoolSiloTeardown</c>'s.
+    /// </summary>
+    /// <param name="services">The service collection to add the gauge and participant to.</param>
+    /// <returns>The same service collection for further chaining.</returns>
+    public static IServiceCollection AddRoutingQuiescence(this IServiceCollection services)
+    {
+        if (services.Any(d => d.ServiceType == typeof(RoutingQuiescence)))
+            return services;
+        services.AddSingleton<RoutingQuiescence>();
+        services.AddSingleton<RoutingQuiescenceSiloParticipant>();
+        services.AddSingleton<ILifecycleParticipant<ISiloLifecycle>>(sp =>
+            sp.GetRequiredService<RoutingQuiescenceSiloParticipant>());
+        return services;
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingQuiescenceClusterTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingQuiescenceClusterTest.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Orleans.Runtime;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// The WIRING half of issue #2638, on a real silo: a route leg <see cref="RoutingGrain"/> has
+/// dispatched is counted on the silo's <see cref="RoutingQuiescence"/> from dispatch until it
+/// terminates, and the silo's lifecycle actually carries <see cref="RoutingQuiescenceSiloParticipant"/>.
+/// <see cref="RoutingQuiescenceTest"/> pins what the participant DOES with that count; this pins
+/// that the grain feeds it and the silo registers it — the two things a pure test cannot see.
+///
+/// <para>Same vehicle as <see cref="RoutingGrainTurnIsolationTest"/>: the silo's
+/// <see cref="IPathResolver"/> is decorated with one whose subscribe BLOCKS for a magic partition,
+/// so a leg is provably in flight for as long as the test wants, and released explicitly. Every
+/// wait is on the gauge's own emissions or on the decorator's counters.</para>
+/// </summary>
+public class RoutingQuiescenceClusterTest(ITestOutputHelper output)
+    : OrleansTestBase<StallingResolverSiloConfigurator>(output)
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(30);
+
+    [Fact]
+    public async Task ADispatchedRouteLeg_IsInFlightOnTheSiloGauge_UntilItTerminates()
+    {
+        var silo = Cluster.SiloServices();
+        var resolver = silo.GetRequiredService<IPathResolver>() as StallingPathResolver;
+        resolver.Should().NotBeNull(
+            "the stalling decorator must be the silo's IPathResolver — without it nothing is in flight "
+            + "long enough to observe and this test would prove nothing");
+
+        // The silo REGISTERS the hold: the gauge and its lifecycle participant are the silo's own.
+        var quiescence = silo.GetRequiredService<RoutingQuiescence>();
+        silo.GetServices<ILifecycleParticipant<ISiloLifecycle>>()
+            .Should().Contain(p => p is RoutingQuiescenceSiloParticipant,
+                "the silo lifecycle must carry the participant, or the count is measured and never acted on");
+
+        var client = GetClient($"quiesce{Guid.NewGuid():N}"[..16]);
+        try
+        {
+            // Precondition: nothing in flight before the delivery is dispatched.
+            (await quiescence.InFlightChanges.FirstAsync().ToTask(Token())).Should().Be(0);
+
+            client.Post(new PingRequest(),
+                o => o.WithTarget(new Address(StallingPathResolver.StallPartition, "held-2638")));
+
+            // The grain claimed the gauge at dispatch — before the leg even reached its subscribe.
+            await quiescence.InFlightChanges.Where(n => n >= 1).FirstAsync().ToTask(Token());
+
+            // …and the leg is provably parked inside its resolve (the standard interval-poll for a
+            // source that is not itself observable).
+            await Observable.Interval(TimeSpan.FromMilliseconds(25))
+                .StartWith(0L)
+                .Where(_ => resolver!.StallsEntered > 0)
+                .FirstAsync()
+                .ToTask(Token());
+
+            (await quiescence.InFlightChanges.FirstAsync().ToTask(Token())).Should().BeGreaterThanOrEqualTo(1,
+                "a leg parked in path resolution is accepted routing work the silo stop must wait for");
+            Output.WriteLine("route leg in flight and stalled — the silo gauge reads it");
+        }
+        finally
+        {
+            // Unblock the stalled leg so no thread, no pool permit and no gauge slot survives into teardown.
+            resolver!.Release();
+        }
+
+        // The leg terminates (NotFound → the sender is NACK'd) and the gauge returns to zero:
+        // termination, not dispatch, is what releases the slot.
+        await quiescence.InFlightChanges.Where(n => n == 0).FirstAsync().ToTask(Token());
+        Output.WriteLine("route leg terminated — the silo gauge is idle again");
+    }
+
+    private static CancellationToken Token() => new CancellationTokenSource(Bound).Token;
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingQuiescenceTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingQuiescenceTest.cs
@@ -1,0 +1,294 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Orleans;
+using Orleans.Runtime;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #2638 — the silo stop must not run over routing work this silo has already
+/// accepted.</b> The open question #2647 left was WHERE in the silo host's stop sequence the Autofac
+/// root goes relative to routing quiescence, and whether a lifecycle hook can hold it without
+/// deadlocking. The answer, from source (Orleans 10.2.2 <c>Silo.Participate</c> /
+/// <c>LifecycleSubject.OnStop</c>, <c>MeshTeardownHostedService</c>, <c>MeshHostApplicationBuilder</c>):
+/// the container is disposed by the HOST after every hosted service — the silo included — has
+/// stopped and <c>StoppedAsync</c> has drained the mesh; and NOTHING in that sequence ever waited
+/// on a route leg, because <c>RoutingGrain.RouteMessage</c> is O(1) (Orleans' deactivation wait
+/// sees no request), the routing pool holds a leg's permit only for its subscribe, and the per-node
+/// delivery plus every NACK were detached from even that.
+///
+/// <para><b>The seam.</b> <see cref="RoutingQuiescence"/> counts every leg and NACK from dispatch
+/// to termination, and <see cref="RoutingQuiescenceSiloParticipant"/> holds the silo stop at
+/// <see cref="ServiceLifecycleStage.Active"/> — before membership announces <c>ShuttingDown</c>
+/// and before <c>Catalog.DeactivateAllActivations</c> at
+/// <see cref="ServiceLifecycleStage.GrainDeactivation"/> — until that count is zero, bounded.</para>
+///
+/// <para><b>Real Orleans lifecycle machinery, no cluster, no mocks, no timing.</b> The stop is
+/// driven through a real <see cref="SiloLifecycleSubject"/> — the exact type
+/// <c>Silo.StopAsync</c> awaits — with a probe subscribed at the grain-deactivation stage that
+/// records what it found in flight when its turn came. Every wait is on the gauge's own emissions
+/// or bounded by a budget; nothing sleeps.</para>
+/// </summary>
+public class RoutingQuiescenceTest
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(10);
+
+    private sealed record Entry(LogLevel Level, string Message);
+
+    private sealed class CapturingLogger : ILogger<RoutingQuiescenceSiloParticipant>
+    {
+        private readonly List<Entry> entries = [];
+
+        public IReadOnlyList<Entry> Entries
+        {
+            get { lock (entries) return entries.ToArray(); }
+        }
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            lock (entries) entries.Add(new Entry(logLevel, formatter(state, exception)));
+        }
+    }
+
+    /// <summary>
+    /// Stands in for <c>Catalog.DeactivateAllActivations</c>: subscribed at the stage the silo
+    /// deactivates its grains, it records the routing gauge as it found it when its stop ran. Reads
+    /// the REPLAYED count, which is the value the hold itself acts on.
+    /// </summary>
+    private sealed class GrainDeactivationProbe(RoutingQuiescence quiescence) : ILifecycleObserver
+    {
+        private int stopped;
+        private int inFlightWhenStopped = -1;
+
+        public bool Stopped => Volatile.Read(ref stopped) != 0;
+        public int InFlightWhenStopped => Volatile.Read(ref inFlightWhenStopped);
+
+        public Task OnStart(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task OnStop(CancellationToken cancellationToken) =>
+            quiescence.InFlightChanges
+                .Take(1)
+                .Do(inFlight =>
+                {
+                    Volatile.Write(ref inFlightWhenStopped, inFlight);
+                    Volatile.Write(ref stopped, 1);
+                })
+                .ToTask();
+    }
+
+    private static async Task<int> WaitForCount(RoutingQuiescence quiescence, int expected) =>
+        await quiescence.InFlightChanges
+            .Where(n => n == expected)
+            .FirstAsync()
+            .ToTask(new CancellationTokenSource(Bound).Token);
+
+    /// <summary>
+    /// 🚨 THE ORDERING. With a leg in flight the silo stop does not reach grain deactivation; once
+    /// the leg terminates it does, and finds nothing in flight. Both halves are positive
+    /// assertions: the stop Task is provably incomplete while the slot is held (nothing can
+    /// complete it — the gauge reads 1 and the budget is 30 s), and the probe records the count it
+    /// actually observed.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SiloStop_HoldsBeforeGrainDeactivation_UntilTheRoutingWorkHasLanded()
+    {
+        using var quiescence = new RoutingQuiescence();
+        var participant = new RoutingQuiescenceSiloParticipant(
+            quiescence, NullLogger<RoutingQuiescenceSiloParticipant>.Instance);
+        var lifecycle = new SiloLifecycleSubject(NullLogger<SiloLifecycleSubject>.Instance);
+        participant.Participate(lifecycle);
+        var probe = new GrainDeactivationProbe(quiescence);
+        lifecycle.Subscribe(nameof(GrainDeactivationProbe), ServiceLifecycleStage.GrainDeactivation, probe);
+        await lifecycle.OnStart(TestContext.Current.CancellationToken);
+
+        // One route leg dispatched and not yet terminated — the gauge has SEEN it (replayed 1)
+        // before the stop begins, so the pre-fix failure is deterministic, not raced.
+        var leg = quiescence.Track();
+        (await WaitForCount(quiescence, 1)).Should().Be(1);
+
+        var stop = lifecycle.OnStop(TestContext.Current.CancellationToken);
+
+        stop.IsCompleted.Should().BeFalse(
+            "the silo stop must be HELD at stage Active while a route leg is in flight — without the "
+            + "hold every stage completes synchronously and the grains deactivate over the leg (#2638)");
+        probe.Stopped.Should().BeFalse(
+            "grain deactivation runs at a LOWER stage than the hold, so it cannot have run yet");
+
+        // The leg lands.
+        leg.Dispose();
+
+        await stop.WaitAsync(Bound);
+
+        probe.Stopped.Should().BeTrue("once the hold releases, the stop proceeds through every lower stage");
+        probe.InFlightWhenStopped.Should().Be(0,
+            "grain deactivation must find NO routing work in flight — that is the whole invariant: a "
+            + "leg finishes against live hubs, a live transport and a live container, never after them");
+    }
+
+    /// <summary>
+    /// The control: an idle silo does not wait at all, and grain deactivation still runs.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SiloStop_WithNothingInFlight_DoesNotHold()
+    {
+        using var quiescence = new RoutingQuiescence();
+        var logger = new CapturingLogger();
+        var participant = new RoutingQuiescenceSiloParticipant(quiescence, logger);
+        var lifecycle = new SiloLifecycleSubject(NullLogger<SiloLifecycleSubject>.Instance);
+        participant.Participate(lifecycle);
+        var probe = new GrainDeactivationProbe(quiescence);
+        lifecycle.Subscribe(nameof(GrainDeactivationProbe), ServiceLifecycleStage.GrainDeactivation, probe);
+        await lifecycle.OnStart(TestContext.Current.CancellationToken);
+
+        await lifecycle.OnStop(TestContext.Current.CancellationToken).WaitAsync(Bound);
+
+        probe.Stopped.Should().BeTrue();
+        probe.InFlightWhenStopped.Should().Be(0);
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Information && e.Message.Contains("no routing work in flight", StringComparison.Ordinal),
+            "an idle stop must SAY it had nothing to hold for — silence is indistinguishable from a hold that never ran");
+        logger.Entries.Should().NotContain(e => e.Level == LogLevel.Error);
+    }
+
+    /// <summary>
+    /// 🚨 Bounded, and the expiry is DATA. A leg that will not land inside the budget must not hang
+    /// the silo stop — and the residual is named at Error, because that leg is the defect and this
+    /// line is the only attribution its tail will get when it later dies on a stopping transport.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SiloStop_BudgetExpiry_ReleasesTheSilo_AndNamesTheResidual()
+    {
+        using var quiescence = new RoutingQuiescence();
+        var logger = new CapturingLogger();
+        var participant = new RoutingQuiescenceSiloParticipant(quiescence, logger, TimeSpan.FromMilliseconds(200));
+
+        // A leg that never terminates.
+        using var stuck = quiescence.Track();
+        (await WaitForCount(quiescence, 1)).Should().Be(1);
+
+        await ((ILifecycleObserver)participant).OnStop(TestContext.Current.CancellationToken).WaitAsync(Bound);
+
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Error
+                 && e.Message.Contains("1 route leg(s) did not land", StringComparison.Ordinal),
+            "the residual must be reported at Error, naming how many legs the silo is proceeding over");
+    }
+
+    /// <summary>
+    /// A NON-graceful stop (the token already cancelled — <c>Silo.Dispose()</c>'s path, on which
+    /// Orleans' own Active-stage stop returns immediately) holds nothing and says what it is
+    /// abandoning.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SiloStop_NonGraceful_DoesNotHold_AndReportsWhatItAbandons()
+    {
+        using var quiescence = new RoutingQuiescence();
+        var logger = new CapturingLogger();
+        var participant = new RoutingQuiescenceSiloParticipant(quiescence, logger);
+        using var leg = quiescence.Track();
+        (await WaitForCount(quiescence, 1)).Should().Be(1);
+
+        using var cancelled = new CancellationTokenSource();
+        cancelled.Cancel();
+
+        await ((ILifecycleObserver)participant).OnStop(cancelled.Token).WaitAsync(Bound);
+
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Warning && e.Message.Contains("NON-gracefully", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// The host's own shutdown budget expiring MID-hold releases the silo too — Orleans keeps
+    /// stopping through its stages on a cancelled token, and a participant that ignored it would
+    /// hold the whole stop hostage to a leg the host has already given up on.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SiloStop_HostBudgetExpiringMidHold_ReleasesTheSilo()
+    {
+        using var quiescence = new RoutingQuiescence();
+        var logger = new CapturingLogger();
+        var participant = new RoutingQuiescenceSiloParticipant(quiescence, logger);
+        using var leg = quiescence.Track();
+        (await WaitForCount(quiescence, 1)).Should().Be(1);
+
+        using var hostBudget = new CancellationTokenSource();
+        var stop = ((ILifecycleObserver)participant).OnStop(hostBudget.Token);
+        stop.IsCompleted.Should().BeFalse("the hold is engaged: one leg in flight, a 30 s budget");
+
+        hostBudget.Cancel();
+
+        await stop.WaitAsync(Bound);
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Warning && e.Message.Contains("shutdown budget expired", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// 🚨 The per-node delivery is PART OF THE LEG now. Pre-#2638 it was subscribed inside a
+    /// <c>Select</c> and its subscription discarded, so the leg "terminated" the moment path
+    /// resolution emitted while the grain call, its retries and its NACK ran detached — the tail
+    /// that outlived the container in prod. The composed leg must stay in flight until the grain
+    /// call has actually answered.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task TheGrainDelivery_IsPartOfTheLeg_WhichTerminatesOnlyOnceTheCallHasAnswered()
+    {
+        var answered = new TaskCompletionSource<IMessageDelivery>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var leg = RoutingGrain.DeliverToGrainRoute(
+                grainCall: () => answered.Task,
+                grainKey: "messagehub/Planning",
+                addressPath: "Planning",
+                deliveryId: "d-2638-leg",
+                postFailureToSender: (_, _) => { },
+                logger: NullLogger.Instance)
+            .ToTask();
+
+        leg.IsCompleted.Should().BeFalse(
+            "the leg must remain in flight while the grain call is pending — a detached delivery is "
+            + "exactly what no drain could see (#2638)");
+
+        answered.SetResult(new MessageDelivery<string>());
+
+        await leg.WaitAsync(Bound);
+    }
+
+    /// <summary>
+    /// The NACK arm is inside the leg as well: a terminal fault NACKs the sender and THEN the leg
+    /// terminates — never the other way round, and never a fault escaping the leg.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task TheGrainDelivery_NacksInsideTheLeg_ThenTerminates()
+    {
+        var nacks = new List<(string Message, ErrorType Type)>();
+
+        await RoutingGrain.DeliverToGrainRoute(
+                grainCall: () => Task.FromException<IMessageDelivery>(new InvalidOperationException("node type not registered")),
+                grainKey: "X",
+                addressPath: "X",
+                deliveryId: "d-2638-nack",
+                postFailureToSender: (m, t) => nacks.Add((m, t)),
+                logger: NullLogger.Instance,
+                backoff: _ => TimeSpan.Zero,
+                scheduler: System.Reactive.Concurrency.Scheduler.Immediate)
+            .ToTask()
+            .WaitAsync(Bound);
+
+        var nack = nacks.Should().ContainSingle().Subject;
+        nack.Type.Should().Be(ErrorType.Failed);
+        nack.Message.Should().Contain("node type not registered");
+    }
+}


### PR DESCRIPTION
Closes #2638. Residual of #2647, which made the window fail clean and classified and left the root cause open.

## The open question, answered from source

> *At which stage of the silo host stop sequence is the Autofac root `LifetimeScope` disposed relative to `RoutingGrain` turn quiescence, and is there a lifecycle hook that can hold disposal until the routing pool has drained without deadlocking on it?*

**Where the root goes.** The host's root container IS the mesh's Autofac container (`MeshHostApplicationBuilder` → `Host.ConfigureContainer(new MessageHubServiceProviderFactory(BuildHub))`, `src/MeshWeaver.Hosting/MeshHostApplicationBuilder.cs:46`; `MessageHubServiceProviderFactory.CreateServiceProvider` → `CreateMeshWeaverServiceProvider` → `new AutofacServiceProvider(containerBuilder.Build())`, `src/MeshWeaver.ServiceProvider/ServiceProviderExtensions.cs:57-60`). The root hub does **not** dispose it — `MessageHub.cs:2295` has that line commented out on purpose. It is disposed by the **host**, in `RunAsync`'s `using`, strictly after `StopAsync` has (1) fired `ApplicationStopping`, (2) stopped every `IHostedService` in reverse registration order — `SiloHostedService` among them (`UseOrleans` runs after the `MeshHostApplicationBuilder` ctor in `UseOrleansMeshServer`, `OrleansServerRegistryExtensions.cs:39-45`, so the silo stops *before* `MeshTeardownHostedService` and Kestrel stops after both) — and (3) run `IHostedLifecycleService.StoppedAsync`, where `MeshTeardownHostedService` drains the mesh root hub (`MeshTeardownHostedService.cs:72-108`).

**What the silo stop does, in order** (Orleans 10.2.2, `Silo.Participate`, `Silo.cs:466-486`; stops run in descending stage, same-stage observers in parallel, `LifecycleSubject.OnStop`, `LifecycleSubject.cs:154-186`):

| stage | value | stop step |
|---|---|---|
| `Active` | 20000 | `OnActiveStop`: gateway stop-send, grain services |
| `BecomeActive` | 19999 | `MembershipAgent.OnBecomeActiveStop` → membership `ShuttingDown` |
| `GrainDeactivation` | 19998 | `Catalog.DeactivateAllActivations(ct)` — each activation bounded by `GrainCollectionOptions.DeactivationTimeout` (30 s) |
| `RuntimeServices` | 4000 | `messageCenter.BlockApplicationMessages()` |
| `RuntimeInitialize` | 2000 | `messageCenter.StopAsync()`; `Terminated` |
| `First` | `int.MinValue` | `IoPoolSiloTeardown`: `IoPoolRegistry.Dispose()` + join |

**Why none of it waited for a route.** Three tiers, none joined:

1. **The turn.** `RoutingGrain.RouteMessage` does O(1) work and returns `Forwarded` (#1028) — the leg is handed to the routing pool. From Orleans' point of view the routing grain never has a request in flight, so `DeactivateAllActivations` deactivates it instantly and the `DeactivationTimeout` wait never applies. The hypothesis "a turn parked in `StreamPostTimeout` / retries / the subscriber probe outlives the deactivation budget" is **false** — there is no such turn.
2. **The leg.** `SubscribeThroughPool` holds its permit for the **subscribe window only** (`IoPool.cs:391-440`, and `MeshTeardownExtensions.cs:60-66` says so). A leg past its subscribe is invisible to `IoPoolSiloTeardown`'s join; the drain at stage `First` disposes it and completes it silently — no NACK.
3. **The delivery and the NACK — detached from even that.** `BuildGrainRoute` subscribed `DeliverToGrainWithRetry` inside a `.Select` and **discarded the subscription**; every `PostFailure` NACK was a bare `.Subscribe`. So the grain call, its ≤6 retry timers (`Scheduler.Default`) and its NACK ran on continuations nothing counted and nothing drained. That is the prod tail: `Delivery to 'Planning' failed: Instances cannot be resolved…` is the retry chain's `grainCall()` → `GetGrain` resolving a codec provider from the disposed scope, and the NACK about it dying the same way.

So: the root is disposed **after** the silo has fully stopped and the mesh has drained — the ordering is what the comments claimed — but *routing quiescence was never a stage of anything*. The window is not "the scope goes too early"; it is "nothing ever waits for a route".

**The hook, and why it cannot deadlock.** A silo lifecycle participant at `ServiceLifecycleStage.Active` — the first thing the stop does, before membership announces `ShuttingDown` and before a single grain deactivates. The wait is a subscription on a mesh-scoped gauge, bridged once at the boundary with `ReactiveCompletion.ObserveCompletion` (never `.ToTask()`, which would resume `LifecycleSubject.OnStop` inline on the gauge's event-loop thread). It parks nothing a leg needs: legs run on pool/thread-pool threads, their grain calls are answered by a fully running scheduler, their NACKs land on hubs that are still alive (the pod-process hubs are disposed only in `StoppedAsync`). And the count converges because `ApplicationStopping` fires **before** any hosted service stops, so `OrleansRoutingService.DeliverMessage` already refuses new dispatches as `ShuttingDown` — the gauge is monotone non-increasing from the first stop step.

## The change

- **`RoutingQuiescence`** (mesh-scoped, `ActivityTracker`'s reactive shape — deltas in, count out, serialised on one scheduler, no lock/gate) counts every leg and every NACK from dispatch to termination.
- **`RoutingQuiescenceSiloParticipant`** holds the silo stop at `Active` until the count is zero. Bounded at 30 s (the same family as `MeshTeardownHostedService` / `IoPoolSiloTeardown`); expiry is reported at **Error** naming the residual — that leg is the defect, and this line is the only attribution its tail will get. A non-graceful stop (token already cancelled — `Silo.Dispose()`'s path, on which Orleans' own Active-stage stop returns immediately) holds nothing; the host's `ShutdownTimeout` expiring mid-hold releases it.
- **`RoutingGrain`**: the per-node delivery is **part of the leg** now (`SelectMany`, `DeliverToGrainRoute` returning `IObservable<Unit>`; `DeliverToGrainWithRetry` is that leg subscribed, kept for the pure tests). Every NACK goes through the routing pool and the gauge. On a healthy roll the count reaches zero in milliseconds; a leg the hold released over is terminated by the pool drain at stage `First`, so nothing routing-related executes after the silo has stopped, let alone after the container is gone.

Not a gate: nothing is refused. This is the "ordering" shape the #2647 comment asked for — accepted work lands, over a transport that still exists.

## Tests

`RoutingQuiescenceTest` — real `SiloLifecycleSubject` (the type `Silo.StopAsync` awaits), a probe observer at `GrainDeactivation` recording the count it found:

| test | asserts |
|---|---|
| `SiloStop_HoldsBeforeGrainDeactivation_UntilTheRoutingWorkHasLanded` | with a leg in flight the stop Task is provably incomplete and the probe has not run; once the leg lands the probe runs and finds **0** |
| `SiloStop_WithNothingInFlight_DoesNotHold` | control: idle stop, no wait, says so |
| `SiloStop_BudgetExpiry_ReleasesTheSilo_AndNamesTheResidual` | bounded, residual at Error |
| `SiloStop_NonGraceful_DoesNotHold_AndReportsWhatItAbandons` | cancelled token: no hold |
| `SiloStop_HostBudgetExpiringMidHold_ReleasesTheSilo` | host budget cancels the hold |
| `TheGrainDelivery_IsPartOfTheLeg_WhichTerminatesOnlyOnceTheCallHasAnswered` | the leg stays in flight while the grain call is pending |
| `TheGrainDelivery_NacksInsideTheLeg_ThenTerminates` | NACK arm inside the leg |

`RoutingQuiescenceClusterTest` — real silo, the `StallingPathResolver` vehicle from #1028: a dispatched leg is counted on the silo's gauge until it terminates, and the silo lifecycle carries the participant.

**Non-vacuity, by mutation** — participant's `OnStop` forced to return `Task.CompletedTask` (the pre-fix shape):

```
[FAIL] SiloStop_HoldsBeforeGrainDeactivation_UntilTheRoutingWorkHasLanded
   Expected value to be false because the silo stop must be HELD at stage Active while a route leg is in flight …, but found True.
Failed!  - Failed: 5, Passed: 2, Total: 7
```

Reverted: `Passed! - Failed: 0, Passed: 75` across this file plus `RoutingGrainDeliveryRetryTest`, `RoutingAfterScopeTeardownTest`, `RoutingGrainFailureClassificationTest`, `RoutingGrainPodHubDeliveryRetryTest`, `RoutedFailureClassificationTest`, `RoutingGrainStreamPostBoundTest`, `OrleansDirectoryInstabilityClassificationTest`, `SiloShutdownActivationGateTest`, `OrleansRoutingShutdownClassificationTest`, `IoPoolSiloTeardownTest`, `RoutingGrainTurnIsolationTest`, `StreamPostTimeoutAttributionTest`, `DeadTargetRefusalWindowTest`, `RoutingFailureTakesTheLocalRouteTest`; and the whole `MeshWeaver.Hosting.Orleans.Test` project locally (Release).

What's New: `2026-08-30-a-departing-pod-lets-accepted-messages-land.md` (Category: Fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPCWramjFYquX5SaMdeJKW
