### PR TITLE
fix(#2679): the permission fold resolves its services once; a render on a disposed scope is a teardown race, not two errors

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PermissionApi.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PermissionApi.md
@@ -91,6 +91,8 @@ Whenever the user's permissions change *or* the node content changes, the combin
 
 `CheckPermission` collapses to a `bool`, and a fold that *faults* (a storage hiccup, a hub whose DI scope is disposing) surfaces as `OnError` on the stream — not as `false`. If your call site turns any non-`true` into an "Access denied" screen, an entitled user gets told to request permissions they already hold.
 
+The disposing-hub case is a lifecycle event, not a fault, and the fold treats it as one: every service it needs is resolved **once**, at the call, so a long-lived fold keeps answering after its hub's scope is gone (it re-emits on every `AccessAssignment` change — the subscription outlives the render that built it); and if it still faults with an `ObjectDisposedException` while that scope no longer resolves, it terminates with the typed `HubDisposingException` ("the address may reactivate; retry"), which the layout host, `MessageService` and `CheckPermissionOutcome` already classify as benign teardown. An `ObjectDisposedException` from an unrelated disposed dependency on a *live* scope is still a defect and still faults the fold as one — the classification is gated on the scope probe, never on the type alone (issue #2679).
+
 `CheckPermissionOutcome` is the one place that distinction is made: it classifies the verdict as `Granted` / `Denied` / `Undetermined` (carrying the reason). `IsGranted` is `false` on the undetermined leg, so a consumer that ignores the tri-state still fails **closed**. Use it wherever the UI or the caller reports *why* access was refused; never re-derive the difference from a `false` or an exception message upstream.
 
 `Permission.None` is a special case in both overloads: it short-circuits to `true` without consulting the evaluator.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-view-that-races-a-restart-no-longer-reports-two-errors.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-view-that-races-a-restart-no-longer-reports-two-errors.md
@@ -1,0 +1,22 @@
+---
+Name: A view that races a restart no longer fails twice
+Category: Fix
+Description: When part of the server was restarting while a page was still rendering, the page could log two errors and show neither its content nor a message. The restart is now recognised for what it is, and the page reconnects on its own.
+Icon: ArrowSync
+Order: -20260830
+---
+
+# A view that races a restart no longer fails twice
+
+When a page was rendering at the very moment the part of the server serving it was being restarted
+— a rolling deploy, or a node's worker being recycled — the permission check behind the page kept
+asking the departing worker for its services, hit the closed door, and reported that as a rendering
+error. It then tried to show you an error message through the same closed door and failed a second
+time. You got neither the page nor the message, and two errors were filed for what was a routine
+restart.
+
+The permission check now takes everything it needs from the worker once, when it starts, so a
+restart in the middle of a page can no longer trip it. And if a render does run into a worker that
+has already gone, that is treated as the restart it is: nothing is reported as an error, no
+message is attempted through the departed worker, and your page reconnects to the fresh worker by
+itself — the same way it already does when a worker announces its own restart.

--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -98,21 +98,11 @@ internal class RoutingGrain(
     /// already-materialised singleton with no side effects; once the host has disposed its root
     /// <c>LifetimeScope</c> it throws, which is the signal.
     ///
-    /// <para>Mirrors <c>MessageHub.IsServiceScopeDisposed</c> deliberately: one shape, one meaning,
-    /// so a routing turn and a hub init classify the same teardown the same way.</para>
+    /// <para>The probe IS <see cref="ScopeTeardown.IsServiceScopeDisposed"/> — one shape, one
+    /// meaning, so a routing turn, a hub init, a permission fold and a layout error path all
+    /// classify the same teardown the same way.</para>
     /// </summary>
-    private bool IsServiceScopeDisposed()
-    {
-        try
-        {
-            meshHub.ServiceProvider.GetService(typeof(IMessageHub));
-            return false;
-        }
-        catch (ObjectDisposedException)
-        {
-            return true;
-        }
-    }
+    private bool IsServiceScopeDisposed() => meshHub.IsServiceScopeDisposed();
 
     /// <summary>
     /// Routes dispatched but not yet terminated. This is the back-pressure signal that used to be
@@ -1495,9 +1485,7 @@ internal class RoutingGrain(
     /// <param name="scopeDisposed">Probe: does this process's DI container still resolve?</param>
     /// <returns><c>true</c> when the fault is the process's container going away.</returns>
     internal static bool IsScopeTeardown(Exception ex, Func<bool>? scopeDisposed) =>
-        scopeDisposed is not null
-        && ExceptionChain.Contains<ObjectDisposedException>(ex)
-        && scopeDisposed();
+        ScopeTeardown.IsScopeTeardown(ex, scopeDisposed);
 
     /// <summary>
     /// The silo hosting the target is going away — an expected lifecycle event during every roll,

--- a/src/MeshWeaver.Layout/AreaErrorClassifier.cs
+++ b/src/MeshWeaver.Layout/AreaErrorClassifier.cs
@@ -97,6 +97,30 @@ public static class AreaErrorClassifier
     public static bool IsHubDisposalRace(Exception? ex) => HubDisposingException.IsHubDisposal(ex);
 
     /// <summary>
+    /// <see cref="IsHubDisposalRace(Exception?)"/> widened by the DI-scope half of the teardown
+    /// contract (#2679): also true when the fault carries a bare
+    /// <see cref="ObjectDisposedException"/> AND <paramref name="scopeDisposed"/> confirms the
+    /// rendering host's OWN scope is gone.
+    ///
+    /// <para>This is the shape the incident arrived in: the render chain resolved a service from
+    /// the host hub's Autofac scope after that scope had been disposed, so the fault was Autofac's
+    /// own <see cref="ObjectDisposedException"/> — not the typed <see cref="HubDisposingException"/>
+    /// the type-only overload matches — and the render reported a routine teardown at Error and then
+    /// faulted AGAIN trying to localise its placeholder on the same dead scope.</para>
+    ///
+    /// <para>🚨 The probe is the point, not the type test — the same argument
+    /// <c>MessageHub</c> makes for #2444 and <c>RoutingGrain</c> for #2638. An
+    /// <see cref="ObjectDisposedException"/> from an unrelated disposed dependency while the host's
+    /// scope is ALIVE is a genuine defect and keeps reporting as one; a null probe keeps exactly the
+    /// type-only answer.</para>
+    /// </summary>
+    /// <param name="ex">The exception to classify; may be null.</param>
+    /// <param name="scopeDisposed">Probe — does the rendering host's own DI scope still resolve?
+    /// See <see cref="ScopeTeardown.IsServiceScopeDisposed"/>.</param>
+    public static bool IsHubDisposalRace(Exception? ex, Func<bool>? scopeDisposed)
+        => IsHubDisposalRace(ex) || ScopeTeardown.IsScopeTeardown(ex, scopeDisposed);
+
+    /// <summary>
     /// Returns the NodeType path of a <see cref="ErrorType.CompilationInProgress"/> NACK
     /// (so the GUI can swap to that NodeType's Progress view at once), or <c>null</c>.
     /// This is NOT retried — it has dedicated, immediate handling.

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -738,11 +738,20 @@ public record LayoutAreaHost : IDisposable
         // RenderingContext. Logging Reference.Area here printed "Rendering failed for
         // area (null)" for exactly those renders, hiding WHICH area failed (issue #1182).
         var area = context.Area;
+        // Probed ONCE per failure: is this host's own DI scope already gone? It gates two things —
+        // the classification of a bare ObjectDisposedException below, and whether a placeholder can
+        // be rendered at all (#2679). On a live scope it is one lookup of an already-materialised
+        // singleton; render failures are rare, so the cost is nil.
+        var ownScopeDisposed = Hub.IsServiceScopeDisposed();
         // 🚨 FIRST — a teardown race is not a render failure, and this is the only arm whose fault
         // arrives WRAPPED past every text-matching predicate below (the reflective
         // SynchronizationStream.Reduce hop mints a TargetInvocationException whose own message is
         // "Exception has been thrown by the target of an invocation"). See the Debug level below.
-        if (AreaErrorClassifier.IsHubDisposalRace(ex))
+        // The probe-gated overload also recognises the DI-scope shape of the same race: Autofac's
+        // own ObjectDisposedException from a service resolved on this host's disposed scope (the
+        // permission fold's next emission, #2679) — the type-only test looked straight past it and
+        // filed an incident for a routine teardown.
+        if (AreaErrorClassifier.IsHubDisposalRace(ex, () => ownScopeDisposed))
             // A hub deactivating is normal grain lifecycle, and its own exception says the address
             // may reactivate. DEBUG, matching SynchronizationStream.OnError's classification of the
             // same exception as benign teardown: at Error this filed an incident for a routine
@@ -766,6 +775,19 @@ public record LayoutAreaHost : IDisposable
                 area, AreaErrorClassifier.TryGetMissingNodePath(ex) ?? "(path not recoverable)");
         else
             logger.LogError(ex, "Rendering failed for area {Area}", area);
+
+        // 🚨 No placeholder on a dead scope (#2679). CreateRenderErrorControl localises its copy
+        // through this host's scope (LayoutAreaLocalizationExtensions.Localize → AccessService), so
+        // on a disposed scope the placeholder itself faulted with a SECOND ObjectDisposedException
+        // — one disposal produced two fail lines and the user got neither the area nor a message.
+        // There is also nobody to render FOR: this host's hub is a tracked component of the very
+        // scope that is gone, so its stream is being torn down with it, and what recovers the area
+        // is the client's own subscription re-attaching to the fresh activation (NamedAreaView +
+        // AreaStreamRetry) — never a frame pushed from a host that cannot outlive the condition it
+        // is reporting. The fault above is already logged at its own level; emit the cleared store.
+        if (ownScopeDisposed)
+            return cleared;
+
         try
         {
             var rendered = RenderArea(context, CreateRenderErrorControl(ex), cleared.Store);
@@ -1295,15 +1317,19 @@ public record LayoutAreaHost : IDisposable
     private void FailRendering(Exception ex, string? area)
     {
         // Same classification as the top-level arm: a hub disposal race is routine lifecycle, not a
-        // render fault, so it must not land on an error dashboard (#2255). The visible frame is
-        // still surfaced below — CreateRenderErrorControl serves the named transient one.
-        if (AreaErrorClassifier.IsHubDisposalRace(ex))
+        // render fault, so it must not land on an error dashboard (#2255) — including the DI-scope
+        // shape, a bare ObjectDisposedException off this host's own disposed scope (#2679). The
+        // visible frame is still surfaced below — CreateRenderErrorControl serves the named
+        // transient one — EXCEPT on a dead scope, where the frame cannot be localised and there is
+        // no live stream to push it into (see RenderRenderingError).
+        var ownScopeDisposed = Hub.IsServiceScopeDisposed();
+        if (AreaErrorClassifier.IsHubDisposalRace(ex, () => ownScopeDisposed))
             logger.LogDebug(ex,
                 "Area {Area} on {Hub} raced a hub disposal — transient, the address reactivates",
                 area ?? "(default)", Hub.Address);
         else
             logger.LogWarning(ex, "Rendering failed for area {Area} on {Hub}", area ?? "(default)", Hub.Address);
-        if (string.IsNullOrEmpty(area))
+        if (string.IsNullOrEmpty(area) || ownScopeDisposed)
             return;
 
         var errorControl = CreateRenderErrorControl(ex);

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -123,27 +123,94 @@ internal static class PermissionEvaluator
         if (userId == MeshNodeCacheIdentityAddress)
             return Observable.Return(Permission.Read);
 
-        var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        // 🚨 Every service the fold needs is resolved HERE, ONCE, on the caller's thread — never
+        // inside a selector (#2679). The fold is long-lived by design (it re-emits on every
+        // AccessAssignment change — see Doc/Architecture/PermissionApi), while the hub's DI scope
+        // is not: a hub deactivating, an area disposing or a pod rolling disposes that scope while
+        // the fold is still subscribed, and a GetRequiredService inside the SelectMany below (the
+        // recursive Public leg, GetRole) then threw Autofac's ObjectDisposedException straight
+        // into the subscriber's render chain on the very next emission. Every dependency travels
+        // in `services` from here on — the Public leg and GetRole included — so a subscribed fold
+        // never touches the scope again.
+        var services = ResolveFoldServices(hub);
+
+        return GetEffectivePermissionsCore(hub, nodePath, userId, services)
+            // The DI-scope half of the teardown contract (Doc/Architecture/ControlledIoPooling →
+            // "The mesh teardown drains THREE things"): a fold that faults with an
+            // ObjectDisposedException while the hub's OWN scope has been disposed is a hub going
+            // away, not a permission failure — the same probe-gated classification
+            // MessageHub.HandleInitialize makes for #2444 and RoutingGrain for #2638. It terminates
+            // as the framework's typed hub-disposal signal (HubDisposingException — "the address
+            // may reactivate; retry"), which every consumer already classifies as benign teardown:
+            // the layout host serves its named transient frame at Debug, MessageService NACKs
+            // ShuttingDown, CheckPermissionOutcome answers Undetermined. 🚨 Probe-gated on purpose:
+            // an ObjectDisposedException from an unrelated disposed dependency on a LIVE scope is a
+            // real defect and still faults the fold as one.
+            .Catch<Permission, Exception>(ex => hub.IsTerminatedByScopeTeardown(ex)
+                ? Observable.Throw<Permission>(new HubDisposingException(
+                    hub.Address, $"the permission fold for '{nodePath}'", ex))
+                : Observable.Throw<Permission>(ex));
+    }
+
+    /// <summary>
+    /// Everything a SUBSCRIBED fold needs, resolved once per
+    /// <see cref="GetEffectivePermissions(IMessageHub,string,string)"/> call on the caller's thread
+    /// (<see cref="ResolveFoldServices"/>) and carried through the recursion. The fold must never
+    /// resolve from <c>hub.ServiceProvider</c> after that point — see #2679.
+    /// </summary>
+    private sealed record FoldServices(
+        IMeshNodeStreamCache Cache,
+        ILogger? Logger,
+        JsonSerializerOptions Options,
+        IReadOnlyList<MeshNode> StaticNodes,
+        IReadOnlyDictionary<string, PartitionAccessPolicy> StaticPolicies,
+        IReadOnlyList<NodeTypeGate> Gates,
+        ImmutableDictionary<string, string> StaticGatedNodes,
+        AccessContext? CapturedContext,
+        AccessContext? CapturedCircuitContext);
+
+    private static FoldServices ResolveFoldServices(IMessageHub hub)
+    {
         var accessService = hub.ServiceProvider.GetService<AccessService>();
-        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Mesh.Security.PermissionEvaluator");
-        var staticNodes = CollectStaticAccessAssignments(hub);
-        var staticPolicies = CollectStaticPolicies(hub);
 
         // Type-declared subtree gates (issue #701). EMPTY on every mesh that declares none, and
-        // every branch below short-circuits on that — a deployment without gates runs the exact
-        // fold it ran before, subscribes no extra query and pays nothing.
+        // every branch of the fold short-circuits on that — a deployment without gates runs the
+        // exact fold it ran before, subscribes no extra query and pays nothing.
         var gates = CollectGates(hub);
-        var staticGatedNodes = CollectStaticGatedNodes(hub, gates);
 
-        // 🚨 Capture AccessContext on the CALLER'S thread before any Rx
-        // scheduler hop. AsyncLocal does NOT flow through SubscribeOn/
-        // ObserveOn — when the .Select lambdas below land on TaskPool
-        // (because cache.GetQuery uses SubscribeOn(TaskPoolScheduler)),
-        // accessService.Context is null or contaminated. CircuitContext is
-        // mesh-global so it survives, but Bearer-token Roles claims live in
-        // AccessContext.Roles and we need that snapshot here.
-        var capturedContext = accessService?.Context;
-        var capturedCircuitContext = accessService?.CircuitContext;
+        return new FoldServices(
+            hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>(),
+            hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Mesh.Security.PermissionEvaluator"),
+            hub.JsonSerializerOptions,
+            CollectStaticAccessAssignments(hub),
+            CollectStaticPolicies(hub),
+            gates,
+            CollectStaticGatedNodes(hub, gates),
+            // 🚨 Capture AccessContext on the CALLER'S thread before any Rx
+            // scheduler hop. AsyncLocal does NOT flow through SubscribeOn/
+            // ObserveOn — when the .Select lambdas in the fold land on TaskPool
+            // (because cache.GetQuery uses SubscribeOn(TaskPoolScheduler)),
+            // accessService.Context is null or contaminated. CircuitContext is
+            // mesh-global so it survives, but Bearer-token Roles claims live in
+            // AccessContext.Roles and we need that snapshot here. The Public leg
+            // of the fold evaluates under the SAME captured viewer context — it
+            // is the same viewer's check, and its API-token gate is subsumed by
+            // the outer one (own | pub is gated on the combined value).
+            accessService?.Context,
+            accessService?.CircuitContext);
+    }
+
+    /// <summary>
+    /// The fold proper — every input already resolved into <paramref name="services"/>. Recursion
+    /// (the Public leg) and custom-role lookups stay inside this method and its service-taking
+    /// helpers, so nothing here touches <c>hub.ServiceProvider</c>; <paramref name="hub"/> is
+    /// only the address and options carrier.
+    /// </summary>
+    private static IObservable<Permission> GetEffectivePermissionsCore(
+        IMessageHub hub, string nodePath, string userId, FoldServices services)
+    {
+        var (cache, logger, options, staticNodes, staticPolicies, gates, staticGatedNodes,
+            capturedContext, capturedCircuitContext) = services;
 
         // 🛡️ Hub credential (ImpersonateAsHub): ObjectId is the hub's OWN mesh address, never a
         // user/group identity — no AccessAssignment ever exists for a hub address. A hub
@@ -162,8 +229,8 @@ internal static class PermissionEvaluator
         // synchronously. Emit immediately; then enrich asynchronously with
         // the synced AccessAssignment query (so long-lived subscribers see
         // updates as runtime grants land).
-        var staticOnlyScopeRoles = ComputeStaticOnlyScopeRoles(staticNodes, userId, hub.JsonSerializerOptions);
-        var staticOnlyDeniedScopeRoles = ComputeStaticOnlyDeniedScopeRoles(staticNodes, userId, hub.JsonSerializerOptions);
+        var staticOnlyScopeRoles = ComputeStaticOnlyScopeRoles(staticNodes, userId, options);
+        var staticOnlyDeniedScopeRoles = ComputeStaticOnlyDeniedScopeRoles(staticNodes, userId, options);
         var fast = ComputeRoleState(staticOnlyScopeRoles, nodePath, userId, capturedContext, capturedCircuitContext, staticPolicies, staticOnlyDeniedScopeRoles);
         // A gate declared over a STATIC node resolves synchronously — the declared public surface
         // is readable on the first emission, with no wait on the synced queries (same reasoning as
@@ -174,7 +241,7 @@ internal static class PermissionEvaluator
         var enriched = Observable.CombineLatest(
                 ObserveEffectiveAssignments(hub, cache, nodePath, staticNodes),
                 ObserveScopePolicies(hub, cache, nodePath, staticPolicies),
-                ObserveAllMembershipNodes(hub),
+                ObserveAllMembershipNodes(cache, options),
                 ObserveGatedNodes(hub, cache, gates, staticGatedNodes),
                 (nodes, policies, memberships, gatedNodes) =>
                 {
@@ -183,8 +250,8 @@ internal static class PermissionEvaluator
                     // off the target's scope walk, and possibly in another partition — so the group
                     // set is resolved globally here, then folded into the subjects ComputeScopeRoles
                     // matches on. Consistent with the Postgres rebuild's global group expansion.
-                    var subjects = ResolveUserGroups(userId, memberships, hub.JsonSerializerOptions).Add(userId);
-                    var (granted, denied) = ComputeScopeRoles(subjects, nodes, staticNodes, hub.JsonSerializerOptions);
+                    var subjects = ResolveUserGroups(userId, memberships, options).Add(userId);
+                    var (granted, denied) = ComputeScopeRoles(subjects, nodes, staticNodes, options);
                     return (Granted: granted, Denied: denied, RuntimePolicies: policies, GatedNodes: gatedNodes);
                 })
             .Select(snap =>
@@ -224,18 +291,21 @@ internal static class PermissionEvaluator
                         customRoleIds = (customRoleIds ?? ImmutableHashSet<string>.Empty).Add(rid);
                 }
 
+                // 🚨 This selector runs on EVERY emission of a long-lived fold, so it must not
+                // resolve anything from the hub's scope (#2679): both the custom-role lookup and
+                // the recursive Public leg take the services resolved once at the entry point.
                 IObservable<Permission> rolePerms = customRoleIds is null
                     ? Observable.Return(rolePermsValue)
                     : Observable.Return(rolePermsValue).CombineLatest(
                         customRoleIds
-                            .Select(id => GetRole(hub, id))
+                            .Select(id => GetRole(cache, options, id))
                             .Merge()
                             .Where(r => r is not null)
                             .Aggregate(Permission.None, (acc, r) => acc | r!.Permissions),
                         (builtIn, custom) => builtIn | custom);
 
                 IObservable<Permission> withPublic = (userId != WellKnownUsers.Anonymous && userId != WellKnownUsers.Public)
-                    ? rolePerms.Zip(GetEffectivePermissions(hub, nodePath, WellKnownUsers.Public),
+                    ? rolePerms.Zip(GetEffectivePermissionsCore(hub, nodePath, WellKnownUsers.Public, services),
                         (own, pub) => own | pub)
                     : rolePerms;
 
@@ -271,13 +341,30 @@ internal static class PermissionEvaluator
         if (BuiltInRoles.TryGetValue(roleId, out var builtIn))
             return Observable.Return<Role?>(builtIn);
 
-        return ObserveAllRoleNodes(hub)
+        // Resolved ONCE, at call time on a live hub — the fold's own lookups go through the
+        // service-taking overload below with the cache they already hold (#2679).
+        return GetRole(hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>(), hub.JsonSerializerOptions, roleId);
+    }
+
+    /// <summary>
+    /// <see cref="GetRole(IMessageHub,string)"/> over an already-resolved cache — the overload the
+    /// subscribed fold uses, so a custom-role lookup on a later emission never resolves from a scope
+    /// that may since have been disposed.
+    /// </summary>
+    private static IObservable<Role?> GetRole(IMeshNodeStreamCache cache, JsonSerializerOptions options, string roleId)
+    {
+        if (string.IsNullOrEmpty(roleId))
+            return Observable.Return<Role?>(null);
+        if (BuiltInRoles.TryGetValue(roleId, out var builtIn))
+            return Observable.Return<Role?>(builtIn);
+
+        return ObserveAllRoleNodes(cache, options)
             .Take(1)
             .Select(nodes =>
             {
                 foreach (var node in nodes)
                 {
-                    var r = DeserializeRole(node, hub.JsonSerializerOptions);
+                    var r = DeserializeRole(node, options);
                     if (r != null && string.Equals(r.Id, roleId, StringComparison.Ordinal))
                         return r;
                 }
@@ -287,7 +374,7 @@ internal static class PermissionEvaluator
 
     public static IObservable<Role> GetRoles(IMessageHub hub)
     {
-        return ObserveAllRoleNodes(hub)
+        return ObserveAllRoleNodes(hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>(), hub.JsonSerializerOptions)
             .Take(1)
             .SelectMany(nodes =>
             {
@@ -834,23 +921,20 @@ internal static class PermissionEvaluator
         IMeshNodeStreamCache cache, object queryId, JsonSerializerOptions options, string query)
         => cache.GetQuery(queryId, options, SecurityQueries.Enumeration(query));
 
-    private static IObservable<MeshNode[]> ObserveAllRoleNodes(IMessageHub hub)
-    {
-        var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
-        return SecurityQuery(cache, RoleQueryId, hub.JsonSerializerOptions, SecurityQueries.Roles)
+    // 🚨 Both global queries take the cache they read from rather than the hub they were asked on
+    // (#2679): the fold resolves it ONCE at its entry point, so a later emission — after the hub's
+    // scope has been disposed — never resolves from that scope.
+    private static IObservable<MeshNode[]> ObserveAllRoleNodes(IMeshNodeStreamCache cache, JsonSerializerOptions options)
+        => SecurityQuery(cache, RoleQueryId, options, SecurityQueries.Roles)
             .Select(arr => arr.ToArray());
-    }
 
     /// <summary>
     /// Every <c>GroupMembership</c> node in the mesh, cached process-wide and read as System (like
     /// the other <c>$security-*</c> queries), so group access resolves GLOBALLY — a group and its
     /// members can live in a different partition than the grant (cross-partition licensing).
     /// </summary>
-    private static IObservable<IEnumerable<MeshNode>> ObserveAllMembershipNodes(IMessageHub hub)
-    {
-        var cache = hub.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
-        return SecurityQuery(cache, MembershipQueryId, hub.JsonSerializerOptions, SecurityQueries.Memberships);
-    }
+    private static IObservable<IEnumerable<MeshNode>> ObserveAllMembershipNodes(IMeshNodeStreamCache cache, JsonSerializerOptions options)
+        => SecurityQuery(cache, MembershipQueryId, options, SecurityQueries.Memberships);
 
     #endregion
 

--- a/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
+++ b/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
@@ -51,6 +51,28 @@ public sealed class HubDisposingException : ObjectDisposedException
     }
 
     /// <summary>
+    /// The same typed refusal, wrapping the fault that REVEALED the teardown — the
+    /// <see cref="ObjectDisposedException"/> Autofac threw when a long-lived subscription (a
+    /// permission fold, #2679) resolved from the hub's already-disposed scope. The probe-gated
+    /// classifier (<c>ScopeTeardown</c>) recognises that fault as the hub going away and re-raises
+    /// it in this shape so every downstream consumer classifies it as the benign teardown it is;
+    /// carrying the original as <see cref="Exception.InnerException"/> keeps the stack that shows
+    /// WHICH resolution raced the disposal. <c>ObjectName</c> is empty on this overload — the
+    /// address lives on <see cref="HubAddress"/> and in the message, and nothing reads it.
+    /// </summary>
+    /// <param name="hubAddress">Address of the disposing hub.</param>
+    /// <param name="what">What could not be created / continued, e.g. the permission fold.</param>
+    /// <param name="innerException">The fault that revealed the teardown.</param>
+    public HubDisposingException(Address hubAddress, object what, Exception innerException)
+        : base(
+            $"Hub {hubAddress} is shutting down — cannot create {Describe(what)}. "
+            + "The address may reactivate (recycle / restart); retry to get the authoritative answer.",
+            innerException)
+    {
+        HubAddress = hubAddress;
+    }
+
+    /// <summary>
     /// Renders <paramref name="what"/> for the message, delimited with DOUBLE quotes — always,
     /// with no inspection of the value.
     ///

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -538,7 +538,9 @@ public sealed class MessageHub : IMessageHub
                 // (mesh/... data-source hubs during the 2026-08-26 host-start aborts). A disposed
                 // scope means this hub cannot live regardless — its own disposal is already queued
                 // in the same disposer, by construction — so classify it as the shutdown it is.
-                if (IsShuttingDown || IsTerminatedByScopeTeardown(ex))
+                // The classifier is the shared, probe-gated ScopeTeardown (one shape for init,
+                // routing, the permission fold and the layout error path — #2444/#2638/#2679).
+                if (IsShuttingDown || this.IsTerminatedByScopeTeardown(ex))
                 {
                     logger.LogDebug(ex,
                         "Hub {Address} initialization ended by shutdown ({ExceptionType}) — recognized "
@@ -562,44 +564,6 @@ public sealed class MessageHub : IMessageHub
                 OpenGate(MessageHubConfiguration.InitializeGateName);
                 return Observable.Return(request.Failed($"Hub '{Address}' initialization failed — {reason}"));
             });
-    }
-
-    /// <summary>
-    /// True when an initialization fault is (or wraps) an <see cref="ObjectDisposedException"/> AND
-    /// this hub's own service scope no longer resolves — i.e. the DI scope backing this hub, one of
-    /// its parent scopes, or the host's root container has begun disposal (issue #2444). The probe
-    /// resolves this hub's own already-materialized <see cref="IMessageHub"/> registration: on a
-    /// live scope that is a cheap instance lookup with no side effects; on a disposing scope it
-    /// throws <see cref="ObjectDisposedException"/> — the positive signal that the
-    /// ObjectDisposedException the BuildupAction saw came from scope teardown, not from some
-    /// unrelated disposed dependency (which must still fault the init).
-    /// <para>A disposed scope is proof this hub is going away: the hub instance is a tracked
-    /// component of that same scope, so its <c>Dispose()</c> is already queued in the very disposer
-    /// that killed the scope. FAILED-state residue on it would outlive nothing.</para>
-    /// </summary>
-    private bool IsTerminatedByScopeTeardown(Exception exception)
-    {
-        // The graph, not the chain: an init fault that reaches here through a reactive Merge or a
-        // WhenAll arrives as an AggregateException whose ordering nobody controls, and walking only
-        // InnerException sees InnerExceptions[0] alone. Classifying a teardown by which fault
-        // happened to land first is a race, so this shares ONE walker with IsHubDisposal.
-        return ExceptionChain.Contains<ObjectDisposedException>(exception)
-               && IsServiceScopeDisposed();
-    }
-
-    /// <summary>Probes whether this hub's own DI scope still resolves (see
-    /// <see cref="IsTerminatedByScopeTeardown"/>).</summary>
-    private bool IsServiceScopeDisposed()
-    {
-        try
-        {
-            ServiceProvider.GetService(typeof(IMessageHub));
-            return false;
-        }
-        catch (ObjectDisposedException)
-        {
-            return true;
-        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/ScopeTeardown.cs
+++ b/src/MeshWeaver.Messaging.Hub/ScopeTeardown.cs
@@ -1,0 +1,77 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// The ONE classifier for "this fault is the hub's DI scope going away" — the DI-scope half of the
+/// teardown contract (Doc/Architecture/ControlledIoPooling → "The mesh teardown drains THREE
+/// things"). Every place that must tell a routine teardown from a genuine defect routes through
+/// here: <c>MessageHub.HandleInitialize</c> (#2444), <c>RoutingGrain</c>'s delivery NACK (#2638),
+/// the permission fold and the layout error placeholder (#2679).
+///
+/// <para>🚨 <b>The type test alone is NOT the signal, and that is deliberate.</b> An
+/// <see cref="ObjectDisposedException"/> from an unrelated disposed dependency — a cache, a
+/// connection, a stream somebody closed early — is a real defect and must keep being reported as
+/// one. Only a PROBE that finds the hub's own scope no longer resolving turns the type test into a
+/// positive statement about teardown. The probe resolves the hub's already-materialised
+/// <see cref="IMessageHub"/> registration: on a live scope that is a cheap instance lookup with no
+/// side effects; on a disposing scope Autofac throws from
+/// <c>LifetimeScope.ThrowDisposedException</c> — which is the signal.</para>
+///
+/// <para><b>Why a disposed scope is proof the hub is going away.</b> The hub instance is a tracked
+/// component of that same scope, so its <c>Dispose()</c> is already queued in the very disposer
+/// that flipped the scope's disposed flag (Autofac sets the flag FIRST, then runs the disposer over
+/// the tracked instances in reverse creation order). Anything observed in that window — an init
+/// BuildupAction, a permission fold's next emission, a render's error placeholder — is racing a
+/// teardown that has already been decided, never a fault on a live hub.</para>
+///
+/// <para>The walk is <see cref="ExceptionChain"/>'s — the exception GRAPH, not the
+/// <c>InnerException</c> line — because these faults arrive through Rx <c>Catch</c> arms,
+/// <c>Merge</c>s and <c>AggregateException</c>s whose ordering nobody controls; classifying by
+/// which fault happened to land at index 0 is a race.</para>
+/// </summary>
+public static class ScopeTeardown
+{
+    /// <summary>
+    /// True when <paramref name="exception"/> carries an <see cref="ObjectDisposedException"/>
+    /// anywhere in its graph AND <paramref name="scopeDisposed"/> confirms the scope in question
+    /// is gone. A null probe answers <c>false</c> — a caller with no scope to probe cannot make a
+    /// teardown claim, so the fault stays what it was.
+    /// </summary>
+    /// <param name="exception">The fault to classify; may be null.</param>
+    /// <param name="scopeDisposed">The probe — does the DI scope the faulting code resolved from
+    /// still resolve? See <see cref="IsServiceScopeDisposed"/>.</param>
+    public static bool IsScopeTeardown(Exception? exception, Func<bool>? scopeDisposed)
+        => scopeDisposed is not null
+           && ExceptionChain.Contains<ObjectDisposedException>(exception)
+           && scopeDisposed();
+
+    /// <summary>
+    /// Probes whether <paramref name="hub"/>'s own DI scope still resolves. The probe is a lookup
+    /// of the hub's already-materialised <see cref="IMessageHub"/> registration — side-effect free
+    /// on a live scope, an <see cref="ObjectDisposedException"/> on a disposing one.
+    /// </summary>
+    /// <param name="hub">The hub whose scope to probe.</param>
+    /// <returns><c>true</c> when the scope (or one of its parents) has been disposed.</returns>
+    public static bool IsServiceScopeDisposed(this IMessageHub hub)
+    {
+        try
+        {
+            hub.ServiceProvider.GetService(typeof(IMessageHub));
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// True when <paramref name="exception"/> is the teardown of <paramref name="hub"/>'s own DI
+    /// scope: an <see cref="ObjectDisposedException"/> in the graph AND
+    /// <see cref="IsServiceScopeDisposed"/> confirming the scope is gone. The convenience form of
+    /// <see cref="IsScopeTeardown"/> for callers that hold the hub.
+    /// </summary>
+    /// <param name="hub">The hub whose scope the faulting code resolved from.</param>
+    /// <param name="exception">The fault to classify; may be null.</param>
+    public static bool IsTerminatedByScopeTeardown(this IMessageHub hub, Exception? exception)
+        => IsScopeTeardown(exception, hub.IsServiceScopeDisposed);
+}

--- a/test/MeshWeaver.Layout.Test/ScopeTeardownRenderTest.cs
+++ b/test/MeshWeaver.Layout.Test/ScopeTeardownRenderTest.cs
@@ -1,0 +1,292 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Autofac;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #2679 — a render that faults on its OWN host's disposed DI scope is a teardown race,
+/// and the error placeholder must not be attempted on that dead scope.</b>
+///
+/// <para><b>What production reported</b> (memex-cloud, 2026-08-29), two <c>fail</c> lines for one
+/// disposal:</para>
+/// <code>
+/// fail: MeshWeaver.Layout.Composition.LayoutAreaHost[0]
+///       Rendering failed for area Overview
+///       System.ObjectDisposedException: Instances cannot be resolved … from this LifetimeScope …
+///          at Autofac.Core.Lifetime.LifetimeScope.ThrowDisposedException()
+///          at MeshWeaver.Mesh.Security.PermissionEvaluator.GetEffectivePermissions(…) :line 126
+/// fail: MeshWeaver.Layout.Composition.LayoutAreaHost[0]
+///       Failed to render the error placeholder for area Overview
+///       System.ObjectDisposedException: …
+///          at MeshWeaver.Layout.Composition.LayoutAreaLocalizationExtensions.Localize(…) :line 26
+///          at MeshWeaver.Layout.Composition.LayoutAreaHost.CreateRenderErrorControl(…)
+/// </code>
+///
+/// <para><b>Why it was mis-reported.</b> <c>AreaErrorClassifier.IsHubDisposalRace</c> matched only
+/// the TYPED <see cref="HubDisposingException"/> (#2255). The DI-scope shape of the same race —
+/// Autofac's bare <see cref="ObjectDisposedException"/> from a service resolved on the host's
+/// already-disposed scope — looked like an ordinary defect, so the render logged it at Error (the
+/// level the red-log filer turns into an incident) and then tried to LOCALISE a placeholder through
+/// the very scope that was gone, faulting a second time. The user got neither the area nor a
+/// message.</para>
+///
+/// <para><b>The fix</b> is probe-gated, the same shape <c>MessageHub</c> uses for #2444 and
+/// <c>RoutingGrain</c> for #2638 (<see cref="ScopeTeardown"/>): a bare ObjectDisposedException
+/// counts as the hub-disposal race only when the host's OWN scope confirms it no longer resolves.
+/// Then it logs at Debug like the typed race, and no placeholder is attempted — there is nothing to
+/// localise it with and nobody to render it for; the client's own resubscribe against the fresh
+/// activation renders the real content.</para>
+///
+/// <para><b>How the race is pinned, deterministically.</b> The parked view generator is resumed
+/// from Autofac's own <see cref="ILifetimeScope.CurrentScopeEnding"/> event on the host hub's
+/// scope. Autofac's <c>Disposable.Dispose()</c> sets the disposed flag FIRST — from that instant
+/// every resolve throws — and <c>LifetimeScope.Dispose(true)</c> then raises this event BEFORE its
+/// disposer reaches a single tracked instance or child scope. So the generator resumes
+/// synchronously on the disposing thread, strictly inside the incident window: the scope is dead,
+/// and the stream, its sub-hub and the hub instance are all still alive and subscribed. It then
+/// resolves from that scope and throws the real Autofac fault into the real render chain. No
+/// sleeps, no fake exception.</para>
+///
+/// <para>🚨 A sentinel <see cref="IDisposable"/> tracked in the scope (the #2444 shape) is a
+/// RACE here, whichever side creates it: the subscription machinery keeps creating tracked
+/// instances and child scopes on other threads, and whatever is newer than the sentinel is
+/// disposed before it — tearing the stream down before the fault arrives on some runs, after it
+/// on others. The event has no position in that order.</para>
+/// </summary>
+public class ScopeTeardownRenderTest : HubTestBase
+{
+    private const string RacingView = nameof(RacingView);
+
+    private readonly RenderReportCapture capture = new();
+    private readonly ReplaySubject<Unit> generatorInvoked = new(1);
+    /// <summary>What the parked generator waits on; the scope's own ending event signals it.</summary>
+    private readonly ReplaySubject<Unit> scopeDisposing = new(1);
+    private int generatorInvocations;
+
+    public ScopeTeardownRenderTest(ITestOutputHelper output) : base(output)
+    {
+        Services.AddLogging(l =>
+        {
+            l.Services.AddSingleton<ILoggerProvider>(capture);
+            // The Debug line IS the fixed behaviour, so the capture must see it — a category-scoped
+            // rule for this provider only; nothing else gets chattier.
+            l.AddFilter<RenderReportCapture>(typeof(LayoutAreaHost).FullName, LogLevel.Trace);
+        });
+    }
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithRoutes(r => r.RouteAddress(ClientType, (_, d) => d.Package()))
+            .AddLayout(layout => layout
+                .WithView(RacingView, (LayoutAreaHost host, RenderingContext _) =>
+                {
+                    System.Threading.Interlocked.Increment(ref generatorInvocations);
+                    generatorInvoked.OnNext(Unit.Default);
+                    return scopeDisposing
+                        .Take(1)
+                        .Select(_ =>
+                        {
+                            // The scope's disposed flag is set, the hub's Dispose has not run: this
+                            // is the resolution the permission fold performed in production, and it
+                            // throws Autofac's ObjectDisposedException into the render chain.
+                            host.Hub.ServiceProvider.GetRequiredService<IMessageHub>();
+                            return (UiControl?)null;
+                        });
+                }));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .AddLayoutClient(d => d);
+
+    /// <summary>
+    /// The pin. RED before the fix: two Error records — "Rendering failed for area RacingView" and
+    /// "Failed to render the error placeholder for area RacingView". GREEN after: one Debug record
+    /// naming the teardown race, nothing at Warning or above, and no placeholder attempt at all.
+    ///
+    /// <para>The barrier is the host's own report: it is written BEFORE the host decides about the
+    /// placeholder, in both the broken and the fixed shape, so "a record for the area exists"
+    /// orders the assertions after the render's fault handling without a sleep.</para>
+    /// </summary>
+    [HubFact]
+    public async Task ARenderFaultingOnItsOwnDisposedScope_IsATeardownRace_NotTwoErrors()
+    {
+        var host = GetHost();
+        var stream = GetClient().GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(),
+            new LayoutAreaReference(RacingView));
+        // ONE subscription for the whole race. A second Rx subscriber on the remote stream (a
+        // FirstAsync() barrier, say) put a SECOND area host into the race on the server: the first,
+        // parked one was torn down "having never rendered" — at Warning, on the hub's thread —
+        // before the disposal below had even begun, and the assertion on "no paging record" then
+        // failed on a fixture artefact. The generator-invocation count below pins that there is
+        // exactly one host. The client's stream will see its host go away, which is the expected
+        // outcome and not what is asserted here.
+        var frames = new ReplaySubject<Unit>(1);
+        using var subscription = stream.Subscribe(_ => frames.OnNext(Unit.Default), _ => { });
+
+        // Two barriers: the render has parked on `scopeDisposing`, and the client has received the
+        // base frame — the render subscription is live and the area is being served.
+        await generatorInvoked.FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask();
+        await frames.FirstAsync().Timeout(TimeSpan.FromSeconds(10)).ToTask();
+
+        // The window, from Autofac itself: CurrentScopeEnding is raised inside Dispose(true), after
+        // the disposed flag is set and before the disposer reaches anything. Resuming the parked
+        // generator from here puts its resolve exactly where the incident's was.
+        host.ServiceProvider.GetRequiredService<ILifetimeScope>().CurrentScopeEnding +=
+            (_, _) => scopeDisposing.OnNext(Unit.Default);
+
+        // Out-of-band scope teardown of the HOST hub — no hub.Dispose(), no CloseCreation cascade.
+        // Disposing the hub's AutofacServiceProvider disposes the underlying lifetime scope: flag,
+        // then the event above (the generator resumes, faults, and the render classifies it while
+        // every subscription is still live), then the sweep over the stream's sub-hub and the
+        // tracked host hub instance.
+        ((IDisposable)host.ServiceProvider).Dispose();
+
+        // The barrier: the host hub's disposal has COMPLETED, so every record its teardown was
+        // going to write — the render's fault handling and the stream's own teardown — is written.
+        await host.DisposalCompleted.FirstAsync().Timeout(TimeSpan.FromSeconds(15)).ToTask();
+
+        // Everything the host reported about this area — a synchronous snapshot, not a wait.
+        var all = capture.Recorded.Where(r => r.Area == RacingView).ToArray();
+        foreach (var report in all)
+            Output.WriteLine($"LayoutAreaHost reported: {report}");
+
+        System.Threading.Volatile.Read(ref generatorInvocations).Should().Be(1,
+            "exactly one area host took part in the race — a second one would be a fixture "
+            + "artefact (a second subscription), not the scenario under test");
+
+        var classified = all.Should().ContainSingle(r => r.Message.Contains("raced a hub disposal"),
+            "the render DID fault on the disposed scope (the sentinel resumed it inside the window), "
+            + "and that fault must be classified exactly once").Subject;
+        classified.Level.Should().Be(LogLevel.Debug,
+            "a render that faulted on its OWN host's disposed scope is the hub going away — routine "
+            + "lifecycle, classified at Debug like the typed HubDisposingException race (#2255); at "
+            + "Error the red-log filer files an incident for it, which is how #2679 was opened");
+        classified.Exception.Should().BeOfType<ObjectDisposedException>(
+            "the fault that arrived is Autofac's own — the bare shape the type-only classifier missed");
+
+        all.Should().NotContain(r => r.Level >= LogLevel.Warning,
+            "one disposal must not produce a paging record — the two fail lines of #2679");
+        all.Should().NotContain(r => r.Message.Contains("error placeholder"),
+            "no placeholder is attempted on a dead scope: the frame cannot be localised through a "
+            + "scope that is gone (the second ObjectDisposedException of #2679), and there is nobody "
+            + "to render it for — the client's resubscribe renders the real content");
+    }
+
+    /// <summary>
+    /// The classifier itself, stated as executable facts — the probe is the whole point.
+    /// </summary>
+    [Fact]
+    public void TheProbeGatedClassifier_OnlyMatchesADisposedScope()
+    {
+        var disposedScope = new ObjectDisposedException(
+            "Instances cannot be resolved and nested lifetimes cannot be created from this "
+            + "LifetimeScope as it (or one of its parent scopes) has already been disposed.");
+
+        AreaErrorClassifier.IsHubDisposalRace(disposedScope, () => true).Should().BeTrue(
+            "an ObjectDisposedException while the host's own scope is gone IS the teardown race");
+        AreaErrorClassifier.IsHubDisposalRace(new AggregateException(disposedScope), () => true)
+            .Should().BeTrue("the graph is walked, not the InnerException line");
+
+        // 🚨 NEGATIVE CONTROLS — what the probe exists for.
+        AreaErrorClassifier.IsHubDisposalRace(new ObjectDisposedException("SomeCache"), () => false)
+            .Should().BeFalse("a disposed DEPENDENCY on a live scope is a genuine defect");
+        AreaErrorClassifier.IsHubDisposalRace(disposedScope, null)
+            .Should().BeFalse("with no probe the answer is exactly the type-only one");
+        AreaErrorClassifier.IsHubDisposalRace(new InvalidOperationException("boom"), () => true)
+            .Should().BeFalse("a dead scope does not turn every other fault into a teardown");
+
+        // The typed race keeps matching regardless of the probe — it names its own hub.
+        AreaErrorClassifier.IsHubDisposalRace(
+                new HubDisposingException(new Address("Posts/Trail"), "anything"), () => false)
+            .Should().BeTrue();
+        AreaErrorClassifier.IsHubDisposalRace(
+                new HubDisposingException(new Address("Posts/Trail"), "the permission fold", disposedScope),
+                () => false)
+            .Should().BeTrue("the fold's re-raised shape carries the original as its inner exception");
+    }
+
+    private sealed record RenderReport(
+        LogLevel Level, string? Area, string Message, Exception? Exception, int ThreadId, DateTime At);
+
+    /// <summary>
+    /// Reads every <c>LayoutAreaHost</c> record carrying an <c>Area</c> out of the logging pipeline,
+    /// at ALL levels — the Debug line is the fixed behaviour, so it has to be observable — as a
+    /// replayed stream (the barrier) plus a snapshot (the final assertions). Structured state,
+    /// never the formatted prose alone.
+    /// </summary>
+    private sealed class RenderReportCapture : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<RenderReport> recorded = new();
+        private readonly ReplaySubject<RenderReport> reports = new();
+
+        /// <summary>The barrier: every report, replayed — wait on it, never poll.</summary>
+        internal IObservable<RenderReport> Reports => reports;
+
+        /// <summary>The snapshot: what has been recorded so far, for the final assertions.</summary>
+        internal RenderReport[] Recorded => recorded.ToArray();
+
+        public ILogger CreateLogger(string categoryName)
+            => categoryName == typeof(LayoutAreaHost).FullName
+                ? new CapturingLogger(recorded, reports)
+                : Silent.Instance;
+
+        public void Dispose() { }
+
+        private sealed class NullScope : IDisposable
+        {
+            internal static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+
+        private sealed class Silent : ILogger
+        {
+            internal static readonly Silent Instance = new();
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+            public bool IsEnabled(LogLevel logLevel) => false;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter) { }
+        }
+
+        private sealed class CapturingLogger(
+            ConcurrentQueue<RenderReport> recorded, ReplaySubject<RenderReport> sink) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (state is not IReadOnlyList<KeyValuePair<string, object?>> values)
+                    return;
+                var area = values.FirstOrDefault(v => v.Key == "Area");
+                if (area.Key is null)
+                    return;
+                var report = new RenderReport(logLevel, area.Value?.ToString(), formatter(state, exception), exception,
+                    Environment.CurrentManagedThreadId, DateTime.UtcNow);
+                // Recorded BEFORE it is published, so a waiter woken by the stream sees it in the
+                // snapshot too.
+                recorded.Enqueue(report);
+                sink.OnNext(report);
+            }
+        }
+    }
+}

--- a/test/MeshWeaver.Security.Test/PermissionFoldAfterScopeTeardownTest.cs
+++ b/test/MeshWeaver.Security.Test/PermissionFoldAfterScopeTeardownTest.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.ShortGuid;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #2679 — a permission fold must not resolve services from its hub's DI scope AFTER it
+/// has been subscribed.</b>
+///
+/// <para><b>What production reported.</b> A layout area's render chain carried a live
+/// <c>PermissionEvaluator.GetEffectivePermissions</c> fold — long-lived by design, it re-emits on
+/// every <c>AccessAssignment</c> change. The host hub's Autofac scope was disposed while that fold
+/// was still subscribed, and the fold's next emission ran its <c>SelectMany</c> selector, which
+/// called <c>GetRequiredService&lt;IMeshNodeStreamCache&gt;</c> for the recursive Public leg (and
+/// <c>GetRole</c>) — on the dead scope. Autofac's <see cref="ObjectDisposedException"/> went
+/// straight into the render chain, was reported at Error as "Rendering failed for area Overview",
+/// and the error placeholder then faulted a second time on the same scope.</para>
+///
+/// <para><b>The fix.</b> Every service the fold needs is resolved ONCE, at the entry point, on the
+/// caller's thread, and carried through the recursion; a subscribed fold never touches
+/// <c>hub.ServiceProvider</c> again. The residual — a fold that DOES fault with an
+/// <see cref="ObjectDisposedException"/> while its hub's scope is gone — terminates as the typed
+/// <see cref="HubDisposingException"/> teardown signal, gated on the same scope probe
+/// <c>MessageHub.HandleInitialize</c> uses for #2444 (<see cref="ScopeTeardown"/>).</para>
+///
+/// <para><b>How the race is pinned, deterministically.</b> The hub's scope is disposed OUT-OF-BAND
+/// (the #2444 mechanism: <c>((IDisposable)hub.ServiceProvider).Dispose()</c>, no hub
+/// <c>Dispose()</c> call), the fold stays subscribed (its subscription belongs to this test, its
+/// sources are the mesh-scoped cache's queries), and then a grant lands. The grant is the positive
+/// signal: RED before the fix — the re-emission resolves from the dead scope and the fold
+/// <c>OnError</c>s with the ObjectDisposedException; GREEN after — the fold answers the new grant
+/// from the services it resolved when it was built.</para>
+/// </summary>
+public class PermissionFoldAfterScopeTeardownTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Subject = "user-2679";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder);
+
+    protected override async Task SetupAccessRightsAsync()
+    {
+        // Grant the test runner Admin on TestPartition so the System-impersonated seed writes
+        // land deterministically (same rationale as LiveQueryRowLevelSecurityTest: TestData is a
+        // statically seeded partition, so routing the first write through a non-System identity
+        // races PartitionWriteGuard's cold-partition provisioning).
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(
+                    AssignmentNodeFactory.UserRole(
+                        Mesh.Address.ToFullString(), "Admin", TestPartition))
+                .Should().Emit();
+        }
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task AFoldWhoseHubScopeIsDisposed_StillAnswersTheNextGrant_FromTheServicesItResolvedOnce()
+    {
+        var scope = $"{TestPartition}/fold2679_{Guid.NewGuid().AsString()}";
+        var target = $"{scope}/Target";
+
+        // A hub with a lifetime scope of its OWN (a hosted hub gets BeginLifetimeScope — see
+        // MessageHubConfiguration.CreateServiceProvider / OwnsServiceProvider), evaluating with the
+        // real algorithm. This is the shape of every per-node hub a layout area renders on.
+        var hub = Mesh.GetHostedHub(
+            new Address("fold-teardown", Guid.NewGuid().AsString()),
+            c => c.AddRowLevelSecurity());
+
+        // The fold under test. Replay(1) so the assertions below observe ONE subscription — the
+        // one that outlives the scope — rather than each building a fresh fold on a dead hub.
+        var fold = hub.GetEffectivePermissions(target, Subject).Replay(1);
+        using var live = fold.Connect();
+
+        // Barrier 1 — the fold is live and has answered from the synced queries: no grant yet.
+        await fold.Should().Within(20.Seconds()).Match(p => p == Permission.None);
+
+        // 🚨 NEGATIVE CONTROL for the classifier, taken while the scope is ALIVE: an
+        // ObjectDisposedException from an unrelated disposed dependency is a genuine defect and
+        // must NOT read as teardown. This is what keeps the probe honest (#2444, #2638).
+        hub.IsServiceScopeDisposed().Should().BeFalse("the hub's scope is alive at this point");
+        hub.IsTerminatedByScopeTeardown(new ObjectDisposedException("SomeCache"))
+            .Should().BeFalse("a disposed DEPENDENCY on a live scope is a defect, not a teardown");
+
+        // Out-of-band scope teardown — exactly the production sequence (#2444): the scope's
+        // disposed flag flips FIRST, every resolve from it throws from that instant, and the hub
+        // instance is disposed later in the same sweep. No hub.Dispose() is called here.
+        ((IDisposable)hub.ServiceProvider).Dispose();
+        await hub.DisposalCompleted.FirstAsync().Timeout(TimeSpan.FromSeconds(15)).ToTask();
+
+        hub.IsServiceScopeDisposed().Should().BeTrue(
+            "the probe is the positive signal every teardown classification is gated on");
+        hub.IsTerminatedByScopeTeardown(new ObjectDisposedException("LifetimeScope"))
+            .Should().BeTrue("an ObjectDisposedException on a hub whose scope is gone IS the teardown");
+        hub.IsTerminatedByScopeTeardown(new InvalidOperationException("a real defect"))
+            .Should().BeFalse("the probe must not turn EVERY fault during teardown into a benign one");
+
+        // A grant lands. The fold's sources are the mesh-scoped cache's synced queries, which are
+        // alive and re-emit; the SelectMany selector then runs on the dead hub's fold. Before the
+        // fix this is where GetRequiredService<IMeshNodeStreamCache> threw — the exact frame the
+        // production stack shows (PermissionEvaluator.cs:126 from <GetEffectivePermissions>b__2).
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        using (accessService.ImpersonateAsSystem())
+        {
+            await meshService.CreateNode(AssignmentNodeFactory.UserRole(Subject, "Viewer", scope))
+                .Should().Emit();
+        }
+
+        // Barrier 2 — the pin. RED before the fix: the Replay'd fold has latched the
+        // ObjectDisposedException and this assertion throws it. GREEN after: the Viewer grant is
+        // answered from the cache the fold resolved when it was built.
+        await fold.Should().Within(20.Seconds()).Match(p => p.HasFlag(Permission.Read));
+    }
+}


### PR DESCRIPTION
## What was failing

Two `fail` lines for one hub disposal (memex-cloud, 2026-08-29):

1. `PermissionEvaluator.GetEffectivePermissions` resolved `IMeshNodeStreamCache` **inside its `SelectMany` selector** — the recursive Public leg (`:237` → `:126`) and `GetRole`. A permission fold is long-lived by design (it re-emits on every `AccessAssignment` change), so when the hub's Autofac scope was disposed while the fold was still subscribed, the next emission threw `ObjectDisposedException` straight into the render chain → `Rendering failed for area Overview` at Error.
2. `LayoutAreaHost.RenderRenderingError` then tried to render the error placeholder, whose copy is localised through `host.Hub.ServiceProvider.GetService<AccessService>()` — the same dead scope → a second `ObjectDisposedException`, `Failed to render the error placeholder`. `AreaErrorClassifier.IsHubDisposalRace` only matched the typed `HubDisposingException`, so the DI-scope shape of the race was reported as an engineering fault and auto-filed.

## What changed

- **`PermissionEvaluator`** — every service the fold needs is resolved **once**, at the entry point, into a private `FoldServices` record carried through the recursion (`GetEffectivePermissionsCore`); the Public leg, `GetRole`, `ObserveAllRoleNodes` and `ObserveAllMembershipNodes` take the already-resolved cache. A subscribed fold never touches `hub.ServiceProvider` again. Public signatures are unchanged.
- **`ScopeTeardown`** (new, `MeshWeaver.Messaging.Hub`) — the one probe-gated classifier for "this `ObjectDisposedException` is the hub's own scope going away": `IsScopeTeardown(ex, probe)`, `hub.IsServiceScopeDisposed()`, `hub.IsTerminatedByScopeTeardown(ex)`. `MessageHub`'s private #2444 pair and `RoutingGrain`'s #2638 copy now delegate to it — one shape, one meaning.
- **Fold residual** — if the fold still faults with an `ObjectDisposedException` while its hub's scope no longer resolves, it terminates as the typed `HubDisposingException` (new overload carrying the original as inner exception), which the layout host, `MessageService` and `CheckPermissionOutcome` already classify as benign teardown. Gated on the probe: an unrelated disposed dependency on a **live** scope still faults the fold as the defect it is.
- **`AreaErrorClassifier.IsHubDisposalRace(ex, scopeDisposed)`** — the DI-scope shape of the race. `LayoutAreaHost` probes its own scope once per failure in `RenderRenderingError` and `FailRendering`, logs the race at Debug (like the #2255 arm), and renders **no placeholder on a dead scope** — nothing to localise with, nobody to render for; the client's own resubscribe renders the real content.
- Doc: `PermissionApi.md` ("Denied vs couldn't decide") describes the disposing-hub leg. What's New entry (`Category: Fix`).

## Tests

- `PermissionFoldAfterScopeTeardownTest` (Security) — subscribes the real fold on a hosted hub, disposes that hub's scope out of band (the #2444 mechanism), then lands a Viewer grant. Red before (the re-emission resolves from the dead scope → `ObjectDisposedException` out of the fold), green after. Also pins the probe's negative control (a disposed dependency on a live scope is not a teardown).
- `ScopeTeardownRenderTest` (Layout) — resumes a parked view generator from Autofac's own `CurrentScopeEnding` (flag set, nothing disposed yet), so it resolves from the dead scope and throws the real Autofac fault into the real render chain. Exactly one `LayoutAreaHost` record: Debug, carrying the `ObjectDisposedException`; nothing at Warning or above; no placeholder attempt. Plus the classifier's negative controls.
- Neighbours re-run green locally: `HubDisposalRenderTransientTest`, `RenderFailureDiagnosticsTest`, `AreaErrorClassifierTest`, `SubscribeDuringRecycleTest` (77), `ScopeDisposedDuringInitializationTest` + init siblings (3), `RoutingAfterScopeTeardownTest` (5), `SecurityServiceTests`/`GroupPermissionTests`/`PermissionFoldUnavailableTest`/`NodeTypeGateTests`/`AdminPartitionAdminTests`/`UserPublicReadTest`/`HubCredentialReadAccessTest` (57). Every touched project and its dependents built `-c Release -warnaserror`, `0 Error(s)`.

Closes #2679

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EPCWramjFYquX5SaMdeJKW
