### PR TITLE
Hosting operator: hosting-audit names what lives only on the cluster

### DIFF
--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -58,8 +58,8 @@ jobs:
         run: |
           set -euo pipefail
           tracked=$(git ls-files deploy/aks/operator/bin/ | wc -l | tr -d ' ')
-          if [ "$tracked" -lt 16 ]; then
-            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 16 (14 commands + run.sh + _common.sh)."
+          if [ "$tracked" -lt 18 ]; then
+            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 18 (15 commands + run.sh + _common.sh + _audit.jq)."
             echo "::error::Almost certainly .gitignore matching this bin/ again. `git add` on an ignored path exits 0 and does NOTHING, so the loss is silent until a fresh checkout builds an image with no scripts in it."
             git check-ignore -v deploy/aks/operator/bin/run.sh || true
             exit 1
@@ -93,6 +93,7 @@ jobs:
           # here so this repo can gate them without a cross-repo checkout. Keep in step with
           # MeshWeaver.Plugins/Hosting/InstanceAction/Source/InstanceActionPlan.cs.
           cat > "$plan_src" <<'EOF'
+          hosting-audit
           hosting-backup
           hosting-deploy
           hosting-dns
@@ -119,7 +120,23 @@ jobs:
             echo "::error::A missing one fails INSIDE a running lifecycle Job — for a teardown, after the quiesce."
             exit 1
           fi
-          echo "all 14 commands present and executable"
+          echo "all 15 commands present and executable"
+          # hosting-audit is two files: the command and the jq program beside it. A command that
+          # ships without its detection dies at "the detection program … is missing" inside a Job.
+          [ -f deploy/aks/operator/bin/_audit.jq ] || { echo "::error::bin/_audit.jq is missing — hosting-audit cannot compute anything without it"; exit 1; }
+          # Parse-check the program. jq exits 3 on a PROGRAM error and 5 on a runtime error();
+          # empty inputs legitimately reach the error() refusal, so only exit 3 is a failure here —
+          # the behaviour tests below exercise the real detection against fixtures.
+          set +e
+          jq -n -f deploy/aks/operator/bin/_audit.jq --slurpfile manifest /dev/null --slurpfile live /dev/null \
+            --arg namespace n --arg release r --arg deployment d --arg container c --argjson revision 1 \
+            --arg chart "" --arg auditedAt now --arg skipped "" >/dev/null 2>"$RUNNER_TEMP/audit-jq.err"
+          jq_rc=$?
+          set -e
+          if [ "$jq_rc" -eq 3 ]; then
+            echo "::error::_audit.jq does not parse:"; cat "$RUNNER_TEMP/audit-jq.err"; exit 1
+          fi
+          echo "_audit.jq parses (exit ${jq_rc} on empty inputs is its own refusal, as designed)"
 
       - name: Behaviour tests
         run: deploy/aks/operator/test/run-tests.sh
@@ -164,7 +181,8 @@ jobs:
             test -x /opt/hosting/bin/run.sh          || { echo "run.sh missing"; exit 1; }
             test -f /opt/hosting/chart/Chart.yaml    || { echo "chart missing — build context must be deploy/"; exit 1; }
             command -v hosting-deploy >/dev/null     || { echo "hosting-* not on PATH"; exit 1; }
-            command -v helm kubectl az pg_dump >/dev/null || { echo "a required tool is missing"; exit 1; }
+            command -v helm kubectl az pg_dump jq >/dev/null || { echo "a required tool is missing"; exit 1; }
+            test -f /opt/hosting/bin/_audit.jq       || { echo "_audit.jq missing — hosting-audit has no detection"; exit 1; }
             echo "image carries: $(ls /opt/hosting/bin/hosting-* | wc -l) commands + chart $(grep ^version /opt/hosting/chart/Chart.yaml)"
           '
 

--- a/.github/workflows/hosting-operator.yml
+++ b/.github/workflows/hosting-operator.yml
@@ -58,8 +58,8 @@ jobs:
         run: |
           set -euo pipefail
           tracked=$(git ls-files deploy/aks/operator/bin/ | wc -l | tr -d ' ')
-          if [ "$tracked" -lt 18 ]; then
-            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 18 (15 commands + run.sh + _common.sh + _audit.jq)."
+          if [ "$tracked" -lt 19 ]; then
+            echo "::error::only ${tracked} file(s) tracked under deploy/aks/operator/bin/ — expected 19 (16 commands + run.sh + _common.sh + _audit.jq)."
             echo "::error::Almost certainly .gitignore matching this bin/ again. `git add` on an ignored path exits 0 and does NOTHING, so the loss is silent until a fresh checkout builds an image with no scripts in it."
             git check-ignore -v deploy/aks/operator/bin/run.sh || true
             exit 1
@@ -101,6 +101,7 @@ jobs:
           hosting-federate
           hosting-kv-ensure
           hosting-kv-purge
+          hosting-pv-purge
           hosting-redirect
           hosting-restore
           hosting-tls
@@ -120,7 +121,7 @@ jobs:
             echo "::error::A missing one fails INSIDE a running lifecycle Job — for a teardown, after the quiesce."
             exit 1
           fi
-          echo "all 15 commands present and executable"
+          echo "all 16 commands present and executable"
           # hosting-audit is two files: the command and the jq program beside it. A command that
           # ships without its detection dies at "the detection program … is missing" inside a Job.
           [ -f deploy/aks/operator/bin/_audit.jq ] || { echo "::error::bin/_audit.jq is missing — hosting-audit cannot compute anything without it"; exit 1; }

--- a/deploy/aks/INSTANCE-LIFECYCLE.md
+++ b/deploy/aks/INSTANCE-LIFECYCLE.md
@@ -121,6 +121,14 @@ rule is in the mesh's pure, unit-tested plan. What the scripts themselves guaran
   it goes into a one-shot Secret the mesh reads once and deletes.
 - **`hosting-verify-catalog` proves the plugin mounts took.** An instance with green pods and an
   empty Store is the failure worth catching, and it is invisible in a rollout status.
+- **`hosting-audit` names what lives ONLY on the cluster** — the `Audit` verb's one step. It diffs
+  the namespace against `helm get manifest` + `helm get hooks` (the truth) and reports, by name and
+  never by value, the portal Deployment's live-only env / envFrom / volumes / mounts / containers /
+  pod-spec patches, the chart ConfigMaps' live-edited keys, objects the chart does not own, secrets
+  the pod reads that nothing renders, and secret-shaped names carried as plain values. It emits the
+  report as `::hosting:: audit=<base64 JSON>` for the mesh to record, exits 0 on drift (drift is a
+  finding, not a failed run) and **refuses** when it cannot measure — no release, no live portal, or
+  a kind its ClusterRole may not list. The mesh side is the Hosting plugin's `Hosting/Audit` page.
 
 ## Two traps worth knowing
 

--- a/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
+++ b/deploy/aks/manifests/hosting-operator/operator-rbac.yaml
@@ -39,6 +39,28 @@ rules:
   - apiGroups: ["secrets-store.csi.x-k8s.io"]
     resources: ["secretproviderclasses"]
     verbs: ["get", "list", "create", "update", "patch", "delete"]
+  # READ-ONLY, for hosting-audit. The live-only-config audit lists every kind a namespace can carry
+  # and compares it against the helm manifest; a kind it is Forbidden to list is one it must NOT
+  # report as clean, so it refuses — which means every kind below has to be readable or the audit
+  # never completes. Nothing here is writable: an audit measures, it never reconciles.
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["policy"]
+    resources: ["poddisruptionbudgets"]
+    verbs: ["get", "list"]
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list"]
+  - apiGroups: ["keda.sh"]
+    resources: ["scaledobjects"]
+    verbs: ["get", "list"]
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list"]
+  - apiGroups: ["rbac.authorization.k8s.io"]
+    resources: ["roles", "rolebindings"]
+    verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/aks/operator/Dockerfile
+++ b/deploy/aks/operator/Dockerfile
@@ -25,7 +25,9 @@ ARG TARGETARCH=amd64
 # refuses with "server version mismatch". Azure Linux 3 ships 16.x and the fleet's flexible servers
 # are major 16 (memexaks-pg, verified 2026-08-22) — bump both together when the fleet moves.
 # tar: needed to unpack helm, and not in the base. shadow-utils: useradd, for the non-root user.
-RUN tdnf install -y --refresh postgresql tar shadow-utils ca-certificates \
+# jq: hosting-audit's detection is a jq program (bin/_audit.jq) — without it the audit cannot
+# compare a single field, and it refuses rather than reporting a namespace it never read as clean.
+RUN tdnf install -y --refresh postgresql tar shadow-utils ca-certificates jq \
  && tdnf clean all \
  && curl -fsSLo /usr/local/bin/kubectl \
       "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/${TARGETARCH}/kubectl" \

--- a/deploy/aks/operator/bin/_audit.jq
+++ b/deploy/aks/operator/bin/_audit.jq
@@ -39,6 +39,13 @@ def only(a; b): [a[] | select(. as $x | (b | index($x)) == null)] | unique;
 def norm: walk(if type == "number" then tostring else . end);
 def compact: tojson | if length > 120 then .[:117] + "…" else . end;
 
+# 🚨 lifecycle values are REDACTED to their shape. Every other compared pod-spec field carries
+# placement and sizing (replicas, selectors, quantities, probe numbers) — but a lifecycle hook
+# holds COMMAND LINES, and a command line can embed anything, tokens included. The comparison uses
+# the full value; the report shows the structure with every string scalar replaced, which is enough
+# to see THAT a hook was patched and WHERE without quoting what it runs.
+def redact($f): if ($f | endswith(".lifecycle")) then walk(if type == "string" then "…" else . end) else . end;
+
 def container($c): ((.spec.template.spec.containers // []) | map(select(.name == $c)) | .[0]);
 def env_names: (.env // []) | map(.name);
 def env_from: (.envFrom // []) | map(.secretRef.name // .configMapRef.name // empty);
@@ -86,7 +93,8 @@ def annotations: (.spec.template.metadata.annotations // {}) | keys;
     {field: "containers[\($container)].startupProbe.failureThreshold", live: ($lc.startupProbe.failureThreshold // 3), manifest: ($mc.startupProbe.failureThreshold // 3)}
   ]
   | map(select((.live | norm) != (.manifest | norm)))
-  | map({field, live: (.live | compact), manifest: (.manifest | compact)})) as $podSpecDiffs
+  | map(.field as $f
+      | {field: $f, live: (.live | redact($f) | compact), manifest: (.manifest | redact($f) | compact)})) as $podSpecDiffs
 
 # ── the chart's ConfigMaps ─────────────────────────────────────────────────────────────────────
 | ($m | map(select(.kind == "ConfigMap")) | map(

--- a/deploy/aks/operator/bin/_audit.jq
+++ b/deploy/aks/operator/bin/_audit.jq
@@ -1,0 +1,161 @@
+# _audit.jq — the detection behind hosting-audit. Pure: manifest objects + live objects in, one
+# LiveOnlyConfigReport out. Sourced by hosting-audit, never run on its own.
+#
+# Inputs (jq -n … -f _audit.jq):
+#   $manifest[0]  the helm manifest + hooks as an ARRAY of Kubernetes objects (the truth)
+#   $live[0]      every live object in the namespace, every kind, as ONE array
+#   $namespace $release $deployment $container $revision $chart $auditedAt $skipped
+#
+# 🚨 NAMES, NEVER VALUES. A ConfigMap value is compared here and never emitted; an env entry's
+# `value` decides whether it is a plain value and is never emitted. The report is written to a node
+# and shown on a page — a value leaking through it would be the secret-in-the-pod-spec finding all
+# over again, one level up.
+
+def oname: "\(.kind)/\(.metadata.name)";
+def owned: ((.metadata.ownerReferences // []) | length) > 0;
+def csi_synced: (((.metadata.labels // {})["secrets-store.csi.k8s.io/managed"]) // "") == "true";
+
+# What is NOT configuration anyone put on the cluster, and so is not a finding:
+#   owned objects (ReplicaSets, CronJob-spawned Jobs, CSI-synced Secrets) exist because of their
+#   owner; helm's own release records and ServiceAccount tokens are the machinery; kube-root-ca.crt
+#   and the `default` ServiceAccount are created by Kubernetes in every namespace.
+def excluded:
+    owned
+    or (.kind == "Secret" and ((.type // "") | (. == "helm.sh/release.v1" or . == "kubernetes.io/service-account-token")))
+    or csi_synced
+    or (.kind == "ConfigMap" and .metadata.name == "kube-root-ca.crt")
+    or (.kind == "ServiceAccount" and .metadata.name == "default");
+
+# A name that looks like it carries a secret. Name-based on purpose: the VALUE is what must not
+# be read, so the name is the only honest signal. A flag that merely ends in Key is a false
+# positive the record can rename; a token that slipped through would be an outage.
+def secretish: test("token|secret|key|password"; "i");
+
+# a minus b, as sorted unique names
+def only(a; b): [a[] | select(. as $x | (b | index($x)) == null)] | unique;
+
+# Kubernetes serialises quantities and ports as strings or numbers depending on who wrote them
+# (`cpu: 4` in a template, `"4"` back from the API). Compare shapes, not spellings.
+def norm: walk(if type == "number" then tostring else . end);
+def compact: tojson | if length > 120 then .[:117] + "…" else . end;
+
+def container($c): ((.spec.template.spec.containers // []) | map(select(.name == $c)) | .[0]);
+def env_names: (.env // []) | map(.name);
+def env_from: (.envFrom // []) | map(.secretRef.name // .configMapRef.name // empty);
+def mounts: (.volumeMounts // []) | map(.mountPath);
+def volumes: (.spec.template.spec.volumes // []) | map(.name);
+def containers: ((.spec.template.spec.containers // []) | map(.name)) + ((.spec.template.spec.initContainers // []) | map(.name));
+def annotations: (.spec.template.metadata.annotations // {}) | keys;
+
+($manifest[0]) as $m
+| ($live[0]) as $l
+| ($m | map(oname)) as $managed
+| ($m | map(select(.kind == "Deployment" and .metadata.name == $deployment)) | .[0]) as $md
+| ($l | map(select(.kind == "Deployment" and .metadata.name == $deployment)) | .[0]) as $ld
+| if $md == null then error("the manifest of release " + $release + " renders no Deployment/" + $deployment + " — pass --deployment naming the portal Deployment the chart renders") else . end
+| if $ld == null then error("no live Deployment/" + $deployment + " in " + $namespace + " — the release is deployed but its portal is not running, which is a finding this audit cannot express as drift") else . end
+| ($md | container($container)) as $mc
+| ($ld | container($container)) as $lc
+| if $mc == null then error("the manifest's Deployment/" + $deployment + " has no container named " + $container) else . end
+| if $lc == null then error("the live Deployment/" + $deployment + " has no container named " + $container + " — a container renamed live is a finding this audit cannot express as drift") else . end
+
+# ── the portal Deployment, field by field ──────────────────────────────────────────────────────
+| only($lc | env_names; $mc | env_names) as $envLiveOnly
+| only($mc | env_names; $lc | env_names) as $envManifestOnly
+| only($lc | env_from; $mc | env_from) as $envFromLiveOnly
+| only($ld | volumes; $md | volumes) as $volumesLiveOnly
+| only($lc | mounts; $mc | mounts) as $mountsLiveOnly
+| only($ld | containers; $md | containers) as $containersLiveOnly
+| only($ld | annotations; $md | annotations) as $podAnnotationsLiveOnly
+
+# replicas belong to the autoscaler when the manifest renders one for this Deployment — the chart
+# then deliberately writes no replicas field, and comparing would blame KEDA for doing its job.
+| ($m | map(select((.kind == "ScaledObject" or .kind == "HorizontalPodAutoscaler")
+                   and (.spec.scaleTargetRef.name // "") == $deployment)) | length > 0) as $autoscaled
+| ([
+    (if $autoscaled then empty else
+      {field: ".spec.replicas", live: ($ld.spec.replicas // 1), manifest: ($md.spec.replicas // 1)} end),
+    {field: ".spec.template.spec.nodeSelector", live: ($ld.spec.template.spec.nodeSelector // {}), manifest: ($md.spec.template.spec.nodeSelector // {})},
+    {field: ".spec.template.spec.tolerations", live: ($ld.spec.template.spec.tolerations // []), manifest: ($md.spec.template.spec.tolerations // [])},
+    {field: ".spec.template.spec.affinity", live: ($ld.spec.template.spec.affinity // {}), manifest: ($md.spec.template.spec.affinity // {})},
+    {field: ".spec.template.spec.serviceAccountName", live: ($ld.spec.template.spec.serviceAccountName // "default"), manifest: ($md.spec.template.spec.serviceAccountName // "default")},
+    {field: ".spec.template.spec.terminationGracePeriodSeconds", live: ($ld.spec.template.spec.terminationGracePeriodSeconds // 30), manifest: ($md.spec.template.spec.terminationGracePeriodSeconds // 30)},
+    {field: "containers[\($container)].resources", live: ($lc.resources // {}), manifest: ($mc.resources // {})},
+    {field: "containers[\($container)].lifecycle", live: ($lc.lifecycle // {}), manifest: ($mc.lifecycle // {})},
+    {field: "containers[\($container)].startupProbe.periodSeconds", live: ($lc.startupProbe.periodSeconds // 10), manifest: ($mc.startupProbe.periodSeconds // 10)},
+    {field: "containers[\($container)].startupProbe.failureThreshold", live: ($lc.startupProbe.failureThreshold // 3), manifest: ($mc.startupProbe.failureThreshold // 3)}
+  ]
+  | map(select((.live | norm) != (.manifest | norm)))
+  | map({field, live: (.live | compact), manifest: (.manifest | compact)})) as $podSpecDiffs
+
+# ── the chart's ConfigMaps ─────────────────────────────────────────────────────────────────────
+| ($m | map(select(.kind == "ConfigMap")) | map(
+    .metadata.name as $n
+    | (.data // {}) as $mdata
+    | ($l | map(select(.kind == "ConfigMap" and .metadata.name == $n)) | .[0]) as $lcm
+    | if $lcm == null then
+        {name: $n, missingLive: true, liveOnlyKeys: [], manifestOnlyKeys: ($mdata | keys), differingKeys: []}
+      else
+        (($lcm.data // {}) as $ldata
+        | {name: $n, missingLive: false,
+           liveOnlyKeys: only($ldata | keys; $mdata | keys),
+           manifestOnlyKeys: only($mdata | keys; $ldata | keys),
+           differingKeys: ([($ldata | keys[]) | select(($mdata[.] != null) and ($ldata[.] != $mdata[.]))] | sort)})
+      end)) as $configMaps
+| ($configMaps | map((.liveOnlyKeys | length) + (.manifestOnlyKeys | length) + (.differingKeys | length)
+                     + (if .missingLive then 1 else 0 end)) | add // 0) as $configMapCount
+
+# ── objects the chart does not own ─────────────────────────────────────────────────────────────
+| ($l | map(select(excluded | not))
+      | map(select(oname as $n | ($managed | index($n)) == null))
+      | group_by(.kind)
+      | map({kind: .[0].kind, names: (map(.metadata.name) | sort | unique)})) as $unmanagedObjects
+| ($unmanagedObjects | map(.names | length) | add // 0) as $unmanagedCount
+
+# ── secrets the live pod reads that nobody renders ─────────────────────────────────────────────
+| ([ ($ld.spec.template.spec.containers // [])[]
+     | ((.envFrom // [])[] | .secretRef.name // empty), ((.env // [])[] | .valueFrom.secretKeyRef.name // empty) ]
+   + [ ($ld.spec.template.spec.volumes // [])[] | .secret.secretName // empty ]
+   | unique
+   | map(select(. as $s | ($managed | index("Secret/" + $s)) == null))
+   | map(select(. as $s | ($l | map(select(.kind == "Secret" and .metadata.name == $s and csi_synced)) | length) == 0))) as $unmanagedSecrets
+
+# ── secret-shaped names carried as plain values ────────────────────────────────────────────────
+| ([ ($ld.spec.template.spec.containers // [])[] | .name as $c
+     | (.env // [])[] | select(.value != null) | select(.name | secretish) | "env:\($c):\(.name)" ]
+   + [ $l[] | select(.kind == "ConfigMap") | select(oname as $n | ($managed | index($n)) != null)
+       | .metadata.name as $n | ((.data // {}) | keys[]) | select(secretish) | "configmap:\($n)/\(.)" ]
+   | unique) as $plainSecretEntries
+
+# ── the verdict — derived from the lists, and re-derived by the mesh ───────────────────────────
+| (($envLiveOnly | length) + ($envManifestOnly | length) + ($envFromLiveOnly | length)
+   + ($volumesLiveOnly | length) + ($mountsLiveOnly | length) + ($containersLiveOnly | length)
+   + ($podAnnotationsLiveOnly | length) + ($podSpecDiffs | length) + $configMapCount
+   + $unmanagedCount + ($unmanagedSecrets | length) + ($plainSecretEntries | length)) as $findingCount
+| {
+    namespace: $namespace,
+    release: $release,
+    deploymentName: $deployment,
+    containerName: $container,
+    helmRevision: $revision,
+    chartVersion: (if $chart == "" then null else $chart end),
+    auditedAt: $auditedAt,
+    managedObjectCount: ($managed | length),
+    runningImage: ($lc.image // null),
+    manifestImage: ($mc.image // null),
+    skippedKinds: ($skipped | split(" ") | map(select(length > 0))),
+    envLiveOnly: $envLiveOnly,
+    envManifestOnly: $envManifestOnly,
+    envFromLiveOnly: $envFromLiveOnly,
+    volumesLiveOnly: $volumesLiveOnly,
+    mountsLiveOnly: $mountsLiveOnly,
+    containersLiveOnly: $containersLiveOnly,
+    podAnnotationsLiveOnly: $podAnnotationsLiveOnly,
+    podSpecDiffs: $podSpecDiffs,
+    configMaps: $configMaps,
+    unmanagedObjects: $unmanagedObjects,
+    unmanagedSecrets: $unmanagedSecrets,
+    plainSecretEntries: $plainSecretEntries,
+    findingCount: $findingCount,
+    verdict: (if $findingCount == 0 then "clean" else "drift" end)
+  }

--- a/deploy/aks/operator/bin/hosting-audit
+++ b/deploy/aks/operator/bin/hosting-audit
@@ -28,7 +28,10 @@
 #     renders that the pod lacks is the same edit from the other side), envFrom, volumes, mounts,
 #     containers, pod annotations, and the pod-spec fields a `kubectl patch` reaches: replicas,
 #     nodeSelector, tolerations, affinity, serviceAccountName, terminationGracePeriodSeconds, the
-#     portal container's resources, lifecycle and startup-probe budget;
+#     portal container's resources, lifecycle and startup-probe budget. Pod-spec DIFFS carry the
+#     two values (placement and sizing, not secrets) — except lifecycle hooks, whose string
+#     scalars are REDACTED to their shape: a hook holds command lines, and a command line can
+#     embed anything;
 #   * the chart's ConfigMaps: keys that exist only live, only in the manifest, or whose VALUE differs;
 #   * Secrets the live pod reads (envFrom, secretKeyRef, secret volumes) that are neither
 #     chart-managed nor CSI-synced;

--- a/deploy/aks/operator/bin/hosting-audit
+++ b/deploy/aks/operator/bin/hosting-audit
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# hosting-audit --namespace <ns> --release <name> [--deployment memex-portal-deployment] [--container memex-portal]
+#
+# What lives ONLY on the cluster — configuration no repository renders?
+#
+# 🚨 WHY THIS EXISTS. On 2026-08-30 the memex portal crashed at boot because its Email section
+# existed TWICE: the chart's ConfigMap defaults, and a cluster-only secret somebody had patched
+# onto the Deployment as env with `kubectl set env`. .NET picks the winner at random per pod start.
+# The audit run by hand afterwards found 25 env patches, 10 live-edited ConfigMap keys, sidecar
+# containers and a volume on memex; 31 env patches and replicas/nodeSelector on memex-cloud; a
+# CronJob, Deployments, Ingresses and PVCs the chart has never heard of in both namespaces; and a
+# plain-text registry token in the pod spec (Systemorph/Memex#148). None of it was visible from any
+# repository, because `helm upgrade` PRESERVES a live-edited ConfigMap key and never touches an
+# object it does not own — drift of this class does not show up as a failed deploy, it shows up as
+# an outage months later. The rule this enforces: NOTHING LIVES ONLY ON THE CLUSTER — every value is
+# a typed field on the Hosting/Deployment record, rendered by the chart; secrets are Key Vault names.
+#
+# THE TRUTH is the helm manifest: `helm get manifest` + `helm get hooks`, turned into objects by
+# `kubectl apply --dry-run=client -o json`. Everything live that is not in it, and every field of
+# the portal Deployment / the chart's ConfigMaps that differs from it, is a finding.
+#
+# WHAT IS DETECTED (names only — a VALUE is never printed, because the point of the exercise is
+# that some of them are secrets):
+#   * live objects in the namespace not in the manifest — owned objects (ReplicaSets, CronJob-spawned
+#     Jobs), helm release secrets, ServiceAccount tokens, CSI-synced secrets, kube-root-ca.crt and
+#     the `default` ServiceAccount excluded, since none of those is configuration anyone put there;
+#   * the portal Deployment's live-only env names (and manifest-only ones — a value the chart
+#     renders that the pod lacks is the same edit from the other side), envFrom, volumes, mounts,
+#     containers, pod annotations, and the pod-spec fields a `kubectl patch` reaches: replicas,
+#     nodeSelector, tolerations, affinity, serviceAccountName, terminationGracePeriodSeconds, the
+#     portal container's resources, lifecycle and startup-probe budget;
+#   * the chart's ConfigMaps: keys that exist only live, only in the manifest, or whose VALUE differs;
+#   * Secrets the live pod reads (envFrom, secretKeyRef, secret volumes) that are neither
+#     chart-managed nor CSI-synced;
+#   * entries whose NAME looks like a secret (token|secret|key|password) carried as a PLAIN value —
+#     inline env on the pod, or a key in a chart ConfigMap.
+#
+# THE OUTPUT is the human summary plus the machine lines the mesh's Hosting plugin parses:
+#   ::hosting:: audit_verdict=clean|drift   ::hosting:: audit_findings=N   ::hosting:: audit=<base64 JSON>
+# The JSON is the LiveOnlyConfigReport the Hosting/InstanceAction `Audit` verb records on the
+# instance's Hosting/ConfigAudit node. The mesh re-derives the verdict from the lists — the lists
+# are the evidence, the word is a convenience.
+#
+# 🚨 READ-ONLY, and it exits 0 on drift. Drift is a FINDING the report carries, not a failure of
+# the run; the run fails only when it cannot measure — no release, no manifest, no live Deployment,
+# or a kind it is not allowed to list. An audit that cannot read a kind must not report that kind as
+# clean, so a Forbidden is fatal and names the ClusterRole to widen. A dry run audits for real:
+# nothing here mutates, so there is nothing to rehearse.
+
+source "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_common.sh"
+# shellcheck disable=SC2034  # read by hosting::die in _common.sh, which shellcheck does not follow here
+HOSTING_CMD="hosting-audit"
+
+AUDIT_JQ="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")/_audit.jq"
+
+namespace="" release="" deployment="memex-portal-deployment" container="memex-portal"
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --namespace)  namespace="${2:-}";  shift 2 ;;
+    --release)    release="${2:-}";    shift 2 ;;
+    --deployment) deployment="${2:-}"; shift 2 ;;
+    --container)  container="${2:-}";  shift 2 ;;
+    *) hosting::die "unknown argument '$1'" ;;
+  esac
+done
+
+hosting::need_flag namespace "$namespace"
+hosting::need_flag release "$release"
+hosting::safe_name namespace "$namespace"
+hosting::safe_name release "$release"
+hosting::safe_name deployment "$deployment"
+hosting::safe_name container "$container"
+
+command -v jq >/dev/null 2>&1 || hosting::die "jq is not installed in this image — the audit's detection is a jq program, and without it nothing can be compared"
+[ -f "$AUDIT_JQ" ] || hosting::die "the detection program ${AUDIT_JQ} is missing beside this script — the image was built without it"
+
+hosting::dry && hosting::log "dry run requested — the audit is read-only, so it runs for real"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+# ── 1. the release: which revision is being audited ─────────────────────────────────────────────
+# `helm status -o json` is the whole release object — including `config`, the user-supplied values,
+# which carry the Key Vault half. Only two fields leave this variable, and neither is a value.
+status="$(hosting::read helm status "$release" -n "$namespace" -o json 2>"$work/err")" \
+  || hosting::die "no helm release '${release}' in namespace '${namespace}' ($(tr -d '\n' < "$work/err")). An audit compares the cluster against a release's manifest; with no release there is nothing to compare against, and reporting the namespace as 'unmanaged' would be a confident wrong answer."
+revision="$(printf '%s' "$status" | jq -r '.version // empty')"
+chart="$(printf '%s' "$status" | jq -r '.chart.metadata.version // empty')"
+[ -n "$revision" ] || hosting::die "helm status answered for '${release}' but named no revision — refusing to audit against a release the output cannot identify"
+hosting::log "release   ${release} in ${namespace} — revision ${revision}${chart:+, chart ${chart}}"
+
+# ── 2. the manifest — the truth ─────────────────────────────────────────────────────────────────
+# Hooks are included: the migration Job is a helm hook, and `helm get manifest` alone would list it
+# as an object the chart has never heard of.
+hosting::read helm get manifest "$release" -n "$namespace" > "$work/manifest.yaml" 2>"$work/err" \
+  || hosting::die "could not read the manifest of release '${release}' ($(tr -d '\n' < "$work/err"))"
+hosting::read helm get hooks "$release" -n "$namespace" > "$work/hooks.yaml" 2>"$work/err" \
+  || hosting::die "could not read the hooks of release '${release}' ($(tr -d '\n' < "$work/err"))"
+if ! cat "$work/manifest.yaml" "$work/hooks.yaml" \
+     | kubectl apply --dry-run=client -o json -f - 2>"$work/err" \
+     | jq -s '[.[] | if .kind == "List" then (.items // [])[] else . end]' > "$work/manifest.json"; then
+  hosting::die "could not turn the manifest into objects ($(tr -d '\n' < "$work/err")). kubectl needs the cluster's discovery to resolve every kind the chart renders — a CRD the chart uses that the cluster does not serve fails here, and that is a finding about the chart, not noise."
+fi
+managed="$(jq 'length' "$work/manifest.json")"
+[ "$managed" -gt 0 ] \
+  || hosting::die "the manifest of '${release}' rendered no objects — an audit against an empty manifest would report every live object as unmanaged, which is not a measurement"
+hosting::log "manifest  ${managed} chart-managed object(s)"
+
+# ── 3. the live namespace ───────────────────────────────────────────────────────────────────────
+# One `kubectl get <kind>` per kind. A kind this cluster does not serve is SKIPPED and recorded in
+# the report (nothing of that kind can exist); anything else — Forbidden above all — is fatal,
+# because a kind the audit could not read is a kind it must not report as clean.
+KINDS="deployment statefulset daemonset cronjob job configmap secret secretproviderclass ingress service serviceaccount role rolebinding poddisruptionbudget scaledobject horizontalpodautoscaler persistentvolumeclaim networkpolicy"
+skipped=""
+: > "$work/live.jsonl"
+for kind in $KINDS; do
+  if hosting::read kubectl get "$kind" -n "$namespace" -o json > "$work/live-${kind}.json" 2>"$work/err"; then
+    jq -c '.items // []' "$work/live-${kind}.json" >> "$work/live.jsonl" \
+      || hosting::die "kubectl's listing of ${kind} in ${namespace} is not JSON"
+  else
+    err="$(tr -d '\n' < "$work/err")"
+    case "$err" in
+      *"doesn't have a resource type"*|*"the server could not find the requested resource"*|*"no matches for kind"*)
+        skipped="${skipped} ${kind}"
+        hosting::log "kind      ${kind} is not served by this cluster — skipped" ;;
+      *)
+        hosting::die "could not list ${kind} in ${namespace}: ${err}. An audit that cannot read a kind must not report it as clean — grant the hosting-operator ClusterRole get/list on it (deploy/aks/manifests/hosting-operator/operator-rbac.yaml) and re-run." ;;
+    esac
+  fi
+done
+jq -s 'add // []' "$work/live.jsonl" > "$work/live.json" \
+  || hosting::die "could not combine the live listings"
+skipped="${skipped# }"
+
+# ── 4. the detection ────────────────────────────────────────────────────────────────────────────
+if ! jq -n \
+      --slurpfile manifest "$work/manifest.json" \
+      --slurpfile live "$work/live.json" \
+      --arg namespace "$namespace" --arg release "$release" \
+      --arg deployment "$deployment" --arg container "$container" \
+      --argjson revision "$revision" --arg chart "$chart" \
+      --arg auditedAt "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+      --arg skipped "$skipped" \
+      -f "$AUDIT_JQ" > "$work/report.json" 2>"$work/err"; then
+  hosting::die "the audit could not be computed: $(sed -e 's/^jq: error (at <unknown>): //' "$work/err" | tr -d '\n')"
+fi
+
+# ── 5. the report — names, never values ─────────────────────────────────────────────────────────
+verdict="$(jq -r '.verdict' "$work/report.json")"
+count="$(jq -r '.findingCount' "$work/report.json")"
+
+say_list() {  # say_list <label> <jq expression yielding an array of strings>
+  local label="$1" expr="$2" n items
+  n="$(jq -r "${expr} | length" "$work/report.json")"
+  [ "$n" -gt 0 ] || return 0
+  items="$(jq -r "${expr} | join(\" \")" "$work/report.json")"
+  hosting::log "${label} (${n}): ${items}"
+}
+echo
+echo "Live-only configuration in ${namespace} (release ${release}, revision ${revision}):"
+say_list "env live-only         " '.envLiveOnly'
+say_list "env manifest-only     " '.envManifestOnly'
+say_list "envFrom live-only     " '.envFromLiveOnly'
+say_list "volumes live-only     " '.volumesLiveOnly'
+say_list "mounts live-only      " '.mountsLiveOnly'
+say_list "containers live-only  " '.containersLiveOnly'
+say_list "pod annotations live-only" '.podAnnotationsLiveOnly'
+jq -r '.podSpecDiffs[] | "  pod spec differs        \(.field): live=\(.live) manifest=\(.manifest)"' "$work/report.json"
+jq -r '.configMaps[] | select(.missingLive or ((.liveOnlyKeys|length) + (.manifestOnlyKeys|length) + (.differingKeys|length)) > 0)
+  | "  ConfigMap \(.name): " + (if .missingLive then "MISSING live" else "live-only keys [\(.liveOnlyKeys|join(" "))] manifest-only keys [\(.manifestOnlyKeys|join(" "))] value-differs [\(.differingKeys|join(" "))]" end)' "$work/report.json"
+jq -r '.unmanagedObjects[] | "  unmanaged \(.kind) (\(.names|length)): \(.names|join(" "))"' "$work/report.json"
+say_list "🚨 unmanaged secrets the pod reads" '.unmanagedSecrets'
+say_list "🚨 secret-shaped entries carried as PLAIN values" '.plainSecretEntries'
+say_list "kinds skipped (not served)" '.skippedKinds'
+echo
+if [ "$verdict" = "clean" ]; then
+  echo "  VERDICT: clean — the cluster runs what revision ${revision} renders, and nothing else."
+else
+  echo "  VERDICT: drift — ${count} finding(s) against revision ${revision}. Each one is configuration that lives only on the cluster; its home is a field on the Hosting/Deployment record (Systemorph/Memex#148 names them)."
+fi
+
+hosting::say audit_revision "$revision"
+hosting::say audit_findings "$count"
+hosting::say audit_verdict "$verdict"
+# The whole report, base64 so a name containing '=' or a space cannot break the key=value line.
+hosting::say audit "$(jq -c . "$work/report.json" | base64 | tr -d '\n')"

--- a/deploy/aks/operator/test/fixtures/audit/clean/hooks.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/hooks.json
@@ -1,0 +1,1 @@
+{ "apiVersion": "batch/v1", "kind": "Job", "metadata": { "name": "memex-migration", "namespace": "memex", "annotations": { "helm.sh/hook": "pre-upgrade" } }, "spec": { "template": { "spec": { "containers": [ { "name": "migration", "image": "x" } ] } } } }

--- a/deploy/aks/operator/test/fixtures/audit/clean/live/configmap.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/live/configmap.json
@@ -1,0 +1,28 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "memex-portal-config",
+        "namespace": "memex"
+      },
+      "data": {
+        "Portal__Name": "memex",
+        "Email__Enabled": "false"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "kube-root-ca.crt",
+        "namespace": "memex"
+      },
+      "data": {
+        "ca.crt": "..."
+      }
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/clean/live/deployment.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/live/deployment.json
@@ -1,0 +1,96 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "name": "memex-portal-deployment",
+        "namespace": "memex"
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "annotations": {
+              "checksum/config": "abc"
+            }
+          },
+          "spec": {
+            "serviceAccountName": "memex-portal-sa",
+            "terminationGracePeriodSeconds": 1800,
+            "containers": [
+              {
+                "name": "memex-portal",
+                "image": "meshweaver.azurecr.io/memex-portal-ai:3.0.0-rc8.ci.5123",
+                "env": [
+                  {
+                    "name": "ASPNETCORE_ENVIRONMENT",
+                    "value": "Production"
+                  },
+                  {
+                    "name": "MEMEX_DATABASENAME",
+                    "value": "memex"
+                  },
+                  {
+                    "name": "RENDERED_ONLY",
+                    "value": "1"
+                  }
+                ],
+                "envFrom": [
+                  {
+                    "configMapRef": {
+                      "name": "memex-portal-config"
+                    }
+                  },
+                  {
+                    "secretRef": {
+                      "name": "memex-kv-secrets"
+                    }
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "4",
+                    "memory": "8Gi"
+                  },
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "4Gi"
+                  }
+                },
+                "startupProbe": {
+                  "httpGet": {
+                    "path": "/health",
+                    "port": 8080
+                  },
+                  "periodSeconds": 5,
+                  "failureThreshold": 60,
+                  "timeoutSeconds": 1,
+                  "successThreshold": 1
+                },
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/data"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "name": "data",
+                "persistentVolumeClaim": {
+                  "claimName": "memex-data"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "status": {
+        "readyReplicas": 1
+      }
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/clean/live/ingress.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/live/ingress.json
@@ -1,0 +1,14 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "networking.k8s.io/v1",
+      "kind": "Ingress",
+      "metadata": {
+        "name": "memex-ingress",
+        "namespace": "memex"
+      },
+      "spec": {}
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/clean/live/job.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/live/job.json
@@ -1,0 +1,14 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "batch/v1",
+      "kind": "Job",
+      "metadata": {
+        "name": "memex-migration",
+        "namespace": "memex"
+      },
+      "spec": {}
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/clean/live/secret.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/live/secret.json
@@ -1,0 +1,40 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "memex-chart-secret",
+        "namespace": "memex"
+      },
+      "type": "Opaque",
+      "data": {
+        "x": "eA=="
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "memex-kv-secrets",
+        "namespace": "memex",
+        "labels": {
+          "secrets-store.csi.k8s.io/managed": "true"
+        }
+      },
+      "type": "Opaque",
+      "data": {}
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "sh.helm.release.v1.memex.v42",
+        "namespace": "memex"
+      },
+      "type": "helm.sh/release.v1",
+      "data": {}
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/clean/live/service.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/live/service.json
@@ -1,0 +1,20 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "name": "memex-portal-service",
+        "namespace": "memex"
+      },
+      "spec": {
+        "ports": [
+          {
+            "port": 80
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/clean/live/serviceaccount.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/live/serviceaccount.json
@@ -1,0 +1,13 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "ServiceAccount",
+      "metadata": {
+        "name": "default",
+        "namespace": "memex"
+      }
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/clean/manifest.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/manifest.json
@@ -1,0 +1,139 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "name": "memex-portal-deployment",
+        "namespace": "memex"
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "annotations": {
+              "checksum/config": "abc"
+            }
+          },
+          "spec": {
+            "serviceAccountName": "memex-portal-sa",
+            "terminationGracePeriodSeconds": 1800,
+            "containers": [
+              {
+                "name": "memex-portal",
+                "image": "meshweaver.azurecr.io/memex-portal-ai:3.0.0-rc8.ci.5000",
+                "env": [
+                  {
+                    "name": "ASPNETCORE_ENVIRONMENT",
+                    "value": "Production"
+                  },
+                  {
+                    "name": "MEMEX_DATABASENAME",
+                    "value": "memex"
+                  },
+                  {
+                    "name": "RENDERED_ONLY",
+                    "value": "1"
+                  }
+                ],
+                "envFrom": [
+                  {
+                    "configMapRef": {
+                      "name": "memex-portal-config"
+                    }
+                  },
+                  {
+                    "secretRef": {
+                      "name": "memex-kv-secrets"
+                    }
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": 4,
+                    "memory": "8Gi"
+                  },
+                  "requests": {
+                    "cpu": 1,
+                    "memory": "4Gi"
+                  }
+                },
+                "startupProbe": {
+                  "httpGet": {
+                    "path": "/health",
+                    "port": 8080
+                  },
+                  "periodSeconds": 5,
+                  "failureThreshold": 60
+                },
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/data"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "name": "data",
+                "persistentVolumeClaim": {
+                  "claimName": "memex-data"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "memex-portal-config",
+        "namespace": "memex"
+      },
+      "data": {
+        "Portal__Name": "memex",
+        "Email__Enabled": "false"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "memex-chart-secret",
+        "namespace": "memex"
+      },
+      "type": "Opaque",
+      "data": {
+        "x": "eA=="
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "name": "memex-portal-service",
+        "namespace": "memex"
+      },
+      "spec": {
+        "ports": [
+          {
+            "port": 80
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "networking.k8s.io/v1",
+      "kind": "Ingress",
+      "metadata": {
+        "name": "memex-ingress",
+        "namespace": "memex"
+      },
+      "spec": {}
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/clean/status.json
+++ b/deploy/aks/operator/test/fixtures/audit/clean/status.json
@@ -1,0 +1,8 @@
+{
+  "name": "memex",
+  "namespace": "memex",
+  "version": 42,
+  "info": { "status": "deployed" },
+  "chart": { "metadata": { "name": "memex", "version": "1.4.0" } },
+  "config": { "secrets": { "note": "the user-supplied values — the audit must never print these: value-that-must-never-print" } }
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/hooks.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/hooks.json
@@ -1,0 +1,1 @@
+{ "apiVersion": "batch/v1", "kind": "Job", "metadata": { "name": "memex-migration", "namespace": "memex", "annotations": { "helm.sh/hook": "pre-upgrade" } }, "spec": { "template": { "spec": { "containers": [ { "name": "migration", "image": "x" } ] } } } }

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/configmap.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/configmap.json
@@ -1,0 +1,19 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": { "name": "memex-portal-config", "namespace": "memex" },
+      "data": {
+        "Portal__Name": "memex",
+        "Email__Enabled": "true",
+        "Hosting__ModuleReportSecret": "rendered-shared-secret",
+        "Features__Ai__Providers__OpenRouter": "live-edited-value-that-must-never-print",
+        "Portal__ReactAppUrl": "https://app.example"
+      }
+    },
+    { "apiVersion": "v1", "kind": "ConfigMap", "metadata": { "name": "kube-root-ca.crt", "namespace": "memex" }, "data": { "ca.crt": "..." } },
+    { "apiVersion": "v1", "kind": "ConfigMap", "metadata": { "name": "hand-made-config", "namespace": "memex" }, "data": { "a": "b" } }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/cronjob.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/cronjob.json
@@ -1,0 +1,6 @@
+{
+  "kind": "List",
+  "items": [
+    { "apiVersion": "batch/v1", "kind": "CronJob", "metadata": { "name": "assembly-cache-prune", "namespace": "memex", "creationTimestamp": "2026-08-22T10:00:00Z" }, "spec": { "schedule": "0 3 * * *" } }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/deployment.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/deployment.json
@@ -1,0 +1,59 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": { "name": "memex-portal-deployment", "namespace": "memex", "labels": { "app.kubernetes.io/managed-by": "Helm" } },
+      "spec": {
+        "replicas": 2,
+        "template": {
+          "metadata": { "annotations": { "checksum/config": "abc", "kubectl.kubernetes.io/restartedAt": "2026-08-30T06:00:00Z" } },
+          "spec": {
+            "serviceAccountName": "memex-portal-sa",
+            "terminationGracePeriodSeconds": 1800,
+            "nodeSelector": { "workload": "silos" },
+            "containers": [
+              {
+                "name": "memex-portal",
+                "image": "meshweaver.azurecr.io/memex-portal-ai:3.0.0-rc8.ci.5123",
+                "env": [
+                  { "name": "ASPNETCORE_ENVIRONMENT", "value": "Production" },
+                  { "name": "MEMEX_DATABASENAME", "value": "memex" },
+                  { "name": "EMAIL__CLIENTSECRET", "value": "s3cr3t-value-that-must-never-print" },
+                  { "name": "PluginCatalog__RegistryToken", "value": "tok-value-that-must-never-print" },
+                  { "name": "PluginCatalog__RegistryUrl", "value": "https://memex.meshweaver.cloud" },
+                  { "name": "EMAIL__TENANTID", "valueFrom": { "secretKeyRef": { "name": "memex-email-secret", "key": "tenant" } } }
+                ],
+                "envFrom": [
+                  { "configMapRef": { "name": "memex-portal-config" } },
+                  { "secretRef": { "name": "memex-kv-secrets" } },
+                  { "secretRef": { "name": "memex-extra-secret" } }
+                ],
+                "resources": {},
+                "startupProbe": { "httpGet": { "path": "/health", "port": 8080 }, "periodSeconds": 5, "failureThreshold": 60, "timeoutSeconds": 1, "successThreshold": 1 },
+                "volumeMounts": [
+                  { "name": "data", "mountPath": "/data" },
+                  { "name": "memex-content", "mountPath": "/mnt/content" }
+                ]
+              },
+              { "name": "node-gate", "image": "node:22", "env": [ { "name": "GATE_API_KEY", "value": "gate-key-value-that-must-never-print" } ] },
+              { "name": "python-gate", "image": "python:3.12" }
+            ],
+            "volumes": [
+              { "name": "data", "persistentVolumeClaim": { "claimName": "memex-data" } },
+              { "name": "memex-content", "persistentVolumeClaim": { "claimName": "memex-content" } }
+            ]
+          }
+        }
+      },
+      "status": { "readyReplicas": 2 }
+    },
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": { "name": "portal-next-deployment", "namespace": "memex" },
+      "spec": { "replicas": 1, "template": { "spec": { "containers": [ { "name": "next", "image": "x" } ] } } }
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/deployment.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/deployment.json
@@ -4,56 +4,169 @@
     {
       "apiVersion": "apps/v1",
       "kind": "Deployment",
-      "metadata": { "name": "memex-portal-deployment", "namespace": "memex", "labels": { "app.kubernetes.io/managed-by": "Helm" } },
+      "metadata": {
+        "name": "memex-portal-deployment",
+        "namespace": "memex",
+        "labels": {
+          "app.kubernetes.io/managed-by": "Helm"
+        }
+      },
       "spec": {
         "replicas": 2,
         "template": {
-          "metadata": { "annotations": { "checksum/config": "abc", "kubectl.kubernetes.io/restartedAt": "2026-08-30T06:00:00Z" } },
+          "metadata": {
+            "annotations": {
+              "checksum/config": "abc",
+              "kubectl.kubernetes.io/restartedAt": "2026-08-30T06:00:00Z"
+            }
+          },
           "spec": {
             "serviceAccountName": "memex-portal-sa",
             "terminationGracePeriodSeconds": 1800,
-            "nodeSelector": { "workload": "silos" },
+            "nodeSelector": {
+              "workload": "silos"
+            },
             "containers": [
               {
                 "name": "memex-portal",
                 "image": "meshweaver.azurecr.io/memex-portal-ai:3.0.0-rc8.ci.5123",
                 "env": [
-                  { "name": "ASPNETCORE_ENVIRONMENT", "value": "Production" },
-                  { "name": "MEMEX_DATABASENAME", "value": "memex" },
-                  { "name": "EMAIL__CLIENTSECRET", "value": "s3cr3t-value-that-must-never-print" },
-                  { "name": "PluginCatalog__RegistryToken", "value": "tok-value-that-must-never-print" },
-                  { "name": "PluginCatalog__RegistryUrl", "value": "https://memex.meshweaver.cloud" },
-                  { "name": "EMAIL__TENANTID", "valueFrom": { "secretKeyRef": { "name": "memex-email-secret", "key": "tenant" } } }
+                  {
+                    "name": "ASPNETCORE_ENVIRONMENT",
+                    "value": "Production"
+                  },
+                  {
+                    "name": "MEMEX_DATABASENAME",
+                    "value": "memex"
+                  },
+                  {
+                    "name": "EMAIL__CLIENTSECRET",
+                    "value": "s3cr3t-value-that-must-never-print"
+                  },
+                  {
+                    "name": "PluginCatalog__RegistryToken",
+                    "value": "tok-value-that-must-never-print"
+                  },
+                  {
+                    "name": "PluginCatalog__RegistryUrl",
+                    "value": "https://memex.meshweaver.cloud"
+                  },
+                  {
+                    "name": "EMAIL__TENANTID",
+                    "valueFrom": {
+                      "secretKeyRef": {
+                        "name": "memex-email-secret",
+                        "key": "tenant"
+                      }
+                    }
+                  }
                 ],
                 "envFrom": [
-                  { "configMapRef": { "name": "memex-portal-config" } },
-                  { "secretRef": { "name": "memex-kv-secrets" } },
-                  { "secretRef": { "name": "memex-extra-secret" } }
+                  {
+                    "configMapRef": {
+                      "name": "memex-portal-config"
+                    }
+                  },
+                  {
+                    "secretRef": {
+                      "name": "memex-kv-secrets"
+                    }
+                  },
+                  {
+                    "secretRef": {
+                      "name": "memex-extra-secret"
+                    }
+                  }
                 ],
                 "resources": {},
-                "startupProbe": { "httpGet": { "path": "/health", "port": 8080 }, "periodSeconds": 5, "failureThreshold": 60, "timeoutSeconds": 1, "successThreshold": 1 },
+                "startupProbe": {
+                  "httpGet": {
+                    "path": "/health",
+                    "port": 8080
+                  },
+                  "periodSeconds": 5,
+                  "failureThreshold": 60,
+                  "timeoutSeconds": 1,
+                  "successThreshold": 1
+                },
                 "volumeMounts": [
-                  { "name": "data", "mountPath": "/data" },
-                  { "name": "memex-content", "mountPath": "/mnt/content" }
+                  {
+                    "name": "data",
+                    "mountPath": "/data"
+                  },
+                  {
+                    "name": "memex-content",
+                    "mountPath": "/mnt/content"
+                  }
+                ],
+                "lifecycle": {
+                  "preStop": {
+                    "exec": {
+                      "command": [
+                        "sh",
+                        "-c",
+                        "lifecycle-cmd-that-must-never-print"
+                      ]
+                    }
+                  }
+                }
+              },
+              {
+                "name": "node-gate",
+                "image": "node:22",
+                "env": [
+                  {
+                    "name": "GATE_API_KEY",
+                    "value": "gate-key-value-that-must-never-print"
+                  }
                 ]
               },
-              { "name": "node-gate", "image": "node:22", "env": [ { "name": "GATE_API_KEY", "value": "gate-key-value-that-must-never-print" } ] },
-              { "name": "python-gate", "image": "python:3.12" }
+              {
+                "name": "python-gate",
+                "image": "python:3.12"
+              }
             ],
             "volumes": [
-              { "name": "data", "persistentVolumeClaim": { "claimName": "memex-data" } },
-              { "name": "memex-content", "persistentVolumeClaim": { "claimName": "memex-content" } }
+              {
+                "name": "data",
+                "persistentVolumeClaim": {
+                  "claimName": "memex-data"
+                }
+              },
+              {
+                "name": "memex-content",
+                "persistentVolumeClaim": {
+                  "claimName": "memex-content"
+                }
+              }
             ]
           }
         }
       },
-      "status": { "readyReplicas": 2 }
+      "status": {
+        "readyReplicas": 2
+      }
     },
     {
       "apiVersion": "apps/v1",
       "kind": "Deployment",
-      "metadata": { "name": "portal-next-deployment", "namespace": "memex" },
-      "spec": { "replicas": 1, "template": { "spec": { "containers": [ { "name": "next", "image": "x" } ] } } }
+      "metadata": {
+        "name": "portal-next-deployment",
+        "namespace": "memex"
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "spec": {
+            "containers": [
+              {
+                "name": "next",
+                "image": "x"
+              }
+            ]
+          }
+        }
+      }
     }
   ]
 }

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/ingress.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/ingress.json
@@ -1,0 +1,7 @@
+{
+  "kind": "List",
+  "items": [
+    { "apiVersion": "networking.k8s.io/v1", "kind": "Ingress", "metadata": { "name": "memex-ingress", "namespace": "memex" }, "spec": {} },
+    { "apiVersion": "networking.k8s.io/v1", "kind": "Ingress", "metadata": { "name": "brand-site", "namespace": "memex" }, "spec": {} }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/job.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/job.json
@@ -1,0 +1,7 @@
+{
+  "kind": "List",
+  "items": [
+    { "apiVersion": "batch/v1", "kind": "Job", "metadata": { "name": "assembly-cache-prune-29123456", "namespace": "memex", "ownerReferences": [ { "kind": "CronJob", "name": "assembly-cache-prune" } ] }, "spec": {} },
+    { "apiVersion": "batch/v1", "kind": "Job", "metadata": { "name": "memex-migration", "namespace": "memex" }, "spec": {} }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/persistentvolumeclaim.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/persistentvolumeclaim.json
@@ -1,0 +1,7 @@
+{
+  "kind": "List",
+  "items": [
+    { "apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": { "name": "memex-data", "namespace": "memex" }, "spec": {} },
+    { "apiVersion": "v1", "kind": "PersistentVolumeClaim", "metadata": { "name": "memex-content", "namespace": "memex" }, "spec": {} }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/secret.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/secret.json
@@ -1,0 +1,11 @@
+{
+  "kind": "List",
+  "items": [
+    { "apiVersion": "v1", "kind": "Secret", "metadata": { "name": "memex-chart-secret", "namespace": "memex" }, "type": "Opaque", "data": { "x": "eA==" } },
+    { "apiVersion": "v1", "kind": "Secret", "metadata": { "name": "memex-kv-secrets", "namespace": "memex", "labels": { "secrets-store.csi.k8s.io/managed": "true" }, "ownerReferences": [ { "kind": "Pod", "name": "memex-portal-deployment-abc" } ] }, "type": "Opaque", "data": {} },
+    { "apiVersion": "v1", "kind": "Secret", "metadata": { "name": "memex-email-secret", "namespace": "memex" }, "type": "Opaque", "data": { "tenant": "dGVuYW50" } },
+    { "apiVersion": "v1", "kind": "Secret", "metadata": { "name": "sh.helm.release.v1.memex.v42", "namespace": "memex" }, "type": "helm.sh/release.v1", "data": {} },
+    { "apiVersion": "v1", "kind": "Secret", "metadata": { "name": "memex-portal-sa-token", "namespace": "memex" }, "type": "kubernetes.io/service-account-token", "data": {} },
+    { "apiVersion": "v1", "kind": "Secret", "metadata": { "name": "memex-tls", "namespace": "memex" }, "type": "kubernetes.io/tls", "data": {} }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/secretproviderclass.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/secretproviderclass.json
@@ -1,0 +1,6 @@
+{
+  "kind": "List",
+  "items": [
+    { "apiVersion": "secrets-store.csi.x-k8s.io/v1", "kind": "SecretProviderClass", "metadata": { "name": "memex-kv", "namespace": "memex" }, "spec": { "provider": "azure" } }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/service.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/service.json
@@ -1,0 +1,7 @@
+{
+  "kind": "List",
+  "items": [
+    { "apiVersion": "v1", "kind": "Service", "metadata": { "name": "memex-portal-service", "namespace": "memex" }, "spec": { "ports": [ { "port": 80 } ] } },
+    { "apiVersion": "v1", "kind": "Service", "metadata": { "name": "portal-next-service", "namespace": "memex" }, "spec": { "ports": [ { "port": 3000 } ] } }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/live/serviceaccount.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/live/serviceaccount.json
@@ -1,0 +1,7 @@
+{
+  "kind": "List",
+  "items": [
+    { "apiVersion": "v1", "kind": "ServiceAccount", "metadata": { "name": "default", "namespace": "memex" } },
+    { "apiVersion": "v1", "kind": "ServiceAccount", "metadata": { "name": "memex-portal-sa", "namespace": "memex" } }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/manifest.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/manifest.json
@@ -1,0 +1,54 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": { "name": "memex-portal-deployment", "namespace": "memex" },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": { "annotations": { "checksum/config": "abc" } },
+          "spec": {
+            "serviceAccountName": "memex-portal-sa",
+            "terminationGracePeriodSeconds": 1800,
+            "containers": [
+              {
+                "name": "memex-portal",
+                "image": "meshweaver.azurecr.io/memex-portal-ai:3.0.0-rc8.ci.5000",
+                "env": [
+                  { "name": "ASPNETCORE_ENVIRONMENT", "value": "Production" },
+                  { "name": "MEMEX_DATABASENAME", "value": "memex" },
+                  { "name": "RENDERED_ONLY", "value": "1" }
+                ],
+                "envFrom": [
+                  { "configMapRef": { "name": "memex-portal-config" } },
+                  { "secretRef": { "name": "memex-kv-secrets" } }
+                ],
+                "resources": { "limits": { "cpu": 4, "memory": "8Gi" }, "requests": { "cpu": 1, "memory": "4Gi" } },
+                "startupProbe": { "httpGet": { "path": "/health", "port": 8080 }, "periodSeconds": 5, "failureThreshold": 60 },
+                "volumeMounts": [ { "name": "data", "mountPath": "/data" } ]
+              }
+            ],
+            "volumes": [ { "name": "data", "persistentVolumeClaim": { "claimName": "memex-data" } } ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": { "name": "memex-portal-config", "namespace": "memex" },
+      "data": { "Portal__Name": "memex", "Email__Enabled": "false", "Hosting__ModuleReportSecret": "rendered-shared-secret" }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": { "name": "memex-chart-secret", "namespace": "memex" },
+      "type": "Opaque",
+      "data": { "x": "eA==" }
+    },
+    { "apiVersion": "v1", "kind": "Service", "metadata": { "name": "memex-portal-service", "namespace": "memex" }, "spec": { "ports": [ { "port": 80 } ] } },
+    { "apiVersion": "networking.k8s.io/v1", "kind": "Ingress", "metadata": { "name": "memex-ingress", "namespace": "memex" }, "spec": {} }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/drift/status.json
+++ b/deploy/aks/operator/test/fixtures/audit/drift/status.json
@@ -1,0 +1,8 @@
+{
+  "name": "memex",
+  "namespace": "memex",
+  "version": 42,
+  "info": { "status": "deployed" },
+  "chart": { "metadata": { "name": "memex", "version": "1.4.0" } },
+  "config": { "secrets": { "note": "the user-supplied values — the audit must never print these: value-that-must-never-print" } }
+}

--- a/deploy/aks/operator/test/fixtures/audit/forbidden/live/configmap.json
+++ b/deploy/aks/operator/test/fixtures/audit/forbidden/live/configmap.json
@@ -1,0 +1,28 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "memex-portal-config",
+        "namespace": "memex"
+      },
+      "data": {
+        "Portal__Name": "memex",
+        "Email__Enabled": "false"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "kube-root-ca.crt",
+        "namespace": "memex"
+      },
+      "data": {
+        "ca.crt": "..."
+      }
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/forbidden/live/deployment.json
+++ b/deploy/aks/operator/test/fixtures/audit/forbidden/live/deployment.json
@@ -1,0 +1,96 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "name": "memex-portal-deployment",
+        "namespace": "memex"
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "annotations": {
+              "checksum/config": "abc"
+            }
+          },
+          "spec": {
+            "serviceAccountName": "memex-portal-sa",
+            "terminationGracePeriodSeconds": 1800,
+            "containers": [
+              {
+                "name": "memex-portal",
+                "image": "meshweaver.azurecr.io/memex-portal-ai:3.0.0-rc8.ci.5123",
+                "env": [
+                  {
+                    "name": "ASPNETCORE_ENVIRONMENT",
+                    "value": "Production"
+                  },
+                  {
+                    "name": "MEMEX_DATABASENAME",
+                    "value": "memex"
+                  },
+                  {
+                    "name": "RENDERED_ONLY",
+                    "value": "1"
+                  }
+                ],
+                "envFrom": [
+                  {
+                    "configMapRef": {
+                      "name": "memex-portal-config"
+                    }
+                  },
+                  {
+                    "secretRef": {
+                      "name": "memex-kv-secrets"
+                    }
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": "4",
+                    "memory": "8Gi"
+                  },
+                  "requests": {
+                    "cpu": "1",
+                    "memory": "4Gi"
+                  }
+                },
+                "startupProbe": {
+                  "httpGet": {
+                    "path": "/health",
+                    "port": 8080
+                  },
+                  "periodSeconds": 5,
+                  "failureThreshold": 60,
+                  "timeoutSeconds": 1,
+                  "successThreshold": 1
+                },
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/data"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "name": "data",
+                "persistentVolumeClaim": {
+                  "claimName": "memex-data"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "status": {
+        "readyReplicas": 1
+      }
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/forbidden/manifest.json
+++ b/deploy/aks/operator/test/fixtures/audit/forbidden/manifest.json
@@ -1,0 +1,139 @@
+{
+  "kind": "List",
+  "items": [
+    {
+      "apiVersion": "apps/v1",
+      "kind": "Deployment",
+      "metadata": {
+        "name": "memex-portal-deployment",
+        "namespace": "memex"
+      },
+      "spec": {
+        "replicas": 1,
+        "template": {
+          "metadata": {
+            "annotations": {
+              "checksum/config": "abc"
+            }
+          },
+          "spec": {
+            "serviceAccountName": "memex-portal-sa",
+            "terminationGracePeriodSeconds": 1800,
+            "containers": [
+              {
+                "name": "memex-portal",
+                "image": "meshweaver.azurecr.io/memex-portal-ai:3.0.0-rc8.ci.5000",
+                "env": [
+                  {
+                    "name": "ASPNETCORE_ENVIRONMENT",
+                    "value": "Production"
+                  },
+                  {
+                    "name": "MEMEX_DATABASENAME",
+                    "value": "memex"
+                  },
+                  {
+                    "name": "RENDERED_ONLY",
+                    "value": "1"
+                  }
+                ],
+                "envFrom": [
+                  {
+                    "configMapRef": {
+                      "name": "memex-portal-config"
+                    }
+                  },
+                  {
+                    "secretRef": {
+                      "name": "memex-kv-secrets"
+                    }
+                  }
+                ],
+                "resources": {
+                  "limits": {
+                    "cpu": 4,
+                    "memory": "8Gi"
+                  },
+                  "requests": {
+                    "cpu": 1,
+                    "memory": "4Gi"
+                  }
+                },
+                "startupProbe": {
+                  "httpGet": {
+                    "path": "/health",
+                    "port": 8080
+                  },
+                  "periodSeconds": 5,
+                  "failureThreshold": 60
+                },
+                "volumeMounts": [
+                  {
+                    "name": "data",
+                    "mountPath": "/data"
+                  }
+                ]
+              }
+            ],
+            "volumes": [
+              {
+                "name": "data",
+                "persistentVolumeClaim": {
+                  "claimName": "memex-data"
+                }
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "ConfigMap",
+      "metadata": {
+        "name": "memex-portal-config",
+        "namespace": "memex"
+      },
+      "data": {
+        "Portal__Name": "memex",
+        "Email__Enabled": "false"
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Secret",
+      "metadata": {
+        "name": "memex-chart-secret",
+        "namespace": "memex"
+      },
+      "type": "Opaque",
+      "data": {
+        "x": "eA=="
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "name": "memex-portal-service",
+        "namespace": "memex"
+      },
+      "spec": {
+        "ports": [
+          {
+            "port": 80
+          }
+        ]
+      }
+    },
+    {
+      "apiVersion": "networking.k8s.io/v1",
+      "kind": "Ingress",
+      "metadata": {
+        "name": "memex-ingress",
+        "namespace": "memex"
+      },
+      "spec": {}
+    }
+  ]
+}

--- a/deploy/aks/operator/test/fixtures/audit/forbidden/status.json
+++ b/deploy/aks/operator/test/fixtures/audit/forbidden/status.json
@@ -1,0 +1,8 @@
+{
+  "name": "memex",
+  "namespace": "memex",
+  "version": 42,
+  "info": { "status": "deployed" },
+  "chart": { "metadata": { "name": "memex", "version": "1.4.0" } },
+  "config": { "secrets": { "note": "the user-supplied values — the audit must never print these: value-that-must-never-print" } }
+}

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -185,6 +185,84 @@ case "$out" in *"DRY-RUN would run"*) ok "a dry run narrates what it would do" ;
   *) bad "a dry run narrates" "said: ${out}" ;; esac
 
 echo
+echo "── hosting-audit: what lives only on the cluster ─────────────────"
+# The stubs are NOT mocks of helm/kubectl — they answer the audit's read-only calls from fixture
+# files so the DETECTION can be asserted without a cluster. What a fixture cannot prove (that a
+# real `helm get manifest | kubectl apply --dry-run=client` round-trips YAML) is proven by the
+# first real audit, same as every other command here.
+STUBS="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/stubs" && pwd)"
+FIXTURES="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/fixtures/audit" && pwd)"
+
+refuses "audit needs --namespace"           "missing required flag --namespace" hosting-audit --release r
+refuses "audit needs --release"             "missing required flag --release"   hosting-audit --namespace n
+refuses "audit rejects unknown flags"       "unknown argument"                  hosting-audit --namespace n --release r --nope 1
+refuses_hard "audit namespace with a metacharacter" "is not a plain name" \
+  hosting-audit --namespace 'n; kubectl delete ns --all' --release r
+refuses "audit refuses when the release does not exist" "no helm release" \
+  env PATH="$STUBS:$PATH" HOSTING_AUDIT_FIXTURE="$FIXTURES/missing" hosting-audit --namespace memex --release memex
+# 🚨 A kind the audit may not LIST is a kind it must not report as clean — Forbidden is fatal and
+# names the ClusterRole to widen, it never degrades to "nothing of that kind".
+refuses "audit refuses a kind it may not read" "ClusterRole" \
+  env PATH="$STUBS:$PATH" HOSTING_AUDIT_FIXTURE="$FIXTURES/forbidden" hosting-audit --namespace memex --release memex
+
+# The drifting namespace: every category detected, by NAME, and no VALUE ever printed.
+out="$(env PATH="$STUBS:$PATH" HOSTING_AUDIT_FIXTURE="$FIXTURES/drift" \
+  hosting-audit --namespace memex --release memex 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "a drifting audit still exits 0 (drift is a finding, not a failed run)" \
+  || bad "a drifting audit exits 0" "exited ${rc}: ${out}"
+case "$out" in *"::hosting:: audit_verdict=drift"*) ok "drift is the verdict" ;;
+  *) bad "drift is the verdict" "said: ${out}" ;; esac
+report="$(printf '%s\n' "$out" | sed -n 's/^::hosting:: audit=//p' | tail -1 | base64 -d 2>/dev/null)"
+if [ -z "$report" ]; then
+  bad "the report rides an ::hosting:: audit= line" "no decodable audit= line in: ${out}"
+else
+  ok "the report rides an ::hosting:: audit= line"
+  check_report() {  # check_report <what> <jq predicate over the report>
+    if printf '%s' "$report" | jq -e "$2" >/dev/null 2>&1; then ok "$1"; else
+      bad "$1" "predicate '$2' false for: $(printf '%s' "$report" | jq -c . 2>/dev/null)"; fi
+  }
+  check_report "env patches are found by name"       '.envLiveOnly | index("PluginCatalog__RegistryToken") and index("EMAIL__CLIENTSECRET")'
+  check_report "a manifest-only env is the same edit" '.envManifestOnly == ["RENDERED_ONLY"]'
+  check_report "envFrom / volumes / mounts patches"   '(.envFromLiveOnly == ["memex-extra-secret"]) and (.volumesLiveOnly == ["memex-content"]) and (.mountsLiveOnly == ["/mnt/content"])'
+  check_report "sidecar containers are found"         '.containersLiveOnly == ["node-gate","python-gate"]'
+  check_report "pod-spec patches are found"           '[.podSpecDiffs[].field] | index(".spec.replicas") and index(".spec.template.spec.nodeSelector")'
+  check_report "live-edited ConfigMap keys are found" '.configMaps[0] | (.liveOnlyKeys | index("Portal__ReactAppUrl")) and (.differingKeys == ["Email__Enabled"])'
+  check_report "unmanaged objects group by kind"      '.unmanagedObjects | map(select(.kind == "CronJob")) | .[0].names == ["assembly-cache-prune"]'
+  check_report "owned/helm/SA-token/CSI objects are excluded" '[.unmanagedObjects[].names[]] | (index("assembly-cache-prune-29123456") or index("sh.helm.release.v1.memex.v42") or index("memex-kv-secrets") or index("memex-portal-sa-token") or index("default")) | not'
+  check_report "the hook Job is chart-managed"        '[.unmanagedObjects[].names[]] | index("memex-migration") | not'
+  check_report "unmanaged secrets the pod reads"      '.unmanagedSecrets == ["memex-email-secret","memex-extra-secret"]'
+  check_report "plain secret-shaped entries, all containers" '.plainSecretEntries | index("env:memex-portal:PluginCatalog__RegistryToken") and index("env:node-gate:GATE_API_KEY") and index("configmap:memex-portal-config/Hosting__ModuleReportSecret")'
+  check_report "the audited revision is recorded"     '.helmRevision == 42 and .managedObjectCount == 6'
+fi
+# 🚨 The most important assertion of the section: names only. The fixture's secret VALUES must
+# never appear anywhere in the output — the report lands on a node a page renders.
+case "$out" in
+  *"must-never-print"*) bad "the audit never prints a value" "a fixture secret VALUE leaked: ${out}" ;;
+  *) ok "the audit never prints a value" ;;
+esac
+
+# The clean namespace: verdict clean, zero findings, and a kind the cluster does not serve is
+# recorded as skipped — never silently absent, never a finding.
+out="$(env PATH="$STUBS:$PATH" HOSTING_AUDIT_FIXTURE="$FIXTURES/clean" \
+  hosting-audit --namespace memex --release memex 2>&1)"; rc=$?
+[ "$rc" -eq 0 ] && ok "a clean audit exits 0" || bad "a clean audit exits 0" "exited ${rc}: ${out}"
+case "$out" in *"::hosting:: audit_verdict=clean"*) ok "clean is the verdict when live matches the manifest" ;;
+  *) bad "clean is the verdict" "said: ${out}" ;; esac
+case "$out" in *"::hosting:: audit_findings=0"*) ok "…with zero findings" ;;
+  *) bad "…with zero findings" "said: ${out}" ;; esac
+report="$(printf '%s\n' "$out" | sed -n 's/^::hosting:: audit=//p' | tail -1 | base64 -d 2>/dev/null)"
+if printf '%s' "$report" | jq -e '.skippedKinds == ["scaledobject"]' >/dev/null 2>&1; then
+  ok "an unserved kind is recorded as skipped, not silently absent"
+else
+  bad "an unserved kind is recorded as skipped" "report: $(printf '%s' "$report" | jq -c .skippedKinds 2>/dev/null)"
+fi
+
+# Read-only: a dry run audits for real — same report, same verdict.
+emits "a dry run still audits (read-only)" "::hosting:: audit_verdict=clean" \
+  env HOSTING_DRY_RUN=true PATH="$STUBS:$PATH" HOSTING_AUDIT_FIXTURE="$FIXTURES/clean" \
+  hosting-audit --namespace memex --release memex
+
+echo
 echo "─────────────────────────────────────────────────────────────────"
 echo "${pass} passed, ${fail} failed"
 [ "$fail" -eq 0 ] || exit 1

--- a/deploy/aks/operator/test/run-tests.sh
+++ b/deploy/aks/operator/test/run-tests.sh
@@ -226,6 +226,7 @@ else
   check_report "envFrom / volumes / mounts patches"   '(.envFromLiveOnly == ["memex-extra-secret"]) and (.volumesLiveOnly == ["memex-content"]) and (.mountsLiveOnly == ["/mnt/content"])'
   check_report "sidecar containers are found"         '.containersLiveOnly == ["node-gate","python-gate"]'
   check_report "pod-spec patches are found"           '[.podSpecDiffs[].field] | index(".spec.replicas") and index(".spec.template.spec.nodeSelector")'
+  check_report "a lifecycle patch is reported with its strings REDACTED" '(.podSpecDiffs | map(select(.field | endswith(".lifecycle")))) as $l | ($l | length) == 1 and ($l[0].live | contains("…")) and (($l[0].live | contains("lifecycle-cmd")) | not)'
   check_report "live-edited ConfigMap keys are found" '.configMaps[0] | (.liveOnlyKeys | index("Portal__ReactAppUrl")) and (.differingKeys == ["Email__Enabled"])'
   check_report "unmanaged objects group by kind"      '.unmanagedObjects | map(select(.kind == "CronJob")) | .[0].names == ["assembly-cache-prune"]'
   check_report "owned/helm/SA-token/CSI objects are excluded" '[.unmanagedObjects[].names[]] | (index("assembly-cache-prune-29123456") or index("sh.helm.release.v1.memex.v42") or index("memex-kv-secrets") or index("memex-portal-sa-token") or index("default")) | not'

--- a/deploy/aks/operator/test/stubs/helm
+++ b/deploy/aks/operator/test/stubs/helm
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# A stand-in `helm` for test/run-tests.sh — answers hosting-audit's three read-only calls from a
+# fixture directory ($HOSTING_AUDIT_FIXTURE). It is NOT a mock of helm: it asserts nothing about
+# what helm does, it only lets the detection run against a known manifest without a cluster.
+#
+#   helm status  <rel> -n <ns> -o json   → $FIXTURE/status.json   (absent → "release: not found")
+#   helm get manifest <rel> -n <ns>      → $FIXTURE/manifest.json (already objects — see kubectl stub)
+#   helm get hooks    <rel> -n <ns>      → $FIXTURE/hooks.json, or nothing
+set -uo pipefail
+fixture="${HOSTING_AUDIT_FIXTURE:?the helm stub needs HOSTING_AUDIT_FIXTURE}"
+case "${1:-} ${2:-}" in
+  "status "*)
+    [ -f "$fixture/status.json" ] || { echo "Error: release: not found" >&2; exit 1; }
+    cat "$fixture/status.json" ;;
+  "get manifest")
+    [ -f "$fixture/manifest.json" ] || { echo "Error: release: not found" >&2; exit 1; }
+    cat "$fixture/manifest.json" ;;
+  "get hooks")
+    [ -f "$fixture/hooks.json" ] && cat "$fixture/hooks.json"
+    exit 0 ;;
+  *) echo "helm stub: unexpected invocation: $*" >&2; exit 1 ;;
+esac

--- a/deploy/aks/operator/test/stubs/kubectl
+++ b/deploy/aks/operator/test/stubs/kubectl
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# A stand-in `kubectl` for test/run-tests.sh — answers hosting-audit's two read-only call shapes
+# from a fixture directory ($HOSTING_AUDIT_FIXTURE). Not a mock of kubectl: the real pipeline turns
+# helm's YAML into objects with `kubectl apply --dry-run=client -o json`; here the fixture manifest
+# is already JSON objects and the "apply" passes stdin through, so what is tested is the detection
+# and the contract lines, not YAML parsing.
+#
+#   kubectl apply --dry-run=client -o json -f -   → stdin, unchanged
+#   kubectl get <kind> -n <ns> -o json            → $FIXTURE/live/<kind>.json, else an empty list
+#       $FIXTURE/live/<kind>.forbidden  present   → "Error from server (Forbidden)" on stderr, exit 1
+#       $FIXTURE/live/<kind>.notype     present   → "doesn't have a resource type" on stderr, exit 1
+set -uo pipefail
+fixture="${HOSTING_AUDIT_FIXTURE:?the kubectl stub needs HOSTING_AUDIT_FIXTURE}"
+case "${1:-}" in
+  apply) cat ;;
+  get)
+    kind="${2:-}"
+    if [ -f "$fixture/live/${kind}.forbidden" ]; then
+      echo "Error from server (Forbidden): ${kind} is forbidden: User \"system:serviceaccount:memex-ops:hosting-operator\" cannot list resource \"${kind}\"" >&2
+      exit 1
+    fi
+    if [ -f "$fixture/live/${kind}.notype" ]; then
+      echo "error: the server doesn't have a resource type \"${kind}\"" >&2
+      exit 1
+    fi
+    if [ -f "$fixture/live/${kind}.json" ]; then cat "$fixture/live/${kind}.json"; else echo '{"items":[]}'; fi ;;
+  *) echo "kubectl stub: unexpected invocation: $*" >&2; exit 1 ;;
+esac

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-the-cluster-can-no-longer-hide-configuration.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-the-cluster-can-no-longer-hide-configuration.md
@@ -1,0 +1,27 @@
+---
+Name: The cluster can no longer hide configuration
+Category: Feature
+Description: The hosting operator gains hosting-audit — one read-only command that diffs a namespace against its helm release's manifest and reports, by name and never by value, everything that lives only on the cluster: env patches, live-edited ConfigMap keys, sidecars, unmanaged objects, secrets nothing renders, and secret-shaped names carried as plain values.
+Icon: ArrowSyncCheckmark
+Order: -20260830
+---
+
+# The cluster can no longer hide configuration
+
+A `kubectl set env`, a live-edited ConfigMap key, a hand-applied CronJob — none of it fails a
+deploy, because `helm upgrade` preserves a live-edited key and never touches an object it does not
+own. It fails months later instead: the memex portal crashed at boot because its Email section
+existed twice — the chart's ConfigMap defaults and a cluster-only secret patched onto the
+Deployment as env — and .NET picks the winner at random per pod start.
+
+The operator image now carries `hosting-audit`. It takes the truth from `helm get manifest` +
+`helm get hooks` and reports what the namespace runs that no repository renders: the portal
+Deployment's live-only env, envFrom, volumes, mounts, containers and pod-spec patches; the chart
+ConfigMaps' live-only and value-differing keys; objects the chart does not own; secrets the pod
+reads that nothing renders; and entries whose name looks like a secret carried as a plain value.
+Names only — a value is never printed, because some of them are the secrets being hunted.
+
+The verdict is `clean` or `drift`, emitted with the full report for the Hosting plugin's new
+`Audit` instance action to record on the mesh. The command refuses rather than guessing: no
+release, no live portal, or a kind it is not permitted to list each fail the run — an audit that
+could not read a kind must not report it as clean.


### PR DESCRIPTION
## What

The operator image gains **`hosting-audit`** — one read-only command that diffs an instance's namespace against its helm release's manifest (`helm get manifest` + `helm get hooks`, turned into objects by `kubectl apply --dry-run=client`) and reports everything that lives ONLY on the cluster, **by name and never by value**:

- the portal Deployment's live-only (and manifest-only) env names, envFrom sources, volumes, mounts, sidecar containers, pod annotations, and the pod-spec fields a `kubectl patch` reaches (replicas — unless an autoscaler owns them — nodeSelector, tolerations, affinity, SA, grace period, the portal container's resources/lifecycle/startup-probe budget);
- the chart ConfigMaps' live-only, manifest-only and **value-differing** keys (values compared on the cluster, only key names leave it);
- live objects the chart does not own, grouped by kind (owned objects, helm release records, SA tokens, CSI-synced secrets and Kubernetes' own furniture excluded);
- Secrets the live pod reads that are neither chart-managed nor CSI-synced;
- entries whose name matches `Token|Secret|Key|Password` carried as a **plain value** (inline env on any container, or a chart ConfigMap key).

The verdict (`clean`/`drift`) plus the full typed report ride `::hosting:: audit=<base64 JSON>` for the Hosting plugin's new `Audit` instance action (MeshWeaver.Plugins PR, follows this one) to record on the mesh. Drift exits 0 — a finding, not a failed run. **Could not measure refuses**: no release, no live portal Deployment, or a kind the ClusterRole may not list each fail the run, because a kind the audit could not read must not be reported as clean.

## Why

The memex portal crashed at boot because its Email section existed twice — chart ConfigMap defaults vs a cluster-only secret patched as env — and .NET picks the winner at random per pod start. `helm upgrade` preserves live-edited ConfigMap keys and never touches objects it does not own, so this class of drift never fails a deploy; it fails months later as an outage. Systemorph/Memex#148 is the hand-measured inventory (25 env patches, 10 live-edited keys, sidecars, a plain-text registry token in the pod spec); this is the machinery that keeps it measured. The rule enforced: **nothing lives only on the cluster** — every value is a typed field on the `Hosting/Deployment` record, rendered by the chart; secrets are Key Vault names.

## How it is proven

- `test/run-tests.sh` gains 26 audit cases run against helm/kubectl **stubs** over fixture manifests: a drifting namespace (every category found by name), a clean one (verdict clean, an unserved kind recorded as skipped — never silently absent), a missing release (refused), a Forbidden kind (refused naming the ClusterRole), injection-shaped names (refused before anything runs), and the one that matters most: **no fixture secret value ever appears in the output**. 65/65 green locally.
- The CI gate updates its tracked-file counts (18), the plan-command list (`hosting-audit`), asserts `_audit.jq` ships and parses (jq exit 3 = red), and the image check now requires `jq` (present in the Azure Linux base; the Dockerfile pins it via tdnf anyway).
- The operator ClusterRole gains **read-only** list/get on the audited kinds (daemonsets, PDBs, HPAs, ScaledObjects, network policies, roles/rolebindings) — an audit measures, it never reconciles. Re-applying the RBAC on the cluster is a separate, deliberate ops step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)