### PR TITLE
fix(#2635): teardown order — hub scopes close AFTER the drains; content collections die with their hub; fate trails outlive the requester's timeout

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -542,8 +542,24 @@ jobs:
         if: ${{ matrix.entry.test != false }}
         env:
           PROJECT: ${{ matrix.entry.project }}
+          # 🚨 THE TRAIL A FLAKE LEAVES. A red here on a diff that cannot reach the module is a
+          # timing failure of the mesh under the runner's load, and the failure block alone cannot
+          # say where the flow stopped (seven distinct AI.Test failures, one sentence each —
+          # MeshWeaver.Plugins#941). So the run WRITES the evidence and the step below keeps it:
+          #   • per-test file logs (MESHWEAVER_TEST_FILE_LOGS — Warning level, one file per test);
+          #   • the MonolithMeshTestBase phase trace (/tmp/meshweaver-test-trace.log: INIT/TEST/
+          #     DISPOSE phases per class, pid-tagged — a crash's last lines name the class);
+          #   • the teardown-straggler captures (written beside the test assembly);
+          #   • a mini dump when the host dies on a signal (exit 139 = SIGSEGV = use-after-unload).
+          # None of it changes timing: the file logs are the same records the console gets, and
+          # the dump is written only by a crash.
+          MESHWEAVER_TEST_FILE_LOGS: "1"
+          DOTNET_DbgEnableMiniDump: "1"
+          DOTNET_DbgMiniDumpType: "2"
+          DOTNET_DbgMiniDumpName: /tmp/coredumps/%e-%p.dmp
         run: |
           set -euo pipefail
+          mkdir -p /tmp/coredumps
           # A module's tests relocate WITH it (the Approvals precedent). Conventional sibling:
           # src/<Module>.Test. Absent is fine; present and red is not.
           tests="$(dirname "$PROJECT").Test"
@@ -553,6 +569,39 @@ jobs:
           else
             echo "no test project at $tests — nothing to run"
           fi
+
+      # 🚨 Only on FAILURE, and only what a diagnosis needs: the failing suite's per-test logs, the
+      # phase trace, the straggler captures and any dump. A green run uploads nothing — the point
+      # is that the ONE red run in five leaves something to read instead of a re-run button.
+      - name: Keep the failing suite's evidence
+        if: ${{ failure() && matrix.entry.test != false }}
+        env:
+          PROJECT: ${{ matrix.entry.project }}
+        run: |
+          set -uo pipefail
+          tests="$(dirname "$PROJECT").Test"
+          out="$RUNNER_TEMP/test-evidence"; mkdir -p "$out"
+          find "$tests" -path '*/test-logs/*.log' -print0 2>/dev/null | while IFS= read -r -d '' f; do
+            cp "$f" "$out/" || true
+          done
+          [ -f /tmp/meshweaver-test-trace.log ] && cp /tmp/meshweaver-test-trace.log "$out/_meshweaver-test-trace.log" || true
+          [ -f /tmp/meshweaver-msg-trace.log ] && cp /tmp/meshweaver-msg-trace.log "$out/_meshweaver-msg-trace.log" || true
+          if compgen -G '/tmp/coredumps/*.dmp' > /dev/null; then
+            # The runtime writes a dump 0600; make it readable for the upload.
+            sudo chmod a+r /tmp/coredumps/*.dmp || true
+            cp /tmp/coredumps/*.dmp "$out/" || true
+            dotnet --list-runtimes > "$out/_runtimes.txt" 2>/dev/null || true
+          fi
+          echo "kept $(ls "$out" | wc -l | tr -d ' ') file(s):"; ls -la "$out" | head -40
+      - name: Upload the failing suite's evidence
+        if: ${{ failure() && matrix.entry.test != false }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-evidence-${{ matrix.entry.module }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/test-evidence
+          if-no-files-found: ignore
+          retention-days: 14
+          compression-level: 9
 
       # 🚨 The hand-over. Without it a module that has LEFT the platform repo is packed, versioned,
       # inspected — and reaches nobody, because a registry serves only bytes it holds. A missing

--- a/src/MeshWeaver.ContentCollections/ContentCollection.cs
+++ b/src/MeshWeaver.ContentCollections/ContentCollection.cs
@@ -192,9 +192,32 @@ public class ContentCollection : IDisposable
 
 
 
-    /// <summary>Stops the change monitor and disposes the underlying markdown synchronization stream.</summary>
+    /// <summary>
+    /// True once <see cref="Dispose"/> has run — the file-system watcher is stopped and the
+    /// markdown stream is closed, so no callback of this collection can touch the hub's services
+    /// any more. Exposed so the disposal wiring is assertable (a collection whose hub died must
+    /// read <c>true</c>).
+    /// </summary>
+    public bool IsDisposed { get; private set; }
+
+    /// <summary>
+    /// Stops the change monitor and disposes the underlying markdown synchronization stream.
+    ///
+    /// <para>🚨 The collection is registered on its HUB's disposables (see
+    /// <c>ContentService.CreateCollection</c>), so this runs when the hub goes down. Nothing else
+    /// ever called it: the service's per-name cache kept every collection — and its live
+    /// <see cref="System.IO.FileSystemWatcher"/> — for the life of the process, so watcher
+    /// callbacks kept firing after the hub's scope was torn down and resolved services from a
+    /// disposed <c>LifetimeScope</c> on the watcher's native thread (the
+    /// <see cref="ObjectDisposedException"/> teardown-straggler class; the defensive catches in
+    /// <c>IngestContentFile</c> exist because of exactly those). Idempotent: the hub's composite
+    /// and a direct caller may both get here.</para>
+    /// </summary>
     public virtual void Dispose()
     {
+        if (IsDisposed)
+            return;
+        IsDisposed = true;
         monitorDisposable?.Dispose();
         markdownStream.Dispose();
     }

--- a/src/MeshWeaver.ContentCollections/ContentService.cs
+++ b/src/MeshWeaver.ContentCollections/ContentService.cs
@@ -187,7 +187,20 @@ public class ContentService : IContentService
 
         return factory.Create(config)
             .Take(1)
-            .Select(provider => new ContentCollection(config, provider, hub))
+            .Select(provider =>
+            {
+                var collection = new ContentCollection(config, provider, hub);
+                // 🚨 The collection DIES WITH THE HUB it resolves services from. Without this,
+                // nothing ever disposed it: this service is not IDisposable, its per-name cache
+                // outlives every consumer, and the file-system watcher AttachMonitor hangs on the
+                // provider kept firing after the hub's scope was gone — IngestContentFile then
+                // resolved IoPoolRegistry from a disposed LifetimeScope on the watcher's native
+                // callback thread (the teardown-straggler class the defensive catches in
+                // ContentCollection describe). RegisterForDisposal is late-safe: a collection
+                // created while the hub is already disposing is disposed immediately.
+                hub.RegisterForDisposal(collection);
+                return collection;
+            })
             .SelectMany(collection => collection.Initialize().Select(_ => (ContentCollection?)collection));
     }
 

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -2026,15 +2026,26 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                                                     // Only now may this touch shared state: the hand-off is
                                                     // released with nothing to publish, because nothing landed.
                                                     onLocalState?.Invoke(null);
+                                                    // 🚨 The TRAIL is the diagnostic. "No terminal" names a
+                                                    // symptom; the request-fate ledger names the EDGE — never
+                                                    // received by the owner, DEFERRED behind an init gate that
+                                                    // never opened, HANDLER_EXIT with no reply, or a reply
+                                                    // RESPONSE_POSTED to a hub nobody awaited on. Seven distinct
+                                                    // tests failed with this one sentence on 2026-08-30
+                                                    // (MeshWeaver.Plugins#941) and not one failure block could
+                                                    // say which; the trail survives the requester's own 2 s
+                                                    // timeout precisely so it can be read here.
+                                                    var trail = _workspace.Hub.DescribeRequestFate(requestId);
                                                     diagLogger?.LogWarning(
-                                                        "[UpdateRemote] VERDICT_TIMEOUT hub={Hub} target={Path} bound={BoundSeconds}s — the owner produced no terminal for this patch inside the late-response window, which dominates every owner-side terminal path; the write is NOT confirmed",
-                                                        _workspace.Hub.Address, _path, verdictBoundSeconds);
+                                                        "[UpdateRemote] VERDICT_TIMEOUT hub={Hub} target={Path} bound={BoundSeconds}s — the owner produced no terminal for this patch inside the late-response window, which dominates every owner-side terminal path; the write is NOT confirmed. Request trail: {Trail}",
+                                                        _workspace.Hub.Address, _path, verdictBoundSeconds, trail);
                                                     RaiseError(new MeshNodeStreamException(new MeshNodeError(
                                                         MeshNodeErrorCode.OwnerUnreachable, _path!,
                                                         $"The owner of '{_path}' returned no verdict for this update within "
                                                         + $"{verdictBoundSeconds:0}s. "
                                                         + "The patch was posted and may still apply, but it is NOT confirmed — "
-                                                        + "re-read the node and re-apply if the change is required.")));
+                                                        + "re-read the node and re-apply if the change is required. "
+                                                        + $"Request trail: {trail}")));
                                                 }));
                                         }
                                         else

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolServiceCollectionExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolServiceCollectionExtensions.cs
@@ -41,6 +41,12 @@ public static class IoPoolServiceCollectionExtensions
         // TeardownReport. Subscribe to this (never to DisposalCompleted alone) before
         // disposing the scope / unloading node ALCs / starting the next mesh.
         services.TryAddSingleton<MeshTeardownSignal>();
+        // Closes a hosted hub's OWN lifetime scope in teardown ORDER: now on a live mesh, after the
+        // drains above (DrainAll → AsyncDisposeQueue → the signal) while the mesh is tearing down.
+        // HostedHubsCollection sits BELOW this assembly and resolves the abstraction; without it a
+        // child scope closed on the hub's DisposalCompleted alone went down UNDER the pooled leaves
+        // and query pipelines still resolving from it (the ObjectDisposedException straggler class).
+        services.TryAddSingleton<IHubScopeDisposalSequencer, TeardownOrderedScopeDisposal>();
         // Mesh-scoped, so in-flight activity runs are counted per mesh and the counter dies with
         // it (NoStaticState). Teardown quiesces on this — see ActivityTracker.
         services.TryAddSingleton<ActivityTracker>();

--- a/src/MeshWeaver.Mesh.Contract/Threading/TeardownOrderedScopeDisposal.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/TeardownOrderedScopeDisposal.cs
@@ -1,0 +1,76 @@
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Mesh.Threading;
+
+/// <summary>
+/// The mesh's <see cref="IHubScopeDisposalSequencer"/>: a hosted hub's lifetime scope closes NOW
+/// while the mesh is live (a recycle frees its scope promptly — an Autofac parent tracks every child
+/// scope until it is closed), and AFTER the teardown drains while the mesh is tearing down.
+///
+/// <para>🚨 The deferral target is <see cref="MeshTeardownSignal.Completed"/>, NOT the
+/// <see cref="AsyncDisposeQueue"/>: the queue's consumer runs in the background the moment an item
+/// is posted, so an enqueued close would still land BEFORE <see cref="IoPoolRegistry.DrainAll()"/>
+/// has joined the pooled leaves that resolve from that scope. The terminal signal fires once every
+/// drain phase is accounted for (<c>MeshTeardownExtensions.DrainAsync</c> phase 4, and the same
+/// point in <c>MonolithMeshTestBase.DisposeAsync</c>) — which is precisely "queues and pools last,
+/// scopes after them". It is the phase rule <c>MeshDataSource.UnloadNodeAssemblyContexts</c> already
+/// follows for the collectible ALCs, applied one layer up to the scopes those assemblies' instances
+/// live in.</para>
+///
+/// <para>Whole-mesh teardown is recognised by the ROOT mesh hub's <see cref="IMessageHub.IsDisposing"/>
+/// — resolved at call time from the root provider, never in the constructor, because a hub can be
+/// hosted (and therefore registered here) while the mesh hub singleton is still being constructed.
+/// A subtree recycle (a package root going down with its children) leaves the root live, so those
+/// scopes close inline exactly as before: nothing on a live mesh is ever deferred to a signal that
+/// only a teardown fires.</para>
+///
+/// <para>Limit, stated: a teardown that disposes the mesh hub without running the drain
+/// orchestration (a run-boundary tool that block-joins <c>DisposalCompleted</c> and exits) never
+/// fires the signal, so its child scopes stay open until the process ends — the same lifetime they
+/// had before scopes were closed at all, and one the root container's own disposal still reclaims
+/// because Autofac disposes the child scopes it tracks.</para>
+/// </summary>
+public sealed class TeardownOrderedScopeDisposal(
+    IServiceProvider rootProvider,
+    ILogger<TeardownOrderedScopeDisposal>? logger = null) : IHubScopeDisposalSequencer
+{
+    /// <inheritdoc />
+    public void CloseWhenDrained(Address hub, Action closeScope)
+    {
+        IMessageHub? mesh;
+        MeshTeardownSignal? signal;
+        try
+        {
+            mesh = rootProvider.GetService<IMessageHub>();
+            signal = rootProvider.GetService<MeshTeardownSignal>();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The root itself is gone — the drains ran (or nothing will run them). Close now.
+            closeScope();
+            return;
+        }
+
+        if (mesh is null || signal is null || !mesh.IsDisposing)
+        {
+            closeScope();
+            return;
+        }
+
+        // ReplaySubject(1)-backed and completing: the subscription releases itself on the report,
+        // and a hub that terminates AFTER the report (a late construction the join disposed) still
+        // gets it immediately — never a silently-skipped close. Both arms close: a faulted signal
+        // is the case where holding the scope open would leak the most.
+        signal.Completed.Subscribe(
+            _ => closeScope(),
+            ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[DISPOSE-CONTAINER] {Address}: the teardown signal faulted before the lifetime "
+                    + "scope was closed — closing it now", hub);
+                closeScope();
+            });
+    }
+}

--- a/src/MeshWeaver.Messaging.Contract/IHubScopeDisposalSequencer.cs
+++ b/src/MeshWeaver.Messaging.Contract/IHubScopeDisposalSequencer.cs
@@ -1,0 +1,39 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// Sequences the closing of a hosted hub's OWN lifetime scope against the mesh's teardown drains.
+///
+/// <para>A hosted hub owns the Autofac scope it was built in, and <c>HostedHubsCollection</c> closes
+/// that scope once the hub's <c>DisposalCompleted</c> fires. That signal covers only the hub's action
+/// block and message round-trips — NOT the offloaded I/O the hub issued on the mesh's
+/// <c>IIoPool</c>s, nor the async cleanup it enqueued, nor the synced-query pipelines still
+/// resolving services from that scope on a scheduler thread. During a WHOLE-MESH teardown those are
+/// joined by the mesh's drain phases (<c>IoPoolRegistry.DrainAll()</c> → <c>AsyncDisposeQueue</c>)
+/// strictly AFTER every hub has signalled — so a scope closed on the hub's signal alone is closed
+/// UNDER live work: every straggler capture in CI names this shape
+/// (<c>PermissionEvaluator.GetEffectivePermissions</c>, <c>MeshNodeStreamCache.GetQueryRaw</c>,
+/// <c>SynchronizationStream.CaptureCallerAccessContext</c>, <c>IoPool.InvokeCore</c> …) resolving
+/// from a <c>LifetimeScope</c> that "has already been disposed", and the one that escapes onto a
+/// bare thread is the anonymous "Catastrophic failure: ObjectDisposedException" that reds a green
+/// shard (MeshWeaver.Plugins#870).</para>
+///
+/// <para>The mesh layer knows the drain order; this assembly does not. So the collection hands the
+/// close to this sequencer, resolved from the owning hub's provider, and the mesh registers the
+/// implementation that closes NOW while the mesh is live (a recycle must free its scope promptly —
+/// an Autofac parent tracks every child scope until it is closed) and defers to the terminal
+/// teardown signal while the mesh is tearing down — the same phase rule
+/// <c>MeshDataSource.UnloadNodeAssemblyContexts</c> follows for the collectible ALCs. A mesh with
+/// no implementation registered (bare messaging-only hubs) keeps the historical inline close.</para>
+/// </summary>
+public interface IHubScopeDisposalSequencer
+{
+    /// <summary>
+    /// Closes the scope <paramref name="hub"/> owned by invoking <paramref name="closeScope"/> —
+    /// immediately when the mesh is live, or after the mesh's teardown drains have joined every
+    /// pooled leaf and async cleanup when the mesh is tearing down. Never throws: a sequencer that
+    /// cannot decide must still close.
+    /// </summary>
+    /// <param name="hub">The address of the hub whose disposal has terminated.</param>
+    /// <param name="closeScope">Closes the hub's lifetime scope; idempotent and non-throwing.</param>
+    void CloseWhenDrained(Address hub, Action closeScope);
+}

--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -234,6 +234,12 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
         if (scope is null)
             return;
 
+        // 🚨 Resolved NOW, from the OWNER's provider, never inside the disposal callback: by the
+        // time the child signals, resolving anything is the "never resolve DI once disposal has
+        // begun" mistake this whole file warns about. Null on a bare messaging-only mesh → the
+        // historical inline close.
+        var sequencer = ResolveScopeDisposalSequencer();
+
         hub.DisposalCompleted
             .Take(1)
             // 🚨 A FAULTED disposal must free the scope TOO — a teardown that failed is when the
@@ -244,11 +250,60 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
             // answer that can never arrive has to be settled from the known-terminal state rather
             // than parked (the same rule DisposeHubsReactive's legs follow).
             .DefaultIfEmpty(Unit.Default)
-            .Subscribe(_ => CloseScope(address, scope));
+            .Subscribe(_ => CloseScopeInSequence(sequencer, address, scope));
         // Not held: `Take(1)` releases the subscription on the terminal notification, and until
         // then the child hub's own completion subject roots it. Holding it in a field would mean
         // disposing it when THIS collection is disposed — which happens strictly BEFORE the
         // children finish, i.e. it would cancel the very closes it exists to perform.
+    }
+
+    /// <summary>
+    /// Hands the close to the mesh's <see cref="IHubScopeDisposalSequencer"/> when one is registered
+    /// — which closes NOW on a live mesh and AFTER the teardown drains (pooled I/O joined, async
+    /// cleanup quiesced) when the mesh is tearing down — and closes inline otherwise.
+    ///
+    /// <para>🚨 Why the ORDER matters: <c>DisposalCompleted</c> covers the action block and the
+    /// message round-trips, not the offloaded work. Closing the scope on that signal alone, during a
+    /// whole-mesh teardown, put every pooled leaf and synced-query pipeline this hub had issued in
+    /// the position of resolving services from a disposed <c>LifetimeScope</c> — the
+    /// <c>ObjectDisposedException</c> straggler class that every CI teardown capture is full of,
+    /// and whose one escape onto a scheduler thread is the anonymous "Catastrophic failure" that
+    /// reds an otherwise green shard (MeshWeaver.Plugins#870). Queues and pools drain LAST; the
+    /// scopes their leaves resolve from must not go first.</para>
+    /// </summary>
+    private void CloseScopeInSequence(IHubScopeDisposalSequencer? sequencer, Address address, IDisposable scope)
+    {
+        if (sequencer is null)
+        {
+            CloseScope(address, scope);
+            return;
+        }
+        try
+        {
+            sequencer.CloseWhenDrained(address, () => CloseScope(address, scope));
+        }
+        catch (Exception e)
+        {
+            // The sequencer is an ordering optimisation over a close that MUST happen; a faulting
+            // sequencer must never turn into a leaked scope.
+            logger.LogWarning(e,
+                "[DISPOSE-CONTAINER] {Address}: the scope-disposal sequencer faulted — closing the "
+                + "lifetime scope inline instead", address);
+            CloseScope(address, scope);
+        }
+    }
+
+    private IHubScopeDisposalSequencer? ResolveScopeDisposalSequencer()
+    {
+        try
+        {
+            return serviceProvider.GetService<IHubScopeDisposalSequencer>();
+        }
+        catch (ObjectDisposedException)
+        {
+            // The owner's own scope is already going down — there is nothing to sequence against.
+            return null;
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/MessageHubExtensions.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHubExtensions.cs
@@ -18,6 +18,34 @@ namespace MeshWeaver.Messaging;
 public static class MessageHubExtensions
 {
     /// <summary>
+    /// Renders the request-fate trail the hub tree recorded for <paramref name="messageId"/> — every
+    /// stage a request passed through (AWAITING → ROUTED → DEFERRED / HANDLER_EXIT / RESPONSE_POSTED …)
+    /// with the hub and the elapsed time of each, and a one-line verdict on where it stopped.
+    ///
+    /// <para>For the DIAGNOSTIC that answers "the owner produced no terminal": it names whether the
+    /// request was ever received by the owner, parked behind an init gate, handled without a reply,
+    /// or answered to a hub nobody was awaiting on. Trails survive the requester's own timeout for a
+    /// bounded while, so a late verdict watcher can still read the owner's side of the story.
+    /// Never throws; a hub without a ledger answers a sentence saying so.</para>
+    /// </summary>
+    /// <param name="hub">Any hub of the tree that posted the request.</param>
+    /// <param name="messageId">The request delivery's id.</param>
+    /// <returns>One greppable line: the stages joined by <c>→</c>, then <c>⇒</c> and the verdict.</returns>
+    public static string DescribeRequestFate(this IMessageHub hub, string messageId)
+    {
+        try
+        {
+            return hub is MessageHub concrete
+                ? concrete.RequestFates.Describe(messageId)
+                : "<no request-fate ledger: the hub is not a MessageHub>";
+        }
+        catch (Exception e)
+        {
+            return $"<request-fate trail unavailable: {e.GetType().Name}: {e.Message}>";
+        }
+    }
+
+    /// <summary>
     /// Builds a new <see cref="IMessageHub"/> for <paramref name="address"/> from
     /// the given service provider, applying the optional configuration transform.
     /// The address's type is registered with the hub automatically.

--- a/src/MeshWeaver.Messaging.Hub/RequestFateLedger.cs
+++ b/src/MeshWeaver.Messaging.Hub/RequestFateLedger.cs
@@ -62,6 +62,19 @@ internal sealed class RequestFateLedger
 
     private readonly ConcurrentDictionary<string, RequestFate> tracked = new();
 
+    // 🚨 Trails OUTLIVE the callback that opened them, boundedly. A cross-hub write waits on its
+    // owner's reply for UpdateResponseWaitBound (2 s), then hands the wait to the late-patch
+    // watch for another ~30 s — and that first timeout disposes the Observe subscription, which
+    // used to drop the trail. So the one diagnostic that could say WHERE a write stalled (DEFERRED
+    // behind an init gate at the owner; HANDLER_EXIT with no reply; RESPONSE_POSTED to a hub nobody
+    // was awaiting on) was gone 29 s before VERDICT_TIMEOUT asked for it, and the CI failure block
+    // read "the owner produced no terminal" with nothing to chase (MeshWeaver.Plugins#941, seven
+    // distinct tests, one message). Stages keep landing on a recent trail, so the owner-side story
+    // that unfolds AFTER the requester stopped awaiting is still written down.
+    private const int RecentCap = 512;
+    private readonly ConcurrentDictionary<string, RequestFate> recent = new();
+    private readonly ConcurrentQueue<string> recentOrder = new();
+
     /// <summary>
     /// Starts a trail for <paramref name="messageId"/>. Called from the ONE place a hub registers a
     /// pending response callback, so "tracked" and "awaited" are the same set by construction.
@@ -89,7 +102,16 @@ internal sealed class RequestFateLedger
     /// its subscription was disposed. Keeping resolved ids would turn a bounded ledger into a leak.
     /// </summary>
     /// <param name="messageId">The request delivery's id.</param>
-    public void Untrack(string messageId) => tracked.TryRemove(messageId, out _);
+    public void Untrack(string messageId)
+    {
+        if (!tracked.TryRemove(messageId, out var fate))
+            return;
+        // Move, never drop: the trail keeps recording until it ages out of the recent ring.
+        recent[messageId] = fate;
+        recentOrder.Enqueue(messageId);
+        while (recentOrder.Count > RecentCap && recentOrder.TryDequeue(out var oldest))
+            recent.TryRemove(oldest, out _);
+    }
 
     /// <summary>
     /// The trail for <paramref name="messageId"/>, or <c>null</c> when nothing is awaiting it.
@@ -100,9 +122,11 @@ internal sealed class RequestFateLedger
     /// <returns>The live trail, or <c>null</c>.</returns>
     public RequestFate? Find(string? messageId)
     {
-        if (tracked.IsEmpty || messageId is not { Length: > 0 })
+        if (messageId is not { Length: > 0 })
             return null;
-        return tracked.TryGetValue(messageId, out var fate) ? fate : null;
+        if (!tracked.IsEmpty && tracked.TryGetValue(messageId, out var fate))
+            return fate;
+        return !recent.IsEmpty && recent.TryGetValue(messageId, out var late) ? late : null;
     }
 
     /// <summary>

--- a/test/MeshWeaver.ContentCollections.Test/ContentCollectionDiesWithItsHubTest.cs
+++ b/test/MeshWeaver.ContentCollections.Test/ContentCollectionDiesWithItsHubTest.cs
@@ -1,0 +1,61 @@
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.ContentCollections.Test;
+
+/// <summary>
+/// 🚨 <b>A content collection dies with the hub it resolves services from.</b>
+///
+/// <para>Nothing disposed a <see cref="ContentCollection"/> before: <c>ContentService</c> is not
+/// <c>IDisposable</c> and its per-name cache kept every collection — and the live
+/// <see cref="FileSystemWatcher"/> its provider attached — for the life of the process. After the
+/// hub's teardown the watcher kept firing on its native callback thread, and
+/// <c>IngestContentFile</c>'s first act (resolving <c>IoPoolRegistry</c> off the hub's provider)
+/// threw <see cref="ObjectDisposedException"/> from the dead <c>LifetimeScope</c> — the teardown
+/// straggler class the collection's own defensive catches describe, and one seam of the FutuRe /
+/// AI-suite teardown flakiness (the collections there are file-system backed).</para>
+/// </summary>
+public class ContentCollectionDiesWithItsHubTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private readonly string path = Path.Combine(
+        AppContext.BaseDirectory, "Files", "DiesWithHub", Guid.NewGuid().ToString("N"));
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddContentCollections()
+            .AddFileSystemContentCollection("doomed", _ => path);
+
+    [Fact(Timeout = 60_000)]
+    public async Task DisposingTheHub_DisposesTheCollectionsItsContentServiceCreated()
+    {
+        Directory.CreateDirectory(path);
+        var host = GetHost();
+
+        var collection = await host.ServiceProvider.GetRequiredService<IContentService>()
+            .GetCollection("doomed")
+            .Where(c => c is not null)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask(TestContext.Current.CancellationToken);
+
+        collection!.IsDisposed.Should().BeFalse(
+            "precondition: the collection (and its watcher) is live while the hub is");
+
+        host.Dispose();
+        await host.DisposalCompleted.ObserveCompletion(
+            ex => Output.WriteLine($"late disposal fault: {ex}"),
+            TestContext.Current.CancellationToken);
+
+        collection.IsDisposed.Should().BeTrue(
+            "the hub owns what its ContentService created — an undisposed collection keeps a live "
+            + "FileSystemWatcher whose callbacks resolve services from the disposed scope on a "
+            + "native thread, which is the teardown-straggler class this wiring removes");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/HubScopeClosesAfterTeardownDrainsTest.cs
+++ b/test/MeshWeaver.Hosting.Test/HubScopeClosesAfterTeardownDrainsTest.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>Queues and pools drain LAST; a hosted hub's lifetime scope closes AFTER them, never
+/// before.</b>
+///
+/// <para><c>HostedHubsCollection.CloseScopeWhenDisposed</c> closes the Autofac scope a hosted hub owns
+/// once that hub's <c>DisposalCompleted</c> fires. That signal covers the action block and the
+/// message round-trips only. The offloaded work the hub issued — <c>IIoPool</c> leaves, synced-query
+/// pipelines on the pool scheduler, async cleanup on the <c>AsyncDisposeQueue</c> — is joined by the
+/// mesh's drain phases strictly AFTER every hub has signalled. Closing the scope on the hub's own
+/// signal during a whole-mesh teardown therefore closed it UNDER that work: every CI teardown capture
+/// is a list of <c>ObjectDisposedException: … LifetimeScope … has already been disposed</c> thrown
+/// from exactly those leaves (<c>PermissionEvaluator.GetEffectivePermissions</c>,
+/// <c>MeshNodeStreamCache.GetQueryRaw</c>, <c>IoPool.InvokeCore</c>, …), and the one that escapes
+/// onto a bare scheduler thread is the anonymous "Catastrophic failure" that reds a green shard with
+/// zero failed tests (MeshWeaver.Plugins#870, recurring).</para>
+///
+/// <para>The fix hands the close to <see cref="IHubScopeDisposalSequencer"/>, which the mesh
+/// implements as <see cref="TeardownOrderedScopeDisposal"/>: on a LIVE mesh a recycled hub's scope
+/// still closes immediately (an Autofac parent tracks every child scope until it is closed — the
+/// leak the close was introduced for); while the mesh is TEARING DOWN the close waits for
+/// <see cref="MeshTeardownSignal.Completed"/>, which fires after the last drain phase. These two
+/// facts are pinned separately because they run different branches, and a sequencer that deferred
+/// the recycle too would reintroduce the leak silently.</para>
+/// </summary>
+public class HubScopeClosesAfterTeardownDrainsTest : HubTestBase
+{
+    /// <summary>Tracks its own disposal; registered by TYPE so the hub's container constructs — and
+    /// therefore owns and disposes — it.</summary>
+    private sealed class TracksItsDisposal : IDisposable
+    {
+        public bool IsDisposed { get; private set; }
+
+        public void Dispose() => IsDisposed = true;
+    }
+
+    public HubScopeClosesAfterTeardownDrainsTest(ITestOutputHelper output) : base(output)
+    {
+        // The mesh's teardown services — the IoPoolRegistry / AsyncDisposeQueue / MeshTeardownSignal
+        // trio AND the sequencer under test — on the ROOT container, exactly where MeshBuilder puts
+        // them. The mesh hub is that container's IMessageHub (HubTestBase registers it so), which is
+        // what the sequencer reads IsDisposing off.
+        Services.AddIoPools();
+    }
+
+    private IMessageHub HostWithTrackedSingleton(string id) =>
+        Mesh.GetHostedHub(new Address("scope-order", id),
+            c => c.WithServices(services => services.AddSingleton<TracksItsDisposal>()));
+
+    /// <summary>
+    /// Whole-mesh teardown: the child has signalled <c>DisposalCompleted</c>, the MESH has signalled
+    /// <c>DisposalCompleted</c> — and the child's scope is STILL OPEN, because the drains have not
+    /// run. It closes on the terminal teardown signal and not a moment earlier.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task DuringMeshTeardown_TheChildScopeClosesOnTheTeardownSignal_NotOnDisposalCompleted()
+    {
+        var hub = HostWithTrackedSingleton("teardown");
+        var tracker = hub.ServiceProvider.GetRequiredService<TracksItsDisposal>();
+        tracker.IsDisposed.Should().BeFalse("precondition: the singleton is alive while the hub is");
+
+        Mesh.Dispose();
+        await Mesh.DisposalCompleted.ObserveCompletion(
+            ex => Output.WriteLine($"late disposal fault: {ex}"),
+            TestContext.Current.CancellationToken);
+        hub.RunLevel.Should().Be(MessageHubRunLevel.Dead,
+            "the mesh's DisposeHostedHubs phase joins every child's disposal before it completes");
+
+        tracker.IsDisposed.Should().BeFalse(
+            "the mesh is tearing down and no drain has run yet — a scope closed here is closed under "
+            + "the pooled leaves and query pipelines that still resolve from it (the "
+            + "ObjectDisposedException straggler class, and Plugins#870 when one escapes)");
+
+        // The drains' terminal report — what MeshTeardownExtensions.DrainAsync / the test base fire
+        // AFTER IoPoolRegistry.DrainAll() and the AsyncDisposeQueue quiesce.
+        ServiceProvider.GetRequiredService<MeshTeardownSignal>()
+            .SignalCompleted(new TeardownReport(LeakedIoLeaves: 0, AsyncDisposeClean: true));
+
+        tracker.IsDisposed.Should().BeTrue(
+            "once every drain phase is accounted for, the scope must close — deferring is an "
+            + "ordering, never a leak");
+    }
+
+    /// <summary>
+    /// A recycle on a LIVE mesh must not be deferred to a signal only a teardown fires: the scope
+    /// closes as soon as the recycled hub has terminated, exactly as before the sequencer existed.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task OnALiveMesh_ARecycledHubsScopeClosesOnItsOwnDisposalCompleted()
+    {
+        var hub = HostWithTrackedSingleton("recycle");
+        var tracker = hub.ServiceProvider.GetRequiredService<TracksItsDisposal>();
+        tracker.IsDisposed.Should().BeFalse("precondition: the singleton is alive while the hub is");
+
+        hub.Dispose();
+        await hub.DisposalCompleted.ObserveCompletion(
+            ex => Output.WriteLine($"late disposal fault: {ex}"),
+            TestContext.Current.CancellationToken);
+
+        tracker.IsDisposed.Should().BeTrue(
+            "the mesh is live, so nothing will ever fire the teardown signal — a recycle that waited "
+            + "for it would leak its scope for the life of the process, which is the leak the close "
+            + "was introduced to stop");
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/RequestFateTrailOutlivesTheCallbackTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/RequestFateTrailOutlivesTheCallbackTest.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>A request's fate trail must outlive the callback that opened it.</b>
+///
+/// <para>A cross-hub write awaits its owner's reply for a short bound (2 s), then hands the wait to
+/// the late-patch watch for ~30 s more. Disposing that first <c>Observe</c> subscription used to
+/// drop the trail from the <c>RequestFateLedger</c> — so when the late watch finally reported
+/// <c>VERDICT_TIMEOUT</c>, the one record that could say WHERE the request stalled (never received;
+/// DEFERRED behind an init gate; HANDLER_EXIT with no reply; RESPONSE_POSTED to the wrong hub) had
+/// been gone for 29 s. Seven distinct tests failed with that empty sentence in one night
+/// (MeshWeaver.Plugins#941).</para>
+///
+/// <para>The ledger now MOVES an untracked trail into a bounded recent ring instead of dropping it,
+/// and stages keep landing on it — so the owner-side story that unfolds AFTER the requester stopped
+/// awaiting is still written down, and <see cref="MessageHubExtensions.DescribeRequestFate"/> can
+/// render it for the late diagnostic.</para>
+/// </summary>
+public class RequestFateTrailOutlivesTheCallbackTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record SlowRequest : IRequest<SlowResponse>;
+    private record SlowResponse;
+
+    private readonly TaskCompletionSource<IMessageDelivery> handlerRan = new();
+
+    /// <summary>A handler that runs and deliberately answers nothing, so the requester's Observe
+    /// can only end by its own timeout — the shape in which the trail used to vanish.</summary>
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithHandler<SlowRequest>((_, delivery) =>
+            {
+                handlerRan.TrySetResult(delivery);
+                return delivery.Processed();
+            });
+
+    [Fact(Timeout = 30_000)]
+    public async Task AfterTheRequestersObserveTimedOut_TheTrailStillRendersTheReceivingSide()
+    {
+        var host = GetHost();
+
+        // The requester gives up after 300 ms — the Observe subscription is then disposed, which
+        // is the exact moment the trail used to be dropped.
+        var timedOut = false;
+        try
+        {
+            await host
+                .Observe<SlowResponse>(new SlowRequest(), o => o.WithTarget(CreateHostAddress()))
+                .Timeout(TimeSpan.FromMilliseconds(300))
+                .FirstAsync()
+                .ToTask(TestContext.Current.CancellationToken);
+        }
+        catch (TimeoutException)
+        {
+            timedOut = true;
+        }
+
+        timedOut.Should().BeTrue("the handler never replies, so the requester's bound is what ends the wait");
+        // The handler saw the very delivery the requester awaited: its id is the ledger key.
+        var handled = await handlerRan.Task.WaitAsync(TimeSpan.FromSeconds(10), TestContext.Current.CancellationToken);
+        var requestId = handled.Id;
+
+        var trail = host.DescribeRequestFate(requestId);
+        Output.WriteLine(trail);
+
+        trail.Should().NotContain("not tracked",
+            "the requester's timeout must not erase the evidence the late diagnostic needs");
+        trail.Should().Contain("HANDLER_EXIT",
+            "the receiving side's stages must still be readable after the callback is gone — that is "
+            + "what tells a VERDICT_TIMEOUT whether the owner ever ran the handler");
+        trail.Should().NotContain("RESPONSE_POSTED",
+            "nothing replied — the trail must say so rather than be missing");
+    }
+}

--- a/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
+++ b/tools/MeshWeaver.PluginTester/PluginGateRunner.cs
@@ -938,13 +938,48 @@ public static class PluginGateRunner
             Mesh.DisposeAndJoin(
                 message => output.WriteLine($"[teardown] {message}"),
                 TimeSpan.FromSeconds(30));
+            var leakedIoLeaves = 0;
             try
             {
-                ServiceProvider.GetRequiredService<IoPoolRegistry>().DrainAll();
+                leakedIoLeaves = ServiceProvider.GetRequiredService<IoPoolRegistry>()
+                    .DrainAll(out var residualByPool);
+                if (residualByPool.Count > 0)
+                    output.WriteLine(
+                        $"[teardown] pooled I/O leaves survived the drain: {string.Join(", ", residualByPool)}");
             }
             catch (Exception ex)
             {
                 output.WriteLine($"[teardown] pool drain failed: {ex.Message}");
+            }
+            // The async half of teardown, then the TERMINAL SIGNAL — the phase everything that
+            // deferred itself to "after the drains" is waiting on: the collectible NodeType ALC
+            // unloads (MeshDataSource.UnloadNodeAssemblyContexts) and the hosted hubs' lifetime
+            // scopes (TeardownOrderedScopeDisposal). Without it those run only when the container
+            // below disposes them mid-teardown — the unordered shape whose stragglers used to kill
+            // this very tool with exit 139. Block-joins are the sanctioned run-boundary exception,
+            // and both are bounded and loud.
+            var asyncDisposeClean = true;
+            try
+            {
+                var queue = ServiceProvider.GetService<AsyncDisposeQueue>();
+                asyncDisposeClean = queue is null
+                    || queue.DrainAsync(TimeSpan.FromSeconds(30)).GetAwaiter().GetResult();
+                if (!asyncDisposeClean)
+                    output.WriteLine("[teardown] async dispose queue did not quiesce within 30s");
+            }
+            catch (Exception ex)
+            {
+                asyncDisposeClean = false;
+                output.WriteLine($"[teardown] async dispose queue drain failed: {ex.Message}");
+            }
+            try
+            {
+                ServiceProvider.GetService<MeshTeardownSignal>()
+                    ?.SignalCompleted(new TeardownReport(leakedIoLeaves, asyncDisposeClean));
+            }
+            catch (Exception ex)
+            {
+                output.WriteLine($"[teardown] teardown signal failed: {ex.Message}");
             }
             (ServiceProvider as IDisposable)?.Dispose();
         }


### PR DESCRIPTION
## What this is

The "flaky tests" backlog (Plugins#941's seven-distinct-tests-in-one-night, the recurring
catastrophic `ObjectDisposedException` of Plugins#870, and the exit-139 family of #2635) is one
class seen from many tests: **teardown work outliving the scope it resolves from, and a
diagnostic that was erased before the failure asked for it.** Two fixes, one CI change, both
pinned by deterministic tests.

## 1. Hosted-hub scopes now close AFTER the teardown drains

`HostedHubsCollection.CloseScopeWhenDisposed` closed a hub's Autofac scope on that hub's
`DisposalCompleted` — which covers the action block and round-trips only. During a whole-mesh
teardown, the pooled I/O leaves, synced-query pipelines and async cleanup that resolve from that
scope are joined by the mesh's drains (`IoPoolRegistry.DrainAll()` → `AsyncDisposeQueue`)
strictly AFTER every hub has signalled — so the scope went down under live work.

Measured on `MeshWeaver.AI.Test` under the runner's shape (`DOTNET_PROCESSOR_COUNT=4` + CPU
burners): **every loaded run capped the teardown-straggler capture at 200 first-chance
`LifetimeScope … has already been disposed` hits** (dominant seams:
`MeshNodeStreamCache.GetQueryRaw → GetWorkspace` ×186, `PermissionEvaluator.GetEffectivePermissions`,
`IoPool.InvokeCore`); CI's captures show the same list on every run. The escape onto a bare
scheduler thread is the anonymous `Catastrophic failure: System.ObjectDisposedException` with
`Passed! Failed: 0` and a non-zero exit (Plugins#870, recurred on run 33292121378).

The close now goes through a new `IHubScopeDisposalSequencer` (Messaging.Contract — the same
lower-layer-abstraction pattern as `IPooledSubscribeScheduler`), implemented by
`TeardownOrderedScopeDisposal` (Mesh.Contract, registered in `AddIoPools`):

- **live mesh** → close immediately (a recycle must free its scope promptly; an Autofac parent
  tracks every child scope until it is closed — the leak the close was introduced for);
- **mesh tearing down** (root hub `IsDisposing`) → defer to `MeshTeardownSignal.Completed`,
  which fires after the last drain phase.

That is the phase rule `MeshDataSource.UnloadNodeAssemblyContexts` already applies to the
collectible ALCs, applied one layer up to the scopes their instances live in. No sequencer
registered (bare messaging-only hubs) → the historical inline close.

**Measured** on `MeshWeaver.AI.Test` (1,615 tests) under the runner's shape
(`DOTNET_PROCESSOR_COUNT=4` + CPU burners, looped `--no-build`): first-chance disposed-scope
stragglers per run **200 (cap) / 198 / 200 / 103 before → 9 / 23 after** (the two other after-runs
were harness casualties: one hit the since-serviced dotnet/runtime#127776 TLS race — the machine ran
runtime 10.0.9, which predates the #131118/#131099 backports; CI's `dotnet-version: 10.x` already
installs the fixed 10.0.11 — and one was killed by an SDK install racing it).

## 2. Content collections die with their hub

`ContentService` is not `IDisposable` and its per-name cache kept every `ContentCollection` — and
the live `FileSystemWatcher` its provider attached — for the life of the process. After hub
teardown the watcher kept firing on its native callback thread, and `IngestContentFile`'s first
act (resolving `IoPoolRegistry` off the hub's provider) threw from the dead scope — the very shape
the collection's own defensive catches document, and one seam of the FutuRe / AI-suite teardown
flakiness (their collections are file-system backed). Collections are now
`hub.RegisterForDisposal`'d at creation (late-safe), `Dispose` is idempotent, and `IsDisposed` is
assertable.

## 3. Request-fate trails survive the requester's timeout — and `VERDICT_TIMEOUT` prints them

Every one of the seven distinct AI.Test failures carried the same empty sentence: *"The owner of
'X' returned no verdict for this update within 31s"* (`UpdateResponseWaitBound` 2 s +
`LateResponseWatchBound` 30 s + 1 s grace). The `RequestFateLedger` had the answer — DEFERRED
behind an init gate / HANDLER_EXIT with no reply / RESPONSE_POSTED to the wrong hub — but the
trail was dropped when the 2 s Observe subscription was disposed, 29 s before the diagnostic
needed it.

`Untrack` now MOVES the trail into a bounded recent ring (512) where stages keep landing; the new
`IMessageHub.DescribeRequestFate(id)` renders it; and `UpdateRemote`'s `VERDICT_TIMEOUT` warning
and `OwnerUnreachable` exception carry `Request trail: …`. The next CI occurrence names the edge
instead of the symptom.

## 4. `node-repo-module-pack.yml`: a failing suite leaves evidence — and the gate runner tears down in order

On failure only, the module's test leg uploads `test-evidence-<module>-<run>-<attempt>`: the
per-test file logs (`MESHWEAVER_TEST_FILE_LOGS=1`, Warning level — the same records the console
gets, timing-neutral), the `MonolithMeshTestBase` phase trace (`/tmp/meshweaver-test-trace.log`),
the teardown-straggler captures, and a mini dump when the host dies on a signal
(`DOTNET_DbgEnableMiniDump`, type 2 — the node-repo-gate precedent, including the `chmod` its
comments document). A green run uploads nothing. `PluginGateRunner` additionally drains the
`AsyncDisposeQueue` and fires `MeshTeardownSignal` before container dispose, so the deferred ALC
unloads and scope closes run in order in the gate too.

## Verification

- New pins: `HubScopeClosesAfterTeardownDrainsTest` (both branches: deferred during mesh
  teardown, immediate on a live-mesh recycle), `ContentCollectionDiesWithItsHubTest`,
  `RequestFateTrailOutlivesTheCallbackTest`.
- Full suites green locally against this branch: Messaging.Hub.Test 332/332, Hosting.Test 263/263,
  ContentCollections.Test 18/18, Hosting.Monolith.Test and Data.Test (re-run below), plus
  `MeshWeaver.AI.Test` (1,612/1,615, 3 skipped) from MeshWeaver.Plugins built against this
  worktree — twice, with the straggler counts above.

Related: #2635 (closed — this closes the seam it left in the test bases' shadow), #2666 (seam
inventory), Plugins#941, Plugins#870.
