### PR TITLE
fix(io): require IoPoolRegistry on file-system adapters — no ledgerless Unbounded fallback (#613 follow-up a)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
@@ -231,7 +231,11 @@ terminates costs one slot and nothing else. See issue #1028.
 
 ## Hidden inside the interfaces
 
-A leaf takes an optional `IIoPool? pool = null` and stores `_pool = pool ?? IoPool.Unbounded`. Each leaf reads uniformly:
+A leaf resolves its pool from the mesh-scoped registry — for a hub-attached leaf via
+`hub.ServiceProvider.GetService<IoPoolRegistry>()`, and for an adapter constructed at a composition
+root via a **required** `IoPoolRegistry` constructor parameter (see the ledgerless-Unbounded rule
+below — an optional parameter with a `?? IoPool.Unbounded` fallback is the shape that let a whole
+mesh's file I/O escape the teardown drain). Each leaf reads uniformly:
 
 ```csharp
 // HTTP leaf (McpRemoteMeshClient) — was Observable.FromAsync(async ct => …).
@@ -247,7 +251,15 @@ public IObservable<MeshNode?> Get(string path)
 => _processPool.InvokeBlocking(ct => RunTestsCore(…));      // MeshPlugin.RunTests
 ```
 
-`IoPool.Unbounded` is a stateless fallback used when a leaf is constructed with `new` outside DI. It still offloads onto the ThreadPool — never *worse* than the bare `Observable.FromAsync` it replaces — but applies no cap. It is an immutable constant, not a cache. Pools come from the mesh-scoped `IoPoolRegistry` (registered by `MeshBuilder.AddIoPools()`), resolved from the owning hub's `ServiceProvider` or injected via the leaf's constructor.
+`IoPool.Unbounded` is a stateless offload onto the ThreadPool with no cap — and, crucially, **no
+ledger**: its `CurrentInFlight` is unconditionally `0`, so I/O on it is invisible to every teardown
+drain and quiescence hold (see "`IoPool.Unbounded` is LEDGERLESS" below). It is an immutable
+constant, not a cache. Pools come from the mesh-scoped `IoPoolRegistry` (registered by
+`MeshBuilder.AddIoPools()`), resolved from the owning hub's `ServiceProvider` or injected via the
+leaf's constructor — and for adapters constructed at composition roots the registry is a
+**required** constructor parameter with a loud failure when the provider lacks one, never an
+optional parameter with a silent `?? IoPool.Unbounded` fallback (that shape is how the FutuRe
+mesh's entire file I/O escaped the teardown drain, issue #613).
 
 ---
 
@@ -428,6 +440,35 @@ So the mesh teardown awaits **all three**, in order, before the scope is dispose
    `DrainAsync` `Complete()`s the block and awaits the remainder (bounded), so it converges even under
    continuous influx — a *version-target* wait would not (the queue is a message stream / endless
    messages). `DrainedVersion` advances once per item, the test hook.
+
+### 🚨 `IoPool.Unbounded` is LEDGERLESS — I/O on it does not exist to this drain
+
+The three-phase drain only covers what it can *see*, and `IoPool.Unbounded` is invisible to it **by
+construction**: its `CurrentInFlight` is unconditionally `0`, its `Invoke` is a bare
+`Observable.FromAsync(io).SubscribeOn(TaskPoolScheduler.Default)`, and it lives outside the
+registry — so `IoPoolRegistry.DrainAll()` never enumerates it, `TotalInFlight`/`WhenDrained` never
+count it, and there is nothing to cancel, dispose, or join. The same blindness applies to every
+other quiescence hold built on the ledgers (e.g. the silo's routing-quiescence hold). Phase 2
+therefore reports a clean drain **while the unbounded I/O is still running** — and that straggler
+is exactly the teardown SIGSEGV shape: a leftover Rx emission enters full hub construction after
+the scope is disposed and faults on a span into the unloaded collectible ALC.
+
+This is not hypothetical. `FileSystemStorageAdapter` took its registry as an *optional* parameter
+with a `?? IoPool.Unbounded` fallback, and every production construction site silently dropped it —
+the storage-adapter factory (the path every config-declared FileSystem data source takes) and both
+`PersistenceExtensions` registration sites. Result: every file-system-backed mesh (the FutuRe
+sample, the one file-system-data-source-backed space) ran **all** of its file I/O on the unbounded
+pool, and issue #613's `exit=139` teardown crash recurred with zero failing tests in the trx —
+the drain had nothing to join.
+
+**The rule.** An adapter or service whose I/O must be drainable takes `IoPoolRegistry` as a
+**REQUIRED constructor parameter** — the compiler then names every dropping site, which an optional
+parameter never does ("check the call sites, not the declaration"). A DI factory or registration
+lambda resolves the registry from the provider and **fails LOUDLY** — a thrown error naming the
+missing registration and how to add it (`AddIoPools()`, which `MeshBuilder` calls by default) —
+never a silent `?? IoPool.Unbounded`. A deliberate `IoPool.Unbounded` use must be written out
+explicitly at the call site with a comment saying why bare-ThreadPool is correct there; a pure test
+convenience is the only acceptable answer, and fixing the test to use a real registry is preferred.
 
 **The only sanctioned `await` is that single three-phase drain at the boundary** — the **mesh teardown**,
 the same in tests and in prod (the silo's mesh disposal at shutdown). Capture the mesh-scoped teardown

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-file-system-io-now-joins-the-teardown-drain.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-file-system-io-now-joins-the-teardown-drain.md
@@ -1,0 +1,28 @@
+---
+Name: File-system I/O now joins the teardown drain
+Category: Fix
+Description: File-system-backed spaces run their reads and writes on the mesh's tracked I/O pool, so shutdown can cancel and join them — closing the untracked-I/O straggler source behind the FutuRe teardown crash family (#613).
+Icon: Sparkle
+Order: -20260830
+---
+
+# File-system I/O now joins the teardown drain
+
+Spaces backed by a file-system data source — the FutuRe sample is the one such space — were
+quietly running every file read and write on an untracked thread-pool bridge instead of the mesh's
+own file-system I/O pool. The construction paths those adapters take simply dropped the pool
+registry, and the fallback pool they landed on keeps no ledger at all: to the shutdown sequence,
+that I/O did not exist. Teardown would report a clean drain while a file read was still in flight,
+and such a straggler entering the framework after the mesh's resources were already released is the
+teardown crash family tracked as issue #613 (`MeshWeaver.FutuRe.Test exit=139`, with no failing
+test in the results).
+
+Every file-system adapter now requires the mesh's pool registry at construction — the compiler
+flags any code path that would drop it — and the configuration-driven factory fails with a clear,
+named error if a host lacks the registration instead of silently falling back to the untracked
+pool. File I/O on these spaces is therefore visible to shutdown like every other pooled operation:
+it gets cancelled, joined, and counted before the mesh lets go of its resources.
+
+This closes the untracked-I/O straggler source feeding that crash family; the remaining half of
+issue #613 — releasing compiled node assemblies that are still referenced at teardown — stays open
+and is tracked there.

--- a/src/MeshWeaver.Hosting/Persistence/CachingStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/CachingStorageAdapter.cs
@@ -31,7 +31,7 @@ public class CachingStorageAdapter : IStorageAdapter
     // obvious to whoever runs the portal.
     private readonly Parsers.IFileFormatParser[] _contributedParsers;
     private readonly FileFormatParserRegistry _parserRegistry;
-    private readonly IoPoolRegistry? _ioPoolRegistry;
+    private readonly IoPoolRegistry _ioPoolRegistry;
     private readonly ILogger<CachingStorageAdapter>? _logger;
     // The Read leaf is bridged to IObservable through this pool — never via a
     // bare Observable.FromAsync, which deadlocks under a blocking subscriber.
@@ -64,23 +64,30 @@ public class CachingStorageAdapter : IStorageAdapter
     /// paths into an in-memory snapshot (file bytes are read lazily on first access).
     /// </summary>
     /// <param name="baseDirectory">Root directory to cache; created if it does not exist. Resolved to an absolute path.</param>
+    /// <param name="ioPoolRegistry">
+    /// REQUIRED mesh-scoped registry resolving the file-system <c>IIoPool</c> that bridges reads to
+    /// observables — forwarded to every throwaway inner <see cref="FileSystemStorageAdapter"/> this
+    /// decorator constructs per write/read call. See that adapter's constructor for why there is no
+    /// unbounded fallback (the ledgerless pool is invisible to the teardown drain — issue #613).
+    /// </param>
     /// <param name="writeOptionsModifier">Optional transform applied to the <c>JsonSerializerOptions</c> used when writing nodes through the inner file-system adapter.</param>
-    /// <param name="ioPoolRegistry">Optional registry used to resolve the file-system <c>IIoPool</c> that bridges blocking reads to observables; falls back to an unbounded pool when null.</param>
     /// <param name="logger">Optional logger for surfacing unparseable cached files.</param>
+    /// <param name="contributedParsers">Module-contributed file-format parsers (see the field comment above).</param>
     public CachingStorageAdapter(
         string baseDirectory,
+        IoPoolRegistry ioPoolRegistry,
         Func<JsonSerializerOptions, JsonSerializerOptions>? writeOptionsModifier = null,
-        IoPoolRegistry? ioPoolRegistry = null,
         ILogger<CachingStorageAdapter>? logger = null,
         IEnumerable<Parsers.IFileFormatParser>? contributedParsers = null)
     {
+        ArgumentNullException.ThrowIfNull(ioPoolRegistry);
         _contributedParsers = (contributedParsers ?? []).ToArray();
         _parserRegistry = new FileFormatParserRegistry(contributedParsers: _contributedParsers);
         _baseDirectory = Path.GetFullPath(baseDirectory);
         _writeOptionsModifier = writeOptionsModifier;
         _ioPoolRegistry = ioPoolRegistry;
         _logger = logger;
-        _ioPool = ioPoolRegistry?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
+        _ioPool = ioPoolRegistry.Get(IoPoolNames.FileSystem);
         _changes = new IsolatedChangeFeed(logger, "caching-file-system");
         Directory.CreateDirectory(_baseDirectory);
         _snapshot = new DirectorySnapshot(_baseDirectory);
@@ -250,7 +257,7 @@ public class CachingStorageAdapter : IStorageAdapter
     /// <inheritdoc />
     public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
     {
-        var innerAdapter = new FileSystemStorageAdapter(_baseDirectory, _writeOptionsModifier, _ioPoolRegistry, _logger, _contributedParsers);
+        var innerAdapter = new FileSystemStorageAdapter(_baseDirectory, _ioPoolRegistry, _writeOptionsModifier, _logger, _contributedParsers);
         return innerAdapter.Write(node, options)
             .Do(written =>
             {
@@ -275,7 +282,7 @@ public class CachingStorageAdapter : IStorageAdapter
         // Cast to the interface: WriteIfVersion is a DEFAULT interface member on the file-system
         // adapter (it does not override it), so it is only reachable through IStorageAdapter.
         IStorageAdapter innerAdapter =
-            new FileSystemStorageAdapter(_baseDirectory, _writeOptionsModifier, _ioPoolRegistry, _logger, _contributedParsers);
+            new FileSystemStorageAdapter(_baseDirectory, _ioPoolRegistry, _writeOptionsModifier, _logger, _contributedParsers);
         return innerAdapter.WriteIfVersion(node, expectedVersion, options)
             .Do(applied =>
             {
@@ -288,7 +295,7 @@ public class CachingStorageAdapter : IStorageAdapter
     /// <inheritdoc />
     public IObservable<string> Delete(string path)
     {
-        var innerAdapter = new FileSystemStorageAdapter(_baseDirectory, _writeOptionsModifier, _ioPoolRegistry, _logger, _contributedParsers);
+        var innerAdapter = new FileSystemStorageAdapter(_baseDirectory, _ioPoolRegistry, _writeOptionsModifier, _logger, _contributedParsers);
         return innerAdapter.Delete(path)
             .Do(deletedPath =>
             {
@@ -497,7 +504,7 @@ public class CachingStorageAdapter : IStorageAdapter
     public IObservable<Unit> SavePartitionObjects(
         string nodePath, string? subPath, IReadOnlyCollection<object> objects, JsonSerializerOptions options)
     {
-        var innerAdapter = new FileSystemStorageAdapter(_baseDirectory, _writeOptionsModifier, _ioPoolRegistry, _logger, _contributedParsers);
+        var innerAdapter = new FileSystemStorageAdapter(_baseDirectory, _ioPoolRegistry, _writeOptionsModifier, _logger, _contributedParsers);
         return innerAdapter.SavePartitionObjects(nodePath, subPath, objects, options)
             .Do(_ => RefreshCacheForPartition(nodePath, subPath));
     }
@@ -505,7 +512,7 @@ public class CachingStorageAdapter : IStorageAdapter
     /// <inheritdoc />
     public IObservable<Unit> DeletePartitionObjects(string nodePath, string? subPath = null)
     {
-        var innerAdapter = new FileSystemStorageAdapter(_baseDirectory, _writeOptionsModifier, _ioPoolRegistry, _logger, _contributedParsers);
+        var innerAdapter = new FileSystemStorageAdapter(_baseDirectory, _ioPoolRegistry, _writeOptionsModifier, _logger, _contributedParsers);
         return innerAdapter.DeletePartitionObjects(nodePath, subPath);
     }
 

--- a/src/MeshWeaver.Hosting/Persistence/FileSystemChangeWatcher.cs
+++ b/src/MeshWeaver.Hosting/Persistence/FileSystemChangeWatcher.cs
@@ -10,6 +10,16 @@ namespace MeshWeaver.Hosting.Persistence;
 /// Watches a directory for file system changes and publishes notifications to <see cref="IObserver{T}"/> of <see cref="DataChangeNotification"/>.
 /// This enables reactive updates when files are modified externally (e.g., by another process or editor).
 /// </summary>
+/// <remarks>
+/// 🚨 NOT on the production path (verified 2026-08-30): nothing in <c>src/</c> registers or
+/// constructs this watcher — the only constructions are <c>FileSystemChangeWatcherTests</c>, and
+/// <c>StorageAdapterMeshQueryProvider</c> mentions it in a comment only. Live synced queries
+/// re-run on the adapters' own in-process change feed (<c>IStorageAdapter.Changes</c>), not on
+/// this class. If it is ever wired into production, its <see cref="FileSystemWatcher"/>/timer
+/// callbacks must route their adapter reads through the mesh-scoped <c>FileSystem</c>
+/// <c>IIoPool</c> (required <c>IoPoolRegistry</c> constructor parameter, like the adapters) so
+/// teardown can cancel and join them — as written its work is invisible to the teardown drain.
+/// </remarks>
 public class FileSystemChangeWatcher : IDisposable
 {
     private readonly string _baseDirectory;

--- a/src/MeshWeaver.Hosting/Persistence/FileSystemChangeWatcher.cs
+++ b/src/MeshWeaver.Hosting/Persistence/FileSystemChangeWatcher.cs
@@ -15,10 +15,15 @@ namespace MeshWeaver.Hosting.Persistence;
 /// constructs this watcher — the only constructions are <c>FileSystemChangeWatcherTests</c>, and
 /// <c>StorageAdapterMeshQueryProvider</c> mentions it in a comment only. Live synced queries
 /// re-run on the adapters' own in-process change feed (<c>IStorageAdapter.Changes</c>), not on
-/// this class. If it is ever wired into production, its <see cref="FileSystemWatcher"/>/timer
-/// callbacks must route their adapter reads through the mesh-scoped <c>FileSystem</c>
-/// <c>IIoPool</c> (required <c>IoPoolRegistry</c> constructor parameter, like the adapters) so
-/// teardown can cancel and join them — as written its work is invisible to the teardown drain.
+/// this class. Its adapter reads are as tracked as the <c>IStorageAdapter</c> it is given —
+/// with a <c>FileSystemStorageAdapter</c> (which now REQUIRES the mesh-scoped
+/// <c>IoPoolRegistry</c>) those leaves are drainable. What is NOT tracked is the watcher's own
+/// driving machinery: <see cref="FileSystemWatcher"/> event callbacks and the debounce
+/// <see cref="Timer"/> fire on bare ThreadPool threads outside any <c>IIoPool</c> ledger, so the
+/// work they initiate is invisible to the teardown drain until it reaches the adapter. If this
+/// class is ever wired into production, give it the registry (required constructor parameter,
+/// like the adapters) and route those callbacks through the <c>FileSystem</c> pool so teardown
+/// can cancel and join them.
 /// </remarks>
 public class FileSystemChangeWatcher : IDisposable
 {

--- a/src/MeshWeaver.Hosting/Persistence/FileSystemStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/FileSystemStorageAdapter.cs
@@ -61,20 +61,31 @@ public class FileSystemStorageAdapter : IStorageAdapter
     /// Creates a new FileSystemStorageAdapter.
     /// </summary>
     /// <param name="baseDirectory">Base directory for file storage</param>
+    /// <param name="ioPoolRegistry">
+    /// REQUIRED mesh-scoped registry — the <c>FileSystem</c> pool bridges async file I/O to
+    /// <c>IObservable</c>. 🚨 This parameter used to be optional with an <see cref="IoPool.Unbounded"/>
+    /// fallback, and every construction site silently dropped it: the FutuRe sample (the one
+    /// file-system-data-source-backed space) ran ALL of its file I/O on the ledgerless unbounded pool,
+    /// whose <c>CurrentInFlight</c> is unconditionally 0 — invisible to <c>IoPoolRegistry.DrainAll()</c>
+    /// and the silo teardown join, so a straggler Read could enter hub construction during teardown and
+    /// fault on an unloaded collectible ALC (the issue #613 exit=139 family). Required-by-constructor
+    /// makes the compiler name every dropping site; there is deliberately no unbounded opt-out.
+    /// </param>
     /// <param name="writeOptionsModifier">Optional modifier for JsonSerializerOptions when writing (e.g., to enable WriteIndented)</param>
-    /// <param name="ioPoolRegistry">Optional I/O pool registry; the <c>FileSystem</c> pool bridges async file I/O to <c>IObservable</c>. When <c>null</c>, the unbounded pool is used.</param>
     /// <param name="logger">Optional logger — the change feed uses it to surface a subscriber that throws during fan-out (without it, the isolation would swallow the fault silently).</param>
+    /// <param name="contributedParsers">Module-contributed file-format parsers (see the field comment above — without them agent files silently degrade).</param>
     public FileSystemStorageAdapter(
         string baseDirectory,
+        IoPoolRegistry ioPoolRegistry,
         Func<JsonSerializerOptions, JsonSerializerOptions>? writeOptionsModifier = null,
-        IoPoolRegistry? ioPoolRegistry = null,
         Microsoft.Extensions.Logging.ILogger? logger = null,
         IEnumerable<Parsers.IFileFormatParser>? contributedParsers = null)
     {
+        ArgumentNullException.ThrowIfNull(ioPoolRegistry);
         _parserRegistry = new FileFormatParserRegistry(contributedParsers: contributedParsers);
         _baseDirectory = baseDirectory;
         _writeOptionsModifier = writeOptionsModifier;
-        _ioPool = ioPoolRegistry?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
+        _ioPool = ioPoolRegistry.Get(IoPoolNames.FileSystem);
         _changes = new IsolatedChangeFeed(logger, "file-system");
         Directory.CreateDirectory(baseDirectory);
     }

--- a/src/MeshWeaver.Hosting/Persistence/FileSystemStorageAdapterFactory.cs
+++ b/src/MeshWeaver.Hosting/Persistence/FileSystemStorageAdapterFactory.cs
@@ -46,11 +46,17 @@ public class FileSystemStorageAdapterFactory : IStorageAdapterFactory
         // A real logger so the change feed can surface a subscriber that throws during fan-out —
         // a null logger restores exactly the silent-failure mode IsolatedChangeFeed exists to kill.
         var logger = serviceProvider.GetService<ILoggerFactory>()?.CreateLogger<FileSystemStorageAdapter>();
+        // 🚨 The mesh-scoped pool registry, resolved LOUDLY — never a silent IoPool.Unbounded
+        // fallback. This factory is the path every config-declared FileSystem data source takes
+        // (the FutuRe sample among them), and dropping the registry here is exactly how all of
+        // that mesh's file I/O ended up on the ledgerless unbounded pool, invisible to the
+        // teardown drain (the issue #613 exit=139 straggler source).
+        var ioPoolRegistry = serviceProvider.GetRequiredIoPoolRegistry();
         // Module-contributed parsers (the AI module's agent parser) — resolved here because this
         // factory is the DI-aware construction site. Without them an `.md` carrying
         // `nodeType: Agent` parses as plain Markdown on every file-system-backed mesh, silently.
         return new FileSystemStorageAdapter(
-            basePath, writeOptionsModifier, logger: logger,
+            basePath, ioPoolRegistry, writeOptionsModifier, logger: logger,
             contributedParsers: serviceProvider.GetServices<Parsers.IFileFormatParser>());
     }
 }

--- a/src/MeshWeaver.Hosting/Persistence/FileSystemVersionStore.cs
+++ b/src/MeshWeaver.Hosting/Persistence/FileSystemVersionStore.cs
@@ -36,16 +36,23 @@ public class FileSystemVersionStore : IVersionQuery
     /// given data directory.
     /// </summary>
     /// <param name="baseDirectory">Data directory whose <c>.versions</c> subfolder holds the snapshots.</param>
+    /// <param name="ioPoolRegistry">
+    /// REQUIRED mesh-scoped registry; the <c>FileSystem</c> pool bridges async file I/O to
+    /// <c>IObservable</c>. No <see cref="IoPool.Unbounded"/> fallback — the unbounded pool is
+    /// ledgerless (<c>CurrentInFlight</c> is unconditionally 0), so a version write routed onto it
+    /// is invisible to the teardown drain (the issue #613 straggler source). See
+    /// <see cref="FileSystemStorageAdapter"/>'s constructor for the full rationale.
+    /// </param>
     /// <param name="writeOptionsModifier">Optional modifier for JsonSerializerOptions when writing snapshots (e.g., to enable WriteIndented).</param>
-    /// <param name="ioPoolRegistry">Optional I/O pool registry; the <c>FileSystem</c> pool bridges async file I/O to <c>IObservable</c>. When <c>null</c>, the unbounded pool is used.</param>
     public FileSystemVersionStore(
         string baseDirectory,
-        Func<JsonSerializerOptions, JsonSerializerOptions>? writeOptionsModifier = null,
-        IoPoolRegistry? ioPoolRegistry = null)
+        IoPoolRegistry ioPoolRegistry,
+        Func<JsonSerializerOptions, JsonSerializerOptions>? writeOptionsModifier = null)
     {
+        ArgumentNullException.ThrowIfNull(ioPoolRegistry);
         _versionsDirectory = Path.Combine(baseDirectory, ".versions");
         _writeOptionsModifier = writeOptionsModifier;
-        _ioPool = ioPoolRegistry?.Get(IoPoolNames.FileSystem) ?? IoPool.Unbounded;
+        _ioPool = ioPoolRegistry.Get(IoPoolNames.FileSystem);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -8,6 +8,7 @@ using MeshWeaver.Mesh.Activity;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using MeshWeaver.Mesh.Threading;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -382,6 +383,26 @@ public static class PersistenceExtensions
     }
 
     /// <summary>
+    /// Resolves the mesh-scoped <see cref="IoPoolRegistry"/> from the provider, failing LOUDLY
+    /// when none is registered — never falling back to <see cref="IoPool.Unbounded"/>. The
+    /// unbounded pool is ledgerless by construction (<c>CurrentInFlight</c> is unconditionally 0),
+    /// so I/O routed onto it is invisible to <c>IoPoolRegistry.DrainAll()</c> and the silo
+    /// teardown join: a straggler file read can then enter hub construction while the mesh is
+    /// tearing down and fault on an unloaded collectible ALC (the issue #613 exit=139 family).
+    /// A missing registration is a wiring bug to surface at construction time, not to paper over.
+    /// </summary>
+    internal static IoPoolRegistry GetRequiredIoPoolRegistry(this IServiceProvider serviceProvider)
+        => serviceProvider.GetService<IoPoolRegistry>()
+           ?? throw new InvalidOperationException(
+               $"No {nameof(IoPoolRegistry)} is registered in this service provider. File-system " +
+               $"persistence bridges its file I/O through the mesh-scoped '{IoPoolNames.FileSystem}' " +
+               "pool so mesh teardown can cancel and join it; silently falling back to the " +
+               "ledgerless unbounded pool would make that I/O invisible to the teardown drain " +
+               "(the issue #613 teardown-crash straggler source). Register the pools via " +
+               $"{nameof(IoPoolServiceCollectionExtensions)}.{nameof(IoPoolServiceCollectionExtensions.AddIoPools)}() " +
+               "— MeshBuilder does this by default — before adding file-system persistence.");
+
+    /// <summary>
     /// Adds file system persistence that reads directly from disk.
     /// Uses the hub's JsonSerializerOptions for proper type polymorphism.
     /// </summary>
@@ -395,10 +416,16 @@ public static class PersistenceExtensions
         Func<JsonSerializerOptions, JsonSerializerOptions>? writeOptionsModifier = null)
     {
         // Factory, not an eager instance: module-contributed parsers (the AI module's agent
-        // parser) can only be resolved from the provider, and without them every `.md` carrying
-        // `nodeType: Agent` degrades to a plain Markdown node with no error anywhere.
+        // parser) and the mesh-scoped IoPoolRegistry can only be resolved from the provider.
+        // Without the parsers every `.md` carrying `nodeType: Agent` degrades to a plain Markdown
+        // node with no error anywhere; without the registry the adapter's file I/O would run on
+        // the ledgerless unbounded pool, invisible to the teardown drain (issue #613) — so the
+        // registry is resolved LOUDLY, and the logger keeps the change feed's fan-out faults visible.
         services.AddSingleton<IStorageAdapter>(sp => new FileSystemStorageAdapter(
-            baseDirectory, writeOptionsModifier,
+            baseDirectory,
+            sp.GetRequiredIoPoolRegistry(),
+            writeOptionsModifier,
+            logger: sp.GetService<ILoggerFactory>()?.CreateLogger<FileSystemStorageAdapter>(),
             contributedParsers: sp.GetServices<Parsers.IFileFormatParser>()));
 
         // Register common services and wrapper services
@@ -419,8 +446,11 @@ public static class PersistenceExtensions
         builder.ConfigureServices(services =>
         {
             services.AddSingleton<IStorageAdapter>(sp => new CachingStorageAdapter(
-                baseDirectory, writeOptionsModifier,
-                logger: sp.GetService<Microsoft.Extensions.Logging.ILogger<CachingStorageAdapter>>()));
+                baseDirectory,
+                sp.GetRequiredIoPoolRegistry(),
+                writeOptionsModifier,
+                logger: sp.GetService<Microsoft.Extensions.Logging.ILogger<CachingStorageAdapter>>(),
+                contributedParsers: sp.GetServices<Parsers.IFileFormatParser>()));
             return services.AddCoreAndWrapperServices();
         });
         return builder.RegisterMeshQueryCoreOnMeshHub();
@@ -538,11 +568,21 @@ public static class PersistenceExtensions
                 priority: 150));
 
         // One shared FileSystemStorageAdapter + wildcard provider — handles every
-        // first-segment partition rooted at baseDirectory. No factory, no per-segment
-        // store provisioning.
-        var fsAdapter = new FileSystemStorageAdapter(baseDirectory, writeOptionsModifier);
-        services.AddSingleton(fsAdapter);
-        services.AddSingleton<IPartitionStorageProvider>(new FileSystemPartitionStorageProvider(fsAdapter));
+        // first-segment partition rooted at baseDirectory. No per-segment store
+        // provisioning. A DI factory (not an eager instance) because the mesh-scoped
+        // IoPoolRegistry, the logger and the module-contributed parsers only exist on
+        // the provider — the former eager `new` here dropped ALL three, so every read
+        // and write of a partitioned file-system mesh ran on the ledgerless unbounded
+        // pool (invisible to the teardown drain, issue #613) and change-feed fan-out
+        // faults were swallowed silently.
+        services.AddSingleton(sp => new FileSystemStorageAdapter(
+            baseDirectory,
+            sp.GetRequiredIoPoolRegistry(),
+            writeOptionsModifier,
+            logger: sp.GetService<ILoggerFactory>()?.CreateLogger<FileSystemStorageAdapter>(),
+            contributedParsers: sp.GetServices<Parsers.IFileFormatParser>()));
+        services.AddSingleton<IPartitionStorageProvider>(sp =>
+            new FileSystemPartitionStorageProvider(sp.GetRequiredService<FileSystemStorageAdapter>()));
 
         // Default IAssemblyStore so dynamic NodeType compiles can persist their
         // bytes cross-silo; see RegisterDefaultAssemblyStore for the rationale.
@@ -728,7 +768,7 @@ public static class PersistenceExtensions
             var inner = sp.GetKeyedService<IStorageAdapter>(InnerStorageAdapterKey)
                         ?? sp.GetService<IStorageAdapter>();
             if (inner is FileSystemStorageAdapter fsAdapter)
-                return new FileSystemVersionStore(fsAdapter.BaseDirectory);
+                return new FileSystemVersionStore(fsAdapter.BaseDirectory, sp.GetRequiredIoPoolRegistry());
             return new NoOpVersionQuery();
         });
 

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -605,29 +605,17 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                     || PathMatcher.ShouldNotify(mainPath!, basePath, effectiveScope))
                 .SelectMany(mainPath => persistence.Read(mainPath!, options)
                     .Take(1)
-                    .Catch<MeshNode?, Exception>(ex =>
-                    {
-                        // Surface as warning so silent swallow-and-return-null
-                        // doesn't make TimeoutException disappear into "node
-                        // dropped by Where(!= null)" — visible cause when a
-                        // query mysteriously returns fewer rows than expected.
-                        logger?.LogWarning(ex,
-                            "[SourceActivity.ReadMain] swallowed for path={Path}; returning null",
-                            mainPath);
-                        return Observable.Return<MeshNode?>(null);
-                    }))
+                    // Surface as warning so silent swallow-and-return-null doesn't make
+                    // TimeoutException disappear into "node dropped by Where(!= null)" — visible
+                    // cause when a query mysteriously returns fewer rows than expected. Teardown
+                    // cancellation is NOT swallowed: it terminates the walk (see SwallowedReadOrStop).
+                    .Catch<MeshNode?, Exception>(ex => SwallowedReadOrStop(ex, "SourceActivity.ReadMain", mainPath!)))
                 .Where(node => node != null)
                 .Select(node => node!)
                 .Where(node => _evaluator.Matches(node, parsedQuery)
                     && !IsExcludedByContext(node, context)
                     && !IsExcludedByIsMain(node, parsedQuery))
-                .Catch<MeshNode, Exception>(ex =>
-                {
-                    logger?.LogWarning(ex,
-                        "[StorageAdapterMeshQueryProvider.SourceActivity] pipeline threw query=[{Query}] basePath={BasePath}",
-                        string.Join(" | ", request.EffectiveQueries), basePath);
-                    return Observable.Empty<MeshNode>();
-                })
+                .Catch<MeshNode, Exception>(ex => PipelineFaultOrStopped<MeshNode>(ex, "SourceActivity", request, basePath))
                 .Cast<object>();
         }
 
@@ -650,24 +638,13 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                 .Where(path => emittedFrontier.Add(path))
                 .SelectMany(path => persistence.Read(path, options)
                     .Take(1)
-                    .Catch<MeshNode?, Exception>(ex =>
-                    {
-                        logger?.LogWarning(ex,
-                            "[NextLevel.Read] swallowed for path={Path}; returning null", path);
-                        return Observable.Return<MeshNode?>(null);
-                    }))
+                    .Catch<MeshNode?, Exception>(ex => SwallowedReadOrStop(ex, "NextLevel.Read", path)))
                 .Where(node => node != null)
                 .Select(node => node!)
                 .Where(node => _evaluator.Matches(node, parsedQuery)
                     && !IsExcludedByContext(node, context)
                     && !IsExcludedByIsMain(node, parsedQuery))
-                .Catch<MeshNode, Exception>(ex =>
-                {
-                    logger?.LogWarning(ex,
-                        "[StorageAdapterMeshQueryProvider.NextLevel] pipeline threw query=[{Query}] basePath={BasePath}",
-                        string.Join(" | ", request.EffectiveQueries), basePath);
-                    return Observable.Empty<MeshNode>();
-                })
+                .Catch<MeshNode, Exception>(ex => PipelineFaultOrStopped<MeshNode>(ex, "NextLevel", request, basePath))
                 .Cast<object>();
         }
 
@@ -707,13 +684,7 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                 && !IsExcludedByContext(node, context)
                 && !IsExcludedByIsMain(node, parsedQuery))
             .Do(node => { if (!string.IsNullOrEmpty(node.Path)) emittedPaths.Add(node.Path); })
-            .Catch<MeshNode, Exception>(ex =>
-            {
-                logger?.LogWarning(ex,
-                    "[StorageAdapterMeshQueryProvider.ExactScope] pipeline threw query=[{Query}] basePath={BasePath}",
-                    string.Join(" | ", request.EffectiveQueries), basePath);
-                return Observable.Empty<MeshNode>();
-            });
+            .Catch<MeshNode, Exception>(ex => PipelineFaultOrStopped<MeshNode>(ex, "ExactScope", request, basePath));
 
         // Children / Descendants / Hierarchy / Subtree / AncestorsAndSelf scopes —
         // walk via the adapter. Each scope expands to a list of (root, scope)
@@ -771,28 +742,16 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
             .SelectMany(path =>
                 persistence.Read(path, options)
                     .Take(1)
-                    .Catch<MeshNode?, Exception>(ex =>
-                    {
-                        // Surface swallowed read errors at warning level so a
-                        // timeout / RLS-deny / corrupt-row doesn't silently
-                        // drop the node out of the result set.
-                        logger?.LogWarning(ex,
-                            "[MatchScope.Read] swallowed for path={Path}; returning null",
-                            path);
-                        return Observable.Return<MeshNode?>(null);
-                    }))
+                    // Surface swallowed read errors at warning level so a timeout / RLS-deny /
+                    // corrupt-row doesn't silently drop the node out of the result set. Teardown
+                    // cancellation is NOT swallowed: it terminates the walk (see SwallowedReadOrStop).
+                    .Catch<MeshNode?, Exception>(ex => SwallowedReadOrStop(ex, "MatchScope.Read", path)))
             .Where(node => node != null)
             .Select(node => node!)
             .Where(node => _evaluator.Matches(node, parsedQuery)
                 && !IsExcludedByContext(node, context)
                 && !IsExcludedByIsMain(node, parsedQuery))
-            .Catch<MeshNode, Exception>(ex =>
-            {
-                logger?.LogWarning(ex,
-                    "[StorageAdapterMeshQueryProvider.MatchScope] pipeline threw query=[{Query}] basePath={BasePath}",
-                    string.Join(" | ", request.EffectiveQueries), basePath);
-                return Observable.Empty<MeshNode>();
-            });
+            .Catch<MeshNode, Exception>(ex => PipelineFaultOrStopped<MeshNode>(ex, "MatchScope", request, basePath));
 
         // Sequential composition: exact-path probes complete first (populating
         // emittedPaths), then scope-walk filters via the shared HashSet. The
@@ -812,6 +771,52 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
     {
         var recursive = scope != QueryScope.Children;
         return WalkLevel(string.IsNullOrEmpty(basePath) ? null : basePath, recursive);
+    }
+
+    /// <summary>
+    /// 🚨 Cancellation is NOT a swallowed read error, and must never be handled as one path's miss.
+    /// It arrives when the adapter's I/O pool has been drained at mesh teardown — from then on every
+    /// pooled <c>Read</c> is refused with an <see cref="OperationCanceledException"/> — and the only
+    /// correct response is to STOP the walk. The per-path swallow used to catch it, log a
+    /// Warning-with-exception, return <c>null</c> and move on to the next path: a synchronous storm of
+    /// one fault record per remaining path (2,342 in ONE CI teardown of a samples-graph walk), which
+    /// exhausted the fault-record budget (100 per 10 s) and suppressed every genuine fault logged in
+    /// the following ten seconds. Before the FileSystem pool became drainable those same stragglers
+    /// ran unsupervised on the unbounded pool instead — the issue #613 teardown-crash shape — so this
+    /// is the same defect seen from the other side, and terminating the walk is what closes it.
+    /// </summary>
+    private static bool IsTeardownCancellation(Exception ex) => ex is OperationCanceledException;
+
+    /// <summary>
+    /// The per-path read catch: a genuine read fault (timeout / RLS-deny / corrupt row) is surfaced
+    /// at Warning and the node dropped (<c>null</c>) so the rest of the result set survives; a
+    /// teardown cancellation propagates so the walk terminates — see <see cref="IsTeardownCancellation"/>.
+    /// </summary>
+    private IObservable<MeshNode?> SwallowedReadOrStop(Exception ex, string site, string path)
+    {
+        if (IsTeardownCancellation(ex))
+            return Observable.Throw<MeshNode?>(ex);
+        logger?.LogWarning(ex, "[{Site}] swallowed for path={Path}; returning null", site, path);
+        return Observable.Return<MeshNode?>(null);
+    }
+
+    /// <summary>
+    /// The pipeline-level catch: a fault is surfaced at Warning; a teardown cancellation is the
+    /// expected end of a walk whose pool has been drained — recorded at Debug (it is not a fault, and
+    /// a Warning-with-exception here would still feed the fault sink once per in-flight query at every
+    /// teardown) — and either way the query answers empty. See <see cref="IsTeardownCancellation"/>.
+    /// </summary>
+    private IObservable<T> PipelineFaultOrStopped<T>(Exception ex, string site, MeshQueryRequest request, string basePath)
+    {
+        if (IsTeardownCancellation(ex))
+            logger?.LogDebug(
+                "[StorageAdapterMeshQueryProvider.{Site}] stopped — the adapter's I/O pool was drained (mesh teardown) query=[{Query}] basePath={BasePath}",
+                site, string.Join(" | ", request.EffectiveQueries), basePath);
+        else
+            logger?.LogWarning(ex,
+                "[StorageAdapterMeshQueryProvider.{Site}] pipeline threw query=[{Query}] basePath={BasePath}",
+                site, string.Join(" | ", request.EffectiveQueries), basePath);
+        return Observable.Empty<T>();
     }
 
     private IObservable<string> WalkLevel(string? parent, bool recursive)
@@ -847,6 +852,10 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
             })
             .Catch<string, Exception>(ex =>
             {
+                // A drained pool cancels the listing exactly like a read — propagate so the walk
+                // stops at this level instead of continuing over dead siblings (see IsTeardownCancellation).
+                if (IsTeardownCancellation(ex))
+                    return Observable.Throw<string>(ex);
                 logger?.LogWarning(ex, "[StorageAdapterMeshQueryProvider.WalkLevel] parent={Parent} failed", parent);
                 return Observable.Empty<string>();
             });

--- a/test/MeshWeaver.Hosting.Test/CodeNodeRoundTripTests.cs
+++ b/test/MeshWeaver.Hosting.Test/CodeNodeRoundTripTests.cs
@@ -26,7 +26,15 @@ public class CodeNodeRoundTripTests : IDisposable
     private static readonly JsonSerializerOptions Options = new();
     private readonly string _dir = Directory.CreateTempSubdirectory("mw-code-roundtrip-").FullName;
 
-    public void Dispose() => Directory.Delete(_dir, recursive: true);
+    // The adapter REQUIRES a registry (no unbounded fallback — issue #613); a per-class
+    // instance disposed with the test stands in for the mesh-scoped one.
+    private readonly MeshWeaver.Mesh.Threading.IoPoolRegistry _ioPools = new();
+
+    public void Dispose()
+    {
+        _ioPools.Dispose();
+        Directory.Delete(_dir, recursive: true);
+    }
 
     private static MeshNode CodeNode(string id, CodeConfiguration config) =>
         new(id, "Scripts") { Name = id, NodeType = "Code", Content = config };
@@ -85,7 +93,7 @@ public class CodeNodeRoundTripTests : IDisposable
     [Fact]
     public async Task ExecutableCodeNode_RoundTripsLosslessly_AsJson()
     {
-        var adapter = new FileSystemStorageAdapter(_dir);
+        var adapter = new FileSystemStorageAdapter(_dir, _ioPools);
         var node = CodeNode("exec", new CodeConfiguration
         {
             Code = "Console.WriteLine(\"hi\"); 1+1",
@@ -111,7 +119,7 @@ public class CodeNodeRoundTripTests : IDisposable
     [Fact]
     public async Task PureSourceCodeNode_KeepsItsCsFileForm()
     {
-        var adapter = new FileSystemStorageAdapter(_dir);
+        var adapter = new FileSystemStorageAdapter(_dir, _ioPools);
         var node = CodeNode("model", new CodeConfiguration { Code = "public record Person(string Name);" });
 
         await adapter.Write(node, Options).FirstAsync();
@@ -131,7 +139,7 @@ public class CodeNodeRoundTripTests : IDisposable
         // the next write (now carrying executable state) must flip it to .json AND remove the
         // stale .cs — the read side prefers .cs over .json, so a leftover .cs would shadow the
         // new file with the metadata-stripped version forever.
-        var adapter = new FileSystemStorageAdapter(_dir);
+        var adapter = new FileSystemStorageAdapter(_dir, _ioPools);
         await adapter.Write(CodeNode("cell", new CodeConfiguration { Code = "1+1" }), Options).FirstAsync();
         Assert.True(File.Exists(Path.Combine(_dir, "Scripts", "cell.cs")));
 

--- a/test/MeshWeaver.Hosting.Test/FileSystemChangeFeedTest.cs
+++ b/test/MeshWeaver.Hosting.Test/FileSystemChangeFeedTest.cs
@@ -31,6 +31,10 @@ public class FileSystemChangeFeedTest : IDisposable
     private readonly string _dir = Path.Combine(
         Path.GetTempPath(), "mw-fs-changefeed-" + Guid.NewGuid().ToString("N"));
 
+    // The adapters REQUIRE a registry (no unbounded fallback — issue #613); a per-class
+    // instance disposed with the test stands in for the mesh-scoped one.
+    private readonly MeshWeaver.Mesh.Threading.IoPoolRegistry _ioPools = new();
+
     private static readonly JsonSerializerOptions Options = new();
 
     private static MeshNode Node(string path) => MeshNode.FromPath(path) with
@@ -42,7 +46,7 @@ public class FileSystemChangeFeedTest : IDisposable
     [Fact]
     public async Task FileSystemAdapter_PublishesChanges_OnWriteAndDelete()
     {
-        IStorageAdapter adapter = new FileSystemStorageAdapter(_dir);
+        IStorageAdapter adapter = new FileSystemStorageAdapter(_dir, _ioPools);
         var seen = new List<DataChangeNotification>();
         using var sub = adapter.Changes.Subscribe(seen.Add);
 
@@ -64,7 +68,7 @@ public class FileSystemChangeFeedTest : IDisposable
     {
         // The caching decorator writes through a THROWAWAY inner file-system adapter per call, so
         // it must publish from its own feed — nobody can subscribe the inner one.
-        IStorageAdapter adapter = new CachingStorageAdapter(_dir);
+        IStorageAdapter adapter = new CachingStorageAdapter(_dir, _ioPools);
         var seen = new List<DataChangeNotification>();
         using var sub = adapter.Changes.Subscribe(seen.Add);
 
@@ -81,6 +85,7 @@ public class FileSystemChangeFeedTest : IDisposable
 
     public void Dispose()
     {
+        _ioPools.Dispose();
         try { Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
     }
 }

--- a/test/MeshWeaver.Hosting.Test/FileSystemVersionStoreAtomicityTest.cs
+++ b/test/MeshWeaver.Hosting.Test/FileSystemVersionStoreAtomicityTest.cs
@@ -54,11 +54,16 @@ public class FileSystemVersionStoreAtomicityTest : IDisposable
     private readonly string _dir = Path.Combine(
         Path.GetTempPath(), "MeshWeaverVersionAtomicity", $"t_{Guid.NewGuid():N}");
 
+    // The store REQUIRES a registry (no unbounded fallback — issue #613); a per-class
+    // instance disposed with the test stands in for the mesh-scoped one.
+    private readonly MeshWeaver.Mesh.Threading.IoPoolRegistry _ioPools = new();
+
     public FileSystemVersionStoreAtomicityTest() => Directory.CreateDirectory(_dir);
 
     public void Dispose()
     {
         GC.SuppressFinalize(this);
+        _ioPools.Dispose();
         try { if (Directory.Exists(_dir)) Directory.Delete(_dir, recursive: true); } catch { /* best effort */ }
     }
 
@@ -75,7 +80,7 @@ public class FileSystemVersionStoreAtomicityTest : IDisposable
     [Fact(Timeout = 60000)]
     public async Task AnEnumeratedSnapshotIsAlwaysReadable()
     {
-        var store = new FileSystemVersionStore(_dir);
+        var store = new FileSystemVersionStore(_dir, _ioPools);
 
         var writesDone = false;
         var observations = 0;
@@ -139,7 +144,7 @@ public class FileSystemVersionStoreAtomicityTest : IDisposable
     [Fact(Timeout = 60000)]
     public async Task WritingLeavesNoTemporaryFileBehind()
     {
-        var store = new FileSystemVersionStore(_dir);
+        var store = new FileSystemVersionStore(_dir, _ioPools);
         await store.WriteVersion(Snapshot(1), JsonOptions).FirstAsync();
 
         var files = Directory.GetFiles(Path.Combine(_dir, ".versions", "test"));

--- a/test/MeshWeaver.Persistence.Test/FileSystemChangeWatcherTests.cs
+++ b/test/MeshWeaver.Persistence.Test/FileSystemChangeWatcherTests.cs
@@ -37,7 +37,11 @@ public class FileSystemChangeWatcherTests(ITestOutputHelper output) : MonolithMe
     private FileSystemStorageAdapter CreateStorageAdapter()
     {
         Directory.CreateDirectory(_testDirectory);
-        return new FileSystemStorageAdapter(_testDirectory);
+        // The mesh's own registry (registered by MeshBuilder.AddIoPools), so the adapter's file
+        // I/O is joined by the same teardown drain production uses — issue #613.
+        return new FileSystemStorageAdapter(
+            _testDirectory,
+            Mesh.ServiceProvider.GetRequiredService<MeshWeaver.Mesh.Threading.IoPoolRegistry>());
     }
 
     /// <summary>

--- a/test/MeshWeaver.Persistence.Test/FileSystemIoPoolRoutingTest.cs
+++ b/test/MeshWeaver.Persistence.Test/FileSystemIoPoolRoutingTest.cs
@@ -1,0 +1,113 @@
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Persistence.Test;
+
+/// <summary>
+/// Pins the issue #613 follow-up (a): a <see cref="FileSystemStorageAdapter"/> created through
+/// <see cref="FileSystemStorageAdapterFactory"/> — the path every config-declared FileSystem data
+/// source takes, the FutuRe sample among them — runs its file I/O on the REGISTRY's
+/// <c>FileSystem</c> pool, never on the ledgerless <c>IoPool.Unbounded</c>.
+///
+/// <para>🚨 Why the pool identity matters: <c>IoPool.Unbounded</c> reports
+/// <c>CurrentInFlight =&gt; 0</c> unconditionally and bridges via a bare
+/// <c>Observable.FromAsync</c>, so I/O routed onto it is invisible to
+/// <c>IoPoolRegistry.DrainAll()</c> and the silo teardown join — nothing to cancel, dispose or
+/// wait for. A straggler file read could then enter hub construction during teardown and fault on
+/// an unloaded collectible ALC: the FutuRe.Test exit=139 teardown-SIGSEGV family. The factory used
+/// to construct the adapter without the registry, silently falling back to Unbounded; it now
+/// resolves the registry from the provider and fails LOUDLY when the provider has none.</para>
+/// </summary>
+public class FileSystemIoPoolRoutingTest : IDisposable
+{
+    private readonly string _dir = Directory.CreateTempSubdirectory("mw-fs-iopool-").FullName;
+
+    private static readonly JsonSerializerOptions Options = new();
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_dir, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    [Fact(Timeout = 30000)]
+    public async Task FactoryCreatedAdapter_RunsItsReadOnTheRegistrysFileSystemPool()
+    {
+        // Cap = 1 so pool membership is OBSERVABLE: work queued on this pool cannot run while its
+        // only slot is held, whereas work on IoPool.Unbounded runs immediately regardless.
+        using var registry = new IoPoolRegistry(new IoPoolOptions { FileSystem = 1 });
+        using var provider = new ServiceCollection()
+            .AddSingleton(registry)
+            .BuildServiceProvider();
+
+        var adapter = new FileSystemStorageAdapterFactory()
+            .Create(new GraphStorageConfig { BasePath = _dir }, provider);
+
+        // Seed through the adapter itself — the Write leaf shares the same pool, so this also
+        // proves the green path end-to-end before the gate goes up.
+        await adapter.Write(
+                MeshNode.FromPath("probe/alpha") with { NodeType = "Markdown", Name = "IoPool probe" },
+                Options)
+            .FirstAsync().ToTask();
+
+        var pool = registry.Get(IoPoolNames.FileSystem);
+        // Test-only TCS (never in src/): parks the pool's single slot until released. WaitAsync(ct)
+        // keeps the leaf observing the pool's cancellation token, as every leaf must.
+        var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var blockerDone = pool.Invoke(async ct =>
+        {
+            await gate.Task.WaitAsync(ct).ConfigureAwait(false);
+            return 0;
+        }).FirstAsync().ToTask();
+
+        // Positive half of the proof: the LEDGER sees the held slot. This counter is exactly what
+        // teardown's DrainAll/WhenDrained join on — and what Unbounded can never report.
+        await Observable.Interval(TimeSpan.FromMilliseconds(10)).StartWith(0L)
+            .Where(_ => pool.CurrentInFlight == 1)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(5))
+            .ToTask();
+
+        // The Read is scheduled onto the adapter's pool at CALL time (IoPoolExtensions.Run is
+        // eager), so with the registry's only FileSystem slot held it must queue…
+        var readTask = adapter.Read("probe/alpha", Options).FirstAsync().ToTask();
+
+        // …and must NOT complete while the slot is held. Sanctioned negative window ("did not
+        // run" has no positive signal to filter for): on the pre-fix Unbounded fallback the read
+        // of this tiny file completes in well under the window and this assertion goes red.
+        var winner = await Task.WhenAny(readTask, Task.Delay(250));
+        winner.Should().NotBeSameAs(readTask,
+            "a factory-created adapter's Read must queue on the registry's cap-1 FileSystem " +
+            "pool; completing while the pool's only slot is held means it ran on the ledgerless " +
+            "unbounded pool — invisible to the teardown drain (issue #613's straggler source)");
+
+        gate.SetResult();
+        (await blockerDone).Should().Be(0);
+        var node = await readTask.WaitAsync(TimeSpan.FromSeconds(10));
+        node.Should().NotBeNull("releasing the slot must let the queued Read run to completion");
+        node!.Name.Should().Be("IoPool probe");
+    }
+
+    [Fact]
+    public void Factory_FailsLoudly_WhenTheProviderHasNoIoPoolRegistry()
+    {
+        using var provider = new ServiceCollection().BuildServiceProvider();
+
+        Action act = () => new FileSystemStorageAdapterFactory()
+            .Create(new GraphStorageConfig { BasePath = _dir }, provider);
+
+        // Loud, named failure — never a silent IoPool.Unbounded fallback that would resurrect
+        // the untracked-I/O straggler source this fix closes.
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*IoPoolRegistry*AddIoPools*");
+    }
+}

--- a/test/MeshWeaver.Persistence.Test/LegacyUserPartitionRepairTest.cs
+++ b/test/MeshWeaver.Persistence.Test/LegacyUserPartitionRepairTest.cs
@@ -31,6 +31,10 @@ public class LegacyUserPartitionRepairTest : IDisposable
 
     private readonly string _dir = Directory.CreateTempSubdirectory("legacy-user-repair").FullName;
 
+    // The adapter REQUIRES a registry (no unbounded fallback — issue #613); a per-class
+    // instance disposed with the test stands in for the mesh-scoped one.
+    private readonly MeshWeaver.Mesh.Threading.IoPoolRegistry _ioPools = new();
+
     // String enums like the hub options (state: "Active" must parse the same way it does live).
     private readonly JsonSerializerOptions _options = new(JsonSerializerDefaults.Web)
     {
@@ -38,7 +42,7 @@ public class LegacyUserPartitionRepairTest : IDisposable
     };
 
     private PersistenceService CreateService()
-        => new([new TestProvider(new FileSystemStorageAdapter(_dir))]);
+        => new([new TestProvider(new FileSystemStorageAdapter(_dir, _ioPools))]);
 
     private void SeedLegacyFile(string relativePath, string json)
     {
@@ -266,7 +270,7 @@ public class LegacyUserPartitionRepairTest : IDisposable
     {
         var persistence = new PersistenceService(
             [new NoLegacyPartitionProvider(
-                new ThrowsInsideLegacyPartitionAdapter(new FileSystemStorageAdapter(_dir)))]);
+                new ThrowsInsideLegacyPartitionAdapter(new FileSystemStorageAdapter(_dir, _ioPools)))]);
 
         // Before the existence guard this FAULTED with the 42P01 surrogate instead of answering.
         var node = await persistence.Read("Skill", _options).FirstAsync().ToTask();
@@ -276,6 +280,7 @@ public class LegacyUserPartitionRepairTest : IDisposable
 
     public void Dispose()
     {
+        _ioPools.Dispose();
         try
         {
             Directory.Delete(_dir, recursive: true);

--- a/test/MeshWeaver.Persistence.Test/PartitionObjectsSubscriberIndependenceTest.cs
+++ b/test/MeshWeaver.Persistence.Test/PartitionObjectsSubscriberIndependenceTest.cs
@@ -44,9 +44,12 @@ public class PartitionObjectsSubscriberIndependenceTest
             File.WriteAllText(Path.Combine(partitionDir, $"item{i:D2}.json"),
                 $$"""{"Name":"object {{i}}"}""");
 
+        // The adapter REQUIRES a registry (no unbounded fallback — issue #613); a local
+        // instance disposed with the test stands in for the mesh-scoped one.
+        using var ioPools = new MeshWeaver.Mesh.Threading.IoPoolRegistry();
         try
         {
-            var adapter = new FileSystemStorageAdapter(baseDir);
+            var adapter = new FileSystemStorageAdapter(baseDir, ioPools);
             var options = new JsonSerializerOptions();
 
             Exception? error = null;

--- a/test/MeshWeaver.Persistence.Test/QueryWalkTeardownCancellationTest.cs
+++ b/test/MeshWeaver.Persistence.Test/QueryWalkTeardownCancellationTest.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Persistence.Test;
+
+/// <summary>
+/// Pins what a query walk does once its adapter's I/O pool has been drained — the state every
+/// still-running walk is left in by the mesh teardown now that the FileSystem pool is drainable
+/// (issue #613 follow-up (a)).
+///
+/// <para>🚨 The storm this guards against, measured on CI run 33300005706 shard 5: with the
+/// FileSystem pool drained, every per-path <c>Read</c> of a samples-graph walk was refused with an
+/// <c>OperationCanceledException</c>, and the walk's per-path catch swallowed each one, logged a
+/// Warning-with-exception and carried on to the next path — 2,342 fault records in a few
+/// milliseconds, which exhausted the fault-record budget (100 per 10 s) and suppressed every
+/// genuine fault logged in the following ten seconds (the fault-sink pin test among them). Before
+/// the pool was drainable those same reads ran unsupervised on the unbounded pool instead — the
+/// teardown-crash shape. Cancellation must TERMINATE the walk, not be handled path by path.</para>
+/// </summary>
+public class QueryWalkTeardownCancellationTest : MonolithMeshTestBase
+{
+    private const string Partition = "WalkCancel";
+    private const int Seeded = 40;
+
+    private readonly string _dir = Directory.CreateTempSubdirectory("mw-walk-cancel-").FullName;
+    private readonly CapturingLoggerProvider _capture = new();
+
+    public QueryWalkTeardownCancellationTest(ITestOutputHelper output) : base(output) { }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        // Seeded on DISK, not through the mesh: the point is a walk whose every node is served
+        // by the file-system adapter's pooled Read leaf.
+        var partitionDir = Path.Combine(_dir, Partition);
+        Directory.CreateDirectory(partitionDir);
+        File.WriteAllText(Path.Combine(_dir, Partition + ".json"),
+            $$"""{"id":"{{Partition}}","namespace":"","name":"Walk cancel","nodeType":"Markdown"}""");
+        for (var i = 0; i < Seeded; i++)
+            File.WriteAllText(Path.Combine(partitionDir, $"n{i:D2}.json"),
+                $$"""{"id":"n{{i:D2}}","namespace":"{{Partition}}","name":"Node {{i}}","nodeType":"Markdown"}""");
+
+        return builder
+            .UseMonolithMesh()
+            .AddPartitionedFileSystemPersistence(_dir)
+            .AddRowLevelSecurity()
+            .AddMeshNodes(TestUsers.PublicAdminAccess())
+            // Registered AFTER TestBase's ClearProviders (which runs in its constructor), so the
+            // mesh's ILoggerFactory includes it — asserted below by a probe, never assumed.
+            .ConfigureServices(s => s.AddSingleton<ILoggerProvider>(_capture))
+            .ConfigureServices(s => s.Configure<CompilationCacheOptions>(o =>
+                o.CacheDirectory = Path.Combine(_dir, ".cache")))
+            .AddGraph();
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task ADrainedFileSystemPool_StopsTheWalk_InsteadOfWarningOncePerPath()
+    {
+        // The capture must be LIVE, or the "no warnings" assertion below checks nothing.
+        Mesh.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            .CreateLogger("WalkCancel.Probe").LogWarning("capture-probe");
+        _capture.Warnings.Should().Contain(w => w.Contains("capture-probe"),
+            "the capturing logger provider must be wired into the mesh's logger factory");
+
+        // Control: with the pool alive the walk reads every seeded node — proves the query below
+        // exercises exactly the per-path Read leaf whose refusal is under test.
+        var alive = await Query();
+        alive.Items.Should().HaveCount(Seeded,
+            "the control walk must read every seeded node, otherwise the drained-pool assertion measures nothing");
+
+        // Dispose ONLY the FileSystem pool: the state a mesh teardown leaves a still-running walk in
+        // (the Query pool that carries the subscribe is still alive, so the walk actually runs).
+        var registry = Mesh.ServiceProvider.GetRequiredService<IoPoolRegistry>();
+        ((IDisposable)registry.Get(IoPoolNames.FileSystem)).Dispose();
+
+        var drained = await Query();
+
+        drained.Items.Should().BeEmpty("every pooled Read is refused once the pool is drained");
+        _capture.Warnings.Where(w => w.Contains($"swallowed for path={Partition}/")).Should().BeEmpty(
+            "a refused-at-teardown read is a cancellation that must STOP the walk — handling it as one " +
+            "path's miss logs a Warning-with-exception per remaining path (2,342 in one CI teardown) and " +
+            "exhausts the fault-record budget that the genuine faults need");
+    }
+
+    private Task<QueryResultChange<MeshNode>> Query()
+        => MeshQuery.Query<MeshNode>(MeshQueryRequest.FromQuery($"namespace:{Partition} scope:subtree"))
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .ToTask();
+
+    public override async ValueTask DisposeAsync()
+    {
+        await base.DisposeAsync();
+        try { Directory.Delete(_dir, recursive: true); } catch (IOException) { /* best effort */ }
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        // Instance field on a per-test object — never static (NoStaticState).
+        public ConcurrentQueue<string> Warnings { get; } = new();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, Warnings);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(string category, ConcurrentQueue<string> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel >= LogLevel.Warning)
+                    sink.Enqueue($"[{category}] {formatter(state, exception)}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The mechanism (issue #613, follow-up (a))

Three construction sites dropped the `IoPoolRegistry` when building `FileSystemStorageAdapter`:

1. `FileSystemStorageAdapterFactory.Create` — the path **every config-declared FileSystem data source takes** (the FutuRe sample among them, the one file-system-data-source-backed space);
2. `PersistenceExtensions.AddFileSystemPersistence` (services overload);
3. `PersistenceExtensions.AddPartitionedFileSystemPersistence` — an eager `new FileSystemStorageAdapter(baseDirectory, writeOptionsModifier)` outside DI, which also dropped the logger and the module-contributed parsers.

Because the ctor parameter was optional with a `?? IoPool.Unbounded` fallback, all of that mesh's file I/O ran on the **static ledgerless pool**: `IoPool.Unbounded.CurrentInFlight` is unconditionally `0` and its `Invoke` is a bare `Observable.FromAsync(io).SubscribeOn(TaskPoolScheduler.Default)` — invisible to `IoPoolRegistry.DrainAll()`, to `IoPoolSiloTeardown`'s join, and to #2726's routing-quiescence hold. Nothing to cancel, dispose, or wait for ⇒ teardown reports a clean drain while file I/O is still running ⇒ a straggler Rx emission enters full hub construction during teardown and faults on a span into the unloaded collectible ALC — the #613 `[CI] MeshWeaver.FutuRe.Test exit=139` fingerprint (recurrences 30216998206 / 30221580847, zero failing tests in the trx; #645's CloseCreation cascade did not close it).

This PR shuts the **untracked-I/O straggler source** (follow-up (a)). Issue #613 stays OPEN — the collectible-ALC retention half (follow-up (b)) is still to be done there. (Wording here deliberately avoids GitHub's auto-close keywords.)

## The fix

- **`FileSystemStorageAdapter`**: `IoPoolRegistry` is now a REQUIRED ctor parameter (2nd position) — the compiler names every dropping site; `ArgumentNullException.ThrowIfNull` guards explicit nulls. There is deliberately **no unbounded opt-out** on this adapter.
- **`CachingStorageAdapter`**: same required parameter; its `_ioPoolRegistry` field is now non-nullable and keeps being forwarded to all 5 inner-adapter constructions (audited — every inner site forwards the real registry).
- **`FileSystemVersionStore`**: same defect, same family — it was constructed at `PersistenceExtensions` (IVersionQuery registration) with only a base directory, so version-snapshot writes on FS-backed meshes were untracked too. Registry now required; the one src call site passes it.
- **`FileSystemStorageAdapterFactory.Create`** resolves the registry from the provider and **fails LOUDLY** via the new internal `IServiceProvider.GetRequiredIoPoolRegistry()` helper (`InvalidOperationException` naming the missing registration and pointing at `AddIoPools()`, which `MeshBuilder` calls by default) — never a silent Unbounded fallback.
- **Both `PersistenceExtensions` sites** resolve the registry the same loud way. The partitioned site became a DI factory and additionally gains the **logger** (its absence "restores exactly the silent-failure mode IsolatedChangeFeed exists to kill", per the factory's own comment) and the **module-contributed parsers** (without them an `.md` carrying `nodeType: Agent` silently degrades). `AddCachedFileSystemPersistence` gains the registry + parsers likewise.

### Call sites touched

| Site | Change |
|---|---|
| `src/MeshWeaver.Hosting/Persistence/FileSystemStorageAdapter.cs` | ctor: registry required, no fallback |
| `src/MeshWeaver.Hosting/Persistence/CachingStorageAdapter.cs` | ctor required + 5 forwarding sites reordered |
| `src/MeshWeaver.Hosting/Persistence/FileSystemVersionStore.cs` | ctor: registry required |
| `src/MeshWeaver.Hosting/Persistence/FileSystemStorageAdapterFactory.cs` | loud registry resolution |
| `src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs` | 3 registration sites + IVersionQuery site + `GetRequiredIoPoolRegistry` helper |
| `src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs` | teardown cancellation terminates a walk (3 per-path catches, 4 pipeline catches, WalkLevel) |
| `test/MeshWeaver.Hosting.Test/{FileSystemChangeFeedTest,CodeNodeRoundTripTests,FileSystemVersionStoreAtomicityTest}.cs` | per-class disposed `IoPoolRegistry` |
| `test/MeshWeaver.Persistence.Test/{FileSystemChangeWatcherTests,LegacyUserPartitionRepairTest,PartitionObjectsSubscriberIndependenceTest}.cs` | mesh registry / per-class registry |

**Deliberate `IoPool.Unbounded` opt-ins remaining for these adapters: none.** Tests construct real (disposed) registries; `FileSystemChangeWatcherTests` uses the mesh's own registry. The repo still carries ~28 *soft* fallbacks of the `hub.ServiceProvider.GetService<IoPoolRegistry>()? … ?? IoPool.Unbounded` shape (PluginCatalog, Graph, Orleans routing, KernelExecutor, `EmbeddedResourceStorageAdapter`, …) — those resolve the real registry on every MeshBuilder-built provider and are out of scope here; they are candidates for the same required-parameter treatment as follow-ups.

## What the first CI run surfaced — and the second half of the fix

Run 33300005706 went red on shard 5 with ONE failing test, `TestOutputLoggingLifecycleTest.AFaultLoggedWithNoActiveTest_StillReachesTheOneLogCiKeeps` (the fault-sink pin): `Expected "" to contain "fault-sink-pin-…"`. The shard's trace log shows why: at 08:02:22.219 the Query.Test host hit `[FAULT-BUDGET] budget of 100 fault records per 10s exhausted`, resumed at 08:02:32.759 **after suppressing 2,342 fault records**, and the pin ran at 08:02:27.913 — inside the suppressed window, so its own Error record was dropped by the process budget. Every one of those 2,342 records is `StorageAdapterMeshQueryProvider [MatchScope.Read] swallowed for path=…` carrying `OperationCanceledException: The I/O pool has been disposed (mesh or silo teardown) — this leaf will not run.` Main's shard-5 trace for the same shard has **zero** such records.

That is this PR working, seen from the other side: the FileSystem pool is now drained at teardown, so a query walk still fanning out after `DrainAll` gets every per-path `Read` refused — and the walk's per-path `.Catch` **swallowed the cancellation, logged a Warning-with-exception, returned null and moved on to the next path**, one fault record per remaining path of a samples-graph walk. On main those same stragglers ran unsupervised on `IoPool.Unbounded` and completed silently after teardown (the #613 shape).

Fix (root cause, `StorageAdapterMeshQueryProvider`): teardown cancellation is not a swallowed read error — it **terminates the walk**. The three per-path catches (`MatchScope.Read`, `NextLevel.Read`, `SourceActivity.ReadMain`) propagate `OperationCanceledException` via a shared `SwallowedReadOrStop`; the four pipeline-level catches record a cancelled walk at Debug (it is the expected end of a drained pool, not a fault) and answer empty via `PipelineFaultOrStopped`; `WalkLevel` propagates too. Genuine read faults (timeout / RLS-deny / corrupt row) keep the exact Warning-and-drop-the-node behaviour. New test `QueryWalkTeardownCancellationTest.ADrainedFileSystemPool_StopsTheWalk_InsteadOfWarningOncePerPath` (Persistence.Test): a 40-node on-disk partition, a control walk reads all 40 (so the assertion measures the pooled Read leaf), then ONLY the FileSystem pool is disposed and the same query must answer empty with **no** per-path swallowed warning (a capturing logger provider, proven live by a probe).

Not changed: the fault-sink pin test itself still spends the process budget (its own comment flags that fragility); with the storm gone it is no longer reachable from this change, and the pin's design is a separate discussion.

## External/in-mesh constructor sweep (before changing the public ctor)

- **Sibling repos** — working trees AND freshly-fetched `origin/main` of MeshWeaver.Plugins, .Education, .Reinsurance, .SocialMedia, .Crm, .Manufacturing, `grep`/`git grep` with **no file-type filter** (node JSON and content trees included): **zero references** to `FileSystemStorageAdapter`/`CachingStorageAdapter`/`FileSystemVersionStore` outside `bin/` XML doc files.
- **Core node trees** (`samples/*/Data`, `memex/`): zero constructions.
- **GitHub org-wide code search** (`org:Systemorph`): 0 hits (indexing coverage of private repos is limited — treated as corroborating, not primary, evidence).
- **Live mesh**: `search_chunks` is INACTIVE on both reachable deployments (memex, systemorph — "content indexing is not active"); node `search` for the identifier returned 0 on both. With the chunk index off this cannot be a positive proof, but the type lives in `MeshWeaver.Hosting` — host-composition plumbing that in-mesh `Source/*.cs` / NodeType `configuration` lambdas do not compile against — so no in-mesh caller is expected and none was found.

Given zero external constructors, the signature changed **outright** (no binary-compatible overload kept).

## FileSystemChangeWatcher settlement

`FileSystemChangeWatcher` is **dead on the production path**: nothing in `src/` registers or constructs it (no DI registration, no reflective construction) — the only constructions are `test/MeshWeaver.Persistence.Test/FileSystemChangeWatcherTests.cs`, and `StorageAdapterMeshQueryProvider.cs` references it in a comment only. Live synced queries re-run on the adapters' own `IStorageAdapter.Changes` feed, not on this watcher. Per scope agreement it is NOT deleted here; a `<remarks>` on the class records the finding and the pool requirement should it ever be wired in.

## Docs + tests

- `ControlledIoPooling.md`: new "`IoPool.Unbounded` is LEDGERLESS" subsection under "the mesh teardown drains THREE things" (what Unbounded is, why `CurrentInFlight => 0` blinds the drain, the incident, the required-parameter + loud-failure rule), and the two paragraphs that still taught the optional-`IIoPool?`-with-fallback shape now teach the rule. No new links added. (`DocumentationLinkIntegrityTest` moved to MeshWeaver.Plugins `src/MeshWeaver.AI.Test` with the AI engine and validates against published core packages, so it cannot see this worktree's edit; this repo's full `MeshWeaver.Documentation.Test` guard suite runs green instead.)
- What's New (Category: Fix): `2026-08-30-file-system-io-now-joins-the-teardown-drain.md` — names #613 as the symptom family, explicitly does not claim to close it.
- **New tests** (`test/MeshWeaver.Persistence.Test/FileSystemIoPoolRoutingTest.cs`, plus `QueryWalkTeardownCancellationTest.cs` described above):
  - `FactoryCreatedAdapter_RunsItsReadOnTheRegistrysFileSystemPool` — cap-1 registry, slot held, ledger observed at `CurrentInFlight == 1`, a Read must queue (fails on the pre-fix Unbounded fallback) and completes on release.
  - `Factory_FailsLoudly_WhenTheProviderHasNoIoPoolRegistry` — asserts the named `InvalidOperationException`.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation, each `0 Warning(s) / 0 Error(s)`: MeshWeaver.Hosting, MeshWeaver.Documentation, MeshWeaver.Persistence.Test, MeshWeaver.Hosting.Test, MeshWeaver.Documentation.Test, MeshWeaver.FutuRe.Test. Test suites run Release `--no-build` with fresh trx: Persistence.Test, Hosting.Test, Documentation.Test (guards incl. `WhatsNewEntryIntegrityTest`), FutuRe.Test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
