### PR TITLE
fix(#2695): a failed key resolution is UNAVAILABLE, not "unknown key" — and is never cached

### DIFF
--- a/memex/Memex.Portal.Shared/Api/InstanceAuthResponses.cs
+++ b/memex/Memex.Portal.Shared/Api/InstanceAuthResponses.cs
@@ -1,0 +1,43 @@
+using System.Globalization;
+using MeshWeaver.PluginCatalog;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+
+namespace Memex.Portal.Shared.Api;
+
+/// <summary>
+/// The ONE answer every instance-key-gated endpoint gives when the registry could not FIND OUT
+/// whether a presented key is valid (#2695).
+///
+/// <para>🚨 It is not a 401, and the difference is the caller's entire next move. A 401 says "your
+/// key is unknown", which sends an operator hunting for a missing registration or grant — precisely
+/// the wrong hunt when the grant was there all along and one read was slow. That is not
+/// hypothetical: MeshWeaver.Crm's gate (run 33269921011) read a transient 401 as "this instance
+/// needs a whole-source grant" while `Admin/_PluginGrant/ci-crm` sat unchanged, and a re-run minutes
+/// later passed with nothing altered anywhere.</para>
+///
+/// <para>Shared rather than copied into each endpoint on purpose: four endpoints gate on the same
+/// authenticator, and a distinction that only three of them make is a distinction callers cannot
+/// rely on. Mirrors the identity side's 503 + <c>Retry-After</c> (#637), including the retry
+/// budget, so a client sees one convention across both legs.</para>
+/// </summary>
+internal static class InstanceAuthResponses
+{
+    /// <summary>503 + <c>Retry-After</c>, logged with the reason and the path.</summary>
+    internal static IResult Unavailable(HttpContext http, string? reason, ILogger? logger)
+    {
+        logger?.LogWarning(
+            "Instance-key resolution UNAVAILABLE for {Path} ({Reason}) — answering 503 + Retry-After, "
+            + "NOT 401: nothing was established about the presented key",
+            http.Request.Path, reason ?? "no reason given");
+        http.Response.Headers.RetryAfter =
+            InstanceRegistryAuthenticator.RetryAfterSeconds.ToString(CultureInfo.InvariantCulture);
+        return Results.Json(
+            new
+            {
+                error = "Instance-key resolution is temporarily unavailable — retry shortly. "
+                    + "This is NOT a statement about your key or your grant.",
+            },
+            statusCode: StatusCodes.Status503ServiceUnavailable);
+    }
+}

--- a/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
@@ -78,9 +78,13 @@ public static class InstanceTokenEndpoints
         // 🚨 Authenticate BEFORE touching the signing key. Resolve() mints this registry's key if it
         // has none, and minting is a node write — so doing it first would let an unauthenticated
         // caller provoke one. The order is the access control.
-        return authenticator.Authenticate(header)
-            .SelectMany(caller =>
+        return authenticator.AuthenticateOutcome(header)
+            .SelectMany(outcome =>
             {
+                if (outcome.IsUnavailable)
+                    return Observable.Return(InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger));
+
+                var caller = outcome.Instance;
                 if (caller is null)
                     return Observable.Return(Results.Json(
                         new { error = "A registered instance key is required (Authorization: Bearer mwi_…)." },

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -90,9 +90,13 @@ public static class PluginBundleEndpoints
                 ?.CreateLogger(typeof(PluginBundleEndpoints));
             var authenticator = http.RequestServices.GetRequiredService<InstanceRegistryAuthenticator>();
 
-            var caller = await authenticator.Authenticate(http.Request.Headers.Authorization)
+            var outcome = await authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
                 .FirstAsync().ToTask(http.RequestAborted);
 
+            if (outcome.IsUnavailable)
+                return InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger);
+
+            var caller = outcome.Instance;
             if (caller is null)
             {
                 // 🚨 Fails CLOSED, with no anonymous escape hatch — unlike /api/plugins, which
@@ -109,6 +113,8 @@ public static class PluginBundleEndpoints
             http.Items[CallerItemKey] = caller;
             return await next(ctx);
         });
+
+
 
         // 🚨 The hub is resolved from RequestServices INSIDE the handler, never bound as a
         // parameter. Minimal-API binds handler arguments BEFORE endpoint filters run, so a bound

--- a/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
@@ -57,9 +57,16 @@ public static class PluginRegistryEndpoints
                 ?.CreateLogger(typeof(PluginRegistryEndpoints));
 
             var authenticator = http.RequestServices.GetRequiredService<InstanceRegistryAuthenticator>();
-            var caller = await authenticator.Authenticate(http.Request.Headers.Authorization)
+            var outcome = await authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
                 .FirstAsync().ToTask(http.RequestAborted);
 
+            // 🚨 BEFORE the anonymous fallback below, deliberately. "I could not find out" must not
+            // fall through to serving this registry's sources anonymously — that would turn a
+            // transient read failure into an open door on any instance where the legacy mode is on.
+            if (outcome.IsUnavailable)
+                return InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger);
+
+            var caller = outcome.Instance;
             if (caller is not null)
             {
                 http.Items[CallerItemKey] = caller;
@@ -94,6 +101,8 @@ public static class PluginRegistryEndpoints
 
         return endpoints;
     }
+
+
 
     /// <summary><see cref="HttpContext.Items"/> key holding the authenticated caller.</summary>
     private const string CallerItemKey = "PluginRegistry.Caller";

--- a/memex/Memex.Portal.Shared/Api/ReleaseGateEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/ReleaseGateEndpoints.cs
@@ -53,15 +53,22 @@ public static class ReleaseGateEndpoints
         var authenticator = http.RequestServices
             .GetRequiredService<InstanceRegistryAuthenticator>();
 
-        return authenticator.Authenticate(http.Request.Headers.Authorization)
-            .SelectMany(caller => caller is null
-                ? Observable.Return(Results.Json(
-                    new { error = "A registered instance key is required (Authorization: Bearer mwi_… or Basic)." },
-                    statusCode: StatusCodes.Status401Unauthorized))
-                : Answer(http, version))
+        var logger = http.RequestServices.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(ReleaseGateEndpoints));
+
+        return authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
+            .SelectMany(outcome => outcome.IsUnavailable
+                ? Observable.Return(InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger))
+                : outcome.Instance is null
+                    ? Observable.Return(Results.Json(
+                        new { error = "A registered instance key is required (Authorization: Bearer mwi_… or Basic)." },
+                        statusCode: StatusCodes.Status401Unauthorized))
+                    : Answer(http, version))
             .FirstAsync()
             .ToTask(ct);
     }
+
+
 
     private static IObservable<IResult> Answer(HttpContext http, string? version)
     {

--- a/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
@@ -32,63 +32,117 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
     /// hot path (a consumer polls its catalog, it does not stream).</summary>
     public static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(1);
 
+    /// <summary>
+    /// How long a DEFINITIVE "this key is unknown" is reused — far shorter than a positive.
+    ///
+    /// <para>The two are not symmetric. A positive answer costs a minute of staleness on a
+    /// revocation, which is the trade <see cref="CacheDuration"/> makes deliberately. A negative
+    /// costs a minute of lockout to an instance that has just been registered or re-keyed, for no
+    /// benefit at all: nobody polls a key that does not work. Five seconds still absorbs a burst of
+    /// unauthenticated requests without turning a registration into a coffee break.</para>
+    /// </summary>
+    public static readonly TimeSpan NegativeCacheDuration = TimeSpan.FromSeconds(5);
+
+    /// <summary>Retry-After (seconds) an endpoint advertises when resolution was UNAVAILABLE.
+    /// Matches the API-token leg's <c>ApiTokenAuthenticationHandler.RetryAfterSeconds</c>.</summary>
+    public const int RetryAfterSeconds = 5;
+
     private readonly ConcurrentDictionary<string, (DateTimeOffset At, AuthenticatedInstance? Result)> cache = new();
 
     private static readonly TimeSpan ReadTimeout = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// The node read, injectable so the CACHE and CLASSIFICATION rules can be driven without a
+    /// mesh. Production is <see cref="IMessageHub"/>'s interrogable one-shot read; a test supplies
+    /// an unavailable/absent/present sequence directly.
+    /// </summary>
+    internal Func<string, IObservable<NodeReadOutcome>>? ReadOverride { get; init; }
 
     /// <summary>
     /// Resolves the caller. Emits the authenticated instance, or <c>null</c> when the header carries
     /// no instance key, the key is unknown, its hash does not match, or the instance is disabled.
     /// Never throws for an unauthenticated caller — a failure to authenticate is a <c>null</c>, and
     /// the endpoint turns that into a 401.
+    ///
+    /// <para>🚨 A <c>null</c> here still conflates "unknown key" with "could not find out", which is
+    /// why every endpoint should call <see cref="AuthenticateOutcome"/> instead. This overload is
+    /// kept for callers that genuinely only need the instance.</para>
     /// </summary>
-    public IObservable<AuthenticatedInstance?> Authenticate(string? authorizationHeader)
+    public IObservable<AuthenticatedInstance?> Authenticate(string? authorizationHeader) =>
+        AuthenticateOutcome(authorizationHeader).Select(outcome => outcome.Instance);
+
+    /// <summary>
+    /// Resolves the caller, keeping "this key is unknown" apart from "I could not find out".
+    ///
+    /// <para>🚨 THE DISTINCTION IS THE POINT (#2695). Three point reads stand between a bearer key
+    /// and its instance, and a transient failure of ANY of them used to become a <c>null</c> — which
+    /// the endpoint renders as <c>401 "A registered instance key is required"</c>, and which was then
+    /// <b>cached for a full minute</b>. One slow read on one pod therefore made a perfectly valid key
+    /// unknown to that pod for sixty seconds, and the 401 steered its owner at the wrong fix: a CI
+    /// guard read it as "this instance needs a whole-source grant" while the grant was present and
+    /// unchanged (MeshWeaver.Crm run 33269921011, both jobs, passing minutes later with no change
+    /// anywhere).</para>
+    ///
+    /// <para>So: an <see cref="NodeReadStatus.Unavailable"/> on any leg yields
+    /// <see cref="InstanceAuthResult.Unavailable"/>, and <b>is never cached</b> — a fault must not
+    /// become a fact. Only a read that reached a verdict is remembered. This is the same two-shape
+    /// outcome the identity side adopted for #637; the instance-key leg simply never got it.</para>
+    /// </summary>
+    public IObservable<InstanceAuthResult> AuthenticateOutcome(string? authorizationHeader)
     {
         var rawKey = InstanceKeys.ExtractKey(authorizationHeader);
         if (rawKey is null)
             return AuthenticateToken(authorizationHeader);
 
         var hash = InstanceKeys.Hash(rawKey);
-        if (cache.TryGetValue(hash, out var hit) && DateTimeOffset.UtcNow - hit.At < CacheDuration)
-            return Observable.Return(hit.Result);
+        if (cache.TryGetValue(hash, out var hit)
+            && DateTimeOffset.UtcNow - hit.At < (hit.Result is null ? NegativeCacheDuration : CacheDuration))
+            return Observable.Return(InstanceAuthResult.Resolved(hit.Result));
 
         return Resolve(hash)
-            .Do(result => cache[hash] = (DateTimeOffset.UtcNow, result))
+            .Do(result =>
+            {
+                // Only a VERDICT is cached. Caching the unavailable branch is the whole defect.
+                if (!result.IsUnavailable)
+                    cache[hash] = (DateTimeOffset.UtcNow, result.Instance);
+            })
             .Catch((Exception ex) =>
             {
-                // A read failure is NOT an authentication success. Surface null (→ 401) and log;
-                // never fall through to "allow" because the mesh was briefly unreachable.
-                logger.LogWarning(ex, "Instance key resolution failed for hash prefix {Prefix}",
-                    InstanceKeys.HashPrefix(hash));
-                return Observable.Return<AuthenticatedInstance?>(null);
+                // A read failure is NOT an authentication success — and it is not a denial either.
+                // It is unavailability: uncached, and surfaced as such so the caller retries instead
+                // of being told its key is unknown.
+                logger.LogWarning(ex, "Instance key resolution UNAVAILABLE for hash prefix {Prefix} "
+                    + "— reporting retryable, NOT 'unknown key'", InstanceKeys.HashPrefix(hash));
+                return Observable.Return(InstanceAuthResult.Unavailable(ex.Message));
             });
     }
 
     /// <summary>
-    /// The short-lived-token half of <see cref="Authenticate"/>. A verified token resolves through
-    /// exactly the same index as the key it was exchanged from — it carries that key's hash — so
-    /// there is one resolution path, and re-issuing an instance key invalidates every outstanding
-    /// token because the instance record then holds a different hash.
+    /// The short-lived-token half of <see cref="AuthenticateOutcome"/>. A verified token resolves
+    /// through exactly the same index as the key it was exchanged from — it carries that key's hash
+    /// — so there is one resolution path, and re-issuing an instance key invalidates every
+    /// outstanding token because the instance record then holds a different hash.
     ///
     /// <para>🚨 The token contributes IDENTITY and SCOPE, never authority. The live
     /// <see cref="PluginGrant"/> is still read and still decides, so a revoked or expired sync
     /// licence takes effect immediately instead of surviving until the token runs out.</para>
     /// </summary>
-    private IObservable<AuthenticatedInstance?> AuthenticateToken(string? authorizationHeader)
+    private IObservable<InstanceAuthResult> AuthenticateToken(string? authorizationHeader)
     {
         var rawToken = SyncAccessToken.ExtractToken(authorizationHeader);
         if (rawToken is null)
-            return Observable.Return<AuthenticatedInstance?>(null);
+            return Observable.Return(InstanceAuthResult.Resolved(null));
 
         var keys = hub.ServiceProvider.GetService<SyncTokenSigningKeyService>();
         if (keys is null)
         {
             // No key service is not "allow": a registry that cannot verify a signature must refuse
-            // the token, never accept it unverified.
+            // the token, never accept it unverified. This is a CONFIGURATION verdict, not a
+            // transient one — retrying will not register the service — so it stays a denial.
             logger.LogWarning(
                 "A sync access token was presented but no {Service} is registered — refusing.",
                 nameof(SyncTokenSigningKeyService));
-            return Observable.Return<AuthenticatedInstance?>(null);
+            return Observable.Return(InstanceAuthResult.Resolved(null));
         }
 
         // Existing(), never Resolve(): this caller has not authenticated yet, so minting on their
@@ -101,35 +155,35 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
                 // token minted moments before a rotation still works.
                 var claims = material?.Verify(rawToken, DateTimeOffset.UtcNow);
                 if (claims is null)
-                    return Observable.Return<AuthenticatedInstance?>(null);
+                    return Observable.Return(InstanceAuthResult.Resolved(null));
 
                 return Resolve(claims.KeyHash)
-                    .Select(resolved =>
+                    .Select(outcome =>
                     {
-                        if (resolved is null)
-                            return null;
+                        if (outcome.IsUnavailable || outcome.Instance is null)
+                            return outcome;
                         // The token names an instance AND routes to one. They must be the same
                         // instance, or it is being replayed against a record it does not describe.
                         if (!string.Equals(
-                                resolved.Instance.InstanceId, claims.InstanceId, StringComparison.Ordinal))
+                                outcome.Instance.Instance.InstanceId, claims.InstanceId, StringComparison.Ordinal))
                         {
                             logger.LogWarning(
                                 "Sync access token claims instance {Claimed} but its key resolves to "
                                 + "{Actual} — refusing.",
-                                claims.InstanceId, resolved.Instance.InstanceId);
-                            return null;
+                                claims.InstanceId, outcome.Instance.Instance.InstanceId);
+                            return InstanceAuthResult.Resolved(null);
                         }
-                        return resolved with { TokenScope = claims };
+                        return InstanceAuthResult.Resolved(outcome.Instance with { TokenScope = claims });
                     });
             })
             .Catch((Exception ex) =>
             {
-                logger.LogWarning(ex, "Sync access token resolution failed");
-                return Observable.Return<AuthenticatedInstance?>(null);
+                logger.LogWarning(ex, "Sync access token resolution UNAVAILABLE");
+                return Observable.Return(InstanceAuthResult.Unavailable(ex.Message));
             });
     }
 
-    private IObservable<AuthenticatedInstance?> Resolve(string hash)
+    private IObservable<InstanceAuthResult> Resolve(string hash)
     {
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         var indexPath = $"{MeshWeaverInstanceNodeType.IndexNamespace}/{InstanceKeys.HashPrefix(hash)}";
@@ -142,41 +196,83 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
         // of that same Subscribe, and delivers every notification under the subscriber's own
         // identity, so the three reads below are System and nothing downstream inherits it.
         return accessService.RunAsSystem(() => Read(indexPath)
-            .SelectMany(indexNode =>
+            .SelectMany(indexRead =>
             {
-                var index = Content<MeshWeaverInstanceIndex>(indexNode);
+                if (Unavailable(indexRead, indexPath) is { } unavailable)
+                    return Observable.Return(unavailable);
+
+                var index = Content<MeshWeaverInstanceIndex>(indexRead.Node);
                 if (index is null || !InstanceKeys.HashEquals(hash, index.KeyHash))
-                    return Observable.Return<AuthenticatedInstance?>(null);
+                    return Observable.Return(InstanceAuthResult.Resolved(null));
 
                 return Read(index.InstancePath)
-                    .SelectMany(instanceNode =>
+                    .SelectMany(instanceRead =>
                     {
-                        var instance = Content<MeshWeaverInstance>(instanceNode);
+                        if (Unavailable(instanceRead, index.InstancePath) is { } instanceUnavailable)
+                            return Observable.Return(instanceUnavailable);
+
+                        var instance = Content<MeshWeaverInstance>(instanceRead.Node);
                         // Re-check the hash on the instance itself: the index is a routing hint,
                         // the instance record is the authority. A stale index must not authenticate.
                         if (instance is null || !InstanceKeys.HashEquals(hash, instance.KeyHash))
-                            return Observable.Return<AuthenticatedInstance?>(null);
+                            return Observable.Return(InstanceAuthResult.Resolved(null));
                         if (instance.IsDisabled)
                         {
                             logger.LogWarning("Instance {InstanceId} presented a valid key but is disabled",
                                 instance.InstanceId);
-                            return Observable.Return<AuthenticatedInstance?>(null);
+                            return Observable.Return(InstanceAuthResult.Resolved(null));
                         }
 
-                        return Read(MeshWeaverInstanceNodeType.GrantPath(instance.InstanceId))
-                            // No grant node at all is the NORMAL state for a freshly registered
-                            // instance — it authenticates, and is entitled to nothing.
-                            .Select(grantNode => (AuthenticatedInstance?)new AuthenticatedInstance(
-                                instance,
-                                Content<PluginGrant>(grantNode) ?? new PluginGrant { InstanceId = instance.InstanceId }));
+                        var grantPath = MeshWeaverInstanceNodeType.GrantPath(instance.InstanceId);
+                        return Read(grantPath)
+                            .Select(grantRead =>
+                            {
+                                // 🚨 The grant leg needs the SAME distinction, and it is the easiest
+                                // one to miss: no grant node at all is the NORMAL state for a freshly
+                                // registered instance (it authenticates, and is entitled to nothing),
+                                // whereas an UNREADABLE grant would silently authenticate the caller
+                                // and then refuse every package it asked for — a 403 nobody can act
+                                // on, cached for a minute.
+                                if (Unavailable(grantRead, grantPath) is { } grantUnavailable)
+                                    return grantUnavailable;
+                                return InstanceAuthResult.Resolved(new AuthenticatedInstance(
+                                    instance,
+                                    Content<PluginGrant>(grantRead.Node)
+                                    ?? new PluginGrant { InstanceId = instance.InstanceId }));
+                            });
                     });
             }));
     }
 
-    /// <summary>One-shot read by exact path. The System identity comes from the single
+    /// <summary>The unavailable result for a read that reached no verdict, or null when it did.
+    /// <see cref="NodeReadStatus.DeleteInProgress"/> counts as a verdict — the record is going away,
+    /// so "unknown key" is the right answer and retrying would only delay it.</summary>
+    private InstanceAuthResult? Unavailable(NodeReadOutcome read, string path)
+    {
+        if (read.Status != NodeReadStatus.Unavailable)
+            return null;
+        var reason = read.Failure?.Message ?? "the read reached no verdict";
+        logger.LogWarning(
+            "Instance key resolution: {Path} was UNAVAILABLE ({Reason}) — answering retryable, "
+            + "never 'unknown key', and caching nothing", path, reason);
+        return InstanceAuthResult.Unavailable($"{path}: {reason}");
+    }
+
+    /// <summary>
+    /// One-shot INTERROGABLE read by exact path. The System identity comes from the single
     /// <see cref="ImpersonationScopeExtensions.RunAsSystem{T}"/> scope in <see cref="Resolve"/>, so
-    /// this composes inside it rather than opening a scope of its own.</summary>
-    private IObservable<MeshNode?> Read(string path) => hub.GetMeshNode(path, ReadTimeout);
+    /// this composes inside it rather than opening a scope of its own.
+    ///
+    /// <para>🚨 <c>GetMeshNodeOutcome</c>, not <c>GetMeshNode</c>: the convenience read maps every
+    /// non-Present outcome to the same <c>null</c>, and "absent" versus "I could not read it" is the
+    /// entire question this authenticator has to answer. <see cref="ReadTimeoutBehavior.EmitNull"/>
+    /// keeps a budget overrun on the outcome channel as <see cref="NodeReadStatus.Unavailable"/>
+    /// rather than throwing it into the caller's catch-all.</para>
+    /// </summary>
+    private IObservable<NodeReadOutcome> Read(string path) =>
+        ReadOverride is { } test
+            ? test(path)
+            : hub.GetMeshNodeOutcome(path, ReadTimeout, ReadTimeoutBehavior.EmitNull);
 
     private T? Content<T>(MeshNode? node) where T : class
     {
@@ -190,6 +286,44 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
             return null;
         }
     }
+}
+
+/// <summary>
+/// The outcome of resolving a presented instance key — the seam that keeps <b>"this key is
+/// unknown"</b> apart from <b>"I could not find out"</b> (#2695).
+///
+/// <para>Exactly two shapes, deliberately mirroring the identity side's
+/// <c>IdentityReadOutcome&lt;T&gt;</c> (#637), because it is the same mistake in a different leg:
+/// <list type="bullet">
+///   <item><description><b>Resolved</b> — the resolution reached a verdict.
+///     <see cref="Instance"/> <c>null</c> here is a DEFINITIVE negative: no such key, hash
+///     mismatch, or the instance is disabled. The endpoint answers <c>401</c>, and the result may
+///     be cached.</description></item>
+///   <item><description><b>Unavailable</b> — one of the three reads reached no verdict. NOTHING was
+///     established about the key, so the endpoint answers <c>503</c> + <c>Retry-After</c> and the
+///     result is NEVER cached.</description></item>
+/// </list></para>
+/// </summary>
+public sealed record InstanceAuthResult
+{
+    /// <summary>The authenticated caller, or <c>null</c> — which is a definitive negative when
+    /// resolved, and carries no meaning at all when <see cref="IsUnavailable"/>.</summary>
+    public AuthenticatedInstance? Instance { get; init; }
+
+    /// <summary>Why no verdict was reached, or <c>null</c> when one was.</summary>
+    public string? UnavailableReason { get; init; }
+
+    /// <summary>True when resolution reached NO verdict — retryable, never "unknown key".</summary>
+    public bool IsUnavailable => UnavailableReason is not null;
+
+    /// <summary>The resolution completed; <paramref name="instance"/> is the answer (possibly a
+    /// definitive <c>null</c>).</summary>
+    public static InstanceAuthResult Resolved(AuthenticatedInstance? instance) =>
+        new() { Instance = instance };
+
+    /// <summary>The resolution reached no verdict — answer retryable, and cache nothing.</summary>
+    public static InstanceAuthResult Unavailable(string reason) =>
+        new() { UnavailableReason = reason };
 }
 
 /// <summary>An authenticated caller: which instance presented the key, and what it may pull.</summary>

--- a/test/MeshWeaver.Auth.Test/InstanceKeyUnavailableNotUnknownTest.cs
+++ b/test/MeshWeaver.Auth.Test/InstanceKeyUnavailableNotUnknownTest.cs
@@ -1,0 +1,198 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Auth.Test;
+
+/// <summary>
+/// Issue #2695 — "I could not find out" must never be reported, or REMEMBERED, as "this key is
+/// unknown".
+///
+/// <para>Three point reads stand between a bearer key and its instance. A transient failure of any
+/// of them used to become a <c>null</c> — rendered as <c>401 "A registered instance key is
+/// required"</c> — and then <b>cached for a full minute</b>, so one slow read on one pod made a
+/// valid key unknown to that pod for sixty seconds. MeshWeaver.Crm's gate (run 33269921011) hit it
+/// in both jobs and read the 401 as "this instance needs a whole-source grant", while the grant sat
+/// unchanged; a re-run minutes later passed with nothing altered anywhere.</para>
+///
+/// <para>These drive the authenticator's read seam directly, so what is pinned is the
+/// CLASSIFICATION and the CACHE rule rather than "an error appears somewhere". The definitive legs
+/// are pinned alongside, so the fix cannot over-reach into "everything is retryable" — an unknown
+/// key must still be a fast, cacheable, definitive no.</para>
+/// </summary>
+public class InstanceKeyUnavailableNotUnknownTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Key = "mwi_0123456789abcdef0123456789abcdef";
+
+    /// <summary>Every read answers Unavailable — the shape of a stalled or faulted partition.</summary>
+    /// <summary>A REAL authenticator on the real mesh hub — only its node READ is driven, so the
+    /// System impersonation, the hashing and the cache are the production ones.</summary>
+    private InstanceRegistryAuthenticator Authenticator(
+        Func<string, IObservable<NodeReadOutcome>> read, List<string>? seen = null) =>
+        new(Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>())
+        {
+            ReadOverride = path =>
+            {
+                seen?.Add(path);
+                return read(path);
+            },
+        };
+
+    private static NodeReadOutcome Unavailable() =>
+        new() { Status = NodeReadStatus.Unavailable, Failure = new TimeoutException("read stalled") };
+
+    private static NodeReadOutcome Absent() => new() { Status = NodeReadStatus.Absent };
+
+    /// <summary>
+    /// SHOULD-FAIL-IF: an unreadable index is reported as an authentication verdict. That is the
+    /// defect — the endpoint then tells a valid caller its key is unknown.
+    /// </summary>
+    [Fact]
+    public async Task AnUnreadableIndex_IsUnavailable_NotUnknownKey()
+    {
+        var outcome = await Authenticator(_ => Observable.Return(Unavailable()))
+            .AuthenticateOutcome($"Bearer {Key}").FirstAsync().ToTask();
+
+        outcome.IsUnavailable.Should().BeTrue(
+            "a read that reached no verdict establishes NOTHING about the presented key");
+        outcome.Instance.Should().BeNull();
+        outcome.UnavailableReason.Should().Contain("read stalled",
+            "the cause travels to the endpoint, which logs it beside the 503");
+    }
+
+    /// <summary>
+    /// SHOULD-FAIL-IF: the unavailable result is cached. This is the part that turned one slow read
+    /// into a MINUTE of 401s — and it is invisible in a single-request test, which is why the second
+    /// call here is the assertion.
+    /// </summary>
+    [Fact]
+    public async Task AnUnavailableResolution_IsNeverCached()
+    {
+        var attempts = 0;
+        var authenticator = Authenticator(_ =>
+        {
+            attempts++;
+            return Observable.Return(Unavailable());
+        });
+
+        await authenticator.AuthenticateOutcome($"Bearer {Key}").FirstAsync().ToTask();
+        var firstRoundAttempts = attempts;
+        await authenticator.AuthenticateOutcome($"Bearer {Key}").FirstAsync().ToTask();
+
+        attempts.Should().BeGreaterThan(firstRoundAttempts,
+            "the second call must RE-READ the mesh: a fault is not a fact, and remembering it is "
+            + "what locked a valid instance out for the whole cache duration");
+    }
+
+    /// <summary>
+    /// SHOULD-FAIL-IF: the fix over-reaches. A key that genuinely resolves to nothing is a verdict —
+    /// it must be reported as a denial (401, not 503) and it must still be cached, or every
+    /// unauthenticated request re-reads three nodes.
+    /// </summary>
+    [Fact]
+    public async Task AnAbsentIndex_IsADefinitiveNo_AndIsCached()
+    {
+        var attempts = 0;
+        var authenticator = Authenticator(_ =>
+        {
+            attempts++;
+            return Observable.Return(Absent());
+        });
+
+        var first = await authenticator.AuthenticateOutcome($"Bearer {Key}").FirstAsync().ToTask();
+        first.IsUnavailable.Should().BeFalse("an absent index IS an answer: this key is unknown");
+        first.Instance.Should().BeNull();
+
+        var after = attempts;
+        var second = await authenticator.AuthenticateOutcome($"Bearer {Key}").FirstAsync().ToTask();
+        second.IsUnavailable.Should().BeFalse();
+        attempts.Should().Be(after, "a definitive negative is cached — briefly, but cached");
+    }
+
+    /// <summary>
+    /// SHOULD-FAIL-IF: only the FIRST read is classified. The grant leg is the easiest to miss and
+    /// the worst to get wrong: an unreadable grant authenticates the caller and then refuses every
+    /// package it asks for — a 403 nobody can act on — whereas an ABSENT grant is the normal state
+    /// of a freshly registered instance and must stay a clean authentication.
+    ///
+    /// <para>This drives all three legs for real: a matching index, a matching instance, and then a
+    /// grant read that either stalls or is absent.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(true)]   // grant unreadable  → UNAVAILABLE, uncached, 503
+    [InlineData(false)]  // grant absent      → authenticated with an empty grant, as designed
+    public async Task TheGrantLegIsClassifiedToo(bool grantStalls)
+    {
+        var hash = InstanceKeys.Hash(Key);
+        const string instancePath = "owner/MeshWeaverInstance/inst-a";
+        var grantPath = MeshWeaverInstanceNodeType.GrantPath("inst-a");
+
+        MeshNode Node(string path, object content) =>
+            MeshNode.FromPath(path) with { Content = content };
+
+        var seen = new List<string>();
+        var authenticator = Authenticator(path =>
+        {
+            if (path == grantPath)
+                return Observable.Return(grantStalls ? Unavailable() : Absent());
+            if (path == instancePath)
+                return Observable.Return(new NodeReadOutcome
+                {
+                    Status = NodeReadStatus.Present,
+                    Node = Node(instancePath, new MeshWeaverInstance
+                    {
+                        InstanceId = "inst-a", KeyHash = hash, DisplayName = "A",
+                    }),
+                });
+            // the index
+            return Observable.Return(new NodeReadOutcome
+            {
+                Status = NodeReadStatus.Present,
+                Node = Node(path, new MeshWeaverInstanceIndex
+                {
+                    KeyHash = hash, InstancePath = instancePath, InstanceId = "inst-a",
+                }),
+            });
+        }, seen);
+
+        var outcome = await authenticator.AuthenticateOutcome($"Bearer {Key}").FirstAsync().ToTask();
+
+        seen.Should().Contain(grantPath, "all three legs must actually be read");
+        if (grantStalls)
+        {
+            outcome.IsUnavailable.Should().BeTrue(
+                "an unreadable GRANT establishes nothing either — authenticating and then denying "
+                + "every package is a verdict the read never reached");
+            outcome.UnavailableReason.Should().Contain(grantPath, "the failing leg is named");
+        }
+        else
+        {
+            outcome.IsUnavailable.Should().BeFalse();
+            outcome.Instance.Should().NotBeNull("an ABSENT grant is the normal freshly-registered state");
+            outcome.Instance!.Grant.Allows("Plugins", "Store").Should().BeFalse(
+                "…and it authorizes nothing");
+        }
+    }
+
+    /// <summary>The negative cache is deliberately far shorter than the positive one: nobody polls
+    /// a key that does not work, and a minute of lockout after a fresh registration buys nothing.</summary>
+    [Fact]
+    public void NegativeCache_IsShorterThanPositive()
+    {
+        InstanceRegistryAuthenticator.NegativeCacheDuration.Should()
+            .BeLessThan(InstanceRegistryAuthenticator.CacheDuration);
+        InstanceRegistryAuthenticator.RetryAfterSeconds.Should().BeGreaterThan(0,
+            "the 503 advertises a retry budget, like the identity leg's");
+    }
+}


### PR DESCRIPTION
## The defect (#2695)

Three point reads stand between a bearer `mwi_…` and its instance. All three went through `GetMeshNode`, which maps **every** non-Present outcome to the same `null` — so a transient read failure became *"this key is unknown"*, the endpoint rendered it as `401 A registered instance key is required`, and `.Do(result => cache[hash] = …)` then **remembered it for a full minute**.

One slow read on one pod made a valid key unknown to that pod for sixty seconds. And the 401 steered its owner at the wrong fix: MeshWeaver.Crm's gate (run `33269921011`) read it as *"this instance needs a whole-source grant"* while `Admin/_PluginGrant/ci-crm` sat unchanged and unrevoked — a re-run minutes later passed with nothing altered anywhere.

**A fault cached as a fact** — the same class as #1369 and #2509, and precisely the collapse the identity side fixed in #637. This applies that fix's two-shape outcome to the instance-key leg, which never got it.

## The fix

| | |
|---|---|
| `InstanceAuthResult` | **Resolved** (a verdict — possibly a definitive "unknown") vs **Unavailable** (no verdict reached). `AuthenticateOutcome` returns it; `Authenticate` still returns just the instance for callers that only need that. |
| the reads | `GetMeshNodeOutcome` with `EmitNull`, so *absent* and *unreadable* stop being the same answer and a budget overrun stays on the outcome channel instead of falling into a catch-all. |
| **all three legs** | including the **grant** — the easiest to miss and the worst to get wrong: an unreadable grant would authenticate the caller and then refuse every package it asked for, a 403 nobody can act on. An *absent* grant stays what it has always been: the normal state of a freshly registered instance. |
| the cache | Unavailable is **never** cached. Only a verdict is. |
| negative TTL | 5 s, not 60. Nobody polls a key that does not work, and a minute of lockout after a fresh registration or re-key buys nothing — the two directions were never symmetric. |
| the endpoints | all four answer **503 + `Retry-After`** on unavailable, through one shared `InstanceAuthResponses.Unavailable`. A distinction only three of them made is one callers cannot rely on. |

🚨 In `PluginRegistryEndpoints` the unavailable check sits **before** the legacy anonymous fallback, deliberately: otherwise a transient read failure would fall through to serving the registry's sources anonymously on any instance where that mode is still on.

## Measured — and proven non-vacuous

6 new tests drive the authenticator's read seam against a **real mesh hub** (real impersonation, real hashing, real cache — only the node read is supplied), so what is pinned is the classification and the cache rule, not "an error appears somewhere".

Both halves were then **mutated back** to confirm the tests can fail:

| mutation | result |
|---|---|
| cache the unavailable result (the original `.Do`) | ✗ `AnUnavailableResolution_IsNeverCached` fails |
| treat Unavailable as a verdict (`GetMeshNode`'s behaviour) | ✗ that test **and** `AnUnreadableIndex_IsUnavailable_NotUnknownKey` fail |

And the definitive legs are pinned alongside so the fix cannot over-reach into "everything is retryable": an absent index is still a fast, **cached**, definitive no; an absent grant still authenticates with an empty grant.

Suites: `MeshWeaver.Auth.Test` **159/159**, `Memex.Portal.Shared.Test` bundle+registry **23/23**.

## Not in this change

The issue's third observation — the reusable gates log only curl's exit status, so neither the URL nor the response body survives — is a CI-side change in the plugin repos' shared workflows, not here. Worth doing (it would have made this a five-minute diagnosis), and it wants its own PR.

Fixes #2695

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116xyzDmWMD7ARtTBMbxj9j