### PR TITLE
ci(harness): a shard with recorded failures and rc<128 is TESTFAIL, not a host crash — xunit v3 exits 1 for any failure

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1111,7 +1111,7 @@ jobs:
             139) marker="[CI] $label exit=$rc SIGNAL SIGSEGV (host died on a signal, not an assertion)"
               crash="SIGNAL SIGSEGV: the host died on a signal, not an assertion — see #613 (use-after-unload of a collectible ALC). A mini dump is in collected-logs/." ;;
             *)
-              # 🚨 xunit v3 exits 1 for ANY number of failures — NOT with the failure count. The
+              # 🚨 xUnit v3 exits 1 for ANY number of failures — NOT with the failure count. The
               # earlier rule `rc == trxfails` held only for the one-failure case by coincidence:
               # on main 81f8869d5 (2026-08-30) Hosting.Monolith.Test printed its normal summary
               # `Total: 331, Failed: 2` and exited 1, and this branch called it a host crash
@@ -1121,7 +1121,7 @@ jobs:
               # signal exit (handled above), no trx at all, or a non-zero exit with NOTHING
               # recorded as failed — never a healthy summary with rc<128.
               if [ -f "$trxfile" ] && [ "${trxfails:-0}" -gt 0 ] && [ "$rc" -lt 128 ]; then
-                marker="[CI] $name exit=$rc TESTFAIL ($trxfails failing test(s) recorded in trx; xunit v3 exits 1 for any failure; the host completed normally)"
+                marker="[CI] $name exit=$rc TESTFAIL ($trxfails failing test(s) recorded in trx; xUnit v3 exits 1 for any failure; the host completed normally)"
               elif [ ! -f "$trxfile" ]; then
                 marker="[CI] $label exit=$rc MASKED (no trx written — the host died before recording any result)"
                 crash="MASKED: exit=$rc with no trx — the host died before recording any result."

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1111,8 +1111,17 @@ jobs:
             139) marker="[CI] $label exit=$rc SIGNAL SIGSEGV (host died on a signal, not an assertion)"
               crash="SIGNAL SIGSEGV: the host died on a signal, not an assertion — see #613 (use-after-unload of a collectible ALC). A mini dump is in collected-logs/." ;;
             *)
-              if [ "$rc" = "$trxfails" ]; then
-                marker="[CI] $name exit=$rc TESTFAIL ($trxfails failing test(s) recorded in trx — xunit v3 exits with the failure count; the host completed normally)"
+              # 🚨 xunit v3 exits 1 for ANY number of failures — NOT with the failure count. The
+              # earlier rule `rc == trxfails` held only for the one-failure case by coincidence:
+              # on main 81f8869d5 (2026-08-30) Hosting.Monolith.Test printed its normal summary
+              # `Total: 331, Failed: 2` and exited 1, and this branch called it a host crash
+              # ("MASKED … host crashed after streaming results") and wrote a synthetic
+              # HOST_CRASHED over two ordinary flakes. A host that recorded failures and exited
+              # below the signal range (128+) completed normally: that is TESTFAIL. A crash is a
+              # signal exit (handled above), no trx at all, or a non-zero exit with NOTHING
+              # recorded as failed — never a healthy summary with rc<128.
+              if [ -f "$trxfile" ] && [ "${trxfails:-0}" -gt 0 ] && [ "$rc" -lt 128 ]; then
+                marker="[CI] $name exit=$rc TESTFAIL ($trxfails failing test(s) recorded in trx; xunit v3 exits 1 for any failure; the host completed normally)"
               elif [ ! -f "$trxfile" ]; then
                 marker="[CI] $label exit=$rc MASKED (no trx written — the host died before recording any result)"
                 crash="MASKED: exit=$rc with no trx — the host died before recording any result."

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-red-shard-with-two-failures-is-not-a-host-crash.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-red-shard-with-two-failures-is-not-a-host-crash.md
@@ -1,14 +1,17 @@
 ---
-title: A red shard with two failing tests is no longer reported as a host crash
-category: Fix
-icon: Bug
-date: 2026-08-30
+Name: A red shard with two failing tests is no longer reported as a host crash
+Category: Fix
+Description: CI's harness assumed xUnit v3 exits with the number of failing tests; a shard that completed with two failures was reported as a host crash, hiding the real failures.
+Order: -20260830
+Icon: Bug
 ---
 
-CI's test harness assumed xunit v3 exits with the number of failing tests, so a shard whose host
+# A red shard with two failing tests is no longer reported as a host crash
+
+CI's test harness assumed xUnit v3 exits with the number of failing tests, so a shard whose host
 completed normally with two recorded failures (exit code 1) was classified as "host crashed after
 streaming results" and a synthetic `HOST_CRASHED` failure was written into the results — hiding the
-two real failures behind a crash that never happened. xunit v3 exits 1 for any number of failures.
+two real failures behind a crash that never happened. xUnit v3 exits 1 for any number of failures.
 The rule now reads: failures recorded and an exit code below the signal range means the host
 completed and the run is a plain test failure; a crash is a signal exit, a missing results file, or
 a non-zero exit with nothing recorded.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-red-shard-with-two-failures-is-not-a-host-crash.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-red-shard-with-two-failures-is-not-a-host-crash.md
@@ -1,0 +1,14 @@
+---
+title: A red shard with two failing tests is no longer reported as a host crash
+category: Fix
+icon: Bug
+date: 2026-08-30
+---
+
+CI's test harness assumed xunit v3 exits with the number of failing tests, so a shard whose host
+completed normally with two recorded failures (exit code 1) was classified as "host crashed after
+streaming results" and a synthetic `HOST_CRASHED` failure was written into the results — hiding the
+two real failures behind a crash that never happened. xunit v3 exits 1 for any number of failures.
+The rule now reads: failures recorded and an exit code below the signal range means the host
+completed and the run is a plain test failure; a crash is a signal exit, a missing results file, or
+a non-zero exit with nothing recorded.


### PR DESCRIPTION
## Measured
main `81f8869d5`, shard 1: `MeshWeaver.Hosting.Monolith.Test  Total: 331, Errors: 0, Failed: 2` (the host's own summary — it completed), exit code **1**. `dotnet-test.yml`'s rule `if [ "$rc" = "$trxfails" ]` ("xunit v3 exits with the failure count") did not match, so the run was classified `MASKED … host crashed after streaming results` and a synthetic `MeshWeaver.Hosting.Monolith.Test.HOST_CRASHED` was written into the trx. The two real failures were `RecycleSurvivesItsOwnDisposeTest` (#2727) and `UserHomeLegacyPathResolutionTest` — flakes, not a crash. `5e73bfcaa` (one failure, exit 1) was classified correctly only because 1 == 1.

xunit v3 exits 1 for any number of failures, not with the count.

## Rule now
Failures recorded in the trx AND `rc < 128` ⇒ `TESTFAIL` (host completed). A crash is: a signal exit (132/134/135/139, handled above), no trx at all, or a non-zero exit with nothing recorded as failed. The `MASKED (… does not explain exit=N)` branch survives only for that last shape.

Guards: `check-workflow-shell.py` 0 live; YAML parses. What's New included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)