### PR TITLE
fix(#2727): a delivery that reaches a RECYCLED hub is refused as transient, not as a permission verdict

### DIFF
--- a/src/MeshWeaver.Hosting/MeshWeaver.Hosting.csproj
+++ b/src/MeshWeaver.Hosting/MeshWeaver.Hosting.csproj
@@ -5,6 +5,10 @@
          PresentationScreenTest, next to the rest of the screen's behaviour, so the completion
          surface's rule cannot drift from the one the tile surfaces apply. -->
     <InternalsVisibleTo Include="MeshWeaver.Graph.Test" />
+    <!-- The recycled-hub refusal (AccessControlPipeline.IsHubGone / RecyclingRefusal, issue #2727)
+         is pinned there: its discrimination and its WORDING are both contract, and the wording is
+         only meaningful against MeshNodeStreamCache's transient classifier in the same assembly. -->
+    <InternalsVisibleTo Include="MeshWeaver.Hosting.Test" />
   </ItemGroup>
   <PropertyGroup>
     <ProjectGuid>{93595120-3ccf-45c6-8783-4829a1120166}</ProjectGuid>

--- a/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
+++ b/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
@@ -35,6 +35,55 @@ public static class AccessControlPipeline
     private static readonly ConcurrentDictionary<Type, RequiresPermissionAttribute?> AttributeCache = new();
 
     /// <summary>
+    /// True when the gate could not run because THIS HUB IS GONE — it is shutting down (its own
+    /// disposal, or an ancestor's freeze), or the failure is the disposed lifetime scope its
+    /// services resolve from.
+    ///
+    /// <para>Both halves are needed and neither is sufficient. <see cref="IMessageHub.IsShuttingDown"/>
+    /// alone misses the RECYCLE window this exists for: the delivery is being evaluated on a hub
+    /// whose disposal has already COMPLETED, so it is not "shutting down" any more, it is gone —
+    /// and the only evidence left is the <see cref="ObjectDisposedException"/> its scope throws.
+    /// The exception test alone would over-claim: an <see cref="ObjectDisposedException"/> from
+    /// something the HANDLER touched on a live hub is a real fault, not a recycle, so the message
+    /// is matched on the Autofac scope wording the rest of the codebase already keys on (the same
+    /// two shapes <c>TeardownStragglerCapturer</c> filters).</para>
+    /// </summary>
+    /// <summary>
+    /// The refusal a delivery gets when it reached a hub that is GONE (see <see cref="IsHubGone"/>).
+    ///
+    /// <para>🚨 THE WORDING IS CONTRACT, exactly as <c>MessageService.NackThroughParent</c>'s is.
+    /// The mesh classifies delivery failures by their MESSAGE TEXT as well as their ErrorType, and
+    /// this sentence must be matched as TRANSIENT by every one of
+    /// <c>MeshNodeStreamCache.IsTransientOwnerFailure</c>, <c>RoutingGrain.IsTransientFailure</c>
+    /// and <c>AreaErrorClassifier.IsTransientHubFailure</c> — that is the whole point: the caller
+    /// must RE-PROBE and land on the fresh activation instead of taking a corpse's answer as
+    /// final. It therefore carries their markers verbatim ("is shutting down", "Rejecting now").
+    /// Reword it casually and #2727 comes back silently — nothing fails to compile, the delivery
+    /// is still refused, and the caller simply stops retrying again. Pinned by
+    /// <c>RecycledHubRefusalTest</c>.</para>
+    /// </summary>
+    internal static string RecyclingRefusal(Address address, string messageTypeName, Exception error) =>
+        $"Hub {address} is shutting down (its lifetime scope is gone, {error.GetType().Name}) "
+        + $"— cannot evaluate access for {messageTypeName}; the address may reactivate "
+        + "(recycle / restart). Rejecting now.";
+
+    internal static bool IsHubGone(IMessageHub hub, Exception error)
+    {
+        if (hub.IsShuttingDown)
+            return true;
+        for (var e = error; e is not null; e = e.InnerException)
+        {
+            if (e is not ObjectDisposedException)
+                continue;
+            var msg = e.Message ?? string.Empty;
+            if (msg.Contains("LifetimeScope", StringComparison.OrdinalIgnoreCase)
+                || msg.Contains("nested lifetimes cannot be created", StringComparison.OrdinalIgnoreCase))
+                return true;
+        }
+        return false;
+    }
+
+    /// <summary>
     /// One (path, permission) check together with the outcome the fold reached for it. Carries the
     /// tri-state (<see cref="PermissionCheckOutcome"/>) AND the identity of the check that produced
     /// it, so the <see cref="DeliveryFailure"/> can name the exact path/permission that refused the
@@ -147,6 +196,55 @@ public static class AccessControlPipeline
                     // NOT a swallow: the delivery is refused (next is never invoked) and the
                     // reason is both logged and carried to the caller. It is classified, because
                     // "the gate could not run" is not the same fact as "you are not allowed".
+                    //
+                    // 🚨 …and "the gate could not run BECAUSE THIS HUB IS GONE" is a third fact
+                    // again, which is what issue #2727 is. A delivery routed to a hub that has
+                    // since been RECYCLED reaches this pipeline holding the OLD hub's captured
+                    // `hub`, whose lifetime scope core#2438 now genuinely closes — so the first
+                    // `GetRequiredService` throws ObjectDisposedException and every such delivery
+                    // was answered `Unavailable` with a sentence carrying none of the markers the
+                    // transient classifiers match (MeshNodeStreamCache.IsTransientOwnerFailure,
+                    // RoutingGrain.IsTransientFailure, AreaErrorClassifier.IsTransientHubFailure).
+                    // The caller therefore treated a hub that is COMING BACK as a terminal answer
+                    // and never re-probed: RecycleSurvivesItsOwnDisposeTest reads null for an
+                    // address that is alive one activation later, SilentReadNackTest gets a
+                    // non-NACK, and a layout render wedges instead of retrying. Before #2438 the
+                    // scope never actually closed, so the same ordering resolved from a zombie
+                    // scope and passed — the bug was always here, the leak fix only exposed it.
+                    //
+                    // So: recognise it, and answer it in the vocabulary the rest of the mesh
+                    // already speaks for a recycling address — the SAME wording MessageService's
+                    // shutting-down gate uses, markers included ("is shutting down", "the address
+                    // may reactivate (recycle / restart)", "Rejecting now"), so the existing
+                    // re-probe machinery rides it out and lands on the fresh activation.
+                    // Refusal is unchanged: `next` is still never invoked, so nothing is granted.
+                    if (IsHubGone(hub, ex))
+                    {
+                        var recycling = RecyclingRefusal(hub.Address, delivery.Message.GetType().Name, ex);
+                        logger?.LogDebug(ex,
+                            "AccessControlPipeline: {MessageType} reached {Hub} after that hub was disposed — "
+                            + "NACKing as SHUTTING DOWN so the caller re-probes the fresh activation, "
+                            + "not as a permission verdict",
+                            delivery.Message.GetType().Name, hub.Address);
+                        // 🚨 Through the PARENT. This hub's own Post is gated closed once it is past
+                        // DisposeHostedHubs (PostImplGeneric refuses every non-shutdown message), so
+                        // posting the refusal here is how the caller ended up with silence instead of
+                        // a NACK. Same escape MessageService.NackThroughParent uses; correlation
+                        // rides ResponseFor's RequestId, never the posting hub's identity. During a
+                        // whole-mesh teardown the parent is itself past that point, the guard skips
+                        // the post, and nobody is waiting anyway.
+                        var parent = hub.Configuration.ParentHub;
+                        if (parent is not null && parent.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
+                            parent.Post(
+                                new DeliveryFailure(delivery)
+                                {
+                                    ErrorType = ErrorType.ShuttingDown,
+                                    Message = recycling
+                                },
+                                o => o.ResponseFor(delivery));
+                        return Observable.Return(delivery.Failed(recycling, ErrorType.ShuttingDown));
+                    }
+
                     logger?.LogWarning(ex,
                         "AccessControlPipeline: could not evaluate access for {MessageType} on {Hub} — "
                         + "reporting UNAVAILABLE (retryable), not a denial",

--- a/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
+++ b/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
@@ -242,7 +242,14 @@ public static class AccessControlPipeline
                                     Message = recycling
                                 },
                                 o => o.ResponseFor(delivery));
-                        return Observable.Return(delivery.Failed(recycling, ErrorType.ShuttingDown));
+                        // 🚨 Forwarded, NOT Failed — the SAME shape both sibling branches use, and
+                        // for the same reason. The authoritative typed DeliveryFailure has just been
+                        // posted; returning a Failed delivery on top of it makes ReportFailure post a
+                        // SECOND, unclassified one for the same request (that is what
+                        // MessageService.FailureAlreadyReported exists to suppress, and this path has
+                        // no marker to carry). Two answers to one correlation is strictly worse than
+                        // the misclassification this fix removes.
+                        return Observable.Return(delivery.Forwarded());
                     }
 
                     logger?.LogWarning(ex,

--- a/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
+++ b/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
@@ -1,3 +1,4 @@
+using System.Reactive.Threading.Tasks;
 using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -70,7 +71,7 @@ public class RecycledHubRefusalTest : HubTestBase
     /// here would convert genuine faults into silent retries.
     /// </summary>
     [Fact]
-    public void OnlyAGoneHub_Qualifies_NotEveryObjectDisposedException()
+    public async Task OnlyAGoneHub_Qualifies_NotEveryObjectDisposedException()
     {
         var live = GetHost();
 
@@ -88,12 +89,10 @@ public class RecycledHubRefusalTest : HubTestBase
                 + "reached no verdict, and not retried as a recycle");
 
         live.Dispose();
-        await_disposal(live);
+        await live.DisposalCompleted.FirstOrDefaultAsync().ToTask();
         AccessControlPipeline.IsHubGone(live, new InvalidOperationException("boom"))
             .Should().BeTrue("a hub that is shutting down qualifies whatever the failure was — its "
                 + "services are going away underneath every check");
 
-        static void await_disposal(IMessageHub hub) =>
-            hub.DisposalCompleted.FirstOrDefaultAsync().Wait();
     }
 }

--- a/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
+++ b/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
@@ -1,4 +1,3 @@
-using System.Reactive.Threading.Tasks;
 using System;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
@@ -89,7 +88,9 @@ public class RecycledHubRefusalTest : HubTestBase
                 + "reached no verdict, and not retried as a recycle");
 
         live.Dispose();
-        await live.DisposalCompleted.FirstOrDefaultAsync().ToTask();
+        // Awaited DIRECTLY on the observable — no `.ToTask()` bridge anywhere, tests included
+        // (maintainer, 2026-08-30). The Timeout keeps a hung disposal a failure, not a hang.
+        await live.DisposalCompleted.FirstOrDefaultAsync().Timeout(TimeSpan.FromSeconds(30));
         AccessControlPipeline.IsHubGone(live, new InvalidOperationException("boom"))
             .Should().BeTrue("a hub that is shutting down qualifies whatever the failure was — its "
                 + "services are going away underneath every check");

--- a/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
+++ b/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
@@ -1,0 +1,95 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>A delivery that reaches a RECYCLED hub must be refused as TRANSIENT, so the caller
+/// re-probes and lands on the fresh activation.</b> Issue #2727.
+///
+/// <para>Core#2438 made a hub's lifetime scope genuinely close. A delivery routed to an address
+/// whose hub was recycled reaches <see cref="AccessControlPipeline"/> holding the OLD hub, so the
+/// gate's first <c>GetRequiredService</c> throws <see cref="ObjectDisposedException"/> from the
+/// closed scope. That was answered <c>Unavailable</c> with a sentence carrying NONE of the markers
+/// the transient classifiers match — so the caller took a corpse's answer as final and never
+/// re-probed: <c>RecycleSurvivesItsOwnDisposeTest</c> reads null for an address that is alive one
+/// activation later, <c>SilentReadNackTest</c> gets a non-NACK, a render wedges. Before #2438 the
+/// scope never actually closed and the same ordering resolved from a zombie scope, so the bug was
+/// always there — the leak fix only exposed it.</para>
+///
+/// <para>These are the two halves of the fix, and both are contract: WHICH failures count as
+/// "this hub is gone", and the WORDING the refusal carries — because the mesh classifies delivery
+/// failures by message text, and a casual reword silently restores #2727 (nothing fails to
+/// compile; the caller merely stops retrying).</para>
+/// </summary>
+public class RecycledHubRefusalTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private static ObjectDisposedException DisposedScope() =>
+        new("LifetimeScope",
+            "Instances cannot be resolved and nested lifetimes cannot be created from this "
+            + "LifetimeScope as it (or one of its parent scopes) has already been disposed.");
+
+    /// <summary>
+    /// The refusal must be recognised as TRANSIENT by the classifier the READ path consults —
+    /// which is the entire point of the change: <c>MeshNodeStreamCache</c> rides a transient owner
+    /// failure out and re-probes, and treats anything else as terminal.
+    /// </summary>
+    [Fact]
+    public void TheRefusal_IsClassifiedTransient_SoTheCallerReProbes()
+    {
+        var refusal = AccessControlPipeline.RecyclingRefusal(
+            new Address("TestData", "recycle-survivor"), "GetDataRequest", DisposedScope());
+
+        output.WriteLine(refusal);
+
+        MeshNodeStreamCache.IsTransientOwnerFailure(new InvalidOperationException(refusal))
+            .Should().BeTrue(
+                "a recycled address is coming BACK — the read path must ride this out and re-probe "
+                + "the fresh activation. The pre-#2727 sentence ('Permission check unavailable … "
+                + "the access gate could not run') matched no marker, so the caller stopped there.");
+
+        MeshNodeStreamCache.IsMissingNodeFailure(new InvalidOperationException(refusal))
+            .Should().BeFalse(
+                "a recycling hub is NOT a provable absence — classifying it as one would poison "
+                + "existence checks and the negative cache for a node that exists (#667)");
+    }
+
+    /// <summary>
+    /// The discrimination. A disposed SCOPE means the hub is gone; an unrelated
+    /// <see cref="ObjectDisposedException"/> from something a handler touched on a LIVE hub is a
+    /// real fault and must keep its honest "the gate could not run" classification — over-claiming
+    /// here would convert genuine faults into silent retries.
+    /// </summary>
+    [Fact]
+    public void OnlyAGoneHub_Qualifies_NotEveryObjectDisposedException()
+    {
+        var live = GetHost();
+
+        AccessControlPipeline.IsHubGone(live, DisposedScope())
+            .Should().BeTrue("the closed lifetime scope IS the evidence the hub is gone — after a "
+                + "recycle the hub is no longer 'shutting down', it has finished, so this is all "
+                + "that is left to recognise it by");
+
+        AccessControlPipeline.IsHubGone(live, new ObjectDisposedException("SomeStream"))
+            .Should().BeFalse("an ObjectDisposedException a handler caused on a LIVE hub is a real "
+                + "fault; answering it 'retry, I am recycling' would hide it forever");
+
+        AccessControlPipeline.IsHubGone(live, new InvalidOperationException("boom"))
+            .Should().BeFalse("an ordinary gate fault stays UNAVAILABLE — honest about having "
+                + "reached no verdict, and not retried as a recycle");
+
+        live.Dispose();
+        await_disposal(live);
+        AccessControlPipeline.IsHubGone(live, new InvalidOperationException("boom"))
+            .Should().BeTrue("a hub that is shutting down qualifies whatever the failure was — its "
+                + "services are going away underneath every check");
+
+        static void await_disposal(IMessageHub hub) =>
+            hub.DisposalCompleted.FirstOrDefaultAsync().Wait();
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
+++ b/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
@@ -27,8 +27,12 @@ namespace MeshWeaver.Hosting.Test;
 /// failures by message text, and a casual reword silently restores #2727 (nothing fails to
 /// compile; the caller merely stops retrying).</para>
 /// </summary>
-public class RecycledHubRefusalTest(ITestOutputHelper output) : HubTestBase(output)
+public class RecycledHubRefusalTest : HubTestBase
 {
+    private readonly ITestOutputHelper output;
+
+    public RecycledHubRefusalTest(ITestOutputHelper output) : base(output) => this.output = output;
+
     private static ObjectDisposedException DisposedScope() =>
         new("LifetimeScope",
             "Instances cannot be resolved and nested lifetimes cannot be created from this "


### PR DESCRIPTION
Fixes the access-pipeline half of #2727 (kept open — see the correction below).

## The defect, in one sentence

A delivery routed to an address whose hub was **recycled** is access-checked on the **old** hub —
whose lifetime scope core#2438 now genuinely closes — and the refusal it produced told the caller
*"no verdict, and don't bother retrying"* about an address that is alive one activation later.

## Why that wording is the bug

`AccessControlPipeline`'s catch classified **every** failure the same way: `ErrorType.Unavailable`,
message *"Permission check unavailable … the access gate could not run"*. For a recycled hub that
is wrong twice over:

1. **It matches no transient marker.** The mesh classifies delivery failures by message text as
   well as `ErrorType` — `MeshNodeStreamCache.IsTransientOwnerFailure`,
   `RoutingGrain.IsTransientFailure` and `AreaErrorClassifier.IsTransientHubFailure` all key on
   `"is shutting down"` / `"invalid activation"` / `"Rejecting now"` / … That sentence carries none
   of them, so every consumer with re-probe machinery treated a corpse's answer as **final**.
2. **It was posted through the dead hub.** `hub.Post` is gated shut once a hub is past
   `DisposeHostedHubs`, so the refusal frequently never arrived at all — the caller got silence,
   not a NACK.

Before #2438 the scope never actually closed, so the same ordering resolved services from a zombie
scope and passed. **The bug was always here; the leak fix only exposed it.**

## What it was costing — the whole #2727 population on `MeshWeaver.Hosting.Monolith.Test`

| test | symptom | covered by this PR? |
|---|---|---|
| `RecycleSurvivesItsOwnDisposeTest.TheHubThatConfirmsTheRecycle_OutlivesTheHubItRecycles` | reads `null` for an address alive one activation later — the issue's own captured stack is `AccessControlPipeline` → `GetRequiredService` → `ObjectDisposedException` | **yes** — that is exactly this seam |
| `UserHomeLegacyPathResolutionTest.LegacyUserPrefix_RendersHomeArea_NotAreaNotFoundPlaceholder` | 30 s wedge, no second output line | **plausibly** — nothing retries a non-transient answer; not proven, no captured stack |
| `SilentReadNackTest.OwnerDisposedWithReadOutstanding_IsNacked_NotLeftHanging` | got a `GetDataResponse{Error = "Exception has been thrown by the target of an invocation."}` where a NACK was expected | **NO — measured, see below** |

These have been red on **trunk** (runs 33298502692, 33298742141) and on PRs whose diffs cannot
reach them (#2721, #2734, and #2735's shard 2 — that last one is how I found this).

### 🚨 Correction: `SilentReadNackTest` is a DIFFERENT terminal, and this PR does not fix it

The third comment on #2727 attributes that test to "the same disposal-arms race". **Measured
against this branch, it is not.** With the fix applied, the full `MeshWeaver.Hosting.Monolith.Test`
run still failed it (1 of 767) — while the same test passes **8/8 in isolation**, the classic
bulk-only signature.

What the evidence says about which terminal answered: the string
`Exception has been thrown by the target of an invocation.` arrives on a `GetDataResponse{Error}`,
and `HandleGetDataRequest` produces that shape in exactly one place — the `Catch` that converts a
NON-hub-disposal fault into a response value. So `HubDisposingException.IsHubDisposal(ex)` returned
**false** for that fault; the read never reached the NACK arm, and the access pipeline (this PR's
seam) is not involved at all.

I checked the obvious explanation and **refuted** it: `IsHubDisposal` → `ExceptionChain.Contains`
walks up to 256 nodes, follows `AggregateException` fan-out and tolerates cycles, so a
`HubDisposingException` would be found at any realistic depth. **Which exception it actually is
remains unconfirmed** — the failure only carries the useless `TargetInvocationException` wrapper
text. The test disposes the data-source stream directly and *then* posts the recycle, so a
plausible (untested) candidate is the stream's own `ObjectDisposedException`, which is not a hub
disposal and is therefore answered as data rather than NACKed.

If that is right, the fix is the same *principle* as this PR one layer down — a disposed-resource
fault is not a read result and must not claim the once-only answer slot (the #1362/#1470 reasoning
already written into that `Catch`'s comment) — but it is a distinct change in a path with a
regression history, so I am not shipping it blind on an unconfirmed cause. Recorded on #2727 with
this evidence so the next person starts from a measurement instead of the wrong attribution.

## The fix

Recognise *"the gate could not run **because this hub is gone**"* as its own fact, and answer it in
the vocabulary the mesh already speaks for a recycling address — the **same wording**
`MessageService`'s shutting-down gate uses, markers included — NACKed **through the parent**, the
same escape `MessageService.NackThroughParent` takes, because the dead hub cannot post.

**Refusal semantics are unchanged: `next` is still never invoked, so nothing is granted.** Only the
classification and the posting route change.

The discrimination is deliberately narrow, and both halves are load-bearing:

- `IsShuttingDown` **alone misses the recycle window** — a hub whose disposal *completed* is not
  "shutting down" any more; the disposed-scope `ObjectDisposedException` is the only evidence left.
- The exception test **alone would over-claim** — an `ObjectDisposedException` from something a
  handler touched on a *live* hub is a real fault and keeps its honest `Unavailable`, so no genuine
  fault becomes a silent retry. It is matched on the Autofac scope wording the codebase already
  keys on (the two shapes `TeardownStragglerCapturer` filters).

## Verification

- **`RecycledHubRefusalTest`** pins both halves: the refusal must be classified **transient** by
  the read path's own classifier (and **not** as a provable absence — #667), and only a gone hub
  qualifies.
- **Mutation-checked, non-vacuous**: restoring the pre-fix wording turns the first test red
  (1 failed / 1 passed); restored, 2/2 pass. The wording is contract — a casual reword silently
  restores #2727, because nothing fails to compile and the caller merely stops retrying. The
  method's doc comment says so.
- Suites locally: `MeshWeaver.Hosting.Test` **265/265** green. `MeshWeaver.Hosting.Monolith.Test`
  **763 passed / 1 failed** — the one failure is `SilentReadNackTest`, the different terminal
  documented above, which was already failing on trunk before this branch existed.
- A paired `flake-repro.yml` `rate` run (100 iterations, `SilentReadNackTest`, main vs this branch)
  is in flight to put a number on that test specifically; results on the thread.

Related: #2438 (the leak fix that exposed it), #2666 (callbacks resolving after their container is
disposed), #1599 (the SilentReadNack shape), #2735 (the teardown-ordering half — deliberately keeps
the immediate close on a live mesh, which is why this window needed its own fix).
