### PR TITLE
fix(#2641): a re-subscribe must declare the same wire capabilities as the first, and 'Frame loss detected' is a resync counter

### DIFF
--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -45,6 +45,40 @@ public static class JsonSynchronizationStream
     private const int MaxRecycleReArms = 3;
 
     /// <summary>
+    /// 🚨 THE ONE PLACE a C# subscriber mints a <see cref="SubscribeRequest"/>. Every post — the
+    /// INITIAL subscribe, the recycle / <c>StreamEndedEvent</c> re-subscribe, and the frame-loss
+    /// resync in <c>SynchronizationStream.RequestFreshSnapshot</c> — goes through here.
+    ///
+    /// <para><b>Why a factory rather than three literals.</b> <see cref="SubscribeRequest"/> carries
+    /// NEGOTIATED wire capabilities, and a capability is a property of the APPLIER this assembly
+    /// ships — not of the moment one particular post is written. Declared at each call site, the
+    /// initial subscribe said <c>AcceptsStringSplice = true</c> and the two RE-subscribes silently
+    /// did not: the owner builds a fresh server-side stream for a re-subscribe it cannot match to a
+    /// live one (the subscriber was evicted on a <c>TargetUnserved</c> verdict, the owner recycled,
+    /// the sync hub was torn down), reads the capability off THAT request, and from then on fans out
+    /// whole-string <c>replace</c> frames to a mirror that understands splices — reinstating the
+    /// per-subscriber quadratic #1284/#1414 removed, permanently and silently, on exactly the paths
+    /// that fire during a resync storm. Nothing fails; the bytes just go back up.</para>
+    ///
+    /// <para>Withdrawing a capability is invisible by construction — a <c>replace</c> is a shape every
+    /// subscriber understands — so no test of the frames could ever notice. The fix is that there is
+    /// no second place to forget: add a capability here and every subscribe declares it.</para>
+    /// </summary>
+    /// <param name="streamId">The subscriber-side stream id the owner keys its fan-out by.</param>
+    /// <param name="reference">The workspace slice being subscribed to.</param>
+    /// <param name="identity">Identity for the owner's access check, or <c>null</c> to leave unset.</param>
+    internal static SubscribeRequest MintSubscribeRequest(
+        string streamId, WorkspaceReference reference, string? identity) =>
+        new(streamId, reference)
+        {
+            Identity = identity,
+            // Declared by the assembly that also OWNS the applier (ApplyPatchWithCorrectUnescaping),
+            // so the claim can never be wrong: whatever version of this code posts the subscribe is
+            // the version that folds the frames.
+            AcceptsStringSplice = true,
+        };
+
+    /// <summary>
     /// How far up the hub tree the recycle re-arm looks for the local instance of a rejecting
     /// owner (see <c>LocalInstanceOf</c>). Real trees are two or three deep — mesh → cache/client
     /// → sync — so this is only a guard against a malformed parent chain.
@@ -422,15 +456,7 @@ public static class JsonSynchronizationStream
         // ends inside one Subscribe, and keeps exactly the property the paragraph above needs: the
         // post below is still issued inside the scope.
         var postSubscribeRequest = () => hub.Observe(
-                new SubscribeRequest(reduced.StreamId, reference)
-                {
-                    Identity = identityForSubscribe,
-                    // Declared by the assembly that also OWNS the applier
-                    // (ApplyPatchWithCorrectUnescaping below), so the claim can never be
-                    // wrong: whatever version of this code posts the subscribe is the version
-                    // that folds the frames.
-                    AcceptsStringSplice = true,
-                },
+                MintSubscribeRequest(reduced.StreamId, reference, identityForSubscribe),
                 o => impersonateAsHub ? o.WithTarget(owner).ImpersonateAsHub(hub.Address) : o.WithTarget(owner))
             .Take(1);
         var observeSubscription = (isRealUser
@@ -590,7 +616,7 @@ public static class JsonSynchronizationStream
                     // Use register-before-post overload to avoid the race where the owner
                     // responds before the subject is registered in responseSubjects.
                     hub.Observe(
-                            new SubscribeRequest(reduced.StreamId, reference) { Identity = SystemUserId },
+                            MintSubscribeRequest(reduced.StreamId, reference, SystemUserId),
                             o => impersonateAsHub
                                 ? o.WithTarget(owner).ImpersonateAsHub(hub.Address)
                                 : o.WithTarget(owner))

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -1687,7 +1687,15 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                 .GetService(typeof(AccessService)) as AccessService;
             using (accessService?.ImpersonateAsSystem())
             {
-                Host.Post(new SubscribeRequest(StreamId, wsRef) { Subscriber = Configuration.Subscriber! },
+                // 🚨 Minted, never constructed inline: a re-subscribe declares the SAME negotiated
+                // wire capabilities as the initial subscribe. When the owner cannot match this
+                // request to a live server-side stream (the subscriber was evicted on a
+                // TargetUnserved verdict, the owner recycled) it builds a fresh one and reads the
+                // capabilities off THIS request — so a capability omitted here is withdrawn for the
+                // rest of the mirror's life, silently. See MintSubscribeRequest.
+                Host.Post(
+                    JsonSynchronizationStream.MintSubscribeRequest(StreamId, wsRef, identity: null)
+                        with { Subscriber = Configuration.Subscriber! },
                     o => o.WithTarget(StreamIdentity.Owner));
             }
         }

--- a/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
@@ -196,6 +196,49 @@ patch arrived with no base, a patch failed to apply, a write was rejected) calls
 with a fresh Full. Gated by `_resyncInFlight` so a burst of confusing patches
 triggers exactly one resubscribe, not a storm.
 
+### The frame chain, and how to read `Frame loss detected`
+
+The transport under the fan-out is **at-most-once** — a frame published before a
+subscriber's stream subscription attached, or dropped under pressure, simply never
+arrives and nothing re-sends it. Before this was detectable, that loss was *silent*:
+later patches kept applying cleanly (they touch other entities), so the mirror tracked
+the owner forever at a constant deficit with no error anywhere.
+
+So every frame the owner emits carries **`BasedOnVersion`** — the version of the frame
+*this same forwarding subscription* sent immediately before it (`-1` for the first).
+A mirror compares an incoming Patch's `BasedOnVersion` against the version it last
+applied; a mismatch proves the gap, and the only sound reaction is a fresh
+authoritative snapshot: `RequestFreshSnapshot()` (above). Frames the owner *skips*
+(value-equal, no updates, an echo-suppressed patch) never enter the chain, so a
+legitimate version gap cannot false-trigger a resync.
+(`JsonSynchronizationStream.ToDataChanged` → `SynchronizationStream.UpdateStream`;
+test `StreamFrameLossResyncTest`.)
+
+🚨 **`[SYNC_STREAM] Frame loss detected …` is a RESYNC counter, not a data-loss
+counter.** Every line is a gap that was *detected and answered*; the mirror converges
+on the Full that follows. A raw count therefore means nothing on its own — the two
+numbers that do are **per-stream count** and **whether a Full ever follows**. Thousands
+spread over hundreds of streams is the recovery working; a stream that logs the line
+repeatedly and never converges is the defect (that one is #2654 — a layout area stuck
+on its `NamedAreaControl` placeholder).
+
+🚨 **The driver is almost always upstream of this file.** Anything that repeatedly ends
+and re-establishes a subscriber's server-side stream costs one gap per cycle, so read
+these lines from the *same window* before blaming the sync protocol:
+
+| line in the same window | what it means for the count |
+|---|---|
+| `Orleans '…' stream subscription could not be attached … cross-process routing … DISABLED` | the hub is reachable in-process only; the router will call it unserved (#2633 / #2692, fixed by #2645) |
+| `[ROUTE] Stream-routed delivery to '…' has no live subscriber` + `ClientSubscriptionEviction` | the owner evicted that subscriber's server-side streams on the router's `TargetUnserved` verdict (#2620). Correct when the subscriber is dead — one gap per cycle when it is not |
+| `Stream {StreamId}: owner {Owner} … — resubscribing for fresh snapshot` | an owner recycle / `StreamEndedEvent`; the re-assert re-bases the chain |
+
+That correlation is the recorded disposition of the memex-cloud storm on **#2641**
+(847 lines / 30 min): the frame-loss count was the *symptom* of an attach latch and the
+eviction cycle it caused, not a defect of the chain. See also
+[Durable Streams Are Mesh Nodes](/Doc/Architecture/DurableStreamsViaMeshNodes) — the
+version chain **is** the durable stream, which is why no durable stream provider is
+bought to stop these lines.
+
 ---
 
 ## 7. Minimal bytes on the wire

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-frame-loss-in-the-log-is-a-resync-counter.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-frame-loss-in-the-log-is-a-resync-counter.md
@@ -1,0 +1,20 @@
+---
+Name: Frame-loss lines in the log are a recovery counter
+Category: Feature
+Description: The data-sync page now documents the frame chain that detects a lost update, and states plainly how to read its log line — every entry is a gap that was already repaired, so the count alone never diagnoses anything.
+Icon: ArrowSync
+Order: -20260830
+---
+
+# Frame-loss lines in the log are a recovery counter
+
+Synchronized data travels as a chain: every update the server sends names the update it sent
+before it, so a viewer that misses one notices immediately and asks for a fresh copy. That
+recovery has been in place for a while, and it works — but it writes a line to the log each time,
+and a large number of those lines has repeatedly been read as a large amount of lost data.
+
+It is the opposite. Each line is a gap that was *detected and already repaired*. The data-sync
+architecture page now says so, and gives the two numbers that actually diagnose something: how
+often a **single** stream logs it, and whether a fresh copy ever follows. It also lists the log
+lines to read alongside it, because the cause is almost always something further upstream ending
+and re-establishing a subscription — not the chain itself.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-reconnecting-no-longer-makes-streaming-heavier.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-reconnecting-no-longer-makes-streaming-heavier.md
@@ -1,0 +1,19 @@
+---
+Name: Reconnecting no longer makes live text heavier
+Category: Fix
+Description: After a page's data connection was re-established, the server went back to resending each streamed text in full on every update instead of only the part that changed. Reconnections now keep the compact form.
+Icon: ArrowSync
+Order: -20260830
+---
+
+# Reconnecting no longer makes live text heavier
+
+When text streams onto a page — an agent's answer, a live document — the server normally sends only
+the piece that changed rather than the whole text again. A viewer says it can handle that compact
+form when it first connects.
+
+It said so only the *first* time. If the connection was re-established afterwards — the owner
+restarted, the subscription was reclaimed, an update was missed and re-requested — the viewer never
+repeated the claim, so the server quietly fell back to resending the full text on every update, for
+the rest of that page's life. Nothing broke; it just got heavier the longer the text grew, and for
+every viewer watching. Every reconnection now makes the same claim as the first connection.

--- a/test/MeshWeaver.Data.Test/ResubscribeKeepsNegotiatedCapabilitiesTest.cs
+++ b/test/MeshWeaver.Data.Test/ResubscribeKeepsNegotiatedCapabilitiesTest.cs
@@ -1,0 +1,114 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// A RE-subscribe must declare the same negotiated wire capabilities as the initial subscribe.
+///
+/// <para><see cref="SubscribeRequest.AcceptsStringSplice"/> is the one negotiated capability of the
+/// owner→subscriber fan-out (#1284/#1414): a changed string leaf travels as the changed span rather
+/// than the whole new string, but ONLY for a subscriber that said it can apply one. The owner reads
+/// that claim off the <see cref="SubscribeRequest"/> it uses to BUILD the server-side stream — and a
+/// re-subscribe builds a fresh one whenever the owner cannot match it to a live stream: the
+/// subscriber was evicted on the router's <c>TargetUnserved</c> verdict (#2620), the owner recycled,
+/// or the per-subscriber sync hub was torn down.</para>
+///
+/// <para>So a capability declared on the initial subscribe and omitted on a re-subscribe is
+/// <b>withdrawn for the rest of that mirror's life</b>, and nothing anywhere fails: the owner simply
+/// goes back to whole-string <c>replace</c> frames, reinstating the per-subscriber quadratic on
+/// exactly the paths that fire during a resync storm (memex-cloud, #2641). No assertion on the
+/// FRAMES could catch it — a <c>replace</c> is a shape every subscriber understands. The only place
+/// it is visible is the request itself, which is what this test reads.</para>
+///
+/// <para>The trigger is the deterministic wire loss <see cref="StreamFrameLossResyncTest"/> uses: eat
+/// exactly one mid-burst Patch, and the mirror's gap detection answers with
+/// <c>RequestFreshSnapshot()</c> — a second <see cref="SubscribeRequest"/> on the same stream. Before
+/// the fix that request carried <c>AcceptsStringSplice = false</c> and this test is RED on its
+/// second row.</para>
+/// </summary>
+public class ResubscribeKeepsNegotiatedCapabilitiesTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>1 after the pipeline has eaten its one frame. Instance field — per-test lifetime.</summary>
+    private int droppedPatches;
+
+    /// <summary>Every SubscribeRequest the subscriber posted, in order. Instance, never static.</summary>
+    private readonly ConcurrentQueue<SubscribeRequest> subscribeRequests = new();
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(ds => ds
+                .WithType<MyData>(t => t.WithKey(d => d.Id))))
+            // THE WIRE LOSS: eat exactly one mid-burst Patch frame as it leaves the owner, so the
+            // mirror detects the gap and posts the RE-subscribe this test is about.
+            .AddPostPipeline(p => p.AddPipeline((d, next) =>
+                d.Message is DataChangedEvent { ChangeType: ChangeType.Patch }
+                && Interlocked.Exchange(ref droppedPatches, 1) == 0
+                    ? d.Ignored()
+                    : next.Invoke(d)));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .AddData(data => data.AddSource(ds => ds
+                .WithType<MyData>(t => t.WithKey(d => d.Id))))
+            // Record every SubscribeRequest the SUBSCRIBER posts — the initial one and the
+            // frame-loss resync — because the declaration is the only place a withdrawn
+            // capability is observable at all.
+            .AddPostPipeline(p => p.AddPipeline((d, next) =>
+            {
+                if (d.Message is SubscribeRequest sr)
+                    subscribeRequests.Enqueue(sr);
+                return next.Invoke(d);
+            }));
+
+    [HubFact]
+    public async Task TheFrameLossResubscribe_StillDeclaresStringSplice()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var accessService = host.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetContext(new AccessContext { ObjectId = "alice", Name = "Alice" });
+
+        var collectionName = host.GetWorkspace().DataContext.GetTypeSource(typeof(MyData))!.CollectionName;
+
+        var clientStream = client.GetWorkspace()
+            .GetRemoteStream<EntityStore>(CreateHostAddress(), new CollectionsReference(collectionName));
+
+        await clientStream.Should().Within(10.Seconds()).Emit();
+
+        for (var i = 1; i <= 3; i++)
+            host.Post(
+                new DataChangeRequest().WithUpdates(new MyData($"doc-{i}", $"value-{i}")),
+                o => o.WithAccessContext(accessService.Context!));
+
+        // Converged again — which is only possible via the resync, so the second SubscribeRequest
+        // has certainly been delivered by the time this completes.
+        await clientStream
+            .Where(ci => ci.Value?.Collections.GetValueOrDefault(collectionName) is { } coll
+                && coll.Instances.Values.OfType<MyData>()
+                    .Count(d => d.Text?.StartsWith("value-") == true) == 3)
+            .Take(1)
+            .Should().Within(15.Seconds())
+            .Emit();
+
+        Volatile.Read(ref droppedPatches).Should().Be(1,
+            "the delivery pipeline must have dropped exactly one mid-burst Patch frame — without the "
+            + "loss there is no resync and this test would assert nothing");
+
+        var requests = subscribeRequests.ToArray();
+        requests.Should().HaveCountGreaterThan(1,
+            "the mirror must have RE-subscribed after detecting the gap; with only the initial "
+            + "subscribe there is no second request to compare and the test proves nothing");
+
+        requests.Should().OnlyContain(r => r.AcceptsStringSplice,
+            "every SubscribeRequest this assembly posts declares the capabilities of the applier it "
+            + "ships — a re-subscribe that omits AcceptsStringSplice silently downgrades the owner's "
+            + "fan-out to whole-string replaces for the rest of the mirror's life");
+    }
+}


### PR DESCRIPTION
Settles the open half of #2641 and fixes the one real defect that reading its resync path turned up.

## The defect: a re-subscribe silently withdrew a negotiated wire capability

`SubscribeRequest.AcceptsStringSplice` is the one negotiated capability of the owner→subscriber
fan-out (#1284 / #1414): a changed string leaf travels as the changed *span* instead of the whole new
string, but only for a subscriber that says it can apply one. `grep -n AcceptsStringSplice src/`
found `= true` at **one** of the three sites that post a `SubscribeRequest`:

| site | declared it |
|---|---|
| `CreateExternalClient` — the initial subscribe | ✅ |
| `Resubscribe` — owner recycle / `StreamEndedEvent` re-ask | ❌ |
| `SynchronizationStream.RequestFreshSnapshot` — the frame-loss resync | ❌ |

When the owner cannot match a re-subscribe to a live server-side stream it **builds a fresh one and
reads the capability off that request** (`GetClientSubscription` → miss → new `reduced` +
`ToDataChanged(…, request.AcceptsStringSplice)`). A miss is not exotic — it is exactly what an
eviction on the router's `TargetUnserved` verdict (#2620), an owner recycle, or a torn-down `sync/`
hub produces. So from the first such cycle the owner fans out whole-string `replace` frames to a
mirror that understands splices: the per-subscriber quadratic #1284/#1414 removed, reinstated
permanently and silently, on precisely the paths that fire during a resync storm.

Nothing fails — a `replace` is a shape every subscriber understands — so no assertion on the
*frames* could have caught it. The only place it is observable is the request.

**Fixed at the root, not with a third literal.** `JsonSynchronizationStream.MintSubscribeRequest` is
now the one place a C# subscriber mints a `SubscribeRequest`: a capability is a property of the
applier this assembly ships, not of the moment a particular post was written, so declaring it once
means there is no second site to forget. The three posts go through it; nothing else changes (the
resync still posts with `identity: null` and the same `Subscriber`, the recycle re-ask still with
`SystemUserId`).

`ResubscribeKeepsNegotiatedCapabilitiesTest` drives the **real** resync — the deterministic one-frame
wire loss `StreamFrameLossResyncTest` already uses — and asserts every `SubscribeRequest` the
subscriber posts carries the capability. Verified failing on the unfixed tree and passing on the
fixed one:

```
# src reverted to HEAD
Failed  MeshWeaver.Data.Test.ResubscribeKeepsNegotiatedCapabilitiesTest.TheFrameLossResubscribe_StillDeclaresStringSplice
  [SYNC_STREAM] Frame loss detected for XQ-G6YrJm0yb4a9CpXK64g: incoming Patch v3 chains onto v2 …
# with the fix
Passed!  - Failed: 0, Passed: 1
```

## The documentation: how to read `Frame loss detected`

#2641 reported 847 of those lines in 30 minutes as data loss. They are not. Every line is a gap that
was *detected and answered* — that is what the `BasedOnVersion` chain exists for — so the raw count
diagnoses nothing on its own. [Data Synchronization & CRDT §6](/Doc/Architecture/DataSyncAndCrdt) now
documents the chain and states the two numbers that do mean something (the **per-stream** count, and
**whether a Full follows**), plus the three log lines to correlate it with, because the driver is
almost always upstream: a latched stream attach (#2633 / #2692, fixed by #2645), the eviction cycle
(#2620), an owner recycle.

That matches the reading the merged design page already takes (#2724): the version chain *is* the
durable stream.

## Issue disposition

#2641 is closed with a per-symptom table on the issue. In short: the `UserIdentityCache` half was
fixed by #2723; the frame-loss half is a duplicate of **#2654**, which owns the residual "does the
resync converge" question with per-stream counts and a user-visible surface; the `no live subscriber`
+ `ClientSubscriptionEviction` lines are #2620 *working* (verified an ancestor of the reported image,
and the logger name exists only in that commit); the 33 `Circuit connection DOWN` are SignalR
transport blips, not circuit churn, which falsifies an earlier comment of mine on that issue.

## Verification

- `dotnet build src/MeshWeaver.Data/MeshWeaver.Data.csproj -c Release -warnaserror` → `0 Warning(s), 0 Error(s)`
- `dotnet build test/MeshWeaver.Data.Test/… -c Release -warnaserror` → `0 Warning(s), 0 Error(s)`
- `dotnet build test/MeshWeaver.Documentation.Test/… -c Release -warnaserror` → `0 Warning(s), 0 Error(s)`
- `MeshWeaver.Data.Test` full project, Release → see below
- `WhatsNewEntryIntegrityTest` → passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
