### PR TITLE
RegistryUpdateReconciler: bound each package's module adopt (a hang starves the chain) and name the failure cause inline

### DIFF
--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -330,9 +330,14 @@ public sealed class PluginBundleClient
             {
                 // A distribution hiccup must not fail the install/reconcile that asked — the module
                 // simply stays as it is until the next boot or a manual re-install.
+                // The cause rides IN the message: the attached exception lives on separate log
+                // lines that single-line pipelines (Loki greps) never pair with this one, and
+                // "landing failed" with no reason made a stuck production module a night-long
+                // dig (Plugins#959).
                 _logger?.LogWarning(ex,
-                    "Module '{Module}' of {Plugin}: landing failed — the module is unchanged",
-                    moduleName, pluginId);
+                    "Module '{Module}' of {Plugin}: landing failed — the module is unchanged. "
+                    + "Cause: {Cause}",
+                    moduleName, pluginId, ex.Message);
                 return Observable.Return(0);
             });
     }

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -248,6 +248,11 @@ public sealed class RegistryUpdateReconciler(
     /// withhold the rest, and <see cref="PluginBundleClient.AdoptModule"/> already absorbs its own
     /// failures into a logged zero.</para>
     /// </summary>
+    /// <summary>The most one package's module adopt may take before the reconcile moves on —
+    /// generous for a large bundle download, small against a boot; the point is only that it is
+    /// FINITE (see the Timeout note below, Plugins#959).</summary>
+    internal static readonly TimeSpan PerPackageAdoptBudget = TimeSpan.FromMinutes(3);
+
     private IObservable<Unit> ReconcileModules(
         PluginBundleClient bundles,
         string registryName,
@@ -270,11 +275,22 @@ public sealed class RegistryUpdateReconciler(
                         // Not installed here → somebody else's module; nothing to reconcile.
                         ? Observable.Return(0)
                         : bundles.AdoptModule(pkg.Id, pkg.Module!, recordPath, unattended: true))
+                    // 🚨 A HANG is worse than a failure here: the packages run as one sequential
+                    // Concat, so a single adopt that never answers (a wedged record read, a
+                    // download that stalls) silently starves EVERY package after it — on
+                    // memex.systemorph.com the Northwind adopt was never even attempted while
+                    // earlier packages logged failures (Plugins#959). A bounded wait turns the
+                    // hang into the loud, caught failure below and the chain proceeds.
+                    .Timeout(PerPackageAdoptBudget)
                     .Catch((Exception ex) =>
                     {
+                        // The CAUSE goes into the message itself, not only the attached exception:
+                        // single-line log pipelines (Loki greps) see the template line alone, and
+                        // "failed" with no reason cost a night of archaeology (Plugins#959).
                         logger.LogWarning(ex,
                             "[RegistryUpdate] module reconcile of {Id} against {Name} failed — "
-                            + "its landed module is unchanged.", pkg.Id, registryName);
+                            + "its landed module is unchanged. Cause: {Cause}",
+                            pkg.Id, registryName, ex.Message);
                         return Observable.Return(0);
                     })
                     .Select(_ => Unit.Default);

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -229,6 +229,11 @@ public sealed class RegistryUpdateReconciler(
             });
     }
 
+    /// <summary>The most one package's module adopt may take before the reconcile moves on —
+    /// generous for a large bundle download, small against a boot; the point is only that it is
+    /// FINITE (see the Timeout note below, Plugins#959).</summary>
+    internal static readonly TimeSpan PerPackageAdoptBudget = TimeSpan.FromMinutes(3);
+
     /// <summary>
     /// The module half of the boot reconcile (#1664 Slice C): for each of the registry's packages
     /// that declares a compiled module AND has an install record here, run the one module-update
@@ -248,11 +253,6 @@ public sealed class RegistryUpdateReconciler(
     /// withhold the rest, and <see cref="PluginBundleClient.AdoptModule"/> already absorbs its own
     /// failures into a logged zero.</para>
     /// </summary>
-    /// <summary>The most one package's module adopt may take before the reconcile moves on —
-    /// generous for a large bundle download, small against a boot; the point is only that it is
-    /// FINITE (see the Timeout note below, Plugins#959).</summary>
-    internal static readonly TimeSpan PerPackageAdoptBudget = TimeSpan.FromMinutes(3);
-
     private IObservable<Unit> ReconcileModules(
         PluginBundleClient bundles,
         string registryName,


### PR DESCRIPTION
## Why
Plugins#959: on memex.systemorph.com the boot module-reconcile left Northwind's adopt **unattempted** while five other packages logged `landing failed — the module is unchanged` with no visible cause (the exception is attached to the log event but lives on separate lines that single-line pipelines — Loki greps — never pair). The packages run as one sequential `Concat`, so one adopt that *hangs* (a wedged record read, a stalled download) silently starves every package after it — a stale production module kept serving a build without its access rule through three restarts.

## What
- `ReconcileModules`: each package's pipeline gets `.Timeout(PerPackageAdoptBudget)` (3 min) **before** the catch — a hang becomes the loud, caught, logged failure and the chain proceeds to the next package.
- Both failure logs (`RegistryUpdateReconciler` catch, `PluginBundleClient.AdoptModule` catch) inline `ex.Message` as `Cause: {Cause}` in the template.

Behavioural fix only for the starvation + observability halves of #959; the typed `InstallManifest` read and a reinstall surface remain on that issue.

`MeshWeaver.PluginCatalog` builds clean (`-warnaserror`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)