### PR TITLE
fix: no ToTask in the memex portal

### DIFF
--- a/memex/Memex.Portal.Shared/Api/InstanceRegistrationEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/InstanceRegistrationEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using Memex.Portal.Shared.Authentication;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
@@ -71,6 +70,11 @@ public static class InstanceRegistrationEndpoints
                 return Observable.Return((IResult)Results.Json(
                     new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway));
             })
-            .FirstAsync().ToTask(ct);
+            .FirstAsync()
+            .ObserveCompletion(
+                ex => logger?.LogWarning(ex,
+                    "Instance registration for '{InstanceId}' faulted after the response had already been sent",
+                    body.InstanceId),
+                ct)!;
     }
 }

--- a/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/InstanceTokenEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
 using MeshWeaver.PluginCatalog;
@@ -130,7 +129,11 @@ public static class InstanceTokenEndpoints
                 return Observable.Return(Results.Json(
                     new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway));
             })
-            .FirstAsync().ToTask(ct);
+            .FirstAsync()
+            .ObserveCompletion(
+                ex => logger?.LogWarning(ex,
+                    "Sync access token exchange faulted after the response had already been sent"),
+                ct)!;
     }
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -251,13 +251,16 @@ public static class MeshApiEndpoints
                             $"'{body.Area ?? "(default)"}' at '{body.Path}'.",
                 },
                 statusCode: StatusCodes.Status504GatewayTimeout)))
-            .FirstAsync().ToTask(ct);
+            .FirstAsync()
+            .ObserveCompletion(LateFault(http, $"/api/mesh/render-area '{body.Path}'"), ct)!;
     }
 
     /// <summary>
     /// <c>POST /api/mesh/mirror</c>. Shaped like <see cref="HandleRenderArea"/>: the body is one
     /// composed observable and the ONLY bridge to <see cref="Task"/> is the trailing
-    /// <c>.FirstAsync().ToTask(ct)</c> at the ASP.NET edge. It used to <c>await</c> the hub
+    /// <c>.FirstAsync().ObserveCompletion(…, ct)</c> at the ASP.NET edge (never <c>.ToTask()</c>,
+    /// which resumes the awaiter inline on the signalling thread — forbidden since 2026-08-30). It
+    /// used to <c>await</c> the hub
     /// round-trip mid-method — the shape that reaches into hub code from an await chain, and the
     /// one the endpoint's own <c>Task&lt;IResult&gt;</c> signature is not licence for.
     /// </summary>
@@ -277,7 +280,8 @@ public static class MeshApiEndpoints
             })
             .Select(result => (IResult)Results.Content(
                 JsonSerializer.Serialize(result, sessionHub.JsonSerializerOptions), "application/json"))
-            .FirstAsync().ToTask(ct);
+            .FirstAsync()
+            .ObserveCompletion(LateFault(http, $"/api/mesh/mirror '{body.SourcePath}'"), ct)!;
     }
 
     private static IResult HandleNavigateTo(HttpContext http, IOptions<McpConfiguration>? mcp, NavigateBody body)
@@ -295,7 +299,7 @@ public static class MeshApiEndpoints
     /// <c>CopyToAsync</c> over the request body are ASP.NET's own IO and belong at this edge — but it
     /// is quarantined in <see cref="ReadUploadAsync"/>, which never touches the mesh. The MESH call
     /// is composed, not awaited: the single bridge back to <see cref="Task"/> is the trailing
-    /// <c>.FirstAsync().ToTask(ct)</c>. An <c>await</c> that reaches into hub code is the shape the
+    /// <c>.FirstAsync().ObserveCompletion(…, ct)</c>. An <c>await</c> that reaches into hub code is the shape the
     /// endpoint's <c>Task&lt;IResult&gt;</c> signature is not licence for, however far from a hub
     /// scheduler this particular request thread happens to be.
     /// </summary>
@@ -306,7 +310,8 @@ public static class MeshApiEndpoints
                 : new MeshOperations(ResolveSession(http, rootHub))
                     .Upload(upload.Path!, upload.Bytes!)
                     .Select(result => (IResult)Results.Content(result, "application/json")))
-            .FirstAsync().ToTask(ct);
+            .FirstAsync()
+            .ObserveCompletion(LateFault(http, "/api/mesh/upload"), ct)!;
 
     /// <summary>
     /// Reads the multipart body: either a <c>Failure</c> result to ship as-is, or the target path
@@ -361,6 +366,24 @@ public static class MeshApiEndpoints
         return services;
     }
 
+    /// <summary>
+    /// The late-fault sink for this surface's <see cref="ReactiveCompletion.ObserveCompletion{T}"/>
+    /// bridges. A fault that lands AFTER the response has already settled can no longer change the
+    /// answer, but it is the only record that anything went wrong on the way out — discarding it is
+    /// half of what <c>ObserveCompletion</c> exists to remove.
+    ///
+    /// <para>The logger is resolved EAGERLY, while the request scope is still alive, and captured:
+    /// a late fault arrives after <see cref="HttpContext.RequestServices"/> has been disposed, so
+    /// resolving from it inside the lambda would throw exactly when the report is needed.</para>
+    /// </summary>
+    private static Action<Exception> LateFault(HttpContext http, string what)
+    {
+        var logger = http.RequestServices.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(MeshApiEndpoints));
+        return ex => logger.LogWarning(
+            ex, "{What}: faulted after its HTTP response had already settled", what);
+    }
+
     private static IMessageHub ResolveSession(HttpContext http, IMessageHub rootHub)
     {
         var logger = http.RequestServices.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(MeshApiEndpoints));
@@ -370,7 +393,9 @@ public static class MeshApiEndpoints
     /// <summary>
     /// The shared body of every string-returning verb on this surface. <c>work</c>'s observable is
     /// composed, never awaited: the single bridge to <see cref="Task"/> is the trailing
-    /// <c>.FirstAsync().ToTask(ct)</c>, which is the ASP.NET edge itself.
+    /// <c>.FirstAsync().ObserveCompletion(…, ct)</c>, which is the ASP.NET edge itself. Rx's own
+    /// <c>.ToTask()</c> is NOT that bridge — it resumes the awaiter inline on the signalling thread,
+    /// which on this surface is a mesh hub's action block (forbidden since 2026-08-30).
     /// </summary>
     private static Task<IResult> RunString(
         HttpContext http,
@@ -385,7 +410,8 @@ public static class MeshApiEndpoints
         // value the client can branch on (mirrors the MCP-tool contract).
         return work(ops)
             .Select(result => (IResult)Results.Content(result, "application/json"))
-            .FirstAsync().ToTask(ct);
+            .FirstAsync()
+            .ObserveCompletion(LateFault(http, $"{http.Request.Path}"), ct)!;
     }
 
     private static string ResolveBaseUrl(HttpContext http, IOptions<McpConfiguration>? mcp)

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
@@ -90,8 +89,13 @@ public static class PluginBundleEndpoints
                 ?.CreateLogger(typeof(PluginBundleEndpoints));
             var authenticator = http.RequestServices.GetRequiredService<InstanceRegistryAuthenticator>();
 
-            var outcome = await authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
-                .FirstAsync().ToTask(http.RequestAborted);
+            var outcome = (await authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
+                .FirstAsync()
+                .ObserveCompletion(
+                    ex => logger?.LogWarning(ex,
+                        "Plugin bundles: instance authentication for {Path} faulted after the request had already been answered",
+                        http.Request.Path),
+                    http.RequestAborted))!;
 
             if (outcome.IsUnavailable)
                 return InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger);
@@ -407,14 +411,19 @@ public static class PluginBundleEndpoints
                     // extracted modules against the very platform update that needed them
                     // (rc6→rc7, 2026-08-22). Real refusals (the app-closure same-identity
                     // trap-door, malformed names) still surface as the observable's error.
-                    outcome = await landing.ShelveModule(
+                    outcome = (await landing.ShelveModule(
                         accepted.Module, accepted.Files,
                         frameworkMvid: accepted.FrameworkMvid,
                         packagePath: accepted.PackagePath,
                         version: accepted.Version,
                         minMeshVersion: accepted.MinMeshVersion,
                         staticAssets: accepted.StaticAssets)
-                        .FirstAsync().ToTask(ct);
+                        .FirstAsync()
+                        .ObserveCompletion(
+                            ex => logger?.LogWarning(ex,
+                                "Module publish for {Plugin}: landing '{Module}' faulted after the "
+                                + "publish had already been answered", plugin, accepted.Module),
+                            ct))!;
                 }
                 catch (Exception exception)
                 {
@@ -586,6 +595,10 @@ public static class PluginBundleEndpoints
     {
         var baseUrl = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}";
         var ledger = Ledger(http);
+        // Resolved NOW, while the request scope is alive: a late fault arrives after
+        // HttpContext.RequestServices has been disposed, so resolving inside the lambda would throw
+        // exactly when the report is needed.
+        var lateFaultLogger = Log(http);
 
         return Servable(rootHub, Anchor(http), ct)
             .Select(state =>
@@ -630,7 +643,10 @@ public static class PluginBundleEndpoints
                     }).ToArray(),
                 })))
             .FirstAsync()
-            .ToTask(ct);
+            .ObserveCompletion(
+                ex => lateFaultLogger?.LogWarning(ex,
+                    "Plugin bundles: the index faulted after the response had already been sent"),
+                ct)!;
     }
 
     /// <summary>
@@ -928,6 +944,8 @@ public static class PluginBundleEndpoints
     {
         var anchorService = Anchor(http);
         var ledger = Ledger(http);
+        // Resolved NOW — see Index: the request scope is gone by the time a late fault lands.
+        var lateFaultLogger = Log(http);
         return Servable(rootHub, anchorService, ct)
             .SelectMany(state =>
             {
@@ -974,7 +992,11 @@ public static class PluginBundleEndpoints
                 return Observable.Return(NoSuchBundle());
             })
             .FirstAsync()
-            .ToTask(ct);
+            .ObserveCompletion(
+                ex => lateFaultLogger?.LogWarning(ex,
+                    "Plugin bundles: {Plugin}@{Version} faulted after the response had already been sent",
+                    plugin, version),
+                ct)!;
     }
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginRegistryEndpoints.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
 using MeshWeaver.PluginCatalog;
@@ -57,8 +56,13 @@ public static class PluginRegistryEndpoints
                 ?.CreateLogger(typeof(PluginRegistryEndpoints));
 
             var authenticator = http.RequestServices.GetRequiredService<InstanceRegistryAuthenticator>();
-            var outcome = await authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
-                .FirstAsync().ToTask(http.RequestAborted);
+            var outcome = (await authenticator.AuthenticateOutcome(http.Request.Headers.Authorization)
+                .FirstAsync()
+                .ObserveCompletion(
+                    ex => logger?.LogWarning(ex,
+                        "Plugin registry: instance authentication for {Path} faulted after the request had already been answered",
+                        http.Request.Path),
+                    http.RequestAborted))!;
 
             // 🚨 BEFORE the anonymous fallback below, deliberately. "I could not find out" must not
             // fall through to serving this registry's sources anonymously — that would turn a
@@ -186,7 +190,11 @@ public static class PluginRegistryEndpoints
                 return Observable.Return((IResult)Results.Json(
                     new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway));
             })
-            .FirstAsync().ToTask(ct);
+            .FirstAsync()
+            .ObserveCompletion(
+                ex => logger?.LogWarning(ex,
+                    "Plugin registry: listing faulted after the response had already been sent"),
+                ct)!;
     }
 
     private static Task<IResult> Files(
@@ -241,7 +249,12 @@ public static class PluginRegistryEndpoints
                 return Observable.Return((IResult)Results.Json(
                     new { error = ex.Message }, statusCode: StatusCodes.Status502BadGateway));
             })
-            .FirstAsync().ToTask(ct);
+            .FirstAsync()
+            .ObserveCompletion(
+                ex => logger?.LogWarning(ex,
+                    "Plugin registry: fetching files for {Id} faulted after the response had already been sent",
+                    body.Id),
+                ct)!;
     }
 
     /// <summary>Fetch-files request: only the package <paramref name="Id"/> is authoritative — the

--- a/memex/Memex.Portal.Shared/Api/ReleaseGateEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/ReleaseGateEndpoints.cs
@@ -1,7 +1,7 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using Memex.Portal.Shared.SelfUpdate;
 using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
 using MeshWeaver.PluginCatalog;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -65,7 +65,11 @@ public static class ReleaseGateEndpoints
                         statusCode: StatusCodes.Status401Unauthorized))
                     : Answer(http, version))
             .FirstAsync()
-            .ToTask(ct);
+            .ObserveCompletion(
+                ex => logger?.LogWarning(ex,
+                    "Release gate for version '{Version}' faulted after the response had already been sent",
+                    version),
+                ct)!;
     }
 
 

--- a/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Xml.Linq;
 using Memex.Portal.Shared.Seo;
@@ -11,6 +10,7 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Memex.Portal.Shared.Api;
 
@@ -33,6 +33,20 @@ public sealed record PublishedPage(MeshNode Node, string Path);
 
 public static class SeoEndpoints
 {
+    /// <summary>
+    /// Late-fault sink for this surface's <see cref="ReactiveCompletion.ObserveCompletion{T}"/>
+    /// bridges: a fault that lands AFTER the crawler response has already settled cannot change the
+    /// answer, but discarding it would hide a mesh read that failed on the way out. The logger is
+    /// captured eagerly, because a late fault arrives long after the request scope is gone.
+    /// </summary>
+    private static Action<Exception> LateFault(IMessageHub hub, string route)
+    {
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(SeoEndpoints));
+        return ex => logger?.LogWarning(
+            ex, "{Route}: faulted after its HTTP response had already settled", route);
+    }
+
     /// <summary>Node types whose top-level mains are sitemap candidates.</summary>
     private static readonly string[] CandidateNodeTypes = ["Store/Plugin", "Store/Catalog", "Space"];
 
@@ -58,7 +72,7 @@ public static class SeoEndpoints
             return BuildSitemap(hub, baseUrl)
                 .Select(xml => Results.Text(xml, "application/xml"))
                 .FirstAsync()
-                .ToTask(ct);
+                .ObserveCompletion(LateFault(hub, "/sitemap.xml"), ct)!;
         }).AllowAnonymous();
 
         MapShareCard(app);
@@ -100,7 +114,7 @@ public static class SeoEndpoints
                     : CardResult(http, renderer, data))
                 .Catch<IResult, Exception>(_ => Observable.Return(Results.NotFound()))
                 .FirstAsync()
-                .ToTask(ct);
+                .ObserveCompletion(LateFault(hub, $"/api/og/{nodePath}"), ct)!;
         }).AllowAnonymous();
 
     private static IResult CardResult(HttpContext http, OgCardRenderer renderer, SeoPageData data)

--- a/memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs
@@ -1,7 +1,6 @@
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Builder;
@@ -64,9 +63,14 @@ public static class WebhookInboxEndpoints
         var headers = request.Headers.Select(h =>
             new KeyValuePair<string, string>(h.Key, h.Value.ToString()));
 
-        var result = await WebhookInbox.Deliver(
+        var result = (await WebhookInbox.Deliver(
                 hub, allowed, target, request.ContentType, headers, body)
-            .FirstAsync().ToTask(ct);
+            .FirstAsync()
+            .ObserveCompletion(
+                ex => logger?.LogWarning(ex,
+                    "Webhook delivery for target '{Target}' faulted after the response had already been sent",
+                    target),
+                ct))!;
         switch (result.Status)
         {
             case WebhookInbox.DeliveryStatus.Accepted:

--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenAuthenticationHandler.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenAuthenticationHandler.cs
@@ -1,7 +1,6 @@
 using System.Diagnostics;
 using System.Globalization;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Security.Claims;
 using System.Text.Encodings.Web;
 using MeshWeaver.Messaging;
@@ -113,8 +112,12 @@ public class ApiTokenAuthenticationHandler(
         // release the wait at once rather than holding it to the validation read's own timeout.
         // That matters most in exactly the degraded window this change is about — storage slow,
         // clients retrying — where holding every abandoned request would compound the pressure.
-        var validation = await tokenService.Validate(rawToken)
-            .FirstAsync().ToTask(Context.RequestAborted);
+        var validation = (await tokenService.Validate(rawToken)
+            .FirstAsync()
+            .ObserveCompletion(
+                ex => Logger.LogWarning(ex,
+                    "API token validation faulted after the authentication result had already settled"),
+                Context.RequestAborted))!;
         if (validation.Status == TokenValidationStatus.Unavailable)
         {
             // Token validation UNAVAILABLE — retry; NOT an auth failure. The token was

--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenController.cs
@@ -1,11 +1,11 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Threading;
 using MeshWeaver.Hosting.AspNetCore.Portal; // PortalApplication
 using MeshWeaver.Messaging;             // AccessService / AccessContext
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Memex.Portal.Shared.Authentication;
 
@@ -19,6 +19,14 @@ namespace Memex.Portal.Shared.Authentication;
 public class ApiTokenController(IServiceProvider serviceProvider) : ControllerBase
 {
     private ApiTokenService tokenService => serviceProvider.GetRequiredService<ApiTokenService>();
+
+    /// <summary>
+    /// Where a fault that arrives AFTER the action's response has already settled goes. Every
+    /// <see cref="ReactiveCompletion.ObserveCompletion{T}"/> bridge below needs one — a discarded
+    /// late fault is half of what that method exists to remove.
+    /// </summary>
+    private ILogger LateFaultLogger => serviceProvider.GetRequiredService<ILoggerFactory>()
+        .CreateLogger(typeof(ApiTokenController));
 
     /// <summary>
     /// The mesh-resolved identity for this request, as stamped on the portal
@@ -77,10 +85,12 @@ public class ApiTokenController(IServiceProvider serviceProvider) : ControllerBa
 
         var label = request.Label ?? "API Token";
 
-        // No await: pull IObservable up to the controller's return type. The
-        // single bridge to Task happens at .ToTask(ct) — passing the
-        // request's cancellation token so a client disconnect tears down the
-        // reactive subscription instead of orphaning it.
+        // No await: pull IObservable up to the controller's return type. The single bridge to Task
+        // happens at .ObserveCompletion(…, ct) — never Rx's .ToTask(), which resumes the awaiter
+        // INLINE on the signalling thread (a mesh hub's action block here) and is forbidden since
+        // 2026-08-30. The request's cancellation token is passed so a client disconnect tears down
+        // the wait instead of orphaning it.
+        var lateFaultLogger = LateFaultLogger;
         return tokenService.CreateToken(userId, userName, userEmail, label, expiresAt)
             .Select(creation => (IActionResult)Ok(new CreateTokenResponse
             {
@@ -91,7 +101,11 @@ public class ApiTokenController(IServiceProvider serviceProvider) : ControllerBa
                 ExpiresAt = expiresAt,
             }))
             .FirstAsync()
-            .ToTask(ct);
+            .ObserveCompletion(
+                ex => lateFaultLogger.LogWarning(ex,
+                    "Minting an API token for {UserId} faulted after the response had already been sent",
+                    userId),
+                ct)!;
     }
 
     /// <summary>
@@ -104,10 +118,15 @@ public class ApiTokenController(IServiceProvider serviceProvider) : ControllerBa
         if (userId is null)
             return Task.FromResult<IActionResult>(Unauthorized("No user identity found"));
 
+        var lateFaultLogger = LateFaultLogger;
         return tokenService.GetTokensForUser(userId)
             .Select(tokens => (IActionResult)Ok(tokens))
             .FirstAsync()
-            .ToTask(ct);
+            .ObserveCompletion(
+                ex => lateFaultLogger.LogWarning(ex,
+                    "Listing API tokens for {UserId} faulted after the response had already been sent",
+                    userId),
+                ct)!;
     }
 
     /// <summary>
@@ -120,13 +139,18 @@ public class ApiTokenController(IServiceProvider serviceProvider) : ControllerBa
         if (userId is null)
             return Task.FromResult<IActionResult>(Unauthorized("No user identity found"));
 
+        var lateFaultLogger = LateFaultLogger;
         return tokenService.GetTokensForUser(userId)
             .SelectMany(tokens => tokens.Any(t => t.NodePath == nodePath)
                 ? tokenService.RevokeToken(nodePath)
                     .Select(success => success ? (IActionResult)Ok() : NotFound())
                 : Observable.Return<IActionResult>(NotFound("Token not found or does not belong to you")))
             .FirstAsync()
-            .ToTask(ct);
+            .ObserveCompletion(
+                ex => lateFaultLogger.LogWarning(ex,
+                    "Revoking API token '{NodePath}' faulted after the response had already been sent",
+                    nodePath),
+                ct)!;
     }
 }
 

--- a/memex/Memex.Portal.Shared/Authentication/BootstrapController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/BootstrapController.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using MeshWeaver.Messaging;
 using MeshWeaver.PluginCatalog;
 using Microsoft.AspNetCore.Mvc;
@@ -60,7 +59,12 @@ public class BootstrapController(
         {
             try
             {
-                await obs.FirstAsync().ToTask(HttpContext.RequestAborted);
+                await obs.FirstAsync()
+                    .ObserveCompletion(
+                        ex => logger.LogWarning(ex,
+                            "Bootstrap: {Step} for '{User}' faulted after the step had already "
+                            + "settled", step, user),
+                        HttpContext.RequestAborted);
                 logger.LogInformation("Bootstrap: {Step} OK for '{User}'", step, user);
                 return true;
             }
@@ -143,10 +147,15 @@ public class BootstrapController(
                     }),
                     _ => keys.Mint(owner, name?.Trim() ?? owner, email?.Trim() ?? "",
                         description?.Trim() ?? "bootstrap-minted"))
-                .FirstAsync().ToTask(HttpContext.RequestAborted);
+                .FirstAsync()
+                .ObserveCompletion(
+                    ex => logger.LogWarning(ex,
+                        "Bootstrap: minting a registration key for '{Owner}' faulted after the "
+                        + "response had already been sent", owner),
+                    HttpContext.RequestAborted);
 
             // The raw key IS the response body — shown once, never stored, same contract as the tab.
-            return Ok(result.RawKey);
+            return Ok(result!.RawKey);
         }
         catch (Exception ex)
         {

--- a/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
+++ b/memex/Memex.Portal.Shared/Authentication/EaGraphAuth.cs
@@ -1,7 +1,6 @@
 using MeshWeaver.AI;   // IProviderKeyProtector & co keep their ORIGINAL namespace in MeshWeaver.Mesh.Contract (#2398 forwarders)
 using MeshWeaver.Mesh.Security;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using MeshWeaver.Hosting.AspNetCore.Portal;     // PortalApplication
 using MeshWeaver.Data;                       // IWorkspace.GetMeshNodeStream
@@ -167,7 +166,12 @@ public sealed class EaGraphAuth(
 
         using (access.ImpersonateAsSystem())
             await (existing is null ? meshService.CreateNode(node) : meshService.UpdateNode(node))
-                .FirstAsync().ToTask(ct);
+                .FirstAsync()
+                .ObserveCompletion(
+                    ex => logger?.LogWarning(ex,
+                        "EaGraphAuth: storing the credential for {User} faulted after the write had "
+                        + "already been reported complete", userObjectId),
+                    ct);
     }
 
     private Task<(MeshNode? node, EaCredential? cred)> LoadAsync(string userObjectId, CancellationToken ct)
@@ -191,7 +195,12 @@ public sealed class EaGraphAuth(
             MeshNode? node;
             using (access.ImpersonateAsSystem())
                 node = await ws.GetMeshNodeStream(PathFor(userObjectId))
-                    .Take(1).Timeout(TimeSpan.FromSeconds(10)).FirstAsync().ToTask(ct);
+                    .Take(1).Timeout(TimeSpan.FromSeconds(10)).FirstAsync()
+                    .ObserveCompletion(
+                        ex => logger?.LogWarning(ex,
+                            "EaGraphAuth: the credential read for {User} faulted after the load had "
+                            + "already settled", userObjectId),
+                        ct);
             var cred = node?.Content switch
             {
                 EaCredential e => e,

--- a/memex/Memex.Portal.Shared/Authentication/OAuthConnectController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OAuthConnectController.cs
@@ -1,6 +1,5 @@
 using System.Linq;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text.Json.Serialization;
@@ -275,7 +274,11 @@ public class OAuthConnectController(
                     new { error = "server_error", error_description = "Failed to persist the authorization code" }));
             })
             .FirstAsync()
-            .ToTask(ct);
+            .ObserveCompletion(
+                ex => logger.LogWarning(ex,
+                    "OAuth /authorize for client {ClientId} faulted after the response had already been sent",
+                    client_id),
+                ct)!;
     }
 
     /// <summary>
@@ -306,7 +309,8 @@ public class OAuthConnectController(
         // Exchange the code against the mesh-backed store (replica-safe: the code may
         // have been minted by any pod, and the single-use consume is atomic across
         // replicas — first delete wins), then mint the mw_ API token. One reactive
-        // chain, single bridge to Task at .ToTask(ct).
+        // chain, single bridge to Task at .ObserveCompletion(…, ct) — never Rx's .ToTask(), which
+        // resumes the awaiter INLINE on the signalling thread (forbidden since 2026-08-30).
         return CodeStore.ExchangeCode(
                 request.code,
                 request.client_id,
@@ -366,7 +370,11 @@ public class OAuthConnectController(
                     });
             })
             .FirstAsync()
-            .ToTask(ct);
+            .ObserveCompletion(
+                ex => logger.LogWarning(ex,
+                    "OAuth /token for client {ClientId} faulted after the response had already been sent",
+                    request.client_id),
+                ct)!;
     }
 
     /// <summary>

--- a/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
@@ -1,6 +1,5 @@
 using System.Globalization;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using MeshWeaver.Hosting.AspNetCore.Portal;
 using MeshWeaver.Data;
@@ -103,7 +102,16 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
         // below — ASP.NET's RequestDelegate signature forces Task at this
         // boundary, but everything else stays observable so a slow query
         // layer can't deadlock by awaiting a result the awaiting thread is
-        // supposed to publish.
+        // supposed to publish. The bridge is ObserveCompletion, NOT Rx's
+        // .ToTask(): the latter resumes this method INLINE on the thread that
+        // signalled — a mesh hub's action block — and then the whole rest of
+        // the request pipeline runs there (forbidden since 2026-08-30).
+        //
+        // No cancellation token: RequestAborted must NOT cut this wait short.
+        // The decision below is what tells the pipeline whether to redirect,
+        // pass through or answer 503, and abandoning it mid-flight would leave
+        // the request with no outcome at all — the LookupTimeout inside
+        // BuildPipeline is the bound that belongs here.
         //
         // Outcome semantics:
         //   • Result = "Redirect" — middleware bounces to /onboarding, doesn't
@@ -112,7 +120,10 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
         //     unauthenticated / virtual / excluded path); fall through to next.
         //   • Result = "Unavailable" — identity could not be RESOLVED (not: resolved
         //     to "no account"); answers 503 + Retry-After, doesn't call next.
-        var decision = await BuildPipeline(context).FirstAsync().ToTask();
+        var decision = (await BuildPipeline(context).FirstAsync()
+            .ObserveCompletion(ex => logger.LogWarning(ex,
+                "Onboarding: the identity pipeline for {Path} faulted after the request had "
+                + "already been answered", context.Request.Path)))!;
         var outcome = decision.Outcome;
 
         if (outcome == OnboardingOutcome.Unavailable)

--- a/memex/Memex.Portal.Shared/Authentication/UserRoleResolver.cs
+++ b/memex/Memex.Portal.Shared/Authentication/UserRoleResolver.cs
@@ -1,8 +1,8 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Memex.Portal.Shared.Authentication;
 
@@ -46,7 +46,10 @@ internal static class UserRoleResolver
     /// <para>The single Task bridge here lives at the ASP.NET
     /// <c>AuthenticationHandler.HandleAuthenticateAsync</c> boundary —
     /// callers expect a Task-returning helper, but everything below
-    /// stays observable.</para>
+    /// stays observable. It is
+    /// <see cref="ReactiveCompletion.ObserveCompletion{T}"/>, never Rx's
+    /// <c>.ToTask()</c>, which would resume the caller inline on whichever hub
+    /// thread published the roles (forbidden since 2026-08-30).</para>
     /// </summary>
     /// <param name="services">Scope to resolve the hub (and through it the workspace) from.</param>
     /// <param name="userId">The mesh user id whose grants to read.</param>
@@ -62,13 +65,16 @@ internal static class UserRoleResolver
         if (string.IsNullOrEmpty(userId))
             return IdentityReadOutcome<IReadOnlyCollection<string>>.Resolved(Array.Empty<string>());
 
+        var lateFaultLogger = services.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(UserRoleResolver));
+
         // 🚨 Resolving the hub and its workspace happens INSIDE the chain, not before it. A hub
         // mid-disposal (portal restart) throws from GetWorkspace(), and that throw used to be
         // absorbed by the caller's bare `catch { }`. With the swallow gone it would escape as a
         // 500 — an availability failure reported as a server error, i.e. this issue's own defect
         // reappearing inside its fix. Deferring puts it on the same classified path as any other
         // read fault: Unavailable, retryable, 503.
-        return await Observable.Defer(() =>
+        return (await Observable.Defer(() =>
                 {
                     var workspace = services.GetService<IMessageHub>()?.GetWorkspace();
                     // No role SOURCE at all is a static configuration fact — there is nothing to
@@ -82,7 +88,11 @@ internal static class UserRoleResolver
             .Catch<IdentityReadOutcome<IReadOnlyCollection<string>>, Exception>(ex =>
                 Observable.Return(IdentityReadOutcome<IReadOnlyCollection<string>>.Unavailable(
                     $"LoadDbRoles({userId}) faulted resolving the role source: {ex.GetType().Name}")))
+            // The trailing Catch turns every fault into a value, so this source emits EXACTLY
+            // ONCE; FirstAsync is kept so an empty completion still surfaces as an error rather
+            // than silently authenticating an under-privileged principal.
             .FirstAsync()
-            .ToTask();
+            .ObserveCompletion(ex => lateFaultLogger?.LogWarning(ex,
+                "LoadDbRoles({UserId}) faulted after the role read had already settled", userId)))!;
     }
 }

--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -6,6 +6,7 @@ using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace Memex.Portal.Shared.Seo;
 
@@ -85,10 +86,27 @@ public static class SeoResolver
             .Catch<SeoPageData?, Exception>(_ => Observable.Return<SeoPageData?>(null));
     }
 
-    /// <summary>The static-SSR boundary bridge — the only <c>Task</c> on this surface.</summary>
-    public static Task<SeoPageData?> ResolveAsync(IMessageHub hub, string path) =>
-        System.Reactive.Threading.Tasks.TaskObservableExtensions.ToTask(
-            Resolve(hub, path).FirstAsync());
+    /// <summary>
+    /// The static-SSR boundary bridge — the only <c>Task</c> on this surface, and it goes through
+    /// <see cref="ReactiveCompletion.ObserveCompletion{T}"/> rather than Rx's <c>.ToTask()</c>:
+    /// the latter resumes its awaiter INLINE on the signalling thread, which here is whichever mesh
+    /// hub answered the path resolution — so the rest of the Razor render would run on that hub's
+    /// action block (forbidden since 2026-08-30).
+    /// </summary>
+    public static Task<SeoPageData?> ResolveAsync(IMessageHub hub, string path)
+    {
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(SeoResolver));
+        // Resolve()'s trailing Catch turns every FAULT into a value, so on the fault path it emits
+        // exactly once. FirstAsync is kept because the remaining case it does NOT cover is an
+        // upstream that completes EMPTY: FirstAsync raises there, and ObserveCompletion would
+        // otherwise settle with a null that reads as "no SEO data" — the same answer a private node
+        // gets. Behaviour is unchanged from the .ToTask() this replaced, which raised identically.
+        return Resolve(hub, path)
+            .FirstAsync()
+            .ObserveCompletion(ex => logger?.LogWarning(
+                ex, "SEO resolution for '{Path}' faulted after the head had already been produced", path));
+    }
 
     /// <summary>
     /// The page description for meta tags: the node's Description, else the content's

--- a/memex/Memex.Portal.Shared/Settings/InvitationsSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/InvitationsSettingsTab.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Threading.Channels;
 using MeshWeaver.Application.Styles;
 using MeshWeaver.Data;

--- a/memex/Memex.Portal.Shared/Social/GitHubConnectEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubConnectEndpoints.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
@@ -129,10 +128,13 @@ public static class GitHubConnectEndpoints
                 return Fail("could not resolve your mesh user id (retry after a normal browser login)");
 
             var redirectUri = BuildRedirectUri(http);
-            // Reactive end-to-end; bridge to Task ONCE at the HTTP boundary via FirstAsync().ToTask()
-            // — the sanctioned edge pattern (see OAuthConnectController.ExchangeToken). NO hand-woven
-            // TaskCompletionSource/Subscribe. The credential write's AccessContext is carried through
-            // the framework's .Subscribe / IoPool boundary from the request context the middleware set.
+            // Reactive end-to-end; bridge to Task ONCE at the HTTP boundary via
+            // FirstAsync().ObserveCompletion(…) — the sanctioned edge pattern (see
+            // OAuthConnectController.ExchangeToken). NEVER Rx's .ToTask(), which resumes the awaiter
+            // INLINE on the signalling thread, so the rest of this request would run on a mesh hub's
+            // action block (forbidden since 2026-08-30). NO hand-woven TaskCompletionSource/Subscribe.
+            // The credential write's AccessContext is carried through the framework's
+            // .Subscribe / IoPool boundary from the request context the middleware set.
             return await oauth.ExchangeCode(code!, redirectUri)
                 .SelectMany(token => oauth.GetLogin(token.AccessToken)
                     .Catch<string?, Exception>(_ => Observable.Return<string?>(null))
@@ -149,7 +151,11 @@ public static class GitHubConnectEndpoints
                     return Observable.Return((IResult)Results.Redirect(SafeReturn(returnPath, "github-error", ex.Message)));
                 })
                 .FirstAsync()
-                .ToTask(http.RequestAborted);
+                .ObserveCompletion(
+                    ex => logger.LogWarning(ex,
+                        "GitHub connect for {User} faulted after the redirect had already been sent",
+                        userId),
+                    http.RequestAborted);
         }).RequireAuthorization();
 
         return endpoints;

--- a/memex/Memex.Portal.Shared/Social/GitHubLoginEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubLoginEndpoints.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Security.Claims;
 using System.Security.Cryptography;
 using System.Text;
 using MeshWeaver.GitSync;
+using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
@@ -112,9 +112,11 @@ public static class GitHubLoginEndpoints
             if (string.IsNullOrEmpty(code)) return Fail("no authorization code returned by GitHub");
 
             var redirectUri = BuildRedirectUri(http);
-            // Reactive end-to-end; bridge to Task ONCE at the HTTP boundary (the sanctioned edge
-            // pattern, as in GitHubConnectEndpoints / OAuthConnectController). Exchange the code,
-            // then fetch login + primary verified email together.
+            // Reactive end-to-end; bridge to Task ONCE at the HTTP boundary via ObserveCompletion
+            // (the sanctioned edge pattern, as in GitHubConnectEndpoints / OAuthConnectController) —
+            // never Rx's .ToTask(), which resumes the awaiter inline on the signalling thread
+            // (forbidden since 2026-08-30). Exchange the code, then fetch login + primary verified
+            // email together.
             return await oauth.ExchangeCode(code!, redirectUri)
                 .SelectMany(token => oauth.GetLogin(token.AccessToken)
                     .Catch<string?, Exception>(_ => Observable.Return<string?>(null))
@@ -162,7 +164,10 @@ public static class GitHubLoginEndpoints
                     return Observable.Return(Fail(ex.Message));
                 })
                 .FirstAsync()
-                .ToTask(http.RequestAborted);
+                .ObserveCompletion(
+                    ex => logger.LogWarning(ex,
+                        "GitHub sign-in faulted after the response had already been sent"),
+                    http.RequestAborted);
         });
 
         return endpoints;

--- a/memex/Memex.Portal.Shared/Social/GitHubWebhookEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Social/GitHubWebhookEndpoints.cs
@@ -1,11 +1,11 @@
 using System;
 using System.IO;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Memex.Portal.Shared.Api;
 using MeshWeaver.GitSync;
+using MeshWeaver.Messaging;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Routing;
@@ -97,7 +97,9 @@ public static class GitHubWebhookEndpoints
 
             // Process() reads the payload synchronously into materialized records before returning
             // its observable, so the JsonDocument may be disposed once this handler returns. Bridge
-            // to Task ONCE here at the HTTP boundary; a processing failure is logged, never 500-thrown.
+            // to Task ONCE here at the HTTP boundary, through ObserveCompletion rather than Rx's
+            // .ToTask() (which resumes inline on the signalling thread — forbidden since
+            // 2026-08-30); a processing failure is logged, never 500-thrown.
             var updated = await processor.Process(eventType, doc.RootElement)
                 .Catch((Exception ex) =>
                 {
@@ -105,7 +107,11 @@ public static class GitHubWebhookEndpoints
                     return Observable.Return(0);
                 })
                 .FirstAsync()
-                .ToTask(http.RequestAborted);
+                .ObserveCompletion(
+                    ex => logger.LogWarning(ex,
+                        "GitHub webhook processing for event {Event} faulted after the response had "
+                        + "already been sent", eventType),
+                    http.RequestAborted);
 
             return Results.Ok(new { ok = true, updated });
         });


### PR DESCRIPTION
Removes every `.ToTask(` call site from `memex/` — 33 of them, all in `Memex.Portal.Shared`. Maintainer ruling of 2026-08-30: *"totask is forbidden", "strictly", "no totask ever"*.

## Why

Rx's `.ToTask()` completes its `TaskCompletionSource` from **inside** the Rx pipeline, without `RunContinuationsAsynchronously`. `TrySetResult` therefore resumes the awaiter **inline on the signalling thread**, still inside Rx's trampoline — and `await` pins `TaskScheduler.Current` for every later continuation in the same method. In an ASP.NET request pipeline that means the rest of the request, the response write included, runs on a mesh hub's single-threaded action block. That is the shape that wedges a partition hub (#2301, #2377).

`ReactiveCompletion.ObserveCompletion` (`MeshWeaver.Messaging`) completes through a TCS created with `RunContinuationsAsynchronously` — the line that stops the deadlock — and keeps its error arm attached after the task settles, so a fault that lands late is reported instead of becoming an unobserved exception.

🚨 `await source.FirstAsync()` (Rx's own awaiter) is **not** a fix: it is built on `AsyncSubject<T>`, which completes its continuation from inside `OnCompleted`, on the signalling thread. Same defect.

## Semantics, preserved site by site

| Trap | What this diff does |
|---|---|
| **first vs last** | All 33 sites **already** had a `First*` reducer immediately upstream — in most cases `.FirstAsync()` on the source line *above* the `.ToTask(...)`, which a single-line grep does not show. So `ToTask`'s last-value semantics and `ObserveCompletion`'s first-value semantics coincide, and **no `.LastAsync()` was added anywhere.** |
| **empty sources** | `FirstAsync()` turns an empty completion into an `OnError`, which `ObserveCompletion` faults the task with — identical to `.ToTask()`. No endpoint that relied on the throw to produce a 404/500 can now return a silent default/null. |
| **the `using`** | `using System.Reactive.Threading.Tasks;` dropped everywhere it is now dead, but **kept in `MeshApiEndpoints.cs`**, which still uses `Task<T>.ToObservable()` — the safe direction. Removing it there yields `CS0411`, which never mentions `Task`. |
| **nullability** | `ObserveCompletion` returns `Task<T?>`; `expr!` on the task, `(await …)!` where the `!` would bind to the task. `-warnaserror` clean. |
| **cancellation** | Every token carried through unchanged (`http.RequestAborted`, `Context.RequestAborted`, `ct`). The three sites that never had one still have none — `SeoResolver.ResolveAsync`, `UserRoleResolver.LoadDbRolesAsync`, `OnboardingMiddleware.InvokeAsync`; the last one now says in a comment why `RequestAborted` must **not** be introduced there (abandoning that wait leaves the request with no outcome at all). |

`reportLateFault` is never an empty lambda. Each site logs through a logger it already had, or through a small `LateFault` helper — and that helper resolves the logger **eagerly**, while the request scope is alive: a late fault arrives after `HttpContext.RequestServices` has been disposed, so resolving inside the lambda would throw exactly when the report is needed.

Comments that *prescribed* `.FirstAsync().ToTask(ct)` as the sanctioned edge pattern are repointed at `ObserveCompletion` and this ruling. Comments that already *proscribe* `.ToTask()` (`AdminMenuGate`, `UserOnboardingService`) are left alone.

## Verification

- `dotnet build -c Release -warnaserror` on `Memex.Portal.Shared` → **0 Warning(s), 0 Error(s)**
- `dotnet build -c Release -warnaserror` on `test/Memex.Portal.Shared.Test` → **0 Warning(s), 0 Error(s)**
- `Memex.Portal.Shared.Test`: **Total 481, Errors 0, Failed 0, Skipped 0** (34.4 s)
- `grep -rn '\.ToTask(' memex --include='*.cs'`, comment lines excluded → **0**

No What's New entry — the umbrella entry ships with #2748.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
