### PR TITLE
fix(#2727): a read that faults on a CLOSED DI SCOPE is NACKed, not answered as data — 20/100 → 1/100

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -2080,7 +2080,7 @@ public static class DataExtensions
             // single answer.
             .Catch<GetDataResponse, Exception>(ex => HubDisposingException.IsHubDisposal(ex)
                 ? Observable.Throw<GetDataResponse>(ex)
-                : Observable.Return(new GetDataResponse(null, 0) { Error = ex.Message }))
+                : Observable.Return(new GetDataResponse(null, 0) { Error = DescribeReadFault(ex) }))
             .Subscribe(
                 response =>
                 {
@@ -2139,6 +2139,30 @@ public static class DataExtensions
                     + "shutting down and never produced a value. Retry against the fresh activation.");
         }));
         return request.Processed();
+    }
+
+    /// <summary>
+    /// The error text a NON-disposal read fault is answered with — the ROOT cause, not the wrapper.
+    ///
+    /// <para>🚨 The reflective Reduce hands this path a <see cref="System.Reflection.TargetInvocationException"/>
+    /// whose own message is the useless <c>"Exception has been thrown by the target of an
+    /// invocation."</c> — and answering THAT is how a read failure reaches a caller, a log and a CI
+    /// failure block naming nothing at all. The error arm three lines below already unwraps for
+    /// exactly this reason ("Name the ROOT cause, not the wrapper"); this arm did not, so every
+    /// non-disposal fault was reported anonymously. `SilentReadNackTest`'s bulk-only failure has
+    /// been arriving with precisely that string, which is why the exception behind it is still
+    /// unidentified (#2727).</para>
+    /// </summary>
+    internal static string DescribeReadFault(Exception exception)
+    {
+        var root = exception;
+        // Bounded, cycle-tolerant walk to the innermost cause — the same discipline
+        // ExceptionChain.Contains applies, kept local because we want the NODE, not a predicate.
+        for (var i = 0; i < 32 && root.InnerException is { } inner && !ReferenceEquals(inner, root); i++)
+            root = inner;
+        return ReferenceEquals(root, exception)
+            ? $"{exception.GetType().Name}: {exception.Message}"
+            : $"{exception.GetType().Name}: {exception.Message} (cause: {root.GetType().Name}: {root.Message})";
     }
 
     /// <summary>

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -2116,8 +2116,15 @@ public static class DataExtensions
                     // that a disposed container reaches this arm: the hub announced its disposal
                     // (HubDisposingException), or its DI scope was closed underneath the read.
                     var cause = FindHubDisposal(ex) ?? InnermostCause(ex);
+                    // 🚨 "shutting down" IS CONTRACT — do not reword it out.
+                    // MeshNodeStreamCache.IsTransientOwnerFailure classifies on that marker, and a
+                    // consumer that does not see it TEARS DOWN instead of riding the recycle out.
+                    // Measured the hard way: an earlier draft of this very change said "is going
+                    // away" and the rate run came back 10/100 with every remaining failure being
+                    // that missing marker — a product regression, not merely a red assertion.
+                    // Both causes are named, but the marker stays.
                     NackSilentRead(hub, request,
-                        "the read faulted because the owning hub is going away — its hosted-hub "
+                        "the read faulted because the owning hub is shutting down — its hosted-hub "
                         + "creation is frozen or its service scope has been closed, so the data "
                         + $"stream for this reference could not be created ({cause.GetType().Name}: "
                         + $"{cause.Message}). Retry against the fresh activation.");

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -2078,9 +2078,22 @@ public static class DataExtensions
             // no IsWindingDown gate: there is no healthy-hub case in which it is a lie. Rethrow so
             // the terminal is decided in exactly one place — the error arm — and the CAS keeps it a
             // single answer.
-            .Catch<GetDataResponse, Exception>(ex => HubDisposingException.IsHubDisposal(ex)
-                ? Observable.Throw<GetDataResponse>(ex)
-                : Observable.Return(new GetDataResponse(null, 0) { Error = DescribeReadFault(ex) }))
+            // 🚨 A DISPOSED CONTAINER is a teardown fact too, and answering it as data is the same
+            // defect this Catch's own comment describes — one cause down. Measured 2026-08-30
+            // (flake-repro, 40 iterations on the 4-vCPU runner): the fault behind
+            // SilentReadNackTest's bulk-only failure is
+            //   TargetInvocationException → ObjectDisposedException: "Instances cannot be resolved
+            //   and nested lifetimes cannot be created from this LifetimeScope …"
+            // i.e. the hub's Autofac scope closed underneath an in-flight read. It is NOT a
+            // HubDisposingException — a scope closed under a live delivery announces nothing — so
+            // it fell to the value arm, fabricated a GetDataResponse{Error}, CLAIMED THE ONCE-ONLY
+            // ANSWER SLOT and left the caller with "this node does not exist" for a node that
+            // exists and an address that reactivates. Exactly #1362/#1470's shape, reached by a
+            // different cause. Rethrow it so the ONE terminal decision stays in the error arm.
+            .Catch<GetDataResponse, Exception>(ex =>
+                HubDisposingException.IsHubDisposal(ex) || HubDisposingException.IsDisposedContainer(ex)
+                    ? Observable.Throw<GetDataResponse>(ex)
+                    : Observable.Return(new GetDataResponse(null, 0) { Error = DescribeReadFault(ex) }))
             .Subscribe(
                 response =>
                 {
@@ -2099,12 +2112,15 @@ public static class DataExtensions
                     // TargetInvocationException whose own message is the useless "Exception has
                     // been thrown by the target of an invocation" — the exact string the CI red
                     // reported, which says nothing about what happened.
-                    var cause = FindHubDisposal(ex) ?? ex;
+                    // Name the ROOT cause, not the wrapper — and cover BOTH teardown shapes now
+                    // that a disposed container reaches this arm: the hub announced its disposal
+                    // (HubDisposingException), or its DI scope was closed underneath the read.
+                    var cause = FindHubDisposal(ex) ?? InnermostCause(ex);
                     NackSilentRead(hub, request,
-                        "the read faulted because the owning hub is shutting down — its hosted-hub "
-                        + "creation is frozen, so the data stream for this reference could not be "
-                        + $"created ({cause.GetType().Name}: {cause.Message}). Retry against the "
-                        + "fresh activation.");
+                        "the read faulted because the owning hub is going away — its hosted-hub "
+                        + "creation is frozen or its service scope has been closed, so the data "
+                        + $"stream for this reference could not be created ({cause.GetType().Name}: "
+                        + $"{cause.Message}). Retry against the fresh activation.");
                 },
                 () =>
                 {
@@ -2153,13 +2169,18 @@ public static class DataExtensions
     /// been arriving with precisely that string, which is why the exception behind it is still
     /// unidentified (#2727).</para>
     /// </summary>
-    internal static string DescribeReadFault(Exception exception)
+    /// <summary>The innermost cause of <paramref name="exception"/> — bounded and cycle-tolerant.</summary>
+    private static Exception InnermostCause(Exception exception)
     {
         var root = exception;
-        // Bounded, cycle-tolerant walk to the innermost cause — the same discipline
-        // ExceptionChain.Contains applies, kept local because we want the NODE, not a predicate.
         for (var i = 0; i < 32 && root.InnerException is { } inner && !ReferenceEquals(inner, root); i++)
             root = inner;
+        return root;
+    }
+
+    internal static string DescribeReadFault(Exception exception)
+    {
+        var root = InnermostCause(exception);
         return ReferenceEquals(root, exception)
             ? $"{exception.GetType().Name}: {exception.Message}"
             : $"{exception.GetType().Name}: {exception.Message} (cause: {root.GetType().Name}: {root.Message})";

--- a/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
+++ b/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
@@ -105,4 +105,28 @@ public sealed class HubDisposingException : ObjectDisposedException
     /// <returns><c>true</c> when the failure is a hub-disposal race.</returns>
     public static bool IsHubDisposal(Exception? exception)
         => ExceptionChain.Contains<HubDisposingException>(exception);
+
+    /// <summary>
+    /// True when <paramref name="exception"/> is (or wraps) the DI container's
+    /// "this scope is gone" — an <see cref="ObjectDisposedException"/> naming a disposed Autofac
+    /// <c>LifetimeScope</c>.
+    ///
+    /// <para>🚨 This is a TEARDOWN fact, not a fault of the work that hit it, and the distinction
+    /// is the whole point: a hub whose scope has been closed cannot serve anything, so a delivery
+    /// that faults this way must be answered as RETRYABLE (the address reactivates) rather than as
+    /// a result. It is the same evidence <c>TeardownStragglerCapturer</c> filters on and the same
+    /// the access pipeline keys on, kept HERE so every layer classifies it identically instead of
+    /// each re-deriving it — <c>HubDisposingException</c> covers only the case where the hub
+    /// announced its own disposal, and a scope closed underneath a live delivery never does.</para>
+    ///
+    /// <para>Matched on the message rather than a type: the exception is raised by Autofac and
+    /// wrapped by whatever invoked it (reflection hands it over as
+    /// <see cref="System.Reflection.TargetInvocationException"/>), so the chain — not the outer
+    /// type — is what carries the fact.</para>
+    /// </summary>
+    public static bool IsDisposedContainer(Exception? exception)
+        => ExceptionChain.Contains(exception, static e =>
+            e is ObjectDisposedException
+            && ((e.Message?.Contains("LifetimeScope", StringComparison.OrdinalIgnoreCase) ?? false)
+                || (e.Message?.Contains("nested lifetimes cannot be created", StringComparison.OrdinalIgnoreCase) ?? false)));
 }

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposedContainerIsATeardownFactTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposedContainerIsATeardownFactTest.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Reflection;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>A closed DI scope is a teardown fact, and every layer must classify it the same way.</b>
+///
+/// <para>A hub whose Autofac <c>LifetimeScope</c> has been closed cannot serve anything, so a
+/// delivery that faults on it must be answered as RETRYABLE — the address reactivates — never as a
+/// result. <see cref="HubDisposingException.IsHubDisposal"/> does not cover it: that is the case
+/// where a hub ANNOUNCED its own disposal, and a scope closed underneath a live delivery announces
+/// nothing.</para>
+///
+/// <para>Measured 2026-08-30 (flake-repro, 40 iterations on the 4-vCPU runner): the fault behind
+/// <c>SilentReadNackTest.OwnerDisposedWithReadOutstanding</c>'s bulk-only failure is exactly this
+/// shape, reflection-wrapped —
+/// <c>TargetInvocationException → ObjectDisposedException("… LifetimeScope …")</c>. Because it was
+/// not recognised, the read path fabricated a <c>GetDataResponse{Error}</c>, claimed the once-only
+/// answer slot, and reported "this node does not exist" for a node that exists (#1362/#1470's
+/// shape, reached by a different cause; #2727).</para>
+/// </summary>
+public class DisposedContainerIsATeardownFactTest
+{
+    private static ObjectDisposedException DisposedScope() =>
+        new("LifetimeScope",
+            "Instances cannot be resolved and nested lifetimes cannot be created from this "
+            + "LifetimeScope as it (or one of its parent scopes) has already been disposed.");
+
+    [Fact]
+    public void TheReflectionWrappedDisposedScope_IsRecognised()
+    {
+        // The exact shape measured in CI: the reflective Reduce hands it over wrapped.
+        var wrapped = new TargetInvocationException(DisposedScope());
+
+        HubDisposingException.IsDisposedContainer(wrapped).Should().BeTrue(
+            "this is the fault that reaches the read path; unrecognised, it is answered as DATA "
+            + "and the caller is told a node that exists does not");
+        HubDisposingException.IsHubDisposal(wrapped).Should().BeFalse(
+            "a scope closed underneath a live delivery announces nothing — which is exactly why "
+            + "IsHubDisposal alone left this case unclassified");
+    }
+
+    [Fact]
+    public void AnUnrelatedFault_IsNotATeardown()
+    {
+        HubDisposingException.IsDisposedContainer(new ObjectDisposedException("SomeStream"))
+            .Should().BeFalse("an ObjectDisposedException a handler caused on a LIVE hub is a real "
+                + "fault; classifying it as teardown would hide it behind an endless retry");
+        HubDisposingException.IsDisposedContainer(new InvalidOperationException("boom"))
+            .Should().BeFalse("an ordinary fault must keep its own answer");
+        HubDisposingException.IsDisposedContainer(null)
+            .Should().BeFalse("no exception is not a teardown");
+    }
+
+    /// <summary>A cyclic chain must terminate — the predicate walks caller-supplied data.</summary>
+    [Fact]
+    public void ACyclicChain_TerminatesRatherThanHanging()
+    {
+        var a = new InvalidOperationException("a");
+        var wrapped = new TargetInvocationException(a);
+        HubDisposingException.IsDisposedContainer(wrapped).Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Fixes the remaining half of #2727 — the one the sibling PR (#2740) explicitly does **not** cover.

## The exception, finally named

Three issues (#1470, #2673, #2727) have discussed this fault without ever identifying it, because
it arrives as `TargetInvocationException` and that type's message is the useless *"Exception has
been thrown by the target of an invocation."* The first commit here fixes that (the error arm three
lines below already unwrapped; the value arm did not), and one `flake-repro` run then named it:

```
TargetInvocationException → ObjectDisposedException:
  "Instances cannot be resolved and nested lifetimes cannot be created from this LifetimeScope
   as it (or one of its parent scopes) has already been disposed."
```

**The hub's Autofac scope was closed underneath an in-flight read.**

## Why it was answered wrongly

That is **not** a `HubDisposingException` — a scope closed under a live delivery announces nothing —
so `HandleGetDataRequest`'s `Catch` sent it to the **value** arm: it fabricated a
`GetDataResponse{Error}`, **claimed the once-only answer slot**, and the caller was told *"this node
does not exist"* for a node that exists, at an address that reactivates. That is exactly the
#1362/#1470 shape the `Catch`'s own comment describes — reached by a different cause, so the
existing guard never saw it.

Consequence in CI: `SilentReadNackTest.OwnerDisposedWithReadOutstanding` gets a `GetDataResponse`
where it asserts a NACK. Measured baseline on `main`: **20 failures / 100** for the class filter
(that count also includes #2673's test), and **2 / 40** for this test alone.

## The fix

`HubDisposingException.IsDisposedContainer` — the shared classification, placed next to
`IsHubDisposal` so every layer answers a closed scope **identically** instead of re-deriving it
(the access pipeline keys on the same evidence in #2740; `TeardownStragglerCapturer` filters on it).
The read path rethrows it, so the single terminal decision stays in the error arm and the caller
gets the retryable NACK it is owed.

This is the third terminal of one root cause, and worth stating as a set, because each was
classified as an *answer* instead of a *teardown*:

| terminal | fix |
|---|---|
| drain ordering — scopes closed before pooled I/O joined | #2735 (merged) |
| access gate — refusal not marked transient, posted through a dead hub | #2740 |
| **read path — a closed scope answered as data** | **this PR** |

## Verification

- `DisposedContainerIsATeardownFactTest` pins the classification on the **reflection-wrapped shape
  actually measured**, plus the negatives: an unrelated `ObjectDisposedException` on a live hub
  keeps its own answer, because classifying that as teardown would hide a real fault behind an
  endless retry.
- **Measured**, `flake-repro` `rate`, 100 iterations, same filter and runner as the baseline:

  | branch | failures / 100 |
  |---|---|
  | `main` (baseline) | **20** |
  | this fix, first draft | **10** (z = −1.98) |
  | **this fix, marker restored** | **1** (z = **−4.38**, a 95 % reduction) |

  And the single remaining failure is **not this test**: it is
  `GetMeshNode_WhenOwnerIsDisposedMidRead_RecoversOnTheReProbe` (#2673), which the class filter also
  matches and which this PR does not claim to fix. `OwnerDisposedWithReadOutstanding` itself went to
  **0 / 100**.

  The first draft is worth recording rather than hiding: the rethrow worked — the answer became a
  `DeliveryFailureException` instead of a fabricated `GetDataResponse` — but I had reworded the NACK
  to *"the owning hub is going away"*, dropping the `"shutting down"` marker
  `MeshNodeStreamCache.IsTransientOwnerFailure` classifies on. **All 10 remaining failures were that
  regression**, and it is a product regression, not a red assertion: a consumer that does not see
  the marker tears down instead of riding the recycle out. Marker restored, both causes still named.
- The target test 3/3 green locally — which proves little on its own (it was 8/8 green *before* the
  fix; the laptop is not the repro vector), hence the rate runs above.
- `MeshWeaver.Messaging.Hub.Test` and `MeshWeaver.Data` build with `-warnaserror`.

**A gap this exposed, worth its own follow-up:** 38 sites emit `"is shutting down"` as a contract
marker and the classifier keys on it at `MeshNodeStreamCache.cs:1374`, but **nothing pins the
pairing**. My regression was caught only by a 20 %-flaky integration test — i.e. it would have been
missed on 4 runs in 5. A deterministic guard (each teardown-NACK producer's wording must satisfy
`IsTransientOwnerFailure`) belongs in the same family as `RecycledHubRefusalTest` from #2740; I have
noted it at the call site rather than starting a 38-site refactor inside this fix.

Honest limit: this removes one terminal. The `GetMeshNode_WhenOwnerIsDisposedMidRead` half of the
class filter (#2673) is a different assertion and is not claimed here.
