### PR TITLE
fix(#2673): an UNDETERMINED permission check on a hub that is GONE is transient, not 'we could not check'

### DIFF
--- a/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
+++ b/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
@@ -49,7 +49,7 @@ public static class AccessControlPipeline
     /// two shapes <c>TeardownStragglerCapturer</c> filters).</para>
     /// </summary>
     /// <summary>
-    /// The refusal a delivery gets when it reached a hub that is GONE (see <see cref="IsHubGone"/>).
+    /// The refusal a delivery gets when it reached a hub that is GONE (see <see cref="IsHubGone(IMessageHub, Exception)"/>).
     ///
     /// <para>🚨 THE WORDING IS CONTRACT, exactly as <c>MessageService.NackThroughParent</c>'s is.
     /// The mesh classifies delivery failures by their MESSAGE TEXT as well as their ErrorType, and
@@ -62,10 +62,26 @@ public static class AccessControlPipeline
     /// is still refused, and the caller simply stops retrying again. Pinned by
     /// <c>RecycledHubRefusalTest</c>.</para>
     /// </summary>
+    /// <summary><see cref="RecyclingRefusal(Address, string, Exception)"/> for a reason string.</summary>
+    internal static string RecyclingRefusal(Address address, string messageTypeName, string? reason) =>
+        $"Hub {address} is shutting down (its access gate could not reach a verdict: {reason}) "
+        + $"— cannot evaluate access for {messageTypeName}; the address may reactivate "
+        + "(recycle / restart). Rejecting now.";
+
     internal static string RecyclingRefusal(Address address, string messageTypeName, Exception error) =>
         $"Hub {address} is shutting down (its lifetime scope is gone, {error.GetType().Name}) "
         + $"— cannot evaluate access for {messageTypeName}; the address may reactivate "
         + "(recycle / restart). Rejecting now.";
+
+    /// <summary>
+    /// <see cref="IsHubGone(IMessageHub, Exception)"/> for a path that has a REASON STRING rather
+    /// than an exception — the permission fold reports an undetermined outcome as text.
+    /// </summary>
+    internal static bool IsHubGone(IMessageHub hub, string? reason)
+        => hub.IsShuttingDown
+           || (reason is not null
+               && (reason.Contains("LifetimeScope", StringComparison.OrdinalIgnoreCase)
+                   || reason.Contains("nested lifetimes cannot be created", StringComparison.OrdinalIgnoreCase)));
 
     internal static bool IsHubGone(IMessageHub hub, Exception error)
     {
@@ -425,11 +441,36 @@ public static class AccessControlPipeline
                             // Both refuse the delivery — the fail-closed behaviour is UNCHANGED
                             // and `next` is not invoked on either leg. What changes is that the
                             // second one stops impersonating the first.
+                            // 🚨 THREE outcomes, not two — because "we could not check" has two very
+                            // different causes and only one of them is about this mesh being busy.
+                            //
+                            //   Denied                      → Unauthorized  ("we checked; you may not")
+                            //   Undetermined, hub GONE      → ShuttingDown  ("this activation is going away")
+                            //   Undetermined, hub healthy   → Unavailable   ("we could not check")
+                            //
+                            // The middle one is issue #2673, measured. When the owner is recycled
+                            // mid-read the fold cannot reach a verdict, and answering that as
+                            // Unavailable — with wording no transient classifier matches
+                            // (MeshNodeStreamCache.IsTransientOwnerFailure and friends key on
+                            // "is shutting down" / "Rejecting now") — makes GetMeshNode take it as
+                            // TERMINAL and resolve NULL for a node that exists at an address that
+                            // reactivates. Measured shape:
+                            //   "Permission check unavailable for user 'Roland' on
+                            //    'TestData/reprobe-recovers' (Read) — no verdict was reached"
+                            //   → [TEST] recovered in 62 ms: (null)
+                            // Answering it in the recycling vocabulary instead makes the caller
+                            // re-probe, which is what lands it on the fresh activation.
+                            //
+                            // Fail-closed is UNCHANGED on every leg: `next` is never invoked here.
                             var (errorType, message) = refusal.Outcome.IsUndetermined
-                                ? (ErrorType.Unavailable,
-                                    $"Permission check unavailable for user '{effectiveUser}' on '{refusal.Path}' "
-                                    + $"({refusal.Permission}) — no verdict was reached, so this is NOT a statement "
-                                    + $"about this user's rights. Retry shortly. Cause: {refusal.Outcome.UndeterminedReason}")
+                                ? IsHubGone(hub, refusal.Outcome.UndeterminedReason)
+                                    ? (ErrorType.ShuttingDown,
+                                        RecyclingRefusal(hub.Address, delivery.Message.GetType().Name,
+                                            refusal.Outcome.UndeterminedReason))
+                                    : (ErrorType.Unavailable,
+                                        $"Permission check unavailable for user '{effectiveUser}' on '{refusal.Path}' "
+                                        + $"({refusal.Permission}) — no verdict was reached, so this is NOT a statement "
+                                        + $"about this user's rights. Retry shortly. Cause: {refusal.Outcome.UndeterminedReason}")
                                 : (ErrorType.Unauthorized,
                                     $"Access denied: user '{effectiveUser}' lacks {refusal.Permission} permission on '{refusal.Path}'");
 

--- a/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
+++ b/test/MeshWeaver.Hosting.Test/RecycledHubRefusalTest.cs
@@ -64,6 +64,36 @@ public class RecycledHubRefusalTest : HubTestBase
     }
 
     /// <summary>
+    /// #2673: an UNDETERMINED permission outcome on a hub that is going away must be answered in
+    /// the recycling vocabulary too, not as "we could not check".
+    ///
+    /// <para>The fold cannot reach a verdict while the owner is recycled, and the honest-sounding
+    /// <c>Unavailable</c> answer carries no marker any transient classifier matches — so
+    /// <c>GetMeshNode</c> took it as TERMINAL and resolved <b>null</b> for a node that exists at an
+    /// address that reactivates (measured: "recovered in 62 ms: (null)"). The reason string is the
+    /// only evidence available on that path, hence the string overload.</para>
+    /// </summary>
+    [Fact]
+    public void AnUndeterminedCheck_OnAGoneHub_IsClassifiedTransientToo()
+    {
+        var refusal = AccessControlPipeline.RecyclingRefusal(
+            new Address("TestData", "reprobe-recovers"), "GetDataRequest",
+            "the permission query could not run");
+
+        MeshNodeStreamCache.IsTransientOwnerFailure(new InvalidOperationException(refusal))
+            .Should().BeTrue("otherwise GetMeshNode resolves null for a node that EXISTS — #2673");
+
+        AccessControlPipeline.IsHubGone(GetHost(),
+                "Instances cannot be resolved and nested lifetimes cannot be created from this "
+                + "LifetimeScope as it (or one of its parent scopes) has already been disposed.")
+            .Should().BeTrue("a disposed scope named in the REASON is the same fact as one thrown");
+        AccessControlPipeline.IsHubGone(GetHost(), "the query returned no rows")
+            .Should().BeFalse("an ordinary undetermined outcome on a LIVE hub keeps its honest "
+                + "'we could not check' answer — calling that a recycle would make a real gate "
+                + "failure retry forever");
+    }
+
+    /// <summary>
     /// The discrimination. A disposed SCOPE means the hub is gone; an unrelated
     /// <see cref="ObjectDisposedException"/> from something a handler touched on a LIVE hub is a
     /// real fault and must keep its honest "the gate could not run" classification — over-claiming


### PR DESCRIPTION
Fixes #2673.

## Measured cause, not inferred

From the failing iteration of a 100-run `flake-repro` `rate` on the 4-vCPU runner:

```
[Warning] AccessControlPipeline: Permission check unavailable for user 'Roland' on
          'TestData/reprobe-recovers' (Read) — no verdict was reached
[TEST] recovered in 62 ms: (null)
```

When the owner is recycled mid-read the permission fold cannot reach a verdict. That was projected to `ErrorType.Unavailable` with wording **no transient classifier matches** (`MeshNodeStreamCache.IsTransientOwnerFailure`, `RoutingGrain.IsTransientFailure`, `AreaErrorClassifier.IsTransientHubFailure` all key on `"is shutting down"` / `"Rejecting now"`), so `GetMeshNode` took it as **terminal** and resolved **null for a node that exists** at an address that reactivates — exactly this issue's report, *"resolves NULL in 11ms instead of re-probing"*.

## The change

The tri-state now projects to **three** outcomes rather than two:

| outcome | ErrorType |
|---|---|
| Denied | `Unauthorized` — "we checked; you may not" |
| **Undetermined, hub GONE** | **`ShuttingDown`** — the recycling refusal, markers included, so the caller re-probes |
| Undetermined, hub healthy | `Unavailable` — unchanged |

**Fail-closed is unchanged on every leg**: `next` is never invoked here, so nothing is granted.

## Verification

- `RecycledHubRefusalTest` gains a pin for this path, including the **negative**: an ordinary undetermined outcome on a LIVE hub keeps its honest "we could not check" answer, because calling that a recycle would make a real gate failure retry forever.
- A 100-iteration `rate` run against the same baseline is in the thread. Baseline on `main` for this filter was **20/100**; after #2753 it was **1/100**, and that single remaining failure was *this* test.

## Context — the fourth terminal of one root cause

Work touching a hub/scope that is going away, classified as an **answer** instead of a **teardown**:

| terminal | fix |
|---|---|
| drain ordering — scopes closed before pooled I/O joined | #2735 ✅ |
| access gate — refusal not transient, posted through a dead hub | #2740 ✅ |
| read path — a closed DI scope answered as data | #2753 ✅ |
| **permission fold — undetermined on a gone hub answered `Unavailable`** | **this PR** |