### PR TITLE
fix(#2742): a permission fold that terminates without a verdict is Undetermined, not an ALLOW (both gates)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -408,11 +408,11 @@ fold therefore has **no terminal at all**, and a `.Take(1)` around it bounds the
 rather than the wait. This is not hypothetical — it is the ordinary cross-silo shape, where the
 owning activation lives on a peer silo that is busy or has just gone away.
 
-Not every leg is like that, and the difference is deliberate. `ObserveGatedNodes` starts with
-`.StartWith(empty)` precisely so a slow leg cannot stall the fold — safe because a gate only ever
-*adds* `Read`. The grant and policy legs **must not** be seeded: "no grants yet" reads as a denial,
-which would be a silent wrong answer. So an unanswerable read cannot be projected onto the yes/no
-axis at all. It needs a third outcome:
+Not every leg is like that, and the difference is deliberate — see
+[the convergence contract](#-the-convergence-contract--which-legs-may-be-seeded-and-why-the-gate-is-not-bounded)
+below for the rule that decides it. `ObserveGatedNodes` starts with `.StartWith(empty)` precisely so a
+slow leg cannot stall the fold; the grant, policy and membership legs **must not** be seeded. So an
+unanswerable read cannot be projected onto the yes/no axis at all. It needs a third outcome:
 
 | Outcome | Means | Reported as |
 |---|---|---|
@@ -443,6 +443,75 @@ deadline, and it must re-emit when the grants finally land.
 Before this existed, `CreateNodeRequest` simply sat `Executing` — 33 s in the reported case — until
 its *caller's* `RequestTimeout` ended it, which names the caller's impatience rather than the read
 that starved (#1446).
+
+### 🚨 The convergence contract — which legs may be seeded, and why the gate is not bounded
+
+The fold's liveness problem has one obvious cure — give every leg a `.StartWith(empty)` so
+`CombineLatest` can never park on a slow source — and it is **wrong for three of the four legs**. The
+rule that decides it is **monotonicity**:
+
+> A leg of the permission fold may carry an empty seed **if and only if** its contribution is purely
+> **ADDITIVE**. A leg that also SUBTRACTS must never be seeded: the seed drops its subtractions, and
+> the fold's first emission is then more permissive than the truth.
+
+| leg | additive contribution | subtractive contribution | seeded? |
+|---|---|---|---|
+| `ObserveGatedNodes` | `GateGrant` ORs in `Read` on a declared public surface | **none** — "a gate NEVER subtracts" | ✅ **yes**, `StartWith(empty)` |
+| `ObserveEffectiveAssignments` | every runtime `AccessAssignment` grant | `Denied` role assignments, from the *same* nodes (`ComputeScopeRoles` returns `Granted` **and** `Denied`) | ❌ no |
+| `ObserveScopePolicies` | `PublicRead` | `GetPermissionCap()`, `BreaksInheritance` — and their **absence widens** | ❌ no |
+| `ObserveAllMembershipNodes` | group grants reach the viewer | the same subject set decides which **denials** match | ❌ no |
+
+**Why the first emission is the whole story.** `AccessControlPipeline` runs
+`hub.CheckPermissionOutcome(…).TakeDecisionOutsideGate()`, and `TakeDecisionOutsideGate` is a
+`Take(1)`. The fold's **first** emission *is* the verdict for every `[RequiresPermission]` delivery. A
+seed is not a "brief pre-load window that settles a moment later" — from the gate's point of view it
+is the answer, permanently.
+
+Each refusal, concretely:
+
+- **`ObserveEffectiveAssignments`** is fail-**OPEN** in the narrow direction (an empty seed drops a
+  runtime *deny* of a role that survives the seed — a static grant, the self-partition Admin) and
+  catastrophically wrong in the wide one: it drops every *runtime* grant, which is what almost all
+  real grants are. The first emission on a cold scope is `Permission.None`, so an entitled user is
+  answered **"Access denied"** — the false, actionable-looking verdict #974 exists to prevent, now
+  fired on every cold scope. A hang is a bad answer; a wrong answer is worse.
+- **`ObserveScopePolicies`** is fail-**OPEN**. `ComputeRoleState` falls back to the *static* policy
+  map when a scope has no runtime policy, and a missing policy means `cap = (Permission)~0` with
+  inheritance unbroken. An empty seed therefore hands the gate a verdict that ignores every runtime
+  permission cap and every `BreaksInheritance` boundary.
+- **`ObserveAllMembershipNodes`** is fail-**OPEN**. The viewer's subject set gates *denials* as much
+  as grants, so an empty seed keeps a viewer's direct grant while dropping the group deny that
+  revokes it.
+
+**The conclusion, and it is a strong one:** there is **no permissive seed that is not a hole and no
+conservative seed that is not a spurious denial**. The fold genuinely needs its inputs, so a starving
+leg's only sound terminal is an **error** — which the fold already propagates as
+`PermissionCheckOutcome.Undetermined` → `ErrorType.Unavailable` (retryable, and attributed to the read
+rather than to the caller's impatience). Making a *silent* starvation produce that error is a
+query-layer change, not a fold change: `MeshQuery` already **detects** it (`InitialStallProbe`, 20 s,
+whose own warning says *"Fix the stalled provider; never bump the consumer's timeout"*) and
+deliberately only logs. Turning that probe into a terminal would change every query in the mesh and is
+a platform decision in its own right — it is tracked, not slipped in under a symptom fix.
+
+**The gate stays unbounded, deliberately.** `AccessControlPipeline` carries no `Timeout` (see its "No
+Timeout here" comment) and this change does not add one. Bounding the shared gate would change the
+behaviour of every `[RequiresPermission]` message; more importantly a ceiling there cannot attribute
+anything — it would only say "the gate ran out of time", never *which* read starved. That attribution
+is exactly what `RlsNodeValidator`'s `PermissionEstablishmentBudget` provides on the node-operation
+path, and it is why the bounded twin's `Unavailable` is a *better* answer than the unbounded path's
+60 s caller timeout even though both describe the same event.
+
+**Silence is not consent (#2742).** The fold has **three** terminals, not two — emit, fault, and
+*complete without ever emitting* — and only the first two were represented. `CombineLatest` completes
+the moment any source completes having produced no value, so one silent leg empties the whole fold;
+`CheckPermissionOutcome` passed that empty completion straight through; and an empty check is not a
+refusal anywhere downstream — the pipeline's `.Take(1).Select(…).DefaultIfEmpty()` reads `null` as
+"no check refused ⇒ every check was granted" and **invokes the handler**. Measured before the fix: a
+`[RequiresPermission(Read)]` `GetDataRequest` was delivered and answered normally with no failure at
+all — a full authorization bypass, reachable through the public `WithPermissionEvaluator` seam.
+`CheckPermissionOutcome` now materialises that terminal as `Undetermined`, so it fails **closed** and
+reports `Unavailable` rather than vanishing. Pinned by `PermissionFoldSilentTerminalTest`; the seeding
+rule above is pinned by `PermissionFoldLegSeedGuardTest`.
 
 ### 🚨 The budget is DERIVED, never configured beside the bound it sits inside (#1198)
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -510,8 +510,25 @@ refusal anywhere downstream — the pipeline's `.Take(1).Select(…).DefaultIfEm
 `[RequiresPermission(Read)]` `GetDataRequest` was delivered and answered normally with no failure at
 all — a full authorization bypass, reachable through the public `WithPermissionEvaluator` seam.
 `CheckPermissionOutcome` now materialises that terminal as `Undetermined`, so it fails **closed** and
-reports `Unavailable` rather than vanishing. Pinned by `PermissionFoldSilentTerminalTest`; the seeding
-rule above is pinned by `PermissionFoldLegSeedGuardTest`.
+reports `Unavailable` rather than vanishing.
+
+**Both consumers had the same hole, so both were closed.** `RlsNodeValidator` — the *node-operation*
+gate — ends its chain in `TakeDecisionOutsideGate().Timeout(budget).Catch(…)`, which covers a value and
+a fault. `Take(1)` on an empty fold completes empty; `Timeout` forwards that completion unchanged (it
+bounds silence *before* a terminal, not an empty one); the `Catch` never fires; and the validator emits
+**no** `NodeValidationResult`. `RunCreationValidatorsObs`'s `Concat` skips a validator that yields
+nothing, so "no verdict" read as "nothing objected" — measured: a caller holding **no grant at all**
+created a node under a silent evaluator and got back `State = Active, CreatedBy = <that user>`. It now
+ends in `.DefaultIfEmpty(UnestablishedCheck(…, cause: null))`, whose message names the silent case
+apart from the stalled and the faulted one, because the three have different causes.
+
+> **The rule, stated once:** wherever a permission answer is consumed, **"no outcome" is not consent.**
+> A chain that can end without emitting must materialise that ending as a refusal — never leave it
+> empty for a downstream `DefaultIfEmpty` / `Concat` / `Where` to read as "nothing objected".
+
+Pinned by `PermissionFoldSilentTerminalTest` (message gate) and `RlsSilentFoldWriteTest` (node
+operations), each with an over-reach control proving a healthy fold on the same mesh still answers; the
+seeding rule above is pinned by `PermissionFoldLegSeedGuardTest`.
 
 ### 🚨 The budget is DERIVED, never configured beside the bound it sits inside (#1198)
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/PermissionApi.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PermissionApi.md
@@ -95,6 +95,8 @@ The disposing-hub case is a lifecycle event, not a fault, and the fold treats it
 
 `CheckPermissionOutcome` is the one place that distinction is made: it classifies the verdict as `Granted` / `Denied` / `Undetermined` (carrying the reason). `IsGranted` is `false` on the undetermined leg, so a consumer that ignores the tri-state still fails **closed**. Use it wherever the UI or the caller reports *why* access was refused; never re-derive the difference from a `false` or an exception message upstream.
 
+🚨 **It always produces exactly one outcome, and that is contract (#2742).** A fold has three terminals, not two: it can emit, it can fault, and it can *complete without ever emitting* — which is what one silent leg of the `CombineLatest` does to the whole fold. That third terminal used to pass straight through as an EMPTY stream, and an empty check is not a refusal anywhere downstream: `AccessControlPipeline` ends its decision chain in `.Take(1).Select(…).DefaultIfEmpty()`, whose `null` means "no check refused ⇒ every check was granted", so the message was delivered. `CheckPermissionOutcome` now materialises that terminal as `Undetermined` too. If you write your own consumer of the raw evaluator, apply the same rule: **treat "no outcome" as no verdict, never as consent.** See [AccessControl → The convergence contract](/Doc/Architecture/AccessControl).
+
 `Permission.None` is a special case in both overloads: it short-circuits to `true` without consulting the evaluator.
 
 ## See also

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-permission-check-that-reaches-no-answer-no-longer-lets-the-request-through.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-permission-check-that-reaches-no-answer-no-longer-lets-the-request-through.md
@@ -22,6 +22,11 @@ tells the caller it is temporarily unavailable and worth retrying. It is deliber
 "access denied": no decision was made about your rights, so saying otherwise would send you off to ask
 for permissions you may already have.
 
+The same gap existed on the other side, where creating, changing or deleting content is checked: a check
+that finished without deciding let the write happen. In a measurement of the old behaviour, someone
+holding no permission at all created a node and it was saved. That path now refuses the write with the
+same "no answer was reached" report.
+
 Nothing changes for a check that does reach an answer. A grant still grants and a denial still reads as
 a denial, in exactly the words it used before.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-permission-check-that-reaches-no-answer-no-longer-lets-the-request-through.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-permission-check-that-reaches-no-answer-no-longer-lets-the-request-through.md
@@ -1,0 +1,37 @@
+---
+Name: A permission check that reaches no answer no longer lets the request through
+Category: Fix
+Description: When the access check finished without deciding anything, the request used to be delivered anyway; it is now refused and reported as temporarily unavailable.
+Icon: ShieldError
+Order: -20260830
+---
+
+# A permission check that reaches no answer no longer lets the request through
+
+Every request that touches protected content is gated by an access check. That check reads your grants,
+your groups, the policies on the space and each of its parents, and combines them into one answer. It
+could finish in three ways: with an answer, with an error — or by simply stopping, having produced
+nothing at all, because one of those reads never returned a value.
+
+The third way had no handling. A check that produced *nothing* was not treated as a refusal: nothing
+had objected, so the request was passed on and answered normally. In other words, an access check that
+established nothing could let a request through instead of stopping it. Nothing in the logs said so.
+
+Such a check is now reported for what it is — **no answer was reached** — which refuses the request and
+tells the caller it is temporarily unavailable and worth retrying. It is deliberately *not* reported as
+"access denied": no decision was made about your rights, so saying otherwise would send you off to ask
+for permissions you may already have.
+
+Nothing changes for a check that does reach an answer. A grant still grants and a denial still reads as
+a denial, in exactly the words it used before.
+
+## Also recorded, not changed: why the access check waits
+
+The same investigation looked at the related complaint that a first read of an idle page can sit
+waiting, then succeed on a retry. The tempting fix — let the check answer from whatever it has so far,
+rather than waiting for every read — turns out to be unsafe: three of the four reads can *remove*
+access as well as grant it (a denial aimed at one of your groups, a space policy that caps what an
+editor may do), so answering early from an incomplete picture would hand out access the full picture
+revokes. The reasoning, and what a correct fix would have to look like instead, is now written down in
+*Architecture → Access Control → The convergence contract*, together with the checks that keep the
+rule honest.

--- a/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
+++ b/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
@@ -143,7 +143,24 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
             // See UnestablishedCheck for why this chain otherwise has no terminal at all (#1446).
             .Timeout(_establishmentBudget)
             .Catch((Exception ex) =>
-                Observable.Return(UnestablishedCheck(context, userId, pathToCheck, ex)));
+                Observable.Return(UnestablishedCheck(context, userId, pathToCheck, ex)))
+            // 🚨 THE THIRD TERMINAL — and it is an ALLOW without this line (issue #2742). The chain
+            // above ends on a value or a fault, but the fold behind it can also COMPLETE WITHOUT
+            // EVER EMITTING: CombineLatest completes the moment any source completes having produced
+            // no value, so one silent leg empties the whole fold. `Take(1)` then completes empty,
+            // `Timeout` forwards that completion unchanged (it bounds silence BEFORE a terminal, not
+            // an empty one), the `Catch` above never sees an error — and this validator emits NO
+            // NodeValidationResult at all. RunCreationValidatorsObs's Concat simply skips a validator
+            // that yields nothing, so "no verdict" became "nothing objected" and the write proceeded.
+            // Measured on this tree before the fix: a user holding NO grant created a node under an
+            // evaluator returning Observable.Empty<Permission>() — State = Active, CreatedBy = that
+            // user. Same defect and same shape as the message gate's (HubPermissionExtensions
+            // .CheckPermissionOutcome); both had two terminals represented where the fold has three.
+            //
+            // Answered as UNAVAILABLE, not a denial, for the reason UnestablishedCheck documents: no
+            // verdict was reached, so the honest report is an availability failure. Fail-CLOSED — the
+            // operation does not proceed. A chain that produced a value never reaches this line.
+            .DefaultIfEmpty(UnestablishedCheck(context, userId, pathToCheck, cause: null));
     }
 
     /// <summary>
@@ -183,15 +200,19 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
     /// does not proceed; it just stops claiming to know why.</para>
     /// </summary>
     private NodeValidationResult UnestablishedCheck(
-        NodeValidationContext context, string? userId, string pathToCheck, Exception cause)
+        NodeValidationContext context, string? userId, string pathToCheck, Exception? cause)
     {
-        // Both roads lead here, and they are NOT the same defect: a stall means nothing answered,
-        // a fault means something answered badly. Saying "did not answer within 30s" about a
+        // THREE roads lead here, and they are NOT the same defect: a stall means nothing answered
+        // in time, a fault means something answered badly, and a null cause means the chain
+        // TERMINATED WITHOUT AN ANSWER (#2742 — a silent leg emptied the fold; there is no exception
+        // to name because nothing ever threw). Saying "did not answer within 30s" about a
         // NullReferenceException would point the reader at a starving peer silo that was never
         // involved — the same mis-naming this fix exists to stop doing to the CALLER.
-        var why = cause is TimeoutException
-            ? $"did not answer within {_establishmentBudget.TotalSeconds:0}s"
-            : $"failed ({cause.GetType().Name}: {cause.Message})";
+        var why = cause is null
+            ? "completed without producing a verdict (a source of the permission fold emitted nothing)"
+            : cause is TimeoutException
+                ? $"did not answer within {_establishmentBudget.TotalSeconds:0}s"
+                : $"failed ({cause.GetType().Name}: {cause.Message})";
 
         _logger.LogWarning(cause,
             "RLS: the {Operation} permission check on {Path} could NOT be established — the "

--- a/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
+++ b/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
@@ -160,7 +160,17 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
             // Answered as UNAVAILABLE, not a denial, for the reason UnestablishedCheck documents: no
             // verdict was reached, so the honest report is an availability failure. Fail-CLOSED — the
             // operation does not proceed. A chain that produced a value never reaches this line.
-            .DefaultIfEmpty(UnestablishedCheck(context, userId, pathToCheck, cause: null));
+            //
+            // 🚨 Built LAZILY, via nullable + DefaultIfEmpty() + a Select — never
+            // `DefaultIfEmpty(UnestablishedCheck(…))`, whose argument is an ordinary C# expression
+            // and is therefore evaluated on EVERY validation: UnestablishedCheck LOGS A WARNING, so
+            // that shape would emit "the permission check could NOT be established" for every
+            // healthy create / update / delete in the mesh — a log flood asserting the opposite of
+            // what happened.
+            .Select(result => (NodeValidationResult?)result)
+            .DefaultIfEmpty()
+            .Select(result => result
+                ?? UnestablishedCheck(context, userId, pathToCheck, cause: null));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
@@ -83,7 +83,12 @@ public static class HubPermissionExtensions
     /// <summary>
     /// Runs ONE permission check and CLASSIFIES its outcome (issue #974): a verdict becomes
     /// <see cref="PermissionCheckOutcome.Granted"/> / <see cref="PermissionCheckOutcome.Denied"/>,
-    /// a FAULTED fold becomes <see cref="PermissionCheckOutcome.Undetermined"/>.
+    /// while a fold that reaches NO verdict — because it FAULTED, or because it terminated without
+    /// ever emitting (issue #2742) — becomes <see cref="PermissionCheckOutcome.Undetermined"/>.
+    ///
+    /// <para>🚨 <b>This observable always produces exactly one outcome.</b> That is contract, not a
+    /// coincidence: every caller treats "no outcome" as "nothing refused the delivery", so an empty
+    /// check is indistinguishable from an all-granted one. See the <c>DefaultIfEmpty</c> below.</para>
     ///
     /// <para>🚨 <b>This is the one place the distinction can be made, so it is the only place it is
     /// made.</b> The fold is the only party that knows whether it reached an answer. Callers branch
@@ -124,7 +129,30 @@ public static class HubPermissionExtensions
             .Select(PermissionCheckOutcome.FromVerdict)
             .Catch<PermissionCheckOutcome, Exception>(ex => Observable.Return(
                 PermissionCheckOutcome.Undetermined(
-                    $"permission fold on '{nodePath}' faulted: {ex.GetType().Name}: {ex.Message}")));
+                    $"permission fold on '{nodePath}' faulted: {ex.GetType().Name}: {ex.Message}")))
+            // 🚨 SILENCE IS NOT CONSENT (issue #2742). A fold has THREE terminals, not two: it can
+            // emit, it can fault — and it can COMPLETE WITHOUT EVER EMITTING. The third one had no
+            // representation here, so it left this observable EMPTY, and an empty check is not a
+            // refusal anywhere downstream: AccessControlPipeline's decision chain ends in
+            // `.Take(1).Select(…).DefaultIfEmpty()`, whose null means "every check was granted" —
+            // so it invoked `next` and DELIVERED the message. Measured on this tree before the fix:
+            // an evaluator returning Observable.Empty<Permission>() let a [RequiresPermission(Read)]
+            // GetDataRequest through with no failure at all. That is a full authorization BYPASS
+            // arriving through the same door as the hang this issue is about — a leg of the
+            // CombineLatest fold that produces no value. CombineLatest completes the instant ANY
+            // source completes without having emitted, so one silent leg empties the whole fold;
+            // the WithPermissionEvaluator seam (a public embedder extension point, see
+            // MeshExtensions) reaches it directly.
+            //
+            // The tri-state already has the right word for "the fold produced no verdict", and it is
+            // the same one a FAULT gets: Undetermined ⇒ IsGranted=false ⇒ fail CLOSED, reported as
+            // ErrorType.Unavailable (retryable), never as "Access denied" — because no verdict was
+            // reached, exactly as #974 established. Placed AFTER the Catch so it covers the whole
+            // chain, and it can only fire on completion, so a healthy fold (which emits, then is
+            // Take(1)'d by the caller) never sees it. Pinned by PermissionFoldSilentTerminalTest.
+            .DefaultIfEmpty(PermissionCheckOutcome.Undetermined(
+                $"permission fold on '{nodePath}' terminated without producing a verdict "
+                + "(a source of the permission fold completed without emitting)"));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubPermissionExtensions.cs
@@ -150,7 +150,15 @@ public static class HubPermissionExtensions
             // reached, exactly as #974 established. Placed AFTER the Catch so it covers the whole
             // chain, and it can only fire on completion, so a healthy fold (which emits, then is
             // Take(1)'d by the caller) never sees it. Pinned by PermissionFoldSilentTerminalTest.
-            .DefaultIfEmpty(PermissionCheckOutcome.Undetermined(
+            //
+            // 🚨 Built LAZILY, via nullable + DefaultIfEmpty() + a Select — never
+            // `DefaultIfEmpty(Undetermined($"…"))`, whose argument is an ordinary C# expression and
+            // is therefore evaluated on EVERY call: that shape formats the interpolated string and
+            // allocates the outcome for every [RequiresPermission] delivery in the mesh, to hand it
+            // to a branch that virtually never fires.
+            .Select(outcome => (PermissionCheckOutcome?)outcome)
+            .DefaultIfEmpty()
+            .Select(outcome => outcome ?? PermissionCheckOutcome.Undetermined(
                 $"permission fold on '{nodePath}' terminated without producing a verdict "
                 + "(a source of the permission fold completed without emitting)"));
     }

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionCheckOutcome.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionCheckOutcome.cs
@@ -12,10 +12,14 @@ namespace MeshWeaver.Mesh.Security;
 ///     the permission. A DEFINITIVE negative: the grants were read and they do not cover this
 ///     (path, permission).</description></item>
 ///   <item><description><b>Undetermined</b> (<see cref="UndeterminedReason"/> non-null) — the fold
-///     FAULTED, so no verdict exists. The caller must report unavailability, NEVER a denial and
-///     NEVER a grant. <see cref="IsGranted"/> is <c>false</c> here so a consumer that ignores the
-///     tri-state still fails CLOSED — but a consumer that reports it as "Access denied" is
-///     lying.</description></item>
+///     reached NO verdict: it FAULTED, or it TERMINATED WITHOUT EMITTING (issue #2742 — one leg of
+///     the <c>CombineLatest</c> completed without a value, which empties the whole fold). The
+///     caller must report unavailability, NEVER a denial and NEVER a grant. <see cref="IsGranted"/>
+///     is <c>false</c> here so a consumer that ignores the tri-state still fails CLOSED — but a
+///     consumer that reports it as "Access denied" is lying. 🚨 The silent variant only fails
+///     closed because it is MATERIALISED as this outcome: leaving the check observable EMPTY is not
+///     a refusal, it is an ALLOW, because every consumer reads "no outcome" as "nothing objected".
+///     </description></item>
 /// </list></para>
 ///
 /// <para><b>Why the distinction has to live at the fold.</b> Only the fold knows whether it

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -238,6 +238,37 @@ internal static class PermissionEvaluator
         fast = (fast.RoleIds, fast.PermissionCap,
             fast.PublicGrant | GateGrant(gates, staticGatedNodes, nodePath));
 
+        // 🚨 THREE OF THESE FOUR LEGS MUST NEVER BE `StartWith`-SEEDED (issue #2742). CombineLatest
+        // emits nothing until every source has, so a leg that starves parks the whole fold — and
+        // seeding it empty is the obvious cure, already applied to ObserveGatedNodes below. It does
+        // NOT generalise, and the rule that decides it is MONOTONICITY:
+        //
+        //   a leg may carry an empty seed ⟺ its contribution is purely ADDITIVE.
+        //
+        // ObserveGatedNodes is the only one that qualifies — GateGrant never subtracts, so an
+        // as-yet-unseen gated node simply has no public surface and the pre-load window is strictly
+        // more restrictive. Every other leg carries SUBTRACTION as well:
+        //
+        //   • ObserveEffectiveAssignments — ComputeScopeRoles derives Denied from the SAME nodes as
+        //     Granted, so an empty seed drops runtime DENIALS of roles that survive it (a static
+        //     grant, the self-partition Admin) → fail-OPEN. It also drops every runtime GRANT,
+        //     which is what almost every real grant is: the first emission is then Permission.None,
+        //     and because AccessControlPipeline takes the fold's FIRST emission as its verdict
+        //     (CheckPermissionOutcome → TakeDecisionOutsideGate → Take(1)), a cold scope answers an
+        //     entitled user "Access denied" — the false, actionable-looking verdict #974 exists to
+        //     prevent. A hang is a bad answer; a wrong answer is worse.
+        //   • ObserveScopePolicies — PermissionCap and BreaksInheritance are RESTRICTIONS, so their
+        //     ABSENCE widens: an empty seed falls back to the static policy map, whose missing entry
+        //     means cap = ~0 and inheritance unbroken → fail-OPEN.
+        //   • ObserveAllMembershipNodes — the subject set decides which DENIALS match as much as
+        //     which grants do, so an empty seed drops a group deny while keeping the viewer's direct
+        //     grant → fail-OPEN.
+        //
+        // So the fold's liveness cannot be bought with a seed: there is no permissive seed that is
+        // not a hole and no conservative seed that is not a spurious denial. A starving leg's only
+        // sound terminal is an ERROR, which the fold already propagates as Undetermined →
+        // ErrorType.Unavailable. Pinned by PermissionFoldLegSeedGuardTest; reasoned out in
+        // Doc/Architecture/AccessControl → "The convergence contract".
         var enriched = Observable.CombineLatest(
                 ObserveEffectiveAssignments(hub, cache, nodePath, staticNodes),
                 ObserveScopePolicies(hub, cache, nodePath, staticPolicies),

--- a/test/MeshWeaver.Security.Test/PermissionFoldLegSeedGuardTest.cs
+++ b/test/MeshWeaver.Security.Test/PermissionFoldLegSeedGuardTest.cs
@@ -1,5 +1,4 @@
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -101,8 +100,15 @@ public class PermissionFoldLegSeedGuardTest(ITestOutputHelper output) : Monolith
     /// The first emission of a COLD fold — the value the <c>[RequiresPermission]</c> gate takes as
     /// its verdict.
     /// </summary>
+    /// <remarks>
+    /// <c>Should().Emit()</c> — the repo's reactive assertion — rather than a <c>.ToTask()</c>
+    /// bridge (ObservableToTaskBridgeGuard). It takes the FIRST emission, which is precisely the
+    /// value under test, and FAILS if the stream completes without one, so a fold that produced
+    /// nothing can never be mistaken here for a fold that answered <c>Permission.None</c>.
+    /// </remarks>
     private Task<Permission> FirstVerdict(string path, string userId)
-        => Mesh.GetEffectivePermissions(path, userId).FirstAsync().ToTask();
+        => Mesh.GetEffectivePermissions(path, userId).Should()
+            .Emit("the gate takes the fold's FIRST emission as its verdict");
 
     [Fact(Timeout = 30_000)]
     public async Task TheMembershipLegIsSUBTRACTIVE_SoAnEmptySeedWouldGrantWhatAGroupDenyRevokes()

--- a/test/MeshWeaver.Security.Test/PermissionFoldLegSeedGuardTest.cs
+++ b/test/MeshWeaver.Security.Test/PermissionFoldLegSeedGuardTest.cs
@@ -1,0 +1,183 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// 🚨 <b>The control behind the seeding rule in Doc/Architecture/AccessControl → "The convergence
+/// contract" (issue #2742): a leg of the permission fold may be <c>StartWith</c>-seeded EMPTY only
+/// if its contribution is PURELY ADDITIVE — and only <c>ObserveGatedNodes</c> is.</b>
+///
+/// <para><b>Why the rule needs a control.</b> Seeding a starving leg is the obvious cure for the
+/// fold's liveness problem, it is already applied to <c>ObserveGatedNodes</c>, and the reasoning that
+/// justifies it there ("the empty seed starts STRICTER") reads as though it generalises. It does not.
+/// <c>ObserveGatedNodes</c> is the ONE leg that can only ADD a permission — <c>GateGrant</c> never
+/// subtracts, and says so. Every other leg carries SUBTRACTION as well as addition: denied role
+/// assignments (<c>ComputeScopeRoles</c> derives <c>Denied</c> from the very same nodes as
+/// <c>Granted</c>), permission caps and <c>BreaksInheritance</c> (<c>PartitionAccessPolicy</c>), and
+/// group membership — whose subject set decides which DENIALS match every bit as much as which
+/// grants do. Seed one of those empty and its subtractions vanish from the fold's first emission,
+/// which is then MORE permissive than the truth.</para>
+///
+/// <para><b>Why the FIRST emission is the one under test.</b> The gate takes exactly one:
+/// <c>AccessControlPipeline</c> runs <c>CheckPermissionOutcome(…).TakeDecisionOutsideGate()</c>, and
+/// <c>TakeDecisionOutsideGate</c> is a <c>Take(1)</c>. The fold's first emission IS the verdict for
+/// every <c>[RequiresPermission]</c> delivery — a "temporary" pre-load window is not temporary from
+/// the gate's point of view, it is the answer.</para>
+///
+/// <para><b>🚨 Why the fold must be COLD, and how that is guaranteed.</b> On a WARM fold a seed is
+/// invisible: the <c>$security-*</c> queries are process-wide <c>Replay(1)</c> streams, so a
+/// <c>StartWith(empty)</c> emits its seed and the replayed value back-to-back during Subscribe, and
+/// <c>CombineLatest</c> — which cannot emit until its LAST source has produced — never sees the seed
+/// as the latest value. A guard that warms the scope first therefore passes with the seed in place,
+/// having proved nothing (measured: all three cases green against a seeded fold). So every case here
+/// seeds its data under <c>ImpersonateAsSystem</c>, which short-circuits
+/// <c>GetEffectivePermissions</c> before any query is built (<c>WellKnownUsers.System</c> returns
+/// immediately), leaving that scope's queries UNSUBSCRIBED. The assertion is then the first emission
+/// of a genuinely cold fold — where a seed does land as the answer.</para>
+///
+/// <para><b>What each case actually detects — measured, not assumed.</b> A seed only changes the
+/// answer while its leg is the LAST to produce, so how directly a case fires depends on which leg is
+/// slowest. Applying <c>.StartWith(empty)</c> and re-running gave:</para>
+/// <list type="bullet">
+///   <item><description><b>assignment leg</b> — RED on an assignment-only seed, and RED on an
+///     all-legs seed. It is a true seed DETECTOR: that leg carries the rows, so it is reliably the
+///     last to answer on a cold scope.</description></item>
+///   <item><description><b>policy and membership legs</b> — green under a policy-only or
+///     membership-only seed, because the assignment leg answers later and its real value is in place
+///     by the time the fold first emits. These two are therefore SEMANTIC pins, not seed detectors:
+///     they pin the fact the rule rests on — that these legs SUBTRACT — which is what makes an empty
+///     seed on either of them fail-OPEN whenever they ARE the slow leg (a cold global membership
+///     query, an evicted policy query). Catching that case directly needs fault injection into
+///     <c>IMeshNodeStreamCache.GetQuery</c>, which this suite does not have.</description></item>
+/// </list>
+/// </summary>
+public class PermissionFoldLegSeedGuardTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder).AddRowLevelSecurity();
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private AccessService AccessService => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    /// <summary>A GroupMembership node placing <paramref name="member"/> into <paramref name="groupPath"/>.</summary>
+    private static MeshNode Membership(string member, string groupPath) =>
+        new($"{member.Replace('/', '_')}_Membership", groupPath)
+        {
+            NodeType = "GroupMembership",
+            Name = $"{member} membership",
+            MainNode = $"{groupPath}/{member.Replace('/', '_')}_Membership",
+            Content = new GroupMembership
+            {
+                Member = member,
+                Groups = [new MembershipEntry { Group = groupPath }]
+            }
+        };
+
+    /// <summary>
+    /// Writes the fixture's access nodes as SYSTEM. Two jobs: the writes are unconditionally
+    /// authorised, and — the load-bearing one — the System short-circuit means no permission fold
+    /// runs for these scopes, so their <c>$security-*</c> queries stay COLD for the assertion.
+    /// </summary>
+    private async Task SeedAsSystem(params MeshNode[] nodes)
+    {
+        using (AccessService.ImpersonateAsSystem())
+            foreach (var node in nodes)
+                await MeshService.CreateNode(node).Should().Emit();
+    }
+
+    /// <summary>
+    /// The first emission of a COLD fold — the value the <c>[RequiresPermission]</c> gate takes as
+    /// its verdict.
+    /// </summary>
+    private Task<Permission> FirstVerdict(string path, string userId)
+        => Mesh.GetEffectivePermissions(path, userId).FirstAsync().ToTask();
+
+    [Fact(Timeout = 30_000)]
+    public async Task TheMembershipLegIsSUBTRACTIVE_SoAnEmptySeedWouldGrantWhatAGroupDenyRevokes()
+    {
+        await SeedAsSystem(
+            // seeduser holds Viewer DIRECTLY at SeedGroup …
+            AssignmentNodeFactory.UserRole("seeduser", "Viewer", "SeedGroup"),
+            // … and belongs to a cohort DENIED Viewer at the same scope. The deny matches ONLY
+            // because the cohort is in the viewer's SUBJECT set — i.e. it is the membership leg
+            // that makes it apply at all.
+            AssignmentNodeFactory.UserRole("SeedGroup/Cohort", "Viewer", "SeedGroup", denied: true),
+            Membership("seeduser", "SeedGroup/Cohort"));
+
+        // 🚨 THE SUBTRACTIVITY PIN (see the class doc for what this does and does not detect).
+        // The deny reaches this viewer ONLY through the membership leg. With that leg seeded empty and
+        // slow, the first
+        // emission resolves subjects = { seeduser } only: the direct Viewer grant survives, the
+        // cohort's deny does not, and the gate's Take(1) reads Read on a node the viewer must not
+        // see. FAIL-OPEN.
+        var denied = await FirstVerdict("SeedGroup/Doc", "seeduser");
+        denied.Should().Be(Permission.None,
+            "the membership leg decides which DENIALS match, not only which grants — so seeding it "
+            + "empty drops a group deny and the fold's first emission grants what the truth revokes");
+
+        // POSITIVE CONTROL. "Permission.None" is also what a fixture that never landed would produce,
+        // so prove the grant half of the same fixture really works: a direct grant at the SAME scope,
+        // for a user in no group, reads. Taken second on purpose — it warms the scope.
+        await SeedAsSystem(AssignmentNodeFactory.UserRole("seedcontrol", "Viewer", "SeedGroup"));
+        await Mesh.GetEffectivePermissions("SeedGroup/Doc", "seedcontrol")
+            .Should().Match(p => p.HasFlag(Permission.Read));
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task ThePolicyLegIsSUBTRACTIVE_SoAnEmptySeedWouldIgnoreARuntimePermissionCap()
+    {
+        await SeedAsSystem(
+            // An Editor at SeedPolicy — the Editor role carries Update …
+            AssignmentNodeFactory.UserRole("seedpolicyuser", "Editor", "SeedPolicy"),
+            // … under a RUNTIME policy that caps Update away for the scope and everything below it.
+            AssignmentNodeFactory.Policy("SeedPolicy", new PartitionAccessPolicy { Update = false }));
+
+        var verdict = await FirstVerdict("SeedPolicy/Doc", "seedpolicyuser");
+
+        // 🚨 THE SUBTRACTIVITY PIN (see the class doc). With ObserveScopePolicies seeded empty and
+        // slow, ComputeRoleState falls back to the
+        // STATIC policy map, which has no entry for this scope — so the cap is (Permission)~0 and the
+        // Editor keeps Update. An absent policy is PERMISSIVE by construction, which is exactly why
+        // this leg can never carry an empty seed. FAIL-OPEN.
+        verdict.HasFlag(Permission.Update).Should().BeFalse(
+            "a policy RESTRICTS — its absence widens, so an empty seed on the policy leg hands the "
+            + "gate a first emission that ignores every runtime cap and BreaksInheritance boundary");
+
+        // POSITIVE CONTROL, in the same emission: the grant itself did land, so the assertion above
+        // is about the cap and not about an empty fixture.
+        verdict.HasFlag(Permission.Read).Should().BeTrue(
+            "the Editor grant is real — only Update is capped");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task TheAssignmentLegCarriesEVERYRuntimeGrant_SoAnEmptySeedWouldDenyEntitledUsers()
+    {
+        // The ordinary case: a grant that exists only at runtime — no IStaticNodeProvider declares
+        // it — which is what almost every real grant is.
+        await SeedAsSystem(AssignmentNodeFactory.UserRole("seedassignuser", "Viewer", "SeedAssign"));
+
+        // 🚨 THE SEED DETECTOR — measured RED under an assignment-leg seed, in isolation and in
+        // combination. Seeding ObserveEffectiveAssignments empty is
+        // fail-closed in the permission lattice and still WRONG: the gate takes the first emission,
+        // so an entitled user reading a cold scope is answered Permission.None and the delivery comes
+        // back "Access denied" — the false, actionable-looking verdict issue #974 exists to prevent,
+        // now fired on every cold scope. (It is ALSO fail-open in a narrower way: an empty seed drops
+        // runtime DENIALS of roles that survive it — static grants and the self-partition Admin.)
+        var verdict = await FirstVerdict("SeedAssign/Doc", "seedassignuser");
+        verdict.HasFlag(Permission.Read).Should().BeTrue(
+            "the assignment leg carries the grant itself — seeding it empty turns a cold-scope read "
+            + "from a wait into a spurious denial, which is a worse answer than the wait");
+    }
+}

--- a/test/MeshWeaver.Security.Test/PermissionFoldSilentTerminalTest.cs
+++ b/test/MeshWeaver.Security.Test/PermissionFoldSilentTerminalTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -80,10 +79,15 @@ public class PermissionFoldSilentTerminalTest(ITestOutputHelper output) : Monoli
         accessService.SetHostIdentity(new AccessContext { ObjectId = "Entitled", Name = "Entitled" });
 
         // GetDataRequest carries [RequiresPermission(Permission.Read)], so it goes through the fold.
+        // 🚨 ObserveCompletion, never `.ToTask()` (ObservableToTaskBridgeGuard): Rx's own bridge
+        // resumes the awaiter INLINE on the thread that signalled, so it changes how the code under
+        // test runs. This one settles off the signalling thread and still faults the task with the
+        // ORIGINAL exception, which is what the assertion below needs to see.
         Func<Task> act = () => client
             .Observe(new GetDataRequest(new UnifiedReference("data:")),
                 o => o.WithTarget(new Address(SilentPath)))
-            .FirstAsync().ToTask();
+            .FirstAsync()
+            .ObserveCompletion(ex => Output.WriteLine($"[late fault] {ex}"));
 
         // 🚨 THE REGRESSION PIN. Before the fix this threw NOTHING — the request was answered
         // normally, i.e. the gate let it through having established nothing at all.
@@ -113,6 +117,6 @@ public class PermissionFoldSilentTerminalTest(ITestOutputHelper output) : Monoli
         await client
             .Observe(new GetDataRequest(new UnifiedReference("data:")),
                 o => o.WithTarget(new Address(HealthyPath)))
-            .FirstAsync().ToTask();
+            .Should().Emit("a healthy fold reaches a verdict, so the delivery goes through");
     }
 }

--- a/test/MeshWeaver.Security.Test/PermissionFoldSilentTerminalTest.cs
+++ b/test/MeshWeaver.Security.Test/PermissionFoldSilentTerminalTest.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #2742 — a permission fold that terminates WITHOUT a verdict must refuse the delivery,
+/// not deliver it.</b>
+///
+/// <para><b>The fold has three terminals, and only two were represented.</b>
+/// <c>PermissionEvaluator.GetEffectivePermissions</c> is an <c>Observable.CombineLatest</c> over the
+/// grant, policy, membership and gate reads of the target's scope and every ancestor scope. A leg
+/// can emit, it can fault — and it can COMPLETE WITHOUT EVER EMITTING. <c>CombineLatest</c> completes
+/// the instant any source completes having produced no value, so ONE silent leg empties the whole
+/// fold. <see cref="HubPermissionExtensions.CheckPermissionOutcome(IMessageHub,string,string,Permission)"/>
+/// classified a value and classified a fault, and passed the empty completion straight through.</para>
+///
+/// <para><b>Why an empty check is an ALLOW, not a refusal.</b> <c>AccessControlPipeline</c>'s decision
+/// chain ends in <c>.Where(!IsGranted).Take(1).Select(…).DefaultIfEmpty()</c>, and its <c>null</c>
+/// means "no check refused ⇒ every check was granted ⇒ invoke next". A check that produced NO outcome
+/// is indistinguishable from one that produced <c>Granted</c>. Measured on this tree before the fix,
+/// with the test below: a <c>[RequiresPermission(Read)]</c> <c>GetDataRequest</c> was DELIVERED and
+/// answered normally — no <c>DeliveryFailure</c>, no log line, nothing. That is a full authorization
+/// bypass, reached through <c>WithPermissionEvaluator</c>, a public embedder seam (see
+/// <c>MeshExtensions</c>), and reachable from the same defect class as the hang #2742 reports: a leg
+/// of the fold that produces no value.</para>
+///
+/// <para><b>The fix, and why it is the honest one.</b> The tri-state already has the word for "the
+/// fold reached no verdict": <see cref="PermissionCheckOutcome.Undetermined"/> — the same one a fault
+/// gets. It carries <c>IsGranted=false</c>, so the delivery is refused (fail CLOSED), and it is
+/// reported as <see cref="ErrorType.Unavailable"/> (retryable), never "Access denied", because no
+/// verdict was reached — exactly the rule #974 established. Nothing is bounded and nothing is
+/// defaulted to a verdict; a terminal that carried no information now says so out loud.</para>
+///
+/// <para><b>Determinism.</b> The evaluator returns <see cref="Observable.Empty{T}()"/> for the one
+/// path under test, so the silent terminal is produced synchronously at subscribe time and cannot
+/// race a warm cached query. Ordinary hub traffic on other paths keeps a normal evaluator, so the
+/// mesh boots.</para>
+/// </summary>
+public class PermissionFoldSilentTerminalTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The node whose fold terminates silently — the bypass under test.</summary>
+    private const string SilentPath = "FoldSilent/Silent";
+
+    /// <summary>
+    /// The OVER-REACH control's node: same mesh, same pipeline, a fold that answers normally. If the
+    /// fix had turned "reached a verdict" into "unavailable" it would be exactly as wrong as the bug.
+    /// </summary>
+    private const string HealthyPath = "FoldSilent/Healthy";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode("FoldSilent") { Name = "Fold Silent" },
+                new MeshNode("Silent", "FoldSilent") { Name = "Silent Fold Node" },
+                new MeshNode("Healthy", "FoldSilent") { Name = "Healthy Fold Node" })
+            .ConfigureDefaultNodeHub(c => c
+                .WithPermissionEvaluator((_, path, _) => path == SilentPath
+                    // A fold whose CombineLatest was emptied by a silent leg looks EXACTLY like
+                    // this from the outside: completes, no value, no error.
+                    ? Observable.Empty<Permission>()
+                    : Observable.Return(Permission.All)));
+
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    [Fact(Timeout = 30_000)]
+    public async Task AFoldThatTerminatesWithoutAVerdict_RefusesTheDelivery_AsUnavailable()
+    {
+        var client = GetClient();
+        var accessService = client.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetHostIdentity(new AccessContext { ObjectId = "Entitled", Name = "Entitled" });
+
+        // GetDataRequest carries [RequiresPermission(Permission.Read)], so it goes through the fold.
+        Func<Task> act = () => client
+            .Observe(new GetDataRequest(new UnifiedReference("data:")),
+                o => o.WithTarget(new Address(SilentPath)))
+            .FirstAsync().ToTask();
+
+        // 🚨 THE REGRESSION PIN. Before the fix this threw NOTHING — the request was answered
+        // normally, i.e. the gate let it through having established nothing at all.
+        var ex = (await act.Should().ThrowAsync<DeliveryFailureException>()).Which;
+
+        ex.Failure.ErrorType.Should().Be(ErrorType.Unavailable,
+            "a fold that reached no verdict is an availability failure, not a statement about "
+            + "this user's rights — and it must never be silence, because silence is delivered");
+
+        ex.Message.Should().NotContain("Access denied",
+            "no verdict was reached, so asserting one would send an entitled user to request "
+            + "permissions they may already hold");
+        ex.Message.Should().Contain("no verdict",
+            "the caller has to be able to tell this is unknown and retryable, not decided");
+    }
+
+    [Fact(Timeout = 30_000)]
+    public async Task AHealthyFold_OnTheSameMesh_StillAnswers()
+    {
+        // The over-reach control. "A thing is refused" is only meaningful if the same pipeline still
+        // lets a real verdict through — otherwise the pin above would pass on a gate that refuses
+        // everything, which is the failure mode a fail-closed fix is most likely to introduce.
+        var client = GetClient();
+        var accessService = client.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetHostIdentity(new AccessContext { ObjectId = "Entitled", Name = "Entitled" });
+
+        await client
+            .Observe(new GetDataRequest(new UnifiedReference("data:")),
+                o => o.WithTarget(new Address(HealthyPath)))
+            .FirstAsync().ToTask();
+    }
+}

--- a/test/MeshWeaver.Security.Test/RlsSilentFoldWriteTest.cs
+++ b/test/MeshWeaver.Security.Test/RlsSilentFoldWriteTest.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Security;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #2742, the node-operation half — a silent permission fold used to let a WRITE through.</b>
+///
+/// <para>The same defect as <see cref="PermissionFoldSilentTerminalTest"/>, in the other consumer.
+/// <c>RlsNodeValidator</c>'s chain ends in <c>TakeDecisionOutsideGate().Timeout(budget).Catch(…)</c>,
+/// which covers a value and a fault — but not the fold's THIRD terminal, completing without ever
+/// emitting. <c>Take(1)</c> then completes empty, <c>Timeout</c> forwards that completion unchanged
+/// (it bounds silence *before* a terminal, not an empty one), the <c>Catch</c> never fires, and the
+/// validator yields NO <c>NodeValidationResult</c>. <c>RunCreationValidatorsObs</c>'s <c>Concat</c>
+/// skips a validator that emits nothing, so "no verdict" read as "nothing objected".</para>
+///
+/// <para><b>Measured before the fix</b> — the probe this test grew out of: a user holding no grant
+/// whatsoever created a node under a silent evaluator, and the result came back
+/// <c>State = Active, CreatedBy = probeuser</c>. Not slow, not denied — written.</para>
+///
+/// <para>The answer is now <c>Unavailable</c> (retryable), never a denial, for the reason
+/// <c>UnestablishedCheck</c> documents: no verdict was reached, so reporting one would send a
+/// correctly-entitled caller to ask for permissions they may already hold. Fail-CLOSED either
+/// way — the write does not happen.</para>
+/// </summary>
+public class RlsSilentFoldWriteTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The partition whose fold is silent. Everything else evaluates normally so the mesh boots.</summary>
+    private const string SilentScope = "SilentRls";
+
+    private static EffectivePermissionsDelegate SilentOn(string scope)
+        => (_, path, _) => path.StartsWith(scope, StringComparison.Ordinal)
+            // What a CombineLatest emptied by a silent leg looks like from outside: completes,
+            // no value, no error.
+            ? Observable.Empty<Permission>()
+            : Observable.Return(Permission.All);
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddRowLevelSecurity()
+            .ConfigureHub(c => c.WithPermissionEvaluator(SilentOn(SilentScope)))
+            .ConfigureDefaultNodeHub(c => c.WithPermissionEvaluator(SilentOn(SilentScope)));
+
+    protected override Task SetupAccessRightsAsync() => Task.CompletedTask;
+
+    [Fact(Timeout = 60_000)]
+    public async Task ASilentFold_RefusesTheWrite_InsteadOfPerformingIt()
+    {
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetHostIdentity(new AccessContext { ObjectId = "probeuser", Name = "probeuser" });
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var node = MeshNode.FromPath($"{SilentScope}/Child") with
+        {
+            Name = "Child",
+            NodeType = "Markdown",
+            Content = "probe"
+        };
+
+        // 🚨 THE REGRESSION PIN. Before the fix this returned a live MeshNode — the write happened.
+        Func<Task> act = () => meshService.CreateNode(node).FirstAsync().ToTask();
+        var ex = (await act.Should().ThrowAsync<Exception>()).Which;
+
+        ex.Message.Should().Contain("could not be established",
+            "no verdict was reached, so the honest answer is an availability failure");
+        ex.Message.Should().Contain("without producing a verdict",
+            "the operator has to be able to tell a SILENT fold from a stalled or faulted one — "
+            + "the three do not have the same cause");
+        ex.Message.Should().NotContain("Access denied",
+            "the fold established nothing about this caller's rights, so claiming a denial would "
+            + "send them to request permissions they may already hold");
+    }
+
+    [Fact(Timeout = 60_000)]
+    public async Task AHealthyFold_OnTheSameMesh_StillWrites()
+    {
+        // The over-reach control: the fix must refuse the SILENT case only. A validator that started
+        // refusing every write would satisfy the pin above while breaking the portal.
+        var accessService = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetHostIdentity(new AccessContext { ObjectId = "probeuser", Name = "probeuser" });
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var node = MeshNode.FromPath("HealthyRls/Child") with
+        {
+            Name = "Healthy Child",
+            NodeType = "Markdown",
+            Content = "probe"
+        };
+
+        var created = await meshService.CreateNode(node).Should().Emit();
+        created.State.Should().Be(MeshNodeState.Active);
+    }
+}

--- a/test/MeshWeaver.Security.Test/RlsSilentFoldWriteTest.cs
+++ b/test/MeshWeaver.Security.Test/RlsSilentFoldWriteTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Hosting.Security;
@@ -68,7 +67,11 @@ public class RlsSilentFoldWriteTest(ITestOutputHelper output) : MonolithMeshTest
         };
 
         // 🚨 THE REGRESSION PIN. Before the fix this returned a live MeshNode — the write happened.
-        Func<Task> act = () => meshService.CreateNode(node).FirstAsync().ToTask();
+        // ObserveCompletion, never `.ToTask()` (ObservableToTaskBridgeGuard) — it settles off the
+        // signalling thread and faults the task with the ORIGINAL exception.
+        Func<Task> act = () => meshService.CreateNode(node)
+            .FirstAsync()
+            .ObserveCompletion(ex => Output.WriteLine($"[late fault] {ex}"));
         var ex = (await act.Should().ThrowAsync<Exception>()).Which;
 
         ex.Message.Should().Contain("could not be established",


### PR DESCRIPTION
Closes #2742

## What this fixes, and what it deliberately does not

The issue asked for the fold's **legs** to be given a terminal, following the `StartWith(empty)` pattern already on `ObserveGatedNodes`. Working through it leg by leg produced two results — one shippable fix, and one refusal with a proof.

### ✅ Fixed: a fold that terminates without a verdict was an **ALLOW**

The fold has **three** terminals, not two: it can emit, it can fault, and it can **complete without ever emitting** — which is exactly what one silent leg does to a `CombineLatest` (it completes the moment any source completes having produced no value). Only the first two had a representation, so the third left `CheckPermissionOutcome`'s observable **empty**.

An empty check is not a refusal anywhere downstream. `AccessControlPipeline` ends its decision chain in `.Take(1).Select(…).DefaultIfEmpty()`, whose `null` means *"no check refused ⇒ every check was granted"* — so it invoked `next` and **delivered the message**.

Measured on this tree before the fix (`PermissionFoldSilentTerminalTest`):

```
Expected a DeliveryFailureException, but no exception was thrown.
```

A `[RequiresPermission(Read)]` `GetDataRequest` was answered normally, with no failure, no log line, nothing — a full authorization bypass, reachable through the public `WithPermissionEvaluator` seam. It is the **fail-open half of the same defect class** the issue is about: a leg of the fold that produces no value.

`CheckPermissionOutcome` now materialises that terminal as `Undetermined` → `IsGranted=false` → the delivery is **refused** and reported as `ErrorType.Unavailable` (retryable), never "Access denied" — exactly the #974 rule. Nothing is bounded, nothing is defaulted to a verdict, and a healthy fold never reaches the new leg.

### ✅ Fixed: the SAME hole in the node-operation gate — a silent fold let an ungranted caller **WRITE**

`RlsNodeValidator` ends its chain in `TakeDecisionOutsideGate().Timeout(budget).Catch(…)` — a value and a fault, again not the third terminal. `Take(1)` on an emptied fold completes empty, `Timeout` forwards that completion unchanged (it bounds silence *before* a terminal, not an empty one), the `Catch` never fires, and the validator emits **no** `NodeValidationResult`. `RunCreationValidatorsObs`'s `Concat` skips a validator that yields nothing.

Measured before the fix — a caller holding **no grant at all**, under a silent evaluator:

```
RESULT: MeshNode { Path = SilentRls/Child, …, State = Active, CreatedBy = probeuser }
ERROR:  (none)
```

Not slow, not denied — **written**. The chain now ends in `.DefaultIfEmpty(UnestablishedCheck(…, cause: null))`, and `UnestablishedCheck` takes a *nullable* cause so its message names the silent case apart from the stalled and the faulted one (three roads, three causes — "did not answer within 20s" about a fold that never started sends the operator to the wrong place). Answered `Unavailable`, never a denial; fail-**closed**.

> **The rule, stated once in the doc:** wherever a permission answer is consumed, **"no outcome" is not consent.** A chain that can end without emitting must materialise that ending as a refusal — never leave it empty for a downstream `DefaultIfEmpty` / `Concat` / `Where` to read as "nothing objected".

### ❌ Refused: seeding the other three legs — every one of them is fail-OPEN

The rule that decides it is **monotonicity**:

> A leg may carry an empty seed **iff** its contribution is purely **ADDITIVE**.

`ObserveGatedNodes` is the only leg that qualifies — `GateGrant` never subtracts, and says so. The other three all subtract, so an empty seed drops their subtractions and the fold's first emission is **more permissive than the truth**:

| leg | why an empty seed is unsafe |
|---|---|
| `ObserveEffectiveAssignments` | `ComputeScopeRoles` derives `Denied` from the **same** nodes as `Granted`, so a seed drops runtime denials of roles that survive it (a static grant, the self-partition Admin) → **fail-OPEN**. It also drops every *runtime* grant — which is what almost all real grants are — so a cold scope's first emission is `Permission.None`. |
| `ObserveScopePolicies` | `GetPermissionCap()` and `BreaksInheritance` are **restrictions**, so their *absence widens*: the seed falls back to the static policy map and the verdict ignores every runtime cap and inheritance boundary → **fail-OPEN**. |
| `ObserveAllMembershipNodes` | the subject set gates **denials** as much as grants, so a seed keeps a viewer's direct grant while dropping the group deny that revokes it → **fail-OPEN**. |

The brief's premise for the assignment and membership legs ("empty ⇒ denied ⇒ stricter") is the half that does not hold: both legs carry denials.

**And the fail-closed direction is not acceptable either.** `AccessControlPipeline` takes the fold's **first** emission as its verdict (`CheckPermissionOutcome(…).TakeDecisionOutsideGate()`, and `TakeDecisionOutsideGate` is a `Take(1)`). A seed is not a "brief pre-load window that settles a moment later" — from the gate's point of view it *is* the answer. Seeding the assignment leg therefore answers an entitled user on a cold scope with **"Access denied"**: the false, actionable-looking verdict #974 exists to prevent, now fired on every cold scope. Measured, not argued — `TheAssignmentLegCarriesEVERYRuntimeGrant_…` goes RED under an assignment-only seed.

So: **there is no permissive seed that is not a hole and no conservative seed that is not a spurious denial.** The fold genuinely needs its inputs; a starving leg's only sound terminal is an **error**, which the fold already propagates as `Undetermined` → `Unavailable`.

### 🚦 The residual, and where its fix belongs

The *silent-starvation hang* (a leg that never emits, completes, or errors) is **not fixed here** — deliberately, rather than traded for a wrong answer. `AccessControlPipeline` is untouched: **no terminal was added to the shared gate**, per the maintainer decision and the file's own "No Timeout here" comment.

The detection already exists one layer down and only logs: `MeshQuery.InitialStallProbe` (20 s) warns *"the query is silently stalled on its all-providers Initial gate and its consumer hangs with no error. Fix the stalled provider; **never bump the consumer's timeout**."* Turning that probe into a terminal would give every consumer — the permission fold included — the attributed `Unavailable` the bounded twin (`RlsNodeValidator`) already produces. That changes every query in the mesh, so it is a platform decision in its own right and is written up rather than slipped in under a symptom fix.

## Tests

`test/MeshWeaver.Security.Test/`

- **`PermissionFoldSilentTerminalTest`** — the regression pin. RED before the fix (no exception at all: the request was delivered). Plus an over-reach control on the same mesh proving a healthy fold still answers, so a fix that refused everything could not pass.
- **`RlsSilentFoldWriteTest`** — the same pin for the write path. RED before the fix (the node was created). Plus its own over-reach control proving a healthy fold on the same mesh still writes.
- **`PermissionFoldLegSeedGuardTest`** — three **cold-fold** cases pinning the seeding rule. Each seeds its fixture under `ImpersonateAsSystem` (the System short-circuit means no fold runs, so the scope's `$security-*` queries stay cold) and asserts the fold's *first* emission.
  - Non-vacuity, measured by applying `.StartWith(empty)` and re-running: the **assignment** case is RED under an assignment-only seed and under an all-legs seed — a true seed detector. The **policy** and **membership** cases stay green under a single-leg seed, because the assignment leg answers later; they are therefore honest **semantic pins** of the subtractivity the rule rests on, and the class doc says exactly that. Catching those two directly needs fault injection into `IMeshNodeStreamCache.GetQuery`, which this suite does not have.

Local: `MeshWeaver.Security.Test` **374/374 passed** (32 s) — covering `PermissionFoldAfterScopeTeardownTest`, `PermissionFoldUnavailableTest`, `SecurityServiceTests`, `GroupPermissionTests`, `NodeTypeGateTests`, `AdminPartitionAdminTests`, `UserPublicReadTest`, `HubCredentialReadAccessTest`. Every touched project builds `-c Release -warnaserror` with `0 Error(s)`.

## Docs

- `Doc/Architecture/AccessControl` → new **"The convergence contract"**: the monotonicity rule, the per-leg fail-open argument, why the gate stays unbounded, the "silence is not consent" finding for **both** consumers, and where a real fix for silent starvation would have to live.
- `Doc/Architecture/PermissionApi` → the exactly-one-outcome contract on `CheckPermissionOutcome`.
- What's New entry, `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
