### PR TITLE
docs: say what ObserveCompletion actually does on a client abort (follow-up to #2751's review)

### DIFF
--- a/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/MeshApiEndpoints.cs
@@ -227,11 +227,17 @@ public static class MeshApiEndpoints
     /// <summary>
     /// <c>POST /api/mesh/render-area</c> — subscribes the node's layout area server-side (the
     /// same <c>GetRemoteStream</c> primitive the Blazor portal binds with), takes the first
-    /// fully-materialised Full <c>{areas,data}</c> frame, disposes the subscription (on every
-    /// path, including client abort — the observable chain tears down with the request's
-    /// <see cref="CancellationToken"/>), and ships the frame verbatim: hub serializer options,
+    /// fully-materialised Full <c>{areas,data}</c> frame, disposes the subscription on every
+    /// normal path, and ships the frame verbatim: hub serializer options,
     /// <c>$type</c> discriminators, JSON-encoded instance keys — byte-identical to the gRPC
     /// wire's Full <c>DataChangedEvent</c>, so an SSR client seeds its area source without
+    /// <para>🚨 On a CLIENT ABORT the wait stops but the subscription is NOT disposed: the
+    /// cancellation token passed to <c>ObserveCompletion</c> cancels the returned <c>Task</c>, and
+    /// that method deliberately keeps its error arm attached so a late fault is reported instead
+    /// of vanishing. The render therefore runs to completion server-side after an abort. Said
+    /// plainly because the earlier wording promised teardown the code does not perform; if a real
+    /// abort-cancels-the-render is wanted, it needs an explicit disposal path, not a doc edit.</para>
+    ///
     /// translation. A timeout returns a 504 JSON error instead of hanging; every other failure
     /// ships the <see cref="MeshOperations"/> <c>"Error: …"</c>/<c>"Not found: …"</c> sentinel
     /// exactly like the sibling verbs.

--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenController.cs
@@ -88,8 +88,12 @@ public class ApiTokenController(IServiceProvider serviceProvider) : ControllerBa
         // No await: pull IObservable up to the controller's return type. The single bridge to Task
         // happens at .ObserveCompletion(…, ct) — never Rx's .ToTask(), which resumes the awaiter
         // INLINE on the signalling thread (a mesh hub's action block here) and is forbidden since
-        // 2026-08-30. The request's cancellation token is passed so a client disconnect tears down
-        // the wait instead of orphaning it.
+        // 2026-08-30. The request's cancellation token is passed so a client disconnect stops the
+        // WAIT. 🚨 It does not dispose the subscription — ObserveCompletion deliberately keeps its
+        // error arm attached so a late fault is reported rather than lost, which means the mesh
+        // work continues to completion after an abort. That is the right trade for a token
+        // creation (the token is either created or not; abandoning it half-way would be worse),
+        // but it is NOT teardown, and saying so here would be a promise the code does not keep.
         var lateFaultLogger = LateFaultLogger;
         return tokenService.CreateToken(userId, userName, userEmail, label, expiresAt)
             .Select(creation => (IActionResult)Ok(new CreateTokenResponse


### PR DESCRIPTION
#2751 merged while I was answering its review; these are the three findings, resolved.

**Two were right, and they are the same defect in prose.** `ApiTokenController` and `MeshApiEndpoints` both told the reader that passing the request's `CancellationToken` to `ObserveCompletion` "tears down" the observable on client abort. It does not: that token cancels the returned `Task`, and `ObserveCompletion` **deliberately keeps its error arm attached** so a late fault is reported rather than lost. The mesh work therefore runs to completion server-side after an abort.

Both sites now say so plainly, and the render-area doc states what a real abort-cancels-the-render would require — an explicit disposal path, not a doc edit. Whether that is wanted is a product question; promising it in a comment while not doing it is the part that had to stop.

**The third does not hold.** `updated` is already `int`, not `int?` — the `Catch` supplies `Observable.Return(0)` and `FirstAsync()` faults on an empty sequence, so nothing nullable reaches the response body or the OpenAPI schema. Verified by the compiler: adding `!.Value` is `CS1061` on `int`.

Docs and one comment only; `Memex.Portal.Shared` builds Release `-warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)