### PR TITLE
fix(#2616): the script reference set must not freeze the assembly list

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-scripts-can-see-assemblies-that-load-late.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-scripts-can-see-assemblies-that-load-late.md
@@ -1,0 +1,42 @@
+---
+Name: Scripts and completions can see assemblies that loaded late
+Category: Fix
+Description: The script reference set froze whatever happened to be loaded when the portal built its first one, so a later-loading assembly stayed invisible for the life of the process — completions silently short a symbol, and a script referencing it will not compile.
+Icon: Bug
+Order: -20260830
+---
+
+# Scripts and completions can see assemblies that loaded late
+
+A symbol could be missing from script completions, and a script referencing it could fail to
+compile, **for no reason visible in your code** — while the same script worked in another portal
+process. Restarting sometimes fixed it, which made it look like a cache.
+
+## What was happening
+
+The script reference set — the surface every script and every completion is compiled against — was
+built once per process and then **frozen**. It was built from the list of assemblies loaded at that
+moment, and .NET loads assemblies **lazily**: an assembly enters the process the first time
+something needs it.
+
+So whatever had not been loaded when the process built its first reference set stayed **invisible
+for the life of that process**. Which assemblies those were came down to what ran first — a
+load-order lottery, decided differently on every start.
+
+The same lottery had already been noticed and half-fixed for plugin assemblies; it was never the
+whole story, because it applies to ordinary assemblies too.
+
+## What changed
+
+The expensive part — reading each assembly's metadata — is still done once and shared, because it
+is genuinely costly and its result never changes for a given file. But the **list** is now composed
+fresh on every request, so an assembly that loaded a moment ago is included. Later calls are
+dictionary lookups against the shared cache, so the cost of being correct is negligible next to the
+compilation itself.
+
+## How this was verified
+
+Not by re-running the intermittent test that exposed it. The regression test loads an assembly
+**after** the first reference set is built and asserts the next one can see it — impossible against
+the frozen implementation, so it fails every time rather than occasionally. Putting the freeze back
+makes it fail, naming the assembly that went missing.

--- a/src/MeshWeaver.Kernel.Hub/KernelScriptReferences.cs
+++ b/src/MeshWeaver.Kernel.Hub/KernelScriptReferences.cs
@@ -61,10 +61,29 @@ internal static class KernelScriptReferences
     // pooled leaf happens to trigger the FIRST-ever build. A caller's own cancellation must never
     // abort this — it is shared by every mesh in the process — so GetReferencesAsync races the
     // CALLER's token against this shared Task with Task.WaitAsync, never against the work itself.
-    private static readonly Lazy<Task<ImmutableArray<PortableExecutableReference>>> SharedSnapshot =
-        new(() => Task.Run(CreateSharedSnapshot), LazyThreadSafetyMode.ExecutionAndPublication);
+    //
+    // 🚨 IT IS A WARM-UP, NOT THE ANSWER (#2616). It used to be the answer: a
+    // Lazy<Task<ImmutableArray<...>>> whose value GetReferencesAsync returned directly. That
+    // FROZE `AppDomain.CurrentDomain.GetAssemblies()` as of the process's FIRST kernel session —
+    // and assemblies load LAZILY, so which ones existed at that instant was a load-order lottery.
+    // Whatever had not loaded yet was missing from every script compilation for the life of the
+    // process: completions silently short a symbol, and a script referencing it fails to compile.
+    // Under parallel shard load the lottery is decided by whichever unrelated test ran first,
+    // which is why it presented as a flake reproducing on completely unrelated diffs
+    // (ScriptCompletions_FilterByTypedPrefix_NotJustTheAlphabet losing "Mesh").
+    // So this Task now only WARMS the memo — the expensive first materialization still happens
+    // once, off the caller's pooled leaf — and GetReferencesAsync composes the set fresh from the
+    // CURRENT assembly list on every call. Later calls are dictionary hits, so the cost of being
+    // correct is an array copy and ~350 lookups, against a Roslyn compilation.
+    private static readonly Lazy<Task> SharedWarmup =
+        new(() => Task.Run(() => MaterializeCurrentAssemblies()), LazyThreadSafetyMode.ExecutionAndPublication);
 
-    private static ImmutableArray<PortableExecutableReference> CreateSharedSnapshot()
+    /// <summary>
+    /// Every non-collectible, production-referenceable assembly loaded RIGHT NOW, as shared
+    /// references. Called on each <see cref="GetReferencesAsync"/> so a late-loading assembly is
+    /// never invisible; the per-file memo makes every call after the first a dictionary hit.
+    /// </summary>
+    private static ImmutableArray<PortableExecutableReference> MaterializeCurrentAssemblies()
         => AppDomain.CurrentDomain.GetAssemblies()
             .Where(IsProductionReferenceable)
             // 🚨 Collectible-ALC assemblies (DynamicNode_* NodeType builds, other kernel
@@ -187,12 +206,15 @@ internal static class KernelScriptReferences
     /// promptly on cancellation and releases its gate permit, while the shared build keeps
     /// running to completion in the background for whichever mesh/request needs it next — safe,
     /// because it never touches a collectible NodeType ALC or any one mesh's disposed DI scope
-    /// (<see cref="CreateSharedSnapshot"/> explicitly excludes collectible-ALC assemblies).</para>
+    /// (<see cref="MaterializeCurrentAssemblies"/> explicitly excludes collectible-ALC assemblies).</para>
     /// </summary>
     public static async Task<ImmutableArray<MetadataReference>> GetReferencesAsync(
         IEnumerable<Assembly> sessionAssemblies, CancellationToken ct)
     {
-        var snapshot = await SharedSnapshot.Value.WaitAsync(ct).ConfigureAwait(false);
+        // Wait for the shared warm-up (never for the caller's own materialization), then build the
+        // set from what is loaded NOW — see SharedWarmup for why this must not be a frozen list.
+        await SharedWarmup.Value.WaitAsync(ct).ConfigureAwait(false);
+        var snapshot = MaterializeCurrentAssemblies();
         var result = ImmutableArray.CreateBuilder<MetadataReference>(snapshot.Length + 4);
         var seen = new HashSet<PortableExecutableReference>();
         foreach (var reference in snapshot)

--- a/src/MeshWeaver.Kernel.Hub/MeshWeaver.Kernel.Hub.csproj
+++ b/src/MeshWeaver.Kernel.Hub/MeshWeaver.Kernel.Hub.csproj
@@ -9,6 +9,9 @@
   <ItemGroup>
     <InternalsVisibleTo Include="MeshWeaver.AI.Test" />
     <InternalsVisibleTo Include="MeshWeaver.Hosting.Monolith.Test" />
+    <!-- KernelScriptReferencesFreshnessTest: the reference set is internal, and the freshness
+         invariant (#2616) is only testable from inside. -->
+    <InternalsVisibleTo Include="MeshWeaver.Kernel.Test" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MeshWeaver.Kernel.Test/KernelScriptReferencesFreshnessTest.cs
+++ b/test/MeshWeaver.Kernel.Test/KernelScriptReferencesFreshnessTest.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Kernel.Hub;
+using Xunit;
+
+namespace MeshWeaver.Kernel.Test;
+
+/// <summary>
+/// 🅿️ The script reference set must reflect the assemblies loaded <b>now</b>, never the ones that
+/// happened to be loaded when this process built its FIRST reference set (#2616).
+///
+/// <para>The defect: <c>KernelScriptReferences</c> held its reference set in a process-wide
+/// <c>Lazy&lt;Task&lt;ImmutableArray&lt;…&gt;&gt;&gt;</c> built from
+/// <see cref="AppDomain.CurrentDomain"/>'s assembly list. Assemblies load LAZILY, so that froze a
+/// load-order lottery: whatever had not loaded by the process's first kernel session was missing
+/// from every script compilation for the life of the process. A completion list silently shorts a
+/// symbol; a script referencing one fails to compile. Under parallel shard load the lottery is
+/// decided by whichever unrelated test ran first, which is exactly why it presented as a flake
+/// reproducing on completely unrelated diffs
+/// (<c>ScriptCompletions_FilterByTypedPrefix_NotJustTheAlphabet</c> losing <c>Mesh</c>).</para>
+///
+/// <para>🚨 This test is DETERMINISTIC by construction, not a re-run of the flake: it loads an
+/// assembly <b>after</b> the first call and asserts the second call can see it. Against the frozen
+/// implementation that is impossible, so it fails every time rather than occasionally.</para>
+/// </summary>
+public class KernelScriptReferencesFreshnessTest
+{
+    [Fact(Timeout = 120_000)]
+    public async Task AnAssemblyLoadedAfterTheFirstCall_IsStillInTheReferenceSet()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // 1. Build the reference set once — this is what used to freeze the assembly list.
+        var before = await KernelScriptReferences.GetReferencesAsync([], ct);
+        Assert.True(before.Length > 0, "the reference set is the script compilation surface");
+
+        // 2. Find a real assembly beside this test binary that is NOT loaded yet, and load it.
+        //    🚨 Asserted, not skipped: "no candidate found" would let this test pass having
+        //    verified nothing, which is the one outcome that must never read as green.
+        var loadedPaths = AppDomain.CurrentDomain.GetAssemblies()
+            .Where(a => !a.IsDynamic && !string.IsNullOrEmpty(a.Location))
+            .Select(a => a.Location)
+            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+
+        var probeDirectory = Path.GetDirectoryName(typeof(KernelScriptReferencesFreshnessTest).Assembly.Location)!;
+        var candidate = Directory.EnumerateFiles(probeDirectory, "*.dll")
+            .Where(f => !loadedPaths.Contains(f))
+            .Select(f =>
+            {
+                try { return (Path: f, Name: AssemblyName.GetAssemblyName(f)); }
+                catch { return (Path: f, Name: (AssemblyName?)null); }   // native/unmanaged: not a candidate
+            })
+            .FirstOrDefault(x => x.Name is not null);
+
+        Assert.True(candidate.Name is not null,
+            "this test needs one not-yet-loaded managed assembly next to the test binary to prove "
+            + "freshness; with none it would assert nothing and pass vacuously");
+
+        var late = Assembly.LoadFrom(candidate.Path);
+
+        // 3. The set built AFTER that load must contain it. The frozen implementation cannot,
+        //    however long you wait — the list was captured in step 1.
+        var after = await KernelScriptReferences.GetReferencesAsync([], ct);
+
+        var paths = after
+            .Select(r => (r as Microsoft.CodeAnalysis.PortableExecutableReference)?.FilePath)
+            .Where(path => path is not null)
+            .ToImmutableArray();
+
+        Assert.True(
+            paths.Any(path => string.Equals(path, late.Location, StringComparison.OrdinalIgnoreCase)),
+            $"an assembly loaded after the first call must still reach the script surface, but "
+            + $"'{late.Location}' was absent from {paths.Length} references — freezing the set made "
+            + "visibility a load-order lottery (#2616)");
+    }
+}

--- a/test/MeshWeaver.Kernel.Test/MeshWeaver.Kernel.Test.csproj
+++ b/test/MeshWeaver.Kernel.Test/MeshWeaver.Kernel.Test.csproj
@@ -5,6 +5,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Kernel\MeshWeaver.Kernel.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.Kernel.Hub\MeshWeaver.Kernel.Hub.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Closes #2616.

## The flake, and why it was never a flake

`MeshNodeLanguageServiceTest.ScriptCompletions_FilterByTypedPrefix_NotJustTheAlphabet` loses the `Mesh` completion, intermittently, on **completely unrelated diffs**. It blocked four PRs in one afternoon — including the authorization-bypass fix (#2760, twice) — each re-run individually justified. That it reproduces across unrelated diffs is what rules out every per-PR explanation.

## Root cause

`KernelScriptReferences` held the script reference set — the surface every script and completion compiles against — in a process-wide `Lazy<Task<ImmutableArray<…>>>` built from `AppDomain.CurrentDomain.GetAssemblies()`.

**Assemblies load lazily.** So that froze a **load-order lottery**: whatever had not loaded by the process's *first* kernel session was missing from every script compilation for the life of that process. Under parallel shard load, which assemblies those are is decided by whichever unrelated test happened to run first.

The file's own comment already records this mechanism — for a *neighbouring* case:

> *"Excluding them also kills the load-order lottery the issue documents: a pack assembly was cell-visible only if it happened to load before the process's first kernel session."*

That was closed by excluding collectible-ALC assemblies. The identical lottery applies to **ordinary** assemblies, and that half was left open.

## The fix

The shared `Task` becomes a **warm-up, not the answer**:

- the **expensive** part — materializing ~350 assemblies' metadata — still happens **once**, on a detached work item off the caller's pooled leaf, memoized per file path (content-addressed, so it never varies). `#2598`'s "race the wait, not the work" property is preserved exactly.
- the **list** is composed fresh on every call from what is loaded *now*. Later calls are dictionary hits, so being correct costs an array copy and ~350 lookups — against a Roslyn compilation.

## Verified deterministically, not by re-running the flake

`KernelScriptReferencesFreshnessTest` loads an assembly **after** the first reference set is built and asserts the next one sees it. Against a frozen list that is impossible, so it fails *every* time rather than occasionally.

| probe | result |
|---|---|
| restore the freeze | 🔴 `'NuGet.DependencyResolver.Core.dll' was absent from 39 references` |
| the fix | 🟢 passes |
| the whole `MeshNodeLanguageServiceTest` class | 🟢 **24/24** |

It asserts it **found** a candidate assembly rather than skipping when there is none — "no candidate" is the one outcome that must never read as green.

Test access is via `InternalsVisibleTo`, following the two entries already in that csproj; no production surface is widened.

## Note

This also removes a frozen process-wide collection, which is the `NoStaticState` hazard: it survived mesh disposal and bled across tests in one process. The remaining `Materialized` memo stays shared deliberately — it is keyed by file path and its value cannot vary per mesh, and making it mesh-scoped would re-materialize ~350 assemblies per mesh, which is the cost the original design exists to avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)