### PR TITLE
fix: a pooled-I/O residual NAMES the leaf that would not unwind

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -155,6 +156,64 @@ public sealed class IoPool : IIoPool, IDisposable
     /// <summary>Number of operations currently executing through this pool.</summary>
     public int CurrentInFlight => Volatile.Read(ref _inFlight);
 
+    // 🚨 WHICH leaf, not just how many. The residual a dirty teardown reports has been an
+    // anonymous "AgentStore=1" — enough to know a pool did not drain, never enough to fix it.
+    // #2480 added the POOL NAME for exactly this reason and stopped one level short: measured
+    // 2026-08-30 on MeshWeaver.AI.Test under load, 3 of 20 runs ended in a dirty teardown naming
+    // AgentStore, Query and FileSystem on different runs — three pools, no leaf, nothing to act on.
+    //
+    // The delegate is kept BY REFERENCE while the leaf is in flight (no stack capture, no string
+    // built on the hot path) and formatted only when a residual is reported, so a pool that drains
+    // cleanly pays one dictionary insert and one removal per leaf and nothing else.
+    private readonly ConcurrentDictionary<long, object> _inFlightLeaves = new();
+    private long _leafSeq;
+
+    /// <summary>
+    /// Records an in-flight leaf so a residual can NAME it; returns its ticket. Takes the work
+    /// ITSELF — a delegate on the three functional entry points, the source observable on
+    /// <see cref="SubscribeThroughPool{T}"/>, which has no delegate to name.
+    /// </summary>
+    private long EnterLeaf(object io)
+    {
+        var id = Interlocked.Increment(ref _leafSeq);
+        _inFlightLeaves[id] = io;
+        return id;
+    }
+
+    /// <summary>Retires a leaf's ticket. Safe to call for an id that was never added.</summary>
+    private void LeaveLeaf(long id) => _inFlightLeaves.TryRemove(id, out _);
+
+    /// <summary>
+    /// The call sites of the leaves still in flight, most useful form first: a lambda's
+    /// compiler-generated method name carries its ENCLOSING method, so
+    /// <c>MeshQuery+&lt;&gt;c__DisplayClass22_0.&lt;MergeProviderObservables&gt;b__1</c> points at the
+    /// exact operation that did not unwind. Empty when the pool drained clean.
+    /// </summary>
+    internal IReadOnlyList<string> PendingLeafSites =>
+        _inFlightLeaves.Values
+            .Select(d =>
+            {
+                try
+                {
+                    // A delegate names its enclosing method through the compiler-generated
+                    // lambda; anything else (the subscribe path's observable) can only offer
+                    // its type, which still says WHICH chain is stuck.
+                    if (d is Delegate del)
+                    {
+                        var m = del.Method;
+                        return $"{m.DeclaringType?.FullName ?? "?"}.{m.Name}";
+                    }
+                    return d.GetType().FullName ?? d.GetType().Name;
+                }
+                catch
+                {
+                    // A diagnostic must never be the reason a teardown fails.
+                    return "(unavailable)";
+                }
+            })
+            .Distinct(StringComparer.Ordinal)
+            .ToArray();
+
     /// <summary>
     /// Runs an async I/O leaf off the calling scheduler under the pool's concurrency gate.
     /// </summary>
@@ -190,12 +249,14 @@ public sealed class IoPool : IIoPool, IDisposable
                 // the inner await, so the gate caps in-flight ops, not threads.
                 await _gate.WaitAsync(ct).ConfigureAwait(false);
                 Interlocked.Increment(ref _inFlight);
+                var leaf = EnterLeaf(io);
                 try
                 {
                     return await io(ct).ConfigureAwait(false);
                 }
                 finally
                 {
+                    LeaveLeaf(leaf);
                     // 🚨 RELEASE THE PERMIT FIRST. TryFinishDisposal disposes _gate the moment the
                     // last leaf's decrement takes _inFlight to zero — so with the decrement first,
                     // THIS leaf disposed the gate and then called Release() on it, throwing
@@ -251,6 +312,7 @@ public sealed class IoPool : IIoPool, IDisposable
                 var ct = linked.Token;
                 await _gate.WaitAsync(ct).ConfigureAwait(false);
                 Interlocked.Increment(ref _inFlight);
+                var leaf = EnterLeaf(source);
                 try
                 {
                     await foreach (var item in source(ct).WithCancellation(ct).ConfigureAwait(false))
@@ -259,6 +321,7 @@ public sealed class IoPool : IIoPool, IDisposable
                 }
                 finally
                 {
+                    LeaveLeaf(leaf);
                     ReleaseGate();
                 }
             }
@@ -312,6 +375,7 @@ public sealed class IoPool : IIoPool, IDisposable
                         // so CurrentInFlight reflects actually-running blocking work,
                         // capped at the scheduler's MaximumConcurrencyLevel.
                         Interlocked.Increment(ref _inFlight);
+                        var blockingLeaf = EnterLeaf(work);
                         if (Interlocked.Increment(ref _blockingInFlight) == 1)
                             _blockingIdle.Reset();
                         try
@@ -320,6 +384,7 @@ public sealed class IoPool : IIoPool, IDisposable
                         }
                         finally
                         {
+                            LeaveLeaf(blockingLeaf);
                             // 🚨 ORDER MATTERS: the signal is set LAST. Drain() wakes on _blockingIdle, so
                             // anything it releases must already observe fully-updated counters — setting
                             // the signal before decrementing _inFlight let Drain return while
@@ -422,6 +487,7 @@ public sealed class IoPool : IIoPool, IDisposable
                             var ct = linked.Token;
                             await _gate.WaitAsync(ct).ConfigureAwait(false);
                             Interlocked.Increment(ref _inFlight);
+                            var subLeaf = EnterLeaf(source);
                             try
                             {
                                 // Draining before we even subscribed → do not open providers / create hubs.
@@ -430,6 +496,7 @@ public sealed class IoPool : IIoPool, IDisposable
                             }
                             finally
                             {
+                                LeaveLeaf(subLeaf);
                                 ReleaseGate();
                             }
                         }

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
@@ -161,9 +161,13 @@ public sealed class IoPoolRegistry : IDisposable
         var residuals = new List<PoolResidual>();
         foreach (var kvp in _pools)
         {
+            // Read the sites BEFORE the drain returns nothing to name: Drain() joins, so by the
+            // time it hands back a residual the surviving leaves are exactly the ones still
+            // registered — but a leaf that unwinds during the join must not be reported, so this
+            // is read after Drain and reflects what is genuinely still running.
             var residual = kvp.Value.Drain();
             if (residual != 0)
-                residuals.Add(new PoolResidual(kvp.Key, residual));
+                residuals.Add(new PoolResidual(kvp.Key, residual) { Sites = kvp.Value.PendingLeafSites });
             if (residual != 0)
                 // 🚨 "IoPoolDrain", not "IoPoolSiloTeardown" (Copilot review, PR #2598): DrainAll()
                 // is the generic mesh-teardown phase 2 (MeshTeardownExtensions AND
@@ -174,7 +178,10 @@ public sealed class IoPoolRegistry : IDisposable
                 _logger?.LogWarning(
                     "IoPoolDrain: pool '{PoolName}' did not finish {Residual} leaf(es) within "
                     + "the drain budget — a leaf ignored its cancellation token; fix the leaf, do not "
-                    + "widen the budget.", kvp.Key, residual);
+                    + "widen the budget. Still running: {Sites}", kvp.Key, residual,
+                    kvp.Value.PendingLeafSites.Count == 0
+                        ? "(no site captured)"
+                        : string.Join(" | ", kvp.Value.PendingLeafSites));
             leaked += residual;
         }
         byPool = residuals;
@@ -188,8 +195,24 @@ public sealed class IoPoolRegistry : IDisposable
     /// </summary>
     public readonly record struct PoolResidual(string Pool, int Residual)
     {
+        /// <summary>
+        /// The call sites of the leaves that did not unwind — a lambda's compiler-generated name
+        /// carries its ENCLOSING method, so this points at the operation to fix. Empty when the
+        /// pool could not offer them.
+        ///
+        /// <para>🚨 Without this the residual is an anonymous <c>AgentStore=1</c>: enough to know a
+        /// pool did not drain, never enough to act. #2480 added the POOL NAME and stopped one level
+        /// short — measured 2026-08-30, three dirty teardowns in 20 loaded runs of
+        /// MeshWeaver.AI.Test named AgentStore, Query and FileSystem on different runs, and none of
+        /// the three could be chased any further.</para>
+        /// </summary>
+        public IReadOnlyList<string> Sites { get; init; } = [];
+
         /// <inheritdoc />
-        public override string ToString() => $"{Pool}={Residual}";
+        public override string ToString() =>
+            Sites.Count == 0
+                ? $"{Pool}={Residual}"
+                : $"{Pool}={Residual} [{string.Join(" | ", Sites)}]";
     }
 
     /// <summary>Disposes every created pool and clears the registry; called when the mesh is torn down.</summary>

--- a/test/MeshWeaver.Hosting.Test/IoPoolResidualNamesItsPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolResidualNamesItsPoolTest.cs
@@ -74,8 +74,20 @@ public class IoPoolResidualNamesItsPoolTest
             "the residual must carry the leaking pool's NAME: Query=1 and Compile=1 are different "
             + "bugs with different owners");
         byPool[0].Residual.Should().BeGreaterThan(0);
-        byPool[0].ToString().Should().Be($"{IoPoolNames.Query}={byPool[0].Residual}",
-            "this is the wire format the teardown traces embed, so it is part of the contract");
+        // The wire format the teardown traces embed, so it is part of the contract: the pool's
+        // name and count first — and, since #2770, the leaf that is still running, in brackets.
+        // A bare `Query=1` sent the reader into every Query-pool caller in the process; the site
+        // is the difference between "some query leaked" and the method that owns it.
+        var wire = byPool[0].ToString();
+        wire.Should().StartWith($"{IoPoolNames.Query}={byPool[0].Residual} [",
+            "the residual leads with the pool's name and count, exactly as before #2770");
+        wire.Should().Contain(nameof(IoPoolResidualNamesItsPoolTest),
+            "the bracketed site names the leaf's enclosing method, and the leaf that leaked is "
+            + "the lambda THIS test handed to the pool — a residual naming any other site would "
+            + "be pointing the reader at somebody else's code");
+        byPool[0].Sites.Should().ContainSingle(
+            "one leaf leaked, so one site; a duplicate here would mean the same delegate was "
+            + "counted twice");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
@@ -870,4 +870,48 @@ public class IoPoolTest
 
         releaseTeardown.Set();
     }
+
+    /// <summary>
+    /// 🚨 A RESIDUAL MUST NAME ITS LEAF. A dirty teardown reporting an anonymous
+    /// <c>AgentStore=1</c> tells you a pool did not drain and nothing about what to fix — measured
+    /// 2026-08-30, three such teardowns in 20 loaded runs of MeshWeaver.AI.Test named three
+    /// different pools and not one operation. #2480 added the pool NAME for this reason; this is
+    /// the level it stopped at.
+    /// </summary>
+    [Fact]
+    public void AResidualNamesTheLeafThatWouldNotUnwind()
+    {
+        var pool = new IoPool(2);
+        using var entered = new ManualResetEventSlim(false);
+        using var release = new ManualResetEventSlim(false);
+
+        // A leaf that ignores its token — exactly the defect the residual exists to report.
+        pool.InvokeBlocking(_ =>
+        {
+            entered.Set();
+            release.Wait(Timeout10);
+            return 0;
+        }).Subscribe(_ => { }, _ => { });
+
+        entered.Wait(Timeout5, TestContext.Current.CancellationToken).Should().BeTrue();
+
+        var sites = pool.PendingLeafSites;
+        sites.Should().NotBeEmpty("a leaf is in flight, so the pool must be able to say WHICH");
+        string.Join(" | ", sites).Should().Contain(nameof(AResidualNamesTheLeafThatWouldNotUnwind),
+            "the lambda's compiler-generated name carries its ENCLOSING method — that is what turns "
+            + "'AgentStore=1' into a pointer at the operation to fix");
+
+        release.Set();
+        pool.Dispose();
+    }
+
+    /// <summary>A pool that drains cleanly reports no sites — the diagnostic is not noise.</summary>
+    [Fact]
+    public async Task ACleanPool_HasNoPendingSites()
+    {
+        var pool = new IoPool(2);
+        await pool.Invoke(_ => Task.FromResult(1)).FirstAsync().Await(TestContext.Current.CancellationToken);
+        pool.PendingLeafSites.Should().BeEmpty("every leaf unwound — there is nothing to name");
+        pool.Dispose();
+    }
 }


### PR DESCRIPTION
## Why

A dirty teardown reports `teardown DIRTY — 1 pooled I/O leaf(s) still running` and, since #2480, **which pool**. It does not report **which leaf** — so the failure is unactionable.

Measured 2026-08-30, `MeshWeaver.AI.Test` (1,630 tests) under load (`DOTNET_PROCESSOR_COUNT=4` + CPU burners), 20 runs:

| run | test | residual | drain |
|---|---|---|---|
| 7 | `MeshNodeAgentFileStoreTest` | `AgentStore=1` | 30 081 ms |
| 12 | `PluginCatalogTest` | `Query=1` | 30 004 ms |
| 16 | `MeshPluginTest` | `FileSystem=1` | 30 043 ms |

Three pools, three tests, always the full budget — and nothing to act on. #2480 added the pool name for this exact reason and stopped one level short.

## How

`IoPool` keeps each in-flight leaf's work **by reference** — no stack capture, no string built on the hot path — and formats only when a drain reports a residual. A lambda's compiler-generated name carries its enclosing method, so the residual reads:

```
AgentStore=1 [MeshWeaver.AI.Stores.MeshNodeAgentFileStore+<>c__DisplayClass…<WriteCore>b__0]
```

All four entry points instrumented (`Invoke`, `InvokeStream`, `InvokeBlocking`, `SubscribeThroughPool` — the last has no delegate, so it reports the source observable's type). `PoolResidual.Sites` flows into both the drain warning and the `pools=[…]` phase trace `MonolithMeshTestBase` already prints, so a CI `test-evidence-*` artifact carries it with no further change.

## Verification

`IoPoolTest` 25/25, including two new pins: a leaf that ignores its token **must** be nameable, and a clean pool reports **no** sites (the diagnostic must not become noise).

Note: on current `main` this class did not reproduce in 24 further loaded runs (P ≈ 0.02 under the measured 15 % rate), so something in the intervening commits — most plausibly the continuing `ToTask` sweep — has largely fixed it. The diagnostic is worth landing regardless: the next occurrence names itself instead of restarting this investigation.