### PR TITLE
feat(memex-local): registry <url> needs no key — an open registration lands on the free tier

### DIFF
--- a/deploy/homebrew/Formula/memex-local.rb
+++ b/deploy/homebrew/Formula/memex-local.rb
@@ -18,7 +18,7 @@
 #
 #   brew tap systemorph/memex
 #   brew install memex-local
-#   memex-local registry https://memex.meshweaver.cloud --key mwr_…   # consume the cloud registry
+#   memex-local registry https://memex.meshweaver.cloud   # consume the cloud registry (free tier; --key mwr_… for a plan)
 #   memex-local up
 #
 # From a checkout (developing memex-local itself), a local tap over THIS file works too:
@@ -72,17 +72,18 @@ class MemexLocal < Formula
     <<~EOS
       memex-local automates Doc/Architecture/LocalColimaMac (Colima k3s on Mac).
 
-      Recommended: consume the cloud plugin registry (LocalColimaMac §17). A platform
-      admin mints a registration key on memex.meshweaver.cloud (Settings ▸
-      Administration ▸ Instance grants ▸ Registration keys), then:
+      Recommended: consume the cloud plugin registry (LocalColimaMac §17) — no key
+      needed, an un-keyed registration lands on the FREE tier:
 
-        memex-local registry https://memex.meshweaver.cloud --key mwr_…
+        memex-local registry https://memex.meshweaver.cloud
         memex-local up
 
       That pulls the CI-built multi-arch image from ACR (`az login` first — no .NET
       SDK, no source checkout), registers this install at the registry on first
       boot, installs the packages it is granted and lands their compiled modules —
       the only way a local install gets Radzen/Analysis/EntityViews/GoogleMaps/Speech.
+      A higher plan is a platform admin's edit of this instance's grant on the
+      registry, or a registration key minted for that plan (--key mwr_…).
 
       Alternative (serving plugins from a source checkout, §16): set MEMEX_REPO to a
       MeshWeaver checkout with MeshWeaver.Plugins beside it, install the .NET SDK

--- a/deploy/homebrew/README.md
+++ b/deploy/homebrew/README.md
@@ -47,27 +47,30 @@ install --HEAD systemorph/memex-dev/memex-local`). A brew install's wrapper pins
 | **Registry** (§17, recommended) | `REGISTRY MODE — consumes https://memex.meshweaver.cloud` | installed from the cloud registry, per the instance's **grant** | **land from the registry's bundles** into `/data` | CI-built multi-arch from ACR (`az login`) |
 | **Self-registry** (§16) | `SELF-REGISTRY MODE` | served from a `MeshWeaver.Plugins` **checkout** beside `MEMEX_REPO` | 🚨 **never** — a checkout has source, not assemblies (MeshWeaver#2417); the five required ones are blanked | built from source (Option B) |
 
-Registry mode is one command; a platform admin on the registry mints the key
-(Settings ▸ Administration ▸ Instance grants ▸ Registration keys):
+Registry mode is one command, and needs **no key by default** — an un-keyed registration is
+an *open* one, which memex.meshweaver.cloud enrols into its default plan, the **free tier**:
 
 ```bash
-memex-local registry https://memex.meshweaver.cloud --key mwr_… [--id my-mac]
+memex-local registry https://memex.meshweaver.cloud [--id my-mac]      # free tier, no key
+memex-local registry https://memex.meshweaver.cloud --key mwr_…         # a plan an admin minted a key for
 memex-local up        # or `update` on an existing install
 ```
 
 `~/.memex-local/registry.yaml` (0600) then carries `pluginCatalog.registryUrl` /
-`instanceId` and the bootstrap key; `helm_deploy` layers it last. On first boot the
-portal presents the key **once**, is issued its own instance key (stored encrypted in
-its database, so it survives every `update`), installs everything it is granted and
-lands the modules; `verify --repair` performs the one activation restart. What it is
-granted is the **registry's** decision — see
-[`PluginRegistry.md`](../../src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md).
-`memex-local registry off` returns to serving a checkout.
+`instanceId` — and the bootstrap key, when one was given; `helm_deploy` layers it last. On
+first boot the portal registers itself (presenting the key **once** if it has one), is issued
+its own instance key (stored encrypted in its database, so it survives every `update`),
+installs everything it is granted and lands the modules; `verify --repair` performs the one
+activation restart. What it is granted is the **registry's** decision — a plan-scoped grant,
+raised by a platform admin there (Instance grants ▸ Plan), never something the install can
+ask for — see
+[`PluginRegistry.md`](../../src/MeshWeaver.Documentation/Data/Architecture/PluginRegistry.md)
+→ *Plans*. `memex-local registry off` returns to serving a checkout.
 
 ## Use
 
 ```bash
-memex-local registry <url> --key mwr_…   # REGISTRY MODE: consume a remote plugin registry (§17)
+memex-local registry <url> [--key mwr_…]  # REGISTRY MODE: consume a remote plugin registry (§17); no key = free tier
 memex-local registry status|off          # which mode this install is in / back to self-registry
 memex-local up                 # full stack, idempotent (registry mode: ACR image; else local build)
 memex-local up --from-acr      # pull the multi-arch image from ACR explicitly (Option A)

--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -79,7 +79,7 @@ readonly MEMEX_LOCAL_VERSION="0.2.0"
 readonly LOCAL_HOME="${MEMEX_LOCAL_HOME:-$HOME/.memex-local}"
 readonly OVERLAY="$LOCAL_HOME/values.local.yaml"
 # ── REGISTRY MODE — this install CONSUMES a remote plugin registry ──────────────────────────────
-# Written by `memex-local registry <url> --key mwr_… [--id ID]`, read by helm_deploy as one more
+# Written by `memex-local registry <url> [--key mwr_…] [--id ID]`, read by helm_deploy as one more
 # values file (passed AFTER the user's overlay, so it wins). Its presence IS the mode switch: with it
 # the local portal stops being its own registry off a source checkout — which can never land a
 # module binary (MeshWeaver#2417) — and instead registers itself at the remote registry on first
@@ -230,31 +230,43 @@ registry_instance_id() {
   awk '/^[[:space:]]+instanceId:/ { gsub(/"/, "", $2); print $2; exit }' "$REGISTRY_FILE"
 }
 
-# Write the registry values file. The bootstrap key is a SECRET (it registers instances under the
-# minting admin's identity), so the file is 0600 like the overlay, and `status` never prints it.
+# Write the registry values file. A bootstrap key, when given, is a SECRET (it registers instances
+# under the minting admin's identity), so the file is 0600 like the overlay, and `status` never
+# prints it. No key = OPEN registration: the portal presents only its instance id, and the registry
+# decides whether it accepts that and which plan it enrols the install into (the free tier on
+# memex.meshweaver.cloud — Doc/Architecture/PluginRegistry → Plans); the secrets block is then left
+# out entirely rather than written empty.
 write_registry_file() {
   local url="$1" key="$2" id="$3"
   mkdir -p "$LOCAL_HOME"
+  local secrets=""
+  if [ -n "$key" ]; then
+    secrets="secrets:
+  memex_portal:
+    PluginCatalog__BootstrapKey: \"$key\""
+  fi
   # Subshell: the umask must not leak into the rest of this process (the overlay, the cert files
   # and every later write keep their own modes).
   ( umask 077; cat > "$REGISTRY_FILE" ) <<YAML
 # memex-local REGISTRY MODE — managed by \`memex-local registry\`; re-run it to change, \`registry off\`
 # to delete. Layered LAST over the overlay by helm_deploy. This install is a CONSUMER of the registry
-# below: it registers itself there on first boot (PluginCatalog__BootstrapKey, presented ONCE — the
-# issued instance key is then stored encrypted in this install's own database and survives every
-# \`memex-local update\`), installs the packages it is granted, and lands their compiled modules
-# from the registry's bundles. What it is granted is decided on the REGISTRY (Admin ▸ Instance
-# grants) — see Doc/Architecture/PluginRegistry.
+# below: it registers itself there on first boot (a bootstrap key is presented ONCE when one was
+# given; without one this is an OPEN registration the registry enrols into its default plan — the
+# free tier on memex.meshweaver.cloud), stores the issued instance key encrypted in its own database
+# (it survives every \`memex-local update\`), installs the packages it is granted, and lands their
+# compiled modules from the registry's bundles. What it is granted is decided on the REGISTRY
+# (Admin ▸ Instance grants) — see Doc/Architecture/PluginRegistry.
 pluginCatalog:
   registryUrl: "$url"
   instanceId: "$id"
   homeUrl: "https://${HOSTNAME_LOCAL}"
-secrets:
-  memex_portal:
-    PluginCatalog__BootstrapKey: "$key"
+${secrets}
 YAML
   chmod 600 "$REGISTRY_FILE"
 }
+
+# Whether the registry file carries a bootstrap key (else the registration is OPEN).
+registry_has_key() { grep -q '^    PluginCatalog__BootstrapKey: "mwr_' "$REGISTRY_FILE" 2>/dev/null; }
 
 # A default instance id: <user>-<host>, lower-cased, restricted to the registry's id alphabet.
 default_instance_id() {
@@ -270,7 +282,12 @@ cmd_registry() {
       if registry_mode; then
         ok "REGISTRY MODE — this install consumes $(registry_url)"
         info "instance id:   $(registry_instance_id)"
-        info "bootstrap key: $(awk '/PluginCatalog__BootstrapKey:/ { gsub(/"/, "", $2); print substr($2, 1, 8) "…" ; exit }' "$REGISTRY_FILE") (presented once on first boot; never printed)"
+        if registry_has_key; then
+          info "registration:  with bootstrap key $(awk '/PluginCatalog__BootstrapKey:/ { gsub(/"/, "", $2); print substr($2, 1, 8) "…" ; exit }' "$REGISTRY_FILE") (presented once on first boot; never printed)"
+        else
+          info "registration:  OPEN — no key; the registry enrols this install into its default plan"
+          info "               (the free tier on memex.meshweaver.cloud). A platform admin there raises it."
+        fi
         info "values file:   $REGISTRY_FILE (layered last by helm_deploy)"
         info "images:        pulled from $ACR (tag $ACR_DEFAULT_TAG) unless --build is passed"
         info "modules:       landed from the registry's bundles into Modules__Root=/data"
@@ -278,7 +295,8 @@ cmd_registry() {
         ok "SELF-REGISTRY MODE — this install serves plugins from a source checkout (§16)"
         info "no module BINARY can land in this mode (MeshWeaver#2417): Radzen, Analysis, EntityViews,"
         info "GoogleMaps and Speech stay absent. Switch with:"
-        info "  memex-local registry $DEFAULT_REGISTRY_URL --key mwr_… [--id $(default_instance_id)]"
+        info "  memex-local registry $DEFAULT_REGISTRY_URL [--id $(default_instance_id)]   # free tier, no key"
+        info "  memex-local registry $DEFAULT_REGISTRY_URL --key mwr_…                     # a plan an admin minted a key for"
       fi
       ;;
     off)
@@ -292,11 +310,11 @@ cmd_registry() {
       fi
       ;;
     *)
-      # `registry <url> --key mwr_… [--id ID]` — the URL is the subcommand word itself.
+      # `registry <url> [--key mwr_…] [--id ID]` — the URL is the subcommand word itself.
       local url="$sub" key="" id=""
       case "$url" in
         http://*|https://*) ;;
-        *) die "registry: expected a URL, 'status' or 'off' — got '$url' (try: memex-local registry $DEFAULT_REGISTRY_URL --key mwr_…)" ;;
+        *) die "registry: expected a URL, 'status' or 'off' — got '$url' (try: memex-local registry $DEFAULT_REGISTRY_URL)" ;;
       esac
       while [ $# -gt 0 ]; do
         case "$1" in
@@ -308,18 +326,26 @@ cmd_registry() {
       done
       # 🚨 The key SHAPE is checked here so a pasted instance key (mwi_) or personal token (mw_) is
       # refused with its name, not by a 401 on first boot that reads like a broken registry. A
-      # bootstrap key registers instances; nothing else does.
+      # bootstrap key registers instances; nothing else does. NO key is the default and is an OPEN
+      # registration — the registry's decision, not this tool's (PluginCatalog:OpenRegistration:Key
+      # on the registry, minted for the free plan on memex.meshweaver.cloud).
       case "$key" in
-        mwr_*) ;;
-        "") die "registry: --key mwr_… is required — mint one on the registry: Settings ▸ Administration ▸ Instance grants ▸ Registration keys (a platform admin, see Doc/Architecture/PluginRegistry)" ;;
-        *) die "registry: '--key' must be a REGISTRATION key (mwr_…); an instance key (mwi_) or a personal token (mw_) cannot register an install" ;;
+        ""|mwr_*) ;;
+        *) die "registry: '--key' must be a REGISTRATION key (mwr_…); an instance key (mwi_) or a personal token (mw_) cannot register an install — or pass no key at all for an open (free-tier) registration" ;;
       esac
       [ -n "$id" ] || id="$(default_instance_id)"
       case "$id" in
         *[!a-z0-9-]*|"") die "registry: --id must be lower-case letters, digits and dashes (got '$id')" ;;
       esac
       write_registry_file "${url%/}" "$key" "$id"
-      ok "registry mode ON — $url, instance id '$id' (stored in $REGISTRY_FILE)"
+      if [ -n "$key" ]; then
+        ok "registry mode ON — $url, instance id '$id', registering with the given key (stored in $REGISTRY_FILE)"
+      else
+        ok "registry mode ON — $url, instance id '$id', OPEN registration (stored in $REGISTRY_FILE)"
+        info "No key: the registry enrols this install into its default plan (the free tier on"
+        info "memex.meshweaver.cloud). A platform admin there raises it — or mints a key for a plan:"
+        info "  memex-local registry $url --key mwr_…"
+      fi
       info "Apply it: memex-local update   (pulls the CI-built image from $ACR and re-renders the chart;"
       info "          the portal registers itself on first boot and installs what it is granted)."
       ;;
@@ -655,7 +681,7 @@ helm_deploy() {
     info "serving plugin repo '$repo_name' from $repo_path (granted to every new instance)"
     idx=$((idx + 1))
   done
-  [ "$idx" -eq 0 ] && ! registry_mode && info "no local plugin repo found — the catalog will be empty (set MEMEX_PLUGIN_REPOS, or switch to registry mode: memex-local registry $DEFAULT_REGISTRY_URL --key mwr_…)"
+  [ "$idx" -eq 0 ] && ! registry_mode && info "no local plugin repo found — the catalog will be empty (set MEMEX_PLUGIN_REPOS, or switch to registry mode: memex-local registry $DEFAULT_REGISTRY_URL)"
 
   # 🚨 InstallByDefault must name the sources we ACTUALLY configured. The chart ships
   # ["Plugins/*"], which is right for the cloud registry but silently installs NOTHING here the
@@ -1002,8 +1028,9 @@ verify_usable() {
      installs DefaultViews/GraphViews from there and lands their modules from its bundles. It did not.
      Remedy: read why with
        memex-local logs --no-follow --tail 400 | grep -E 'DefaultInstall|Module|register'
-     — a 401 means the bootstrap key was refused (revoked/expired: mint a new one, 'memex-local
-     registry <url> --key …'); 'advertises 0 package(s)' means the registry granted this instance
+     — a 401 means the registration was refused: with a key, it is revoked/expired (mint a new one,
+     'memex-local registry <url> --key …'); without one, that registry accepts no OPEN registrations
+     (ask its platform admin for a key); 'advertises 0 package(s)' means the registry granted this instance
      nothing (a platform admin adds Plugins/* under Admin ▸ Instance grants for '$(registry_instance_id)')."
     failed=1
   elif [ -n "$missing" ]; then
@@ -2055,15 +2082,18 @@ COMMANDS:
                   --from-acr in registry mode (the CI-built multi-arch image, native
                   arm64 member), --build otherwise (Option B, source → Colima's
                   Docker store — the no-cloud-creds path).
-  registry <url> --key mwr_… [--id ID] | status | off
+  registry <url> [--key mwr_…] [--id ID] | status | off
                   REGISTRY MODE (§17): make this install a CONSUMER of a remote plugin
                   registry — normally $DEFAULT_REGISTRY_URL. It registers itself
-                  there on first boot with the registration key a platform admin
-                  minted (Settings ▸ Administration ▸ Instance grants), installs what
-                  it is granted, and lands the compiled modules from the registry's
-                  bundles — the only way a local install gets Radzen/Analysis/
-                  EntityViews/GoogleMaps/Speech at all (MeshWeaver#2417). Then run
-                  \`memex-local update\`. \`off\` returns to serving a checkout (§16).
+                  there on first boot — with NO key by default (an OPEN registration
+                  the registry enrols into its default plan, the free tier), or with
+                  a registration key a platform admin minted for a plan (Settings ▸
+                  Administration ▸ Instance grants) — installs what it is granted, and
+                  lands the compiled modules from the registry's bundles: the only way
+                  a local install gets Radzen/Analysis/EntityViews/GoogleMaps/Speech
+                  at all (MeshWeaver#2417). Then run \`memex-local update\`. Raising
+                  the plan is the registry admin's edit of this instance's grant.
+                  \`off\` returns to serving a checkout (§16).
   down [--purge] [--stop-colima]
                   Uninstall the release (keeps the Postgres PVC). --purge wipes
                   data (namespace + PVC + ingress-nginx); --stop-colima stops VM.

--- a/deploy/homebrew/test/run-tests.sh
+++ b/deploy/homebrew/test/run-tests.sh
@@ -309,10 +309,21 @@ if [ "$RC" -eq 0 ] && case "$OUT" in *SELF-REGISTRY*) true ;; *) false ;; esac; 
   ok "a fresh install reports self-registry mode"
 else bad "a fresh install reports self-registry mode" "exited ${RC}: ${OUT}"; fi
 
-reg https://memex.example.test
-if [ "$RC" -ne 0 ] && case "$OUT" in *"--key"*) true ;; *) false ;; esac; then
-  ok "a registry URL without a key refuses and names --key"
-else bad "a registry URL without a key refuses and names --key" "exited ${RC}: ${OUT}"; fi
+# No key is the DEFAULT: an open registration the registry enrols into its default plan (the free
+# tier). The file must then carry NO secrets block at all — an empty PluginCatalog__BootstrapKey
+# would still render into the chart's secret and read as "a key was given".
+reg https://memex.example.test --id open-box
+rfile="$RHOME/registry.yaml"
+if [ "$RC" -eq 0 ] && case "$OUT" in *"OPEN registration"*) true ;; *) false ;; esac; then
+  ok "a registry URL without a key is an OPEN (free-tier) registration"
+else bad "a registry URL without a key is an OPEN (free-tier) registration" "exited ${RC}: ${OUT}"; fi
+if [ -f "$rfile" ] && ! grep -q "PluginCatalog__BootstrapKey\|^secrets:" "$rfile"; then
+  ok "an open registration writes no secrets block"
+else bad "an open registration writes no secrets block" "$(cat "$rfile" 2>/dev/null)"; fi
+reg status
+case "$OUT" in *"OPEN"*"free tier"*) ok "status names the open registration and the free tier" ;;
+  *) bad "status names the open registration and the free tier" "$OUT" ;; esac
+reg off >/dev/null 2>&1 || true
 
 reg https://memex.example.test --key mwi_this-is-an-instance-key
 if [ "$RC" -ne 0 ] && case "$OUT" in *"REGISTRATION key"*) true ;; *) false ;; esac; then
@@ -330,7 +341,6 @@ if [ "$RC" -ne 0 ] && case "$OUT" in *"--id must be"*) true ;; *) false ;; esac;
 else bad "an instance id outside the registry's alphabet refuses" "exited ${RC}: ${OUT}"; fi
 
 reg https://memex.example.test/ --key mwr_abcdefghijklmnop --id my-box
-rfile="$RHOME/registry.yaml"
 if [ "$RC" -eq 0 ] && [ -f "$rfile" ]; then ok "registry <url> --key --id writes the registry file"
 else bad "registry <url> --key --id writes the registry file" "exited ${RC}: ${OUT}"; fi
 if grep -q 'registryUrl: "https://memex.example.test"$' "$rfile" 2>/dev/null; then

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
@@ -646,8 +646,9 @@ What changes under the hood, and why:
 | `Modules__Required__0..4` | blanked (nothing can land them) | the image baseline stands — a store-delivered required module reads `ExpectedLater`, never a rollout blocker, and `verify --repair` performs the one activation restart |
 | image | built from source (Option B) | ACR `main` (`--build` still works — `up`/`update` only change their default) |
 
-The registry file is `0600` because a bootstrap key registers instances under the minting admin's
-identity; `registry status` never prints it. **What this install may pull is decided on the
+The registry file is always `0600`: it may carry a bootstrap key, and a bootstrap key is a secret
+— it registers instances under the minting admin's identity — so the mode does not vary by whether
+one was given; `registry status` never prints it. **What this install may pull is decided on the
 registry**, per instance, in `Admin/_PluginGrant/{instanceId}` — registering is identity, not
 entitlement ([PluginRegistry.md](/Doc/Architecture/PluginRegistry)). A first boot that installs
 nothing has one of two causes, and `memex-local verify` names both: the registration was refused

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
@@ -40,7 +40,7 @@ brew install socket_vmnet
 
 You also need the **.NET SDK** (10.0) to build the portal image — install from [dotnet.microsoft.com](https://dotnet.microsoft.com/download) or `brew install --cask dotnet-sdk`.
 
-> **Prefer one command?** `brew tap systemorph/memex && brew install memex-local` — the `memex-local` CLI automates **every step on this page**, idempotently: `up` / `down` / `status` / `logs` / `update`. The tap is published by this repository's CI on every merge to `main` (`brew upgrade memex-local` follows main). Point it at the cloud plugin registry first (**§17**, `memex-local registry https://memex.meshweaver.cloud --key mwr_…`) and it needs neither a source checkout nor the .NET SDK. See `deploy/homebrew/README.md`. The rest of this page is the manual reference the CLI follows 1:1.
+> **Prefer one command?** `brew tap systemorph/memex && brew install memex-local` — the `memex-local` CLI automates **every step on this page**, idempotently: `up` / `down` / `status` / `logs` / `update`. The tap is published by this repository's CI on every merge to `main` (`brew upgrade memex-local` follows main). Point it at the cloud plugin registry first (**§17**, `memex-local registry https://memex.meshweaver.cloud` — no key needed, that is the free tier) and it needs neither a source checkout nor the .NET SDK. See `deploy/homebrew/README.md`. The rest of this page is the manual reference the CLI follows 1:1.
 
 The work splits across three areas, which the rest of this page walks through in order:
 
@@ -621,14 +621,20 @@ unchanged. (Prebuilt NodeType *bakes* are identity-gated and amd64-only; a local
 those on first access, which is the `PreWarm__DynamicTypes: "false"` behaviour it already has.)
 
 ```bash
-# 1. On the registry, a platform admin mints a registration key:
-#    Settings ▸ Administration ▸ Instance grants ▸ Registration keys  →  mwr_…
-# 2. On the Mac:
-memex-local registry https://memex.meshweaver.cloud --key mwr_… --id my-mac
+memex-local registry https://memex.meshweaver.cloud --id my-mac    # no key: an OPEN registration → the free tier
 memex-local up            # a fresh install …
 memex-local update        # … or an existing self-registry one: pulls the ACR image, re-renders the chart
 memex-local registry status
 ```
+
+**No key is the default.** An un-keyed registration is an *open* one: memex.meshweaver.cloud
+accepts it and enrols the install into its default plan, the **free tier** — every package the
+free plan covers, plus the platform baseline. Raising it is a platform admin's edit of the
+instance's grant on the registry (Instance grants ▸ Plan); an install never asks for a plan
+itself. A registration key (`--key mwr_…`, minted by a platform admin under Settings ▸
+Administration ▸ Instance grants ▸ Registration keys, *for a plan*) is the way an install lands
+on a higher plan from its first boot — and the only way in on a registry that accepts no open
+registrations ([PluginRegistry.md](/Doc/Architecture/PluginRegistry) → *Plans*).
 
 What changes under the hood, and why:
 
@@ -636,17 +642,18 @@ What changes under the hood, and why:
 |---|---|---|
 | values layers | `values.local.defaults.yaml` + `values.local.self-registry.yaml` + overlay | `values.local.defaults.yaml` + `~/.memex-local/registry.yaml` + overlay |
 | `pluginCatalog` | `sources` + `localRepoMounts` off the checkout, `defaultGrants` | `registryUrl`, `instanceId`, `homeUrl`; the chart's `installByDefault: ["Plugins/*"]` |
-| bootstrap key | minted on the local portal (`instance up`) | **presented once** (`PluginCatalog__BootstrapKey`); the issued `mwi_` key is stored encrypted in this install's database and survives every `update` |
+| bootstrap key | minted on the local portal (`instance up`) | none by default (open registration → the registry's default plan); with `--key`, **presented once** (`PluginCatalog__BootstrapKey`). Either way the issued `mwi_` key is stored encrypted in this install's database and survives every `update` |
 | `Modules__Required__0..4` | blanked (nothing can land them) | the image baseline stands — a store-delivered required module reads `ExpectedLater`, never a rollout blocker, and `verify --repair` performs the one activation restart |
 | image | built from source (Option B) | ACR `main` (`--build` still works — `up`/`update` only change their default) |
 
-The registry file is `0600` because the bootstrap key registers instances under the minting admin's
+The registry file is `0600` because a bootstrap key registers instances under the minting admin's
 identity; `registry status` never prints it. **What this install may pull is decided on the
 registry**, per instance, in `Admin/_PluginGrant/{instanceId}` — registering is identity, not
 entitlement ([PluginRegistry.md](/Doc/Architecture/PluginRegistry)). A first boot that installs
-nothing has one of two causes, and `memex-local verify` names both: the key was refused (401 —
-revoked or expired; mint a new one and re-run `registry`), or the registry advertises `0
-package(s)` to this instance (no grant yet — a platform admin adds `Plugins/*` for it).
+nothing has one of two causes, and `memex-local verify` names both: the registration was refused
+(401 — with a key: revoked or expired, mint a new one and re-run `registry`; without one: that
+registry accepts no open registrations, ask its platform admin for a key), or the registry
+advertises `0 package(s)` to this instance (no grant yet — a platform admin adds one for it).
 
 `memex-local registry off` deletes the file and the next `update` serves a checkout again; the
 instance stays registered on the registry until an admin revokes it there.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-local-install-registers-without-a-key.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-local-install-registers-without-a-key.md
@@ -1,0 +1,22 @@
+---
+Name: A local install registers without a key
+Category: Feature
+Description: memex-local registry no longer asks for a registration key — an un-keyed registration is an open one, which memex.meshweaver.cloud enrols into the free tier; a key is now only how an install lands on a higher plan from its first boot.
+Icon: Sparkle
+Order: -20260830
+---
+
+# A local install registers without a key
+
+`memex-local registry https://memex.meshweaver.cloud` used to refuse without a registration key
+minted by a platform admin. That put an admin between every Homebrew install and its first
+useful boot, for the one plan everybody starts on.
+
+The key is optional now. Without one the install registers **openly**: it presents only its
+instance id, memex.meshweaver.cloud enrols it into its default plan — the free tier — and it
+comes up with everything that plan covers and the platform baseline, modules included. Moving it
+up is a platform admin's edit of the instance's grant on the registry, or a key minted for that
+plan — the admin's decision either way, never the install's. `memex-local registry status` says
+which kind of registration an install made, and `memex-local verify` names the two ways an
+un-keyed first boot can end up with nothing: a registry that accepts no open registrations, and
+one that granted the instance nothing yet.


### PR DESCRIPTION
The CLI half of #2768's open registration. `memex-local registry https://memex.meshweaver.cloud` no longer requires `--key`: without one the registry file carries **no** secrets block (an empty `PluginCatalog__BootstrapKey` would render into the chart's secret and read as a given key), the portal registers openly with only its instance id, and the registry decides — the free tier on memex.meshweaver.cloud once #2768 is live there. `--key mwr_…` stays the way onto a higher plan from the first boot; `registry status` says which kind of registration was made; `verify`'s 401 remedy tells a revoked key from a registry that accepts no open registrations.

Docs: README, LocalColimaMac §17, formula caveats, What's New. Tests: 52/52 behaviour tests under `/bin/bash` 3.2 (the no-key case writes an open registration with no secrets block; status names the free tier); shellcheck clean; formula parses. The macOS Homebrew job re-exercises the installed CLI on this PR.

Merge after #2768 (the registry side); independent in code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1SquDKJNKZxEUbuaPjUgu