### PR TITLE
ci: delete the type-forward allow entry that went stale the moment #2771 merged

### DIFF
--- a/scripts/type-forwards.allow
+++ b/scripts/type-forwards.allow
@@ -35,4 +35,3 @@
 # surface; its only consumers are TestBase assemblies and test projects that compile from source.
 # A forwarder is impossible without keeping `namespace MeshWeaver.Fixture` inside a product
 # assembly, which would tell product code to `using MeshWeaver.Fixture` — the wrong direction.
-MeshWeaver.Fixture:MeshWeaver.Fixture.ObservableAwait  #2771 — added by #2750 after v3.0.0-rc8; never shipped


### PR DESCRIPTION
## Main is blocking every PR

`scripts/type-forwards.allow` still lists `MeshWeaver.Fixture:MeshWeaver.Fixture.ObservableAwait`. #2771 has merged, so that move is **in main** — and the gate compares against the **merge base**, so relative to any branch cut after #2771 nothing of that name moves:

```
STALE ALLOW ENTRY: scripts/type-forwards.allow lists
`MeshWeaver.Fixture:MeshWeaver.Fixture.ObservableAwait`,
but nothing of that name moved in this diff
```

🚨 **This reddens every subsequent PR, not one.** Both currently open PRs fail `Public surface (binary compatibility)` on it:

| PR | what it changes | can it reach a public type? |
|---|---|---|
| #2782 | a test guard + an allow file | no |
| #2781 | **documentation only** (Homebrew) | no |

Neither is at fault. They are blocked by main.

## This is a known, already-paid-for failure mode

An allow entry goes stale **fleet-wide the instant its move merges**, so it has to be deleted in the *very next* change — the lesson of #2678 → #2688, which left seven stale entries behind. It was flagged on #2771 before that merge:

> *"this entry goes stale the moment this merges — delete it in the very next change rather than leaving it as free budget."*

and landed with it anyway. That is precisely how the previous batch accumulated, so this is the next change.

## After this, the file carries no live entries

Header only — which is the correct state: nothing is currently exempt, and the next author who needs an exemption writes one with its reason rather than inheriting somebody else's.

## Verified

| | |
|---|---|
| `check-type-forwards.py --self-test` | **All 28 self-tests passed** |
| `check-type-forwards.py --base <merge-base>` | `OK — no unguarded public-type move` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)