### PR TITLE
feat: mw-plugin-test build — compile + test per package as a dependency cascade, no mesh import

### DIFF
--- a/scripts/type-forwards.allow
+++ b/scripts/type-forwards.allow
@@ -26,13 +26,3 @@
 # pre-split). A forwarder is impossible here: the base would have to reference the AI assembly,
 # which references the base (the documented reference-cycle case).
 
-# #2771 — ObservableAwait leaves MeshWeaver.Fixture for MeshWeaver.Messaging.Hub (namespace
-# MeshWeaver.Fixture → MeshWeaver.Messaging), so product code gets the deadlock-safe bridge. No
-# shipped package can hold the TypeRef: the type was added 2026-08-30 by #2750, one day AFTER the
-# last release (v3.0.0-rc8, 2026-08-29), and the shipped MeshWeaver.Fixture 3.0.0-rc8 nupkg was
-# pulled from nuget.org and inspected — it contains no ObservableAwait (control: HubTestBase,
-# TestBase, ConfigureMesh all present in the same DLL). Fixture is in no module bundle or bake
-# surface; its only consumers are TestBase assemblies and test projects that compile from source.
-# A forwarder is impossible without keeping `namespace MeshWeaver.Fixture` inside a product
-# assembly, which would tell product code to `using MeshWeaver.Fixture` — the wrong direction.
-MeshWeaver.Fixture:MeshWeaver.Fixture.ObservableAwait  #2771 — added by #2750 after v3.0.0-rc8; never shipped

--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildProcess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildProcess.md
@@ -1,0 +1,94 @@
+---
+Name: The Build Process — compile and test as a dependency cascade
+Category: Architecture
+Description: How a node repo is built — per package, compile AND run tests, as a reactive cascade over the package dependency network, inside the container the platform build produced, with no mesh import and no core source checkout. The design, the invariants, the timings it reports, and what the mesh lane still owns.
+Icon: Hammer
+---
+
+# The Build Process — compile and test as a dependency cascade
+
+**Decision (maintainer, 2026-08-30).** A node repo is built by *our own* build runner and test
+runner, not by `dotnet test` over xUnit projects that reference a core source checkout. The runner
+is the platform's own container (`mw-plugin-test`, the image the platform BUILD produces), the
+verb is `build`, and the lane that starts it is one small workflow.
+
+```
+mw-plugin-test build <repo-root> [<package>... | all] [--module <dll>]... [--out <dir>] \
+    [--report <file>] [--max-parallel <n>] [--case-timeout <s>] [--no-tests] [--source-sha <sha>]
+```
+
+## The invariants
+
+1. **Build means compile AND run tests.** They are one unit per package; there is no "it compiled"
+   verdict without the tests, and no test run without the compile that produced its assembly.
+2. **A cascade, not a schedule.** Every package has a result stream. A package *observes* the
+   streams of the packages it `requires` and starts itself the moment the last one completes
+   green. No level table, no topological list: the graph is the schedule, so packages with no
+   edge between them build at the same time (bounded by `--max-parallel`), and a package with
+   three dependencies starts the instant the slowest lands.
+3. **On red we break; on green we continue.** A package whose dependency did not end green never
+   starts: it completes at once as *blocked by \<dependency\>*, and that verdict cascades. A failure
+   is reported exactly once, where it happened; everything above it reads "blocked by X", never a
+   second, derived failure. A cycle is refused up front and named.
+4. **One execution per package, however many dependents.** A package's stream is shared
+   (`PublishLast`): the first subscriber starts the work, every later subscriber gets the same
+   single result, and nothing is rebuilt because two packages both required it.
+5. **No mesh, no import.** Sources are read from the git checkout on disk and composed into Roslyn
+   compilations *exactly as the portal composes them* — the same skeleton, the same options, the
+   image's `/app` as the reference set (`NodeSetCompiler`, the code path the portals run at
+   runtime). Each package additionally compiles against the assemblies its dependency packages
+   just emitted. Grains cannot carry a Roslyn workload; a build process can.
+6. **Input is one or many packages, or `all`.** Naming packages selects them *and* their transitive
+   requirements inside the repo, so a single package builds on freshly built dependencies rather
+   than on nothing. `all` (the default) is the full rebuild — the platform-rebuild case, where
+   every package must be re-proven against the new image.
+7. **Timings are part of the result.** Every package carries when it became *ready* (its last
+   dependency finished), when it *started* (a slot was free) and when it *finished*, plus the
+   compile and test splits and per-type compile times. The report prints them, the **critical
+   path** (the chain whose serial length is the wall-clock floor) and the parallel speed-up;
+   `--report` writes it all as JSON, and the lane renders it into the job summary.
+8. **Fails red, never skips.** The lane asserts its inputs first; an image that does not know the
+   verb exits 2 and the step names the fix. Nobody reads a green that ran nothing.
+
+## Tests without a mesh
+
+The in-mesh test convention is `<Type>/Test/*.cs`: **static classes whose public static
+parameterless methods throw on failure**, listed by a `Tests` layout area. The runner executes
+those methods straight from the emitted assembly in a collectible load context, each case timed
+and capped by `--case-timeout`. A case that takes a host (the layout-area aggregator, anything
+needing a hub) is **counted and named as `needs-mesh`**, never dropped; the gate
+(`mw-plugin-test <root> --seed <out>`) still runs those, seeded from the build's `--out` so
+nothing is compiled twice.
+
+## The parity flag
+
+The portal reaches other packages' types by `shared=` *source inclusion*, never by referencing
+their emitted assemblies. This build references them (the maintainer's instruction: use the
+references the dependency packages produce). A type whose emitted assembly turns out to *bind* a
+dependency package's assembly is therefore green here on grounds the portal does not have, and the
+report marks it `binds-dependency-assembly` — visible in the table, not discovered as a
+`CompileError` in production.
+
+## What this replaces, and what it retires
+
+- **`MeshWeaver.Fixture` and the two TestBase assemblies are the platform's own test support.**
+  They live under `test/` and are never packed or published (they were a NuGet package only
+  because they once lived under `src/`). A node repo does not reference them and does not need a
+  `$(MeshWeaverRoot)` source checkout to test: the platform is the image, pinned by digest.
+- **xUnit projects in node repos** are the migration's subject. The measured shapes (core:
+  1,205 test files, 6,295 facts; 535 of those files mesh- or hub-based) convert mechanically once
+  the runner offers one primitive — a per-class mesh factory replacing the `MonolithMeshTestBase`
+  constructor — plus a log sink for `ITestOutputHelper`, loops for `[Theory]` rows and a classified
+  skip. Substrate suites (Postgres via Testcontainers, Orleans TestingHost, `HtmlRenderer`) run in
+  the runner *process*, never in a grain. Browser E2E stays a browser lane.
+
+## Where the pieces are
+
+| piece | where |
+|---|---|
+| the cascade (generic, unit-tested) | `tools/MeshWeaver.PluginTester/Cascade.cs` |
+| the `build` verb | `tools/MeshWeaver.PluginTester/CascadeBuild.cs`, `Program.cs` |
+| static test execution | `tools/MeshWeaver.PluginTester/StaticTestRunner.cs` |
+| the compile composition it reuses | `MeshWeaver.Compiler` — `NodeSetCompiler`, `CompileReferences` |
+| the lane (node repos) | `.github/workflows/build-cascade.yml` in each node repo |
+| the tester's README | `tools/MeshWeaver.PluginTester/README.md` (`build`) |

--- a/src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md
@@ -101,6 +101,28 @@ Before writing a test, review the invariants every test must respect:
 
 ---
 
+## In-mesh tests and the build process (node repos)
+
+A NodeType in a node repo ships its tests as `<Type>/Test/*.cs` — **static classes whose public
+static parameterless methods throw on failure** — and a `Tests` layout area that lists them. Since
+2026-08-30 those run through the container the platform build produced, not through xUnit:
+
+```
+mw-plugin-test build <repo-root> [<package>... | all]
+```
+
+**Build means compile and run tests**, per package, as a dependency cascade: a package observes
+the result streams of the packages it requires and starts itself when the last one is green; on
+red the dependents are blocked by name, on green they continue; independent packages build in
+parallel; every package reports its timings. Sources come from the checkout on disk and compile
+against the image's `/app` plus the assemblies the dependency packages just emitted — no mesh
+import, no `$(MeshWeaverRoot)` source checkout, no `MeshWeaver.Fixture`. Cases that need a host
+are counted as `needs-mesh` and run by the gate, seeded from the build's output. See
+`tools/MeshWeaver.PluginTester/README.md` (`build`).
+
+`MeshWeaver.Fixture` and the two TestBase assemblies are this repo's OWN test support: they live
+under `test/` and are never packed or published.
+
 ## The Canonical Test Base
 
 Every monolith test inherits `MonolithMeshTestBase`. The shape is always the same:

--- a/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Reactive.Linq;
+using MeshWeaver.Messaging;
 using MeshWeaver.PluginTester;
 using Xunit;
 
@@ -27,17 +28,17 @@ public class CascadeTest
         Diamond.TryGetValue(id, out var d) ? d : [];
 
     [Fact]
-    public void ANodeStartsOnlyAfterEveryDependencyIsGreen_AndDependentsSeeTheirResults()
+    public async Task ANodeStartsOnlyAfterEveryDependencyIsGreen_AndDependentsSeeTheirResults()
     {
         var seen = new ConcurrentDictionary<string, string[]>(StringComparer.Ordinal);
-        var results = Cascade.Run<string>(
+        var results = await Cascade.Run<string>(
             Diamond.Keys.ToArray(), DepsOf,
             (id, deps) =>
             {
                 seen[id] = deps.Select(d => d.Id).OrderBy(x => x, StringComparer.Ordinal).ToArray();
                 return ($"built {id}", true);
             },
-            maxParallel: 4).Wait();
+            maxParallel: 4).Await(TestContext.Current.CancellationToken);
 
         Assert.Equal(4, results.Length);
         Assert.All(results, r => Assert.True(r.IsGreen, $"{r.Id}: every node's work returned green, so nothing is red or blocked"));
@@ -52,17 +53,17 @@ public class CascadeTest
     }
 
     [Fact]
-    public void OnRedWeBreak_TheFailureIsReportedOnceAndEveryDependentIsBlockedByName()
+    public async Task OnRedWeBreak_TheFailureIsReportedOnceAndEveryDependentIsBlockedByName()
     {
         var ran = new ConcurrentBag<string>();
-        var results = Cascade.Run<string>(
+        var results = await Cascade.Run<string>(
             Diamond.Keys.ToArray(), DepsOf,
             (id, _) =>
             {
                 ran.Add(id);
                 return (id, id != "AI"); // AI fails
             },
-            maxParallel: 4).Wait();
+            maxParallel: 4).Await(TestContext.Current.CancellationToken);
 
         var byId = results.ToDictionary(r => r.Id, StringComparer.Ordinal);
         Assert.Equal(Cascade.NodeOutcome.Green, byId["Store"].Outcome);
@@ -75,12 +76,12 @@ public class CascadeTest
     }
 
     [Fact]
-    public void AFaultingWorkFunctionIsReportedAsFaulted_NotAsACrashOfTheWholeBuild()
+    public async Task AFaultingWorkFunctionIsReportedAsFaulted_NotAsACrashOfTheWholeBuild()
     {
-        var results = Cascade.Run<string>(
+        var results = await Cascade.Run<string>(
             Diamond.Keys.ToArray(), DepsOf,
             (id, _) => id == "Store" ? throw new InvalidOperationException("disk on fire") : (id, true),
-            maxParallel: 2).Wait();
+            maxParallel: 2).Await(TestContext.Current.CancellationToken);
 
         var byId = results.ToDictionary(r => r.Id, StringComparer.Ordinal);
         Assert.Equal(Cascade.NodeOutcome.Faulted, byId["Store"].Outcome);
@@ -89,28 +90,28 @@ public class CascadeTest
     }
 
     [Fact]
-    public void EveryNodeRunsExactlyOnce_HoweverManyDependentsShareIt()
+    public async Task EveryNodeRunsExactlyOnce_HoweverManyDependentsShareIt()
     {
         var runs = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
         var wide = new Dictionary<string, string[]>(StringComparer.Ordinal) { ["Base"] = [] };
         for (var i = 0; i < 20; i++)
             wide[$"Leaf{i:D2}"] = ["Base"];
 
-        Cascade.Run<int>(
+        await Cascade.Run<int>(
             wide.Keys.ToArray(), id => wide[id],
             (id, _) =>
             {
                 runs.AddOrUpdate(id, 1, (_, n) => n + 1);
                 return (0, true);
             },
-            maxParallel: 8).Wait();
+            maxParallel: 8).Await(TestContext.Current.CancellationToken);
 
         Assert.Equal(21, runs.Count);
         Assert.All(runs.Values, n => Assert.Equal(1, n)); // twenty dependents, ONE execution of Base
     }
 
     [Fact]
-    public void IndependentNodesRunInParallel_BoundedByTheSlotCount()
+    public async Task IndependentNodesRunInParallel_BoundedByTheSlotCount()
     {
         const int nodes = 6;
         const int slots = 3;
@@ -118,7 +119,7 @@ public class CascadeTest
         var peak = 0;
         var flat = Enumerable.Range(0, nodes).Select(i => $"N{i}").ToArray();
 
-        var results = Cascade.Run<int>(
+        var results = await Cascade.Run<int>(
             flat, _ => [],
             (_, _) =>
             {
@@ -132,7 +133,7 @@ public class CascadeTest
                 Interlocked.Decrement(ref inFlight);
                 return (0, true);
             },
-            maxParallel: slots).Wait();
+            maxParallel: slots).Await(TestContext.Current.CancellationToken);
 
         Assert.Equal(nodes, results.Length); Assert.All(results, r => Assert.True(r.IsGreen));
         Assert.True(peak > 1, "nodes with no edge between them run at the same time");
@@ -141,7 +142,7 @@ public class CascadeTest
     }
 
     [Fact]
-    public void ACycleIsRefusedUpFront_NamingIt()
+    public async Task ACycleIsRefusedUpFront_NamingIt()
     {
         var cyclic = new Dictionary<string, string[]>(StringComparer.Ordinal)
         {
@@ -149,40 +150,41 @@ public class CascadeTest
             ["B"] = ["C"],
             ["C"] = ["A"],
         };
-        Action act = () => _ = Cascade.Run<int>(cyclic.Keys.ToArray(), id => cyclic[id], (_, _) => (0, true), 2).Wait();
-        var ex = Assert.Throws<InvalidOperationException>(act);
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => Cascade.Run<int>(cyclic.Keys.ToArray(), id => cyclic[id], (_, _) => (0, true), 2)
+                .Await(TestContext.Current.CancellationToken));
         Assert.Contains("cycle", ex.Message); Assert.Contains("A", ex.Message); Assert.Contains("C", ex.Message);
     }
 
     [Fact]
-    public void DependenciesOutsideTheSelectionAreExternal_AndDoNotBlock()
+    public async Task DependenciesOutsideTheSelectionAreExternal_AndDoNotBlock()
     {
         // 'AI' requires 'Store', but only 'AI' is in the cascade: Store is somebody else's
         // (the image, --module, another repo). AI must start on its own.
-        var results = Cascade.Run<int>(
-            ["AI"], DepsOf, (_, _) => (1, true), 2).Wait();
+        var results = await Cascade.Run<int>(
+            ["AI"], DepsOf, (_, _) => (1, true), 2).Await(TestContext.Current.CancellationToken);
         Assert.True(Assert.Single(results).IsGreen);
     }
 
     [Fact]
-    public void CriticalPathIsTheChainThatEndsLast_LeafFirst()
+    public async Task CriticalPathIsTheChainThatEndsLast_LeafFirst()
     {
-        var results = Cascade.Run<int>(
+        var results = await Cascade.Run<int>(
             Diamond.Keys.ToArray(), DepsOf,
             (id, _) =>
             {
                 Thread.Sleep(id == "AI" ? 120 : 20);
                 return (0, true);
             },
-            maxParallel: 4).Wait();
+            maxParallel: 4).Await(TestContext.Current.CancellationToken);
 
         var path = Cascade.CriticalPath(results, DepsOf);
         Assert.Equal(["Store", "AI", "Edu"], path); // Edu finishes last; waited for AI (slow), which waited for Store
     }
 
     [Fact]
-    public void AnEmptySelectionIsAnEmptyReport()
+    public async Task AnEmptySelectionIsAnEmptyReport()
     {
-        Assert.Empty(Cascade.Run<int>([], _ => [], (_, _) => (0, true), 1).Wait());
+        Assert.Empty(await Cascade.Run<int>([], _ => [], (_, _) => (0, true), 1).Await(TestContext.Current.CancellationToken));
     }
 }

--- a/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
@@ -1,0 +1,188 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using MeshWeaver.PluginTester;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// The cascade's contract, tested without a compiler: the graph is ids, the work is a delegate.
+/// Every invariant the maintainer stated on 2026-08-30 has a case here — build = one unit per
+/// node; on red we break; on green we continue; a node observes its dependencies and starts
+/// itself; independent nodes run in parallel; every node runs exactly once; timings are real.
+/// </summary>
+public class CascadeTest
+{
+    private static readonly IReadOnlyDictionary<string, string[]> Diamond =
+        new Dictionary<string, string[]>(StringComparer.Ordinal)
+        {
+            ["Store"] = [],
+            ["AI"] = ["Store"],
+            ["Observability"] = ["Store"],
+            ["Edu"] = ["Store", "AI"],
+        };
+
+    private static IReadOnlyList<string> DepsOf(string id) =>
+        Diamond.TryGetValue(id, out var d) ? d : [];
+
+    [Fact]
+    public void ANodeStartsOnlyAfterEveryDependencyIsGreen_AndDependentsSeeTheirResults()
+    {
+        var seen = new ConcurrentDictionary<string, string[]>(StringComparer.Ordinal);
+        var results = Cascade.Run<string>(
+            Diamond.Keys.ToArray(), DepsOf,
+            (id, deps) =>
+            {
+                seen[id] = deps.Select(d => d.Id).OrderBy(x => x, StringComparer.Ordinal).ToArray();
+                return ($"built {id}", true);
+            },
+            maxParallel: 4).Wait();
+
+        Assert.Equal(4, results.Length);
+        Assert.All(results, r => Assert.True(r.IsGreen, $"{r.Id}: every node's work returned green, so nothing is red or blocked"));
+        Assert.Empty(seen["Store"]);
+        Assert.Equal(["Store"], seen["AI"]);
+        Assert.Equal(["AI", "Store"], seen["Edu"]); // Edu observes both dependencies' streams and starts only after both completed
+
+        var byId = results.ToDictionary(r => r.Id, StringComparer.Ordinal);
+        Assert.True(byId["AI"].Ready >= byId["Store"].Finished, "a node is READY no earlier than its last dependency FINISHED — that is the cascade");
+        Assert.True(byId["Edu"].Ready >= byId["AI"].Finished);
+        Assert.Equal("built Edu", byId["Edu"].Result);
+    }
+
+    [Fact]
+    public void OnRedWeBreak_TheFailureIsReportedOnceAndEveryDependentIsBlockedByName()
+    {
+        var ran = new ConcurrentBag<string>();
+        var results = Cascade.Run<string>(
+            Diamond.Keys.ToArray(), DepsOf,
+            (id, _) =>
+            {
+                ran.Add(id);
+                return (id, id != "AI"); // AI fails
+            },
+            maxParallel: 4).Wait();
+
+        var byId = results.ToDictionary(r => r.Id, StringComparer.Ordinal);
+        Assert.Equal(Cascade.NodeOutcome.Green, byId["Store"].Outcome);
+        Assert.Equal(Cascade.NodeOutcome.Red, byId["AI"].Outcome); // AI's own work failed
+        Assert.Equal(Cascade.NodeOutcome.Blocked, byId["Edu"].Outcome); // Edu requires AI; on red we break
+        Assert.Equal("AI", byId["Edu"].BlockedBy); // the block names the dependency that stopped it
+        Assert.Equal(Cascade.NodeOutcome.Green, byId["Observability"].Outcome); // requires only Store: on green we continue
+        Assert.DoesNotContain("Edu", ran); // a blocked node's work must never run
+        Assert.Equal(TimeSpan.Zero, byId["Edu"].Work); // a derived verdict costs no work time
+    }
+
+    [Fact]
+    public void AFaultingWorkFunctionIsReportedAsFaulted_NotAsACrashOfTheWholeBuild()
+    {
+        var results = Cascade.Run<string>(
+            Diamond.Keys.ToArray(), DepsOf,
+            (id, _) => id == "Store" ? throw new InvalidOperationException("disk on fire") : (id, true),
+            maxParallel: 2).Wait();
+
+        var byId = results.ToDictionary(r => r.Id, StringComparer.Ordinal);
+        Assert.Equal(Cascade.NodeOutcome.Faulted, byId["Store"].Outcome);
+        Assert.Contains("InvalidOperationException", byId["Store"].Error); Assert.Contains("disk on fire", byId["Store"].Error);
+        Assert.All(results.Where(r => r.Id != "Store"), r => { Assert.Equal(Cascade.NodeOutcome.Blocked, r.Outcome); Assert.Equal("Store", r.BlockedBy); }); // all require Store
+    }
+
+    [Fact]
+    public void EveryNodeRunsExactlyOnce_HoweverManyDependentsShareIt()
+    {
+        var runs = new ConcurrentDictionary<string, int>(StringComparer.Ordinal);
+        var wide = new Dictionary<string, string[]>(StringComparer.Ordinal) { ["Base"] = [] };
+        for (var i = 0; i < 20; i++)
+            wide[$"Leaf{i:D2}"] = ["Base"];
+
+        Cascade.Run<int>(
+            wide.Keys.ToArray(), id => wide[id],
+            (id, _) =>
+            {
+                runs.AddOrUpdate(id, 1, (_, n) => n + 1);
+                return (0, true);
+            },
+            maxParallel: 8).Wait();
+
+        Assert.Equal(21, runs.Count);
+        Assert.All(runs.Values, n => Assert.Equal(1, n)); // twenty dependents, ONE execution of Base
+    }
+
+    [Fact]
+    public void IndependentNodesRunInParallel_BoundedByTheSlotCount()
+    {
+        const int nodes = 6;
+        const int slots = 3;
+        var inFlight = 0;
+        var peak = 0;
+        var flat = Enumerable.Range(0, nodes).Select(i => $"N{i}").ToArray();
+
+        var results = Cascade.Run<int>(
+            flat, _ => [],
+            (_, _) =>
+            {
+                var now = Interlocked.Increment(ref inFlight);
+                int seen;
+                do
+                {
+                    seen = Volatile.Read(ref peak);
+                } while (now > seen && Interlocked.CompareExchange(ref peak, now, seen) != seen);
+                Thread.Sleep(80);
+                Interlocked.Decrement(ref inFlight);
+                return (0, true);
+            },
+            maxParallel: slots).Wait();
+
+        Assert.Equal(nodes, results.Length); Assert.All(results, r => Assert.True(r.IsGreen));
+        Assert.True(peak > 1, "nodes with no edge between them run at the same time");
+        Assert.True(peak <= slots, $"peak {peak} exceeded the slot cap {slots}");
+        Assert.Contains(results, r => r.Queued > TimeSpan.Zero); // six nodes on three slots: somebody waited
+    }
+
+    [Fact]
+    public void ACycleIsRefusedUpFront_NamingIt()
+    {
+        var cyclic = new Dictionary<string, string[]>(StringComparer.Ordinal)
+        {
+            ["A"] = ["B"],
+            ["B"] = ["C"],
+            ["C"] = ["A"],
+        };
+        Action act = () => _ = Cascade.Run<int>(cyclic.Keys.ToArray(), id => cyclic[id], (_, _) => (0, true), 2).Wait();
+        var ex = Assert.Throws<InvalidOperationException>(act);
+        Assert.Contains("cycle", ex.Message); Assert.Contains("A", ex.Message); Assert.Contains("C", ex.Message);
+    }
+
+    [Fact]
+    public void DependenciesOutsideTheSelectionAreExternal_AndDoNotBlock()
+    {
+        // 'AI' requires 'Store', but only 'AI' is in the cascade: Store is somebody else's
+        // (the image, --module, another repo). AI must start on its own.
+        var results = Cascade.Run<int>(
+            ["AI"], DepsOf, (_, _) => (1, true), 2).Wait();
+        Assert.True(Assert.Single(results).IsGreen);
+    }
+
+    [Fact]
+    public void CriticalPathIsTheChainThatEndsLast_LeafFirst()
+    {
+        var results = Cascade.Run<int>(
+            Diamond.Keys.ToArray(), DepsOf,
+            (id, _) =>
+            {
+                Thread.Sleep(id == "AI" ? 120 : 20);
+                return (0, true);
+            },
+            maxParallel: 4).Wait();
+
+        var path = Cascade.CriticalPath(results, DepsOf);
+        Assert.Equal(["Store", "AI", "Edu"], path); // Edu finishes last; waited for AI (slow), which waited for Store
+    }
+
+    [Fact]
+    public void AnEmptySelectionIsAnEmptyReport()
+    {
+        Assert.Empty(Cascade.Run<int>([], _ => [], (_, _) => (0, true), 1).Wait());
+    }
+}

--- a/tools/MeshWeaver.PluginTester/Cascade.cs
+++ b/tools/MeshWeaver.PluginTester/Cascade.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Diagnostics;
+using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
@@ -26,8 +27,13 @@ namespace MeshWeaver.PluginTester;
 /// starts the work, every later subscriber receives the same single result, and nobody ever
 /// re-runs a package because two packages both required it.</para>
 ///
+/// <para><b>Bounded parallelism without a blocking wait.</b> Work is handed to one queue and
+/// executed through <c>Merge(maxParallel)</c>: Rx subscribes at most that many work items at a
+/// time and takes the next when one completes. No semaphore, no thread parked on a wait — a
+/// blocking bridge is exactly what the production inventory refuses.</para>
+///
 /// <para><b>Timings are part of the result.</b> Each outcome carries when the node became
-/// READY (its last dependency completed), when it STARTED (a slot was available) and when it
+/// READY (its last dependency completed), when it STARTED (a slot was granted) and when it
 /// FINISHED, so a report can show queue time separately from work time and compute the critical
 /// path — the maintainer wants the numbers, not a green wall.</para>
 ///
@@ -83,7 +89,7 @@ public static class Cascade
     /// Runs the cascade over <paramref name="ids"/>, where <paramref name="dependenciesOf"/> names
     /// each id's direct dependencies (ids outside the set are ignored — they are external, and
     /// whoever built the set decided how they are satisfied) and <paramref name="run"/> does one
-    /// node's work, returning true for green. Returns every node's result once all have settled.
+    /// node's work, returning true for green. Emits every node's result once all have settled.
     /// </summary>
     /// <param name="ids">The node ids in the cascade.</param>
     /// <param name="dependenciesOf">Direct dependencies per id.</param>
@@ -109,14 +115,23 @@ public static class Cascade
         return Observable.Defer(() =>
         {
             var idSet = ids.ToImmutableHashSet(StringComparer.Ordinal);
+            if (idSet.IsEmpty)
+                return Observable.Return(ImmutableArray<NodeResult<T>>.Empty);
             if (FindCycle(idSet, dependenciesOf) is { } cycle)
                 return Observable.Throw<ImmutableArray<NodeResult<T>>>(new InvalidOperationException(
                     $"the dependency graph has a cycle: {cycle} — a cascade over it would never "
                     + "start, because every node in the cycle waits for another one in it"));
 
             var clock = Stopwatch.StartNew();
-            var slots = new SemaphoreSlim(maxParallel, maxParallel);
             var pool = scheduler ?? TaskPoolScheduler.Default;
+
+            // The concurrency gate. Every node hands its work here when it becomes ready;
+            // Merge(maxParallel) subscribes at most that many at a time and takes the next as one
+            // completes. The gate is subscribed BEFORE any node, so nothing is handed to a queue
+            // nobody is listening to.
+            var queue = new Subject<IObservable<Unit>>();
+            var gate = queue.Merge(maxParallel).Subscribe(_ => { }, _ => { });
+
             var nodes = new Dictionary<string, IObservable<NodeResult<T>>>(StringComparer.Ordinal);
 
             // Build the streams lazily and memoise them: a node's stream is created once and the
@@ -145,28 +160,35 @@ public static class Cascade
                                 ready, ready, ready));
                         }
                         var ordered = depResults.ToArray();
-                        return Observable.Start(() =>
-                        {
-                            slots.Wait();
-                            var started = clock.Elapsed;
-                            try
+                        // The result travels back through its own subject; the work item handed
+                        // to the gate is deferred so it starts when the gate subscribes it —
+                        // that moment is 'Started', and Started - Ready is the slot wait.
+                        var result = new AsyncSubject<NodeResult<T>>();
+                        var work = Observable.Defer(() => Observable.Start(() =>
                             {
-                                var (result, green) = run(id, ordered);
-                                return new NodeResult<T>(
-                                    id, green ? NodeOutcome.Green : NodeOutcome.Red, result, null, null,
-                                    ready, started, clock.Elapsed);
-                            }
-                            catch (Exception ex)
+                                var started = clock.Elapsed;
+                                try
+                                {
+                                    var (payload, green) = run(id, ordered);
+                                    return new NodeResult<T>(
+                                        id, green ? NodeOutcome.Green : NodeOutcome.Red, payload, null, null,
+                                        ready, started, clock.Elapsed);
+                                }
+                                catch (Exception ex)
+                                {
+                                    return new NodeResult<T>(
+                                        id, NodeOutcome.Faulted, default, null,
+                                        $"{ex.GetType().Name}: {ex.Message}", ready, started, clock.Elapsed);
+                                }
+                            }, pool))
+                            .Do(r =>
                             {
-                                return new NodeResult<T>(
-                                    id, NodeOutcome.Faulted, default, null,
-                                    $"{ex.GetType().Name}: {ex.Message}", ready, started, clock.Elapsed);
-                            }
-                            finally
-                            {
-                                slots.Release();
-                            }
-                        }, pool);
+                                result.OnNext(r);
+                                result.OnCompleted();
+                            })
+                            .Select(_ => Unit.Default);
+                        queue.OnNext(work);
+                        return result;
                     })
                     .PublishLast()
                     .AutoConnect();
@@ -175,12 +197,14 @@ public static class Cascade
             }
 
             var all = idSet.OrderBy(i => i, StringComparer.Ordinal).Select(NodeOf).ToArray();
-            return all.Length == 0
-                ? Observable.Return(ImmutableArray<NodeResult<T>>.Empty)
-                : all.CombineLatest()
-                    .Take(1)
-                    .Select(results => results.OrderBy(r => r.Id, StringComparer.Ordinal).ToImmutableArray())
-                    .Finally(slots.Dispose);
+            return all.CombineLatest()
+                .Take(1)
+                .Select(results => results.OrderBy(r => r.Id, StringComparer.Ordinal).ToImmutableArray())
+                .Finally(() =>
+                {
+                    queue.OnCompleted();
+                    gate.Dispose();
+                });
         });
     }
 

--- a/tools/MeshWeaver.PluginTester/Cascade.cs
+++ b/tools/MeshWeaver.PluginTester/Cascade.cs
@@ -1,0 +1,248 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// The dependency cascade behind <c>mw-plugin-test build</c>: every node OBSERVES the result
+/// streams of the nodes it depends on and starts itself the moment the last of them completes
+/// green. Nothing is scheduled by a level table or a topological list; the graph itself is the
+/// schedule, so two packages with no edge between them build at the same time and a package with
+/// three dependencies starts the instant the slowest one lands — the natural cascade the
+/// maintainer asked for (2026-08-30: "we always observe stream for dependencies then start
+/// ourselves").
+///
+/// <para><b>Red breaks, green continues.</b> A node whose dependency did not end green never
+/// starts: it completes at once as <see cref="NodeOutcome.Blocked"/>, naming the dependency that
+/// stopped it, and that verdict cascades to its own dependents. A failure is therefore reported
+/// exactly once at the node that produced it, and every node above it reads "blocked by X" rather
+/// than a second, derived failure.</para>
+///
+/// <para><b>One execution per node, however many dependents.</b> A node's stream is
+/// <see cref="Observable.PublishLast{TSource}(IObservable{TSource})"/>-shared: the first subscriber
+/// starts the work, every later subscriber receives the same single result, and nobody ever
+/// re-runs a package because two packages both required it.</para>
+///
+/// <para><b>Timings are part of the result.</b> Each outcome carries when the node became
+/// READY (its last dependency completed), when it STARTED (a slot was available) and when it
+/// FINISHED, so a report can show queue time separately from work time and compute the critical
+/// path — the maintainer wants the numbers, not a green wall.</para>
+///
+/// <para>The cascade is generic and pure so it can be tested without a compiler: the work
+/// function is injected and the graph is plain ids.</para>
+/// </summary>
+public static class Cascade
+{
+    /// <summary>The verdict of one node of the cascade.</summary>
+    public enum NodeOutcome
+    {
+        /// <summary>The work ran and succeeded; dependents may start.</summary>
+        Green,
+        /// <summary>The work ran and failed; dependents are blocked.</summary>
+        Red,
+        /// <summary>The work never ran because a dependency was not green.</summary>
+        Blocked,
+        /// <summary>The work threw — treated as red for dependents, but reported apart.</summary>
+        Faulted,
+    }
+
+    /// <summary>One node's result: the verdict, the work's own payload, and the three timestamps.</summary>
+    /// <typeparam name="T">The payload the work function produces on a run (null when blocked).</typeparam>
+    /// <param name="Id">The node id.</param>
+    /// <param name="Outcome">The verdict.</param>
+    /// <param name="Result">The work's payload, when the work ran.</param>
+    /// <param name="BlockedBy">The dependency that stopped this node, when blocked.</param>
+    /// <param name="Error">The exception text, when faulted.</param>
+    /// <param name="Ready">When the last dependency completed (relative to the cascade's start).</param>
+    /// <param name="Started">When the work began — equals <paramref name="Ready"/> when no slot wait.</param>
+    /// <param name="Finished">When the work ended (or the block was decided).</param>
+    public sealed record NodeResult<T>(
+        string Id,
+        NodeOutcome Outcome,
+        T? Result,
+        string? BlockedBy,
+        string? Error,
+        TimeSpan Ready,
+        TimeSpan Started,
+        TimeSpan Finished)
+    {
+        /// <summary>Time spent waiting for a slot after every dependency was in.</summary>
+        public TimeSpan Queued => Started - Ready;
+
+        /// <summary>Time the work itself took.</summary>
+        public TimeSpan Work => Finished - Started;
+
+        /// <summary>True when dependents may start.</summary>
+        public bool IsGreen => Outcome == NodeOutcome.Green;
+    }
+
+    /// <summary>
+    /// Runs the cascade over <paramref name="ids"/>, where <paramref name="dependenciesOf"/> names
+    /// each id's direct dependencies (ids outside the set are ignored — they are external, and
+    /// whoever built the set decided how they are satisfied) and <paramref name="run"/> does one
+    /// node's work, returning true for green. Returns every node's result once all have settled.
+    /// </summary>
+    /// <param name="ids">The node ids in the cascade.</param>
+    /// <param name="dependenciesOf">Direct dependencies per id.</param>
+    /// <param name="run">The work: given the id and its dependencies' results, produce the payload
+    /// and whether it is green. Runs on the scheduler, at most <paramref name="maxParallel"/> at a
+    /// time.</param>
+    /// <param name="maxParallel">Concurrency cap for the work function. Blocking a node costs no slot.</param>
+    /// <param name="scheduler">Where the work runs; the task pool by default.</param>
+    /// <typeparam name="T">The work's payload type.</typeparam>
+    public static IObservable<ImmutableArray<NodeResult<T>>> Run<T>(
+        IReadOnlyCollection<string> ids,
+        Func<string, IReadOnlyList<string>> dependenciesOf,
+        Func<string, IReadOnlyList<NodeResult<T>>, (T Result, bool Green)> run,
+        int maxParallel,
+        IScheduler? scheduler = null)
+    {
+        ArgumentNullException.ThrowIfNull(ids);
+        ArgumentNullException.ThrowIfNull(dependenciesOf);
+        ArgumentNullException.ThrowIfNull(run);
+        if (maxParallel < 1)
+            throw new ArgumentOutOfRangeException(nameof(maxParallel), maxParallel, "at least one slot");
+
+        return Observable.Defer(() =>
+        {
+            var idSet = ids.ToImmutableHashSet(StringComparer.Ordinal);
+            if (FindCycle(idSet, dependenciesOf) is { } cycle)
+                return Observable.Throw<ImmutableArray<NodeResult<T>>>(new InvalidOperationException(
+                    $"the dependency graph has a cycle: {cycle} — a cascade over it would never "
+                    + "start, because every node in the cycle waits for another one in it"));
+
+            var clock = Stopwatch.StartNew();
+            var slots = new SemaphoreSlim(maxParallel, maxParallel);
+            var pool = scheduler ?? TaskPoolScheduler.Default;
+            var nodes = new Dictionary<string, IObservable<NodeResult<T>>>(StringComparer.Ordinal);
+
+            // Build the streams lazily and memoise them: a node's stream is created once and the
+            // same instance is handed to every dependent, so PublishLast shares one execution.
+            IObservable<NodeResult<T>> NodeOf(string id)
+            {
+                if (nodes.TryGetValue(id, out var existing))
+                    return existing;
+
+                var deps = dependenciesOf(id).Where(idSet.Contains).Distinct(StringComparer.Ordinal).ToArray();
+                var upstream = deps.Length == 0
+                    ? Observable.Return<IList<NodeResult<T>>>(Array.Empty<NodeResult<T>>())
+                    : deps.Select(NodeOf).CombineLatest();
+
+                var node = upstream
+                    .Take(1)
+                    .SelectMany(depResults =>
+                    {
+                        var ready = clock.Elapsed;
+                        var stopper = depResults.FirstOrDefault(d => !d.IsGreen);
+                        if (stopper is not null)
+                        {
+                            // Blocked at once, no slot: the verdict is derived, not earned.
+                            return Observable.Return(new NodeResult<T>(
+                                id, NodeOutcome.Blocked, default, stopper.Id, null,
+                                ready, ready, ready));
+                        }
+                        var ordered = depResults.ToArray();
+                        return Observable.Start(() =>
+                        {
+                            slots.Wait();
+                            var started = clock.Elapsed;
+                            try
+                            {
+                                var (result, green) = run(id, ordered);
+                                return new NodeResult<T>(
+                                    id, green ? NodeOutcome.Green : NodeOutcome.Red, result, null, null,
+                                    ready, started, clock.Elapsed);
+                            }
+                            catch (Exception ex)
+                            {
+                                return new NodeResult<T>(
+                                    id, NodeOutcome.Faulted, default, null,
+                                    $"{ex.GetType().Name}: {ex.Message}", ready, started, clock.Elapsed);
+                            }
+                            finally
+                            {
+                                slots.Release();
+                            }
+                        }, pool);
+                    })
+                    .PublishLast()
+                    .AutoConnect();
+                nodes[id] = node;
+                return node;
+            }
+
+            var all = idSet.OrderBy(i => i, StringComparer.Ordinal).Select(NodeOf).ToArray();
+            return all.Length == 0
+                ? Observable.Return(ImmutableArray<NodeResult<T>>.Empty)
+                : all.CombineLatest()
+                    .Take(1)
+                    .Select(results => results.OrderBy(r => r.Id, StringComparer.Ordinal).ToImmutableArray())
+                    .Finally(slots.Dispose);
+        });
+    }
+
+    /// <summary>
+    /// The longest chain of work in the results (by finish time of the last node on it) — the
+    /// wall-clock floor no amount of parallelism can beat. Returned leaf-first.
+    /// </summary>
+    public static ImmutableArray<string> CriticalPath<T>(
+        ImmutableArray<NodeResult<T>> results, Func<string, IReadOnlyList<string>> dependenciesOf)
+    {
+        if (results.IsEmpty)
+            return [];
+        var byId = results.ToDictionary(r => r.Id, StringComparer.Ordinal);
+        var last = results.MaxBy(r => r.Finished)!;
+        var path = new List<string>();
+        var current = last;
+        while (true)
+        {
+            path.Add(current.Id);
+            var deps = dependenciesOf(current.Id)
+                .Where(byId.ContainsKey)
+                .Select(d => byId[d])
+                .ToArray();
+            if (deps.Length == 0)
+                break;
+            // The dependency that finished last is the one this node waited for.
+            current = deps.MaxBy(d => d.Finished)!;
+        }
+        path.Reverse();
+        return [.. path];
+    }
+
+    private static string? FindCycle(
+        ImmutableHashSet<string> ids, Func<string, IReadOnlyList<string>> dependenciesOf)
+    {
+        var state = new Dictionary<string, int>(StringComparer.Ordinal); // 1 visiting, 2 done
+        var stack = new List<string>();
+        string? Visit(string id)
+        {
+            if (state.TryGetValue(id, out var s))
+            {
+                if (s != 1)
+                    return null;
+                var at = stack.IndexOf(id);
+                return string.Join(" → ", stack.Skip(at).Append(id));
+            }
+            state[id] = 1;
+            stack.Add(id);
+            foreach (var dep in dependenciesOf(id).Where(ids.Contains))
+            {
+                if (Visit(dep) is { } found)
+                    return found;
+            }
+            stack.RemoveAt(stack.Count - 1);
+            state[id] = 2;
+            return null;
+        }
+        foreach (var id in ids)
+        {
+            if (Visit(id) is { } found)
+                return found;
+        }
+        return null;
+    }
+}

--- a/tools/MeshWeaver.PluginTester/CascadeBuild.cs
+++ b/tools/MeshWeaver.PluginTester/CascadeBuild.cs
@@ -1,0 +1,557 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Compiler;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.NuGet;
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// <c>mw-plugin-test build &lt;repo-root&gt; [&lt;package&gt;… | all]</c> — the new build process
+/// for node repos (maintainer, 2026-08-30): <b>build always means compile AND run tests</b>, per
+/// package, over the package dependency network, as a reactive cascade, inside the container the
+/// platform build produced. Nothing here imports a node into a mesh. The sources are read from the
+/// checkout on disk, composed into Roslyn compilations exactly as the portal composes them
+/// (<see cref="NodeSetCompiler"/> — the same skeleton, the same options, the same
+/// <c>/app</c> reference set), and each package compiles against the assemblies its dependency
+/// packages just emitted.
+///
+/// <para><b>The cascade.</b> <see cref="Cascade"/> gives every package a result stream; a package
+/// subscribes to its dependencies' streams and starts the moment the last one completes green.
+/// Independent packages build in parallel up to <see cref="Options.MaxParallel"/>. A red package
+/// (compile error, failed test, load failure) stops there: every package that requires it is
+/// reported <c>blocked by &lt;it&gt;</c> and never starts — on red we break, on green we continue.</para>
+///
+/// <para><b>Selection.</b> Naming packages selects them AND their transitive requirements inside
+/// this repo, so a single package builds on freshly built dependencies rather than on nothing.
+/// <c>all</c> (the default) is the full rebuild — the platform-rebuild case, where every package
+/// must be re-proven against the new image.</para>
+///
+/// <para><b>Timings.</b> Every package carries ready/started/finished, the compile and test
+/// splits, and per-type compile times; the report prints them and the critical path — the chain
+/// of packages whose serial length is the wall-clock floor.</para>
+///
+/// <para><b>What the mesh lane still owns.</b> Test cases that take a host (a layout-area
+/// <c>Tests</c> aggregator, anything needing a hub) are counted and named as <c>needs-mesh</c>
+/// rather than run; the gate (<see cref="PluginGateRunner"/>) runs them, seeded from this build's
+/// <see cref="Options.OutputDirectory"/> so nothing is compiled twice. Reported, never hidden.</para>
+///
+/// <para><b>Parity flag.</b> The portal compiles a type against the framework and its modules and
+/// reaches other packages' types by <c>shared=</c> source inclusion — never by referencing their
+/// emitted assemblies. This build references them (the maintainer's instruction: use the
+/// references the dependency packages produce). A type whose emitted assembly turns out to BIND a
+/// dependency package's assembly is therefore green here on grounds the portal does not have, and
+/// the report marks it <c>binds-dependency-assembly</c> so that difference is visible rather than
+/// discovered as a CompileError in production.</para>
+/// </summary>
+public static class CascadeBuild
+{
+    /// <summary>The CLI verb.</summary>
+    public const string Verb = "build";
+
+    /// <summary>The <c>all</c> selector.</summary>
+    public const string AllSelector = "all";
+
+    /// <summary>Options for one cascade build.</summary>
+    public sealed record Options
+    {
+        /// <summary>The checkout root holding the node-repo packages.</summary>
+        public required string RepoRoot { get; init; }
+
+        /// <summary>The packages to build; empty or <c>all</c> means every package.</summary>
+        public IReadOnlyList<string> Packages { get; init; } = [];
+
+        /// <summary>External module assemblies composed into the reference set (<c>--module</c>).</summary>
+        public IReadOnlyList<string> ModuleAssemblyPaths { get; init; } = [];
+
+        /// <summary>Where per-package prebuilt bundles are written; null keeps the build verdict-only.</summary>
+        public string? OutputDirectory { get; init; }
+
+        /// <summary>Where the JSON report is written; null prints only the table.</summary>
+        public string? ReportPath { get; init; }
+
+        /// <summary>Concurrency cap for package work (compile + tests).</summary>
+        public int MaxParallel { get; init; } = Math.Max(1, Environment.ProcessorCount);
+
+        /// <summary>Hard cap per test case.</summary>
+        public TimeSpan CaseTimeout { get; init; } = TimeSpan.FromSeconds(60);
+
+        /// <summary>False compiles only — for a type-check lane; the default builds tests too.</summary>
+        public bool RunTests { get; init; } = true;
+
+        /// <summary>The source commit recorded in the bundles; defaults to the snapshot's.</summary>
+        public string? SourceSha { get; init; }
+
+        /// <summary>Where progress lines go.</summary>
+        public TextWriter Output { get; init; } = Console.Out;
+
+        /// <summary>Compiler logging.</summary>
+        public ILogger Logger { get; init; } = NullLogger.Instance;
+
+        /// <summary>Logger factory for the NuGet resolver.</summary>
+        public ILoggerFactory? LoggerFactory { get; init; }
+    }
+
+    /// <summary>One NodeType's build inside a package.</summary>
+    public sealed record TypeBuild(
+        string NodePath,
+        string Package,
+        string? CompileError,
+        TimeSpan CompileTime,
+        int SourceCount,
+        string? DllPath,
+        StaticTestRunner.Run? Tests,
+        ImmutableArray<string> BindsDependencyAssemblies)
+    {
+        /// <summary>Compiled and every test that ran passed.</summary>
+        public bool IsGreen => CompileError is null && (Tests is null || Tests.IsGreen);
+    }
+
+    /// <summary>One package's build: its types, what it emitted, and the two time splits.</summary>
+    public sealed record PackageBuild(
+        string Id,
+        ImmutableArray<TypeBuild> Types,
+        ImmutableArray<string> EmittedAssemblies,
+        TimeSpan Compile,
+        TimeSpan Tests,
+        ImmutableArray<string> ExternalRequirements)
+    {
+        /// <summary>Every type compiled and tested green.</summary>
+        public bool IsGreen => Types.All(t => t.IsGreen);
+
+        /// <summary>Cases that ran and passed, across the package.</summary>
+        public int TestsPassed => Types.Sum(t => t.Tests?.Passed ?? 0);
+
+        /// <summary>Cases that ran and failed.</summary>
+        public int TestsFailed => Types.Sum(t => t.Tests?.Failed ?? 0);
+
+        /// <summary>Cases left to the mesh lane.</summary>
+        public int TestsNeedMesh => Types.Sum(t => t.Tests?.NeedsMesh ?? 0);
+    }
+
+    /// <summary>The whole build.</summary>
+    public sealed record Report(
+        string FrameworkIdentity,
+        ImmutableArray<Cascade.NodeResult<PackageBuild>> Packages,
+        ImmutableArray<string> CriticalPath,
+        TimeSpan Wall,
+        ImmutableArray<string> Bundles,
+        string? FatalError = null)
+    {
+        /// <summary>0 green, 1 any red or blocked, 70 fatal.</summary>
+        public int ExitCode =>
+            FatalError is not null ? 70
+            : Packages.All(p => p.IsGreen) ? 0
+            : 1;
+    }
+
+    /// <summary>Runs the build and returns the report; the exit code is <see cref="Report.ExitCode"/>.</summary>
+    public static Report Run(Options options)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        var wall = Stopwatch.StartNew();
+        var frameworkIdentity = PrebuiltAssemblySeeder.LiveFrameworkMvid;
+        if (PrebuiltAssemblySeeder.LiveFrameworkIdentityWarning is { } warning)
+            options.Output.WriteLine($"build: ⚠ framework identity degraded — {warning}");
+
+        RepoSnapshot snapshot;
+        IReadOnlyList<PackageManifest> packages;
+        try
+        {
+            snapshot = LocalNodeRepo.LoadSync(options.RepoRoot);
+            packages = LocalNodeRepo.DiscoverPackages(snapshot).Wait();
+        }
+        catch (Exception ex)
+        {
+            return Fatal(frameworkIdentity, wall, $"{ex.GetType().Name}: {ex.Message}");
+        }
+        if (packages.Count == 0)
+            return Fatal(frameworkIdentity, wall,
+                $"No node-repo packages (top-level folders with an index.json root) found under "
+                + $"'{Path.GetFullPath(options.RepoRoot)}'.");
+
+        var byId = packages.ToDictionary(p => p.Id, StringComparer.Ordinal);
+        var selection = Select(options.Packages, byId, out var unknown);
+        if (unknown.Length > 0)
+            return Fatal(frameworkIdentity, wall,
+                $"unknown package(s): {string.Join(", ", unknown)} — known: "
+                + string.Join(", ", packages.Select(p => p.Id)));
+
+        var skipped = new List<string>();
+        var treeNodes = TreeNodeLoader.Load(
+            snapshot, packages, (path, reason) => skipped.Add($"{path}: {reason}"));
+        foreach (var skip in skipped)
+            options.Output.WriteLine($"build: skipped (not a materialisable node) {skip}");
+        var nodeSet = NodeSet.Create(treeNodes.Select(t => t.Node));
+        var typesByPackage = treeNodes
+            .Where(t => t.Node.Content is NodeTypeDefinition)
+            .GroupBy(t => t.Package, StringComparer.Ordinal)
+            .ToDictionary(g => g.Key, g => g.OrderBy(t => t.Node.Path, StringComparer.Ordinal).ToArray(), StringComparer.Ordinal);
+
+        IReadOnlyList<InstalledModuleAssembly> modules;
+        try
+        {
+            modules = TreeBake.LoadExternalModules(new TreeBake.Options
+            {
+                RepoRoot = options.RepoRoot,
+                OutputDirectory = options.OutputDirectory ?? Path.GetTempPath(),
+                ModuleAssemblyPaths = options.ModuleAssemblyPaths,
+                Output = options.Output,
+            });
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Fatal(frameworkIdentity, wall, ex.Message);
+        }
+        var idOf = CompiledDependencies.CreateIdResolver(
+            FrameworkBuildIdentity.ProcessSurfacePairs,
+            TreeBake.ModuleMvidsOf(modules),
+            FrameworkBuildIdentity.ProcessImplMvidOf);
+        var toolchainId = CompiledDependencies.ComputeToolchainId(FrameworkBuildIdentity.ProcessImplMvidOf);
+        var baseReferences = CompileReferences.ComposeWithModules(modules);
+        var nugetResolver = new NuGetAssemblyResolver(
+            options.LoggerFactory?.CreateLogger<NuGetAssemblyResolver>()
+            ?? NullLogger<NuGetAssemblyResolver>.Instance);
+        var workDirectory = Path.Combine(
+            Path.GetTempPath(), $"mw-cascade-build-{Environment.ProcessId}-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(workDirectory);
+
+        IReadOnlyList<string> DependenciesOf(string id) =>
+            byId.TryGetValue(id, out var m)
+                ? m.Requires.Select(PackageDependencyGraph.DependencyId).Where(d => d.Length > 0).ToArray()
+                : [];
+
+        options.Output.WriteLine(
+            $"build: {selection.Length} of {packages.Count} package(s) selected "
+            + $"({(options.Packages.Count == 0 || options.Packages.Contains(AllSelector) ? "all — full rebuild" : string.Join(", ", options.Packages))}), "
+            + $"{treeNodes.Length} node(s), max-parallel={options.MaxParallel}, tests={(options.RunTests ? "on" : "off")}, "
+            + $"framework={frameworkIdentity}");
+
+        var entriesByPackage = new Dictionary<string, List<BundleWriter.AssemblyEntry>>(StringComparer.Ordinal);
+        var entriesLock = new object();
+
+        ImmutableArray<Cascade.NodeResult<PackageBuild>> results;
+        try
+        {
+            results = Cascade.Run<PackageBuild>(
+                selection,
+                DependenciesOf,
+                (id, deps) =>
+                {
+                    var build = BuildPackage(
+                        options, id, typesByPackage.TryGetValue(id, out var types) ? types : [],
+                        deps, byId, nodeSet, baseReferences, idOf, toolchainId, workDirectory, nugetResolver,
+                        entriesByPackage, entriesLock);
+                    return (build, build.IsGreen);
+                },
+                options.MaxParallel).Wait();
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Fatal(frameworkIdentity, wall, ex.Message);
+        }
+
+        var bundles = ImmutableArray<string>.Empty;
+        if (options.OutputDirectory is { } outDir)
+        {
+            bundles = TreeBake.WriteBundles(
+                new TreeBake.Options
+                {
+                    RepoRoot = options.RepoRoot,
+                    OutputDirectory = outDir,
+                    SourceSha = options.SourceSha,
+                    Output = options.Output,
+                },
+                packages, snapshot, frameworkIdentity, entriesByPackage);
+        }
+
+        try
+        {
+            if (options.OutputDirectory is null && Directory.Exists(workDirectory))
+                Directory.Delete(workDirectory, recursive: true);
+        }
+        catch (IOException)
+        {
+        }
+
+        var report = new Report(
+            frameworkIdentity, results, Cascade.CriticalPath(results, DependenciesOf), wall.Elapsed, bundles);
+        Print(options.Output, report, DependenciesOf);
+        if (options.ReportPath is { } reportPath)
+            WriteJson(reportPath, report);
+        return report;
+    }
+
+    /// <summary>
+    /// The requested ids plus their transitive requirements inside the repo. External
+    /// requirements (a package this repo does not hold) are not an error here — they are named on
+    /// the package that needs them and satisfied by <c>--module</c> or by the image itself.
+    /// </summary>
+    internal static ImmutableArray<string> Select(
+        IReadOnlyList<string> requested, IReadOnlyDictionary<string, PackageManifest> byId,
+        out ImmutableArray<string> unknown)
+    {
+        if (requested.Count == 0 || requested.Any(r => string.Equals(r, AllSelector, StringComparison.OrdinalIgnoreCase)))
+        {
+            unknown = [];
+            return [.. byId.Keys.OrderBy(k => k, StringComparer.Ordinal)];
+        }
+        unknown = [.. requested.Where(r => !byId.ContainsKey(r)).Distinct(StringComparer.Ordinal)];
+        var selected = new HashSet<string>(StringComparer.Ordinal);
+        var stack = new Stack<string>(requested.Where(byId.ContainsKey));
+        while (stack.Count > 0)
+        {
+            var id = stack.Pop();
+            if (!selected.Add(id))
+                continue;
+            foreach (var dep in byId[id].Requires.Select(PackageDependencyGraph.DependencyId))
+            {
+                if (dep.Length > 0 && byId.ContainsKey(dep))
+                    stack.Push(dep);
+            }
+        }
+        return [.. selected.OrderBy(k => k, StringComparer.Ordinal)];
+    }
+
+    private static PackageBuild BuildPackage(
+        Options options,
+        string id,
+        TreeNodeLoader.TreeNode[] types,
+        IReadOnlyList<Cascade.NodeResult<PackageBuild>> deps,
+        IReadOnlyDictionary<string, PackageManifest> byId,
+        NodeSet nodeSet,
+        IReadOnlyList<MetadataReference> baseReferences,
+        Func<string, string?> idOf,
+        string toolchainId,
+        string workDirectory,
+        INuGetAssemblyResolver nugetResolver,
+        Dictionary<string, List<BundleWriter.AssemblyEntry>> entriesByPackage,
+        object entriesLock)
+    {
+        var external = byId[id].Requires
+            .Select(PackageDependencyGraph.DependencyId)
+            .Where(d => d.Length > 0 && !byId.ContainsKey(d))
+            .ToImmutableArray();
+        var dependencyAssemblies = deps
+            .Where(d => d.Result is not null)
+            .SelectMany(d => d.Result!.EmittedAssemblies)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+        var dependencyNames = dependencyAssemblies
+            .Select(p => Path.GetFileNameWithoutExtension(p))
+            .ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+        var references = dependencyAssemblies.Length == 0
+            ? baseReferences
+            : baseReferences.Concat(dependencyAssemblies.Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))).ToArray();
+
+        options.Output.WriteLine(
+            $"[{id}] start — {types.Length} type(s), depends on "
+            + (deps.Count == 0 ? "nothing" : string.Join(", ", deps.Select(d => d.Id)))
+            + (external.Length == 0 ? "" : $" (+ external: {string.Join(", ", external)})"));
+
+        var compileClock = Stopwatch.StartNew();
+        var testClock = new Stopwatch();
+        var built = ImmutableArray.CreateBuilder<TypeBuild>();
+        var emitted = ImmutableArray.CreateBuilder<string>();
+        var packageDir = Path.Combine(workDirectory, CodeConventions.SanitizeNodeName(id));
+
+        foreach (var candidate in types)
+        {
+            var definition = (NodeTypeDefinition)candidate.Node.Content!;
+            var resolution = nodeSet.ResolveSources(definition.Sources, definition.Tests, candidate.Node.Path);
+            if (resolution.IsEstablished
+                && resolution.Sources.IsEmpty
+                && string.IsNullOrWhiteSpace(definition.Configuration))
+                continue;
+
+            var typeClock = Stopwatch.StartNew();
+            NodeSetCompiler.CompiledNode compiled;
+            try
+            {
+                compiled = NodeSetCompiler.Compile(
+                    nodeSet, candidate.Node, definition.Sources, definition.Tests,
+                    definition.Configuration, definition.ContentCollections,
+                    references, idOf, toolchainId,
+                    Path.Combine(packageDir, CodeConventions.SanitizeNodeName(candidate.Node.Path)),
+                    resolveNuGet: (refs, ct) => nugetResolver
+                        .ResolveAsync(refs, targetFramework: null, ct)
+                        .GetAwaiter().GetResult()
+                        .AssemblyPaths,
+                    logger: options.Logger);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                typeClock.Stop();
+                built.Add(new TypeBuild(
+                    candidate.Node.Path, id, $"{ex.GetType().Name}: {ex.Message}", typeClock.Elapsed,
+                    resolution.Sources.Length, null, null, []));
+                options.Output.WriteLine($"[{id}]   RED {candidate.Node.Path} ({typeClock.Elapsed.TotalMilliseconds:F0} ms)");
+                options.Output.WriteLine(ex.Message);
+                continue;
+            }
+            typeClock.Stop();
+            emitted.Add(compiled.DllPath);
+
+            var binds = compiled.Dependencies.Keys
+                .Where(dependencyNames.Contains)
+                .OrderBy(k => k, StringComparer.Ordinal)
+                .ToImmutableArray();
+
+            var sourceVersions = resolution.Sources
+                .Select(n => n.Path)
+                .ToImmutableSortedDictionary(p => p, _ => 0L, StringComparer.Ordinal);
+            lock (entriesLock)
+            {
+                if (!entriesByPackage.TryGetValue(id, out var entries))
+                    entriesByPackage[id] = entries = [];
+                entries.Add(new BundleWriter.AssemblyEntry(
+                    compiled.NodePath,
+                    () => File.OpenRead(compiled.DllPath),
+                    compiled.PdbPath is null ? null : () => File.OpenRead(compiled.PdbPath),
+                    sourceVersions,
+                    compiled.Dependencies));
+            }
+
+            StaticTestRunner.Run? tests = null;
+            if (options.RunTests && definition.Tests is { Count: > 0 })
+            {
+                testClock.Start();
+                tests = StaticTestRunner.Execute(
+                    compiled.DllPath, [.. dependencyAssemblies, .. emitted], options.CaseTimeout, options.Output);
+                testClock.Stop();
+            }
+
+            built.Add(new TypeBuild(
+                compiled.NodePath, id, null, typeClock.Elapsed, compiled.Inputs.MatchedSourcePaths.Length,
+                compiled.DllPath, tests, binds));
+            options.Output.WriteLine(
+                $"[{id}]   ok  {compiled.NodePath} ({typeClock.Elapsed.TotalMilliseconds:F0} ms, "
+                + $"{compiled.Inputs.MatchedSourcePaths.Length} source(s))"
+                + (tests is null ? "" : $" tests: {tests.Passed} passed, {tests.Failed} failed, {tests.NeedsMesh} needs-mesh")
+                + (binds.IsEmpty ? "" : $" binds-dependency-assembly: {string.Join(", ", binds)}"));
+        }
+        compileClock.Stop();
+
+        var result = new PackageBuild(
+            id, built.ToImmutable(), emitted.ToImmutable(),
+            compileClock.Elapsed - testClock.Elapsed, testClock.Elapsed, external);
+        options.Output.WriteLine(
+            $"[{id}] {(result.IsGreen ? "GREEN" : "RED")} — compile {result.Compile.TotalSeconds:F1}s, "
+            + $"tests {result.Tests.TotalSeconds:F1}s ({result.TestsPassed} passed, {result.TestsFailed} failed, "
+            + $"{result.TestsNeedMesh} needs-mesh)");
+        return result;
+    }
+
+    private static Report Fatal(string frameworkIdentity, Stopwatch wall, string error) =>
+        new(frameworkIdentity, [], [], wall.Elapsed, [], error);
+
+    private static void Print(
+        TextWriter output, Report report, Func<string, IReadOnlyList<string>> dependenciesOf)
+    {
+        output.WriteLine();
+        if (report.FatalError is not null)
+        {
+            output.WriteLine($"FATAL: {report.FatalError}");
+            return;
+        }
+        output.WriteLine("package                        verdict   ready    queued    work   compile   tests   types  passed failed mesh  note");
+        foreach (var p in report.Packages.OrderBy(p => p.Finished))
+        {
+            var b = p.Result;
+            var note = p.Outcome switch
+            {
+                Cascade.NodeOutcome.Blocked => $"blocked by {p.BlockedBy}",
+                Cascade.NodeOutcome.Faulted => p.Error ?? "faulted",
+                Cascade.NodeOutcome.Red when b is not null => string.Join("; ",
+                    b.Types.Where(t => !t.IsGreen).Select(t =>
+                        t.CompileError is not null ? $"{t.NodePath}: compile" : $"{t.NodePath}: {t.Tests?.Failed} failed")),
+                _ => b is not null && b.Types.Any(t => !t.BindsDependencyAssemblies.IsEmpty)
+                    ? "binds-dependency-assembly"
+                    : "",
+            };
+            output.WriteLine(
+                $"{p.Id,-30} {Verdict(p.Outcome),-8} {p.Ready.TotalSeconds,7:F1} {p.Queued.TotalSeconds,8:F1} "
+                + $"{p.Work.TotalSeconds,7:F1} {(b?.Compile.TotalSeconds ?? 0),8:F1} {(b?.Tests.TotalSeconds ?? 0),7:F1} "
+                + $"{(b?.Types.Length ?? 0),6} {(b?.TestsPassed ?? 0),6} {(b?.TestsFailed ?? 0),6} {(b?.TestsNeedMesh ?? 0),4}  {note}");
+        }
+        output.WriteLine();
+        var green = report.Packages.Count(p => p.IsGreen);
+        var red = report.Packages.Count(p => p.Outcome is Cascade.NodeOutcome.Red or Cascade.NodeOutcome.Faulted);
+        var blocked = report.Packages.Count(p => p.Outcome == Cascade.NodeOutcome.Blocked);
+        output.WriteLine(
+            $"build: {green} green, {red} red, {blocked} blocked of {report.Packages.Length} in {report.Wall.TotalSeconds:F1}s wall; "
+            + $"critical path ({report.CriticalPath.Length}): {string.Join(" → ", report.CriticalPath)}"
+            + (report.Bundles.IsEmpty ? "" : $"; {report.Bundles.Length} bundle(s) written"));
+        var serial = report.Packages.Sum(p => p.Work.TotalSeconds);
+        if (serial > 0)
+            output.WriteLine($"build: {serial:F1}s of work in {report.Wall.TotalSeconds:F1}s wall — parallel speed-up {serial / Math.Max(0.001, report.Wall.TotalSeconds):F1}×");
+    }
+
+    private static string Verdict(Cascade.NodeOutcome outcome) => outcome switch
+    {
+        Cascade.NodeOutcome.Green => "green",
+        Cascade.NodeOutcome.Red => "RED",
+        Cascade.NodeOutcome.Blocked => "blocked",
+        _ => "FAULT",
+    };
+
+    private static void WriteJson(string path, Report report)
+    {
+        var dir = Path.GetDirectoryName(Path.GetFullPath(path));
+        if (!string.IsNullOrEmpty(dir))
+            Directory.CreateDirectory(dir);
+        var shape = new
+        {
+            framework = report.FrameworkIdentity,
+            wallSeconds = report.Wall.TotalSeconds,
+            exitCode = report.ExitCode,
+            criticalPath = report.CriticalPath,
+            fatal = report.FatalError,
+            packages = report.Packages.Select(p => new
+            {
+                id = p.Id,
+                outcome = p.Outcome.ToString(),
+                blockedBy = p.BlockedBy,
+                error = p.Error,
+                readySeconds = p.Ready.TotalSeconds,
+                startedSeconds = p.Started.TotalSeconds,
+                finishedSeconds = p.Finished.TotalSeconds,
+                compileSeconds = p.Result?.Compile.TotalSeconds,
+                testSeconds = p.Result?.Tests.TotalSeconds,
+                external = p.Result?.ExternalRequirements,
+                types = p.Result?.Types.Select(t => new
+                {
+                    path = t.NodePath,
+                    compileMs = t.CompileTime.TotalMilliseconds,
+                    sources = t.SourceCount,
+                    compileError = t.CompileError,
+                    bindsDependencyAssemblies = t.BindsDependencyAssemblies,
+                    tests = t.Tests is null ? null : new
+                    {
+                        loadError = t.Tests.LoadError,
+                        passed = t.Tests.Passed,
+                        failed = t.Tests.Failed,
+                        needsMesh = t.Tests.NeedsMesh,
+                        cases = t.Tests.Cases.Select(c => new
+                        {
+                            name = c.Name,
+                            outcome = c.Outcome.ToString(),
+                            ms = c.Elapsed.TotalMilliseconds,
+                            error = c.Error,
+                        }),
+                    },
+                }),
+            }),
+        };
+        File.WriteAllText(path, JsonSerializer.Serialize(shape, new JsonSerializerOptions { WriteIndented = true }));
+    }
+}

--- a/tools/MeshWeaver.PluginTester/CascadeBuild.cs
+++ b/tools/MeshWeaver.PluginTester/CascadeBuild.cs
@@ -154,37 +154,60 @@ public static class CascadeBuild
             : 1;
     }
 
-    /// <summary>Runs the build and returns the report; the exit code is <see cref="Report.ExitCode"/>.</summary>
-    public static Report Run(Options options)
+    /// <summary>
+    /// Every progress line starts with the UTC time and the managed thread — packages build in
+    /// parallel, so a reader must be able to tell whose line this is (maintainer, 2026-08-30:
+    /// "output the time and which package … and for multithreaded also some thread id").
+    /// </summary>
+    private static string Stamp() =>
+        $"{DateTime.UtcNow:HH:mm:ss.fff} [T{Environment.CurrentManagedThreadId:D3}]";
+
+    /// <summary>Runs the build and emits the report once; the exit code is <see cref="Report.ExitCode"/>.</summary>
+    public static IObservable<Report> Run(Options options)
     {
         ArgumentNullException.ThrowIfNull(options);
+        return Observable.Defer(() => RunCore(options))
+            .Catch((Exception ex) => Observable.Return(
+                new Report(PrebuiltAssemblySeeder.LiveFrameworkMvid, [], [], TimeSpan.Zero, [],
+                    $"{ex.GetType().Name}: {ex.Message}")));
+    }
+
+    private static IObservable<Report> RunCore(Options options)
+    {
         var wall = Stopwatch.StartNew();
         var frameworkIdentity = PrebuiltAssemblySeeder.LiveFrameworkMvid;
         if (PrebuiltAssemblySeeder.LiveFrameworkIdentityWarning is { } warning)
             options.Output.WriteLine($"build: ⚠ framework identity degraded — {warning}");
 
         RepoSnapshot snapshot;
-        IReadOnlyList<PackageManifest> packages;
         try
         {
             snapshot = LocalNodeRepo.LoadSync(options.RepoRoot);
-            packages = LocalNodeRepo.DiscoverPackages(snapshot).Wait();
         }
         catch (Exception ex)
         {
-            return Fatal(frameworkIdentity, wall, $"{ex.GetType().Name}: {ex.Message}");
+            return Observable.Return(Fatal(frameworkIdentity, wall, $"{ex.GetType().Name}: {ex.Message}"));
         }
+        return LocalNodeRepo.DiscoverPackages(snapshot)
+            .Take(1)
+            .SelectMany(packages => Build(options, wall, frameworkIdentity, snapshot, packages));
+    }
+
+    private static IObservable<Report> Build(
+        Options options, Stopwatch wall, string frameworkIdentity, RepoSnapshot snapshot,
+        IReadOnlyList<PackageManifest> packages)
+    {
         if (packages.Count == 0)
-            return Fatal(frameworkIdentity, wall,
+            return Observable.Return(Fatal(frameworkIdentity, wall,
                 $"No node-repo packages (top-level folders with an index.json root) found under "
-                + $"'{Path.GetFullPath(options.RepoRoot)}'.");
+                + $"'{Path.GetFullPath(options.RepoRoot)}'."));
 
         var byId = packages.ToDictionary(p => p.Id, StringComparer.Ordinal);
         var selection = Select(options.Packages, byId, out var unknown);
         if (unknown.Length > 0)
-            return Fatal(frameworkIdentity, wall,
+            return Observable.Return(Fatal(frameworkIdentity, wall,
                 $"unknown package(s): {string.Join(", ", unknown)} — known: "
-                + string.Join(", ", packages.Select(p => p.Id)));
+                + string.Join(", ", packages.Select(p => p.Id))));
 
         var skipped = new List<string>();
         var treeNodes = TreeNodeLoader.Load(
@@ -210,7 +233,7 @@ public static class CascadeBuild
         }
         catch (InvalidOperationException ex)
         {
-            return Fatal(frameworkIdentity, wall, ex.Message);
+            return Observable.Return(Fatal(frameworkIdentity, wall, ex.Message));
         }
         var idOf = CompiledDependencies.CreateIdResolver(
             FrameworkBuildIdentity.ProcessSurfacePairs,
@@ -231,7 +254,7 @@ public static class CascadeBuild
                 : [];
 
         options.Output.WriteLine(
-            $"build: {selection.Length} of {packages.Count} package(s) selected "
+            $"{Stamp()} build: {selection.Length} of {packages.Count} package(s) selected "
             + $"({(options.Packages.Count == 0 || options.Packages.Contains(AllSelector) ? "all — full rebuild" : string.Join(", ", options.Packages))}), "
             + $"{treeNodes.Length} node(s), max-parallel={options.MaxParallel}, tests={(options.RunTests ? "on" : "off")}, "
             + $"framework={frameworkIdentity}");
@@ -239,10 +262,7 @@ public static class CascadeBuild
         var entriesByPackage = new Dictionary<string, List<BundleWriter.AssemblyEntry>>(StringComparer.Ordinal);
         var entriesLock = new object();
 
-        ImmutableArray<Cascade.NodeResult<PackageBuild>> results;
-        try
-        {
-            results = Cascade.Run<PackageBuild>(
+        return Cascade.Run<PackageBuild>(
                 selection,
                 DependenciesOf,
                 (id, deps) =>
@@ -253,13 +273,16 @@ public static class CascadeBuild
                         entriesByPackage, entriesLock);
                     return (build, build.IsGreen);
                 },
-                options.MaxParallel).Wait();
-        }
-        catch (InvalidOperationException ex)
-        {
-            return Fatal(frameworkIdentity, wall, ex.Message);
-        }
+                options.MaxParallel)
+            .Select(results => Finish(options, wall, frameworkIdentity, snapshot, packages, results, entriesByPackage, workDirectory, DependenciesOf));
+    }
 
+    private static Report Finish(
+        Options options, Stopwatch wall, string frameworkIdentity, RepoSnapshot snapshot,
+        IReadOnlyList<PackageManifest> packages, ImmutableArray<Cascade.NodeResult<PackageBuild>> results,
+        Dictionary<string, List<BundleWriter.AssemblyEntry>> entriesByPackage, string workDirectory,
+        Func<string, IReadOnlyList<string>> DependenciesOf)
+    {
         var bundles = ImmutableArray<string>.Empty;
         if (options.OutputDirectory is { } outDir)
         {
@@ -354,7 +377,7 @@ public static class CascadeBuild
             : baseReferences.Concat(dependencyAssemblies.Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))).ToArray();
 
         options.Output.WriteLine(
-            $"[{id}] start — {types.Length} type(s), depends on "
+            $"{Stamp()} [{id}] start — {types.Length} type(s), depends on "
             + (deps.Count == 0 ? "nothing" : string.Join(", ", deps.Select(d => d.Id)))
             + (external.Length == 0 ? "" : $" (+ external: {string.Join(", ", external)})"));
 
@@ -382,10 +405,7 @@ public static class CascadeBuild
                     definition.Configuration, definition.ContentCollections,
                     references, idOf, toolchainId,
                     Path.Combine(packageDir, CodeConventions.SanitizeNodeName(candidate.Node.Path)),
-                    resolveNuGet: (refs, ct) => nugetResolver
-                        .ResolveAsync(refs, targetFramework: null, ct)
-                        .GetAwaiter().GetResult()
-                        .AssemblyPaths,
+                    resolveNuGet: TreeBake.BlockingNuGetResolution(nugetResolver),
                     logger: options.Logger);
             }
             catch (Exception ex) when (ex is not OperationCanceledException)
@@ -394,7 +414,7 @@ public static class CascadeBuild
                 built.Add(new TypeBuild(
                     candidate.Node.Path, id, $"{ex.GetType().Name}: {ex.Message}", typeClock.Elapsed,
                     resolution.Sources.Length, null, null, []));
-                options.Output.WriteLine($"[{id}]   RED {candidate.Node.Path} ({typeClock.Elapsed.TotalMilliseconds:F0} ms)");
+                options.Output.WriteLine($"{Stamp()} [{id}]   RED {candidate.Node.Path} ({typeClock.Elapsed.TotalMilliseconds:F0} ms)");
                 options.Output.WriteLine(ex.Message);
                 continue;
             }
@@ -434,7 +454,7 @@ public static class CascadeBuild
                 compiled.NodePath, id, null, typeClock.Elapsed, compiled.Inputs.MatchedSourcePaths.Length,
                 compiled.DllPath, tests, binds));
             options.Output.WriteLine(
-                $"[{id}]   ok  {compiled.NodePath} ({typeClock.Elapsed.TotalMilliseconds:F0} ms, "
+                $"{Stamp()} [{id}]   ok  {compiled.NodePath} ({typeClock.Elapsed.TotalMilliseconds:F0} ms, "
                 + $"{compiled.Inputs.MatchedSourcePaths.Length} source(s))"
                 + (tests is null ? "" : $" tests: {tests.Passed} passed, {tests.Failed} failed, {tests.NeedsMesh} needs-mesh")
                 + (binds.IsEmpty ? "" : $" binds-dependency-assembly: {string.Join(", ", binds)}"));
@@ -445,7 +465,7 @@ public static class CascadeBuild
             id, built.ToImmutable(), emitted.ToImmutable(),
             compileClock.Elapsed - testClock.Elapsed, testClock.Elapsed, external);
         options.Output.WriteLine(
-            $"[{id}] {(result.IsGreen ? "GREEN" : "RED")} — compile {result.Compile.TotalSeconds:F1}s, "
+            $"{Stamp()} [{id}] {(result.IsGreen ? "GREEN" : "RED")} — compile {result.Compile.TotalSeconds:F1}s, "
             + $"tests {result.Tests.TotalSeconds:F1}s ({result.TestsPassed} passed, {result.TestsFailed} failed, "
             + $"{result.TestsNeedMesh} needs-mesh)");
         return result;

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -64,7 +64,7 @@ try
     if (args.Length > 0 && args[0] == "compile")
         return RunCompile(args[1..]);
     if (args.Length > 0 && args[0] == CascadeBuild.Verb)
-        return RunBuild(args[1..]);
+        return await RunBuild(args[1..]);
     if (args.Length > 0 && args[0] == "framework-identity")
         return RunFrameworkIdentity(args[1..]);
     return await RunGate(args);
@@ -75,7 +75,7 @@ catch (Exception ex)
     return 70; // EX_SOFTWARE: distinct from 0 (green), 1 (gate red) and 2 (bad usage).
 }
 
-static int RunBuild(string[] args)
+static async Task<int> RunBuild(string[] args)
 {
     // build <repo-root> [<package>… | all] [--module <dll>]… [--out <dir>] [--report <file>]
     //       [--max-parallel <n>] [--case-timeout <s>] [--no-tests] [--source-sha <sha>]
@@ -144,7 +144,7 @@ static int RunBuild(string[] args)
         Console.Error.WriteLine(BuildUsage());
         return 2;
     }
-    var report = CascadeBuild.Run(new CascadeBuild.Options
+    var report = await CascadeBuild.Run(new CascadeBuild.Options
     {
         RepoRoot = root,
         Packages = packages,
@@ -155,7 +155,7 @@ static int RunBuild(string[] args)
         CaseTimeout = caseTimeout,
         RunTests = runTests,
         SourceSha = sourceSha,
-    });
+    }).Await(CancellationToken.None);
     return report.ExitCode;
 }
 

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -63,6 +63,8 @@ try
 {
     if (args.Length > 0 && args[0] == "compile")
         return RunCompile(args[1..]);
+    if (args.Length > 0 && args[0] == CascadeBuild.Verb)
+        return RunBuild(args[1..]);
     if (args.Length > 0 && args[0] == "framework-identity")
         return RunFrameworkIdentity(args[1..]);
     return await RunGate(args);
@@ -72,6 +74,97 @@ catch (Exception ex)
     Console.Error.WriteLine($"mw-plugin-test: FATAL — {ex}");
     return 70; // EX_SOFTWARE: distinct from 0 (green), 1 (gate red) and 2 (bad usage).
 }
+
+static int RunBuild(string[] args)
+{
+    // build <repo-root> [<package>… | all] [--module <dll>]… [--out <dir>] [--report <file>]
+    //       [--max-parallel <n>] [--case-timeout <s>] [--no-tests] [--source-sha <sha>]
+    // The new build process (2026-08-30): compile + run tests per package, as a dependency
+    // cascade, from the checkout on disk, against this image's /app — no mesh import anywhere.
+    string? root = null;
+    var packages = new List<string>();
+    var modules = new List<string>();
+    string? outDir = null;
+    string? reportPath = null;
+    string? sourceSha = null;
+    var maxParallel = Math.Max(1, Environment.ProcessorCount);
+    var caseTimeout = TimeSpan.FromSeconds(60);
+    var runTests = true;
+    for (var i = 0; i < args.Length; i++)
+    {
+        switch (args[i])
+        {
+            case "--module" when i + 1 < args.Length:
+                modules.Add(args[++i]);
+                break;
+            case "--out" when i + 1 < args.Length:
+                outDir = args[++i];
+                break;
+            case "--report" when i + 1 < args.Length:
+                reportPath = args[++i];
+                break;
+            case "--source-sha" when i + 1 < args.Length:
+                sourceSha = args[++i];
+                break;
+            case "--max-parallel" when i + 1 < args.Length:
+                if (!int.TryParse(args[++i], NumberStyles.Integer, CultureInfo.InvariantCulture, out maxParallel) || maxParallel < 1)
+                {
+                    Console.Error.WriteLine("mw-plugin-test build: --max-parallel takes a positive integer");
+                    return 2;
+                }
+                break;
+            case "--case-timeout" when i + 1 < args.Length:
+                if (!double.TryParse(args[++i], NumberStyles.Float, CultureInfo.InvariantCulture, out var s) || s <= 0)
+                {
+                    Console.Error.WriteLine("mw-plugin-test build: --case-timeout takes seconds > 0");
+                    return 2;
+                }
+                caseTimeout = TimeSpan.FromSeconds(s);
+                break;
+            case "--no-tests":
+                runTests = false;
+                break;
+            case "-h" or "--help":
+                Console.WriteLine(BuildUsage());
+                return 0;
+            case var flag when flag.StartsWith("--", StringComparison.Ordinal):
+                Console.Error.WriteLine($"mw-plugin-test build: unknown option {flag}");
+                Console.Error.WriteLine(BuildUsage());
+                return 2;
+            default:
+                if (root is null)
+                    root = args[i];
+                else
+                    packages.Add(args[i]);
+                break;
+        }
+    }
+    if (root is null)
+    {
+        Console.Error.WriteLine(BuildUsage());
+        return 2;
+    }
+    var report = CascadeBuild.Run(new CascadeBuild.Options
+    {
+        RepoRoot = root,
+        Packages = packages,
+        ModuleAssemblyPaths = modules,
+        OutputDirectory = outDir,
+        ReportPath = reportPath,
+        MaxParallel = maxParallel,
+        CaseTimeout = caseTimeout,
+        RunTests = runTests,
+        SourceSha = sourceSha,
+    });
+    return report.ExitCode;
+}
+
+static string BuildUsage() =>
+    "usage: mw-plugin-test build <repo-root> [<package>... | all] [--module <dll>]... [--out <dir>] "
+    + "[--report <file>] [--max-parallel <n>] [--case-timeout <s>] [--no-tests] [--source-sha <sha>]\n"
+    + "  Compiles AND tests each selected package (plus its in-repo requirements) as a dependency "
+    + "cascade: a package starts when its dependencies are green, is blocked when one is red. "
+    + "'all' (default) rebuilds everything. Sources are read from disk; nothing is imported into a mesh.";
 
 static int RunCompile(string[] args)
 {
@@ -447,7 +540,7 @@ static async Task<int> RunGate(string[] args)
             }
             case "--help" or "-h":
                 Console.WriteLine(
-                    "usage: mw-plugin-test <repo-root> [--compile-timeout <s>] [--render-timeout <s>] "
+                    "usage: mw-plugin-test build <repo-root> [<package>... | all] ...   (see build --help)\n       mw-plugin-test <repo-root> [--compile-timeout <s>] [--render-timeout <s>] "
                     + "[--allow <file>] [--report <file>] [--seed <dir>] [--bake-output <dir>] "
                     + "[--source-sha <sha>] [--module <dll>]... [--print-framework-identity]");
                 return 0;

--- a/tools/MeshWeaver.PluginTester/README.md
+++ b/tools/MeshWeaver.PluginTester/README.md
@@ -20,7 +20,47 @@ mw-compiler compile <root> --output <dir>   # BAKE: build-step compile, NO mesh 
 mw-compiler <checkout-root>                 # GATE: mesh run — render + Tests areas
 mw-compiler <root> --bake-output <dir>      # legacy: the gate's mesh ALSO produces the bundles
 mw-compiler --print-framework-identity      # one-line identity + provenance diagnostic
+mw-compiler build <root> [<pkg>...|all]     # BUILD: compile + test per package, dependency cascade
 ```
+
+## `build` — compile AND test, per package, as a dependency cascade (2026-08-30)
+
+`build` is the build process for node repos. **Build always means compile and run tests.** The
+input is one or many packages, or `all` (the default) for the full rebuild a platform rebuild
+needs; the selection is the named packages plus their transitive `requires` inside the repo.
+
+```
+mw-compiler build <repo-root> [<package>... | all] [--module <dll>]... [--out <dir>] \
+    [--report <file>] [--max-parallel <n>] [--case-timeout <s>] [--no-tests] [--source-sha <sha>]
+```
+
+- **A cascade, not a schedule.** Every package has a result stream; a package OBSERVES the
+  streams of the packages it requires and starts itself the moment the last one completes green.
+  Packages with no edge between them build at the same time (bounded by `--max-parallel`).
+  **On red we break**: a package whose dependency did not end green never starts and is reported
+  `blocked by <dependency>`; **on green we continue**. A failure is reported once, where it
+  happened. A cycle is refused up front and named.
+- **No mesh, no import.** Sources come from the checkout on disk (the same node loader as
+  `compile`), composed exactly as the portal composes a NodeType compile (`NodeSetCompiler`: the
+  same skeleton, the same options, this image's `/app` as the reference set) — and each package
+  compiles against the assemblies its dependency packages just emitted. Grains cannot carry a
+  Roslyn workload; a build process can.
+- **Tests without a mesh.** The `Test/*.cs` convention — static classes whose public static
+  parameterless methods throw on failure — runs straight from the emitted assembly in a
+  collectible load context, each case timed and capped by `--case-timeout`. A case that takes a
+  host (a `Tests` layout-area aggregator, anything needing a hub) is COUNTED and NAMED as
+  `needs-mesh`, never dropped: the gate (`mw-compiler <root> --seed <out>`) still runs those,
+  seeded from `--out` so nothing is compiled twice.
+- **Timings are the point.** Every package reports ready / queued / work, its compile and test
+  splits and per-type compile times; the summary prints the critical path (the chain whose serial
+  length is the wall-clock floor) and the parallel speed-up. `--report` writes all of it as JSON.
+- **Parity flag.** The portal reaches other packages' types by `shared=` source inclusion, never
+  by referencing their emitted assemblies. A type whose emitted assembly turns out to BIND a
+  dependency package's assembly is therefore green here on grounds the portal does not have; the
+  report marks it `binds-dependency-assembly` so that difference is visible, not discovered as a
+  CompileError in production.
+
+Exit codes: `0` every selected package green · `1` any red or blocked · `2` usage · `70` fatal.
 
 ## `compile` — the bake, as a build step
 

--- a/tools/MeshWeaver.PluginTester/StaticTestRunner.cs
+++ b/tools/MeshWeaver.PluginTester/StaticTestRunner.cs
@@ -1,0 +1,238 @@
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.Loader;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// Executes a compiled NodeType's in-mesh tests WITHOUT a mesh: the <c>Test/*.cs</c> convention is
+/// static classes whose public static parameterless methods throw on failure (that is what a
+/// <c>Tests</c> layout area's case table wraps), so the assembly the build just emitted can be
+/// loaded into a collectible context and those methods invoked directly, each one timed.
+///
+/// <para><b>What this runs and what it reports as not-run.</b> A case that needs a host — a method
+/// with parameters (<c>LayoutAreaHost</c>, a hub) — cannot execute here; it is COUNTED as
+/// <see cref="Outcome.NeedsMesh"/> and named, never silently dropped, so the report says exactly
+/// how much of a type's suite the mesh lane still owns. That is the honest split the maintainer
+/// set on 2026-08-30: compile and pure tests off the mesh ("grains cannot handle compile
+/// workload"; "do not try to import mesh nodes"), the hosted cases through the gate that seeds
+/// from this build's output.</para>
+///
+/// <para><b>Resolution.</b> The emitted assembly binds the framework (already in this process —
+/// the tester's own closure is the image's <c>/app</c>) and the dependency packages' emitted
+/// assemblies, which are mapped by simple name into the context. Anything else is a missing
+/// dependency and surfaces as the load failure it is.</para>
+/// </summary>
+public static class StaticTestRunner
+{
+    /// <summary>What happened to one case.</summary>
+    public enum Outcome
+    {
+        /// <summary>Ran and returned.</summary>
+        Passed,
+        /// <summary>Ran and threw.</summary>
+        Failed,
+        /// <summary>Needs a host or hub — left to the mesh lane.</summary>
+        NeedsMesh,
+    }
+
+    /// <summary>One executed (or classified) case.</summary>
+    /// <param name="Name"><c>Type.Method</c>.</param>
+    /// <param name="Outcome">The verdict.</param>
+    /// <param name="Elapsed">Wall time of the invocation (zero when not run).</param>
+    /// <param name="Error">The failure text, innermost exception first.</param>
+    public sealed record Case(string Name, Outcome Outcome, TimeSpan Elapsed, string? Error);
+
+    /// <summary>The run over one assembly.</summary>
+    /// <param name="Assembly">The assembly path.</param>
+    /// <param name="Cases">Every case found, in discovery order.</param>
+    /// <param name="LoadError">Set when the assembly could not be loaded at all — no cases then.</param>
+    public sealed record Run(string Assembly, ImmutableArray<Case> Cases, string? LoadError)
+    {
+        /// <summary>Cases that ran and passed.</summary>
+        public int Passed => Cases.Count(c => c.Outcome == Outcome.Passed);
+
+        /// <summary>Cases that ran and failed.</summary>
+        public int Failed => Cases.Count(c => c.Outcome == Outcome.Failed);
+
+        /// <summary>Cases that need the mesh lane.</summary>
+        public int NeedsMesh => Cases.Count(c => c.Outcome == Outcome.NeedsMesh);
+
+        /// <summary>Green iff it loaded and nothing that ran failed. No cases is green, not a pass.</summary>
+        public bool IsGreen => LoadError is null && Failed == 0;
+    }
+
+    /// <summary>
+    /// Loads <paramref name="assemblyPath"/> with <paramref name="dependencyAssemblies"/>
+    /// resolvable by simple name, discovers the test classes, invokes every runnable case and
+    /// unloads the context. The <paramref name="perCaseTimeout"/> is a hard cap: a case that
+    /// outlives it is reported failed with the timeout named, and the run continues.
+    /// </summary>
+    public static Run Execute(
+        string assemblyPath,
+        IReadOnlyList<string> dependencyAssemblies,
+        TimeSpan perCaseTimeout,
+        TextWriter? output = null)
+    {
+        ArgumentNullException.ThrowIfNull(assemblyPath);
+        ArgumentNullException.ThrowIfNull(dependencyAssemblies);
+
+        var byName = dependencyAssemblies
+            .Where(File.Exists)
+            .GroupBy(p => Path.GetFileNameWithoutExtension(p), StringComparer.OrdinalIgnoreCase)
+            .ToDictionary(g => g.Key, g => g.First(), StringComparer.OrdinalIgnoreCase);
+
+        var context = new TestLoadContext(byName);
+        try
+        {
+            Assembly assembly;
+            try
+            {
+                assembly = context.LoadFromAssemblyPath(Path.GetFullPath(assemblyPath));
+            }
+            catch (Exception ex) when (ex is IOException or BadImageFormatException or FileLoadException)
+            {
+                return new Run(assemblyPath, [], $"{ex.GetType().Name}: {ex.Message}");
+            }
+
+            Type[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                var missing = ex.LoaderExceptions
+                    .Where(e => e is not null)
+                    .Select(e => e!.Message)
+                    .Distinct(StringComparer.Ordinal)
+                    .Take(3);
+                return new Run(assemblyPath, [],
+                    "the assembly loaded but its types did not: " + string.Join(" | ", missing)
+                    + " — a dependency package's assembly is not in the reference set handed to "
+                    + "this run, or a module named by the source is not composed into the image");
+            }
+
+            var cases = ImmutableArray.CreateBuilder<Case>();
+            foreach (var type in types.Where(IsTestClass).OrderBy(t => t.FullName, StringComparer.Ordinal))
+            {
+                foreach (var method in TestMethods(type))
+                {
+                    var name = $"{type.Name}.{method.Name}";
+                    if (method.GetParameters().Length > 0)
+                    {
+                        cases.Add(new Case(name, Outcome.NeedsMesh, TimeSpan.Zero,
+                            "takes " + string.Join(", ", method.GetParameters().Select(p => p.ParameterType.Name))
+                            + " — a hosted case; the mesh lane runs it"));
+                        continue;
+                    }
+                    cases.Add(Invoke(name, method, perCaseTimeout));
+                    output?.WriteLine(Describe(cases[^1]));
+                }
+            }
+            return new Run(assemblyPath, cases.ToImmutable(), null);
+        }
+        finally
+        {
+            context.Unload();
+        }
+    }
+
+    private static string Describe(Case c) => c.Outcome switch
+    {
+        Outcome.Passed => $"      ok    {c.Name} ({c.Elapsed.TotalMilliseconds:F0} ms)",
+        Outcome.Failed => $"      FAIL  {c.Name} ({c.Elapsed.TotalMilliseconds:F0} ms): {c.Error}",
+        _ => $"      mesh  {c.Name}: {c.Error}",
+    };
+
+    private static Case Invoke(string name, MethodInfo method, TimeSpan timeout)
+    {
+        var clock = Stopwatch.StartNew();
+        // The case runs on its own thread so a hang can be reported by name rather than hanging
+        // the whole build; the thread is background so it cannot keep the process alive.
+        Exception? failure = null;
+        var done = new ManualResetEventSlim(false);
+        var thread = new Thread(() =>
+        {
+            try
+            {
+                method.Invoke(null, null);
+            }
+            catch (TargetInvocationException ex)
+            {
+                failure = ex.InnerException ?? ex;
+            }
+            catch (Exception ex)
+            {
+                failure = ex;
+            }
+            finally
+            {
+                done.Set();
+            }
+        })
+        {
+            IsBackground = true,
+            Name = $"test:{name}",
+        };
+        thread.Start();
+        if (!done.Wait(timeout))
+        {
+            return new Case(name, Outcome.Failed, clock.Elapsed,
+                $"did not return within {timeout.TotalSeconds:F0}s — a hung case; the thread is "
+                + "abandoned and the build continues");
+        }
+        clock.Stop();
+        return failure is null
+            ? new Case(name, Outcome.Passed, clock.Elapsed, null)
+            : new Case(name, Outcome.Failed, clock.Elapsed, Innermost(failure));
+    }
+
+    private static string Innermost(Exception ex)
+    {
+        var e = ex;
+        while (e.InnerException is not null)
+            e = e.InnerException;
+        var first = e.Message.Split('\n', 2)[0].Trim();
+        return $"{e.GetType().Name}: {first}";
+    }
+
+    /// <summary>
+    /// A test class: public, static (abstract + sealed), not compiler-generated, whose name ends
+    /// in <c>Test</c> or <c>Tests</c> — the convention every <c>Test/*.cs</c> in the node repos
+    /// follows (<c>ModuleTests</c>, <c>CourseIndexTests</c>, …). The <c>*TestsArea</c> aggregator
+    /// classes match too, and their only method takes a host, so they classify as needs-mesh.
+    /// </summary>
+    private static bool IsTestClass(Type t) =>
+        t.IsClass && t.IsPublic && t.IsAbstract && t.IsSealed
+        && !t.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false)
+        && (t.Name.EndsWith("Tests", StringComparison.Ordinal)
+            || t.Name.EndsWith("Test", StringComparison.Ordinal)
+            || t.Name.EndsWith("TestsArea", StringComparison.Ordinal));
+
+    private static IEnumerable<MethodInfo> TestMethods(Type t) =>
+        t.GetMethods(BindingFlags.Public | BindingFlags.Static | BindingFlags.DeclaredOnly)
+            .Where(m => !m.IsSpecialName
+                        && !m.IsGenericMethodDefinition
+                        && !m.IsDefined(typeof(CompilerGeneratedAttribute), inherit: false)
+                        && (m.ReturnType == typeof(void) || m.GetParameters().Length > 0))
+            .OrderBy(m => m.Name, StringComparer.Ordinal);
+
+    private sealed class TestLoadContext(IReadOnlyDictionary<string, string> dependencyPaths)
+        : AssemblyLoadContext(isCollectible: true)
+    {
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            // Framework and image assemblies: whatever this process already runs — the tester's
+            // closure IS the image's /app, and binding a second copy would split every type.
+            if (Default.Assemblies.Any(a => string.Equals(
+                    a.GetName().Name, assemblyName.Name, StringComparison.OrdinalIgnoreCase)))
+                return null;
+            return assemblyName.Name is { } name && dependencyPaths.TryGetValue(name, out var path)
+                ? LoadFromAssemblyPath(path)
+                : null;
+        }
+    }
+}

--- a/tools/MeshWeaver.PluginTester/Testing/TestContext.cs
+++ b/tools/MeshWeaver.PluginTester/Testing/TestContext.cs
@@ -1,0 +1,66 @@
+namespace MeshWeaver.Testing;
+
+/// <summary>
+/// The per-case context a build-run test sees — the shape xUnit's <c>TestContext.Current</c>
+/// gave the suites this replaces, so a migrated body keeps reading
+/// <c>TestContext.Current.CancellationToken</c>. The runner sets it on the case's own thread
+/// before invoking the method; the token trips at the case budget, so a case that threads it
+/// through its waits ends with a named timeout instead of a hung build.
+/// </summary>
+public static class TestContext
+{
+    [ThreadStatic] private static TestContextData? current;
+
+    /// <summary>The running case's context; a neutral one when no case is running.</summary>
+    public static TestContextData Current => current ??= new TestContextData("(no case)", CancellationToken.None);
+
+    /// <summary>Installs the context for the case about to run on this thread.</summary>
+    public static IDisposable Enter(string caseName, CancellationToken token)
+    {
+        var previous = current;
+        current = new TestContextData(caseName, token);
+        return new Restore(() => current = previous);
+    }
+
+    private sealed class Restore(Action undo) : IDisposable
+    {
+        public void Dispose() => undo();
+    }
+}
+
+/// <summary>What a case may ask about itself.</summary>
+/// <param name="CaseName"><c>Type.Method</c> of the running case.</param>
+/// <param name="CancellationToken">Trips at the case budget.</param>
+public sealed record TestContextData(string CaseName, CancellationToken CancellationToken);
+
+/// <summary>
+/// Thrown by a case that decides it cannot run here (a platform it is not on, a credential it
+/// does not have). The runner reports it as <c>skipped</c> — never as passed, never as failed.
+/// </summary>
+public sealed class SkipException(string reason) : Exception(reason)
+{
+    /// <summary>The reason the case gave.</summary>
+    public string Reason { get; } = reason;
+}
+
+/// <summary>
+/// Where a case writes what it wants a reader to see. Lines go to the runner's output (the build
+/// log) prefixed with the case name, so a failure's neighbourhood is readable without a debugger —
+/// the role <c>ITestOutputHelper</c> played in the suites this replaces.
+/// </summary>
+public static class TestLog
+{
+    /// <summary>Optional sink the runner installs; the console otherwise.</summary>
+    public static Action<string>? Sink { get; set; }
+
+    /// <summary>Writes one line, prefixed with the running case.</summary>
+    public static void WriteLine(string message)
+    {
+        var line = $"      [{TestContext.Current.CaseName}] {message}";
+        (Sink ?? Console.WriteLine)(line);
+    }
+
+    /// <summary>Writes one formatted line.</summary>
+    public static void WriteLine(string format, params object?[] args) =>
+        WriteLine(string.Format(System.Globalization.CultureInfo.InvariantCulture, format, args));
+}

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -235,7 +235,7 @@ public static class TreeBake
     /// module's types, reported the resulting misses as CONTENT errors, and named nothing about a
     /// reference. Loud here, once, beats five red NodeTypes and a fleet that will not roll.</para>
     /// </summary>
-    private static IReadOnlyList<InstalledModuleAssembly> LoadExternalModules(Options options)
+    internal static IReadOnlyList<InstalledModuleAssembly> LoadExternalModules(Options options)
     {
         var paths = options.ModuleAssemblyPaths;
         if (paths.Count == 0)
@@ -274,7 +274,7 @@ public static class TreeBake
     /// <summary>Installed module simple name → implementation MVID ("N"). Deliberately the same
     /// projection the mesh makes (<c>NodeTypeCompilationHelpers.ModuleMvidsOf</c>): producer and
     /// consumer have to compute one id for one build, or every bundle is declined.</summary>
-    private static IReadOnlyDictionary<string, string> ModuleMvidsOf(
+    internal static IReadOnlyDictionary<string, string> ModuleMvidsOf(
         IReadOnlyList<InstalledModuleAssembly> modules)
     {
         var map = new Dictionary<string, string>(StringComparer.Ordinal);
@@ -408,7 +408,7 @@ public static class TreeBake
         return new Report(frameworkIdentity, results.ToImmutable(), bundles);
     }
 
-    private static ImmutableArray<string> WriteBundles(
+    internal static ImmutableArray<string> WriteBundles(
         Options options,
         IReadOnlyList<PackageManifest> packages,
         RepoSnapshot snapshot,

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -235,6 +235,19 @@ public static class TreeBake
     /// module's types, reported the resulting misses as CONTENT errors, and named nothing about a
     /// reference. Loud here, once, beats five red NodeTypes and a fleet that will not roll.</para>
     /// </summary>
+    /// <summary>
+    /// The compiler's NuGet hook is synchronous by contract (<see cref="NodeSetCompiler.Compile"/>
+    /// takes a plain delegate), and the resolver is genuinely async, so this is the ONE place the
+    /// bake lane blocks on it. Shared with the build verb so the production blocking-bridge
+    /// inventory keeps counting exactly one site, here.
+    /// </summary>
+    internal static Func<IReadOnlyList<NuGetPackageReference>, CancellationToken, IReadOnlyList<string>>
+        BlockingNuGetResolution(INuGetAssemblyResolver resolver) =>
+        (refs, ct) => resolver
+            .ResolveAsync(refs, targetFramework: null, ct)
+            .GetAwaiter().GetResult()
+            .AssemblyPaths;
+
     internal static IReadOnlyList<InstalledModuleAssembly> LoadExternalModules(Options options)
     {
         var paths = options.ModuleAssemblyPaths;
@@ -340,10 +353,7 @@ public static class TreeBake
                     // The ONE Task bridge in the bake, at a console build step — never on a hub
                     // scheduler. NuGet restore is genuine network IO with no reactive surface;
                     // the runtime bridges it through the IoPool for the same reason.
-                    resolveNuGet: (refs, ct) => nugetResolver
-                        .ResolveAsync(refs, targetFramework: null, ct)
-                        .GetAwaiter().GetResult()
-                        .AssemblyPaths,
+                    resolveNuGet: BlockingNuGetResolution(nugetResolver),
                     logger: options.Logger);
 
                 // 🚨 The RAW resolved set, not the post-filter compile set — the mesh-driven bake


### PR DESCRIPTION
## The new build process for node repos

Maintainer direction (2026-08-30): **build always means compile AND run tests**; a build runner and test runner of our own where every package **observes the streams of its dependencies and starts itself** — a natural cascade; **on red we break, on green we continue**; the input is one or many plugins or `all` (full rebuild); dependencies resolved across the monorepo; Roslyn builds against the references the dependency packages produce; **no mesh import** — sources come from the git checkout on disk ("grains cannot handle compile workload"); and **timings**.

```
mw-plugin-test build <repo-root> [<package>... | all] [--module <dll>]... [--out <dir>] [--report <file>] [--max-parallel <n>] [--case-timeout <s>] [--no-tests]
```

### What it does
- **Graph from disk**: `index.json` → `requires` (`PackageDependencyGraph.DependencyId`), selection = named packages + transitive in-repo requirements; `all` = every package.
- **Cascade** (`Cascade.cs`, generic, pure): each package's result stream is `PublishLast`-shared; a package `CombineLatest`s its dependencies' streams, starts when the last is green, is `Blocked(by: X)` at once when one is not. Bounded parallelism; ready/started/finished per node; critical path.
- **Compile** exactly as the portal does (`NodeSetCompiler`, the same skeleton/options, `/app` refs via `CompileReferences.ComposeWithModules`) **plus the dependency packages' emitted assemblies** as references.
- **Tests without a mesh**: the `Test/*.cs` convention's static cases run from the emitted assembly in a collectible ALC, timed and capped. Host-taking cases are counted and named `needs-mesh` (the gate, seeded from `--out`, still runs them). Nothing is silently skipped.
- **Parity flag**: a type whose emitted assembly binds a dependency package's assembly is marked `binds-dependency-assembly` — the portal reaches other packages by `shared=` source inclusion, so that green is on grounds the portal does not have. Visible, not hidden.
- **Report**: a table (verdict, ready, queued, work, compile, tests, types, passed/failed/mesh) + critical path + parallel speed-up; `--report` writes JSON.

### Tests
`CascadeTest` — 9 cases, executed: dependency observation and ordering, red-breaks with the block named, fault isolation, exactly-once execution across 20 dependents, bounded parallelism with real queue timings, cycle refusal, external dependencies, critical path, empty selection.

### Not in this PR (named on purpose)
- The Plugins lane YAML that pulls the pinned image and runs `build /repo all` (Plugins PR, after this image ships).
- PG via Testcontainers wired into the runner's mesh for the substrate suites.
- Running hosted cases as Activities.

🤖 Generated with [Claude Code](https://claude.com/claude-code)