### PR TITLE
ci: test runs are not dark — timestamped host start, live test output, long-running detection

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1077,8 +1077,14 @@ jobs:
             echo "$label: ${#classargs[@]} of ${#allclasses[@]} classes"
           fi
           started=$SECONDS
+          # The run is not dark (maintainer, 2026-08-30: "we are completely in the dark in the test
+          # runs"): a timestamped line says which host starts now, -showLiveOutput streams the test
+          # bases' TEST START / TEST END lines as they happen instead of holding them for the file,
+          # and -longRunning names any test still running after 60s WHILE it runs — so a wedge is
+          # readable in the job log before the 8m cap kills the host.
+          echo "[CI] $(date -u +%H:%M:%S) ▶ $label starting (${#classargs[@]:-all} class(es))"
           ( cd "$dir" && timeout --signal=TERM --kill-after=30s 8m \
-              dotnet "$name.dll" -trx "TestResults/$trxname.trx" "${classargs[@]}" )
+              dotnet "$name.dll" -trx "TestResults/$trxname.trx" -showLiveOutput -longRunning 60 "${classargs[@]}" )
           rc=$?
           # Wall-clock for THIS unit. This is the number shard-assign.sh's weight table is
           # made of, so record it rather than making the next person reconstruct it from

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1082,7 +1082,7 @@ jobs:
           # bases' TEST START / TEST END lines as they happen instead of holding them for the file,
           # and -longRunning names any test still running after 60s WHILE it runs — so a wedge is
           # readable in the job log before the 8m cap kills the host.
-          echo "[CI] $(date -u +%H:%M:%S) ▶ $label starting (${#classargs[@]:-all} class(es))"
+          echo "[CI] $(date -u +%H:%M:%S) ▶ $label starting (${#classargs[@]} class arg(s))"
           ( cd "$dir" && timeout --signal=TERM --kill-after=30s 8m \
               dotnet "$name.dll" -trx "TestResults/$trxname.trx" -showLiveOutput -longRunning 60 "${classargs[@]}" )
           rc=$?


### PR DESCRIPTION
Maintainer (2026-08-30): *"we are completely in the dark in the test runs"*.

The shard ran the xunit v3 host with the default reporter, which prints nothing per test until the summary — a 7-minute shard was a blank log until it ended (and the archived-log API returns `BlobNotFound` for an in-progress job).

Now each host prints `[CI] HH:MM:SS ▶ <suite> starting (N classes)`, runs with **`-showLiveOutput`** (the test bases' `TEST START` / `TEST END` lines stream live) and **`-longRunning 60`** (any test still running after 60 s is named *while it runs*), so a wedge is readable in the job log before the 8 m cap kills the host. Flags verified against the host's own `-?`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)