### PR TITLE
feat: MeshWeaver.Testcontainers — a disposable memex as a test substrate (like Testcontainers.PostgreSql)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -145,6 +145,10 @@
     <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.17.0" />
     <PackageVersion Include="OpenTelemetry.Instrumentation.Runtime" Version="1.17.0" />
     <PackageVersion Include="System.Interactive" Version="7.0.1" />
+    <!-- The memex test container package (src/MeshWeaver.Testcontainers): a real memex from the
+         platform build as a test substrate, the way Testcontainers.PostgreSql gives a test a real
+         Postgres. Same version as the test tree pins. -->
+    <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="SSH.NET" Version="2026.0.0" /> <!-- High GHSA-q939-rpr3-3284; transitive via Testcontainers, direct-ref override in test/Directory.Build.props -->
     <PackageVersion Include="System.Reactive" Version="6.1.0" />
     <PackageVersion Include="Microsoft.Reactive.Testing" Version="6.1.0" />

--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -42,6 +42,7 @@
     <Project Path="src/MeshWeaver.Domain/MeshWeaver.Domain.csproj" />
     <Project Path="src/MeshWeaver.Fixture/MeshWeaver.Fixture.csproj" />
     <Project Path="src/MeshWeaver.Reactive.Assertions/MeshWeaver.Reactive.Assertions.csproj" />
+    <Project Path="src/MeshWeaver.Testcontainers/MeshWeaver.Testcontainers.csproj" />
     <Project Path="src/MeshWeaver.Maps/MeshWeaver.Maps.csproj" />
     <Project Path="src/MeshWeaver.Hosting.AspNetCore/MeshWeaver.Hosting.AspNetCore.csproj" />
     <Project Path="src/MeshWeaver.Graph/MeshWeaver.Graph.csproj" />
@@ -112,6 +113,7 @@
     <Project Path="test/MeshWeaver.Autocomplete.Test/MeshWeaver.Autocomplete.Test.csproj" />
     <Project Path="test/MeshWeaver.Query.Test/MeshWeaver.Query.Test.csproj" />
     <Project Path="test/MeshWeaver.Reactive.Assertions.Test/MeshWeaver.Reactive.Assertions.Test.csproj" />
+    <Project Path="test/MeshWeaver.Testcontainers.Test/MeshWeaver.Testcontainers.Test.csproj" />
     <Project Path="test/MeshWeaver.Portal.E2E.Test/MeshWeaver.Portal.E2E.Test.csproj" />
     <Project Path="test/MeshWeaver.Serialization.Test/MeshWeaver.Serialization.Test.csproj" />
     <Project Path="test/Memex.Portal.Shared.Test/Memex.Portal.Shared.Test.csproj" />

--- a/src/MeshWeaver.Testcontainers/MemexContainer.cs
+++ b/src/MeshWeaver.Testcontainers/MemexContainer.cs
@@ -1,0 +1,172 @@
+using Docker.DotNet.Models;
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Configurations;
+using DotNet.Testcontainers.Containers;
+
+namespace MeshWeaver.Testcontainers;
+
+/// <summary>
+/// A disposable memex — the portal image the platform BUILD produced, started as a test substrate
+/// the way <c>Testcontainers.PostgreSql</c> starts a real Postgres (maintainer, 2026-08-30:
+/// "clean test container package for memex … similar to pg"). The test is a client: it reaches
+/// the instance over HTTP/MCP at <see cref="BaseAddress"/>, and the platform under test is
+/// exactly the image the pipeline promoted — no core source checkout, no in-process mesh, no
+/// <c>MeshWeaver.Fixture</c>.
+///
+/// <para><b>What the image needs, and what the builder sets.</b> The portal image runs
+/// <c>Memex.Portal.Distributed</c> (Orleans + Postgres). A throwaway instance is single-node
+/// (<c>Features:Orleans:Clustering=Localhost</c>), Azure-free (<c>Deployment:Backend=Filesystem</c>
+/// with <c>Deployment:DataRoot=/data</c>), has dev login ON (the host forces it OFF unless the
+/// value is literally <c>true</c>) and needs ONE Postgres for its data
+/// (<c>ConnectionStrings:memex</c>) — which is why <see cref="MemexBuilder.WithPostgres(string)"/>
+/// is required: the memex reaches Postgres INSIDE the Docker network, so hand it the alias-based
+/// connection string of a Postgres container on the same network, never a host-mapped port.</para>
+///
+/// <para><b>The container's log is the test's log.</b> stdout/stderr are redirected to the test
+/// output by default, so a failing test shows the portal's own lines beside it (maintainer:
+/// "pls see we log out from container to github logging").</para>
+/// </summary>
+public sealed class MemexContainer(MemexConfiguration configuration) : DockerContainer(configuration)
+{
+    /// <summary>The instance's HTTP root as seen from the test host.</summary>
+    public Uri BaseAddress =>
+        new UriBuilder(Uri.UriSchemeHttp, Hostname, GetMappedPublicPort(MemexBuilder.HttpPort)).Uri;
+
+    /// <summary>The MCP endpoint (<c>/mcp</c>).</summary>
+    public Uri McpEndpoint => new(BaseAddress, "/mcp");
+
+    /// <summary>The health endpoint the wait strategy polls (<c>/healthz</c>).</summary>
+    public Uri HealthEndpoint => new(BaseAddress, MemexBuilder.HealthPath);
+}
+
+/// <summary>The memex-specific part of the container configuration.</summary>
+public sealed class MemexConfiguration : ContainerConfiguration
+{
+    /// <summary>A fresh configuration with the memex-specific values.</summary>
+    public MemexConfiguration(string? memexConnectionString = null)
+    {
+        MemexConnectionString = memexConnectionString;
+    }
+
+    /// <summary>Clones a resource configuration (Testcontainers' builder contract).</summary>
+    public MemexConfiguration(IResourceConfiguration<CreateContainerParameters> resourceConfiguration)
+        : base(resourceConfiguration)
+    {
+    }
+
+    /// <summary>Clones a container configuration (Testcontainers' builder contract).</summary>
+    public MemexConfiguration(IContainerConfiguration resourceConfiguration)
+        : base(resourceConfiguration)
+    {
+    }
+
+    /// <summary>Clones a memex configuration (Testcontainers' builder contract).</summary>
+    public MemexConfiguration(MemexConfiguration resourceConfiguration)
+        : this(new MemexConfiguration(), resourceConfiguration)
+    {
+    }
+
+    /// <summary>Merges two configurations, the newer winning (Testcontainers' builder contract).</summary>
+    public MemexConfiguration(MemexConfiguration oldValue, MemexConfiguration newValue)
+        : base(oldValue, newValue)
+    {
+        MemexConnectionString = BuildConfiguration.Combine(oldValue.MemexConnectionString, newValue.MemexConnectionString);
+    }
+
+    /// <summary>The Postgres the instance stores its data in, as reachable FROM the container.</summary>
+    public string? MemexConnectionString { get; }
+}
+
+/// <summary>
+/// Builds a <see cref="MemexContainer"/>. The image is the consumer's to name — the pinned portal
+/// image of the build under test (<c>meshweaver.azurecr.io/memex-portal-ai@sha256:…</c>); this
+/// module never guesses a tag. A Postgres connection string is required.
+/// </summary>
+public sealed class MemexBuilder : ContainerBuilder<MemexBuilder, MemexContainer, MemexConfiguration>
+{
+    /// <summary>The port the portal listens on inside the container.</summary>
+    public const ushort HttpPort = 8080;
+
+    /// <summary>The health path the wait strategy polls.</summary>
+    public const string HealthPath = "/healthz";
+
+    /// <summary>Starts a builder with the memex defaults applied.</summary>
+    public MemexBuilder() : this(new MemexConfiguration())
+    {
+        DockerResourceConfiguration = Init().DockerResourceConfiguration;
+    }
+
+    private MemexBuilder(MemexConfiguration resourceConfiguration) : base(resourceConfiguration)
+    {
+        DockerResourceConfiguration = resourceConfiguration;
+    }
+
+    /// <inheritdoc />
+    protected override MemexConfiguration DockerResourceConfiguration { get; }
+
+    /// <summary>
+    /// The Postgres the memex stores its data in — <c>ConnectionStrings:memex</c>. The string must
+    /// resolve FROM INSIDE the container: on a shared Docker network, use the Postgres container's
+    /// network alias and port 5432, not the host-mapped port a test on the host would use.
+    /// </summary>
+    public MemexBuilder WithPostgres(string connectionString)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(connectionString);
+        return Merge(DockerResourceConfiguration, new MemexConfiguration(memexConnectionString: connectionString))
+            .WithEnvironment("ConnectionStrings__memex", connectionString);
+    }
+
+    /// <summary>
+    /// Dev login on or off. On by default for a test instance; the host forces it OFF unless the
+    /// configured value is literally <c>true</c>, so this always writes an explicit value.
+    /// </summary>
+    public MemexBuilder WithDevLogin(bool enabled = true) =>
+        WithEnvironment("Authentication__EnableDevLogin", enabled ? "true" : "false");
+
+    /// <inheritdoc />
+    public override MemexContainer Build()
+    {
+        Validate();
+        return new MemexContainer(DockerResourceConfiguration);
+    }
+
+    /// <inheritdoc />
+    protected override MemexBuilder Init() =>
+        base.Init()
+            .WithPortBinding(HttpPort, assignRandomHostPort: true)
+            .WithEnvironment("ASPNETCORE_HTTP_PORTS", HttpPort.ToString(System.Globalization.CultureInfo.InvariantCulture))
+            // Azure-free, single-node: the self-host filesystem backend and Localhost clustering
+            // are the two switches that make the Distributed host run alone in one container.
+            .WithEnvironment("Deployment__Backend", "Filesystem")
+            .WithEnvironment("Deployment__DataRoot", "/data")
+            .WithEnvironment("Features__Orleans__Clustering", "Localhost")
+            .WithEnvironment("Authentication__EnableDevLogin", "true")
+            // The container's log IS the test's log.
+            .WithOutputConsumer(Consume.RedirectStdoutAndStderrToConsole())
+            .WithWaitStrategy(Wait.ForUnixContainer()
+                .UntilHttpRequestIsSucceeded(request => request.ForPort(HttpPort).ForPath(HealthPath)));
+
+    /// <inheritdoc />
+    protected override void Validate()
+    {
+        base.Validate();
+        if (string.IsNullOrWhiteSpace(DockerResourceConfiguration.MemexConnectionString))
+            throw new ArgumentException(
+                "a memex needs a Postgres: call WithPostgres(<connection string reachable from inside "
+                + "the container>) — the portal image runs Memex.Portal.Distributed, whose data lives "
+                + "in ConnectionStrings:memex, and an instance without it does not start.",
+                nameof(MemexConfiguration.MemexConnectionString));
+    }
+
+    /// <inheritdoc />
+    protected override MemexBuilder Clone(IResourceConfiguration<CreateContainerParameters> resourceConfiguration) =>
+        Merge(DockerResourceConfiguration, new MemexConfiguration(resourceConfiguration));
+
+    /// <inheritdoc />
+    protected override MemexBuilder Clone(IContainerConfiguration resourceConfiguration) =>
+        Merge(DockerResourceConfiguration, new MemexConfiguration(resourceConfiguration));
+
+    /// <inheritdoc />
+    protected override MemexBuilder Merge(MemexConfiguration oldValue, MemexConfiguration newValue) =>
+        new(new MemexConfiguration(oldValue, newValue));
+}

--- a/src/MeshWeaver.Testcontainers/MeshWeaver.Testcontainers.csproj
+++ b/src/MeshWeaver.Testcontainers/MeshWeaver.Testcontainers.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <!-- The memex test container: a real memex from the platform build as a test SUBSTRATE, the way
+         Testcontainers.PostgreSql gives a test a real Postgres (maintainer, 2026-08-30: "let's create
+         clean test container package for memex … similar to pg"). Test support, never a NuGet package:
+         consumers get it through the test container image or a source reference. -->
+    <IsPackable>false</IsPackable>
+    <Description>A Testcontainers module that starts the memex portal image as a disposable test substrate.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Testcontainers" />
+  </ItemGroup>
+</Project>

--- a/src/MeshWeaver.Testcontainers/README.md
+++ b/src/MeshWeaver.Testcontainers/README.md
@@ -1,0 +1,47 @@
+# MeshWeaver.Testcontainers — a disposable memex as a test substrate
+
+A [Testcontainers](https://dotnet.testcontainers.org/) module that starts the **portal image the
+platform build produced** the way `Testcontainers.PostgreSql` starts a real Postgres: the test is a
+client of a real memex, and the platform under test is exactly the image the pipeline promoted — no
+core source checkout, no in-process mesh, no `MeshWeaver.Fixture`.
+
+```csharp
+await using INetwork network = new NetworkBuilder().Build();
+await using var postgres = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+    .WithNetwork(network).WithNetworkAliases("postgres")
+    .WithDatabase("memex").WithUsername("postgres").WithPassword("postgres")
+    .Build();
+await postgres.StartAsync(ct);
+
+await using var memex = new MemexBuilder()
+    .WithImage("meshweaver.azurecr.io/memex-portal-ai@sha256:…")   // the pinned build under test
+    .WithNetwork(network)
+    .WithPostgres("Host=postgres;Port=5432;Database=memex;Username=postgres;Password=postgres")
+    .Build();
+await memex.StartAsync(ct);
+
+// memex.BaseAddress, memex.McpEndpoint, memex.HealthEndpoint
+```
+
+## What the builder sets, and why
+
+The portal image runs `Memex.Portal.Distributed` (Orleans + Postgres). A throwaway instance is:
+
+| setting | value | reason |
+|---|---|---|
+| `Deployment:Backend` | `Filesystem` | Azure-free self-host backend; `Deployment:DataRoot=/data` |
+| `Features:Orleans:Clustering` | `Localhost` | single silo in one container |
+| `ConnectionStrings:memex` | **required** — `WithPostgres(...)` | the instance's data; reachable *from inside* the container (a network alias, not a host-mapped port) |
+| `Authentication:EnableDevLogin` | `true` (explicit) | the host forces it OFF unless the value is literally `true` |
+| wait strategy | HTTP 2xx on `/healthz` (port 8080) | the instance answers before the test proceeds |
+| output | stdout/stderr → the test output | the container's log is the test's log |
+
+`WithImage` is the consumer's: this module never guesses a tag.
+
+## Where it fits
+
+- **Black-box and substrate suites** (the Postgres hosting suites, end-to-end flows) use this — a
+  memex on a Postgres, exercised over HTTP/MCP.
+- **Engine suites that inject fakes through DI** keep an in-process mesh; that is a different
+  primitive, not this one.
+- The library is test support: `IsPackable=false`, never a NuGet package.

--- a/test/Directory.Packages.props
+++ b/test/Directory.Packages.props
@@ -6,7 +6,6 @@
     <PackageVersion Include="JsonDiffPatch.Net" Version="2.3.0" />
     <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="10.0.7" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="9.0.0" />
-    <PackageVersion Include="Testcontainers" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.CosmosDb" Version="4.11.0" />
     <PackageVersion Include="Testcontainers.PostgreSql" Version="4.11.0" />
   </ItemGroup>

--- a/test/MeshWeaver.Testcontainers.Test/MemexContainerTest.cs
+++ b/test/MeshWeaver.Testcontainers.Test/MemexContainerTest.cs
@@ -1,0 +1,81 @@
+using DotNet.Testcontainers.Builders;
+using DotNet.Testcontainers.Networks;
+using MeshWeaver.Testcontainers;
+using Testcontainers.PostgreSql;
+using Xunit;
+
+namespace MeshWeaver.Testcontainers.Test;
+
+/// <summary>
+/// The memex test container's contract. The builder cases need no Docker; the end-to-end case
+/// starts a Postgres and a memex on one network and is SKIPPED, never silently green, when the
+/// environment does not name the portal image to test against (<c>MEMEX_TEST_IMAGE</c>).
+/// </summary>
+public class MemexContainerTest
+{
+    /// <summary>The pinned portal image of the build under test, e.g. <c>meshweaver.azurecr.io/memex-portal-ai@sha256:…</c>.</summary>
+    private static string? Image => Environment.GetEnvironmentVariable("MEMEX_TEST_IMAGE");
+
+    [Fact]
+    public void AMemexWithoutAPostgresDoesNotBuild_AndSaysWhy()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => new MemexBuilder().WithImage("memex:test").Build());
+        Assert.Contains("WithPostgres", ex.Message);
+        Assert.Contains("ConnectionStrings:memex", ex.Message);
+    }
+
+    [Fact]
+    public void AMemexWithAPostgresBuilds_WithoutStarting()
+    {
+        var container = new MemexBuilder()
+            .WithImage("memex:test")
+            .WithPostgres("Host=postgres;Port=5432;Database=memex;Username=postgres;Password=postgres")
+            .Build();
+        Assert.NotNull(container);
+        // Not started: no Docker involved, and the mapped port would throw — that is the boundary
+        // between the builder's contract (testable anywhere) and the substrate (needs Docker).
+    }
+
+    [Fact]
+    public void DevLoginIsExplicitEitherWay()
+    {
+        // The host forces dev login OFF unless the value is literally "true", so the builder must
+        // always write an explicit value — on by default, and off when asked. Verified by building
+        // both shapes; the environment is applied at start, so this proves the builder accepts
+        // the toggle in both positions without a Docker daemon.
+        var on = new MemexBuilder().WithImage("memex:test").WithPostgres("Host=pg").Build();
+        var off = new MemexBuilder().WithImage("memex:test").WithPostgres("Host=pg").WithDevLogin(false).Build();
+        Assert.NotNull(on);
+        Assert.NotNull(off);
+    }
+
+    [Fact]
+    public async Task ARealMemexStartsBesideAPostgres_AndAnswersHealthz()
+    {
+        Assert.SkipWhen(string.IsNullOrWhiteSpace(Image),
+            "MEMEX_TEST_IMAGE is not set — name the pinned portal image (e.g. "
+            + "meshweaver.azurecr.io/memex-portal-ai@sha256:…) to run the substrate end to end");
+
+        var ct = TestContext.Current.CancellationToken;
+        await using INetwork network = new NetworkBuilder().Build();
+        await using var postgres = new PostgreSqlBuilder("pgvector/pgvector:pg17")
+            .WithNetwork(network)
+            .WithNetworkAliases("postgres")
+            .WithDatabase("memex")
+            .WithUsername("postgres")
+            .WithPassword("postgres")
+            .Build();
+        await postgres.StartAsync(ct);
+
+        await using var memex = new MemexBuilder()
+            .WithImage(Image!)
+            .WithNetwork(network)
+            .WithPostgres("Host=postgres;Port=5432;Database=memex;Username=postgres;Password=postgres")
+            .Build();
+        await memex.StartAsync(ct);
+
+        using var http = new HttpClient();
+        using var response = await http.GetAsync(memex.HealthEndpoint, ct);
+        Assert.True(response.IsSuccessStatusCode, $"{memex.HealthEndpoint} answered {(int)response.StatusCode}");
+    }
+}

--- a/test/MeshWeaver.Testcontainers.Test/MeshWeaver.Testcontainers.Test.csproj
+++ b/test/MeshWeaver.Testcontainers.Test/MeshWeaver.Testcontainers.Test.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MeshWeaver.Testcontainers\MeshWeaver.Testcontainers.csproj" />
+    <!-- The end-to-end case stands a Postgres beside the memex on one Docker network, exactly as a
+         consumer would. -->
+    <PackageReference Include="Testcontainers.PostgreSql" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- The test tree's global `using MeshWeaver.Messaging;` (#2771) cannot resolve here: this project
+         talks to a memex over HTTP and references no messaging assembly. -->
+    <Using Remove="MeshWeaver.Messaging" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Maintainer (2026-08-30): *"let's create clean test container package for memex … similar to pg"*.

```csharp
await using var memex = new MemexBuilder()
    .WithImage("meshweaver.azurecr.io/memex-portal-ai@sha256:…")   // the pinned build under test
    .WithNetwork(network)
    .WithPostgres("Host=postgres;Port=5432;Database=memex;Username=postgres;Password=postgres")
    .Build();
await memex.StartAsync(ct);   // memex.BaseAddress / McpEndpoint / HealthEndpoint
```

**What the builder sets** (each traced to the Distributed host's own config reads): `Deployment:Backend=Filesystem` + `DataRoot=/data` (Azure-free), `Features:Orleans:Clustering=Localhost` (one silo), `Authentication:EnableDevLogin=true` explicitly (the host forces it off unless literally `true`), a **required** `ConnectionStrings:memex` via `WithPostgres(...)` — reachable *from inside* the container (network alias, not a host-mapped port) — port 8080, wait on `/healthz`, and **stdout/stderr redirected into the test output** so the container's log is the test's log.

The test is a client of a real memex from the platform build: no core source checkout, no in-process mesh, no `MeshWeaver.Fixture`. Test support only — `IsPackable=false`.

**Tests**: 3 builder cases with no Docker (required Postgres named in the error, a full build, the explicit dev-login toggle) + 1 end-to-end case (pgvector Postgres beside a memex on one network, asserts `/healthz`) that is **skipped, never silently green**, unless `MEMEX_TEST_IMAGE` names the image. Executed: 3 passed, 1 skipped locally.

Where it fits: black-box and substrate suites (the Postgres hosting suites, end-to-end flows) use this; engine suites that inject fakes through DI keep an in-process mesh — a different primitive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)