### PR TITLE
test: InlineResumptionMechanismTest signals from a dedicated thread, not a pool worker

### DIFF
--- a/test/MeshWeaver.Messaging.Hub.Test/InlineResumptionMechanismTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/InlineResumptionMechanismTest.cs
@@ -33,7 +33,20 @@ namespace MeshWeaver.Messaging.Hub.Test;
 /// </summary>
 public class InlineResumptionMechanismTest
 {
-    /// <summary>Signals from a known thread and reports where the awaiter resumed.</summary>
+    /// <summary>
+    /// Signals from a known thread and reports where the awaiter resumed.
+    ///
+    /// <para>🚨 The signalling thread is a DEDICATED thread, never a pool worker. The measurement is
+    /// "did the awaiter resume on the signalling thread", and that is only a proxy for "inline" if
+    /// the pool can never legitimately put the continuation on that same thread. After an
+    /// <c>await Task.Delay</c> this method itself runs on a pool worker; a
+    /// <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/> completion queues the
+    /// continuation to the pool, and the moment <c>OnCompleted</c> returns and this method yields
+    /// at <c>await waiter</c>, that same worker is free to pick the continuation up — same managed
+    /// thread id, NOT inline. Measured on CI (2026-08-30, #2781, shard 5): thread 84 both sides,
+    /// on a diff of three documentation lines. A thread the pool does not own closes that hole:
+    /// inline resumption runs on it by definition, pooled resumption never can.</para>
+    /// </summary>
     private static async Task<(int Signalling, int Resumed)> Measure(Func<IObservable<int>, Task> wait)
     {
         var subject = new Subject<int>();
@@ -49,9 +62,18 @@ public class InlineResumptionMechanismTest
         // arrives with no observer attached, so the wait would never complete.
         await Task.Delay(300, TestContext.Current.CancellationToken);
 
-        var signalling = Environment.CurrentManagedThreadId;
-        subject.OnNext(1);
-        subject.OnCompleted();
+        var signalling = 0;
+        var producer = new Thread(() =>
+        {
+            signalling = Environment.CurrentManagedThreadId;
+            subject.OnNext(1);
+            subject.OnCompleted();
+        }) { IsBackground = true, Name = "InlineResumptionMechanismTest.producer" };
+        producer.Start();
+        // No Join: in the inline cases the waiter completes INSIDE OnCompleted, and a task
+        // continuation runs synchronously on the completing thread — so this very method resumes
+        // on the producer, and a Join here would be a thread joining itself. `signalling` is written
+        // before the signal that completes `waiter`, so it is visible once the await returns.
         await waiter;
         return (signalling, resumed);
     }

--- a/test/MeshWeaver.Messaging.Hub.Test/InlineResumptionMechanismTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/InlineResumptionMechanismTest.cs
@@ -65,17 +65,18 @@ public class InlineResumptionMechanismTest
         var signalling = 0;
         var producer = new Thread(() =>
         {
-            signalling = Environment.CurrentManagedThreadId;
+            Volatile.Write(ref signalling, Environment.CurrentManagedThreadId);
             subject.OnNext(1);
             subject.OnCompleted();
         }) { IsBackground = true, Name = "InlineResumptionMechanismTest.producer" };
         producer.Start();
         // No Join: in the inline cases the waiter completes INSIDE OnCompleted, and a task
         // continuation runs synchronously on the completing thread — so this very method resumes
-        // on the producer, and a Join here would be a thread joining itself. `signalling` is written
-        // before the signal that completes `waiter`, so it is visible once the await returns.
+        // on the producer, and a Join here would be a thread joining itself. `signalling` is
+        // published before the signal that completes `waiter` (the completion's interlocked state
+        // change already orders it); the volatile pair makes that hand-off explicit.
         await waiter;
-        return (signalling, resumed);
+        return (Volatile.Read(ref signalling), resumed);
     }
 
     /// <summary>


### PR DESCRIPTION
## The red

`MeshWeaver.Messaging.Hub.Test.InlineResumptionMechanismTest.ObserveCompletion_DoesNotResumeOnTheSignallingThread` failed on #2781 — a three-line documentation diff that cannot reach it:

```
Assert.NotEqual() Failure: Values are equal
Expected: Not 84
Actual:   84
   at InlineResumptionMechanismTest.cs(94,0)
```

Run [33316511834](https://github.com/Systemorph/MeshWeaver/actions/runs/33316511834) (shard 5, `MeshWeaver.Messaging.Hub.Test exit=1 TESTFAIL`). Main's last five Build-and-Test runs executed the shard and were green; the test was added today by efd515df4.

## The defect is in the measurement, not in `ObserveCompletion`

The test measures "did the awaiter resume inline" as "did it resume on the same *managed thread id*". That proxy is only sound if the thread pool can never legitimately hand the continuation to the signalling thread — and it can:

1. `Measure` does `await Task.Delay(300)` before signalling, so from there on the measuring method itself runs on a **pool worker**.
2. `ObserveCompletion` completes a `TaskCompletionSource(RunContinuationsAsynchronously)` — the continuation is **queued to the pool**, exactly as intended.
3. `Measure` returns from `subject.OnCompleted()` and yields at `await waiter`. That worker is now free, and on a warm pool it is the first to pick the queued continuation up.

Same id, **not** inline. On CI's loaded shard that is what happened: thread 84 signalled, thread 84 resumed — after the signal had returned.

## The fix

Signal from a **dedicated** thread the pool does not own. Inline resumption lands on it by definition (the two positive cases — `.ToTask()` and a direct `await` — still assert equality), and a pooled continuation can never run on it, so the negative assertion is now sound rather than probabilistic.

No `Join` after the wait: in the inline cases the continuation runs synchronously on the producer, so `Measure` itself resumes there, and a `Join` is a thread joining itself (found by the first local run wedging). `signalling` is written before the signal that completes `waiter`, so it is visible once the await returns.

## Verification

`dotnet build test/MeshWeaver.Messaging.Hub.Test -c Release -warnaserror` → `0 Warning(s) 0 Error(s)`; `dotnet test --filter FullyQualifiedName~InlineResumptionMechanismTest` → `Passed! Failed: 0, Passed: 3, Total: 3, Duration: 937 ms`, `.trx` written.

No What's New entry — test-only change, nothing a user can notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1SquDKJNKZxEUbuaPjUgu
