### PR TITLE
fix(main): PluginTester's case timeout uses Thread.Join, not a hand-woven event

### DIFF
--- a/tools/MeshWeaver.PluginTester/StaticTestRunner.cs
+++ b/tools/MeshWeaver.PluginTester/StaticTestRunner.cs
@@ -153,7 +153,6 @@ public static class StaticTestRunner
         // The case runs on its own thread so a hang can be reported by name rather than hanging
         // the whole build; the thread is background so it cannot keep the process alive.
         Exception? failure = null;
-        var done = new ManualResetEventSlim(false);
         var thread = new Thread(() =>
         {
             try
@@ -168,17 +167,19 @@ public static class StaticTestRunner
             {
                 failure = ex;
             }
-            finally
-            {
-                done.Set();
-            }
         })
         {
             IsBackground = true,
             Name = $"test:{name}",
         };
         thread.Start();
-        if (!done.Wait(timeout))
+        // 🚨 Thread.Join(timeout), not a ManualResetEventSlim. It is the built-in primitive for
+        // exactly this — "did that thread finish within the budget" — and it is STRICTER: the event
+        // fired from a `finally` signalled before the thread had actually terminated, whereas Join
+        // returns only on real termination, which is also what gives `failure` its happens-before.
+        // A hand-woven gate here was flagged by HandWovenGateRatchetGuard; the fix is to delete the
+        // gate rather than exempt it, because the standard library already has this one.
+        if (!thread.Join(timeout))
         {
             return new Case(name, Outcome.Failed, clock.Elapsed,
                 $"did not return within {timeout.TotalSeconds:F0}s — a hung case; the thread is "


### PR DESCRIPTION
🚨 **Main is red, and this is my break.** Two PRs each green alone, red together — the classic shape:

- `tools/MeshWeaver.PluginTester/StaticTestRunner.cs` landed with a `ManualResetEventSlim`
- **#2782** landed the ratchet that holds `tools/` at zero

Neither run could see the other. The merged tree fails `ProductionCodeHasNoHandWovenGate_OutsideTheSanctionedOne`.

## The fix deletes the gate rather than exempting it

The runner gives each case its own background `Thread` with a timeout, so a hang is reported by name instead of hanging the build — and waited on an event the thread `Set()` in a `finally`:

```csharp
var done = new ManualResetEventSlim(false);
… finally { done.Set(); }
thread.Start();
if (!done.Wait(timeout)) { /* hung case */ }
```

`Thread.Join(timeout)` answers exactly that question, and is **stricter**: the event fired from `finally` signalled *before* the thread had actually terminated, whereas `Join` returns only on real termination — which is also what gives the `failure` field its happens-before.

So this is a simplification, not a workaround: one fewer primitive, standard-library semantics, no exemption.

## Why an exemption would have been wrong here

This is **not** the `ThumbnailGenerator` case. That entry rests on a machine-verified premise — its csproj references no MeshWeaver assembly, so there is no hub in the process. `PluginTester` **does** reference them (`Hosting.Monolith`, `Hosting`, `Mesh.Operations`, `ContentCollections.Indexing.Graph`), so that premise is false and registering it would have been the exemption-shaped mistake the register exists to prevent.

## Verified

| | |
|---|---|
| `MeshWeaver.PluginTester` | `-c Release -warnaserror` → 0 errors |
| `HandWovenGateRatchetGuard` | **4/4 green** |

## Worth noting

The ratchet caught this within minutes of merging, on a file that landed independently. That is the mechanism working — but it also shows a new guard's first hours are exactly when a same-window merge can break main, and I should have re-run it against main's tip immediately after merge rather than after the next task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)