### PR TITLE
fix: the build verb runs the test classes the emitted assembly contains (modules resolvable)

### DIFF
--- a/tools/MeshWeaver.PluginTester/CascadeBuild.cs
+++ b/tools/MeshWeaver.PluginTester/CascadeBuild.cs
@@ -442,11 +442,18 @@ public static class CascadeBuild
             }
 
             StaticTestRunner.Run? tests = null;
-            if (options.RunTests && definition.Tests is { Count: > 0 })
+            if (options.RunTests)
             {
+                // Run whatever test classes the emitted assembly actually contains. A type's
+                // Test/*.cs reaches the compile through the compiler's DEFAULT query — the node
+                // declares `sources`, rarely `tests` — so gating on the declaration reported zero
+                // tests for every package on the first real run (33319413459). The assembly is
+                // the truth: no test classes, no cases, and the report says so.
                 testClock.Start();
                 tests = StaticTestRunner.Execute(
-                    compiled.DllPath, [.. dependencyAssemblies, .. emitted], options.CaseTimeout, options.Output);
+                    compiled.DllPath,
+                    [.. options.ModuleAssemblyPaths, .. dependencyAssemblies, .. emitted],
+                    options.CaseTimeout, options.Output);
                 testClock.Stop();
             }
 
@@ -456,7 +463,9 @@ public static class CascadeBuild
             options.Output.WriteLine(
                 $"{Stamp()} [{id}]   ok  {compiled.NodePath} ({typeClock.Elapsed.TotalMilliseconds:F0} ms, "
                 + $"{compiled.Inputs.MatchedSourcePaths.Length} source(s))"
-                + (tests is null ? "" : $" tests: {tests.Passed} passed, {tests.Failed} failed, {tests.NeedsMesh} needs-mesh")
+                + (tests is null ? "" : tests.Cases.IsEmpty
+                    ? " tests: no test classes in the assembly"
+                    : $" tests: {tests.Cases.Length} case(s) — {tests.Passed} passed, {tests.Failed} failed, {tests.NeedsMesh} needs-mesh")
                 + (binds.IsEmpty ? "" : $" binds-dependency-assembly: {string.Join(", ", binds)}"));
         }
         compileClock.Stop();


### PR DESCRIPTION
The lane's first real run over MeshWeaver.Plugins (run 33319413459: 53 packages, 811 nodes, 47 green in 48.5 s) reported **zero tests for every package**. Cause: a type's `Test/*.cs` reaches the compile through the compiler's *default* query — the node declares `sources`, rarely `tests` — so gating the run on `definition.Tests` skipped every suite the assembly actually carried.

The assembly is the truth: the runner now executes whatever test classes it contains, reports the case count (`no test classes in the assembly` reads apart from `0 of N passed`), and the composed `--module` assemblies are resolvable in the collectible load context, since the AI-bound types bind them.

Cascade tests 9/9 locally. Follow-up to #2784; the Plugins lane (Plugins#973) composes the modules on its side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)