### PR TITLE
test(acme): the progress-area test waits for the AREA to emit, not for a neighbouring stream

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-progress-area-test-waits-for-the-area.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-progress-area-test-waits-for-the-area.md
@@ -1,0 +1,23 @@
+---
+Name: The NodeType progress-area test waits for the area, not for a neighbouring stream
+Category: Fix
+Description: An intermittent that switched delivery off — the test asserted a snapshot of the Progress area's emissions before the area had emitted, trusting an ordering nothing guarantees. It now waits on the area's own first control.
+Icon: Bug
+Order: -20260830
+---
+
+# The NodeType progress-area test waits for the area, not for a neighbouring stream
+
+`NodeTypeProgressAreaTest.ColdCycle_TriggersCompile_StreamsTransitions_LandsAssemblyOnDisk` failed
+on a PR this morning and then on `main` itself, where a red required check turns delivery **off**
+until the next green commit.
+
+It waited for the NodeType to reach `Ok` on one stream, then asserted that a queue filled by a
+*different* subscription — the Progress layout area — was non-empty. Its own comment claimed the
+area "has emitted at least the terminal control by then". The area subscribes to the same state
+through its own hop, and nothing orders the two, so the queue was sometimes still empty when the
+snapshot was taken.
+
+The test now waits on the area's control stream for its first non-null control — the same wait its
+warm-cache path already used — and only then asserts. A wedged area now fails with a bounded wait
+that names it, rather than an empty-queue assertion that reads as a race.

--- a/test/MeshWeaver.Acme.Test/NodeTypeProgressAreaTest.cs
+++ b/test/MeshWeaver.Acme.Test/NodeTypeProgressAreaTest.cs
@@ -282,10 +282,16 @@ public class NodeTypeProgressAreaTest(ITestOutputHelper output) : MonolithMeshTe
         Output.WriteLine($"Subscribed to typeStream + Progress area for {NodeTypePath}");
 
         // Wait for terminal Ok state on the NodeType MeshNode stream — this is
-        // the canonical "compile finished" signal. The Progress area's last
-        // emission tracks the same state (it subscribes to the same stream
-        // internally), so by the time this completes the area has emitted at
-        // least the terminal control.
+        // the canonical "compile finished" signal.
+        //
+        // 🚨 It is NOT a signal that the Progress area has emitted. The old comment here claimed
+        // "by the time this completes the area has emitted at least the terminal control" — the
+        // area subscribes to the same stream, but through its OWN subscription on a different
+        // hop, and nothing orders the two. The queue below was then asserted as a snapshot and
+        // came up empty: shard 4 on #2750 this morning, then main itself (e3a73f3b4, run
+        // 33320002359), which switched delivery off. So after the terminal wait, wait on the
+        // area's control stream directly for its first non-null control — exactly what the warm
+        // path further down already does — and only then assert the snapshot.
         var terminal = await clientWorkspace.GetMeshNodeStream(NodeTypePath)
             .Should().Within(30.Seconds()).Match(n => n?.Content is NodeTypeDefinition d
                         && d.CompilationStatus == CompilationStatus.Ok
@@ -325,6 +331,14 @@ public class NodeTypeProgressAreaTest(ITestOutputHelper output) : MonolithMeshTe
         // The "the area is wired up and reacting to typeStream" signal is
         // sufficient; the rendering itself is unit-tested elsewhere via the
         // helper that builds the Stack from a NodeTypeDefinition.
+        // The positive signal, before the snapshot: the area has rendered at least one control.
+        // Bounded, so a wedged area fails here with a message that names it rather than with an
+        // empty-queue assertion that looks like a race.
+        await clientWorkspace
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(nodeTypeAddress, progressRef)
+            .GetControlStream(progressRef.Area!)
+            .Should().Within(30.Seconds()).Match(c => c != null);
+
         progressEmissions.Should().NotBeEmpty(
             "the Progress layout area must emit at least one UiControl " +
             "across the compile lifecycle");


### PR DESCRIPTION
## It switched delivery off

`NodeTypeProgressAreaTest.ColdCycle_TriggersCompile_StreamsTransitions_LandsAssemblyOnDisk` failed on #2750's shard 4 this morning, and then on **`main` itself** (`e3a73f3b4`, run 33320002359). A red required check on main turns CD delivery **off** until the next green commit — which is what "cd is failing" looked like from the outside.

## Mechanism

The test waited for the NodeType stream to settle at `Ok`, then asserted a **snapshot** of `progressEmissions` — a `ConcurrentQueue` filled by a *separate* subscription on the Progress layout area — trusting its own comment:

> *"by the time this completes the area has emitted at least the terminal control"*

The area subscribes to the same state through its **own** hop. Nothing orders the two subscriptions, so the queue was sometimes still empty at snapshot time:

```
Expected collection to contain an item matching the predicate because at least one
emission must be non-null — the Stack with status header.
```

## Fix

After the terminal wait, wait on the area's control stream for its first non-null control — **the exact pattern the warm-cache path in the same file already uses** (`.Should().Within(5.Seconds()).Match(c => c != null)`) — and only then assert the snapshot. A wedged area now fails at a bounded wait that names it, instead of at an empty-queue assertion that reads as a race. The misleading comment is replaced with what is actually guaranteed.

Not a widened bound; the removal of an unordered assumption.

## Honest verification note

This test fails **locally on every tree** in my environment (measured this morning: 0/5 on main, 0/5 on the branch, and on four earlier main commits), so a local run cannot discriminate the fix. CI is the verification, and I am saying so rather than implying a local green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)