### PR TITLE
ci: Build and Test fires on merge_group, so a merge queue can be enabled (#2412)

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -108,6 +108,23 @@ on:
   push:
     branches: [ "main" ]
   pull_request:      # ← NO `branches:` filter. See the block above (#1401) before adding one.
+  # 🚨 THE MERGE QUEUE CANNOT WORK WITHOUT THIS TRIGGER, and its absence does not look like a
+  # missing trigger — it looks like a PR that queues and then sits there. The queue builds a
+  # temporary `gh-readonly-queue/main/…` ref and waits for the REQUIRED CONTEXT (`Consolidate test
+  # results`) to report on it; a workflow that never fires on `merge_group` reports nothing, so the
+  # entry waits out its timeout and is ejected, with no failing check to point at.
+  #
+  # Why a queue at all (#2412): with `strict: false` every PR is tested against the main it
+  # branched from, so a burst of merges lands a COMBINATION no run ever compiled. Measured twice —
+  # `CS0246: MeshOperations` on 2026-08-26, and on 2026-08-30 a new guard (#2782) plus an
+  # independently-landed gate primitive (#2792) that were each green alone and red together, which
+  # held main red for five consecutive runs and reddened a documentation-only PR. A queue builds
+  # each entry on top of the entries ahead of it, so the combination is compiled BEFORE it lands.
+  #
+  # This repo is PUBLIC, so the queue is available on the org's plan (private repos need
+  # Enterprise Cloud — MeshWeaver.Plugins carries the same trigger dormant for that reason).
+  # Enable it in the `main pr protection` ruleset ONLY after this trigger is on main.
+  merge_group:
   workflow_dispatch:
 
 # A force-push to a PR branch obsoletes the in-flight run — cancel it instead of
@@ -254,7 +271,10 @@ jobs:
     # 🚨 Runs on PRs only, and deliberately does NOT depend on precheck: this is a DIFF gate, so
     # a tree that is already green elsewhere still has to answer "is this change binary-breaking
     # for a consumer compiled earlier?" — a question no repo-local suite can answer.
-    if: github.event_name == 'pull_request'
+    # A merge_group entry HAS a base — main, by construction (the queue ref is main plus the
+    # entries ahead of this one) — so both diff gates keep holding inside the queue rather than
+    # going quiet exactly where the merge actually happens.
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
     steps:
     - uses: actions/checkout@v7
       with:
@@ -265,7 +285,7 @@ jobs:
     - name: "Refuse a binary-breaking primary-constructor change"
       run: |
         set -euo pipefail
-        git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
+        git fetch --no-tags --depth=200 origin "${{ github.event_name == 'merge_group' && 'main' || github.base_ref }}"
         # 🚨 The MERGE BASE, not the base branch tip — same reasoning as the type-move gate below.
         # This step disagreed with its own script until #2398: check-record-signatures.py's
         # docstring says it compares "the merge base against the working tree", while the step
@@ -279,7 +299,7 @@ jobs:
         # reverting it. A red on somebody else's commit, on a gate whose whole value is that people
         # believe it. Passing the merge-base SHA fixes both halves consistently (`sha...HEAD`
         # degenerates to `sha`, since it is an ancestor of HEAD).
-        base=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+        base=$(git merge-base "origin/${{ github.event_name == 'merge_group' && 'main' || github.base_ref }}" HEAD)
         echo "Comparing against merge base $base"
         python3 scripts/check-record-signatures.py --base "$base"
     # The OTHER half of the same class (#2370): a public TYPE moving assemblies, which no repo-local
@@ -302,12 +322,12 @@ jobs:
       run: |
         set -euo pipefail
         # Already fetched above for the record gate; repeated explicitly so the steps can be reordered.
-        git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
+        git fetch --no-tags --depth=200 origin "${{ github.event_name == 'merge_group' && 'main' || github.base_ref }}"
         # 🚨 The MERGE BASE, not the base branch tip. This is a diff question, and a public type that
         # moves on main while this PR is open reads, against the tip, as THIS PR moving it back — a
         # red on somebody else's change. Four such moves landed on main in one day (#2398), so this
         # is the difference between a gate people believe and one they learn to allow-list past.
-        base=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+        base=$(git merge-base "origin/${{ github.event_name == 'merge_group' && 'main' || github.base_ref }}" HEAD)
         echo "Comparing against merge base $base"
         python3 scripts/check-type-forwards.py --base "$base"
 


### PR DESCRIPTION
Toward **#2412** — the structural fix rather than a third partial one.

## Why

With `strict: false` every PR is tested against the main it branched from, so a burst of merges lands a **combination no run ever compiled**. Measured twice: `CS0246: MeshOperations` on 2026-08-26, and today #2782 + #2792 — each green alone, red together — which held main red for five consecutive runs and caught a documentation-only PR in the blast. #2447 and #2767 each changed *when you find out*; neither builds the combination before it lands. A merge queue does: each entry is built on top of the entries ahead of it.

## Availability, measured

This repo is **public**, so GitHub's merge queue is available on the org's Team plan. `mergeQueue(branch:"main")` → `null` today: *available, not enabled*. (MeshWeaver.Plugins carries the same trigger dormant because it is private — its own comment says so.)

## What changes

- **`merge_group:` trigger.** Without it, a queued entry sits, times out and is ejected with no failing check to point at.
- **Both diff gates run on `merge_group` too**, with the base resolved to `main` — `github.base_ref` is empty on `merge_group`, and a queue entry's base *is* main by construction. Resolved inline at all four uses so the two gates cannot drift.
- Nothing else: concurrency groups the queue ref per entry, the fork gates read `null` as "not a fork", `HEAD_SHA` falls through to `github.sha`, the executed-and-green marker stays push-only.

## 🚨 Order matters

This must be **on main before** the `merge_queue` rule is added to the `main pr protection` ruleset, or the first queued PR sits forever. Enabling the rule is the next step, via the ruleset API, once this lands.

## Verified

| | |
|---|---|
| YAML | parses; triggers `[push, pull_request, merge_group, workflow_dispatch]` |
| `MainRunsAreNeverCancelledGuard` | 11/11 — the concurrency expressions are untouched |

🤖 Generated with [Claude Code](https://claude.com/claude-code)