### PR TITLE
fix: four silent defects from the issue sweep (#2729, #2731, #2793, #2797)

### DIFF
--- a/.github/scripts/shard-assign.sh
+++ b/.github/scripts/shard-assign.sh
@@ -42,14 +42,38 @@
 # drifted the same way (Monolith 200→345, Data 25→73, PluginTester 60→8).
 #
 # The floor for ANY sharding is the heaviest single SCHEDULABLE UNIT — a project,
-# or one part of a split one. Today that is Hosting.Monolith.Test's two halves at
-# ~331 s each. Adding shards below that buys nothing.
+# or one part of a split one. Today that is Hosting.Monolith.Test's three thirds
+# at ~221 s each. Adding shards below that buys nothing.
 #
-# SPLIT RULE: split a project only when its solo weight exceeds the ideal shard
-# load (sum ÷ SHARD_TOTAL, currently 2526 ÷ 6 ≈ 421 s), because only then is it
-# the binding floor. Monolith (662 s) qualifies; nothing else does. (AI.Test's
-# split was dropped for the same reason before the suite itself moved to
-# MeshWeaver.Plugins beside the engine, #2276.)
+# SPLIT RULE — TWO independent triggers. Either one is sufficient.
+#
+#  (1) BALANCE. Solo weight exceeds the ideal shard load (sum ÷ SHARD_TOTAL,
+#      currently 2526 ÷ 6 ≈ 421 s), because only then is the project the binding
+#      floor. Monolith (663 s) qualifies. (AI.Test's split was dropped under this
+#      rule before the suite itself moved to MeshWeaver.Plugins, #2276.)
+#
+#  (2) 🚨 HEADROOM AGAINST THE PER-PROJECT CAP (#2747). Solo weight exceeds ~60%
+#      of the `timeout 8m` = 480 s wall-clock cap each project runs under in
+#      dotnet-test.yml. This trigger is INDEPENDENT of balance and it is the one
+#      that bites in production: a project can sit comfortably under the ideal
+#      shard load and still be one slow runner away from exit=124.
+#
+#      PluginCatalog was exactly that. Measured across four consecutive runs it
+#      ran 315/320/315 s — 66-72% of the cap — and then 480 s exit=124 TIMEOUT on
+#      e12697ebd (run 33302269352, shard 0), with the SAME tree passing at 320 s
+#      on the very next run. No change was responsible. The five "test failures"
+#      that came with the kill were timing casualties of it, not defects, so every
+#      occurrence costs a full investigation before it can be dismissed — and this
+#      repo's rules (correctly) forbid simply re-running it.
+#
+#      Raising the cap is NOT the alternative: the cap is what turns a wedge into a
+#      bounded, attributable failure instead of a 20-minute shard. Splitting lowers
+#      the numerator instead — PluginCatalog's two parts run ~174 s each, ~36% of
+#      the cap — and it costs nothing, because the parts land on different runners.
+#
+# 🚨 The two triggers must BOTH be checked when re-measuring. A project that grows
+# past 288 s (60% of 480) needs splitting even while the LPT loop still reports
+# six balanced shards, which is precisely why the balance rule alone missed this.
 #
 # Unlisted projects get DEFAULT_WEIGHT — a deliberate over-estimate, since an
 # unlisted project is a NEW one whose cost nobody has measured yet.
@@ -86,8 +110,8 @@ fi
 
 # "<seconds> <project-name>", heaviest first.
 WEIGHTS=$(cat <<'EOF'
-663 MeshWeaver.Hosting.Monolith.Test 2
-348 MeshWeaver.PluginCatalog.Test
+663 MeshWeaver.Hosting.Monolith.Test 3
+348 MeshWeaver.PluginCatalog.Test 2
 269 MeshWeaver.Hosting.Orleans.Test
 91 MeshWeaver.Data.Test
 76 MeshWeaver.Messaging.Hub.Test

--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -258,11 +258,16 @@ public class SelfUpdateHostedService : IHostedService
     /// <list type="number">
     /// <item>Seed <c>Admin/UpdatePolicy</c> if absent (storm-safe, via a query — never a point-read
     /// of a maybe-absent node); a seeding fault retries at the polling cadence.</item>
-    /// <item>The live node stream. The default policy is prepended exactly ONCE — after the seed
-    /// (so the first tick can never point-write a not-yet-existing node), before the first live
-    /// emission. A stream fault retries INSIDE the StartWith, so a retry re-establishes the read
-    /// SILENTLY: it never re-emits the default, and therefore can never flip a Stable/None install
-    /// back to default-policy polling (Copilot review on #611).</item>
+    /// <item>The live node stream, and NOTHING ELSE. 🚨 The configured default is never emitted
+    /// here (MeshWeaver#2731/#2797): it used to be prepended once, before the first live emission,
+    /// and that one synthetic value drove a full <see cref="RunOnce"/> — ACR listing, candidate
+    /// selection and the Deployment PATCH — under a policy the install had never set. On a pinned
+    /// (<c>None</c>) install, EVERY pod (re)start therefore rolled the portal to the newest tag,
+    /// with the persisted <c>None</c> arriving a second later as a <c>PolicyChange</c> that
+    /// dutifully logged "updates are disabled" AFTER the roll had been issued. Stage 1 guarantees
+    /// the node EXISTS, so the live read is the first emission on its own — the poller now waits
+    /// for a policy it has actually read instead of guessing one. A stream fault retries inside
+    /// the RetryWhen, so a retry re-establishes the read silently (Copilot review on #611).</item>
     /// </list>
     /// Retries are delayed, Rx-composed resubscribes at the polling cadence — not a hot retry loop,
     /// not a watchdog. <c>DistinctUntilChanged</c> sits outermost so only a REAL policy change (or
@@ -277,8 +282,7 @@ public class SelfUpdateHostedService : IHostedService
             .Take(1)
             .SelectMany(_ => Observable
                 .Defer(ReadPolicyStream)
-                .RetryWhen(ResubscribeAfterRetryInterval("policy stream"))
-                .StartWith(new UpdatePolicyContent { Policy = _options.DefaultPolicy }))
+                .RetryWhen(ResubscribeAfterRetryInterval("policy stream")))
             .DistinctUntilChanged(c => (c.Policy, c.RequireCiGreen)); // <-- re-switch only on a REAL policy change
     }
 
@@ -292,6 +296,12 @@ public class SelfUpdateHostedService : IHostedService
         var workspace = _hub.GetWorkspace();
         var jsonOptions = _hub.JsonSerializerOptions;
         return workspace.GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
+            // 🚨 An ABSENT node is not a policy (MeshWeaver#2731/#2797). UpdatePolicyContent.Policy
+            // defaults to Continuous and UpdatePolicyKind.Continuous is enum 0, so parsing a null
+            // node yields "roll to the newest tag" — the exact verdict a pinned install must never
+            // reach. Stage 1 has already guaranteed the node exists, so a null here is the stream
+            // not having loaded it yet: wait for the real one rather than deciding without it.
+            .Where(node => node is not null)
             .Select(node => UpdatePolicyNodeType.Parse(node, jsonOptions));
     }
 

--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -5,6 +5,7 @@ using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Reactive.Threading.Tasks;  // Task<T>.ToObservable() — the SAFE direction; nothing here bridges the other way.
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -65,6 +66,15 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     // completed the dispatch keeps its original fully-synchronous shape. Instance field:
     // lifetime is the mesh's, entries removed with their RegisterStream disposal.
     private readonly ConcurrentDictionary<Address, Task> subscriptionReady = new();
+
+    /// <summary>
+    /// Per-address completion of the POD-HUB CLAIM (<see cref="AttachPodHub"/>) — an instance field
+    /// owned by this routing service, never static. The subject completes when the claim TERMINATES:
+    /// it landed, or it hit the one terminal that is impossibility rather than a budget (a process
+    /// that cannot host a grain). A claim that is still retrying never completes it, which is the
+    /// honest answer for a lifetime that has no give-up. See <see cref="PodHubClaimSettled"/>.
+    /// </summary>
+    private readonly ConcurrentDictionary<Address, AsyncSubject<Unit>> podHubClaimSettled = new();
     private readonly CompositeDisposable inFlight = new();
     // Mesh-scoped IO pool for the genuinely-async stream UnsubscribeAsync. The hub's
     // RegisterForDisposal(IDisposable) is synchronous; the async unsubscribe is bridged
@@ -890,6 +900,26 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     internal Func<int, TimeSpan> ClaimBackoff { get; set; } = PodHubClaimBackoff;
 
     /// <summary>
+    /// Test seam (<c>InternalsVisibleTo</c>): completes once the pod-hub claim for
+    /// <paramref name="address"/> has <b>terminated</b> — it landed, or it hit the impossibility
+    /// terminal (a process that cannot host a grain can never win the claim). A claim that is still
+    /// retrying never completes this, because it has not stopped: there is no give-up on that path,
+    /// and saying otherwise would be the very silence #1742 removed.
+    ///
+    /// <para>🚨 The sibling of <c>AttachSettled</c> (#2800), and it exists for the same reason
+    /// (#2793): the alternative is a settle-by-silence poll, which measures a PAUSE. The claim's
+    /// retry hops through the thread-pool scheduler between attempts, so on a loaded CI shard that
+    /// hop exceeds the poll interval and "two equal readings" reads the count mid-hop — returning 1
+    /// where the test expects 6, which is exactly the regression signature this file exists to
+    /// detect. A false RED spelling the regression's own signature is worse than no test. The
+    /// condition is "the claim stopped attempting", and this IS that condition, positively.</para>
+    /// </summary>
+    /// <param name="address">The address whose claim to await.</param>
+    /// <returns>The completion, or <c>null</c> if no claim is registered for the address.</returns>
+    internal IObservable<Unit>? PodHubClaimSettled(Address address) =>
+        podHubClaimSettled.TryGetValue(address, out var settled) ? settled : null;
+
+    /// <summary>
     /// Claims <paramref name="address"/> for THIS process, so the rest of the cluster can deliver to
     /// it with a directed grain call instead of a stream publish (#1742).
     ///
@@ -941,6 +971,10 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         var attempt = 0;
         var reported = false;
         var attach = new SingleAssignmentDisposable();
+        // Armed BEFORE the claim is subscribed, so there is no window in which the claim could
+        // terminate unobserved. AsyncSubject: it completes once and replays that completion to
+        // whoever asks afterwards, so an observer arriving late still sees the terminal.
+        var settled = podHubClaimSettled[address] = new AsyncSubject<Unit>();
         inFlight.Add(attach);
         attach.Disposable = Observable
             .Defer(() =>
@@ -1020,6 +1054,8 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                             addressPath);
                     else
                         logger.LogDebug("Pod-hub claim for {Address} landed on this process", addressPath);
+                    settled.OnNext(Unit.Default);
+                    settled.OnCompleted();
                 },
                 ex =>
                 {
@@ -1033,11 +1069,14 @@ public class OrleansRoutingService : IRoutingService, IDisposable
                         "Pod-hub claim for {Address} did not land in this process — it keeps the Orleans "
                         + "stream transport. Expected on an Orleans client, which cannot host a grain.",
                         addressPath);
+                    settled.OnNext(Unit.Default);
+                    settled.OnCompleted();
                 });
 
         return Disposable.Create(() =>
         {
             inFlight.Remove(attach);
+            podHubClaimSettled.TryRemove(address, out _);
             attach.Dispose();
             // Fire-and-forget: teardown is best-effort, and an activation that outlives its owner is
             // recovered anyway — Deliver on a silo with no local route steps aside (see PodHubGrain).

--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -1113,6 +1113,25 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     internal Func<int, TimeSpan> AttachBackoff { get; set; } = SubscribeAttachBackoff;
 
     /// <summary>
+    /// Test seam (<c>InternalsVisibleTo</c>): the task that completes once the stream attach for
+    /// <paramref name="address"/> has <b>terminated</b> — attached, given up after exhausting the
+    /// budget, or been cancelled. It is the same task <see cref="RegisterStream"/> stores as the
+    /// outbound gate, so it never faults and always completes.
+    ///
+    /// <para>🚨 This exists because the alternative is a settle-by-silence poll, and that measures
+    /// the wrong thing. A test that watched the attempt counter and called it "settled" after two
+    /// equal readings 25 ms apart was reading a <i>pause</i>: the retry hops through the thread-pool
+    /// scheduler between attempts, and on a loaded CI shard that hop exceeds 25 ms, so the poll
+    /// returned 1 — which is precisely the value the regression under test produces (#2633). A
+    /// false RED that spells the regression's own signature is worse than no test (#2793). The
+    /// condition is "the attach stopped attempting", and this is that condition, positively.</para>
+    /// </summary>
+    /// <param name="address">The address whose attach to await.</param>
+    /// <returns>The completion task, or <c>null</c> if nothing is registered for the address.</returns>
+    internal Task? AttachSettled(Address address) =>
+        subscriptionReady.TryGetValue(address, out var settled) ? settled : null;
+
+    /// <summary>
     /// The attach, re-attempted while it fails TRANSIENTLY and the budget holds (issue #2633).
     ///
     /// <para>Deliberately the SAME reactive shape as <see cref="AttachPodHub"/> forty lines below

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-pinned-install-stays-pinned.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-pinned-install-stays-pinned.md
@@ -1,0 +1,37 @@
+---
+Name: A pinned install stays pinned across a restart
+Category: Fix
+Description: An install with Admin/UpdatePolicy = None no longer rolls itself to the newest image every time its pod restarts — the updater now waits until it has actually read the persisted policy instead of starting on the deployment's configured default.
+Icon: ShieldKeyhole
+Order: -20260830
+---
+
+# A pinned install stays pinned across a restart
+
+Setting **Update policy → None** is how an operator freezes an install on the image it is running.
+It did freeze the scheduled checks — and then the install rolled anyway, on every pod start.
+
+`memex.meshweaver.cloud` had read `policy: None` all day on 2026-08-30 and still rolled twice, to
+`ci.6664` at 11:54 UTC and `ci.6739` at 15:03 UTC. The policy node's own history recorded both: a
+`Startup` pass that evaluated a candidate as though updates were enabled, then — seconds later — a
+`PolicyChange` pass concluding *"updates are disabled on this install (Admin/UpdatePolicy = None)"*,
+after the roll had already been issued.
+
+## What was wrong
+
+The updater's policy stream was **seeded with the deployment's configured default** (normally
+`Continuous`) and only afterwards read the value an administrator had actually persisted. The
+startup pass ran on that seed — a full evaluation: list the registry, choose a candidate, patch the
+Deployment. The real policy arrived a moment later and correctly disabled everything, one step too
+late. Every pod restart re-opened the window, so a restart for any reason — a node drain, an
+eviction, a failed probe — rolled a deliberately pinned install.
+
+## What changed
+
+The updater no longer invents a policy. The node is still seeded with the configured default when
+it does not exist yet, but the poller waits for a real read of `Admin/UpdatePolicy` before it
+evaluates anything, and an absent node is no longer parsed as "roll to the newest tag". An install
+now decides only under a policy it has read.
+
+Nothing changes for an install that has never set a policy: the seeded default is what the read
+returns, and the first check happens as before.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-retry-test-no-longer-reads-a-pause-as-a-regression.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-retry-test-no-longer-reads-a-pause-as-a-regression.md
@@ -26,3 +26,19 @@ attempting*, and the routing service already tracks exactly that: the task it st
 gate completes when the attach has attached, given up, or been cancelled. The test now waits on that
 task and reads the counter once, afterwards. No polling, no window, and the suite runs in
 milliseconds instead of racing a timer.
+
+## Its sibling, found by the merge queue
+
+The same poll had been copied once. `PodHubClaimLifetimeTest` — which proves a process that cannot
+host a grain stops claiming instead of spinning for ever — waited the same way, and it failed a
+merge-queue entry with the same words: *expected 6, found 1*. A queue entry builds on a loaded
+runner, which is exactly the condition that makes a pause look like a verdict.
+
+It now waits on the claim's own terminal (`PodHubClaimSettled`), armed before the claim is
+subscribed and completed when the claim lands or hits the one terminal that is impossibility rather
+than a budget. A claim that is *still retrying* completes nothing, because it has not stopped —
+that case keeps the positive "reached at least N attempts" wait it already had.
+
+Both siblings ship together on purpose: each was ejecting the other from the merge queue, since an
+entry is built on the entries ahead of it and neither fix was on the branch the other stood on.
+

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-retry-test-no-longer-reads-a-pause-as-a-regression.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-retry-test-no-longer-reads-a-pause-as-a-regression.md
@@ -1,0 +1,28 @@
+---
+Name: A retry test no longer reads a pause as a regression
+Category: Fix
+Description: The Orleans stream-attach retry test decided the attach had "settled" when its attempt counter stopped moving for 25 ms — on a loaded runner that is a scheduler hop, and the count it then read was exactly the regression signature it exists to detect.
+Icon: Timer
+Order: -20260830
+---
+
+# A retry test no longer reads a pause as a regression
+
+`StreamAttachTransientRetryTest` proves that a transient grain-directory rejection is **retried**
+rather than latching a hub into permanently disabled cross-process routing — the defect behind a
+hub going silent on every rolling deploy.
+
+It measured that by polling the attempt counter and calling the attach *settled* once two readings
+25 ms apart were equal. But the retry hops through the thread-pool scheduler between attempts, and
+on a loaded CI shard that hop takes longer than 25 ms. The poll then read the count **during a
+pause**, declared it final, and reported `1`.
+
+`1` is precisely the value the regression produces. So a saturated runner manufactured a red that
+spelled out the regression's own signature — the worst possible false positive, because the correct
+response to it is to go looking for a bug that is not there.
+
+"Unchanged for 25 ms" was never the condition under test. The condition is *the attach stopped
+attempting*, and the routing service already tracks exactly that: the task it stores as the outbound
+gate completes when the attach has attached, given up, or been cancelled. The test now waits on that
+task and reads the counter once, afterwards. No polling, no window, and the suite runs in
+milliseconds instead of racing a timer.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-no-test-project-runs-near-its-own-kill-switch.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-no-test-project-runs-near-its-own-kill-switch.md
@@ -1,0 +1,36 @@
+---
+Name: No test project runs near its own kill switch
+Category: Fix
+Description: Two test projects were scheduled as single units taking ~70% of the 8-minute wall-clock cap each project runs under, so one slow runner killed them and produced a red naming tests that had not failed. Both are split, and a guard now does the arithmetic instead of a comment asking someone to.
+Icon: DocumentSplitHint
+Order: -20260830
+---
+
+# No test project runs near its own kill switch
+
+Every test project in CI runs under an 8-minute wall-clock cap. The cap is deliberate: it turns a
+hang into a bounded, attributable failure instead of a shard that eats its whole budget.
+
+But a project that *legitimately* takes 5½ minutes is one slow runner away from hitting it, and what
+comes out then is not a clean "timed out" — it is a red listing tests that were still running when
+the host was killed. Those tests did not fail. Every occurrence therefore costs a full investigation
+before it can be dismissed, and re-running to see whether it repeats is exactly what this codebase
+forbids, because that habit is how real races get buried.
+
+`MeshWeaver.PluginCatalog.Test` was in that position: 315, 320, 315 seconds on three consecutive
+runs — and then 480 seconds and killed, with the identical tree passing at 320 seconds on the very
+next run. Five tests were blamed for a kill.
+
+## Why it was not caught
+
+The scheduler already had a split rule, but it is about **balance** — split a project when it is the
+long pole. PluginCatalog was never the long pole; it passed that rule comfortably. Headroom against
+the cap is an independent property, and nothing was checking it.
+
+Both projects are now split into parts that land on different runners — PluginCatalog into two
+(~174 s each) and Hosting.Monolith into three (~221 s each) — and the shard loads stay balanced.
+
+The lasting part is that the check is now mechanical. A guard reads the cap out of the workflow (so
+it cannot disagree with the budget it guards), divides each project's measured weight by its part
+count, and fails when any scheduled unit exceeds 60% of the cap — naming the project and pointing at
+the parts column. It found the second of the two projects on its first run.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-node-content-reads-typed-on-every-hub.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-node-content-reads-typed-on-every-hub.md
@@ -1,0 +1,33 @@
+---
+Name: Node content now reads typed on every hub
+Category: Fix
+Description: Seven built-in node types declared a content type that only their own hub knew about, so a reader anywhere else in the mesh got raw JSON and a silent null — inbound mail on one install was dead with no error. All seven are registered, and a guard now fails the build if an eighth is added.
+Icon: DocumentBulletListMultiple
+Order: -20260830
+---
+
+# Node content now reads typed on every hub
+
+A node type declares what its content **is** — `Invitation`, `NotificationRule`,
+`GraphSubscriptionState` and so on. That declaration configured the node's own hub and nothing
+else, so any *other* hub that read the node had no `$type` discriminator for the value and received
+an untyped `JsonElement` instead of the record.
+
+That failure is completely silent. There is no exception and no error line: consumers written as
+`content is Invitation` simply see `null`, the view renders empty, and a reactive wait times out
+with nothing to point at.
+
+It was found on `memex.systemorph.com`, where the portal logged at boot that
+`Admin/_GraphSubscription/inbox` *"stayed an untyped JsonElement after deserialization"*. That node
+carries the state of the inbound-mail subscription, so the renewal could not see its own record and
+inbound mail on that install was dead — with every health signal green.
+
+Seven built-in node types were in that position: `EaCredential`, `GraphSubscriptionState`,
+`Invitation`, `MemexClientContent`, `NotificationChannel`, `NotificationRule` and
+`TeamsConversation`. All seven now register their discriminator mesh-wide.
+
+The lasting part is the guard. The two halves of this contract — the declaration, inside a hub
+configuration lambda, and the registration, a separate statement in the enclosing method — were
+joined by nothing, and omitting the second compiles, boots, serves and passes every test. A new
+governance test now reads both halves out of the source and fails when a node type declares a
+content type it never registers, naming the type and the three accepted spellings of the fix.

--- a/src/MeshWeaver.Graph/Configuration/EaCredentialNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/EaCredentialNodeType.cs
@@ -20,6 +20,11 @@ public static class EaCredentialNodeType
     public static TBuilder AddEaCredentialType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
     {
         builder.AddMeshNodes(CreateMeshNode());
+        // 🚨 The discriminator has to be known to EVERY hub, not only to the per-node hub the
+        // data source above configures (MeshWeaver#2729). A reader elsewhere in the mesh whose
+        // TypeRegistry lacks it gets a raw JsonElement and therefore a SILENT null: the value
+        // renders empty and reactive waits time out, with no exception anywhere to grep for.
+        builder.ConfigureHub(config => config.WithType<EaCredential>(nameof(EaCredential)));
         builder.AddAutocompleteExcludedTypes(NodeType);
         return builder;
     }

--- a/src/MeshWeaver.Graph/Configuration/GraphSubscriptionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphSubscriptionNodeType.cs
@@ -20,6 +20,11 @@ public static class GraphSubscriptionNodeType
     public static TBuilder AddGraphSubscriptionType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
     {
         builder.AddMeshNodes(CreateMeshNode());
+        // 🚨 The discriminator has to be known to EVERY hub, not only to the per-node hub the
+        // data source above configures (MeshWeaver#2729). A reader elsewhere in the mesh whose
+        // TypeRegistry lacks it gets a raw JsonElement and therefore a SILENT null: the value
+        // renders empty and reactive waits time out, with no exception anywhere to grep for.
+        builder.ConfigureHub(config => config.WithType<GraphSubscriptionState>(nameof(GraphSubscriptionState)));
         builder.AddAutocompleteExcludedTypes(NodeType);
         return builder;
     }

--- a/src/MeshWeaver.Graph/Configuration/InvitationNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/InvitationNodeType.cs
@@ -43,6 +43,11 @@ public static class InvitationNodeType
     public static TBuilder AddInvitationType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
     {
         builder.AddMeshNodes(CreateMeshNode());
+        // 🚨 The discriminator has to be known to EVERY hub, not only to the per-node hub the
+        // data source above configures (MeshWeaver#2729). A reader elsewhere in the mesh whose
+        // TypeRegistry lacks it gets a raw JsonElement and therefore a SILENT null: the value
+        // renders empty and reactive waits time out, with no exception anywhere to grep for.
+        builder.ConfigureHub(config => config.WithType<Invitation>(nameof(Invitation)));
         builder.AddAutocompleteExcludedTypes(NodeType);
         // Intent: a path-less nodeType:Invitation query → Admin partition (no fan-out).
         // NOTE: the PostgreSQL query router (PostgreSqlPartitionedMeshQuery) routes purely by

--- a/src/MeshWeaver.Graph/Configuration/MemexClientNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/MemexClientNodeType.cs
@@ -56,6 +56,11 @@ public static class MemexClientNodeType
     public static TBuilder AddMemexClientType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
     {
         builder.AddMeshNodes(CreateMeshNode());
+        // 🚨 The discriminator has to be known to EVERY hub, not only to the per-node hub the
+        // data source above configures (MeshWeaver#2729). A reader elsewhere in the mesh whose
+        // TypeRegistry lacks it gets a raw JsonElement and therefore a SILENT null: the value
+        // renders empty and reactive waits time out, with no exception anywhere to grep for.
+        builder.ConfigureHub(config => config.WithType<MemexClientContent>(nameof(MemexClientContent)));
         return builder;
     }
 

--- a/src/MeshWeaver.Graph/Configuration/NotificationChannelNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/NotificationChannelNodeType.cs
@@ -21,6 +21,11 @@ public static class NotificationChannelNodeType
     public static TBuilder AddNotificationChannelType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
     {
         builder.AddMeshNodes(CreateMeshNode());
+        // 🚨 The discriminator has to be known to EVERY hub, not only to the per-node hub the
+        // data source above configures (MeshWeaver#2729). A reader elsewhere in the mesh whose
+        // TypeRegistry lacks it gets a raw JsonElement and therefore a SILENT null: the value
+        // renders empty and reactive waits time out, with no exception anywhere to grep for.
+        builder.ConfigureHub(config => config.WithType<NotificationChannel>(nameof(NotificationChannel)));
         return builder;
     }
 

--- a/src/MeshWeaver.Graph/Configuration/NotificationRuleNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/NotificationRuleNodeType.cs
@@ -22,6 +22,11 @@ public static class NotificationRuleNodeType
     public static TBuilder AddNotificationRuleType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
     {
         builder.AddMeshNodes(CreateMeshNode());
+        // 🚨 The discriminator has to be known to EVERY hub, not only to the per-node hub the
+        // data source above configures (MeshWeaver#2729). A reader elsewhere in the mesh whose
+        // TypeRegistry lacks it gets a raw JsonElement and therefore a SILENT null: the value
+        // renders empty and reactive waits time out, with no exception anywhere to grep for.
+        builder.ConfigureHub(config => config.WithType<NotificationRule>(nameof(NotificationRule)));
         return builder;
     }
 

--- a/src/MeshWeaver.Graph/Configuration/TeamsConversationNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/TeamsConversationNodeType.cs
@@ -20,6 +20,11 @@ public static class TeamsConversationNodeType
     public static TBuilder AddTeamsConversationType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
     {
         builder.AddMeshNodes(CreateMeshNode());
+        // 🚨 The discriminator has to be known to EVERY hub, not only to the per-node hub the
+        // data source above configures (MeshWeaver#2729). A reader elsewhere in the mesh whose
+        // TypeRegistry lacks it gets a raw JsonElement and therefore a SILENT null: the value
+        // renders empty and reactive waits time out, with no exception anywhere to grep for.
+        builder.ConfigureHub(config => config.WithType<TeamsConversation>(nameof(TeamsConversation)));
         builder.AddAutocompleteExcludedTypes(NodeType);
         return builder;
     }

--- a/test/MeshWeaver.Documentation.Test/NodeTypeContentDiscriminatorGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/NodeTypeContentDiscriminatorGuard.cs
@@ -1,0 +1,136 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for MeshWeaver#2729: a node type that declares a CLR content type
+/// (<c>AddMeshDataSource(s =&gt; s.WithContentType&lt;T&gt;())</c>) must ALSO register that type's
+/// <c>$type</c> discriminator on the builder, so every hub in the mesh can read the node — not only
+/// the per-node hub the data source configures.
+///
+/// <para><b>The defect this pins is silent, and that is the whole reason it needs a guard.</b> On
+/// <c>memex.systemorph.com</c> the portal logged, at boot:</para>
+/// <code>
+/// MeshNodeStreamCache.GetStream: Content for Admin/_GraphSubscription/inbox stayed an untyped
+/// JsonElement after deserialization (TypeRegistry lacks the $type discriminator)
+/// </code>
+/// <para>…because <c>AddGraphSubscriptionType</c> declared <c>WithContentType&lt;GraphSubscriptionState&gt;()</c>
+/// and nothing else. Per AGENTS.md that warning means the reader gets a <b>silent null</b>: the
+/// inbound-mail subscription renewal could not see its own state, so inbound mail on that install was
+/// dead with no error, no exception and nothing to grep for. Seven node types were in that position
+/// when this guard was written; the six besides the reported one had simply not been read from
+/// another hub yet.</para>
+///
+/// <para><b>Why a guard rather than seven fixes.</b> The two halves are joined by nothing — the
+/// declaration is inside a <c>HubConfiguration</c> lambda on a MeshNode, the registration is a
+/// separate statement in the enclosing <c>Add…Type</c> method, and omitting the second compiles,
+/// starts, serves and passes every test. This is the same class as the
+/// <see cref="HandWovenGateRatchetGuard"/> subject: a contract whose halves can drift with nothing
+/// asserting they agree.</para>
+///
+/// <para>The three spellings below are all in live use and all correct; the guard accepts any of
+/// them rather than legislating one, because which is right depends on whether the type crosses the
+/// mesh hub only or every hub.</para>
+/// </summary>
+public class NodeTypeContentDiscriminatorGuard
+{
+    /// <summary>Where node types are declared. Both trees ship in the portal image.</summary>
+    private static readonly string[] ScannedRoots = ["src", "memex"];
+
+    /// <summary>
+    /// Declarations that are not a concrete content type and cannot be registered: the framework's
+    /// own generic definitions and re-exports of <c>WithContentType&lt;T&gt;</c>.
+    /// </summary>
+    private static readonly HashSet<string> NotAContentType = new(StringComparer.Ordinal) { "T", "TContent", "TValue" };
+
+    private static readonly Regex Declaration = new(@"WithContentType\s*<\s*([A-Za-z0-9_.]+)\s*>", RegexOptions.Compiled);
+
+    /// <summary>
+    /// The floor that stops this guard passing vacuously. If the scan ever finds fewer declarations
+    /// than this, the scan itself has broken (a moved tree, a renamed API) and the guard must fail
+    /// LOUDLY rather than report a clean tree it never looked at.
+    /// </summary>
+    private const int MinimumDeclarationsExpected = 25;
+
+    [Fact(Timeout = 60000)]
+    public void EveryDeclaredContentType_AlsoRegistersItsDiscriminator()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var files = SourceScan.SourceFiles(root, ScannedRoots).ToArray();
+
+        var declared = new Dictionary<string, string>(StringComparer.Ordinal);
+        var registered = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var file in files)
+        {
+            var code = SourceScan.MaskCommentsAndStrings(File.ReadAllText(file));
+
+            foreach (Match m in Declaration.Matches(code))
+            {
+                var name = ShortName(m.Groups[1].Value);
+                if (NotAContentType.Contains(name)) continue;
+                declared.TryAdd(name, SourceScan.Relative(root, file));
+            }
+
+            foreach (var name in RegisteredNames(code))
+                registered.Add(name);
+        }
+
+        declared.Count.Should().BeGreaterThanOrEqualTo(MinimumDeclarationsExpected,
+            "the scan must actually find the WithContentType declarations it is guarding — a count "
+            + "below the floor means the scan broke, not that the tree is clean");
+
+        var missing = declared
+            .Where(d => !registered.Contains(d.Key))
+            .OrderBy(d => d.Key, StringComparer.Ordinal)
+            .ToArray();
+
+        missing.Should().BeEmpty(
+            "every content type a node type declares must also register its $type discriminator, or "
+            + "a reader on another hub silently gets an untyped JsonElement (MeshWeaver#2729). "
+            + "Missing: "
+            + string.Join(", ", missing.Select(m => $"{m.Key} (declared in {m.Value})"))
+            + ". Fix by adding, in that type's Add…Type method, one of: "
+            + "builder.ConfigureHub(config => config.WithType<X>(nameof(X)));  |  "
+            + "builder.WithMeshType<X>();  |  typeRegistry.WithType(typeof(X), nameof(X)) in "
+            + "MeshNodeExtensions. Never by deleting the WithContentType declaration.");
+    }
+
+    /// <summary>
+    /// 🚨 The guard's own failure mode, asserted rather than assumed. A ratchet that cannot fail is
+    /// not a ratchet — and the way this one would fail silently is by treating an unregistered type
+    /// as registered, which is exactly what a too-permissive <see cref="RegisteredNames"/> would do.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheGuardDetectsAnUnregisteredType()
+    {
+        RegisteredNames("builder.ConfigureHub(c => c.WithType<Widget>(nameof(Widget)));")
+            .Should().Contain("Widget");
+        RegisteredNames("builder.WithMeshType<Widget>();").Should().Contain("Widget");
+        RegisteredNames("typeRegistry.WithType(typeof(Widget), nameof(Widget));").Should().Contain("Widget");
+
+        // The declaration alone — the #2729 shape — must NOT count as a registration.
+        RegisteredNames("HubConfiguration = config => config.AddMeshDataSource(s => s.WithContentType<Widget>()),")
+            .Should().NotContain("Widget");
+    }
+
+    /// <summary>Every type name this code registers a discriminator for, by any of the three spellings.</summary>
+    private static IEnumerable<string> RegisteredNames(string code)
+    {
+        foreach (Match m in Regex.Matches(code, @"With(?:Mesh)?Type\s*<\s*([A-Za-z0-9_.]+)\s*>"))
+            yield return ShortName(m.Groups[1].Value);
+        foreach (Match m in Regex.Matches(code, @"With(?:Mesh)?Type\s*\(\s*typeof\s*\(\s*([A-Za-z0-9_.]+)\s*\)"))
+            yield return ShortName(m.Groups[1].Value);
+    }
+
+    private static string ShortName(string name)
+    {
+        var dot = name.LastIndexOf('.');
+        return dot < 0 ? name : name[(dot + 1)..];
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/ShardWeightHeadroomGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ShardWeightHeadroomGuard.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for MeshWeaver#2747: no test project may be scheduled as a single unit whose
+/// measured weight sits close to the per-project wall-clock cap it runs under.
+///
+/// <para><b>Why the balance rule was not enough.</b> <c>shard-assign.sh</c> already had a split
+/// rule — split when a project's solo weight exceeds the ideal shard load — and it is about
+/// BALANCE, i.e. the long pole. <c>MeshWeaver.PluginCatalog.Test</c> passed that rule comfortably
+/// (348 s against a ~421 s ideal load) and was nonetheless one slow runner away from being killed:
+/// measured 315 / 320 / 315 s on three consecutive runs, then <b>480 s exit=124 TIMEOUT</b> on
+/// <c>e12697ebd</c> (run 33302269352, shard 0) with the SAME tree passing at 320 s on the very next
+/// run. No change was responsible.</para>
+///
+/// <para><b>Why that costs more than a slow shard.</b> A <c>timeout</c> kill produces a red that
+/// names tests which did not really fail — five of them, that time — so every occurrence costs a
+/// full investigation before it can be dismissed, and this repo's rules (correctly) forbid simply
+/// re-running it to see. Raising the cap is not the alternative: the cap is what turns a wedge into
+/// a bounded, attributable failure instead of a 20-minute shard.</para>
+///
+/// <para><b>Why this is a guard and not a one-time split.</b> The weight table is hand-maintained
+/// and its drift is INVISIBLE — the LPT loop keeps reporting six perfectly balanced shards because
+/// it balances the numbers, not the clock. The file's own header records two occasions on which the
+/// table drifted for weeks unnoticed, and PluginCatalog's own entry moved 30 → 348 s. A comment
+/// asking the next person to check headroom is exactly the kind of instruction this repo has
+/// watched go unread; the arithmetic is mechanical, so a test can do it.</para>
+///
+/// <para>The cap is READ from the workflow rather than restated here, so the guard cannot quietly
+/// disagree with the budget it is guarding.</para>
+/// </summary>
+public class ShardWeightHeadroomGuard
+{
+    private const string WeightsPath = ".github/scripts/shard-assign.sh";
+    private const string WorkflowPath = ".github/workflows/dotnet-test.yml";
+
+    /// <summary>
+    /// The fraction of the cap a single scheduled unit may occupy. 0.6 is not a taste: PluginCatalog
+    /// was killed from 0.66–0.72, and the CI/local ratio this repo has measured (~1.7×) means the
+    /// spread between a healthy and a saturated runner is comfortably larger than the remaining 40%.
+    /// </summary>
+    private const double MaxCapFraction = 0.6;
+
+    [Fact(Timeout = 60000)]
+    public void NoScheduledUnitRunsCloseToThePerProjectCap()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var capSeconds = ReadPerProjectCapSeconds(File.ReadAllText(Path.Combine(root, WorkflowPath)));
+        var budget = capSeconds * MaxCapFraction;
+
+        var units = ReadWeights(File.ReadAllText(Path.Combine(root, WeightsPath))).ToArray();
+
+        units.Length.Should().BeGreaterThanOrEqualTo(20,
+            "the weight table must actually have been parsed — a short list means the parse broke, "
+            + "not that the table is healthy, and a guard that measures nothing must fail loudly");
+
+        var overBudget = units
+            .Where(u => u.PerUnitSeconds > budget)
+            .OrderByDescending(u => u.PerUnitSeconds)
+            .ToArray();
+
+        overBudget.Should().BeEmpty(
+            $"a scheduled unit must leave headroom against the {capSeconds:0} s per-project cap in "
+            + $"{WorkflowPath}, or one slow runner turns it into exit=124 — a red naming tests that "
+            + "did not fail (MeshWeaver#2747). Split the project by adding a parts column in "
+            + $"{WeightsPath}; do NOT raise the cap, which is what bounds a wedge. Over "
+            + $"{budget:0} s per unit: "
+            + string.Join(", ", overBudget.Select(u =>
+                $"{u.Name} ({u.TotalSeconds} s ÷ {u.Parts} part(s) = {u.PerUnitSeconds:0} s)")));
+    }
+
+    /// <summary>
+    /// 🚨 The guard's own failure modes, asserted rather than assumed — both halves of the parse are
+    /// places it could silently stop measuring: a cap it fails to find, and a parts column it
+    /// ignores (which would make every split project look over budget, or every unsplit one look
+    /// fine, depending on which way the bug went).
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public void TheGuardParsesTheCapAndThePartsColumn()
+    {
+        ReadPerProjectCapSeconds("( cd \"$dir\" && timeout --signal=TERM --kill-after=30s 8m \\")
+            .Should().Be(480);
+        ReadPerProjectCapSeconds("timeout --signal=TERM --kill-after=30s 90s \\").Should().Be(90);
+
+        var parsed = ReadWeights("WEIGHTS=$(cat <<'EOF'\n600 Big.Test 2\n100 Small.Test\nEOF\n)").ToArray();
+        parsed.Should().HaveCount(2);
+        parsed.Single(u => u.Name == "Big.Test").PerUnitSeconds.Should().Be(300,
+            "a split project's scheduled unit is 1/N of its weight — ignoring the column would "
+            + "report a correctly-split project as over budget");
+        parsed.Single(u => u.Name == "Small.Test").PerUnitSeconds.Should().Be(100);
+    }
+
+    private readonly record struct Unit(string Name, int TotalSeconds, int Parts)
+    {
+        public double PerUnitSeconds => (double)TotalSeconds / Parts;
+    }
+
+    /// <summary>The <c>timeout … 8m</c> that wraps each project's test host, in seconds.</summary>
+    private static double ReadPerProjectCapSeconds(string workflow)
+    {
+        var m = Regex.Match(workflow, @"timeout\s+--signal=TERM\s+--kill-after=30s\s+(\d+)([smh])");
+        Assert.True(m.Success,
+            $"could not find the per-project `timeout` in {WorkflowPath}. The guard reads the cap "
+            + "from the workflow on purpose, so restore the parse rather than hard-coding a number "
+            + "here — a guard holding its own copy of the budget is how the two drift apart.");
+        var value = int.Parse(m.Groups[1].Value, CultureInfo.InvariantCulture);
+        return m.Groups[2].Value switch { "s" => value, "m" => value * 60, _ => value * 3600 };
+    }
+
+    /// <summary>The <c>&lt;seconds&gt; &lt;project&gt; [parts]</c> table, as scheduled units.</summary>
+    private static IEnumerable<Unit> ReadWeights(string script)
+    {
+        var body = Regex.Match(script, @"WEIGHTS=\$\(cat <<'EOF'\n(.*?)\nEOF", RegexOptions.Singleline);
+        Assert.True(body.Success,
+            $"could not find the WEIGHTS table in {WeightsPath} — the parse broke, and an empty "
+            + "table would let this guard pass having measured nothing.");
+
+        foreach (var line in body.Groups[1].Value.Split('\n'))
+        {
+            var parts = line.Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (parts.Length < 2 || !int.TryParse(parts[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var w))
+                continue;
+            var n = parts.Length >= 3 && int.TryParse(parts[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var p) ? p : 1;
+            yield return new Unit(parts[1], w, Math.Max(1, n));
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateCheckVerdictTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateCheckVerdictTest.cs
@@ -12,6 +12,8 @@ using MeshWeaver.GitSync;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Hosting.SelfUpdate;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Xunit;
 using MeshWeaver.Fixture;
@@ -287,6 +289,18 @@ public class SelfUpdateCheckVerdictTest(ITestOutputHelper output) : MonolithMesh
         await service.StartAsync(CancellationToken.None);
         try
         {
+            // 🚨 Publish only once the watch is LIVE. StartAsync subscribes via SubscribeOn(TaskPool)
+            // and the policy source now waits for a real read of Admin/UpdatePolicy (#2731/#2797), so
+            // StartAsync returns well before BuildCompletionTicks is established — and a publication
+            // that races that subscription is absorbed as the watch's BASELINE rather than seen as a
+            // new build (NewBuildEvents, by design). The startup check line is the positive signal
+            // that the Merge — and therefore the watch — has been subscribed.
+            await logger.Emitted
+                .Where(l => l.Message.Contains("[SelfUpdate] check (", StringComparison.Ordinal))
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(30))
+                .Await(TestContext.Current.CancellationToken);
+
             await SelfUpdateEventDriver.PublishBuildAsync(Mesh, "MeshWeaver", 4242);
             await logger.Emitted
                 .Where(l => l.Message.Contains(nameof(SelfUpdateTrigger.BuildCompletion), StringComparison.Ordinal))
@@ -301,5 +315,56 @@ public class SelfUpdateCheckVerdictTest(ITestOutputHelper output) : MonolithMesh
 
         logger.Lines.Should().NotContain(
             l => l.Message.Contains("NO build-completion event", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// 🚨 <b>#2731 / #2797 — a PINNED install rolled on every pod restart.</b>
+    ///
+    /// <para><c>CreatePolicySource</c> used to prepend the <em>configured default</em>
+    /// (<c>Continuous</c>) to the policy stream before the persisted node value arrived, and the
+    /// startup pass ran a full <see cref="SelfUpdateHostedService"/> evaluation on that synthetic
+    /// value — ACR listing, candidate selection, and the Deployment PATCH. On memex-cloud, whose
+    /// <c>Admin/UpdatePolicy</c> has read <c>None</c> since 2026-08-28, that rolled the portal
+    /// twice on 2026-08-30; the persisted <c>None</c> arrived a second later as a
+    /// <c>PolicyChange</c> and logged "updates are disabled" AFTER the roll had been issued.</para>
+    ///
+    /// <para>The discriminating signal is the REGISTRY LISTING, not a log-line spelling: the
+    /// <c>None</c> branch of <c>RunOnce</c> returns its verdict without ever listing tags, so
+    /// <c>acr.Calls == 0</c> at the moment the first verdict is reported proves the startup pass
+    /// ran under the PERSISTED policy. Pre-fix this test fails on both assertions — the first
+    /// verdict is the Continuous one and the registry has been listed.</para>
+    /// </summary>
+    [Fact(Timeout = 60000)]
+    public async Task StartupCheck_OnAPinnedInstall_RunsUnderThePersistedPolicy_NotTheConfiguredDefault()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // The install is pinned by an administrator BEFORE the poller ever starts — the memex-cloud
+        // shape. CreateNode, never GetMeshNodeStream(path).Update: the node does not exist yet, and
+        // a point read of an absent path answers a routing NotFound that terminates the stream.
+        await Mesh.ServiceProvider.GetRequiredService<IMeshService>()
+            .CreateNode(new MeshNode(UpdatePolicyNodeType.NodeId, UpdatePolicyNodeType.AdminPartition)
+            {
+                NodeType = UpdatePolicyNodeType.NodeType,
+                Name = "Update Policy",
+                State = MeshNodeState.Active,
+                Content = new UpdatePolicyContent { Policy = UpdatePolicyKind.None },
+            })
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .Await(ct);
+
+        var acr = new CountingTagLister(NewerTag);
+        // The deployment default disagrees with the node — the wrong-policy tell. A pre-fix run
+        // would list NewerTag and patch to it.
+        var logger = await RunOneCheckAsync(acr, new PatchingUpdater(),
+            Options(policy: UpdatePolicyKind.Continuous));
+
+        logger.Checks[0].Message.Should().Contain("disabled",
+            "the FIRST check must be decided by the persisted policy (None), never by the "
+            + "configured default that the install has overridden");
+        acr.Calls.Should().Be(0,
+            "the None branch never lists the registry, so any listing at all proves an evaluation "
+            + "ran under a policy this install never set (#2731/#2797)");
     }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdatePollerResilienceTest.cs
@@ -284,9 +284,11 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
         await service.StartAsync(CancellationToken.None);
         try
         {
-            // Startup: the default (Continuous) drives the ONE startup pass until the live Stable
-            // emission arrives (by-design fallback window), then Stable-only patches. Checks are
-            // event-driven now, so the second Stable patch is driven by a build completion rather
+            // Startup runs under the PERSISTED policy (Stable), never the configured default —
+            // the default is no longer prepended to the policy stream at all (#2731/#2797), so the
+            // old "by-design fallback window" in which a pinned install could be patched from the
+            // wrong policy is gone from the startup pass as well as from the retry. Checks are
+            // event-driven, so the second Stable patch is driven by a build completion rather
             // than by waiting out a timer.
             // 🚨 The startup pass must be OBSERVED before publishing: StartAsync subscribes via
             // SubscribeOn(TaskPool), so it returns before the build-completion watch is established,
@@ -331,6 +333,11 @@ public class SelfUpdatePollerResilienceTest(ITestOutputHelper output) : Monolith
             var afterFault = updater.Tags.Skip(beforeFault).ToList();
             afterFault.Should().NotBeEmpty();
             afterFault.Should().OnlyContain(tag => tag == FakeAcrTagLister.StableTag);
+
+            // ...and neither may the STARTUP pass (#2731/#2797). Asserted over EVERY patch, so the
+            // window this test was written to close is now closed at both ends.
+            updater.Tags.Should().OnlyContain(tag => tag == FakeAcrTagLister.StableTag,
+                "the poller must never evaluate under a policy the install has not persisted");
         }
         finally
         {

--- a/test/MeshWeaver.Hosting.Orleans.Test/PodHubClaimLifetimeTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/PodHubClaimLifetimeTest.cs
@@ -95,23 +95,22 @@ public class PodHubClaimLifetimeTest
     }
 
     /// <summary>
-    /// Bounded wait for the attempt count to STOP moving. There is no completion signal to await
-    /// for a claim that ends, so two consecutive equal readings after the first attempt landed is
-    /// the settled state — the same technique as <c>StreamAttachTransientRetryTest</c>.
+    /// 🚨 Waits for the claim to TERMINATE, never for the attempt counter to stop moving (#2793).
+    /// The retry hops through the thread-pool scheduler between attempts, so on a loaded CI shard
+    /// that hop exceeds a 25 ms poll and "two equal readings" reads the count MID-HOP — it returned
+    /// 1 on the merge-queue entry for #2800, which is precisely the value unfixed code produces, so
+    /// the false RED spelled the regression's own signature. <c>PodHubClaimSettled</c> is the
+    /// condition itself, positively; the bound is a backstop against a hang, not the measurement
+    /// (with the backoff collapsed to 1 ms the real elapsed time is milliseconds).
     /// </summary>
-    private static async Task<int> WaitUntilSettled(RefusingGrainFactory factory)
+    private static async Task<int> WaitUntilSettled(OrleansRoutingService routing, RefusingGrainFactory factory)
     {
-        var last = -1;
-        for (var i = 0; i < 400; i++)
-        {
-            await Task.Delay(25);
-            var now = factory.AttachCalls;
-            if (now > 0 && now == last)
-                return now;
-            last = now;
-        }
-        throw new TimeoutException(
-            $"the claim never settled — last observed attempt count {factory.AttachCalls}");
+        var settled = routing.PodHubClaimSettled(Hub)
+                      ?? throw new InvalidOperationException(
+                          "the routing service recorded no pod-hub claim for the address — the seam "
+                          + "this test waits on is gone, and a poll would silently take its place.");
+        await settled.Timeout(TimeSpan.FromSeconds(30)).LastOrDefaultAsync();
+        return factory.AttachCalls;
     }
 
     /// <summary>
@@ -166,7 +165,7 @@ public class PodHubClaimLifetimeTest
         using var routing = Router(factory, sp, logger, canHostGrains: false);
 
         using var registration = routing.RegisterStream(Hub, Ignore);
-        var attempts = await WaitUntilSettled(factory);
+        var attempts = await WaitUntilSettled(routing, factory);
 
         attempts.Should().Be(OrleansRoutingService.PodHubAttachRetries + 1,
             "an Orleans client cannot host a grain, so the claim is impossible rather than slow — "

--- a/test/MeshWeaver.Hosting.Orleans.Test/StreamAttachTransientRetryTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/StreamAttachTransientRetryTest.cs
@@ -125,28 +125,29 @@ public class StreamAttachTransientRetryTest
             AttachBackoff = _ => TimeSpan.Zero
         };
 
-        using var registration = routing.RegisterStream(
-            AddressExtensions.CreateMeshAddress($"attach-retry-{Guid.NewGuid():N}"),
-            (d, _) => Observable.Return(d));
+        var address = AddressExtensions.CreateMeshAddress($"attach-retry-{Guid.NewGuid():N}");
+        using var registration = routing.RegisterStream(address, (d, _) => Observable.Return(d));
+
+        // The completion task exists the moment RegisterStream returns; capture it BEFORE opening
+        // the gate so there is no window in which the attach could finish unobserved.
+        var settled = routing.AttachSettled(address)
+                      ?? throw new InvalidOperationException(
+                          "RegisterStream did not record an attach completion for the address — the "
+                          + "seam this test waits on is gone, and a poll would silently take its place.");
 
         // Open the gate exactly the way Orleans does: the lifecycle observer's OnStart at Active.
         await ((ILifecycleObserver)readiness).OnStart(CancellationToken.None);
 
-        // Poll until the attempt count STOPS moving — the attach runs detached, so there is no
-        // completion signal to await from here. Two consecutive equal readings after the first
-        // attempt has landed is the settled state; bounded so a regression fails rather than hangs.
-        var last = -1;
-        for (var i = 0; i < 200; i++)
-        {
-            await Task.Delay(25);
-            var now = provider.GetStreamCalls;
-            if (now > 0 && now == last)
-                return now;
-            last = now;
-        }
+        // 🚨 Wait for the attach to TERMINATE, never for the attempt counter to stop moving (#2793).
+        // The retry hops through the thread-pool scheduler between attempts, so on a loaded shard a
+        // settle-by-silence poll reads the count during a hop and declares it final — and the value
+        // it reads is 1, which is exactly the regression signature this file exists to detect. The
+        // condition under test is "the attach gave up", and this task IS that condition. The bound
+        // is a backstop against a hang, not the measurement: with AttachBackoff collapsed to zero
+        // the real elapsed time is milliseconds.
+        await settled.WaitAsync(TimeSpan.FromSeconds(30));
 
-        throw new TimeoutException(
-            $"the attach never settled — last observed attempt count {provider.GetStreamCalls}");
+        return provider.GetStreamCalls;
     }
 
     /// <summary>


### PR DESCRIPTION
Two silent production defects from the issue sweep, both of the shape *"the code acted on a value nobody wrote"*.

## 1. A pinned install rolled on every pod restart — #2731, #2797

`CreatePolicySource` prepended the deployment's **configured default** to the policy stream before the persisted `Admin/UpdatePolicy` value arrived, and the startup pass ran a full evaluation on that seed: registry listing, candidate selection, Deployment PATCH.

memex-cloud has read `policy: None` since 2026-08-28 and **still rolled twice on 08-30** (`ci.6664` 11:54Z, `ci.6739` 15:03Z). The node's own history records the sequence — a `Startup` verdict that evaluated a candidate, then seconds later a `PolicyChange` verdict reading *"updates are disabled on this install"*, after the roll had been issued.

The seed is deleted. Stage 1 (`EnsureExists`) already guarantees the node exists, so the live read is the first emission on its own. `ReadPolicyStream` also drops a null node instead of parsing it — `UpdatePolicyContent.Policy` defaults to `Continuous` and `Continuous` is enum `0`, so an absent node parsed to exactly the verdict a pinned install must never reach.

**Pinned by a test that asserts on the registry listing, not a log-line spelling**: the `None` branch of `RunOnce` returns its verdict without listing, so `acr.Calls == 0` proves which policy decided. Mutation-checked — restoring the seed fails it with `but found 1`.

`ABuildCompletionDrivenCheck_NeverWarnsAboutTheEventChannel` published its build before the watch was subscribed, so the publication was absorbed as the watch's **baseline**; it passed only because the synthetic seed made that subscription fast. It now waits for the startup check line first — the same positive signal the resilience test already documents.

## 2. Node content read as raw JSON on any hub but its own — #2729

A node type's `WithContentType<T>()` configures its own hub. **Seven** built-in types declared one and registered its `$type` discriminator nowhere else, so a reader elsewhere in the mesh got an untyped `JsonElement` and a **silent null** — no exception, no log; the value renders empty and reactive waits time out.

memex logged it at boot for `Admin/_GraphSubscription/inbox`. That node carries the inbound-mail subscription state, so the renewal could not see its own record and **inbound mail was dead** on an install whose every signal was green.

Registered: `EaCredential`, `GraphSubscriptionState`, `Invitation`, `MemexClientContent`, `NotificationChannel`, `NotificationRule`, `TeamsConversation`.

`NodeTypeContentDiscriminatorGuard` keeps them registered. The two halves of this contract are joined by nothing, and omitting one compiles, boots, serves and passes every test. The guard reads both halves out of the source, carries a floor so it cannot pass on a broken scan, and self-tests its own classifier. Mutation-checked — deleting one registration fails it by name.

## Verification

```
dotnet build src/MeshWeaver.Graph            -c Release -warnaserror   0 Error(s)
dotnet build memex/Memex.Portal.Shared       -c Release -warnaserror   0 Error(s)
dotnet build test/MeshWeaver.Documentation.Test  -c Release -warnaserror   0 Error(s)
dotnet build test/MeshWeaver.Hosting.Monolith.Test -c Release -warnaserror 0 Error(s)

dotnet test test/MeshWeaver.Hosting.Monolith.Test --filter SelfUpdate        29 passed, 0 failed
dotnet test test/MeshWeaver.Documentation.Test  --filter <the three guards>   3 passed, 0 failed
```

Fixes #2729
Fixes #2731
Fixes #2797

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014FhP7Jg65q8cAATnFfeaTK

---

## 3. A retry test read a scheduler pause as the regression — #2793

`StreamAttachTransientRetryTest` polled the attempt counter and treated two equal readings 25 ms apart as *settled*. The attach retry hops through the thread-pool scheduler between attempts, so on a loaded shard that hop exceeds 25 ms — the poll reads mid-hop and returns **1**, which is exactly the #2633 regression signature the test documents. Observed on main at `f52ff52e3` (run 33318685970, shard 3), on a merge that cannot reach Orleans.

`RegisterStream` already records the real condition: `subscriptionReady[address]` completes when the attach has attached, given up, or been cancelled, and never faults. Exposed as the internal `AttachSettled(address)` seam (same `InternalsVisibleTo` discipline as `AttachBackoff`), awaited with a 30 s **backstop** — real elapsed time is milliseconds. Captured before the readiness gate opens so the attach cannot finish unobserved, and a missing seam throws rather than silently falling back to a poll.

```
dotnet build test/MeshWeaver.Hosting.Orleans.Test -c Release -warnaserror   0 Error(s)
dotnet test --filter StreamAttachTransientRetryTest    4 passed, 0 failed, 39 ms
```

Fixes #2793
