### PR TITLE
fix(chart): a ConfigMap/Secret change rolls the portal — checksum annotations on the pod template

### DIFF
--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -31,6 +31,19 @@ spec:
         # node image-upgrade, but gracefully and one at a time (the PDB beside this file + the 120s
         # terminationGracePeriod above), never on every autoscaler bin-packing pass.
         cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        # 🚨 A ConfigMap or Secret change is delivered as ENV at pod START, so without these two
+        # hashes `helm upgrade` reports "deployed", the rendered objects carry the new value, and
+        # no running process ever reads it — the "we set it and it vanished" shape helm-release.yml
+        # warns about, now measured: memex-cloud revision 21 (2026-08-30 16:13Z) rendered
+        # PluginCatalog__OpenRegistration__Key into memex-portal-secrets and both pods kept
+        # answering 401, because the image was unchanged and nothing told the Deployment to roll.
+        # Hashing the rendered config + secrets templates into the pod template turns a
+        # configuration change into the SAME rollout an image change gets — graceful, one pod at a
+        # time under the PDB and the drain budget below — and into nothing when nothing changed:
+        # both templates render deterministically from values (no rand/now/lookup), so a re-render
+        # with the same values yields the same hash.
+        checksum/config: {{ include (print $.Template.BasePath "/memex-portal/config.yaml") . | sha256sum }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/memex-portal/secrets.yaml") . | sha256sum }}
     spec:
       # The in-pod self-updater patches this deployment via the Kubernetes API using this SA's
       # projected token (RBAC in rbac.yaml). See Doc/Architecture/ReleaseStrategy.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-configuration-change-now-restarts-the-portal.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-configuration-change-now-restarts-the-portal.md
@@ -1,0 +1,11 @@
+---
+Name: A configuration or secret change now restarts the portal
+Category: Fix
+Description: helm upgrade with a changed ConfigMap or Secret rolls the portal pods, so the new setting is actually running — before, the release reported deployed while the pods kept the old configuration
+Icon: Sparkle
+Order: -20260830
+---
+
+# A configuration or secret change now restarts the portal
+
+Changing a portal setting or secret and running `helm upgrade` (or `memex-local up`) now rolls the portal pods, one at a time and gracefully, so the setting you changed is the one the portal runs with. Before, the release reported "deployed" and the rendered ConfigMap and Secret carried the new value, but the running pods — which read configuration only at start — kept the old one until something else happened to restart them. That is how an open-registration key delivered to memex.meshweaver.cloud still answered 401 for an hour after the deploy. An upgrade that changes nothing still restarts nothing.


### PR DESCRIPTION
## The defect, measured

`deploy/helm/templates/memex-portal/deployment.yaml` carries no hash of the rendered ConfigMap/Secret on its pod template. The portal reads both as **env at pod start** (`envFrom: configMapRef memex-portal-config / secretRef memex-portal-secrets`), so a `helm upgrade` that changes only configuration **rolls nothing**:

- memex-cloud, 2026-08-30 16:13Z, `helm-release.yml deploy` → revision 21, `Release "memexcloud" has been upgraded`, image kept (`ci.6762`).
- `kubectl get secret memex-portal-secrets` (key names only): `PluginCatalog__OpenRegistration__Key` **present**.
- Both portal pods: unchanged (started 16:07/16:09, before the upgrade).
- `POST /api/instances/register` without a key: still **401** `A valid registration bootstrap key is required` — the process never loaded the value.

This is the "we set it and it vanished" shape `helm-release.yml`'s header warns about, from the other side: the value did land, in an object nobody re-read.

## The fix

Two annotations on the pod template, hashing the rendered `config.yaml` and `secrets.yaml`:

```yaml
checksum/config:  {{ include (print $.Template.BasePath "/memex-portal/config.yaml")  . | sha256sum }}
checksum/secrets: {{ include (print $.Template.BasePath "/memex-portal/secrets.yaml") . | sha256sum }}
```

A configuration change now gets exactly the rollout an image change gets — graceful, one pod at a time under the PDB and the drain budget already on this template — and an upgrade that changes nothing restarts nothing.

## Verification

- `helm lint deploy/helm` → 0 failed.
- `helm template` twice with the same values → identical hashes. With `--set secrets.memex_portal.PluginCatalog__OpenRegistration__Key=…` → only `checksum/secrets` changes, `checksum/config` identical (both templates render deterministically: no `rand`/`now`/`lookup`).
- Chart Gate scripts locally: `check-chart-invariants.sh` → all 3 values combinations self-consistent; `check-values-are-read.sh` → all 115 keys read.
- Only `memex-portal-deployment` consumes these objects (`portal-next.yaml` references neither), so the scope is that one Deployment.

What's New entry included (Category: Fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1SquDKJNKZxEUbuaPjUgu
