### PR TITLE
fix(chart): the startup budget the chart DESCRIBES is now the one it ships (#2787, #2274)

### DIFF
--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -275,10 +275,12 @@ spec:
             # ⚠️ This budget is what bounds a NodeType BAKE (PreWarm__GateReadiness). A cold compile
             # is ~2.4 s per NodeType and the sweep is strictly sequential (measured 2026-08-10), so
             # the largest mesh we run (~240 types) needs ~10 min of bake on top of a plain cold boot.
-            # periodSeconds × failureThreshold is the ceiling: the default 5 × 60 = 5 minutes is
-            # right for a plain boot and too small for a cold bake — turning the gate on without
-            # raising this kills the pod mid-bake, every time. Paired setting and full derivation:
-            # values.yaml (probes.startup) — 10 × 180 = 30 min.
+            # periodSeconds × failureThreshold is the ceiling. What this chart SHIPS, and what
+            # every environment in the fleet runs today, is the ungated default — right for a plain
+            # boot and far too small for a cold bake, so turning the gate on without raising it in
+            # the SAME change kills the pod mid-bake, every time, for ever. The paired setting and
+            # the full derivation live in values.yaml (probes.startup); PreWarmGateReadinessGuard
+            # enforces the coupling, so this comment can no longer drift away from what ships.
             httpGet: { path: /health, port: 8080 }
             periodSeconds: {{ .Values.probes.startup.periodSeconds }}
             timeoutSeconds: {{ .Values.probes.startup.timeoutSeconds }}
@@ -451,9 +453,9 @@ spec:
   # ⏱️ How long a rollout may be "not progressing" before k8s marks it ProgressDeadlineExceeded.
   #
   # 🚨 The k8s DEFAULT IS 600s, and against this deployment that default is simply WRONG: the
-  # startupProbe budget above is periodSeconds × failureThreshold, which managed envs set to
-  # 10 × 180 = 30 MINUTES to cover a cold NodeType bake. A legitimately-baking pod is therefore
-  # declared failed after 10 minutes — and `kubectl rollout status` reports a perfectly healthy
+  # startupProbe budget above is periodSeconds × failureThreshold, which an environment running a
+  # gated cold NodeType bake must raise to tens of minutes. A legitimately-baking pod would then be
+  # declared failed after 10 minutes — and `kubectl rollout status` would report a perfectly healthy
   # long bake as a failed rollout, which is exactly the signal an operator would act on by
   # rolling back the good image.
   #

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-the-chart-can-no-longer-describe-a-budget-it-does-not-have.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-the-chart-can-no-longer-describe-a-budget-it-does-not-have.md
@@ -1,0 +1,43 @@
+---
+Name: The chart can no longer describe a startup budget it does not have
+Category: Fix
+Description: The deployment template said, twice, that the portal's startup-probe budget was 30 minutes. It ships 5. Anyone arming the NodeType bake gate on that sentence would have had every pod killed mid-bake — the exact failure the same comment warns about. The prose now states what ships, and a guard keeps it that way.
+Icon: Timer
+Order: -20260830
+---
+
+# The chart can no longer describe a startup budget it does not have
+
+`PreWarm__GateReadiness` is the portal's safest deploy switch: it holds `/health` red until the new
+image's NodeType bake is proven green, so an image that regressed a type stalls its own rollout with
+the previous image still serving, instead of erroring in front of users.
+
+It is also the switch with the most prerequisites, and the chart lists them carefully — including
+one that is arithmetic: the startup probe's budget (`periodSeconds × failureThreshold`) has to cover
+a full cold bake, measured from production at roughly 2.4 seconds per NodeType, sequential, or about
+ten minutes on the largest mesh we run. The chart is emphatic about what happens otherwise:
+*Kubernetes kills the pod mid-bake, every time, forever.*
+
+And then, two lines later, it told you the budget was already thirty minutes. Twice — once as the
+"paired setting", once as what "managed envs set". **Every environment in the fleet runs five
+minutes.** So the prerequisite was satisfied only in the reader's head, and the first person to arm
+the gate on that sentence would have walked straight into the failure the sentence was warning them
+about.
+
+## What changed
+
+The comments now describe what the chart actually ships, and say plainly that arming the gate means
+raising the budget *in the same change*.
+
+More usefully, the coupling stopped being a paragraph. A new guard fails the build when:
+
+- any line in the chart **talks about** a startup budget that is not the one `values.yaml` ships —
+  unless it marks itself as a suggested setting to move to, which is what a paired-setting note
+  should look like; or
+- `PreWarm__GateReadiness` is armed without all four of its prerequisites moving with it: a budget
+  covering the cold bake plus a plain boot, `PreWarm__DynamicTypes` also on, `maxUnavailable: 0`,
+  and a startup probe actually pointed at `/health` — the only endpoint that reads the gate.
+
+The first half is the one that matters most, because it fails **today**, on the drifted comment. A
+guard that only woke up once someone armed the gate would have caught nothing on the day the prose
+went wrong — which is the whole reason the prose was still there to find.

--- a/test/MeshWeaver.Documentation.Test/PreWarmGateReadinessGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/PreWarmGateReadinessGuard.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>The chart stated its own startup budget in prose, and the prose was wrong</b> (#2787).
+///
+/// <para><c>PreWarm__GateReadiness</c> holds <c>/health</c> red until the NodeType bake is green,
+/// which is only safe with three paired settings — the chart's own comment lists them, numbered,
+/// and warns that missing one "means Kubernetes kills the pod mid-bake, every time, forever".
+/// Prerequisite 2 is a budget: <c>probes.startup.periodSeconds × failureThreshold</c> must cover a
+/// full cold bake.</para>
+///
+/// <para><b>What was actually there.</b> The deployment template asserted "values.yaml
+/// (probes.startup) — 10 × 180 = 30 min" and, forty lines down, "which managed envs set to
+/// 10 × 180 = 30 MINUTES". `values.yaml` shipped <c>5 × 60</c>, and memex-cloud was measured live
+/// on 2026-08-30 running exactly that. So an operator arming the gate would read prerequisite 2,
+/// believe it already satisfied, and walk straight into the failure the same comment warns about.
+/// That is the <i>prose asserts a guard that does not exist</i> shape, in the one file where being
+/// wrong costs a rollout.</para>
+///
+/// <para>So the coupling stops being a paragraph. This guard reads the numbers the chart actually
+/// ships and fails when the chart TALKS about a budget it does not have, or when the gate is armed
+/// without every prerequisite moving in the same change.</para>
+/// </summary>
+public class PreWarmGateReadinessGuard
+{
+    private const string Deployment = "deploy/helm/templates/memex-portal/deployment.yaml";
+    private const string Values = "deploy/helm/values.yaml";
+
+    /// <summary>
+    /// The cold-bake ceiling the chart itself derives, from production Loki on 2026-08-10:
+    /// ~2.4 s per NodeType, strictly sequential, ~240 types on the largest mesh we run ⇒ ~570 s.
+    /// Plus the plain cold boot (schema provisioning + static import) the ungated budget covers.
+    /// A gated environment needs BOTH, which is why arming the gate is never a one-key change.
+    /// </summary>
+    private const int ColdBakeSeconds = 570;
+
+    private const int PlainColdBootSeconds = 300;
+
+    [Fact]
+    public void TheChart_NeverStatesAStartupBudgetItDoesNotShip()
+    {
+        var root = FindRepoRoot();
+        var (period, threshold) = StartupBudget(File.ReadAllText(Path.Combine(root, Values)));
+        var shipped = period * threshold;
+
+        // Every "N × M" the chart writes about the startup probe must be the one it ships. The
+        // multiplication sign is the ASCII 'x' or the '×' the chart uses; both are matched.
+        foreach (var file in new[] { Deployment, Values })
+        {
+            var text = File.ReadAllText(Path.Combine(root, file));
+            foreach (Match m in Regex.Matches(text, @"(?<a>\d{1,4})\s*[x×]\s*(?<b>\d{1,4})"))
+            {
+                var a = int.Parse(m.Groups["a"].Value, CultureInfo.InvariantCulture);
+                var b = int.Parse(m.Groups["b"].Value, CultureInfo.InvariantCulture);
+                var line = LineOf(text, m.Index);
+
+                // Only lines that are TALKING about the startup probe are in scope; the chart does
+                // arithmetic about other things, and this guard must not police those.
+                if (!MentionsStartupBudget(line)) continue;
+
+                // A line may legitimately quote a SUGGESTED paired setting for a gated
+                // environment — values.yaml does exactly that — as long as it is marked as the
+                // thing to move TO, not as the thing that is there.
+                if (IsSuggestion(line)) continue;
+
+                Assert.True(a * b == shipped,
+                    $"{file} states a startup budget of {a} × {b} = {a * b}s on this line:\n"
+                    + $"    {line.Trim()}\n"
+                    + $"but {Values} ships probes.startup {period} × {threshold} = {shipped}s. "
+                    + "A chart that describes a budget it does not have is how PreWarm__GateReadiness "
+                    + "gets armed on a five-minute probe: the operator reads prerequisite 2, believes "
+                    + "it satisfied, and every pod is killed mid-bake. State what ships, or mark the "
+                    + "number as a suggested paired setting.");
+            }
+        }
+    }
+
+    [Fact]
+    public void ArmingTheReadinessGate_MovesEveryPrerequisiteInTheSameChange()
+    {
+        var root = FindRepoRoot();
+        var values = File.ReadAllText(Path.Combine(root, Values));
+
+        if (!BoolKey(values, "PreWarm__GateReadiness"))
+            // 🚦 The gate is OFF in this chart, which is the fleet's setting and the safe default.
+            // This is a CONDITIONAL invariant, and its unconditional half — the one that fails
+            // today if the chart's prose drifts — is the test above. Both must exist: a guard that
+            // only fires once someone arms the gate would have caught nothing on the day the prose
+            // went wrong.
+            return;
+
+        var (period, threshold) = StartupBudget(values);
+        var required = ColdBakeSeconds + PlainColdBootSeconds;
+        Assert.True(period * threshold >= required,
+            $"PreWarm__GateReadiness is armed, but probes.startup is {period} × {threshold} = "
+            + $"{period * threshold}s and a gated boot needs at least {required}s "
+            + $"({ColdBakeSeconds}s cold bake + {PlainColdBootSeconds}s plain boot). Kubernetes "
+            + "kills the pod mid-bake, every time, forever — prerequisite 2 of the chart's own list.");
+
+        Assert.True(BoolKey(values, "PreWarm__DynamicTypes"),
+            "PreWarm__GateReadiness is armed without PreWarm__DynamicTypes: the gate reads state "
+            + "only the sweep writes, so gate-without-sweep is permanently GREEN — a gate that "
+            + "certifies nothing. Prerequisite 1 of the chart's own list.");
+
+        var deployment = File.ReadAllText(Path.Combine(root, Deployment));
+        Assert.True(Regex.IsMatch(deployment, @"maxUnavailable:\s*0\b"),
+            "PreWarm__GateReadiness is armed without strategy.maxUnavailable: 0. The gate works by "
+            + "making the NEW pod refuse readiness, which protects nothing if the serving pod was "
+            + "already deleted. Prerequisite 3 of the chart's own list.");
+
+        Assert.True(Regex.IsMatch(deployment, @"startupProbe:(?s).{0,400}?path:\s*/health"),
+            "PreWarm__GateReadiness is armed but the startupProbe does not target /health — the "
+            + "only endpoint that reads the gate. A namespace probing /alive or /healthz ignores it "
+            + "entirely, so the gate is silently useless.");
+    }
+
+    private static bool MentionsStartupBudget(string line) =>
+        line.Contains("startup", StringComparison.OrdinalIgnoreCase)
+        || line.Contains("failureThreshold", StringComparison.Ordinal)
+        || line.Contains("periodSeconds", StringComparison.Ordinal)
+        || line.Contains("min", StringComparison.OrdinalIgnoreCase)
+           && line.Contains("bake", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>A number offered as the setting to move TO, not claimed as the setting in force.</summary>
+    private static bool IsSuggestion(string line) =>
+        line.Contains("suggested", StringComparison.OrdinalIgnoreCase)
+        || line.Contains("raise", StringComparison.OrdinalIgnoreCase)
+        || line.Contains("→", StringComparison.Ordinal);
+
+    private static (int Period, int Threshold) StartupBudget(string values)
+    {
+        var block = Regex.Match(values, @"^probes:\s*$(?<body>(?:\n(?:[ \t].*)?)+)",
+            RegexOptions.Multiline);
+        Assert.True(block.Success,
+            $"{Values} no longer has a top-level 'probes:' block — this guard reads the budget from "
+            + "it, and a guard that cannot find its subject passes having checked nothing.");
+        var body = block.Groups["body"].Value;
+        var period = Regex.Match(body, @"periodSeconds:\s*(\d+)");
+        var threshold = Regex.Match(body, @"failureThreshold:\s*(\d+)");
+        Assert.True(period.Success && threshold.Success,
+            $"{Values} probes.startup no longer declares both periodSeconds and failureThreshold.");
+        return (int.Parse(period.Groups[1].Value, CultureInfo.InvariantCulture),
+                int.Parse(threshold.Groups[1].Value, CultureInfo.InvariantCulture));
+    }
+
+    private static bool BoolKey(string values, string key) =>
+        Regex.Match(values, Regex.Escape(key) + @":\s*""?(?<v>true|false)""?", RegexOptions.IgnoreCase)
+            is { Success: true } m
+        && string.Equals(m.Groups["v"].Value, "true", StringComparison.OrdinalIgnoreCase);
+
+    private static string LineOf(string text, int index)
+    {
+        var start = text.LastIndexOf('\n', Math.Min(index, text.Length - 1)) + 1;
+        var end = text.IndexOf('\n', index);
+        return end < 0 ? text[start..] : text[start..end];
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
Found while measuring #2787's *"close it at the source"* direction against the live cluster.

## The defect

`deploy/helm/templates/memex-portal/deployment.yaml` asserted the portal's startup-probe budget **twice**:

> `:281` — *"Paired setting and full derivation: values.yaml (probes.startup) — **10 × 180 = 30 min**."*
> `:455` — *"the startupProbe budget above … which **managed envs set to 10 × 180 = 30 MINUTES**"*

`values.yaml` ships `probes.startup` **5 × 60 = 300 s**, and memex-cloud was measured live on 2026-08-30 running exactly that (`failureThreshold=60, periodSeconds=5`).

That is not cosmetic. `PreWarm__GateReadiness` — the pod-side backstop for the very rollout window #2787 is about, recorded as `"false"` in #2274's measurement — has three numbered prerequisites, and #2 is *a startup budget covering a full cold bake* (~570 s: ~2.4 s per NodeType, sequential, ~240 types, derived by the chart itself from production Loki). So an operator arming the gate reads prerequisite 2, is told by the next comment that the budget is already 30 minutes, and arms it on a five-minute probe — at which point Kubernetes *"kills the pod mid-bake, every time, forever"*, which is **verbatim what the same comment warns about**.

Prose asserting a guarantee that does not exist, in the one file where being wrong costs a rollout.

## The fix

Both comments now describe what ships. More usefully, the coupling stops being a paragraph:

**`PreWarmGateReadinessGuard`**

- **Unconditional** — no line in the chart may state an `N × M` startup budget that is not the one `values.yaml` ships, unless the line marks itself as a *suggested* paired setting (`raise…`, `suggested`, `→`). **This half fails today**, on the drifted comment. A guard that only woke up once someone armed the gate would have caught nothing on the day the prose went wrong — which is exactly why it survived this long.
- **Conditional** — `GateReadiness: "true"` requires the budget ≥ 570 s bake + 300 s plain boot, `PreWarm__DynamicTypes: "true"`, `maxUnavailable: 0`, and a startupProbe on `/health` (the only endpoint that reads the gate). The chart's own numbered list, now arithmetic.

It reads `probes.startup` out of `values.yaml` rather than restating it, and fails loudly if the `probes:` block ever moves — a guard that cannot find its subject passes having checked nothing.

## Mutation-proved, both halves

| probe | result |
|---|---|
| restore the false `10 x 180` prose | **FAILS** — *"states a startup budget of 10 × 180 = 1800s … but values.yaml ships 5 × 60 = 300s"* |
| arm `GateReadiness` on the shipped budget | **FAILS** — *"armed, but probes.startup is 5 × 60 = 300s and a gated boot needs at least 870s"* |

Restored and re-verified 2/2 green after each.

## Negative result, recorded on #2787

The rollout configuration itself is **correct** and I nearly "fixed" it before the chart's own comment stopped me: `maxUnavailable: 0` + `maxSurge: 1` + a PDB, readiness deliberately on `/alive` (pointing it back at `/health` re-creates the documented *probe death-spiral*), and the **startup** probe holding readiness on `/health` until the mesh is up. The nginx 503 dependent repos see during promotion is not explained by any of those, so that mechanism stays open on #2787.

Touches no workflow file, so #2800's `ShardWeightHeadroomGuard` timeout parse is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)