### PR TITLE
fix(recycle): a DENIED release stamp refuses the recycle instead of disposing the hub anyway

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-refused-recycle-no-longer-tears-the-hub-down.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-refused-recycle-no-longer-tears-the-hub-down.md
@@ -1,0 +1,37 @@
+---
+Name: A refused recycle no longer tears the hub down anyway
+Category: Fix
+Description: Recycling a NodeType stamps a release request and then disposes its hub. When the stamp was refused for lack of permission, the dispose ran regardless — so a caller who was not allowed to change anything still got the destructive half. It now refuses outright.
+Icon: ShieldError
+Order: -20260830
+---
+
+# A refused recycle no longer tears the hub down anyway
+
+Recycling a NodeType is two halves of one operation: stamp a release request on the node, then
+dispose its hub so the next activation acts on that stamp. The stamp goes through the access
+pipeline. The dispose does not.
+
+The stamp's failure handler treated every failure as transient — reasonable for a timeout, and the
+hub bounce is genuinely still worth doing there. But a **denial** is not a transient fault. On
+2026-08-30 an operator without write access to a GitSynced module space asked for a recycle; the
+access pipeline correctly refused the stamp, and the handler logged *"disposing the hub anyway"* and
+tore the hub down. The NodeType was left with no release request to act on, and its watcher went
+quiet.
+
+So the one caller who should have changed nothing changed the only thing that mattered.
+
+A refused stamp now refuses the whole recycle. Nothing is disposed, and the caller is told plainly
+that they lacked permission — which leaves them exactly where they started, the correct outcome for
+an operation they were never allowed to perform. A stamp that fails for any other reason still
+proceeds, because that caller *was* allowed to ask.
+
+## Two layers, and why both are needed
+
+Recycle already checks permission before it starts, and answers with a legible reason. That check
+is the first layer, and this change pins it with a test — the operator in the incident received a
+*settle-timeout* instead, and could not tell "the trigger never dispatched" from "you were refused".
+
+The incident proves the first layer is not enough: the operator got past it, and the **owner** of
+the node refused the write. The owner's answer is the authoritative one and it arrives after the
+local check has already said yes. Refusing on that answer too is what actually closes the hole.

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -3640,10 +3640,31 @@ public class MeshOperations
                 .Select(_ => true)
                 .Catch((Exception ex) =>
                 {
-                    // A failed stamp must not swallow the recycle: the hub bounce is still
-                    // worth doing (it is the caller's actual ask), and the compile trigger
-                    // is recoverable by a second Recycle/Compile. Surface it in the log
-                    // rather than silently degrading to the old racy behaviour.
+                    // 🚨 A DENIAL IS NOT A TRANSIENT FAULT. A caller who may not write this node
+                    // may not tear its hub down either: the stamp and the dispose are two halves
+                    // of ONE authorised operation, and proceeding after the write was refused
+                    // hands an unauthorised caller the destructive half for free. It happened on
+                    // memex 2026-08-30 17:11:21Z — an operator without Update on a GitSynced
+                    // module space called Recycle, the access pipeline correctly refused the
+                    // stamp, and this Catch disposed the hub anyway; the NodeType then had no
+                    // release request to act on and its watcher went silent. Refusing outright
+                    // leaves the caller exactly where they started, which is the right outcome
+                    // for someone who was not permitted to change anything.
+                    if (ex is UnauthorizedAccessException)
+                    {
+                        logger.LogWarning(ex,
+                            "Recycle REFUSED for {Path}: the release-request stamp was DENIED, so the "
+                            + "hub is NOT disposed — a caller who may not write this node may not "
+                            + "recycle it either. Nothing was changed.",
+                            resolvedPath);
+                        return Observable.Throw<bool>(ex);
+                    }
+
+                    // Anything else IS transient (a timeout, an owner mid-move): the hub bounce is
+                    // still worth doing — it is the caller's actual ask, and they were allowed to
+                    // ask — and the compile trigger is recoverable by a second Recycle/Compile.
+                    // Surface it in the log rather than silently degrading to the old racy
+                    // behaviour.
                     logger.LogWarning(ex,
                         "Recycle: failed to stamp release request for {Path} — disposing the hub anyway",
                         resolvedPath);

--- a/test/MeshWeaver.Hosting.Monolith.Test/RecycleDeniedStampTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/RecycleDeniedStampTest.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract, not a tidy-up
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 <b>A denied write must not buy the destructive half of the operation</b> (memex,
+/// 2026-08-30 17:11:21Z).
+///
+/// <para><c>Recycle</c> on a NodeType is two halves of ONE authorised operation: stamp a release
+/// request on the node, then dispose its hub so the next activation acts on that stamp. The stamp
+/// goes through the access pipeline; the dispose does not.</para>
+///
+/// <para>The stamp's failure handler caught <i>every</i> exception and disposed the hub anyway,
+/// reasoning that a failed stamp is transient and "the hub bounce is still the caller's actual
+/// ask". That is true of a timeout. It is not true of a <b>denial</b>. On memex an operator
+/// without <c>Update</c> on a GitSynced module space called Recycle; the pipeline correctly
+/// refused the stamp — <c>AccessControlPipeline: Access denied: user 'rbuergi' lacks Update
+/// permission on 'Crm/Migration'</c> — and the handler then logged <c>disposing the hub
+/// anyway</c> and tore it down. The NodeType was left with no release request to act on and its
+/// watcher went silent; recovering it needed a second, also-unauthorised call.</para>
+///
+/// <para>So an unauthorised caller was handed the one half of the operation that changes the
+/// world, having been refused the half that records why. Refusing outright leaves them exactly
+/// where they started, which is the correct outcome for someone not permitted to change anything.
+/// A transient stamp failure still proceeds — that distinction is what the fix makes.</para>
+///
+/// <para>🚨 <b>Two layers, and this test can only reach the first.</b> Recycle already PRE-CHECKS
+/// Update and answers with a legible refusal — that is what this test observes, and it is worth
+/// pinning because the memex operator received a settle-TIMEOUT instead and could not tell "the
+/// trigger did not dispatch" from "you were refused". But memex proves the pre-check is not
+/// sufficient: there the operator got PAST it and the OWNER refused the write, which is the
+/// authoritative answer and arrives after the optimistic local fold has already said yes. The
+/// second layer — throwing on <see cref="UnauthorizedAccessException"/> from the stamp rather
+/// than disposing anyway — closes that gap, and no deterministic local repro exists for it
+/// because it needs the pre-check and the owner to disagree. Recorded rather than faked: a test
+/// that manufactured the disagreement would be pinning its own scaffolding.</para>
+/// </summary>
+public class RecycleDeniedStampTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Dana = "dana-recycle-denied";
+
+    /// <summary>No root-level Public→Admin: a denial must be observable rather than granted away.</summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder);
+
+    protected override async Task SetupAccessRightsAsync()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        await meshService.CreateNode(AssignmentNodeFactory.UserRole(TestUsers.Admin.ObjectId, "Admin", null))
+            .Should().Within(30.Seconds()).Emit();
+    }
+
+    /// <summary>
+    /// Dana's identity. 🚨 It is switched on the MESH's AccessService, not a client hub's:
+    /// <c>MeshOperations</c> resolves <c>IWorkspace</c> from the hub it is given, and a client hub
+    /// has none (constructing it against one answers "An exception was thrown while activating
+    /// MeshWeaver.Data.IWorkspace" — an error that has nothing to do with permissions and would
+    /// have let this test 'fail' for the wrong reason).
+    /// </summary>
+    private static AccessContext DanaContext => new() { ObjectId = Dana, Name = Dana, Roles = [] };
+
+    [Fact(Timeout = 60_000)]
+    public async Task Recycle_WhenTheReleaseStampIsDenied_RefusesInsteadOfDisposingTheHubAnyway()
+    {
+        var space = $"{TestPartition}/recyclespace";
+        await NodeFactory.CreateNode(new MeshNode("recyclespace", TestPartition)
+        { Name = "Space", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        // 🚨 It has to be a NODETYPE node. Recycle only stamps a release request when
+        // IsNodeTypeNode(curr) holds; on anything else the Update lambda returns the node
+        // unchanged, which is a NO-OP that never reaches the access pipeline — so a Markdown
+        // node would exercise no denial at all and the test would pass having proved nothing.
+        await NodeFactory.CreateNode(new MeshNode("SomeType", space)
+        { Name = "Some Type", NodeType = MeshNode.NodeTypePath }).Should().Within(30.Seconds()).Emit();
+
+        // Dana can READ the space (Viewer = Read | Execute | Api — no Update) — so the recycle resolves its target and reaches the stamp —
+        // but is explicitly denied Update, which is exactly the memex operator's shape on a
+        // GitSynced module space: allowed to look, never to write.
+        await NodeFactory.CreateNode(AssignmentNodeFactory.UserRole(Dana, "Viewer", space))
+            .Should().Within(30.Seconds()).Emit();
+
+        await Mesh.GetEffectivePermissions(space, Dana)
+            .Should().Within(30.Seconds()).Match(p => p.HasFlag(Permission.Read) && !p.HasFlag(Permission.Update));
+
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var ops = new MeshOperations(Mesh);
+
+        // The whole operation must FAIL. Before the fix this returned a success payload, having
+        // logged "disposing the hub anyway" — the destructive half, granted to a refused caller.
+        // The context is switched around the SUBSCRIBE, because Recycle is cold: the identity that
+        // matters is the one live when the write is issued, not when the observable was built.
+        var failed = false;
+        string? outcome = null;
+        try
+        {
+            using (access.SwitchAccessContext(DanaContext))
+                outcome = await ops.Recycle($"{space}/SomeType").Should().Within(45.Seconds()).Emit();
+            Output.WriteLine($"Recycle returned: {outcome}");
+        }
+        catch (Exception ex)
+        {
+            Output.WriteLine($"Recycle threw: {ex.GetType().Name}: {ex.Message}");
+            failed = ex is UnauthorizedAccessException || ex.InnerException is UnauthorizedAccessException;
+        }
+
+        // A structured refusal counts — what must NOT happen is a success payload. Locally the
+        // PRE-CHECK catches this caller and answers with a legible reason; that is layer one and
+        // it is worth pinning, because the memex operator got a settle-TIMEOUT instead of a denial
+        // and could not tell "not dispatched" from "refused".
+        failed = failed
+                 || (outcome?.Contains("Update permission", StringComparison.OrdinalIgnoreCase) ?? false)
+                 || (outcome?.Contains("denied", StringComparison.OrdinalIgnoreCase) ?? false);
+
+        outcome.Should().NotContain("\"status\":\"Recycled\"",
+            "a refused caller must never receive the success payload — that IS the destructive half");
+
+        failed.Should().BeTrue(
+            "a caller who may not WRITE the node may not RECYCLE it either — the stamp and the "
+            + "dispose are two halves of one authorised operation, and proceeding after the write "
+            + "was refused hands an unauthorised caller the destructive half for free");
+    }
+}


### PR DESCRIPTION
Reported from production (memex, **2026-08-30 17:11:21Z**) — and it is my own regression from #2763.

## What happened

`Recycle` on a NodeType is two halves of **one authorised operation**: stamp a release request on the node, then dispose its hub so the next activation acts on that stamp. The stamp goes through the access pipeline; the dispose does not. The failure handler I added in #2763 caught *every* exception and disposed anyway:

```csharp
.Catch((Exception ex) => {
    logger.LogWarning(ex, "Recycle: failed to stamp release request for {Path} — disposing the hub anyway", …);
    return Observable.Return(false);
});
```

I wrote that reasoning for a **timeout** and then applied it to everything, including `UnauthorizedAccessException`. An operator without `Update` on a GitSynced module space — where the only Admin is `system-security`, by design — called Recycle:

```
AccessControlPipeline: Access denied: user 'rbuergi' lacks Update permission on 'Crm/Migration'
   (triggered by message=PatchDataRequest sender=cache/_ciqCj6MNUWJjheeu08jRg)
[UpdateRemote] OWNER_DENIED … [UpdateQueue] FAILED path=Crm/Migration seq=632
Recycle: failed to stamp release request for Crm/Migration — disposing the hub anyway
```

The NodeType was left with no release request to act on and its watcher went silent. **A caller who may not write the node may not recycle it either** — proceeding after the write was refused hands an unauthorised caller the destructive half for free. It now throws and disposes nothing; anything that is *not* a denial still proceeds, because that caller was allowed to ask.

## 🚨 Two layers, and the test can only reach the first — stated, not papered over

Recycle already **pre-checks** `Update` and answers with a legible refusal. `RecycleDeniedStampTest` pins that, and it is worth pinning: the operator in the incident received a **settle-timeout** instead and could not tell *"the trigger did not dispatch"* from *"you were refused"*. (Same complaint, other end: MeshWeaver.Plugins#985, where the `compile` tool's description claimed no Update permission was required at all.)

But the incident proves the pre-check is **not sufficient** — the operator got past it and the **owner** refused the write. The owner's answer is the authoritative one and it arrives *after* the optimistic local fold has said yes. That is the gap this fix closes, and **no deterministic local repro exists** for it because it needs the pre-check and the owner to disagree. I did not manufacture one: a test that faked the disagreement would be pinning its own scaffolding. It is recorded in the doc comment instead.

## Two real traps hit while writing the test, both now documented in it

- It must recycle a **NodeType** node. On anything else the `Update` lambda returns the node unchanged — a NO-OP that never reaches the access pipeline — so a Markdown node would have passed having proved nothing.
- `MeshOperations` resolves `IWorkspace` from the hub it is given, and a **client** hub has none (`"An exception was thrown while activating MeshWeaver.Data.IWorkspace"`). The identity is switched on the **mesh's** `AccessService` around the `Subscribe`, because `Recycle` is cold.

## Verified

`MeshWeaver.Mesh.Operations` and `MeshWeaver.Hosting.Monolith.Test` each `-c Release -warnaserror` → **0 Error(s)**; `RecycleDeniedStampTest` **1/1 green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)