### PR TITLE
fix(#890): a compile the PROCESS could not run is not a verdict about the code

### DIFF
--- a/src/MeshWeaver.Compiler/EmitPipeline.cs
+++ b/src/MeshWeaver.Compiler/EmitPipeline.cs
@@ -153,6 +153,45 @@ public static class EmitPipeline
     internal const string EmitCanaryDataKey = "MeshWeaver.EmitCanary";
 
     /// <summary>
+    /// Did the canary PROVE that this PROCESS can no longer emit — as opposed to this
+    /// compilation's own inputs being at fault?
+    ///
+    /// <para>Both <c>REFERENCES</c> and <c>BELOW-ROSLYN</c> are reached only after the control
+    /// compilation — trivial, freshly parsed, known-good source — ALSO failed to emit. Whatever
+    /// broke, it is not the code the caller handed in, so a compile that aborts this way has
+    /// formed NO verdict about that code. <c>NodeTypeCompilationHelpers.IsAvailabilityNonVerdict</c>
+    /// reads this and stamps <c>CompilationStatus.Unavailable</c> instead of <c>Error</c>.</para>
+    ///
+    /// <para>🚨 The three withholding verdicts are deliberately false, for the same reason each of
+    /// them exists:</para>
+    /// <list type="bullet">
+    ///   <item><c>OK</c> — the control emitted fine against the SAME references, so the fault IS a
+    ///     property of this compilation's inputs. That is a genuine <c>Error</c>.</item>
+    ///   <item><c>INCONCLUSIVE</c> — leg 2 never ran (no on-disk CoreLib to build the control
+    ///     from), so nothing was proven either way. Reading "I could not run" as "the process is
+    ///     dead" is the exact defect that branch was carved out to avoid.</item>
+    ///   <item><c>DIVERGENT</c> — both legs failed but in DIFFERENT frames, which the verdict
+    ///     already refuses to call one process-wide fault.</item>
+    /// </list>
+    ///
+    /// <para>🚨 And it is <b>not</b> "the exception carries a canary at all". Every emit-phase
+    /// throw carries one; only two of the five verdicts say the process is the broken thing.
+    /// Keying on presence would widen the non-verdict to every infrastructure fault — the blind
+    /// spot <c>SourceSnapshotEstablishmentTest.EveryOtherCompileFailure_StillStampsError</c>
+    /// exists to refuse — so the verdict has to be READ, not merely found.</para>
+    ///
+    /// <para>Pure and total: any other string, and <c>null</c>, answer false. The parameter is
+    /// <see cref="object"/> because it is read straight out of
+    /// <see cref="System.Collections.IDictionary"/> <c>Exception.Data</c>, where a value of the
+    /// wrong type is a real possibility and must degrade to "not proven".</para>
+    /// </summary>
+    /// <param name="canaryVerdict">The value stamped under <see cref="EmitCanaryDataKey"/>.</param>
+    internal static bool IsProcessEmitFailure(object? canaryVerdict) =>
+        canaryVerdict is string verdict
+        && (verdict.StartsWith("canary=BELOW-ROSLYN", StringComparison.Ordinal)
+            || verdict.StartsWith("canary=REFERENCES", StringComparison.Ordinal));
+
+    /// <summary>
     /// A minimal, self-contained compilation used ONLY by <see cref="ProbeSharedEmitState"/>.
     /// Three levels of nested generics on purpose: that is what makes Roslyn's metadata writer
     /// walk a type's containing chain (<c>GetConsolidatedTypeParameters</c> recursing through

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -652,6 +652,31 @@ container, so a diagnostic emitted from inside a `catch` or an Rx `onError` can 
 fault into an unhandled one. Route such emissions through a guarded helper whose single empty catch
 swallows only the *logging* failure.
 
+## 🚨 The managed twin — #890 — produces NO dump, and no amount of asking will change that
+
+`#890` is the same "one 8-byte word reads as zero" shape surfacing in **managed** code: Roslyn's
+`Emit` throws `NullReferenceException` from `Cci.MetadataWriter`, reading a `ContainingType` that
+the guard immediately above it had just read as non-null. Its canary's verdict has told triage to
+*"capture a core dump and re-run with tiering disabled"* since 2026-08-28, and **not one has ever
+arrived** — because the advice is unfollowable by construction:
+
+`DOTNET_DbgEnableMiniDump` fires on a **signal**. The #890 process never crashes; it throws a
+managed exception, logs it, and keeps running until CI's 8-minute cap kills it — `exit=124`, which
+is `timeout --signal=TERM`, which produces **no dump**. Every occurrence in the 9-event
+2026-08-22→08-29 sweep ends `exit=124` or `TESTFAIL`. **The dump route belongs to this page's family
+(#613), not to #890.**
+
+What #890 *can* contribute that a dump cannot is a measurement #613 has no way to take, because a
+crashed process has no "after": **the fault is total and permanent.** On run `33322993649` shard 1,
+after the first throw at 16:42:42.375, **7 of 7** compiles that reached the metadata writer failed
+identically over 6 m 15 s and **none** succeeded — while every compile that needed only diagnostics
+kept returning correct `CS####` codes. A one-off zeroed word cannot produce a 100 % failure rate over
+freshly allocated symbols; a **tier-1 / dynamic-PGO miscompilation** of one method can, and also
+explains the fixed frame, the load dependence and the onset ~80 s into a compile-heavy assembly.
+So the cheap next measurement for BOTH issues is the half of the advice that *is* followable:
+re-run with `DOTNET_TieredCompilation=0` (or `DOTNET_TieredPGO=0`, the sharper probe). See
+[NodeTypeCompilation → When the PROCESS cannot emit](/Doc/Architecture/NodeTypeCompilation).
+
 ## Related
 
 - [DebuggingMessageFlow](../DebuggingMessageFlow) — for hangs and lost messages (a

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -514,6 +514,75 @@ completely silent: nothing anywhere named a NodeType that is broken and will not
 > token that happened to match the importing deployment's live inputs would suppress precisely the
 > retry it exists to grant.
 
+### 🚨 When the PROCESS cannot emit — a failure that is not a verdict at all
+
+Everything above assumes the compile *found something out*. Sometimes it does not: Roslyn's `Emit`
+**throws** instead of returning diagnostics, and from that moment the process cannot emit any
+assembly at all. This is [#890](https://github.com/Systemorph/MeshWeaver/issues/890) — a
+`NullReferenceException` inside `Cci.MetadataWriter.GetConsolidatedTypeParameters`, reading a
+`ContainingType` that the guard immediately above it had just read as non-null.
+
+**The condition is total and permanent, not intermittent.** Measured on run `33322993649` shard 1
+(2026-08-30): the first throw landed at 16:42:42.375, and across the remaining 6 m 15 s of that
+process **7 of 7** compiles that reached the metadata writer failed identically and **none**
+succeeded. Compiles that only needed *diagnostics* kept working perfectly — the deliberately-broken
+NodeTypes in `NodeTypeCompileParkTest` still reported their real `CS1040`/`CS0246` codes — so parse
+and bind were healthy and only the **emit** was dead. That split is the fastest way to recognise it
+in a log: correct `CS####` for broken source, `NullReferenceException` for source that should
+succeed.
+
+**It is not a MeshWeaver defect and no compile-side change fixes it.** `EmitPipeline`'s canary
+answers that at the first throw, in two legs: re-emit a trivial, freshly parsed, known-good
+compilation against the same references, then — if that fails too — against an image-backed CoreLib
+that shares neither the `MetadataReference` instances nor their file mappings. `REFERENCES` and
+`BELOW-ROSLYN` both mean **the control could not emit either**.
+
+#### What that changes about the verdict
+
+A compile that aborts this way has learned **nothing** about the code it was handed, so recording
+`CompilationStatus.Error` states a verdict that was never formed — and it is durable: the same write
+stamps `FailedBuildInputs`, the re-drive above reads it back as *"formed under exactly the live
+inputs"*, and declines. The type is left saying *"your code is broken"* about code nothing evaluated,
+retried by nothing until a human presses **Compile** or an input genuinely moves.
+
+So `IsAvailabilityNonVerdict` treats it as the third availability fact, beside an unestablished
+source set and a recycling address: status `Unavailable`, no verdict recorded, the park budget
+untouched, and the type re-drivable — which is what lets a later, healthy process compile it. The
+bake gate filing this as *unevaluated* rather than as a code regression is the correct reading: a
+bake whose process cannot emit has evaluated nothing.
+
+🚨 **The predicate reads the VERDICT, never the presence of a canary.** Every emit-phase throw
+carries one, and three of the five verdicts deliberately withhold the claim — `OK` (the control
+emitted fine against the same references, so the fault *is* this compilation's inputs — a genuine
+`Error`), `INCONCLUSIVE` (the control could not be built, so leg 2 never ran) and `DIVERGENT` (both
+legs failed, in different frames). Widening this to "any infrastructure fault" is the blind spot
+`SourceSnapshotEstablishmentTest.EveryOtherCompileFailure_StillStampsError` exists to refuse.
+
+#### Reading it in CI — one event, many names
+
+One poisoned process reports as up to ten unrelated test failures; across 2026-08-22→08-29 that was
+**9 events wearing 37 distinct test names**, 23 % of all failing test names in the week. Every
+occurrence has cost a fresh and always-identical misdiagnosis. In run `33322993649` all five
+failures — three `NodeTypeCompileParkTest`, one `CodeEditRecompileTest`, one
+`ReleaseRequestWatcherHighWaterTest` — were this one event, and the shard's `exit=124` was its
+consequence, not a second problem.
+
+Two readings that look right and are not:
+
+- **"The retry compiled stale source."** It did not. The retry runs a real compile; the broken
+  source's `CS####` lines in the same test's output belong to the *first* compile, before the fix was
+  written. The retry's own error is the `NullReferenceException`. Compare timestamps, not adjacency.
+- **"That one is just a slow shard."** `ReleaseRequestWatcherHighWaterTest`'s compile threw **174 ms**
+  after `TEST START`; the 50 s wait that followed was waiting for an `Ok` that could never arrive.
+
+> 🚨 **The core dump the canary asks for cannot be captured this way.** `DOTNET_DbgEnableMiniDump`
+> fires on a *signal*, and this process never crashes — it throws a managed exception and keeps
+> running until CI's 8-minute cap kills it (`exit=124`, no dump). That is why three weeks of
+> "capture a core dump" produced none. Its SIGSEGV twin,
+> [#613](https://github.com/Systemorph/MeshWeaver/issues/613), *does* dump — see
+> [Debugging Native Crashes](/Doc/Architecture/DebuggingNativeCrashes) for the invariant the two share (a single
+> 8-byte word reading exactly zero while its block stays coherent) and for how to read one.
+
 ### Framework-version freezing
 
 A compiled NodeType DLL references the MeshWeaver framework assemblies present

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-compile-the-process-could-not-run-no-longer-blames-your-code.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-a-compile-the-process-could-not-run-no-longer-blames-your-code.md
@@ -1,0 +1,46 @@
+---
+Name: A compile the process could not run no longer blames your code
+Category: Fix
+Description: When Roslyn's emit breaks process-wide, every later compile threw — and each one was recorded as "your code is broken", which also stopped anything from ever retrying it. Those aborts are now recorded as not-evaluated, so the type recovers on the next healthy process instead of staying stuck until someone presses Compile.
+Icon: Bug
+Order: -20260830
+---
+
+# A compile the process could not run no longer blames your code
+
+Very occasionally a portal reaches a state where the C# compiler can no longer **emit** an assembly
+at all. Every NodeType compiled after that point failed — and each one was written down as
+`Error`, *"your code did not compile"*, even though nothing had looked at the code.
+
+That verdict was sticky. A failed compile also records **which inputs it was formed from** (the
+framework, the installed modules, the type's own sources), and the automatic retry deliberately
+declines when none of those have moved — because re-running an identical compile would produce an
+identical failure. For a fault that had nothing to do with the inputs, that reasoning was simply
+wrong: the type sat at `Error` reporting an error its source never caused, and **nothing retried
+it** — not a restart, not a redeploy — until someone opened it and pressed **Compile**.
+
+## What changed
+
+When a compile aborts inside the emit, the compiler now re-runs a tiny, known-good control
+compilation on the spot. If that one cannot emit either, the failure is recorded as
+**not evaluated** rather than as a verdict:
+
+- the NodeType is left **Unavailable** — *"the compile state could not be determined; nothing is
+  known to be wrong with the source"* — instead of `Error`;
+- no verdict and no input fingerprint are written, so the type is **re-driven automatically** and a
+  later, healthy process compiles it normally;
+- the log says so in one line, naming the condition and stating that every later compile in that
+  process will fail the same way — so the failures that follow are read as one event instead of a
+  dozen unrelated ones.
+
+If that control compilation **succeeds**, the fault really is specific to the code being compiled,
+and it is still recorded as `Error` exactly as before. Only a measured, process-wide emit failure
+takes the new path — an infrastructure fault that has *not* been shown to be process-wide is still
+a full verdict, so nothing that should be caught can slip through as "not evaluated".
+
+## What this does not change
+
+The underlying emit failure is a fault below the framework, in the .NET runtime, and this does not
+fix it — a portal in that state still cannot compile anything until it restarts. What it fixes is
+the damage it used to leave behind: NodeTypes permanently marked broken, on evidence that was never
+gathered.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -2187,9 +2187,36 @@ internal static class NodeTypeCompilationHelpers
     /// the only automatic un-park is a SOURCE change, which a recycle never produces — it stayed
     /// there until a human pressed Compile. Duplicating the type test at both sites is how they
     /// drifted apart in the first place, so there is deliberately exactly one.</para>
+    ///
+    /// <para>🚨 <b>The third member is an emit the CANARY proved the PROCESS could not do
+    /// (#890).</b> When Roslyn's <c>Emit</c> THROWS, <see cref="EmitPipeline"/> immediately
+    /// re-emits a trivial, freshly parsed, known-good control compilation — first against the same
+    /// references, then against an image-backed CoreLib that shares nothing. A
+    /// <c>REFERENCES</c> or <c>BELOW-ROSLYN</c> verdict means <b>that control also failed</b>: the
+    /// process can no longer emit ANY assembly, so this compile learned nothing whatsoever about
+    /// the code it was handed. Recording it as <see cref="CompilationStatus.Error"/> states a
+    /// verdict that was never formed — and it is durable state: <see cref="ApplyCompileFailure"/>
+    /// also stamps <see cref="NodeTypeDefinition.FailedBuildInputs"/>, so
+    /// <see cref="HasStaleFailureVerdict"/> then reads "this failure was formed under exactly the
+    /// live inputs" and the automatic re-drive correctly declines — for a fault the inputs had
+    /// nothing to do with, and which a fresh process would not reproduce. Measured on run
+    /// 33322993649 shard 1: after the first such throw, <b>7 of 7</b> later compiles that reached
+    /// Roslyn's metadata writer failed identically over 6 m 15 s and none succeeded, while every
+    /// compile that needed only DIAGNOSTICS still returned correct <c>CS####</c> codes — the
+    /// process was emit-dead and five tests reported it under five unrelated names.</para>
+    ///
+    /// <para>🚨 It is keyed on the verdict being READ, never on a canary being PRESENT — every
+    /// emit-phase throw carries one, and <c>OK</c> / <c>INCONCLUSIVE</c> / <c>DIVERGENT</c> all
+    /// mean the process was NOT shown to be at fault. Widening this to "any infrastructure fault"
+    /// is the blind spot <c>SourceSnapshotEstablishmentTest.EveryOtherCompileFailure_StillStampsError</c>
+    /// exists to refuse, and it stays refused: see <see cref="EmitPipeline.IsProcessEmitFailure"/>.
+    /// The bake gate filing THIS case as unevaluated rather than as a code regression is the
+    /// correct reading, not a hole — a bake whose process cannot emit has evaluated nothing.</para>
     /// </summary>
     internal static bool IsAvailabilityNonVerdict(Exception? error) =>
-        error is SourceDiscoveryUnavailableException or AddressRecyclingException;
+        error is SourceDiscoveryUnavailableException or AddressRecyclingException
+        || (error is not null
+            && EmitPipeline.IsProcessEmitFailure(error.Data[EmitPipeline.EmitCanaryDataKey]));
 
     /// <summary>
     /// THE terminal stamp of a FAILED compile — the exact field set <see cref="RunCompile"/>'s
@@ -2564,11 +2591,34 @@ internal static class NodeTypeCompilationHelpers
                             parkRegistry.OnCompileSucceeded(hubPath);
                         else if (IsAvailabilityNonVerdict(outcome.Error))
                         {
-                            logger?.LogInformation(
-                                "Compile for {HubPath} reached NO VERDICT ({Type}) — an availability fact, "
-                                + "not a compile failure: it does not count towards the park budget and the "
-                                + "type is left at Unavailable for the automatic re-drive to retry. {Error}",
-                                hubPath, outcome.Error!.GetType().Name, outcome.Error.Message);
+                            // 🚨 ATTRIBUTION for the emit-dead case (#890). One poisoned process
+                            // reports as up to ten unrelated test names — 23 % of all distinct
+                            // failing test names in the 08-22→08-29 sweep — and each occurrence has
+                            // cost a fresh, always-identical misdiagnosis. The canary already KNOWS
+                            // the process is the broken thing at the first throw; nothing said so in
+                            // a form the next reader could act on. This line is that statement, and
+                            // it is deliberately louder than its sibling: an Information line about
+                            // one node does not describe a process that can no longer compile
+                            // anything, and every compile after it in this process will fail the
+                            // same way for the same reason.
+                            if (EmitPipeline.IsProcessEmitFailure(
+                                    outcome.Error!.Data[EmitPipeline.EmitCanaryDataKey]))
+                                logger?.LogError(
+                                    "PROCESS CANNOT EMIT (#890) — the compile of {HubPath} aborted inside "
+                                    + "Roslyn's emit, and the canary's control compilation (trivial, freshly "
+                                    + "parsed, known-good) could not emit either. This says NOTHING about that "
+                                    + "type's code: it is left at Unavailable, no verdict is recorded and the "
+                                    + "park budget is untouched. 🚨 EVERY LATER COMPILE IN THIS PROCESS WILL "
+                                    + "FAIL THE SAME WAY — attribute the failures that follow to this line, not "
+                                    + "to the change under test, and do not re-diagnose them one by one. "
+                                    + "Verdict: {Verdict}",
+                                    hubPath, outcome.Error.Data[EmitPipeline.EmitCanaryDataKey]);
+                            else
+                                logger?.LogInformation(
+                                    "Compile for {HubPath} reached NO VERDICT ({Type}) — an availability fact, "
+                                    + "not a compile failure: it does not count towards the park budget and the "
+                                    + "type is left at Unavailable for the automatic re-drive to retry. {Error}",
+                                    hubPath, outcome.Error!.GetType().Name, outcome.Error.Message);
                         }
                         else
                         {

--- a/test/MeshWeaver.Graph.Test/EmitDeadProcessIsNotAVerdictTest.cs
+++ b/test/MeshWeaver.Graph.Test/EmitDeadProcessIsNotAVerdictTest.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using MeshWeaver.Compiler;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 A compile that aborted because the PROCESS can no longer emit has formed no verdict about
+/// the code, and must not record one (#890).
+///
+/// <para><b>What actually happens.</b> Roslyn's <c>Emit</c> throws
+/// <see cref="NullReferenceException"/> from <c>Cci.MetadataWriter</c>, and from that instant the
+/// process cannot emit ANY assembly. Measured on run <c>33322993649</c> shard 1: the first throw
+/// landed at 16:42:42.375, and over the remaining 6 m 15 s <b>7 of 7</b> compiles that reached the
+/// metadata writer failed identically while <b>none</b> succeeded — yet every compile that needed
+/// only DIAGNOSTICS still returned correct <c>CS####</c> codes, so parse and bind were healthy and
+/// only the emit was dead. The canary
+/// (<see cref="EmitPipeline.ProbeSharedEmitState"/>) says so at the FIRST throw: its control
+/// compilation is trivial, freshly parsed and known-good, and it could not emit either.</para>
+///
+/// <para><b>What was recorded instead.</b> <see cref="NodeTypeCompilationHelpers.ApplyCompileFailure"/>
+/// stamped <see cref="CompilationStatus.Error"/> — "Roslyn's verdict" — plus
+/// <see cref="NodeTypeDefinition.FailedBuildInputs"/>, the durable claim *"this failure was formed
+/// under these compile inputs"*. <see cref="NodeTypeCompilationHelpers.HasStaleFailureVerdict"/>
+/// then reads that claim back, finds it equal to the live inputs, and the automatic re-drive
+/// declines — for a fault the framework, the modules and the sources had nothing to do with, and
+/// which a healthy process would not reproduce. The type is left saying *"your code is broken"*
+/// about code nothing ever evaluated, and nothing retries it until a human presses Compile or an
+/// input genuinely moves.</para>
+///
+/// <para><b>The other half — the park budget — was already right</b> and that is exactly why this
+/// mattered: <c>RunCompile</c>'s terminal handler classifies a non-<c>CompilationException</c>
+/// abort as non-deterministic, so the two consumers of one classification disagreed. This file
+/// pins them back together on the predicate the file itself insists there be only one of.</para>
+///
+/// <para>🚨 <b>The non-vacuity half is the point.</b> Only two of the canary's five verdicts prove
+/// the process is at fault. A predicate keyed on "an emit-phase throw carries a canary" would be
+/// true for all five and would hand the bake gate the blind spot
+/// <c>SourceSnapshotEstablishmentTest.EveryOtherCompileFailure_StillStampsError</c> exists to
+/// refuse. Every withholding verdict is pinned below.</para>
+/// </summary>
+public class EmitDeadProcessIsNotAVerdictTest
+{
+    private const string Site = "NamedTypeSymbol.Microsoft.Cci.ITypeDefinitionMember.get_ContainingTypeDefinition";
+
+    /// <summary>The real thing, built the way the pipeline builds it: the ORIGINAL exception with
+    /// the canary verdict stamped on <see cref="Exception.Data"/> — never a wrapper, because the
+    /// exception TYPE is what CI triage keys on.</summary>
+    private static Exception EmitThrewWith(string verdict)
+    {
+        var error = new NullReferenceException("Object reference not set to an instance of an object.");
+        error.Data[EmitPipeline.EmitCanaryDataKey] = verdict;
+        return error;
+    }
+
+    private static string Threw(string site = Site)
+        => $"THREW NullReferenceException at {site}: Object reference not set to an instance of an object.";
+
+    // The verdicts as EmitPipeline.Verdict actually produces them — derived, never hand-typed, so
+    // a change to the verdict wording cannot leave this file asserting against strings that no
+    // longer exist.
+    private static string BelowRoslyn => EmitPipeline.Verdict(Threw(), Threw());
+    private static string References => EmitPipeline.Verdict(Threw(), "OK");
+    private static string Divergent => EmitPipeline.Verdict(Threw(), Threw("SomethingElse.Unrelated"));
+
+    /// <summary>
+    /// The defect, at the durable stamp. A process that cannot emit is an availability fact, so
+    /// the status is <see cref="CompilationStatus.Unavailable"/> — "the compile state could not be
+    /// determined; nothing is known to be wrong with the source" — exactly as an unestablished
+    /// source set already is.
+    /// </summary>
+    [Fact]
+    public void AnEmitTheProcessCouldNotDo_IsNotAVerdictAboutTheCode()
+    {
+        NodeTypeCompilationHelpers.ApplyCompileFailure(
+                new NodeTypeDefinition(),
+                result: null,
+                error: EmitThrewWith(BelowRoslyn),
+                activityPath: null)
+            .CompilationStatus.Should().Be(CompilationStatus.Unavailable,
+                "the canary's control compilation — trivial, freshly parsed, known-good — could "
+                + "not emit either, so this compile learned nothing about the code it was handed; "
+                + "recording Error states a verdict that was never formed");
+    }
+
+    /// <summary>
+    /// …and the durable consequence, which is the one that actually costs: an <c>Error</c> stamped
+    /// with <see cref="NodeTypeDefinition.FailedBuildInputs"/> equal to the live inputs is the
+    /// state in which the automatic re-drive declines. <see cref="CompilationStatus.Unavailable"/>
+    /// is stale on its own, so a later, healthy process re-drives the type instead of leaving it
+    /// bricked on a fault its inputs never caused.
+    /// </summary>
+    [Fact]
+    public void TheTypeStaysReDrivable_SoAHealthyProcessRecoversIt()
+    {
+        var sources = ImmutableDictionary.CreateRange(
+            new Dictionary<string, long> { ["Acme/Type/Source/code"] = 3 });
+        var def = new NodeTypeDefinition { CurrentSourceVersions = sources };
+
+        var afterEmitDeath = NodeTypeCompilationHelpers.ApplyCompileFailure(
+            def, result: null, error: EmitThrewWith(BelowRoslyn),
+            activityPath: null, modulesHash: "mod-1");
+
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(afterEmitDeath, "mod-1")
+            .Should().BeTrue(
+                "nothing about the framework, the modules or the sources caused this, so the "
+                + "verdict-inputs token cannot express what has to change for a retry to be worth "
+                + "making — a fresh process is what changes, and Unavailable is stale on its own");
+
+        // The control: a REAL compile error, formed under exactly these inputs, still stops the
+        // re-drive. Without this, "always re-drive" would pass the assertion above and turn a
+        // permanently-broken type into an unbounded recompile.
+        var afterRealCompileError = NodeTypeCompilationHelpers.ApplyCompileFailure(
+            def, result: null,
+            error: new CompilationException("Acme/Type", "CS0246: The type or namespace name 'X' could not be found"),
+            activityPath: null, modulesHash: "mod-1");
+
+        afterRealCompileError.CompilationStatus.Should().Be(CompilationStatus.Error);
+        NodeTypeCompilationHelpers.HasStaleFailureVerdict(afterRealCompileError, "mod-1")
+            .Should().BeFalse(
+                "a genuine Roslyn diagnostic IS a verdict about the code, formed under these very "
+                + "inputs — re-running it would change nothing and the park exists to stop exactly "
+                + "that");
+    }
+
+    /// <summary>
+    /// 🚨 Non-vacuity, verdict by verdict. Three of the canary's five outcomes deliberately
+    /// WITHHOLD the claim that the process is the broken thing, and each one is a case where
+    /// treating the abort as a non-verdict would hide a real fault:
+    /// <list type="bullet">
+    ///   <item><c>OK</c> — the control emitted fine against the SAME references, so the fault IS a
+    ///     property of this compilation's inputs. That is a genuine <c>Error</c>.</item>
+    ///   <item><c>INCONCLUSIVE</c> — the control could not be BUILT, so leg 2 never ran. Reading
+    ///     "I could not run" as "the process is dead" is the defect that branch exists to avoid.</item>
+    ///   <item><c>DIVERGENT</c> — both legs failed, in DIFFERENT frames, which the verdict already
+    ///     refuses to call one process-wide fault.</item>
+    /// </list>
+    /// </summary>
+    [Theory]
+    [InlineData("OK")]
+    [InlineData("INCONCLUSIVE")]
+    [InlineData("DIVERGENT")]
+    public void EveryWithholdingVerdict_StillStampsError(string which)
+    {
+        var verdict = which switch
+        {
+            "OK" => EmitPipeline.ProbeSharedEmitState(
+                Microsoft.CodeAnalysis.CSharp.CSharpCompilation.Create(
+                    "probe", references: CompileReferences.Default)),
+            "INCONCLUSIVE" => "canary=INCONCLUSIVE shared:THREW … pristine:UNAVAILABLE(no on-disk "
+                + "System.Private.CoreLib to reference) — the shared reference set cannot emit, but "
+                + "the pristine control could not be BUILT",
+            _ => Divergent,
+        };
+
+        // The OK leg is produced by the real probe against the real reference set, so this also
+        // proves the canary can still emit in a HEALTHY process — a control that had quietly
+        // stopped compiling would make every assertion here vacuous.
+        if (which == "OK")
+            verdict.Should().StartWith("canary=OK");
+        else if (which == "DIVERGENT")
+            verdict.Should().StartWith("canary=DIVERGENT");
+
+        EmitPipeline.IsProcessEmitFailure(verdict).Should().BeFalse();
+
+        NodeTypeCompilationHelpers.ApplyCompileFailure(
+                new NodeTypeDefinition(), result: null,
+                error: EmitThrewWith(verdict), activityPath: null)
+            .CompilationStatus.Should().Be(CompilationStatus.Error,
+                $"'{which}' does not show the process to be at fault, and filing an unproven "
+                + "process fault as 'not evaluated' is the blind spot that would let a real code "
+                + "regression through the bake gate");
+    }
+
+    /// <summary>
+    /// The two verdicts that DO prove it, plus the shapes a value read out of an untyped
+    /// <see cref="Exception.Data"/> can really take. The predicate is total: it never throws and
+    /// answers false for anything it does not recognise.
+    /// </summary>
+    [Fact]
+    public void TheClassifierReadsTheVerdict_NotThePresenceOfACanary()
+    {
+        EmitPipeline.IsProcessEmitFailure(BelowRoslyn).Should().BeTrue();
+        EmitPipeline.IsProcessEmitFailure(References).Should().BeTrue(
+            "a control that emits only against BRAND-NEW references still means this process "
+            + "cannot compile what it is being asked to compile");
+
+        EmitPipeline.IsProcessEmitFailure(null).Should().BeFalse();
+        EmitPipeline.IsProcessEmitFailure(42).Should().BeFalse(
+            "Exception.Data is untyped, so a non-string value must degrade to 'not proven'");
+        EmitPipeline.IsProcessEmitFailure("canary=BELOW-ROSLYN").Should().BeTrue();
+        EmitPipeline.IsProcessEmitFailure("BELOW-ROSLYN mentioned in prose").Should().BeFalse(
+            "the verdict is a prefix, not a substring — an error message that happens to quote a "
+            + "previous verdict must not become one");
+
+        // An exception with no canary at all — every infrastructure fault that never reached
+        // Roslyn's emit — is untouched.
+        NodeTypeCompilationHelpers.IsAvailabilityNonVerdict(
+                new InvalidOperationException("something else went wrong"))
+            .Should().BeFalse();
+    }
+}


### PR DESCRIPTION
Run `33322993649` shard 1 failed five tests on PR #2807 — a **documentation-only** PR. All five are
one event, and it is **#890**, not anything the diff could reach.

## The measurement that settles it

Every `Compile failure for X` line in that shard, split by whether it carries the NRE:

| when | node | outcome |
|---|---|---|
| 16:41:52 · 16:42:06 · 16:42:14 | `type/CompletionDemo`, `AdoptOnDemandTest/AdoptOnDemandBroken` ×2 | real `CS####` |
| **16:42:42.375** | **`ACME/Project`** | **NRE ← onset** |
| 16:42:48.357 | `TestData/HighWaterType` | **NRE** |
| 16:43:40 · 43:44 · 43:45 · 43:49 · 45:21 ×2 · 47:21 ×2 | the park types' deliberately-broken FIRST compiles | real `CS####` |
| 16:43:46.528 · 43:50.978 · 45:21.695 · 47:22.109 · 48:52.274 | the same types' retries, **fixed source** | **NRE** ×5 |

**After the onset, 7 of 7 compiles that reached Roslyn's metadata writer failed identically over
6 m 15 s and NONE succeeded** — while every compile that needed only *diagnostics* kept returning
correct `CS1040`/`CS0246`. Parse and bind healthy; **emit dead, permanently**. The `exit=124` is a
consequence, not a second problem.

Two readings that look right and are not, both proposed in earnest while this was being diagnosed:

- **"The retry compiled stale source / adopted a prebuilt."** No adoption anywhere near these nodes.
  `ParkTest/CompileRetry`'s output *does* carry the broken source's `CS1040 line 58` — from the
  **first** compile at `16:43:45.406`, before the test wrote the valid `Configuration`. The retry ran
  at `16:43:46.528` and returned the `NullReferenceException` + `canary=BELOW-ROSLYN`.
- **"`ReleaseRequestWatcherHighWaterTest` is a timing casualty of the 480 s cap."** Its compile threw
  **174 ms** after `TEST START`; the 50 s wait that followed was waiting for an `Ok` the process could
  no longer produce. Re-splitting the shard does not touch it.

Full evidence, including why this is the first occurrence with #2663's image-backed control (so
`BELOW-ROSLYN` is *earned* for the first time) and why the core dump the canary asks for **cannot be
captured** — the process never crashes, so `DOTNET_DbgEnableMiniDump` never fires and `exit=124`
yields nothing: https://github.com/Systemorph/MeshWeaver/issues/890#issuecomment-5470218211

## What this PR fixes — and what it deliberately does not

🚨 **It does not fix the NRE and does not turn that red green.** Roslyn's
`AsNestedTypeDefinitionImpl` reads `ContainingType` non-null and, microseconds later on the same
object, `ContainingTypeDefinition` reads it null — two reads of a readonly reference field, no writer
in between. Nothing above the CLR produces that.

What it fixes is the **durable damage that fault leaves behind**, which is a MeshWeaver defect on its
own. `ApplyCompileFailure` recorded these aborts as `CompilationStatus.Error` **and** stamped
`FailedBuildInputs` — the durable claim *"this verdict was formed under these compile inputs"*.
`HasStaleFailureVerdict` reads it back, finds it equal to the live inputs, and the automatic re-drive
**correctly declines** — for a fault the framework, the modules and the sources had nothing to do
with, and which a healthy process would not reproduce. The NodeType is left asserting *"your code is
broken"* about code nothing evaluated, retried by nothing until a human presses **Compile**.

Meanwhile the *other* consumer of the same classification — the park budget — already treated it as
non-deterministic. So the two halves of this file's own *"one predicate, two consumers, and they MUST
agree (#1701)"* contract had drifted apart again, on a different pair.

`IsAvailabilityNonVerdict` now covers an emit the canary **proved the process could not do**: status
`Unavailable`, no verdict recorded, park budget untouched, type re-drivable — so a later healthy
process compiles it normally.

### It reads the VERDICT, never the presence of a canary

Every emit-phase throw carries one; only two of the five say the process is at fault.

| verdict | meaning | recorded as |
|---|---|---|
| `BELOW-ROSLYN` | control failed against an image-backed CoreLib sharing nothing | **`Unavailable`** |
| `REFERENCES` | control failed against the shared set, emitted against a fresh one | **`Unavailable`** |
| `OK` | control emitted fine against the SAME references ⇒ the fault IS this compilation's inputs | `Error` |
| `INCONCLUSIVE` | the control could not be BUILT — leg 2 never ran | `Error` |
| `DIVERGENT` | both legs failed, in DIFFERENT frames | `Error` |

Widening this to "any infrastructure fault" is exactly the blind spot
`SourceSnapshotEstablishmentTest.EveryOtherCompileFailure_StillStampsError` exists to refuse, and it
stays refused — the three withholding verdicts are pinned as a `Theory`. The bake gate filing the
first two as *unevaluated* rather than as a code regression is the correct reading: a bake whose
process cannot emit has evaluated nothing.

### Attribution — #890's recommendation (3), at the smallest scope that helps

One poisoned process reports as up to ten unrelated test names (9 events wearing **37** distinct
names, 23 % of all failing test names in the 08-22→08-29 week), and each occurrence has cost a fresh
and always-identical misdiagnosis — three of them in the last day alone. The pipeline now logs one
`PROCESS CANNOT EMIT (#890)` line saying that every later compile in this process will fail the same
way. A **new** Error line for a genuinely process-fatal condition, not a level change on an existing
call: an `Information` line about one node cannot describe a process that has stopped being able to
compile anything.

## Tests — mutation-checked

`EmitDeadProcessIsNotAVerdictTest`, 6 cases. Reverting the one-line `IsAvailabilityNonVerdict`
extension fails **2 of 6**, naming the defect:

```
Expected value to be Unavailable because the canary's control compilation … could not emit
either, so this compile learned nothing about the code it was handed …, but found Error.

Expected value to be true because nothing about the framework, the modules or the sources
caused this …, but found False.
```

The verdicts are **derived from `EmitPipeline.Verdict`**, never hand-typed, so a change to the
wording cannot leave the file asserting against strings that no longer exist — and the `OK` leg runs
the **real** probe against the **real** reference set, so it also re-proves the canary can still emit
in a healthy process (a control that had quietly stopped compiling would make every assertion here
vacuous).

```
dotnet build src/MeshWeaver.Compiler               -c Release -warnaserror   0 Error(s)
dotnet build src/MeshWeaver.Graph                  -c Release -warnaserror   0 Error(s)
dotnet build src/MeshWeaver.Documentation          -c Release -warnaserror   0 Error(s)
dotnet build test/MeshWeaver.Graph.Test            -c Release -warnaserror   0 Error(s)
dotnet build test/MeshWeaver.Documentation.Test    -c Release -warnaserror   0 Error(s)
dotnet build test/MeshWeaver.Hosting.Monolith.Test -c Release -warnaserror   0 Error(s)

dotnet test MeshWeaver.Graph.Test                                 1582 passed, 0 failed
dotnet test MeshWeaver.Documentation.Test                          117 passed, 0 failed
dotnet test SourceSnapshot|ShippedNodeTypeState|NeverCompiledFailureRedrive
                                                                     8 passed, 0 failed
```

## Docs

- **NodeTypeCompilation** → *"When the PROCESS cannot emit — a failure that is not a verdict at
  all"*: how to recognise it in a log (correct `CS####` for source that should fail, `NRE` for source
  that should succeed), what it changes about the verdict, and the two wrong readings written out so
  the next reader does not re-derive them.
- **DebuggingNativeCrashes** → the managed twin produces **no dump**, by construction, and the
  followable half of the canary's advice (`DOTNET_TieredCompilation=0` / `DOTNET_TieredPGO=0`) is the
  cheap next measurement for both #890 and #613.
- What's New entry (`Category: Fix`).

Related: #890 (this fault), #613 (its SIGSEGV twin), #1701 (the predicate that must have one
definition), #1793 (the re-drive this restores access to). Not #2813 — that is the *success*
direction of the same "unearned claim" class and is separate; recorded there with the log evidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
