### PR TITLE
test: two more bounds become conditions — the merge queue has been ejecting releases on them (#2777, #2700)

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
@@ -159,12 +160,33 @@ public class SelfUpdateHostedService : IHostedService
                 .SelectMany(verdict => ReportCheck(check.trigger, verdict)))
             .SubscribeOn(TaskPoolScheduler.Default)
             .Subscribe(
-                _ => { },
+                _ => _checksReported.OnNext(Unit.Default),
                 ex => _logger?.LogError(ex, "[SelfUpdate] update watch terminated unexpectedly."));
 
         _subscription = new CompositeDisposable(checks, policy.Connect());
         return Task.CompletedTask;
     }
+
+    /// <summary>
+    /// One emission per CHECK that has been evaluated AND reported (#2777). An instance field —
+    /// its lifetime is this service's — never static.
+    ///
+    /// <para>🚨 It exists because the alternative is a test bounding a POLL. This service is
+    /// event-driven but its first check is still work that has to happen, so a test that waits
+    /// "up to 30 s for the held state to appear" is really waiting for the first check to run:
+    /// on a loaded shard it may simply not have, and the test then reports the absence of a
+    /// verdict as a wrong verdict. That is the same false-RED shape as #2793, and the answer is
+    /// the same — publish the condition, do not infer it from a bound. Production never
+    /// subscribes; nothing here changes what a check does or when it runs.</para>
+    /// </summary>
+    private readonly Subject<Unit> _checksReported = new();
+
+    /// <summary>
+    /// Test seam (<c>InternalsVisibleTo</c>): fires once per check whose verdict has been written.
+    /// Await the FIRST emission to know the service has evaluated at least once, then assert on the
+    /// state it produced — never race a timer against it.
+    /// </summary>
+    protected internal IObservable<Unit> ChecksReported => _checksReported;
 
     /// <summary>
     /// The safety net (#2494): a bounded liveness floor on the CHECK, never on the roll.
@@ -246,6 +268,9 @@ public class SelfUpdateHostedService : IHostedService
     public Task StopAsync(CancellationToken cancellationToken)
     {
         _subscription?.Dispose();
+        // Complete the seam so a subscriber awaiting a check that will now never come is
+        // released rather than left hanging on a stopped service.
+        _checksReported.OnCompleted();
         return Task.CompletedTask;
     }
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-two-more-tests-measure-the-condition-not-a-stopwatch.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-two-more-tests-measure-the-condition-not-a-stopwatch.md
@@ -1,0 +1,42 @@
+---
+Name: Two more tests measure the condition, not a stopwatch
+Category: Fix
+Description: A self-update test waited up to 30 seconds for a hold to appear and read its absence as a wrong verdict; a data-context test read "slow" as "never answered". Both now wait on the thing they are actually testing. One of them had already ejected a release from the merge queue.
+Icon: Timer
+Order: -20260830
+---
+
+# Two more tests measure the condition, not a stopwatch
+
+A test bound is not an assertion. When a test waits *up to N seconds* for something to appear and
+then reports its absence as a failure, it has quietly asserted two different things at once: that
+the behaviour is wrong, and that the machine was fast enough. On a loaded runner only the second one
+is ever false — and the failure it prints describes the first.
+
+That is not hypothetical any more. Since the merge queue went live, every entry is built on a
+runner under load *by construction*, and three separate releases have been ejected by three
+different tests of this shape. Two of them are fixed here.
+
+**The self-update availability gate** waited 30 seconds for a "held" marker to land on the policy
+node. But the service that writes it is event-driven, so "the hold is not there yet" and "the first
+check has not run yet" are indistinguishable from outside — and on a busy shard it is always the
+second. The service now publishes each completed check, and the test waits for *the service to have
+evaluated* before asserting on what it produced. No timer, no race.
+
+**The data-context watchdog** proves that a hub whose initialisation threw answers requests with an
+error rather than hanging — *and answers fast*. One 15-second bound was asserting both of those, and
+they want opposite values: generous for "was it answered at all", tight for "was it answered
+quickly". A runner that merely delayed the rejection produced a timeout, and the test reported
+*"the faulted arm left the gate shut"* — the defect's own signature, for a defect that was not
+there.
+
+Simply widening the bound would have deleted the other half in silence: the test would have kept
+passing if the answer took 55 seconds, which is exactly what its name says it guards. So the two
+are separated. The wait is now generous, so a timeout genuinely means **never answered**; and the
+elapsed time is asserted on its own, against a threshold taken from the mechanism rather than from
+a feeling of "fast" — the hub's own request budget, which is what a request that *fell through* the
+faulted arm would wait out. A slow answer and an absent one now fail with different messages,
+because they are different defects.
+
+Neither change weakens what is being tested. One replaces a bound with the condition itself; the
+other splits a bound that was quietly standing in for two.

--- a/test/MeshWeaver.Data.Test/DataContextInitWatchdogTest.cs
+++ b/test/MeshWeaver.Data.Test/DataContextInitWatchdogTest.cs
@@ -138,22 +138,54 @@ public class DataContextInitFaultedTest(ITestOutputHelper output) : HubTestBase(
     protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
         => configuration.WithTypes(typeof(ProbeRequest), typeof(ProbeResponse));
 
+    /// <summary>
+    /// The hub's own request budget — the latency a request that FELL THROUGH the faulted arm
+    /// would wait out. Derived from the mechanism, not from a feeling of "fast": the rejection
+    /// handler answers in milliseconds, so any headroom below this separates the two outcomes
+    /// while leaving a loaded runner far more room than it needs.
+    /// </summary>
+    private static readonly TimeSpan HubRequestBudget = TimeSpan.FromSeconds(30);
+
     [Fact(Timeout = 60000)]
     public async Task FaultedInit_ReachesTerminalFailedState_AndAnswersFast()
     {
         var host = GetHost();
         var client = GetClient();
 
+        // 🚨 ONE bound was doing TWO jobs, and they want opposite values (#2700).
+        //
+        // This test asserts both "a faulted init is ANSWERED at all" (liveness — wants a generous
+        // bound, so a timeout means NEVER) and "…AndAnswersFast" (latency — wants a tight one).
+        // A single 15 s wait conflated them: a loaded runner pushed the rejection past it, the
+        // wait produced a TimeoutException, and the assertion read that as "the gate is shut" —
+        // the defect's own signature, for a defect that was not there. It ejected core #2803 from
+        // the merge queue at 17:32Z (a PR touching only Mesh.Contract/Security and an operator
+        // script, which cannot reach a DataContext). Simply widening to 60 s would have deleted
+        // the latency half instead — the test would still pass if the answer took 55 s, which is
+        // precisely what its name says it guards.
+        //
+        // So they are separated. The WAIT is generous, and the ELAPSED time is asserted on its
+        // own against a threshold derived from the mechanism rather than from a feeling of
+        // "fast": the rejection handler answers in milliseconds, whereas the failure mode — the
+        // faulted arm skipping the settle body — leaves the request to fall through to the hub's
+        // own request budget. Anything at or beyond that budget IS the fall-through.
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         var act = () => client
             .Observe(new ProbeRequest(), o => o.WithTarget(host.Address))
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(15)).Await();
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(60)).Await();
 
         var ex = (await act.Should().ThrowAsync<Exception>(
             "a hub whose data-source init threw must answer requests with an error")).Which;
+        stopwatch.Stop();
 
         ex.Should().NotBeOfType<TimeoutException>(
-            "a faulted init must be answered FAST by the rejection handler — a timeout means "
-            + "the faulted arm skipped the settle body and left the gate shut");
+            "a faulted init must be ANSWERED by the rejection handler — a timeout at a 60 s bound "
+            + "means the faulted arm skipped the settle body and left the gate shut for good");
+
+        stopwatch.Elapsed.Should().BeLessThan(HubRequestBudget,
+            $"the rejection handler answers in milliseconds; this took {stopwatch.Elapsed.TotalSeconds:F1}s, "
+            + $"at or beyond the hub's own {HubRequestBudget.TotalSeconds:F0}s request budget — which is what a "
+            + "request that FELL THROUGH the faulted arm looks like, rather than one it rejected");
         ex.ToString().Should().Contain("initialization failed",
             "the rejection must be reported as an initialization failure");
 

--- a/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SelfUpdateAvailabilityGateTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using System.Threading;
@@ -164,6 +165,13 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
         {
             // POSITIVE signal for a refusal: the hold lands on the policy node. Waiting for "no
             // patch" alone would pass against a poller that had simply died.
+            // 🚨 Wait for the service to have EVALUATED, never for a held state to appear inside a
+            // bound (#2777). This service is event-driven, so "the hold is not there yet" and "the
+            // first check has not run yet" are indistinguishable from outside — and on a loaded
+            // shard the second is what actually happened, reported as if it were a wrong verdict.
+            // ChecksReported is the condition itself; the state is then asserted, not raced.
+            await service.Evaluations.FirstAsync().Timeout(TimeSpan.FromSeconds(45)).Await(ct);
+
             var held = await Mesh.GetWorkspace()
                 .GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
                 .Select(node => UpdatePolicyNodeType.Parse(node, Mesh.JsonSerializerOptions))
@@ -264,6 +272,13 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
         await service.StartAsync(CancellationToken.None);
         try
         {
+            // 🚨 Wait for the service to have EVALUATED, never for a held state to appear inside a
+            // bound (#2777). This service is event-driven, so "the hold is not there yet" and "the
+            // first check has not run yet" are indistinguishable from outside — and on a loaded
+            // shard the second is what actually happened, reported as if it were a wrong verdict.
+            // ChecksReported is the condition itself; the state is then asserted, not raced.
+            await service.Evaluations.FirstAsync().Timeout(TimeSpan.FromSeconds(45)).Await(ct);
+
             var held = await Mesh.GetWorkspace()
                 .GetMeshNodeStream(UpdatePolicyNodeType.NodePath)
                 .Select(node => UpdatePolicyNodeType.Parse(node, Mesh.JsonSerializerOptions))
@@ -423,6 +438,14 @@ public class SelfUpdateAvailabilityGateTest(ITestOutputHelper output) : Monolith
         IConfiguration? configuration = null)
         : SelfUpdateHostedService(hub, acr, updater, options, logger)
     {
+        /// <summary>
+        /// Surfaces the base class's per-check completion so the tests can await it. The base
+        /// member is <c>protected internal</c> and this assembly is not in its
+        /// <c>InternalsVisibleTo</c> list, so a derived-class forward is the local way to reach it
+        /// — cheaper than widening the production assembly's friend list for one test file.
+        /// </summary>
+        public IObservable<Unit> Evaluations => ChecksReported;
+
         protected override ReleaseAvailabilityService? ResolveAvailabilityGate() => gate;
 
         /// <summary>Present a deployment that consumes no CI bakes when the test asks for one —


### PR DESCRIPTION
Since the merge queue went live, every entry builds on a **loaded runner by construction** — and three releases have now been ejected by three different tests whose assertion is a bound rather than a condition, each burning a full CI run:

| time | PR | ejected on | fixed by |
|---|---|---|---|
| 16:48Z | #2800 | `PodHubClaimLifetimeTest` | #2800 (merged) |
| 17:00Z | #2803 | `StreamAttachTransientRetryTest` | #2800 (merged) |
| **17:32Z** | **#2803** | **`DataContextInitFaultedTest`** | **this PR** |

#2803 touches `Mesh.Contract/Security` and an operator shell script. It cannot reach a `DataContext`.

## 1. `SelfUpdateAvailabilityGateTest` — #2777

`NeverRolled_WithTheGateUnavailable_StillHolds` waited up to 30 s for a *held* marker to land on `Admin/UpdatePolicy`. The service is **event-driven**, so *"the hold is not there yet"* and *"the first check has not run yet"* are indistinguishable from outside — and on a loaded shard it is always the second. #2777's own diagnosis, adopted verbatim: **make the first poll deterministic rather than widen the bound.**

`SelfUpdateHostedService` now publishes **`ChecksReported`** — one emission per check that has been evaluated *and* reported; an **instance** `Subject` (never static), completed in `StopAsync` so a subscriber on a stopped service is released rather than left hanging. The tests await the first emission, then assert on the state it produced. Production never subscribes; nothing about what a check does or when it runs changes.

## 2. `FaultedInit_ReachesTerminalFailedState_AndAnswersFast` — one bound doing two jobs

This is the interesting one. The test asserts **liveness** (*is a faulted init answered at all* — wants a generous bound, so a timeout means **never**) and **latency** (the `AndAnswersFast` in its own name — wants a tight one). A single 15 s wait conflated them: a loaded runner pushed the rejection past it, and the assertion read the resulting `TimeoutException` as *"the faulted arm left the gate shut"* — the defect's own signature, for a defect that was not there.

🚨 **Merely widening to 60 s would have deleted the latency half in silence** — the test would still pass if the answer took 55 seconds, which is precisely what its name guards. So the two are separated:

- a generous **60 s wait**, so a timeout genuinely means *never answered*;
- an **elapsed-time assertion of its own**, against a threshold **derived from the mechanism** rather than a feeling of "fast": the hub's own 30 s request budget, which is exactly what a request that *fell through* the faulted arm waits out.

A slow answer and an absent one now fail with different messages, because they are different defects. *(The split is owed to the reviewing session, who caught that my first pass would have quietly dropped the latency half — I had it half-right.)*

## Verified

`Memex.Portal.Shared`, `MeshWeaver.Hosting.Monolith.Test` and `MeshWeaver.Data.Test` each `-c Release -warnaserror` → **0 Error(s)**; `SelfUpdateAvailabilityGateTest` **6/6**, `FaultedInit_ReachesTerminalFailedState` **1/1**.

🚨 **Trap worth knowing:** `--filter "FullyQualifiedName~DataContextInitWatchdogTest"` matched **nothing** and exited **0**. The file is `DataContextInitWatchdogTest.cs`; the *class* is `DataContextInitFaultedTest`. A filter that matches nothing is a silent pass — filter on the method name when you inferred the class from a filename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)