### PR TITLE
fix(#2813): an adopted build records whether it was ever checked against the source

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -514,6 +514,89 @@ completely silent: nothing anywhere named a NodeType that is broken and will not
 > token that happened to match the importing deployment's live inputs would suppress precisely the
 > retry it exists to grant.
 
+### 🚨 An ADOPTED build must say whether it was ever checked against the source
+
+Adoption — taking a prebuilt assembly from a bundle instead of compiling — is what makes installs
+and restarts cheap. It is also, until #2813, the one path that could make a NodeType assert something
+nobody established.
+
+`PrebuiltAssemblySeeder.Seed` writes CROSS-HUB, so it cannot read the owner's live source snapshot
+(#1834); it asks instead, via `RequestedSourceStampAt`, and the owner answers by stamping
+`CompiledSources = CurrentSourceVersions`. **That stamp is what makes `IsDirty` false**, which is
+what `InstallReleaseRequestWatcher`'s "satisfied by the existing current build" branch requires and
+what makes an adoption stick.
+
+And it is also how an adopted build lied. The two signals an operator is taught to trust —
+`CompilationStatus.Ok` and `CompiledSources == CurrentSourceVersions` — both read clean **whether or
+not the bytes have anything to do with the live source**, because the adoption writes the second one
+itself. The staleness detector was never broken; it was answering a question the adoption had already
+answered for it. On 2026-08-30 a GitSync `update` pulled new source, adopted a prebuilt built from
+older source, reported `Succeeded`, and the stale code destroyed four client documents' bodies — one
+unrecoverable. Only forcing a compile moved the MVID.
+
+#### The check, and where it can be made
+
+The producer records a **content** fingerprint of the sources the bytes were built from
+(`PartitionSourceFingerprint`). It has to be content, not versions: `CurrentSourceVersions` is
+`{path → LastModified.UtcTicks}`, mesh-LOCAL modification times the producer cannot know and does not
+have (the bake writes zeros), so a fingerprint over ticks would never match and every adoption would
+be refused.
+
+The comparison happens on the **owner**, in `ApplyAdoptedSourceStamp` — one pure function shared by
+all three writers that can fulfil the request, so turning assert into check fixes all three at once:
+
+| bundle stamp | matches the live one | outcome |
+|---|---|---|
+| yes | yes | adopt; `BuildProvenance = AdoptedVerified` |
+| yes | **no** | 🚨 **refuse** — no stamp, flip `Pending` to compile the live source; `AdoptionRefused` |
+| no (legacy), or the owner's own not published yet | — | adopt, **keep the stamp**; `AdoptedUnverified` |
+
+> 🚨 **The legacy row keeps the stamp deliberately.** Withholding it makes every legacy-bundle type
+> `IsDirty` on arrival, the `!IsDirty` absorb branch stops firing, and every install recompiles
+> everything — the 43 activations / 13.5 s of boot the prebuilt lane exists to remove. On a
+> `Modules:RequirePrebuilt` mesh a local compile is refused by design, so not stamping would **park
+> every legacy-bundle type**: the outage that refusing unproven bundles was rejected to avoid,
+> arriving through a different door. A bundle with no fingerprint is of **unknown** provenance, not
+> **proven stale**, and those deserve different answers. The requirement is VISIBILITY, not refusal.
+
+`BuildProvenance` is operational (stripped on export, preserved from the live node on import) and is
+mirrored onto the compile-state satellite, so a control plane can read it through
+`GetMeshNodeStream(path)`.
+
+#### Whether the refused bytes keep serving is CONDITIONAL
+
+`Seed` has already stamped the adopted build's assembly coordinates by the time the owner judges it,
+so a refusal that changes nothing else leaves proven-stale code executing. Both answers are wrong in
+one direction, and the fork is decided at the point of refusal rather than by assuming how a flag is
+set on a mesh nobody can see:
+
+- **this mesh can compile** → **clear** the coordinates. The `Pending` flip has already dispatched a
+  fresh compile, so the type is unserviceable for seconds — and "marked and still serving" is exactly
+  the state that lets an armed control-plane node fire pre-fix code unattended.
+- **`Modules:RequirePrebuilt`** → **keep** them, and log `Critical` naming the type. The local compile
+  that would replace the bytes is refused by design, so clearing leaves the type with no assembly at
+  all, indefinitely — an outage with no recovery path, self-inflicted by a guard. Only a rebake fixes
+  it, and the log says so.
+
+> 🚨 Do not collapse this to "`RequirePrebuilt` is unset everywhere". It is measured absent on
+> **memex** and **memex-cloud** (#2194 item 3 records the same) — two instances, saying nothing about
+> `pearl`, `atioz`, local installs, or any external instance the registry serves.
+
+#### Two things this deliberately does NOT do
+
+- **Nothing writes a fingerprint into a bundle yet**, so today every adoption reads
+  `AdoptedUnverified`. That is the honest state and the whole visibility win; the refusal row is armed
+  and starts discriminating the day the bake records one, with no further change here.
+- **Refusing to LOAD is the second line of defence.** The damage needs two ingredients — stale bytes
+  *and something armed to run them*. A type that renders read-only pages from unverified bytes is a
+  degraded system; a type that WRITES from them is the incident. The execute-time interlock is
+  tracked separately, and `BuildProvenance` is what makes it stateable.
+
+> 🚨 **Do not use `LatestReleasePath` vs the NodeType as a staleness signal.** It lags routinely —
+> a healthy type can serve perfectly with its release pointer several versions behind, and a check of
+> that shape fires constantly on healthy meshes. The fingerprint comparison above is the signal
+> precisely because it does not have this problem.
+
 ### Framework-version freezing
 
 A compiled NodeType DLL references the MeshWeaver framework assemblies present

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-an-adopted-assembly-now-says-whether-it-matches-your-source.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-an-adopted-assembly-now-says-whether-it-matches-your-source.md
@@ -1,0 +1,55 @@
+---
+Name: An adopted assembly now says whether it matches your source
+Category: Fix
+Description: A NodeType that took a prebuilt assembly instead of compiling looked identical to one that compiled — same Ok status, same "sources up to date" — even when the bytes were built from older source. Adopted builds now carry their provenance on the record, and an adoption that provably disagrees with your source is refused instead of accepted.
+Icon: ShieldError
+Order: -20260830
+---
+
+# An adopted assembly now says whether it matches your source
+
+When a NodeType can take a ready-built assembly from a package instead of compiling it here, it
+does — that is what makes installs and restarts fast. The problem was that afterwards **nothing
+told you which had happened**, and the two states were indistinguishable by every signal you would
+think to check: the type read **Ok**, and its sources read **up to date**.
+
+They read up to date because the adoption said so. Taking a prebuilt assembly *also* recorded
+"these are the sources it was built from" — copied from whatever the type was holding at that
+moment, without ever comparing them to the bytes. So the staleness check was not broken; it was
+answering a question the adoption had already answered for it.
+
+On 30 August that cost a client real data: a sync pulled new source, took a prebuilt assembly built
+from **older** source, and reported success. The next run executed the old code and stripped the
+text out of four documents — one of them a 7,000-word offer, and one that could not be recovered.
+Every check available said the fix was live.
+
+## What changed
+
+A package can now record **which sources an assembly was built from**, and the check happens where
+it can actually be made — on the NodeType itself, against the sources it is holding right now:
+
+| | what happens |
+|---|---|
+| the package records sources and they **match** | adopted, marked **verified** |
+| the package records sources and they **disagree** | 🚨 **refused** — the assembly is not accepted, and your source is compiled instead |
+| the package records nothing (anything published so far) | adopted, marked **unverified** |
+
+Every NodeType now carries this as **build provenance** you can read on the type — compiled here,
+adopted and verified, adopted but unverified, or an adoption that was refused. That is the piece
+that was missing: not a better checker, but a record of whether anything was ever checked.
+
+**"Unverified" is not a warning that something is wrong.** It means nobody has compared these bytes
+to your source, because the package that supplied them does not yet say what it was built from.
+Until packages start recording that, every adopted assembly reads unverified — which is simply the
+truth, and better than a record that claims a check that never happened.
+
+## What still needs care
+
+- A refused adoption **stops serving** the rejected assembly and compiles your source instead — on
+  an installation that is allowed to compile. On one configured to use only prebuilt assemblies
+  there is no local compile to fall back on, so the assembly is left in place (nothing at all would
+  be worse) and a **critical** message names the type: that one needs the package rebuilt and
+  republished.
+- Something that is *armed to run* against a NodeType — a scheduled or triggered action — does not
+  yet refuse to run against an unverified one. That interlock is the next step and is tracked
+  separately; provenance is what makes it possible to state.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeAdoptionRegistry.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeAdoptionRegistry.cs
@@ -12,7 +12,7 @@ namespace MeshWeaver.Graph.Configuration;
 ///
 /// <para><b>The race this closes, measured 2026-08-22.</b> Adopting a prebuilt assembly requires
 /// writing the NodeType's node, and that write goes through the type's OWN hub — so
-/// <see cref="PrebuiltAssemblySeeder.Seed"/> ACTIVATES the hub it is about to stamp. Activation is
+/// <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> ACTIVATES the hub it is about to stamp. Activation is
 /// exactly what arms the first-build kickoff (<c>CompilationStatus is null</c> + no usable build ⇒
 /// flip Pending), so the seeder's own probe started the very Roslyn compile the adoption exists to
 /// avoid:</para>

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -930,20 +930,40 @@ internal static class NodeTypeCompilationHelpers
     }
 
     /// <summary>
-    /// THE adopted-build source stamp (#1834), as a PURE function: <paramref name="def"/> with
-    /// <see cref="NodeTypeDefinition.CompiledSources"/> set to the owner's live
-    /// <paramref name="snapshot"/> and the request that asked for it consumed.
+    /// THE adopted-build source stamp (#1834), as a PURE function — and, since #2813, the place
+    /// the adoption is CHECKED rather than merely asserted.
     ///
-    /// <para>The post-condition is the whole point and is exact, not approximate: the two
-    /// dictionaries are the SAME content, so <see cref="NodeTypeDefinition.IsDirty"/> is false by
+    /// <para>The stamp sets <see cref="NodeTypeDefinition.CompiledSources"/> to the owner's live
+    /// <paramref name="snapshot"/> and consumes the request that asked for it, so the two
+    /// dictionaries are the SAME content and <see cref="NodeTypeDefinition.IsDirty"/> is false by
     /// construction — which is what <c>InstallReleaseRequestWatcher</c>'s "satisfied by the
     /// existing current build" branch requires, and what makes an adoption stick.</para>
     ///
-    /// <para>Pure so the invariant is unit-testable with no hub, no mesh and no timing, and shared
-    /// by all three writers that may fulfil the request (the sources watcher's publication, the
-    /// release-request dispatch, and the standalone
+    /// <para>🚨 <b>That post-condition is also how an adopted build lied.</b> It makes the
+    /// staleness detector read clean whether or not the bytes have anything to do with the live
+    /// source — the detector is not broken, it is answering a question this write already answered
+    /// for it. A GitSync <c>update</c> adopted a prebuilt built from older source than the commit
+    /// it had just pulled, reported <c>Succeeded</c>, and the stale code destroyed four client
+    /// documents' bodies, one unrecoverable (#2813). So the stamp is now conditional on the
+    /// producer's recorded source fingerprint:</para>
+    ///
+    /// <list type="table">
+    ///   <item><term>fingerprint present, MATCHES the live one</term><description>stamp;
+    ///     <see cref="BuildProvenance.AdoptedVerified"/></description></item>
+    ///   <item><term>fingerprint present, DISAGREES</term><description>🚨 refuse — no stamp, flip
+    ///     <see cref="CompilationStatus.Pending"/> to compile the live source;
+    ///     <see cref="BuildProvenance.AdoptionRefused"/></description></item>
+    ///   <item><term>absent (a legacy bundle, or the owner's own not computed yet)</term>
+    ///     <description>stamp — provenance is UNKNOWN, not proven stale;
+    ///     <see cref="BuildProvenance.AdoptedUnverified"/></description></item>
+    /// </list>
+    ///
+    /// <para>Pure so all three rows are unit-testable with no hub, no mesh and no timing, and
+    /// shared by all three writers that may fulfil the request (the sources watcher's publication,
+    /// the release-request dispatch, and the standalone
     /// <see cref="InstallAdoptedSourceStampWatcher"/>) — one stamp shape, so two of them can never
-    /// disagree about what "adopted and current" means.</para>
+    /// disagree about what "adopted and current" means, and turning assert into check here fixes
+    /// all three at once.</para>
     /// </summary>
     /// <param name="def">The owner's own definition.</param>
     /// <param name="snapshot">The owner's live source snapshot
@@ -951,14 +971,142 @@ internal static class NodeTypeCompilationHelpers
     /// into it in this same update).</param>
     internal static NodeTypeDefinition ApplyAdoptedSourceStamp(
         NodeTypeDefinition def,
-        IReadOnlyDictionary<string, long> snapshot)
-        => def with
+        IReadOnlyDictionary<string, long> snapshot,
+        bool canCompileLocally)
+    {
+        var stamped = def with
         {
             CompiledSources = snapshot as System.Collections.Immutable.ImmutableDictionary<string, long>
                               ?? System.Collections.Immutable.ImmutableDictionary
                                   .CreateRange(snapshot),
             RequestedSourceStampAt = null,
         };
+
+        // ── #2813 — the three-way. ─────────────────────────────────────────────────────────────
+        // The producer's fingerprint is a CONTENT hash of the sources the bytes were built from;
+        // CurrentSourceFingerprint is the same shape over the live set. Both are on the node, so
+        // this stays pure.
+        if (def.AdoptedSourceFingerprint is not { Length: > 0 } adopted)
+            // LEGACY bundle — no fingerprint, so provenance is UNKNOWN, not proven stale.
+            //
+            // 🚨 It KEEPS the stamp, deliberately. Withholding it would make every legacy-bundle
+            // type IsDirty on arrival, which stops InstallReleaseRequestWatcher's "satisfied by the
+            // existing current build" branch (it requires !IsDirty) from ever absorbing — so every
+            // install would recompile everything, the 43 activations / 13.5 s of boot the prebuilt
+            // lane exists to remove. On a Modules:RequirePrebuilt mesh it is worse than slow: a
+            // local compile is refused by design, so not stamping would PARK every legacy-bundle
+            // type. That is the outage refusing unproven bundles was rejected to avoid, arriving
+            // through a different door. The requirement here is VISIBILITY, not refusal: the stamp
+            // stays and the provenance says it was never earned.
+            return stamped with { BuildProvenance = BuildProvenance.AdoptedUnverified };
+
+        if (def.CurrentSourceFingerprint is not { Length: > 0 } live)
+            // The owner has an adopted fingerprint but has not computed its own yet (the sources
+            // watcher publishes both in one write, so this is the pre-publication window). Not a
+            // mismatch — nothing has been compared. Treat exactly as unknown rather than refusing
+            // on an absence, which is the INCONCLUSIVE lesson from the emit canary (#890): a probe
+            // must not answer its scariest branch on its own inability to run.
+            return stamped with { BuildProvenance = BuildProvenance.AdoptedUnverified };
+
+        if (string.Equals(adopted, live, StringComparison.Ordinal))
+            return stamped with { BuildProvenance = BuildProvenance.AdoptedVerified };
+
+        // 🚨 REFUSED — the only hard fail, and the one this whole mechanism exists for. The bundle
+        // states which sources it was built from and they are NOT the ones this mesh holds, so the
+        // bytes are last week's code over today's data (#2813: four client documents' bodies lost,
+        // one unrecoverable). Do NOT stamp CompiledSources — that write is what makes IsDirty false
+        // by construction and is precisely the lie — and drive a real local compile of the live
+        // source by flipping Pending. The request is still consumed so it cannot re-fire.
+        //
+        // The refusal is recorded on the node rather than only logged: a reader must be able to see
+        // that the assembly currently serving was rejected, not merely that a compile is pending.
+        var refused = def with
+        {
+            RequestedSourceStampAt = null,
+            CompilationStatus = CompilationStatus.Pending,
+            BuildProvenance = BuildProvenance.AdoptionRefused,
+        };
+
+        // 🚨 …AND WHETHER THE REJECTED BYTES KEEP SERVING IS CONDITIONAL ON THIS MESH BEING ABLE TO
+        // REPLACE THEM. Seed has already stamped the adopted build's assembly coordinates, so doing
+        // nothing here leaves proven-stale code executing. The two answers are wrong in opposite
+        // directions, and the fork is decidable right here rather than by assuming how a flag is set
+        // on some mesh we cannot see:
+        //
+        //   canCompileLocally  -> CLEAR the coordinates. #2813 is a data-loss issue and stale bytes
+        //     EXECUTING is what destroyed the documents; the Pending flip above has already
+        //     dispatched a fresh compile, so the type is unserviceable for seconds. "Marked and
+        //     still serving" is exactly the state that let an armed control-plane node fire pre-fix
+        //     code unattended.
+        //
+        //   !canCompileLocally -> KEEP them (Modules:RequirePrebuilt refuses a local compile by
+        //     design, so clearing would leave the type with NO assembly at all, INDEFINITELY - an
+        //     outage with no recovery path, self-inflicted by a guard). The caller logs Critical
+        //     naming the node, because on such a mesh nothing this process can do will fix it and a
+        //     human has to rebake.
+        //
+        // 🚨 Do NOT collapse this to "RequirePrebuilt is unset everywhere". It is measured absent on
+        // memex and memex-cloud, and #2194 item 3 records the same - that is TWO instances, and says
+        // nothing about pearl, atioz, local installs, or any external instance the registry serves.
+        // Configuration lives on AKS in places this repo has never heard of (Memex#148).
+        return canCompileLocally
+            ? refused with
+            {
+                // The exact pair HasUsableBuild reads, plus the served-build identity - leaving the
+                // MVID would name bytes nothing serves.
+                LatestAssemblyCollection = null,
+                LatestAssemblyPath = null,
+                LatestAssemblyMvid = null,
+            }
+            : refused;
+    }
+
+    /// <summary>
+    /// <see cref="ApplyAdoptedSourceStamp"/> plus the two things a pure function cannot do: resolve
+    /// whether THIS mesh may compile locally, and say so when an adoption is refused on a mesh that
+    /// cannot replace the rejected bytes.
+    ///
+    /// <para>🚨 The <c>Critical</c> level on the <c>RequirePrebuilt</c> branch is not severity
+    /// inflation. On such a mesh a refused adoption is terminal by construction — the local compile
+    /// that would replace the bytes is refused by design — so the type keeps serving code this
+    /// process has PROVEN is not built from the live source, and no amount of waiting or retrying
+    /// changes that. Only a human rebaking the package does. That is the same class of statement
+    /// <c>DbVersionGate</c> makes when a portal is ahead of its schema.</para>
+    /// </summary>
+    internal static NodeTypeDefinition ApplyAdoptedSourceStampAndReport(
+        NodeTypeDefinition def,
+        IReadOnlyDictionary<string, long> snapshot,
+        IMessageHub hub,
+        string hubPath,
+        ILogger? logger)
+    {
+        var canCompileLocally = !PrebuiltAssemblySeeder.RequirePrebuilt(hub.ServiceProvider);
+        var result = ApplyAdoptedSourceStamp(def, snapshot, canCompileLocally);
+
+        if (result.BuildProvenance is not BuildProvenance.AdoptionRefused)
+            return result;
+
+        if (canCompileLocally)
+            logger?.LogError(
+                "ADOPTION REFUSED for {HubPath} (#2813): the prebuilt bundle records source "
+                + "fingerprint {Adopted} but this mesh's live sources are {Live}. The bytes were "
+                + "NOT accepted — assembly coordinates cleared so the rejected build stops serving "
+                + "— and a fresh compile of the live source has been dispatched.",
+                hubPath, def.AdoptedSourceFingerprint, def.CurrentSourceFingerprint);
+        else
+            logger?.LogCritical(
+                "ADOPTION REFUSED for {HubPath} (#2813) AND THIS MESH CANNOT COMPILE ({Key}=true). "
+                + "The bundle records source fingerprint {Adopted} but the live sources are {Live}, "
+                + "so the assembly currently serving is NOT built from the source this mesh holds. "
+                + "Its coordinates are deliberately LEFT IN PLACE — clearing them would leave the "
+                + "type with no assembly at all, indefinitely, which is worse than marked-stale when "
+                + "there is no path to a fresh build. 🚨 NOTHING THIS PROCESS CAN DO WILL FIX IT: "
+                + "rebake and republish this package, then request a release.",
+                hubPath, PrebuiltAssemblySeeder.RequirePrebuiltConfigKey,
+                def.AdoptedSourceFingerprint, def.CurrentSourceFingerprint);
+
+        return result;
+    }
 
     /// <summary>
     /// Fulfils an adoption's <see cref="NodeTypeDefinition.RequestedSourceStampAt"/> on the OWNER —
@@ -1046,7 +1194,8 @@ internal static class NodeTypeCompilationHelpers
                     if (def.RequestedSourceStampAt is null) return curr;
                     if (def.CurrentSourceVersions is not { } liveSources) return curr;
                     stampHighWater.Advance(def.RequestedSourceStampAt.Value);
-                    return curr with { Content = ApplyAdoptedSourceStamp(def, liveSources) };
+                    return curr with { Content = ApplyAdoptedSourceStampAndReport(
+                        def, liveSources, hub, hubPath, logger) };
                 }).Subscribe(
                     _ => logger?.LogInformation(
                         "[AdoptedSourceStamp] {HubPath}: adopted build stamped with the owner's live "
@@ -1195,10 +1344,15 @@ internal static class NodeTypeCompilationHelpers
                 foreach (var n in sources)
                     if (!string.IsNullOrEmpty(n.Path))
                         snap = snap.SetItem(n.Path!, NodeTypeDefinition.SourceVersionOf(n));
-                return (IReadOnlyDictionary<string, long>)snap;
+                // #2813 — carry the live source NODES alongside the tick snapshot so the
+                // publication below can fingerprint their CONTENT when (and only when) there is an
+                // adopted fingerprint to compare it against. The nodes are already materialised
+                // here; the hash is what costs, and it is paid only where it is used.
+                return (Snapshot: (IReadOnlyDictionary<string, long>)snap, Nodes: sources);
             }),
-                snapshot =>
+                published =>
                 {
+                    var snapshot = published.Snapshot;
                     // 🅿️ Auto-retry a PARKED (terminally-failed) type when its SOURCE snapshot has
                     // CHANGED since the failure — the "retry only if the sources changed" path. The
                     // compile watcher's parked short-circuit swallows a bare Pending flip, so we
@@ -1261,8 +1415,26 @@ internal static class NodeTypeCompilationHelpers
                             return curr;
 
                         var updated = def with { CurrentSourceVersions = snapshot };
+
+                        // 🚨 #2813 — the live CONTENT fingerprint, computed HERE because this is
+                        // the one place that already holds the live source nodes, and written in
+                        // the SAME update as the tick snapshot so a reader can never see one
+                        // without the other.
+                        //
+                        // Computed ONLY when it can be used: a type carrying an adopted
+                        // fingerprint, or a stamp request about to be judged against one. A
+                        // locally-compiled type has nothing to compare against, and hashing every
+                        // source node's serialised content on every source emission — a path that
+                        // today only reads timestamps — would be a real cost for no answer.
+                        if (pendingStamp || def.AdoptedSourceFingerprint is { Length: > 0 })
+                            updated = updated with
+                            {
+                                CurrentSourceFingerprint = PartitionSourceFingerprint.Compute(
+                                    published.Nodes, versioned: false, hub.JsonSerializerOptions),
+                            };
+
                         if (pendingStamp)
-                            updated = ApplyAdoptedSourceStamp(updated, snapshot);
+                            updated = ApplyAdoptedSourceStampAndReport(updated, snapshot, hub, hubPath, logger);
 
                         return curr with { Content = updated };
                     }).Subscribe(
@@ -1463,7 +1635,7 @@ internal static class NodeTypeCompilationHelpers
                         // still requires a genuinely non-dirty definition.
                         if (def.RequestedSourceStampAt is not null
                             && def.CurrentSourceVersions is { } liveSources)
-                            def = ApplyAdoptedSourceStamp(def, liveSources);
+                            def = ApplyAdoptedSourceStampAndReport(def, liveSources, hub, hubPath, logger);
                         // 🚨 Gate on the CARRIED triggerAt, NOT def.RequestedReleaseAt
                         // (which may have flapped back to an older value). Already
                         // handled at or beyond this trigger? bail.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -1025,6 +1025,16 @@ internal static class NodeTypeCompilationHelpers
             RequestedSourceStampAt = null,
             CompilationStatus = CompilationStatus.Pending,
             BuildProvenance = BuildProvenance.AdoptionRefused,
+            // 🚨 CLEARED, not merely "not stamped". Seed does NOT clear CompiledSources, so a type
+            // that had previously COMPILED here carries a snapshot matching CurrentSourceVersions
+            // straight into the refusal — and IsDirty would read FALSE while BuildProvenance reads
+            // AdoptionRefused. That contradictory record is the same unearned claim this function
+            // exists to remove, one step along: "my compiled sources are current" about bytes that
+            // were explicitly rejected. It matters most exactly where it is least visible — if the
+            // compile dispatched below never completes (the process dies, or RequirePrebuilt parks
+            // it), that false !IsDirty is the state the node is LEFT in. ApplyCompileFailure sets
+            // the same field to null for the same reason.
+            CompiledSources = null,
         };
 
         // 🚨 …AND WHETHER THE REJECTED BYTES KEEP SERVING IS CONDITIONAL ON THIS MESH BEING ABLE TO

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompileState.cs
@@ -119,6 +119,20 @@ public record NodeTypeCompileState
     /// <summary>See <see cref="NodeTypeDefinition.FailedBuildInputs"/>.</summary>
     public string? FailedBuildInputs { get; init; }
 
+    /// <summary>See <see cref="NodeTypeDefinition.AdoptedSourceFingerprint"/>.</summary>
+    public string? AdoptedSourceFingerprint { get; init; }
+
+    /// <summary>See <see cref="NodeTypeDefinition.CurrentSourceFingerprint"/>.</summary>
+    public string? CurrentSourceFingerprint { get; init; }
+
+    /// <summary>
+    /// See <see cref="NodeTypeDefinition.BuildProvenance"/> — WHERE the build came from, and
+    /// whether an adopted one was ever checked against the source (#2813). The satellite carries
+    /// it for the same reason the node does: a reader that cannot tell an adopted build from a
+    /// compiled one cannot tell a stale one either.
+    /// </summary>
+    public Mesh.Services.BuildProvenance BuildProvenance { get; init; }
+
     /// <summary>The state projected from a NodeType definition — pure. Null in, null out.</summary>
     public static NodeTypeCompileState? FromDefinition(NodeTypeDefinition? definition) =>
         definition is null
@@ -146,6 +160,9 @@ public record NodeTypeCompileState
                 RequestedSourceStampAt = definition.RequestedSourceStampAt,
                 CompiledFrameworkVersion = definition.CompiledFrameworkVersion,
                 FailedBuildInputs = definition.FailedBuildInputs,
+                AdoptedSourceFingerprint = definition.AdoptedSourceFingerprint,
+                CurrentSourceFingerprint = definition.CurrentSourceFingerprint,
+                BuildProvenance = definition.BuildProvenance,
             };
 
     /// <summary>Whether NO compile machinery has recorded anything yet — a never-compiled,
@@ -160,7 +177,9 @@ public record NodeTypeCompileState
         && LatestAssemblyCollection is null && LatestAssemblyPath is null
         && CompiledSources is null && CurrentSourceVersions is null
         && RequestedSourceStampAt is null
-        && CompiledFrameworkVersion is null && FailedBuildInputs is null;
+        && CompiledFrameworkVersion is null && FailedBuildInputs is null
+        && AdoptedSourceFingerprint is null && CurrentSourceFingerprint is null
+        && BuildProvenance is Mesh.Services.BuildProvenance.Compiled;
 }
 
 /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -496,7 +496,7 @@ public record NodeTypeDefinition
     /// <summary>
     /// A REQUEST to the owning per-NodeType hub: "stamp <see cref="CompiledSources"/> from your own
     /// <see cref="CurrentSourceVersions"/>". Written by
-    /// <see cref="PrebuiltAssemblySeeder.Seed"/> when it adopts a prebuilt assembly; consumed —
+    /// <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> when it adopts a prebuilt assembly; consumed —
     /// exactly once — on the owner, which clears it in the same write that applies the stamp.
     ///
     /// <para>🚨 <b>Why the value cannot be written by the adopter</b> (#1834). A bundle's own
@@ -525,6 +525,56 @@ public record NodeTypeDefinition
     /// import (<see cref="Mesh.NodeTypeOperationalContent"/>).</para>
     /// </summary>
     public DateTimeOffset? RequestedSourceStampAt { get; init; }
+
+    /// <summary>
+    /// The source fingerprint the PRODUCER recorded for the adopted bytes — a content hash over
+    /// the Code/Test nodes the bundle was compiled from
+    /// (<see cref="Mesh.PartitionSourceFingerprint"/>). Written by
+    /// <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> beside <see cref="RequestedSourceStampAt"/>;
+    /// <c>null</c> for a locally-compiled build and for a LEGACY bundle published before producers
+    /// recorded one.
+    ///
+    /// <para>🚨 <b>It must be a CONTENT hash, never a version one.</b>
+    /// <see cref="CurrentSourceVersions"/> is <c>{path → LastModified.UtcTicks}</c> — mesh-LOCAL
+    /// modification times, which the producer cannot know and does not have (the bake writes
+    /// zeros). A fingerprint over ticks would therefore never match and every adoption would be
+    /// refused. Content is the only thing both sides can compute the same way.</para>
+    ///
+    /// <para>Compared against <see cref="CurrentSourceFingerprint"/> by
+    /// <c>NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp</c>, on the OWNER — the only party
+    /// that holds both authoritatively (#1834).</para>
+    /// </summary>
+    public string? AdoptedSourceFingerprint { get; init; }
+
+    /// <summary>
+    /// Content fingerprint of the LIVE source set — the same
+    /// <see cref="Mesh.PartitionSourceFingerprint"/> shape as
+    /// <see cref="AdoptedSourceFingerprint"/>, computed over this NodeType's own Code/Test nodes
+    /// by the sources watcher and written in the SAME update as
+    /// <see cref="CurrentSourceVersions"/>.
+    ///
+    /// <para>🚨 <b>Computed only when it can be USED</b> — when the node carries an
+    /// <see cref="AdoptedSourceFingerprint"/> or a pending
+    /// <see cref="RequestedSourceStampAt"/>. Hashing every source node's serialised content on
+    /// every source emission, for every NodeType, would put a SHA-256 over the whole source set on
+    /// a path that today only reads timestamps, and a locally-compiled type has nothing to compare
+    /// it against. So a type that never adopts pays nothing, and the field stays <c>null</c> —
+    /// which is deliberately DISTINCT from "computed and empty".</para>
+    /// </summary>
+    public string? CurrentSourceFingerprint { get; init; }
+
+    /// <summary>
+    /// Where the current build came from, and whether an adopted one was ever checked against the
+    /// source this node holds. See <see cref="Mesh.Services.BuildProvenance"/> for why this has to
+    /// be READABLE ON THE RECORD rather than inferable — every other signal
+    /// (<see cref="CompilationStatus"/>, <see cref="IsDirty"/>) reads clean for an adopted build,
+    /// because the adoption writes the second one itself (#2813).
+    ///
+    /// <para>Operational, never authored: stripped on export, preserved from the live node on
+    /// import. An authored value would forge a provenance claim — the same class of unearned claim
+    /// this field exists to expose.</para>
+    /// </summary>
+    public Mesh.Services.BuildProvenance BuildProvenance { get; init; }
 
     /// <summary>
     /// <see cref="DateTime"/> ticks for <c>1601-01-01</c> — the FILETIME epoch, and the value

--- a/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
@@ -133,7 +133,7 @@ public static class PrebuiltAssemblySeeder
     /// <para>🚨 The counterpart to <see cref="DeclineReason(string?)"/>, and the reason both are
     /// public: <c>DeclineReason</c> answers "must we NOT adopt", this answers "need we adopt at
     /// all". Without it every boot re-adopts every bundle entry it holds — and adoption is not
-    /// cheap bookkeeping: <see cref="Seed"/> opens the type's own mesh-node stream (which ACTIVATES
+    /// cheap bookkeeping: <see cref="Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> opens the type's own mesh-node stream (which ACTIVATES
     /// its per-node hub), re-uploads the assembly bytes to the shared store, and writes the node.
     /// Measured on memex-cloud 2026-08-17, that was 43 hub activations, 43 uploads and 43 writes —
     /// <b>13.5 s of a 101 s boot</b> — establishing that nothing had changed since the previous pod
@@ -159,7 +159,7 @@ public static class PrebuiltAssemblySeeder
     /// precisely what the bake would call <see cref="BakeState.Baked"/></b>.</para>
     ///
     /// <para>🚨 Note in particular what this does NOT compare: the NodeType MeshNode's CURRENT
-    /// version. <see cref="Seed"/> uploads and stamps the version it read BEFORE its own write, and
+    /// version. <see cref="Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> uploads and stamps the version it read BEFORE its own write, and
     /// that write bumps the node — so after any adoption <c>LastCompiledVersion</c> is permanently
     /// one behind <c>node.Version</c>, and a naive equality check is unsatisfiable. That mismatch
     /// is also why today's unconditional re-adoption uploads the SAME bytes under a NEW store key
@@ -253,6 +253,46 @@ public static class PrebuiltAssemblySeeder
         string? frameworkMvid,
         ILogger? logger = null,
         IReadOnlyDictionary<string, string>? dependencies = null)
+        => Seed(hub, nodeTypePath, assemblyBytes, pdbBytes, frameworkMvid, logger, dependencies,
+            sourceFingerprint: null);
+
+    /// <summary>
+    /// Seeds <paramref name="assemblyBytes"/> as the build for <paramref name="nodeTypePath"/>,
+    /// carrying the producer's source fingerprint so the OWNER can check the adoption (#2813).
+    ///
+    /// <para>Cold: the write runs on Subscribe. Emits <c>true</c> when the assembly was adopted and
+    /// <c>false</c> when it was declined — a decline is not an error, it is the caller's signal to
+    /// compile normally.</para>
+    /// </summary>
+    /// <param name="hub">The calling hub.</param>
+    /// <param name="nodeTypePath">Mesh path of the NodeType this assembly implements.</param>
+    /// <param name="assemblyBytes">The compiled assembly.</param>
+    /// <param name="pdbBytes">Symbols, when the assembly does not embed them.</param>
+    /// <param name="frameworkMvid">The framework build identity the bytes were compiled against,
+    /// as recorded by the producer. <c>null</c> declines the seed.</param>
+    /// <param name="logger">Diagnostics. Every decline is logged with its reason.</param>
+    /// <param name="dependencies">The producer's per-type dependency record, or <c>null</c> for a
+    /// legacy bundle.</param>
+    /// <param name="sourceFingerprint">🚨 <b>The producer's CONTENT fingerprint of the sources these
+    /// bytes were built from</b> (#2813) — <see cref="PartitionSourceFingerprint"/> shape. Stamped
+    /// onto the node, where the OWNER compares it against its own live source set before honouring
+    /// the adoption's <c>RequestedSourceStampAt</c>. <c>null</c> for a legacy bundle that records
+    /// none: the adoption still lands, but as <c>BuildProvenance.AdoptedUnverified</c> — never
+    /// silently as verified.
+    ///
+    /// <para>A separate OVERLOAD rather than an eighth optional parameter: the seven-parameter form
+    /// is public surface with shipped callers, and adding an optional parameter to it is a BINARY
+    /// break the compatibility gate is right to refuse. This parameter carries no default, so an
+    /// existing seven-argument call still binds unambiguously to the old form.</para></param>
+    public static IObservable<bool> Seed(
+        IMessageHub hub,
+        string nodeTypePath,
+        byte[] assemblyBytes,
+        byte[]? pdbBytes,
+        string? frameworkMvid,
+        ILogger? logger,
+        IReadOnlyDictionary<string, string>? dependencies,
+        string? sourceFingerprint)
     {
         // 🚨 THE GATE. FrameworkVersion is the resolved framework build identity — a content/
         // surface identity, not a version string — and the assembly-store key carries the first
@@ -371,6 +411,14 @@ public static class PrebuiltAssemblySeeder
                                     // instead has no ordering to lose: whichever of the two writes
                                     // lands second carries the owner's authoritative pair.
                                     RequestedSourceStampAt = DateTimeOffset.UtcNow,
+                                    // 🚨 #2813 — WHAT the producer says these bytes were built
+                                    // from. The owner checks it against its own live source set
+                                    // when it fulfils the request above; it cannot be checked
+                                    // here, for the same cross-hub reason the request exists.
+                                    // Null (a legacy bundle) is carried as null, never as a
+                                    // match: the owner then records AdoptedUnverified rather
+                                    // than AdoptedVerified.
+                                    AdoptedSourceFingerprint = sourceFingerprint,
                                     // The producer's dependency record (#1707 slice 2) — validated
                                     // above; stamped so ongoing validity checks judge the adopted
                                     // build like a locally-compiled one. Legacy bundles (null)

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -435,7 +435,7 @@ public static class ShippedPrebuiltBundles
     /// node path and dependency record; the assemblies are the bundle's entire weight. Reading the
     /// manifest alone is enough to answer the whole adoption question, so a bundle whose types are
     /// all current is answered without decompressing a single assembly — on top of the per-type hub
-    /// activation and store upload that <see cref="PrebuiltAssemblySeeder.Seed"/> would cost.</para>
+    /// activation and store upload that <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> would cost.</para>
     ///
     /// <para>Emits the tally; folds its own faults to zero.</para>
     /// </summary>

--- a/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
+++ b/src/MeshWeaver.Mesh.Contract/NodeTypeOperationalContent.cs
@@ -70,6 +70,12 @@ public static class NodeTypeOperationalContent
         // sharper one: an authored value would ask the owner to re-stamp a compile's source
         // snapshot from the live set, silently suppressing a needed rebuild.
         "requestedSourceStampAt",
+        // #2813 — build PROVENANCE. Operational for the same reason the verdict fields are:
+        // an authored value would forge the very claim these exist to expose (an adopted
+        // assembly asserting it was checked against source nobody compared it to).
+        "adoptedSourceFingerprint",
+        "currentSourceFingerprint",
+        "buildProvenance",
         "compiledFrameworkVersion",
         // #1793 — the inputs the standing FAILURE verdict was formed from. Operational for the
         // same reason compiledFrameworkVersion is, and for one sharper one: an authored token that

--- a/src/MeshWeaver.Mesh.Contract/Services/BuildProvenance.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/BuildProvenance.cs
@@ -1,0 +1,63 @@
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// WHERE a NodeType's current build came from, and — for an adopted one — whether the bytes were
+/// ever checked against the source the node is holding.
+///
+/// <para>🚨 <b>Why this has to be on the record and not in a log.</b> An adopted assembly was
+/// indistinguishable from a compiled one by every signal an operator was taught to trust:
+/// <see cref="CompilationStatus.Ok"/>, and <c>CompiledSources == CurrentSourceVersions</c> (i.e.
+/// <c>IsDirty == false</c>). Both read clean — because the adoption itself WRITES the second one
+/// (<c>NodeTypeDefinition.RequestedSourceStampAt</c> asks the owner to stamp
+/// <c>CompiledSources</c> from its own live snapshot). So the staleness detector was not broken;
+/// it was answering a question the adoption had already answered for it. On 2026-08-30 that cost a
+/// client four documents' bodies, one of them unrecoverable, because a GitSync <c>update</c>
+/// adopted a prebuilt built from older source than the commit it had just pulled, and every check
+/// available said the fix was live (MeshWeaver#2813).</para>
+///
+/// <para>The verdict a control plane needs before it arms anything is therefore not "is this Ok"
+/// but "was this build ever compared to the source" — which is exactly what this states.</para>
+///
+/// <para>🚨 <see cref="AdoptedUnverified"/> is NEVER silently equivalent to
+/// <see cref="AdoptedVerified"/>. A bundle published before producers recorded a source
+/// fingerprint carries none, so its provenance is <b>unknown</b>, not <b>proven stale</b> — those
+/// deserve different answers, and refusing the unknown one would break every bundle published to
+/// date and the node-repo CI gates that depend on prebuilt fetches. It is adopted and MARKED;
+/// only a fingerprint that is present and DISAGREES is refused.</para>
+///
+/// <para>Appended-only: the persisted ordinal of every existing member must stay unchanged, and
+/// <see cref="Compiled"/> is deliberately the zero value so a record written before this field
+/// existed reads as the honest default — nothing was adopted, so nothing is unverified.</para>
+/// </summary>
+public enum BuildProvenance
+{
+    /// <summary>
+    /// Roslyn compiled it here, from the source this mesh holds. The default, and what every
+    /// record written before this field existed reads as.
+    /// </summary>
+    Compiled,
+
+    /// <summary>
+    /// Adopted from a prebuilt bundle whose recorded source fingerprint MATCHED the live source
+    /// set at the moment the owner stamped it. The bytes and the source have been compared and
+    /// they agree.
+    /// </summary>
+    AdoptedVerified,
+
+    /// <summary>
+    /// Adopted from a prebuilt bundle that carries NO source fingerprint — a legacy bundle. The
+    /// bytes may or may not correspond to the live source; nothing has compared them.
+    ///
+    /// <para>🚨 This is the state in which <c>CompiledSources == CurrentSourceVersions</c> is
+    /// true without having been earned. Read it as "unknown provenance", never as a clean bill of
+    /// health, and do not arm a control plane against it without a deliberate decision.</para>
+    /// </summary>
+    AdoptedUnverified,
+
+    /// <summary>
+    /// An adoption was REFUSED because the bundle's recorded source fingerprint DISAGREED with the
+    /// live source set. The bytes were not accepted; a local compile of the live source was
+    /// driven instead. This is the data-loss case, caught.
+    /// </summary>
+    AdoptionRefused
+}

--- a/test/MeshWeaver.Graph.Test/AdoptedBuildProvenanceTest.cs
+++ b/test/MeshWeaver.Graph.Test/AdoptedBuildProvenanceTest.cs
@@ -1,0 +1,240 @@
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 An adopted assembly must be distinguishable from a compiled one, and a bundle that states
+/// which sources it was built from must be REFUSED when those are not the sources this mesh holds
+/// (#2813).
+///
+/// <para><b>What went wrong.</b> A GitSync <c>update</c> pulled new source for <c>Crm/Migration</c>
+/// and then adopted a prebuilt assembly instead of compiling what it had just pulled. The node
+/// reported <c>Succeeded</c>; the next run executed the OLD code and destroyed live client data —
+/// four documents lost their bodies, one of them a 7,000-word commercial offer, and one
+/// unrecoverable because its only version in history was the one the stale code wrote.</para>
+///
+/// <para><b>Why every check said it was fine.</b> The two signals an operator is taught to trust —
+/// <see cref="CompilationStatus.Ok"/> and <c>CompiledSources == CurrentSourceVersions</c> (i.e.
+/// <c>IsDirty == false</c>) — both read clean, because <b>the adoption writes the second one
+/// itself</b>: <c>PrebuiltAssemblySeeder.Seed</c> asks the owner (via
+/// <c>RequestedSourceStampAt</c>) to stamp <c>CompiledSources</c> from its own live snapshot. The
+/// staleness detector was not broken. It was answering a question the adoption had already
+/// answered for it. Only forcing a compile moved the MVID.</para>
+///
+/// <para><b>The three rows, and why the middle one is the only hard fail.</b> A bundle that carries
+/// no fingerprint is of <i>unknown</i> provenance, not <i>proven stale</i>; refusing those would
+/// break every bundle published to date and the node-repo CI gates that depend on prebuilt
+/// fetches. Only a fingerprint that is PRESENT and DISAGREES is a lie, and only that is refused.
+/// The requirement for the other two is visibility, not refusal.</para>
+/// </summary>
+public class AdoptedBuildProvenanceTest
+{
+    private static readonly ImmutableDictionary<string, long> LiveSources =
+        ImmutableDictionary.CreateRange(new Dictionary<string, long>
+        {
+            ["Crm/Migration/Source/code"] = 638_000_000_000_000_000,
+        });
+
+    /// <summary>An adoption exactly as <c>PrebuiltAssemblySeeder.Seed</c> leaves it: the request is
+    /// standing, and the producer's fingerprint (or its absence) is stamped.</summary>
+    private static NodeTypeDefinition PendingAdoption(
+        string? producerFingerprint, string? liveFingerprint) =>
+        new()
+        {
+            CompilationStatus = CompilationStatus.Ok,
+            RequestedSourceStampAt = System.DateTimeOffset.UtcNow,
+            AdoptedSourceFingerprint = producerFingerprint,
+            CurrentSourceFingerprint = liveFingerprint,
+            CurrentSourceVersions = LiveSources,
+            // Seed has ALREADY stamped the adopted build's coordinates by the time the owner judges
+            // it — which is why "refuse" has to decide whether those bytes keep serving.
+            LatestAssemblyCollection = "assemblies",
+            LatestAssemblyPath = "adopted/Crm.Migration.dll",
+            LatestAssemblyMvid = "ed21acce00000000",
+        };
+
+    /// <summary>
+    /// 🚨 THE DATA-LOSS ROW. The bundle names sources that are NOT the ones this mesh holds, so
+    /// the bytes are last week's code over today's data. The stamp is withheld — that write is the
+    /// lie, because it is what makes <c>IsDirty</c> false by construction — and a real compile of
+    /// the live source is driven instead.
+    /// </summary>
+    [Fact]
+    public void AFingerprintThatDisagrees_IsRefused_AndDrivesARealCompile()
+    {
+        var result = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            PendingAdoption(producerFingerprint: "aaaaaaaaaaaaaaaa",
+                            liveFingerprint: "bbbbbbbbbbbbbbbb"),
+            LiveSources, canCompileLocally: true);
+
+        result.BuildProvenance.Should().Be(BuildProvenance.AdoptionRefused,
+            "the bundle states which sources it was built from and they are not the live ones — "
+            + "that is the case this whole mechanism exists to catch");
+        result.CompiledSources.Should().BeNull(
+            "stamping CompiledSources is precisely the lie: it makes IsDirty false by "
+            + "construction, which is what let a stale adopted build read as current");
+        result.IsDirty.Should().BeTrue(
+            "the staleness question must be left visibly OPEN, not answered by the adoption");
+        result.CompilationStatus.Should().Be(CompilationStatus.Pending,
+            "refusing is not enough — the live source has to actually get compiled");
+        result.RequestedSourceStampAt.Should().BeNull(
+            "the request is consumed on every path, so it can never re-fire");
+
+        // 🚨 …and the rejected bytes STOP SERVING. Seed had already stamped the adopted build's
+        // coordinates; leaving them is what let proven-stale code keep executing while the node
+        // merely said so. A fresh compile is dispatched above, so the gap is seconds.
+        result.LatestAssemblyPath.Should().BeNull();
+        result.LatestAssemblyCollection.Should().BeNull(
+            "\"marked and still serving\" is the state that let an armed control-plane node fire "
+            + "pre-fix code unattended — on a mesh that CAN rebuild, stale bytes must stop running");
+        result.LatestAssemblyMvid.Should().BeNull(
+            "leaving the served-build identity would name bytes nothing serves");
+    }
+
+    /// <summary>
+    /// 🚨 THE CONDITIONAL, and the branch that must never be decided by assuming a flag's value.
+    /// On a <c>Modules:RequirePrebuilt</c> mesh the local compile the refusal dispatches is refused
+    /// BY DESIGN, so clearing the coordinates would leave the type with no assembly at all,
+    /// INDEFINITELY — an outage with no recovery path, self-inflicted by the guard. Marked-stale
+    /// beats dead when there is no path to a fresh build, and the caller escalates to
+    /// <c>Critical</c> because only a human rebaking fixes it.
+    ///
+    /// <para>The flag is measured absent on memex and memex-cloud (and #2194 item 3 records the
+    /// same) — that is TWO instances, and says nothing about pearl, atioz, local installs, or any
+    /// external instance the registry serves. This branch exists because configuration lives on AKS
+    /// in places this repo has never heard of.</para>
+    /// </summary>
+    [Fact]
+    public void OnAMeshThatCannotCompile_TheRefusedBytesKeepServing_RatherThanLeavingNothing()
+    {
+        var result = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            PendingAdoption(producerFingerprint: "aaaaaaaaaaaaaaaa",
+                            liveFingerprint: "bbbbbbbbbbbbbbbb"),
+            LiveSources, canCompileLocally: false);
+
+        result.BuildProvenance.Should().Be(BuildProvenance.AdoptionRefused,
+            "the verdict is the same — what changes is only whether the rejected bytes keep serving");
+        result.CompiledSources.Should().BeNull(
+            "the staleness question stays open on both branches; the stamp is the lie either way");
+
+        result.LatestAssemblyPath.Should().Be("adopted/Crm.Migration.dll");
+        result.LatestAssemblyCollection.Should().Be("assemblies",
+            "RequirePrebuilt refuses the local compile that would replace these bytes, so clearing "
+            + "them leaves the type with NO assembly at all, indefinitely — worse than marked-stale "
+            + "when there is no path to a fresh build");
+    }
+
+    /// <summary>
+    /// Matching fingerprint: the bytes and the source have been compared and they agree. Stamps
+    /// exactly as before, so an adoption still sticks and the release watcher's "satisfied by the
+    /// existing current build" branch still absorbs.
+    /// </summary>
+    [Fact]
+    public void AMatchingFingerprint_AdoptsAndRecordsThatItWasVerified()
+    {
+        var result = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            PendingAdoption(producerFingerprint: "cafebabecafebabe",
+                            liveFingerprint: "cafebabecafebabe"),
+            LiveSources, canCompileLocally: true);
+
+        result.BuildProvenance.Should().Be(BuildProvenance.AdoptedVerified);
+        result.IsDirty.Should().BeFalse(
+            "a verified adoption must still satisfy the release watcher's !IsDirty branch — "
+            + "otherwise every install recompiles what it just adopted");
+        result.RequestedSourceStampAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 🚨 THE ROW THAT MUST NOT BECOME A REFUSAL. A legacy bundle records no fingerprint, so its
+    /// provenance is UNKNOWN — and it still stamps.
+    ///
+    /// <para>Withholding the stamp here would make every legacy-bundle type <c>IsDirty</c> on
+    /// arrival, which stops <c>InstallReleaseRequestWatcher</c>'s "satisfied by the existing
+    /// current build" branch (it requires <c>!IsDirty</c>) from ever absorbing — so every install
+    /// recompiles everything, the 43 activations / 13.5 s of boot the prebuilt lane exists to
+    /// remove. On a <c>Modules:RequirePrebuilt</c> mesh it is worse: a local compile is refused by
+    /// design, so not stamping would PARK every legacy-bundle type. The requirement is
+    /// <b>visibility, not refusal</b> — so the stamp stays and the provenance says it was never
+    /// earned.</para>
+    /// </summary>
+    [Fact]
+    public void ALegacyBundle_StillAdoptsAndStamps_ButIsNeverRecordedAsVerified()
+    {
+        var result = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            PendingAdoption(producerFingerprint: null, liveFingerprint: "cafebabecafebabe"),
+            LiveSources, canCompileLocally: true);
+
+        result.BuildProvenance.Should().Be(BuildProvenance.AdoptedUnverified,
+            "no fingerprint means UNKNOWN provenance, which is not the same fact as proven stale "
+            + "— and it must never read as Verified");
+        result.IsDirty.Should().BeFalse(
+            "🚨 the stamp is KEPT deliberately: withholding it makes every legacy-bundle type "
+            + "dirty on arrival, the release watcher's !IsDirty absorb branch stops firing, and on "
+            + "a RequirePrebuilt mesh — where a local compile is refused by design — every "
+            + "legacy-bundle type PARKS. That is the outage refusing unproven bundles was "
+            + "rejected to avoid, arriving through a different door");
+        result.RequestedSourceStampAt.Should().BeNull();
+    }
+
+    /// <summary>
+    /// The owner has an adopted fingerprint but has not published its own yet — the window before
+    /// the sources watcher writes both in one update. Nothing has been COMPARED, so this is
+    /// unknown, not a mismatch. Refusing on an absence is the <c>INCONCLUSIVE</c> lesson from the
+    /// emit canary (#890): a probe must not answer its scariest branch on its own inability to run.
+    /// </summary>
+    [Fact]
+    public void AnAdoptedFingerprintWithNoLiveOneYet_IsUnknown_NeverARefusal()
+    {
+        var result = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            PendingAdoption(producerFingerprint: "cafebabecafebabe", liveFingerprint: null),
+            LiveSources, canCompileLocally: true);
+
+        result.BuildProvenance.Should().Be(BuildProvenance.AdoptedUnverified);
+        result.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            "an absence is not a disagreement — driving a compile here would recompile every "
+            + "adoption that lands before its owner has published a fingerprint");
+    }
+
+    /// <summary>
+    /// 🚨 The reporter-side assertion the incident actually needed, stated as the thing that was
+    /// NOT stateable before: two nodes that are byte-identical on every signal an operator reads
+    /// must still be distinguishable. If this ever fails, the provenance field has stopped
+    /// carrying the only information that separates them.
+    /// </summary>
+    [Fact]
+    public void AVerifiedAndAnUnverifiedAdoption_AgreeOnEveryOldSignal_AndDifferOnlyInProvenance()
+    {
+        var verified = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            PendingAdoption("cafebabecafebabe", "cafebabecafebabe"), LiveSources,
+            canCompileLocally: true);
+        var unverified = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            PendingAdoption(null, "cafebabecafebabe"), LiveSources, canCompileLocally: true);
+
+        // Every signal that existed before this change reads the same on both — which is exactly
+        // why the stale one was invisible.
+        verified.CompilationStatus.Should().Be(unverified.CompilationStatus);
+        verified.IsDirty.Should().Be(unverified.IsDirty);
+        verified.CompiledSources!.Count.Should().Be(unverified.CompiledSources!.Count);
+        verified.CompiledSources["Crm/Migration/Source/code"].Should()
+            .Be(unverified.CompiledSources["Crm/Migration/Source/code"]);
+
+        verified.BuildProvenance.Should().NotBe(unverified.BuildProvenance,
+            "provenance is the ONLY thing that separates a checked adoption from an unchecked "
+            + "one — an operator, and a control plane, must be able to see it before arming "
+            + "anything against the node");
+    }
+
+    /// <summary>
+    /// Non-vacuity on the default: a locally-compiled record — one that never adopted, and every
+    /// record written before this field existed — reads as <see cref="BuildProvenance.Compiled"/>.
+    /// If the zero value were an adopted one, every historical node would claim a provenance it
+    /// never had.
+    /// </summary>
+    [Fact]
+    public void ARecordThatNeverAdopted_ReadsAsCompiled()
+        => new NodeTypeDefinition().BuildProvenance.Should().Be(BuildProvenance.Compiled);
+}

--- a/test/MeshWeaver.Graph.Test/AdoptedBuildProvenanceTest.cs
+++ b/test/MeshWeaver.Graph.Test/AdoptedBuildProvenanceTest.cs
@@ -55,6 +55,12 @@ public class AdoptedBuildProvenanceTest
             LatestAssemblyCollection = "assemblies",
             LatestAssemblyPath = "adopted/Crm.Migration.dll",
             LatestAssemblyMvid = "ed21acce00000000",
+            // 🚨 …and the type had COMPILED here before, so it carries a CompiledSources snapshot
+            // that MATCHES the live one. Seed does not clear it. Without this line the fixture
+            // models only a never-compiled type, CompiledSources is null for free, and the refusal
+            // row's "the staleness question stays open" assertion passes without exercising
+            // anything — which is exactly how it read green while the defect was live.
+            CompiledSources = LiveSources,
         };
 
     /// <summary>
@@ -75,8 +81,11 @@ public class AdoptedBuildProvenanceTest
             "the bundle states which sources it was built from and they are not the live ones — "
             + "that is the case this whole mechanism exists to catch");
         result.CompiledSources.Should().BeNull(
-            "stamping CompiledSources is precisely the lie: it makes IsDirty false by "
-            + "construction, which is what let a stale adopted build read as current");
+            "🚨 the PRIOR snapshot has to be CLEARED, not merely left unstamped: this type compiled "
+            + "here before, so it arrives carrying a CompiledSources that MATCHES the live sources "
+            + "(Seed never clears it). Leaving it reads IsDirty=false beside "
+            + "BuildProvenance=AdoptionRefused — 'my compiled sources are current' about bytes that "
+            + "were explicitly rejected, which is the same unearned claim one step along");
         result.IsDirty.Should().BeTrue(
             "the staleness question must be left visibly OPEN, not answered by the adoption");
         result.CompilationStatus.Should().Be(CompilationStatus.Pending,
@@ -119,7 +128,12 @@ public class AdoptedBuildProvenanceTest
         result.BuildProvenance.Should().Be(BuildProvenance.AdoptionRefused,
             "the verdict is the same — what changes is only whether the rejected bytes keep serving");
         result.CompiledSources.Should().BeNull(
-            "the staleness question stays open on both branches; the stamp is the lie either way");
+            "the staleness question stays open on BOTH branches — and it matters most here, where "
+            + "the compile that would refresh it is refused by design, so this record is the one "
+            + "the node is LEFT in until a human rebakes");
+        result.IsDirty.Should().BeTrue(
+            "a refused adoption must never read as 'sources current', least of all on the mesh "
+            + "that cannot produce fresh ones");
 
         result.LatestAssemblyPath.Should().Be("adopted/Crm.Migration.dll");
         result.LatestAssemblyCollection.Should().Be("assemblies",

--- a/test/MeshWeaver.Graph.Test/AdoptedSourceStampTest.cs
+++ b/test/MeshWeaver.Graph.Test/AdoptedSourceStampTest.cs
@@ -61,7 +61,8 @@ public class AdoptedSourceStampTest
         // !IsDirty — so without the stamp the next release request recompiles it.
         adopted.IsDirty.Should().BeTrue("this is the state the adoption used to commit");
 
-        var stamped = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(adopted, live);
+        var stamped = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            adopted, live, canCompileLocally: true);
 
         stamped.CompiledSources.Should().Equal(live,
             "the stamp IS the owner's live snapshot — equal by construction, never by timing");
@@ -77,7 +78,8 @@ public class AdoptedSourceStampTest
     {
         var live = Snapshot(("P/T/Source/Model", 7));
         var adopted = JustAdopted() with { CurrentSourceVersions = live };
-        var stamped = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(adopted, live);
+        var stamped = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            adopted, live, canCompileLocally: true);
 
         // Everything the adoption itself decided must survive verbatim — the stamp answers ONE
         // question and must not become a second, competing terminal write.
@@ -98,7 +100,7 @@ public class AdoptedSourceStampTest
         // null — that is what NodeTypeDefinition documents a sourceless success as recording.
         var empty = ImmutableDictionary<string, long>.Empty;
         var stamped = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
-            JustAdopted() with { CurrentSourceVersions = empty }, empty);
+            JustAdopted() with { CurrentSourceVersions = empty }, empty, canCompileLocally: true);
 
         stamped.CompiledSources.Should().NotBeNull();
         stamped.CompiledSources!.Count.Should().Be(0);
@@ -114,7 +116,7 @@ public class AdoptedSourceStampTest
         // would silently rewrite what "was compiled".
         var live = new Dictionary<string, long> { ["P/T/Source/Model"] = 5 };
         var stamped = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
-            JustAdopted() with { CurrentSourceVersions = live }, live);
+            JustAdopted() with { CurrentSourceVersions = live }, live, canCompileLocally: true);
 
         stamped.CompiledSources.Should().BeAssignableTo<ImmutableDictionary<string, long>>();
         live["P/T/Source/Model"] = 6;

--- a/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
@@ -316,7 +316,7 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
 
     /// <summary>
     /// One NodeType's files on the assembly store, relative and ordered — the race-free half of
-    /// "did Seed run". <see cref="PrebuiltAssemblySeeder.Seed"/> uploads BEFORE it stamps the
+    /// "did Seed run". <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> uploads BEFORE it stamps the
     /// record, and the upload is a local filesystem write, so this is settled the moment the
     /// seeding observable emits; the NODE, by contrast, is written through the owner and its
     /// mirror may not have caught up, so a regression could otherwise read as a pass. A


### PR DESCRIPTION
An adopted prebuilt assembly was indistinguishable from a compiled one by **every** signal an
operator is taught to trust — and that is how a GitSync `update` shipped last week's code over live
client data, destroying four documents' bodies, one unrecoverable (#2813).

## Why every check said it was fine

`PrebuiltAssemblySeeder.Seed` writes CROSS-HUB, so it cannot read the owner's live source snapshot
(#1834). It asks instead — `RequestedSourceStampAt` — and the owner answers by stamping
`CompiledSources = CurrentSourceVersions`. **That stamp is what makes `IsDirty` false**, which is
what `InstallReleaseRequestWatcher`'s *"satisfied by the existing current build"* branch requires and
what makes an adoption stick.

It is also the lie. `CompilationStatus.Ok` and `CompiledSources == CurrentSourceVersions` both read
clean **whether or not the bytes have anything to do with the live source**, because the adoption
writes the second one itself. The staleness detector was never broken — it was answering a question
the adoption had already answered for it. Only forcing a compile moved the MVID.

## The three-way

The producer records a **content** fingerprint of the sources the bytes were built from. Content, not
versions: `CurrentSourceVersions` is `{path → LastModified.UtcTicks}`, mesh-local times the producer
cannot know (the bake writes zeros), so a fingerprint over ticks would never match and *every*
adoption would be refused. The owner publishes its own in the **same update** as
`CurrentSourceVersions`, so `ApplyAdoptedSourceStamp` — one pure function shared by all three writers,
so assert→check fixes all three at once — compares two strings already on the node:

| bundle stamp | matches | outcome |
|---|---|---|
| yes | yes | adopt; `AdoptedVerified` |
| yes | **no** | 🚨 **refuse** — no stamp, flip `Pending` to compile the live source; `AdoptionRefused` |
| no (legacy, or the owner's not published yet) | — | adopt, **keep the stamp**; `AdoptedUnverified` |

> 🚨 **The legacy row keeps the stamp deliberately.** Withholding it makes every legacy-bundle type
> `IsDirty` on arrival, the `!IsDirty` absorb branch stops firing, and every install recompiles
> everything — the 43 activations / 13.5 s of boot the prebuilt lane exists to remove. On a
> `Modules:RequirePrebuilt` mesh a local compile is refused by design, so not stamping would **park
> every legacy-bundle type**: the outage that refusing unproven bundles was rejected to avoid,
> arriving through a different door. No fingerprint means **unknown** provenance, not **proven
> stale**. The requirement is visibility, not refusal.

## Whether refused bytes keep serving is CONDITIONAL

`Seed` has already stamped the adopted build's assembly coordinates by the time the owner judges it,
so a refusal that changes nothing else leaves proven-stale code executing. Both answers are wrong in
one direction, so the fork is decided **at the point of refusal** rather than by assuming how a flag
is set on a mesh nobody can see:

| | |
|---|---|
| **can compile** | **clear** the coordinates — a fresh compile is already dispatched, so the gap is seconds, and *"marked and still serving"* is the state that lets an armed node fire pre-fix code unattended |
| **`RequirePrebuilt`** | **keep** them + `LogCritical` naming the type — the compile that would replace the bytes is refused by design, so clearing leaves **no assembly at all, indefinitely**: an outage with no recovery, self-inflicted by a guard |

> 🚨 Not built on *"`RequirePrebuilt` is unset everywhere"*. It is measured absent on **memex** and
> **memex-cloud** (#2194 item 3 agrees) — two instances, saying nothing about `pearl`, `atioz`, local
> installs, or any external instance the registry serves. Configuration lives on AKS in places this
> repo has never heard of.

## 🚨 Every adoption reads `AdoptedUnverified` today — that is the honest state, not a bug

Nothing writes a `sourceFingerprint` into a bundle yet, so every adoption genuinely *is* unverifiable
and a field saying so is **true**. A uniform value here should not later be read as a defect. The
refusal row is armed and starts discriminating the day the bake records a fingerprint, with **no
further change here**. Consumer-first is safe precisely *because* legacy = adopt+mark.

## 🚨 Refusing to LOAD is the SECOND line of defence — the first is #2820

From the session that owns the incident, and it is the better framing:

> The damage needed TWO ingredients — stale bytes, **and something armed to run them.** Stale bytes
> sitting unloaded harm nobody. A type that renders read-only pages from unverified bytes is a
> degraded system; a type that WRITES from them is the incident.

So the load-time decision above is second-order. The first-order requirement is that provenance be
**readable by a control plane**, and it is: `BuildProvenance` is a property of the NodeType's own
content **and** is mirrored onto the compile-state satellite at `{type}/_Activity/compile-state`, so a
watcher reads it through `GetMeshNodeStream(path)` with no new plumbing. It is operational — stripped
on export, preserved from the live node on import — so an authored value cannot forge it.

**#2820** is the execute-time interlock itself, filed and named rather than left to be discovered.

## Also NOT here, named

- **#2818** — the missing recovery verb. `RequestedReleaseForce` is honoured by the release watcher
  and then silently discarded by the compile watcher, which re-adopts the sealed bundle and settles
  *"without a Roslyn pass"*. An operator who sees `AdoptedUnverified` can see the problem and still
  cannot force a rebuild. Its regression needs an `IPrebuiltAssemblyConsumer` stood up on a real mesh
  — nothing in `test/` registers one today — so it gets its own change, not a ride-along.
- **No release-pointer staleness anywhere in this diff.** `LatestReleasePath` lags routinely on
  healthy meshes (Crm#33: all fifteen types stale, serving perfectly), so a check of that shape cries
  wolf. Verified by grep: the diff never reads or writes it.

## Fallout handled

- **`Seed` gains an OVERLOAD**, not an eighth optional parameter — the seven-parameter form is public
  surface and adding an optional parameter is a binary break the compatibility gate is right to
  refuse. The new parameter carries no default, so existing seven-argument calls still bind
  unambiguously. Six bare `<see cref="…Seed"/>` became CS0419-ambiguous; all now carry explicit
  signatures, repo-wide grep clean.
- **`NodeTypeCompileState` carries all three fields** — caught by
  `StateMembers_AreExactlyTheMaskedOperationalMembers`, which failed with *"masked by the sync seams
  but missing from `NodeTypeCompileState` — the satellite would silently drop it"*. The guard did its
  job on its author.

## Tests — mutation-checked twice

`AdoptedBuildProvenanceTest`, 7 cases. Two independent mutations:

- **revert the three-way** → **5 of 6** fail, naming each row (`AdoptionRefused`, `AdoptedVerified`,
  `AdoptedUnverified` ×2). The survivor is the enum-default case, which the three-way does not decide.
- **collapse the clear/keep conditional to always-clear** → fails **exactly** the `RequirePrebuilt`
  case (`Expected "adopted/Crm.Migration.dll", but found <null>`), and nothing else.

Two cases are not row assertions and are the ones to keep if the design moves: the legacy row asserts
`IsDirty == false` (so "tightening" it later fails with the parking reason written out), and
`AVerifiedAndAnUnverifiedAdoption_AgreeOnEveryOldSignal_AndDifferOnlyInProvenance` — the reporter-side
assertion the incident needed: two nodes identical on `CompilationStatus`, `IsDirty` and
`CompiledSources` must still be distinguishable.

The four pre-existing `AdoptedSourceStampTest` cases are all legacy-row and pass unchanged — including
`Stamp_TouchesNothingElseOnTheRecord`, which now also guards that the legacy path never clears
coordinates.

```
Mesh.Contract / Graph / Hosting / PluginCatalog / Documentation
+ Graph.Test / PluginCatalog.Test / Documentation.Test / Monolith.Test
                                   -c Release -warnaserror   0 Error(s)

dotnet test MeshWeaver.Graph.Test            1583 passed, 0 failed
dotnet test MeshWeaver.PluginCatalog.Test     698 passed, 0 failed
dotnet test MeshWeaver.Documentation.Test     121 passed, 0 failed
```

## Docs

`NodeTypeCompilation` → *"An ADOPTED build must say whether it was ever checked against the source"*:
the stamp that lied, the content-vs-versions constraint, the three-way, the conditional with both
branches' reasoning, and the two explicit non-goals. Plus the release-pointer warning, so the next
reader does not reach for the signal that cries wolf. What's New entry (`Category: Fix`).

Fixes #2813

🤖 Generated with [Claude Code](https://claude.com/claude-code)
