### PR TITLE
fix(#2818): a FORCED release compiles the live source even when a prebuilt still resolves

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -449,6 +449,26 @@ a valid build of the current sources — the trigger is consumed without dispatc
 `RequestNodeTypeRelease(force: true)` remains the documented escape hatch and always compiles.
 Anything not adopted compiles exactly as before — the "generate" branch is untouched.
 
+🚨 **"Always compiles" has to hold in the compile watcher, not only in the release watcher
+(#2818).** The release watcher bypasses its satisfied-branch on a force and flips the type
+`Pending` — but the on-demand adoption step lives in the *compile* watcher, where every `Pending`
+converges, and until #2818 that step asked the bundle sources again regardless of the force. On any
+mesh whose bundle still resolved, a force re-adopted the very bytes the operator was trying to
+replace and settled "without a Roslyn pass" with a fresh `LastCompileSucceededAt` over the same
+`LatestAssemblyMvid`; it only worked where the bundle had gone missing. This is what left the stale
+prebuilt of #2813 unrecoverable on a node whose source was already fixed. Now a `Pending` that
+carries `RequestedReleaseForce` skips adoption and dispatches (or parks, under `RequirePrebuilt`,
+with the park's named reason), and every terminal stamp — `ApplyCompileSuccess`,
+`ApplyCompileFailure`, `ApplyGateSettle` — sets the flag back to `false`, so a spent force can never
+suppress adoption for a later, unforced trigger. The regression
+(`NodeTypeOnDemandAdoptionTest.AForcedRelease_NeverConsultsTheBundleSources`) asserts the
+discriminating fact — the forced `Pending` never *consults* the consumer — rather than the MVID
+moving, because a force on a type whose bundle does not resolve compiled correctly even before the
+fix. Its third phase found the adjacent gap: the on-demand step judged an adoption "landed" by
+`HasUsableBuild` alone, which a type's PREVIOUS build already satisfies — so a consumer that
+reported an adoption it never wrote back stranded such a type at `Pending`. Landed now also
+requires `CompilationStatus == Ok`, which is what a real `PrebuiltAssemblySeeder.Seed` stamps.
+
 Anything else triggers a recompile. This makes a cold hub start **self-healing**:
 
 | Situation | Why the bare record lies | Caught by |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-compile-now-forces-a-rebuild-even-when-a-prebuilt-still-resolves.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-compile-now-forces-a-rebuild-even-when-a-prebuilt-still-resolves.md
@@ -1,0 +1,26 @@
+---
+Name: Compile (force) now rebuilds from your source even when a prebuilt assembly still resolves
+Category: Fix
+Description: A forced Compile used to be silently replaced by the deployment's prebuilt assembly whenever one still resolved for the type — the very bytes you were trying to replace came back, and the node reported a fresh build. A forced release now skips prebuilt adoption and compiles the live source, and the force is spent by that compile so it cannot suppress adoption later.
+Icon: Bug
+Order: -20260830
+---
+
+# Compile (force) now rebuilds from your source even when a prebuilt assembly still resolves
+
+Forcing a release (**Create Release** with force, or `RequestNodeTypeRelease(force: true)`) is the
+one verb that is supposed to say "build what is on the node now, whatever you already have". It did
+not: the request was honoured, the type flipped to *Pending*, and the compile watcher then asked the
+deployment's bundle sources again and adopted whatever still resolved — settling "without a Roslyn
+pass" and stamping a fresh success time over the same assembly. Forcing only worked on a type whose
+prebuilt had already gone missing, which is exactly where nobody needed it.
+
+This is how a stale prebuilt adopted over freshly synced source could not be pushed off a node whose
+code was already fixed (#2813). A forced release now goes straight to the compiler, and the force is
+consumed by the compile it dispatches, so an ordinary trigger afterwards is free to adopt a prebuilt
+again.
+
+Found alongside it: a type that already had a build could be left stuck at *Pending* when a
+prebuilt source reported an adoption it never actually wrote back — its old assembly record made the
+adoption look landed. "Landed" now also requires the type to have left *Pending*, so such a type
+compiles instead of hanging every page that waits on it.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -334,6 +334,29 @@ internal static class NodeTypeCompilationHelpers
                         return;
                     }
 
+                    // 🚨 #2818 — A FORCE MEANS "BUILD THE LIVE SOURCE", NOT "SERVE ME WHATEVER A
+                    // BUNDLE STILL RESOLVES". InstallReleaseRequestWatcher honours
+                    // RequestedReleaseForce (it bypasses its "already satisfied" short-circuit) and
+                    // flips the type Pending — but the flip lands HERE, and until now this branch
+                    // asked the bundle sources again regardless. On any mesh whose bundle still
+                    // resolved, a force therefore re-adopted the very bytes the operator was trying
+                    // to replace and settled "without a Roslyn pass"; it worked only where
+                    // SeedForTypes MISSED, i.e. exactly where nobody needed it. That is how the
+                    // stale prebuilt in #2813 could not be forced off a node whose live source was
+                    // already fixed. The flag survives the Pending flip (the dispatch commit keeps
+                    // it) and is consumed by the terminal stamp of the compile it dispatches —
+                    // ApplyCompileSuccess / ApplyCompileFailure / ApplyGateSettle — so a stale force
+                    // can never suppress adoption for a later, unforced trigger.
+                    if (pendingNode!.Content is NodeTypeDefinition { RequestedReleaseForce: true })
+                    {
+                        logger?.LogInformation(
+                            "Compile watcher: {HubPath} was flipped Pending by a FORCED release — "
+                            + "skipping on-demand prebuilt adoption and compiling the live source.",
+                            hubPath);
+                        DispatchOrPark();
+                        return;
+                    }
+
                     var attempt = new SingleAssignmentDisposable();
                     onDemandAdoptionSubs.Add(attempt);
                     attempt.Disposable = prebuiltConsumer.SeedForTypes([hubPath])
@@ -396,9 +419,19 @@ internal static class NodeTypeCompilationHelpers
                         // module MVID map on every attempt, for nothing: adoption stamps assembly
                         // coordinates on the NODE, and changes no part of the environment these
                         // guards describe.
+                        // 🚨 …and the node must have LEFT Pending. A real adoption stamps
+                        // CompilationStatus=Ok together with the coordinates
+                        // (PrebuiltAssemblySeeder.Seed), so an Ok node with a usable build is
+                        // what "landed" looks like. HasUsableBuild alone is not enough on a type
+                        // that already HAD a build: its old coordinates satisfy the predicate on
+                        // the very Pending node this watcher is trying to settle, so a consumer
+                        // that reported an adoption it never wrote back was believed — and the
+                        // type sat at Pending for ever (#2818's regression, third phase: a dirty
+                        // type with the previous build's coordinates, re-triggered unforced).
                         return ownStream
                             .Where(n => n?.ContentAs<NodeTypeDefinition>(
                                             hub.JsonSerializerOptions, logger) is { } adoptedDef
+                                        && adoptedDef.CompilationStatus == CompilationStatus.Ok
                                         && HasUsableBuild(n, adoptedDef, guards))
                             .Take(1)
                             .Select(_ => true)
@@ -2064,6 +2097,10 @@ internal static class NodeTypeCompilationHelpers
             FailedBuildInputs = formedUnderLiveInputs
                 ? BuildInputsToken(modulesHash, parkedDef.CurrentSourceVersions)
                 : parkedDef.FailedBuildInputs,
+            // A forced release that ends in a park is spent too (#2818): under RequirePrebuilt the
+            // compile it asked for is refused by design and the park names that; a bundle that
+            // arrives later must be adoptable again, not refused by the stale force.
+            RequestedReleaseForce = false,
         };
 
     /// <summary>
@@ -2135,6 +2172,10 @@ internal static class NodeTypeCompilationHelpers
             // Clear the consumed release-requester so a later System-only recompile doesn't
             // mis-attribute its release to a stale prior user.
             RequestedReleaseBy = null,
+            // The force that dispatched this compile (if any) is spent: the compile watcher read
+            // it to skip on-demand adoption (#2818), and leaving it set would make the NEXT,
+            // unforced trigger skip adoption too.
+            RequestedReleaseForce = false,
             // 🚨 The standing FAILURE verdict is gone, so the inputs it was formed from must go
             // with it (#1793). Leaving the token behind would make a LATER failure look like it
             // had already had its automatic attempt under these inputs, and the type would sit
@@ -2263,6 +2304,8 @@ internal static class NodeTypeCompilationHelpers
             // Clear the consumed release-requester on failure too — the failed request is
             // done; a fresh request must re-stamp it.
             RequestedReleaseBy = null,
+            // Spent, like the requester — see ApplyCompileSuccess (#2818).
+            RequestedReleaseForce = false,
             // The adopted build this request belonged to is gone (CompiledSources is cleared
             // above), so the request goes with it — see ApplyCompileSuccess (#1834).
             RequestedSourceStampAt = null

--- a/test/MeshWeaver.Graph.Test/ForcedReleaseIsSpentTest.cs
+++ b/test/MeshWeaver.Graph.Test/ForcedReleaseIsSpentTest.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Immutable;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 A force is SPENT by the compile it dispatches (#2818).
+///
+/// <para>The compile watcher reads <see cref="NodeTypeDefinition.RequestedReleaseForce"/> off the
+/// <c>Pending</c> node to skip on-demand prebuilt adoption — a forced release means "build the
+/// live source", not "serve me whatever a bundle still resolves". The flag therefore has to
+/// survive the dispatch commit (the release watcher keeps it) and die with the compile's terminal
+/// stamp: left standing, the NEXT, unforced trigger on the same type would skip adoption too, and
+/// on a <c>Modules:RequirePrebuilt</c> mesh that is a park for a type whose bundle exists. All
+/// three terminal writers are pure functions, so the contract is pinned here without a mesh.</para>
+/// </summary>
+public class ForcedReleaseIsSpentTest
+{
+    private static NodeTypeDefinition Forced() => new()
+    {
+        Configuration = "config => config",
+        CompilationStatus = CompilationStatus.Pending,
+        RequestedReleaseAt = DateTimeOffset.UtcNow,
+        RequestedReleaseForce = true,
+        RequestedReleaseBy = "operator",
+        CurrentSourceVersions = ImmutableDictionary<string, long>.Empty.Add("P/T/Source/Model", 42),
+    };
+
+    [Fact]
+    public void ASuccessfulCompile_SpendsTheForce()
+    {
+        var compiled = NodeTypeCompilationHelpers.ApplyCompileSuccess(
+            Forced(),
+            new NodeCompilationResult(
+                AssemblyLocation: "/cache/T/T.dll",
+                NodeTypeConfigurations: [],
+                CompiledSources: ImmutableDictionary<string, long>.Empty.Add("P/T/Source/Model", 42),
+                Collection: "assemblies",
+                ContentPath: "P_T/v13.dll",
+                Version: 13),
+            currentNodeVersion: 13, activityPath: null, releasePath: null);
+
+        compiled.CompilationStatus.Should().Be(CompilationStatus.Ok);
+        compiled.RequestedReleaseForce.Should().BeFalse(
+            "the force dispatched THIS compile and is done; a standing flag would make the next, "
+            + "unforced trigger skip prebuilt adoption too");
+        compiled.RequestedReleaseBy.Should().BeNull("the requester is consumed alongside the force");
+    }
+
+    [Fact]
+    public void AFailedCompile_SpendsTheForce()
+    {
+        var failed = NodeTypeCompilationHelpers.ApplyCompileFailure(
+            Forced(), result: null, error: new InvalidOperationException("boom"), activityPath: null);
+
+        failed.CompilationStatus.Should().Be(CompilationStatus.Error);
+        failed.RequestedReleaseForce.Should().BeFalse(
+            "a forced compile that failed is still a compile that RAN; the force does not roll "
+            + "over into the retry a fresh request will ask for");
+    }
+
+    [Fact]
+    public void AParkedForce_IsSpentToo()
+    {
+        // Under Modules:RequirePrebuilt a forced compile is refused by design and the type parks
+        // with that reason. The bundle that arrives later must be adoptable — a stale force would
+        // refuse it and leave the type parked for good.
+        var parked = NodeTypeCompilationHelpers.ApplyGateSettle(
+            Forced(), reason: "Modules:RequirePrebuilt: no compiler on this mesh",
+            formedUnderLiveInputs: true, modulesHash: "m1");
+
+        parked.CompilationStatus.Should().Be(CompilationStatus.Error);
+        parked.CompilationError.Should().Contain("RequirePrebuilt");
+        parked.RequestedReleaseForce.Should().BeFalse();
+    }
+}

--- a/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeOnDemandAdoptionTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NodeTypeOnDemandAdoptionTest.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
@@ -97,6 +99,135 @@ public class NodeTypeOnDemandAdoptionTest(ITestOutputHelper output) : MonolithMe
         parkRegistry.GetCompileAttemptCount(NodeTypePath).Should().Be(1,
             "the reported adoption did not produce a usable build, so the type must compile — "
             + "reaching a terminal state is the proof it was not left stranded at Pending");
+    }
+
+    private const string ForcedPartition = "AdoptOnDemandForceTest";
+    private const string ForcedTypeId = "ForcedType";
+    private const string ForcedTypePath = $"{ForcedPartition}/{ForcedTypeId}";
+
+    private const string ForcedCodeV1 = """
+        public static class ForcedTypeMarker
+        {
+            public const string Version = "V1";
+        }
+        """;
+
+    private const string ForcedCodeV2 = """
+        public static class ForcedTypeMarker
+        {
+            public const string Version = "V2";
+        }
+        """;
+
+    /// <summary>
+    /// 🚨 #2818 — A FORCE MUST NOT BE ANSWERED BY THE BUNDLE SOURCES.
+    ///
+    /// <para>The release watcher honoured <c>RequestedReleaseForce</c> (it bypassed its
+    /// "already satisfied" short-circuit) and flipped the type <c>Pending</c> — and the compile
+    /// watcher then asked the bundle sources again regardless, re-adopted whatever still resolved,
+    /// and settled "without a Roslyn pass". So a force worked exactly when <c>SeedForTypes</c>
+    /// MISSED, and was inert whenever a bundle still resolved — which is when an operator needs it
+    /// (#2813: a stale prebuilt adopted over freshly synced source could not be forced off the
+    /// node). A test that forces a type with NO resolvable bundle therefore passes against the
+    /// unfixed code; the discriminating assertion is that the forced <c>Pending</c> never
+    /// <b>consults</b> the consumer at all, on a consumer that answers "adopted".</para>
+    ///
+    /// <para>Three phases on one compiling type: the first build consults the sources once (the
+    /// #1782 gap-4 contract, unchanged); the forced release compiles WITHOUT consulting them and
+    /// leaves the force spent; an ordinary source edit afterwards consults them again — the proof
+    /// the force was consumed by its own compile rather than left standing on the node.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task AForcedRelease_NeverConsultsTheBundleSources_AndCompilesTheLiveSource()
+    {
+        // A bundle that "still resolves": the consumer answers adopted (it writes nothing back, so
+        // the node never gains a usable build from it and the compile proceeds either way — what
+        // the fix changes is whether the question is asked).
+        consumer.AdoptedToReport = 1;
+        var parkRegistry = Mesh.ServiceProvider.GetRequiredService<NodeTypeCompileParkRegistry>();
+
+        // 1. Create the type + one source; the first-build kickoff compiles it.
+        await NodeFactory.CreateNode(new MeshNode(ForcedTypeId, ForcedPartition)
+        {
+            Name = "Forced Type",
+            NodeType = MeshNode.NodeTypePath,
+            Content = new NodeTypeDefinition
+            {
+                Description = "Pin for the forced-release path (#2818).",
+                Configuration = "config => config.AddDefaultLayoutAreas()"
+            }
+        }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(new MeshNode("code", $"{ForcedTypePath}/Source")
+        {
+            Name = "Code",
+            NodeType = "Code",
+            Content = new CodeConfiguration { Code = ForcedCodeV1, Language = "csharp" }
+        }).Should().Within(30.Seconds()).Emit();
+
+        var firstBuild = await SettledOk(after: null);
+        Output.WriteLine($"=== first build Ok at {firstBuild.LastCompileSucceededAt:O}; asked=[{string.Join(", ", consumer.Asked)}] ===");
+        consumer.Asked.Should().Equal([ForcedTypePath],
+            "the first build is an unforced compile miss and consults the bundle sources once (#1782 gap 4)");
+        parkRegistry.GetCompileAttemptCount(ForcedTypePath).Should().Be(1);
+
+        // 2. FORCE. The type flips Pending with RequestedReleaseForce=true; the compile watcher must
+        //    go straight to Roslyn.
+        Mesh.RequestNodeTypeRelease(ForcedTypePath, force: true,
+            onError: msg => Output.WriteLine($"forced request refused: {msg}"));
+
+        var forcedBuild = await SettledOk(after: firstBuild.LastCompileSucceededAt);
+        Output.WriteLine($"=== forced build Ok at {forcedBuild.LastCompileSucceededAt:O}; asked=[{string.Join(", ", consumer.Asked)}] ===");
+        consumer.Asked.Should().Equal([ForcedTypePath],
+            "a FORCED release must never consult the bundle sources — on a mesh whose bundle still "
+            + "resolves that consultation re-adopts the very bytes the operator is trying to replace");
+        parkRegistry.GetCompileAttemptCount(ForcedTypePath).Should().Be(2,
+            "the forced release must run a real Roslyn pass — the settle above is not enough on its "
+            + "own, because an adoption also settles the type");
+        forcedBuild.RequestedReleaseForce.Should().BeFalse(
+            "the force is spent by the compile it dispatched; left standing it would make every later, "
+            + "unforced trigger skip adoption too");
+
+        // 3. An ORDINARY trigger afterwards consults the bundle sources again. A source edit marks
+        //    the type dirty (InstallSourcesWatcher: CurrentSourceVersions vs CompiledSources); the
+        //    rebuild itself is asked for by an UNFORCED release request, exactly as
+        //    CodeEditRecompileTest does — a dirty type is not satisfied by its current build, so
+        //    the request dispatches a Pending that carries no force.
+        await Mesh.GetWorkspace().GetMeshNodeStream($"{ForcedTypePath}/Source/code")
+            .Update(n => n with { Content = new CodeConfiguration { Code = ForcedCodeV2, Language = "csharp" } })
+            .Take(1).Await(TestContext.Current.CancellationToken);
+        await Mesh.GetWorkspace().GetMeshNodeStream(ForcedTypePath)
+            .Should().Within(30.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d && d.IsDirty);
+        Output.WriteLine("=== source edited, type dirty; requesting an UNFORCED release ===");
+        Mesh.RequestNodeTypeRelease(ForcedTypePath,
+            onError: msg => Output.WriteLine($"unforced request refused: {msg}"));
+
+        var editedBuild = await SettledOk(after: forcedBuild.LastCompileSucceededAt);
+        Output.WriteLine($"=== edited build Ok at {editedBuild.LastCompileSucceededAt:O}; asked=[{string.Join(", ", consumer.Asked)}] ===");
+        consumer.Asked.Should().Equal([ForcedTypePath, ForcedTypePath],
+            "once the force is spent, an unforced trigger reaches on-demand adoption again — "
+            + "a sticky force would have skipped it here as well");
+        parkRegistry.GetCompileAttemptCount(ForcedTypePath).Should().Be(3);
+    }
+
+    /// <summary>Waits for the forced-path type to settle Ok with a success stamp strictly after
+    /// <paramref name="after"/> (or any stamp when null), and returns that definition.</summary>
+    private async Task<NodeTypeDefinition> SettledOk(DateTimeOffset? after)
+    {
+        await Mesh.GetWorkspace().GetMeshNodeStream(ForcedTypePath)
+            .Should().Within(90.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && d.LastCompileSucceededAt is { } at
+                && (after is null || at > after.Value)
+                && !d.IsDirty);
+        return await Mesh.GetWorkspace().GetMeshNodeStream(ForcedTypePath)
+            .Where(n => n?.Content is NodeTypeDefinition d
+                && d.CompilationStatus == CompilationStatus.Ok
+                && d.LastCompileSucceededAt is { } at
+                && (after is null || at > after.Value))
+            .Select(n => (NodeTypeDefinition)n!.Content!)
+            .FirstAsync().Await(TestContext.Current.CancellationToken);
     }
 
     /// <summary>Creates a NodeType whose Configuration is not valid C# and waits for the compile


### PR DESCRIPTION
Fixes #2818. The recovery verb for #2813 (whose provenance half is #2821, which explicitly leaves this to its own change).

## The defect

`RequestNodeTypeRelease(force: true)` is documented as "always compiles". The **release-request watcher** honours it — it bypasses its *satisfied by the current build* short-circuit and flips the type `Pending`. But the flip lands in the **compile watcher**, where every `Pending` converges, and its on-demand adoption step (#1782 gap 4) asked the deployment's bundle sources again **regardless of the force**: on any mesh whose bundle still resolved, a forced release re-adopted the very bytes the operator was trying to replace and settled *"without a Roslyn pass"* — with a fresh `LastCompileSucceededAt` over the same `LatestAssemblyMvid`. Force only worked where `SeedForTypes` **missed**, i.e. exactly where nobody needed it. That is what left the stale prebuilt in #2813 unrecoverable on a node whose source was already fixed.

## The fix

- **`InstallCompileWatcher`**: a `Pending` whose definition carries `RequestedReleaseForce` skips the `SeedForTypes` branch and goes straight to `DispatchOrPark()` — compiles, or under `Modules:RequirePrebuilt` parks with the gate's named reason (a verdict the settle-waiters read, not a timeout).
- **The force is spent by the compile it dispatches**: `ApplyCompileSuccess`, `ApplyCompileFailure` and `ApplyGateSettle` set `RequestedReleaseForce = false`. The dispatch commit keeps the flag (the compile watcher has to read it off the `Pending` node); consuming it at the terminal stamp means a stale force can never suppress adoption for a later, unforced trigger — on a `RequirePrebuilt` mesh that would park a type whose bundle exists.

### Found alongside it — a reported adoption on a type that already had a build stranded it

The on-demand step judged "landed" by `HasUsableBuild` alone. A type's *previous* build already satisfies that on the very `Pending` node the watcher is trying to settle, so a consumer that reported an adoption it never wrote back was believed, and the type sat at `Pending` for good (the third phase of the new regression, before the predicate change: `Ok` → dirty edit → unforced release → `Pending` for the full 90 s, no compile). The existing control (`AnAdoptionThatNeverWroteBack_MustNotStrandTheType`) only covered a type with no prior build. "Landed" now also requires `CompilationStatus == Ok` — what a real `PrebuiltAssemblySeeder.Seed` stamps.

## Tests

- `NodeTypeOnDemandAdoptionTest.AForcedRelease_NeverConsultsTheBundleSources_AndCompilesTheLiveSource` (Monolith, real mesh, `RecordingPrebuiltConsumer` registered): the first build consults the consumer once (gap-4 contract unchanged); a forced release compiles **without consulting it** (`GetCompileAttemptCount` 1 → 2, `RequestedReleaseForce == false` after settle); an ordinary source edit afterwards consults it again (proof the force was consumed, not left standing). The discriminating assertion is *not consulted*, not "the MVID moved": a fake consumer never writes bytes back, and a force on a type whose bundle does not resolve compiled correctly before this fix too — so a test of that shape would pass against the unfixed code. Mutation-checked: with only the force check disabled, the run fails on exactly the "never consults" assertion (`Expected collection {path, path} to equal {path}`); without the `Ok` requirement in the landed-predicate, its third phase strands at `Pending` for 90 s.
- `ForcedReleaseIsSpentTest` (Graph.Test, pure): the three terminal stamps clear the flag.

## Docs

`NodeTypeCompilation.md` → *Adopt-before-compile*: why "always compiles" has to hold in the compile watcher, not only the release watcher. What's New: `Category: Fix`.

## Verification

`MeshWeaver.Graph`, `MeshWeaver.Graph.Test`, `MeshWeaver.Hosting.Monolith.Test` — `-c Release -warnaserror`, `0 Error(s)` each; the new Graph.dll carries the new log string. Test runs (local, Release):
- `NodeTypeOnDemandAdoptionTest` — 3/3 (the two existing gap-4 tests + the new regression), `.trx` written.
- `ForcedReleaseIsSpentTest` — 3/3.
- Watcher neighbourhood in Monolith.Test (CodeEditRecompile, NodeTypeRelease, NodeTypeReleaseGate, ReleaseRequestWatcherHighWater, ReleaseRequestSatisfiedByCurrentBuild, CompileLegBoundWedge, CompileSourceSnapshotWedge, DynamicTypePreWarmer, OverlaySelfHealInstanceRecycle, BrokenNodeTypeAccess) — 36/36.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C1SquDKJNKZxEUbuaPjUgu
