### PR TITLE
fix(cd): a broken pipe mid-push no longer throws away the whole release (#2810)

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -848,16 +848,59 @@ jobs:
       # that IS what pushing costs) but under a name no consumer can select, so this leg succeeding
       # ships NOTHING on its own. `promote` applies version/sha/main once every leg has succeeded.
       - name: Build + push portal-ai (staging tag)
-        run: >
-          dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj
-          -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
-          -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
-          -p:CIRun=true
-          -p:MeshWeaverRoot=${{ github.workspace }}
-          -p:ContainerRegistry=${{ env.ACR }}
-          -p:ContainerRepository=memex-portal-ai
-          -p:ContainerImageTags=${{ needs.gate.outputs.staging_tag }}
-          -p:ContainerBaseImage=${{ env.ACR }}/memex-portal-ai-base:latest
+        run: |
+          # 🚨 Bounded retry, and deliberately NOT a skip-trapdoor: after the last attempt this
+          # still fails RED. It exists because the BLOB UPLOAD is the failure, not the build.
+          #
+          # Measured 2026-08-30, run 33328213655 (target 84bf70b17): the linux-arm64 leg pushed
+          # cleanly at 18:48:05, then at 18:52:58 the x64 leg logged
+          #     [Registry] Encountered a HttpRequestException Unknown with message "Broken pipe".
+          #     Pausing before retry.
+          # and nine seconds later
+          #     CONTAINER1013: Failed to push to the output registry: CONTAINER1001: Failed to
+          #     upload blob using PATCH https://meshweaver.azurecr.io/v2/memex-portal-ai/blobs/uploads/...
+          # The SDK's own retry did not recover it. Same pair on run 33322756606 (target
+          # 8cbf69ac9) at 16:49Z. Between those two, ci.6846 promoted successfully at 18:14Z — so
+          # the fault is INTERMITTENT, not a credential, quota or purge problem, and the registry
+          # is Premium SKU and healthy throughout.
+          #
+          # Publication is ALL-OR-NOTHING (the promote job tags only when every leg succeeded), so
+          # one broken pipe on one architecture costs the whole delivery: no image, and every
+          # self-updating install stays on the previous one until a later run happens to get a
+          # clean connection. That is the cost this retry removes.
+          #
+          # It does NOT paper over a real failure: a compile error, a missing project or a bad
+          # credential fails identically on all three attempts and the step ends RED, naming the
+          # last attempt's output. Only a connection that dies mid-upload gets a second chance,
+          # which is what a bounded retry is for. Mirrors the idiom already used by
+          # node-repo-{compile-check,gate,publish-bake}.yml for their registry logins.
+          set -euo pipefail
+          for attempt in 1 2 3; do
+            echo "::group::portal-ai publish attempt $attempt of 3"
+            if dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj \
+                 -c Release --no-self-contained -t:PublishContainer -p:PublishProfile= \
+                 -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"' \
+                 -p:CIRun=true \
+                 -p:MeshWeaverRoot=${{ github.workspace }} \
+                 -p:ContainerRegistry=${{ env.ACR }} \
+                 -p:ContainerRepository=memex-portal-ai \
+                 -p:ContainerImageTags=${{ needs.gate.outputs.staging_tag }} \
+                 -p:ContainerBaseImage=${{ env.ACR }}/memex-portal-ai-base:latest; then
+              echo "::endgroup::"
+              echo "portal-ai published on attempt $attempt"
+              exit 0
+            fi
+            echo "::endgroup::"
+            if [ "$attempt" -lt 3 ]; then
+              # Re-login before retrying: an ACR token can expire during a long multi-arch push,
+              # and a re-auth costs seconds against a leg that takes minutes.
+              echo "attempt $attempt failed — re-authenticating and retrying in 30s"
+              az acr login --name meshweaver || true
+              sleep 30
+            fi
+          done
+          echo "::error::portal-ai publish failed on all 3 attempts — read the LAST attempt's output above. A CONTAINER1001 blob-upload failure there means the registry connection died three times running, which is no longer a transient and wants investigating rather than another retry (#2810)."
+          exit 1
 
   migration-image:
     name: "Build + push migration image"

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-one-broken-pipe-no-longer-costs-a-whole-release.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-30-one-broken-pipe-no-longer-costs-a-whole-release.md
@@ -1,0 +1,41 @@
+---
+Name: One broken pipe no longer costs a whole release
+Category: Fix
+Description: A container layer upload that lost its connection mid-push failed the portal image, and because publication is all-or-nothing that meant no release at all — twice in two hours, with a successful publish in between. The push now retries, bounded, and still fails red if the connection dies three times.
+Icon: CloudArrowUp
+Order: -20260830
+---
+
+# One broken pipe no longer costs a whole release
+
+Publishing the platform is all-or-nothing on purpose: the promote step applies the real tags only
+once **every** image leg has succeeded, so an install can never pull a half-shipped set. The cost of
+that guarantee is that any single leg failing throws the whole release away.
+
+On 2026-08-30 that happened twice in two hours, and not because anything was wrong with the code.
+The `linux-arm64` image pushed cleanly; five minutes later the `linux-x64` leg's layer upload
+reported **"Broken pipe"**, retried once inside the SDK, and gave up:
+
+```
+CONTAINER1001: Failed to upload blob using PATCH https://…/v2/memex-portal-ai/blobs/uploads/…
+```
+
+A release published successfully *between* the two failures, so this was not credentials, not a
+quota, not a purge policy, and not the registry being unwell — just a connection that died partway
+through a large upload, twice, on a link that is otherwise fine.
+
+Meanwhile every self-updating install stayed on the previous image, because from the outside
+"nothing published" looks exactly the same whether the cause was a real defect or a dropped TCP
+connection.
+
+## What changed
+
+The portal image push now makes up to three attempts, re-authenticating with the registry between
+them — a token can expire during a multi-architecture push that takes minutes per leg.
+
+It is deliberately **not** a way to make failures go away. A compile error, a missing project or a
+rejected credential fails identically on all three attempts and the step still ends red, pointing
+at the last attempt's output. Only a connection that dies mid-upload gets a second chance, which is
+the one thing a retry is actually for. And if the connection dies three times in a row, the error
+says so in as many words — at that point it is no longer a transient and deserves investigating
+rather than another retry.


### PR DESCRIPTION
Delivery has been blocked for hours. **Across the last 20 CD runs there is not one non-skipped `Promote` job**, so every self-updating install is still on the previous image. There are two independent causes; this PR fixes the one nobody owns.

## The measurement

Run 33328213655 (target `84bf70b17`):

```
18:48:05  linux-arm64 pushed cleanly
18:52:58  [Registry] Encountered a HttpRequestException Unknown with message "Broken pipe".
          Pausing before retry.
18:53:07  CONTAINER1013 → CONTAINER1001: Failed to upload blob using
          PATCH https://meshweaver.azurecr.io/v2/memex-portal-ai/blobs/uploads/…
```

Same pair on run 33322756606 (target `8cbf69ac9`) at 16:49Z. **The SDK's own retry did not recover either.**

And `ci.6846` promoted successfully at **18:14Z — between the two failures.** So this is **intermittent**: not credentials, not quota, not a purge policy. The registry is Premium SKU and healthy throughout.

Publication is all-or-nothing by design — `promote` applies the real tags only once every leg succeeded, so an install can never pull a half-shipped set. The cost of that guarantee is that **one broken pipe on one architecture throws away the entire release.**

## The change

Up to three attempts on the portal-ai push, with an `az acr login` between them (a token can expire during a multi-arch push whose legs take minutes each).

🚨 **Not a skip-trapdoor**, and the distinction is the whole point:

- a compile error, a missing project or a rejected credential fails **identically on all three attempts** and the step ends **RED**, naming the last attempt's output;
- only a connection dying mid-upload gets a second chance;
- three consecutive failures emit an `::error::` saying it is no longer a transient and wants investigating rather than another retry, pointing at #2810.

It mirrors the idiom already in `node-repo-{compile-check,gate,publish-bake}.yml`, which carry the same *"Bounded retry, and deliberately NOT a skip-trapdoor"* comment for their registry logins — added after three ACR logins failed on 2026-08-28 with the registry healthy throughout.

## Verified

| | |
|---|---|
| YAML parses | `yaml.safe_load` |
| the failure path **exits 1** | **proved, not assumed** — the loop shape simulated with an always-failing command ends `::error::` + `exit 1` |
| no guard's parse broken | `MeshWeaver.Documentation.Test` **123/123**, which is every guard that reads this workflow: `ReleaseDeliveryChainGuard`, `MainRunsAreNeverCancelledGuard`, `PlatformBakeLaneGuard`, `PlatformReleaseNotifyGuard`, `WorkflowJobIfContextGuard` |

## The other blocker, so they are not conflated

A `CS0419` ambiguous cref in **MeshWeaver.Plugins** (`MeshStoreAccess.cs:72` and two more) — core CD builds the portal hosts from `plugins-repo`, and #2772's new `ObserveCompletion` overload made three bare `<see cref>`s ambiguous there. Fixed by MeshWeaver.Plugins#993.

**Different cause, different commits:** both ACR failures are on commits that **predate** the overload. If `Promote` is still skipped after both land, read *which* error the portal-ai job carries — `CS0419` means the cref fix did not take; `CONTAINER1001` means the connection died three times running and this is no longer transient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)