### PR TITLE
fix(#2819): a test wait must dominate the framework's own write bound

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/BoundsMustBeOrdered.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BoundsMustBeOrdered.md
@@ -1,0 +1,144 @@
+---
+Name: Bounds Must Be Ordered
+Description: "Two independently authored timeouts that share a number do not merely overlap — the shorter one silently suppresses the longer one's diagnosis, on every occurrence. The fix is not a bigger number but deriving the outer bound from the inner one."
+---
+
+# Bounds must be ordered, and derived — never authored twice
+
+Every wait in this system has a bound. Most of them were written as literals, independently, by
+people who could not see each other's numbers. That is fine right up to the moment two of those
+bounds sit on the *same* operation — because then the shorter one always fires first, and whatever
+the longer one was going to say is never said.
+
+This is not a tuning problem. **A bound placed just under another bound converts a diagnosable
+failure into an anonymous one**, and it does so silently, on every occurrence, forever.
+
+## The concrete case (#2819)
+
+A mesh write has a framework-side outer bound. `UpdateRemote` waits for the owner's commit verdict
+and, if none arrives, fails the write:
+
+| constant | value | why |
+|---|---|---|
+| `LatePatchResponseRegistry.LateResponseWatchBound` | 30 s | the registry stops honouring a late verdict here |
+| `LatePatchResponseRegistry.VerdictBoundGrace` | 1 s | **deliberate** slack so the caller's failure cannot race a verdict that is still admissible |
+| `LatePatchResponseRegistry.WriteVerdictBound` | **31 s** | the instant the caller is told `OwnerUnreachable` |
+
+The grace is the interesting part. Someone thought carefully about ordering *those two* bounds, and
+wrote a comment saying so: fire at the same instant and you race an admissible verdict, so add a
+second.
+
+Meanwhile, the test convention for waiting on anything was a hand-written `30.Seconds()` — about
+2,679 times across the fleet. Nobody chose it to relate to `LateResponseWatchBound`. It is the same
+number by coincidence.
+
+The consequence is exact and total: **a test awaiting a mesh write gives up one second before the
+framework produces its diagnosis.** Not sometimes — always. So every one of these failures reads
+
+```
+ObservableAssertionException : Expected the observable to emit a value within 30s,
+but it did not. The observable emitted nothing at all.
+```
+
+when the framework was one second away from saying
+
+```
+MeshNodeStreamException: MeshNode OwnerUnreachable —
+the owner produced no terminal for this patch (bound=31s)
+```
+
+The second message names a subsystem, a path and a contract breach. The first names nothing. The
+bound had been placed at precisely the value that destroys the most information.
+
+## Why this is worth a rule
+
+Note what did *not* go wrong:
+
+- Nobody set the bound carelessly. 30 s was a reasonable guess about convergence.
+- The framework's own two bounds *were* correctly ordered, with a comment explaining why.
+- The test bound and the framework bound were each defensible in isolation.
+
+The defect is **entirely relational**. It exists only in the pairing, and neither author could see
+the pair. That is why "be careful when choosing a timeout" cannot prevent it, and why a review
+cannot catch it: the two numbers live in different trees, and both look right.
+
+It also explains why this survived a fix. #2708 introduced `TestTimeouts` for #2700 and scaled the
+CI bound to 90 s, which incidentally cleared 31 s — so on CI the diagnosis started arriving. Locally
+the baseline stayed 30 s, so on the machine where a developer actually reads the failure, it still
+said nothing. **A partial fix that repairs the loud environment and leaves the quiet one is worse
+than none**, because it removes the pressure to look again.
+
+## The rule
+
+> 🚨 **When one bound wraps another, the outer one is DERIVED from the inner one, never authored
+> alongside it.**
+
+Concretely, in `TestTimeouts`:
+
+```csharp
+// The framework's own outer bound on a caller-visible write.
+private static TimeSpan FrameworkWriteBound => LatePatchResponseRegistry.WriteVerdictBound;
+
+// Derived, so the ordering holds by construction rather than by whoever writes the next test.
+private static TimeSpan LocalConvergence => FrameworkWriteBound + TimeSpan.FromSeconds(5);
+```
+
+Two properties matter, and both are load-bearing:
+
+1. **Derivation, not duplication.** The moment the framework bound moves, the test bound moves with
+   it. A literal that "currently satisfies" the ordering is a bug scheduled for the next time
+   somebody tunes the other end.
+2. **Additive slack, not a ratio.** What must be covered is the propagation of *one terminal* — the
+   framework produces its verdict and it has to reach the assertion. That cost is constant; it does
+   not scale with the bound. A multiplier buys the same few seconds while inflating every wedged
+   test's failure time.
+
+Make the framework bound `public` even if nothing outside needs to *use* it. **A bound nobody can
+see gets re-authored as a literal somewhere else** — and that is the whole mechanism above.
+
+## Guarding it
+
+The ordering is a property, so assert the property, under the inputs that could break it — at every
+scale factor, including the local `1.0`:
+
+```csharp
+[Theory]
+[InlineData(null)] [InlineData("1")] [InlineData("3")] [InlineData("10")]
+public void AConvergenceWaitDominatesTheFrameworkWriteBound(string? factor)
+{
+    using var _  = new EnvironmentVariable("GITHUB_ACTIONS", factor is null ? null : "true");
+    using var __ = new EnvironmentVariable("MW_TEST_TIMEOUT_FACTOR", factor);
+
+    Assert.True(TestTimeouts.Convergence > LatePatchResponseRegistry.WriteVerdictBound, "…");
+}
+```
+
+🚨 **Check the local factor.** A guard that only runs at CI scale passes on a codebase where the
+laptop still reports nothing — which is exactly the state #2708 left behind, green.
+
+And **prove it by mutation**: restore the old literal and confirm the guard goes red on the local
+and `1` cases and stays green on `3` and `10`. That asymmetry is itself the evidence — it shows the
+guard is measuring the ordering and not merely the size of the number.
+
+## Where else to look
+
+The same shape appears wherever a wait wraps a wait. When you write a bound, ask what *else* bounds
+the operation underneath it:
+
+- a test wait around a framework write bound (this page);
+- an xunit `[Fact(Timeout)]` around an internal convergence wait — `TestTimeouts` already derives
+  `TestMilliseconds` from `Convergence` for exactly this reason;
+- a CI step `timeout` around a test-runner bound — see
+  [Shard weight headroom](../ReadingCiSignals);
+- a caller's `.Timeout(...)` around `RequestTimeout` (60 s).
+
+In every case the question is the same, and it is not "is this long enough?" but **"if this fires
+first, whose explanation do I lose?"**
+
+## Related
+
+- [Guards and unknown states](../GuardsAndUnknownStates) — a guard whose stated reason is wrong can
+  still be load-bearing; a classifier with no "I cannot tell" bucket picks the nearest one.
+- [Writing tests](../WritingTests) — wait on the condition, never on a delay.
+- [Debugging message flow](../DebuggingMessageFlow) — read the duration first: seconds means a real
+  assertion failure, minutes with no assertion text means a hang.

--- a/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
+++ b/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
@@ -69,6 +69,34 @@ public sealed class LatePatchResponseRegistry
     /// </summary>
     public static readonly TimeSpan LateResponseWatchBound = TimeSpan.FromSeconds(30);
 
+    /// <summary>
+    /// 🚨 Slack added to <see cref="LateResponseWatchBound"/> before a caller's write is failed for
+    /// SILENCE. The registry stops honouring a verdict at exactly the watch bound; firing the
+    /// caller's bound at the same instant would race a verdict that is still admissible. One second
+    /// is enough to order the two, and it is not a retry, a backoff, or a knob to widen when
+    /// something times out — a write still unanswered here has outlived every owner-side terminal
+    /// path, so the answer is a fault, not a longer wait.
+    /// </summary>
+    public static readonly TimeSpan VerdictBoundGrace = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// 🚨 The outer bound on a caller-visible mesh WRITE: the instant <c>UpdateRemote</c> gives up
+    /// and reports <c>OwnerUnreachable</c>. Public because a bound nobody can see gets re-authored
+    /// as a literal somewhere else, and then the two numbers collide.
+    ///
+    /// <para>They did collide. The convention for a test wait was a hand-written <c>30 s</c> — the
+    /// same number as <see cref="LateResponseWatchBound"/>, and one second BELOW this. So a test
+    /// awaiting a write always lost the race to the framework's own diagnosis by design: the
+    /// assertion reported "the observable emitted nothing at all" one second before the write would
+    /// have said <c>OwnerUnreachable — the owner produced no terminal for this patch</c>. The
+    /// failure that carried the explanation was never the one anybody read (#2819).</para>
+    ///
+    /// <para>🚨 Anything waiting on a write must bound itself STRICTLY ABOVE this, so the
+    /// framework's terminal wins and names the cause. <c>TestTimeouts.Convergence</c> derives from
+    /// it rather than restating it.</para>
+    /// </summary>
+    public static TimeSpan WriteVerdictBound => LateResponseWatchBound + VerdictBoundGrace;
+
     private sealed record Entry(
         string Path,
         DateTimeOffset ExpiresAt,

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -111,12 +111,12 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     private static readonly TimeSpan UpdateResponseWaitBound = TimeSpan.FromSeconds(2);
 
     // 🚨 Slack added to LateResponseWatchBound before the caller's write is failed for SILENCE.
-    // The registry stops honouring a verdict at exactly LateResponseWatchBound; firing the
-    // caller's bound at the same instant would race a verdict that is still admissible. One
-    // second is enough to order the two, and it is not a retry, a backoff, or a knob to widen
-    // when something times out — a write still unanswered here has outlived every owner-side
-    // terminal path, so the answer is a fault, not a longer wait.
-    private static readonly TimeSpan VerdictBoundGrace = TimeSpan.FromSeconds(1);
+    // Now sourced from LatePatchResponseRegistry rather than restated here: this grace is what puts
+    // the caller's outer write bound at 31s, and a test that waits on a write must sit strictly
+    // ABOVE that to let the framework's OwnerUnreachable win the race and name the cause. A private
+    // copy was invisible to the test tree, which independently authored the SAME 30s as
+    // LateResponseWatchBound and so could never observe the verdict (#2819).
+    private static readonly TimeSpan VerdictBoundGrace = LatePatchResponseRegistry.VerdictBoundGrace;
 
     // 🚨 Retry budget for the provably-safe NACK cases — the ones where the owner STATED the
     // patch never applied: OwnerDisposing, OwnerNotReady, and Conflict. Each re-enqueue re-runs

--- a/test/MeshWeaver.Fixture/TestTimeouts.cs
+++ b/test/MeshWeaver.Fixture/TestTimeouts.cs
@@ -1,3 +1,5 @@
+using MeshWeaver.Mesh;
+
 namespace MeshWeaver.Fixture;
 
 /// <summary>
@@ -25,8 +27,33 @@ namespace MeshWeaver.Fixture;
 /// </summary>
 public static class TestTimeouts
 {
-    /// <summary>Local baseline for one convergence wait. Every other value is derived from it.</summary>
-    private static readonly TimeSpan LocalConvergence = TimeSpan.FromSeconds(30);
+    /// <summary>
+    /// 🚨 The framework's own outer bound on a caller-visible write — the instant
+    /// <c>UpdateRemote</c> gives up and reports <c>OwnerUnreachable</c>. A test wait must DOMINATE
+    /// it, never equal it.
+    ///
+    /// <para>The old baseline was a literal <c>30 s</c>, which is exactly
+    /// <c>LateResponseWatchBound</c> and one second below this. A test awaiting a mesh write
+    /// therefore gave up one second BEFORE the framework produced its diagnosis, every single time
+    /// — so the failure always read "the observable emitted nothing at all" and never
+    /// "OwnerUnreachable: the owner produced no terminal for this patch". The bound was placed at
+    /// precisely the value that destroys the most information (#2819).</para>
+    /// </summary>
+    private static TimeSpan FrameworkWriteBound => LatePatchResponseRegistry.WriteVerdictBound;
+
+    /// <summary>
+    /// Local baseline for one convergence wait. Every other value is derived from it — and it is
+    /// itself derived from <see cref="FrameworkWriteBound"/> rather than written as a literal, so
+    /// the ordering holds by construction instead of by whoever writes the next test remembering
+    /// it.
+    ///
+    /// <para>The slack is ADDITIVE, not a ratio: what has to be covered is the propagation of one
+    /// terminal — the framework produces <c>OwnerUnreachable</c> at the write bound and it has to
+    /// reach the assertion — and that cost does not scale with the bound. Five seconds is ample
+    /// for it and keeps the local wait near the familiar half-minute; a multiplier would inflate
+    /// every wedged test's failure time to buy the same few seconds.</para>
+    /// </summary>
+    private static TimeSpan LocalConvergence => FrameworkWriteBound + TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// How much slower CI is assumed to be. Overridable with <c>MW_TEST_TIMEOUT_FACTOR</c> so the

--- a/test/MeshWeaver.Graph.Test/TestTimeoutsTest.cs
+++ b/test/MeshWeaver.Graph.Test/TestTimeoutsTest.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS1591
 
 using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -34,6 +35,41 @@ public class TestTimeoutsTest
             $"the [Fact(Timeout)] value ({TestTimeouts.TestMilliseconds} ms) must exceed the "
             + $"convergence wait ({TestTimeouts.Convergence.TotalMilliseconds} ms), or an inner "
             + "wait can never lose first and the failure cannot say what it was waiting for.");
+    }
+
+    /// <summary>
+    /// 🚨 THE SECOND INVARIANT, and the one that was violated for as long as the bound was a
+    /// literal: a test wait must DOMINATE the framework's own outer write bound.
+    ///
+    /// <para><c>UpdateRemote</c> fails a silent write at
+    /// <c>LateResponseWatchBound + VerdictBoundGrace</c> = 31 s, and the grace exists precisely so
+    /// the framework's terminal arrives AFTER the registry stops honouring a verdict. The test
+    /// convention was a hand-written 30 s — the same number as <c>LateResponseWatchBound</c>, one
+    /// second below the terminal. So a test awaiting a write gave up before the framework could
+    /// answer, every time, and the failure read "the observable emitted nothing at all" instead of
+    /// naming <c>OwnerUnreachable</c>. The bound sat at exactly the value that destroys the most
+    /// information (#2819).</para>
+    ///
+    /// <para>Checked at every factor, including the local 1.0: a rule that holds only on CI leaves
+    /// the laptop — where the diagnosis is actually read — reporting nothing.</para>
+    /// </summary>
+    [Theory]
+    [InlineData(null)]      // local
+    [InlineData("1")]
+    [InlineData("3")]
+    [InlineData("10")]
+    public void AConvergenceWaitDominatesTheFrameworkWriteBound(string? factor)
+    {
+        using var _ = new EnvironmentVariable("GITHUB_ACTIONS", factor is null ? null : "true");
+        using var __ = new EnvironmentVariable("MW_TEST_TIMEOUT_FACTOR", factor);
+
+        Assert.True(
+            TestTimeouts.Convergence > LatePatchResponseRegistry.WriteVerdictBound,
+            $"a convergence wait ({TestTimeouts.Convergence.TotalSeconds:0.##}s) must exceed the "
+            + $"framework's write verdict bound "
+            + $"({LatePatchResponseRegistry.WriteVerdictBound.TotalSeconds:0.##}s), or a test "
+            + "awaiting a mesh write gives up before UpdateRemote can report OwnerUnreachable and "
+            + "the failure can never say why.");
     }
 
     /// <summary>The ordering of the three convergence scales holds wherever it runs.</summary>

--- a/test/MeshWeaver.Persistence.Test/FileSystemObservableQueryTests.cs
+++ b/test/MeshWeaver.Persistence.Test/FileSystemObservableQueryTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reactive.Linq;
 using System.Threading.Tasks;
+using MeshWeaver.Fixture;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Hosting.Persistence.Query;
@@ -37,16 +38,19 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
     /// accumulator <paramref name="changes"/> has at least
     /// <paramref name="expectedMinCount"/> items, or the timeout elapses (a
     /// failed assertion). Keeps the test bodies <c>void</c> and await-free per
-    /// the reactive assertion model. The 30 s default absorbs CI contention; the
-    /// per-method xUnit <c>methodTimeout</c> (60 s) is the upper bound either way.
+    /// the reactive assertion model. The bound comes from
+    /// <see cref="TestTimeouts.Convergence"/> — never a literal: the old hand-written 30 s was
+    /// exactly the framework's own <c>LateResponseWatchBound</c> and one second below the
+    /// <c>UpdateRemote</c> terminal, so a write that ran long failed here as "emitted nothing at
+    /// all" one second before the framework would have named <c>OwnerUnreachable</c> (#2819).
     /// </summary>
     private static async Task WaitForChanges<T>(
         IReadOnlyCollection<T> changes,
         int expectedMinCount,
-        int timeoutMs = 30_000)
+        TimeSpan? timeout = null)
         => await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
             .Where(_ => changes.Count >= expectedMinCount)
-            .Should().Within(TimeSpan.FromMilliseconds(timeoutMs)).Emit(
+            .Should().Within(timeout ?? TestTimeouts.Convergence).Emit(
                 $"expected at least {expectedMinCount} change(s) on the accumulator");
 
     #region Create Tests
@@ -68,7 +72,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         {
             Name = "Project 1",
             NodeType = "Markdown"
-        }).Should().Within(30.Seconds()).Emit();
+        }).Should().Within(TestTimeouts.Convergence).Emit();
 
         await WaitForChanges(receivedChanges, 2);
 
@@ -90,9 +94,9 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
 
         await WaitForChanges(receivedChanges, 1); // Initial
 
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project3")) with { Name = "Project 3", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project3")) with { Name = "Project 3", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
 
         // Wait until 3 Added items have been observed (possibly batched into
         // a single Added emission). Polling the inner item-count via
@@ -118,8 +122,8 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
     [Fact]
     public async Task ObserveQuery_Read_EmitsInitialResults()
     {
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
 
         var receivedChanges = new ChangeAccumulator<QueryResultChange<MeshNode>>();
         var subscription = MeshQuery
@@ -147,7 +151,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         {
             Name = "Project 1",
             NodeType = "Markdown"
-        }).Should().Within(30.Seconds()).Emit();
+        }).Should().Within(TestTimeouts.Convergence).Emit();
 
         var receivedChanges = new ChangeAccumulator<QueryResultChange<MeshNode>>();
         var subscription = MeshQuery
@@ -162,7 +166,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         {
             Name = "Updated Project 1",
             NodeType = "Markdown"
-        }).Should().Within(30.Seconds()).Emit();
+        }).Should().Within(TestTimeouts.Convergence).Emit();
 
         await WaitForChanges(receivedChanges, 2);
 
@@ -181,8 +185,8 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
     [Fact]
     public async Task ObserveQuery_Delete_EmitsRemovedNotification()
     {
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
 
         var receivedChanges = new ChangeAccumulator<QueryResultChange<MeshNode>>();
         var subscription = MeshQuery
@@ -193,7 +197,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         receivedChanges.Should().HaveCount(1);
         receivedChanges[0].Items.Should().HaveCount(2);
 
-        await NodeFactory.DeleteNode(NodePath("Project1")).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.DeleteNode(NodePath("Project1")).Should().Within(TestTimeouts.Convergence).Emit();
 
         await WaitForChanges(receivedChanges, 2);
 
@@ -222,14 +226,14 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         receivedChanges[0].ChangeType.Should().Be(QueryChangeType.Initial);
 
         // CREATE
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
         await WaitForChanges(receivedChanges, 2);
 
         var addedChange = receivedChanges.Last(c => c.ChangeType == QueryChangeType.Added);
         addedChange.Items[0].Name.Should().Be("Project 1");
 
         // UPDATE
-        await NodeFactory.UpdateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Updated Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.UpdateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Updated Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
         await WaitForChanges(receivedChanges, 3);
 
         var updatedChange = receivedChanges.Last(c => c.ChangeType == QueryChangeType.Updated);
@@ -239,7 +243,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         // Under CI load the delete propagation can take longer than the 3s
         // WaitForChanges budget, so the silent-timeout path leaves the test
         // with no Removed in receivedChanges and the .Last() below throws.
-        await NodeFactory.DeleteNode(NodePath("Project1")).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.DeleteNode(NodePath("Project1")).Should().Within(TestTimeouts.Convergence).Emit();
         await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
             .Where(_ => receivedChanges.Any(c => c.ChangeType == QueryChangeType.Removed))
             .Should().Within(10.Seconds()).Emit();
@@ -267,7 +271,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         await WaitForChanges(changes1, 1);
         await WaitForChanges(changes2, 1);
 
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
         await WaitForChanges(changes1, 2);
         await WaitForChanges(changes2, 2);
 
@@ -288,7 +292,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
     public async Task ObserveQuery_ScopeExact_OnlyNotifiesExactPath()
     {
         var orgPath = NodePath("TestOrg");
-        await NodeFactory.CreateNode(MeshNode.FromPath(orgPath) with { Name = "TestOrg", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(orgPath) with { Name = "TestOrg", NodeType = "Group" }).Should().Within(TestTimeouts.Convergence).Emit();
 
         var receivedChanges = new ChangeAccumulator<QueryResultChange<MeshNode>>();
         var subscription = MeshQuery
@@ -298,14 +302,14 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         await WaitForChanges(receivedChanges, 1);
         receivedChanges.Should().HaveCount(1);
 
-        await NodeFactory.UpdateNode(MeshNode.FromPath(orgPath) with { Name = "TestOrg Updated", NodeType = "Group" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.UpdateNode(MeshNode.FromPath(orgPath) with { Name = "TestOrg Updated", NodeType = "Group" }).Should().Within(TestTimeouts.Convergence).Emit();
         await WaitForChanges(receivedChanges, 2);
 
         receivedChanges.Should().HaveCount(2);
         receivedChanges[1].ChangeType.Should().Be(QueryChangeType.Updated);
 
         // Create a child — should NOT trigger for exact-path query
-        await NodeFactory.CreateNode(MeshNode.FromPath($"{orgPath}/Project1") with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath($"{orgPath}/Project1") with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
         // Negative assertion ("no new emission") — a third change must NOT land
         // within a small barrier. The polling observable fires only if a 3rd
         // change is accumulated; NotEmit asserts it never does (300 ms barrier,
@@ -323,7 +327,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
     public async Task ObserveQuery_ScopeChildren_OnlyNotifiesDirectChildren()
     {
         var proj1 = NodePath("Project1");
-        await NodeFactory.CreateNode(MeshNode.FromPath(proj1) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(proj1) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
 
         var receivedChanges = new ChangeAccumulator<QueryResultChange<MeshNode>>();
         var subscription = MeshQuery
@@ -333,13 +337,13 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
         await WaitForChanges(receivedChanges, 1);
         receivedChanges.Should().HaveCount(1);
 
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
         await WaitForChanges(receivedChanges, 2);
 
         receivedChanges.Should().HaveCount(2);
 
         // Create a grandchild — should NOT trigger for namespace query
-        await NodeFactory.CreateNode(MeshNode.FromPath($"{proj1}/Task1") with { Name = "Task 1", NodeType = "Code" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath($"{proj1}/Task1") with { Name = "Task 1", NodeType = "Code" }).Should().Within(TestTimeouts.Convergence).Emit();
         // Negative assertion — a third change must NOT land within a small barrier.
         await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
             .Where(_ => receivedChanges.Count >= 3)
@@ -364,13 +368,13 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
 
         await WaitForChanges(receivedChanges, 1);
 
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
         await WaitForChanges(receivedChanges, 2);
 
         receivedChanges.Should().HaveCount(2);
 
         // Create a non-matching node (different NodeType)
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Task1")) with { Name = "Task 1", NodeType = "Code" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Task1")) with { Name = "Task 1", NodeType = "Code" }).Should().Within(TestTimeouts.Convergence).Emit();
         // Negative assertion — a third change must NOT land within a small barrier.
         await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
             .Where(_ => receivedChanges.Count >= 3)
@@ -434,10 +438,10 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
 
         await WaitForChanges(receivedChanges, 1);
 
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
         await WaitForChanges(receivedChanges, 2);
 
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
         await WaitForChanges(receivedChanges, 3);
 
         receivedChanges.Should().HaveCountGreaterThanOrEqualTo(2);
@@ -454,7 +458,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
     [Fact]
     public async Task ObserveQuery_DisposalStopsNotifications()
     {
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project1")) with { Name = "Project 1", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
 
         var receivedChanges = new ChangeAccumulator<QueryResultChange<MeshNode>>();
         var subscription = MeshQuery
@@ -466,7 +470,7 @@ public class FileSystemObservableQueryTests(ITestOutputHelper output) : Monolith
 
         subscription.Dispose();
 
-        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(30.Seconds()).Emit();
+        await NodeFactory.CreateNode(MeshNode.FromPath(NodePath("Project2")) with { Name = "Project 2", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
         // Negative assertion — disposed subscription should NOT receive any
         // more emissions. Small barrier to surface a regression if Dispose
         // accidentally leaks the subscription.


### PR DESCRIPTION
`FileSystemObservableQueryTests.ObserveQuery_ScopeExact_OnlyNotifiesExactPath` ejected #2814 from the merge queue. The issue's *Shape* section guessed at the file-watcher or the exact-scope filter. Neither: **line 301 is the `UpdateNode` write**, not the observation, and the quoted error carries no `because` clause — which `WaitForChanges` always supplies. The write is what timed out.

## The defect is relational, and total

A mesh write's outer bound:

| constant | value |
|---|---|
| `LateResponseWatchBound` | 30 s — the registry stops honouring a late verdict |
| `VerdictBoundGrace` | 1 s — **deliberate**, so the caller's failure cannot race an admissible verdict |
| **caller's terminal** | **31 s** → `OwnerUnreachable` |

The grace is the tell: someone thought about ordering *those two* and wrote a comment explaining it.

The test convention was a hand-written `30.Seconds()` — the same number as `LateResponseWatchBound` **by coincidence**, one second below the terminal. So a test awaiting a write gives up before the framework can answer. Not sometimes — **always**. Every such failure reads

```
Expected the observable to emit a value within 30s … emitted nothing at all.
```

one second before the framework would have said `OwnerUnreachable — the owner produced no terminal for this patch`. **The bound sat at precisely the value that destroys the most information.**

Nothing here was careless: 30 s is a reasonable convergence guess, the framework's own two bounds *are* correctly ordered, and each number is defensible alone. The defect exists only in the pairing, and neither author could see the pair — which is why review cannot catch it.

## Why it survived its own fix

#2708 (for #2700) introduced `TestTimeouts` and scaled CI to 90 s, incidentally clearing 31 s. So **CI started reporting the cause and the laptop never did** — a partial fix that repairs the loud environment and leaves the quiet one, which removes the pressure to look again.

🚨 And `TestTimeouts` had **zero adopters**. The only references were its own test. #2708 landed the mechanism; nothing consumed it, so all ~2,679 literals are still literals and #2700 is not fixed. This PR is its first real adopter.

## The change

- `LatePatchResponseRegistry` exposes `VerdictBoundGrace` and `WriteVerdictBound`; `MeshNodeStreamExtensions` consumes them rather than keeping a private copy the test tree could not see. **A bound nobody can see gets re-authored as a literal somewhere else** — that is the entire mechanism.
- `TestTimeouts` **derives** `LocalConvergence` from `WriteVerdictBound + 5 s`. Additive, not a ratio: what must be covered is one terminal propagating to the assertion, and that cost does not scale with the bound — a multiplier buys the same few seconds while inflating every wedged test's failure time.
- `FileSystemObservableQueryTests` drops its 27 literals.
- `Architecture/BoundsMustBeOrdered` records the rule.

## The guard, and its mutation proof

Asserted at every factor **including local `1.0`** — a guard that only runs at CI scale passes on a codebase where the laptop still reports nothing, which is exactly the green state #2708 left.

Restoring the old literal:

```
Failed … AConvergenceWaitDominatesTheFrameworkWriteBound(factor: null)
Failed … AConvergenceWaitDominatesTheFrameworkWriteBound(factor: "1")
   a convergence wait (30s) must exceed the framework's write verdict bound (31s) …
   Failed: 2, Passed: 12
```

Red on local and `"1"`, green on `"3"` and `"10"`. **That asymmetry is the evidence** — it shows the guard measures the ordering, not the size of the number, and it independently confirms the CI-only-repair diagnosis above.

## Verification

- `MeshWeaver.Persistence.Test` **1106/1106 green** (44 s) — the whole project, not a filter: this changes a shared bound, and a filter excludes the population that would prove it.
- Release `-warnaserror` clean: `Mesh.Contract`, `Fixture`, `Graph.Test`, `Persistence.Test`, `Documentation.Test`.

Fixes #2819