### PR TITLE
feat(cli): memex build plugin <path> --image <image> — a plugin repo's CI in three lines

### DIFF
--- a/src/MeshWeaver.Cli/BuildPluginCommand.cs
+++ b/src/MeshWeaver.Cli/BuildPluginCommand.cs
@@ -1,0 +1,184 @@
+using System.Diagnostics;
+
+namespace MeshWeaver.Cli;
+
+/// <summary>
+/// <c>memex build plugin &lt;path&gt; --image &lt;image&gt;</c> — the whole CI contract for building a
+/// plugin, in one verb (<c>Doc/Architecture/InMeshBuildAndTest</c>).
+///
+/// <para>A plugin repo's CI job becomes three lines: check out, install this tool, run this. The
+/// tool pulls the image, pins it by DIGEST, and runs the platform's own builder and tester inside
+/// it — so nothing in the job knows about docker, mounts, seeds, allow-files or registries.</para>
+///
+/// <para><b>Two stages, and the split is deliberate (#1763).</b> The same tool produces and
+/// consumes: <c>compile … --output /bake</c> emits one bundle per package plus the bake identity,
+/// then the gate runs with <c>--seed /bake</c> and stands a mesh up on <b>those bytes</b>. Testing
+/// the baked bytes is a strictly stronger claim than a fused pass, because the bytes judged are the
+/// bytes that ship.</para>
+/// </summary>
+public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
+{
+    /// <summary>Attempts for a registry PULL — see <see cref="PullImage"/>.</summary>
+    private const int PullAttempts = 3;
+
+    /// <summary>
+    /// The file the compile stage writes to record which framework the bundles were built against.
+    /// Its presence is the POSITIVE signal that a bake actually happened: a compile that emitted no
+    /// bundles still exits 0, so "the command returned" proves nothing.
+    /// </summary>
+    private const string BakeIdentityFile = "framework-mvid.txt";
+
+    public async Task<int> RunAsync(BuildPluginOptions options, CancellationToken ct)
+    {
+        var repo = Path.GetFullPath(options.PluginPath);
+        if (!Directory.Exists(repo))
+        {
+            await error.WriteLineAsync($"error: plugin path '{repo}' does not exist.");
+            return 2;
+        }
+
+        // Pin by DIGEST once, and use it for both stages. The workflow this replaces already did
+        // this (`${IMAGE%%:*}@${DIGEST}`) for a reason: a tag can move between the compile and the
+        // gate, and then the bytes tested are not the bytes baked — which is the one claim the
+        // two-stage split exists to make.
+        var pinned = await PullImage(options.Image, ct);
+        if (pinned is null) return 4;
+        await output.WriteLineAsync($"image: {pinned}");
+
+        var bake = options.BakeOutput is { Length: > 0 }
+            ? Path.GetFullPath(options.BakeOutput)
+            : Path.Combine(Path.GetTempPath(), $"memex-bake-{Environment.ProcessId}");
+        Directory.CreateDirectory(bake);
+
+        // ── stage 1: PRODUCE ───────────────────────────────────────────────────────────────────
+        var compile = await RunInImage(pinned, repo, options,
+            mounts: [$"{bake}:/bake"],
+            env: [],
+            args: ["compile", "/repo", ..AllowArgs(repo, options), ..options.ExtraArgs,
+                   "--output", "/bake", ..SourceShaArgs(options)],
+            ct);
+        if (compile != 0) return compile;
+
+        var identity = Path.Combine(bake, BakeIdentityFile);
+        if (!File.Exists(identity) || new FileInfo(identity).Length == 0)
+        {
+            await error.WriteLineAsync(
+                $"error: compile ran but wrote no bake identity ({BakeIdentityFile} missing or empty) "
+                + "— the bake stage regressed. Refusing to test bytes that were never produced.");
+            return 5;
+        }
+
+        // ── stage 2: CONSUME — stand a mesh up on the bytes stage 1 produced ───────────────────
+        return await RunInImage(pinned, repo, options,
+            mounts: [$"{bake}:/seed:ro"],
+            env: ["MW_INSTALL_DIFF=1"],
+            args: ["/repo", ..AllowArgs(repo, options), ..options.ExtraArgs, "--seed", "/seed"],
+            ct);
+    }
+
+    private static IEnumerable<string> AllowArgs(string repo, BuildPluginOptions o)
+    {
+        var allow = o.AllowFile is { Length: > 0 } ? o.AllowFile : "plugin-gate.allow";
+        return File.Exists(Path.Combine(repo, allow)) ? ["--allow", $"/repo/{allow}"] : [];
+    }
+
+    private static IEnumerable<string> SourceShaArgs(BuildPluginOptions o) =>
+        o.SourceSha is { Length: > 0 } sha ? ["--source-sha", sha] : [];
+
+    /// <summary>
+    /// Pull the image and resolve it to a digest.
+    ///
+    /// <para>🚨 Bounded retry, and deliberately NOT a skip-trapdoor: after the last attempt this
+    /// returns null and the command fails RED. It exists because a registry pull is the one step
+    /// here that fails for reasons that have nothing to do with the change under test — on
+    /// 2026-08-30 core CD lost a whole release to `Connection refused` on one pull, and the same
+    /// class of fault had already put a bounded retry into three node-repo workflows.</para>
+    /// </summary>
+    private async Task<string?> PullImage(string image, CancellationToken ct)
+    {
+        for (var attempt = 1; attempt <= PullAttempts; attempt++)
+        {
+            if (await Exec("docker", ["pull", image], ct) == 0)
+            {
+                var digest = await Capture("docker",
+                    ["image", "inspect", image, "--format", "{{index .RepoDigests 0}}"], ct);
+                // No digest is not a failure to retry: a locally-built image legitimately has none,
+                // and pinning is then simply not available. Say so rather than inventing one.
+                if (string.IsNullOrWhiteSpace(digest))
+                {
+                    await output.WriteLineAsync(
+                        $"note: '{image}' has no repo digest (local image?) — using the tag as given, "
+                        + "so the two stages are pinned only as well as the tag is.");
+                    return image;
+                }
+                return digest.Trim();
+            }
+            if (attempt < PullAttempts)
+            {
+                await error.WriteLineAsync(
+                    $"pull attempt {attempt} of {PullAttempts} failed for '{image}' — retrying in 10s");
+                await Task.Delay(TimeSpan.FromSeconds(10), ct);
+            }
+        }
+        await error.WriteLineAsync(
+            $"error: could not pull '{image}' in {PullAttempts} attempts. Three consecutive failures "
+            + "is no longer a transient — check the registry and the credentials rather than retrying.");
+        return null;
+    }
+
+    private Task<int> RunInImage(
+        string image, string repo, BuildPluginOptions o,
+        IEnumerable<string> mounts, IEnumerable<string> env, IEnumerable<string> args,
+        CancellationToken ct)
+    {
+        var docker = new List<string> { "run", "--rm", "-v", $"{repo}:/repo" };
+        foreach (var m in mounts) { docker.Add("-v"); docker.Add(m); }
+        if (o.ExternalModulesDir is { Length: > 0 } ext)
+        { docker.Add("-v"); docker.Add($"{Path.GetFullPath(ext)}:/ext"); }
+        foreach (var e in env) { docker.Add("-e"); docker.Add(e); }
+        docker.Add("--entrypoint"); docker.Add("/app/mw-plugin-test");
+        docker.Add(image);
+        docker.AddRange(args);
+        return Exec("docker", docker, ct);
+    }
+
+    private async Task<int> Exec(string file, IEnumerable<string> args, CancellationToken ct)
+    {
+        var psi = new ProcessStartInfo(file) { UseShellExecute = false };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        await output.WriteLineAsync($"$ {file} {string.Join(' ', psi.ArgumentList)}");
+        using var p = Process.Start(psi);
+        if (p is null)
+        {
+            await error.WriteLineAsync($"error: could not start '{file}' — is Docker installed and on PATH?");
+            return 127;
+        }
+        await p.WaitForExitAsync(ct);
+        return p.ExitCode;
+    }
+
+    private static async Task<string> Capture(string file, IEnumerable<string> args, CancellationToken ct)
+    {
+        var psi = new ProcessStartInfo(file)
+        { UseShellExecute = false, RedirectStandardOutput = true, RedirectStandardError = true };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        using var p = Process.Start(psi);
+        if (p is null) return string.Empty;
+        var stdout = await p.StandardOutput.ReadToEndAsync(ct);
+        await p.WaitForExitAsync(ct);
+        return p.ExitCode == 0 ? stdout : string.Empty;
+    }
+}
+
+/// <summary>Arguments for <see cref="BuildPluginCommand"/>. A record so a caller cannot half-set it.</summary>
+public sealed record BuildPluginOptions(
+    string PluginPath,
+    string Image,
+    string? BakeOutput = null,
+    string? ExternalModulesDir = null,
+    string? SourceSha = null,
+    string? AllowFile = null,
+    IReadOnlyList<string>? Extra = null)
+{
+    public IReadOnlyList<string> ExtraArgs => Extra ?? [];
+}

--- a/src/MeshWeaver.Cli/Program.cs
+++ b/src/MeshWeaver.Cli/Program.cs
@@ -273,4 +273,40 @@ static string? PromptForToken()
     return sb.ToString().Trim();
 }
 
+// --- build ------------------------------------------------------------------
+// 🚨 `build` does NOT talk to the portal REST API, so it does not use Run(client, …) above: it
+// pulls an image and runs the platform's builder inside it. See Doc/Architecture/InMeshBuildAndTest.
+{
+    var build = new Command("build", "Build and test artefacts inside a MeshWeaver image.");
+
+    var pathArg = new Argument<string>("path")
+    { Description = "Path to the plugin repo (the directory mounted as /repo)." };
+    var imageOpt = new Option<string>("--image")
+    { Description = "Image to build against, e.g. meshweaver.azurecr.io/mw-plugin-test:<tag>. Pulled and pinned by digest.", Required = true };
+    var bakeOpt = new Option<string?>("--bake-output")
+    { Description = "Directory for the bake (bundles + framework-mvid.txt). Default: a temp dir." };
+    var extOpt = new Option<string?>("--external-modules")
+    { Description = "Directory of external module DLLs to mount at /ext." };
+    var shaOpt = new Option<string?>("--source-sha")
+    { Description = "Commit stamped into the bake, so a bundle records the source it came from." };
+    var allowOpt = new Option<string?>("--allow")
+    { Description = "Allow-file relative to the plugin path (default: plugin-gate.allow, used only if present)." };
+
+    var plugin = new Command("plugin", "Build a plugin: bake its packages, then test the BAKED bytes.")
+    { pathArg, imageOpt, bakeOpt, extOpt, shaOpt, allowOpt };
+
+    plugin.SetAction((result, ct) => new BuildPluginCommand(Console.Out, Console.Error).RunAsync(
+        new BuildPluginOptions(
+            result.GetValue(pathArg)!,
+            result.GetValue(imageOpt)!,
+            result.GetValue(bakeOpt),
+            result.GetValue(extOpt),
+            result.GetValue(shaOpt),
+            result.GetValue(allowOpt)),
+        ct));
+
+    build.Subcommands.Add(plugin);
+    root.Subcommands.Add(build);
+}
+
 return await root.Parse(args).InvokeAsync();

--- a/src/MeshWeaver.Cli/README.md
+++ b/src/MeshWeaver.Cli/README.md
@@ -18,6 +18,52 @@ memex login mw_yourtoken --base-url https://memex.meshweaver.cloud
 
 The token and base URL are stored in `~/.memex/config.json`; `$MEMEX_TOKEN` / `$MEMEX_BASE_URL` or `--token` / `--base-url` override per call.
 
+## Building a plugin (`memex build plugin`)
+
+The whole CI contract for a plugin repo, in three lines:
+
+```yaml
+- uses: actions/checkout@v7
+- run: dotnet tool install -g MeshWeaver.Cli
+- run: memex build plugin . --image meshweaver.azurecr.io/mw-plugin-test:<tag>
+```
+
+The tool pulls the image, **pins it by digest**, and runs the platform's own builder and tester
+inside it. Nothing in the job needs to know about docker, mounts, seeds or allow-files.
+
+It runs the two stages the plugin build contract defines, in order:
+
+1. **produce** — `compile /repo … --output /bake`, then assert the bake identity
+   (`framework-mvid.txt`) is non-empty. A compile that emitted no bundles still exits 0, so
+   "the command returned" is not evidence.
+2. **consume** — the gate with `--seed /bake`, standing a mesh up on **those bytes**. Testing the
+   baked bytes is a stronger claim than a fused pass: the bytes judged are the bytes that ship.
+
+| option | meaning |
+|---|---|
+| `--image` *(required)* | image to build against; pulled and pinned by digest |
+| `--bake-output <dir>` | where the bundles land (default: a temp dir) |
+| `--external-modules <dir>` | module DLLs to mount at `/ext` |
+| `--source-sha <sha>` | commit stamped into the bake |
+| `--allow <file>` | allow-file relative to the plugin path (default `plugin-gate.allow`, used only if present) |
+
+The image is an **argument, not an ambient**: which image a plugin is built against decides the
+result, so it belongs where a reader can see it. A gate that resolves its framework from an
+environment variable while advertising a branch name will eventually report a missing type against
+the wrong repository — which is exactly what happened on 2026-08-30.
+
+### Before the package is published
+
+The verb ships in `MeshWeaver.Cli`, so `dotnet tool install -g MeshWeaver.Cli` needs a release that
+contains it. From a platform checkout it runs directly:
+
+```bash
+dotnet run --project src/MeshWeaver.Cli -c Release -- \
+  build plugin ../MeshWeaver.Plugins --image meshweaver.azurecr.io/mw-plugin-test:<tag>
+```
+
+Same behaviour, no install — useful for trying it on a repo before the tool version is out.
+
 ## Commands
 
 | Command | Purpose |


### PR DESCRIPTION
Implements the CI shape from [In-Mesh Build and Test](/Doc/Architecture/InMeshBuildAndTest) (#2831):

```yaml
- uses: actions/checkout@v7
- run: dotnet tool install -g MeshWeaver.Cli
- run: memex build plugin . --image meshweaver.azurecr.io/mw-plugin-test:<tag>
```

A plugin repo's job stops being a program about MeshWeaver. What this replaces is ~20 lines of YAML **per repo**: `docker login`, digest resolution, two `docker run`s with `-v`/`-e`/`--entrypoint`, the allow-file path, the bake-identity assertion, and a `tee` into a log a python script then re-reads.

## What it does — the contract the workflow spells out today, in one verb

1. **Pulls the image and pins it by digest**, using that digest for *both* stages. A tag can move between the compile and the gate, and then the bytes tested are not the bytes baked — which is the one claim the two-stage split (#1763) exists to make.
2. **Stage 1 — produce:** `compile /repo --allow … --output /bake --source-sha …`, then asserts `framework-mvid.txt` is non-empty. **A compile that emitted no bundles still exits 0**, so "the command returned" is not evidence.
3. **Stage 2 — consume:** the gate with `--seed /bake` and `MW_INSTALL_DIFF=1`, standing a mesh up on **those bytes**.

🚨 **Bounded retry (3×) on the pull only, and deliberately not a skip-trapdoor** — after the last attempt it fails RED, saying three consecutive failures is no longer a transient. This is the fault that cost core CD a whole release today (`Connection refused` on one pull, #2810) and the same class that put a bounded retry into three `node-repo-*` workflows.

## Failure paths proven, not assumed

```
missing plugin path   exit=2    error: plugin path '/nope/not/here' does not exist.
missing --image       exit=1    Option '--image' is required.
docker absent         exit=127  legible message, not an unhandled exception
```

🚨 **And my first proof was invalid.** I piped the run through `head` and read **`head`'s** exit code — it reported `exit=0` for a failing command. Re-verified without the pipe. Recording it because it is the masked-exit trap this repo has paid for before, hit inside a test written specifically to prove a failure path.

## Scope — what this is not, stated rather than implied

The **affected-set closure** (`MeshWeaver.Plugins/scripts/affected-modules.py`) still decides *what* to build. This verb builds **what it is pointed at**. Folding the closure in behind the same verb — so the tool works out what changed and everything that depends on it, and builds each package exactly once — is the next slice, and it is the one that has to preserve the `--self-test` proving the computation **can say no**.

## Trying it before a tool version exists

The README documents the pre-release path, so the verb can be exercised on a real repo now:

```bash
dotnet run --project src/MeshWeaver.Cli -c Release -- \
  build plugin ../MeshWeaver.Plugins --image meshweaver.azurecr.io/mw-plugin-test:<tag>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)