### PR TITLE
release: PlatformVersion 3.0.0-rc8 → 3.0.0-rc9 (HOLD until #2832 lands)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -97,7 +97,7 @@
          it publishes are the ones the platform still builds. Do not "fill in" rc4 later: the
          version never shipped, and minting a tag for it now would publish that superseded
          content set for real. -->
-    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc8</PlatformVersion>
+    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0-rc9</PlatformVersion>
   </PropertyGroup>
   <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
        -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK's _PublishMultiArchContainers


### PR DESCRIPTION
🚨 **Do not merge before #2832.** An rc cut ahead of it would publish a tool without the verb it exists to deliver. I am holding this out of the merge queue until #2832 is on `main`.

## Why

`memex build plugin <path> --image <image>` (#2832) is the new CI contract for plugin repos:

```yaml
- uses: actions/checkout@v7
- run: dotnet tool install -g MeshWeaver.Cli
- run: memex build plugin . --image meshweaver.azurecr.io/mw-plugin-test:<tag>
```

That install line needs a published package containing the verb. `MeshWeaver.Cli` is `IsPackable`, `release-packages.yml` publishes on a `v*.*.*` tag, and `v3.0.0-rc9` matches that pattern — so cutting the line here and tagging the merge commit is what puts the tool in CI's hands.

## Verified, not assumed

- **The computed version is right.** `dotnet msbuild src/MeshWeaver.Cli -getProperty:Version -p:CIRun=true` → **`3.0.0-rc9.ci.35653`**. The `.ci.<n>` suffix still derives from the run number, so CI builds stay monotonic on the new line.
- **The `-rc` label is kept**, which `Directory.Build.props` explains is not cosmetic: pre-release identifiers compare ASCII-lexically and `"ci" < "preview1"`, so a bare `3.0.0` core would sort every CI build **below** the published `v3.0.0-preview1`, and the self-updater — which picks the newest version off the registry — would pin there and never roll forward.
- **Five test files mention `3.0.0-rc8`, and none of them pins `PlatformVersion`.** I opened each rather than trusting the grep count: `ReleaseFactTest` compares two identical literals (a determinism test); `FrameworkReleaseBroadcasterTest` feeds one in and asserts it back; `DockerImageGateArgsTest` is a const image string; `ViewerZoneTimestampTest` is a fixture value; `CdImageVersionsShareOneSourceGuard` is prose in a doc comment.

Previous line: rc3, rc5, rc6, rc7, rc8 — rc9 is next.

## Sequence

1. #2832 lands on `main`
2. this PR lands
3. tag `v3.0.0-rc9` on that merge commit → `release-packages.yml` publishes `MeshWeaver.Cli 3.0.0-rc9`
4. a plugin repo's CI becomes the three lines above

🤖 Generated with [Claude Code](https://claude.com/claude-code)