### PR TITLE
fix(#2463): a PARTIAL merge refusal is still a refusal — stop acking it Success

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1285,6 +1285,32 @@ public static class DataExtensions
                         return;
                     }
 
+                    // 🚨 A PARTIAL refusal is still a refusal (#2463). The check above only fires
+                    // when NOTHING landed; a patch where some fields applied and others were
+                    // refused fell through here and acked SUCCESS, so the caller believed its whole
+                    // write had landed and never re-applied the refused half. That is the #648
+                    // acked-write-loss in its partial form, and it is the harder one to see: the
+                    // node really did change, so every "did it commit?" check says yes.
+                    //
+                    // It has a name in the wild. RolePlay/Scenery compiled fine, the mesh phase
+                    // patched four compile-outcome fields, MergeGuard refused all four as
+                    // stale/reordered, another field in the same patch landed — so this path acked
+                    // Success, `IsDirty` never converged, and the gate read a status that was never
+                    // written and called it a compile failure. A false RED on the required check.
+                    //
+                    // AckOnce LATCHES, so nacking here and letting the commit proceed is
+                    // deliberate: the fields that were NOT in conflict are valid and keeping them
+                    // is right, while the caller re-reads and re-applies. The re-run re-diffs
+                    // against fresh state, so what already landed is a no-op and only the refused
+                    // fields are retried. Conflict is one of the provably-safe retried codes and
+                    // its budget is bounded, so this cannot spin.
+                    if (refusedKeys > 0)
+                        AckOnce(false, new MeshNodeError(
+                            MeshNodeErrorCode.Conflict, hubPath,
+                            $"cross-hub write PARTIALLY refused: {refusedKeys} field(s) changed on "
+                            + "the owner since the writer's base. What did not conflict was kept — "
+                            + "re-read and re-apply so the refused field(s) converge."));
+
                     // 🚨 The OWNER mints the new Version on apply.
                     // Per the owned-stream contract — SynchronizationStream
                     // ("ONLY the owning hub sets Version", line ~255) and
@@ -1635,6 +1661,33 @@ public static class DataExtensions
                             AckOnce(true);
                         return null;
                     }
+
+                    // 🚨 A PARTIAL refusal is still a refusal (#2463). The check above only fires
+                    // when NOTHING landed; a patch where some fields applied and others were
+                    // refused fell through here and acked SUCCESS, so the caller believed its whole
+                    // write had landed and never re-applied the refused half. That is the #648
+                    // acked-write-loss in its partial form, and it is the harder one to see: the
+                    // node really did change, so every "did it commit?" check says yes.
+                    //
+                    // It has a name in the wild. RolePlay/Scenery compiled fine, the mesh phase
+                    // patched four compile-outcome fields, MergeGuard refused all four as
+                    // stale/reordered, another field in the same patch landed — so this path acked
+                    // Success, `IsDirty` never converged, and the gate read a status that was never
+                    // written and called it a compile failure. A false RED on the required check.
+                    //
+                    // AckOnce LATCHES, so nacking here and letting the commit proceed is
+                    // deliberate: the fields that were NOT in conflict are valid and keeping them
+                    // is right, while the caller re-reads and re-applies. The re-run re-diffs
+                    // against fresh state, so what already landed is a no-op and only the refused
+                    // fields are retried. Conflict is one of the provably-safe retried codes and
+                    // its budget is bounded, so this cannot spin.
+                    if (refusedKeys > 0)
+                        AckOnce(false, new MeshNodeError(
+                            MeshNodeErrorCode.Conflict, hubPath,
+                            $"cross-hub write PARTIALLY refused: {refusedKeys} field(s) changed on "
+                            + "the owner since the writer's base. What did not conflict was kept — "
+                            + "re-read and re-apply so the refused field(s) converge."));
+
                     // The OWNER bumps the Version on apply (same rule as the deferred path).
                     // 🚨 Count from the PRE-MERGE node: the patch is client-supplied, and a
                     // `version` field in it has already been merged into currentNode — counting

--- a/test/MeshWeaver.Hosting.Monolith.Test/SupersededActivationPatchNackTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/SupersededActivationPatchNackTest.cs
@@ -114,6 +114,82 @@ public class SupersededActivationPatchNackTest(ITestOutputHelper output) : Monol
     }
 
     /// <summary>
+    /// #648 pin 3 — the PARTIAL refusal (#2463), and the one that hid the longest.
+    ///
+    /// <para>Pin 1 covers a patch where EVERY key is refused, which the no-change backstop
+    /// catches because the node is byte-identical afterwards. A patch that refuses SOME keys and
+    /// applies others slips past that check: the node really did change, so
+    /// <c>DeepEquals(preMerge, current)</c> is false and the owner acked SUCCESS while part of the
+    /// caller's write was on the floor.</para>
+    ///
+    /// <para>That is harder to see than pin 1, because every "did it commit?" question answers
+    /// yes. It is #2463: RolePlay/Scenery compiled fine, the mesh phase patched four
+    /// compile-outcome fields, MergeGuard refused all four as stale/reordered while another field
+    /// in the same patch landed — so the write was acked Success, <c>IsDirty</c> never converged,
+    /// and the gate read a status that had never been written and called it a compile failure. A
+    /// false RED on the required check, from a write that reported itself applied.</para>
+    ///
+    /// <para>Fail-without: <c>Success = true</c> and the refused field silently absent.
+    /// Pass-with: Conflict, AND the non-conflicting field is still kept — a partial refusal must
+    /// not throw away the half that was valid.</para>
+    /// </summary>
+    [Fact(Timeout = 55_000)]
+    public async Task PartiallyRefusedThreeWayMerge_IsNackedConflict_AndKeepsWhatDidNotConflict()
+    {
+        var id = $"partial-refuse-{Guid.NewGuid():N}";
+        var path = $"{TestPartition}/{id}";
+
+        await NodeFactory.CreateNode(new MeshNode(id, TestPartition)
+        {
+            Name = "created", NodeType = "Markdown", State = MeshNodeState.Active
+        }).Should().Within(30.Seconds()).Emit();
+        await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "created" });
+
+        // Advance ONLY Name through the owner, so the writer's base for Name is stale while its
+        // base for Description is still current. That asymmetry is the whole point.
+        var client = GetClient(c => c.AddData());
+        await client.GetWorkspace().GetMeshNodeStream(path)
+            .Update(n => n with { Name = "live-truth" })
+            .Should().Within(30.Seconds()).Emit();
+        await ReadNode(path).Should().Within(30.Seconds()).Match(n => n is { Name: "live-truth" });
+
+        var descriptionKey = JsonOptions.PropertyNamingPolicy?.ConvertName(nameof(MeshNode.Description))
+            ?? nameof(MeshNode.Description);
+        var owner = await ResolveOwner(path);
+        var patch = new PatchDataRequest(
+            new MeshNodeReference(),
+            new RawJson($"{{\"{NameKey}\":\"stale-mirror-write\",\"{descriptionKey}\":\"landed\"}}"))
+        {
+            // Base carries the PRE-advance Name (stale ⇒ refused) and the untouched Description
+            // (current ⇒ applies). One patch, two fates.
+            BaseValues = new RawJson($"{{\"{NameKey}\":\"created\"}}")
+        };
+
+        var response = await AwaitResponseAsync(patch, o => o.WithTarget(owner));
+        var patchResponse = response.Message;
+        Output.WriteLine(
+            $"[response] success={patchResponse.Success} code={patchResponse.NodeError?.Code} "
+            + $"error={patchResponse.Error}");
+
+        patchResponse.Success.Should().BeFalse(
+            "part of the caller's write was refused, so the write did not fully land — acking "
+            + "Success is the #648 acked-write-loss in its partial form, and the caller stops "
+            + "retrying a field that never converged (#2463's IsDirty that never settles)");
+        patchResponse.NodeError.Should().NotBeNull();
+        patchResponse.NodeError!.Code.Should().Be(MeshNodeErrorCode.Conflict,
+            "Conflict is the retried, provably-safe code: the caller re-reads and re-applies, and "
+            + "the half that already landed re-diffs to a no-op");
+
+        var final = await ReadNode(path).Should().Within(30.Seconds()).Emit();
+        final!.Name.Should().Be("live-truth",
+            "the refused key keeps the newer live value — that is the merge's verdict");
+        final.Description.Should().Be("landed",
+            "🚨 a partial refusal must NOT discard the half that did not conflict: those fields "
+            + "were written against a current base and are valid. Rolling them back would turn a "
+            + "reportable conflict into real data loss.");
+    }
+
+    /// <summary>
     /// #648 pin 2 — single-writer activation invariant. The patch is posted right after the
     /// owner's <c>Dispose()</c>: the DisposeRequest is queued ahead of it in the same inbox,
     /// so the handler sees a hub past Started. Fail-without: the quiescing activation merges


### PR DESCRIPTION
## The defect

`ApplyMeshNodeMerge` returns how many keys the owner's three-way merge refused. Both callers act on it only inside this branch:

```csharp
if (JsonNode.DeepEquals(preMergeNode, currentNode))   // ← only when NOTHING landed
{
    if (refusedKeys > 0) AckOnce(false, Conflict);
    else                 AckOnce(true);
    return;
}
```

A patch where **some** fields applied and others were refused never reaches it — the node changed, so `DeepEquals` is false — and falls straight through to the success path.

**So the caller is told its whole write landed when half of it is on the floor.** That is the #648 acked-write-loss in its partial form, and it is the harder one to see: the node really *did* change, so every "did it commit?" question answers yes. The existing pin covers only the all-refused case precisely *because* that one leaves the node byte-identical.

## It has a name in the wild

#2463, verbatim from the run: `RolePlay/Scenery` compiled fine (`ok … 4 source(s)`), the mesh phase patched four compile-outcome fields, `MergeGuard` refused all four as stale/reordered while another field in the same patch landed — so this path acked Success, `IsDirty` never converged, and the gate read a status that had **never been written** and called it a compile failure.

A false RED on the required check, produced by a write that reported itself applied.

## The fix, and the arguable part

NACK `Conflict` on **any** refusal, and **let the commit proceed**. `AckOnce` latches on `Interlocked.Exchange`, so the caller learns either way.

Letting the commit stand is deliberate: the fields that did not conflict were written against a *current* base and are valid. Rolling them back would convert a reportable conflict into **real data loss**. The caller re-reads and re-applies; what already landed re-diffs to a no-op, and `Conflict` is one of the three provably-safe retried codes with a bounded budget, so this cannot spin.

The test pins that half explicitly — `Description` must still read `"landed"` — so a future change cannot satisfy the guard by discarding the valid fields.

## Mutation-proven, both directions

With the fix reverted behind a runtime-false condition the compiler cannot fold (`&& Environment.TickCount < 0`), so `--no-build` cannot run stale binaries:

```
PartiallyRefusedThreeWayMerge_IsNackedConflict_AndKeepsWhatDidNotConflict [FAIL]
   Expected value to be false because part of the caller's write was refused …
   but found True
```

The owner really does ack `Success = true`. Restored: green.

## Verification

- `MeshWeaver.Hosting.Test` **269/269** (whole project — it owns `ConflictRetryPolicyTest`, the caller-side path this change routes more traffic into).
- Conflict-path suites `SupersededActivationPatchNack` + `StoreLevelWriteConflict` + `ActivityWriteSurvivesConflict`: **5/5**.
- Release `-warnaserror` clean.

## 🚨 No timing claim

A peer rightly asked for a cost measurement, having had two fixes refuted by wall-clock tonight. I am **not** offering one, because the honest answer is that it would measure noise: the change adds one integer comparison to the common path — `refusedKeys` is already computed, and the extra ack only fires when it is non-zero. There is no new work on any path that was previously fast. The structural argument is the cost argument here, and I would rather say that than dress up a contended single-sided run as evidence.

Fixes #2463