### PR TITLE
fix(#2833): the shutdown residual names WHICH leg is stuck, not just how many

### DIFF
--- a/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingGrain.cs
@@ -250,8 +250,9 @@ internal class RoutingGrain(
         {
             ReportSaturation(Interlocked.Increment(ref inFlightRoutes), addressPath);
             // Claimed at ENQUEUE like the in-flight slot — a leg queued behind another leg is work
-            // this silo has accepted and must let land before it stops (#2638).
-            var slot = quiescence?.Track();
+            // this silo has accepted and must let land before it stops (#2638). Labelled so the
+            // shutdown residual can NAME it if it never lands (#2833).
+            var slot = quiescence?.Track($"stream-routed → {addressPath} (delivery {delivery.Id})");
             orderedDispatcher.Enqueue(
                 addressPath,
                 BuildPodHubRoute(delivery, address, addressPath, streamProvider, grainFactory),
@@ -276,7 +277,7 @@ internal class RoutingGrain(
     private void Dispatch(IObservable<Unit> route, string addressPath, string deliveryId)
     {
         ReportSaturation(Interlocked.Increment(ref inFlightRoutes), addressPath);
-        var slot = quiescence?.Track();
+        var slot = quiescence?.Track($"dispatch → {addressPath} (delivery {deliveryId})");
         routingPool.SubscribeThroughPool(route)
             .Finally(() =>
             {
@@ -1073,7 +1074,8 @@ internal class RoutingGrain(
         // gauge the silo stop holds until it has been carried — over a transport that still exists.
         void SubscribeNack(IObservable<Unit> nack, string transport = "")
         {
-            var slot = quiescence?.Track();
+            var slot = quiescence?.Track(
+                $"NACK{(string.IsNullOrEmpty(transport) ? string.Empty : $" over {transport}")}");
             routingPool.SubscribeThroughPool(nack)
                 .Finally(() => slot?.Dispose())
                 .Subscribe(

--- a/src/MeshWeaver.Hosting.Orleans/RoutingQuiescence.cs
+++ b/src/MeshWeaver.Hosting.Orleans/RoutingQuiescence.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.Reactive;
 using System.Reactive.Concurrency;
@@ -51,6 +52,19 @@ public sealed class RoutingQuiescence : IDisposable
     private readonly IDisposable connection;
     private int disposed;
 
+    // 🚨 What is in flight, not just HOW MANY. The count alone made the shutdown residual
+    // undiagnosable: #2833 reports one leg outliving the budget and says so itself — "the message
+    // names no target, sender, or delivery id and carries no exception or stack", so the confidence
+    // was "high on the class of defect, low on the specific leg". A leg that cannot be named cannot
+    // be found, and this participant only runs at silo stop, so the occurrence is not reproducible
+    // on demand: whatever the log did not say is lost until the next shutdown.
+    //
+    // Instance state on a mesh-scoped singleton (never static), and a ConcurrentDictionary because
+    // legs enter and leave from many threads — the one sanctioned mutable collection, as an
+    // instance field.
+    private readonly ConcurrentDictionary<long, string> inFlightLabels = new();
+    private long ticket;
+
     /// <summary>Initializes a new instance of the <see cref="RoutingQuiescence"/> class.</summary>
     public RoutingQuiescence()
     {
@@ -81,10 +95,43 @@ public sealed class RoutingQuiescence : IDisposable
     /// TERMINATES — landed, NACK'd, or faulted — never when it was merely dispatched. A double
     /// dispose does not double-decrement.
     /// </summary>
-    public IDisposable Track()
+    public IDisposable Track() => Track("unlabelled");
+
+    /// <summary>
+    /// Registers one piece of routing work as in flight, under a label that identifies it if it
+    /// fails to land. Dispose the returned handle when it TERMINATES — landed, NACK'd, or faulted —
+    /// never when it was merely dispatched. A double dispose does not double-decrement.
+    ///
+    /// <para>🚨 Pass something that identifies the LEG — a target path, a delivery id, a transport
+    /// — because this label is the only thing the shutdown residual can name (#2833). The count
+    /// tells you a leg is stuck; the label tells you which.</para>
+    /// </summary>
+    /// <param name="label">Identity of the work, e.g. <c>"pod-hub → acme/Foo (delivery abc123)"</c>.</param>
+    /// <returns>A handle whose disposal marks the work terminated.</returns>
+    public IDisposable Track(string label)
     {
+        var id = Interlocked.Increment(ref ticket);
+        inFlightLabels[id] = label;
         Push(1);
-        return Disposable.Create(() => Push(-1));
+        return Disposable.Create(() =>
+        {
+            inFlightLabels.TryRemove(id, out _);
+            Push(-1);
+        });
+    }
+
+    /// <summary>
+    /// A snapshot of the labels of the work currently in flight, capped so a saturated silo cannot
+    /// turn its own shutdown log into a flood. The cap is on the REPORT, not on the tracking.
+    /// </summary>
+    /// <param name="max">Maximum labels to return.</param>
+    /// <returns>Up to <paramref name="max"/> labels, and a count of any remainder.</returns>
+    public (IReadOnlyList<string> Labels, int NotShown) InFlightSample(int max = 10)
+    {
+        var all = inFlightLabels.Values.ToArray();
+        return all.Length <= max
+            ? (all, 0)
+            : (all.Take(max).ToArray(), all.Length - max);
     }
 
     // 🚨 Tolerant of a straggler AFTER the mesh is gone. This singleton is disposed with the
@@ -244,13 +291,24 @@ public sealed class RoutingQuiescenceSiloParticipant
                     // the budget.
                     .Catch<Unit, TimeoutException>(_ => quiescence.InFlightChanges
                         .Take(1)
-                        .Do(residual => logger.LogError(
-                            "RoutingQuiescence: {Residual} route leg(s) did not land within {Budget} — "
-                            + "the silo is proceeding to deactivate its grains over them. Each will now "
-                            + "fail on its own bound against a stopping transport, and its NACK may be "
-                            + "undeliverable. A leg that cannot land in {Budget} is stuck; find it, do "
-                            + "not widen the budget.",
-                            residual, budget, budget))
+                        .Do(residual =>
+                        {
+                            // 🚨 Name the legs. This participant runs ONLY at silo stop, so an
+                            // occurrence is not reproducible on demand — whatever this line does not
+                            // say is lost until the next shutdown. #2833 is exactly that: one leg
+                            // outlived the budget and the report could say nothing about which,
+                            // leaving "high confidence on the class, low on the specific leg".
+                            var (labels, notShown) = quiescence.InFlightSample();
+                            logger.LogError(
+                                "RoutingQuiescence: {Residual} route leg(s) did not land within {Budget} — "
+                                + "the silo is proceeding to deactivate its grains over them. Each will now "
+                                + "fail on its own bound against a stopping transport, and its NACK may be "
+                                + "undeliverable. A leg that cannot land in {Budget} is stuck; find it, do "
+                                + "not widen the budget. Stuck leg(s): {StuckLegs}{More}",
+                                residual, budget, budget,
+                                labels.Count == 0 ? "(none recorded)" : string.Join(" | ", labels),
+                                notShown == 0 ? string.Empty : $" (+{notShown} more)");
+                        })
                         .Select(_ => Unit.Default));
 
                 // The host's own shutdown budget can expire mid-hold (HostOptions.ShutdownTimeout).
@@ -261,10 +319,19 @@ public sealed class RoutingQuiescenceSiloParticipant
                         cancellationToken.Register(() => observer.OnNext(Unit.Default)))
                     .Take(1)
                     .SelectMany(_ => quiescence.InFlightChanges.Take(1))
-                    .Do(residual => logger.LogWarning(
-                        "RoutingQuiescence: the host's shutdown budget expired with {Residual} route "
-                        + "leg(s) still in flight after {Elapsed} ms — releasing the silo stop over them.",
-                        residual, Stopwatch.GetElapsedTime(started).TotalMilliseconds))
+                    .Do(residual =>
+                    {
+                        // Same reasoning as the budget-expiry arm: this is the other way the hold
+                        // ends over live work, and it is just as unreproducible.
+                        var (labels, notShown) = quiescence.InFlightSample();
+                        logger.LogWarning(
+                            "RoutingQuiescence: the host's shutdown budget expired with {Residual} route "
+                            + "leg(s) still in flight after {Elapsed} ms — releasing the silo stop over "
+                            + "them. Still in flight: {StuckLegs}{More}",
+                            residual, Stopwatch.GetElapsedTime(started).TotalMilliseconds,
+                            labels.Count == 0 ? "(none recorded)" : string.Join(" | ", labels),
+                            notShown == 0 ? string.Empty : $" (+{notShown} more)");
+                    })
                     .Select(_ => Unit.Default);
 
                 return landed.Amb(hostGaveUp);

--- a/test/MeshWeaver.Hosting.Orleans.Test/RoutingQuiescenceTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/RoutingQuiescenceTest.cs
@@ -189,6 +189,71 @@ public class RoutingQuiescenceTest
     }
 
     /// <summary>
+    /// 🚨 The residual must name WHICH leg, not just how many (#2833).
+    ///
+    /// <para>#2833 reports one leg outliving the budget and is explicit about why it went nowhere:
+    /// <i>"the message names no target, sender, or delivery id and carries no exception or stack"</i>
+    /// — leaving "high confidence on the class of defect, low on the specific leg". This
+    /// participant runs ONLY at silo stop, so an occurrence cannot be reproduced on demand:
+    /// whatever the line does not say is lost until the next shutdown.</para>
+    ///
+    /// <para>Fail-without: the count only. Pass-with: the label the leg was tracked under.</para>
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SiloStop_BudgetExpiry_NamesTheStuckLeg_NotJustHowMany()
+    {
+        using var quiescence = new RoutingQuiescence();
+        var logger = new CapturingLogger();
+        var participant = new RoutingQuiescenceSiloParticipant(quiescence, logger, TimeSpan.FromMilliseconds(200));
+
+        using var stuck = quiescence.Track("dispatch → acme/Stuck (delivery abc123)");
+        (await WaitForCount(quiescence, 1)).Should().Be(1);
+
+        await ((ILifecycleObserver)participant).OnStop(TestContext.Current.CancellationToken).WaitAsync(Bound);
+
+        logger.Entries.Should().Contain(
+            e => e.Level == LogLevel.Error
+                 && e.Message.Contains("acme/Stuck", StringComparison.Ordinal)
+                 && e.Message.Contains("abc123", StringComparison.Ordinal),
+            "a count cannot be chased — the residual must carry the leg's target and delivery id, "
+            + "because this line is the only record that will ever exist of that shutdown");
+    }
+
+    /// <summary>
+    /// The sample is CAPPED, so a saturated silo cannot turn its own shutdown log into a flood —
+    /// and the cap must say what it elided rather than silently truncating, or the reader cannot
+    /// tell a complete list from a clipped one.
+    /// </summary>
+    [Fact(Timeout = 30000)]
+    public async Task SiloStop_ManyStuckLegs_SamplesThemAndSaysHowManyItElided()
+    {
+        using var quiescence = new RoutingQuiescence();
+        var logger = new CapturingLogger();
+        var participant = new RoutingQuiescenceSiloParticipant(quiescence, logger, TimeSpan.FromMilliseconds(200));
+
+        var legs = new List<IDisposable>();
+        for (var i = 0; i < 25; i++)
+            legs.Add(quiescence.Track($"dispatch → acme/Leg{i}"));
+        (await WaitForCount(quiescence, 25)).Should().Be(25);
+
+        try
+        {
+            await ((ILifecycleObserver)participant).OnStop(TestContext.Current.CancellationToken).WaitAsync(Bound);
+
+            logger.Entries.Should().Contain(
+                e => e.Level == LogLevel.Error
+                     && e.Message.Contains("25 route leg(s) did not land", StringComparison.Ordinal)
+                     && e.Message.Contains("+15 more", StringComparison.Ordinal),
+                "25 legs must report 10 by name and admit the other 15 — a truncation the reader "
+                + "cannot see is worse than no sample at all");
+        }
+        finally
+        {
+            foreach (var leg in legs) leg.Dispose();
+        }
+    }
+
+    /// <summary>
     /// A NON-graceful stop (the token already cancelled — <c>Silo.Dispose()</c>'s path, on which
     /// Orleans' own Active-stage stop returns immediately) holds nothing and says what it is
     /// abandoning.


### PR DESCRIPTION
#2833 reports a route leg outliving the 30 s quiescence budget, and is explicit about why the investigation stopped there:

> *"the message names no target, sender, or delivery id and carries no exception or stack"* — **Confidence: high on the class of defect, low on the specific leg.**

## Why that is worse than an ordinary missing log field

`RoutingQuiescenceSiloParticipant` runs **only at silo stop**. An occurrence cannot be reproduced on demand — you cannot re-run a shutdown that already happened. So whatever the line does not say is **lost until the next shutdown**, on a different pod, possibly weeks later, and quite possibly for a different leg.

The gauge counted legs and nothing else, so the report could only ever say `1 route leg(s) did not land` — true, and unchaseable.

## The change

`RoutingQuiescence` carries identity alongside the count:

- **`Track(string label)`** records the label. `Track()` is unchanged for callers with no identity to give. The store is an instance `ConcurrentDictionary` on a mesh-scoped singleton — never `static`, and a concurrent dictionary because legs enter and leave from many threads.
- **`InFlightSample(max)`** returns a bounded snapshot **and the count it elided**. A saturated silo must not turn its own shutdown into a log flood — but a truncation the reader cannot see is worse than no sample at all, so the line says `(+15 more)`.
- **Both** arms that end the hold over live work now name the legs: budget expiry, and the host's own shutdown budget expiring mid-hold.

The three `RoutingGrain` call sites pass what they already had in scope — the stream-routed enqueue has target + delivery id, `Dispatch` has both, the NACK path has its transport. No new plumbing.

## Mutation-proven

With the label store disabled behind a runtime-false condition the compiler cannot fold (so `--no-build` cannot silently run stale binaries):

```
SiloStop_BudgetExpiry_NamesTheStuckLeg_NotJustHowMany        [FAIL]
SiloStop_ManyStuckLegs_SamplesThemAndSaysHowManyItElided     [FAIL]
Failed: 2, Passed: 7
```

The **seven existing tests still pass**, which is the part that matters: the mutation is isolated to the new behaviour rather than breaking the gauge, so the two failures are attributable to exactly the property being claimed.

## 🚨 What this does NOT do

It does not fix the stuck leg, and **#2833 should stay open for that**. Its own advice stands and is quoted in the code: *a leg that cannot land in the budget is stuck; find it, do not widen the budget.* This makes the next occurrence **diagnosable**, which is the precondition for finding it at all — the issue currently has no path forward precisely because the one artefact it produced named nothing.

## Verification

`MeshWeaver.Hosting.Orleans.Test` **207/207 green** (whole project). Release `-warnaserror` clean.