### PR TITLE
fix(#2844): an EMPTY scan is a broken scan, not a clean tree

### DIFF
--- a/test/MeshWeaver.Documentation.Test/SourceScan.cs
+++ b/test/MeshWeaver.Documentation.Test/SourceScan.cs
@@ -52,13 +52,53 @@ internal static class SourceScan
     /// only <c>.cs</c> would report a tree as clean while the same defect sat in a file no compiler
     /// ever looks at. Two <c>.ToTask(</c> sites were found in exactly that position.</para>
     /// </summary>
-    public static IEnumerable<string> SourceFiles(string root, IEnumerable<string> scannedRoots) =>
-        scannedRoots
+    /// <remarks>
+    /// 🚨 <b>An EMPTY result is treated as a BROKEN SCAN, not as a clean tree (#2844).</b>
+    ///
+    /// <para>The <c>Where(Directory.Exists)</c> below silently drops a root that is not there. That
+    /// is deliberate — a caller may name an optional root — but it means that pointing this scanner
+    /// at the wrong tree drops EVERY root and yields an empty sequence. For the ~30 zero-tolerance
+    /// guards built on it, "no offenders found" and "nothing was scanned" are then the same result,
+    /// so all of them report green while enforcing nothing.</para>
+    ///
+    /// <para>That is not hypothetical: relocating <c>MeshWeaver.Documentation.Test</c> into another
+    /// repository — a one-line csproj move considered on 2026-08-30 — would have disarmed the lot,
+    /// silently and permanently. Only 4 of 34 guards asserted that their scan found anything.</para>
+    ///
+    /// <para>🚨 A planted-tree self-test does NOT cover this. Running the real scanner over a temp
+    /// directory proves the SCANNER works; it cannot prove the scanner found the PRODUCTION tree.
+    /// The two fail independently, and only the second produces a wall of green over an unenforced
+    /// rule. Hence the check here, at the one place every guard passes through, rather than 30
+    /// individually-tuned floors — a rule copied 30 times is how 30 came to lack it.</para>
+    /// </remarks>
+    public static IEnumerable<string> SourceFiles(string root, IEnumerable<string> scannedRoots)
+    {
+        var roots = scannedRoots as string[] ?? scannedRoots.ToArray();
+        var files = roots
             .Select(r => Path.Combine(root, r))
             .Where(Directory.Exists)
             .SelectMany(dir => Directory.EnumerateFiles(dir, "*", SearchOption.AllDirectories))
             .Where(f => Path.GetExtension(f) is ".cs" or ".razor" or ".csx")
-            .Where(f => !IsExcluded(root, f));
+            .Where(f => !IsExcluded(root, f))
+            .ToArray();
+
+        if (files.Length == 0)
+        {
+            var missing = roots.Where(r => !Directory.Exists(Path.Combine(root, r))).ToArray();
+            throw new InvalidOperationException(
+                $"SourceScan found NO source files under '{root}' for root(s) "
+                + $"[{string.Join(", ", roots)}]"
+                + (missing.Length == 0
+                    ? " — every root exists but contains no .cs/.razor/.csx. "
+                    : $" — these do not exist: [{string.Join(", ", missing)}]. ")
+                + "🚨 This is a BROKEN SCAN, not a clean tree. A guard that reports green here has "
+                + "checked nothing: the repo root resolved somewhere unexpected (a relocated test "
+                + "project, a shadow-copied binary, a renamed root). Fix the scan — never soften "
+                + "the guard that surfaced it (#2844).");
+        }
+
+        return files;
+    }
 
     /// <summary>
     /// Blanks comment and string-literal characters, preserving offsets and newlines, so the scan

--- a/test/MeshWeaver.Documentation.Test/SourceScanFloorTest.cs
+++ b/test/MeshWeaver.Documentation.Test/SourceScanFloorTest.cs
@@ -1,0 +1,86 @@
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 The guard that guards the guards (#2844).
+///
+/// <para><see cref="SourceScan.SourceFiles"/> is the one seam every source-tree guard and ratchet in
+/// this project passes through — 34 of them. For a zero-tolerance guard, "no offenders found" and
+/// "nothing was scanned" are the SAME result, so an empty scan reports green while enforcing
+/// nothing. Only 4 of the 34 asserted that their scan found anything; the rest inherited it from
+/// here once <c>SourceFiles</c> started refusing an empty result.</para>
+///
+/// <para>This is not hypothetical. Relocating <c>MeshWeaver.Documentation.Test</c> into another
+/// repository — a one-line csproj move, seriously considered on 2026-08-30 as part of a test
+/// migration — would have pointed <c>FindRepoRoot()</c> at a tree with no <c>src/</c>, dropping
+/// every root and disarming ~30 rules silently and permanently.</para>
+///
+/// <para>🚨 <b>Why the existing <c>TheScannerSeesWhatItClaimsTo</c> self-tests do not cover this.</b>
+/// Planting a temp tree and running the real scanner over it proves the SCANNER works. It cannot
+/// prove the scanner found the PRODUCTION tree. Those two fail independently, and only the second
+/// produces a wall of green over an unenforced rule — so it needs its own test, which is this one.</para>
+/// </summary>
+public class SourceScanFloorTest
+{
+    /// <summary>
+    /// A root with no source files is a BROKEN SCAN. Fail-without: an empty sequence, and every
+    /// caller reports clean. Pass-with: a throw naming the roots.
+    /// </summary>
+    [Fact]
+    public void AnEmptyScanThrows_RatherThanReportingACleanTree()
+    {
+        var dir = Directory.CreateTempSubdirectory("sourcescan-floor");
+        try
+        {
+            Directory.CreateDirectory(Path.Combine(dir.FullName, "src"));   // exists, but empty
+
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => SourceScan.SourceFiles(dir.FullName, ["src"]).ToArray());
+
+            Assert.Contains("BROKEN SCAN", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("checked nothing", ex.Message, StringComparison.Ordinal);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    /// <summary>
+    /// The wrong-tree case, which is the one that actually happens: the roots are not there at all
+    /// because the repo root resolved somewhere unexpected. The message must NAME the missing roots,
+    /// or the reader cannot tell a mis-rooted scan from a genuinely empty one.
+    /// </summary>
+    [Fact]
+    public void AMissingRootThrows_AndNamesWhatWasNotThere()
+    {
+        var dir = Directory.CreateTempSubdirectory("sourcescan-wrongtree");
+        try
+        {
+            var ex = Assert.Throws<InvalidOperationException>(
+                () => SourceScan.SourceFiles(dir.FullName, ["src", "memex"]).ToArray());
+
+            Assert.Contains("do not exist", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("src", ex.Message, StringComparison.Ordinal);
+            Assert.Contains("memex", ex.Message, StringComparison.Ordinal);
+        }
+        finally { dir.Delete(recursive: true); }
+    }
+
+    /// <summary>
+    /// 🚨 And it must NOT fire on the real tree, or the cure is worse than the disease — a floor
+    /// that false-positives gets removed, taking the protection with it. An optional root that is
+    /// absent stays tolerated, because the check is on the RESULT, not on every root existing.
+    /// </summary>
+    [Fact]
+    public void TheRealTreeScansFine_AndAnAbsentOptionalRootIsStillTolerated()
+    {
+        var root = SourceScan.FindRepoRoot();
+
+        SourceScan.SourceFiles(root, ["src"]).Should().NotBeEmpty();
+        SourceScan.SourceFiles(root, ["src", "no-such-root-here"]).Should().NotBeEmpty(
+            "one missing root among several must not break a scan that still found the tree — "
+            + "the floor is on the RESULT, so callers naming an optional root keep working");
+    }
+}


### PR DESCRIPTION
34 source-tree guards and ratchets share one seam — `SourceScan.SourceFiles`. **Only 4 of them asserted that the scan found anything.**

For the other 30, every one a zero-tolerance guard, *"no offenders found"* and *"nothing was scanned"* produce the **identical** result. An empty scan reports green while enforcing nothing.

## The hole is one line

```csharp
.Where(Directory.Exists)      // silently drops a root that is not there
```

That is deliberate — a caller may name an optional root — but it means pointing the scanner at the **wrong tree** drops *every* root and yields an empty sequence.

## Not hypothetical

A session preparing a test migration considered relocating `MeshWeaver.Documentation.Test` into MeshWeaver.Plugins — **a one-line csproj move** — and stopped only on realising the guards would then *"scan the wrong tree and pass on an empty scan, which is worse than deleting them."*

That move would have disarmed ~30 rules **silently and permanently**, every one of them still reporting green. Deleting them would at least have been visible.

## Fixed at the seam, not as 30 floors

A rule copied 30 times is how 30 came to lack it. `SourceFiles` now throws on an empty result, naming the roots and which of them do not exist.

🚨 **The check is on the RESULT, not on every root existing.** A caller naming an optional root that is absent keeps working. That matters: a floor that false-positives gets removed, taking the protection with it — so `TheRealTreeScansFine_AndAnAbsentOptionalRootIsStillTolerated` pins it explicitly.

## 🚨 This is not what the existing self-tests cover

Several guards carry an excellent `TheScannerSeesWhatItClaimsTo` that plants a temp tree and runs the **real** scanner. Those should stay — but they prove **the scanner works**, not **that the scanner found the production tree**. The two fail independently:

| failure | caught by planted-tree self-test? |
|---|---|
| scanner logic broken | ✅ |
| scanner pointed at the wrong/empty tree | ❌ — self-test passes, guard passes, rule unenforced |

Only the second produces a wall of green over an unenforced rule, which is why it needs its own test.

## Mutation-proven

With the throw disabled behind a runtime-false condition the compiler cannot fold (so `--no-build` cannot run stale binaries):

```
AnEmptyScanThrows_RatherThanReportingACleanTree   [FAIL]
AMissingRootThrows_AndNamesWhatWasNotThere        [FAIL]
Failed: 2, Passed: 1
```

The real-tree test **still passes**, so the mutation is isolated to the new behaviour rather than breaking the scanner.

## Verification

`MeshWeaver.Documentation.Test` **132/132 green** — the whole project, since this changes the seam all 34 guards run through. Release `-warnaserror` clean.

Fixes #2844