### PR TITLE
fix(build): a FATAL is never silent, and one unreadable file no longer kills the whole build

### DIFF
--- a/tools/MeshWeaver.PluginTester/CascadeBuild.cs
+++ b/tools/MeshWeaver.PluginTester/CascadeBuild.cs
@@ -169,7 +169,27 @@ public static class CascadeBuild
         return Observable.Defer(() => RunCore(options))
             .Catch((Exception ex) => Observable.Return(
                 new Report(PrebuiltAssemblySeeder.LiveFrameworkMvid, [], [], TimeSpan.Zero, [],
-                    $"{ex.GetType().Name}: {ex.Message}")));
+                    // The full exception, stack included — this string is the ONLY trace a fatal
+                    // leaves, and "TypeName: message" was not enough to locate the first real one.
+                    ex.ToString())))
+            // 🚨 A FATAL is NEVER silent. Every early exit — LoadSync throwing, no packages, an
+            // unknown package id, LoadExternalModules refusing, the Catch above — returns its
+            // Report BEFORE the pipeline reaches Finish, so Print never sees it and Program only
+            // turns it into an exit code. Measured on the staging-7f99ee5 image (2026-08-30):
+            // `build /repo OgCard` died with exit 70 and ZERO bytes on stdout AND stderr — CI's
+            // cascade step would render that as "fatal (exit 70) — see build.log" over an EMPTY
+            // log, a signal that cannot distinguish "crashed before it could speak" from "ran and
+            // produced nothing". Print at the one seam every report passes; Finish never sets
+            // FatalError, so nothing prints twice. The report file is written too when asked —
+            // a fatal must be machine-readable to the lane, not only human-readable in the log.
+            .Do(report =>
+            {
+                if (report.FatalError is null)
+                    return;
+                options.Output.WriteLine($"FATAL: {report.FatalError}");
+                if (options.ReportPath is { } reportPath)
+                    WriteJson(reportPath, report);
+            });
     }
 
     private static IObservable<Report> RunCore(Options options)
@@ -186,7 +206,8 @@ public static class CascadeBuild
         }
         catch (Exception ex)
         {
-            return Observable.Return(Fatal(frameworkIdentity, wall, $"{ex.GetType().Name}: {ex.Message}"));
+            // Full exception — the fatal string is the only trace this run leaves (see Run's Do).
+            return Observable.Return(Fatal(frameworkIdentity, wall, ex.ToString()));
         }
         return LocalNodeRepo.DiscoverPackages(snapshot)
             .Take(1)

--- a/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
+++ b/tools/MeshWeaver.PluginTester/LocalNodeRepo.cs
@@ -58,7 +58,25 @@ public static class LocalNodeRepo
         foreach (var file in Directory.EnumerateFiles(directory))
         {
             var relative = Path.GetRelativePath(root, file).Replace(Path.DirectorySeparatorChar, '/');
-            var bytes = File.ReadAllBytes(file);
+            byte[] bytes;
+            try
+            {
+                bytes = File.ReadAllBytes(file);
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // A file that CANNOT be read is skipped loudly, never a fatal for the whole
+                // sweep. A local checkout legitimately holds debris no clean CI checkout has —
+                // the first real `build` run on a dev machine died, with nothing printed, on
+                // e2e/.auth/profile/RunningChromeVersion, a dead symlink left by a Playwright
+                // profile (gitignored, so invisible to every CI run). Such a file would have
+                // crashed BOTH bake paths before, so skipping it cannot fork the swept content
+                // set between them ("which files are content" stays shared). Console.Error, not
+                // a callback: both callers are CLI entry points, and a silent skip would be the
+                // same defect this tool just taught us about.
+                Console.Error.WriteLine($"sweep: skipped unreadable '{relative}': {ex.Message}");
+                continue;
+            }
             files.Add(TryDecodeUtf8(bytes, out var text)
                 ? new RepoFile(relative, text)
                 : new RepoFile(relative, string.Empty, bytes));


### PR DESCRIPTION
The first real `mw-plugin-test build` run on a dev machine (staging-7f99ee5, the maintainer's checkout) died with **exit 70 and zero bytes on stdout AND stderr**. Two defects compounded:

## 1. Every early fatal was mute

`Print` lives at the end of `Finish`, which only the successful pipeline reaches. Every early exit — `LoadSync` throwing, no packages, an unknown package id, `LoadExternalModules` refusing, `Run`'s outer `.Catch` — returned its `Report` straight to `Program`, which turned it into an exit code and nothing else. CI's cascade step would render that as *"fatal (exit 70) — see build.log"* over an **empty** log: a signal that cannot distinguish "crashed before it could speak" from "ran and produced nothing".

`Run` now guarantees at its one seam that a `FatalError` report prints `FATAL: …` (full exception, stack included — the fatal string is the only trace such a run leaves, and `TypeName: message` was not enough to locate the first real one) and writes `report.json` when asked, so a fatal is machine-readable to the lane too. `Finish` never sets `FatalError`, so nothing prints twice.

## 2. One unreadable file was a fatal for the whole build

With the silence fixed, the actual cause self-identified on the next run: `LocalNodeRepo.Sweep` eagerly reads **every** file under the repo root, and hit `e2e/.auth/profile/RunningChromeVersion` — a dead symlink left by a Playwright profile. Gitignored, so invisible to every CI checkout — which is why the lane looked healthy while the local no-dotnet loop (the very thing the verb exists for) was dead on arrival. Not arch-specific; the earlier arm64 suspicion was wrong.

The sweep now skips an unreadable file **loudly** (`sweep: skipped unreadable '…': reason`) and continues. Contract-safe for the shared gate path: such a file crashed both bake paths before, so skipping it cannot fork the swept content set.

## Measured, same dirty checkout that died silently

```
sweep: skipped unreadable 'e2e/.auth/profile/RunningChromeVersion': Could not find file …
sweep: skipped unreadable 'e2e/.auth/profile/SingletonSocket': Operation not supported …
build: 2 of 53 package(s) selected (OgCard), 811 node(s) …
Store    green   17 types   713 passed   0 failed
OgCard   green    1 type     12 passed   0 failed
build: 2 green, 0 red, 0 blocked of 2 in 13.6s wall
```

And the fatal path now speaks: `build /nonexistent-repo` → `FATAL: System.IO.DirectoryNotFoundException: Repo root '/nonexistent-repo' does not exist.` + stack, exit 70.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoG4USP5fd8wsxCD7e9q4x