### PR TITLE
feat(image): the container compiles Razor — the SDK-free build covers Blazor

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1055,12 +1055,55 @@ jobs:
       # csproj (project-local — a global -p:RuntimeIdentifiers breaks referenced libs, see above).
       # `latest` (the tag the plugins repo pins as MW_TEST_IMAGE) and the GHCR mirror both moved
       # to `promote`: they are consumer-visible, so they must not appear until every leg is green.
+      # 🚨 THE RAZOR COMPILER, STAGED FOR BOTH IMAGE ARCHITECTURES.
+      # `mw-plugin-test build-project` compiles .razor/.cshtml, and Razor compilation in the .NET
+      # SDK is a Roslyn SOURCE GENERATOR. This image ships the runtime and no SDK, so the generator
+      # has to travel with the builder — and it CANNOT be copied once: the SDK crossgens it for the
+      # SDK's own RID, so the same 10.0.400 file carries PE machine 0xFD1D on linux-x64 and 0xD11D
+      # on linux-arm64, and the wrong one throws BadImageFormatException at run time and nowhere
+      # else. This image publishes BOTH architectures from ONE x64 host, so both copies are staged
+      # and the builder picks the one for the RID it is running on.
+      #
+      # The arm64 copy comes from the dotnet/sdk image of the EXACT SAME SDK VERSION the runner is
+      # using — one source of truth, no second pin to drift — and `docker create` + `docker cp`
+      # reads it out without ever executing an arm64 binary, so no qemu is needed.
+      - name: Stage the Razor source generator for linux-x64 and linux-arm64
+        id: razor
+        run: |
+          set -euo pipefail
+          test "$(uname -m)" = "x86_64" \
+            || { echo "::error::this step assumes an x64 runner (it takes the host SDK's copy as the linux-x64 one)"; exit 1; }
+          SDK_VERSION="$(dotnet --version)"
+          SDK_ROOT="$(dotnet --list-sdks | sed -n "s|^${SDK_VERSION} \[\(.*\)\]$|\1|p" | head -1)"
+          HOST_SOURCE="$SDK_ROOT/$SDK_VERSION/Sdks/Microsoft.NET.Sdk.Razor/source-generators"
+          ROOT="$RUNNER_TEMP/razor-generators"
+          echo "SDK $SDK_VERSION; host source-generators: $HOST_SOURCE"
+
+          mkdir -p "$ROOT/linux-x64" "$ROOT/linux-arm64"
+          cp "$HOST_SOURCE"/*.dll "$ROOT/linux-x64/"
+
+          IMAGE="mcr.microsoft.com/dotnet/sdk:$SDK_VERSION"
+          docker pull --platform linux/arm64 "$IMAGE"
+          CID="$(docker create --platform linux/arm64 "$IMAGE")"
+          trap 'docker rm -f "$CID" >/dev/null 2>&1 || true' EXIT
+          docker cp "$CID:/usr/share/dotnet/sdk/$SDK_VERSION/Sdks/Microsoft.NET.Sdk.Razor/source-generators/." \
+            "$ROOT/linux-arm64/"
+
+          # 🚨 Fail closed. An empty or half-staged RID ships an image whose Razor builds fail on
+          # exactly one architecture — which nothing in this pipeline would notice.
+          for rid in linux-x64 linux-arm64; do
+            test -f "$ROOT/$rid/Microsoft.CodeAnalysis.Razor.Compiler.dll" \
+              || { echo "::error::no Razor compiler staged for $rid"; exit 1; }
+            echo "$rid: $(ls "$ROOT/$rid" | tr '\n' ' ')"
+          done
+          echo "root=$ROOT" >> "$GITHUB_OUTPUT"
       - name: Build + push mw-plugin-test (staging tag, ACR)
         run: >
           dotnet publish tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
           -c Release --no-self-contained -t:PublishContainer -p:PublishProfile=
           -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:CIRun=true
+          -p:MeshWeaverRazorGeneratorRoot=${{ steps.razor.outputs.root }}
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=mw-plugin-test
           -p:ContainerImageTags=${{ needs.gate.outputs.staging_tag }}

--- a/src/MeshWeaver.Cli/README.md
+++ b/src/MeshWeaver.Cli/README.md
@@ -75,9 +75,16 @@ assembly the image already carries. See
 | `--output <dir>` | where the emitted assemblies land (default: a temp dir) |
 | `--root <dir>` | directory mounted as `/repo` (default: the nearest `Directory.Build.props` ancestor) |
 | `--extra-refs <dir>` | libraries ADDITIONAL to the platform — the only way to satisfy a `PackageReference` the image does not supply. Repeatable |
-| `--accept <construct>` | acknowledge one construct the evaluator cannot reproduce (`target:<Name>`, `embedded-resource`, `conditions`). Repeatable |
+| `--accept <construct>` | acknowledge one construct the evaluator cannot reproduce (`target:<Name>`, `embedded-resource`, `conditions`, `razor-css-scope`, `razor-not-compiled`). Repeatable |
 | `--no-warn` / `--allow-warnings` | warnings fail the build (default); `--no-warn=false` or `--allow-warnings` opts out |
 | `--no-pull` | use the image the docker daemon already has, for one built locally |
+
+**Razor/Blazor compiles** (2026-08-31): the image ships the SDK's Razor source generator beside the
+builder, per RID, and `build-project` runs it for any project whose `Sdk` processes Razor items —
+`MeshWeaver.Blazor` (31 `.cs` + 42 `.razor`) builds green against `memex-portal-ai`. What it will
+not do quietly is skip a `.razor` file: a project with Razor input and no generator fails by name,
+and CSS isolation (`*.razor.css`) needs `--accept razor-css-scope` because the `b-…` scope comes
+from an MSBuild task this builder does not run.
 
 🚨 **Nothing is dropped in silence.** A project construct this builder cannot reproduce — an unknown
 element, an unevaluatable `Condition`, a `<Target>`, an `<EmbeddedResource>` — FAILS the run naming

--- a/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md
@@ -392,17 +392,92 @@ with `--accept targets --accept embedded-resource` and ClosedXML + CsvHelper as 
 | | count | why |
 |---|---|---|
 | **green** | **12** | incl. `MeshWeaver.Import` — 90 source files, 0 warnings under warnings-as-errors |
-| Razor/Blazor (CS0115) | 15 | `.razor` components are not compiled — see below |
+| Razor/Blazor (CS0115) | 15 | *fixed 2026-08-31 — see below* |
 | source generators (CS8795) | 15 | `[GeneratedRegex]` / `[LoggerMessage]` / `[JsonSerializable]` |
 | gRPC `<Protobuf>` | 3 | protoc codegen is a build task, not a compile |
 | additional libraries | 5 | Snowflake.Data, Microsoft.Data.Sqlite, Azure.Cosmos, … — supply with `--extra-refs` |
 | portal hosts | 3 | an `<Import>` above the mount; Aspire's `<Sdk>` ELEMENT |
 
+## The container compiles Razor (2026-08-31)
+
+Razor was the biggest single category above, and it was one missing file rather than a missing
+feature: **Razor compilation in the .NET SDK is a Roslyn source generator**
+(`Microsoft.CodeAnalysis.Razor.Compiler`) that turns each `.razor` into the partial class carrying
+its generated `BuildRenderTree` override. A runtime image ships no SDK, so without the generator
+every component compiled to a class with nothing to override — a wall of CS0115 that reads exactly
+like broken source.
+
+The image now carries it, in `razor-generators/` beside the builder, and `build-project` finds and
+runs it automatically for any project whose `Sdk` processes Razor items.
+
+### The dependency closure, measured
+
+Exactly **two** assemblies, established by reading the compiler's own assembly references and then
+proving it by deleting one:
+
+| assembly | why |
+|---|---|
+| `Microsoft.CodeAnalysis.Razor.Compiler` | carries `RazorSourceGenerator`, the `[Generator]` type |
+| `Microsoft.AspNetCore.Razor.Utilities.Shared` | its one private dependency — with it absent the compiler loads, its types enumerate, and every call into it throws |
+
+Everything else it references — `netstandard`, `Microsoft.CodeAnalysis(.CSharp)`,
+`System.Collections.Immutable`, `System.Memory`, `System.Buffers` — binds to the assemblies the
+image already has. 🚨 **`Microsoft.Extensions.ObjectPool` is NOT needed**, though an older Razor
+compiler build referenced it; the belief that it was is exactly why the closure was measured rather
+than assumed.
+
+### Two traps, both of which fail at run time and nowhere else
+
+🚨 **The generator is built against the SDK's Roslyn, not the image's.** SDK 10.0.400's copy
+references `Microsoft.CodeAnalysis` **5.9.0.0** while the image carries this repo's pin, **5.6.0**.
+The default load context binds by name *and refuses a lower version*, so a plain `Assembly.LoadFrom`
+fails — and a generator loader that treats "cannot load" as "not a generator" then produces a build
+indistinguishable from one where nobody asked for Razor. The generator is therefore loaded into a
+context that binds every assembly the HOST already has to the host's copy, version ignored. That is
+also what keeps `ISourceGenerator` ONE type: a second Roslyn in that context would give the
+generator a different interface than the driver expects.
+
+🚨 **The generator is ReadyToRun-compiled for the SDK's own RID.** The same SDK 10.0.400 file carries
+PE machine `0xFD1D` on linux-x64, `0xD11D` on linux-arm64 and `0xEC20` on osx-arm64 (the target
+machine XOR'd with the operating system's R2R marker), and the wrong one throws
+`BadImageFormatException`. `mw-plugin-test` publishes BOTH architectures from ONE x64 build host, so
+copying the build machine's SDK once would have shipped an arm64 image that cannot compile a single
+Blazor project. CD stages one directory per RID (`razor-generators/<rid>/`, the arm64 copy read out
+of the dotnet/sdk image of the same SDK version with `docker create` + `docker cp`, so no emulation
+is involved), and the builder picks the directory for the RID it is running on.
+
+### What it refuses, and why
+
+- **A project with Razor files and no generator.** One named failure that says what the CS0115 wall
+  would have been, not the wall.
+- **A generator that ran and emitted nothing.** Not a compile error — a generator that did not
+  recognise its input, which otherwise fails four steps later as CS0115.
+- **CSS isolation (`*.razor.css`).** The `b-…` scope identifier comes from the SDK's
+  `ComputeCssScope`/`ApplyCssScopes` tasks, and this builder runs no MSBuild task, so the components
+  would compile without their scope attributes. `--accept razor-css-scope` builds them anyway (the
+  assembly is valid; only the isolated stylesheet stops applying). Reproducing the scope hash from
+  memory is the guess this evaluator exists to avoid.
+- **`.razor` under a project whose `Sdk` does not process Razor.** The SDK's build ignores them too,
+  so the outcome matches — but it is stated rather than skipped. `--accept razor-not-compiled`.
+
+### Measured, 2026-08-31 — 10 of the 11 Razor projects
+
+Every `Microsoft.NET.Sdk.Razor` project in `MeshWeaver.Plugins/src`, built against
+`memex-portal-ai@sha256:6f38db08…` with the builder mounted, `--accept targets --accept
+razor-css-scope --accept embedded-resource`:
+
+| | count | |
+|---|---|---|
+| **green, no extra help** | **7** | Blazor (31 `.cs` + **42 `.razor`**), Blazor.EntityViews, Blazor.Graph, Blazor.Analysis, Blazor.OpenStreetMap, Blazor.GoogleMaps, Blazor.AppleMaps |
+| green with `--generators` (the SDK's regex generator) | +2 | Blazor.Views, Blazor.Portal — they were blocked by `[GeneratedRegex]` in `MeshWeaver.Markdown.Collaboration`, not by Razor |
+| green with `--extra-refs` | +1 | Blazor.Radzen — `Radzen.Blazor` is an additional library |
+| still red | 1 | `Memex.Portal.Gui` — a transitive `MeshWeaver.Hosting.Grpc` carries `<Protobuf>`; protoc is a build task, not a compile |
+
+**Razor is no longer what blocks any of them.** The two remaining categories are the pre-existing
+ones — SDK source generators and `<Protobuf>`.
+
 ### What it does NOT do, and what each would take
 
-- **Razor/Blazor.** `.razor` and `.cshtml` are not compiled at all. Doing so needs
-  `Microsoft.CodeAnalysis.Razor.Compiler`, `Microsoft.AspNetCore.Razor.Utilities.Shared` and
-  `Microsoft.Extensions.ObjectPool` present in the image — today it ships none of them.
 - **Source generators.** They live in the .NET **SDK**, and a MeshWeaver image ships the **runtime**.
   `--generators <dir|dll>` loads them when supplied; with none, the builder names the generator that
   did not run rather than leaving a wall of CS8795 that reads like broken source.

--- a/test/MeshWeaver.PluginTester.Test/MeshWeaver.PluginTester.Test.csproj
+++ b/test/MeshWeaver.PluginTester.Test/MeshWeaver.PluginTester.Test.csproj
@@ -11,6 +11,15 @@
     <ProjectReference Include="..\..\tools\MeshWeaver.ComboVerifier\MeshWeaver.ComboVerifier.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- RazorBuildTest LOADS the Blazor component it just compiled and reads the generated
+         BuildRenderTree override off it — which resolves ComponentBase, so this host has to be able
+         to bind Microsoft.AspNetCore.App. Without it the assertion cannot run at all, and "the
+         compiler returned" would be the only evidence a component exists, which is exactly the
+         CS0115 blind spot the suite is about. Same reason MeshWeaver.Auth.Test carries it. -->
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <!-- The gate boots in-process here, and the gate requires the AI engine MODULE beside the
        binary (#2276) — modules/ is laid by the closure lane, not copied by a ProjectReference, so
        this TEST bin needs its own lane run with the same tester-local single row. Same pattern as

--- a/test/MeshWeaver.PluginTester.Test/RazorBuildTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/RazorBuildTest.cs
@@ -1,0 +1,387 @@
+using System.Reactive;
+using System.Reflection;
+using MeshWeaver.Data;
+using Microsoft.CodeAnalysis;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// <c>mw-plugin-test build-project</c> compiles Razor — the whole chain, executed: the generator the
+/// image SHIPS is found beside the builder, loaded against THIS repo's Roslyn, and run over a real
+/// <c>.razor</c> file whose emitted component type is then LOADED and its generated
+/// <c>BuildRenderTree</c> override found on it.
+///
+/// <para>🚨 Every assertion here exists because the failure it guards is SILENT. A Razor generator
+/// that does not load looks exactly like a project with broken components (a wall of CS0115); a
+/// generator that loads but emits nothing looks the same; a <c>.razor</c> file the item glob never
+/// found looks the same again. So the suite proves the positive (a component is generated and
+/// loads) AND the three negatives (each failure names its own cause).</para>
+///
+/// <para>This is also the gate on the SDK pairing. The generator is built against the Roslyn of the
+/// SDK it shipped in and the image carries the Roslyn this repo pins — the two disagreed by three
+/// minor versions the day this was written (5.9.0.0 wanted, 5.6.0.0 present), and the load context
+/// is what reconciles them. If a future SDK's Razor compiler cannot run against this repo's Roslyn,
+/// these tests go red on the PR that bumps it rather than in an image nobody can debug.</para>
+/// </summary>
+public class RazorBuildTest : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"mw-razorbuild-{Guid.NewGuid():N}");
+
+    private string Write(string relativePath, string content)
+    {
+        var full = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// A Razor class library, exactly as every <c>MeshWeaver.Blazor.*</c> project declares itself.
+    /// The assembly name is per-test because these tests LOAD what they emit into this process, and
+    /// the default context refuses a second assembly of the same simple name; the root namespace
+    /// stays fixed so the namespace assertions stay about the TargetPath.
+    /// </summary>
+    private static string RazorProject(string assemblyName) => $"""
+        <Project Sdk="Microsoft.NET.Sdk.Razor">
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <Nullable>enable</Nullable>
+            <ImplicitUsings>enable</ImplicitUsings>
+            <AssemblyName>{assemblyName}</AssemblyName>
+            <RootNamespace>Widgets</RootNamespace>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    /// <summary>
+    /// The same <c>/app</c>-shaped fixture <see cref="ProjectBuildTest"/> uses: the REAL shipped
+    /// <c>deps.json</c> plus one assembly, with everything else arriving through the process's TPA
+    /// and the shared frameworks — which is where <c>Microsoft.AspNetCore.Components</c> comes from,
+    /// exactly as it does inside a portal image.
+    /// </summary>
+    private string AppDirectory()
+    {
+        var app = Path.Combine(_root, "_container");
+        if (Directory.Exists(app))
+            return app;
+        Directory.CreateDirectory(app);
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "mw-plugin-test.deps.json"),
+            Path.Combine(app, "mw-plugin-test.deps.json"));
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "MeshWeaver.ShortGuid.dll"),
+            Path.Combine(app, "MeshWeaver.ShortGuid.dll"));
+        return app;
+    }
+
+    private ProjectBuild.Options OptionsFor(string entry, params string[] accept) =>
+        new()
+        {
+            EntryProject = entry,
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "out"),
+            Output = TextWriter.Null,
+            Accept = accept,
+            MaxParallel = 2,
+        };
+
+    private static Task<ProjectBuild.Report> Build(ProjectBuild.Options options) =>
+        ProjectBuild.Run(options).Await(TestContext.Current.CancellationToken);
+
+    // ── what the image ships ───────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheImageShipsARazorGeneratorBesideTheBuilderAndItLOADS()
+    {
+        // Locate() with no override is the in-image path: razor-generators/ beside the builder.
+        var directory = RazorGenerators.Locate(null, "/nonexistent-app");
+        directory.Should().NotBeNull(
+            "the image build stages the SDK's Razor source generator beside the builder; without it "
+            + "no Blazor project can be compiled and every one reports CS0115 instead");
+
+        // 🚨 The load is the assertion. The generator is a netstandard2.0 assembly built against a
+        // DIFFERENT Roslyn than this process carries, so "the file is there" proves nothing.
+        var set = RazorGenerators.Load(directory!, NullLogger.Instance);
+        set.Generators.Should().NotBeEmpty();
+        set.Generators.Select(g => g.GetGeneratorType().Name)
+            .Should().Contain("RazorSourceGenerator");
+        set.Provenance.Should().Contain("Microsoft.CodeAnalysis.Razor.Compiler.dll");
+        set.Provenance.Should().Contain("\"sdk\"", "the provenance is the staged manifest, not a file listing");
+    }
+
+    [Fact]
+    public void TheShippedClosureIsTheCompilerPlusItsOnePrivateDependency()
+    {
+        var directory = RazorGenerators.Locate(null, "/nonexistent-app")!;
+        var assemblies = Directory.GetFiles(directory, "*.dll")
+            .Select(Path.GetFileName)
+            .Order(StringComparer.Ordinal)
+            .ToArray();
+
+        // Measured, not assumed: everything else Razor.Compiler references (Microsoft.CodeAnalysis,
+        // Microsoft.CodeAnalysis.CSharp, System.Collections.Immutable, System.Memory, System.Buffers,
+        // netstandard) resolves to the HOST. Only Utilities.Shared has to travel with it — with that
+        // file absent the compiler assembly still loads and every call into it throws.
+        assemblies.Should().Contain("Microsoft.CodeAnalysis.Razor.Compiler.dll");
+        assemblies.Should().Contain("Microsoft.AspNetCore.Razor.Utilities.Shared.dll");
+
+        // 🚨 STAGED PER RID. The SDK crossgens its Razor compiler for the SDK's own runtime
+        // identifier, so one copy cannot serve a multi-arch image — the directory it loads from is
+        // named for this process's RID.
+        Path.GetFileName(directory).Should().BeOneOf([.. RazorGenerators.RuntimeIdentifiers]);
+
+        File.Exists(Path.Combine(
+                Path.GetDirectoryName(directory)!, RazorGenerators.ManifestName))
+            .Should().BeTrue(
+                "the image must say WHICH Razor compiler it carries and for which architectures — "
+                + "the image is the pin, and a pin nobody can read is not a pin");
+    }
+
+    // ── the positive: a real component compiles, and the type LOADS ────────────────────────────
+
+    [Fact]
+    public async Task ARealRazorComponentCompilesAndItsGeneratedOverrideIsONTheEmittedType()
+    {
+        var project = Write("Widgets/Widgets.csproj", RazorProject("Widgets.Spacer"));
+        // The shape of MeshWeaver.Blazor.Views/Components/SpacerView.razor: an @inherits onto a base
+        // in the same project, markup, and a @code block — the three things a component is made of.
+        Write("Widgets/Base/WidgetBase.cs", """
+            namespace Widgets.Base;
+            /// <summary>A widget base, so @inherits has something real to point at.</summary>
+            public abstract class WidgetBase : Microsoft.AspNetCore.Components.ComponentBase
+            {
+                /// <summary>The label every widget carries.</summary>
+                protected string Label { get; set; } = "widget";
+            }
+            """);
+        Write("Widgets/Spacer.razor", """
+            @inherits Widgets.Base.WidgetBase
+
+            <div class="spacer">@Label</div>
+
+            @code {
+                private int Height => 8;
+            }
+            """);
+
+        var report = await Build(OptionsFor(project));
+
+        report.FatalError.Should().BeNull();
+        report.ExitCode.Should().Be(0);
+        var result = report.Projects.Single().Result!;
+        result.Failure.Should().BeNull();
+        result.RazorCount.Should().BeGreaterThan(0, "the .razor file must have produced a document");
+        result.AssemblyPath.Should().NotBeNull();
+
+        // 🚨 LOAD it. "the compiler returned" is not evidence that a component exists — the whole
+        // CS0115 family is about a type whose override half is missing, and only reflection over the
+        // emitted assembly can tell the difference.
+        var assembly = Assembly.LoadFrom(result.AssemblyPath!);
+        var component = assembly.GetType("Widgets.Spacer");
+        component.Should().NotBeNull("the component's namespace comes from RootNamespace + TargetPath");
+        component!.BaseType!.FullName.Should().Be("Widgets.Base.WidgetBase");
+
+        var buildRenderTree = component.GetMethod(
+            "BuildRenderTree", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly);
+        buildRenderTree.Should().NotBeNull(
+            "BuildRenderTree is what the Razor generator emits; a component without it is exactly the "
+            + "CS0115 failure this whole feature exists to end");
+    }
+
+    [Fact]
+    public async Task ASubdirectoryComponentLandsInTheNamespaceTheTargetPathDictates()
+    {
+        var project = Write("Widgets/Widgets.csproj", RazorProject("Widgets.Panels"));
+        Write("Widgets/Panels/Card.razor", "<article>card</article>\n");
+
+        var report = await Build(OptionsFor(project));
+
+        report.ExitCode.Should().Be(0);
+        var assembly = Assembly.LoadFrom(report.Projects.Single().Result!.AssemblyPath!);
+        // AssignTargetPath's RootFolder is the project directory, so Panels/Card.razor is
+        // <RootNamespace>.Panels.Card. Get the TargetPath wrong and this compiles into a namespace
+        // nothing references — green, and useless.
+        assembly.GetType("Widgets.Panels.Card").Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task AnImportsFileContributesItsUsingsToASiblingComponent()
+    {
+        var project = Write("Widgets/Widgets.csproj", RazorProject("Widgets.Clock"));
+        Write("Widgets/_Imports.razor", "@using System.Globalization\n");
+        // Only _Imports.razor makes CultureInfo resolvable here — so if _Imports were dropped from
+        // the item set (it is a .razor file like any other) this would not compile.
+        Write("Widgets/Clock.razor", """
+            <time>@CultureInfo.InvariantCulture.Name</time>
+            """);
+
+        var report = await Build(OptionsFor(project));
+
+        report.ExitCode.Should().Be(0);
+        Assembly.LoadFrom(report.Projects.Single().Result!.AssemblyPath!)
+            .GetType("Widgets.Clock").Should().NotBeNull();
+    }
+
+    // ── the negatives: every silent failure gets a name ────────────────────────────────────────
+
+    [Fact]
+    public async Task WithNoRazorGeneratorTheBuildNAMESIT_ratherThanEmittingCS0115Noise()
+    {
+        var project = Write("Widgets/Widgets.csproj", RazorProject("Widgets.NoGenerator"));
+        Write("Widgets/Spacer.razor", "<div>spacer</div>\n");
+        var empty = Path.Combine(_root, "no-generators");
+        Directory.CreateDirectory(empty);
+
+        var options = OptionsFor(project) with { RazorGeneratorDirectory = empty };
+        var report = await Build(options);
+
+        report.ExitCode.Should().Be(1);
+        var result = report.Projects.Single().Result!;
+        result.Failure.Should().NotBeNull();
+        result.Failure.Should().Contain("Microsoft.CodeAnalysis.Razor.Compiler",
+            "the builder must name the generator that did not run");
+        result.Failure.Should().Contain("CS0115",
+            "and must say what the wall of errors would have been, so nobody debugs the source");
+        // 🚨 ONE failure, not a wall. The point of naming the cause is that the symptom never gets
+        // printed at all.
+        result.Errors.Should().Be(1);
+    }
+
+    [Fact]
+    public void APlainSdkProjectWithRazorFilesIsREFUSED_untilItIsAcknowledged()
+    {
+        var project = Write("Plain/Plain.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+            </Project>
+            """);
+        Write("Plain/Thing.cs", "namespace Plain; public static class Thing { }");
+        Write("Plain/Stray.razor", "<p>stray</p>\n");
+
+        var refusal = Assert.Throws<ProjectFile.UnsupportedConstructException>(
+            () => ProjectFile.Load(project));
+        refusal.Message.Should().Contain("Stray.razor");
+        refusal.Message.Should().Contain(ProjectFile.Accept.RazorNotCompiled);
+
+        // Acknowledged, the project loads and carries NO Razor items — the SDK ignores them too.
+        var model = ProjectFile.Load(project, [ProjectFile.Accept.RazorNotCompiled]);
+        model.RazorItems.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void ScopedCssIsREFUSED_becauseTheScopeIdentifierIsAnMSBuildTaskThisBuilderCannotRun()
+    {
+        var project = Write("Widgets/Widgets.csproj", RazorProject("Widgets.Scoped"));
+        Write("Widgets/Spacer.razor", "<div>spacer</div>\n");
+        Write("Widgets/Spacer.razor.css", ".spacer { height: 8px; }\n");
+
+        var refusal = Assert.Throws<ProjectFile.UnsupportedConstructException>(
+            () => ProjectFile.Load(project));
+        refusal.Message.Should().Contain(ProjectFile.Accept.RazorCssScope);
+        refusal.Message.Should().Contain("scope");
+
+        var model = ProjectFile.Load(project, [ProjectFile.Accept.RazorCssScope]);
+        model.RazorItems.Should().ContainSingle();
+        // The .razor.css itself is never a Razor input — it is a stylesheet, and the default
+        // *.razor glob must not pick it up.
+        model.RazorItems.Single().Path.Should().EndWith("Spacer.razor");
+    }
+
+    [Fact]
+    public void ContentRemoveTakesAComponentOutOfTheBuild()
+    {
+        var project = Write("Widgets/Widgets.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk.Razor">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+              </PropertyGroup>
+              <ItemGroup>
+                <Content Remove="Legacy.razor" />
+              </ItemGroup>
+            </Project>
+            """);
+        Write("Widgets/Keep.razor", "<p>keep</p>\n");
+        Write("Widgets/Legacy.razor", "<p>legacy</p>\n");
+
+        var model = ProjectFile.Load(project);
+
+        model.RazorItems.Select(i => i.TargetPath).Should().Equal("Keep.razor");
+    }
+
+    [Fact]
+    public void TheRazorItemsCarryTheTargetPathTheSdkWouldHaveAssigned()
+    {
+        var project = Write("Widgets/Widgets.csproj", RazorProject("Widgets.TargetPaths"));
+        Write("Widgets/Panels/Card.razor", "<article>card</article>\n");
+        Write("Widgets/Views/Index.cshtml", "@{ }\n<p>index</p>\n");
+
+        var model = ProjectFile.Load(project);
+
+        model.RazorItems.Select(i => i.TargetPath).Order(StringComparer.Ordinal)
+            .Should().Equal(Path.Combine("Panels", "Card.razor"), Path.Combine("Views", "Index.cshtml"));
+        model.RazorItems.Single(i => i.TargetPath.EndsWith(".razor", StringComparison.Ordinal))
+            .IsComponent.Should().BeTrue();
+        model.RazorItems.Single(i => i.TargetPath.EndsWith(".cshtml", StringComparison.Ordinal))
+            .IsComponent.Should().BeFalse();
+    }
+
+    [Fact]
+    public void AMissingGeneratorDirectoryIsAFAILURE_neverAnEmptyGeneratorSet()
+    {
+        var absent = Path.Combine(_root, "gone");
+
+        var refusal = Assert.Throws<RazorGenerators.MissingRazorCompilerException>(
+            () => RazorGenerators.Load(absent, NullLogger.Instance));
+
+        refusal.Message.Should().Contain(absent);
+    }
+
+    [Fact]
+    public void ADirectoryOfNonGeneratorAssembliesIsAFAILURE_byName()
+    {
+        // An assembly that loads fine and carries no [Generator]: the "it is there, so it works"
+        // assumption, refused.
+        var directory = Path.Combine(_root, "not-generators");
+        Directory.CreateDirectory(directory);
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "MeshWeaver.ShortGuid.dll"),
+            Path.Combine(directory, "MeshWeaver.ShortGuid.dll"));
+
+        var refusal = Assert.Throws<RazorGenerators.MissingRazorCompilerException>(
+            () => RazorGenerators.Load(directory, NullLogger.Instance));
+
+        refusal.Message.Should().Contain("no usable Roslyn source generator");
+    }
+
+    [Fact]
+    public void AnOperatorsDirectoryREPLACESTheSearchPath_itDoesNotHeadIt()
+    {
+        // 🚨 No fallback. A --razor-generators that turns out to be empty must FAIL, not quietly
+        // pick up the image's own copy and report on a generator nobody named.
+        RazorGenerators.SearchPath("/tmp/mine", "/app")
+            .Should().AllSatisfy(p => p.Should().StartWith(Path.GetFullPath("/tmp/mine")));
+
+        // Per-RID before flat, builder before /app — the layout a multi-arch image publishes read
+        // in the order that makes the RID-specific copy win.
+        var standard = RazorGenerators.SearchPath(null, "/app");
+        standard[0].Should().Be(Path.Combine(
+            Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, RazorGenerators.DirectoryName)),
+            RazorGenerators.RuntimeIdentifiers[0]));
+        standard.Should().Contain(Path.GetFullPath(
+            Path.Combine(AppContext.BaseDirectory, RazorGenerators.DirectoryName)));
+        standard[^1].Should().Be(Path.GetFullPath(
+            Path.Combine("/app", RazorGenerators.DirectoryName)));
+    }
+}

--- a/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+++ b/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -15,6 +15,96 @@
     <MeshWeaverSurfaceManifest>true</MeshWeaverSurfaceManifest>
   </PropertyGroup>
 
+  <!-- ═════════ THE RAZOR COMPILER RIDES ALONG — as ASSETS, never as a reference ═════════
+       `build-project` compiles .razor/.cshtml, and Razor compilation in the .NET SDK is a Roslyn
+       SOURCE GENERATOR (Microsoft.CodeAnalysis.Razor.Compiler). A MeshWeaver image ships the
+       RUNTIME and no SDK, so without these two assemblies every Blazor project fails with a wall of
+       CS0115 "no suitable method found to override" — the generated BuildRenderTree half of every
+       component simply is not there. That was 15 of the 42 failures in the first no-SDK sweep of
+       MeshWeaver.Plugins/src, more than any other category.
+
+       🚨 CONTENT, NOT PackageReference and NOT ProjectReference. This project's reference closure IS
+       the framework build identity (see the block below); a compile-time reference here would move
+       the identity every bake host resolves. These are laid beside the binary and LOADED AT RUNTIME
+       by RazorGenerators, into a load context that binds Roslyn to the host's copy — the generator
+       is built against the SDK's Roslyn (10.0.400's wants Microsoft.CodeAnalysis 5.9.0.0) and the
+       image carries this repo's pin (5.6.0), and the default context refuses the lower version.
+
+       🚨 The closure is EXACTLY these two, measured rather than assumed: Razor.Compiler references
+       netstandard, Microsoft.CodeAnalysis(.CSharp), System.Collections.Immutable, System.Memory,
+       System.Buffers and Razor.Utilities.Shared — every one but the last resolves to the host.
+       Microsoft.Extensions.ObjectPool, which older Razor compiler builds needed, is NOT referenced
+       by this one. The glob copies whatever the SDK's source-generators directory holds, so a
+       future SDK that adds a third assembly needs no code change here.
+
+       🚨 PER-RID, because the SDK's copy is READYTORUN-compiled for the SDK's own RID and does not
+       load on another. Measured on SDK 10.0.400: Razor.Compiler.dll carries PE machine 0xFD1D on
+       linux-x64 and 0xEC20 on osx-arm64 (the target machine XOR'd with the OS's R2R marker), and the
+       wrong one throws BadImageFormatException. This image is published for linux-x64 AND
+       linux-arm64 from ONE x64 build host, so copying the build machine's SDK would have shipped an
+       arm64 image that cannot compile a single Blazor project — loudly, but only for arm64 users.
+       -p:MeshWeaverRazorGeneratorRoot=<dir> names a directory of <rid>/ subdirectories (what CD
+       stages from the pinned dotnet/sdk image, both architectures); with none, a build stages the
+       host SDK's copy under its own RID, which is what a developer and the test suite need.
+
+       PROVENANCE: razor-generators.json records the SDK version, the source and the RIDs — the image
+       is the pin, and it says what it pinned. The pairing is GATED by a test that EXECUTES the
+       shipped generator against this repo's Roslyn (RazorBuildTest), so an SDK whose Razor compiler
+       cannot run here turns a PR red instead of shipping a silent image. -->
+  <PropertyGroup>
+    <MeshWeaverRazorGeneratorSource Condition="'$(MeshWeaverRazorGeneratorSource)' == ''">$(NetCoreRoot)sdk/$(NETCoreSdkVersion)/Sdks/Microsoft.NET.Sdk.Razor/source-generators</MeshWeaverRazorGeneratorSource>
+    <MeshWeaverRazorGeneratorRid Condition="'$(MeshWeaverRazorGeneratorRid)' == ''">$(NETCoreSdkRuntimeIdentifier)</MeshWeaverRazorGeneratorRid>
+  </PropertyGroup>
+
+  <Target Name="StageRazorSourceGenerator" BeforeTargets="AssignTargetPaths">
+    <!-- Two layouts, and the staged one wins: CD hands over a root of <rid>/ directories (every
+         architecture the image publishes), while an ordinary build has only the host SDK's copy and
+         stages it under the host's own RID. -->
+    <ItemGroup Condition="'$(MeshWeaverRazorGeneratorRoot)' != ''">
+      <_MeshWeaverRazorGenerator Include="$(MeshWeaverRazorGeneratorRoot)/*/*.dll" />
+      <_MeshWeaverRazorGenerator>
+        <RidFolder>$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName('%(FullPath)'))))</RidFolder>
+      </_MeshWeaverRazorGenerator>
+    </ItemGroup>
+    <ItemGroup Condition="'$(MeshWeaverRazorGeneratorRoot)' == ''">
+      <_MeshWeaverRazorGenerator Include="$(MeshWeaverRazorGeneratorSource)/*.dll" RidFolder="$(MeshWeaverRazorGeneratorRid)" />
+    </ItemGroup>
+    <!-- 🚨 An empty glob would ship an image that silently cannot compile a single Blazor project,
+         and nothing downstream could tell the difference from "this project has errors". -->
+    <Error Condition="'@(_MeshWeaverRazorGenerator)' == ''"
+           Text="No Razor source generator found in '$(MeshWeaverRazorGeneratorSource)'. build-project compiles .razor through Microsoft.CodeAnalysis.Razor.Compiler, which ships in the .NET SDK's Microsoft.NET.Sdk.Razor/source-generators directory; an image built without it cannot compile any Blazor project and would report a wall of CS0115 instead of saying so. Install a .NET SDK that carries it, or point -p:MeshWeaverRazorGeneratorSource=&lt;dir&gt; at a copy." />
+    <Error Condition="'@(_MeshWeaverRazorGenerator->WithMetadataValue('Filename', 'Microsoft.CodeAnalysis.Razor.Compiler'))' == ''"
+           Text="The staged Razor generators do not include Microsoft.CodeAnalysis.Razor.Compiler.dll — that is the assembly carrying the [Generator] type, and without it the directory compiles nothing." />
+    <Error Condition="'%(_MeshWeaverRazorGenerator.RidFolder)' == ''"
+           Text="A staged Razor generator has no RID folder. The SDK's copy is ReadyToRun-compiled for one RID; shipping it un-labelled would put an x64 compiler in an arm64 image, which fails at run time and nowhere else." />
+    <PropertyGroup>
+      <!-- Item transforms cannot be concatenated with literals inside a task's string parameter
+           (MSB4012), so the lists become properties first. -->
+      <_MeshWeaverRazorGeneratorNames>@(_MeshWeaverRazorGenerator->'%(RidFolder)/%(Filename)%(Extension)', '&quot;, &quot;')</_MeshWeaverRazorGeneratorNames>
+      <_MeshWeaverRazorGeneratorOrigin Condition="'$(MeshWeaverRazorGeneratorRoot)' != ''">$(MeshWeaverRazorGeneratorRoot)</_MeshWeaverRazorGeneratorOrigin>
+      <_MeshWeaverRazorGeneratorOrigin Condition="'$(MeshWeaverRazorGeneratorRoot)' == ''">$(MeshWeaverRazorGeneratorSource)</_MeshWeaverRazorGeneratorOrigin>
+    </PropertyGroup>
+    <WriteLinesToFile
+        File="$(IntermediateOutputPath)razor-generators.json"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+        Lines="{ &quot;sdk&quot;: &quot;$(NETCoreSdkVersion)&quot;, &quot;source&quot;: &quot;$(_MeshWeaverRazorGeneratorOrigin)&quot;, &quot;assemblies&quot;: [&quot;$(_MeshWeaverRazorGeneratorNames)&quot;] }" />
+    <ItemGroup>
+      <Content Include="@(_MeshWeaverRazorGenerator)"
+               Link="razor-generators/%(RidFolder)/%(Filename)%(Extension)"
+               CopyToOutputDirectory="PreserveNewest"
+               CopyToPublishDirectory="PreserveNewest"
+               Pack="false"
+               Visible="false" />
+      <Content Include="$(IntermediateOutputPath)razor-generators.json"
+               Link="razor-generators/razor-generators.json"
+               CopyToOutputDirectory="PreserveNewest"
+               CopyToPublishDirectory="PreserveNewest"
+               Pack="false"
+               Visible="false" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <!-- GateDiscoveryEqualsBakeDiscoveryTest pins PluginGateRunner.DiscoverNodeTypes equal to the
          compiler-driven bake's discovery (#2063). The two halves disagreeing IS the defect, and

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -174,6 +174,7 @@ static async Task<int> RunBuildProject(string[] args)
     var app = ContainerReferenceSet.DefaultAppDirectory;
     var extraRefs = new List<string>();
     var generatorPaths = new List<string>();
+    string? razorGenerators = null;
     var accept = new List<string>();
     var allowWarnings = false;
     var maxParallel = Math.Max(1, Environment.ProcessorCount);
@@ -192,6 +193,11 @@ static async Task<int> RunBuildProject(string[] args)
                 break;
             case "--generators" when i + 1 < args.Length:
                 generatorPaths.Add(args[++i]);
+                break;
+            // The RAZOR generator is found automatically beside the builder (the image ships it in
+            // razor-generators/); this names a different copy — a newer SDK's, or a mount.
+            case "--razor-generators" when i + 1 < args.Length:
+                razorGenerators = args[++i];
                 break;
             case "--accept" when i + 1 < args.Length:
                 accept.Add(args[++i]);
@@ -243,6 +249,7 @@ static async Task<int> RunBuildProject(string[] args)
         AppDirectory = app,
         ExtraReferenceDirectories = extraRefs,
         GeneratorPaths = generatorPaths,
+        RazorGeneratorDirectory = razorGenerators,
         Accept = accept,
         AllowWarnings = allowWarnings,
         MaxParallel = maxParallel,
@@ -252,13 +259,17 @@ static async Task<int> RunBuildProject(string[] args)
 
 static string BuildProjectUsage() =>
     "usage: mw-plugin-test build-project <csproj|dir> [--output <dir>] [--app <dir>] "
-    + "[--extra-refs <dir>]... [--accept <construct>]... [--allow-warnings] [--max-parallel <n>]\n"
+    + "[--extra-refs <dir>]... [--generators <dir|dll>]... [--razor-generators <dir>] "
+    + "[--accept <construct>]... [--allow-warnings] [--max-parallel <n>]\n"
     + "  Compiles a .NET project with NO dotnet SDK and NO NuGet restore: the .csproj is evaluated "
     + "without MSBuild, every reference is resolved from this container's /app (and its .deps.json), "
     + "ProjectReferences inside the source root are built first in dependency order, and Roslyn runs "
     + "with the SDK's diagnostic standard (nullable analysis, DocumentationMode.Diagnose). Warnings "
     + "fail the build unless --allow-warnings. A construct the evaluator cannot reproduce fails the "
-    + "run by name; --accept <construct> acknowledges one.";
+    + "run by name; --accept <construct> acknowledges one. .razor/.cshtml are compiled by the Razor "
+    + "source generator the image ships in razor-generators/ beside this builder; --razor-generators "
+    + "<dir> names another copy, and a project with Razor files and no generator FAILS rather than "
+    + "quietly emitting an assembly with no components in it.";
 
 static string BuildUsage() =>
     "usage: mw-plugin-test build <repo-root> [<package>... | all] [--module <dll>]... [--out <dir>] "

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -82,6 +82,16 @@ public static class ProjectBuild
         /// </summary>
         public IReadOnlyList<string> GeneratorPaths { get; init; } = [];
 
+        /// <summary>
+        /// Where the RAZOR source generator lives. Null means the standard search —
+        /// <c>razor-generators/</c> beside this builder, then under <see cref="AppDirectory"/> —
+        /// which is where the image build lays it. Named separately from
+        /// <see cref="GeneratorPaths"/> because it is not optional in the same way: a project with
+        /// <c>.razor</c> files and no Razor compiler is a FAILURE, never a build that quietly
+        /// omits every component.
+        /// </summary>
+        public string? RazorGeneratorDirectory { get; init; }
+
         /// <summary>Concurrency cap across independent projects.</summary>
         public int MaxParallel { get; init; } = Math.Max(1, Environment.ProcessorCount);
 
@@ -108,6 +118,7 @@ public static class ProjectBuild
     /// <param name="AssemblyPath">The emitted DLL, when the emit succeeded.</param>
     /// <param name="UnresolvedPackages">Packages neither the container nor <c>--extra-refs</c> supplies.</param>
     /// <param name="Failure">Why the project is red, when it is.</param>
+    /// <param name="RazorCount">How many <c>.razor</c>/<c>.cshtml</c> files the Razor generator compiled.</param>
     public sealed record ProjectResult(
         string ProjectPath,
         string AssemblyName,
@@ -117,7 +128,8 @@ public static class ProjectBuild
         int Warnings,
         string? AssemblyPath,
         ImmutableArray<string> UnresolvedPackages,
-        string? Failure)
+        string? Failure,
+        int RazorCount = 0)
     {
         /// <summary>Compiled, emitted, and within the warning policy.</summary>
         public bool IsGreen => Failure is null && AssemblyPath is not null;
@@ -405,7 +417,9 @@ public static class ProjectBuild
     {
         var clock = Stopwatch.StartNew();
         var name = Path.GetFileNameWithoutExtension(model.ProjectPath);
-        sink.Info($"[{name}] start — {model.CompileItems.Length} source file(s), "
+        var razorGenerated = 0;
+        sink.Info($"[{name}] start — {model.CompileItems.Length} source file(s)"
+                  + (model.RazorItems.IsEmpty ? "" : $" + {model.RazorItems.Length} Razor file(s)") + ", "
                   + $"target {(model.TargetFramework.Length > 0 ? model.TargetFramework : "(unset)")}, "
                   + $"nullable {model.NullableOptions}, "
                   + $"warnings-as-errors {(model.TreatWarningsAsErrors ? "on" : "off")}");
@@ -528,6 +542,39 @@ public static class ProjectBuild
 
         var compilation = CSharpCompilation.Create(
             model.AssemblyName, trees, references, compilationOptions);
+
+        // 🚨 RAZOR FIRST. `.razor` becomes C# through a Roslyn source generator, so a Blazor project
+        // whose components have not been generated is not "a project with errors" — it is a project
+        // that was never fully read. Running it before any other generator also means an ordinary
+        // `--generators` generator sees the component partials, exactly as csc does.
+        if (!model.RazorItems.IsEmpty)
+        {
+            try
+            {
+                var directory = RazorGenerators.Locate(options.RazorGeneratorDirectory, options.AppDirectory)
+                    ?? throw new RazorGenerators.MissingRazorCompilerException(
+                        RazorGenerators.MissingCompilerMessage(
+                            name, model.RazorItems.Length,
+                            RazorGenerators.SearchPath(options.RazorGeneratorDirectory, options.AppDirectory)));
+                var razor = RazorGenerators.Load(directory, sink.Logger);
+                sink.Info(
+                    $"[{name}] Razor: {model.RazorItems.Length} file(s) through "
+                    + $"{razor.Generators.Length} generator(s) from {razor.Directory} ({razor.Provenance})");
+                var outcome = RazorGenerators.Run(compilation, model, razor, parseOptions, CancellationToken.None);
+                compilation = outcome.Compilation;
+                razorGenerated = outcome.GeneratedSources;
+                foreach (var diagnostic in outcome.Diagnostics.Where(d => d.Severity >= DiagnosticSeverity.Warning))
+                    sink.Warn($"[{name}] razor: {Render(diagnostic)}");
+                sink.Info($"[{name}] Razor: {razorGenerated} generated document(s)");
+            }
+            catch (RazorGenerators.MissingRazorCompilerException ex)
+            {
+                sink.Error($"[{name}] {ex.Message}");
+                return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
+                    model.CompileItems.Length, 1, 0, null, [], ex.Message);
+            }
+        }
+
         if (!generators.IsEmpty)
             compilation = GeneratorPipeline.RunSourceGenerators(
                 compilation, generators, sink.Logger, CancellationToken.None);
@@ -535,6 +582,7 @@ public static class ProjectBuild
         var errors = 0;
         var warnings = 0;
         var missingGeneratorPartials = 0;
+        var missingComponentOverrides = 0;
         foreach (var diagnostic in compilation.GetDiagnostics())
         {
             switch (diagnostic.Severity)
@@ -543,6 +591,11 @@ public static class ProjectBuild
                     errors++;
                     if (diagnostic.Id is "CS8795" or "CS8785" or "CS9248")
                         missingGeneratorPartials++;
+                    // CS0115 "no suitable method found to override" is what a Razor component looks
+                    // like when its generated half is absent: the .razor.cs declares
+                    // BuildRenderTree, the generator never produced the partial that has it.
+                    if (diagnostic.Id is "CS0115")
+                        missingComponentOverrides++;
                     sink.Error($"[{name}] {Render(diagnostic)}");
                     break;
                 case DiagnosticSeverity.Warning:
@@ -568,10 +621,21 @@ public static class ProjectBuild
                     + "built-in generators (GeneratedRegex, LoggerMessage, JsonSerializable) ship in "
                     + "the .NET SDK, not in a runtime image, so this container has none. Supply them "
                     + "with --generators <dir>, or the project cannot be built in this mode.");
+            if (model.RazorItems.IsEmpty && missingComponentOverrides > 0)
+                // 🚨 The other half of the same rule. CS0115 in a project this builder found NO
+                // Razor items in means the components were never offered to the generator at all —
+                // the item glob, not the compile, is what went wrong. Say which.
+                sink.Error(
+                    $"[{name}] {missingComponentOverrides} of those errors are overrides with nothing "
+                    + "to override — the signature of Razor components whose generated partial is "
+                    + "missing. This build found NO .razor/.cshtml items in the project, so the "
+                    + "generator was never asked to produce them: check the project's Sdk (Razor "
+                    + "items are compiled only under Microsoft.NET.Sdk.Razor/.Web) and its Content "
+                    + "items, rather than reading these as broken source.");
             sink.Error($"[{name}] RED — {errors} error(s), {warnings} warning(s) in {clock.Elapsed.TotalMilliseconds:F0} ms");
             return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
                 model.CompileItems.Length, errors, warnings, null, [],
-                $"{errors} compile error(s)");
+                $"{errors} compile error(s)", razorGenerated);
         }
         if (warnings > 0 && !options.AllowWarnings)
         {
@@ -599,10 +663,12 @@ public static class ProjectBuild
             }
             NameTheDocumentationFile(outputDirectory, model);
             sink.Info(
-                $"[{name}] OK — {model.CompileItems.Length} source file(s), {warnings} warning(s), "
+                $"[{name}] OK — {model.CompileItems.Length} source file(s)"
+                + (razorGenerated == 0 ? "" : $" + {model.RazorItems.Length} Razor file(s)")
+                + $", {warnings} warning(s), "
                 + $"{artifact.Length} bytes in {clock.Elapsed.TotalMilliseconds:F0} ms → {artifact.DllPath}");
             return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
-                model.CompileItems.Length, 0, warnings, artifact.DllPath, [], null);
+                model.CompileItems.Length, 0, warnings, artifact.DllPath, [], null, razorGenerated);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -118,7 +118,6 @@ public static class ProjectBuild
     /// <param name="AssemblyPath">The emitted DLL, when the emit succeeded.</param>
     /// <param name="UnresolvedPackages">Packages neither the container nor <c>--extra-refs</c> supplies.</param>
     /// <param name="Failure">Why the project is red, when it is.</param>
-    /// <param name="RazorCount">How many <c>.razor</c>/<c>.cshtml</c> files the Razor generator compiled.</param>
     public sealed record ProjectResult(
         string ProjectPath,
         string AssemblyName,
@@ -128,9 +127,19 @@ public static class ProjectBuild
         int Warnings,
         string? AssemblyPath,
         ImmutableArray<string> UnresolvedPackages,
-        string? Failure,
-        int RazorCount = 0)
+        string? Failure)
     {
+        /// <summary>
+        /// How many <c>.razor</c>/<c>.cshtml</c> documents the Razor generator produced.
+        ///
+        /// <para>🚨 An <c>init</c> PROPERTY, not a primary-constructor parameter. Adding a
+        /// parameter — even with a default — REPLACES the record's constructor signature, and
+        /// <c>scripts/check-record-signatures.py</c> refuses that for exactly the reason it should:
+        /// every assembly compiled against the old arity calls a constructor that no longer
+        /// exists.</para>
+        /// </summary>
+        public int RazorCount { get; init; }
+
         /// <summary>Compiled, emitted, and within the warning policy.</summary>
         public bool IsGreen => Failure is null && AssemblyPath is not null;
     }
@@ -635,7 +644,7 @@ public static class ProjectBuild
             sink.Error($"[{name}] RED — {errors} error(s), {warnings} warning(s) in {clock.Elapsed.TotalMilliseconds:F0} ms");
             return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
                 model.CompileItems.Length, errors, warnings, null, [],
-                $"{errors} compile error(s)", razorGenerated);
+                $"{errors} compile error(s)") { RazorCount = razorGenerated };
         }
         if (warnings > 0 && !options.AllowWarnings)
         {
@@ -668,7 +677,8 @@ public static class ProjectBuild
                 + $", {warnings} warning(s), "
                 + $"{artifact.Length} bytes in {clock.Elapsed.TotalMilliseconds:F0} ms → {artifact.DllPath}");
             return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
-                model.CompileItems.Length, 0, warnings, artifact.DllPath, [], null, razorGenerated);
+                model.CompileItems.Length, 0, warnings, artifact.DllPath, [], null)
+            { RazorCount = razorGenerated };
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/tools/MeshWeaver.PluginTester/ProjectFile.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectFile.cs
@@ -75,10 +75,6 @@ public static class ProjectFile
     /// <param name="GlobalUsings">Namespaces the SDK would have emitted as <c>global using</c>.</param>
     /// <param name="Properties">Every evaluated property, for diagnosis.</param>
     /// <param name="UnexecutedTargets">Names of <c>Target</c> elements this evaluator did not run.</param>
-    /// <param name="RazorItems">Every <c>.razor</c>/<c>.cshtml</c> the Razor SDK would compile, ordered.</param>
-    /// <param name="RazorLangVersion">The <c>RazorLangVersion</c> the generator is given.</param>
-    /// <param name="RazorConfiguration">The <c>RazorConfiguration</c> the generator is given.</param>
-    /// <param name="SupportLocalizedComponentNames">The <c>SupportLocalizedComponentNames</c> setting.</param>
     public sealed record Model(
         string ProjectPath,
         string Sdk,
@@ -100,12 +96,29 @@ public static class ProjectFile
         ImmutableArray<PackageRef> PackageReferences,
         ImmutableArray<string> GlobalUsings,
         ImmutableDictionary<string, string> Properties,
-        ImmutableArray<string> UnexecutedTargets,
-        ImmutableArray<RazorItem> RazorItems,
-        string RazorLangVersion,
-        string RazorConfiguration,
-        bool SupportLocalizedComponentNames)
+        ImmutableArray<string> UnexecutedTargets)
     {
+        /// <summary>
+        /// Every <c>.razor</c>/<c>.cshtml</c> the Razor SDK would compile, ordered.
+        ///
+        /// <para>🚨 These four are <c>init</c> PROPERTIES, not primary-constructor parameters.
+        /// Adding a parameter — even with a default — REPLACES the record's constructor signature,
+        /// which <c>scripts/check-record-signatures.py</c> refuses for exactly the right reason:
+        /// every assembly compiled against the old arity calls a constructor that no longer
+        /// exists. Defaulted to empty so a model built without them is still safe to enumerate
+        /// (a default <c>ImmutableArray</c> throws).</para>
+        /// </summary>
+        public ImmutableArray<RazorItem> RazorItems { get; init; } = [];
+
+        /// <summary>The <c>RazorLangVersion</c> the generator is given.</summary>
+        public string RazorLangVersion { get; init; } = DefaultRazorLangVersion;
+
+        /// <summary>The <c>RazorConfiguration</c> the generator is given.</summary>
+        public string RazorConfiguration { get; init; } = DefaultRazorConfiguration;
+
+        /// <summary>The <c>SupportLocalizedComponentNames</c> setting.</summary>
+        public bool SupportLocalizedComponentNames { get; init; }
+
         /// <summary>The project's own directory.</summary>
         public string Directory => Path.GetDirectoryName(ProjectPath)!;
     }
@@ -579,11 +592,13 @@ public static class ProjectFile
                     .Select(p => new PackageRef(p.Id, p.Version ?? _packageVersions.GetValueOrDefault(p.Id)))],
                 globalUsings,
                 _properties.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
-                [.. _unexecutedTargets],
-                razorItems,
-                Prop("RazorLangVersion") is { Length: > 0 } rlv ? rlv : DefaultRazorLangVersion,
-                Prop("RazorConfiguration") is { Length: > 0 } rc ? rc : DefaultRazorConfiguration,
-                IsTrue(Prop("SupportLocalizedComponentNames")));
+                [.. _unexecutedTargets])
+            {
+                RazorItems = razorItems,
+                RazorLangVersion = Prop("RazorLangVersion") is { Length: > 0 } rlv ? rlv : DefaultRazorLangVersion,
+                RazorConfiguration = Prop("RazorConfiguration") is { Length: > 0 } rc ? rc : DefaultRazorConfiguration,
+                SupportLocalizedComponentNames = IsTrue(Prop("SupportLocalizedComponentNames")),
+            };
         }
 
         /// <summary>

--- a/tools/MeshWeaver.PluginTester/ProjectFile.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectFile.cs
@@ -43,6 +43,16 @@ public static class ProjectFile
     /// with no matching <c>PackageVersion</c>.</param>
     public sealed record PackageRef(string Id, string? Version);
 
+    /// <summary>
+    /// One Razor input — a <c>.razor</c> component or a <c>.cshtml</c> view — with the
+    /// <c>TargetPath</c> the SDK's <c>AssignTargetPath</c> task would have given it (the path
+    /// relative to the project directory, which is what decides the generated type's namespace).
+    /// </summary>
+    /// <param name="Path">Absolute path of the file.</param>
+    /// <param name="TargetPath">Path relative to the project directory.</param>
+    /// <param name="IsComponent">True for <c>.razor</c>, false for <c>.cshtml</c>.</param>
+    public sealed record RazorItem(string Path, string TargetPath, bool IsComponent);
+
     /// <summary>The evaluated project.</summary>
     /// <param name="ProjectPath">Absolute path of the <c>.csproj</c>.</param>
     /// <param name="Sdk">The <c>Sdk</c> attribute, verbatim.</param>
@@ -65,6 +75,10 @@ public static class ProjectFile
     /// <param name="GlobalUsings">Namespaces the SDK would have emitted as <c>global using</c>.</param>
     /// <param name="Properties">Every evaluated property, for diagnosis.</param>
     /// <param name="UnexecutedTargets">Names of <c>Target</c> elements this evaluator did not run.</param>
+    /// <param name="RazorItems">Every <c>.razor</c>/<c>.cshtml</c> the Razor SDK would compile, ordered.</param>
+    /// <param name="RazorLangVersion">The <c>RazorLangVersion</c> the generator is given.</param>
+    /// <param name="RazorConfiguration">The <c>RazorConfiguration</c> the generator is given.</param>
+    /// <param name="SupportLocalizedComponentNames">The <c>SupportLocalizedComponentNames</c> setting.</param>
     public sealed record Model(
         string ProjectPath,
         string Sdk,
@@ -86,7 +100,11 @@ public static class ProjectFile
         ImmutableArray<PackageRef> PackageReferences,
         ImmutableArray<string> GlobalUsings,
         ImmutableDictionary<string, string> Properties,
-        ImmutableArray<string> UnexecutedTargets)
+        ImmutableArray<string> UnexecutedTargets,
+        ImmutableArray<RazorItem> RazorItems,
+        string RazorLangVersion,
+        string RazorConfiguration,
+        bool SupportLocalizedComponentNames)
     {
         /// <summary>The project's own directory.</summary>
         public string Directory => Path.GetDirectoryName(ProjectPath)!;
@@ -108,6 +126,25 @@ public static class ProjectFile
         /// <summary>Acknowledge a <c>Condition</c> expression outside the supported grammar,
         /// treating it as FALSE. <c>condition:&lt;text&gt;</c> accepts one.</summary>
         public const string AllConditions = "conditions";
+
+        /// <summary>
+        /// Acknowledge that CSS ISOLATION is not applied — the project has <c>*.razor.css</c> files
+        /// whose scope identifier the SDK computes with an MSBuild task this builder does not run,
+        /// so the components compile WITHOUT their <c>b-…</c> scope attributes. The assembly is
+        /// valid and every component in it renders; what it loses is the attribute that makes the
+        /// isolated stylesheet apply. Refused by default because reproducing the scope hash from
+        /// memory is exactly the guess this evaluator exists to avoid, and a half-right scope is
+        /// worse than a named refusal.
+        /// </summary>
+        public const string RazorCssScope = "razor-css-scope";
+
+        /// <summary>
+        /// Acknowledge that <c>.razor</c>/<c>.cshtml</c> files in the project tree are NOT compiled,
+        /// because the project's <c>Sdk</c> does not process Razor items (the SDK's own build would
+        /// ignore them too). Said out loud rather than skipped: a Razor file nobody compiles is the
+        /// exact failure this builder was extended to prevent.
+        /// </summary>
+        public const string RazorNotCompiled = "razor-not-compiled";
     }
 
     /// <summary>
@@ -121,6 +158,16 @@ public static class ProjectFile
         "System", "System.Collections.Generic", "System.IO", "System.Linq",
         "System.Net.Http", "System.Threading", "System.Threading.Tasks",
     ];
+
+    /// <summary>
+    /// What <c>build_property.RazorLangVersion</c> gets when the project does not set one. The SDK
+    /// sets it from the target framework; <c>Latest</c> is what the generator itself falls back to,
+    /// so this matches rather than inventing a third answer.
+    /// </summary>
+    public const string DefaultRazorLangVersion = "Latest";
+
+    /// <summary>What <c>build_property.RazorConfiguration</c> gets when the project does not set one.</summary>
+    public const string DefaultRazorConfiguration = "Default";
 
     /// <summary>The extra implicit usings <c>Microsoft.NET.Sdk.Web</c> adds on top.</summary>
     private static readonly ImmutableArray<string> WebImplicitUsings =
@@ -187,6 +234,8 @@ public static class ProjectFile
         private readonly Dictionary<string, string> _properties = new(StringComparer.OrdinalIgnoreCase);
         private readonly List<string> _compileIncludes = [];
         private readonly List<string> _compileRemoves = [];
+        private readonly List<string> _razorIncludes = [];
+        private readonly List<string> _razorRemoves = [];
         private readonly List<string> _projectReferences = [];
         private readonly List<(string Id, string? Version)> _packageReferences = [];
         private readonly List<string> _usings = [];
@@ -435,8 +484,21 @@ public static class ProjectFile
                             + "two definitions of the same type in one compilation.");
                     break;
 
-                case "None":
+                // 🚨 Content is where Razor lives. The Razor SDK's default items are
+                // `Content Include="**\*.razor"` / `"**\*.cshtml"`, and its ResolveRazorComponentInputs
+                // /ResolveRazorGenerateInputs targets promote exactly those Content items to
+                // RazorComponent / RazorGenerate. So a project's own Content Include/Remove of a
+                // Razor file CHANGES WHAT COMPILES, and dropping it here would silently omit or
+                // silently add a component. Everything else about Content is packaging, which does
+                // not reach csc.
                 case "Content":
+                case "RazorComponent":
+                case "RazorGenerate":
+                    if (include.Length > 0) _razorIncludes.AddRange(Split(include).Where(IsRazorPattern));
+                    if (remove.Length > 0) _razorRemoves.AddRange(Split(remove).Where(IsRazorPattern));
+                    break;
+
+                case "None":
                 case "AdditionalFiles":
                 case "InternalsVisibleTo":
                 case "AssemblyAttribute":
@@ -445,9 +507,9 @@ public static class ProjectFile
                 case "SupportedPlatform":
                 case "TrimmerRootAssembly":
                 case "RuntimeHostConfigurationOption":
-                    // None/Content are packaging inputs; FrameworkReference is satisfied by the
-                    // container's own reference set (the process IS the framework); the rest are
-                    // metadata that does not change which sources compile against what.
+                    // None is a packaging input; FrameworkReference is satisfied by the container's
+                    // own reference set (the process IS the framework); the rest are metadata that
+                    // does not change which sources compile against what.
                     break;
 
                 default:
@@ -478,8 +540,9 @@ public static class ProjectFile
             _defaultCompileItemsDisabled =
                 IsFalse(Prop("EnableDefaultItems")) || IsFalse(Prop("EnableDefaultCompileItems"));
 
+            var razorItems = ResolveRazorItems(sdk);
             var sources = ResolveCompileItems();
-            if (sources.IsEmpty)
+            if (sources.IsEmpty && razorItems.IsEmpty)
                 throw new UnsupportedConstructException(
                     $"{projectPath}: no source files. A compile with nothing in it is a failure here, "
                     + "never a green no-op.");
@@ -516,8 +579,105 @@ public static class ProjectFile
                     .Select(p => new PackageRef(p.Id, p.Version ?? _packageVersions.GetValueOrDefault(p.Id)))],
                 globalUsings,
                 _properties.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
-                [.. _unexecutedTargets]);
+                [.. _unexecutedTargets],
+                razorItems,
+                Prop("RazorLangVersion") is { Length: > 0 } rlv ? rlv : DefaultRazorLangVersion,
+                Prop("RazorConfiguration") is { Length: > 0 } rc ? rc : DefaultRazorConfiguration,
+                IsTrue(Prop("SupportLocalizedComponentNames")));
         }
+
+        /// <summary>
+        /// The Razor inputs, by the Razor SDK's own rule: <c>Content Include="**\*.razor"</c> and
+        /// <c>"**\*.cshtml"</c> (its default items), promoted to <c>RazorComponent</c> /
+        /// <c>RazorGenerate</c>, plus whatever the project itself included or removed.
+        ///
+        /// <para>🚨 Two refusals live here, and both exist because the alternative is a silently
+        /// smaller assembly. A project whose <c>Sdk</c> does not process Razor but which HAS Razor
+        /// files is named (the SDK ignores them too — but this builder says so). A project with
+        /// <c>*.razor.css</c> is named, because the scope identifier comes from an MSBuild task this
+        /// builder does not run, so the components would compile without their isolation
+        /// attributes.</para>
+        /// </summary>
+        private ImmutableArray<RazorItem> ResolveRazorItems(string sdk)
+        {
+            var onDisk = RazorFilesOnDisk().ToImmutableArray();
+            if (!ProcessesRazor(sdk))
+            {
+                if (!onDisk.IsEmpty && !IsAccepted(Accept.RazorNotCompiled))
+                    throw new UnsupportedConstructException(
+                        $"{projectPath}: {onDisk.Length} Razor file(s) under a project whose Sdk is "
+                        + $"'{sdk}', which does not process Razor items — so they are NOT compiled "
+                        + $"({string.Join(", ", onDisk.Take(5).Select(f => Path.GetRelativePath(ProjectDirectory, f)))}"
+                        + (onDisk.Length > 5 ? ", …" : "") + "). The SDK's own build ignores them too, "
+                        + $"so re-run with --accept {Accept.RazorNotCompiled} if that is intended — a "
+                        + "silently skipped .razor file is the failure this check exists to prevent.");
+                return [];
+            }
+
+            var files = new List<string>();
+            // EnableDefaultItems/EnableDefaultContentItems are the two switches the Razor SDK guards
+            // its default Content globs with; either one off means the project lists its own.
+            if (!IsFalse(Prop("EnableDefaultItems")) && !IsFalse(Prop("EnableDefaultContentItems")))
+                files.AddRange(onDisk);
+            foreach (var include in _razorIncludes)
+                files.AddRange(ExpandGlob(include));
+
+            var removed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var pattern in _razorRemoves)
+                foreach (var match in ExpandGlob(pattern))
+                    removed.Add(match);
+
+            var items = files
+                .Where(f => !removed.Contains(f))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(f => f, StringComparer.Ordinal)
+                .Select(f => new RazorItem(
+                    f,
+                    // AssignTargetPath with RootFolder=$(MSBuildProjectDirectory): the path relative
+                    // to the project, which is what the generator turns into the component's
+                    // namespace. Get it wrong and every component lands in the wrong namespace —
+                    // compiles, and nothing resolves it.
+                    Path.GetRelativePath(ProjectDirectory, f),
+                    f.EndsWith(".razor", StringComparison.OrdinalIgnoreCase)))
+                .ToImmutableArray();
+
+            if (!items.IsEmpty && !IsFalse(Prop("ScopedCssEnabled")))
+            {
+                var scoped = ScopedCssFilesOnDisk().ToImmutableArray();
+                if (!scoped.IsEmpty && !IsAccepted(Accept.RazorCssScope))
+                    throw new UnsupportedConstructException(
+                        $"{projectPath}: {scoped.Length} scoped-CSS file(s) (*.razor.css) — the SDK's "
+                        + "ComputeCssScope/ApplyCssScopes tasks derive each component's `b-…` scope "
+                        + "identifier, and this builder runs no MSBuild task, so the components would "
+                        + "compile WITHOUT their scope attributes and the isolated styles would not "
+                        + $"apply. Re-run with --accept {Accept.RazorCssScope} to build them anyway "
+                        + "(the assembly is valid; only CSS isolation is missing).");
+            }
+
+            return items;
+        }
+
+        /// <summary>Every <c>.razor</c>/<c>.cshtml</c> under the project, minus the output trees.</summary>
+        private IEnumerable<string> RazorFilesOnDisk() =>
+            DefaultGlob("*.razor").Concat(DefaultGlob("*.cshtml"));
+
+        /// <summary>Every <c>*.razor.css</c> under the project, minus the output trees.</summary>
+        private IEnumerable<string> ScopedCssFilesOnDisk() => DefaultGlob("*.razor.css");
+
+        /// <summary>
+        /// Whether this SDK compiles Razor. <c>Microsoft.NET.Sdk.Razor</c> does;
+        /// <c>Microsoft.NET.Sdk.Web</c> and <c>Microsoft.NET.Sdk.BlazorWebAssembly</c> import it.
+        /// Plain <c>Microsoft.NET.Sdk</c> does not, and neither does this builder then.
+        /// </summary>
+        private static bool ProcessesRazor(string sdk) =>
+            sdk.Contains("Sdk.Razor", StringComparison.OrdinalIgnoreCase)
+            || sdk.Contains("Sdk.Web", StringComparison.OrdinalIgnoreCase)
+            || sdk.Contains("BlazorWebAssembly", StringComparison.OrdinalIgnoreCase);
+
+        /// <summary>Whether a Content/RazorComponent pattern can name a Razor input at all.</summary>
+        private static bool IsRazorPattern(string pattern) =>
+            pattern.EndsWith(".razor", StringComparison.OrdinalIgnoreCase)
+            || pattern.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase);
 
         private string Prop(string name) => _properties.GetValueOrDefault(name, string.Empty);
 
@@ -544,13 +704,25 @@ public static class ProjectFile
         }
 
         /// <summary>The SDK's default glob: every .cs under the project, minus the output trees.</summary>
-        private IEnumerable<string> DefaultCompileGlob()
+        private IEnumerable<string> DefaultCompileGlob() => DefaultGlob("*.cs");
+
+        /// <summary>
+        /// One of the SDK's default item globs — <c>**\&lt;suffix&gt;</c> under the project, minus
+        /// <c>bin</c>/<c>obj</c>, dot-directories and <c>DefaultItemExcludes</c>. The suffix is
+        /// matched EXACTLY rather than left to <c>EnumerateFiles</c>' three-character-extension
+        /// quirk, so <c>*.razor</c> can never quietly pick up a <c>*.razor.css</c>.
+        /// </summary>
+        /// <param name="suffix">e.g. <c>*.cs</c>, <c>*.razor</c>, <c>*.razor.css</c>.</param>
+        private IEnumerable<string> DefaultGlob(string suffix)
         {
+            var extension = suffix.TrimStart('*');
             var excludes = Split(Prop("DefaultItemExcludes"))
                 .Select(p => Path.GetFullPath(Path.Combine(ProjectDirectory, p.TrimEnd('*', '/', '\\'))))
                 .ToArray();
-            foreach (var file in Directory.EnumerateFiles(ProjectDirectory, "*.cs", SearchOption.AllDirectories))
+            foreach (var file in Directory.EnumerateFiles(ProjectDirectory, suffix, SearchOption.AllDirectories))
             {
+                if (!file.EndsWith(extension, StringComparison.OrdinalIgnoreCase))
+                    continue;
                 var relative = Path.GetRelativePath(ProjectDirectory, file);
                 var segments = relative.Split(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
                 if (segments.Any(s => s is "bin" or "obj" || s.StartsWith('.')))

--- a/tools/MeshWeaver.PluginTester/README.md
+++ b/tools/MeshWeaver.PluginTester/README.md
@@ -31,7 +31,8 @@ mw-compiler build-project <csproj|dir>     # BUILD A .csproj: no dotnet SDK, no 
 
 ```
 mw-plugin-test build-project <csproj|dir> [--output <dir>] [--app <dir>] [--extra-refs <dir>]... \
-    [--generators <dir|dll>]... [--accept <construct>]... [--allow-warnings] [--max-parallel <n>]
+    [--generators <dir|dll>]... [--razor-generators <dir>] \
+    [--accept <construct>]... [--allow-warnings] [--max-parallel <n>]
 ```
 
 Runs INSIDE the image (`memex build project --image …` is the trip in). Three parts:
@@ -75,11 +76,30 @@ for no doc file — which is when csc would not raise it either. The SDK's defau
 (`ActivityCategory.Compilation`) and pushed to the caller's observer the moment it is produced; the
 console is a rendering of that stream, which is why nothing is batched to the end.
 
-**Not supported, and each says so:** Razor/Blazor compilation (needs
-`Microsoft.CodeAnalysis.Razor.Compiler`, `Microsoft.AspNetCore.Razor.Utilities.Shared` and
-`Microsoft.Extensions.ObjectPool` in the image — it ships none), SDK source generators (they live in
-the SDK, not the runtime; `--generators` supplies them), embedded resources, `<Protobuf>`, MSBuild
-`<Target>`s and `<Sdk>` elements. Full measurements:
+**Razor/Blazor compiles** (2026-08-31). `.razor` and `.cshtml` are turned into C# by the SDK's
+Roslyn **source generator**, which the image now ships in `razor-generators/<rid>/` beside the
+builder: `Microsoft.CodeAnalysis.Razor.Compiler.dll` + `Microsoft.AspNetCore.Razor.Utilities.Shared.dll`
+— the measured closure, everything else the compiler references binds to the host.
+
+- 🚨 **Per RID.** The SDK crossgens its Razor compiler for the SDK's own runtime identifier, so ONE
+  copy cannot serve a multi-arch image: the same 10.0.400 file carries PE machine `0xFD1D` on
+  linux-x64 and `0xD11D` on linux-arm64, and the wrong one throws `BadImageFormatException`. CD
+  stages both; `--razor-generators <dir>` names another copy and REPLACES the search rather than
+  heading it.
+- 🚨 **Loaded into a host-first load context.** The generator is built against the SDK's Roslyn
+  (10.0.400's wants `Microsoft.CodeAnalysis` 5.9.0.0) and the image carries this repo's pin (5.6.0);
+  the default context refuses the lower version, so every assembly the host already has is bound to
+  the host's copy with the version ignored — which is also the only way the generator and the driver
+  agree on the identity of `ISourceGenerator`.
+- **Refused by name rather than skipped:** a project with Razor files and no generator (it says what
+  the CS0115 wall would have been); a generator that runs and emits nothing; `*.razor.css` CSS
+  isolation, whose `b-…` scope comes from an MSBuild task this builder does not run
+  (`--accept razor-css-scope` builds without it); and `.razor` files under a project whose `Sdk`
+  does not process them (`--accept razor-not-compiled`).
+
+**Still not supported, and each says so:** SDK source generators (they live in the SDK, not the
+runtime; `--generators` supplies them), embedded resources, `<Protobuf>`, MSBuild `<Target>`s and
+`<Sdk>` elements. Full measurements:
 [In-Mesh Build and Test](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md).
 
 ## `build` — compile AND test, per package, as a dependency cascade (2026-08-30)

--- a/tools/MeshWeaver.PluginTester/RazorGenerators.cs
+++ b/tools/MeshWeaver.PluginTester/RazorGenerators.cs
@@ -1,0 +1,494 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Runtime.Loader;
+using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Text;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// The Razor half of <c>mw-plugin-test build-project</c>: the source generator that turns
+/// <c>.razor</c> / <c>.cshtml</c> into C#, SHIPPED IN THE IMAGE and run against the container's own
+/// Roslyn.
+///
+/// <para><b>Why this exists at all.</b> Razor compilation in the .NET SDK is not a task and not a
+/// tool — it is a Roslyn <b>source generator</b> (<c>Microsoft.CodeAnalysis.Razor.Compiler</c>) that
+/// emits each component as a <c>partial class</c> carrying the generated
+/// <c>BuildRenderTree</c> override. Without it every component compiles to a class whose declared
+/// override has nothing to override, and the build dies in a wall of <b>CS0115</b> — 15 of the 42
+/// failures in the first no-SDK sweep of <c>MeshWeaver.Plugins/src</c>, more than any other
+/// category. A runtime image ships no SDK, so the generator has to be laid into the image
+/// deliberately; <c>razor-generators/</c> beside the builder is where it lands.</para>
+///
+/// <para>🚨 <b>The load context is the whole trick, and it is not a hack.</b> The generator is built
+/// against the Roslyn of the SDK it shipped in (measured: SDK 10.0.400's copy references
+/// <c>Microsoft.CodeAnalysis 5.9.0.0</c>), while the image carries the Roslyn this repo pins
+/// (<c>5.6.0</c>). The default load context binds by name AND refuses a lower version, so a plain
+/// <see cref="Assembly.LoadFrom(string)"/> fails with <i>"Could not load … Microsoft.CodeAnalysis,
+/// Version=5.9.0.0"</i> — and <c>SourceGeneratorLoader</c> correctly treats that as "not a usable
+/// generator" and moves on, which is how a missing Razor generator would otherwise look exactly
+/// like a <c>.razor</c> file nobody asked to compile. So generators load into a context that binds
+/// every assembly the HOST already has to the host's copy, version ignored — the same thing Roslyn's
+/// own analyzer loader does, and the only way the generator and the host agree on the identity of
+/// <c>ISourceGenerator</c>.</para>
+///
+/// <para><b>Nothing here is silent.</b> A project with Razor items and no generator is a named
+/// failure, not a skipped file; a generator that loads but emits nothing for a non-empty item set is
+/// a named failure too. Both say what is missing and where to put it.</para>
+/// </summary>
+public static class RazorGenerators
+{
+    /// <summary>
+    /// The directory, beside the builder, that carries the Razor generator. It is a directory rather
+    /// than two file names because the closure is the SDK's to decide: today it is exactly
+    /// <c>Microsoft.CodeAnalysis.Razor.Compiler.dll</c> + <c>Microsoft.AspNetCore.Razor.Utilities.Shared.dll</c>
+    /// (measured — everything else the compiler references resolves to the host), and a future SDK
+    /// adding a third is then a copy, not a code change.
+    /// </summary>
+    public const string DirectoryName = "razor-generators";
+
+    /// <summary>The provenance manifest the image build writes beside the assemblies.</summary>
+    public const string ManifestName = "razor-generators.json";
+
+    /// <summary>The assembly that carries <c>RazorSourceGenerator</c>.</summary>
+    public const string CompilerAssemblyName = "Microsoft.CodeAnalysis.Razor.Compiler";
+
+    /// <summary>
+    /// 🚨 The RIDs the generator is staged under, most specific first — because the SDK's copy is
+    /// <b>ReadyToRun-compiled for the SDK's own RID</b> and is NOT portable. Measured: the same
+    /// SDK 10.0.400 ships <c>Microsoft.CodeAnalysis.Razor.Compiler.dll</c> with PE machine
+    /// <c>0xFD1D</c> on linux-x64 and <c>0xEC20</c> on osx-arm64 (the target machine XOR'd with the
+    /// operating system's R2R marker), and loading the wrong one throws
+    /// <see cref="BadImageFormatException"/>. The tester image is published for linux-x64 AND
+    /// linux-arm64 from one x64 build host, so "copy the build machine's SDK" would have shipped an
+    /// arm64 image that cannot compile a single Blazor project.
+    /// </summary>
+    public static ImmutableArray<string> RuntimeIdentifiers =>
+    [
+        .. new[]
+        {
+            RuntimeInformation.RuntimeIdentifier,
+            // The portable form, for a host whose RID carries a distro qualifier the staging step
+            // does not know about (linux-musl-x64, for one).
+            $"{OperatingSystemMoniker()}-{RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant()}",
+        }.Distinct(StringComparer.OrdinalIgnoreCase),
+    ];
+
+    private static string OperatingSystemMoniker() =>
+        OperatingSystem.IsWindows() ? "win"
+        : OperatingSystem.IsMacOS() ? "osx"
+        : OperatingSystem.IsLinux() ? "linux"
+        : "unknown";
+
+    /// <summary>
+    /// Raised when Razor input exists and the generator that would compile it does not. Never
+    /// swallowed: the alternative is an assembly that silently lacks every component in the project.
+    /// </summary>
+    /// <param name="message">What is missing, and where it is looked for.</param>
+    public sealed class MissingRazorCompilerException(string message) : Exception(message);
+
+    /// <summary>The generators loaded out of one directory.</summary>
+    /// <param name="Directory">Where they came from.</param>
+    /// <param name="Provenance">The manifest's description of them, or a fallback naming the files.</param>
+    /// <param name="Generators">The discovered <c>[Generator]</c> instances.</param>
+    public sealed record Set(
+        string Directory, string Provenance, ImmutableArray<ISourceGenerator> Generators);
+
+    /// <summary>What running the generator over one project produced.</summary>
+    /// <param name="Compilation">The compilation with the generated components added.</param>
+    /// <param name="GeneratedSources">How many C# documents the generator emitted.</param>
+    /// <param name="Diagnostics">Diagnostics the generator itself reported.</param>
+    public sealed record Outcome(
+        CSharpCompilation Compilation, int GeneratedSources, ImmutableArray<Diagnostic> Diagnostics);
+
+    /// <summary>
+    /// Where a Razor generator is looked for: <c>razor-generators/</c> beside this builder (the
+    /// shape the image publishes, and the shape a mounted <c>/builder</c> keeps), then
+    /// <c>razor-generators/</c> under the container's <c>/app</c>.
+    ///
+    /// <para>🚨 <c>--razor-generators</c> REPLACES that search rather than heading it. An operator
+    /// who names a directory has made a choice, and quietly falling back to the image's own copy
+    /// when the named one turns out to be empty would report on a generator nobody asked for — the
+    /// same class of lie as a build that resolves a reference from somewhere the command line does
+    /// not mention.</para>
+    /// </summary>
+    /// <param name="explicitDirectory">The <c>--razor-generators</c> value, when given.</param>
+    /// <param name="appDirectory">The container's assembly directory.</param>
+    /// <returns>The candidate directories, in the order they are tried.</returns>
+    public static ImmutableArray<string> SearchPath(string? explicitDirectory, string appDirectory)
+    {
+        var bases = ImmutableArray.CreateBuilder<string>();
+        if (explicitDirectory is { Length: > 0 })
+        {
+            bases.Add(Path.GetFullPath(explicitDirectory));
+        }
+        else
+        {
+            bases.Add(Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, DirectoryName)));
+            if (appDirectory is { Length: > 0 })
+                bases.Add(Path.GetFullPath(Path.Combine(appDirectory, DirectoryName)));
+        }
+        // Per-RID first (a multi-arch image stages one directory per RID), then the flat layout a
+        // same-architecture build produces.
+        var candidates = ImmutableArray.CreateBuilder<string>();
+        foreach (var directory in bases)
+        {
+            foreach (var rid in RuntimeIdentifiers)
+                candidates.Add(Path.Combine(directory, rid));
+            candidates.Add(directory);
+        }
+        return [.. candidates.Distinct(StringComparer.Ordinal)];
+    }
+
+    /// <summary>
+    /// Finds the first directory on the search path that actually holds the Razor compiler.
+    /// </summary>
+    /// <param name="explicitDirectory">The <c>--razor-generators</c> value, when given.</param>
+    /// <param name="appDirectory">The container's assembly directory.</param>
+    /// <returns>The directory, or null when the image ships none.</returns>
+    public static string? Locate(string? explicitDirectory, string appDirectory)
+    {
+        foreach (var candidate in SearchPath(explicitDirectory, appDirectory))
+            if (Directory.Exists(candidate)
+                && File.Exists(Path.Combine(candidate, CompilerAssemblyName + ".dll")))
+                return candidate;
+        return null;
+    }
+
+    /// <summary>
+    /// The message a build gets when it has Razor input and the image has no Razor compiler. Public
+    /// because it is asserted: "the generator that did not run" must be NAMED, and a message that
+    /// only the failure path can produce is a message nothing checks.
+    /// </summary>
+    /// <param name="projectName">The project that has the Razor items.</param>
+    /// <param name="razorItemCount">How many <c>.razor</c>/<c>.cshtml</c> files it has.</param>
+    /// <param name="searched">The directories that were tried.</param>
+    /// <returns>The failure text.</returns>
+    public static string MissingCompilerMessage(
+        string projectName, int razorItemCount, IEnumerable<string> searched) =>
+        $"{projectName}: {razorItemCount} Razor file(s) and no Razor source generator. "
+        + $"'{CompilerAssemblyName}.dll' is what turns a .razor component into the partial class "
+        + "carrying its BuildRenderTree override; without it every component in this project would "
+        + "compile to a class with nothing to override (a wall of CS0115) — so this fails here, by "
+        + "name, rather than there, as broken-looking source. Looked in: "
+        + string.Join(", ", searched)
+        + $". Ship it in the image ({DirectoryName}/ beside the builder, or "
+        + $"{DirectoryName}/{RuntimeInformation.RuntimeIdentifier}/ — the SDK's copy is "
+        + "ReadyToRun-compiled for one RID and does not load on another) or pass "
+        + "--razor-generators <dir>.";
+
+    /// <summary>
+    /// Loads the Razor generator out of <paramref name="directory"/>.
+    ///
+    /// <para>Every <c>*.dll</c> in the directory is a load candidate — the assemblies are the SDK's
+    /// closure, not a list this repo maintains — but only types carrying
+    /// <see cref="GeneratorAttribute"/> become generators.</para>
+    /// </summary>
+    /// <param name="directory">The directory holding the generator and its private dependencies.</param>
+    /// <param name="logger">Where load failures are reported; they are never swallowed.</param>
+    /// <returns>The loaded set.</returns>
+    /// <exception cref="MissingRazorCompilerException">The directory holds no usable generator.</exception>
+    public static Set Load(string directory, ILogger logger)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(directory);
+        ArgumentNullException.ThrowIfNull(logger);
+        var full = Path.GetFullPath(directory);
+        if (!Directory.Exists(full))
+            throw new MissingRazorCompilerException(
+                $"--razor-generators '{full}' does not exist. A generator directory that is not there "
+                + "compiles no component and silently produces a different assembly.");
+
+        var context = new HostFirstLoadContext(full);
+        var generators = ImmutableArray.CreateBuilder<ISourceGenerator>();
+        var loadFailures = new List<string>();
+        foreach (var dll in Directory.GetFiles(full, "*.dll").OrderBy(p => p, StringComparer.Ordinal))
+        {
+            Assembly assembly;
+            try
+            {
+                assembly = context.LoadFromAssemblyPath(dll);
+            }
+            catch (BadImageFormatException ex)
+            {
+                // 🚨 The architecture trap, named. The SDK crossgens its Razor compiler for the
+                // SDK's own RID, so an image that staged the build host's copy into an
+                // arm64 leg fails EXACTLY here — and "incorrect format" on its own sends the reader
+                // hunting for a corrupt file.
+                loadFailures.Add(
+                    $"{Path.GetFileName(dll)}: {ex.Message.TrimEnd()} — this is what a Razor compiler "
+                    + $"built for another architecture looks like. This process is "
+                    + $"{RuntimeInformation.RuntimeIdentifier}; the SDK's copy is ReadyToRun-compiled "
+                    + "for exactly one RID, so the image must stage the copy for THIS one.");
+                continue;
+            }
+            catch (Exception ex) when (ex is FileLoadException or FileNotFoundException)
+            {
+                loadFailures.Add($"{Path.GetFileName(dll)}: {ex.GetType().Name}: {ex.Message}");
+                continue;
+            }
+
+            Type?[] types;
+            try
+            {
+                types = assembly.GetTypes();
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                // 🚨 The signature of the version skew this loader exists to defeat, kept LOUD:
+                // Roslyn's own loader logs this at debug and moves on, which is how "the Razor
+                // generator did not load" turns into "the .razor files were never compiled".
+                loadFailures.Add(
+                    $"{Path.GetFileName(dll)}: {ex.LoaderExceptions.FirstOrDefault()?.Message ?? ex.Message}");
+                types = ex.Types;
+            }
+
+            foreach (var type in types)
+            {
+                if (type is null || type.IsAbstract) continue;
+                if (type.GetCustomAttributes(typeof(GeneratorAttribute), inherit: false).Length == 0) continue;
+                if (type.GetConstructor(Type.EmptyTypes) is null) continue;
+                try
+                {
+                    switch (Activator.CreateInstance(type))
+                    {
+                        case IIncrementalGenerator incremental:
+                            generators.Add(incremental.AsSourceGenerator());
+                            break;
+                        case ISourceGenerator source:
+                            generators.Add(source);
+                            break;
+                        default:
+                            break;
+                    }
+                }
+                catch (Exception ex) when (ex is TargetInvocationException or MissingMethodException
+                                               or TypeLoadException or FileNotFoundException)
+                {
+                    loadFailures.Add($"{type.FullName}: {ex.GetType().Name}: {ex.Message}");
+                }
+            }
+        }
+
+        if (generators.Count == 0)
+            throw new MissingRazorCompilerException(
+                $"'{full}' holds no usable Roslyn source generator"
+                + (loadFailures.Count == 0
+                    ? ". The Razor compiler is a [Generator] type; a directory of assemblies with none "
+                      + "of them compiles no component."
+                    : " — " + string.Join("; ", loadFailures))
+                + ".");
+
+        foreach (var failure in loadFailures)
+            logger.LogWarning("razor generator: {Failure}", failure);
+
+        return new Set(full, ReadProvenance(full), generators.ToImmutable());
+    }
+
+    /// <summary>
+    /// Runs the Razor generator over <paramref name="compilation"/> with the project's Razor items as
+    /// <see cref="AdditionalText"/>s and the MSBuild properties the SDK marks compiler-visible.
+    /// </summary>
+    /// <param name="compilation">The C# compilation the components join.</param>
+    /// <param name="model">The evaluated project — its Razor items, root namespace and directory.</param>
+    /// <param name="set">The loaded generator.</param>
+    /// <param name="parseOptions">The same parse options the project's own sources use.</param>
+    /// <param name="ct">Cancellation.</param>
+    /// <returns>The updated compilation and what the generator reported.</returns>
+    /// <exception cref="MissingRazorCompilerException">The generator produced nothing at all.</exception>
+    public static Outcome Run(
+        CSharpCompilation compilation,
+        ProjectFile.Model model,
+        Set set,
+        CSharpParseOptions parseOptions,
+        CancellationToken ct)
+    {
+        ArgumentNullException.ThrowIfNull(compilation);
+        ArgumentNullException.ThrowIfNull(model);
+        ArgumentNullException.ThrowIfNull(set);
+        ArgumentNullException.ThrowIfNull(parseOptions);
+
+        var texts = model.RazorItems
+            .Select(item => (AdditionalText)new RazorFile(item.Path))
+            .ToImmutableArray();
+        var options = new RazorOptionsProvider(model);
+
+        var driver = CSharpGeneratorDriver.Create(
+            set.Generators, texts, parseOptions, options);
+        driver.RunGeneratorsAndUpdateCompilation(compilation, out var updated, out var diagnostics, ct);
+
+        var generated = updated.SyntaxTrees.Count() - compilation.SyntaxTrees.Count();
+        if (generated <= 0)
+            // 🚨 A generator that ran and produced nothing is the WORST outcome available: the build
+            // goes on to fail on CS0115 as if the components were broken, and the real answer —
+            // "the generator saw no input it recognised" — is nowhere. So it is a failure here.
+            throw new MissingRazorCompilerException(
+                $"{Path.GetFileNameWithoutExtension(model.ProjectPath)}: the Razor generator ran over "
+                + $"{model.RazorItems.Length} file(s) and emitted NOTHING. That is not a compile error, "
+                + "it is a generator that did not recognise its input — check the TargetPath metadata "
+                + "and the RazorLangVersion this build passed it"
+                + (diagnostics.IsDefaultOrEmpty
+                    ? "; the generator reported no diagnostic of its own."
+                    : ": " + string.Join("; ", diagnostics.Select(d => d.ToString()))));
+
+        return new Outcome((CSharpCompilation)updated, generated, diagnostics);
+    }
+
+    /// <summary>
+    /// Reads the image build's provenance note, or describes the files when there is none. The
+    /// manifest sits at the ROOT of the staged tree, one level above the per-RID directory the
+    /// generator was actually loaded from, so both are checked.
+    /// </summary>
+    private static string ReadProvenance(string directory)
+    {
+        foreach (var candidate in new[]
+                 {
+                     Path.Combine(directory, ManifestName),
+                     Path.Combine(Path.GetDirectoryName(directory) ?? directory, ManifestName),
+                 })
+        {
+            if (!File.Exists(candidate)) continue;
+            try
+            {
+                return string.Join(' ', File.ReadAllLines(candidate).Select(l => l.Trim()))
+                    .Replace("  ", " ", StringComparison.Ordinal);
+            }
+            catch (IOException)
+            {
+                // Fall through to the file listing: an unreadable manifest must not cost the build.
+            }
+        }
+        return string.Join(", ", Directory
+            .GetFiles(directory, "*.dll")
+            .Select(Path.GetFileName)
+            .OrderBy(n => n, StringComparer.Ordinal));
+    }
+
+    // ── the load context ───────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// A load context that binds every assembly the HOST already has to the host's copy, IGNORING
+    /// the version the generator asked for, and loads only what the host does not have from the
+    /// generator directory.
+    ///
+    /// <para>🚨 Both halves are load-bearing. Binding Roslyn to the host is what lets a generator
+    /// built against a newer Roslyn run at all (SDK 10.0.400 wants 5.9.0.0; the image has 5.6.0.0) —
+    /// and, more importantly, it is what keeps <see cref="ISourceGenerator"/> ONE type: a second
+    /// Roslyn loaded into this context would give the generator a different
+    /// <c>ISourceGenerator</c> than the driver expects, and nothing would ever match. Loading the
+    /// private dependency (<c>Microsoft.AspNetCore.Razor.Utilities.Shared</c>) from the directory is
+    /// what makes the compiler work at all: with it absent the compiler assembly loads, its types
+    /// enumerate, and every call into it throws — measured.</para>
+    /// </summary>
+    private sealed class HostFirstLoadContext : AssemblyLoadContext
+    {
+        private readonly ImmutableDictionary<string, string> _local;
+
+        internal HostFirstLoadContext(string directory)
+            : base("mw-razor-generators", isCollectible: false)
+        {
+            _local = Directory
+                .GetFiles(directory, "*.dll")
+                .ToImmutableDictionary(
+                    p => Path.GetFileNameWithoutExtension(p), p => p, StringComparer.OrdinalIgnoreCase);
+        }
+
+        protected override Assembly? Load(AssemblyName assemblyName)
+        {
+            if (assemblyName.Name is not { Length: > 0 } name)
+                return null;
+            try
+            {
+                // Version-BLIND on purpose: `new AssemblyName(name)` carries no version, so the
+                // default context resolves by simple name and hands back whatever the image ships.
+                return Default.LoadFromAssemblyName(new AssemblyName(name));
+            }
+            catch (Exception ex) when (ex is FileNotFoundException or FileLoadException or BadImageFormatException)
+            {
+                // Not a host assembly — fall through to the generator's own directory.
+            }
+            return _local.TryGetValue(name, out var path) ? LoadFromAssemblyPath(path) : null;
+        }
+    }
+
+    // ── the compiler-visible inputs ────────────────────────────────────────────────────────────
+
+    /// <summary>One <c>.razor</c> / <c>.cshtml</c> file, as Roslyn's generator driver wants it.</summary>
+    private sealed class RazorFile(string path) : AdditionalText
+    {
+        public override string Path { get; } = path;
+
+        public override SourceText? GetText(CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                using var stream = File.OpenRead(Path);
+                return SourceText.From(stream, Encoding.UTF8);
+            }
+            catch (IOException)
+            {
+                // The driver treats a null text as "no content"; the generator then reports its own
+                // diagnostic naming the file, which is a better message than an exception here.
+                return null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// The MSBuild inputs <c>Microsoft.NET.Sdk.Razor.SourceGenerators.targets</c> marks
+    /// <c>CompilerVisibleProperty</c> / <c>CompilerVisibleItemMetadata</c>, reproduced exactly:
+    /// <c>RazorLangVersion</c>, <c>RootNamespace</c>, <c>SupportLocalizedComponentNames</c>,
+    /// <c>GenerateRazorMetadataSourceChecksumAttributes</c>, <c>MSBuildProjectDirectory</c>, and per
+    /// file <c>TargetPath</c> (base64, as the SDK's <c>EncodeRazorInputItem</c> task writes it) plus
+    /// <c>CssScope</c>.
+    /// </summary>
+    private sealed class RazorOptionsProvider : AnalyzerConfigOptionsProvider
+    {
+        private readonly ImmutableDictionary<string, AnalyzerConfigOptions> _perFile;
+
+        internal RazorOptionsProvider(ProjectFile.Model model)
+        {
+            GlobalOptions = new Options(new Dictionary<string, string>(StringComparer.Ordinal)
+            {
+                ["build_property.RootNamespace"] = model.RootNamespace,
+                ["build_property.RazorLangVersion"] = model.RazorLangVersion,
+                ["build_property.RazorConfiguration"] = model.RazorConfiguration,
+                ["build_property.MSBuildProjectDirectory"] = model.Directory,
+                ["build_property.SupportLocalizedComponentNames"] =
+                    model.SupportLocalizedComponentNames ? "true" : "false",
+                ["build_property.GenerateRazorMetadataSourceChecksumAttributes"] = "false",
+            });
+            _perFile = model.RazorItems.ToImmutableDictionary(
+                item => item.Path,
+                item => (AnalyzerConfigOptions)new Options(new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    // 🚨 BASE64. The SDK pipes every Razor item through EncodeRazorInputItem before
+                    // handing it to the compiler, and the generator decodes it unconditionally — a
+                    // plain relative path here throws inside the generator instead of producing a
+                    // component.
+                    ["build_metadata.AdditionalFiles.TargetPath"] =
+                        Convert.ToBase64String(Encoding.UTF8.GetBytes(item.TargetPath)),
+                }),
+                StringComparer.Ordinal);
+        }
+
+        public override AnalyzerConfigOptions GlobalOptions { get; }
+
+        public override AnalyzerConfigOptions GetOptions(SyntaxTree tree) => Options.Empty;
+
+        public override AnalyzerConfigOptions GetOptions(AdditionalText textFile) =>
+            _perFile.GetValueOrDefault(textFile.Path, Options.Empty);
+
+        private sealed class Options(Dictionary<string, string> values) : AnalyzerConfigOptions
+        {
+            internal static readonly Options Empty = new([]);
+
+            public override bool TryGetValue(string key, out string value) =>
+                values.TryGetValue(key, out value!);
+        }
+    }
+}


### PR DESCRIPTION
> **Stacks on #2850** (`feat/cli-build-project`, the SDK-free `memex build project`). This PR is
> based on that branch and targets it, so the diff here is only the Razor work; GitHub retargets it
> to `main` when #2850 lands. **Do not merge this into the feature branch by hand** — a stacked
> sub-PR that merges into its parent is merged and *not delivered*.

Razor was the **biggest single gap** in #2850's first no-SDK sweep of `MeshWeaver.Plugins/src`:
**15 of 42 failures were CS0115**, more than any other category. The cause was one missing file, not
a missing feature — **Razor compilation in the .NET SDK is a Roslyn source generator**
(`Microsoft.CodeAnalysis.Razor.Compiler`) that turns each `.razor` into the partial class carrying
its `BuildRenderTree` override. A runtime image ships no SDK, so every component compiled to a class
with nothing to override.

The image now carries the generator in `razor-generators/<rid>/` beside the builder, and
`build-project` finds and runs it automatically for any project whose `Sdk` processes Razor items.

## The dependency closure, established rather than assumed

The brief named three assemblies. **Two are needed; the third is not.**

| assembly | verdict |
|---|---|
| `Microsoft.CodeAnalysis.Razor.Compiler` | needed — carries `RazorSourceGenerator` |
| `Microsoft.AspNetCore.Razor.Utilities.Shared` | needed — its one private dependency |
| `Microsoft.Extensions.ObjectPool` | **not referenced at all** by this compiler build |

**How it was established.** Read the compiler's own `AssemblyRef` table (`netstandard`,
`Microsoft.CodeAnalysis` 5.9.0.0, `Microsoft.CodeAnalysis.CSharp` 5.9.0.0,
`System.Collections.Immutable`, `System.Memory`, `System.Buffers`,
`Microsoft.AspNetCore.Razor.Utilities.Shared` — no ObjectPool), then **proved it by deleting**:
with `Utilities.Shared` removed the compiler assembly still loads and its types still enumerate, and
every call into it throws — the exact "generator silently produces nothing" shape this design exists
to prevent. `Microsoft.Extensions.ObjectPool` is referenced by the older *NuGet* build of the Razor
compiler (`10.0.0-preview.25277.114`), which is presumably where the belief came from.

## Two traps that fail at run time and nowhere else

🚨 **The generator is built against the SDK's Roslyn, not the image's.** SDK 10.0.400's copy wants
`Microsoft.CodeAnalysis` **5.9.0.0**; the image carries this repo's pin, **5.6.0**. The default load
context binds by name *and refuses a lower version*, so a plain `Assembly.LoadFrom` fails with
`Could not load … Version=5.9.0.0` — and `SourceGeneratorLoader` correctly reads that as "not a
usable generator" and moves on, which is how a missing Razor compiler ends up indistinguishable from
a `.razor` file nobody asked to compile. Generators therefore load into a context that binds **every
assembly the host already has to the host's copy, version ignored** (the same thing Roslyn's own
analyzer loader does). That is also what keeps `ISourceGenerator` **one** type: a second Roslyn in
that context would hand the generator a different interface than the driver expects.

🚨 **The generator is ReadyToRun-compiled for the SDK's own RID.** Measured on SDK 10.0.400, the same
`Microsoft.CodeAnalysis.Razor.Compiler.dll` carries PE machine **`0xFD1D` on linux-x64**, **`0xD11D`
on linux-arm64** and **`0xEC20` on osx-arm64** (the target machine XOR'd with the OS's R2R marker),
and the wrong one throws `BadImageFormatException`. `mw-plugin-test` publishes **both** architectures
from **one x64 host**, so "copy the build machine's SDK" would have shipped an arm64 image that
cannot compile a single Blazor project. CD now stages one directory per RID — the arm64 copy read out
of `mcr.microsoft.com/dotnet/sdk:<the runner's own SDK version>` with `docker create` + `docker cp`,
so no emulation runs and there is no second pin to drift.

## The `.razor` item glob, and what is refused

`ProjectFile` now evaluates the Razor SDK's default items (`Content Include="**\*.razor"` /
`"**\*.cshtml"`, promoted to `RazorComponent`/`RazorGenerate`) plus the project's own
`Content`/`RazorComponent`/`RazorGenerate` `Include`/`Remove`, and assigns each the `TargetPath`
`AssignTargetPath` would have (relative to the project directory — that is what decides the generated
type's namespace, and getting it wrong compiles into a namespace nothing references).

**Nothing is skipped in silence.** Four named failures, all tested:

| refusal | why |
|---|---|
| Razor files + no generator | says what the CS0115 wall *would* have been, instead of printing it — **one** error, not a wall |
| generator ran, emitted nothing | not a compile error; a generator that did not recognise its input |
| `*.razor.css` CSS isolation | the `b-…` scope comes from the SDK's `ComputeCssScope`/`ApplyCssScopes` tasks; this builder runs no MSBuild task, so the components would compile without their scope attributes. `--accept razor-css-scope` builds them anyway. Reproducing the scope hash from memory is the guess this evaluator exists to avoid |
| `.razor` under a non-Razor `Sdk` | the SDK ignores them too — but this says so. `--accept razor-not-compiled` |

## Measured, 2026-08-31 — 10 of the 11 Razor projects

Every `Microsoft.NET.Sdk.Razor` project in `MeshWeaver.Plugins/src`, built inside
`memex-portal-ai@sha256:6f38db08…` with this branch's builder mounted:

| | count | |
|---|---|---|
| **green, no extra help** | **7** | `MeshWeaver.Blazor` (**31 `.cs` + 42 `.razor`**, 0 warnings under warnings-as-errors), `.EntityViews`, `.Graph`, `.Analysis`, `.OpenStreetMap`, `.GoogleMaps`, `.AppleMaps` |
| green with `--generators` | +2 | `.Views`, `.Portal` — blocked by `[GeneratedRegex]` in `MeshWeaver.Markdown.Collaboration`, **not** by Razor |
| green with `--extra-refs` | +1 | `.Radzen` — `Radzen.Blazor` is an additional library |
| still red | 1 | `Memex.Portal.Gui` — a transitive `MeshWeaver.Hosting.Grpc` carries `<Protobuf>`; protoc is a build task, not a compile |

**Razor blocks none of them.** The two remaining categories are the pre-existing ones.

⚠️ The sweep ran on **`linux/arm64`**, natively on an Apple Silicon host. The `linux/amd64` runs on
that host crash under Rosetta — and the **control proves it is the emulator, not this change**: the
same emulated container dies with `AccessViolationException` building `MeshWeaver.Speech`, a project
with no Razor in it that #2850 verified green. CI runs on real x64 and is the x64 evidence.

## The framework build identity is untouched

No `ProjectReference` was added to `tools/MeshWeaver.PluginTester` — whose closure **is** the
framework identity. The assemblies ride along as `Content` with `CopyToPublishDirectory` and are
loaded at run time. `FrameworkBuildIdentityTest` (23 cases) still passes. `OptionsFingerprint` and
`EmitPipeline.CreateCompilationOptions` are not touched either; `MeshWeaver.Compiler` is not
modified at all by this PR.

## Tests — 13 new, EXECUTED

`dotnet test test/MeshWeaver.PluginTester.Test -c Release` → **Passed! Failed: 0, Passed: 188**
(175 before, no regressions).

- the shipped generator is found beside the builder and **loads** against this repo's Roslyn, and the
  loaded generator is `RazorSourceGenerator`;
- the staged closure is the compiler + its one private dependency, in a **per-RID** directory, with a
  provenance manifest;
- a **real** `.razor` (with `@inherits`, markup and `@code`) compiles and the emitted assembly's
  component type is **loaded** and its generated `BuildRenderTree` override found on it;
- a sub-directory component lands in the namespace the `TargetPath` dictates;
- `_Imports.razor` contributes its usings to a sibling (it would not compile otherwise);
- **the failure path names the missing generator** and reports **one** error rather than CS0115 noise;
- scoped CSS, and `.razor` under a plain `Sdk`, are each refused by name and build under their
  `--accept` token;
- `Content Remove` takes a component out of the build; `--razor-generators` **replaces** the search
  path rather than heading it (no silent fallback to the image's own copy);
- a missing directory, and a directory of non-generator assemblies, are each a named failure.

## Docs

`Doc/Architecture/InMeshBuildAndTest.md` gains a *"The container compiles Razor"* section — the
measured closure, both traps, the refusals and the sweep table — and the two READMEs
(`MeshWeaver.Cli`, `MeshWeaver.PluginTester`) are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
