### PR TITLE
fix(cd): every ACR login gets the bounded transport retry — the bare one blocked delivery

### DIFF
--- a/.github/scripts/acr-login.sh
+++ b/.github/scripts/acr-login.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Bounded transport retry for `az acr login` — the SAME idiom the bake job's
+# "ACR login + pull" step proved out (5 attempts, 5s→40s exponential backoff,
+# loud between attempts, red after the last).
+#
+# Why this exists: ACR reachability from a single runner is INTERMITTENT per
+# job, not an outage — measured three distinct symptoms in one evening
+# (2026-08-30): `Connection refused` (16:35, migration), 416
+# `RequestedRangeNotSatisfiable` (18:53, portal-ai), and
+# `az acr login … context deadline exceeded` (23:43, portal-ai) — each while
+# SIBLING jobs in the same run logged into the same registry minutes earlier
+# and pushed successfully (#2827). The portal-ai PUBLISH already carries a
+# bounded, class-discriminating retry that even re-logins between attempts —
+# but the INITIAL login step sat outside it, so the one transport failure the
+# retry could not see was the one that blocked delivery.
+#
+# Login is pure transport: there is no compiler-diagnostics class to
+# discriminate here (that discrimination belongs to the publish retry, #2839),
+# so a plain bounded retry suppresses nothing deterministic.
+set -uo pipefail
+attempts=5
+for attempt in $(seq 1 "$attempts"); do
+  if az acr login --name meshweaver; then
+    [ "$attempt" -gt 1 ] && echo "acr-login: reached the registry on attempt $attempt"
+    exit 0
+  fi
+  if [ "$attempt" -lt "$attempts" ]; then
+    delay=$((5 * 2 ** (attempt - 1)))
+    echo "acr-login: attempt $attempt failed; retrying in ${delay}s" >&2
+    sleep "$delay"
+  fi
+done
+echo "::error::az acr login failed after $attempts attempts — the registry was unreachable from this runner for the whole backoff window (~75s), not a blip. See #2827 for the symptom family."
+exit 1

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -847,7 +847,9 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: ACR login
-        run: az acr login --name meshweaver
+        # Bounded transport retry — the bare one-liner died on `context deadline exceeded`
+        # (2026-08-30 23:43) OUTSIDE the publish retry and blocked delivery. See the script.
+        run: bash .github/scripts/acr-login.sh
       # portal-ai app image — the deployment image (aspnet + node + Claude Code/Copilot CLIs),
       # layered on the base already in ACR. The base (memex-portal-ai-base) changes rarely and is
       # rebuilt by the release path / runbook §1, NOT on every main merge.
@@ -1013,7 +1015,9 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: ACR login
-        run: az acr login --name meshweaver
+        # Bounded transport retry — the bare one-liner died on `context deadline exceeded`
+        # (2026-08-30 23:43) OUTSIDE the publish retry and blocked delivery. See the script.
+        run: bash .github/scripts/acr-login.sh
       # migration — lean image on the standard (already multi-arch) aspnet base; same multi-arch publish.
       # <RuntimeIdentifiers> lives in Memex.Database.Migration.csproj (project-local, same reason as above).
       - name: Build + push migration (staging tag)
@@ -1067,7 +1071,9 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: ACR login
-        run: az acr login --name meshweaver
+        # Bounded transport retry — the bare one-liner died on `context deadline exceeded`
+        # (2026-08-30 23:43) OUTSIDE the publish retry and blocked delivery. See the script.
+        run: bash .github/scripts/acr-login.sh
       # Lean console image on the standard multi-arch base; <RuntimeIdentifiers> lives in the
       # csproj (project-local — a global -p:RuntimeIdentifiers breaks referenced libs, see above).
       # `latest` (the tag the plugins repo pins as MW_TEST_IMAGE) and the GHCR mirror both moved
@@ -1111,7 +1117,9 @@ jobs:
       # buildx reads registry credentials from ~/.docker/config.json, which is what both of these
       # logins write — one store, both registries.
       - name: ACR login
-        run: az acr login --name meshweaver
+        # Bounded transport retry — the bare one-liner died on `context deadline exceeded`
+        # (2026-08-30 23:43) OUTSIDE the publish retry and blocked delivery. See the script.
+        run: bash .github/scripts/acr-login.sh
       - name: Log in to GHCR
         uses: docker/login-action@v4
         with:
@@ -1852,7 +1860,9 @@ jobs:
           V_PLUGIN: ${{ needs.plugin-test-image.outputs.version }}
         run: |
           set -euo pipefail
-          az acr login --name meshweaver
+          # Retried login (same transport class as the step-level sites — and this one guards the
+          # BUILD FACT, which drives every consumer repo's pin update; see acr-login.sh).
+          bash .github/scripts/acr-login.sh
           # The digest of mw-plugin-test:main — the exact pin (MW_IMAGE_DIGEST) the plugin repos
           # compile against. Resolved HERE so the mesh side needs no registry credential.
           # 🚨 Resolved from THIS run's version tag, never `:main` — `main` moves the moment another run
@@ -1978,7 +1988,9 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: ACR login
-        run: az acr login --name meshweaver
+        # Bounded transport retry — the bare one-liner died on `context deadline exceeded`
+        # (2026-08-30 23:43) OUTSIDE the publish retry and blocked delivery. See the script.
+        run: bash .github/scripts/acr-login.sh
       - name: Resolve the promoted tester image's digest
         id: digest
         env:


### PR DESCRIPTION
CD run 33342526974 — the first post-#993 run to attempt publication — lost its `portal-ai` leg to `az acr login` → `context deadline exceeded`, with `Promote` correctly skipping all-or-nothing. The OIDC exchange succeeded; the Docker daemon simply couldn't reach the registry from that runner. Third distinct ACR transport symptom in one evening, each intermittent **per job** while sibling jobs pushed to the same registry minutes earlier (#2827, c5's writeup).

The irony fixed here: the portal-ai **publish** already carries a bounded, class-discriminating retry (#2839) that *re-logins between attempts* — but the **initial login step sat outside it**, so the one transport failure the retry couldn't see was the one that blocked delivery.

## Change

`.github/scripts/acr-login.sh` — the exact idiom the bake job's "ACR login + pull" step already proved (5 attempts, 5s→40s exponential backoff, loud between attempts, `::error` naming the ~75s window after the last). Login is pure transport — there is no compiler-diagnostics class to discriminate at login (that discrimination stays where it belongs, in the publish retry, #2839) — so a plain bounded retry suppresses nothing deterministic, consistent with the workflow's "never paper over a failing build leg" rule.

Swapped in at the **5 bare step-level sites** (portal-ai, migration, tester, promote-digest, fact legs) and the **inline login inside "Sign and POST the build fact"** — that one guards the build fact that drives every consumer repo's pin update, and under `set -euo pipefail` a single transport blip would have killed it identically. Untouched on purpose: the `|| true` re-login inside the publish retry, and the already-retried login+pull in the bake job.

`bash -n` clean · `check-workflow-shell.py` 0 live findings · YAML parses.

Meanwhile the blocked run itself was re-run (`gh run rerun --failed`, in progress) — this PR is the fix for the class, per "when CD is wrong, FIX CD"; the rerun is tonight's remediation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoG4USP5fd8wsxCD7e9q4x