### PR TITLE
fix(activity): the compile lane finishes by OUTCOME — both terminal writers, one answer

### DIFF
--- a/src/MeshWeaver.Data.Contract/ActivityLog.cs
+++ b/src/MeshWeaver.Data.Contract/ActivityLog.cs
@@ -261,6 +261,34 @@ public record ActivityLog(string Category)
         };
 
     /// <summary>
+    /// Finish by OUTCOME: <see cref="ActivityStatus.Failed"/> when the log (or a sub-activity)
+    /// recorded an error, otherwise <see cref="ActivityStatus.Succeeded"/> — warning entries stay
+    /// in the transcript (and in <see cref="MaxSeverity"/>) but never demote the terminal status.
+    ///
+    /// <para>🚨 This exists because <see cref="Finish(int, ActivityStatus?)"/>'s
+    /// <c>overrideStatus</c> is a FLOOR, not a pin: <c>Finish(v, Succeeded)</c> with one Warning
+    /// message yields <see cref="ActivityStatus.Warning"/>. The compile lane finished with that
+    /// fold while <c>NodeTypeCompilationActivity</c> pinned the activity node — two terminal
+    /// writers disagreeing on the same activity, and which one a
+    /// <c>GetCompilationPathResponse</c> surfaced depended on the compile write-back race
+    /// (2026-08-30 merge-queue incident: <c>Status=Succeeded</c> + <c>MaxSeverity=Warning</c> on
+    /// one log; CI load flipped the surfaced side to Warning and red-flagged green compiles).
+    /// A pipeline whose contract is "warnings are reported, never demote" finishes through
+    /// THIS method at every terminal write, so both writers give one answer.</para>
+    /// </summary>
+    /// <param name="version">The workspace version to record on the finished activity.</param>
+    /// <returns>The finished activity log, Failed on recorded errors, otherwise Succeeded.</returns>
+    public ActivityLog FinishByOutcome(int version) =>
+        this with
+        {
+            Status = HasErrors() || SubActivities.Any(s => s.Status == ActivityStatus.Failed)
+                ? ActivityStatus.Failed
+                : ActivityStatus.Succeeded,
+            End = DateTime.UtcNow,
+            Version = version
+        };
+
+    /// <summary>
     /// The status implied by what has been logged: the worse of the sub-activities' statuses and the
     /// severity roll-up.
     /// <para>🚨 Derived from <see cref="MaxSeverity"/> — a counter — <b>not</b> from a scan of

--- a/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshNodeCompilationService.cs
@@ -335,7 +335,7 @@ internal class MeshNodeCompilationService(
             logger.LogDebug("Node {NodePath} has no NodeType, skipping assembly compilation", node.Path);
             return Observable.Return(new CompileAttempt(null, null,
                 AppendInfo(log, $"Skipped — node '{node.Path}' has no NodeType.")
-                    .Finish((int)hub.Version, ActivityStatus.Succeeded),
+                    .FinishByOutcome((int)hub.Version),
                 Array.Empty<MeshNode>()));
         }
 
@@ -417,7 +417,7 @@ internal class MeshNodeCompilationService(
                                 null,
                                 AppendInfo(log,
                                     $"Cache hit — returning {cachedDllPath} (effective LastModified={effectiveLastModified:O}).")
-                                    .Finish((int)hub.Version, ActivityStatus.Succeeded),
+                                    .FinishByOutcome((int)hub.Version),
                                 sources));
                         }
                     }
@@ -975,7 +975,7 @@ internal class MeshNodeCompilationService(
                                 $"Compiled assembly loaded in-memory ({actualPath}).");
                         }
                         return (finalPath, emit.InputDigest,
-                            finalLog.Finish((int)hub.Version, ActivityStatus.Succeeded));
+                            finalLog.FinishByOutcome((int)hub.Version));
                     })
                     // 🚨 THE SINGLE REPORTER of a compile failure. Every CompilationException —
                     // Roslyn diagnostics from the disk emit (EmitCompilationToDirectory) or the
@@ -1165,15 +1165,16 @@ internal class MeshNodeCompilationService(
                             node, assemblyLocation, log, snapshot, attempt.InputDigest)),
                     _cacheOptions.AssemblyLoadTimeout, "assembly-load", node.Path))
                 // Re-Finish the log after CompileResultFromAssembly. CompileCore already
-                // Finished it Succeeded, but CompileResultFromAssembly's downstream steps
+                // finished it, but CompileResultFromAssembly's downstream steps
                 // (assembly load, MeshNodeProviderAttribute reflection) can append fresh
                 // Error messages — those need to flip Status to Failed.
-                // ActivityLog.Finish(version, override) takes MAX(override, GetFinalStatus
-                // from Messages), so an Error message appended after the first Finish
-                // bumps Status to Failed automatically.
+                // FinishByOutcome re-reads the log: an Error appended after the first
+                // finish flips Status to Failed; warnings stay in the transcript without
+                // demoting a green compile (the pin/fold split-brain fix — see
+                // ActivityLog.FinishByOutcome).
                 .Select(result => result is null
                     ? result
-                    : result with { Log = result.Log?.Finish((int)hub.Version, ActivityStatus.Succeeded) })
+                    : result with { Log = result.Log?.FinishByOutcome((int)hub.Version) })
                 .SelectMany(result => UploadToStoreIfNeeded(result, node));
         });
 
@@ -1303,7 +1304,7 @@ internal class MeshNodeCompilationService(
         {
             result = result with
             {
-                Log = (result.Log ?? log).Finish((int)hub.Version, ActivityStatus.Succeeded)
+                Log = (result.Log ?? log).FinishByOutcome((int)hub.Version)
             };
         }
         return Observable.Return(result);

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationActivity.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationActivity.cs
@@ -153,11 +153,26 @@ internal static class NodeTypeCompilationActivity
     }
 
     /// <summary>
-    /// Flip the activity content to <see cref="ActivityStatus.Succeeded"/>.
+    /// Flip the activity content to its settled OUTCOME — <see cref="ActivityStatus.Succeeded"/>,
+    /// unless the log already recorded an error, in which case <see cref="ActivityStatus.Failed"/>.
     /// No-op when <paramref name="activityPath"/> is <c>null</c>.
+    /// <para>🚨 Computed from the log, not pinned blind: this writer and the pipeline's
+    /// <c>ActivityLog.FinishByOutcome</c> must give the SAME answer for the same log, or the
+    /// activity node and the compile result disagree and a reader's status becomes a race
+    /// (the 2026-08-30 pin/fold split-brain). Warnings deliberately do not demote — the
+    /// compile lane's contract is "warnings are reported, never turn a green compile red".</para>
     /// </summary>
-    public static void MarkSucceeded(IMessageHub hub, string? activityPath, ILogger logger) =>
-        Update(hub, activityPath, ActivityStatus.Succeeded, error: null, logger);
+    public static void MarkSucceeded(IMessageHub hub, string? activityPath, ILogger logger)
+    {
+        if (string.IsNullOrEmpty(activityPath)) return;
+        Write(hub, activityPath, [],
+            log => log with
+            {
+                Status = log.HasErrors() ? ActivityStatus.Failed : ActivityStatus.Succeeded,
+                End = DateTime.UtcNow
+            },
+            logger, "MarkSucceeded");
+    }
 
     /// <summary>
     /// Flip the activity content to <see cref="ActivityStatus.Failed"/>, attaching

--- a/test/MeshWeaver.Data.Test/ActivityLogRollupTest.cs
+++ b/test/MeshWeaver.Data.Test/ActivityLogRollupTest.cs
@@ -148,4 +148,73 @@ public class ActivityLogRollupTest
         Assert.Equal(ActivityStatus.Failed,
             log.Append(Msg(LogLevel.Error)).Finish(1, ActivityStatus.Succeeded).Status);
     }
+
+    // ── FinishByOutcome: the pin/fold split-brain fix (2026-08-30 merge-queue incident) ──────────
+    // Finish(v, Succeeded) treats the override as a FLOOR, so one Warning entry finishes the
+    // activity Warning — while NodeTypeCompilationActivity pins the activity node Succeeded. Two
+    // terminal writers disagreeing on one log made the surfaced status a race. FinishByOutcome is
+    // the single semantic both compile-lane writers now share: errors fail, warnings surface
+    // without demoting.
+
+    /// <summary>The incident shape, both halves: the fold demotes on a warning (pinned so a future
+    /// "fix" to Finish is caught loudly), the outcome finish does not — and keeps the warning
+    /// visible in the transcript and the severity roll-up.</summary>
+    [Fact]
+    public void FinishByOutcome_WarningsSurfaceWithoutDemoting()
+    {
+        var log = new ActivityLog("Test")
+            .Append(Msg(LogLevel.Information))
+            .Append(Msg(LogLevel.Warning));
+
+        Assert.Equal(ActivityStatus.Warning, log.Finish(1, ActivityStatus.Succeeded).Status);
+
+        var finished = log.FinishByOutcome(1);
+        Assert.Equal(ActivityStatus.Succeeded, finished.Status);
+        Assert.Equal(LogLevel.Warning, finished.MaxSeverity);
+        Assert.Equal(2, finished.TotalMessageCount);
+        Assert.NotNull(finished.End);
+        Assert.Equal(1, finished.Version);
+    }
+
+    [Fact]
+    public void FinishByOutcome_ErrorFails()
+    {
+        var log = new ActivityLog("Test").Append(Msg(LogLevel.Error));
+        Assert.Equal(ActivityStatus.Failed, log.FinishByOutcome(1).Status);
+    }
+
+    /// <summary>An error whose line has flushed out of the bounded message window still fails —
+    /// the outcome reads the <see cref="ActivityLog.MaxSeverity"/> roll-up, not a list scan.</summary>
+    [Fact]
+    public void FinishByOutcome_FlushedError_StillFails()
+    {
+        var log = new ActivityLog("Test") with
+        {
+            MaxSeverity = LogLevel.Error,
+            MessageCount = 5
+        };
+        Assert.Equal(ActivityStatus.Failed, log.FinishByOutcome(1).Status);
+    }
+
+    [Fact]
+    public void FinishByOutcome_FailedSubActivity_Fails()
+    {
+        var log = new ActivityLog("Test") with
+        {
+            SubActivities = [new ActivityLog("Sub") with { Status = ActivityStatus.Failed }]
+        };
+        Assert.Equal(ActivityStatus.Failed, log.FinishByOutcome(1).Status);
+        // A Warning sub-activity, like a warning message, does not demote.
+        var warnSub = new ActivityLog("Test") with
+        {
+            SubActivities = [new ActivityLog("Sub") with { Status = ActivityStatus.Warning }]
+        };
+        Assert.Equal(ActivityStatus.Succeeded, warnSub.FinishByOutcome(1).Status);
+    }
+
+    [Fact]
+    public void FinishByOutcome_CleanLog_Succeeds()
+    {
+        Assert.Equal(ActivityStatus.Succeeded, new ActivityLog("Test").FinishByOutcome(1).Status);
+    }
 }

--- a/test/MeshWeaver.Hosting.Monolith.Test/CompileFinishAndDisposeTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/CompileFinishAndDisposeTest.cs
@@ -105,13 +105,36 @@ public class CompileFinishAndDisposeTest(ITestOutputHelper output) : MonolithMes
 
         response.Log.Should().NotBeNull("every compile is a proper Activity with a log");
 
+        // 🔬 Diagnostic transcript (queue incident 2026-08-30): CI intermittently sees
+        // Status=Warning here with no warning visible anywhere in the job log. Status is
+        // folded from the MaxSeverity COUNTER, not from a scan of Messages, so the entry
+        // that raised it can be flushed out of the bounded message window by the time the
+        // response surfaces. Print the whole transcript on every run — pass or fail — so
+        // the next CI occurrence names the entry instead of an anonymous status.
+        var log = response.Log!;
+        FileOutput.WriteLine(
+            $"[compile-activity transcript] Id={log.Id} Status={log.Status} " +
+            $"MaxSeverity={log.MaxSeverity} MessageCount={log.TotalMessageCount} " +
+            $"(window holds {log.Messages.Count}) Version={log.Version} End={log.End:O}");
+        foreach (var m in log.Messages)
+            FileOutput.WriteLine($"[compile-activity transcript]   {m.LogLevel}: {m.Message}");
+        foreach (var sub in log.SubActivities)
+            FileOutput.WriteLine(
+                $"[compile-activity transcript]   sub {sub.Id}: Status={sub.Status} " +
+                $"MaxSeverity={sub.MaxSeverity} messages={sub.TotalMessageCount}");
+
         // Terminal / auto-dispose: a finished activity is Succeeded with an End
         // timestamp. The bug left it stuck (Status stays Running, End null) so
         // every instance fell through to the 30s "compile did not settle"
         // overlay. Asserting Succeeded + End locks in that the activity actually
         // completes and is free to deactivate.
         response.Log!.Status.Should().Be(ActivityStatus.Succeeded,
-            "the compile activity must reach a terminal Succeeded status — finished generation");
+            "the compile activity must reach a terminal Succeeded status — finished generation; " +
+            $"transcript: MaxSeverity={log.MaxSeverity}, windowed messages=[{string.Join(" | ",
+                log.Messages.Select(m => $"{m.LogLevel}:{m.Message}"))}], " +
+            $"flushed-before-window={log.TotalMessageCount - log.Messages.Count}, " +
+            $"subActivities=[{string.Join(", ",
+                log.SubActivities.Select(s => $"{s.Id}:{s.Status}/{s.MaxSeverity}"))}]");
         response.Log.Status.Should().NotBe(ActivityStatus.Running,
             "the activity must not be left Running (the wedged-compile symptom)");
         response.Log.End.Should().NotBeNull(


### PR DESCRIPTION
The writer-consistency half of the [#2842 RCA](https://github.com/Systemorph/MeshWeaver/pull/2842#issuecomment-5472066551) — the split-brain that ejected the merge queue for 2.5h on 2026-08-30.

**Defect:** `ActivityLog.Finish(v, override)` treats the override as a FLOOR (MAX with the MaxSeverity fold), so `.Finish(v, Succeeded)` + one Warning entry = terminal `Warning` — while `NodeTypeCompilationActivity` PINS the activity node `Succeeded`. Which of the two a `GetCompilationPathResponse` surfaces depends on the #2463 stamp write-back race. Live proof: a green instrumented run shows `Status=Succeeded, MaxSeverity=Warning`, four CS1591 entries — one log, two truths.

**Fix:** `FinishByOutcome(version)` — Failed on recorded errors (roll-up counter, so a flushed message window still fails; a Failed sub-activity too), otherwise Succeeded with warnings surfacing without demoting. All five compile-lane `.Finish(v, Succeeded)` sites move to it; `MarkSucceeded` computes from the log instead of pinning blind. The post-emit re-finish contract (late Error still flips to Failed) is preserved and pinned by test.

**This makes #2842's stated premise true** ("surfacing warnings cannot turn a green compile red on its own") — #2842 should rebase onto this and re-run on the actual tree before re-queuing.

**Diagnosability:** `CompileFinishAndDisposeTest` prints the full activity transcript every run — tonight's red was anonymous because nothing printed the log.

**Policy note:** the alternative policy (warning-compile ⇒ `Warning` status) is one edit in one place (`FinishByOutcome`) applied to both writers, if preferred — split-brain was the defect, not the choice of color.

Mutation-proven both directions (fold-degraded body fails 2 tests; restored 20/20). Release `-warnaserror` clean ×4 projects; CompileFinishAndDispose 2/2; Graph.Test compile suites 188/188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)