### PR TITLE
fix(cd): the three script-less ACR login sites get a working tree — promote is broken on main

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1106,6 +1106,15 @@ jobs:
       V_MIGRATION: ${{ needs.migration-image.outputs.version }}
       V_PLUGIN: ${{ needs.plugin-test-image.outputs.version }}
     steps:
+      # 🚨 The ACR login below is a SCRIPT now (#2857), so this job needs a working tree — the
+      # inline `az acr login` it replaced needed none. Sparse: only the scripts directory, so this
+      # costs nothing. Without it the step dies `bash: .github/scripts/acr-login.sh: No such file
+      # or directory` with exit 127, which is what broke `promote` on 2026-08-31 00:54 and left a
+      # published image set untagged.
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
       - name: Ensure Azure CLI
         run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: Azure login (OIDC)
@@ -1844,6 +1853,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
+      # 🚨 The ACR login below is a SCRIPT now (#2857), so this job needs a working tree — the
+      # inline `az acr login` it replaced needed none. Sparse: only the scripts directory, so this
+      # costs nothing. Without it the step dies `bash: .github/scripts/acr-login.sh: No such file
+      # or directory` with exit 127, which is what broke `promote` on 2026-08-31 00:54 and left a
+      # published image set untagged.
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
       - name: Ensure Azure CLI
         run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
       - name: Azure login (OIDC)
@@ -1981,6 +1999,15 @@ jobs:
       digest: ${{ steps.digest.outputs.digest }}
       image: ${{ steps.digest.outputs.image }}
     steps:
+      # 🚨 The ACR login below is a SCRIPT now (#2857), so this job needs a working tree — the
+      # inline `az acr login` it replaced needed none. Sparse: only the scripts directory, so this
+      # costs nothing. Without it the step dies `bash: .github/scripts/acr-login.sh: No such file
+      # or directory` with exit 127, which is what broke `promote` on 2026-08-31 00:54 and left a
+      # published image set untagged.
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
       - name: Azure login (OIDC)
         uses: azure/login@v3
         with:


### PR DESCRIPTION
🚨 **`main` is currently broken for delivery.** CD run [33344774738](https://github.com/Systemorph/MeshWeaver/actions/runs/33344774738) on `74a13086a` built and pushed **all three images**, then died in `promote`:

```
Run bash .github/scripts/acr-login.sh
bash: .github/scripts/acr-login.sh: No such file or directory
##[error]Process completed with exit code 127
```

The set was pushed to staging and **never tagged**. `Verify every image shipped` then correctly reported all three MISSING, and every self-updating install stayed on the previous image.

## What happened

#2857 replaced every inline `az acr login` with the shared `acr-login.sh`, closing a real hole — the bare login sat **outside** the publish retry, and a `context deadline exceeded` on it blocked delivery at 23:43. **That reasoning is right and stays.**

But **a script needs a working tree and the inline one-liner did not**, and three of the seven call sites live in jobs that never check out.

## Audited all seven, not just the one that failed

| job | checkout | |
|---|---|---|
| `portal-image` | ✅ | |
| `migration-image` | ✅ | |
| `plugin-test-image` | ✅ | |
| **`promote`** | ❌ | ← the observed failure |
| **`notify-platform-update`** | ❌ | two call sites |
| **`plugins-bake-image`** | ❌ | |

The other two would have failed **identically** the first time they were reached — on paths that do not run every time, so they would have surfaced much later and looked like a new problem.

## The fix

A **sparse** checkout of `.github/scripts` only, added to each of the three. Negligible cost, and the login keeps **one implementation** across all seven sites rather than reverting some to an unretried inline call — which would reopen exactly what #2857 closed.

## 🚨 Why #2857's own green could not have caught this

`promote`, `notify-platform-update` and `plugins-bake-image` **only run on a publishing CD run, never on a pull request.** So #2857's checks attested to code paths that never executed.

That is worth naming as a class: **a job that only runs in production is not covered by anything that gates the change to it.** It is the same shape as a PR's green attesting only to its merge base, one level further out — and it is why the audit above matters more than the single fix.

## Verification

- `yaml.safe_load` parses the workflow (15 jobs) — a malformed workflow is a startup failure that publishes nothing, so this is not optional.
- Re-audit: every `acr-login.sh` call site is now in a job carrying a checkout.

Credit to the #2857 author for the diagnosis and the shared-script direction; this is the missing half, not a disagreement.