### PR TITLE
fix(#2471): a stale bind is REFUSED at activation — recompile instead of serving bytes the type did not publish

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -1181,6 +1181,28 @@ internal static class NodeTypeEnrichmentHelpers
                     // publication-driven watcher stayed silent while memex served old code.
                     var boundMvid = ServedBuildIdentity.OfFile(localPath);
 
+                    // 🚨 #2471, the SAME-PATH half, healed where it is FIRST true. The path is a
+                    // store key resolved through a per-pod local cache, so the bytes behind it can
+                    // differ from the bytes the type published — and once BOUND, nothing downstream
+                    // can fix it: the banner is report-only ("a recycle re-binds the same local
+                    // copy"), and the served instance splits the type family across two collectible
+                    // assemblies, degrading every cross-hub read of its content (As<T> case 3 — the
+                    // 2026-08-31 paid-fulfilment outage: StoreContent, all TierContent and the
+                    // order degraded in one run, the fulfilment watcher never fired). So a
+                    // mismatch is REFUSED here, before the bind, by the same bounded machinery the
+                    // bytes-missing sibling uses: a fresh compile mints new bytes AND a new
+                    // published MVID, and the retry re-enriches against them. On exhaustion the
+                    // activation falls through to today's bind-and-banner — degraded but
+                    // functional beats parked.
+                    if (ShouldRefuseStaleBind(def.LatestAssemblyMvid, boundMvid, nodeType, recompileAttempts))
+                        return TriggerRecompileAndRetry(
+                            node, nodeType, meshConfiguration, compilationService, meshHub,
+                            logger, recompileAttempts,
+                            reason: "served bytes are not the published build ("
+                                + ServedBuildIdentity.Mismatch(def.LatestAssemblyMvid, boundMvid, nodeType)
+                                + ") — refusing the stale bind (#2471)",
+                            staleVersion: typeNode.Version);
+
                     if (compilationService is null)
                         return Observable.Return(WithStaleAssemblySelfHeal(
                             ApplyEntry(node, localPath, hubConfig: null, nodeType, meshConfiguration),
@@ -1533,6 +1555,20 @@ internal static class NodeTypeEnrichmentHelpers
     /// (blob / filesystem). Null/empty collection short-circuits to a null
     /// emission so callers can fall through to the error overlay.
     /// </summary>
+    /// <summary>
+    /// Whether an activation that resolved bytes with <paramref name="boundMvid"/> for a type
+    /// publishing <paramref name="publishedMvid"/> must REFUSE the bind and recompile instead —
+    /// true exactly when the identities give EVIDENCE of a mismatch
+    /// (<see cref="ServedBuildIdentity.Mismatch"/>: both present and different; a legacy node
+    /// without a published MVID never refuses) and the bounded retry budget
+    /// (<see cref="MaxRecompileAttempts"/>) is not exhausted. Pure — pinned by
+    /// <c>ServedBuildIsVerifiableTest</c>.
+    /// </summary>
+    internal static bool ShouldRefuseStaleBind(
+        string? publishedMvid, string? boundMvid, string nodeType, int recompileAttempts)
+        => recompileAttempts < MaxRecompileAttempts
+           && ServedBuildIdentity.Mismatch(publishedMvid, boundMvid, nodeType) is not null;
+
     private static IObservable<string?> ResolveAssembly(
         IMessageHub meshHub, string? collection, string nodeTypePath, long version)
     {

--- a/test/MeshWeaver.Graph.Test/ServedBuildIsVerifiableTest.cs
+++ b/test/MeshWeaver.Graph.Test/ServedBuildIsVerifiableTest.cs
@@ -147,6 +147,26 @@ public class ServedBuildIsVerifiableTest(ITestOutputHelper output) : HubTestBase
     /// …and when both sides ARE known and differ, the message must name both builds and say the
     /// thing the reader most needs: the node's status is not evidence, and a recycle will not help.
     /// </summary>
+    /// <summary>
+    /// 🚨 The bind seam REFUSES a stale bind rather than reporting one (#2471 reopened,
+    /// 2026-08-31): with evidence of a mismatch and retry budget left, the activation goes to
+    /// TriggerRecompileAndRetry — a fresh compile mints new bytes AND a new published MVID —
+    /// instead of binding bytes the type did not publish. Once bound, nothing downstream can fix
+    /// it: the banner is report-only, and the instance splits the type family across two
+    /// collectible assemblies (As&lt;T&gt; case 3), which is what degraded StoreContent, every
+    /// TierContent and the order in the paid-fulfilment run this pins.
+    /// </summary>
+    [Theory]
+    [InlineData(PublishedMvid, BoundMvid, 0, true)]   // mismatch, budget left → refuse
+    [InlineData(PublishedMvid, BoundMvid, 1, false)]  // budget exhausted → bind + banner (degraded beats parked)
+    [InlineData(PublishedMvid, PublishedMvid, 0, false)] // identical bytes → bind
+    [InlineData(null, BoundMvid, 0, false)]           // legacy node, no published MVID → no evidence → bind
+    [InlineData(PublishedMvid, null, 0, false)]       // unreadable local file → no evidence → bind
+    public void StaleBind_IsRefusedExactlyOnEvidence_WithinTheRetryBudget(
+        string? published, string? bound, int attempts, bool refused)
+        => Assert.Equal(refused,
+            NodeTypeEnrichmentHelpers.ShouldRefuseStaleBind(published, bound, NodeTypePath, attempts));
+
     [Fact]
     public void Mismatch_NamesBothBuilds_AndSaysARecycleWillNotHelp()
     {


### PR DESCRIPTION
Closes the reopened half of #2471 with tonight's production evidence (Plugins e2e, 2-of-2 on `1dc5fc41`): an instance hub bound `Store/Plugin` bytes with MVID `810f4775…` while the type published `7f5df496…` — and from that single stale bind, the whole paid-fulfilment failure followed (family-wide `As<T>` case-3 degradation across StoreContent/TierContent/OrderContent, the fulfilment watcher never firing, Plugins #455's "completed without an outcome" blocking the #2802 rotation chain).

## Why the existing fix couldn't help here

The #2655 fix made the same-path mismatch **detectable** (the banner + `LogError` fired, on schedule) but deliberately **report-only** — its own comment: *"a recycle re-binds the same local copy and will not change it."* Correct reasoning, wrong conclusion for the bind moment: once bound, nothing downstream can fix it. But **at activation, before the bind, both MVIDs are already in hand** — and there a refusal is cheap.

## Change

At the enrichment seam, after `ResolveAssembly` + `ServedBuildIdentity.OfFile`, a mismatch with retry budget left routes into the **existing** `TriggerRecompileAndRetry` machinery — the same bounded path the bytes-missing sibling case has used all along. A fresh compile mints new bytes **and a new published MVID**, and the retry re-enriches against them; the store's own `Put` contract ("same version → same output") is exactly the assumption this state violates, so recompiling is the honest reconciliation. On budget exhaustion (`MaxRecompileAttempts`), the activation falls through to today's bind-and-banner — degraded but functional beats parked.

The decision is extracted pure (`ShouldRefuseStaleBind`) with the evidence rules pinned: refuses only on **evidence** (both MVIDs present and different — a legacy node without a published MVID never refuses; an unreadable local file never refuses) and only within budget.

## Tests

`ServedBuildIsVerifiableTest` + 5 new theory cases (refuse on mismatch-with-budget; bind on exhaustion / identical / no-evidence both ways). Graph suite: **1603/1603 passed**.

Diagnosis trail: Plugins #455 (comment 5472886155) · #2471 reopen comment with the MVID pair and blast radius.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QoG4USP5fd8wsxCD7e9q4x