### PR TITLE
fix(#2836, #2787): a transient 503 is not a refusal — on the portal and in the gate

### DIFF
--- a/.github/scripts/compose-sealed-modules.sh
+++ b/.github/scripts/compose-sealed-modules.sh
@@ -53,6 +53,48 @@ case "$identity" in */*|*..*|"") echo "::error::compose-sealed-modules.sh: ident
 mkdir -p "$out"
 work=$(mktemp -d); trap 'rm -rf "$work"' EXIT
 
+# ── re-ask a registry that has not answered yet ───────────────────────────────────────────────
+# 🚨 A 5xx is not an answer — it is the ABSENCE of one. Promoting the platform ROLLS the portal
+# that serves this registry, so every promotion opens a window in which a dependent repo's gate
+# reads a 503 through no fault of its own diff (MeshWeaver#2787: three promotions in one day, six
+# repos reading this endpoint). Refusing on it makes the fleet's CI a function of deploy timing.
+#
+# A DEFINITE answer is untouched and still refuses at once — 404 (unsealed / predates module
+# sealing) and 401/403 (no grant) are decisions the registry has already made, and waiting on one
+# only delays the message naming it. Same distinction, same reason, as MeshWeaver#2836 on the
+# portal side: branch on what the server SAID, never on "the read failed".
+#
+# 🚨 A retry, NOT a skip-trapdoor: when the attempts are spent the last status is returned and
+# every caller still fails RED — a registry that is genuinely down fails the gate exactly as it
+# did before, about three minutes later.
+#
+# 🚨 There is a SECOND copy of this function, in .github/workflows/node-repo-gate.yml (same
+# policy, REGISTRY_KEY spelled upper-case there). It is duplicated ON PURPOSE rather than
+# factored into a third file: THIS script is fetched from core at a pinned `platform-ref` while
+# that workflow is pinned by the caller's `uses:`, so a shared file would be a THIRD
+# independently-pinned artefact — the exact skew that once let an old workflow drive a new
+# script and seal an empty module set. Change one, change both.
+registry_get() { # <url> <out-file> → echoes the final HTTP status
+  local url="$1" out="$2" code="" attempt=0
+  local -r delays="15 30 60 90"
+  while :; do
+    code=$(curl -sS -o "$out" -w '%{http_code}' \
+             -H "Authorization: Bearer $registry_key" "$url") || code="000"
+    case "$code" in
+      # Transient: a roll window, a gateway blip, or a connection that never landed (000).
+      408|429|5??|000) ;;
+      *) printf '%s' "$code"; return 0 ;;
+    esac
+    attempt=$((attempt+1))
+    local delay
+    delay=$(printf '%s\n' $delays | sed -n "${attempt}p")
+    [ -n "$delay" ] || { printf '%s' "$code"; return 0; }
+    echo "registry answered $code for $url — transient (a platform roll looks like this);" \
+         "re-asking in ${delay}s, attempt $((attempt+1))" >&2
+    sleep "$delay"
+  done
+}
+
 # ── one upstream's sealed module set (an index), or a RED reason ──────────────────────────────
 # Writes the listed bundle names, one per line, into <list-file>. Exit 1 with ::error when the
 # upstream has no seal for this identity or the seal predates module sealing — both are stop
@@ -65,7 +107,7 @@ sealed_modules_of() { # <source> <list-file>
   if [ -n "$registry_url" ]; then
     local base="${registry_url%/}/api/plugins/bundles/prebuilt/$identity/$src"
     local code
-    code=$(curl -sS -o "$work/$src.modules.json" -w '%{http_code}' -H "Authorization: Bearer $registry_key" "$base/modules")
+    code=$(registry_get "$base/modules" "$work/$src.modules.json")
     case "$code" in
       200) ;;
       404)
@@ -102,9 +144,10 @@ sealed_modules_of() { # <source> <list-file>
 fetch_module() { # <source> <bundle-name> <dest>
   local src="$1" name="$2" dest="$3"
   if [ -n "$registry_url" ]; then
-    curl -sSf -H "Authorization: Bearer $registry_key" -o "$dest" \
-      "${registry_url%/}/api/plugins/bundles/prebuilt/$identity/$src/modules/$name" \
-      || { echo "::error::could not fetch sealed module $name of '$src' for identity $identity"; return 1; }
+    local code
+    code=$(registry_get \
+      "${registry_url%/}/api/plugins/bundles/prebuilt/$identity/$src/modules/$name" "$dest")
+    [ "$code" = 200 ] || { echo "::error::could not fetch sealed module $name of '$src' for identity $identity — registry answered $code."; return 1; }
   else
     local account="${storage_target%%/*}" rest="${storage_target#*/}"
     local share="${rest%%/*}" base=""

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -416,13 +416,56 @@ jobs:
           set -euo pipefail
           SEED_DIR="${RUNNER_TEMP:-/tmp}/upstream-seed"
           mkdir -p "$SEED_DIR"
+
+          # 🚨 A 5xx is not an answer — it is the ABSENCE of one, and refusing on it makes every
+          # platform promotion a source of red CI across the fleet (MeshWeaver#2787). Promotion
+          # rolls the portal that SERVES this registry, so the window is STRUCTURAL: the more
+          # reliably promotion works, the more often a dependent repo's gate lands inside it. One
+          # day's three promotions opened it three times, and six repos read this endpoint.
+          #
+          # A DEFINITE answer still refuses immediately and unchanged — 404 (unsealed), 401/403
+          # (no grant) are decisions the registry has already made, and waiting on one only
+          # delays the message that names it. Same distinction, same reason, as MeshWeaver#2836
+          # on the portal side: branch on what the server SAID, never on "the read failed".
+          #
+          # 🚨 This is a retry, NOT a skip-trapdoor. Exhausting the attempts returns the last
+          # status to the caller, which still refuses RED — a registry that is genuinely down
+          # fails the gate exactly as before, roughly three minutes later.
+          #
+          # 🚨 There is a SECOND copy of this function, in .github/scripts/compose-sealed-modules.sh
+          # (same policy, `registry_key` spelled lower-case there). It is duplicated ON PURPOSE
+          # rather than factored into a third file: that script is fetched from core at a pinned
+          # `platform-ref` while this workflow is pinned by the caller's `uses:`, so a shared file
+          # would be a THIRD independently-pinned artefact — the exact skew that once let an old
+          # workflow drive a new script and seal an empty module set. Change one, change both.
+          registry_get() { # <url> <out-file> → echoes the final HTTP status
+            local url="$1" out="$2" code="" attempt=0
+            local -r delays="15 30 60 90"
+            while :; do
+              code=$(curl -sS -o "$out" -w '%{http_code}' \
+                       -H "Authorization: Bearer $REGISTRY_KEY" "$url") || code="000"
+              case "$code" in
+                # Transient: a roll window, a gateway blip, or a connection that never landed
+                # (curl reports 000). Everything else is the registry's decision — return it.
+                408|429|5??|000) ;;
+                *) printf '%s' "$code"; return 0 ;;
+              esac
+              attempt=$((attempt+1))
+              local delay
+              delay=$(printf '%s\n' $delays | sed -n "${attempt}p")
+              [ -n "$delay" ] || { printf '%s' "$code"; return 0; }
+              echo "registry answered $code for $url — transient (a platform roll looks like this);" \
+                   "re-asking in ${delay}s, attempt $((attempt+1))" >&2
+              sleep "$delay"
+            done
+          }
           if [ -n "${REGISTRY_URL:-}" ]; then
             # The REGISTRY serves the sealed publication (MeshWeaver#2487) — HTTPS + instance key,
             # no Azure, works on pull_request. Fails RED on 404 (unsealed) or 401/403 (no grant).
             fetched=0
             for src in $UPSTREAMS; do
               base="${REGISTRY_URL%/}/api/plugins/bundles/prebuilt/$IDENTITY/$src"
-              code=$(curl -sS -o "$SEED_DIR/.index.json" -w '%{http_code}' -H "Authorization: Bearer $REGISTRY_KEY" "$base")
+              code=$(registry_get "$base" "$SEED_DIR/.index.json")
               case "$code" in
                 200) ;;
                 404) echo "::error::upstream '$src' has no SEALED publication on $REGISTRY_URL for identity $IDENTITY. Not compiling it instead."; exit 1 ;;
@@ -441,7 +484,8 @@ jobs:
                 exit 1
               fi
               for name in $(jq -r '.bundles[]' "$SEED_DIR/.index.json"); do
-                curl -sSf -H "Authorization: Bearer $REGISTRY_KEY" -o "$SEED_DIR/$name" "$base/$name" || { echo "::error::could not fetch $name"; exit 1; }
+                bcode=$(registry_get "$base/$name" "$SEED_DIR/$name")
+                [ "$bcode" = 200 ] || { echo "::error::could not fetch $name from $base — registry answered $bcode."; exit 1; }
                 fetched=$((fetched+1))
               done
               rm -f "$SEED_DIR/.index.json"

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-a-platform-promotion-no-longer-reds-a-dependent-repos-ci.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-a-platform-promotion-no-longer-reds-a-dependent-repos-ci.md
@@ -1,0 +1,29 @@
+---
+Name: A platform promotion no longer reds a dependent repository's build
+Category: Fix
+Description: Promoting the platform rolls the portal that serves the plugin registry, and any repository whose CI read that registry inside the roll window failed on a 503 through no fault of its own change. Those reads now wait out a brief unavailability, while a genuine refusal still fails immediately.
+Icon: Sparkle
+Order: -20260831
+---
+
+# A platform promotion no longer reds a dependent repository's build
+
+Repositories that build modules against the platform ask the registry, during their build, for the
+sealed upstream artefacts they compile against. Promoting a new platform version rolls the portal —
+and that portal is what serves the registry. For the length of the roll, the registry answers
+**503 — temporarily unavailable**, and any build that happened to ask inside that window failed,
+reporting an error about a change that had nothing to do with it.
+
+The window is structural rather than incidental: every promotion opens one, six repositories read
+that endpoint, and on a day with three promotions it opened three times. The more reliably promotion
+works, the more often somebody's build lands inside it. Re-running the build was the only recourse,
+which is the habit worth removing — it teaches people to re-run red builds without reading them.
+
+A registry that has not answered yet is now told apart from a registry that has answered *no*. A
+temporary condition — 503, 429, a gateway error, or a connection that never landed — is re-asked
+with a widening pause, over about three minutes. A definite answer is untouched: a missing
+publication, or a key the registry refuses, still fails at once and says exactly what is wrong,
+because waiting on one of those would only delay the message naming it.
+
+A registry that is genuinely down still fails the build, and still fails it red — just after it has
+been given a fair chance to come back.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-a-registry-hiccup-no-longer-freezes-your-installed-packages.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-a-registry-hiccup-no-longer-freezes-your-installed-packages.md
@@ -1,0 +1,35 @@
+---
+Name: A brief registry hiccup no longer freezes your installed packages until the next restart
+Category: Fix
+Description: When the plugin registry answered "temporarily unavailable" while an instance was starting, that instance stopped reconciling its installed packages for as long as it stayed up — no updates, no grant changes, and no sign anything was wrong. A momentary outage is now retried during startup instead of being mistaken for a refusal.
+Icon: Sparkle
+Order: -20260831
+---
+
+# A brief registry hiccup no longer freezes your installed packages until the next restart
+
+An instance that installs from a registry checks in with it once at startup, compares what it has
+against what the registry now serves, and lands anything newer. There is deliberately no background
+poll behind that check — the promise is simply "you pick up changes the next time you start" — which
+also means the startup attempt is the only chance an instance gets.
+
+That attempt already retried a network stumble. What it did not retry was the registry answering
+**503 — temporarily unavailable, retry shortly**: the code could not tell that apart from the
+registry answering **403 — you are not allowed**, because every unsuccessful answer arrived as the
+same kind of error, with the status buried in the message text. Declining to re-ask a refusal is
+right; a registry that has refused your key will refuse it again a second later. Applying that rule
+to a momentary outage was not — it turned a hiccup lasting seconds into an instance that never
+reconciled again.
+
+The consequence was quiet, which is what made it worth fixing. The instance kept running and serving
+pages normally; it simply stopped noticing that packages had new versions or that grants had changed,
+until somebody restarted it or opened the catalog page by hand.
+
+The status the registry sends now travels as data rather than as prose, so startup can tell "come
+back shortly" apart from "no". A temporary answer — 503, 429, or a gateway error — is retried within
+the existing startup budget; a definite one still fails immediately and says so in the log, because
+waiting on it would only delay the message naming what is actually wrong.
+
+This matters more than it did a day ago: installing from the cloud registry and registering without a
+key both shipped on 2026-08-30, which puts the registry on the startup path of every new local
+install.

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -128,7 +128,10 @@ public sealed class PluginBundleClient
 
             var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
-                throw new InvalidOperationException(
+                // Carries the status (see RegistryResponseException): the index read shares the
+                // registry's availability, so a caller deciding whether to re-ask must be able to
+                // tell a refusal from a transient 5xx without reading the message text.
+                throw new RegistryResponseException(resp.StatusCode,
                     $"Bundle index fetch failed ({(int)resp.StatusCode}): {json}");
 
             return JsonSerializer.Deserialize<BundleIndex>(json, Json) ?? new BundleIndex(null, []);

--- a/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using System.Net.Http;
 using System.Reactive.Linq;
 using System.Text.Json;
@@ -85,7 +86,7 @@ public sealed class RegistryPackageSource : IPackageSource
             using var resp = await _http.SendAsync(request, ct).ConfigureAwait(false);
             var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
-                throw new InvalidOperationException(
+                throw new RegistryResponseException(resp.StatusCode,
                     $"Registry catalog list failed ({(int)resp.StatusCode}): {json}");
             var parsed = JsonSerializer.Deserialize<ListResponse>(json, Json);
             return (IReadOnlyList<PackageManifest>)(parsed?.Packages ?? []);
@@ -111,7 +112,7 @@ public sealed class RegistryPackageSource : IPackageSource
             using var resp = await _http.SendAsync(request, ct).ConfigureAwait(false);
             var json = await resp.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
             if (!resp.IsSuccessStatusCode)
-                throw new InvalidOperationException(
+                throw new RegistryResponseException(resp.StatusCode,
                     $"Registry file fetch for '{package.Id}' failed ({(int)resp.StatusCode}): {json}");
             var parsed = JsonSerializer.Deserialize<FilesResponse>(json, Json);
             var files = (IReadOnlyList<PackageFile>)(parsed?.Files ?? []);
@@ -140,4 +141,47 @@ public static class PluginRegistryPayloads
     /// <summary>Serializes the fetch-files response: <c>{ files: [PackageFile…] }</c>.</summary>
     public static string Files(IReadOnlyList<PackageFile> files) =>
         JsonSerializer.Serialize(new { files }, Json);
+}
+
+/// <summary>
+/// A non-success answer from the registry, carrying the HTTP status so a caller can branch on
+/// <b>refused</b> versus <b>temporarily unavailable</b> without matching on the message text —
+/// the same shape, and for the same reason, as
+/// <see cref="InstanceRegistrationException"/>.
+///
+/// <para>🚨 <b>Why the status has to survive as data.</b> Every non-2xx used to collapse into a
+/// bare <see cref="InvalidOperationException"/> whose only record of the status was the text of
+/// its message. <see cref="RegistryUpdateReconciler"/> reasonably reads that type as "a definite
+/// HTTP answer (401/403/404) — asking again in two seconds cannot change it" and skips its retry.
+/// A <c>503 Instance-key resolution is temporarily unavailable — retry shortly</c> arrived as the
+/// very same type, so the one condition the boot retry exists for was the one condition it
+/// declined to retry, and a transient registry blip stranded package reconciliation for the whole
+/// life of the pod (Systemorph/MeshWeaver#2836). Deriving from <see cref="InvalidOperationException"/>
+/// keeps every existing <c>catch</c> behaving as before; the added property is what lets the
+/// policy stop conflating the two.</para>
+/// </summary>
+public sealed class RegistryResponseException(HttpStatusCode statusCode, string message)
+    : InvalidOperationException(message)
+{
+    /// <summary>The HTTP status the registry answered with.</summary>
+    public HttpStatusCode StatusCode { get; } = statusCode;
+
+    /// <summary>
+    /// Whether <paramref name="statusCode"/> describes a condition that may clear on its own, so
+    /// re-asking is worthwhile: any 5xx (the server failed to serve a request it accepts —
+    /// including the 503 of #2836), plus 408 and 429, where the server explicitly invites a
+    /// retry. This is the conventional transient-HTTP set (the same one Polly's
+    /// <c>HandleTransientHttpError</c> uses), chosen so the boundary is a published convention
+    /// rather than a judgement call re-litigated at each call site.
+    ///
+    /// <para>Everything else — 401, 403, 404, 409 — is a decision the registry has already made
+    /// and will make identically on the next attempt; retrying it only delays the log line that
+    /// names it.</para>
+    /// </summary>
+    public static bool IsTransient(HttpStatusCode statusCode) =>
+        (int)statusCode >= 500
+        || statusCode is HttpStatusCode.RequestTimeout or HttpStatusCode.TooManyRequests;
+
+    /// <summary>Whether this particular answer is worth re-asking — see <see cref="IsTransient"/>.</summary>
+    public bool IsTransientFailure => IsTransient(StatusCode);
 }

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -79,6 +79,35 @@ public sealed class RegistryUpdateReconciler(
     private static TimeSpan FeedReadBackoff(int attempt) =>
         TimeSpan.FromSeconds(2 * Math.Pow(3, attempt));
 
+    /// <summary>
+    /// Whether a failed feed read is worth re-asking within the boot window.
+    ///
+    /// <para>🚨 <b>The distinction is the whole point, and it used to be lost.</b> This predicate
+    /// was once <c>fault is not InvalidOperationException</c> — reading that type as "a definite
+    /// HTTP answer (401/403/404), which will answer the same in two seconds". That was true of the
+    /// statuses it named and false of the type: <see cref="RegistryPackageSource"/> threw the SAME
+    /// bare <see cref="InvalidOperationException"/> for every non-2xx, so a
+    /// <c>503 Instance-key resolution is temporarily unavailable — retry shortly</c> was excluded
+    /// by a rule written for permission errors. The one condition a boot retry exists for was the
+    /// one condition it skipped, and a transient registry blip left a pod's installed set
+    /// unreconciled for the rest of its life — silently, because the portal itself stays up
+    /// (Systemorph/MeshWeaver#2836).</para>
+    ///
+    /// <para>The fix is not a longer budget nor a poll behind it: it is that the status now
+    /// survives as data (<see cref="RegistryResponseException.StatusCode"/>), so the policy can ask
+    /// what the server actually said instead of inferring it from a CLR type.</para>
+    /// </summary>
+    internal static bool ShouldRetryFeedRead(Exception fault) => fault switch
+    {
+        // A definite answer naming a transient server-side condition (503/429/5xx) — re-ask.
+        RegistryResponseException http => http.IsTransientFailure,
+        // Any other definite answer (401/403/404, a malformed payload) — re-asking cannot help.
+        InvalidOperationException => false,
+        // A transport fault (TCP hiccup, DNS blip, request timeout): the original #1500 case,
+        // where the read never reached an HTTP answer at all.
+        _ => true,
+    };
+
     /// <inheritdoc />
     public Task StartAsync(CancellationToken cancellationToken)
     {
@@ -181,14 +210,13 @@ public sealed class RegistryUpdateReconciler(
                     // timeout's length, but that the boot attempt is unrepeated.
                     //
                     // So this is a bounded retry INSIDE the boot attempt, not a clock. It does not
-                    // widen any bound and it adds no background load — and it deliberately does not
-                    // retry an InvalidOperationException, which is how RegistryPackageSource reports
-                    // a definite HTTP answer (401/403/404): a registry that refuses this instance's
-                    // key will refuse it again in two seconds, and burning the boot window on that
-                    // would only delay the log line that names it.
+                    // widen any bound and it adds no background load. What it retries is decided by
+                    // ShouldRetryFeedRead below — a DEFINITE refusal is not re-asked, because a
+                    // registry that refuses this instance's key will refuse it again in two seconds,
+                    // and burning the boot window on that would only delay the log line naming it.
                     .RetryWhen(faults => faults
                         .Select((fault, attempt) => (fault, attempt))
-                        .SelectMany(f => f.fault is not InvalidOperationException && f.attempt < FeedReadRetries
+                        .SelectMany(f => ShouldRetryFeedRead(f.fault) && f.attempt < FeedReadRetries
                             ? Observable.Timer(FeedReadBackoff(f.attempt)).Select(_ => Unit.Default)
                                 .Do(_ => logger.LogWarning(f.fault,
                                     "[RegistryUpdate] reading {Url} failed (attempt {Attempt}/{Total}) — retrying; "

--- a/test/MeshWeaver.PluginCatalog.Test/RegistryTransientFailureRetryTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/RegistryTransientFailureRetryTest.cs
@@ -1,0 +1,172 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Globalization;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.PluginCatalog.Test;
+
+/// <summary>
+/// 🚨 <b>#2836 — a transient 503 stranded package reconciliation for the whole life of the pod.</b>
+///
+/// <para><see cref="RegistryUpdateReconciler"/> deliberately has no poll timer: the bound it
+/// promises is "a consumer learns on its NEXT BOOT", so the boot's bounded retry is the only thing
+/// standing between a hiccup and a pod that never reconciles again. That retry declined to re-ask
+/// on <see cref="InvalidOperationException"/>, reasoning it meant "a definite HTTP answer
+/// (401/403/404) — the same answer will come back in two seconds".</para>
+///
+/// <para><b>The reasoning was sound about the statuses it named and false about the type.</b>
+/// <see cref="RegistryPackageSource"/> threw that one bare type for EVERY non-2xx, keeping the
+/// status only inside the message text. So a <c>503 Instance-key resolution is temporarily
+/// unavailable — retry shortly</c> — the exact condition the retry exists for — was excluded by a
+/// rule written for permission errors, and the installed set went stale silently, because the
+/// portal itself stays up.</para>
+///
+/// <para>🚨 <b>The two halves are tested TOGETHER on purpose.</b> A policy that branches correctly
+/// on a status the throw site never records is still broken, and each half passes its own test
+/// while the system fails. So the last test feeds a REAL thrown exception, produced by a real HTTP
+/// round trip, into the REAL predicate.</para>
+/// </summary>
+public class RegistryTransientFailureRetryTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// Answers with the status named in the FIRST PATH SEGMENT of the request
+    /// (<c>https://registry.example/503/api/plugins</c> → 503), so each test picks its own
+    /// condition through the URL it constructs the source with — no shared mutable state, and
+    /// nothing to reset between tests.
+    /// </summary>
+    private sealed class StatusFromUrlHandler : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var segments = request.RequestUri!.Segments;
+            var status = segments.Length > 1
+                && int.TryParse(segments[1].TrimEnd('/'), NumberStyles.Integer,
+                    CultureInfo.InvariantCulture, out var code)
+                ? (HttpStatusCode)code
+                : HttpStatusCode.OK;
+            return Task.FromResult(new HttpResponseMessage(status)
+            {
+                Content = new StringContent(
+                    status == HttpStatusCode.ServiceUnavailable
+                        ? "Instance-key resolution is temporarily unavailable — retry shortly"
+                        : $"canned {(int)status}"),
+                RequestMessage = request,
+            });
+        }
+    }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services
+                .AddHttpClient(InstanceRegistrationClient.HttpClientName)
+                .ConfigurePrimaryHttpMessageHandler(() => new StatusFromUrlHandler())
+                .Services);
+
+    private RegistryPackageSource SourceAnswering(HttpStatusCode status) =>
+        new(Mesh, $"https://registry.example/{(int)status}", "mwi_key");
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // 1. The POLICY — which answers are worth re-asking.
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    public static TheoryData<HttpStatusCode> TransientStatuses =>
+    [
+        HttpStatusCode.ServiceUnavailable,   // 503 — the status of #2836
+        HttpStatusCode.TooManyRequests,      // 429 — the server explicitly invites a retry
+        HttpStatusCode.BadGateway,           // 502 — may not have reached the app at all
+        HttpStatusCode.GatewayTimeout,       // 504
+        HttpStatusCode.InternalServerError,  // 500
+        HttpStatusCode.RequestTimeout,       // 408
+    ];
+
+    [Theory]
+    [MemberData(nameof(TransientStatuses))]
+    public void ATransientAnswer_IsReAsked(HttpStatusCode status) =>
+        Assert.True(
+            RegistryUpdateReconciler.ShouldRetryFeedRead(
+                new RegistryResponseException(status, $"failed ({(int)status})")),
+            $"{(int)status} may clear on its own — not re-asking it strands the whole boot's "
+            + "reconcile, and there is no poll behind this service to recover it");
+
+    public static TheoryData<HttpStatusCode> DefiniteStatuses =>
+    [
+        HttpStatusCode.Unauthorized,   // 401 — a bad or revoked instance key
+        HttpStatusCode.Forbidden,      // 403 — a grant this instance does not hold
+        HttpStatusCode.NotFound,       // 404 — no such feed
+        HttpStatusCode.Conflict,       // 409
+        HttpStatusCode.BadRequest,     // 400
+    ];
+
+    [Theory]
+    [MemberData(nameof(DefiniteStatuses))]
+    public void ADefiniteRefusal_IsNotReAsked(HttpStatusCode status) =>
+        Assert.False(
+            RegistryUpdateReconciler.ShouldRetryFeedRead(
+                new RegistryResponseException(status, $"failed ({(int)status})")),
+            $"{(int)status} is a decision the registry has already made; re-asking only delays "
+            + "the log line that names it");
+
+    [Fact]
+    public void ATransportFault_IsReAsked()
+    {
+        // The original #1500 case: the read never reached an HTTP answer at all.
+        Assert.True(RegistryUpdateReconciler.ShouldRetryFeedRead(
+            new HttpRequestException("connection reset")));
+        Assert.True(RegistryUpdateReconciler.ShouldRetryFeedRead(
+            new TimeoutException("the feed read timed out")));
+    }
+
+    [Fact]
+    public void ANonHttpInvalidOperation_IsStillNotReAsked() =>
+        // The pre-existing exclusion must survive: a malformed payload or a misconfiguration —
+        // anything reported as a plain InvalidOperationException — is not a transient condition.
+        Assert.False(RegistryUpdateReconciler.ShouldRetryFeedRead(
+            new InvalidOperationException("the feed returned no packages array")));
+
+    // ─────────────────────────────────────────────────────────────────────────────
+    // 2. The THROW SITE — the status has to survive as data, or the policy is blind.
+    // ─────────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AFeedRead_ThatIsRefused_CarriesTheStatus()
+    {
+        var thrown = await Assert.ThrowsAsync<RegistryResponseException>(async () =>
+            await SourceAnswering(HttpStatusCode.Forbidden)
+                .ListPackages("HEAD").FirstAsync().Timeout(TestTimeouts.Quick));
+
+        Assert.Equal(HttpStatusCode.Forbidden, thrown.StatusCode);
+        Assert.False(thrown.IsTransientFailure);
+    }
+
+    /// <summary>
+    /// 🚨 The composition, and the test that actually pins #2836: a REAL 503 from a REAL feed read,
+    /// fed to the REAL retry predicate. Before the fix the throw site produced a bare
+    /// <see cref="InvalidOperationException"/> and the predicate answered <c>false</c> — the boot
+    /// gave up on its first and only attempt. Testing either half alone goes on passing.
+    /// </summary>
+    [Fact]
+    public async Task A503FromTheRealFeedRead_IsReAskedByTheRealPredicate()
+    {
+        var thrown = await Assert.ThrowsAsync<RegistryResponseException>(async () =>
+            await SourceAnswering(HttpStatusCode.ServiceUnavailable)
+                .ListPackages("HEAD").FirstAsync().Timeout(TestTimeouts.Quick));
+
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, thrown.StatusCode);
+        Assert.Contains("retry shortly", thrown.Message, StringComparison.Ordinal);
+        Assert.True(RegistryUpdateReconciler.ShouldRetryFeedRead(thrown),
+            "a 503 the registry itself marks retryable must be re-asked inside the boot window; "
+            + "this service has no poll behind it, so declining leaves the installed set stale "
+            + "for the whole life of the pod (#2836)");
+    }
+}


### PR DESCRIPTION
Closes Systemorph/MeshWeaver#2836. Closes Systemorph/MeshWeaver#2787.

Two faces of one mistake, found a day apart in different layers: **a registry that has not answered yet was treated as a registry that answered *no*.**

Both readers collapsed every unsuccessful HTTP status into one failure, so the policy that (correctly) declines to re-ask a refusal also declined to re-ask a `503 … retry shortly`. In both places the fix is the same, and it is not a longer budget or a poll behind it: **make the status survive as data, then branch on what the server actually said.**

---

## Systemorph/MeshWeaver#2836 — the portal stopped reconciling its own packages

`RegistryUpdateReconciler` has no poll timer *by design* — its promise is "a consumer learns on its **next boot**". That makes the boot's bounded retry the only thing between a hiccup and a pod that never reconciles again. It skipped `InvalidOperationException`, reading it as *"a definite HTTP answer (401/403/404) — the same answer will come back in two seconds"*.

**That reasoning was right about the statuses it named and wrong about the type.** `RegistryPackageSource` threw that one bare type for *every* non-2xx, keeping the status only inside the message text:

```csharp
if (!resp.IsSuccessStatusCode)
    throw new InvalidOperationException(
        $"Registry catalog list failed ({(int)resp.StatusCode}): {json}");   // 401, 404, 503 — all the same type
```

So the single condition a boot retry exists for was the single condition it skipped. The pod's installed set then went stale for the rest of its life — no package updates, no grant changes — and **silently**, because the portal itself stays up.

- `RegistryResponseException(HttpStatusCode, message) : InvalidOperationException` — the same shape, and for the same stated reason, as the `InstanceRegistrationException` already in this file's neighbour (*"so callers can branch … without string matching"*). Deriving from `InvalidOperationException` keeps every existing `catch` behaving exactly as before.
- Thrown from the three sites that discarded the status: `ListPackages`, `FetchPackageFiles`, `PluginBundleClient.FetchIndex`.
- `ShouldRetryFeedRead` replaces the type test. Transient (any 5xx, 408, 429 — the conventional set, so the boundary is a published convention rather than a per-call-site judgement) is re-asked; definite still fails at once; a transport fault is re-asked exactly as before (#1500).

## Systemorph/MeshWeaver#2787 — and a platform promotion redded other repos' builds

Promoting the platform **rolls the portal**, and that portal *is* what serves the registry. On Manufacturing run `33316402646`: image promoted `14:12:41` → gate read 503 at `~14:16` → a portal pod started `14:18:22`. Six repos read that endpoint and three images were promoted that day, so the window opened three times. The only recourse was re-running a red build — precisely the habit worth removing.

Both gate readers now re-ask a transient answer with a widening pause (15/30/60/90 s, five attempts, ~3 min — sized to the *measured* window):

- `node-repo-gate.yml` — the upstream-seed index read **and** the per-bundle fetches. The latter were `curl -sSf`, which discards the very status that says whether re-asking would help.
- `compose-sealed-modules.sh` — the module-set index read and `fetch_module`, the same shape one lane over.

🚨 **A retry, not a skip-trapdoor.** When the attempts are spent the last status is returned and every caller still fails **RED**. A registry that is genuinely down fails the gate exactly as before, about three minutes later.

The helper is **duplicated on purpose**. That script is fetched from core at a pinned `platform-ref` while the workflow is pinned by the caller's `uses:`, so a shared third file would be a *third* independently-pinned artefact — the exact skew that once let an old workflow drive a new script and seal an empty module set. Each copy names the other.

---

## Verification

**#2836 — mutation-proved.** Restoring the pre-fix code (bare throw + type test) fails **8 of 15**, including the composed test. The 7 that still pass are the pre-existing behaviours the change preserves — which is the point of listing them.

> The two halves are tested **together** deliberately. A policy that branches on a status the throw site never records is still broken, and *each half passes its own test while the system fails*. So the pinning test feeds a **real** exception, from a real HTTP round trip through a stub handler, into the **real** predicate.

- `RegistryTransientFailureRetryTest` — 15/15 green.
- Full `MeshWeaver.PluginCatalog.Test`: **716 passed, 0 failed** (5 m 21 s).
- `MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`, `MeshWeaver.Documentation.Test`, `MeshWeaver.PluginCatalog.Test` — each `-c Release -warnaserror`, `0 Warning(s) 0 Error(s)`.
- All ratchet guards + `WhatsNewEntryIntegrityTest` green.

**#2787 — behaviour-tested, not read.** Both copies driven through a stubbed `curl` across 13 scripted status sequences:

```
── Systemorph/MeshWeaver#2787: a roll window, then the portal is back ──
  ok   503 then 200          code=200 calls=2 slept=[15]
  ok   503 503 200           code=200 calls=3 slept=[15 30]
── a definite answer is NOT re-asked (behaviour unchanged) ──
  ok   404 refuses immediately   code=404 calls=1 slept=[]
  ok   401 refuses immediately   code=401 calls=1 slept=[]
  ok   403 refuses immediately   code=403 calls=1 slept=[]
  ok   200 first time            code=200 calls=1 slept=[]
── a registry genuinely down still fails RED, just later ──
  ok   503 forever           code=503 calls=5 slept=[15 30 60 90]
  ok   500 forever           code=500 calls=5 slept=[15 30 60 90]
── the rest of the transient set ──
  ok   429/502/504/408 then 200, and a doubled connection failure — all recover
```

`ALL PASS` for both copies; YAML parses; `bash -n` clean.

> A note on that harness: my first version reported **13 failures**, and every one was the harness — it read a counter across a `$( )` boundary. The function was correct the whole time. Worth recording because a broken harness and a broken subject look identical from the summary line.

Two What's New entries (`Category: Fix`), one per user-visible behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)