### PR TITLE
fix(#2778): the OwnerDisposing NACK is handed to the waiter, not posted and hoped for

### DIFF
--- a/src/MeshWeaver.Data.Contract/ILatePatchVerdictSink.cs
+++ b/src/MeshWeaver.Data.Contract/ILatePatchVerdictSink.cs
@@ -1,0 +1,42 @@
+namespace MeshWeaver.Data;
+
+/// <summary>
+/// 🚨 The seam a LATE owner verdict for a cross-hub MeshNode write is handed to, declared here so
+/// the hub that MINTS the verdict can reach the watch that is waiting for it.
+///
+/// <para><b>Why the interface exists at all.</b> The implementation is
+/// <c>MeshWeaver.Mesh.LatePatchResponseRegistry</c>, in <c>MeshWeaver.Mesh.Contract</c>. The owner
+/// side that mints the <c>OwnerDisposing</c> NACK is
+/// <c>DataExtensions.RegisterOwnerDisposingNack</c>, in <c>MeshWeaver.Data</c> — and
+/// <c>MeshWeaver.Data</c> cannot reference <c>MeshWeaver.Mesh.Contract</c>, because that would
+/// close the cycle <c>Data → Mesh.Contract → Layout → Data</c>. <see cref="PatchDataResponse"/>
+/// already lives here, in the assembly both sides reference, so this is where the verb belongs
+/// too.</para>
+///
+/// <para><b>What it is for.</b> A verdict that lands after <c>UpdateRemote</c>'s ~2 s bounded wait
+/// has no pending <c>Observe</c> callback left, so posting it is only a way of reaching this same
+/// registry the long way round — routed to the caller, into the cache hub's
+/// <see cref="PatchDataResponse"/> handler, and finally to <c>Dispatch</c>. Within one mesh the
+/// registry is a singleton both hubs already share, so the owner can hand the verdict over
+/// directly: same waiter, no hub woken, no message routed. That matters most exactly when the post
+/// is unavailable — a parent already past <c>DisposeHostedHubs</c> (#2778).</para>
+///
+/// <para>🚨 It also turns an assumption into a fact. The dropped-NACK guard justified itself with
+/// "nobody is waiting", which no code could verify and which was false precisely when it mattered.
+/// <see cref="Dispatch"/> REPORTS whether a caller was armed, so the question is answered rather
+/// than assumed — and a miss costs one dictionary lookup, which is what makes it affordable to ask
+/// on every teardown.</para>
+/// </summary>
+public interface ILatePatchVerdictSink
+{
+    /// <summary>
+    /// Delivers a late owner response to its armed watch, if one is still armed and unexpired.
+    /// </summary>
+    /// <param name="requestId">The originating <c>PatchDataRequest</c> delivery id — the same value
+    /// carried back as the response's <c>RequestId</c> correlation property.</param>
+    /// <param name="response">The owner's verdict.</param>
+    /// <returns><c>true</c> when an armed, unexpired watch consumed it; <c>false</c> when nobody in
+    /// this mesh was waiting — which the caller may then treat as a checked fact rather than a
+    /// guess.</returns>
+    bool Dispatch(string requestId, PatchDataResponse response);
+}

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -892,6 +892,40 @@ public static class DataExtensions
                 Error = nodeErr.Message,
                 NodeError = nodeErr,
             };
+            // 🚨 Hand the verdict to the waiting caller DIRECTLY, before considering a post.
+            //
+            // The transport below is not the seam this NACK was designed to arrive on. A verdict
+            // that lands after UpdateRemote's ~2 s bounded wait has NO pending Observe callback,
+            // so the post is only ever a way to reach LatePatchResponseRegistry the long way round
+            // — routed to the caller, into the cache hub's PatchDataResponse handler, and finally
+            // Dispatch. That handler's own comment names this NACK as the thing it exists for.
+            // Inside one mesh the registry is a singleton both hubs already share, so asking it
+            // first reaches the same waiter with no hub woken and no message routed.
+            //
+            // 🚨 This is what makes the fix affordable. The obvious repair — walk the parent chain
+            // and post through the first ancestor that can still post — is correct about the
+            // caller and was MEASURED at ~10x on teardown: MeshWeaver.Content.Test went 29 s → 176 s,
+            // a uniform ~0.9 s per test, because every hub going down with a delivery outstanding
+            // now wakes callers mid-drain. It was implemented and reverted for that reason. A
+            // dictionary lookup that misses costs nothing, so the common teardown — nobody waiting
+            // — pays nothing at all.
+            //
+            // 🚨 And it replaces an assumption with a fact. The old guard's rationale was "during a
+            // whole-mesh teardown the parent is past that mark too, the post is skipped, and NOBODY
+            // IS WAITING". Nobody-is-waiting is not something that code could verify, and it was
+            // false precisely when it mattered: the caller whose wait outlives the start of
+            // teardown is still waiting, and it is the one guaranteed to get silence instead of its
+            // NACK, then to burn the full 31 s WriteVerdictBound (#2778). Dispatch RETURNS whether
+            // a caller was armed, so the question is now answered rather than assumed.
+            var lateVerdicts = hub.ServiceProvider.GetService<ILatePatchVerdictSink>();
+            if (lateVerdicts is not null && lateVerdicts.Dispatch(request.Id, resp))
+                return;
+
+            // No caller armed in THIS mesh. Either nobody is waiting — now a checked fact, and
+            // skipping is correct — or the caller is in another process, which the registry here
+            // cannot see. The existing post remains that case's only route, with its run-level
+            // guard unchanged: removing it is the ~10x regression above, and a cross-process
+            // caller during owner teardown is not the case #2778 reproduced.
             var parent = hub.Configuration.ParentHub;
             if (parent is not null && parent.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
                 parent.Post(resp, o => o.ResponseFor(request));

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-a-write-is-answered-even-when-its-owner-goes-down.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-a-write-is-answered-even-when-its-owner-goes-down.md
@@ -1,0 +1,34 @@
+---
+Name: A write is answered even when its owner goes down with the mesh
+Category: Fix
+Description: When a node's owner was shut down as part of a wider teardown, the "this write never applied" answer it produced was thrown away, and whoever was waiting heard nothing for a full 31 seconds. The answer now goes straight to the waiter.
+Icon: Sparkle
+Order: -20260831
+---
+
+# A write is answered even when its owner goes down with the mesh
+
+When the component that owns a node shuts down with a write still in flight, it produces an explicit
+answer — *the write never applied; it is safe to try again*. Delivering that answer is the whole
+point of producing it: whoever is waiting can retry immediately instead of waiting to find out.
+
+The answer was sent as a message through the owner's parent, and only while that parent had not yet
+begun shutting its own children down. That excluded exactly the case it was needed for. A whole
+batch of owners going down at once — which is what a shutdown *is* — happens after the parent has
+passed that point, so every answer in that batch was discarded. The waiter then heard nothing, and
+nothing is indistinguishable from a slow owner, so it waited out the full 31-second budget for an
+answer that had already been written and thrown away.
+
+The justification recorded in the code was that during a wider teardown *nobody is waiting*. That
+was never something the code could check, and it is false precisely when it matters: somebody whose
+wait began before the shutdown started is still waiting, and they were the ones guaranteed to be
+ignored.
+
+The answer is now handed directly to whoever is waiting, rather than posted and routed in the hope
+of arriving. Waiters are already tracked by name, so the owner can simply look — which also replaces
+the old guess with a fact: if nobody is registered, nobody is waiting.
+
+Handing it over directly is also what makes this affordable. The obvious repair — send the message
+through whichever ancestor can still forward it — was implemented and measured at roughly ten times
+the cost on every shutdown, because it wakes waiters throughout the drain. A lookup that finds
+nothing costs nothing, so the ordinary case pays nothing at all.

--- a/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
+++ b/src/MeshWeaver.Hosting/Persistence/PersistenceExtensions.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using MeshWeaver.Data;
 using MeshWeaver.Data.Completion;
 using MeshWeaver.Hosting.Completion;
 using MeshWeaver.Hosting.Persistence.Http;
@@ -821,6 +822,15 @@ public static class PersistenceExtensions
         // 2s caller window already closed (see LatePatchResponseRegistry). Mesh-scoped
         // instance singleton — dies with the mesh.
         services.TryAddSingleton<LatePatchResponseRegistry>();
+        // 🚨 The SAME instance under the seam MeshWeaver.Data can see. The owner side that mints
+        // the OwnerDisposing NACK cannot reference MeshWeaver.Mesh.Contract (Data → Mesh.Contract
+        // → Layout → Data is a cycle), so it resolves ILatePatchVerdictSink from Data.Contract and
+        // hands the verdict straight to the waiting caller (#2778). Registered as a FACTORY over
+        // the concrete singleton, never as a second AddSingleton — two instances would mean the
+        // owner dispatching into a registry nobody armed, which reads exactly like "nobody was
+        // waiting" and would restore the bug in a form no test could see.
+        services.TryAddSingleton<ILatePatchVerdictSink>(sp =>
+            sp.GetRequiredService<LatePatchResponseRegistry>());
         // Post-commit durable-flush hook for the PatchDataRequest handler: chains the
         // owner's ack off the storage write so a cross-hub stream.Update completion
         // guarantees read-after-write (see IPostCommitFlush / StoragePostCommitFlush).

--- a/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
+++ b/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
@@ -51,7 +51,7 @@ namespace MeshWeaver.Mesh;
 /// write the owner had refused. <see cref="DispatchFailure"/> is that missing seam, and it obeys
 /// the identical exactly-once rule.</para>
 /// </summary>
-public sealed class LatePatchResponseRegistry
+public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
 {
     /// <summary>
     /// 🚨 How long after the patch post a late owner response is still acted upon. This is

--- a/test/MeshWeaver.Hosting.Monolith.Test/NackReachesTheWaiterDuringTeardownTest.cs
+++ b/test/MeshWeaver.Hosting.Monolith.Test/NackReachesTheWaiterDuringTeardownTest.cs
@@ -1,0 +1,157 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Hosting.Monolith.Test;
+
+/// <summary>
+/// 🚨 <b>#2778 — the OwnerDisposing NACK was dropped exactly when the parent is disposing hosted
+/// hubs, and the caller then burned its full verdict budget in silence.</b>
+///
+/// <para><c>RegisterOwnerDisposingNack</c> delivered the NACK as
+/// <c>parent.Post(...)</c> guarded by <c>parent.RunLevel &lt; DisposeHostedHubs</c>. With the run
+/// levels ordered <c>Starting, Started, Quiescing, DisposeHostedHubs, …</c> that guard is open
+/// for the first three and shut for the rest — so the one moment a whole BATCH of owner hubs goes
+/// down with patches in flight is the one moment none of their NACKs is delivered.</para>
+///
+/// <para><b>The guard's rationale was an assumption the code could not verify.</b> It read:
+/// <i>"during a whole-mesh teardown the parent is past that mark too, the post is skipped, and
+/// nobody is waiting."</i> A caller whose wait outlives the START of teardown is still waiting,
+/// and it is exactly that caller which is guaranteed to get silence instead of its answer.</para>
+///
+/// <para><b>Why this test disposes the MESH and not just the owner.</b> Disposing only the
+/// per-node hub — what <c>LateNackReenqueueTest</c> and <c>OwnerDisposalNackTest</c> do — leaves
+/// the parent at <c>Started</c>, where the old guard was OPEN and the NACK was delivered. Those
+/// tests therefore pass with the defect fully present. Reaching the hole at all requires the
+/// parent to be past <c>DisposeHostedHubs</c> when the owner's disposal action runs, and disposing
+/// the mesh is what puts it there — which is also precisely the production shape the issue
+/// reported (~13 distinct stream ids retiring in one burst).</para>
+///
+/// <para><b>What is asserted is that the NACK REACHES THE ARMED WATCH, not that the caller's
+/// callback runs.</b> This distinction was learned from the first draft of this test, which
+/// asserted the caller's terminal and failed even with the fix in place. The reason is sound and
+/// worth recording: disposing the mesh takes the CALLER's own subscription down along with the
+/// owner, so by the time the verdict is raised there is no live observer left to receive it —
+/// `observer.OnError` on a disposed subscription is a silent no-op. Asserting on the caller's
+/// callback would therefore be asserting on something this scenario cannot produce, whatever the
+/// framework does.</para>
+///
+/// <para>The armed watch is the right subject because it IS the thing #2778 is about. The registry
+/// entry is armed while a caller waits and is REMOVED by <c>Dispatch</c> — so the entry returning
+/// to zero is precisely "the owner's verdict reached the waiter", the step that used to be skipped.
+/// With the defect present the post is never made, nothing dispatches, and the entry simply sits
+/// armed until it expires 30 s later.</para>
+/// </summary>
+public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    [Fact]
+    public async Task OwnerDisposingUnderMeshTeardown_StillAnswersTheWaitingCaller()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var path = $"{TestPartition}/teardown-nack-node";
+        await NodeFactory.CreateNode(
+                new MeshNode("teardown-nack-node", TestPartition) { Name = "initial", NodeType = "Markdown" })
+            .Should().Emit();
+
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            .Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(10.Seconds()).Await(ct);
+
+        var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull();
+
+        // Park the owner's merge executor, so the write below is ACCEPTED by the owner's handler
+        // (which is what registers the disposal NACK) but provably cannot be answered inside the
+        // caller's ~2 s response bound. The caller therefore hands its wait to the late watch —
+        // and being armed there is the precondition the whole issue turns on.
+        //
+        // 🚨 No hand-woven gate: the turn → test signal is an AsyncSubject the parked turn
+        // completes; the release travels back INTO the deliberately parked turn, so it is a
+        // volatile flag polled under a bounded SpinUntil and written in the `finally`.
+        var primary = nodeHub!.GetWorkspace().DataContext
+            .GetDataSourceForType(typeof(MeshNode))!
+            .GetStreamForPartition(null)!;
+        var gateEntered = new AsyncSubject<Unit>();
+        var releaseGate = 0;
+        primary.Update((Func<EntityStore?, ChangeItem<EntityStore>?>)(_ =>
+        {
+            gateEntered.OnNext(Unit.Default);
+            gateEntered.OnCompleted();
+            SpinWait.SpinUntil(() => Volatile.Read(ref releaseGate) == 1, TimeSpan.FromSeconds(60));
+            return null;
+        }), _ => { });
+        try
+        {
+            await gateEntered.Should().Within(10.Seconds()).Emit(
+                "the gated turn must be running on the primary stream's executor before the write");
+
+            var marker = $"teardown-nack-{Guid.NewGuid():N}"[..24];
+            var workspace = Mesh.GetWorkspace();
+            MeshNode? callerTerminal = null;
+            Exception? callerError = null;
+            using var writeSub = workspace.GetMeshNodeStream(path)
+                .Update(n => n with { Name = marker })
+                .Subscribe(n => callerTerminal = n, ex => callerError = ex);
+            Output.WriteLine($"[write] patch posted with marker {marker}; owner merge is parked");
+
+            // Fence on the caller actually WAITING — an armed late watch is that fact, and it is
+            // the same fact the disposal NACK has to land on. Without it this test could pass by
+            // asserting about a caller that was never waiting in the first place.
+            var registry = Mesh.ServiceProvider.GetRequiredService<LatePatchResponseRegistry>();
+            await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+                .Where(_ => registry.ArmedCount > 0)
+                .FirstAsync().Timeout(30.Seconds()).Await(ct);
+            Output.WriteLine($"[fence] caller is armed on the late watch (ArmedCount={registry.ArmedCount})");
+
+            // 🚨 The scenario. Dispose the MESH, not the node hub: the owner's disposal action then
+            // runs with its parent already past DisposeHostedHubs — the exact window in which the
+            // old guard skipped the post and the caller heard nothing.
+            Mesh.Dispose();
+            Output.WriteLine("[dispose] mesh disposal invoked — parent is past DisposeHostedHubs");
+
+            // 🚨 The assertion: the armed watch is CONSUMED. Dispatch removes the entry, so
+            // ArmedCount returning to zero is the observable fact "the owner's verdict reached the
+            // waiter". The bound is deliberately far below LateResponseWatchBound (30 s), because
+            // an entry that merely EXPIRES would also end at zero — waiting that long is
+            // indistinguishable from the defect, so a generous bound would pass on it.
+            await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+                .Where(_ => registry.ArmedCount == 0)
+                .FirstAsync().Timeout(10.Seconds()).Await(ct);
+
+            registry.ArmedCount.Should().Be(0,
+                "the owner minted an OwnerDisposing NACK for this patch, and a caller was armed and "
+                + "waiting for it; the verdict must reach that watch even though the parent is past "
+                + "DisposeHostedHubs. Leaving the watch armed is the #2778 defect — the caller then "
+                + "hears nothing and burns the whole 31 s verdict budget for an answer that had "
+                + "already been minted");
+
+            // Diagnostics only — under a full mesh teardown the caller's own subscription is going
+            // down too, so whether its callback still runs is not this test's subject (see the
+            // class remarks).
+            Output.WriteLine(
+                $"[caller] terminal={(callerTerminal is null ? "<null>" : callerTerminal.Name)} "
+                + $"error={(callerError is null ? "<null>" : callerError.GetType().Name)}");
+        }
+        finally
+        {
+            // In a `finally` so a failing assertion above cannot strand the parked executor turn.
+            Volatile.Write(ref releaseGate, 1);
+        }
+    }
+}


### PR DESCRIPTION
Closes Systemorph/MeshWeaver#2778.

The owner mints an explicit *"this patch was NOT applied — safe to retry"* NACK when it goes down mid-write. Delivering it is the entire point of minting it. It was delivered like this:

```csharp
var parent = hub.Configuration.ParentHub;
if (parent is not null && parent.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
    parent.Post(resp, o => o.ResponseFor(request));
```

With the levels ordered `Starting, Started, Quiescing, DisposeHostedHubs, …`, that guard is open for the first three and shut for the rest — **so the one moment a whole batch of owner hubs goes down with patches in flight is the one moment none of their NACKs is delivered.** The caller then burns the full 31 s `WriteVerdictBound` waiting for an answer that had already been written and thrown away.

The guard justified itself with *"during a whole-mesh teardown the parent is past that mark too, the post is skipped, and **nobody is waiting**."* That is not something the code could verify, and it is false exactly when it matters.

## The post was never the seam this NACK was designed to arrive on

A verdict that lands after `UpdateRemote`'s ~2 s bounded wait has **no pending `Observe` callback left**. So posting it is only a way of reaching `LatePatchResponseRegistry` the long way round — routed to the caller, into the cache hub's `PatchDataResponse` handler, and finally `Dispatch`. That handler's own comment already names this NACK as the thing it exists for:

> *"the ONLY place a post-optimistic-emit verdict (**above all the OwnerDisposing disposal NACK**) can still be observed"*

Within one mesh the registry is a singleton both hubs already share, so the owner can hand the verdict over directly: same waiter, no hub woken, no message routed. And `Dispatch` **returns whether a caller was armed** — so "nobody is waiting" stops being an assumption and becomes a checked fact.

- **`ILatePatchVerdictSink`**, new in `MeshWeaver.Data.Contract`. The owner side lives in `MeshWeaver.Data`, which cannot reference `MeshWeaver.Mesh.Contract` — that closes the cycle `Data → Mesh.Contract → Layout → Data`. `PatchDataResponse` already lives in `Data.Contract`, so the verb belongs there too.
- `LatePatchResponseRegistry` implements it — its existing `Dispatch` already has the signature. Registered as a **factory over the concrete singleton**, never a second `AddSingleton`: two instances would mean the owner dispatching into a registry nobody armed, which reads exactly like *"nobody was waiting"* and would restore the bug in a form no test could see.
- The parent post **stays, unchanged**, as the only route to a caller in another process, which this registry cannot see.

## Cost — why the obvious fix was reverted, and why this one is affordable

A previous attempt walked the parent chain to the first ancestor that could still post. It is correct about the caller and was measured at **~10× on teardown**, so it was reverted. This shape is a dictionary lookup that misses, so the common teardown — nobody waiting — pays nothing.

Measured on one box, one variable at a time, same 166 tests, `DOTNET_PROCESSOR_COUNT=4`:

| variant | duration | tests |
|---|---:|---|
| baseline (main-equivalent worktree, measured now) | **24 s** | 166/166 |
| **this branch** | **25 s** | 166/166 |
| the rejected ancestor walk | 176 s | *(prior session)* |

## The test, and two things it taught me

`NackReachesTheWaiterDuringTeardownTest` disposes the **mesh**, not just the node hub. Disposing only the owner leaves the parent at `Started`, where the old guard was **open** — which is why `OwnerDisposalNackTest` and `LateNackReenqueueTest` both pass with the defect fully present, and why it survived this long.

🚨 **It asserts the armed watch is consumed, not that the caller's callback runs.** My first draft asserted the caller's terminal and **failed with the fix in place**. The reason is sound: a mesh teardown takes the caller's own subscription down along with the owner, so `observer.OnError` lands on a disposed subscription and is a silent no-op. That is a property of the scenario, not of the framework — asserting it would have meant asserting something no implementation could satisfy. The registry entry is armed while a caller waits and is removed by `Dispatch`, so it returning to zero **is** "the verdict reached the waiter". The bound is well under the 30 s watch bound, because an entry that merely *expires* also ends at zero.

The failing draft is also what proved the fix works end to end: `LATE_NACK_REENQUEUE … code=OwnerDisposing` appears in its log, which the pre-fix code cannot produce at all.

**Mutation-proved:** with the direct hand-off removed, the new test fails on a timeout. All **9** sibling NACK / late-watch tests stay green — and `LateNackReenqueueTest` now exercises the new path, since its caller is armed.

`MeshWeaver.Data.Contract`, `MeshWeaver.Data`, `MeshWeaver.Mesh.Contract`, `MeshWeaver.Hosting`, `MeshWeaver.Hosting.Monolith.Test`, `MeshWeaver.Content.Test` — each `-c Release -warnaserror`, `0 Warning(s) 0 Error(s)`.

One What's New entry (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)