### PR TITLE
fix(#2622): the image set is keyed on the PAIR of commits, so a plugins host change heals itself

### DIFF
--- a/.github/scripts/check-image-set.sh
+++ b/.github/scripts/check-image-set.sh
@@ -2,8 +2,25 @@
 #
 # Is the COMPLETE deployment image set present in ACR for one commit?
 #
-#   .github/scripts/check-image-set.sh <short-sha>
+#   .github/scripts/check-image-set.sh <short-sha> [<plugins-short-sha>]
 #   exit 0 = complete   exit 1 = something is missing / malformed
+#
+# 🚨 THE SECOND ARGUMENT IS WHAT MAKES THE IDENTITY HONEST (MeshWeaver#2622). The portal HOSTS
+# live in MeshWeaver.Plugins, so a merge THERE that edits a file shipping in the image — an
+# appsettings.json, a csproj — changes what the image should contain while core's HEAD does not
+# move. Keyed on core's sha alone this script answers "complete", the reconciler does nothing,
+# and the fix has no producer that would ever rebuild it. That is not hypothetical: Plugins#814
+# fixed fresh-install engine activation at 14:54Z and the newest image predated it.
+#
+# Given a plugins sha, "the set" additionally requires the PAIR tag memex-portal-ai:<sha>-p<psha>,
+# which `promote` phase A stamps on the image it publishes. A plugins merge therefore makes the
+# set INCOMPLETE on core's next reconcile tick, and the reconciler heals it on its own.
+#
+# 🚨 Callers MUST pass a value RESOLVED ONCE by `gate` and threaded through, never re-resolve it.
+# `gate` and `verify-images` both call this file and their answers must agree (see below); if
+# each resolved plugins HEAD itself, a plugins merge landing during the ~20 min run would make
+# verify look for a tag the publish could not have written, and every such publish would go red
+# on a correct result. Cry wolf, and the ledger becomes noise.
 #
 # 🚨 THIS FILE IS THE DEFINITION OF "THE SET". Used by BOTH jobs in main-cd.yml that need to
 # answer the question, and they MUST agree:
@@ -28,7 +45,8 @@
 # is not a cross-image identity.
 set -uo pipefail
 
-SHA="${1:?usage: check-image-set.sh <short-sha>}"
+SHA="${1:?usage: check-image-set.sh <short-sha> [<plugins-short-sha>]}"
+PLUGINS_SHA="${2:-}"
 REGISTRY="${ACR_NAME:-meshweaver}"
 
 # Reads manifests through ARM (an `az login` is enough — `az acr login` is for docker push creds).
@@ -67,8 +85,21 @@ done
 # it, so it is not part of THIS repo's all-or-nothing set. Asserting an image this repo does not
 # build would fail every commit.
 
+# 🚨 The PAIR tag — is the published portal image the one built from the CURRENT plugins HEAD?
+# Only checked when a caller supplies the plugins sha, so every other caller keeps today's exact
+# behaviour and nothing else has to change. Absent argument = absent check, deliberately: this is
+# the one place the answer may narrow, and it narrows only for callers that opted in.
+if [ -n "$PLUGINS_SHA" ]; then
+  pair="$SHA-p$PLUGINS_SHA"
+  if az acr manifest show --registry "$REGISTRY" --name "memex-portal-ai:$pair" -o json >/dev/null 2>&1; then
+    ok "memex-portal-ai:$pair — built from plugins $PLUGINS_SHA"
+  else
+    report "memex-portal-ai:$pair is MISSING — the published portal image was NOT built from the current plugins HEAD ($PLUGINS_SHA). The portal hosts live in MeshWeaver.Plugins, so a merge there ships in the image while core's sha does not move (#2622). The reconciler will rebuild."
+  fi
+fi
+
 if [ "$fail" -ne 0 ]; then
   echo "::error::main $SHA does NOT have a complete image set. Every self-updating install stays on the previous image until a CD run publishes all of them."
   exit 1
 fi
-echo "All four images exist in ACR for $SHA."
+echo "All images exist in ACR for $SHA${PLUGINS_SHA:+ (built from plugins $PLUGINS_SHA)}."

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -321,6 +321,11 @@ jobs:
       # The three facts the delivery verdict below judges. Exposed as outputs so the check is a
       # JOB anyone can read in the run summary, not a conclusion buried in this job's log.
       complete: ${{ steps.acr.outputs.complete }}
+      # 🚨 Resolved ONCE (steps.plugins) and consumed by promote + verify-images. Never
+      # re-resolved downstream — see the step's own comment for why re-resolving turns a correct
+      # publish red (#2622).
+      plugins_short: ${{ steps.plugins.outputs.plugins_short }}
+      plugins_sha: ${{ steps.plugins.outputs.plugins_sha }}
       # Reconcile found the images complete: no image build is due, but the content bake still
       # is — the images being present says nothing about whether the bundles are.
       bake_only: ${{ steps.decide.outputs.bake_only }}
@@ -500,12 +505,58 @@ jobs:
           fi
           echo "Newest published ci tag: ${newest:-<none>} (${age_min} min ago)"
           echo "age_min=$age_min" >> "$GITHUB_OUTPUT"
+      # 🚨 Resolve the plugins HEAD ONCE, here, and thread it. Everything downstream — the
+      # completeness probe below, promote's pair tag, verify-images' assertion — consumes THIS
+      # output and never re-resolves (MeshWeaver#2622).
+      #
+      # That is not tidiness, it is the correctness condition. The run takes ~20 minutes. If
+      # `verify-images` re-resolved, a plugins merge landing inside that window would make it look
+      # for `…-pB` on an image this run correctly built from `A`, and a successful publish would go
+      # red. Cry wolf, and the ledger becomes noise — the failure mode the gate's own comments
+      # already name. Resolving once means the identity is minted by the run that owns it, exactly
+      # like the staging tag; the NEXT reconcile tick re-resolves and correctly finds the set
+      # stale, which is the desired behaviour at the right moment.
+      #
+      # 🚨 No `if:` on a secret and no `continue-on-error`. An unresolvable plugins HEAD means the
+      # image identity cannot be established at all, so this FAILS RED naming what to provision —
+      # a skipped resolution would silently disable the pair check and be indistinguishable from
+      # a passing one.
+      - name: "Resolve the plugins HEAD this image set is bound to"
+        id: plugins
+        env:
+          PLUGINS_REF: ${{ vars.MW_PLUGINS_REF || 'main' }}
+          SSH_KEY: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SSH_KEY:-}" ]; then
+            echo "::error::PLUGINS_REPO_SSH_KEY is not set on this repository. main-cd cannot resolve the plugins HEAD, so it cannot tell whether the published portal image carries the current hosts (#2622). Provision the deploy key used by the host checkouts."
+            exit 1
+          fi
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/plugins_key && chmod 600 ~/.ssh/plugins_key
+          ssh-keyscan -t rsa,ecdsa,ed25519 github.com >> ~/.ssh/known_hosts 2>/dev/null
+          export GIT_SSH_COMMAND="ssh -i ~/.ssh/plugins_key -o IdentitiesOnly=yes"
+          # One network round trip; no clone. A ref that resolves to nothing is a hard error, not
+          # an empty string travelling downstream as "no pair to check".
+          full=$(git ls-remote git@github.com:Systemorph/MeshWeaver.Plugins.git \
+                   "refs/heads/$PLUGINS_REF" | awk '{print $1}' | head -1)
+          rm -f ~/.ssh/plugins_key
+          if [ -z "$full" ]; then
+            echo "::error::'refs/heads/$PLUGINS_REF' does not resolve in Systemorph/MeshWeaver.Plugins — check MW_PLUGINS_REF."
+            exit 1
+          fi
+          short="${full:0:7}"
+          echo "plugins HEAD ($PLUGINS_REF) = $full  short=$short"
+          echo "plugins_short=$short" >> "$GITHUB_OUTPUT"
+          echo "plugins_sha=$full" >> "$GITHUB_OUTPUT"
       - name: "Does main's HEAD already have a complete image set?"
         id: acr
         if: steps.target.outputs.reason == 'reconcile'
         run: |
           set -uo pipefail
-          if .github/scripts/check-image-set.sh "${{ steps.target.outputs.short_sha }}"; then
+          # 🚨 The second argument is what lets a plugins-only host change be SEEN. Without it a
+          # complete-for-core's-sha set answers "complete" and the reconciler does nothing (#2622).
+          if .github/scripts/check-image-set.sh "${{ steps.target.outputs.short_sha }}" "${{ steps.plugins.outputs.plugins_short }}"; then
             echo "complete=true" >> "$GITHUB_OUTPUT"
           else
             echo "complete=false" >> "$GITHUB_OUTPUT"
@@ -649,11 +700,15 @@ jobs:
           # fresh-install engine activation by editing src/Memex.Portal.Distributed/appsettings.json
           # at 14:54Z, and the newest image predated it with no producer that would ever rebuild.
           #
-          # This is the ESCAPE HATCH, not the fix. The durable shape is to make the identity honest
-          # — record the plugins sha the image was baked from and have check-image-set.sh compare it
-          # against plugins@main — so the RECONCILER notices on its own. Until that exists, an
-          # operator who knows the hosts changed has no way to say so, and a dispatch is a
-          # structural no-op for exactly this case.
+          # 🚨 THE DURABLE FIX NOW EXISTS and runs above this line: `gate` resolves plugins HEAD
+          # once and passes it to check-image-set.sh, which requires the pair tag
+          # memex-portal-ai:<core-short>-p<plugins-short> that promote phase A stamps. So a
+          # plugins-only host merge makes the set INCOMPLETE and the RECONCILER heals it on its
+          # own — `COMPLETE` below is already pair-aware.
+          #
+          # `rebuild` stays as the operator escape hatch (it is still the only way to force a
+          # rebuild for a reason no tag encodes), but it is no longer the ONLY way this case is
+          # noticed, which is what made it a structural no-op before.
           if [ "$COMPLETE" = "true" ] && [ "${FORCE_REBUILD:-false}" != "true" ]; then
             echo "bake_only=true" >> "$GITHUB_OUTPUT"
             decision false "✅ main \`$SHORT\` already has a complete image set — no image build; re-asserting the content bake (publication is idempotent)"
@@ -1105,6 +1160,9 @@ jobs:
       V_PORTAL: ${{ needs.portal-image.outputs.version }}
       V_MIGRATION: ${{ needs.migration-image.outputs.version }}
       V_PLUGIN: ${{ needs.plugin-test-image.outputs.version }}
+      # 🚨 The plugins sha `gate` resolved, threaded — NOT re-resolved here. See gate's
+      # "Resolve the plugins HEAD" step: re-resolving is what turns a correct publish red (#2622).
+      PLUGINS_SHORT: ${{ needs.gate.outputs.plugins_short }}
     steps:
       # 🚨 The retried ACR login is a SCRIPT (.github/scripts/acr-login.sh, #2857), and a script
       # needs a working tree — this job had none, so the first publishing run after #2857 failed
@@ -1146,8 +1204,21 @@ jobs:
           }
           promote memex-migration   "$V_MIGRATION" "$SHA"
           promote mw-plugin-test    "$V_PLUGIN"    "$SHA"
+          # 🚨 The portal carries a PAIR tag as well as its SHA tag (MeshWeaver#2622): the portal
+          # HOSTS live in MeshWeaver.Plugins, so core's sha alone does not say what is in this
+          # image. `<core-short>-p<plugins-short>` does, and it is what makes a plugins-only host
+          # change visible to check-image-set.sh — the set goes INCOMPLETE on the next reconcile
+          # tick and heals itself, instead of waiting for an unrelated core merge or a human
+          # remembering to pass `rebuild`.
+          #
+          # It belongs HERE, in phase A, with the other identity tags — never on the build. The
+          # build pushes only the staging tag, which is the all-or-nothing gate; putting a
+          # consumer-selectable identity on a leg that has not yet earned promotion is exactly
+          # what that design prevents.
+          #
+          # Additive: it names a tag nothing else writes, so it cannot disturb an existing one.
           # The portal's SHA tag, but NOT its version tag — see phase C.
-          promote memex-portal-ai   "$SHA"
+          promote memex-portal-ai   "$SHA" "$SHA-p$PLUGINS_SHORT"
       - name: "Phase B — moving pointers (main, latest, GHCR mirror)"
         run: |
           set -euo pipefail
@@ -2093,7 +2164,10 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: Every image for this commit must exist in ACR
-        run: .github/scripts/check-image-set.sh "${{ needs.gate.outputs.short_sha }}"
+        # 🚨 The SAME plugins sha `gate` resolved — read from its output, never re-resolved. A
+        # plugins merge landing during this ~20 min run must not make this assert a tag the
+        # publish could not have written (#2622).
+        run: .github/scripts/check-image-set.sh "${{ needs.gate.outputs.short_sha }}" "${{ needs.gate.outputs.plugins_short }}"
       # A heal that WORKED has to say so on the same issue that recorded the attempt, or the
       # ledger only ever grows and nobody can tell a fixed hole from an open one.
       - name: Report a successful heal

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -28,13 +28,46 @@ two properties that make a partial or missing release impossible rather than mer
 
 `.github/scripts/check-image-set.sh` **is** the definition of that set. It is asked by two jobs —
 `gate` on the reconcile path, `verify-images` after a publish — and lives in one file precisely so
-those two can never disagree. It asserts the **architectures**, not just tag existence: an image
+those two can never disagree. Both now pass the same, once-resolved plugins sha (see
+[The set is keyed on a PAIR of commits](#the-set-is-keyed-on-a-pair-of-commits-not-on-cores-alone)). It asserts the **architectures**, not just tag existence: an image
 index that lost a leg still resolves for one architecture, and a swallowed cancellation in
 `Microsoft.NET.Build.Containers` is exactly how a leg goes missing while its job reports success.
 
 A partial set is worse than no set: the self-updater sees a new `memex-portal-ai` version and rolls
 the portal onto it, while the migration image or the bake certification for that commit does not
 exist. That is how a portal increment the bake gate never certified reached production.
+
+### The set is keyed on a PAIR of commits, not on core's alone
+
+🚨 **The portal HOSTS live in `MeshWeaver.Plugins`**, so core's HEAD does not, by itself, say what is
+in a portal image. A merge in that repo which edits a file shipping *in* the image — an
+`appsettings.json`, a `.csproj` — changes what the image ought to contain while core's sha stands
+still. Keyed on core alone the reconciler asked "does HEAD have a complete set?", answered *yes*, and
+did nothing; the fix had **no producer that would ever rebuild it**. Not hypothetical: Plugins#814
+fixed fresh-install engine activation at 14:54Z and the newest image predated it (#2622).
+
+So `promote` phase A stamps a **pair tag** alongside the sha tag:
+
+```
+memex-portal-ai:<core-short>-p<plugins-short>
+```
+
+and `check-image-set.sh` takes the plugins sha as an optional second argument. Given one, the pair
+tag is part of "the set" — so a plugins-only host merge makes the set *incomplete* on core's next
+reconcile tick and the reconciler heals it **on its own**, instead of waiting for an unrelated core
+merge or for a human to remember `rebuild`. Given no second argument it behaves exactly as before,
+so every other caller is unaffected.
+
+🚨 **The plugins sha is resolved ONCE, by `gate`, and threaded** to `promote` and `verify-images` as
+a job output. This is a correctness condition, not tidiness. A run takes ~20 minutes; if
+`verify-images` re-resolved, a plugins merge landing inside that window would make it look for
+`…-pB` on an image the run correctly built from `A`, and a **successful publish would go red**. Cry
+wolf, and the ledger becomes noise. Resolving once means the identity is minted by the run that owns
+it — the same discipline as the staging tag — and the next reconcile tick re-resolves and correctly
+finds the set stale, which is the desired behaviour at the right moment.
+
+The `rebuild` input (#2825) remains as the operator escape hatch; it is no longer the only way this
+case is noticed.
 
 ## Property 1 — all-or-nothing publication
 
@@ -210,6 +243,7 @@ But the rule underneath is unchanged and applies to every "did it deploy?" quest
 ```bash
 # 1. Does the image exist, for the commit you care about?
 .github/scripts/check-image-set.sh <short-sha>      # the exact assertion CD itself makes
+.github/scripts/check-image-set.sh <short-sha> <plugins-short>   # ...including the pair tag (#2622)
 
 # 2. What is actually in the registry, newest first?
 az acr repository show-tags -n meshweaver --repository memex-portal-ai --orderby time_desc --top 5 -o tsv

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-a-portal-host-fix-ships-without-waiting-for-an-unrelated-change.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-a-portal-host-fix-ships-without-waiting-for-an-unrelated-change.md
@@ -1,0 +1,30 @@
+---
+Name: A portal host fix now ships on its own, instead of waiting for an unrelated change
+Category: Fix
+Description: The portal's own configuration lives in a second repository, and delivery could not see changes there — a fix could sit unshipped, with nothing that would ever build it, until some unrelated change happened to trigger a rebuild. Delivery now recognises those changes and ships them by itself.
+Icon: Sparkle
+Order: -20260831
+---
+
+# A portal host fix now ships on its own, instead of waiting for an unrelated change
+
+The portal image is assembled from two repositories: the platform, and a second one holding the
+portal's own host configuration. Delivery identified each published image by the platform commit it
+was built from — and only that. A change to the host configuration would therefore ship inside the
+next image built, but nothing ever noticed that a new one was *due*.
+
+The hourly check that keeps delivery honest asks a single question: does the current platform commit
+have a complete set of published images? When only the host configuration had changed, the answer was
+yes, so the check did nothing. The fix would sit unshipped with no producer that would ever build it,
+until somebody merged an unrelated platform change and the rebuild carried it along by accident.
+
+This happened. A fix for engine activation on a fresh install merged one afternoon, and the newest
+image had been built minutes earlier — so the fix had no route to production at all.
+
+Published portal images now carry both commits in their identity, so the hourly check can ask the
+question it was always meant to ask: is the published image built from the *current* host
+configuration? When it is not, the image set counts as incomplete and delivery rebuilds on its own.
+A host fix now ships within the hour, without anyone having to notice it or ask for it by hand.
+
+The manual override added earlier stays available for the cases no identity can capture, but it is no
+longer the only thing standing between a merged fix and a shipped one.


### PR DESCRIPTION
Closes #2622. Implements item 2 exactly as worked out on the issue, including the race it flags.

The portal **hosts** live in `MeshWeaver.Plugins`, so core's HEAD does not by itself say what is in a portal image. A merge there editing a file that ships *in* the image — an `appsettings.json`, a `.csproj` — changes what the image ought to contain while core's sha stands still. Keyed on core alone, the reconciler asked *"does HEAD have a complete image set?"*, answered **yes**, and did nothing. The fix had **no producer that would ever rebuild it.**

Measured, not hypothetical: Plugins#814 fixed fresh-install engine activation at `14:54Z`; the newest image (`ci.6327`, ~`14:4x`, core `bf1ae3a`) predated it. The `rebuild` input from #2825 says of itself it is *"the ESCAPE HATCH, not the fix"*. This is the fix.

## The change

- **`promote` phase A** stamps a pair tag beside the sha tag: `memex-portal-ai:<core-short>-p<plugins-short>`. **Phase A, never the build** — the build pushes only the staging tag, and putting a consumer-selectable identity on a leg that has not yet earned promotion is precisely what that design prevents. Additive: it names a tag nothing else writes.
- **`check-image-set.sh` takes the plugins sha as an optional second argument.** Given one, the pair tag is part of "the set", so a plugins-only host merge makes the set *incomplete* on core's next reconcile tick and the reconciler heals it **on its own**. Given none, it behaves exactly as before — no other caller changes.
- **`gate` resolves plugins HEAD once** (`git ls-remote` over the deploy key already used for the host checkouts) and exposes `plugins_short`; `promote` and `verify-images` consume *that output*.

## 🚨 Resolving once is a correctness condition, not tidiness

This is the race the issue said not to skip. A run takes ~20 minutes. If `verify-images` re-resolved:

```
gate resolves plugins HEAD = A, publishes
   … ~20 min … plugins main moves to B …
verify-images resolves B, looks for …-pB, fails a publish that was correct for A
```

**A successful publish would go red on every plugins merge landing mid-run.** Cry wolf, and the ledger becomes noise — the failure mode the gate's own comments already identify. Threading one value means the identity is minted by the run that owns it, the same discipline as the staging tag; the *next* reconcile tick re-resolves and correctly finds the set stale, which is the desired behaviour at the right moment.

## 🚨 No skip-trapdoor

The resolution step carries **no `continue-on-error`** and **no `if:` asking whether the secret is set**. An unresolvable plugins HEAD means the image identity cannot be established, so it fails **RED** naming what to provision. A skipped resolution would silently disable the pair check and be indistinguishable from a passing one — the exact shape `AGENTS.md` forbids for a gate.

## Verification — behaviour, not reading

Driven against a stubbed `az`, 8 scripted cases. The first three matter as much as the rest: they pin that a **one-argument** call is byte-for-byte what it was.

```
── 1. ONE arg: behaviour must be byte-for-byte as before ──
  ok   complete set, no pair arg                      exit=0
  ok   missing migration, no pair arg                 exit=1
  ok   single-arch index (a lost leg)                 exit=1
── 2. TWO args: the #2622 case ──
  ok   pair tag PRESENT                               exit=0
  ok   pair MISSING (a plugins host merge)            exit=1
  ok   pair present, migration missing                exit=1
  ok   pair for a DIFFERENT plugins sha               exit=1
── 3. empty second arg = no pair check (the opt-in boundary) ──
  ok   explicit empty pair arg behaves as one         exit=0
ALL PASS
```

`shellcheck` clean; the workflow parses (15 jobs); `promote` and `verify-images` both carry `gate` in `needs`, so the threaded outputs resolve rather than silently expanding to empty.

> Two of those cases were wrong on the first run, and both were the harness. One read a counter across a `$( )` boundary; the other claimed to test a single-arch index while the stub only ever returned a multi-arch one — **a case that cannot fail for its stated reason is not a case**, so the stub grew a `SINGLE` list to produce the condition for real.

## Expected one-off

No existing image carries a pair tag, so the first tick after this lands sees an incomplete set and **rebuilds once**. That is the mechanism working, and it self-corrects on the following tick.

## Not in scope

Item 3 (`repository_dispatch` from Plugins → core CD) stays optional. With this in place the system is already self-healing, just on the hour; that item is a latency improvement on a correct reconciler, not a substitute for one.

Docs: `ContinuousDeliveryContract.md` gains *"The set is keyed on a PAIR of commits"*, and the now-stale *"the durable shape is …"* comment in `main-cd.yml` is replaced by what actually runs. One What's New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)