### PR TITLE
fix(ci): dependabot PRs could never merge — the shared-rule exemption named only forks

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1808,10 +1808,28 @@ jobs:
     #   * no `continue-on-error:` anywhere, and no path filter (an unrelated PR would otherwise
     #     "pass" by not running);
     #   * the checker fails closed on every unreadable input, including its own manifest.
-    # The ONE exemption is expressed on the EVENT, never on the secret: a pull request from a
-    # FORK has no access to any secret by GitHub's design, so it cannot mint the token at all.
-    # `collect-results` mirrors that same event predicate rather than inventing a second one.
-    if: ${{ github.event.pull_request.head.repo.fork != true }}
+    # The exemption is expressed on the EVENT, never on the secret. There are TWO events where
+    # GitHub withholds the credential by design, and the rule is the same for both: the job
+    # genuinely cannot run, so it must not pretend to.
+    #
+    #   * a pull request from a FORK — no access to any secret;
+    #   * a pull request opened by DEPENDABOT — its runs read the separate `dependabot` secrets
+    #     scope, so repository secrets resolve EMPTY.
+    #
+    # 🚨 Dependabot was the missing half, and it did not look like a missing exemption: a
+    # dependabot branch lives in THIS repo, so `head.repo.fork` is false, the job ran, the
+    # credential assertion fired exactly as designed, and the gate went red naming two secrets
+    # that are in fact provisioned. Because this gate is REQUIRED, that made every dependabot PR
+    # permanently unmergeable — #2870 and #2871 were both sitting on it. A gate failing for a
+    # reason no pull request can fix is as useless as one that skips.
+    #
+    # 🚨 And this is NOT a skip-trapdoor, for a reason specific to this workflow: it also triggers
+    # on `merge_group`, where the credential IS available. So an exempted PR still has its shared
+    # rule blocks checked — on the queue's temporary ref, with the token minted, BEFORE the merge
+    # lands. The exemption moves WHERE the gate runs, never WHETHER it runs.
+    #
+    # `collect-results` mirrors this same event predicate rather than inventing a second one.
+    if: ${{ github.event.pull_request.head.repo.fork != true && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     permissions:
@@ -2252,11 +2270,13 @@ jobs:
 
     # `!= 'success'` rather than `== 'failure'`, for the same reason as the gate above: a job
     # that was skipped or cancelled produced no verdict, and no verdict must never read as
-    # passed. The fork clause is the SAME event predicate the gate itself carries — a fork PR
-    # cannot mint the App token by GitHub's design, so the job genuinely does not run there. It
-    # is written on the event and never on the secret, and it is the only exemption.
+    # passed. The fork and dependabot clauses are the SAME event predicate the gate itself
+    # carries — in both, GitHub withholds the credential by design, so the job genuinely does not
+    # run. Written on the event and never on the secret, and kept identical to the gate's own
+    # `if:` so the two can never disagree about who is exempt. The merge_group run enforces it
+    # with credentials before anything lands.
     - name: Fail if the shared rule blocks drifted
-      if: github.event.pull_request.head.repo.fork != true && needs.shared-rules.result != 'success'
+      if: github.event.pull_request.head.repo.fork != true && github.actor != 'dependabot[bot]' && needs.shared-rules.result != 'success'
       run: |
         echo "::error::The 'AGENTS.md shared rule blocks' gate concluded '${{ needs.shared-rules.result }}' — see that job, which names the repo and the exact drift. Every repo's CLAUDE.md is a one-line @AGENTS.md include, so a block that differs between repos means agents follow different instructions in each of them. The register is .github/shared-rules.json; the rationale is Doc/Architecture/SharedRuleBlocks. The fix is always a pull request in the repo the error names — never a bypass here."
         exit 1

--- a/test/MeshWeaver.Documentation.Test/SharedRuleExemptionIsOneEventPredicateGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/SharedRuleExemptionIsOneEventPredicateGuard.cs
@@ -1,0 +1,122 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 The shared-rule gate's exemption is written TWICE — on the <c>shared-rules</c> job and on the
+/// <c>collect-results</c> step that fails the build when that job did not succeed. Both files'
+/// comments assert the two "can never disagree". Nothing enforced that, which is the shape
+/// <c>AGENTS.md</c> warns about: prose asserting a guard that does not exist.
+///
+/// <para><b>What drift would cost.</b> If the gate exempts an event that the failure step does not,
+/// the job is skipped and <c>collect-results</c> then fails the build for a gate that was never
+/// meant to run — a red nobody can fix from a pull request. If the failure step exempts an event the
+/// gate does not, a genuine drift in the shared rule blocks passes silently. Neither direction is
+/// detectable by reading one of the two in isolation.</para>
+///
+/// <para><b>And the exemption must stay EVENT-shaped.</b> <c>AGENTS.md</c> → "A gate NEVER tests its
+/// own inputs": an <c>if:</c> that asks whether a secret is set turns "the credential is missing"
+/// into a green tick, because GitHub paints a skipped job the same colour as a passed one. The two
+/// sanctioned exemptions both name a situation in which GitHub withholds the credential BY DESIGN —
+/// a fork PR, and a Dependabot PR (whose runs read the separate <c>dependabot</c> secrets scope) —
+/// so the job genuinely cannot run. That is a statement about the event, not about the input.</para>
+///
+/// <para>Dependabot was missing until 2026-08-31 and did not look like a missing exemption: a
+/// dependabot branch lives in this repo, so <c>head.repo.fork</c> is false, the job ran, the
+/// credential assertion fired exactly as designed, and the gate went red naming two secrets that are
+/// in fact provisioned. Because the gate is required, every dependabot PR was permanently
+/// unmergeable.</para>
+/// </summary>
+public class SharedRuleExemptionIsOneEventPredicateGuard
+{
+    private const string Workflow = "dotnet-test.yml";
+
+    /// <summary>The clauses that together ARE the exemption. Both sites must carry all of them.</summary>
+    private static readonly string[] ExemptionClauses =
+    [
+        "github.event.pull_request.head.repo.fork != true",
+        "github.actor != 'dependabot[bot]'",
+    ];
+
+    private static string WorkflowText() =>
+        File.ReadAllText(Path.Combine(FindRepoRoot(), ".github", "workflows", Workflow));
+
+    /// <summary>
+    /// The actual <c>if:</c> EXPRESSIONS carrying the exemption — never comments. The first version
+    /// of this matched any line containing <c>head.repo.fork</c> and immediately failed on the
+    /// explanatory comment beside the predicate, which is the right failure for the wrong reason:
+    /// a guard that reads prose is measuring the documentation, not the workflow.
+    /// </summary>
+    private static string[] ExemptionIfExpressions(string text) =>
+        text.Split('\n')
+            .Select(l => l.Trim())
+            .Where(l => !l.StartsWith("#", StringComparison.Ordinal))
+            .Where(l => l.StartsWith("if:", StringComparison.Ordinal))
+            .Where(l => l.Contains("head.repo.fork", StringComparison.Ordinal))
+            .ToArray();
+
+    [Fact]
+    public void BothSitesCarryTheSameExemption()
+    {
+        var sites = ExemptionIfExpressions(WorkflowText());
+
+        Assert.True(sites.Length >= 2,
+            $"expected the fork exemption on BOTH the shared-rules job and the collect-results "
+            + $"step in {Workflow}; found {sites.Length}:\n  " + string.Join("\n  ", sites));
+
+        foreach (var clause in ExemptionClauses)
+        {
+            var missing = sites.Where(s => !s.Contains(clause, StringComparison.Ordinal)).ToArray();
+            Assert.True(missing.Length == 0,
+                $"every site expressing the shared-rule exemption must carry `{clause}` — the gate "
+                + $"and the step that fails on it must never disagree about who is exempt. Missing "
+                + $"from:\n  " + string.Join("\n  ", missing));
+        }
+    }
+
+    [Fact]
+    public void TheExemptionNeverAsksWhetherASecretIsSet()
+    {
+        var offenders = ExemptionIfExpressions(WorkflowText())
+            .Where(s => s.Contains("secrets.", StringComparison.Ordinal))
+            .ToArray();
+
+        Assert.True(offenders.Length == 0,
+            "the shared-rule exemption must be expressed on the EVENT, never on the input. An `if:` "
+            + "reading `secrets.*` makes a missing credential skip the job, and GitHub paints a "
+            + "skipped job with the same tick as a passed one — so 'the gate never ran' and 'the "
+            + "gate passed' become indistinguishable. Offending:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// 🚨 The guard must be able to FAIL. A matcher that finds nothing would satisfy both tests
+    /// above vacuously — the failure mode this whole file exists to prevent, one level up.
+    /// </summary>
+    [Fact]
+    public void TheMatcherActuallyFindsTheSites()
+    {
+        var sites = ExemptionIfExpressions(WorkflowText());
+        Assert.True(sites.Length >= 2, $"the matcher found {sites.Length} site(s) in {Workflow}");
+
+        // And it must reject a doctored line, or "contains the clause" proves nothing.
+        var doctored = new[] { "if: ${{ github.event.pull_request.head.repo.fork != true }}" };
+        Assert.DoesNotContain(doctored[0], sites.Where(s => s.Contains("dependabot", StringComparison.Ordinal)));
+        Assert.False(doctored[0].Contains("dependabot[bot]", StringComparison.Ordinal),
+            "the negative control must genuinely lack the clause the guard requires");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".github")))
+            dir = dir.Parent;
+        Assert.True(dir is not null, "could not locate the repository root (no .github directory found)");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
Found while draining the PR backlog: **both open dependabot PRs (#2870, #2871) are permanently unmergeable**, and neither can be fixed from the pull request.

The `AGENTS.md shared rule blocks` gate asserts a cross-repo App credential and fails **RED** naming what to provision. That is right, and it is exactly what `AGENTS.md` prescribes over a skip. Its one exemption is expressed on the **event**, also right:

```yaml
# The ONE exemption is expressed on the EVENT, never on the secret: a pull request from a
# FORK has no access to any secret by GitHub's design, so it cannot mint the token at all.
if: ${{ github.event.pull_request.head.repo.fork != true }}
```

🚨 **Forks are not the only such event.** A Dependabot PR's runs read the separate `dependabot` secrets scope, so repository secrets resolve **empty** — and a dependabot branch lives in *this* repo, so `head.repo.fork` is `false`. The job therefore ran, the credential assertion fired exactly as designed, and the gate went red naming two secrets that are in fact provisioned:

```
##[error]The shared-rule gate cannot read the fleet — provision the following, then re-run:
  • secrets.MESHWEAVER_APP_ID
  • secrets.MESHWEAVER_APP_PRIVATE_KEY
```

Because the gate is required, that is a permanent block. **A gate that fails for a reason no pull request can fix is as useless as one that skips** — and this one is harder to spot, because it fails loudly and correctly-looking.

## 🚨 Why this is not a skip-trapdoor

Specific to this workflow: it also triggers on **`merge_group`**, where the credential *is* available. So an exempted PR still has its shared rule blocks checked — on the queue's temporary ref, with the token minted, **before the merge lands**. The exemption moves *where* the gate runs, never *whether* it runs.

That is what makes extending it safe rather than a bypass, and it is now written down beside the predicate.

## The guard, because the comment already claimed the invariant

Both sites' comments asserted the gate's `if:` and the `collect-results` step's `if:` "can never disagree", and **nothing enforced it** — prose asserting a guard that does not exist.

`SharedRuleExemptionIsOneEventPredicateGuard`:
- both sites carry every clause of the exemption;
- **no site reads `secrets.*`** — the exemption stays event-shaped, because an `if:` on an input turns a missing credential into a green tick;
- the matcher provably finds the sites, so a vacuous matcher cannot satisfy the other two silently — the same failure mode, one level up.

**Mutation-proved:** reverting the dependabot clause on the `collect-results` step alone fails the guard, naming the missing clause and the offending line.

> The guard's own first draft matched any line containing `head.repo.fork` and failed on the explanatory **comment** beside the predicate — the right failure for the wrong reason. It now matches `if:` expressions only: a guard that reads prose is measuring the documentation, not the workflow.

`MeshWeaver.Documentation.Test`: **135/135**, `-c Release -warnaserror`, `0 Warning(s) 0 Error(s)`.

Unblocks #2870 and #2871.

🤖 Generated with [Claude Code](https://claude.com/claude-code)