### PR TITLE
fix: a leaf both sides already agree on is not a conflict — and the audit stamp never was one

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1052,6 +1052,16 @@ public static class DataExtensions
                 // request LOST (memex-cloud 2026-07-20 GitSync burst: every explicit Store/Plugin
                 // compile trigger was dropped while mirrors lagged the owner).
                 RebaseMonotonicTriggers(currentNode, patchNode, baseValues, jsonOpts, logger, hubPath);
+                // 🚨 …and the same resolution for the node's AUDIT STAMP, which is not caller data at
+                // all: MeshNodeStreamHandle stamps LastModified/LastModifiedBy onto EVERY cross-hub
+                // patch itself. So the moment two writers touch one node the second one's base stamp
+                // is stale by construction, the generic scalar rule refuses it, and — since a PARTIAL
+                // refusal nacks Conflict (#2463/#2840) — a write that fully landed is answered with
+                // "re-read and re-apply", which re-runs the caller's mutation. For a RELATIVE mutation
+                // that is a second application, not a no-op. LastModified is monotonic by construction
+                // (every writer sets it to UtcNow), so newest-wins is the correct merge, exactly as for
+                // RequestedReleaseAt — never a refusal.
+                RebaseAuditStamp(currentNode, patchNode, baseValues, jsonOpts, logger, hubPath);
                 var refused = 0;
                 Serialization.MeshNodePatchMerge.Apply(currentNode, patchNode, baseValues,
                     onRefuse: key =>
@@ -1181,6 +1191,73 @@ public static class DataExtensions
                 + "monotonically (newest wins) instead of being refused as a scalar conflict.",
                 hubPath, triggerKey, patchAt, liveAt);
             baseContent[triggerKey] = liveContent[triggerKey]!.DeepClone();
+        }
+    }
+
+    /// <summary>
+    /// 🚨 Audit-stamp resolution for the THREE-WAY merge path — the sibling of
+    /// <see cref="RebaseMonotonicTriggers"/> for the two TOP-LEVEL fields the write path stamps on
+    /// the caller's behalf: <c>MeshNode.LastModified</c> and <c>MeshNode.LastModifiedBy</c>.
+    ///
+    /// <para>These are framework metadata, never a value the caller's update lambda chose:
+    /// <c>MeshNodeStreamHandle.UpdateRemote</c> writes <c>LastModified = UtcNow</c> into every
+    /// cross-hub patch. That makes them the one pair guaranteed to differ from a lagging mirror's
+    /// base whenever ANY other writer touched the node first — so the generic "conflicting scalar ⇒
+    /// refuse" rule turns every concurrent cross-hub write into a refusal, and therefore (a partial
+    /// refusal being a refusal since #2463/#2840) into a Conflict NACK whose prescribed remedy is to
+    /// re-run the caller's mutation. Re-running a RELATIVE mutation applies it twice.</para>
+    ///
+    /// <para><c>LastModified</c> is monotonic by construction, so the conflict IS mergeable and the
+    /// resolution is the monotonic one: patch BEHIND live ⇒ drop the stamp from the patch (the live
+    /// stamp is the newer truth); patch AHEAD of live ⇒ rebase the writer's base onto the live value
+    /// so the three-way merge sees "unchanged since base" and lands it. <c>LastModifiedBy</c> travels
+    /// with whichever stamp wins — an author without its instant is meaningless — so it is dropped or
+    /// rebased in lockstep and likewise never refused.</para>
+    /// </summary>
+    internal static void RebaseAuditStamp(
+        System.Text.Json.Nodes.JsonObject currentNode,
+        System.Text.Json.Nodes.JsonObject patchNode,
+        System.Text.Json.Nodes.JsonObject baseValues,
+        System.Text.Json.JsonSerializerOptions jsonOpts,
+        ILogger? logger,
+        string hubPath)
+    {
+        var stampKey = jsonOpts.PropertyNamingPolicy?.ConvertName("LastModified") ?? "LastModified";
+        var authorKey = jsonOpts.PropertyNamingPolicy?.ConvertName("LastModifiedBy") ?? "LastModifiedBy";
+
+        if (!TryReadDateTimeOffset(patchNode, stampKey, out var patchAt)
+            || !TryReadDateTimeOffset(currentNode, stampKey, out var liveAt))
+            return;
+
+        if (patchAt < liveAt)
+        {
+            logger?.LogInformation(
+                "[MergeGuard] {HubPath}: dropping superseded audit stamp ({PatchAt:o} < live {LiveAt:o}) — "
+                + "the node was modified again after this writer stamped it; keeping the live stamp.",
+                hubPath, patchAt, liveAt);
+            patchNode.Remove(stampKey);
+            patchNode.Remove(authorKey);
+            return;
+        }
+
+        if (patchAt <= liveAt)
+            return; // equal — nothing to resolve, the generic merge sees no conflict
+
+        Rebase(stampKey);
+        Rebase(authorKey);
+
+        void Rebase(string key)
+        {
+            if (!patchNode.ContainsKey(key)
+                || !baseValues.TryGetPropertyValue(key, out var baseVal)
+                || baseVal is null
+                || System.Text.Json.Nodes.JsonNode.DeepEquals(baseVal, currentNode[key]))
+                return;
+            logger?.LogInformation(
+                "[MergeGuard] {HubPath}: rebasing audit field {Key} — the writer's base is stale but an "
+                + "audit stamp merges newest-wins rather than being refused as a scalar conflict.",
+                hubPath, key);
+            baseValues[key] = currentNode[key]?.DeepClone();
         }
     }
 

--- a/src/MeshWeaver.Data/Serialization/MeshNodePatchMerge.cs
+++ b/src/MeshWeaver.Data/Serialization/MeshNodePatchMerge.cs
@@ -75,6 +75,29 @@ public static class MeshNodePatchMerge
                 continue;
             }
 
+            // 🚨 NOT A CONFLICT: the writer's value is ALREADY the live value. `live != base` only
+            // says the owner moved since the writer read; it does not say the two DISAGREE. When the
+            // patch and the live value are the same, applying it is a no-op and refusing it invents a
+            // conflict out of nothing — including the commonest shape of all, an RFC 7396 REMOVAL
+            // (patch null) of a key the owner has already removed.
+            //
+            // That invention is expensive, because a refusal is no longer only a dropped field: since
+            // "a PARTIAL merge refusal is still a refusal" (#2463/#2840) it NACKs Conflict on a write
+            // that LANDED, and Conflict's remedy is to re-run the caller's update lambda
+            // (MeshNodeStreamHandle.UpdateRemote's re-enqueue, MeshNodeStreamCache's conflict retry).
+            // A lambda that performs a RELATIVE mutation — truncate at an index, drop a tail — then
+            // performs it a second and third time against a node that has already moved on. Measured
+            // on MeshWeaver.Plugins#1009: a chat resubmit whose patch set Status/ActiveMessageId/
+            // ExecutionStartedAt to EXACTLY what the owner already held was refused three times, the
+            // write was re-run three times, and the thread's Messages list oscillated
+            // [u,r] → [] → [u,r'] → [r'] → [r',u,r''] → … losing cells and scrambling order.
+            //
+            // Checked before the string and array resolutions as well: an identical string needs no
+            // splice rebase (and an overlapping-delta pair would REFUSE it), and an identical array
+            // needs no element merge.
+            if (JsonNode.DeepEquals(patchVal, liveVal))
+                continue;
+
             // CONFLICT: the field changed on the owner since the writer's base.
             // String on all three → rebase the writer's edit over the intervening edit and merge.
             if (TryGetString(patchVal, out var newStr)

--- a/test/MeshWeaver.Data.Test/MeshNodePatchMergeTest.cs
+++ b/test/MeshWeaver.Data.Test/MeshNodePatchMergeTest.cs
@@ -226,4 +226,77 @@ public class MeshNodePatchMergeTest
         Assert.Single(pending);
         Assert.Equal("m2", pending[0]!["id"]!.GetValue<string>());
     }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // A LEAF THE WRITER AND THE OWNER ALREADY AGREE ON IS NOT A CONFLICT
+    //
+    // `live != base` says the owner moved since the writer read it. It does NOT say the two
+    // DISAGREE — and when the patch value already equals the live value, applying it is a no-op,
+    // so refusing it invents a conflict. That invention is not free: a refusal NACKs Conflict
+    // (partial refusals included, #2463/#2840), Conflict's remedy is to re-run the caller's update
+    // lambda, and a RELATIVE mutation re-run against a node that has moved on applies twice.
+    // Measured on MeshWeaver.Plugins#1009 — a chat resubmit refused three times on three fields it
+    // had set to exactly the owner's own values, then re-run three times, losing message cells.
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public void NoOpLeaf_PatchAlreadyEqualsLive_NotRefused()
+    {
+        // The writer computed "Status: Idle" off a stale base that still said Executing.
+        // The owner is ALREADY Idle. Nothing to resolve; nothing to refuse.
+        var live = Obj(("Status", "Idle"));
+        var @base = Obj(("Status", "Executing"));
+        var patch = Obj(("Status", "Idle"));
+
+        var refused = Merge(live, patch, @base);
+
+        Assert.Empty(refused);
+        Assert.Equal("Idle", live["Status"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void NoOpLeaf_RemovalOfAnAlreadyRemovedKey_NotRefused()
+    {
+        // The commonest shape of all, and the exact #1009 trigger: an RFC 7396 REMOVAL
+        // (patch value null) of a key the owner has already removed. ActiveMessageId /
+        // ExecutionStartedAt were cleared by the round that finished; the resubmit patch
+        // clears them too.
+        var live = Obj(("Name", "n"));                                  // ActiveMessageId absent
+        var @base = Obj(("ActiveMessageId", "cell-1"), ("Name", "n"));
+        var patch = Obj(("ActiveMessageId", null));
+
+        var refused = Merge(live, patch, @base);
+
+        Assert.Empty(refused);
+        Assert.False(live.ContainsKey("ActiveMessageId"));
+    }
+
+    [Fact]
+    public void NoOpLeaf_IdenticalString_NotRefused()
+    {
+        // Checked BEFORE the string rebase: an identical string needs no splice, and the
+        // overlapping-delta arm would otherwise refuse it.
+        var live = Obj(("Text", "the same text"));
+        var @base = Obj(("Text", "something entirely different"));
+        var patch = Obj(("Text", "the same text"));
+
+        var refused = Merge(live, patch, @base);
+
+        Assert.Empty(refused);
+        Assert.Equal("the same text", live["Text"]!.GetValue<string>());
+    }
+
+    [Fact]
+    public void NoOpLeaf_DoesNotMaskAGenuineScalarConflict()
+    {
+        // The guard is exact: the moment the values differ, the flap guard is back in force.
+        var live = Obj(("Status", "Ok"));
+        var @base = Obj(("Status", "Compiling"));
+        var patch = Obj(("Status", "Error"));
+
+        var refused = Merge(live, patch, @base);
+
+        Assert.Contains("Status", refused);
+        Assert.Equal("Ok", live["Status"]!.GetValue<string>());
+    }
 }

--- a/test/MeshWeaver.Data.Test/MonotonicTriggerMergeTest.cs
+++ b/test/MeshWeaver.Data.Test/MonotonicTriggerMergeTest.cs
@@ -133,4 +133,92 @@ public class MonotonicTriggerMergeTest
         // …while the monotonic trigger in the SAME patch still lands.
         Assert.Equal(T3, ReadTrigger(live));
     }
+
+    // ═════════════════════════════════════════════════════════════════════════════
+    // THE AUDIT STAMP IS NOT CALLER DATA — DataExtensions.RebaseAuditStamp
+    //
+    // MeshNodeStreamHandle stamps LastModified = UtcNow onto EVERY cross-hub patch itself, so
+    // the second of two concurrent writers ALWAYS carries a base stamp the owner has already
+    // moved past. Under the generic scalar rule that is a guaranteed refusal on every
+    // concurrent write — and since a PARTIAL refusal nacks Conflict (#2463/#2840), a write that
+    // fully landed is answered with "re-read and re-apply", re-running the caller's mutation.
+    // LastModified is monotonic by construction, so it merges newest-wins like the release
+    // trigger; LastModifiedBy travels with whichever stamp wins.
+    // ═════════════════════════════════════════════════════════════════════════════
+
+    private static JsonObject Stamped(DateTimeOffset at, string? by = null)
+    {
+        var o = new JsonObject { ["LastModified"] = Instant(at), ["Content"] = new JsonObject() };
+        if (by is not null) o["LastModifiedBy"] = JsonValue.Create(by);
+        return o;
+    }
+
+    private static int MergeCountingRefusals(JsonObject live, JsonObject patch, JsonObject baseValues)
+    {
+        var message = new PatchDataRequest(new MeshNodeReference(), new RawJson(patch.ToJsonString(Options)))
+        {
+            BaseValues = new RawJson(baseValues.ToJsonString(Options))
+        };
+        return DataExtensions.ApplyMeshNodeMerge(
+            live, patch, isMeshNode: true, message, Options, logger: null, HubPath);
+    }
+
+    /// <summary>
+    /// The concurrent-write case, and the reason #1009's resubmit was re-run: the writer's base
+    /// stamp (T1) is stale because another writer stamped T2 first, and this writer stamps T3.
+    /// Refusing that would report a Conflict for a write with no disagreement in it at all.
+    /// </summary>
+    [Fact]
+    public void ForwardAuditStamp_OverStaleBase_LandsAndIsNotRefused()
+    {
+        var live = Stamped(T2, "user-a");
+        var @base = Stamped(T1, "user-b");
+        var patch = Stamped(T3, "user-b");
+
+        var refused = MergeCountingRefusals(live, patch, @base);
+
+        Assert.Equal(0, refused);
+        Assert.Equal(T3, DateTimeOffset.Parse(live["LastModified"]!.GetValue<string>()));
+        Assert.Equal("user-b", live["LastModifiedBy"]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// A stamp that arrives BEHIND the live one is superseded, not conflicting: drop it (with its
+    /// author) and keep the newer live stamp. Still no refusal — nothing was lost that the newer
+    /// write did not already replace.
+    /// </summary>
+    [Fact]
+    public void BackwardAuditStamp_IsDroppedNotRefused()
+    {
+        var live = Stamped(T2, "user-a");
+        var @base = Stamped(T0, "user-b");
+        var patch = Stamped(T1, "user-b");
+
+        var refused = MergeCountingRefusals(live, patch, @base);
+
+        Assert.Equal(0, refused);
+        Assert.Equal(T2, DateTimeOffset.Parse(live["LastModified"]!.GetValue<string>()));
+        Assert.Equal("user-a", live["LastModifiedBy"]!.GetValue<string>());
+    }
+
+    /// <summary>
+    /// Scoped exactly like the monotonic trigger: the audit stamp merging never softens the flap
+    /// guard on a real content field carried in the SAME patch.
+    /// </summary>
+    [Fact]
+    public void AuditStampMerge_DoesNotSoftenAConflictingContentScalar()
+    {
+        var live = Stamped(T2, "user-a");
+        live["Content"]!["CompilationStatus"] = JsonValue.Create("Compiling");
+        var @base = Stamped(T1, "user-b");
+        @base["Content"]!["CompilationStatus"] = JsonValue.Create("Ok");
+        var patch = Stamped(T3, "user-b");
+        patch["Content"]!["CompilationStatus"] = JsonValue.Create("Pending");
+
+        var refused = MergeCountingRefusals(live, patch, @base);
+
+        Assert.Equal(1, refused);
+        Assert.Equal("Compiling", live["Content"]!["CompilationStatus"]!.GetValue<string>());
+        Assert.Equal(T3, DateTimeOffset.Parse(live["LastModified"]!.GetValue<string>()));
+    }
 }


### PR DESCRIPTION
## The measurement

`OrleansResubmitDeadlockTest.Resubmit_AfterExecution_DoesNotDeadlock` on `MeshWeaver.Plugins` fails **3 of 12 unloaded runs**, each in about a second. A failure in milliseconds is state, not timing, and the thread's `Messages` list says which state — it oscillates and loses cells:

```
[u,r] → [] → [u,r'] → [r'] → [r',u,r''] → …
```

## What the owner was actually refusing

Instrumenting `MeshNodePatchMerge.Apply` at the refusal point, on a failing run:

```
[PROBE-LEAF] key=status             live=<null> base="Executing" patch=<null> patchEqLive=True
[PROBE-LEAF] key=activeMessageId    live=<null> base="d2a7479e"  patch=<null> patchEqLive=True
[PROBE-LEAF] key=executionStartedAt live=<null> base="…44068Z"   patch=<null> patchEqLive=True
```

The writer's patch asked for **exactly the state the owner was already in** — an RFC 7396 removal of three keys the owner had already removed — and all three were refused.

`Apply` classified each leaf on `live != base` alone. That says the owner moved since the writer read it; it does **not** say the two disagree. When `patch == live` there is nothing to resolve: applying it is a no-op, and refusing it invents a conflict.

## Why inventing one is expensive

Since *"a PARTIAL merge refusal is still a refusal"* (#2463 / #2840) a refusal NACKs `Conflict` on a write that **landed**. `Conflict`'s prescribed remedy is *"re-read and re-apply"*, which `MeshNodeStreamHandle.UpdateRemote` and `MeshNodeStreamCache` both implement by **re-running the caller's update lambda** — up to three attempts each. Sound for a lambda that SETS a value; unsound for one that performs a RELATIVE mutation. The chat resubmit truncates a thread at an index, so each re-run truncated away the round the submission watcher had dispatched in between.

The re-enqueue arm still documents the invariant it was written under, and #2840 ended it:

> *"The owner emits Conflict ONLY when the merge refused keys AND the node is byte-identical to its pre-merge state — i.e. nothing landed"*

The measured sequence on one failing run: 3 lambda invocations ~100 ms apart (`UpdateRemote`'s re-enqueue budget), then `[PROBE-CONFLICT-RETRY] … attempt=1 … PARTIALLY refused: 2 field(s)` from the cache's own retry on top.

## The second guaranteed refusal, same reason

`LastModified` / `LastModifiedBy` are not caller data — `UpdateRemote` stamps them onto **every** cross-hub patch itself. So the second of two concurrent writers always carries a base stamp the owner has moved past, and the generic scalar rule refused it **every time**, i.e. every concurrent cross-hub write was a `Conflict` and a re-run. Observed in the same trace:

```
[PROBE-REFUSE] key=lastModified live="…20.513404" base="…20.398719" patch="…20.614317"
```

The stamp is monotonic by construction, so this is the `RequestedReleaseAt` case one field along: `RebaseAuditStamp` drops a superseded stamp and rebases a newer one, with `LastModifiedBy` travelling with whichever wins.

## Scope

Both changes are exact. A leaf whose values genuinely differ is still refused (`NoOpLeaf_DoesNotMaskAGenuineScalarConflict`), and a conflicting content scalar carried in the same patch as an audit stamp is still refused (`AuditStampMerge_DoesNotSoftenAConflictingContentScalar`).

## Verification

- 6 new unit tests in `MeshNodePatchMergeTest` / `MonotonicTriggerMergeTest`. **Mutation-proved**: with the two source changes reverted, all 6 fail and the "does not mask a genuine conflict" case correctly still passes.
- `MeshWeaver.Data.Test` full suite: **413 passed, 0 failed**.
- `OrleansResubmitDeadlockTest` against this branch, with the Plugins tree **unchanged**: **30 runs, 0 failures** (baseline 3 in 12).

## Not fixed here, and worth its own issue

A **partial** refusal and a **total** refusal both NACK `Conflict`, and the two retry layers cannot tell them apart. With the spurious refusals gone this is much rarer, but a genuine partial refusal still answers a landed write with "re-run your mutation", which is unsound for any relative mutation. The companion PR on `MeshWeaver.Plugins` hardens the one caller this bit; the general contract is a maintainer call.

Fixes Systemorph/MeshWeaver.Plugins#1009

🤖 Generated with [Claude Code](https://claude.com/claude-code)