### PR TITLE
chore(deps): the Roslyn family moves together — CSharp, Features and Scripting to 5.9.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -104,9 +104,9 @@
     <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.10" />
     <PackageVersion Include="System.Composition.AttributedModel" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.6.0" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.6.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.9.0" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.9.0" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />


### PR DESCRIPTION
Unblocks dependabot's #2870, which is **not merely gate-blocked** — it carries a genuine `NU1107` across five test projects:

```
MeshWeaver.Kernel.Hub -> MeshWeaver.NuGet
                      -> Microsoft.CodeAnalysis.CSharp (>= 5.9.0)
MeshWeaver.Kernel.Hub -> Microsoft.CodeAnalysis.CSharp.Scripting 5.6.0
                      -> Microsoft.CodeAnalysis.CSharp (= 5.6.0)
```

#2870 bumps `Microsoft.CodeAnalysis.CSharp` to 5.9.0 and leaves `.Features` and `.Scripting` at 5.6.0. **Those two pin CSharp and Common exactly**, so the three cannot move independently — the family moves as a set or not at all. All three publish a 5.9.0.

Done here rather than by pushing onto the dependabot branch: a rebase had already been requested on #2870, which would have discarded a commit pushed there. Once this lands, #2870's own bump is a no-op and the conflict dissolves.

## 🚨 Verified harder than a version bump normally warrants

The mesh **compiles C# at runtime** with these assemblies, so a clean build proves much less here than usual. What was actually exercised:

| | |
|---|---|
| `MeshWeaver.Compiler` / `Kernel.Hub` / `Graph` | `-c Release -warnaserror`, `0 Warning(s) 0 Error(s)` |
| `MeshWeaver.Kernel.Test` | **11/11** |
| `MeshWeaver.Content.Test` | **166/166**, 25 s *(baseline 24 s)* |
| `MeshWeaver.Graph.Test` | **1603/1603**, 1 m 12 s *(baseline 1 m 7 s)* |

`Content.Test` and `Graph.Test` compile **real NodeTypes** — that is the capability that would break if the Roslyn surface had shifted, and it is why those two are the evidence rather than the build.

*(Graph.Test reads 1603 against the 1598 measured earlier tonight because main gained tests in between, not because of this change. Durations are within noise.)*

No source changes — `Directory.Packages.props` only, per the repo's central package management.

🤖 Generated with [Claude Code](https://claude.com/claude-code)