### PR TITLE
feat(build-project): embedded resources + assembly identity — the batch that unblocks memex-as-compiler

### DIFF
--- a/src/MeshWeaver.Cli/README.md
+++ b/src/MeshWeaver.Cli/README.md
@@ -76,6 +76,7 @@ assembly the image already carries. See
 | `--root <dir>` | directory mounted as `/repo` (default: the nearest `Directory.Build.props` ancestor) |
 | `--extra-refs <dir>` | libraries ADDITIONAL to the platform — the only way to satisfy a `PackageReference` the image does not supply. Repeatable |
 | `--accept <construct>` | acknowledge one construct the evaluator cannot reproduce (`target:<Name>`, `embedded-resource`, `conditions`, `razor-css-scope`, `razor-not-compiled`). Repeatable |
+| `--accept <construct>` | acknowledge one construct the evaluator cannot reproduce (`target:<Name>`, `conditions`, `embedded-resource`, `embedded-resource:{resx,culture,dependent-upon,manifest-resource-name,build-output}`). Repeatable |
 | `--no-warn` / `--allow-warnings` | warnings fail the build (default); `--no-warn=false` or `--allow-warnings` opts out |
 | `--no-pull` | use the image the docker daemon already has, for one built locally |
 
@@ -87,7 +88,8 @@ and CSS isolation (`*.razor.css`) needs `--accept razor-css-scope` because the `
 from an MSBuild task this builder does not run.
 
 🚨 **Nothing is dropped in silence.** A project construct this builder cannot reproduce — an unknown
-element, an unevaluatable `Condition`, a `<Target>`, an `<EmbeddedResource>` — FAILS the run naming
+element, an unevaluatable `Condition`, a `<Target>`, a resource whose SDK manifest name cannot be
+matched exactly — FAILS the run naming
 the construct and the file, and a `PackageReference` the container does not supply is reported by
 name rather than skipped. A silently dropped `Nullable` or `NoWarn` produces a build that looks green
 and is not the build the SDK would have produced.

--- a/src/MeshWeaver.Compiler/EmitPipeline.cs
+++ b/src/MeshWeaver.Compiler/EmitPipeline.cs
@@ -133,6 +133,35 @@ public static class EmitPipeline
     /// </summary>
     internal static EmittedArtifact EmitCompilationToDirectory(
         CSharpCompilation compilation, string nodeName, string nodePath, string releaseDir, CancellationToken ct)
+        => EmitCompilationToDirectory(compilation, nodeName, nodePath, releaseDir, [], ct);
+
+    /// <summary>
+    /// The same verified emit, carrying MANAGED RESOURCES into the assembly — the shape
+    /// <c>mw-plugin-test build-project</c> needs to reproduce an SDK build of a project with
+    /// <c>&lt;EmbeddedResource&gt;</c> items.
+    ///
+    /// <para>🚨 <b>A separate overload rather than an optional parameter on the one above.</b>
+    /// Adding a parameter — even a defaulted one — REPLACES a method's signature, so an assembly
+    /// compiled against the old arity calls a method the new one does not have; that is the same
+    /// binary break <c>scripts/check-record-signatures.py</c> exists to refuse for records, and it
+    /// applies here for exactly the same reason. The overload leaves the four-argument entry point
+    /// byte-identical for <c>MeshNodeCompilationService</c> and <c>NodeSetCompiler</c>, which pass
+    /// no resources and never will: a dynamic NodeType is generated source, not a project.</para>
+    ///
+    /// <para>Nothing else differs. The emit is still to MEMORY first and the bytes written out, so
+    /// <see cref="EmittedArtifact"/> can prove the file on disk is the image that was emitted
+    /// (#1412), and this still does not log (the log-once contract).</para>
+    /// </summary>
+    /// <param name="compilation">The compilation to emit.</param>
+    /// <param name="nodeName">Base name for the emitted files.</param>
+    /// <param name="nodePath">Path reported in a <see cref="CompilationException"/>.</param>
+    /// <param name="releaseDir">Directory to write into.</param>
+    /// <param name="manifestResources">Managed resources to embed; empty for a dynamic NodeType.</param>
+    /// <param name="ct">Cancellation.</param>
+    /// <returns>The artifact descriptor, for the publisher to verify.</returns>
+    internal static EmittedArtifact EmitCompilationToDirectory(
+        CSharpCompilation compilation, string nodeName, string nodePath, string releaseDir,
+        IReadOnlyCollection<ResourceDescription> manifestResources, CancellationToken ct)
     {
         var dllPath = Path.Combine(releaseDir, $"{nodeName}.dll");
         var pdbPath = Path.Combine(releaseDir, $"{nodeName}.pdb");
@@ -151,6 +180,7 @@ public static class EmitPipeline
         {
             emitResult = compilation.Emit(
                 dllImage, pdbImage, xmlDocumentationStream: xmlDoc,
+                manifestResources: manifestResources.Count == 0 ? null : manifestResources,
                 options: emitOptions, cancellationToken: ct);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
@@ -188,7 +218,7 @@ public static class EmitPipeline
     }
 
     /// <summary>
-    /// Key under which <see cref="EmitCompilationToDirectory"/> stamps the canary verdict on a
+    /// Key under which <see cref="EmitCompilationToDirectory(CSharpCompilation, string, string, string, CancellationToken)"/> stamps the canary verdict on a
     /// thrown-from-Emit exception, and under which
     /// <c>NodeTypeCompilationHelpers.SummarizeCompileError</c> reads it back.
     /// </summary>
@@ -672,7 +702,7 @@ public static class EmitPipeline
 
     /// <summary>
     /// Compiles and emits the assembly to memory (no disk I/O), returning the DLL + PDB bytes for
-    /// the caller to load. Like <see cref="EmitCompilationToDirectory"/>, a failed emit throws
+    /// the caller to load. Like <see cref="EmitCompilationToDirectory(CSharpCompilation, string, string, string, CancellationToken)"/>, a failed emit throws
     /// UNLOGGED — the pipeline's single <c>.Catch&lt;…, CompilationException&gt;</c> funnel is the
     /// one reporter of a compile failure.
     /// </summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md
@@ -412,8 +412,8 @@ platform is always visible in the command that ran it.
 
 The evaluator FAILS the load on any construct it cannot reproduce, naming the construct and the file
 — an unknown element or item type, a `Condition` outside its grammar, an `<Import>` of a missing
-file, a `<Target>` (which it cannot execute), an `<EmbeddedResource>` (which it cannot embed).
-`--accept <construct>` acknowledges one deliberately. The reason is that the alternative is worse
+file, a `<Target>` (which it cannot execute), an embedded-resource construct whose SDK manifest name
+it cannot match exactly. `--accept <construct>` acknowledges one deliberately. The reason is that the alternative is worse
 than no build: a silently dropped `Nullable`, `NoWarn` or `DefineConstants` produces a green build
 that is *not the build the SDK would have produced*, and nothing downstream can tell.
 
@@ -527,8 +527,61 @@ ones — SDK source generators and `<Protobuf>`.
 - **Source generators.** They live in the .NET **SDK**, and a MeshWeaver image ships the **runtime**.
   `--generators <dir|dll>` loads them when supplied; with none, the builder names the generator that
   did not run rather than leaving a wall of CS8795 that reads like broken source.
-- **Embedded resources**, **`<Protobuf>`**, **MSBuild `<Target>`s** and **`<Sdk>` elements** — each a
-  named failure with an `--accept` where one is meaningful.
+- **`<Protobuf>`**, **MSBuild `<Target>`s** and **`<Sdk>` elements** — each a named failure with an
+  `--accept` where one is meaningful.
+
+### Embedded resources — supported, under the SDK's own manifest names
+
+**`<EmbeddedResource>` items are embedded**, each under the name the SDK's own
+`CreateCSharpManifestResourceName` would have produced. That was the single biggest coverage gap
+measured over `MeshWeaver.Plugins/src` — 15 projects failed on nothing but
+`<EmbeddedResource Include="Data\**\*.md">`.
+
+🚨 **Fidelity of the NAME is the whole problem, because getting it wrong is SILENT.** The assembly
+compiles, ships, loads, and `Assembly.GetManifestResourceStream(name)` returns `null` at run time in
+some other process — no error, no failing test, nothing for a review to catch. Core's own
+`MeshWeaver.Messaging.Hub.csproj` already carries a comment describing exactly that outcome ("the
+build succeeds, the main assembly carries ZERO manifest resources, every lookup falls through to the
+key-fallback path, and the UI renders raw `chat.new` tokens"). So no rule below was recalled: each
+was established by building a probe project with the real .NET SDK and reading the manifest-resource
+table back out of the emitted PE.
+
+**The pipeline, reproduced step for step.** `AssignTargetPath` assigns each item a `%(TargetPath)`
+(Microsoft.Common.CurrentVersion.targets says so out loud: *"AssignTargetPath generates TargetPath
+metadata that is consumed by CreateManifestResourceNames target for manifest name generation"*),
+`AssignCulture` routes the culture-carrying items towards SATELLITE assemblies, and
+`CreateCSharpManifestResourceName` turns the survivors into
+`$(RootNamespace).<mangled directory>.<file name>`.
+
+| rule | measured |
+|---|---|
+| the default name | `$(RootNamespace)` + the directory with separators as dots + the file name |
+| the DIRECTORY is mangled | `Data\with-dash\Three.md` → `…Data.with_dash.Three.md` |
+| the FILE NAME is **not** | `Weird-File.Name.md` → `…Weird-File.Name.md`, hyphen and dot intact |
+| a leading digit is PREFIXED | `9digits` → `_9digits` (never `_digits`) |
+| a dot in a directory is a SEPARATOR | `Dot.9Dir` → `Dot._9Dir`; each half mangled on its own |
+| a segment reducing to one `_` DOUBLES | `--` and `_` both → `__` — sibling dirs so named fail the real SDK build with `CS1508` |
+| `$(RootNamespace)` defaults to the PROJECT name | not `$(AssemblyName)`; empty means no prefix at all |
+| `LogicalName` replaces the name outright | attribute or child element |
+| `TargetPath` beats `Link` beats the item spec | a `Link` renames a file that is already inside the project |
+| a file OUTSIDE the project loses its directory | `..\shared\Shared.md` → `<ns>.Shared.md` |
+| resources are emitted PUBLIC | `ManifestResourceAttributes.Public`, every one |
+| a missing LITERAL include is `CS1566` | a glob matching nothing is legal |
+
+**Refused BY NAME rather than guessed**, each with its own `--accept` token, because a plausible
+wrong name is worse than no build:
+
+| construct | why |
+|---|---|
+| `.resx` / `.restext` | the NAME is reproducible; the CONTENT needs resgen (`GenerateResource`), and this builder runs no MSBuild tasks. Embedding the XML under the `.resources` name compiles green and throws at run time. The SDK's default glob `**/*.resx` is reproduced so a stray one is a refusal rather than a silent omission |
+| a CULTURE in the file name | the SDK routes it into a satellite assembly (`de/…resources.dll`) and OUT of the main one, and an explicit `LogicalName` does **not** rescue it — measured. This builder emits one assembly. `WithCulture="false"` on the item is the project-side fix and needs no acceptance |
+| `DependentUpon` | replaces the name with the first CLASS declared in that file, fully qualified — extracted by MSBuild's own C# tokenizer, which skips `struct`/`interface`/`enum`, takes `record`, and drops generic arity |
+| `ManifestResourceName` | makes the SDK skip its own naming task, which is also what sets `%(LogicalName)`, so csc falls back to the bare file name — the metadata does not do what it appears to do |
+| the build's OWN OUTPUT | `Include="bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml"` builds green under the real SDK from a clean tree (csc writes `/doc:` and reads `/resource:` in one invocation); this builder writes its doc file elsewhere, so it is named and skipped rather than failing the project |
+
+Under invariant globalization the runtime reports no predefined culture even for `de`, so the culture
+question cannot be answered at all — the capability is PROBED, and any dotted-basename resource is
+refused rather than embedded under a guessed name.
 
 **The boundary is the point.** This is not an MSBuild reimplementation and must not become one: it
 evaluates the subset a library project under this organisation's `Directory.Build.props` actually

--- a/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md
@@ -430,10 +430,12 @@ not ask for a doc file, which is when csc itself would not raise it. The SDK's o
 `NoWarn` (`1701;1702`) is seeded before any `Directory.Build.props` appends to `$(NoWarn)`. Warnings
 fail the build by default; `--allow-warnings` is the deliberate opt-out.
 
-### Measured, 2026-08-31 — 12 of 54
+### Measured, 2026-08-31 — the sweep, before and after embedded resources
 
-Against `memex-portal-ai@sha256:15c49ee…`, over every non-test project in `MeshWeaver.Plugins/src`,
-with `--accept targets --accept embedded-resource` and ClosedXML + CsvHelper as `--extra-refs`:
+Over every non-test project in `MeshWeaver.Plugins/src` (54 of them), against the portal image
+`memex-portal-ai@sha256:6f38db08…` (the pin `MeshWeaver.Plugins/.github/workflows/ci.yml` carries),
+with `--accept targets` and no `--extra-refs`. Both columns come from the SAME image, so the delta is
+the change and nothing else.
 
 | | count | why |
 |---|---|---|
@@ -443,6 +445,28 @@ with `--accept targets --accept embedded-resource` and ClosedXML + CsvHelper as 
 | gRPC `<Protobuf>` | 3 | protoc codegen is a build task, not a compile |
 | additional libraries | 5 | Snowflake.Data, Microsoft.Data.Sqlite, Azure.Cosmos, … — supply with `--extra-refs` |
 | portal hosts | 3 | an `<Import>` above the mount; Aspire's `<Sdk>` ELEMENT |
+| | before | after | |
+|---|---|---|---|
+| **green** | **9** | **10** | |
+| `<EmbeddedResource>` refused | **19** | **0** | the gap is closed |
+| Razor/Blazor (CS0115) | 12 | 15 | `.razor` is not compiled — fixed separately |
+| source generators (CS8795) | 3 | 14 | they live in the SDK, not a runtime image |
+| additional libraries | 5 | 8 | supply with `--extra-refs` |
+| gRPC `<Protobuf>` | 2 | 3 | protoc codegen is a build task |
+| `<Import>` above the mount | 2 | 2 | portal hosts |
+| Aspire `<Sdk>` ELEMENT | 1 | 1 | |
+| other | 1 | 1 | pre-existing compile errors |
+
+🚨 **Read the two columns together, not the green count alone.** Nineteen projects were failing on
+the resource refusal and NOTHING ELSE WAS KNOWN ABOUT THEM — a refusal stops the load, so it MASKS
+every gap behind it. Closing it moved one project to green and revealed the real blocker for the
+other eighteen: ten of them want SDK source generators, three want Razor, three want an additional
+library, one wants protoc. That is why the "before" column undercounts source generators by a factor
+of four. **No project regressed**, and no project fails on an embedded resource any more.
+
+The lesson generalises: in a builder whose whole design is to refuse rather than guess, a failure
+ranking is a ranking of FIRST refusals, and removing the top one does not add its count to the green
+column — it redistributes it.
 
 ## The container compiles Razor (2026-08-31)
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-the-sdk-free-builder-embeds-resources-under-the-sdks-own-names.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-the-sdk-free-builder-embeds-resources-under-the-sdks-own-names.md
@@ -1,0 +1,66 @@
+---
+Name: The SDK-free builder embeds resources, under the SDK's own names
+Category: Feature
+Description: build-project compiles a project with no dotnet SDK, and it now carries <EmbeddedResource> items into the assembly under the manifest names the real SDK would produce — every rule established by measuring the SDK rather than recalling it, and every construct whose name could not be matched refused out loud.
+Icon: Package
+Order: -20260831
+---
+
+# The SDK-free builder embeds resources, under the SDK's own names
+
+`mw-plugin-test build-project` compiles a `.csproj` with no dotnet SDK, no NuGet restore and no
+platform checkout, against the assemblies of a MeshWeaver image. Until now it **refused**
+`<EmbeddedResource>` outright, and that refusal was the single biggest coverage gap: of the 54
+non-test projects in `MeshWeaver.Plugins/src`, **19 failed on nothing else** — most of them on one
+line, `<EmbeddedResource Include="Data\**\*.md">`.
+
+The refusal was not timidity. **A wrong manifest-resource name is the quietest defect this builder
+could ship.** The assembly compiles, the emit is verified, the DLL loads — and
+`Assembly.GetManifestResourceStream(name)` returns `null` at run time, in some other process, weeks
+later. Nothing goes red anywhere in between. Core's own `MeshWeaver.Messaging.Hub.csproj` already
+carries a comment describing that exact outcome for its `strings.*.json`: *"the build succeeds, the
+main assembly carries ZERO manifest resources, every lookup falls through to the key-fallback path,
+and the UI renders raw `chat.new` tokens."*
+
+So the rules were **measured, not remembered**. Each one was established by building a probe project
+with the real .NET SDK and reading the manifest-resource table back out of the emitted PE. They are
+not guessable:
+
+- The **directory** is mangled into identifiers and the **file name is not** —
+  `Data\with-dash\Three.md` becomes `…Data.with_dash.Three.md`, while `Weird-File.Name.md` keeps its
+  hyphen and its dot.
+- A leading digit is **prefixed**, not replaced: `9digits` → `_9digits`.
+- A dot inside a directory name is a **separator**: `Dot.9Dir` → `Dot._9Dir`.
+- A segment that reduces to a single underscore is **doubled** — sibling directories `--` and `_`
+  both become `__`, and a project with both fails the real SDK build with `CS1508`.
+- `$(RootNamespace)` defaults to the **project** name, never `$(AssemblyName)`; empty means no prefix
+  at all.
+- A file outside the project with no `Link` **loses its directory entirely**.
+
+## What it refuses, and why that is the feature
+
+Where a rule could not be matched exactly, the construct is refused **by name**, with its own
+`--accept` token — because a plausible-looking wrong name is worse than no build:
+
+- **`.resx` / `.restext`** — the name is reproducible, the *content* is not: it needs resgen.
+- **A culture in the file name** — the SDK routes it into a **satellite assembly** and out of the
+  main one, and an explicit `LogicalName` does **not** rescue it. `WithCulture="false"` is the
+  project-side fix. (An explicitly declared `Culture` beats even that — also measured, also the
+  opposite of what the two names suggest.)
+- **`DependentUpon`**, **`ManifestResourceName`**, and embedding **the build's own output**.
+
+## The number, and how to read it
+
+Over the same 54 projects and the same pinned portal image: **9 green before, 10 after — and 19
+resource refusals down to 0.**
+
+That looks like a poor return until you notice what a refusal does. **It stops the load, so it masks
+every gap behind it.** Those 19 projects were not "19 projects away from green"; they were 19
+projects about which nothing further was known. Closing the gap turned one green and revealed the
+real blocker for the other eighteen — ten want SDK source generators, three want Razor, three want an
+additional library, one wants protoc. The previous sweep counted 3 source-generator failures; the
+true figure was 14.
+
+**In a builder designed to refuse rather than guess, a failure ranking is a ranking of FIRST
+refusals.** Removing the top entry does not add its count to the green column. It redistributes it —
+and that is the honest way to read every such table, including the next one.

--- a/test/MeshWeaver.PluginTester.Test/EmbeddedResourceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/EmbeddedResourceTest.cs
@@ -381,6 +381,26 @@ public class EmbeddedResourceTest : IDisposable
             ]));
     }
 
+    /// <summary>
+    /// 🚨 An EXPLICIT <c>Culture</c> metadata beats <c>WithCulture="false"</c> — the opposite of what
+    /// the two names suggest, and measured both ways: <c>Include="A.md" Culture="fr"
+    /// WithCulture="false"</c> still emitted a <c>fr/</c> satellite and left the main assembly
+    /// without the resource, while <c>Include="C.de.md" WithCulture="false"</c> kept it. Checking
+    /// them in the other order would embed, under a name the SDK never produces, a resource the SDK
+    /// does not put in this assembly at all.
+    /// </summary>
+    [Fact]
+    public void AnExplicitCultureBeatsWithCultureFalse()
+    {
+        var project = ProjectWith("""
+                <EmbeddedResource Include="A.md" Culture="fr" WithCulture="false" />
+            """);
+        Write("Lib/A.md", "a");
+
+        Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(project))
+            .Message.Should().Contain("Culture='fr'").And.Contain("does NOT override");
+    }
+
     /// <summary>A culture-SHAPED name that is not a culture is embedded normally.</summary>
     [Fact]
     public async Task ASecondExtensionThatIsNotACultureIsNotTreatedAsOne()
@@ -554,6 +574,45 @@ public class EmbeddedResourceTest : IDisposable
         var accepted = ProjectFile.Load(project, [ProjectFile.Accept.BuildOutputResource]);
         accepted.EmbeddedResources.Should().BeEmpty();
         accepted.SkippedResources.Should().ContainSingle().Which.Should().Contain("Own.xml");
+    }
+
+    /// <summary>
+    /// 🚨 A glob reaching OUTSIDE the project expands to nothing here — and an empty glob is legal,
+    /// so without a refusal the resources would simply be absent with no line of output saying so.
+    /// The real SDK expands <c>..\lb\**\*.md</c> and embeds what it finds (measured). A LITERAL
+    /// outside include still works, because that path is resolvable.
+    /// </summary>
+    [Fact]
+    public void AnOutsideGlobIsRefusedRatherThanSilentlyMatchingNothing()
+    {
+        var project = ProjectWith("""    <EmbeddedResource Include="..\shared\**\*.md" />""");
+        Write("shared/A.md", "a");
+        Write("shared/nested/B.md", "b");
+
+        Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(project))
+            .Message.Should().Contain("match NOTHING").And.Contain(ProjectFile.Accept.OutsideGlobResource);
+
+        var accepted = ProjectFile.Load(project, [ProjectFile.Accept.OutsideGlobResource]);
+        accepted.EmbeddedResources.Should().BeEmpty();
+        accepted.SkippedResources.Should().ContainSingle();
+    }
+
+    /// <summary>
+    /// <c>LinkBase</c> changes the name only for a file OUTSIDE the project — measured both ways —
+    /// so the outside case is refused and the inside case is ignored, exactly as the SDK ignores it.
+    /// </summary>
+    [Fact]
+    public void LinkBaseIsRefusedOutsideTheProjectAndIgnoredInsideIt()
+    {
+        var outside = ProjectWith("""    <EmbeddedResource Include="..\shared\Out.md" LinkBase="Based" />""", "Outside");
+        Write("shared/Out.md", "o");
+        Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(outside))
+            .Message.Should().Contain("LinkBase='Based'").And.Contain(ProjectFile.Accept.LinkBaseResource);
+
+        var inside = ProjectWith("""    <EmbeddedResource Include="in\deep\In.md" LinkBase="AlsoBased" />""", "Inside");
+        Write("Inside/in/deep/In.md", "i");
+        ProjectFile.Load(inside).EmbeddedResources.Should().ContainSingle()
+            .Which.ManifestName.Should().Be("Probe.Root.Ns.in.deep.In.md");
     }
 
     // ── the parity test ────────────────────────────────────────────────────────────────────────

--- a/test/MeshWeaver.PluginTester.Test/EmbeddedResourceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/EmbeddedResourceTest.cs
@@ -1,0 +1,653 @@
+using System.Diagnostics;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using MeshWeaver.Data;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// <c>&lt;EmbeddedResource&gt;</c> support for <c>mw-plugin-test build-project</c>, held to the one
+/// standard that matters: <b>the manifest NAME the SDK would have produced</b>.
+///
+/// <para>🚨 <b>Every assertion here reads the emitted PE, never this repo's own source.</b> A
+/// manifest name cannot be checked by inspecting the code that computes it — that only proves the
+/// code does what it does. The failure being defended against is a name that is plausible and
+/// wrong, which compiles green, ships, and returns <c>null</c> from
+/// <c>GetManifestResourceStream</c> in another process. So the names come out of
+/// <see cref="MetadataReader.ManifestResources"/> of the assembly this builder actually emitted, and
+/// <see cref="ParityWithTheRealSdk"/> compares that set against the set a REAL
+/// <c>dotnet build</c> of the same project produces.</para>
+/// </summary>
+public class EmbeddedResourceTest : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"mw-embres-{Guid.NewGuid():N}");
+
+    private string Write(string relativePath, string content)
+    {
+        var full = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// An <c>/app</c>-shaped reference directory, the same one <c>ProjectBuildTest</c> builds and
+    /// for the same reason: a test bin carries three <c>*.deps.json</c> and the reference set
+    /// correctly refuses an ambiguous one.
+    /// </summary>
+    private string AppDirectory()
+    {
+        var app = Path.Combine(_root, "_container");
+        if (Directory.Exists(app))
+            return app;
+        Directory.CreateDirectory(app);
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "mw-plugin-test.deps.json"),
+            Path.Combine(app, "mw-plugin-test.deps.json"));
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "MeshWeaver.ShortGuid.dll"),
+            Path.Combine(app, "MeshWeaver.ShortGuid.dll"));
+        return app;
+    }
+
+    private ProjectBuild.Options OptionsFor(string entry, params string[] accept) =>
+        new()
+        {
+            EntryProject = entry,
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "out"),
+            Output = TextWriter.Null,
+            Accept = accept,
+            MaxParallel = 4,
+        };
+
+    private static Task<ProjectBuild.Report> Build(ProjectBuild.Options options) =>
+        ProjectBuild.Run(options).Await(TestContext.Current.CancellationToken);
+
+    /// <summary>
+    /// The manifest resource table of an emitted assembly — names and the public/private flag —
+    /// read straight out of the PE. This is the only oracle in this file.
+    /// </summary>
+    /// <param name="assemblyPath">The DLL to read.</param>
+    /// <returns>Name → attributes, in name order.</returns>
+    internal static IReadOnlyDictionary<string, ManifestResourceAttributes> ResourcesIn(string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var metadata = pe.GetMetadataReader();
+        return metadata.ManifestResources
+            .Select(metadata.GetManifestResource)
+            .ToDictionary(r => metadata.GetString(r.Name), r => r.Attributes, StringComparer.Ordinal);
+    }
+
+    /// <summary>The manifest names of an emitted assembly, ordinal-sorted so the comparison is
+    /// order-free without being set-shaped (a duplicate would still show).</summary>
+    /// <param name="assemblyPath">The DLL to read.</param>
+    /// <returns>The names, sorted.</returns>
+    internal static IReadOnlyList<string> NamesIn(string assemblyPath) =>
+        [.. ResourcesIn(assemblyPath).Keys.Order(StringComparer.Ordinal)];
+
+    /// <summary>The same ordering applied to an expectation, so a test can list names readably.</summary>
+    /// <param name="names">The expected names, in any order.</param>
+    /// <returns>The names, sorted.</returns>
+    private static IEnumerable<string> Sorted(params string[] names) => names.Order(StringComparer.Ordinal);
+
+    private const string Library = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <RootNamespace>Probe.Root.Ns</RootNamespace>
+            <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+          </PropertyGroup>
+          <ItemGroup>
+        {ITEMS}
+          </ItemGroup>
+        </Project>
+        """;
+
+    /// <summary>Writes a project whose only variable is its EmbeddedResource ItemGroup.</summary>
+    private string ProjectWith(string items, string projectName = "Lib")
+    {
+        var path = Write($"{projectName}/{projectName}.csproj", Library.Replace("{ITEMS}", items));
+        Write($"{projectName}/Type.cs", """
+            namespace Probe.Root.Ns;
+            /// <summary>A type, so the compile has something to do.</summary>
+            public static class Type1
+            {
+                /// <summary>One.</summary>
+                /// <returns>1.</returns>
+                public static int One() => 1;
+            }
+            """);
+        return path;
+    }
+
+    // ── the default rule, measured against the SDK ─────────────────────────────────────────────
+
+    /// <summary>
+    /// <c>$(RootNamespace).&lt;directory with separators as dots&gt;.&lt;file name&gt;</c> — and the
+    /// two halves are NOT treated alike. The directory is mangled into identifiers; the file name is
+    /// carried verbatim, hyphens, extra dots and all. Getting that backwards produces a name that
+    /// reads perfectly well and is wrong.
+    /// </summary>
+    [Fact]
+    public async Task TheDefaultNameIsRootNamespacePlusTheMangledDirectoryPlusTheVerbatimFileName()
+    {
+        var project = ProjectWith("""
+                <EmbeddedResource Include="Top.md" />
+                <EmbeddedResource Include="Data\**\*.md" />
+                <EmbeddedResource Include="Weird-File.Name.md" />
+            """);
+        Write("Lib/Top.md", "t");
+        Write("Lib/Weird-File.Name.md", "w");
+        Write("Lib/Data/One.md", "1");
+        Write("Lib/Data/Nested/Two.md", "2");
+        Write("Lib/Data/with-dash/Three.md", "3");
+        Write("Lib/Data/9digits/Four.md", "4");
+        Write("Lib/Data/space dir/Five.md", "5");
+        Write("Lib/Data/Dot.Dir/Six.md", "6");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+
+        // Measured with the real SDK (probe p1). Every one of these was READ OUT of an assembly
+        // `dotnet build` produced, not derived from a rule anyone remembered.
+        NamesIn(report.Projects.Single().Result!.AssemblyPath!)
+            .Should().Equal(Sorted(
+            [
+                "Probe.Root.Ns.Top.md",
+                "Probe.Root.Ns.Weird-File.Name.md",      // the FILE name keeps its hyphen and dot
+                "Probe.Root.Ns.Data.One.md",
+                "Probe.Root.Ns.Data.Nested.Two.md",
+                "Probe.Root.Ns.Data.with_dash.Three.md", // the DIRECTORY does not
+                "Probe.Root.Ns.Data._9digits.Four.md",   // a leading digit is PREFIXED, not replaced
+                "Probe.Root.Ns.Data.space_dir.Five.md",
+                "Probe.Root.Ns.Data.Dot.Dir.Six.md",     // a dot in a directory stays a dot
+            ]));
+    }
+
+    /// <summary>
+    /// The bytes have to arrive too, and under the name — a resource table entry pointing at the
+    /// wrong offset is exactly as invisible as a wrong name.
+    /// </summary>
+    [Fact]
+    public async Task TheEmbEDDEDBytesAreTheFilesBytesAndTheResourceIsPUBLIC()
+    {
+        // 🚨 A unique project name, because this is the one test here that LOADS the emitted
+        // assembly: the default AssemblyLoadContext dedupes by simple name, so a second `Lib` in the
+        // same test process fails with "Assembly with same name is already loaded" — a collision
+        // with ProjectBuildTest, not a defect in either.
+        var project = ProjectWith("""    <EmbeddedResource Include="Data\payload.txt" />""", "PayloadLib");
+        Write("PayloadLib/Data/payload.txt", "the exact bytes");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+        var assemblyPath = report.Projects.Single().Result!.AssemblyPath!;
+
+        // 🚨 Public, not private. Every resource the SDK emits carries
+        // ManifestResourceAttributes.Public (measured); a private one is invisible to
+        // GetManifestResourceStream from outside the assembly — the same silent null again.
+        ResourcesIn(assemblyPath)["Probe.Root.Ns.Data.payload.txt"]
+            .Should().Be(ManifestResourceAttributes.Public);
+
+        var assembly = Assembly.LoadFrom(assemblyPath);
+        using var stream = assembly.GetManifestResourceStream("Probe.Root.Ns.Data.payload.txt");
+        stream.Should().NotBeNull("the name in the table is the name the loader answers to");
+        new StreamReader(stream!).ReadToEnd().Should().Be("the exact bytes");
+    }
+
+    /// <summary>
+    /// <c>$(RootNamespace)</c> defaults to the PROJECT NAME, never to <c>$(AssemblyName)</c> —
+    /// measured with a project whose two differ. This was wrong in the evaluator while
+    /// <c>RootNamespace</c> was informational, and it prefixes every resource name now.
+    /// </summary>
+    [Fact]
+    public async Task RootNamespaceDefaultsToTheProjectNameNotTheAssemblyName()
+    {
+        var project = Write("ProjNameDiffers/ProjNameDiffers.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <AssemblyName>DifferentAsmName</AssemblyName>
+                <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+              </PropertyGroup>
+              <ItemGroup><EmbeddedResource Include="A.md" /></ItemGroup>
+            </Project>
+            """);
+        Write("ProjNameDiffers/A.md", "a");
+        Write("ProjNameDiffers/T.cs", "namespace P; internal static class T { }");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+        NamesIn(report.Projects.Single().Result!.AssemblyPath!)
+            .Should().Equal(Sorted(["ProjNameDiffers.A.md"]));
+    }
+
+    /// <summary>An empty <c>RootNamespace</c> means no prefix at all — not the assembly name.</summary>
+    [Fact]
+    public async Task AnEmptyRootNamespaceMeansNoPrefix()
+    {
+        var project = Write("Bare/Bare.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <RootNamespace></RootNamespace>
+                <EnableDefaultEmbeddedResourceItems>false</EnableDefaultEmbeddedResourceItems>
+              </PropertyGroup>
+              <ItemGroup><EmbeddedResource Include="d\In.md" /></ItemGroup>
+            </Project>
+            """);
+        Write("Bare/d/In.md", "i");
+        Write("Bare/T.cs", "namespace P; internal static class T { }");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+        NamesIn(report.Projects.Single().Result!.AssemblyPath!)
+            .Should().Equal(Sorted(["d.In.md"]));
+    }
+
+    // ── the metadata that changes the name ─────────────────────────────────────────────────────
+
+    /// <summary><c>LogicalName</c> replaces the computed name outright — in either XML form.</summary>
+    [Fact]
+    public async Task LogicalNameOverridesEverything_AsAnAttributeAndAsAChildElement()
+    {
+        var project = ProjectWith("""
+                <EmbeddedResource Include="A.md" LogicalName="From.The.Attribute" />
+                <EmbeddedResource Include="B.md">
+                  <LogicalName>From.The.Child.Element</LogicalName>
+                </EmbeddedResource>
+            """);
+        Write("Lib/A.md", "a");
+        Write("Lib/B.md", "b");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+        NamesIn(report.Projects.Single().Result!.AssemblyPath!)
+            .Should().Equal(Sorted(["From.The.Attribute", "From.The.Child.Element"]));
+    }
+
+    /// <summary>
+    /// <c>Link</c> replaces the PATH the name is computed from — even for a file that is inside the
+    /// project — and <c>TargetPath</c> beats <c>Link</c>. Both measured.
+    /// </summary>
+    [Fact]
+    public async Task LinkRenamesThePathAndTargetPathBeatsLink()
+    {
+        var project = ProjectWith("""
+                <EmbeddedResource Include="inner\F.md" Link="re\named\G.md" />
+                <EmbeddedResource Include="inner\H.md" TargetPath="hand\set\P.md" Link="ignored\me.md" />
+            """);
+        Write("Lib/inner/F.md", "f");
+        Write("Lib/inner/H.md", "h");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+        NamesIn(report.Projects.Single().Result!.AssemblyPath!)
+            .Should().Equal(Sorted(["Probe.Root.Ns.re.named.G.md", "Probe.Root.Ns.hand.set.P.md"]));
+    }
+
+    /// <summary>
+    /// A file OUTSIDE the project with no <c>Link</c> loses its directory ENTIRELY — the target path
+    /// falls all the way back to the bare file name. Nothing about
+    /// <c>Include="..\shared\Shared.md"</c> suggests the resource will be called
+    /// <c>&lt;ns&gt;.Shared.md</c>, which is precisely why it is measured rather than assumed.
+    /// </summary>
+    [Fact]
+    public async Task AFileOutsideTheProjectLosesItsDirectoryRatherThanKeepingDotDot()
+    {
+        var project = ProjectWith("""    <EmbeddedResource Include="..\shared\Shared.md" />""");
+        Write("shared/Shared.md", "s");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+        NamesIn(report.Projects.Single().Result!.AssemblyPath!)
+            .Should().Equal(Sorted(["Probe.Root.Ns.Shared.md"]));
+    }
+
+    /// <summary><c>Exclude</c>, <c>Remove</c> and <c>Update</c> all behave as MSBuild's items do.</summary>
+    [Fact]
+    public async Task ExcludeAndRemoveAndUpdateAllApply()
+    {
+        var project = ProjectWith("""
+                <EmbeddedResource Include="g\*.md" Exclude="g\Skip.md" />
+                <EmbeddedResource Remove="g\Gone.md" />
+                <EmbeddedResource Update="g\Kept.md" LogicalName="Updated.Name" />
+            """);
+        Write("Lib/g/Kept.md", "k");
+        Write("Lib/g/Skip.md", "s");
+        Write("Lib/g/Gone.md", "g");
+        Write("Lib/g/Plain.md", "p");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+        NamesIn(report.Projects.Single().Result!.AssemblyPath!)
+            .Should().Equal(Sorted(["Updated.Name", "Probe.Root.Ns.g.Plain.md"]));
+    }
+
+    // ── the loud refusals ──────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 A culture in the file name sends the resource to a SATELLITE assembly, and an explicit
+    /// <c>LogicalName</c> does NOT rescue it (measured: <c>strings.de.json</c> with a pinned
+    /// LogicalName still landed in <c>de/…resources.dll</c>). This builder emits one assembly, so it
+    /// refuses by name rather than embedding a resource the SDK would not have embedded.
+    /// </summary>
+    [Fact]
+    public void ACultureInTheFileNameIsRefusedByName()
+    {
+        var project = ProjectWith("""
+                <EmbeddedResource Include="L\strings.de.json" LogicalName="Pinned.strings.de.json" />
+            """);
+        Write("Lib/L/strings.de.json", "{}");
+
+        var refusal = Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(project));
+        refusal.Message.Should().Contain("strings.de.json").And.Contain("SATELLITE")
+            .And.Contain("WithCulture").And.Contain(ProjectFile.Accept.CultureResource);
+    }
+
+    /// <summary>
+    /// …and <c>WithCulture="false"</c> — which is what core's <c>MeshWeaver.Messaging.Hub</c>
+    /// already writes — keeps it, under the name including the culture segment.
+    /// </summary>
+    [Fact]
+    public async Task WithCultureFalseKeepsTheResourceAndItsFullFileName()
+    {
+        var project = ProjectWith("""
+                <EmbeddedResource Include="L\strings.de.json" WithCulture="false" />
+                <EmbeddedResource Include="L\strings.en.json" WithCulture="false"
+                                  LogicalName="MeshWeaver.Messaging.Localization.strings.en.json" />
+            """);
+        Write("Lib/L/strings.de.json", "{}");
+        Write("Lib/L/strings.en.json", "{}");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+        NamesIn(report.Projects.Single().Result!.AssemblyPath!)
+            .Should().Equal(Sorted(
+            [
+                "Probe.Root.Ns.L.strings.de.json",
+                "MeshWeaver.Messaging.Localization.strings.en.json",
+            ]));
+    }
+
+    /// <summary>A culture-SHAPED name that is not a culture is embedded normally.</summary>
+    [Fact]
+    public async Task ASecondExtensionThatIsNotACultureIsNotTreatedAsOne()
+    {
+        var project = ProjectWith("""    <EmbeddedResource Include="C\*.md" />""");
+        Write("Lib/C/Foo.zz.md", "z");
+        Write("Lib/C/Foo.notaculture.md", "n");
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0);
+        NamesIn(report.Projects.Single().Result!.AssemblyPath!)
+            .Should().Equal(Sorted(
+                ["Probe.Root.Ns.C.Foo.zz.md", "Probe.Root.Ns.C.Foo.notaculture.md"]));
+    }
+
+    /// <summary>
+    /// <c>.resx</c> is refused because its CONTENT needs resgen, not because of its name — and the
+    /// refusal says so, including the accept token that builds without it.
+    /// </summary>
+    [Fact]
+    public void AResxIsRefusedByNameBecauseItsContentNeedsResgen()
+    {
+        var project = ProjectWith("""    <EmbeddedResource Include="Res\Strings.resx" />""");
+        Write("Lib/Res/Strings.resx", "<root />");
+
+        var refusal = Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(project));
+        refusal.Message.Should().Contain("Strings.resx").And.Contain("resgen")
+            .And.Contain(ProjectFile.Accept.ResxResource);
+
+        // …and accepting it SKIPS the resource, loudly, rather than embedding the XML.
+        var model = ProjectFile.Load(project, [ProjectFile.Accept.ResxResource]);
+        model.EmbeddedResources.Should().BeEmpty();
+        model.SkippedResources.Should().ContainSingle().Which.Should().Contain("Strings.resx");
+    }
+
+    /// <summary>
+    /// 🚨 The SDK's DEFAULT EmbeddedResource glob is <c>**/*.resx</c>, so a stray <c>.resx</c> nobody
+    /// declared is still an SDK resource. Reproducing the default glob is what makes that a named
+    /// refusal instead of an assembly quietly missing a resource the SDK would have embedded.
+    /// </summary>
+    [Fact]
+    public void TheSdkDefaultResxGlobIsReproducedSoAStrayResxIsNotSilentlyDropped()
+    {
+        var project = Write("Def/Def.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+            </Project>
+            """);
+        Write("Def/T.cs", "namespace P; internal static class T { }");
+        Write("Def/Nested/Stray.resx", "<root />");
+
+        Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(project))
+            .Message.Should().Contain("Stray.resx");
+    }
+
+    /// <summary><c>DependentUpon</c> replaces the name with a class name; refused by name.</summary>
+    [Fact]
+    public void DependentUponIsRefusedByName()
+    {
+        var project = ProjectWith("""
+                <EmbeddedResource Include="A.md" DependentUpon="Type.cs" />
+            """);
+        Write("Lib/A.md", "a");
+
+        Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(project))
+            .Message.Should().Contain("DependentUpon").And.Contain("first class")
+            .And.Contain(ProjectFile.Accept.DependentUponResource);
+    }
+
+    /// <summary>
+    /// <c>ManifestResourceName</c> metadata is refused because in the SDK it does not do what it
+    /// says: it makes the naming task skip the item, so csc gets no logical name and falls back to
+    /// the bare file name (measured). Reproducing that quirk would not be fidelity.
+    /// </summary>
+    [Fact]
+    public void ManifestResourceNameMetadataIsRefusedRatherThanReproducedAsAQuirk()
+    {
+        var project = ProjectWith("""
+                <EmbeddedResource Include="A.md" ManifestResourceName="I.Win.Outright" />
+            """);
+        Write("Lib/A.md", "a");
+
+        Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(project))
+            .Message.Should().Contain("ManifestResourceName").And.Contain("LogicalName");
+    }
+
+    /// <summary>
+    /// A LITERAL include of a file that is not there is csc's CS1566, which fails the SDK build — so
+    /// it fails here. A GLOB that matches nothing is legal and matches nothing. Both measured.
+    /// </summary>
+    [Fact]
+    public void AMissingLiteralIncludeFailsWhileAnEmptyGlobDoesNot()
+    {
+        var missing = ProjectWith("""    <EmbeddedResource Include="does\not\exist.md" />""", "Missing");
+        Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(missing))
+            .Message.Should().Contain("does not exist").And.Contain("CS1566");
+
+        var empty = ProjectWith("""    <EmbeddedResource Include="none\**\*.md" />""", "Empty");
+        ProjectFile.Load(empty).EmbeddedResources.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Two resources that mangle to the SAME manifest name is csc's CS1508. Naming both files beats
+    /// naming the collision: sibling directories <c>--</c> and <c>_</c> both mangle to <c>__</c>,
+    /// and nothing about either name says so.
+    /// </summary>
+    [Fact]
+    public void TwoResourcesClaimingOneNameAreRefusedNamingBOTHFiles()
+    {
+        var project = ProjectWith("""    <EmbeddedResource Include="**\F.md" />""");
+        Write("Lib/--/F.md", "1");
+        Write("Lib/_/F.md", "2");
+
+        var refusal = Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(project));
+        refusal.Message.Should().Contain("Probe.Root.Ns.__.F.md").And.Contain("CS1508");
+        refusal.Message.Should().Contain("--").And.Contain("_");
+    }
+
+    /// <summary>
+    /// The blanket escape hatch still exists and is still LOUD: <c>--accept embedded-resource</c>
+    /// builds an assembly deliberately missing its resources, and says which ones.
+    /// </summary>
+    [Fact]
+    public async Task TheBlanketAcceptSkipsEverythingAndListsWhatItSkipped()
+    {
+        var project = ProjectWith("""    <EmbeddedResource Include="Data\**\*.md" />""");
+        Write("Lib/Data/a.md", "a");
+        Write("Lib/Data/b.md", "b");
+
+        var report = await Build(OptionsFor(project, ProjectFile.Accept.EmbeddedResource));
+        report.ExitCode.Should().Be(0);
+        report.Projects.Single().Result!.ResourceCount.Should().Be(0);
+        ResourcesIn(report.Projects.Single().Result!.AssemblyPath!).Should().BeEmpty();
+        report.Activity.Warnings().Should().Contain(m => m.Message.Contains("resource NOT embedded"));
+    }
+
+    /// <summary>
+    /// 🚨 A missing BUILD OUTPUT is not a missing input, and conflating them turns a project the SDK
+    /// builds GREEN into a red one. <c>MeshWeaver.Northwind.Domain</c> embeds its own XML doc as
+    /// <c>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</c>, and a real
+    /// <c>dotnet build</c> of that shape succeeds from a CLEAN tree — measured — because csc writes
+    /// <c>/doc:</c> and reads <c>/resource:</c> in one invocation. This builder writes its doc file
+    /// somewhere else, so it names the case and skips it rather than failing the project.
+    /// </summary>
+    [Fact]
+    public void EmbeddingTheBuildsOwnOutputIsNamedAndSkippable_NotAMissingInput()
+    {
+        var project = Write("Own/Own.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <GenerateDocumentationFile>true</GenerateDocumentationFile>
+              </PropertyGroup>
+              <ItemGroup>
+                <EmbeddedResource Include="bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml">
+                  <LogicalName>$(AssemblyName).xml</LogicalName>
+                </EmbeddedResource>
+              </ItemGroup>
+            </Project>
+            """);
+        Write("Own/T.cs", "namespace P; internal static class T { }");
+
+        var refusal = Assert.Throws<ProjectFile.UnsupportedConstructException>(() => ProjectFile.Load(project));
+        refusal.Message.Should().Contain("build's OWN OUTPUT")
+            .And.Contain(ProjectFile.Accept.BuildOutputResource);
+        // 🚨 …and the property expansion has to WORK, or the item names a file called ".xml" and the
+        // refusal blames the wrong thing. $(AssemblyName) and $(RootNamespace) default to the
+        // PROJECT NAME, exactly as Microsoft.NET.Sdk.props sets them.
+        refusal.Message.Should().Contain("Own.xml");
+
+        var accepted = ProjectFile.Load(project, [ProjectFile.Accept.BuildOutputResource]);
+        accepted.EmbeddedResources.Should().BeEmpty();
+        accepted.SkippedResources.Should().ContainSingle().Which.Should().Contain("Own.xml");
+    }
+
+    // ── the parity test ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 <b>THE test.</b> One project, built twice — once by the real .NET SDK, once by
+    /// <c>build-project</c> — and the two manifest resource name SETS must be identical. Everything
+    /// else in this file pins a rule that was measured once; this re-measures on every run, so a
+    /// future SDK that changes a rule turns THIS red rather than shipping assemblies whose resources
+    /// nobody can find.
+    ///
+    /// <para>The project deliberately carries the hard cases together: a recursive glob, a
+    /// non-identifier directory, a leading-digit directory, a dotted directory, a dotted FILE name,
+    /// an explicit <c>LogicalName</c>, a <c>Link</c>, a file outside the project, and a
+    /// <c>WithCulture="false"</c> file whose name carries a real culture.</para>
+    ///
+    /// <para>The SDK build runs with an EMPTY NuGet source list, so it needs no network: the project
+    /// has no <c>PackageReference</c> and restores against the SDK's own targeting pack.</para>
+    /// </summary>
+    [Fact]
+    public async Task ParityWithTheRealSdk()
+    {
+        const string items = """
+                <EmbeddedResource Include="Top.md" />
+                <EmbeddedResource Include="Data\**\*.md" />
+                <EmbeddedResource Include="Weird-File.Name.md" />
+                <EmbeddedResource Include="Logical.md" LogicalName="My.Custom.Logical.Name" />
+                <EmbeddedResource Include="inner\F.md" Link="re\named\G.md" />
+                <EmbeddedResource Include="..\shared\Shared.md" />
+                <EmbeddedResource Include="L\strings.de.json" WithCulture="false" />
+            """;
+        var project = ProjectWith(items, "Parity");
+        Write("Parity/Top.md", "t");
+        Write("Parity/Weird-File.Name.md", "w");
+        Write("Parity/Logical.md", "l");
+        Write("Parity/inner/F.md", "f");
+        Write("Parity/L/strings.de.json", "{}");
+        Write("shared/Shared.md", "s");
+        Write("Parity/Data/One.md", "1");
+        Write("Parity/Data/Nested/Two.md", "2");
+        Write("Parity/Data/with-dash/Three.md", "3");
+        Write("Parity/Data/9digits/Four.md", "4");
+        Write("Parity/Data/space dir/Five.md", "5");
+        Write("Parity/Data/Dot.Dir/Six.md", "6");
+        // No sources, so restore reaches nothing: the SDK build is offline and hermetic.
+        Write("Parity/NuGet.config", """
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration><packageSources><clear /></packageSources></configuration>
+            """);
+
+        var report = await Build(OptionsFor(project));
+        report.ExitCode.Should().Be(0, "the builder under test must produce an assembly to compare");
+        var ours = ResourcesIn(report.Projects.Single().Result!.AssemblyPath!).Keys.Order(StringComparer.Ordinal);
+
+        var sdkAssembly = BuildWithTheRealSdk(Path.GetDirectoryName(project)!, "Parity");
+        var theirs = ResourcesIn(sdkAssembly).Keys.Order(StringComparer.Ordinal);
+
+        ours.Should().Equal(theirs,
+            "the manifest names build-project commits to must be the ones the SDK produces — a name "
+            + "that differs is a resource nothing can ever find, and it fails no other test");
+    }
+
+    /// <summary>
+    /// Runs a real <c>dotnet build</c> and returns the assembly it produced.
+    ///
+    /// <para>🚨 It does not SKIP when the SDK is missing. A parity test that quietly passes because
+    /// it could not find the thing it compares against is worse than no parity test — so an absent
+    /// or failing SDK build fails this test, naming the command and its output.</para>
+    /// </summary>
+    private static string BuildWithTheRealSdk(string projectDirectory, string assemblyName)
+    {
+        var start = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = projectDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        foreach (var argument in new[] { "build", "-c", "Release", "--nologo", "-v", "q" })
+            start.ArgumentList.Add(argument);
+        start.Environment["DOTNET_CLI_TELEMETRY_OPTOUT"] = "1";
+        start.Environment["DOTNET_NOLOGO"] = "1";
+
+        using var process = Process.Start(start)
+            ?? throw new InvalidOperationException("could not start `dotnet` — the parity test needs the real SDK.");
+        var output = process.StandardOutput.ReadToEnd() + process.StandardError.ReadToEnd();
+        process.WaitForExit();
+        if (process.ExitCode != 0)
+            throw new InvalidOperationException(
+                $"the reference `dotnet build` failed in {projectDirectory} (exit {process.ExitCode}). "
+                + "This test compares against the SDK's answer, so it cannot pass without one.\n" + output);
+
+        var assembly = Path.Combine(projectDirectory, "bin", "Release", "net10.0", $"{assemblyName}.dll");
+        return File.Exists(assembly)
+            ? assembly
+            : throw new InvalidOperationException($"the reference build produced no {assembly}.\n{output}");
+    }
+}

--- a/test/MeshWeaver.PluginTester.Test/ManifestResourceNamesTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ManifestResourceNamesTest.cs
@@ -1,0 +1,181 @@
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// The naming rules of <see cref="ManifestResourceNames"/>, pinned one input at a time.
+///
+/// <para>🚨 <b>Every expectation in this file is a MEASUREMENT, not a derivation.</b> Each was read
+/// out of an assembly the real .NET SDK emitted, with
+/// <c>System.Reflection.Metadata</c>'s manifest-resource table — the probe projects are named in the
+/// comments. That matters because the rules are not guessable and a wrong one is silent: the
+/// directory is mangled and the file name is not, a leading digit is PREFIXED rather than replaced,
+/// a dot inside a directory name survives as a dot, and a segment that reduces to a single
+/// underscore is DOUBLED.</para>
+///
+/// <para><see cref="EmbeddedResourceTest"/> then proves the rules end to end against a real
+/// <c>dotnet build</c>. This file is the microscope; that one is the control.</para>
+/// </summary>
+public class ManifestResourceNamesTest
+{
+    // ── the Everett mangling of a directory path ───────────────────────────────────────────────
+
+    /// <summary>
+    /// The mangling table. Every row was produced by building a probe project with those exact
+    /// directories and reading the emitted names back (probe p2); the <c>--</c> and <c>_</c> rows
+    /// were established by the SDK build FAILING with <c>CS1508: Resource identifier 'R.__.F.md' has
+    /// already been used</c>, which is only possible if both mangle to <c>__</c>.
+    /// </summary>
+    /// <param name="directory">The directory path as it is on disk.</param>
+    /// <param name="expected">The dotted, mangled identifier the SDK produced.</param>
+    [Theory]
+    [InlineData("Data", "Data")]
+    [InlineData("Data/Nested", "Data.Nested")]
+    [InlineData("with-dash", "with_dash")]                  // an invalid character becomes '_'
+    [InlineData("9digits", "_9digits")]                     // a leading digit is PREFIXED
+    [InlineData("space dir", "space_dir")]
+    [InlineData("Dot.Dir", "Dot.Dir")]                      // a dot is a SEPARATOR, not a character
+    [InlineData("Dot.9Dir", "Dot._9Dir")]                   // …so each half is mangled on its own
+    [InlineData("--", "__")]
+    [InlineData("_", "__")]                                 // a lone underscore is DOUBLED
+    [InlineData("ü-dir", "ü_dir")]                          // a letter is a letter, ASCII or not
+    [InlineData("x y.z-w", "x_y.z_w")]
+    [InlineData("deep/a-b/9c", "deep.a_b._9c")]
+    [InlineData("", "")]
+    public void EveryMangledDirectorySegmentMatchesWhatTheSdkEmitted(string directory, string expected) =>
+        ManifestResourceNames.MakeValidEverettIdentifier(directory).Should().Be(expected);
+
+    /// <summary>
+    /// 🚨 The FILE name is never mangled — the asymmetry that makes this whole file necessary.
+    /// <c>Weird-File.Name.md</c> in a <c>with-dash</c> directory keeps its own hyphen and dot while
+    /// the directory loses both (probe p1).
+    /// </summary>
+    [Fact]
+    public void TheFileNameIsCarriedVERBATIMWhileTheDirectoryIsMangled() =>
+        ManifestResourceNames.Compute("Probe.Root.Ns", Path.Combine("with-dash", "Weird-File.Name.md"))
+            .Should().Be("Probe.Root.Ns.with_dash.Weird-File.Name.md");
+
+    /// <summary>An empty root namespace contributes no prefix and no leading dot (probe p5).</summary>
+    [Fact]
+    public void AnEmptyRootNamespaceContributesNothing() =>
+        ManifestResourceNames.Compute("", Path.Combine("d", "In.md")).Should().Be("d.In.md");
+
+    /// <summary>A file at the project root has no directory part and therefore no extra dot.</summary>
+    [Fact]
+    public void AFileAtTheRootHasNoDirectorySegment() =>
+        ManifestResourceNames.Compute("R", "Top.md").Should().Be("R.Top.md");
+
+    /// <summary>
+    /// A <c>.resources</c> file needs no special case: the SDK's strip-and-re-append branch is
+    /// arithmetically identical to the plain rule for an input already carrying that extension, and
+    /// it mangles the directory in that branch too (probe p11: <c>r-dir\Bin.resources</c> →
+    /// <c>RB.r_dir.Bin.resources</c>).
+    /// </summary>
+    [Fact]
+    public void ADotResourcesFileFollowsTheSamePathRuleAsAnythingElse() =>
+        ManifestResourceNames.Compute("RB", Path.Combine("r-dir", "Bin.resources"))
+            .Should().Be("RB.r_dir.Bin.resources");
+
+    // ── the target path the name is computed FROM ──────────────────────────────────────────────
+
+    /// <summary>
+    /// <c>%(TargetPath)</c> wins outright, then <c>%(Link)</c>, then the item spec — the order the
+    /// SDK's <c>AssignTargetPath</c> applies (probes p9/p10), and the reason a <c>Link</c> renames a
+    /// resource that is sitting inside the project already.
+    /// </summary>
+    [Fact]
+    public void TargetPathBeatsLinkWhichBeatsTheItemSpec()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "proj");
+        var file = Path.Combine(directory, "inner", "F.md");
+
+        ManifestResourceNames.TargetPathFor(directory, Path.Combine("inner", "F.md"), file,
+            link: Path.Combine("ignored", "me.md"), targetPath: Path.Combine("a-b", "c.md"))
+            .Should().Be(Path.Combine("a-b", "c.md"));
+
+        ManifestResourceNames.TargetPathFor(directory, Path.Combine("inner", "F.md"), file,
+            link: Path.Combine("re", "named", "G.md"), targetPath: null)
+            .Should().Be(Path.Combine("re", "named", "G.md"));
+
+        ManifestResourceNames.TargetPathFor(directory, Path.Combine("inner", "F.md"), file,
+            link: null, targetPath: null)
+            .Should().Be(Path.Combine("inner", "F.md"));
+    }
+
+    /// <summary>
+    /// 🚨 A file OUTSIDE the project with no <c>Link</c> loses its directory ENTIRELY, rather than
+    /// keeping a <c>..</c> that would mangle into something. Measured (probe p4):
+    /// <c>Include="..\shared\Shared.md"</c> emitted <c>ProjNameDiffers.Shared.md</c>.
+    /// </summary>
+    [Fact]
+    public void AFileOutsideTheProjectFallsAllTheWayBackToItsBareFileName()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "proj");
+        var outside = Path.GetFullPath(Path.Combine(directory, "..", "shared", "Shared.md"));
+
+        ManifestResourceNames.TargetPathFor(
+                directory, Path.Combine("..", "shared", "Shared.md"), outside, link: null, targetPath: null)
+            .Should().Be("Shared.md");
+    }
+
+    /// <summary>An ABSOLUTE item spec inside the project resolves back to its relative path.</summary>
+    [Fact]
+    public void AnAbsoluteItemSpecInsideTheProjectBecomesItsRelativePath()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "proj");
+        var file = Path.Combine(directory, "Abs.md");
+
+        ManifestResourceNames.TargetPathFor(directory, file, file, link: null, targetPath: null)
+            .Should().Be("Abs.md");
+    }
+
+    // ── the culture that routes a resource out of the assembly ─────────────────────────────────
+
+    /// <summary>
+    /// Which second extensions are cultures, and which merely look like one. <c>de</c> and
+    /// <c>de-DE</c> sent probe p1's files into <c>de/</c> and <c>de-DE/</c> satellite assemblies;
+    /// <c>zz</c> and <c>notaculture</c> left theirs in the main assembly.
+    /// </summary>
+    /// <param name="fileName">The file name.</param>
+    /// <param name="expected">The culture the SDK would assign, or null.</param>
+    [Theory]
+    [InlineData("Foo.de.md", "de")]
+    [InlineData("Foo.de-DE.md", "de-DE")]
+    [InlineData("strings.en.json", "en")]
+    [InlineData("Foo.zz.md", null)]
+    [InlineData("Foo.notaculture.md", null)]
+    [InlineData("Plain.md", null)]
+    [InlineData("Weird-File.Name.md", null)]
+    public void ACultureIsRecognisedExactlyWhereTheSdkRecognisesOne(string fileName, string? expected)
+    {
+        Assert.SkipUnless(ManifestResourceNames.CanDecideCulture,
+            "this process reports no predefined culture even for 'de' (invariant globalization), which "
+            + "is the condition ProjectFile refuses under rather than guessing — there is nothing to "
+            + "assert about a decision that is not being made.");
+        ManifestResourceNames.CultureOf(fileName).Should().Be(expected);
+    }
+
+    /// <summary>
+    /// The invariant-globalization self-check itself. Under a normal runtime it is true, and this
+    /// asserts the probe is asking a question with a knowable answer — if <c>de</c> ever stops
+    /// being a predefined culture, the refusal path in <see cref="ProjectFile"/> takes over and
+    /// nothing is embedded under a guessed name.
+    /// </summary>
+    [Fact]
+    public void TheCultureCapabilityIsPROBEDRatherThanAssumed()
+    {
+        ManifestResourceNames.CanDecideCulture.Should().Be(
+            ManifestResourceNames.IsValidCultureString("de")
+            && ManifestResourceNames.IsValidCultureString("de-DE"));
+        ManifestResourceNames.IsValidCultureString("notaculture").Should().BeFalse();
+        ManifestResourceNames.IsValidCultureString("").Should().BeFalse();
+    }
+
+    /// <summary>Only a base name with its own extension can possibly carry a culture.</summary>
+    [Theory]
+    [InlineData("Foo.de.md", true)]
+    [InlineData("Foo.md", false)]
+    [InlineData("Foo", false)]
+    public void ADottedBaseNameIsTheOnlyThingThatCanCarryACulture(string fileName, bool dotted) =>
+        ManifestResourceNames.HasDottedBaseName(fileName).Should().Be(dotted);
+}

--- a/test/MeshWeaver.PluginTester.Test/ProjectAssemblyIdentityTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ProjectAssemblyIdentityTest.cs
@@ -1,0 +1,523 @@
+using System.Collections.Immutable;
+using System.Reflection;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// 🔴 <b>The emitted assembly's IDENTITY — the one property of this builder's output that no
+/// compile, no warning and no reviewer can catch when it is wrong.</b>
+///
+/// <para><c>build-project</c> runs no MSBuild targets, so the SDK's <c>GenerateAssemblyInfo</c>
+/// never runs and Roslyn emits its own default identity: <c>0.0.0.0</c>. Measured first-hand on
+/// 2026-08-30 by building <c>MeshWeaver.Plugins/src/MeshWeaver.Speech.Contract</c> through the
+/// container and reading the result — <c>AssemblyVersion=0.0.0.0</c>, where that repo's
+/// <c>src/Directory.Build.props</c> pins <c>3.0.0.0</c> and the whole fleet binds <c>3.0.0.0</c>.
+/// The build was GREEN. The failure would have arrived in a different repo, in a different
+/// process, as <c>FileNotFoundException: Could not load file or assembly '…, Version=3.0.0.0'</c>
+/// — which is exactly the shape of Systemorph/MeshWeaver#143.</para>
+///
+/// <para><b>Every assertion here reads the emitted FILE.</b> Inspecting the synthesized source
+/// would prove only that this suite and the builder agree about a string; the claim under test is
+/// about the bytes on disk. The version table is not recalled either — it was
+/// measured against SDK 10.0.400 by building the same projects with <c>dotnet build</c> and
+/// reading the generated <c>*.AssemblyInfo.cs</c>.</para>
+/// </summary>
+public class ProjectAssemblyIdentityTest : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"mw-asmidentity-{Guid.NewGuid():N}");
+
+    private string Write(string relativePath, string content)
+    {
+        var full = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// An <c>/app</c>-shaped reference directory, built the same way <see cref="ProjectBuildTest"/>
+    /// builds one: the suite's own real <c>.deps.json</c> plus one assembly, with everything else
+    /// arriving through the process's TPA as the shared framework does in a container.
+    /// </summary>
+    private string AppDirectory()
+    {
+        var app = Path.Combine(_root, "_container");
+        if (Directory.Exists(app))
+            return app;
+        Directory.CreateDirectory(app);
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "mw-plugin-test.deps.json"),
+            Path.Combine(app, "mw-plugin-test.deps.json"));
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "MeshWeaver.ShortGuid.dll"),
+            Path.Combine(app, "MeshWeaver.ShortGuid.dll"));
+        return app;
+    }
+
+    private ProjectBuild.Options OptionsFor(string entry) =>
+        new()
+        {
+            EntryProject = entry,
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "out"),
+            Output = TextWriter.Null,
+            MaxParallel = 4,
+        };
+
+    private static Task<ProjectBuild.Report> Build(ProjectBuild.Options options) =>
+        ProjectBuild.Run(options).Await(TestContext.Current.CancellationToken);
+
+    /// <summary>Writes a library whose only property block is <paramref name="properties"/>.</summary>
+    private string Library(string properties, string? sourceText = null)
+    {
+        var project = Write("Lib/Lib.csproj", $"""
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+            {properties}
+              </PropertyGroup>
+            </Project>
+            """);
+        Write("Lib/Thing.cs", sourceText ?? "namespace Lib; public class Thing;");
+        return project;
+    }
+
+    /// <summary>
+    /// Builds and returns the EMITTED assembly's own name — read off the file, never off the model.
+    /// </summary>
+    private async Task<(AssemblyName Name, string Path)> Emit(ProjectBuild.Options options)
+    {
+        var report = await Build(options);
+        report.FatalError.Should().BeNull();
+        report.ExitCode.Should().Be(0);
+        var path = report.Projects.Single().Result!.AssemblyPath;
+        path.Should().NotBeNull();
+        return (AssemblyName.GetAssemblyName(path!), path!);
+    }
+
+    /// <summary>
+    /// Every assembly-level attribute in the emitted file, read out of its METADATA.
+    ///
+    /// <para>🚨 Deliberately not <see cref="Assembly.LoadFrom(string)"/>. These cases differ only in
+    /// the identity of an assembly whose simple name is the same in all of them, and the default
+    /// load context refuses the second one — <c>Assembly with same name is already loaded</c> —
+    /// which would turn an identity suite into a load-order suite. Reading the metadata also asserts
+    /// the thing actually claimed: what is in the BYTES.</para>
+    /// </summary>
+    private static ImmutableArray<(string TypeName, ImmutableArray<string?> Arguments)> AssemblyAttributes(
+        string assemblyPath)
+    {
+        using var stream = File.OpenRead(assemblyPath);
+        using var pe = new PEReader(stream);
+        var metadata = pe.GetMetadataReader();
+        var found = ImmutableArray.CreateBuilder<(string, ImmutableArray<string?>)>();
+        foreach (var handle in metadata.CustomAttributes)
+        {
+            var attribute = metadata.GetCustomAttribute(handle);
+            if (attribute.Parent.Kind != HandleKind.AssemblyDefinition)
+                continue;
+            if (attribute.Constructor.Kind != HandleKind.MemberReference)
+                continue;
+            var member = metadata.GetMemberReference((MemberReferenceHandle)attribute.Constructor);
+            if (member.Parent.Kind != HandleKind.TypeReference)
+                continue;
+            var type = metadata.GetTypeReference((TypeReferenceHandle)member.Parent);
+            var typeName = $"{metadata.GetString(type.Namespace)}.{metadata.GetString(type.Name)}";
+            var value = attribute.DecodeValue(StringOnlyAttributeTypes.Instance);
+            found.Add((typeName, [.. value.FixedArguments.Select(a => a.Value as string)]));
+        }
+        return found.ToImmutable();
+    }
+
+    /// <summary>The single-value read: the first constructor argument of one attribute type.</summary>
+    private static string? AttributeValue(string assemblyPath, string attributeTypeName) =>
+        AssemblyAttributes(assemblyPath)
+            .Where(a => a.TypeName == attributeTypeName)
+            .Select(a => a.Arguments.Length > 0 ? a.Arguments[0] : null)
+            .FirstOrDefault();
+
+    /// <summary>
+    /// The minimum a <see cref="CustomAttribute.DecodeValue{TType}"/> needs. Every attribute
+    /// <c>GenerateAssemblyInfo</c> writes takes string arguments only, so nothing here has to
+    /// resolve a real type.
+    /// </summary>
+    private sealed class StringOnlyAttributeTypes : ICustomAttributeTypeProvider<string>
+    {
+        internal static readonly StringOnlyAttributeTypes Instance = new();
+
+        public string GetPrimitiveType(PrimitiveTypeCode typeCode) => typeCode.ToString();
+
+        public string GetSystemType() => "System.Type";
+
+        public string GetSZArrayType(string elementType) => elementType + "[]";
+
+        public string GetTypeFromDefinition(MetadataReader reader, TypeDefinitionHandle handle, byte rawTypeKind) =>
+            "definition";
+
+        public string GetTypeFromReference(MetadataReader reader, TypeReferenceHandle handle, byte rawTypeKind) =>
+            "reference";
+
+        public string GetTypeFromSerializedName(string name) => name;
+
+        public PrimitiveTypeCode GetUnderlyingEnumType(string type) => PrimitiveTypeCode.Int32;
+
+        public bool IsSystemType(string type) => type == "System.Type";
+    }
+
+    // ── the defect ─────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🔴 <b>THE MUTATION PROOF.</b> Revert the synthesized assembly-info tree in
+    /// <c>ProjectBuild.Compile</c> and this test fails with <c>Expected 3.0.0.0, found
+    /// 0.0.0.0</c> — the measured defect, verbatim. The shape is MeshWeaver.Plugins':
+    /// <c>AssemblyVersion</c> pinned as a LITERAL in a <c>Directory.Build.props</c> that the
+    /// project itself never mentions.
+    /// </summary>
+    [Fact]
+    public async Task ADirectoryBuildPropsAssemblyVersionIsWhatTheEMITTEDAssemblyCarries()
+    {
+        Write("Directory.Build.props", """
+            <Project>
+              <PropertyGroup>
+                <AssemblyVersion>3.0.0.0</AssemblyVersion>
+                <FileVersion>3.0.0.0</FileVersion>
+              </PropertyGroup>
+            </Project>
+            """);
+        var project = Library("    <Nullable>enable</Nullable>");
+
+        var (name, path) = await Emit(OptionsFor(project));
+
+        name.Version.Should().Be(new Version(3, 0, 0, 0),
+            "the fleet binds 3.0.0.0 — an assembly at 0.0.0.0 fails at runtime binding in another "
+            + "repo, never at build time here");
+        AttributeValue(path, "System.Reflection.AssemblyFileVersionAttribute").Should().Be("3.0.0.0");
+    }
+
+    // ── the SDK's derivation rules, as measured against SDK 10.0.400 ───────────────────────────
+
+    /// <summary>
+    /// <c>GetAssemblyVersion</c>: with no explicit <c>AssemblyVersion</c>, the binding identity is
+    /// the NUMERIC core of <c>$(Version)</c>, normalised to four fields. Each row was produced by
+    /// building the same project with the real SDK and reading its generated AssemblyInfo.
+    /// </summary>
+    [Theory]
+    [InlineData("1.2.3-beta.4", "1.2.3.0")]   // the pre-release label is dropped
+    [InlineData("1.2.3+meta", "1.2.3.0")]     // …so is build metadata
+    [InlineData("1.2.3.4", "1.2.3.4")]        // four fields survive intact
+    [InlineData("1.2.3", "1.2.3.0")]          // three are padded
+    [InlineData("4.5", "4.5.0.0")]            // two are padded
+    [InlineData("1", "1.0.0.0")]              // one is padded
+    [InlineData("01.2.3", "1.2.3.0")]         // leading zeros normalise
+    public async Task TheVersionPropertyDerivesTheBindingIdentityTheWayTheSdkDoes(
+        string version, string expected)
+    {
+        var project = Library($"    <Version>{version}</Version>");
+
+        var (name, _) = await Emit(OptionsFor(project));
+
+        name.Version.Should().Be(Version.Parse(expected));
+    }
+
+    /// <summary>
+    /// No version anywhere is the SDK's <c>VersionPrefix</c> default — <c>1.0.0</c> — and the
+    /// resulting binding identity is <c>1.0.0.0</c>, NOT Roslyn's <c>0.0.0.0</c>. The two look
+    /// alike in a log and are a different assembly to the loader.
+    /// </summary>
+    [Fact]
+    public async Task WithNoVersionAtAllTheIdentityIsTheSdksDefaultAndNotRoslynsDefault()
+    {
+        var project = Library("    <Nullable>enable</Nullable>");
+
+        var (name, path) = await Emit(OptionsFor(project));
+
+        name.Version.Should().Be(new Version(1, 0, 0, 0));
+        AttributeValue(path, "System.Reflection.AssemblyInformationalVersionAttribute").Should().Be("1.0.0");
+    }
+
+    /// <summary><c>VersionPrefix</c> + <c>VersionSuffix</c> compose <c>$(Version)</c>.</summary>
+    [Fact]
+    public async Task VersionPrefixAndSuffixComposeTheVersionTheIdentityDerivesFrom()
+    {
+        var project = Library("""
+                <VersionPrefix>2.5.0</VersionPrefix>
+                <VersionSuffix>rc1</VersionSuffix>
+            """);
+
+        var (name, path) = await Emit(OptionsFor(project));
+
+        name.Version.Should().Be(new Version(2, 5, 0, 0));
+        AttributeValue(path, "System.Reflection.AssemblyInformationalVersionAttribute").Should().Be("2.5.0-rc1");
+    }
+
+    /// <summary>
+    /// The fallback ORDER, which is the part that is easy to get backwards: <c>FileVersion</c>
+    /// follows <c>AssemblyVersion</c> — including an EXPLICIT one — and never <c>$(Version)</c>,
+    /// while <c>InformationalVersion</c> follows <c>$(Version)</c>.
+    /// </summary>
+    [Fact]
+    public async Task FileVersionFollowsAssemblyVersionAndInformationalVersionFollowsVersion()
+    {
+        var project = Library("""
+                <Version>7.8.9</Version>
+                <AssemblyVersion>3.0.0.0</AssemblyVersion>
+            """);
+
+        var (name, path) = await Emit(OptionsFor(project));
+
+        name.Version.Should().Be(new Version(3, 0, 0, 0));
+        AttributeValue(path, "System.Reflection.AssemblyFileVersionAttribute").Should().Be("3.0.0.0");
+        AttributeValue(path, "System.Reflection.AssemblyInformationalVersionAttribute").Should().Be("7.8.9");
+    }
+
+    /// <summary>
+    /// A <c>$(Version)</c> the SDK's task would reject is a NAMED refusal, never a fallback. A
+    /// plausible-looking substitute here is the whole defect: it cannot be caught downstream.
+    /// </summary>
+    [Fact]
+    public void AnUnparseableVersionIsARefusalThatNamesTheProperty()
+    {
+        var project = Library("    <Version>1.2.3.4.5</Version>");
+
+        Action act = () => ProjectFile.Load(project);
+
+        act.Should().Throw<ProjectFile.UnsupportedConstructException>()
+            .Which.Message.Should().Contain("Version='1.2.3.4.5'");
+    }
+
+    // ── GenerateAssemblyInfo=false: the project supplies its own ───────────────────────────────
+
+    /// <summary>
+    /// <c>GenerateAssemblyInfo=false</c> means the project's own source carries the attributes.
+    /// Synthesizing a second set would be CS0579, so nothing is synthesized — and the identity the
+    /// SOURCE declares is the one that reaches the assembly.
+    /// </summary>
+    [Fact]
+    public async Task GenerateAssemblyInfoFalseEmitsNothingAndTheProjectsOwnAttributesWin()
+    {
+        var project = Library(
+            "    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>\n    <Version>9.9.9</Version>",
+            """
+            [assembly: System.Reflection.AssemblyVersion("2.1.0.0")]
+            [assembly: System.Reflection.AssemblyFileVersion("2.1.0.0")]
+            namespace Lib; public class Thing;
+            """);
+
+        var (name, path) = await Emit(OptionsFor(project));
+
+        name.Version.Should().Be(new Version(2, 1, 0, 0));
+        AttributeValue(path, "System.Reflection.AssemblyFileVersionAttribute").Should().Be("2.1.0.0");
+    }
+
+    /// <summary>
+    /// …and the CONTROL for the case above: leave <c>GenerateAssemblyInfo</c> at its default and
+    /// the same source is the SDK's own duplicate-attribute error, CS0579. Without this the test
+    /// above would pass just as well against a builder that synthesizes nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task WithoutThatFlagTheSameSourceIsCS0579JustAsItIsUnderTheSdk()
+    {
+        var project = Library("    <Version>9.9.9</Version>", """
+            [assembly: System.Reflection.AssemblyVersion("2.1.0.0")]
+            namespace Lib; public class Thing;
+            """);
+
+        var report = await Build(OptionsFor(project));
+
+        report.ExitCode.Should().Be(1);
+        report.Activity.Messages.Select(m => m.Message)
+            .Should().Contain(m => m.Contains("CS0579", StringComparison.Ordinal));
+    }
+
+    // ── the rest of what GenerateAssemblyInfo writes ───────────────────────────────────────────
+
+    /// <summary>
+    /// <c>Description</c> is set on nearly every project in these repos and was silently absent
+    /// from everything this builder emitted. So were <c>Company</c>, <c>Product</c> and
+    /// <c>Title</c>, whose defaults come off <c>$(AssemblyName)</c> through <c>$(Authors)</c>.
+    /// </summary>
+    [Fact]
+    public async Task TheDescriptiveAttributesAreEmittedWithTheSdksOwnFallbackChain()
+    {
+        var project = Library("""
+                <Description>A seam under test.</Description>
+                <Authors>Systemorph</Authors>
+            """);
+
+        var (_, path) = await Emit(OptionsFor(project));
+
+        AttributeValue(path, "System.Reflection.AssemblyDescriptionAttribute").Should().Be("A seam under test.");
+        AttributeValue(path, "System.Reflection.AssemblyCompanyAttribute").Should().Be("Systemorph");
+        AttributeValue(path, "System.Reflection.AssemblyProductAttribute").Should().Be("Lib");
+        AttributeValue(path, "System.Reflection.AssemblyTitleAttribute").Should().Be("Lib");
+        AttributeValue(path, "System.Reflection.AssemblyConfigurationAttribute").Should().Be("Release");
+    }
+
+    /// <summary>
+    /// An individual <c>Generate…Attribute</c> switch turns one attribute off, exactly as under the
+    /// SDK — the mechanism a project uses when it declares that attribute itself.
+    /// </summary>
+    [Fact]
+    public async Task AGenerateAttributeSwitchSuppressesJustThatOneAttribute()
+    {
+        var project = Library("""
+                <Description>Present.</Description>
+                <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+            """);
+
+        var (name, path) = await Emit(OptionsFor(project));
+
+        AttributeValue(path, "System.Reflection.AssemblyDescriptionAttribute").Should().BeNull();
+        name.Version.Should().Be(new Version(1, 0, 0, 0), "the other attributes are untouched");
+    }
+
+    /// <summary>
+    /// <c>InternalsVisibleTo</c> items — which sixty-odd projects across these repos declare — were
+    /// on this evaluator's "changes nothing" list. That was true of the COMPILE and false of the
+    /// ASSEMBLY: dropped here, the friend project fails to compile in a later, unrelated run.
+    /// </summary>
+    [Fact]
+    public async Task InternalsVisibleToItemsBecomeAttributesOnTheEmittedAssembly()
+    {
+        var project = Write("Lib/Lib.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+              <ItemGroup>
+                <InternalsVisibleTo Include="Lib.Test" />
+                <AssemblyMetadata Include="CommitHash" Value="deadbeef" />
+              </ItemGroup>
+            </Project>
+            """);
+        Write("Lib/Thing.cs", "namespace Lib; public class Thing;");
+
+        var (_, path) = await Emit(OptionsFor(project));
+
+        var attributes = AssemblyAttributes(path);
+        attributes
+            .Where(a => a.TypeName == "System.Runtime.CompilerServices.InternalsVisibleToAttribute")
+            .Select(a => a.Arguments[0])
+            .Should().Equal("Lib.Test");
+        attributes
+            .Where(a => a.TypeName == "System.Reflection.AssemblyMetadataAttribute")
+            .Select(a => (a.Arguments[0], a.Arguments[1]))
+            .Should().Contain(("CommitHash", "deadbeef"));
+    }
+
+    /// <summary>
+    /// A raw <c>&lt;AssemblyAttribute&gt;</c> item — how the platform's own
+    /// <c>Directory.Build.props</c> stamps its commit hash — carries its <c>_ParameterN</c>
+    /// metadata through in order.
+    /// </summary>
+    [Fact]
+    public async Task AnAssemblyAttributeItemCarriesItsParametersThrough()
+    {
+        var project = Write("Lib/Lib.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup><TargetFramework>net10.0</TargetFramework></PropertyGroup>
+              <ItemGroup>
+                <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+                  <_Parameter1>MeshWeaverFrameworkIdentity</_Parameter1>
+                  <_Parameter2>gabc123</_Parameter2>
+                </AssemblyAttribute>
+              </ItemGroup>
+            </Project>
+            """);
+        Write("Lib/Thing.cs", "namespace Lib; public class Thing;");
+
+        var (_, path) = await Emit(OptionsFor(project));
+
+        AssemblyAttributes(path)
+            .Where(a => a.TypeName == "System.Reflection.AssemblyMetadataAttribute")
+            .Select(a => (a.Arguments[0], a.Arguments[1]))
+            .Should().Contain(("MeshWeaverFrameworkIdentity", "gabc123"));
+    }
+
+    /// <summary>
+    /// A value carrying a quote, a backslash and a newline has to survive as ONE literal — these
+    /// repos' <c>Description</c> properties carry all three, and naive concatenation would either
+    /// fail to parse or, worse, parse into something else.
+    /// </summary>
+    [Fact]
+    public async Task AnAwkwardStringSurvivesAsExactlyItself()
+    {
+        var project = Library("""
+                <Description>He said "hi" \ then stopped.</Description>
+            """);
+
+        var (_, path) = await Emit(OptionsFor(project));
+
+        AttributeValue(path, "System.Reflection.AssemblyDescriptionAttribute")
+            .Should().Be("He said \"hi\" \\ then stopped.");
+    }
+
+    // ── SourceRevisionId: the one semantic this builder cannot compute for itself ──────────────
+
+    /// <summary>
+    /// The SDK's <c>AddSourceRevisionToInformationalVersion</c> appends the git commit under
+    /// SemVer 2.0 rules. This builder runs no git, so the id arrives as a property — and when it
+    /// does, the append is the SDK's, including the '.' rather than '+' when the string already
+    /// carries build metadata.
+    /// </summary>
+    [Theory]
+    [InlineData("1.2.3", "1.2.3+abc123")]
+    [InlineData("1.2.3+meta", "1.2.3+meta.abc123")]
+    public async Task ASuppliedSourceRevisionIdIsAppendedTheWaySemVerRequires(
+        string version, string expected)
+    {
+        var project = Library($"    <Version>{version}</Version>");
+        var options = OptionsFor(project) with
+        {
+            Properties = new Dictionary<string, string> { ["SourceRevisionId"] = "abc123" },
+        };
+
+        var (_, path) = await Emit(options);
+
+        AttributeValue(path, "System.Reflection.AssemblyInformationalVersionAttribute").Should().Be(expected);
+    }
+
+    /// <summary>
+    /// …and with none supplied the divergence is SAID rather than hidden: the log names the
+    /// property, because an InformationalVersion quietly missing its <c>+&lt;sha&gt;</c> suffix is
+    /// exactly the plausible-looking difference this file exists to refuse.
+    /// </summary>
+    [Fact]
+    public async Task WithNoSourceRevisionIdTheAbsentSuffixIsNamedInTheLog()
+    {
+        var project = Library("    <Version>1.2.3</Version>");
+
+        var report = await Build(OptionsFor(project));
+
+        report.ExitCode.Should().Be(0);
+        report.Activity.Messages.Select(m => m.Message)
+            .Should().Contain(m => m.Contains("SourceRevisionId", StringComparison.Ordinal));
+    }
+
+    /// <summary>
+    /// A global property beats the project file, exactly as MSBuild's <c>-p:</c> does — the escape
+    /// hatch a pack lane uses to stamp the platform's version onto a module.
+    /// </summary>
+    [Fact]
+    public async Task AGlobalPropertyOverridesTheProjectsOwnAssemblyVersion()
+    {
+        var project = Library("    <AssemblyVersion>1.1.1.1</AssemblyVersion>");
+        var options = OptionsFor(project) with
+        {
+            Properties = new Dictionary<string, string> { ["AssemblyVersion"] = "3.0.0.0" },
+        };
+
+        var (name, _) = await Emit(options);
+
+        name.Version.Should().Be(new Version(3, 0, 0, 0));
+    }
+}

--- a/test/MeshWeaver.PluginTester.Test/ProjectFileTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ProjectFileTest.cs
@@ -304,8 +304,17 @@ public class ProjectFileTest : IDisposable
             .Which.Message.Should().Contain("Choose");
     }
 
+    /// <summary>
+    /// An <c>&lt;EmbeddedResource&gt;</c> is EMBEDDED now, under the manifest name the SDK would
+    /// have given it — this used to be a named refusal, and the refusal is gone because the naming
+    /// rules were established by measurement rather than left to a guess
+    /// (<see cref="ManifestResourceNames"/>, <c>EmbeddedResourceTest</c>).
+    ///
+    /// <para>The blanket <c>--accept embedded-resource</c> survives as the escape hatch, and it now
+    /// SAYS what it dropped instead of leaving an assembly quietly short of a resource.</para>
+    /// </summary>
     [Fact]
-    public void AnEmbeddedResourceFailsUntilAcknowledged_BecauseTheAssemblyWouldDiffer()
+    public void AnEmbeddedResourceIsResolvedToItsSdkManifestName_AndTheBlanketAcceptStillSkipsItLoudly()
     {
         var project = Write("App/App.csproj", """
             <Project Sdk="Microsoft.NET.Sdk">
@@ -316,11 +325,17 @@ public class ProjectFileTest : IDisposable
         Write("App/One.cs", "class One;");
         Write("App/Data.txt", "payload");
 
-        Action act = () => ProjectFile.Load(project);
-        act.Should().Throw<ProjectFile.UnsupportedConstructException>()
-            .Which.Message.Should().Contain("embedded-resource");
+        var model = ProjectFile.Load(project);
+        model.CompileItems.Should().HaveCount(1);
+        // RootNamespace defaults to the PROJECT name, and a root-level file has no directory part.
+        model.EmbeddedResources.Should().ContainSingle()
+            .Which.ManifestName.Should().Be("App.Data.txt");
+        model.SkippedResources.Should().BeEmpty();
 
-        ProjectFile.Load(project, [ProjectFile.Accept.EmbeddedResource]).CompileItems.Should().HaveCount(1);
+        var skipped = ProjectFile.Load(project, [ProjectFile.Accept.EmbeddedResource]);
+        skipped.CompileItems.Should().HaveCount(1);
+        skipped.EmbeddedResources.Should().BeEmpty();
+        skipped.SkippedResources.Should().ContainSingle().Which.Should().Contain("Data.txt");
     }
 
     // ── references ─────────────────────────────────────────────────────────────────────────────

--- a/tools/MeshWeaver.PluginTester/ManifestResourceNames.cs
+++ b/tools/MeshWeaver.PluginTester/ManifestResourceNames.cs
@@ -1,0 +1,283 @@
+using System.Globalization;
+using System.Text;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// The SDK's manifest-resource NAMING rules, reproduced — the part of
+/// <c>&lt;EmbeddedResource&gt;</c> support that fails SILENTLY when it is wrong.
+///
+/// <para>🚨 <b>Why this is its own file, and why every rule in it was MEASURED.</b> A wrong
+/// manifest name does not fail a build, a test or a review. The assembly compiles, ships, loads,
+/// and <c>Assembly.GetManifestResourceStream(name)</c> returns <c>null</c> at run time in some
+/// other process — which is the exact failure shape
+/// <c>MeshWeaver.Messaging.Hub</c>'s <c>Localization/strings.*.json</c> comment in core already
+/// records ("the build succeeds, the main assembly carries ZERO manifest resources, every lookup
+/// falls through to the key-fallback path, and the UI renders raw <c>chat.new</c> tokens").
+/// So none of the rules below are recalled: each was established by building a probe project with
+/// the real .NET SDK and reading <c>ManifestResourceTable</c> back out of the emitted PE. Where a
+/// rule could not be established that way, the construct is REFUSED by name in
+/// <see cref="ProjectFile"/> rather than guessed here.</para>
+///
+/// <para><b>The pipeline the SDK actually runs</b>, which this file follows step for step:
+/// <c>AssignTargetPath</c> gives every <c>EmbeddedResource</c> a <c>%(TargetPath)</c>
+/// (Microsoft.Common.CurrentVersion.targets says so out loud: <i>"AssignTargetPath generates
+/// TargetPath metadata that is consumed by CreateManifestResourceNames target for manifest name
+/// generation"</i>), <c>AssignCulture</c> splits the culture-carrying items off towards SATELLITE
+/// assemblies, and <c>CreateCSharpManifestResourceName</c> turns the surviving
+/// <c>%(TargetPath)</c> into <c>$(RootNamespace).&lt;mangled directory&gt;.&lt;file name&gt;</c>.</para>
+/// </summary>
+public static class ManifestResourceNames
+{
+    /// <summary>
+    /// The <c>%(TargetPath)</c> the SDK's <c>AssignTargetPath</c> task would assign — the path the
+    /// manifest name is computed FROM, which is not necessarily where the file is.
+    ///
+    /// <para>Measured, in this order (probe projects p4/p9/p10):</para>
+    /// <list type="number">
+    ///   <item><description>An explicit <c>%(TargetPath)</c> wins outright — even over
+    ///   <c>%(Link)</c> (<c>TargetPath="a-b\c.md" Link="ignored\me.md"</c> → <c>RA.a_b.c.md</c>).</description></item>
+    ///   <item><description>Otherwise <c>%(Link)</c>, even for a file that is INSIDE the project
+    ///   (<c>Include="inner\F.md" Link="re\named\G.md"</c> → <c>R9.re.named.G.md</c>).</description></item>
+    ///   <item><description>Otherwise the item spec, when it is relative and does not climb out.</description></item>
+    ///   <item><description>Otherwise the path relative to the project directory — and if THAT still
+    ///   climbs out, the bare file name. This is why <c>Include="..\shared\Shared.md"</c> with no
+    ///   <c>Link</c> lands at <c>ProjNameDiffers.Shared.md</c> with its directory gone entirely,
+    ///   rather than at anything containing <c>shared</c>.</description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="projectDirectory">The project's own directory (MSBuild's <c>RootFolder</c>).</param>
+    /// <param name="itemSpec">The item spec as evaluated — relative to the project directory, or absolute.</param>
+    /// <param name="fullPath">The resolved absolute path of the file.</param>
+    /// <param name="link">The <c>%(Link)</c> metadata, if any.</param>
+    /// <param name="targetPath">The <c>%(TargetPath)</c> metadata, if any.</param>
+    /// <returns>The target path, using the platform separator.</returns>
+    public static string TargetPathFor(
+        string projectDirectory, string itemSpec, string fullPath, string? link, string? targetPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(projectDirectory);
+        ArgumentException.ThrowIfNullOrWhiteSpace(itemSpec);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fullPath);
+
+        var assigned = Normalise(targetPath);
+        if (assigned.Length == 0)
+            assigned = Normalise(link);
+
+        if (assigned.Length > 0 && !ClimbsOut(assigned))
+            return assigned;
+
+        var spec = Normalise(itemSpec);
+        if (!ClimbsOut(spec))
+            return spec;
+
+        var relative = Path.GetRelativePath(projectDirectory, fullPath);
+        return ClimbsOut(relative) ? Path.GetFileName(fullPath) : relative;
+
+        static string Normalise(string? value) =>
+            (value ?? string.Empty).Trim()
+                .Replace('\\', Path.DirectorySeparatorChar)
+                .Replace('/', Path.DirectorySeparatorChar);
+
+        // MSBuild's own test: rooted, or starting with "..". Both mean "this does not describe a
+        // location inside the project", which is what sends it down the relative-then-filename path.
+        static bool ClimbsOut(string path) =>
+            path.Length == 0 || Path.IsPathRooted(path) || path.StartsWith("..", StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The manifest name for a resource at <paramref name="targetPath"/> —
+    /// <c>$(RootNamespace).&lt;mangled directory&gt;.&lt;file name VERBATIM&gt;</c>.
+    ///
+    /// <para>🚨 <b>The directory is mangled and the FILE NAME is not.</b> Measured:
+    /// <c>Data\with-dash\Three.md</c> → <c>…Data.with_dash.Three.md</c>, while
+    /// <c>Weird-File.Name.md</c> in the project root keeps its hyphen →
+    /// <c>…Weird-File.Name.md</c>. Nothing about that is guessable, and getting it backwards
+    /// produces a name that looks entirely plausible.</para>
+    ///
+    /// <para>An EMPTY <paramref name="rootNamespace"/> means no prefix at all — measured with
+    /// <c>&lt;RootNamespace&gt;&lt;/RootNamespace&gt;</c>, which produced bare <c>d.In.md</c>.</para>
+    ///
+    /// <para><b>On <c>.resources</c> / <c>.resx</c>.</b> The SDK takes a different branch for those
+    /// three extensions — strip the extension, dot the separators, re-append <c>.resources</c> — but
+    /// it mangles the directory in that branch too (measured: <c>rx\r-dir\S.resx</c> →
+    /// <c>R.rx.r_dir.S.resources</c>), so for an input already named <c>*.resources</c> the branch is
+    /// arithmetically identical to this one and needs no special case. <c>.resx</c>/<c>.restext</c>
+    /// are refused in <see cref="ProjectFile"/> because their CONTENT needs resgen, not because of
+    /// their name.</para>
+    /// </summary>
+    /// <param name="rootNamespace">The project's <c>$(RootNamespace)</c>; may be empty.</param>
+    /// <param name="targetPath">The target path from <see cref="TargetPathFor"/>.</param>
+    /// <returns>The manifest resource name.</returns>
+    public static string Compute(string rootNamespace, string targetPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
+        var name = new StringBuilder();
+        if (!string.IsNullOrEmpty(rootNamespace))
+            name.Append(rootNamespace).Append('.');
+        var directory = Path.GetDirectoryName(targetPath);
+        if (!string.IsNullOrEmpty(directory))
+            name.Append(MakeValidEverettIdentifier(directory)).Append('.');
+        name.Append(Path.GetFileName(targetPath));
+        return name.ToString();
+    }
+
+    /// <summary>
+    /// A directory path as an "Everett identifier" — each path segment made into an identifier,
+    /// the separators becoming dots. Named after the algorithm's own name inside MSBuild
+    /// (<c>MakeValidEverettIdentifier</c>), so a reader can find the original.
+    ///
+    /// <para>Every branch below was measured against the real SDK (probe p2):
+    /// <c>a-b</c>→<c>a_b</c>, <c>9x</c>→<c>_9x</c>, <c>Dot.9Dir</c>→<c>Dot._9Dir</c>,
+    /// <c>--</c>→<c>__</c>, <c>_</c>→<c>__</c>, <c>ü-dir</c>→<c>ü_dir</c>,
+    /// <c>x y.z-w</c>→<c>x_y.z_w</c>, <c>deep/a-b/9c</c>→<c>deep.a_b._9c</c>.</para>
+    /// </summary>
+    /// <param name="directoryPath">A relative directory path.</param>
+    /// <returns>The dotted, mangled form.</returns>
+    public static string MakeValidEverettIdentifier(string directoryPath)
+    {
+        if (string.IsNullOrEmpty(directoryPath))
+            return string.Empty;
+        var segments = directoryPath.Split('/', '\\');
+        var identifier = new StringBuilder(directoryPath.Length);
+        for (var i = 0; i < segments.Length; i++)
+        {
+            if (i > 0)
+                identifier.Append('.');
+            identifier.Append(MakeValidEverettFolderIdentifier(segments[i]));
+        }
+        return identifier.ToString();
+    }
+
+    /// <summary>
+    /// One path segment. It is itself split on <c>'.'</c> — which is why a directory literally
+    /// called <c>Dot.Dir</c> survives as <c>Dot.Dir</c> rather than becoming <c>Dot_Dir</c> — and a
+    /// segment that reduces to a single underscore is DOUBLED. That last rule is not decoration: a
+    /// project with sibling directories <c>--</c> and <c>_</c> fails the real SDK build with
+    /// <c>CS1508: Resource identifier 'R.__.F.md' has already been used</c>, which is how it was
+    /// measured.
+    /// </summary>
+    /// <param name="segment">One directory name.</param>
+    /// <returns>The mangled segment.</returns>
+    internal static string MakeValidEverettFolderIdentifier(string segment)
+    {
+        if (string.IsNullOrEmpty(segment))
+            return string.Empty;
+        var parts = segment.Split('.');
+        var folder = new StringBuilder(segment.Length);
+        for (var i = 0; i < parts.Length; i++)
+        {
+            if (i > 0)
+                folder.Append('.');
+            AppendSubFolderIdentifier(folder, parts[i]);
+        }
+        var result = folder.ToString();
+        return result == "_" ? "__" : result;
+    }
+
+    private static void AppendSubFolderIdentifier(StringBuilder builder, string part)
+    {
+        if (part.Length == 0)
+            return;
+        // The FIRST character carries a stricter test than the rest: a digit is a legal identifier
+        // character but not a legal first one, so it is PREFIXED with an underscore rather than
+        // replaced by one (9x → _9x, never _x).
+        if (IsValidFirstChar(part[0]))
+            builder.Append(part[0]);
+        else if (IsValidChar(part[0]))
+            builder.Append('_').Append(part[0]);
+        else
+            builder.Append('_');
+
+        for (var i = 1; i < part.Length; i++)
+            builder.Append(IsValidChar(part[i]) ? part[i] : '_');
+    }
+
+    private static bool IsValidFirstChar(char c) =>
+        char.IsLetter(c) || CharUnicodeInfo.GetUnicodeCategory(c) == UnicodeCategory.ConnectorPunctuation;
+
+    private static bool IsValidChar(char c) =>
+        char.IsLetterOrDigit(c) || CharUnicodeInfo.GetUnicodeCategory(c) is
+            UnicodeCategory.ConnectorPunctuation
+            or UnicodeCategory.NonSpacingMark
+            or UnicodeCategory.SpacingCombiningMark
+            or UnicodeCategory.EnclosingMark;
+
+    /// <summary>
+    /// 🚨 <b>The culture in the file NAME, which routes a resource into a SATELLITE ASSEMBLY and
+    /// out of the main one.</b>
+    ///
+    /// <para>Measured (probes p1/p12): <c>Culture\Foo.de.md</c> and <c>Culture\Foo.de-DE.md</c> are
+    /// NOT in the emitted assembly at all — they become <c>de/…resources.dll</c> and
+    /// <c>de-DE/…resources.dll</c> beside it — while <c>Foo.zz.md</c> and
+    /// <c>Foo.notaculture.md</c> stay put. <b>An explicit <c>LogicalName</c> does not rescue
+    /// one</b>: <c>strings.de.json</c> with <c>LogicalName="Pinned.strings.de.json"</c> still went
+    /// to the satellite. Only <c>WithCulture="false"</c> keeps it in the main assembly — which is
+    /// exactly what core's <c>MeshWeaver.Messaging.Hub.csproj</c> already does, and why.</para>
+    ///
+    /// <para>This builder emits ONE assembly, so a satellite-bound resource cannot be reproduced
+    /// and is refused by name in <see cref="ProjectFile"/>. The detection therefore only has to be
+    /// conservative in one direction, and it uses the same primitive MSBuild's
+    /// <c>CultureInfoCache.IsValidCultureString</c> uses on .NET —
+    /// <c>CultureInfo.GetCultureInfo(name, predefinedOnly: true)</c> — so <c>de</c> and
+    /// <c>de-DE</c> answer yes while <c>zz</c> and <c>notaculture</c> answer no, exactly as
+    /// measured.</para>
+    /// </summary>
+    /// <param name="targetPath">The target path from <see cref="TargetPathFor"/>.</param>
+    /// <returns>The culture name, or null when the file carries none.</returns>
+    public static string? CultureOf(string targetPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(targetPath);
+        var withoutExtension = Path.GetFileNameWithoutExtension(targetPath);
+        var candidate = Path.GetExtension(withoutExtension);
+        if (candidate.Length <= 1)
+            return null;
+        candidate = candidate[1..];
+        return IsValidCultureString(candidate) ? candidate : null;
+    }
+
+    /// <summary>
+    /// Whether <paramref name="name"/> names a culture the runtime knows — the exact test
+    /// MSBuild applies.
+    /// </summary>
+    /// <param name="name">A candidate culture name, e.g. <c>de-DE</c>.</param>
+    /// <returns>True when the runtime has a predefined culture by that name.</returns>
+    public static bool IsValidCultureString(string name)
+    {
+        if (string.IsNullOrEmpty(name))
+            return false;
+        try
+        {
+            CultureInfo.GetCultureInfo(name, predefinedOnly: true);
+            return true;
+        }
+        catch (CultureNotFoundException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// 🚨 <b>Whether this process can decide the culture question at all.</b>
+    ///
+    /// <para>Under <c>InvariantGlobalization</c> the runtime has NO predefined cultures, so
+    /// <see cref="IsValidCultureString"/> answers "no" to everything — including <c>de</c> — and a
+    /// culture-carrying resource would sail through as an ordinary one under a name the SDK never
+    /// produces. That is the silent failure this whole file exists to prevent, arriving through the
+    /// back door of the container's own configuration rather than through a rule.</para>
+    ///
+    /// <para>So the capability is PROBED rather than assumed, and <see cref="ProjectFile"/> refuses
+    /// any dotted-basename resource outright when the answer is no. A false refusal is an
+    /// inconvenience; a resource embedded under a name nothing will ever ask for is a defect that
+    /// surfaces in another repo, months later.</para>
+    /// </summary>
+    public static bool CanDecideCulture { get; } = IsValidCultureString("de") && IsValidCultureString("de-DE");
+
+    /// <summary>
+    /// Whether a file name carries a second extension at all — the only thing that can possibly be
+    /// a culture. Used for the conservative refusal when <see cref="CanDecideCulture"/> is false.
+    /// </summary>
+    /// <param name="targetPath">The target path.</param>
+    /// <returns>True when the base name itself has an extension.</returns>
+    public static bool HasDottedBaseName(string targetPath) =>
+        Path.GetExtension(Path.GetFileNameWithoutExtension(targetPath)).Length > 1;
+}

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -176,12 +176,27 @@ static async Task<int> RunBuildProject(string[] args)
     var generatorPaths = new List<string>();
     string? razorGenerators = null;
     var accept = new List<string>();
+    var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     var allowWarnings = false;
     var maxParallel = Math.Max(1, Environment.ProcessorCount);
     for (var i = 0; i < args.Length; i++)
     {
+        // MSBuild's -p:Name=Value, in both its spellings. It is how the caller supplies the
+        // identity inputs this builder cannot compute — SourceRevisionId above all, which the SDK
+        // reads from git and this builder has no git to read.
+        if (args[i].StartsWith("-p:", StringComparison.Ordinal)
+            || args[i].StartsWith("/p:", StringComparison.Ordinal))
+        {
+            if (!TryAddProperty(properties, args[i][3..]))
+                return 2;
+            continue;
+        }
         switch (args[i])
         {
+            case "--property" when i + 1 < args.Length:
+                if (!TryAddProperty(properties, args[++i]))
+                    return 2;
+                break;
             case "--output" or "-o" when i + 1 < args.Length:
                 outDir = args[++i];
                 break;
@@ -251,16 +266,32 @@ static async Task<int> RunBuildProject(string[] args)
         GeneratorPaths = generatorPaths,
         RazorGeneratorDirectory = razorGenerators,
         Accept = accept,
+        Properties = properties,
         AllowWarnings = allowWarnings,
         MaxParallel = maxParallel,
     }).Await(CancellationToken.None);
     return projectReport.ExitCode;
 }
 
+// A global property, as `Name=Value`. An unparseable one is a refusal rather than a silent
+// omission: a property that does not arrive changes the assembly this builder emits.
+static bool TryAddProperty(Dictionary<string, string> properties, string assignment)
+{
+    var split = assignment.IndexOf('=', StringComparison.Ordinal);
+    if (split <= 0)
+    {
+        Console.Error.WriteLine(
+            $"mw-plugin-test build-project: '{assignment}' is not a property assignment — write Name=Value.");
+        return false;
+    }
+    properties[assignment[..split]] = assignment[(split + 1)..];
+    return true;
+}
+
 static string BuildProjectUsage() =>
     "usage: mw-plugin-test build-project <csproj|dir> [--output <dir>] [--app <dir>] "
     + "[--extra-refs <dir>]... [--generators <dir|dll>]... [--razor-generators <dir>] "
-    + "[--accept <construct>]... [--allow-warnings] [--max-parallel <n>]\n"
+    + "[--accept <construct>]... [-p:Name=Value]... [--allow-warnings] [--max-parallel <n>]\n"
     + "  Compiles a .NET project with NO dotnet SDK and NO NuGet restore: the .csproj is evaluated "
     + "without MSBuild, every reference is resolved from this container's /app (and its .deps.json), "
     + "ProjectReferences inside the source root are built first in dependency order, and Roslyn runs "
@@ -269,7 +300,10 @@ static string BuildProjectUsage() =>
     + "run by name; --accept <construct> acknowledges one. .razor/.cshtml are compiled by the Razor "
     + "source generator the image ships in razor-generators/ beside this builder; --razor-generators "
     + "<dir> names another copy, and a project with Razor files and no generator FAILS rather than "
-    + "quietly emitting an assembly with no components in it.";
+    + "quietly emitting an assembly with no components in it. The emitted assembly carries the "
+    + "identity GenerateAssemblyInfo would have given it (AssemblyVersion/FileVersion/"
+    + "InformationalVersion and the rest); -p:Name=Value supplies the properties it is derived "
+    + "from, SourceRevisionId included — this builder runs no git.";
 
 static string BuildUsage() =>
     "usage: mw-plugin-test build <repo-root> [<package>... | all] [--module <dll>]... [--out <dir>] "

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -37,6 +37,29 @@ namespace MeshWeaver.PluginTester;
 /// and a builder that cannot see them is not reproducing the build the SDK would have produced.
 /// Warnings fail the run by default; <c>--allow-warnings</c> is the deliberate opt-out.</para>
 ///
+/// <para>🔴 <b>The emitted assembly carries the SDK's IDENTITY.</b> <c>GenerateAssemblyInfo</c> is a
+/// TARGET, and this builder runs no targets — so before <see cref="ProjectFile.AssemblyInfo"/>
+/// existed every assembly it produced was <c>AssemblyVersion=0.0.0.0</c> while the fleet binds
+/// <c>3.0.0.0</c>. Nothing went red: the compile was green and the failure would have surfaced in
+/// another repo, at runtime, as a missing-file error. The identity is now EVALUATED from the
+/// project (<c>AssemblyVersion</c>/<c>FileVersion</c>/<c>Version</c>/<c>InformationalVersion</c>
+/// and the descriptive attributes, plus <c>InternalsVisibleTo</c>, <c>AssemblyMetadata</c> and
+/// <c>AssemblyAttribute</c> items) and synthesized into the compilation as one more source
+/// document, exactly as the SDK's generated <c>&lt;Project&gt;.AssemblyInfo.cs</c> is one more
+/// Compile item.</para>
+///
+/// <para><b>Two things it deliberately does not reproduce, both named rather than hidden.</b>
+/// (1) <c>$(SourceRevisionId)</c>: the SDK reads the commit from git and appends <c>+&lt;sha&gt;</c>
+/// to <c>InformationalVersion</c>; there is no git here, so the suffix is absent and every build
+/// SAYS so — pass <c>-p:SourceRevisionId=&lt;sha&gt;</c> for exact parity.
+/// (2) <c>TargetFrameworkAttribute</c>: written by a DIFFERENT target
+/// (<c>GenerateTargetFrameworkMonikerAttribute</c>), with its own switches and its own
+/// <c>TargetPlatform</c>/<c>SupportedOSPlatform</c> companions for a platform-suffixed TFM that
+/// this evaluator cannot compute. Emitting half of that set would be worse than the gap, so the gap
+/// is written down here instead. Everything else was compared attribute-for-attribute against a
+/// real <c>dotnet build</c> of <c>MeshWeaver.Plugins/src/MeshWeaver.Speech.Contract</c> and
+/// matches.</para>
+///
 /// <para><b>Reactive.</b> The graph is sequenced by <see cref="Cascade"/> — the same dependency
 /// cascade <c>mw-plugin-test build</c> runs on: every project observes its dependencies' result
 /// streams and starts when the last one lands green, a cycle is refused by name before anything
@@ -71,6 +94,15 @@ public static class ProjectBuild
 
         /// <summary>The <c>--accept</c> tokens acknowledging constructs the evaluator cannot reproduce.</summary>
         public IReadOnlyList<string> Accept { get; init; } = [];
+
+        /// <summary>
+        /// Global properties — MSBuild's <c>-p:Name=Value</c>. They win over anything the project
+        /// files set unconditionally, and they are how a caller supplies the identity inputs this
+        /// builder cannot compute for itself: <c>PlatformVersion</c>, <c>Version</c>, and above all
+        /// <c>SourceRevisionId</c> (the SDK gets it from git; there is no git here).
+        /// </summary>
+        public IReadOnlyDictionary<string, string> Properties { get; init; } =
+            ImmutableDictionary<string, string>.Empty;
 
         /// <summary>
         /// Assemblies (or directories of them) to load Roslyn <c>[Generator]</c> source generators
@@ -381,7 +413,7 @@ public static class ProjectBuild
             {
                 var current = pending.Pop();
                 if (models.ContainsKey(current)) continue;
-                var model = ProjectFile.Load(current, options.Accept);
+                var model = ProjectFile.Load(current, options.Accept, options.Properties);
                 models[current] = model;
                 foreach (var target in model.UnexecutedTargets)
                     sink.Warn($"{Path.GetFileName(current)}: target not executed — {target}");
@@ -522,13 +554,45 @@ public static class ProjectBuild
                 .Concat(ProjectFile.FrameworkSymbols(model.TargetFramework))
                 .Distinct(StringComparer.Ordinal));
 
-        var trees = ImmutableArray.CreateBuilder<SyntaxTree>(model.CompileItems.Length + 1);
+        var trees = ImmutableArray.CreateBuilder<SyntaxTree>(model.CompileItems.Length + 2);
         if (!model.GlobalUsings.IsEmpty)
             trees.Add(CSharpSyntaxTree.ParseText(
                 SourceText.From(
                     string.Join('\n', model.GlobalUsings.Select(u => $"global using global::{u};")) + "\n",
                     Encoding.UTF8),
                 parseOptions, path: GlobalUsingsPath));
+
+        // 🔴 THE ASSEMBLY'S IDENTITY. Without this tree Roslyn emits its own default — 0.0.0.0 —
+        // and NOTHING goes red: the compile is green, the DLL loads, and the failure arrives later
+        // in a different process as `FileNotFoundException: … Version=3.0.0.0`. Synthesized here
+        // rather than in ProjectFile because it is a compile INPUT, exactly as the SDK's generated
+        // <Project>.AssemblyInfo.cs is a Compile item.
+        var assemblyInfo = model.AssemblyInfo;
+        if (assemblyInfo.Generate && !assemblyInfo.Attributes.IsEmpty)
+        {
+            trees.Add(CSharpSyntaxTree.ParseText(
+                SourceText.From(RenderAssemblyInfo(assemblyInfo.Attributes), Encoding.UTF8),
+                parseOptions, path: AssemblyInfoPath));
+            sink.Info(
+                $"[{name}] assembly identity — AssemblyVersion {assemblyInfo.AssemblyVersion}, "
+                + $"FileVersion {assemblyInfo.FileVersion}, "
+                + $"InformationalVersion {assemblyInfo.InformationalVersion}"
+                + (assemblyInfo.SourceRevisionApplied
+                    ? string.Empty
+                    : " (no SourceRevisionId: this builder runs no git, so the SDK's +<sha> suffix on "
+                      + "InformationalVersion is absent — pass --property SourceRevisionId=<sha> to "
+                      + "reproduce it)"));
+        }
+        else if (!assemblyInfo.Generate)
+        {
+            // GenerateAssemblyInfo=false means the project supplies its own attributes; synthesizing
+            // a second set is CS0579, so this is a deliberate no-op — said out loud, because an
+            // assembly with no identity attributes at all is otherwise indistinguishable from this
+            // builder having forgotten them.
+            sink.Info(
+                $"[{name}] GenerateAssemblyInfo=false — no identity attributes synthesized; the "
+                + "project's own sources supply them.");
+        }
         foreach (var file in model.CompileItems)
         {
             try
@@ -746,6 +810,31 @@ public static class ProjectBuild
     /// <summary>Sentinel path for the synthesized implicit-usings document.</summary>
     internal const string GlobalUsingsPath = "__implicit_usings__.cs";
 
+    /// <summary>Sentinel path for the synthesized assembly-info document.</summary>
+    internal const string AssemblyInfoPath = "__assembly_info__.cs";
+
+    /// <summary>
+    /// The generated <c>&lt;Project&gt;.AssemblyInfo.cs</c>, as the SDK's <c>WriteCodeFragment</c>
+    /// task writes it: one fully-qualified <c>[assembly: …]</c> per attribute, arguments as C#
+    /// string literals.
+    /// </summary>
+    /// <param name="attributes">What <c>GetAssemblyAttributes</c> collected.</param>
+    /// <returns>The source text.</returns>
+    internal static string RenderAssemblyInfo(ImmutableArray<ProjectFile.AssemblyAttributeSpec> attributes)
+    {
+        var text = new StringBuilder("// <auto-generated/> — the SDK's GenerateAssemblyInfo, without MSBuild.\n");
+        foreach (var attribute in attributes)
+        {
+            text.Append("[assembly: global::").Append(attribute.TypeName).Append('(');
+            // 🚨 FormatLiteral, never string concatenation. A Description carrying a quote, a
+            // backslash or a newline — and these repos' Description properties carry all three —
+            // would otherwise produce source that does not parse, or worse, parses differently.
+            text.AppendJoin(", ", attribute.Arguments.Select(a => SymbolDisplay.FormatLiteral(a, quote: true)));
+            text.Append(")]\n");
+        }
+        return text.ToString();
+    }
+
     /// <summary>
     /// The doc-COMPLETENESS warning family — the one csc raises only when <c>/doc</c> is on. Kept
     /// as a named list beside the compile so the distinction from doc-QUALITY is legible rather
@@ -779,7 +868,12 @@ public static class ProjectBuild
         if (!location.IsInSource)
             return $"{diagnostic.Id} {diagnostic.Severity}: {diagnostic.GetMessage()}";
         var span = location.GetLineSpan();
-        var file = span.Path == GlobalUsingsPath ? "(implicit usings)" : span.Path;
+        var file = span.Path switch
+        {
+            GlobalUsingsPath => "(implicit usings)",
+            AssemblyInfoPath => "(generated assembly info)",
+            _ => span.Path,
+        };
         return $"{file}({span.StartLinePosition.Line + 1},{span.StartLinePosition.Character + 1}): "
                + $"{diagnostic.Severity.ToString().ToLowerInvariant()} {diagnostic.Id}: {diagnostic.GetMessage()}";
     }

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -140,6 +140,16 @@ public static class ProjectBuild
         /// </summary>
         public int RazorCount { get; init; }
 
+        /// <summary>
+        /// How many managed resources were embedded in the emitted assembly.
+        ///
+        /// <para>🚨 An <c>init</c> PROPERTY, not a primary-constructor parameter — adding a
+        /// parameter REPLACES the record's signature, and every assembly compiled against the old
+        /// arity would call a constructor that no longer exists
+        /// (<c>scripts/check-record-signatures.py</c>).</para>
+        /// </summary>
+        public int ResourceCount { get; init; }
+
         /// <summary>Compiled, emitted, and within the warning policy.</summary>
         public bool IsGreen => Failure is null && AssemblyPath is not null;
     }
@@ -433,6 +443,23 @@ public static class ProjectBuild
                   + $"nullable {model.NullableOptions}, "
                   + $"warnings-as-errors {(model.TreatWarningsAsErrors ? "on" : "off")}");
 
+        // 🚨 Say the NAMES, not the count. A manifest resource is asked for BY NAME in some other
+        // process, months later, and a wrong name is a null stream rather than an error — so the
+        // names this build committed to belong in the log, where a reader can compare them against
+        // what the code asks for. Capped: MeshWeaver.Documentation embeds hundreds.
+        if (!model.EmbeddedResources.IsEmpty)
+        {
+            sink.Info($"[{name}] embedded resources: {model.EmbeddedResources.Length}");
+            foreach (var resource in model.EmbeddedResources.Take(MaxListedResources))
+                sink.Info($"[{name}]   {resource.ManifestName}  ({resource.Origin})");
+            if (model.EmbeddedResources.Length > MaxListedResources)
+                sink.Info($"[{name}]   … and {model.EmbeddedResources.Length - MaxListedResources} more");
+        }
+        // A resource the operator ACCEPTED away is still missing from the assembly, so it is a
+        // WARNING every time — never a footnote on the accept token.
+        foreach (var skipped in model.SkippedResources)
+            sink.Warn($"[{name}] resource NOT embedded — {skipped}");
+
         // Packages: the container is authoritative for what the container HAS. Anything it does not
         // have is an ADDITIONAL library, and this mode cannot invent one.
         var unresolved = ImmutableArray.CreateBuilder<string>();
@@ -663,7 +690,8 @@ public static class ProjectBuild
             // The platform's own verified emit: emit to memory, write, and prove the file on disk IS
             // the image that was emitted (EmittedArtifact). Nothing here re-implements it.
             var artifact = EmitPipeline.EmitCompilationToDirectory(
-                compilation, model.AssemblyName, model.ProjectPath, outputDirectory, CancellationToken.None);
+                compilation, model.AssemblyName, model.ProjectPath, outputDirectory,
+                ManifestResources(model), CancellationToken.None);
             if (!artifact.MatchesFileOnDisk(out var reason))
             {
                 sink.Error($"[{name}] RED — the emitted assembly did not survive the write: {reason}");
@@ -674,11 +702,15 @@ public static class ProjectBuild
             sink.Info(
                 $"[{name}] OK — {model.CompileItems.Length} source file(s)"
                 + (razorGenerated == 0 ? "" : $" + {model.RazorItems.Length} Razor file(s)")
+                + (model.EmbeddedResources.IsEmpty ? "" : $" + {model.EmbeddedResources.Length} resource(s)")
                 + $", {warnings} warning(s), "
                 + $"{artifact.Length} bytes in {clock.Elapsed.TotalMilliseconds:F0} ms → {artifact.DllPath}");
             return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
                 model.CompileItems.Length, 0, warnings, artifact.DllPath, [], null)
-            { RazorCount = razorGenerated };
+            {
+                RazorCount = razorGenerated,
+                ResourceCount = model.EmbeddedResources.Length,
+            };
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {
@@ -687,6 +719,29 @@ public static class ProjectBuild
                 model.CompileItems.Length, 1, warnings, null, [], $"{ex.GetType().Name}: {ex.Message}");
         }
     }
+
+    /// <summary>
+    /// The project's <c>&lt;EmbeddedResource&gt;</c> items as Roslyn resource descriptions.
+    ///
+    /// <para>🚨 <c>isPublic: true</c>, and it is not a preference. Every resource the real SDK
+    /// emits carries <c>ManifestResourceAttributes.Public</c> — measured by reading the
+    /// <c>ManifestResource</c> table out of a probe assembly the SDK built. A private resource is
+    /// invisible to <c>Assembly.GetManifestResourceStream</c> from outside the assembly, which is
+    /// the same silent null the manifest NAME rules exist to prevent.</para>
+    ///
+    /// <para>The stream is opened lazily, by Roslyn, during the emit — so a file that vanishes
+    /// between evaluation and emit fails the emit rather than embedding zero bytes.</para>
+    /// </summary>
+    /// <param name="model">The evaluated project.</param>
+    /// <returns>One description per resource, in declaration order.</returns>
+    private static ImmutableArray<ResourceDescription> ManifestResources(ProjectFile.Model model) =>
+    [
+        .. model.EmbeddedResources.Select(resource => new ResourceDescription(
+            resource.ManifestName, () => File.OpenRead(resource.Path), isPublic: true)),
+    ];
+
+    /// <summary>How many resource names a build lists before it counts the rest instead.</summary>
+    internal const int MaxListedResources = 25;
 
     /// <summary>Sentinel path for the synthesized implicit-usings document.</summary>
     internal const string GlobalUsingsPath = "__implicit_usings__.cs";
@@ -700,7 +755,7 @@ public static class ProjectBuild
         ["CS1591", "CS1573", "CS1712"];
 
     /// <summary>
-    /// <see cref="EmitPipeline.EmitCompilationToDirectory"/> names the XML doc for a dynamic NodeType
+    /// <see cref="EmitPipeline"/>'s emit names the XML doc for a dynamic NodeType
     /// (<c>DynamicNode_&lt;name&gt;.xml</c>). A project's doc file is <c>&lt;AssemblyName&gt;.xml</c>
     /// beside the DLL, and a project that did not ask for one gets none.
     /// </summary>

--- a/tools/MeshWeaver.PluginTester/ProjectFile.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectFile.cs
@@ -53,6 +53,25 @@ public static class ProjectFile
     /// <param name="IsComponent">True for <c>.razor</c>, false for <c>.cshtml</c>.</param>
     public sealed record RazorItem(string Path, string TargetPath, bool IsComponent);
 
+    /// <summary>
+    /// One <c>&lt;EmbeddedResource&gt;</c>, resolved to the file on disk AND to the manifest name
+    /// the SDK would have given it.
+    ///
+    /// <para>🚨 The NAME is the whole point. Embedding the right bytes under the wrong name is a
+    /// green build that ships an assembly whose <c>GetManifestResourceStream</c> returns
+    /// <c>null</c> — see <see cref="ManifestResourceNames"/> for how each naming rule was
+    /// measured.</para>
+    /// </summary>
+    /// <param name="Path">Absolute path of the file to embed.</param>
+    /// <param name="ManifestName">The manifest resource name, as the SDK computes it.</param>
+    /// <param name="TargetPath">The <c>%(TargetPath)</c> the name was computed from, for diagnosis
+    /// — it is not always the file's location (a <c>Link</c> changes it, and a file outside the
+    /// project loses its directory entirely).</param>
+    /// <param name="Origin">Why the name is what it is — <c>path</c> or <c>LogicalName</c> — so a
+    /// build log can be read without re-deriving the rule.</param>
+    public sealed record EmbeddedResourceItem(
+        string Path, string ManifestName, string TargetPath, string Origin);
+
     /// <summary>The evaluated project.</summary>
     /// <param name="ProjectPath">Absolute path of the <c>.csproj</c>.</param>
     /// <param name="Sdk">The <c>Sdk</c> attribute, verbatim.</param>
@@ -119,6 +138,26 @@ public static class ProjectFile
         /// <summary>The <c>SupportLocalizedComponentNames</c> setting.</summary>
         public bool SupportLocalizedComponentNames { get; init; }
 
+        /// <summary>
+        /// Every <c>&lt;EmbeddedResource&gt;</c> to embed, in declaration order, each already
+        /// carrying the manifest name the SDK would have produced.
+        ///
+        /// <para>🚨 An <c>init</c> PROPERTY, not a primary-constructor parameter. Adding a
+        /// parameter — even a defaulted one — REPLACES the record's constructor signature, which
+        /// <c>scripts/check-record-signatures.py</c> refuses for exactly the right reason: every
+        /// assembly compiled against the old arity calls a constructor that no longer exists.
+        /// Defaulted to empty so a model built without it is still safe to enumerate (a default
+        /// <see cref="ImmutableArray{T}"/> throws).</para>
+        /// </summary>
+        public ImmutableArray<EmbeddedResourceItem> EmbeddedResources { get; init; } = [];
+
+        /// <summary>
+        /// Resources the evaluator deliberately did NOT embed because the operator accepted the
+        /// construct that made them unreproducible — one line each, so a build log says what is
+        /// missing from the assembly rather than leaving it to be discovered at run time.
+        /// </summary>
+        public ImmutableArray<string> SkippedResources { get; init; } = [];
+
         /// <summary>The project's own directory.</summary>
         public string Directory => Path.GetDirectoryName(ProjectPath)!;
     }
@@ -133,8 +172,67 @@ public static class ProjectFile
         /// <c>target:&lt;Name&gt;</c> accepts one target; <c>targets</c> accepts all of them.</summary>
         public const string AllTargets = "targets";
 
-        /// <summary>Acknowledge that <c>EmbeddedResource</c> items are not embedded.</summary>
+        /// <summary>
+        /// Acknowledge that <c>EmbeddedResource</c> items are not embedded AT ALL — the escape
+        /// hatch, and the meaning this token has always had. It is no longer needed for an ordinary
+        /// project (resources are embedded now, under the SDK's own names), and passing it produces
+        /// an assembly that is deliberately NOT the one the SDK would have produced, so every
+        /// skipped resource is listed in the build output rather than silently dropped.
+        /// </summary>
         public const string EmbeddedResource = "embedded-resource";
+
+        /// <summary>
+        /// Acknowledge that <c>.resx</c> / <c>.restext</c> resources are SKIPPED. Their manifest
+        /// name is reproducible; their CONTENT is not — a <c>.resx</c> is XML that
+        /// <c>GenerateResource</c> (resgen) turns into a binary <c>.resources</c> stream, including
+        /// typed and file-reference entries, and this builder runs no MSBuild tasks. Embedding the
+        /// XML under the <c>.resources</c> name would produce an assembly whose
+        /// <c>ResourceManager</c> throws at run time.
+        /// </summary>
+        public const string ResxResource = "embedded-resource:resx";
+
+        /// <summary>
+        /// Acknowledge that a resource whose file name carries a CULTURE is skipped. The SDK routes
+        /// it into a SATELLITE assembly (<c>de/Foo.resources.dll</c>) and out of the main one, and
+        /// this builder emits a single assembly. <c>WithCulture="false"</c> on the item is the
+        /// project-side fix and needs no acceptance — it is what core's
+        /// <c>MeshWeaver.Messaging.Hub</c> already does for its <c>strings.de.json</c>.
+        /// </summary>
+        public const string CultureResource = "embedded-resource:culture";
+
+        /// <summary>
+        /// Acknowledge that a resource carrying <c>%(DependentUpon)</c> is skipped. Its manifest
+        /// name is not derived from its path at all but from the first CLASS declared in the file
+        /// it depends on, fully qualified — and MSBuild extracts that with a hand-rolled C#
+        /// tokenizer whose behaviour is quirky enough that reproducing it from anything other than
+        /// its own source would be a guess (measured: it skips <c>struct</c>, <c>interface</c> and
+        /// <c>enum</c> but takes <c>record</c>, and drops generic arity).
+        /// </summary>
+        public const string DependentUponResource = "embedded-resource:dependent-upon";
+
+        /// <summary>
+        /// Acknowledge that a resource carrying <c>%(ManifestResourceName)</c> is skipped. That
+        /// metadata makes the SDK SKIP its own naming task, which is also what would have set
+        /// <c>%(LogicalName)</c> — so csc receives no logical name and falls back to the bare file
+        /// name, meaning the metadata does not do what it appears to do (measured:
+        /// <c>ManifestResourceName="I.Win.Outright"</c> produced <c>Direct.md</c>). Reproducing an
+        /// SDK quirk is not fidelity; use <c>LogicalName</c>.
+        /// </summary>
+        public const string ManifestResourceNameMetadata = "embedded-resource:manifest-resource-name";
+
+        /// <summary>
+        /// Acknowledge that a resource which is the BUILD'S OWN OUTPUT is skipped — an
+        /// <c>&lt;EmbeddedResource Include="bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml"&gt;</c>,
+        /// which is how <c>MeshWeaver.Northwind.Domain</c> embeds its own XML documentation.
+        ///
+        /// <para>Measured: the real SDK builds that from a CLEAN tree, because csc writes
+        /// <c>/doc:</c> and reads <c>/resource:</c> in ONE invocation. This builder emits the doc
+        /// file into its own output directory — never back into a <c>bin/</c> inside a read-only
+        /// source mount — so the file the item names cannot exist, and the resource is genuinely
+        /// absent rather than merely late. Skipped by name instead of failing the whole project,
+        /// because unlike a missing INPUT this one is not a broken project.</para>
+        /// </summary>
+        public const string BuildOutputResource = "embedded-resource:build-output";
 
         /// <summary>Acknowledge a <c>Condition</c> expression outside the supported grammar,
         /// treating it as FALSE. <c>condition:&lt;text&gt;</c> accepts one.</summary>
@@ -241,6 +339,40 @@ public static class ProjectFile
 
     // ── evaluation ─────────────────────────────────────────────────────────────────────────────
 
+    /// <summary>Which of MSBuild's three item verbs a declaration used.</summary>
+    private enum ResourceVerb
+    {
+        /// <summary>Adds items.</summary>
+        Include,
+
+        /// <summary>Removes items already added.</summary>
+        Remove,
+
+        /// <summary>Attaches metadata to items already added, adding none.</summary>
+        Update,
+    }
+
+    /// <summary>One <c>&lt;EmbeddedResource&gt;</c> element, verbatim, awaiting replay.</summary>
+    /// <param name="Verb">Include / Remove / Update.</param>
+    /// <param name="Patterns">The semicolon-split specs of the verb's attribute.</param>
+    /// <param name="Excludes">The <c>Exclude</c> specs (Include only).</param>
+    /// <param name="Metadata">Metadata from attributes and child elements.</param>
+    /// <param name="File">The file the element came from, for the refusal message.</param>
+    private sealed record ResourceDeclaration(
+        ResourceVerb Verb,
+        ImmutableArray<string> Patterns,
+        ImmutableArray<string> Excludes,
+        ImmutableDictionary<string, string> Metadata,
+        string File);
+
+    /// <summary>A resource item mid-evaluation, before its manifest name is settled.</summary>
+    private sealed record PendingResource(string ItemSpec, string FullPath, string DeclaredIn)
+    {
+        /// <summary>Metadata accumulated from the Include and every later Update.</summary>
+        public ImmutableDictionary<string, string> Metadata { get; init; } =
+            ImmutableDictionary<string, string>.Empty;
+    }
+
     private sealed class EvaluationState(
         string projectPath, IReadOnlyCollection<string> accepted, IReadOnlyDictionary<string, string> globals)
     {
@@ -249,6 +381,11 @@ public static class ProjectFile
         private readonly List<string> _compileRemoves = [];
         private readonly List<string> _razorIncludes = [];
         private readonly List<string> _razorRemoves = [];
+        // EmbeddedResource is order-sensitive in a way Compile is not: an Update that arrives before
+        // its Include attaches nothing, and a Remove only removes what is already there. So the
+        // declarations are kept as an ORDERED LOG and replayed in ToModel, rather than being
+        // flattened into three unrelated lists.
+        private readonly List<ResourceDeclaration> _resourceDeclarations = [];
         private readonly List<string> _projectReferences = [];
         private readonly List<(string Id, string? Version)> _packageReferences = [];
         private readonly List<string> _usings = [];
@@ -297,6 +434,19 @@ public static class ProjectFile
             // $(Configuration) reads the same value the emit uses.
             _properties["Configuration"] = "Release";
             _properties["Platform"] = "AnyCPU";
+            // 🚨 The SDK's own conditional defaults, verbatim from
+            // Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.Sdk.props:
+            //     <AssemblyName Condition=" '$(AssemblyName)' == '' ">$(MSBuildProjectName)</AssemblyName>
+            //     <RootNamespace Condition=" '$(RootNamespace)' == '' ">$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+            // Seeded rather than resolved at the end, because a project READS them: MeshWeaver's own
+            // MeshWeaver.Northwind.Domain writes <DocumentationFile>bin\$(Configuration)\
+            // $(TargetFramework)\$(AssemblyName).xml</DocumentationFile> and embeds that same path,
+            // and with $(AssemblyName) expanding to the empty string the item pointed at a file
+            // called ".xml" that exists nowhere. RootNamespace joins it because it now PREFIXES
+            // every manifest resource name, where an empty value is a silently wrong name rather
+            // than a broken path.
+            _properties["AssemblyName"] = Path.GetFileNameWithoutExtension(projectPath);
+            _properties["RootNamespace"] = Path.GetFileNameWithoutExtension(projectPath).Replace(" ", "_");
             // 🚨 THE SDK'S OWN DEFAULT NoWarn, and it is not cosmetic. Microsoft.NET.Sdk seeds
             // `1701;1702` for every C# project — the assembly-binding advisories ("assuming
             // assembly reference X matches Y, you may need a supplemental binding redirect"). A
@@ -476,14 +626,20 @@ public static class ProjectFile
                     break;
 
                 case "EmbeddedResource":
-                    if (remove.Length > 0 || update.Length > 0) break;
-                    if (include.Length == 0) break;
-                    if (!IsAccepted(Accept.EmbeddedResource))
-                        throw new UnsupportedConstructException(
-                            $"{file}: <EmbeddedResource Include=\"{include}\"> — this builder emits no "
-                            + "managed resources, so the assembly it produces would differ from the "
-                            + $"SDK's. Re-run with --accept {Accept.EmbeddedResource} to build without them.");
+                {
+                    var exclude = Expand((string?)item.Attribute("Exclude") ?? string.Empty, file);
+                    var metadata = ReadMetadata(item, file);
+                    if (remove.Length > 0)
+                        _resourceDeclarations.Add(new ResourceDeclaration(
+                            ResourceVerb.Remove, [.. Split(remove)], [], metadata, file));
+                    else if (update.Length > 0)
+                        _resourceDeclarations.Add(new ResourceDeclaration(
+                            ResourceVerb.Update, [.. Split(update)], [], metadata, file));
+                    else if (include.Length > 0)
+                        _resourceDeclarations.Add(new ResourceDeclaration(
+                            ResourceVerb.Include, [.. Split(include)], [.. Split(exclude)], metadata, file));
                     break;
+                }
 
                 case "Reference":
                     // A raw <Reference Include="path/*.dll"> is how Directory.PlatformRefs.targets
@@ -532,6 +688,296 @@ public static class ProjectFile
             }
         }
 
+        /// <summary>
+        /// An item's metadata, from BOTH forms MSBuild accepts — attributes on the element and
+        /// child elements — because the repos this builder serves use both in the same file
+        /// (<c>MeshWeaver.Messaging.Hub</c> writes <c>LogicalName="…"</c> as an attribute,
+        /// <c>MeshWeaver.Northwind.Domain</c> writes <c>&lt;LogicalName&gt;…&lt;/LogicalName&gt;</c>
+        /// as a child). Reading only one of them would drop a name that pins the whole contract.
+        /// </summary>
+        private ImmutableDictionary<string, string> ReadMetadata(XElement item, string file)
+        {
+            var metadata = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var attribute in item.Attributes())
+            {
+                var name = attribute.Name.LocalName;
+                if (name is "Include" or "Exclude" or "Remove" or "Update" or "Condition" or "Label")
+                    continue;
+                metadata[name] = Expand(attribute.Value, file);
+            }
+            foreach (var child in item.Elements())
+            {
+                if (!ConditionHolds(child, file))
+                    continue;
+                metadata[child.Name.LocalName] = Expand(child.Value, file);
+            }
+            return metadata.ToImmutable();
+        }
+
+        /// <summary>
+        /// Replays the <c>&lt;EmbeddedResource&gt;</c> declarations in order and settles every
+        /// manifest name — the one part of this evaluator whose mistakes are invisible, so every
+        /// construct it cannot reproduce EXACTLY leaves by a named refusal rather than a plausible
+        /// name. See <see cref="ManifestResourceNames"/> for how each rule was measured.
+        /// </summary>
+        private (ImmutableArray<EmbeddedResourceItem> Items, ImmutableArray<string> Skipped) ResolveEmbeddedResources(
+            string rootNamespace)
+        {
+            var skipEverything = IsAccepted(Accept.EmbeddedResource);
+            var pending = new List<PendingResource>();
+            var byPath = new Dictionary<string, PendingResource>(StringComparer.OrdinalIgnoreCase);
+            var skippedBuildOutputs = new List<string>();
+
+            // The SDK's own default item, verbatim from Microsoft.NET.Sdk.DefaultItems.props:
+            //   <EmbeddedResource Include="**/*.resx" Exclude="$(DefaultItemExcludes);…" />
+            // Reproduced rather than skipped BECAUSE .resx is refused: a project with a stray .resx
+            // that nobody declared must fail by name, not build without a resource the SDK embeds.
+            if (!IsFalse(Prop("EnableDefaultItems")) && !IsFalse(Prop("EnableDefaultEmbeddedResourceItems")))
+                foreach (var file in DefaultGlob("*.resx"))
+                    Add(file, Path.GetRelativePath(ProjectDirectory, file), "(SDK default items)",
+                        ImmutableDictionary<string, string>.Empty);
+
+            foreach (var declaration in _resourceDeclarations)
+            {
+                switch (declaration.Verb)
+                {
+                    case ResourceVerb.Include:
+                    {
+                        var excluded = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        foreach (var pattern in declaration.Excludes)
+                            foreach (var match in ExpandGlob(pattern))
+                                excluded.Add(match);
+                        foreach (var pattern in declaration.Patterns)
+                        {
+                            var matched = 0;
+                            foreach (var match in ExpandGlob(pattern).OrderBy(p => p, StringComparer.Ordinal))
+                            {
+                                matched++;
+                                if (excluded.Contains(match))
+                                    continue;
+                                Add(match, SpecFor(pattern, match), declaration.File, declaration.Metadata);
+                            }
+                            // 🚨 A LITERAL include of a file that is not there is csc's CS1566
+                            // ("Error reading resource … Could not find"), which fails the SDK build.
+                            // A GLOB that matches nothing is legal and matches nothing, so only the
+                            // literal form is an error — measured both ways.
+                            if (matched == 0 && !pattern.Contains('*') && !pattern.Contains('?'))
+                                MissingLiteral(pattern, declaration.File, skippedBuildOutputs);
+                        }
+                        break;
+                    }
+
+                    case ResourceVerb.Remove:
+                        foreach (var pattern in declaration.Patterns)
+                            foreach (var match in ExpandGlob(pattern))
+                                if (byPath.Remove(match, out var gone))
+                                    pending.Remove(gone);
+                        break;
+
+                    case ResourceVerb.Update:
+                        foreach (var pattern in declaration.Patterns)
+                            foreach (var match in ExpandGlob(pattern))
+                                if (byPath.TryGetValue(match, out var existing))
+                                {
+                                    // MSBuild's Update MERGES metadata onto the item; it never adds one.
+                                    var merged = existing with
+                                    {
+                                        Metadata = existing.Metadata.SetItems(declaration.Metadata),
+                                    };
+                                    byPath[match] = merged;
+                                    pending[pending.IndexOf(existing)] = merged;
+                                }
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+
+            var items = ImmutableArray.CreateBuilder<EmbeddedResourceItem>(pending.Count);
+            var skipped = ImmutableArray.CreateBuilder<string>();
+            skipped.AddRange(skippedBuildOutputs);
+            var claimed = new Dictionary<string, string>(StringComparer.Ordinal);
+            foreach (var resource in pending)
+            {
+                var relative = Path.GetRelativePath(ProjectDirectory, resource.FullPath);
+                if (skipEverything)
+                {
+                    skipped.Add($"{relative} (--accept {Accept.EmbeddedResource})");
+                    continue;
+                }
+
+                var targetPath = ManifestResourceNames.TargetPathFor(
+                    ProjectDirectory, resource.ItemSpec, resource.FullPath,
+                    resource.Metadata.GetValueOrDefault("Link"),
+                    resource.Metadata.GetValueOrDefault("TargetPath"));
+
+                if (Refuse(resource, relative, targetPath) is { } reason)
+                {
+                    skipped.Add(reason);
+                    continue;
+                }
+
+                var logicalName = resource.Metadata.GetValueOrDefault("LogicalName", string.Empty);
+                var origin = logicalName.Length > 0 ? "LogicalName" : "path";
+                var manifestName = logicalName.Length > 0
+                    ? logicalName
+                    : ManifestResourceNames.Compute(rootNamespace, targetPath);
+
+                // csc raises CS1508 for this; naming BOTH files beats naming the collision, because
+                // the two declarations are usually in different ItemGroups (measured: sibling
+                // directories `--` and `_` both mangle to `__`, which nothing about either name
+                // suggests).
+                if (claimed.TryGetValue(manifestName, out var first))
+                    throw new UnsupportedConstructException(
+                        $"{projectPath}: two embedded resources both claim the manifest name "
+                        + $"'{manifestName}' — '{first}' and '{relative}'. csc refuses this with "
+                        + "CS1508. Give one of them an explicit LogicalName.");
+                claimed[manifestName] = relative;
+                items.Add(new EmbeddedResourceItem(resource.FullPath, manifestName, targetPath, origin));
+            }
+
+            return (items.ToImmutable(), skipped.ToImmutable());
+
+            void Add(string fullPath, string itemSpec, string declaredIn, ImmutableDictionary<string, string> metadata)
+            {
+                if (byPath.TryGetValue(fullPath, out var existing))
+                {
+                    // MSBuild would carry two items and csc would raise CS1508 on the duplicate
+                    // name; the SDK pre-empts that with NETSDK1022 when its own default glob is the
+                    // second one. Either way it is an error, and merging is the wrong answer — so
+                    // the later metadata wins and the duplicate NAME check downstream still fires.
+                    var merged = existing with { Metadata = existing.Metadata.SetItems(metadata) };
+                    byPath[fullPath] = merged;
+                    pending[pending.IndexOf(existing)] = merged;
+                    return;
+                }
+                var item = new PendingResource(itemSpec, fullPath, declaredIn) { Metadata = metadata };
+                byPath[fullPath] = item;
+                pending.Add(item);
+            }
+
+            // 🚨 Two kinds of "the file is not there", and conflating them turns a project the SDK
+            // builds GREEN into a red one.
+            //
+            //  * A missing INPUT is csc's CS1566 and a broken project — measured: `dotnet build` of
+            //    an <EmbeddedResource Include="does\not\exist.md"> fails.
+            //  * A missing BUILD OUTPUT is not. `Include="bin\$(Configuration)\$(TargetFramework)\
+            //    $(AssemblyName).xml"` — how MeshWeaver.Northwind.Domain embeds its own XML doc —
+            //    builds green from a CLEAN tree, because csc writes /doc: and reads /resource: in
+            //    ONE invocation. This builder emits its doc file into its own output directory
+            //    rather than back into a bin/ inside a read-only source mount, so that file cannot
+            //    exist here. Named and skippable, never a hard failure.
+            void MissingLiteral(string pattern, string file, List<string> buildOutputs)
+            {
+                var segments = pattern.Replace('\\', '/').Split('/');
+                if (segments.Any(s => s is "bin" or "obj"))
+                {
+                    if (!IsAccepted(Accept.BuildOutputResource))
+                        throw new UnsupportedConstructException(
+                            $"{file}: <EmbeddedResource Include=\"{pattern}\"> embeds the build's OWN OUTPUT. "
+                            + "The real SDK manages that from a clean tree because csc writes /doc: and reads "
+                            + "/resource: in one invocation; this builder emits its documentation file into "
+                            + "its own output directory, never back into a bin/ inside a read-only source "
+                            + $"mount, so the file cannot exist. Re-run with --accept {Accept.BuildOutputResource} "
+                            + "to build without it.");
+                    buildOutputs.Add($"{pattern} (--accept {Accept.BuildOutputResource})");
+                    return;
+                }
+                throw new UnsupportedConstructException(
+                    $"{file}: <EmbeddedResource Include=\"{pattern}\"> names a file that does not exist "
+                    + $"(looked in '{ProjectDirectory}'). csc fails this with CS1566 rather than embedding "
+                    + "nothing, and so does this builder — a resource silently missing from an assembly is "
+                    + "only discovered at run time, by whoever asks for it.");
+            }
+
+            // A glob's item spec is the matched path relative to the project; a literal include's is
+            // the spec as written, because that is what AssignTargetPath sees and its rooted/".."
+            // tests key on it.
+            string SpecFor(string pattern, string match) =>
+                pattern.Contains('*') || pattern.Contains('?')
+                    ? Path.GetRelativePath(ProjectDirectory, match)
+                    : pattern;
+        }
+
+        /// <summary>
+        /// The named refusals — every construct whose manifest name this builder cannot promise to
+        /// match. Returns the log line when the operator accepted it, and THROWS when they did not.
+        /// </summary>
+        private string? Refuse(PendingResource resource, string relative, string targetPath)
+        {
+            var extension = Path.GetExtension(targetPath);
+            if (extension.Equals(".resx", StringComparison.OrdinalIgnoreCase)
+                || extension.Equals(".restext", StringComparison.OrdinalIgnoreCase))
+                return Named(Accept.ResxResource,
+                    $"<EmbeddedResource> '{relative}' is a {extension} resource. Its manifest name is "
+                    + "reproducible, but its CONTENT is not: the SDK runs resgen (the GenerateResource "
+                    + "task) to turn that XML into the binary .resources stream a ResourceManager reads, "
+                    + "including typed and file-reference entries, and this builder runs no MSBuild "
+                    + "tasks. Embedding the XML under the .resources name would compile green and throw "
+                    + "at run time.");
+
+            if (resource.Metadata.ContainsKey("DependentUpon"))
+                return Named(Accept.DependentUponResource,
+                    $"<EmbeddedResource> '{relative}' carries DependentUpon="
+                    + $"'{resource.Metadata["DependentUpon"]}'. That does not adjust the name — it "
+                    + "REPLACES it with the first class declared in that file, fully qualified "
+                    + "(measured: a .md dependent on a file declaring Owner.Ns.Owner is embedded as "
+                    + "'Owner.Ns.Owner', extension and path gone). MSBuild extracts the class with its "
+                    + "own C# tokenizer, which skips struct/interface/enum, takes record, and drops "
+                    + "generic arity; reproducing that from anything but its source would be a guess.");
+
+            if (resource.Metadata.ContainsKey("ManifestResourceName"))
+                return Named(Accept.ManifestResourceNameMetadata,
+                    $"<EmbeddedResource> '{relative}' carries ManifestResourceName metadata. In the SDK "
+                    + "that metadata makes CreateManifestResourceNames SKIP the item — and that task is "
+                    + "also what sets %(LogicalName) — so csc receives no logical name and falls back to "
+                    + "the bare file name (measured: ManifestResourceName=\"I.Win.Outright\" produced "
+                    + "'Direct.md'). Reproducing an SDK quirk is not fidelity. Use LogicalName.");
+
+            var withCulture = resource.Metadata.GetValueOrDefault("WithCulture", string.Empty);
+            if (string.Equals(withCulture, "false", StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            if (resource.Metadata.TryGetValue("Culture", out var declaredCulture) && declaredCulture.Length > 0)
+                return Named(Accept.CultureResource,
+                    $"<EmbeddedResource> '{relative}' declares Culture='{declaredCulture}', which routes it "
+                    + $"into a SATELLITE assembly ({declaredCulture}/…resources.dll) and OUT of the main "
+                    + "one. This builder emits a single assembly. Add WithCulture=\"false\" to keep it in "
+                    + "the main assembly.");
+
+            if (!ManifestResourceNames.CanDecideCulture)
+                return ManifestResourceNames.HasDottedBaseName(targetPath)
+                    ? Named(Accept.CultureResource,
+                        $"<EmbeddedResource> '{relative}' has a second extension, and THIS PROCESS CANNOT TELL "
+                        + "whether it is a culture: the runtime reports no predefined culture even for 'de', "
+                        + "which means globalization is invariant here. A culture-carrying resource belongs in "
+                        + "a satellite assembly and must not be embedded in the main one, so it is refused "
+                        + "rather than guessed. Add WithCulture=\"false\" if the second extension is not a "
+                        + "culture.")
+                    : null;
+
+            if (ManifestResourceNames.CultureOf(targetPath) is { } culture)
+                return Named(Accept.CultureResource,
+                    $"<EmbeddedResource> '{relative}' carries the culture '{culture}' in its file name, so the "
+                    + $"SDK puts it in a SATELLITE assembly ({culture}/…resources.dll) and NOT in the main "
+                    + "one — an explicit LogicalName does NOT rescue it (measured). This builder emits a "
+                    + "single assembly. Add WithCulture=\"false\" to the item to keep it in the main "
+                    + "assembly, which is what core's MeshWeaver.Messaging.Hub already does for its "
+                    + "Localization/strings.*.json.");
+
+            return null;
+
+            string? Named(string token, string message)
+            {
+                if (!IsAccepted(token))
+                    throw new UnsupportedConstructException(
+                        $"{resource.DeclaredIn}: {message} Re-run with --accept {token} to build WITHOUT "
+                        + "this resource, knowing the assembly will not carry it.");
+                return $"{relative} (--accept {token})";
+            }
+        }
+
         private void ReadPackageVersions(string path)
         {
             var doc = LoadXml(path);
@@ -569,11 +1015,21 @@ public static class ProjectFile
             }
             globalUsings = globalUsings.AddRange(_usings).Distinct(StringComparer.Ordinal).ToImmutableArray();
 
+            // 🚨 $(RootNamespace) defaults to the PROJECT NAME, never to $(AssemblyName) — measured
+            // against the real SDK with a project whose two differ (ProjNameDiffers.csproj emitting
+            // DifferentAsmName.dll named its resources `ProjNameDiffers.*`). It used to fall back to
+            // the assembly name here, which was harmless while RootNamespace was informational and
+            // is not now that it PREFIXES every manifest resource name. The default itself is seeded
+            // in SeedWellKnown, exactly where the SDK's props set it, so a project that READS
+            // $(RootNamespace) or $(AssemblyName) sees the same value the SDK would give it.
+            var rootNamespace = Prop("RootNamespace");
+            var (resources, skippedResources) = ResolveEmbeddedResources(rootNamespace);
+
             return new Model(
                 projectPath,
                 sdk,
                 assemblyName,
-                Prop("RootNamespace") is { Length: > 0 } rn ? rn : assemblyName,
+                rootNamespace,
                 ParseOutputKind(Prop("OutputType")),
                 Prop("TargetFramework"),
                 ParseNullable(Prop("Nullable")),
@@ -598,6 +1054,8 @@ public static class ProjectFile
                 RazorLangVersion = Prop("RazorLangVersion") is { Length: > 0 } rlv ? rlv : DefaultRazorLangVersion,
                 RazorConfiguration = Prop("RazorConfiguration") is { Length: > 0 } rc ? rc : DefaultRazorConfiguration,
                 SupportLocalizedComponentNames = IsTrue(Prop("SupportLocalizedComponentNames")),
+                EmbeddedResources = resources,
+                SkippedResources = skippedResources,
             };
         }
 

--- a/tools/MeshWeaver.PluginTester/ProjectFile.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectFile.cs
@@ -123,7 +123,15 @@ public static class ProjectFile
         string FileVersion,
         string InformationalVersion,
         bool SourceRevisionApplied,
-        ImmutableArray<AssemblyAttributeSpec> Attributes);
+        ImmutableArray<AssemblyAttributeSpec> Attributes)
+    {
+        /// <summary>The identity of a model built without evaluating GenerateAssemblyInfo —
+        /// every field the "nothing was stamped" shape: no generation, empty versions, no
+        /// attributes. Exists so <see cref="Model.AssemblyInfo"/> can default to a VALID value
+        /// instead of null, keeping the property non-nullable.</summary>
+        public static readonly AssemblyInfo None =
+            new(false, "", "", "", "", false, []);
+    }
 
     /// <summary>The evaluated project.</summary>
     /// <param name="ProjectPath">Absolute path of the <c>.csproj</c>.</param>
@@ -147,8 +155,6 @@ public static class ProjectFile
     /// <param name="GlobalUsings">Namespaces the SDK would have emitted as <c>global using</c>.</param>
     /// <param name="Properties">Every evaluated property, for diagnosis.</param>
     /// <param name="UnexecutedTargets">Names of <c>Target</c> elements this evaluator did not run.</param>
-    /// <param name="AssemblyInfo">🔴 The assembly's identity — what <c>GenerateAssemblyInfo</c>
-    /// would have written. Omitting it emits <c>0.0.0.0</c>, which no compile can catch.</param>
     public sealed record Model(
         string ProjectPath,
         string Sdk,
@@ -170,8 +176,7 @@ public static class ProjectFile
         ImmutableArray<PackageRef> PackageReferences,
         ImmutableArray<string> GlobalUsings,
         ImmutableDictionary<string, string> Properties,
-        ImmutableArray<string> UnexecutedTargets,
-        AssemblyInfo AssemblyInfo)
+        ImmutableArray<string> UnexecutedTargets)
     {
         /// <summary>
         /// Every <c>.razor</c>/<c>.cshtml</c> the Razor SDK would compile, ordered.
@@ -213,6 +218,19 @@ public static class ProjectFile
         /// missing from the assembly rather than leaving it to be discovered at run time.
         /// </summary>
         public ImmutableArray<string> SkippedResources { get; init; } = [];
+
+        /// <summary>
+        /// 🔴 The assembly's identity — what <c>GenerateAssemblyInfo</c> would have stamped.
+        ///
+        /// <para>🚨 An <c>init</c> PROPERTY, not a primary-constructor parameter — the same rule
+        /// this record already documents for RazorItems and EmbeddedResources: adding a parameter,
+        /// even a defaulted one, REPLACES the constructor signature, and
+        /// <c>scripts/check-record-signatures.py</c> refuses that. The original #2855 commit added
+        /// this as a 22nd positional parameter; its green attested to a stale merge base where the
+        /// arity check compared against a tree that already had it. Defaulted to
+        /// <see cref="ProjectFile.AssemblyInfo.None"/> so a model built without it stays valid.</para>
+        /// </summary>
+        public AssemblyInfo AssemblyInfo { get; init; } = ProjectFile.AssemblyInfo.None;
 
         /// <summary>The project's own directory.</summary>
         public string Directory => Path.GetDirectoryName(ProjectPath)!;
@@ -1273,9 +1291,9 @@ public static class ProjectFile
                     .Select(p => new PackageRef(p.Id, p.Version ?? _packageVersions.GetValueOrDefault(p.Id)))],
                 globalUsings,
                 _properties.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
-                [.. _unexecutedTargets],
-                BuildAssemblyInfo(assemblyName))
+                [.. _unexecutedTargets])
             {
+                AssemblyInfo = BuildAssemblyInfo(assemblyName),
                 RazorItems = razorItems,
                 RazorLangVersion = Prop("RazorLangVersion") is { Length: > 0 } rlv ? rlv : DefaultRazorLangVersion,
                 RazorConfiguration = Prop("RazorConfiguration") is { Length: > 0 } rc ? rc : DefaultRazorConfiguration,

--- a/tools/MeshWeaver.PluginTester/ProjectFile.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectFile.cs
@@ -234,6 +234,30 @@ public static class ProjectFile
         /// </summary>
         public const string BuildOutputResource = "embedded-resource:build-output";
 
+        /// <summary>
+        /// Acknowledge that an <c>&lt;EmbeddedResource&gt;</c> GLOB reaching OUTSIDE the project
+        /// directory is not expanded.
+        ///
+        /// <para>🚨 This evaluator's glob expansion is rooted at the project directory, so a pattern
+        /// like <c>..\shared\**\*.md</c> matches NOTHING — and a glob matching nothing is legal, so
+        /// without this refusal the resources would simply not be there and no line of output would
+        /// say so. Measured: the real SDK expands that pattern and embeds two resources.</para>
+        /// </summary>
+        public const string OutsideGlobResource = "embedded-resource:outside-glob";
+
+        /// <summary>
+        /// Acknowledge that <c>%(LinkBase)</c> on an <c>&lt;EmbeddedResource&gt;</c> OUTSIDE the
+        /// project is not applied.
+        ///
+        /// <para>Measured: <c>LinkBase</c> synthesizes <c>%(Link)</c> as
+        /// <c>&lt;LinkBase&gt;\%(RecursiveDir)%(Filename)%(Extension)</c> for items outside the
+        /// project cone — <c>..\lb\nested\Deep.md</c> with <c>LinkBase="Based"</c> becomes
+        /// <c>R15.Based.nested.Deep.md</c> — and is IGNORED for items inside it
+        /// (<c>inside\deep\In.md</c> stayed <c>R15.inside.deep.In.md</c>). Only the outside case
+        /// changes a name, so only the outside case is refused.</para>
+        /// </summary>
+        public const string LinkBaseResource = "embedded-resource:link-base";
+
         /// <summary>Acknowledge a <c>Condition</c> expression outside the supported grammar,
         /// treating it as FALSE. <c>condition:&lt;text&gt;</c> accepts one.</summary>
         public const string AllConditions = "conditions";
@@ -749,6 +773,26 @@ public static class ProjectFile
                                 excluded.Add(match);
                         foreach (var pattern in declaration.Patterns)
                         {
+                            // 🚨 A glob that climbs OUT of the project directory expands to nothing
+                            // here — ExpandGlob enumerates from the project directory down — and a
+                            // glob matching nothing is legal, so the resources would be missing with
+                            // NOTHING in the output saying so. The real SDK expands it (measured:
+                            // `..\lb\**\*.md` embedded two resources), which is precisely why this
+                            // has to be a refusal rather than a quiet zero.
+                            if (ClimbsOutOfProject(pattern) && (pattern.Contains('*') || pattern.Contains('?')))
+                            {
+                                if (!IsAccepted(Accept.OutsideGlobResource))
+                                    throw new UnsupportedConstructException(
+                                        $"{declaration.File}: <EmbeddedResource Include=\"{pattern}\"> is a glob "
+                                        + "reaching outside the project directory. This evaluator expands globs "
+                                        + "from the project directory down, so it would match NOTHING and embed "
+                                        + "nothing — silently, because an empty glob is legal. Re-run with "
+                                        + $"--accept {Accept.OutsideGlobResource} to build without those "
+                                        + "resources, or list the files individually.");
+                                skippedBuildOutputs.Add($"{pattern} (--accept {Accept.OutsideGlobResource})");
+                                continue;
+                            }
+
                             var matched = 0;
                             foreach (var match in ExpandGlob(pattern).OrderBy(p => p, StringComparer.Ordinal))
                             {
@@ -868,6 +912,19 @@ public static class ProjectFile
             //    ONE invocation. This builder emits its doc file into its own output directory
             //    rather than back into a bin/ inside a read-only source mount, so that file cannot
             //    exist here. Named and skippable, never a hard failure.
+            // Whether a pattern names something the project directory does not contain.
+            bool ClimbsOutOfProject(string pattern)
+            {
+                var normalised = pattern.Replace('\\', Path.DirectorySeparatorChar)
+                                        .Replace('/', Path.DirectorySeparatorChar);
+                if (normalised.StartsWith("..", StringComparison.Ordinal))
+                    return true;
+                if (!Path.IsPathRooted(normalised))
+                    return false;
+                var relative = Path.GetRelativePath(ProjectDirectory, normalised);
+                return relative.StartsWith("..", StringComparison.Ordinal);
+            }
+
             void MissingLiteral(string pattern, string file, List<string> buildOutputs)
             {
                 var segments = pattern.Replace('\\', '/').Split('/');
@@ -927,6 +984,21 @@ public static class ProjectFile
                     + "own C# tokenizer, which skips struct/interface/enum, takes record, and drops "
                     + "generic arity; reproducing that from anything but its source would be a guess.");
 
+            // 🚨 LinkBase changes the name only for a file OUTSIDE the project — measured both ways:
+            // `..\lb\nested\Deep.md` with LinkBase="Based" became `R15.Based.nested.Deep.md`, while
+            // `inside\deep\In.md` with LinkBase="AlsoBased" stayed `R15.inside.deep.In.md`, the
+            // metadata ignored. So only the outside case is refused; refusing the inside one would
+            // be a false refusal on a no-op.
+            if (resource.Metadata.TryGetValue("LinkBase", out var linkBase) && linkBase.Length > 0
+                && Path.GetRelativePath(ProjectDirectory, resource.FullPath)
+                    .StartsWith("..", StringComparison.Ordinal))
+                return Named(Accept.LinkBaseResource,
+                    $"<EmbeddedResource> '{relative}' is outside the project and carries "
+                    + $"LinkBase='{linkBase}', which the SDK turns into a %(Link) of "
+                    + $"'{linkBase}\\%(RecursiveDir)%(Filename)%(Extension)' — so the manifest name is "
+                    + "built from a path this evaluator does not compute. Give the item an explicit "
+                    + "Link or LogicalName instead.");
+
             if (resource.Metadata.ContainsKey("ManifestResourceName"))
                 return Named(Accept.ManifestResourceNameMetadata,
                     $"<EmbeddedResource> '{relative}' carries ManifestResourceName metadata. In the SDK "
@@ -935,16 +1007,23 @@ public static class ProjectFile
                     + "the bare file name (measured: ManifestResourceName=\"I.Win.Outright\" produced "
                     + "'Direct.md'). Reproducing an SDK quirk is not fidelity. Use LogicalName.");
 
-            var withCulture = resource.Metadata.GetValueOrDefault("WithCulture", string.Empty);
-            if (string.Equals(withCulture, "false", StringComparison.OrdinalIgnoreCase))
-                return null;
-
+            // 🚨 ORDER. An EXPLICIT %(Culture) beats %(WithCulture)='false' — measured, and the two
+            // are easy to assume the other way round: `Include="A.md" Culture="fr" WithCulture="false"`
+            // still emitted a `fr/` SATELLITE and left the main assembly without the resource, while
+            // `Include="C.de.md" WithCulture="false"` kept it. So the declared culture is checked
+            // FIRST; putting the WithCulture escape hatch ahead of it embeds, under a name the SDK
+            // never produces, a resource the SDK does not put in this assembly at all.
             if (resource.Metadata.TryGetValue("Culture", out var declaredCulture) && declaredCulture.Length > 0)
                 return Named(Accept.CultureResource,
                     $"<EmbeddedResource> '{relative}' declares Culture='{declaredCulture}', which routes it "
                     + $"into a SATELLITE assembly ({declaredCulture}/…resources.dll) and OUT of the main "
-                    + "one. This builder emits a single assembly. Add WithCulture=\"false\" to keep it in "
-                    + "the main assembly.");
+                    + "one — and WithCulture=\"false\" does NOT override an explicitly declared culture "
+                    + "(measured). This builder emits a single assembly. Remove the Culture metadata to "
+                    + "keep the resource in the main assembly.");
+
+            var withCulture = resource.Metadata.GetValueOrDefault("WithCulture", string.Empty);
+            if (string.Equals(withCulture, "false", StringComparison.OrdinalIgnoreCase))
+                return null;
 
             if (!ManifestResourceNames.CanDecideCulture)
                 return ManifestResourceNames.HasDottedBaseName(targetPath)

--- a/tools/MeshWeaver.PluginTester/ProjectFile.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectFile.cs
@@ -72,6 +72,59 @@ public static class ProjectFile
     public sealed record EmbeddedResourceItem(
         string Path, string ManifestName, string TargetPath, string Origin);
 
+    /// <summary>
+    /// One assembly-level attribute the SDK's <c>GenerateAssemblyInfo</c> would have written into
+    /// <c>obj/&lt;Configuration&gt;/&lt;tfm&gt;/&lt;Project&gt;.AssemblyInfo.cs</c>. Every attribute
+    /// that target emits takes string arguments only, which is why they are modelled as strings.
+    /// </summary>
+    /// <param name="TypeName">The attribute's fully-qualified type name.</param>
+    /// <param name="Arguments">Positional constructor arguments, in order.</param>
+    public sealed record AssemblyAttributeSpec(string TypeName, ImmutableArray<string> Arguments);
+
+    /// <summary>
+    /// 🔴 <b>THE ASSEMBLY'S IDENTITY — the part of an SDK build that fails at RUNTIME BINDING, not
+    /// at compile time, when it is wrong.</b>
+    ///
+    /// <para>The SDK does not compile <c>&lt;AssemblyVersion&gt;</c> into anything by magic: the
+    /// <c>GenerateAssemblyInfo</c> target writes it as an <c>[assembly: AssemblyVersion("…")]</c>
+    /// attribute into a generated source file, and csc reads that file like any other. A builder
+    /// that runs NO MSBuild targets therefore emits Roslyn's default identity — <c>0.0.0.0</c> —
+    /// and nothing anywhere goes red: the compile is green, the DLL is well-formed, and the failure
+    /// surfaces later, in a different process, as
+    /// <c>FileNotFoundException: Could not load file or assembly '…, Version=3.0.0.0'</c>.</para>
+    ///
+    /// <para>That is not hypothetical. MeshWeaver.Plugins pins <c>&lt;AssemblyVersion&gt;3.0.0.0
+    /// &lt;/AssemblyVersion&gt;</c> in its <c>src/Directory.Build.props</c> precisely because
+    /// Systemorph/MeshWeaver#143 shipped 1.0.0.0 assemblies into a 3.0.0.0 process and
+    /// CrashLoopBackOff'd a migration. Building one of those projects through this builder without
+    /// this record produced <c>AssemblyVersion=0.0.0.0</c> — the same defect, one version number
+    /// further from the truth.</para>
+    /// </summary>
+    /// <param name="Generate">False when the project sets <c>GenerateAssemblyInfo=false</c> and
+    /// supplies its own attributes; synthesizing them anyway is CS0579.</param>
+    /// <param name="Version">The NuGet-shaped <c>$(Version)</c>, after the
+    /// <c>VersionPrefix</c>/<c>VersionSuffix</c> defaults.</param>
+    /// <param name="AssemblyVersion">The BINDING identity: the explicit
+    /// <c>$(AssemblyVersion)</c>, else the numeric core of <see cref="Version"/> padded to four
+    /// fields.</param>
+    /// <param name="FileVersion">The explicit <c>$(FileVersion)</c>, else
+    /// <see cref="AssemblyVersion"/> — never <see cref="Version"/>.</param>
+    /// <param name="InformationalVersion">The explicit <c>$(InformationalVersion)</c>, else
+    /// <see cref="Version"/>, with <c>$(SourceRevisionId)</c> appended under SemVer 2.0 rules when
+    /// one is known.</param>
+    /// <param name="SourceRevisionApplied">Whether a <c>$(SourceRevisionId)</c> was available to
+    /// append. False means the emitted <see cref="InformationalVersion"/> is the SDK's MINUS its
+    /// <c>+&lt;sha&gt;</c> suffix — see the remark on <see cref="Model.AssemblyInfo"/>.</param>
+    /// <param name="Attributes">Every attribute to synthesize, in the SDK's own order.</param>
+    public sealed record AssemblyInfo(
+        bool Generate,
+        string Version,
+        string AssemblyVersion,
+        string FileVersion,
+        string InformationalVersion,
+        bool SourceRevisionApplied,
+        ImmutableArray<AssemblyAttributeSpec> Attributes);
+
     /// <summary>The evaluated project.</summary>
     /// <param name="ProjectPath">Absolute path of the <c>.csproj</c>.</param>
     /// <param name="Sdk">The <c>Sdk</c> attribute, verbatim.</param>
@@ -94,6 +147,8 @@ public static class ProjectFile
     /// <param name="GlobalUsings">Namespaces the SDK would have emitted as <c>global using</c>.</param>
     /// <param name="Properties">Every evaluated property, for diagnosis.</param>
     /// <param name="UnexecutedTargets">Names of <c>Target</c> elements this evaluator did not run.</param>
+    /// <param name="AssemblyInfo">🔴 The assembly's identity — what <c>GenerateAssemblyInfo</c>
+    /// would have written. Omitting it emits <c>0.0.0.0</c>, which no compile can catch.</param>
     public sealed record Model(
         string ProjectPath,
         string Sdk,
@@ -115,7 +170,8 @@ public static class ProjectFile
         ImmutableArray<PackageRef> PackageReferences,
         ImmutableArray<string> GlobalUsings,
         ImmutableDictionary<string, string> Properties,
-        ImmutableArray<string> UnexecutedTargets)
+        ImmutableArray<string> UnexecutedTargets,
+        AssemblyInfo AssemblyInfo)
     {
         /// <summary>
         /// Every <c>.razor</c>/<c>.cshtml</c> the Razor SDK would compile, ordered.
@@ -414,8 +470,21 @@ public static class ProjectFile
         private readonly List<(string Id, string? Version)> _packageReferences = [];
         private readonly List<string> _usings = [];
         private readonly List<string> _unexecutedTargets = [];
+        // The three item types GenerateAssemblyInfo turns into assembly attributes. They used to be
+        // in this evaluator's "metadata that changes nothing" list, which was true of the COMPILE
+        // and false of the ASSEMBLY: an InternalsVisibleTo dropped here makes the friend assembly
+        // fail to compile in a later run, and an AssemblyMetadata dropped here makes the About page
+        // fall back — both without a word.
+        private readonly List<(string Name, string? Key)> _internalsVisibleTo = [];
+        private readonly List<(string Key, string Value)> _assemblyMetadata = [];
+        private readonly List<AssemblyAttributeSpec> _assemblyAttributes = [];
         private readonly Dictionary<string, string> _packageVersions = new(StringComparer.OrdinalIgnoreCase);
         private readonly HashSet<string> _imported = new(StringComparer.OrdinalIgnoreCase);
+        // 🚨 A GLOBAL PROPERTY IS IMMUTABLE, exactly as under MSBuild: a <PropertyGroup> cannot
+        // overwrite one, which is what makes `-p:Name=Value` an override rather than a suggestion.
+        // Before this set existed, the project body silently won and the flag meant nothing for
+        // precisely the properties a caller passes it for — AssemblyVersion above all.
+        private readonly HashSet<string> _globalNames = new(StringComparer.OrdinalIgnoreCase);
         private bool _defaultCompileItemsDisabled;
 
         private string ProjectDirectory => Path.GetDirectoryName(projectPath)!;
@@ -424,7 +493,10 @@ public static class ProjectFile
         {
             SeedWellKnown();
             foreach (var (name, value) in globals)
+            {
                 _properties[name] = value;
+                _globalNames.Add(name);
+            }
 
             // MSBuild's implicit outer imports: the NEAREST Directory.Build.props before the
             // project body, the NEAREST Directory.Build.targets after it. Directory.Packages.props
@@ -516,6 +588,7 @@ public static class ProjectFile
                         if (!ConditionHolds(element, file)) continue;
                         foreach (var property in element.Elements())
                         {
+                            if (_globalNames.Contains(property.Name.LocalName)) continue;
                             if (!ConditionHolds(property, file)) continue;
                             _properties[property.Name.LocalName] = Expand(property.Value, file);
                         }
@@ -677,6 +750,47 @@ public static class ProjectFile
                             + "two definitions of the same type in one compilation.");
                     break;
 
+                case "InternalsVisibleTo":
+                    if (remove.Length > 0)
+                    {
+                        foreach (var friend in Split(remove))
+                            _internalsVisibleTo.RemoveAll(
+                                i => string.Equals(i.Name, friend, StringComparison.OrdinalIgnoreCase));
+                        break;
+                    }
+                    if (include.Length == 0) break;
+                    // The SDK reads `Key`, falling back to `PublicKey`; both spell the same thing.
+                    var friendKey = Metadata(item, "Key", file) is { Length: > 0 } k
+                        ? k : Metadata(item, "PublicKey", file);
+                    foreach (var friend in Split(include))
+                        _internalsVisibleTo.Add((friend, friendKey.Length > 0 ? friendKey : null));
+                    break;
+
+                case "AssemblyMetadata":
+                    if (remove.Length > 0)
+                    {
+                        foreach (var key in Split(remove))
+                            _assemblyMetadata.RemoveAll(
+                                m => string.Equals(m.Key, key, StringComparison.OrdinalIgnoreCase));
+                        break;
+                    }
+                    if (include.Length == 0) break;
+                    _assemblyMetadata.Add((include, Metadata(item, "Value", file)));
+                    break;
+
+                case "AssemblyAttribute":
+                    if (remove.Length > 0)
+                    {
+                        foreach (var typeName in Split(remove))
+                            _assemblyAttributes.RemoveAll(
+                                a => string.Equals(a.TypeName, typeName, StringComparison.Ordinal));
+                        break;
+                    }
+                    if (include.Length == 0) break;
+                    _assemblyAttributes.Add(new AssemblyAttributeSpec(include, ReadParameters(item, file)));
+                    break;
+
+                case "None":
                 // 🚨 Content is where Razor lives. The Razor SDK's default items are
                 // `Content Include="**\*.razor"` / `"**\*.cshtml"`, and its ResolveRazorComponentInputs
                 // /ResolveRazorGenerateInputs targets promote exactly those Content items to
@@ -691,12 +805,8 @@ public static class ProjectFile
                     if (remove.Length > 0) _razorRemoves.AddRange(Split(remove).Where(IsRazorPattern));
                     break;
 
-                case "None":
                 case "AdditionalFiles":
-                case "InternalsVisibleTo":
-                case "AssemblyAttribute":
                 case "FrameworkReference":
-                case "AssemblyMetadata":
                 case "SupportedPlatform":
                 case "TrimmerRootAssembly":
                 case "RuntimeHostConfigurationOption":
@@ -1057,6 +1167,42 @@ public static class ProjectFile
             }
         }
 
+        /// <summary>
+        /// One piece of item metadata, in either of MSBuild's two spellings — the XML attribute
+        /// (<c>&lt;AssemblyMetadata Include="k" Value="v" /&gt;</c>) and the child element
+        /// (<c>&lt;Value&gt;v&lt;/Value&gt;</c>). Both appear in these repos, so reading only one
+        /// would drop the other silently.
+        /// </summary>
+        private string Metadata(XElement item, string name, string file)
+        {
+            if ((string?)item.Attribute(name) is { } attribute)
+                return Expand(attribute, file);
+            var child = item.Elements().FirstOrDefault(
+                e => string.Equals(e.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
+            return child is null || !ConditionHolds(child, file) ? string.Empty : Expand(child.Value, file);
+        }
+
+        /// <summary>
+        /// The positional constructor arguments of an <c>&lt;AssemblyAttribute&gt;</c> item:
+        /// <c>_Parameter1</c>, <c>_Parameter2</c>, … read in NUMERIC order and stopping at the
+        /// first gap, which is how <c>WriteCodeFragment</c> reads them.
+        /// </summary>
+        private ImmutableArray<string> ReadParameters(XElement item, string file)
+        {
+            var arguments = ImmutableArray.CreateBuilder<string>();
+            for (var index = 1; ; index++)
+            {
+                var name = $"_Parameter{index.ToString(CultureInfo.InvariantCulture)}";
+                var hasAttribute = item.Attribute(name) is not null;
+                var hasChild = item.Elements().Any(
+                    e => string.Equals(e.Name.LocalName, name, StringComparison.OrdinalIgnoreCase));
+                if (!hasAttribute && !hasChild)
+                    break;
+                arguments.Add(Metadata(item, name, file));
+            }
+            return arguments.ToImmutable();
+        }
+
         private void ReadPackageVersions(string path)
         {
             var doc = LoadXml(path);
@@ -1127,7 +1273,8 @@ public static class ProjectFile
                     .Select(p => new PackageRef(p.Id, p.Version ?? _packageVersions.GetValueOrDefault(p.Id)))],
                 globalUsings,
                 _properties.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
-                [.. _unexecutedTargets])
+                [.. _unexecutedTargets],
+                BuildAssemblyInfo(assemblyName))
             {
                 RazorItems = razorItems,
                 RazorLangVersion = Prop("RazorLangVersion") is { Length: > 0 } rlv ? rlv : DefaultRazorLangVersion,
@@ -1232,6 +1379,164 @@ public static class ProjectFile
             || pattern.EndsWith(".cshtml", StringComparison.OrdinalIgnoreCase);
 
         private string Prop(string name) => _properties.GetValueOrDefault(name, string.Empty);
+
+        // ── the assembly identity ──────────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Reproduces the SDK's <c>GetAssemblyVersion</c> + <c>GetAssemblyAttributes</c> pair —
+        /// <c>Microsoft.NET.DefaultAssemblyInfo.targets</c> and
+        /// <c>Microsoft.NET.GenerateAssemblyInfo.targets</c> — as evaluation rather than execution.
+        /// Every rule below was MEASURED against the real SDK (10.0.400) rather than recalled:
+        /// <c>Version=1.2.3-beta.4</c> → <c>AssemblyVersion=1.2.3.0</c>, <c>Version=1</c> →
+        /// <c>1.0.0.0</c>, <c>Version=01.2.3</c> → <c>1.2.3.0</c>, an explicit
+        /// <c>AssemblyVersion</c> wins and <c>FileVersion</c> follows IT rather than
+        /// <c>Version</c>.
+        /// </summary>
+        private AssemblyInfo BuildAssemblyInfo(string assemblyName)
+        {
+            var generate = Prop("GenerateAssemblyInfo");
+            if (generate.Length > 0 && !IsTrue(generate) && !IsFalse(generate))
+                throw new UnsupportedConstructException(
+                    $"{projectPath}: GenerateAssemblyInfo='{generate}' is neither true nor false. The "
+                    + "assembly's binding identity depends on it, and a guessed identity fails at "
+                    + "runtime binding rather than here.");
+
+            // Microsoft.NET.DefaultAssemblyInfo.targets: the VersionPrefix/VersionSuffix defaults
+            // apply ONLY when $(Version) is empty.
+            var version = Prop("Version");
+            if (version.Length == 0)
+            {
+                var prefix = Prop("VersionPrefix") is { Length: > 0 } p ? p : "1.0.0";
+                var suffix = Prop("VersionSuffix");
+                version = suffix.Length > 0 ? $"{prefix}-{suffix}" : prefix;
+            }
+
+            // 🚨 The ONE derivation that matters. An explicit AssemblyVersion is an override the SDK
+            // leaves alone; otherwise the GetAssemblyVersion task parses $(Version) as a NuGet
+            // version and renders its NUMERIC core, normalised to four fields.
+            var assemblyVersion = Prop("AssemblyVersion") is { Length: > 0 } av
+                ? av
+                : DeriveAssemblyVersion(version, projectPath);
+            var fileVersion = Prop("FileVersion") is { Length: > 0 } fv ? fv : assemblyVersion;
+            var informational = Prop("InformationalVersion") is { Length: > 0 } iv ? iv : version;
+
+            // AddSourceRevisionToInformationalVersion, verbatim including its SemVer 2.0 rule: a
+            // string that already carries build metadata gets '.sha', everything else '+sha'. This
+            // builder runs no git, so the id is only ever present when a caller supplied it — see
+            // AssemblyInfo.SourceRevisionApplied for what its absence means.
+            var revision = Prop("SourceRevisionId");
+            if (revision.Length > 0)
+                informational = informational.Contains('+', StringComparison.Ordinal)
+                    ? $"{informational}.{revision}"
+                    : $"{informational}+{revision}";
+
+            var generates = generate.Length == 0 || IsTrue(generate);
+            return new AssemblyInfo(
+                generates, version, assemblyVersion, fileVersion, informational,
+                revision.Length > 0,
+                generates
+                    ? ComposeAttributes(assemblyName, assemblyVersion, fileVersion, informational)
+                    : []);
+        }
+
+        /// <summary>
+        /// The attribute list, in the order <c>GetAssemblyAttributes</c> declares it, honouring each
+        /// <c>Generate…Attribute</c> switch and each "only when the property is non-empty" condition.
+        /// </summary>
+        private ImmutableArray<AssemblyAttributeSpec> ComposeAttributes(
+            string assemblyName, string assemblyVersion, string fileVersion, string informational)
+        {
+            // Microsoft.NET.DefaultAssemblyInfo.targets' own fallback chain.
+            var authors = Prop("Authors") is { Length: > 0 } a ? a : assemblyName;
+            var company = Prop("Company") is { Length: > 0 } c ? c : authors;
+            var title = Prop("AssemblyTitle") is { Length: > 0 } t ? t : assemblyName;
+            var product = Prop("Product") is { Length: > 0 } pr ? pr : assemblyName;
+
+            var attributes = ImmutableArray.CreateBuilder<AssemblyAttributeSpec>();
+
+            void Add(string switchName, string typeName, params string[] arguments)
+            {
+                if (IsFalse(Prop(switchName))) return;
+                attributes.Add(new AssemblyAttributeSpec(typeName, [.. arguments]));
+            }
+
+            void AddIfSet(string switchName, string typeName, string value)
+            {
+                if (value.Length == 0) return;
+                Add(switchName, typeName, value);
+            }
+
+            AddIfSet("GenerateAssemblyCompanyAttribute", "System.Reflection.AssemblyCompanyAttribute", company);
+            AddIfSet("GenerateAssemblyConfigurationAttribute",
+                "System.Reflection.AssemblyConfigurationAttribute", Prop("Configuration"));
+            AddIfSet("GenerateAssemblyCopyrightAttribute",
+                "System.Reflection.AssemblyCopyrightAttribute", Prop("Copyright"));
+            AddIfSet("GenerateAssemblyDescriptionAttribute",
+                "System.Reflection.AssemblyDescriptionAttribute", Prop("Description"));
+            AddIfSet("GenerateAssemblyFileVersionAttribute",
+                "System.Reflection.AssemblyFileVersionAttribute", fileVersion);
+            AddIfSet("GenerateAssemblyInformationalVersionAttribute",
+                "System.Reflection.AssemblyInformationalVersionAttribute", informational);
+            AddIfSet("GenerateAssemblyProductAttribute", "System.Reflection.AssemblyProductAttribute", product);
+            AddIfSet("GenerateAssemblyTrademarkAttribute",
+                "System.Reflection.AssemblyTrademarkAttribute", Prop("Trademark"));
+            AddIfSet("GenerateAssemblyTitleAttribute", "System.Reflection.AssemblyTitleAttribute", title);
+            AddIfSet("GenerateAssemblyVersionAttribute",
+                "System.Reflection.AssemblyVersionAttribute", assemblyVersion);
+
+            // RepositoryUrl: the SDK also accepts PublishRepositoryUrl=true, which makes it read
+            // $(PrivateRepositoryUrl) — a value SourceLink derives from the git remote. There is no
+            // git here, so that path is a NAMED refusal rather than a plausible-looking omission.
+            if (!IsFalse(Prop("GenerateRepositoryUrlAttribute")))
+            {
+                var repositoryUrl = Prop("RepositoryUrl");
+                if (repositoryUrl.Length > 0)
+                    attributes.Add(new AssemblyAttributeSpec(
+                        "System.Reflection.AssemblyMetadataAttribute", ["RepositoryUrl", repositoryUrl]));
+                else if (IsTrue(Prop("PublishRepositoryUrl")))
+                    throw new UnsupportedConstructException(
+                        $"{projectPath}: PublishRepositoryUrl=true with no $(RepositoryUrl). The SDK "
+                        + "would stamp AssemblyMetadata(\"RepositoryUrl\") from $(PrivateRepositoryUrl), "
+                        + "which SourceLink derives from the git remote — and this builder runs no git. "
+                        + "Set RepositoryUrl explicitly (in the project or with --property "
+                        + "RepositoryUrl=…), or turn the attribute off with "
+                        + "GenerateRepositoryUrlAttribute=false.");
+            }
+
+            AddIfSet("GenerateNeutralResourcesLanguageAttribute",
+                "System.Resources.NeutralResourcesLanguageAttribute", Prop("NeutralLanguage"));
+
+            if (!IsFalse(Prop("GenerateInternalsVisibleToAttributes")))
+            {
+                var publicKey = Prop("PublicKey");
+                foreach (var (name, key) in _internalsVisibleTo)
+                {
+                    var effective = key ?? (publicKey.Length > 0 ? publicKey : null);
+                    attributes.Add(new AssemblyAttributeSpec(
+                        "System.Runtime.CompilerServices.InternalsVisibleToAttribute",
+                        [effective is null ? name : $"{name}, PublicKey={effective}"]));
+                }
+            }
+
+            if (!IsFalse(Prop("GenerateAssemblyMetadataAttributes")))
+                foreach (var (key, value) in _assemblyMetadata)
+                    attributes.Add(new AssemblyAttributeSpec(
+                        "System.Reflection.AssemblyMetadataAttribute", [key, value]));
+
+            if (IsTrue(Prop("EnablePreviewFeatures")) && !IsFalse(Prop("GenerateRequiresPreviewFeaturesAttribute")))
+                attributes.Add(new AssemblyAttributeSpec(
+                    "System.Runtime.Versioning.RequiresPreviewFeaturesAttribute", []));
+
+            if (IsTrue(Prop("DisableRuntimeMarshalling"))
+                && !IsFalse(Prop("GenerateDisableRuntimeMarshallingAttribute")))
+                attributes.Add(new AssemblyAttributeSpec(
+                    "System.Runtime.CompilerServices.DisableRuntimeMarshallingAttribute", []));
+
+            // Anything the project declared itself, last — the same position WriteCodeFragment gives
+            // items contributed outside GetAssemblyAttributes' own ItemGroup.
+            attributes.AddRange(_assemblyAttributes);
+            return attributes.ToImmutable();
+        }
 
         private ImmutableArray<string> ResolveCompileItems()
         {
@@ -1642,6 +1947,47 @@ public static class ProjectFile
                     throw new FormatException($"unexpected '{text[_position..]}'");
             }
         }
+    }
+
+    /// <summary>
+    /// The SDK's <c>GetAssemblyVersion</c> task, reproduced: parse <paramref name="version"/> as a
+    /// NuGet version and render its NUMERIC core normalised to four fields.
+    ///
+    /// <para>Measured against SDK 10.0.400 rather than recalled — <c>1.2.3-beta.4</c> → <c>1.2.3.0</c>
+    /// (the pre-release label is dropped), <c>1.2.3+meta</c> → <c>1.2.3.0</c> (so is build metadata),
+    /// <c>1</c> → <c>1.0.0.0</c> and <c>4.5</c> → <c>4.5.0.0</c> (short forms are padded),
+    /// <c>01.2.3</c> → <c>1.2.3.0</c> (leading zeros normalise), and <c>1.2.3.4.5</c> is rejected.</para>
+    /// </summary>
+    /// <param name="version">The <c>$(Version)</c> to derive from.</param>
+    /// <param name="projectPath">Named in the failure message.</param>
+    /// <returns>A four-field version string.</returns>
+    /// <exception cref="UnsupportedConstructException"><paramref name="version"/> is not a version.</exception>
+    internal static string DeriveAssemblyVersion(string version, string projectPath)
+    {
+        var core = version;
+        if (core.IndexOf('+', StringComparison.Ordinal) is var plus and >= 0)
+            core = core[..plus];
+        if (core.IndexOf('-', StringComparison.Ordinal) is var dash and >= 0)
+            core = core[..dash];
+
+        var parts = core.Split('.');
+        var fields = new int[4];
+        var valid = parts.Length is >= 1 and <= 4;
+        for (var i = 0; valid && i < parts.Length; i++)
+            valid = int.TryParse(parts[i], NumberStyles.None, CultureInfo.InvariantCulture, out fields[i]);
+        if (!valid)
+            // 🚨 Loud, and it names the property. The alternative — falling back to something
+            // plausible — is precisely the defect this whole record exists to prevent: a wrong
+            // binding identity cannot be caught by any compile, any test of this build, or any
+            // reviewer; it surfaces in another process as a missing-file error.
+            throw new UnsupportedConstructException(
+                $"{projectPath}: Version='{version}' is not a version the SDK's GetAssemblyVersion task "
+                + "would accept (up to four non-negative integer fields, optionally followed by "
+                + "'-prerelease' and '+metadata'), so the AssemblyVersion cannot be derived from it. "
+                + "Set AssemblyVersion explicitly, or fix Version — a guessed binding identity fails "
+                + "at runtime in another process, not here.");
+
+        return string.Join('.', fields.Select(f => f.ToString(CultureInfo.InvariantCulture)));
     }
 
     /// <summary>

--- a/tools/MeshWeaver.PluginTester/README.md
+++ b/tools/MeshWeaver.PluginTester/README.md
@@ -32,7 +32,7 @@ mw-compiler build-project <csproj|dir>     # BUILD A .csproj: no dotnet SDK, no 
 ```
 mw-plugin-test build-project <csproj|dir> [--output <dir>] [--app <dir>] [--extra-refs <dir>]... \
     [--generators <dir|dll>]... [--razor-generators <dir>] \
-    [--accept <construct>]... [--allow-warnings] [--max-parallel <n>]
+    [--accept <construct>]... [-p:Name=Value]... [--allow-warnings] [--max-parallel <n>]
 ```
 
 Runs INSIDE the image (`memex build project --image …` is the trip in). Three parts:
@@ -67,6 +67,45 @@ Runs INSIDE the image (`memex build project --image …` is the trip in). Three 
 entry project) is built from source, in dependency order. **Outside it, the container supplies the
 assembly** — which is exactly the `$(MeshWeaverRoot)/src/…` shape every `MeshWeaver.Plugins/src`
 project carries, and it resolves to the assembly the image ships rather than to a checkout.
+
+### 🔴 The emitted assembly carries the SDK's binding identity
+
+`GenerateAssemblyInfo` is a TARGET, and this builder runs no targets — so it emitted Roslyn's own
+default, **`AssemblyVersion=0.0.0.0`**, while the whole fleet binds `3.0.0.0`. Nothing went red: the
+compile was green, the DLL loaded, and the failure would have arrived in a different repo, at
+runtime, as `FileNotFoundException: Could not load file or assembly '…, Version=3.0.0.0'` — the
+shape of Systemorph/MeshWeaver#143, which CrashLoopBackOff'd a migration.
+
+The identity is now **evaluated** from the project and synthesized into the compilation as one more
+source document, exactly as the SDK's generated `<Project>.AssemblyInfo.cs` is one more Compile
+item: `AssemblyVersion` (explicit, else the numeric core of `$(Version)` padded to four fields,
+which is what the SDK's `GetAssemblyVersion` task does), `FileVersion` (following `AssemblyVersion`,
+never `$(Version)`), `InformationalVersion` (following `$(Version)`), the descriptive attributes
+with the SDK's `$(AssemblyName)` → `$(Authors)` → `$(Company)` fallback chain, and the
+`InternalsVisibleTo` / `AssemblyMetadata` / `AssemblyAttribute` items — all of which this evaluator
+used to drop as "metadata that changes nothing", true of the COMPILE and false of the ASSEMBLY.
+`GenerateAssemblyInfo=false` synthesizes nothing (the project supplies its own; a second set is
+CS0579), and each `Generate…Attribute` switch is honoured individually.
+
+🚨 **A property it cannot derive is a NAMED failure, never a plausible substitute** — an
+unparseable `$(Version)`, or `PublishRepositoryUrl=true` with no `$(RepositoryUrl)` (the SDK reads
+that one off the git remote).
+
+**Two things it deliberately does not reproduce, and both are said out loud:**
+
+- **`$(SourceRevisionId)`** — the SDK appends `+<sha>` to `InformationalVersion` from git; there is
+  no git here, so every build reports the absent suffix by name. `-p:SourceRevisionId=<sha>` gives
+  exact parity. `-p:Name=Value` (or `--property Name=Value`) is MSBuild's global property, and it is
+  immutable during evaluation exactly as MSBuild makes it: a `<PropertyGroup>` cannot overwrite one.
+- **`TargetFrameworkAttribute`** — written by a different target
+  (`GenerateTargetFrameworkMonikerAttribute`) with its own switches and its own
+  `TargetPlatform`/`SupportedOSPlatform` companions for a platform-suffixed TFM this evaluator
+  cannot compute. Emitting half of that set would be worse than the gap.
+
+Measured, not assumed: every rule above was produced by building the same project with SDK 10.0.400
+and reading the generated `*.AssemblyInfo.cs`, and the container output for
+`MeshWeaver.Plugins/src/MeshWeaver.Speech.Contract` was compared attribute-for-attribute against a
+real `dotnet build` of it — identical but for `TargetFrameworkAttribute`.
 
 **The diagnostic standard is the SDK's.** Nullable analysis follows the project;
 `DocumentationMode.Diagnose` is ALWAYS on so doc-QUALITY defects surface (CS1574, CS0419, CS1570),

--- a/tools/MeshWeaver.PluginTester/README.md
+++ b/tools/MeshWeaver.PluginTester/README.md
@@ -41,11 +41,13 @@ Runs INSIDE the image (`memex build project --image …` is the trip in). Three 
   `**/*.cs` glob minus `bin`/`obj`, `Compile Include/Remove`, `ProjectReference`,
   `PackageReference`, implicit usings, the target-framework symbol ladder, the nearest
   `Directory.Build.props` / `.targets` / `Directory.Packages.props`, and every `<Import>` whose
-  condition holds. 🚨 **Anything it cannot reproduce FAILS the load by name** — an unknown element
-  or item type, a `Condition` outside its grammar, an `<Import>` of a missing file (MSB4019's
-  behaviour, deliberately), a `<Target>`, an `<EmbeddedResource>`. `--accept <construct>`
-  acknowledges one. The alternative is worse than no build: a dropped `Nullable`, `NoWarn` or
-  `DefineConstants` produces a green build that is not the build the SDK would have produced.
+  condition holds, plus every **`<EmbeddedResource>`** with the manifest NAME the SDK would give it.
+  🚨 **Anything it cannot reproduce FAILS the load by name** — an unknown element or item type, a
+  `Condition` outside its grammar, an `<Import>` of a missing file (MSB4019's behaviour,
+  deliberately), a `<Target>`, a resource construct whose name cannot be matched exactly.
+  `--accept <construct>` acknowledges one. The alternative is worse than no build: a dropped
+  `Nullable`, `NoWarn` or `DefineConstants` produces a green build that is not the build the SDK
+  would have produced.
 - **`ContainerReferenceSet`** reads `/app`, the image's own `*.deps.json` and the shared frameworks
   installed in the container. The C# port of `MeshWeaver.Plugins/scripts/container-refs.py`, read
   from disk instead of an extracted image. 🚨 **Fails closed** on an unreadable `/app`, a missing or
@@ -100,6 +102,16 @@ builder: `Microsoft.CodeAnalysis.Razor.Compiler.dll` + `Microsoft.AspNetCore.Raz
 **Still not supported, and each says so:** SDK source generators (they live in the SDK, not the
 runtime; `--generators` supplies them), embedded resources, `<Protobuf>`, MSBuild `<Target>`s and
 `<Sdk>` elements. Full measurements:
+**Not supported, and each says so:** Razor/Blazor compilation (needs
+`Microsoft.CodeAnalysis.Razor.Compiler`, `Microsoft.AspNetCore.Razor.Utilities.Shared` and
+`Microsoft.Extensions.ObjectPool` in the image — it ships none), SDK source generators (they live in
+the SDK, not the runtime; `--generators` supplies them), `<Protobuf>`, MSBuild `<Target>`s and
+`<Sdk>` elements. **Embedded resources ARE supported** — under the SDK's own manifest names, every
+rule established by building probe projects with the real SDK and reading the names back out of the
+emitted PE; `.resx`, a culture in a file name (which the SDK routes to a SATELLITE assembly),
+`DependentUpon` and `ManifestResourceName` are each refused BY NAME rather than guessed, because a
+plausible-looking wrong resource name is the one defect nothing downstream can see. Full
+measurements:
 [In-Mesh Build and Test](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md).
 
 ## `build` — compile AND test, per package, as a dependency cascade (2026-08-30)


### PR DESCRIPTION
Replaces **#2855** and **#2860**, which cannot pass the merge queue as they stand: their branches descend from `integration/core-batch` and carry the originals of commits main has as squashes, so they read `CLEAN` on their pages and come back `UNMERGEABLE` from the queue, every time. This branch is **current main + exactly their three unique commits**, cherry-picked and union-resolved:

```
a3a07ac54  feat(build-project): embedded resources, with the SDK's manifest names
df443bcf7  fix(build-project): three more resource rules the SDK does not do the obvious thing with
bd5a1622b  fix(build-project): the emitted assembly carries the platform's binding identity
```

## The resolution is a UNION, and the naive alternatives both lose a feature

Main gained **Razor** support (#2856, via #2850) in the same files these commits extend. Taking either side wholesale is destructive — checking the branch's files onto main would have **deleted `RazorGenerators.cs` (−494 lines) and `RazorBuildTest` (−387)**, measured before resolving, which is why every conflicted region was merged by hand instead:

- `ProjectFile.cs` — Razor's record/items/globs **and** the EmbeddedResource ordered log **and** the AssemblyInfo records now coexist; main's stricter exact-suffix glob helper kept; main's `case "None"` grouping (a `.razor` can arrive as a `None` item) kept over the branch's.
- `ProjectBuild.cs` — `RazorCount` **and** `ResourceCount` on `ProjectResult`; the OK-log line reports sources + Razor files + resources.
- `Program.cs` / READMEs — usage and help are the union of `--razor-generators` and `-p:Name=Value`.

**Proof neither feature was lost:** `MeshWeaver.PluginTester.Test` runs **265/265** — more than either source branch alone (#2860: 229, #2855: 198), because it is both suites together.

## Why this is priority: it un-blocks the memex-as-compiler lane, measured

Swept all 49 non-test `MeshWeaver.Plugins/src` projects through `build-project` locally (native, fresh portal reference set built from current main):

| builder | green |
|---|---|
| main today (Razor only) | 9 |
| **this batch** (+ resources, + identity) | AI-family refusal **gone** — `MeshWeaver.AI` itself: **169 sources, 0 errors, GREEN** |
| this batch + the SDK's regex-generator DLL via `--generators` | AI *satellites* flipping green in the running sweep (Anthropic ✅, AppleIntelligence ✅ …) |

Three separate blockers fell in one afternoon: the `<EmbeddedResource>` refusal (this batch), the stale-reference CS0436s (fresh app), and CS8795 (`[GeneratedRegex]`) — closed by handing the builder the SDK's own `System.Text.RegularExpressions.Generator.dll`, which answers #2854's *"source generators are the honest unknown"* with a measured **yes, they run**.

Full final numbers land on #2854 when the sweep completes; the per-module opt-in list there grows from measurement, exactly as that draft prescribes.

`MeshWeaver.PluginTester` / `.Test` / `MeshWeaver.Cli` / `MeshWeaver.Compiler`: `-c Release -warnaserror`, `0 Warning(s) 0 Error(s)`.

*(#2855 and #2860 will be closed in favour of this once it lands — their content is byte-identical here, their history is what could not merge.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)