### PR TITLE
fix(deploy): budget the ingress header buffer for the chunked auth cookie

### DIFF
--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -469,6 +469,18 @@ ingress:
     # ingress has carried this for its own uploads since it was written; the portal ingress —
     # which is the one serving /api — did not, so the two disagreed about how big a POST may be.
     nginx.ingress.kubernetes.io/proxy-body-size: "100m"
+    # 🚨 SIGN-IN 502s WITHOUT THIS. proxy-body-size above bounds how big a REQUEST may be;
+    # this bounds how big a RESPONSE HEADER may be, and the sign-in callback's is large by
+    # construction. ASP.NET Core serialises the whole authentication ticket — the external
+    # identity's claims — into the auth cookie and splits anything past ~4 KB into numbered
+    # chunks (MemexAuthC1, MemexAuthC2, …), each its own Set-Cookie header; the same response
+    # also deletes the OIDC correlation and nonce cookies, whose NAMES alone are ~380 chars.
+    # nginx's DEFAULT proxy_buffer_size is 4 KB, so it discards its own upstream's answer with
+    # "upstream sent too big header" and serves the user 502 Bad Gateway — while the portal's
+    # logs show the callback handled successfully, because the response died one hop later.
+    # Developer login writes a small cookie and passes, so a deployment looks healthy while
+    # EVERY external provider is broken. Observed on a chart-deployed portal, 2026-08-31.
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"
 # ---- Next.js React portal (experimental frontend — FEATURE-FLAGGED) --------
 # When enabled, a Next.js streaming-SSR build of the React GUI (clients/portal-next)
 # runs as its OWN Deployment beside memex-portal, and the portal ingress gains a

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-external-sign-in-no-longer-502s.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-external-sign-in-no-longer-502s.md
@@ -1,0 +1,26 @@
+---
+Name: Signing in with Microsoft or Google no longer fails with 502
+Category: Fix
+Description: Fixed a self-hosted deployment returning 502 Bad Gateway at the end of an external sign-in, after the identity provider had already accepted the password.
+Icon: Sparkle
+Order: -20260831
+---
+
+# Signing in with Microsoft or Google no longer fails with 502
+
+On a self-hosted portal, signing in with an external provider could end in a bare
+**502 Bad Gateway** page — after the provider had accepted your password and sent you back.
+Nothing in the portal's own logs looked wrong, because nothing in the portal was: the sign-in
+was completed correctly, and the answer was discarded on the way back to your browser.
+
+The proxy in front of the portal reserves a fixed amount of room for a response's headers, and
+its default is 4 KB. The last step of a sign-in writes your session cookie, which carries your
+identity's full set of claims — for a work or school account with group memberships, comfortably
+more than that. The proxy dropped the response it could not fit and answered 502 instead.
+
+The deployment chart now reserves enough room for it. Developer login was never affected, since
+it writes a much smaller cookie — which is why a deployment could look perfectly healthy while
+every external sign-in was broken.
+
+**If you self-host:** upgrade the chart, or add
+`nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"` to your portal ingress annotations.

--- a/test/MeshWeaver.Documentation.Test/IngressAuthCookieHeaderBudgetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/IngressAuthCookieHeaderBudgetGuard.cs
@@ -1,0 +1,104 @@
+using System;
+using System.Globalization;
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>An external sign-in through this chart's ingress returned 502 Bad Gateway — from nginx,
+/// not from the portal.</b>
+///
+/// <para>Observed on a chart-deployed portal on 2026-08-31. The Entra round-trip is correct end to
+/// end: <c>GET /auth/login?provider=Microsoft</c> answers 302, the user authenticates, and Entra
+/// form-POSTs back to <c>/signin-microsoft</c>. The portal handles that callback and answers with
+/// the sign-in <c>Set-Cookie</c> block. nginx then refuses its OWN upstream's answer:</para>
+///
+/// <code>
+/// "POST /signin-microsoft HTTP/2.0" 502
+/// [error] upstream sent too big header while reading response header from upstream
+/// </code>
+///
+/// <para><b>Why the header is large by construction.</b> ASP.NET Core's cookie authentication
+/// serialises the whole authentication ticket — the external identity's claims — into the auth
+/// cookie, and splits anything past ~4 KB into numbered chunks (<c>MemexAuthC1</c>,
+/// <c>MemexAuthC2</c>, …), each its own <c>Set-Cookie</c> header. The same response also deletes
+/// the OIDC correlation and nonce cookies, whose NAMES alone are ~380 characters. An Entra ticket
+/// with group claims therefore lands well past nginx's DEFAULT <c>proxy_buffer_size</c> of 4 KB —
+/// so the header block is too big on the very first real sign-in, not in some edge case.</para>
+///
+/// <para><b>Why nothing caught it.</b> Developer login writes a small cookie and passes, so a
+/// deployment can look completely healthy while every external provider 502s. And the failure is
+/// invisible from the portal side: its logs show the callback handled successfully — the response
+/// is discarded one hop later, by the proxy.</para>
+///
+/// <para>This is the same shape as the module-bundle 413 (#2489): the chart carried
+/// <c>proxy-body-size</c> for how big a REQUEST may be, and said nothing about how big a RESPONSE
+/// HEADER may be. So the budget stops being implicit.</para>
+/// </summary>
+public class IngressAuthCookieHeaderBudgetGuard
+{
+    private const string Values = "deploy/helm/values.yaml";
+
+    private const string BufferSizeAnnotation = "nginx.ingress.kubernetes.io/proxy-buffer-size";
+
+    /// <summary>
+    /// The floor, in kilobytes. Four chunks of the ~4 KB ASP.NET Core cookie limit is the ticket
+    /// size an Entra identity with group claims reaches, and the response carries the correlation
+    /// and nonce deletions on top. Below this the sign-in 502s; nginx's default 4 KB is not close.
+    /// </summary>
+    private const int MinimumKilobytes = 32;
+
+    [Fact]
+    public void ThePortalIngress_BudgetsForTheChunkedAuthCookie()
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Values));
+
+        var match = Regex.Match(
+            text,
+            @"^\s*" + Regex.Escape(BufferSizeAnnotation) + @":\s*""(?<size>\d+)k""\s*$",
+            RegexOptions.Multiline);
+
+        Assert.True(match.Success,
+            $"The portal ingress ships no '{BufferSizeAnnotation}', so nginx applies its 4 KB "
+            + "default and answers 502 to the sign-in callback of every external provider — with "
+            + "the portal's own logs showing the callback handled successfully. Set it in "
+            + $"{Values} under ingress.annotations.");
+
+        var kilobytes = int.Parse(match.Groups["size"].Value, CultureInfo.InvariantCulture);
+
+        Assert.True(kilobytes >= MinimumKilobytes,
+            $"'{BufferSizeAnnotation}' is {kilobytes}k, below the {MinimumKilobytes}k a chunked "
+            + "authentication ticket needs. A value that merely beats the 4 KB default still 502s "
+            + "the moment an identity carries group claims.");
+    }
+
+    /// <summary>
+    /// The budget only helps if the ingress that terminates the sign-in flow actually receives it.
+    /// The portal Ingress renders <c>.Values.ingress.annotations</c> wholesale, so a future edit
+    /// that moves the annotations behind a condition, or hard-codes a competing set on the
+    /// resource, would leave this guard passing while the deployed object lost the value.
+    /// </summary>
+    [Fact]
+    public void ThePortalIngress_TakesItsAnnotationsFromTheValuesTheGuardChecks()
+    {
+        var template = File.ReadAllText(Path.Combine(
+            FindRepoRoot(), "deploy/helm/templates/memex-portal/ingress.yaml"));
+
+        // The `memex-portal` resource — the one serving /signin-* — up to the next document.
+        var portal = template[..template.IndexOf("---", template.IndexOf("name: \"memex-portal\"",
+            StringComparison.Ordinal), StringComparison.Ordinal)];
+
+        Assert.Contains(".Values.ingress.annotations", portal, StringComparison.Ordinal);
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/IngressAuthCookieHeaderBudgetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/IngressAuthCookieHeaderBudgetGuard.cs
@@ -43,6 +43,11 @@ public class IngressAuthCookieHeaderBudgetGuard
 
     private const string BufferSizeAnnotation = "nginx.ingress.kubernetes.io/proxy-buffer-size";
 
+    private const string IngressTemplate = "deploy/helm/templates/memex-portal/ingress.yaml";
+
+    /// <summary>The resource that terminates the sign-in flow, as the template names it.</summary>
+    private const string PortalResourceMarker = "name: \"memex-portal\"";
+
     /// <summary>
     /// The floor, in kilobytes. Four chunks of the ~4 KB ASP.NET Core cookie limit is the ticket
     /// size an Entra identity with group claims reaches, and the response carries the correlation
@@ -83,14 +88,25 @@ public class IngressAuthCookieHeaderBudgetGuard
     [Fact]
     public void ThePortalIngress_TakesItsAnnotationsFromTheValuesTheGuardChecks()
     {
-        var template = File.ReadAllText(Path.Combine(
-            FindRepoRoot(), "deploy/helm/templates/memex-portal/ingress.yaml"));
+        var template = File.ReadAllText(Path.Combine(FindRepoRoot(), IngressTemplate));
 
         // The `memex-portal` resource — the one serving /signin-* — up to the next document.
-        var portal = template[..template.IndexOf("---", template.IndexOf("name: \"memex-portal\"",
-            StringComparison.Ordinal), StringComparison.Ordinal)];
+        // Both markers are asserted before they are used to slice: a template refactor that renamed
+        // the resource or moved the document separator would otherwise surface as an opaque
+        // ArgumentOutOfRangeException, which says nothing about what an author has to fix.
+        var resource = template.IndexOf(PortalResourceMarker, StringComparison.Ordinal);
+        Assert.True(resource >= 0,
+            $"{IngressTemplate} declares no '{PortalResourceMarker}' — the resource this guard "
+            + "exists to pin was renamed or removed, and the guard now covers nothing.");
 
-        Assert.Contains(".Values.ingress.annotations", portal, StringComparison.Ordinal);
+        var nextDocument = template.IndexOf("---", resource, StringComparison.Ordinal);
+        Assert.True(nextDocument > resource,
+            $"The '{PortalResourceMarker}' resource in {IngressTemplate} is not followed by a YAML "
+            + "document separator, so this guard cannot tell where it ends — it would otherwise "
+            + "read annotations belonging to the gRPC or MCP Ingress and pass on the wrong object.");
+
+        Assert.Contains(".Values.ingress.annotations", template[resource..nextDocument],
+            StringComparison.Ordinal);
     }
 
     private static string FindRepoRoot()


### PR DESCRIPTION
## The defect

Every external sign-in through the chart's ingress ended in **502 Bad Gateway** — served by nginx, *after* the identity provider had already accepted the password.

```
"GET  /auth/login?provider=Microsoft HTTP/2.0"  302   ← challenge fine
"POST /signin-microsoft HTTP/2.0"               502   ← callback rejected

[error] upstream sent too big header while reading response header from upstream,
        request: "POST /signin-microsoft HTTP/2.0",
        upstream: "http://10.42.0.157:8080/signin-microsoft"
```

The portal was answering that callback correctly. ASP.NET Core serialises the whole authentication ticket — the external identity's claims — into the auth cookie and splits anything past ~4 KB into numbered chunks (`MemexAuthC1`, `MemexAuthC2`, …), each its own `Set-Cookie` header; the same response also deletes the OIDC correlation and nonce cookies, whose *names* alone are ~380 characters. nginx's default `proxy_buffer_size` is 4 KB, so it discarded its own upstream's response and served the user a 502.

## Why nothing caught it

- **The portal's logs look clean.** The callback is handled successfully; the response dies one hop later, at the proxy. There is nothing to grep for on the application side.
- **Developer login passes.** It writes a small cookie, so a deployment looks completely healthy while *every* external provider is broken.

Same shape as the module-bundle 413 (#2489): the chart carried `proxy-body-size` for how big a REQUEST may be, and said nothing about how big a RESPONSE HEADER may be.

## The change

1. `deploy/helm/values.yaml` — `nginx.ingress.kubernetes.io/proxy-buffer-size: "32k"` on the portal ingress annotations, with the failure recorded in the comment. 32k covers four cookie chunks plus the deletions.
2. `test/MeshWeaver.Documentation.Test/IngressAuthCookieHeaderBudgetGuard.cs` — two guards. The annotation exists and is at least 32k; and the portal `Ingress` still renders `.Values.ingress.annotations` wholesale, so a template edit cannot leave the guard passing while the deployed object loses the value.
3. What's New entry, `Category: Fix`.

## Verification

Live, on a chart-deployed portal — the **identical request** before and after applying the annotation, nothing else changed:

| Time | Request | Length | Status |
|---|---|---|---|
| 09:10:33 | `POST /signin-microsoft` | 2572 | **502** |
| 09:30:20 | `POST /signin-microsoft` | 2570 | **302** |

The portal then logged `Circuit opened: user=sglauser`.

TDD: guard verified RED (`ships no 'nginx.ingress.kubernetes.io/proxy-buffer-size'`) then GREEN. `MeshWeaver.Documentation.Test` is 142/142 under `-c Release -warnaserror`, 0 warnings.

## For self-hosters already deployed

Either upgrade the chart, or patch the live ingress with no redeploy:

```
kubectl -n <ns> annotate ingress memex-portal \
  nginx.ingress.kubernetes.io/proxy-buffer-size=32k --overwrite
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
