### PR TITLE
fix(memex-local): keep Azure's answer instead of guessing at the remedy

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -573,8 +573,26 @@ image_pull_acr() {                                     # §3 Option A
   step "Pulling multi-arch images from ACR ($ACR, tag=$tag) (§3 Option A)"
   # The registry is private. `az acr login` is idempotent (a docker credential helper entry), and
   # failing HERE names the remedy — a bare `docker pull` denial reads like a missing tag.
-  az acr login -n "$ACR_NAME" -o none 2>/dev/null \
-    || die "cannot log in to $ACR — run 'az login' first (the account needs pull access to the '$ACR_NAME' registry)"
+  #
+  # 🚨 NEVER discard Azure's answer. This ran `2>/dev/null` and then said "run 'az login' first",
+  # which is the one remedy that cannot help the failure people actually hit: an account that IS
+  # signed in and simply holds no role on the registry. Azure states the missing permission exactly
+  # — "(AuthorizationFailed) … does not have authorization to perform action
+  # 'Microsoft.Resources/subscriptions/resources/read'" — and that sentence IS the diagnosis.
+  # Reported 2026-08-31 by a developer who signed out, signed back in and switched tenant on the old
+  # advice before asking; the role had been missing the whole time. Note also that `az acr login`
+  # resolves the registry through ARM BEFORE it talks to the registry, so a bare AcrPull grant is
+  # not enough for this command — hence both roles below.
+  local acr_err=""
+  if ! acr_err="$(az acr login -n "$ACR_NAME" -o none 2>&1)"; then
+    [ -n "$acr_err" ] && printf '%s\n' "$acr_err" >&2
+    die "cannot log in to $ACR — Azure's own answer is printed above.
+     signed OUT     -> az login
+     signed IN      -> the account needs the AcrPull role on the '$ACR_NAME' registry, and Reader on
+                       its subscription ('az acr login' resolves the registry through ARM first)
+     no ACR access  -> build the image instead:  memex-local update --build
+                       or keep the running one:  memex-local update --skip-image"
+  fi
   info "Verify the tag is multi-arch (must list arm64):"
   docker manifest inspect "$ACR/memex-portal-ai:$tag" | grep -A1 '"architecture"' || \
     warn "could not inspect manifest — continuing (amd64-only tags crash on arm64, see §14)"
@@ -2331,11 +2349,17 @@ PLIST
       if [ "$(cat "$AUTOROLL_SOURCE_STATE" 2>/dev/null)" = "acr" ] \
           && [ -z "$(find "$AUTOROLL_ACR_CHECKED" -mmin "-$AUTOROLL_ACR_INTERVAL_MIN" 2>/dev/null)" ]; then
         touch "$AUTOROLL_ACR_CHECKED"
-        local rdigest rlast
-        rdigest="$(az acr manifest show-metadata -r "${ACR%%.*}" -n "memex-portal-ai:$ACR_DEFAULT_TAG" --query digest -o tsv 2>/dev/null || true)"
+        local rdigest rlast racr_err=""
+        # 🚨 Same rule as image_pull_acr: keep Azure's answer. Guessing "(az not logged in /
+        # offline?)" in a line that repeats every polling window is worse than saying nothing —
+        # a missing AcrPull role reads as a transient network blip forever.
+        rdigest="$(az acr manifest show-metadata -r "${ACR%%.*}" -n "memex-portal-ai:$ACR_DEFAULT_TAG" --query digest -o tsv 2>&1)" \
+          || { racr_err="$rdigest"; rdigest=""; }
         rlast="$(cat "$AUTOROLL_ACR_STATE" 2>/dev/null || true)"
         if [ -z "$rdigest" ]; then
-          printf '%s autoroll: acr poll FAILED (az not logged in / offline?) — keeping current images, will retry\n' "$(date -u +%FT%TZ)"
+          printf '%s autoroll: acr poll FAILED — keeping current images, will retry. Azure said: %s\n' \
+            "$(date -u +%FT%TZ)" \
+            "$(printf '%s' "${racr_err:-<no output>}" | tr '\n' ' ' | cut -c1-400)"
         elif [ "$rdigest" != "$rlast" ]; then
           printf '%s autoroll: acr %s:%s moved (%s -> %s) — pulling portal + migration\n' \
             "$(date -u +%FT%TZ)" "memex-portal-ai" "$ACR_DEFAULT_TAG" "${rlast:-none}" "$rdigest"

--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -2363,9 +2363,19 @@ PLIST
         elif [ "$rdigest" != "$rlast" ]; then
           printf '%s autoroll: acr %s:%s moved (%s -> %s) — pulling portal + migration\n' \
             "$(date -u +%FT%TZ)" "memex-portal-ai" "$ACR_DEFAULT_TAG" "${rlast:-none}" "$rdigest"
-          if az acr login -n "${ACR%%.*}" >/dev/null 2>&1 \
-              && docker pull --platform linux/arm64 "$ACR/memex-portal-ai:$ACR_DEFAULT_TAG" >/dev/null 2>&1 \
-              && docker pull --platform linux/arm64 "$ACR/memex-migration:$ACR_DEFAULT_TAG" >/dev/null 2>&1; then
+          # 🚨 Inverted so the FAILING step's output is the one kept: each arm assigns its combined
+          # output and negates, so the first failure short-circuits with its own message in
+          # $stage_err. The success arm below is unchanged. Written this way because
+          # `A && B && C` with every arm suppressed could only ever report "FAILED", which is what
+          # this line did — three commands deep, with no reason. Raised in review of #2903.
+          local stage_err=""
+          if ! stage_err="$(az acr login -n "${ACR%%.*}" 2>&1)" \
+              || ! stage_err="$(docker pull --platform linux/arm64 "$ACR/memex-portal-ai:$ACR_DEFAULT_TAG" 2>&1)" \
+              || ! stage_err="$(docker pull --platform linux/arm64 "$ACR/memex-migration:$ACR_DEFAULT_TAG" 2>&1)"; then
+            printf '%s autoroll: acr pull FAILED — keeping current images, will retry. Last error: %s\n' \
+              "$(date -u +%FT%TZ)" \
+              "$(printf '%s' "${stage_err:-<no output>}" | tr '\n' ' ' | cut -c1-400)"
+          else
             # Never stage a wrong-arch image: an amd64 image runs EMULATED here and .NET's
             # ConfigurationBinder NREs at startup — the exact crash that forced local source
             # builds before the registry went multi-arch.
@@ -2380,8 +2390,6 @@ PLIST
               printf '%s autoroll: acr image is %s, not arm64 — REFUSING to stage (would crash under emulation), will retry\n' \
                 "$(date -u +%FT%TZ)" "${arch:-unknown}"
             fi
-          else
-            printf '%s autoroll: acr pull FAILED — keeping current images, will retry\n' "$(date -u +%FT%TZ)"
           fi
         fi
         # 0b. Plugin content: refresh the hostPath-mounted Plugins checkout (see the constants

--- a/test/MeshWeaver.Documentation.Test/MemexLocalSurfacesAzureErrorsGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/MemexLocalSurfacesAzureErrorsGuard.cs
@@ -1,0 +1,108 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>A fatal step must never discard the error that explains it.</b>
+///
+/// <para><c>image_pull_acr</c> ran <c>az acr login -n meshweaver -o none <b>2>/dev/null</b></c> and,
+/// on failure, said <i>"run 'az login' first"</i>. That is the one remedy which cannot help the
+/// failure people actually hit: an account that IS signed in and simply holds no role on the
+/// registry. Azure had answered precisely —</para>
+///
+/// <code>
+/// (AuthorizationFailed) The client 'user@example.com' … does not have authorization to perform
+/// action 'Microsoft.Resources/subscriptions/resources/read' over scope '/subscriptions/…'
+/// </code>
+///
+/// <para>— and the redirect to <c>/dev/null</c> threw that sentence away. Reported 2026-08-31 by a
+/// developer who signed out, signed back in and switched tenant before asking, because the tool had
+/// told them to. The role was missing the whole time.</para>
+///
+/// <para><b>Why a guard and not just a fix.</b> The suppression is one character sequence, easy to
+/// reintroduce whenever someone finds a command chatty — and the cost is not a worse message but a
+/// WRONG one, sending the reader after a remedy the tool has effectively ruled out. So the rule is
+/// asserted where it can be re-broken.</para>
+/// </summary>
+public class MemexLocalSurfacesAzureErrorsGuard
+{
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    private static readonly string ScriptPath =
+        Path.Combine("deploy", "homebrew", "bin", "memex-local");
+
+    private static string Script() =>
+        File.ReadAllText(Path.Combine(RepoRoot(), ScriptPath));
+
+    /// <summary>
+    /// Every line that invokes the Azure CLI and sends its stderr to <c>/dev/null</c>.
+    ///
+    /// <para>Scoped to <c>az</c> deliberately. Discarding stderr is legitimate for a PROBE whose
+    /// failure is expected and handled — <c>docker image inspect</c> asking whether an image is
+    /// present — and this guard must not police those. Azure's CLI is different in kind: its
+    /// failures are configuration and entitlement problems whose only readable statement is the
+    /// message itself.</para>
+    /// </summary>
+    private static IEnumerable<string> AzureCallsThatDiscardStderr(string script) =>
+        script.Split('\n')
+            .Select(line => line.Trim())
+            .Where(line => !line.StartsWith('#'))
+            .Where(line => Regex.IsMatch(line, @"(^|\s|\()az\s"))
+            .Where(line => line.Contains("2>/dev/null", StringComparison.Ordinal)
+                        || line.Contains("2> /dev/null", StringComparison.Ordinal));
+
+    [Fact]
+    public void TheAcrLogin_NeverDiscardsAzuresOwnError()
+    {
+        var offenders = AzureCallsThatDiscardStderr(Script()).ToList();
+
+        Assert.True(offenders.Count == 0,
+            $"{ScriptPath} sends the Azure CLI's stderr to /dev/null on {offenders.Count} line(s), "
+            + "so the only statement of what is actually wrong — a missing role, an expired "
+            + "session, the wrong subscription — is destroyed before anyone can read it:\n  "
+            + string.Join("\n  ", offenders));
+    }
+
+    /// <summary>
+    /// The remedy must cover the case the old text got wrong. "Run 'az login'" is right only when
+    /// the caller is signed OUT; the reported failure was a signed-in account with no role, and a
+    /// message that names only the sign-in leaves that reader with nothing to do.
+    /// </summary>
+    [Fact]
+    public void TheAcrFailure_NamesTheRoleAndNotOnlyTheSignIn()
+    {
+        var script = Script();
+
+        var start = script.IndexOf("image_pull_acr()", StringComparison.Ordinal);
+        Assert.True(start >= 0,
+            $"{ScriptPath} no longer defines image_pull_acr — this guard would silently stop "
+            + "covering the ACR failure path.");
+
+        // The function body, to its closing brace at column 0.
+        var end = script.IndexOf("\n}", start, StringComparison.Ordinal);
+        Assert.True(end > start, $"could not delimit image_pull_acr in {ScriptPath}.");
+        var body = script[start..end];
+
+        Assert.True(body.Contains("AcrPull", StringComparison.Ordinal),
+            "The ACR login failure does not name the AcrPull role. An account that is signed in "
+            + "but unauthorized is the common case, and the message must say what to ask for.");
+
+        Assert.True(body.Contains("--build", StringComparison.Ordinal),
+            "The ACR login failure does not mention '--build'. A developer with no registry access "
+            + "at all still has a way to run: build the image locally instead of pulling it.");
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/MemexLocalSurfacesAzureErrorsGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/MemexLocalSurfacesAzureErrorsGuard.cs
@@ -62,8 +62,22 @@ public class MemexLocalSurfacesAzureErrorsGuard
             .Select(line => line.Trim())
             .Where(line => !line.StartsWith('#'))
             .Where(line => Regex.IsMatch(line, @"(^|\s|\()az\s"))
-            .Where(line => line.Contains("2>/dev/null", StringComparison.Ordinal)
-                        || line.Contains("2> /dev/null", StringComparison.Ordinal));
+            .Where(DiscardsStderr);
+
+    /// <summary>
+    /// Every shell spelling that sends stderr to <c>/dev/null</c>, not just the obvious one.
+    ///
+    /// <para>🚨 The first version of this guard matched <c>2&gt;/dev/null</c> alone and passed while
+    /// the script still discarded Azure's output through <c>&gt;/dev/null 2&gt;&amp;1</c> — a guard
+    /// with a loophole exactly the size of the remaining bug. Raised in review of #2903.</para>
+    /// </summary>
+    private static bool DiscardsStderr(string line) =>
+        new[]
+        {
+            "2>/dev/null", "2> /dev/null",
+            ">/dev/null 2>&1", "> /dev/null 2>&1",
+            "&>/dev/null", "&> /dev/null",
+        }.Any(form => line.Contains(form, StringComparison.Ordinal));
 
     [Fact]
     public void TheAcrLogin_NeverDiscardsAzuresOwnError()


### PR DESCRIPTION
## The defect

`image_pull_acr` ran `az acr login -n meshweaver -o none **2>/dev/null**` and, on failure, said:

```
err  cannot log in to meshweaver.azurecr.io — run 'az login' first
     (the account needs pull access to the 'meshweaver' registry)
```

That is the one remedy which cannot help the failure people actually hit: an account that **is** signed in and simply holds no role on the registry. Azure had answered precisely, and the redirect destroyed the sentence:

```
ERROR: (AuthorizationFailed) The client '…@systemorph.com' with object id '…' does not have
authorization to perform action 'Microsoft.Resources/subscriptions/resources/read'
over scope '/subscriptions/…' or the scope is invalid.
```

Reported 2026-08-31 by a developer who signed out, signed back in and switched tenant on that advice before asking. The role had been missing the whole time, and nothing the message suggested could have revealed it.

This became reachable only yesterday: `b791b8e0d` introduced registry mode along with `registry_mode && image_source="acr"`, so `memex-local update` contacts ACR now where it previously always built locally.

## The change

**Two sites, because the guard found a second one.**

1. **`image_pull_acr`** — prints Azure's own output, then names the three distinct situations rather than one:
   - signed **out** → `az login`
   - signed **in** → the account needs **AcrPull** on the registry *and* **Reader** on its subscription, because `az acr login` resolves the registry through ARM before it ever contacts it — so a bare AcrPull grant does not make this command work
   - **no** registry access → `memex-local update --build`, or `--skip-image` to keep the running image
2. **The autoroll daemon** had the same defect with worse consequences: it discarded the error and logged `acr poll FAILED (az not logged in / offline?)` every polling window, so a missing role reads as a transient network blip forever. It now logs what Azure said.

## The guard

`MemexLocalSurfacesAzureErrorsGuard` pins both halves: no `az` invocation may send its stderr to `/dev/null`, and the ACR failure must name the role and the build escape rather than only the sign-in.

Scoped to `az` deliberately — discarding stderr stays legitimate for a probe whose failure is expected and handled, such as `docker image inspect` asking whether an image is present. The guard must not police those.

## Verification

TDD: the guard was written first and failed RED on **2** lines (it found the autoroll site I had not been looking for), then GREEN. `MeshWeaver.Documentation.Test` is 144/144 under `-c Release -warnaserror`, 0 warnings; `bash -n` clean.

The new message was then run against the real failing credential rather than assumed:

```
ERROR: (AuthorizationFailed) The client '…' does not have authorization to perform action
'Microsoft.Resources/subscriptions/resources/read' over scope '/subscriptions/…'
…
err  cannot log in to meshweaver.azurecr.io — Azure's own answer is printed above.
     signed OUT     -> az login
     signed IN      -> the account needs the AcrPull role on the 'meshweaver' registry, and Reader on
                       its subscription ('az acr login' resolves the registry through ARM first)
     no ACR access  -> build the image instead:  memex-local update --build
                       or keep the running one:  memex-local update --skip-image
```

No What's New entry: this is a local developer-CLI diagnostic, the class of change `4543d75f9` and `8ca7fd688` also shipped without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
