### PR TITLE
feat(memex-local): discover the node repos beside the checkout, by content

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -1133,11 +1133,40 @@ plugin_repo_paths() {
     done
     return 0
   fi
-  local repo sibling
+  # Otherwise: every node repo checked out BESIDE the platform, discovered by CONTENT.
+  #
+  # 🚨 This used to be the single sibling literally named MeshWeaver.Plugins, with
+  # MEMEX_PLUGIN_REPOS as the only way to serve anything else. A developer with the course repo
+  # checked out next to it therefore had a portal that could not serve a single course, and
+  # nothing said so — the Store just listed less. Setting the variable fixed it until the next
+  # `memex-local update` typed without it, at which point the courses silently went away again.
+  local repo parent d
   repo="$(resolve_repo 2>/dev/null)" || return 0
-  sibling="$(dirname "$repo")/MeshWeaver.Plugins"
-  [ -d "$sibling" ] && printf '%s\n' "$sibling"
+  parent="$(dirname "$repo")"
+  for d in "$parent"/*/; do
+    d="${d%/}"
+    [ -d "$d" ] || continue
+    is_node_repo "$d" && printf '%s\n' "$d"
+  done
   return 0
+}
+
+# Whether a directory is a node repo: does it DECLARE a package root — <Folder>/index.json with a
+# root nodeType? That is the registry's own predicate (NodeRepoPackageSource: Space, Store/Plugin,
+# Store/Catalog), applied at the same depth.
+#
+# 🚨 By content, never by a list of names. That is what makes the platform checkout and its
+# worktrees exclude THEMSELVES — they carry no root manifest at this depth — so no name list has to
+# enumerate them and none can go stale; and a node repo added or renamed tomorrow is picked up with
+# no change here. The glob is exactly depth 2, so a manifest nested deeper does not qualify, which
+# is the same line the registry draws.
+is_node_repo() {
+  local f
+  for f in "$1"/*/index.json; do
+    [ -f "$f" ] || continue
+    grep -qE '"nodeType"[[:space:]]*:[[:space:]]*"(Space|Store/Plugin|Store/Catalog)"' "$f" && return 0
+  done
+  return 1
 }
 
 readonly E2E_DB="memex_e2e"
@@ -2480,4 +2509,7 @@ main() {
     *) die "unknown command '$cmd' (try: memex-local help)" ;;
   esac
 }
-main "$@"
+# Sourceable for tests: `MEMEX_LOCAL_LIB=1 . memex-local` defines the functions without dispatching.
+# Without this the only way to check a helper's BEHAVIOUR is to assert on the script's text, which
+# is not a check of what the helper does.
+[ "${MEMEX_LOCAL_LIB:-}" = "1" ] || main "$@"

--- a/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LocalColimaMac.md
@@ -470,7 +470,7 @@ The result: every device trusts the cert out of the box (no mkcert CA install), 
 | Uploaded documents aren't searchable / `nodeType:Document` returns 0 / an agent can't find its input | Content **indexing** needs an embedding provider, which is separate from the chat model and off by default. Set `Embedding__Provider`/`Embedding__Endpoint`/`Embedding__Model` (§10.1) and **re-upload** — indexing fires on the upload event, so pre-existing files aren't retro-indexed. |
 | `memex-local` targets the **wrong cluster** — `helm` fails `kubernetes cluster unreachable: …privatelink…azmk8s.io`, or (worse) a reachable cloud cluster gets rolled | 🚨 `memex-local` uses the **ambient `kubectl` context**, not a pinned one. If your current context is an AKS cluster, `up`/`update` deploy *there*. Check with `kubectl config current-context` and switch: `kubectl config use-context colima`. It failed loudly here only because that cluster is private and unroutable — a reachable one would have been rolled silently. |
 | `https://memex.localhost:8443` refuses the connection although the pods are healthy | Same root cause as above: the launchd port-forward agent runs `kubectl port-forward` with **no context**, so an AKS current-context breaks it. Fix the context, then `memex-local port-forward`. |
-| Plugin Catalog is empty / a new instance installs nothing | The local portal is the **registry** and serves plugins from your **checkout** (§16). No checkout found ⇒ nothing to serve. Confirm the config landed: `kubectl -n memex get cm memex-portal-config -o json \| grep PluginCatalog__Sources` and that the mount exists: `kubectl -n memex exec deploy/memex-portal-deployment -- ls /plugin-repos/Plugins`. Point it explicitly with `MEMEX_PLUGIN_REPOS=/path/to/MeshWeaver.Plugins`. |
+| Plugin Catalog is empty / a new instance installs nothing | The local portal is the **registry** and serves plugins from your **checkout** (§16). No checkout found ⇒ nothing to serve. Confirm the config landed: `kubectl -n memex get cm memex-portal-config -o json \| grep PluginCatalog__Sources` and that the mount exists: `kubectl -n memex exec deploy/memex-portal-deployment -- ls /plugin-repos/Plugins`. Node repos beside `MEMEX_REPO` are discovered by content (a `<Folder>/index.json` with a root `nodeType`), so a repo that declares no package root is silently not one; point at it explicitly with `MEMEX_PLUGIN_REPOS=/path/to/repo`. |
 | `instance up` fails `409 — Instance id '<id>' is already registered` | An instance id is claimed **globally** on the registry, and dropping the instance's database does not release it. Use `memex-local instance down --id <id>` (which releases the claim and restarts the registry) before re-running, or pick a new id. |
 | A plugin install fails with `NodeType(s) not registered: <Other>/<Type>` | The package depends on another that is not installed yet. The default install orders by the manifest's `requires`; a package that depends on something **outside** the granted set cannot be ordered against and will fail. Grant the dependency too (§16). |
 | Instance pod OOMs mid-install (`OutOfMemoryException`, often surfacing inside Npgsql) and the remaining packages never install | A first boot compiles every default-installed plugin's node types back to back, and each compile **retains** its collectible ALC. `memex-local` sizes the instance pod 3cpu/6Gi for this; a smaller pod dies partway. Installing fewer packages by default (a narrower `InstallByDefault`) is the other lever. |
@@ -539,15 +539,27 @@ no such credential, so it reads them straight off disk: `helm_deploy` mounts eac
 **read-only** (`pluginCatalog.localRepoMounts` → a `hostPath`; Colima runs the node on this very
 machine) and points a source at the in-container path.
 
-Discovery is by convention — a `MeshWeaver.Plugins` checkout **beside** your `MEMEX_REPO`. Override
-or add repos with `MEMEX_PLUGIN_REPOS` (colon-separated absolute paths):
+**Discovery is automatic, and by CONTENT.** Every directory beside your `MEMEX_REPO` that declares
+a package root — a `<Folder>/index.json` whose `nodeType` is `Space`, `Store/Plugin` or
+`Store/Catalog`, the registry's own predicate — is mounted and served. Clone a node repo next to the
+platform checkout and it is picked up on the next `memex-local update`; nothing to configure.
+
+The platform checkout and its worktrees exclude *themselves*: they carry no root manifest at that
+depth, so the rule needs no list of names to skip, and none can go stale.
+
+`MEMEX_PLUGIN_REPOS` (colon-separated absolute paths) still overrides the discovered set, for
+serving *fewer* repos than you have checked out:
 
 ```bash
-# One extra repo alongside the platform one. Each folder's basename (minus a "MeshWeaver." prefix)
-# becomes the SOURCE NAME, and every new instance is granted that source.
-MEMEX_PLUGIN_REPOS=/Users/me/code/MeshWeaver.Plugins:/Users/me/code/education \
+# Each folder's basename (minus a "MeshWeaver." prefix) becomes the SOURCE NAME, and every new
+# instance is granted that source.
+MEMEX_PLUGIN_REPOS=/Users/me/code/MeshWeaver.Plugins \
   memex-local update --build
 ```
+
+🚨 It is an environment variable, so it applies to **that one invocation**. A later
+`memex-local update` typed without it serves the discovered set again — which is why discovery,
+not the variable, is the default.
 
 Verify what actually landed — the values file is not the evidence, the pod is:
 
@@ -589,7 +601,8 @@ Expected on a healthy run — the instance registers, is granted `Plugins/*` by
 
 ### Adding another plugin repo
 
-1. Clone it next to your checkout (or anywhere) and list it in `MEMEX_PLUGIN_REPOS`.
+1. Clone it **next to your checkout** — nothing else to do, it is discovered. (Somewhere else? Then
+   list every repo you want in `MEMEX_PLUGIN_REPOS`, which replaces the discovered set.)
 2. `memex-local update --build` — the chart mounts it and adds it as a source **and** grants it to
    every new instance (`defaultGrants: <name>/*`).
 3. Whether new instances **install** it as well is separate: `pluginCatalog.installByDefault`

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-local-portal-serves-every-checked-out-repo.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-08-31-local-portal-serves-every-checked-out-repo.md
@@ -1,0 +1,27 @@
+---
+Name: A local portal serves every plugin repo you have checked out
+Category: Feature
+Description: A local install now discovers the node repos beside your platform checkout and serves all of them, instead of only the one named MeshWeaver.Plugins.
+Icon: Sparkle
+Order: -20260831
+---
+
+# A local portal serves every plugin repo you have checked out
+
+A local install acts as its own plugin registry and reads plugin repositories straight off your
+disk. It used to look for exactly one directory — the one literally named `MeshWeaver.Plugins` —
+and everything else had to be listed in an environment variable, on every single command.
+
+The effect was quiet and easy to misread. With the course repository checked out right next to the
+platform, the portal still could not serve a single course, and nothing said why: the Store simply
+listed less than you expected. Setting the variable fixed it, until the next update typed without
+it, at which point the courses disappeared again.
+
+Now every repository beside your checkout that actually declares packages is discovered and served.
+Clone one next to the others and it appears on the next update — no configuration, and nothing to
+remember a second time.
+
+Discovery goes by what a repository *contains* rather than what it is called, so the platform
+checkout and its worktrees leave themselves out, and a repository added or renamed later is picked
+up with no change. `MEMEX_PLUGIN_REPOS` still works when you want to serve fewer repositories than
+you have checked out.

--- a/test/MeshWeaver.Documentation.Test/MemexLocalDiscoversNodeRepoSiblingsGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/MemexLocalDiscoversNodeRepoSiblingsGuard.cs
@@ -1,0 +1,145 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>Which plugin repos a local install serves must not depend on an environment variable a
+/// developer has to remember.</b>
+///
+/// <para><c>plugin_repo_paths</c> mounted exactly one directory — the sibling literally named
+/// <c>MeshWeaver.Plugins</c> — and offered <c>MEMEX_PLUGIN_REPOS</c> as the only way to serve
+/// anything else. A developer with the course repo checked out beside it therefore had a portal
+/// that could not serve a single course, with nothing to indicate why: the Store simply listed
+/// less. Setting the variable fixed it until the next <c>memex-local update</c> typed without it,
+/// at which point the courses silently went away again. Reported 2026-08-31 after exactly that
+/// sequence.</para>
+///
+/// <para><b>Discovery is by CONTENT, never by name.</b> A node repo is one that has at least one
+/// <c>&lt;Folder&gt;/index.json</c> declaring a root node type — the same predicate the registry's
+/// own <c>NodeRepoPackageSource</c> applies (<c>Space</c>, <c>Store/Plugin</c>,
+/// <c>Store/Catalog</c>). That is what makes the platform checkout and its worktrees exclude
+/// themselves: they carry no root manifest at that depth, so no name list has to enumerate them —
+/// and a repo added or renamed tomorrow is picked up with no change here.</para>
+/// </summary>
+public class MemexLocalDiscoversNodeRepoSiblingsGuard : IDisposable
+{
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "memex-local-discovery-" + Guid.NewGuid().ToString("N")[..8]);
+
+    private static string RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+
+    private static string Script() =>
+        Path.Combine(RepoRoot(), "deploy", "homebrew", "bin", "memex-local");
+
+    public MemexLocalDiscoversNodeRepoSiblingsGuard()
+    {
+        // The platform checkout itself: the marker resolve_repo keys on, and no root manifest.
+        Directory.CreateDirectory(Path.Combine(root, "Platform"));
+        File.WriteAllText(Path.Combine(root, "Platform", "MeshWeaver.slnx"), "<Solution />");
+
+        // A worktree of it — same shape, and just as wrong to mount.
+        Directory.CreateDirectory(Path.Combine(root, "Platform-wt"));
+        File.WriteAllText(Path.Combine(root, "Platform-wt", "MeshWeaver.slnx"), "<Solution />");
+
+        NodeRepo("Acme.Courses", "Course", "Store/Plugin");
+        NodeRepo("Acme.Views", "Pack", "Space");
+
+        // A plain directory — nothing to serve.
+        Directory.CreateDirectory(Path.Combine(root, "Notes"));
+
+        // A manifest at the WRONG DEPTH. The registry reads <Folder>/index.json and nothing deeper,
+        // so a repo whose only manifest is nested is not a node repo.
+        Directory.CreateDirectory(Path.Combine(root, "Deep.Repo", "Sub", "Nested"));
+        File.WriteAllText(Path.Combine(root, "Deep.Repo", "Sub", "Nested", "index.json"),
+            """{ "id": "Nested", "nodeType": "Store/Plugin" }""");
+
+        // Right depth, wrong node type — a content node, not a package root.
+        NodeRepo("Not.A.Repo", "Thing", "Markdown");
+    }
+
+    private void NodeRepo(string repo, string package, string nodeType)
+    {
+        Directory.CreateDirectory(Path.Combine(root, repo, package));
+        File.WriteAllText(Path.Combine(root, repo, package, "index.json"),
+            $$"""{ "id": "{{package}}", "nodeType": "{{nodeType}}" }""");
+    }
+
+    /// <summary>
+    /// Runs the shipped script's own function, sourced, rather than asserting on its text — the
+    /// question is what it RESOLVES, and only running it answers that.
+    /// </summary>
+    private IReadOnlyList<string> Discovered(string? overrideVar = null)
+    {
+        var info = new ProcessStartInfo("/bin/bash",
+            ["-c", $". '{Script()}'; plugin_repo_paths"])
+        {
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        info.Environment["MEMEX_LOCAL_LIB"] = "1";
+        info.Environment["MEMEX_REPO"] = Path.Combine(root, "Platform");
+        if (overrideVar is not null) info.Environment["MEMEX_PLUGIN_REPOS"] = overrideVar;
+
+        using var process = Process.Start(info)!;
+        var stdout = process.StandardOutput.ReadToEnd();
+        var stderr = process.StandardError.ReadToEnd();
+        Assert.True(process.WaitForExit(60_000), "memex-local did not finish resolving plugin repos");
+        Assert.True(process.ExitCode == 0,
+            $"sourcing memex-local failed (exit {process.ExitCode}). stderr:\n{stderr}");
+
+        return stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => Path.GetFileName(line.Trim()))
+            .Where(name => name.Length > 0)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    [Fact]
+    public void EveryNodeRepoBesideTheCheckout_IsServed_WithNoEnvironmentVariable()
+    {
+        Assert.Equal(["Acme.Courses", "Acme.Views"], Discovered());
+    }
+
+    /// <summary>
+    /// 🚨 The platform checkout is not a node repo and mounting it would hand the portal the whole
+    /// source tree. It excludes itself on content — no root manifest — so this holds for its
+    /// worktrees too, which look identical and are just as wrong.
+    /// </summary>
+    [Fact]
+    public void ThePlatformCheckoutAndItsWorktrees_AreNeverServed()
+    {
+        var discovered = Discovered();
+
+        Assert.DoesNotContain("Platform", discovered);
+        Assert.DoesNotContain("Platform-wt", discovered);
+    }
+
+    /// <summary>
+    /// Discovery is the default, not a takeover: an explicit list still decides, so a developer who
+    /// wants fewer repos than they have checked out keeps saying so.
+    /// </summary>
+    [Fact]
+    public void AnExplicitList_StillWins()
+    {
+        Assert.Equal(["Acme.Views"], Discovered(Path.Combine(root, "Acme.Views")));
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); } catch (IOException) { }
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/MemexLocalDiscoversNodeRepoSiblingsGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/MemexLocalDiscoversNodeRepoSiblingsGuard.cs
@@ -84,20 +84,30 @@ public class MemexLocalDiscoversNodeRepoSiblingsGuard : IDisposable
     /// </summary>
     private IReadOnlyList<string> Discovered(string? overrideVar = null)
     {
+        // 🚨 The shell redirects to FILES and nothing is piped back. Reading a redirected stream
+        // with ReadToEnd() before WaitForExit blocks in the read, so the bounded wait below could
+        // never fire and a hung script would hang the runner instead of failing it — a cap that
+        // cannot fire is not a cap. Raised in review of #2904. With no pipe to drain, WaitForExit
+        // is the only thing that waits, and it is bounded.
+        var outPath = Path.Combine(root, "stdout.txt");
+        var errPath = Path.Combine(root, "stderr.txt");
+
         var info = new ProcessStartInfo("/bin/bash",
-            ["-c", $". '{Script()}'; plugin_repo_paths"])
-        {
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-        };
+            ["-c", $"{{ . '{Script()}'; plugin_repo_paths; }} > '{outPath}' 2> '{errPath}'"]);
         info.Environment["MEMEX_LOCAL_LIB"] = "1";
         info.Environment["MEMEX_REPO"] = Path.Combine(root, "Platform");
         if (overrideVar is not null) info.Environment["MEMEX_PLUGIN_REPOS"] = overrideVar;
 
         using var process = Process.Start(info)!;
-        var stdout = process.StandardOutput.ReadToEnd();
-        var stderr = process.StandardError.ReadToEnd();
-        Assert.True(process.WaitForExit(60_000), "memex-local did not finish resolving plugin repos");
+        if (!process.WaitForExit(60_000))
+        {
+            process.Kill(entireProcessTree: true);
+            Assert.Fail("memex-local did not finish resolving plugin repos within 60s — it is "
+                + "stuck, and the cap must report that rather than wait forever.");
+        }
+
+        var stdout = File.Exists(outPath) ? File.ReadAllText(outPath) : "";
+        var stderr = File.Exists(errPath) ? File.ReadAllText(errPath) : "";
         Assert.True(process.ExitCode == 0,
             $"sourcing memex-local failed (exit {process.ExitCode}). stderr:\n{stderr}");
 
@@ -138,8 +148,13 @@ public class MemexLocalDiscoversNodeRepoSiblingsGuard : IDisposable
         Assert.Equal(["Acme.Views"], Discovered(Path.Combine(root, "Acme.Views")));
     }
 
+    /// <summary>
+    /// Best-effort: a temp tree that outlives the test is untidy, never a failure, so no cleanup
+    /// problem may turn a passing assertion red. Raised in review of #2904 — catching only
+    /// IOException left UnauthorizedAccessException and friends able to fail the test.
+    /// </summary>
     public void Dispose()
     {
-        try { Directory.Delete(root, recursive: true); } catch (IOException) { }
+        try { Directory.Delete(root, recursive: true); } catch (Exception) { }
     }
 }


### PR DESCRIPTION
## The defect

`plugin_repo_paths` mounted exactly one directory — the sibling **literally named** `MeshWeaver.Plugins` — and offered `MEMEX_PLUGIN_REPOS` as the only way to serve anything else:

```bash
sibling="$(dirname "$repo")/MeshWeaver.Plugins"
[ -d "$sibling" ] && printf '%s\n' "$sibling"
```

A developer with the course repository checked out right beside it therefore had a portal that could not serve a single course, and **nothing said so** — the Store simply listed less than expected. Setting the variable fixed it, until the next `memex-local update` typed without it, at which point the courses silently went away again. It is an environment variable: it applies to one invocation.

Reported 2026-08-31, after exactly that sequence.

## The change

Every directory beside `MEMEX_REPO` that **declares a package root** is now discovered and served. A node repo is one with a `<Folder>/index.json` whose `nodeType` is `Space`, `Store/Plugin` or `Store/Catalog` — the registry's own predicate (`NodeRepoPackageSource.RootNodeTypes`), applied at the same depth.

**By content, never by a list of names.** That is what makes the platform checkout and its worktrees exclude *themselves* — they carry no root manifest at that depth — so nothing has to enumerate them and no list can go stale, and a node repo added or renamed tomorrow is picked up with no change here.

`MEMEX_PLUGIN_REPOS` still overrides, for serving *fewer* repos than are checked out.

## Verification

Run on a real machine, against the actual sibling tree:

| Sibling | root `*/index.json` | `MeshWeaver.slnx` | Discovered |
|---|---|---|---|
| MeshWeaver.Plugins | 40 | no | ✅ |
| MeshWeaver.Reinsurance | 14 | no | ✅ |
| MeshWeaver.Education | 9 | no | ✅ |
| MeshWeaver.SocialMedia | 5 | no | ✅ |
| MeshWeaver.Crm, MeshWeaver.Manufacturing | 1 each | no | ✅ |
| **MeshWeaver** (the platform checkout) | 0 | yes | ❌ |
| **MW-marketplace** (a worktree of it) | 0 | yes | ❌ |
| Memex, _archive, loose files | — | — | ❌ |

Six node repos, and both platform trees excluded on content alone.

## The guard

`MemexLocalDiscoversNodeRepoSiblingsGuard` **runs the shipped function** against a fixture tree rather than asserting on the script's text — the question is what it *resolves*, and only running it answers that. `MEMEX_LOCAL_LIB=1` makes `memex-local` sourceable without dispatching, which is what allows a behavioural test at all.

Three cases: everything beside the checkout is served with no environment variable; the platform checkout and a worktree of it are never served; an explicit list still wins. The fixture also includes a manifest at the **wrong depth** and one with the **wrong nodeType**, since either would otherwise let a non-repo through.

TDD: verified RED (`Assert.Equal() Failure: Collections differ` — nothing discovered) then GREEN. `MeshWeaver.Documentation.Test` is 147/147 under `-c Release -warnaserror`, 0 warnings; `bash -n` clean.

## Also

- `LocalColimaMac.md` §16 rewritten — it documented the convention that just changed, including the troubleshooting row that told readers to point `MEMEX_PLUGIN_REPOS` at the repo by hand.
- What's New entry, `Category: Feature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
