### PR TITLE
feat(build-project): ship the SDK's built-in generators in the image — [GeneratedRegex] modules compile with no flag

### DIFF
--- a/test/MeshWeaver.PluginTester.Test/SdkGeneratorBuildTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/SdkGeneratorBuildTest.cs
@@ -1,0 +1,134 @@
+using System.Reactive;
+using MeshWeaver.Data;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// <c>mw-plugin-test build-project</c> runs the SDK's BUILT-IN generators — the whole chain,
+/// executed: the <c>sdk-generators/</c> directory the image SHIPS is found beside the builder with
+/// no flag, loaded against THIS repo's Roslyn, and run over a real <c>[GeneratedRegex]</c> partial
+/// whose body only the generator can supply.
+///
+/// <para>🚨 The failure this guards is SILENT in the image and LOUD only here. These generators
+/// live in the SDK's targeting pack, not the runtime an image ships, so an image staged without
+/// them fails every <c>[GeneratedRegex]</c> project as CS8795 — indistinguishable, from the module
+/// lane's side, from "this project has errors" (measured on MeshWeaver.Markdown.Collaboration,
+/// 2026-08-31: 7 errors → 0 with exactly this generator supplied). Like <see cref="RazorBuildTest"/>
+/// gates the Razor pairing, this test EXECUTES the staged copy so a ref pack whose generator cannot
+/// run against this repo's Roslyn turns the PR red instead of shipping a silent image.</para>
+/// </summary>
+public class SdkGeneratorBuildTest : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"mw-sdkgen-{Guid.NewGuid():N}");
+
+    private string Write(string relativePath, string content)
+    {
+        var full = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// The same <c>/app</c>-shaped fixture <see cref="RazorBuildTest"/> uses: the REAL shipped
+    /// <c>deps.json</c> plus one assembly, everything else arriving through the process's TPA and
+    /// the shared frameworks — which is where <c>System.Text.RegularExpressions</c> comes from,
+    /// exactly as it does inside a portal image.
+    /// </summary>
+    private string AppDirectory()
+    {
+        var app = Path.Combine(_root, "_container");
+        if (Directory.Exists(app))
+            return app;
+        Directory.CreateDirectory(app);
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "mw-plugin-test.deps.json"),
+            Path.Combine(app, "mw-plugin-test.deps.json"));
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "MeshWeaver.ShortGuid.dll"),
+            Path.Combine(app, "MeshWeaver.ShortGuid.dll"));
+        return app;
+    }
+
+    private static Task<ProjectBuild.Report> Build(ProjectBuild.Options options) =>
+        ProjectBuild.Run(options).Await(TestContext.Current.CancellationToken);
+
+    [Fact]
+    public void TheImageShipsTheSdkGeneratorsBesideTheBuilder()
+    {
+        var directory = Path.Combine(AppContext.BaseDirectory, ProjectBuild.SdkGeneratorDirectoryName);
+        Directory.Exists(directory).Should().BeTrue(
+            "the image build stages the SDK's built-in generators beside the builder; without them "
+            + "every [GeneratedRegex] project fails CS8795 under build-project while compiling fine "
+            + "on the SDK path — the exact split-brain the container lane exists to remove");
+
+        var assemblies = Directory.GetFiles(directory, "*.dll")
+            .Select(Path.GetFileName)
+            .ToArray();
+        assemblies.Should().Contain("System.Text.RegularExpressions.Generator.dll",
+            "the regex generator is the one the module lane's green list is measured against");
+
+        File.Exists(Path.Combine(directory, "sdk-generators.json")).Should().BeTrue(
+            "the image must say WHICH ref pack it staged from — the image is the pin, and a pin "
+            + "nobody can read is not a pin");
+    }
+
+    /// <summary>
+    /// 🚨 The build IS the assertion: without the staged generator this partial has no body and the
+    /// compile fails (CS8795), so a green report proves the generator was found with NO flag,
+    /// loaded against this repo's Roslyn, and executed.
+    /// </summary>
+    [Fact]
+    public async Task AGeneratedRegexProjectCompilesGreenWithNoGeneratorsFlag()
+    {
+        var entry = Write("Regexy/Regexy.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <AssemblyName>Widgets.Regexy</AssemblyName>
+                <RootNamespace>Widgets</RootNamespace>
+              </PropertyGroup>
+            </Project>
+            """);
+        Write("Regexy/Patterns.cs", """
+            using System.Text.RegularExpressions;
+
+            namespace Widgets;
+
+            public static partial class Patterns
+            {
+                [GeneratedRegex("^a+b$")]
+                public static partial Regex AaB();
+            }
+            """);
+
+        var report = await Build(new()
+        {
+            EntryProject = entry,
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "out"),
+            Output = TextWriter.Null,
+            MaxParallel = 2,
+        });
+
+        report.FatalError.Should().BeNull();
+        report.ExitCode.Should().Be(0,
+            "a CS8795 here means the staged sdk-generators/ copy was not found or did not run — "
+            + "the exact silent gap this test exists to keep red");
+        var result = report.Projects.Single().Result!;
+        result.Failure.Should().BeNull();
+        result.Errors.Should().Be(0);
+        result.IsGreen.Should().BeTrue();
+    }
+}

--- a/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+++ b/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -105,6 +105,62 @@
     </ItemGroup>
   </Target>
 
+  <!-- ═══ The SDK's BUILT-IN source generators (GeneratedRegex, JsonSerializable, LibraryImport…) ═══
+       A MeshWeaver image ships the RUNTIME; these generators live in the SDK's targeting pack
+       (packs/Microsoft.NETCore.App.Ref/<version>/analyzers/dotnet/cs), so a module using
+       [GeneratedRegex] compiles on the SDK path and dies as CS8795 under build-project unless the
+       image carries the generator (measured on MeshWeaver.Markdown.Collaboration, 2026-08-31:
+       7 errors → 0 with exactly this DLL supplied by hand via the generators flag). Staging them beside the
+       builder lets build-project pick them up with NO flag, the same way razor-generators/ works.
+
+       Staged FLAT — no per-RID split. Unlike the Razor compiler these are plain AnyCPU IL
+       (PE machine 0x014C, measured on ref pack 10.0.11), so one copy loads on every RID the image
+       publishes. Satellite-resource subfolders are left behind on purpose: diagnostics in English.
+
+       PROVENANCE: sdk-generators.json records the ref-pack version and source. The pairing is
+       GATED by a test that EXECUTES the staged regex generator against this repo's Roslyn
+       (SdkGeneratorBuildTest), so a pack whose generator cannot run here turns a PR red instead
+       of shipping a silent image. -->
+  <PropertyGroup>
+    <MeshWeaverSdkGeneratorSource Condition="'$(MeshWeaverSdkGeneratorSource)' == ''">$(NetCoreRoot)packs/Microsoft.NETCore.App.Ref/$(BundledNETCoreAppPackageVersion)/analyzers/dotnet/cs</MeshWeaverSdkGeneratorSource>
+  </PropertyGroup>
+
+  <Target Name="StageSdkSourceGenerators" BeforeTargets="AssignTargetPaths">
+    <ItemGroup>
+      <_MeshWeaverSdkGenerator Include="$(MeshWeaverSdkGeneratorSource)/*.dll" />
+    </ItemGroup>
+    <!-- 🚨 An empty glob would ship an image whose container builds fail every [GeneratedRegex]
+         project as CS8795, and nothing downstream could tell that from "this project has errors". -->
+    <Error Condition="'@(_MeshWeaverSdkGenerator)' == ''"
+           Text="No SDK built-in source generators found in '$(MeshWeaverSdkGeneratorSource)'. build-project supplies the SDK's own generators (GeneratedRegex, JsonSerializable, LibraryImport) from this staged copy, because a runtime image has no SDK; an image built without them fails every project that uses one, as a compile error naming a generator that never ran. Install a .NET SDK whose targeting pack carries them, or point -p:MeshWeaverSdkGeneratorSource=&lt;dir&gt; at a copy." />
+    <Error Condition="'@(_MeshWeaverSdkGenerator->WithMetadataValue('Filename', 'System.Text.RegularExpressions.Generator'))' == ''"
+           Text="The staged SDK generators do not include System.Text.RegularExpressions.Generator.dll — the one generator the module lane's green list is measured against (CS8795)." />
+    <PropertyGroup>
+      <!-- Item transforms cannot be concatenated with literals inside a task's string parameter
+           (MSB4012), so the list becomes a property first. -->
+      <_MeshWeaverSdkGeneratorNames>@(_MeshWeaverSdkGenerator->'%(Filename)%(Extension)', '&quot;, &quot;')</_MeshWeaverSdkGeneratorNames>
+    </PropertyGroup>
+    <WriteLinesToFile
+        File="$(IntermediateOutputPath)sdk-generators.json"
+        Overwrite="true"
+        WriteOnlyWhenDifferent="true"
+        Lines="{ &quot;refPack&quot;: &quot;$(BundledNETCoreAppPackageVersion)&quot;, &quot;source&quot;: &quot;$(MeshWeaverSdkGeneratorSource)&quot;, &quot;assemblies&quot;: [&quot;$(_MeshWeaverSdkGeneratorNames)&quot;] }" />
+    <ItemGroup>
+      <Content Include="@(_MeshWeaverSdkGenerator)"
+               Link="sdk-generators/%(Filename)%(Extension)"
+               CopyToOutputDirectory="PreserveNewest"
+               CopyToPublishDirectory="PreserveNewest"
+               Pack="false"
+               Visible="false" />
+      <Content Include="$(IntermediateOutputPath)sdk-generators.json"
+               Link="sdk-generators/sdk-generators.json"
+               CopyToOutputDirectory="PreserveNewest"
+               CopyToPublishDirectory="PreserveNewest"
+               Pack="false"
+               Visible="false" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <!-- GateDiscoveryEqualsBakeDiscoveryTest pins PluginGateRunner.DiscoverNodeTypes equal to the
          compiler-driven bake's discovery (#2063). The two halves disagreeing IS the defect, and

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -351,9 +351,26 @@ public static class ProjectBuild
     }
 
     /// <summary>
+    /// The directory, beside the builder (then under the container's <c>/app</c>), that carries the
+    /// SDK's BUILT-IN generators (<c>GeneratedRegex</c>, <c>JsonSerializable</c>,
+    /// <c>LibraryImport</c>…). They live in the SDK's targeting pack, not the runtime the image
+    /// ships, so the image build stages them here (<c>StageSdkSourceGenerators</c> in this
+    /// project's <c>.csproj</c>) and every build picks them up without a flag — the same shipping
+    /// pattern as <c>razor-generators/</c>, minus the per-RID split (these are plain AnyCPU IL).
+    /// </summary>
+    public const string SdkGeneratorDirectoryName = "sdk-generators";
+
+    /// <summary>
     /// Expands <c>--generators</c> into assembly paths. A directory contributes its <c>*.dll</c>;
     /// a path that does not exist is a failure, because a generator directory that is not there
     /// would silently run no generator and produce a different assembly.
+    ///
+    /// <para>The image-shipped <see cref="SdkGeneratorDirectoryName"/> directory is then appended
+    /// unconditionally when present — beside the builder first, then under the container's
+    /// <c>/app</c>. Absence is NOT an error here: a from-source run on a dev machine has no staged
+    /// copy, and a project that uses no SDK generator builds identically either way; a project
+    /// that DOES need one still fails by name (the missing-partials diagnostic below names the
+    /// generator that never ran), so nothing goes quietly.</para>
     /// </summary>
     private static ImmutableArray<string> ResolveGenerators(Options options, Sink sink)
     {
@@ -369,6 +386,20 @@ public static class ProjectBuild
                 throw new InvalidOperationException(
                     $"--generators '{full}' does not exist. A generator path that is not there runs "
                     + "no generator and silently produces a different assembly.");
+        }
+        var shipped = new[]
+            {
+                Path.Combine(AppContext.BaseDirectory, SdkGeneratorDirectoryName),
+                Path.Combine(options.AppDirectory, SdkGeneratorDirectoryName),
+            }
+            .Select(Path.GetFullPath)
+            .Distinct(StringComparer.Ordinal)
+            .FirstOrDefault(Directory.Exists);
+        if (shipped is not null)
+        {
+            var dlls = Directory.GetFiles(shipped, "*.dll");
+            paths.AddRange(dlls);
+            sink.Info($"sdk generators: {dlls.Length} from {shipped} (staged by the image build)");
         }
         if (paths.Count > 0)
             sink.Info($"source generators: {paths.Count} candidate assembl(y|ies)");


### PR DESCRIPTION
Part of the memex-as-compiler program (#2854): the measured 18-green list was produced with the SDK's regex generator handed in by hand (`--generators`); the module lane deliberately passes no such flag, so flipping entries would have redded on CS8795. This puts the key in the image instead:

- **`StageSdkSourceGenerators`** (tester csproj): stages `packs/Microsoft.NETCore.App.Ref/<bundled>/analyzers/dotnet/cs/*.dll` — GeneratedRegex, System.Text.Json, and the three interop generators — flat into `sdk-generators/` beside the builder. Plain AnyCPU IL (PE machine 0x014C, measured), so no per-RID split; one copy serves both image architectures. Provenance in `sdk-generators.json`, loud `<Error>`s on an empty glob, mirroring the razor-generators target.
- **`ProjectBuild.ResolveGenerators`**: appends the shipped directory (beside the builder, then under `/app`) to every build, no flag needed. Explicit `--generators` stays additive; absence stays soft (a dev-machine from-source run), and a project that needs a generator still fails BY NAME.
- **`SdkGeneratorBuildTest`**: executes the chain — asserts the staged layout, then compiles a real `[GeneratedRegex]` partial through `build-project` with no flag and requires green (impossible unless the staged generator loaded against this repo's Roslyn and ran).

Verified locally: tester + test project build Release `-warnaserror` clean; full tester suite 267/267; the staged directory flows transitively into consumers' output exactly like `razor-generators/`. No CD change needed — the publish host's SDK carries the pack, and the existing `-p:MeshWeaverRazorGeneratorRoot` handling is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)