### PR TITLE
feat(build-project): CSS isolation — SDK scope hash reproduced, styles aggregate emitted, unstyled-landing asserted

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -802,6 +802,20 @@ jobs:
               "$manifest" > /dev/null \
               || { echo "::error::the container-built bundle carries a non-MeshWeaver assembly, which contradicts the reason it needs no --deps-closure: every reference was supposed to resolve from the image's /app"; exit 1; }
             echo "container path: closure is entry + module-owned MeshWeaver siblings only, as derived"
+            # 🚨 The STATIC-ASSET half, asserted — because its absence is the one failure with no
+            # symptom at any later gate: the publish 200s, the module lands and loads, every page
+            # renders, only UNSTYLED (#2221's exact signature; PluginBundlePublishAssetsTest names
+            # it). The packer nulls `staticAssets` when the pack input has no wwwroot, and nothing
+            # downstream distinguishes "this module ships no assets" from "the compiler forgot
+            # them" — so this lane distinguishes it HERE, from the source of truth: a project that
+            # has *.razor.css or wwwroot/ in its tree must produce a bundle that declares assets.
+            src_dir="$GITHUB_WORKSPACE/$(dirname "$PROJECT")"
+            if [ -d "$src_dir/wwwroot" ] \
+               || find "$src_dir" -name '*.razor.css' -not -path '*/bin/*' -not -path '*/obj/*' -print -quit | grep -q .; then
+              jq -e '(.module.staticAssets // []) | length > 0' "$manifest" > /dev/null \
+                || { echo "::error::$MODULE has wwwroot/ or *.razor.css in its source tree, but the container-built bundle declares NO staticAssets — it would land, load, and render unstyled with nothing in any log (#2221). The builder must emit wwwroot/ (its .styles.css aggregate included) into the pack input."; exit 1; }
+              echo "container path: staticAssets declared ($(jq '(.module.staticAssets // []) | length' "$manifest") file(s)) for a source tree that has assets"
+            fi
           fi
           echo "path=$bundle" >> "$GITHUB_OUTPUT"
           echo "bundle OK:"; jq . "$manifest"

--- a/test/MeshWeaver.PluginTester.Test/RazorBuildTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/RazorBuildTest.cs
@@ -281,22 +281,31 @@ public class RazorBuildTest : IDisposable
     }
 
     [Fact]
-    public void ScopedCssIsREFUSED_becauseTheScopeIdentifierIsAnMSBuildTaskThisBuilderCannotRun()
+    public void ScopedCssPairsTheComponentWithTheSdkScope_andTheOldAcceptStaysANoOp()
     {
+        // This used to be a REFUSAL (the scope hash was an MSBuild task this builder could not
+        // run); ScopedCss now reproduces that hash, pinned against SDK-built values
+        // (ScopedCssTest), so evaluation pairs the component with its stylesheet's scope instead.
         var project = Write("Widgets/Widgets.csproj", RazorProject("Widgets.Scoped"));
         Write("Widgets/Spacer.razor", "<div>spacer</div>\n");
         Write("Widgets/Spacer.razor.css", ".spacer { height: 8px; }\n");
+        Write("Widgets/Bare.razor", "<div>no stylesheet</div>\n");
 
-        var refusal = Assert.Throws<ProjectFile.UnsupportedConstructException>(
-            () => ProjectFile.Load(project));
-        refusal.Message.Should().Contain(ProjectFile.Accept.RazorCssScope);
-        refusal.Message.Should().Contain("scope");
-
-        var model = ProjectFile.Load(project, [ProjectFile.Accept.RazorCssScope]);
-        model.RazorItems.Should().ContainSingle();
+        var model = ProjectFile.Load(project);
+        var spacer = model.RazorItems.Single(i => i.Path.EndsWith("Spacer.razor"));
+        spacer.CssScope.Should().Be(
+            ScopedCss.GenerateScope("Spacer.razor.css", "Widgets.Scoped"),
+            "the generator's markup attribute and the bundler's selector suffix are this one value");
+        model.RazorItems.Single(i => i.Path.EndsWith("Bare.razor")).CssScope.Should().BeNull(
+            "a component without a stylesheet sibling gets no scope, exactly like ApplyCssScopes");
         // The .razor.css itself is never a Razor input — it is a stylesheet, and the default
         // *.razor glob must not pick it up.
-        model.RazorItems.Single().Path.Should().EndWith("Spacer.razor");
+        model.RazorItems.Should().HaveCount(2);
+
+        // A caller still passing the historical accept keeps building identically.
+        ProjectFile.Load(project, [ProjectFile.Accept.RazorCssScope])
+            .RazorItems.Single(i => i.Path.EndsWith("Spacer.razor"))
+            .CssScope.Should().Be(spacer.CssScope);
     }
 
     [Fact]

--- a/test/MeshWeaver.PluginTester.Test/ScopedCssTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ScopedCssTest.cs
@@ -1,0 +1,333 @@
+using System.Reactive;
+using MeshWeaver.Data;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// CSS isolation in <c>build-project</c> — the whole chain, pinned against the REAL SDK:
+/// <see cref="ScopedCss.GenerateScope"/> against scope values measured from an SDK build of
+/// MeshWeaver.Blazor, <see cref="ScopedCss.Rewrite"/> against VERBATIM <c>.rz.scp.css</c> outputs
+/// the SDK produced for the same inputs, and the executing build against both halves of the
+/// contract at once: the scope stamped into the compiled markup IS the scope in the emitted
+/// <c>wwwroot/&lt;Name&gt;.styles.css</c>.
+///
+/// <para>🚨 Every expected string here is SDK OUTPUT, not this repo's opinion. A rewriter that
+/// drifts from the SDK produces stylesheets whose selectors match nothing — the page renders,
+/// unstyled, with empty logs (#2221's signature) — so fidelity is asserted byte-for-byte. The
+/// full-corpus run (all 21 scoped stylesheets across five module projects, 2026-08-31) was
+/// byte-identical; these embedded pairs are the durable representatives: one dense synthetic
+/// (::deep leading and infix, pseudo-classes before pseudo-elements, @media recursion, selector
+/// lists, :not()) and one production file (@keyframes rename + animation shorthand references).</para>
+/// </summary>
+public class ScopedCssTest : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"mw-scopedcss-{Guid.NewGuid():N}");
+
+    private string Write(string relativePath, string content)
+    {
+        var full = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+        GC.SuppressFinalize(this);
+    }
+
+    private string AppDirectory()
+    {
+        var app = Path.Combine(_root, "_container");
+        if (Directory.Exists(app))
+            return app;
+        Directory.CreateDirectory(app);
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "mw-plugin-test.deps.json"),
+            Path.Combine(app, "mw-plugin-test.deps.json"));
+        File.Copy(
+            Path.Combine(AppContext.BaseDirectory, "MeshWeaver.ShortGuid.dll"),
+            Path.Combine(app, "MeshWeaver.ShortGuid.dll"));
+        return app;
+    }
+
+    // ── the scope hash: pinned to values MEASURED from an SDK build of MeshWeaver.Blazor ────────
+
+    [Theory]
+    [InlineData("Components/CodeBlock.razor.css", "MeshWeaver.Blazor", "b-h3pg7owarf")]
+    [InlineData("Components/DialogView.razor.css", "MeshWeaver.Blazor", "b-qf8u66cq1w")]
+    [InlineData("FileExplorer/FileBrowser.razor.css", "MeshWeaver.Blazor", "b-1v0kb17jfa")]
+    public void TheScopeHashMatchesTheSdk(string relativePath, string targetName, string expected)
+        => ScopedCss.GenerateScope(relativePath, targetName).Should().Be(expected,
+            "the generator-stamped attribute and an SDK-built neighbour must agree; a from-memory "
+            + "hash was the reason this used to be a refusal");
+
+    [Fact]
+    public void TheScopeHashIsSeparatorAndCaseInsensitive()
+        => ScopedCss.GenerateScope(@"Components\CodeBlock.RAZOR.css", "MeshWeaver.Blazor")
+            .Should().Be("b-h3pg7owarf", "the SDK lowercases and the path arrives OS-flavoured");
+
+    // ── the rewriter: verbatim SDK outputs ───────────────────────────────────────────────────────
+
+    /// <summary>The dense synthetic, SDK-built 2026-08-31 (scope b-jiiuxwrs1r for Card.razor.css
+    /// under Widgets.CssProbe): ::deep leading and infix — note the SDK's double space where an
+    /// infix ::deep is excised — pseudo-class before pseudo-element, @media recursion, lists.</summary>
+    private const string ProbeSource = """
+.card, .panel > .row + .cell {
+    color: red;
+}
+.card::before {
+    content: "*";
+}
+.card:hover::after {
+    content: "!";
+}
+::deep .external {
+    margin: 0;
+}
+.card ::deep .inner, ::deep.attached>li {
+    padding: 0;
+}
+@media (max-width: 700px) {
+    .card:not(.wide) {
+        display: none;
+    }
+    li::marker {
+        color: blue;
+    }
+}
+""";
+
+    private const string ProbeSdkOutput = """
+.card[b-jiiuxwrs1r], .panel > .row + .cell[b-jiiuxwrs1r] {
+    color: red;
+}
+.card[b-jiiuxwrs1r]::before {
+    content: "*";
+}
+.card:hover[b-jiiuxwrs1r]::after {
+    content: "!";
+}
+[b-jiiuxwrs1r] .external {
+    margin: 0;
+}
+.card[b-jiiuxwrs1r]  .inner, [b-jiiuxwrs1r].attached>li {
+    padding: 0;
+}
+@media (max-width: 700px) {
+    .card:not(.wide)[b-jiiuxwrs1r] {
+        display: none;
+    }
+    li[b-jiiuxwrs1r]::marker {
+        color: blue;
+    }
+}
+""";
+
+    /// <summary>Production file (MeshWeaver.Blazor's NamedAreaView.razor.css, scope
+    /// b-r8wvn3lp5k): @keyframes renamed with the scope suffix, the animation SHORTHAND's
+    /// name reference follows, timing keywords (infinite, ease-in-out) untouched.</summary>
+    private const string NamedAreaSource = """
+.dots-spinner {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px;
+}
+
+.dots-spinner .dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--neutral-foreground-rest, currentColor);
+    animation: dots-blink 1.4s infinite ease-in-out both;
+}
+
+.dots-spinner .dot:nth-child(1) {
+    animation-delay: -0.32s;
+}
+
+.dots-spinner .dot:nth-child(2) {
+    animation-delay: -0.16s;
+}
+
+.dots-spinner .dot:nth-child(3) {
+    animation-delay: 0s;
+}
+
+@keyframes dots-blink {
+    0%, 80%, 100% {
+        opacity: 0.25;
+        transform: scale(0.8);
+    }
+    40% {
+        opacity: 0.8;
+        transform: scale(1);
+    }
+}
+
+.skeleton-placeholder {
+    padding: 16px;
+    border-radius: 12px;
+    background: var(--neutral-layer-2);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.skeleton-line {
+    height: 12px;
+    border-radius: 6px;
+    background: var(--neutral-stroke-rest);
+    opacity: 0.3;
+    animation: skeleton-pulse 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 0.12; }
+}
+""";
+
+    private const string NamedAreaSdkOutput = """
+.dots-spinner[b-r8wvn3lp5k] {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    padding: 8px;
+}
+
+.dots-spinner .dot[b-r8wvn3lp5k] {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background-color: var(--neutral-foreground-rest, currentColor);
+    animation: dots-blink-b-r8wvn3lp5k 1.4s infinite ease-in-out both;
+}
+
+.dots-spinner .dot:nth-child(1)[b-r8wvn3lp5k] {
+    animation-delay: -0.32s;
+}
+
+.dots-spinner .dot:nth-child(2)[b-r8wvn3lp5k] {
+    animation-delay: -0.16s;
+}
+
+.dots-spinner .dot:nth-child(3)[b-r8wvn3lp5k] {
+    animation-delay: 0s;
+}
+
+@keyframes dots-blink-b-r8wvn3lp5k {
+    0%, 80%, 100% {
+        opacity: 0.25;
+        transform: scale(0.8);
+    }
+    40% {
+        opacity: 0.8;
+        transform: scale(1);
+    }
+}
+
+.skeleton-placeholder[b-r8wvn3lp5k] {
+    padding: 16px;
+    border-radius: 12px;
+    background: var(--neutral-layer-2);
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 8px;
+}
+
+.skeleton-line[b-r8wvn3lp5k] {
+    height: 12px;
+    border-radius: 6px;
+    background: var(--neutral-stroke-rest);
+    opacity: 0.3;
+    animation: skeleton-pulse-b-r8wvn3lp5k 1.5s ease-in-out infinite;
+}
+
+@keyframes skeleton-pulse-b-r8wvn3lp5k {
+    0%, 100% { opacity: 0.3; }
+    50% { opacity: 0.12; }
+}
+""";
+
+    [Fact]
+    public void TheDenseSyntheticRewritesByteForByteLikeTheSdk()
+        => ScopedCss.Rewrite(ProbeSource, "b-jiiuxwrs1r").Should().Be(ProbeSdkOutput);
+
+    [Fact]
+    public void KeyframesAndAnimationReferencesFollowTheSdkRename()
+        => ScopedCss.Rewrite(NamedAreaSource, "b-r8wvn3lp5k").Should().Be(NamedAreaSdkOutput);
+
+    [Fact]
+    public void AnAtRuleOutsideTheProvenSubsetIsRefusedByName()
+    {
+        Action act = () => ScopedCss.Rewrite("@import url(x.css);\n.a { color: red; }", "b-0000000000");
+        act.Should().Throw<InvalidOperationException>().WithMessage("*@import*",
+            "a construct the rewriter cannot prove it reproduces must fail by name, never "
+            + "half-rewrite into an unstyled page");
+    }
+
+    // ── the executing chain: one scope value, stamped in the markup AND in the stylesheet ───────
+
+    [Fact]
+    public async Task TheMarkupAndTheStylesheetCarryTheSameScope()
+    {
+        var entry = Write("Scoped/Scoped.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk.Razor">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <AssemblyName>Widgets.Scoped</AssemblyName>
+                <RootNamespace>Widgets</RootNamespace>
+              </PropertyGroup>
+            </Project>
+            """);
+        Write("Scoped/Badge.razor", """
+            <div class="badge">@Text</div>
+            @code { [Microsoft.AspNetCore.Components.Parameter] public string? Text { get; set; } }
+            """);
+        Write("Scoped/Badge.razor.css", ".badge { color: red; }\n");
+        Write("Scoped/wwwroot/js/badge.js", "// carried verbatim\n");
+
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProject = entry,
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "out"),
+            Output = TextWriter.Null,
+            MaxParallel = 2,
+        }).Await(TestContext.Current.CancellationToken);
+
+        report.FatalError.Should().BeNull();
+        report.ExitCode.Should().Be(0);
+        var result = report.Projects.Single().Result!;
+
+        var scope = ScopedCss.GenerateScope("Badge.razor.css", "Widgets.Scoped");
+        var outputDirectory = Path.GetDirectoryName(result.AssemblyPath!)!;
+
+        // The stylesheet half: the aggregate exists, under the scope.
+        var aggregate = File.ReadAllText(
+            Path.Combine(outputDirectory, "wwwroot", "Widgets.Scoped.styles.css"));
+        aggregate.Should().Contain($".badge[{scope}]");
+
+        // The markup half: the SAME scope is a string literal in the compiled component —
+        // Blazor string literals live in the #US heap as UTF-16, so that is what is probed.
+        // Without this the stylesheet ships and matches NOTHING, silently.
+        var image = File.ReadAllBytes(result.AssemblyPath!);
+        image.AsSpan().IndexOf(System.Text.Encoding.Unicode.GetBytes(scope)).Should().BeGreaterThan(0,
+            "the generator must have received build_metadata.AdditionalFiles.CssScope");
+
+        // The project's own wwwroot rides verbatim beside the aggregate.
+        File.Exists(Path.Combine(outputDirectory, "wwwroot", "js", "badge.js")).Should().BeTrue();
+    }
+}

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -794,10 +794,12 @@ public static class ProjectBuild
                     model.CompileItems.Length, 0, warnings, null, [], reason);
             }
             NameTheDocumentationFile(outputDirectory, model);
+            var scopedCssCount = EmitStaticAssets(outputDirectory, model, sink, name);
             sink.Info(
                 $"[{name}] OK — {model.CompileItems.Length} source file(s)"
                 + (razorGenerated == 0 ? "" : $" + {model.RazorItems.Length} Razor file(s)")
                 + (model.EmbeddedResources.IsEmpty ? "" : $" + {model.EmbeddedResources.Length} resource(s)")
+                + (scopedCssCount == 0 ? "" : $" + {scopedCssCount} scoped stylesheet(s)")
                 + $", {warnings} warning(s), "
                 + $"{artifact.Length} bytes in {clock.Elapsed.TotalMilliseconds:F0} ms → {artifact.DllPath}");
             return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
@@ -834,6 +836,50 @@ public static class ProjectBuild
         .. model.EmbeddedResources.Select(resource => new ResourceDescription(
             resource.ManifestName, () => File.OpenRead(resource.Path), isPublic: true)),
     ];
+
+    /// <summary>
+    /// The static-asset half of the module: the project's own <c>wwwroot/**</c> copied verbatim,
+    /// plus the CSS-isolation aggregate <c>wwwroot/&lt;AssemblyName&gt;.styles.css</c> — each
+    /// <c>*.razor.css</c> rewritten under the SAME scope the generator stamped into the markup
+    /// (<see cref="ScopedCss"/>), concatenated in item order. The packer sweeps <c>wwwroot/</c>
+    /// into the bundle's <c>staticAssets</c>, and the portal's module-asset host links the
+    /// aggregate at runtime — without this a converted pack lands, loads, and renders UNSTYLED
+    /// with nothing in any log (#2221's signature).
+    /// </summary>
+    /// <returns>How many scoped stylesheets went into the aggregate.</returns>
+    private static int EmitStaticAssets(
+        string outputDirectory, ProjectFile.Model model, Sink sink, string name)
+    {
+        var projectDirectory = Path.GetDirectoryName(model.ProjectPath)!;
+        var wwwroot = Path.Combine(projectDirectory, "wwwroot");
+        var target = Path.Combine(outputDirectory, "wwwroot");
+        if (Directory.Exists(wwwroot))
+        {
+            foreach (var file in Directory.GetFiles(wwwroot, "*", SearchOption.AllDirectories))
+            {
+                var destination = Path.Combine(target, Path.GetRelativePath(wwwroot, file));
+                Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+                File.Copy(file, destination, overwrite: true);
+            }
+            sink.Info($"[{name}] static assets: wwwroot/ copied "
+                + $"({Directory.GetFiles(wwwroot, "*", SearchOption.AllDirectories).Length} file(s))");
+        }
+
+        var scoped = model.RazorItems
+            .Where(item => item.CssScope is { Length: > 0 })
+            .Select(item => (
+                RelativePath: item.TargetPath + ".css",
+                Rewritten: ScopedCss.Rewrite(File.ReadAllText(item.Path + ".css"), item.CssScope!)))
+            .ToImmutableArray();
+        if (scoped.IsEmpty)
+            return 0;
+        Directory.CreateDirectory(target);
+        var aggregatePath = Path.Combine(target, model.AssemblyName + ".styles.css");
+        File.WriteAllText(aggregatePath, ScopedCss.Aggregate(scoped.Select(s => (s.RelativePath, s.Rewritten))));
+        sink.Info($"[{name}] css isolation: {scoped.Length} scoped stylesheet(s) → "
+            + $"wwwroot/{model.AssemblyName}.styles.css (scopes match the generated markup)");
+        return scoped.Length;
+    }
 
     /// <summary>How many resource names a build lists before it counts the rest instead.</summary>
     internal const int MaxListedResources = 25;

--- a/tools/MeshWeaver.PluginTester/ProjectFile.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectFile.cs
@@ -51,7 +51,22 @@ public static class ProjectFile
     /// <param name="Path">Absolute path of the file.</param>
     /// <param name="TargetPath">Path relative to the project directory.</param>
     /// <param name="IsComponent">True for <c>.razor</c>, false for <c>.cshtml</c>.</param>
-    public sealed record RazorItem(string Path, string TargetPath, bool IsComponent);
+    public sealed record RazorItem(string Path, string TargetPath, bool IsComponent)
+    {
+        /// <summary>
+        /// The <c>b-…</c> CSS-isolation scope, when a <c>{Path}.css</c> sibling exists — the value
+        /// <c>ComputeCssScope</c> would have derived, reproduced by
+        /// <see cref="ScopedCss.GenerateScope"/> and pinned by test against SDK-built artifacts.
+        /// The generator receives it per file (<c>build_metadata.AdditionalFiles.CssScope</c>) and
+        /// the bundler appends the SAME value to the stylesheet's selectors — one string, two
+        /// consumers, or the isolated styles match nothing.
+        ///
+        /// <para>🚨 An <c>init</c> PROPERTY, not a primary-constructor parameter — adding a
+        /// parameter REPLACES the record's constructor signature
+        /// (<c>scripts/check-record-signatures.py</c>).</para>
+        /// </summary>
+        public string? CssScope { get; init; }
+    }
 
     /// <summary>
     /// One <c>&lt;EmbeddedResource&gt;</c>, resolved to the file on disk AND to the manifest name
@@ -337,13 +352,12 @@ public static class ProjectFile
         public const string AllConditions = "conditions";
 
         /// <summary>
-        /// Acknowledge that CSS ISOLATION is not applied — the project has <c>*.razor.css</c> files
-        /// whose scope identifier the SDK computes with an MSBuild task this builder does not run,
-        /// so the components compile WITHOUT their <c>b-…</c> scope attributes. The assembly is
-        /// valid and every component in it renders; what it loses is the attribute that makes the
-        /// isolated stylesheet apply. Refused by default because reproducing the scope hash from
-        /// memory is exactly the guess this evaluator exists to avoid, and a half-right scope is
-        /// worse than a named refusal.
+        /// 🕰️ A NO-OP since CSS isolation became supported: <see cref="ScopedCss"/> reproduces the
+        /// SDK's scope hash (pinned by test against SDK-built artifacts, not from memory — the
+        /// original reason this was a refusal), the generator receives it per file, and the build
+        /// emits the <c>wwwroot/&lt;TargetName&gt;.styles.css</c> aggregate. Kept so a caller that
+        /// still passes <c>--accept razor-css-scope</c> keeps building rather than failing on an
+        /// unknown token.
         /// </summary>
         public const string RazorCssScope = "razor-css-scope";
 
@@ -1360,15 +1374,24 @@ public static class ProjectFile
 
             if (!items.IsEmpty && !IsFalse(Prop("ScopedCssEnabled")))
             {
-                var scoped = ScopedCssFilesOnDisk().ToImmutableArray();
-                if (!scoped.IsEmpty && !IsAccepted(Accept.RazorCssScope))
-                    throw new UnsupportedConstructException(
-                        $"{projectPath}: {scoped.Length} scoped-CSS file(s) (*.razor.css) — the SDK's "
-                        + "ComputeCssScope/ApplyCssScopes tasks derive each component's `b-…` scope "
-                        + "identifier, and this builder runs no MSBuild task, so the components would "
-                        + "compile WITHOUT their scope attributes and the isolated styles would not "
-                        + $"apply. Re-run with --accept {Accept.RazorCssScope} to build them anyway "
-                        + "(the assembly is valid; only CSS isolation is missing).");
+                // ApplyCssScopes, reproduced: a component pairs with its `{name}.razor.css` sibling
+                // and both sides of the isolation get ONE scope value — the generator stamps it into
+                // the markup, the bundler appends it to the selectors. The algorithm is pinned by
+                // test against SDK-built artifacts (ScopedCss.GenerateScope), so an SDK-built
+                // neighbour and a container-built module agree on the attribute. This used to be a
+                // refusal (--accept razor-css-scope built WITHOUT isolation); the accept is now a
+                // no-op kept for callers that still pass it.
+                var assemblyName = Prop("AssemblyName") is { Length: > 0 } an
+                    ? an : System.IO.Path.GetFileNameWithoutExtension(projectPath);
+                items = items
+                    .Select(item =>
+                    {
+                        if (!item.IsComponent || !File.Exists(item.Path + ".css"))
+                            return item;
+                        var relative = System.IO.Path.GetRelativePath(ProjectDirectory, item.Path + ".css");
+                        return item with { CssScope = ScopedCss.GenerateScope(relative, assemblyName) };
+                    })
+                    .ToImmutableArray();
             }
 
             return items;

--- a/tools/MeshWeaver.PluginTester/RazorGenerators.cs
+++ b/tools/MeshWeaver.PluginTester/RazorGenerators.cs
@@ -464,15 +464,25 @@ public static class RazorGenerators
             });
             _perFile = model.RazorItems.ToImmutableDictionary(
                 item => item.Path,
-                item => (AnalyzerConfigOptions)new Options(new Dictionary<string, string>(StringComparer.Ordinal)
+                item =>
                 {
-                    // 🚨 BASE64. The SDK pipes every Razor item through EncodeRazorInputItem before
-                    // handing it to the compiler, and the generator decodes it unconditionally — a
-                    // plain relative path here throws inside the generator instead of producing a
-                    // component.
-                    ["build_metadata.AdditionalFiles.TargetPath"] =
-                        Convert.ToBase64String(Encoding.UTF8.GetBytes(item.TargetPath)),
-                }),
+                    var values = new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        // 🚨 BASE64. The SDK pipes every Razor item through EncodeRazorInputItem
+                        // before handing it to the compiler, and the generator decodes it
+                        // unconditionally — a plain relative path here throws inside the generator
+                        // instead of producing a component.
+                        ["build_metadata.AdditionalFiles.TargetPath"] =
+                            Convert.ToBase64String(Encoding.UTF8.GetBytes(item.TargetPath)),
+                    };
+                    // CssScope rides plain (the SDK encodes only TargetPath). With it the generator
+                    // stamps `b-…` attributes into the rendered markup; the bundler appends the SAME
+                    // value to the stylesheet's selectors (ScopedCss), which is what makes the
+                    // isolated styles apply.
+                    if (item.CssScope is { Length: > 0 } cssScope)
+                        values["build_metadata.AdditionalFiles.CssScope"] = cssScope;
+                    return (AnalyzerConfigOptions)new Options(values);
+                },
                 StringComparer.Ordinal);
         }
 

--- a/tools/MeshWeaver.PluginTester/ScopedCss.cs
+++ b/tools/MeshWeaver.PluginTester/ScopedCss.cs
@@ -1,0 +1,446 @@
+using System.Collections.Immutable;
+using System.Numerics;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// Reproduces the SDK's CSS-isolation pipeline for <c>build-project</c>: the <c>b-…</c> scope
+/// identifier (<c>ComputeCssScope</c>), the per-file selector rewrite (<c>RewriteCss</c> — what a
+/// <c>*.razor.rz.scp.css</c> holds), and the per-project aggregate
+/// (<c>wwwroot/&lt;TargetName&gt;.styles.css</c>) the portal's module-asset host links at runtime.
+///
+/// <para>🚨 <b>The scope value is a CONTRACT, verified against the SDK, not designed here.</b>
+/// <see cref="GenerateScope"/> reproduces the SDK's <c>ComputeCssScope.GenerateScope</c> —
+/// SHA-256 over the LOWERCASED project-relative path (forward slashes) concatenated with the
+/// target name, first nine bytes little-endian to a non-negative integer, ten base-36 digits
+/// least-significant first, <c>b-</c> prefix. Pinned by test against three values measured from a
+/// real SDK build of MeshWeaver.Blazor (<c>components/codeblock.razor.css</c> → <c>b-h3pg7owarf</c>
+/// et al.), so a drifted reimplementation cannot ship: the attribute the generator stamps into the
+/// markup and the attribute this rewriter appends to the selectors must be the SAME string, and
+/// both must match what an SDK-built neighbour in the same process would have produced.</para>
+///
+/// <para>🚨 <b>The rewriter covers the corpus, refuses the rest BY NAME.</b> The SDK rewrites CSS
+/// with a full parser; this one is an evaluator in the build-project tradition — it handles
+/// exactly what the module corpus uses (style rules, selector lists, pseudo-classes and
+/// pseudo-elements, <c>::deep</c>, nested-block at-rules like <c>@media</c>/<c>@supports</c>/
+/// <c>@container</c>, <c>@keyframes</c> with animation-name rewriting, <c>@font-face</c>,
+/// comments) and throws naming the construct for anything else (<c>@import</c>, CSS nesting),
+/// because a half-rewritten stylesheet renders as the silent unstyled page this tool exists to
+/// prevent (#2221's signature). Fidelity is pinned by corpus-equivalence tests whose expected
+/// halves are VERBATIM SDK outputs.</para>
+/// </summary>
+public static class ScopedCss
+{
+    /// <summary>
+    /// The SDK's scope identifier for one <c>*.razor.css</c> file.
+    /// </summary>
+    /// <param name="projectRelativePath">Path of the CSS file relative to the project directory.
+    /// Separators are normalised to <c>/</c> and the path is lowercased here — callers pass what
+    /// <see cref="Path.GetRelativePath(string, string)"/> gave them.</param>
+    /// <param name="targetName">The assembly's simple name (<c>$(TargetName)</c>).</param>
+    public static string GenerateScope(string projectRelativePath, string targetName)
+    {
+        var normalized = projectRelativePath.Replace('\\', '/').ToLowerInvariant();
+        var hash = SHA256.HashData(Encoding.UTF8.GetBytes(normalized + targetName));
+        // Nine little-endian bytes, absolute value, ten base-36 digits least-significant first —
+        // byte-for-byte the SDK's ToBase36, and the part a from-memory guess gets wrong.
+        var dividend = BigInteger.Abs(new BigInteger(hash.AsSpan(0, 9), isUnsigned: false));
+        Span<char> digits = stackalloc char[10];
+        for (var i = 0; i < 10; i++)
+        {
+            dividend = BigInteger.DivRem(dividend, 36, out var remainder);
+            digits[i] = "0123456789abcdefghijklmnopqrstuvwxyz"[(int)remainder];
+        }
+        return "b-" + new string(digits);
+    }
+
+    /// <summary>
+    /// Rewrites one scoped stylesheet: every selector gains <c>[scope]</c>, <c>::deep</c> becomes
+    /// the scope boundary, <c>@keyframes</c> names (and the <c>animation</c>/<c>animation-name</c>
+    /// declarations that reference them) gain a <c>-scope</c> suffix. Comments and formatting are
+    /// preserved verbatim — the corpus-equivalence tests compare against SDK output byte-for-byte.
+    /// </summary>
+    public static string Rewrite(string css, string scope)
+    {
+        ArgumentNullException.ThrowIfNull(css);
+        ArgumentException.ThrowIfNullOrWhiteSpace(scope);
+        var keyframeNames = CollectKeyframeNames(css);
+        var output = new StringBuilder(css.Length + 512);
+        RewriteBlockContents(new Cursor(css), output, scope, keyframeNames, topLevel: true);
+        return output.ToString();
+    }
+
+    /// <summary>
+    /// Writes the per-project aggregate the portal links: each rewritten file in input order,
+    /// separated by a blank line — the shape of the SDK's bundle minus the dependency
+    /// <c>@import</c> header, which the module-asset host strips and re-derives anyway
+    /// (MeshModuleStaticAssetExtensions), so it is deliberately not reproduced.
+    /// </summary>
+    /// <param name="files">Pairs of (project-relative path, rewritten content), in item order.</param>
+    public static string Aggregate(IEnumerable<(string RelativePath, string Rewritten)> files)
+    {
+        var builder = new StringBuilder();
+        foreach (var (relativePath, rewritten) in files)
+        {
+            if (builder.Length > 0)
+                builder.Append('\n');
+            builder.Append("/* ").Append(relativePath.Replace('\\', '/')).Append(".rz.scp.css */\n");
+            builder.Append(rewritten);
+            if (rewritten.Length > 0 && rewritten[^1] != '\n')
+                builder.Append('\n');
+        }
+        return builder.ToString();
+    }
+
+    // ── the tokenizer ────────────────────────────────────────────────────────────────────────────
+
+    private sealed class Cursor(string text)
+    {
+        public string Text { get; } = text;
+        public int Position { get; set; }
+        public bool AtEnd => Position >= Text.Length;
+        public char Current => Text[Position];
+        public bool StartsWith(string s) =>
+            string.CompareOrdinal(Text, Position, s, 0, s.Length) == 0;
+    }
+
+    private static ImmutableHashSet<string> CollectKeyframeNames(string css)
+    {
+        var names = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+        var cursor = new Cursor(css);
+        while (!cursor.AtEnd)
+        {
+            if (cursor.StartsWith("/*")) { SkipComment(cursor); continue; }
+            if (cursor.StartsWith("@keyframes"))
+            {
+                cursor.Position += "@keyframes".Length;
+                SkipWhitespaceAndComments(cursor);
+                var name = ReadIdentifier(cursor);
+                if (name.Length > 0)
+                    names.Add(name);
+                continue;
+            }
+            cursor.Position++;
+        }
+        return names.ToImmutable();
+    }
+
+    private static void RewriteBlockContents(
+        Cursor cursor, StringBuilder output, string scope,
+        ImmutableHashSet<string> keyframeNames, bool topLevel)
+    {
+        while (!cursor.AtEnd)
+        {
+            if (!topLevel && cursor.Current == '}')
+                return;
+            if (cursor.StartsWith("/*"))
+            {
+                CopyComment(cursor, output);
+                continue;
+            }
+            if (char.IsWhiteSpace(cursor.Current))
+            {
+                output.Append(cursor.Current);
+                cursor.Position++;
+                continue;
+            }
+            if (cursor.Current == '@')
+            {
+                RewriteAtRule(cursor, output, scope, keyframeNames);
+                continue;
+            }
+            RewriteStyleRule(cursor, output, scope, keyframeNames);
+        }
+    }
+
+    private static void RewriteAtRule(
+        Cursor cursor, StringBuilder output, string scope, ImmutableHashSet<string> keyframeNames)
+    {
+        var nameStart = cursor.Position + 1;
+        var nameEnd = nameStart;
+        while (nameEnd < cursor.Text.Length
+               && (char.IsAsciiLetterOrDigit(cursor.Text[nameEnd]) || cursor.Text[nameEnd] == '-'))
+            nameEnd++;
+        var name = cursor.Text[nameStart..nameEnd];
+
+        switch (name.ToLowerInvariant())
+        {
+            case "media" or "supports" or "container" or "layer" or "scope":
+                // Prelude verbatim, contents recursively — a selector inside @media scopes exactly
+                // like one outside it.
+                output.Append(cursor.Text, cursor.Position, nameEnd - cursor.Position);
+                cursor.Position = nameEnd;
+                CopyUntil(cursor, output, '{');
+                if (cursor.AtEnd)
+                    return;
+                output.Append('{');
+                cursor.Position++;
+                RewriteBlockContents(cursor, output, scope, keyframeNames, topLevel: false);
+                if (!cursor.AtEnd) { output.Append('}'); cursor.Position++; }
+                return;
+            case "keyframes":
+                // The name gains the scope suffix; the frame blocks are percentages and
+                // declarations, copied verbatim — nothing inside a keyframe is a selector.
+                output.Append(cursor.Text, cursor.Position, nameEnd - cursor.Position);
+                cursor.Position = nameEnd;
+                var wsStart = cursor.Position;
+                SkipWhitespaceAndComments(cursor);
+                output.Append(cursor.Text, wsStart, cursor.Position - wsStart);
+                var keyframeName = ReadIdentifier(cursor);
+                output.Append(keyframeName).Append('-').Append(scope);
+                CopyUntil(cursor, output, '{');
+                CopyBalancedBlock(cursor, output);
+                return;
+            case "font-face":
+                output.Append(cursor.Text, cursor.Position, nameEnd - cursor.Position);
+                cursor.Position = nameEnd;
+                CopyUntil(cursor, output, '{');
+                CopyBalancedBlock(cursor, output);
+                return;
+            default:
+                // @import in a SCOPED sheet, @charset, CSS nesting — outside the corpus and outside
+                // what this rewriter can prove it reproduces. A named refusal beats a stylesheet
+                // that half-applies.
+                throw new InvalidOperationException(
+                    $"@{name} in a scoped stylesheet — this rewriter reproduces the SDK's CSS "
+                    + "isolation for the constructs the module corpus uses (@media/@supports/"
+                    + "@container/@layer/@scope, @keyframes, @font-face, ::deep); it does not "
+                    + $"reproduce @{name}, and a half-rewritten stylesheet renders as an unstyled "
+                    + "page with nothing in the log. Restructure the stylesheet, or extend "
+                    + "ScopedCss with SDK-verified expected output first.");
+        }
+    }
+
+    private static void RewriteStyleRule(
+        Cursor cursor, StringBuilder output, string scope, ImmutableHashSet<string> keyframeNames)
+    {
+        // The prelude: everything up to '{' at depth zero is the selector list.
+        var start = cursor.Position;
+        while (!cursor.AtEnd && cursor.Current != '{')
+        {
+            if (cursor.StartsWith("/*")) SkipComment(cursor);
+            else if (cursor.Current is '(' or '[') SkipBalanced(cursor);
+            else cursor.Position++;
+        }
+        var prelude = cursor.Text[start..cursor.Position];
+        output.Append(RewriteSelectorList(prelude, scope));
+        if (cursor.AtEnd)
+            return;
+        output.Append('{');
+        cursor.Position++;
+        // The declaration block: verbatim except animation name references. Depth tracking keeps a
+        // stray nested brace from ending the rule early; rewriting only applies at this level.
+        var body = new StringBuilder();
+        var depth = 0;
+        while (!cursor.AtEnd)
+        {
+            if (cursor.StartsWith("/*")) { CopyComment(cursor, body); continue; }
+            var c = cursor.Current;
+            if (c == '{') depth++;
+            else if (c == '}')
+            {
+                if (depth == 0) break;
+                depth--;
+            }
+            body.Append(c);
+            cursor.Position++;
+        }
+        output.Append(RewriteAnimationNames(body.ToString(), scope, keyframeNames));
+        if (!cursor.AtEnd) { output.Append('}'); cursor.Position++; }
+    }
+
+    /// <summary>
+    /// Scopes every complex selector in a comma-separated list, preserving the surrounding
+    /// whitespace exactly (the equivalence tests compare against SDK output verbatim).
+    /// </summary>
+    internal static string RewriteSelectorList(string prelude, string scope)
+    {
+        var output = new StringBuilder(prelude.Length + 32);
+        var start = 0;
+        var depth = 0;
+        for (var i = 0; i < prelude.Length; i++)
+        {
+            var c = prelude[i];
+            if (c is '(' or '[') depth++;
+            else if (c is ')' or ']') depth--;
+            else if (c == ',' && depth == 0)
+            {
+                output.Append(RewriteComplexSelector(prelude[start..i], scope)).Append(',');
+                start = i + 1;
+            }
+        }
+        output.Append(RewriteComplexSelector(prelude[start..], scope));
+        return output.ToString();
+    }
+
+    private static string RewriteComplexSelector(string selector, string scope)
+    {
+        if (selector.Trim().Length == 0)
+            return selector;
+
+        var deep = selector.IndexOf("::deep", StringComparison.OrdinalIgnoreCase);
+        if (deep >= 0)
+        {
+            // `::deep` marks the scope boundary: the part before it belongs to this component (and
+            // is scoped), the part after it is intentionally unscoped. Leading `::deep X` becomes
+            // `[scope] X`; `.a ::deep .b` becomes `.a[scope] .b` — measured against DialogView's
+            // SDK output.
+            var before = selector[..deep];
+            var after = selector[(deep + "::deep".Length)..];
+            if (before.Trim().Length == 0)
+                return before + "[" + scope + "]" + after;
+            return ScopeLastCompound(before) + after;
+        }
+        return ScopeLastCompound(selector);
+
+        string ScopeLastCompound(string part)
+        {
+            // Insertion point: end of the last compound — after trailing whitespace is trimmed
+            // logically (kept textually), before any pseudo-ELEMENT of that compound. Pseudo-classes
+            // keep the scope AFTER them (`.dot:nth-child(1)[scope]`, measured); pseudo-elements
+            // take it BEFORE (`.foo[scope]::before`), because an attribute cannot follow one.
+            var end = part.Length;
+            while (end > 0 && char.IsWhiteSpace(part[end - 1]))
+                end--;
+            if (end == 0)
+                return part;
+            // Find where the last compound starts: the last top-level combinator/whitespace.
+            var compoundStart = 0;
+            var depth = 0;
+            for (var i = 0; i < end; i++)
+            {
+                var c = part[i];
+                if (c is '(' or '[') depth++;
+                else if (c is ')' or ']') depth--;
+                else if (depth == 0 && (char.IsWhiteSpace(c) || c is '>' or '+' or '~'))
+                    compoundStart = i + 1;
+            }
+            // Within the compound, a pseudo-element starts at the first `::` (or a legacy
+            // single-colon `:before`/`:after`).
+            var insert = end;
+            for (var i = compoundStart; i < end - 1; i++)
+            {
+                if (part[i] != ':') continue;
+                var legacy = part.AsSpan(i + 1).StartsWith("before", StringComparison.OrdinalIgnoreCase)
+                             || part.AsSpan(i + 1).StartsWith("after", StringComparison.OrdinalIgnoreCase);
+                if (part[i + 1] == ':' || legacy)
+                {
+                    insert = i;
+                    break;
+                }
+            }
+            return part[..insert] + "[" + scope + "]" + part[insert..];
+        }
+    }
+
+    /// <summary>
+    /// Rewrites <c>animation:</c> / <c>animation-name:</c> declarations so identifiers naming one
+    /// of this file's <c>@keyframes</c> follow the rename. Only known names move — timing keywords
+    /// (<c>infinite</c>, <c>ease-in-out</c>…) never match the collected set.
+    /// </summary>
+    internal static string RewriteAnimationNames(
+        string block, string scope, ImmutableHashSet<string> keyframeNames)
+    {
+        if (keyframeNames.IsEmpty)
+            return block;
+        var output = new StringBuilder(block.Length + 64);
+        var i = 0;
+        while (i < block.Length)
+        {
+            var c = block[i];
+            if (char.IsAsciiLetter(c) || c is '_' or '-')
+            {
+                var start = i;
+                while (i < block.Length
+                       && (char.IsAsciiLetterOrDigit(block[i]) || block[i] is '_' or '-'))
+                    i++;
+                var word = block[start..i];
+                output.Append(word);
+                if (keyframeNames.Contains(word))
+                    output.Append('-').Append(scope);
+                continue;
+            }
+            output.Append(c);
+            i++;
+        }
+        return output.ToString();
+    }
+
+    // ── low-level copying ────────────────────────────────────────────────────────────────────────
+
+    private static void SkipComment(Cursor cursor)
+    {
+        var end = cursor.Text.IndexOf("*/", cursor.Position + 2, StringComparison.Ordinal);
+        cursor.Position = end < 0 ? cursor.Text.Length : end + 2;
+    }
+
+    private static void CopyComment(Cursor cursor, StringBuilder output)
+    {
+        var start = cursor.Position;
+        SkipComment(cursor);
+        output.Append(cursor.Text, start, cursor.Position - start);
+    }
+
+    private static void SkipWhitespaceAndComments(Cursor cursor)
+    {
+        while (!cursor.AtEnd)
+        {
+            if (char.IsWhiteSpace(cursor.Current)) cursor.Position++;
+            else if (cursor.StartsWith("/*")) SkipComment(cursor);
+            else return;
+        }
+    }
+
+    private static string ReadIdentifier(Cursor cursor)
+    {
+        var start = cursor.Position;
+        while (!cursor.AtEnd
+               && (char.IsAsciiLetterOrDigit(cursor.Current) || cursor.Current is '_' or '-'))
+            cursor.Position++;
+        return cursor.Text[start..cursor.Position];
+    }
+
+    private static void CopyUntil(Cursor cursor, StringBuilder output, char stop)
+    {
+        while (!cursor.AtEnd && cursor.Current != stop)
+        {
+            output.Append(cursor.Current);
+            cursor.Position++;
+        }
+    }
+
+    private static void SkipBalanced(Cursor cursor)
+    {
+        var open = cursor.Current;
+        var close = open == '(' ? ')' : ']';
+        var depth = 0;
+        while (!cursor.AtEnd)
+        {
+            if (cursor.Current == open) depth++;
+            else if (cursor.Current == close && --depth == 0) { cursor.Position++; return; }
+            cursor.Position++;
+        }
+    }
+
+    private static void CopyBalancedBlock(Cursor cursor, StringBuilder output)
+    {
+        if (cursor.AtEnd || cursor.Current != '{')
+            return;
+        var depth = 0;
+        while (!cursor.AtEnd)
+        {
+            var c = cursor.Current;
+            if (c == '{') depth++;
+            else if (c == '}' && --depth == 0)
+            {
+                output.Append('}');
+                cursor.Position++;
+                return;
+            }
+            output.Append(c);
+            cursor.Position++;
+        }
+    }
+}


### PR DESCRIPTION
Unblocks the Blazor half of the container-build program (the last big blocker class after #2905/#2907).

- **`ScopedCss.GenerateScope`** reproduces `ComputeCssScope` exactly — pinned by test against three values measured from a real SDK build (`components/codeblock.razor.css` → `b-h3pg7owarf` …), so a container-built module and an SDK-built neighbour agree on the attribute.
- **`ScopedCss.Rewrite`** reproduces the `.rz.scp.css` transform: scope after pseudo-classes and before pseudo-elements, `::deep` as the boundary (leading and infix — including the SDK's double-space excision), `@media`/`@supports`/`@container` recursion, `@keyframes` renamed with animation-reference rewriting. **Corpus-proven: byte-identical to the SDK's outputs for all 21 scoped stylesheets across MeshWeaver.Blazor{,.Analysis,.Graph,.EntityViews,.GoogleMaps}**, plus a dense synthetic probe; the two representative pairs are embedded verbatim as tests. Anything outside the proven subset refuses by name.
- **The evaluator pairs** each component with its stylesheet (`ApplyCssScopes`), the generator receives `build_metadata.AdditionalFiles.CssScope` (the key the provider's doc already claimed), and the build emits `wwwroot/<Name>.styles.css` + the project's `wwwroot/` verbatim — the exact layout the packer sweeps and `MeshModuleStaticAssetExtensions` links at runtime.
- **The lane's container inspection asserts `staticAssets`** whenever the source tree has `wwwroot/` or `*.razor.css` — closing the only failure mode with no later symptom (#2221: lands, loads, renders unstyled).
- The old `--accept razor-css-scope` is a tolerated no-op.

Verified: tester + tests build Release `-warnaserror`; **275/275** suite; end-to-end container-shape build of MeshWeaver.Blazor.Analysis (with MeshWeaver.Blazor as in-root dep, 13+3 scoped stylesheets) is GREEN with the SDK's exact scope both in the compiled markup (UTF-16 probe) and the aggregate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)