### PR TITLE
fix(deps): align the Microsoft.Extensions family — Options 10.0.10 was a downgrade

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -120,9 +120,9 @@
     <PackageVersion Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.Json" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Identity.Web" Version="4.14.2" />
     <PackageVersion Include="Microsoft.Identity.Web.Ui" Version="4.14.2" />
     <PackageVersion Include="Microsoft.Orleans.Core.Abstractions" Version="10.2.2" />
@@ -147,18 +147,18 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Features" Version="5.9.0" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Scripting" Version="5.9.0" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Abstractions" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Caching.Memory" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Diagnostics.Runtime" Version="3.1.512801" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.10" />
-    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.FileSystemGlobbing" Version="10.0.11" />
+    <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.11" />
-    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Extensions.ServiceDiscovery" Version="10.8.0" />
     <PackageVersion Include="Microsoft.Orleans.Core" Version="10.2.2" />
     <PackageVersion Include="Microsoft.Orleans.Sdk" Version="10.2.2" />
@@ -240,7 +240,7 @@
     <PackageVersion Include="Microsoft.Extensions.AI.AzureAIInference" Version="10.0.0-preview.1.25559.3" />
     <PackageVersion Include="Microsoft.Extensions.AI.OpenAI" Version="10.8.3" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.7" />
-    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.10" />
+    <PackageVersion Include="Microsoft.Extensions.Options" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Graph" Version="6.2.0" />
     <PackageVersion Include="OpenAI" Version="2.12.0" />
   </ItemGroup>


### PR DESCRIPTION
**MeshWeaver.Plugins `main` is RED** — 11 module bundles fail restore:

```
NU1605: Warning As Error: Detected package downgrade:
Microsoft.Extensions.Options from 10.0.11 to 10.0.10
  MeshWeaver.AI.Anthropic -> MeshWeaver.Messaging.Hub
    -> Microsoft.Extensions.Logging 10.0.11 -> Microsoft.Extensions.Options (>= 10.0.11)
```

A partial servicing bump split this central list: **nine** `Microsoft.Extensions.*` at 10.0.11, **eight** at 10.0.10. `Logging` 10.0.11 requires `Options >= 10.0.11`, so that pin is a real downgrade and warnings-as-errors fails the restore.

Plugins declares no `PackageVersion` — it imports this list through `$(MeshWeaverRoot)` — so it can only be fixed here, and every satellite inherits it.

Aligning the **whole family** rather than only the named package: leaving seven siblings a patch behind is what produced this, and the next transitive bump would surface it through another edge.

### Verified, one variable at a time

| | NU1605 | CS0115 | exit |
|---|---|---|---|
| control (unmodified) | **6** | 0 | 1 |
| this change | **0** | **0** | **0** |

An intermediate run showed 78 `CS0115` and I nearly reported a regression. It wasn't: NU1605 is a **restore-time** failure that stops the build *before* those projects compile, so fixing it revealed pre-existing errors rather than causing them — and those came from a 116-commit-stale consumer checkout. Re-run from a current tree (`MeshWeaver.Plugins@405fcdcd`): clean.

Verified against `src/MeshWeaver.AI.Anthropic.Test`, the project NU1605 names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)