### PR TITLE
feat(build-project): the reference set includes the platform image's shared frameworks

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -617,9 +617,18 @@ jobs:
               # The reference set: the platform image's /app, extracted ONCE and mounted read-only.
               # docker create + cp rather than a run — the portal's entrypoint must never start here.
               platform_app="$RUNNER_TEMP/platform-app"
-              rm -rf "$platform_app"
+              platform_shared="$RUNNER_TEMP/platform-shared"
+              rm -rf "$platform_app" "$platform_shared"
               pcid=$(docker create --platform linux/amd64 "$pinned")
               docker cp -q "$pcid:/app" "$platform_app"
+              # 🚨 The platform's SHARED FRAMEWORKS ride too — the reference set is the RUNTIME the
+              # module lands in, and that runtime's ASP.NET Core framework supplies assemblies the
+              # tester image's console runtime does not (measured on Plugins#1032: every container
+              # entry red on Microsoft.Extensions.FileSystemGlobbing, which lives in the portal's
+              # Microsoft.AspNetCore.App and nowhere in the tester image). /usr/share/dotnet/shared
+              # is the aspnet base image's layout; a portal image without it must fail HERE, by
+              # name, not later as a false "additional library".
+              docker cp -q "$pcid:/usr/share/dotnet/shared" "$platform_shared"                 || { docker rm "$pcid" >/dev/null; echo "::error::could not extract /usr/share/dotnet/shared from $pinned — the platform image's shared frameworks ARE part of the reference set (they supply framework-provided packages like Microsoft.Extensions.FileSystemGlobbing); if the base image moved its dotnet root, update this extraction rather than letting framework assemblies read as missing packages"; exit 1; }
               docker rm "$pcid" >/dev/null
               out="$RUNNER_TEMP/module-build"
               rm -rf "$out"; mkdir -p "$out"; chmod 777 "$out"
@@ -637,9 +646,10 @@ jobs:
               docker run --rm --init --platform linux/amd64 \
                 -v "$GITHUB_WORKSPACE:/repo:ro" \
                 -v "$platform_app:/platform-app:ro" \
+                -v "$platform_shared:/platform-shared:ro" \
                 -v "$out:/out" \
                 --entrypoint /app/mw-plugin-test "$tester_pinned" \
-                build-project "/repo/$PROJECT" --app /platform-app --output /out ${accepts[@]+"${accepts[@]}"} 2>&1 | tee "$log"
+                build-project "/repo/$PROJECT" --app /platform-app --shared-frameworks /platform-shared --output /out ${accepts[@]+"${accepts[@]}"} 2>&1 | tee "$log"
               # build-project emits <output>/<AssemblyName>/, so the module folder IS the pack input.
               packdir="$out/$MODULE"
               if [ ! -f "$packdir/$MODULE.dll" ]; then

--- a/test/MeshWeaver.PluginTester.Test/ContainerReferenceSetTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ContainerReferenceSetTest.cs
@@ -287,4 +287,49 @@ public class ContainerReferenceSetTest : IDisposable
         act.Should().Throw<ContainerReferenceSet.UnreadableContainerException>()
             .Which.Message.Should().Contain("exactly one *.deps.json");
     }
+
+    // ── the platform's shared frameworks ───────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The false-"additional library" this parameter kills, measured on Plugins#1032: a
+    /// framework-provided (NU1510-prunable) package like Microsoft.Extensions.FileSystemGlobbing
+    /// lives in the PLATFORM's ASP.NET Core shared framework — absent from the platform /app AND
+    /// from the tester image's console runtime, so without the explicit root every container
+    /// entry binding it went red on a package the landing runtime supplies.
+    /// </summary>
+    [Fact]
+    public void AFrameworkProvidedPackageResolvesFromTheExplicitSharedFrameworksRoot()
+    {
+        var app = App("fw-app");
+        Dll(app, "MeshWeaver.Data");
+        File.WriteAllText(Path.Combine(app, "host.deps.json"), Deps());
+        var shared = Path.Combine(_root, "platform-shared", "Microsoft.AspNetCore.App", "10.0.11");
+        Directory.CreateDirectory(shared);
+        Dll(shared, "Microsoft.Extensions.FileSystemGlobbing");
+
+        var refs = ContainerReferenceSet.Read(
+            app, string.Empty, Path.Combine(_root, "platform-shared"));
+
+        var resolution = refs.Resolve("Microsoft.Extensions.FileSystemGlobbing");
+        resolution.Supplied.Should().BeTrue(
+            "the reference set is the runtime the module LANDS in, shared frameworks included");
+        resolution.AssemblyPaths.Single().Should().Be(
+            Path.Combine(shared, "Microsoft.Extensions.FileSystemGlobbing.dll"));
+    }
+
+    [Fact]
+    public void AnExplicitSharedFrameworksRootThatIsMissingIsARefusalNotAFallback()
+    {
+        var app = App("fw-missing");
+        Dll(app, "MeshWeaver.Data");
+        File.WriteAllText(Path.Combine(app, "host.deps.json"), Deps());
+
+        Action act = () => ContainerReferenceSet.Read(
+            app, string.Empty, Path.Combine(_root, "not-there"));
+
+        act.Should().Throw<ContainerReferenceSet.UnreadableContainerException>()
+            .Which.Message.Should().Contain("--shared-frameworks",
+                "silently falling back to the builder's own runtime would resurrect the exact "
+                + "false verdicts the parameter exists to kill");
+    }
 }

--- a/tools/MeshWeaver.PluginTester/ContainerReferenceSet.cs
+++ b/tools/MeshWeaver.PluginTester/ContainerReferenceSet.cs
@@ -78,10 +78,20 @@ public sealed class ContainerReferenceSet
     /// <param name="trustedPlatformAssemblies">The process's TPA list — the shared framework plus
     /// this app's own closure. Defaults to the running process's; injectable so the fail-closed
     /// behaviour is testable without a container.</param>
+    /// <param name="sharedFrameworksRoot">The PLATFORM image's <c>shared/</c> frameworks root
+    /// (<c>&lt;dotnet root&gt;/shared</c>, one directory per framework, one per version below it).
+    /// 🚨 Pass it whenever the app directory comes from a DIFFERENT image than the one this
+    /// process runs in: the module lands in the PLATFORM's runtime, whose ASP.NET Core shared
+    /// framework supplies assemblies (FileSystemGlobbing, Components.Web…) that a console-image
+    /// builder's own runtime does not have — measured on MeshWeaver.Plugins#1032, where every
+    /// container entry redded on Microsoft.Extensions.FileSystemGlobbing, a framework-provided
+    /// (NU1510-prunable) assembly the portal runtime carries and the tester image does not. When
+    /// null, the RUNNING runtime's shared root is used, which is correct only in-place.</param>
     /// <returns>The reference set.</returns>
     /// <exception cref="UnreadableContainerException">Anything that would leave the set partial.</exception>
     public static ContainerReferenceSet Read(
-        string? appDirectory = null, string? trustedPlatformAssemblies = null)
+        string? appDirectory = null, string? trustedPlatformAssemblies = null,
+        string? sharedFrameworksRoot = null)
     {
         var app = Path.GetFullPath(appDirectory ?? DefaultAppDirectory);
         if (!Directory.Exists(app))
@@ -111,7 +121,7 @@ public sealed class ContainerReferenceSet
         //    modules reported Microsoft.AspNetCore.Components.Web "not supplied" against an image
         //    that ships it. This is the C# form of Directory.PlatformRefs.targets'
         //    <FrameworkReference Include="Microsoft.AspNetCore.App" />.
-        foreach (var path in SharedFrameworkAssemblies())
+        foreach (var path in SharedFrameworkAssemblies(sharedFrameworksRoot))
             byName.TryAdd(Path.GetFileNameWithoutExtension(path), path);
 
         // 2. This process's own closure.
@@ -146,15 +156,35 @@ public sealed class ContainerReferenceSet
     /// grandparent is the <c>shared</c> root. Returns nothing when that shape does not hold — a
     /// self-contained deployment has no shared root, and TPA already carries everything there.</para>
     /// </summary>
-    private static IEnumerable<string> SharedFrameworkAssemblies()
+    private static IEnumerable<string> SharedFrameworkAssemblies(string? explicitRoot = null)
     {
-        var runtime = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
-        var frameworkDirectory = Path.GetDirectoryName(runtime.TrimEnd(Path.DirectorySeparatorChar, '/'));
-        var sharedRoot = frameworkDirectory is null ? null : Path.GetDirectoryName(frameworkDirectory);
-        if (sharedRoot is null
-            || !string.Equals(Path.GetFileName(sharedRoot), "shared", StringComparison.OrdinalIgnoreCase)
-            || !Directory.Exists(sharedRoot))
-            yield break;
+        string? sharedRoot;
+        if (explicitRoot is { Length: > 0 })
+        {
+            // The PLATFORM's frameworks, handed over explicitly (see Read). A named root that is
+            // not there is a hard failure — silently falling back to the builder's own runtime
+            // would resurrect exactly the false "additional library" verdicts this parameter
+            // exists to kill.
+            sharedRoot = Path.GetFullPath(explicitRoot);
+            if (!Directory.Exists(sharedRoot))
+                throw new UnreadableContainerException(
+                    $"--shared-frameworks '{sharedRoot}' does not exist. It must be the platform "
+                    + "image's <dotnet root>/shared directory; without it, framework-provided "
+                    + "assemblies read as missing packages.");
+        }
+        else
+        {
+            var runtime = System.Runtime.InteropServices.RuntimeEnvironment.GetRuntimeDirectory();
+            var frameworkDirectory = Path.GetDirectoryName(runtime.TrimEnd(Path.DirectorySeparatorChar, '/'));
+            sharedRoot = frameworkDirectory is null ? null : Path.GetDirectoryName(frameworkDirectory);
+            // The name check only guards the DERIVED shape (a self-contained deployment has no
+            // shared root and TPA already carries everything); an explicit root was validated above
+            // and may be mounted under any name.
+            if (sharedRoot is null
+                || !string.Equals(Path.GetFileName(sharedRoot), "shared", StringComparison.OrdinalIgnoreCase)
+                || !Directory.Exists(sharedRoot))
+                yield break;
+        }
 
         foreach (var framework in Directory.GetDirectories(sharedRoot).OrderBy(d => d, StringComparer.Ordinal))
         {

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -172,6 +172,7 @@ static async Task<int> RunBuildProject(string[] args)
     string? entry = null;
     string? outDir = null;
     var app = ContainerReferenceSet.DefaultAppDirectory;
+    string? sharedFrameworks = null;
     var extraRefs = new List<string>();
     var generatorPaths = new List<string>();
     string? razorGenerators = null;
@@ -199,6 +200,9 @@ static async Task<int> RunBuildProject(string[] args)
                 break;
             case "--output" or "-o" when i + 1 < args.Length:
                 outDir = args[++i];
+                break;
+            case "--shared-frameworks" when i + 1 < args.Length:
+                sharedFrameworks = args[++i];
                 break;
             case "--app" when i + 1 < args.Length:
                 app = args[++i];
@@ -262,6 +266,7 @@ static async Task<int> RunBuildProject(string[] args)
         EntryProject = entry,
         OutputDirectory = outDir,
         AppDirectory = app,
+        SharedFrameworksRoot = sharedFrameworks,
         ExtraReferenceDirectories = extraRefs,
         GeneratorPaths = generatorPaths,
         RazorGeneratorDirectory = razorGenerators,
@@ -290,6 +295,7 @@ static bool TryAddProperty(Dictionary<string, string> properties, string assignm
 
 static string BuildProjectUsage() =>
     "usage: mw-plugin-test build-project <csproj|dir> [--output <dir>] [--app <dir>] "
+    + "[--shared-frameworks <dir>] "
     + "[--extra-refs <dir>]... [--generators <dir|dll>]... [--razor-generators <dir>] "
     + "[--accept <construct>]... [-p:Name=Value]... [--allow-warnings] [--max-parallel <n>]\n"
     + "  Compiles a .NET project with NO dotnet SDK and NO NuGet restore: the .csproj is evaluated "

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -138,6 +138,13 @@ public static class ProjectBuild
 
         /// <summary>Overrides the process's TPA list; for tests that have no container.</summary>
         public string? TrustedPlatformAssemblies { get; init; }
+
+        /// <summary>
+        /// The PLATFORM image's <c>shared/</c> frameworks root — required whenever
+        /// <see cref="AppDirectory"/> comes from a different image than the one running this
+        /// builder (see <see cref="ContainerReferenceSet.Read"/>). Null = the running runtime's.
+        /// </summary>
+        public string? SharedFrameworksRoot { get; init; }
     }
 
     /// <summary>One project's build.</summary>
@@ -242,7 +249,8 @@ public static class ProjectBuild
         ContainerReferenceSet container;
         try
         {
-            container = ContainerReferenceSet.Read(options.AppDirectory, options.TrustedPlatformAssemblies);
+            container = ContainerReferenceSet.Read(
+                options.AppDirectory, options.TrustedPlatformAssemblies, options.SharedFrameworksRoot);
         }
         catch (ContainerReferenceSet.UnreadableContainerException ex)
         {


### PR DESCRIPTION
The first real acceptance run (Plugins#1032) redded every container entry on one name: `Microsoft.Extensions.FileSystemGlobbing`. Diagnosis, measured by image content:

- it is **framework-provided** (NU1510-prunable — adding it as a PackageReference to the portal host is refused by the SDK);
- it lives in the portal image's `Microsoft.AspNetCore.App/10.0.11/`, so the **landing runtime supplies it** (the SDK path smuggled a copy inside each bundle's private closure, which the container path rightly doesn't have);
- the tester image's console runtime carries only `Microsoft.NETCore.App`, so the builder's own shared-framework probe can't see it.

The reference set's own doctrine — *the image the module lands into* — decides it: `ContainerReferenceSet.Read` gains `sharedFrameworksRoot` (`--shared-frameworks`), the lane extracts `/usr/share/dotnet/shared` from the platform image beside `/app` and mounts both, and a named root that is missing is a refusal, never a silent fallback to the wrong runtime. Tests cover the resolve-from-explicit-root and refusal paths; empirically `MeshWeaver.AI` (168 sources, the red family's root) builds GREEN with the flag.

Also explains why local native measurements over-report: the builder's process TPA legitimately supplies framework assemblies, so local-vs-CI verdicts only converge with this in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)