### PR TITLE
feat(build-project): the module-libraries shelf — additional libraries ride with a recorded closure

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -1175,6 +1175,25 @@ jobs:
             echo "$rid: $(ls "$ROOT/$rid" | tr '\n' ' ')"
           done
           echo "root=$ROOT" >> "$GITHUB_OUTPUT"
+      # The module-libraries SHELF: the curated additional libraries a container-built module may
+      # bind (tools/MeshWeaver.ModuleLibraries). One publish — the assemblies are AnyCPU IL, so
+      # both image architectures stage the same copy — and its deps.json travels with it: it IS
+      # the record every shelf ride's closure is derived from.
+      - name: Stage the module-libraries shelf
+        id: shelf
+        run: |
+          set -euo pipefail
+          ROOT="$RUNNER_TEMP/module-libs-staging"
+          dotnet publish tools/MeshWeaver.ModuleLibraries/MeshWeaver.ModuleLibraries.csproj \
+            -c Release -o "$ROOT"
+          # 🚨 Fail closed: a half-staged shelf ships an image where every shelf-resolved module
+          # reds on "the container does not supply" — indistinguishable from a module defect.
+          test -f "$ROOT/MeshWeaver.ModuleLibraries.deps.json" \
+            || { echo "::error::the shelf publish produced no deps.json — the ride record is what makes shelf closures accountable"; exit 1; }
+          count=$(ls "$ROOT"/*.dll | wc -l)
+          [ "$count" -gt 10 ] || { echo "::error::the shelf publish staged only $count assemblies — not a shelf"; exit 1; }
+          echo "shelf: $count assemblies"
+          echo "root=$ROOT" >> "$GITHUB_OUTPUT"
       - name: Build + push mw-plugin-test (staging tag, ACR)
         run: >
           dotnet publish tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -1182,6 +1201,7 @@ jobs:
           -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"'
           -p:CIRun=true
           -p:MeshWeaverRazorGeneratorRoot=${{ steps.razor.outputs.root }}
+          -p:MeshWeaverModuleLibrariesRoot=${{ steps.shelf.outputs.root }}
           -p:ContainerRegistry=${{ env.ACR }}
           -p:ContainerRepository=mw-plugin-test
           -p:ContainerImageTags=${{ needs.gate.outputs.staging_tag }}

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -682,6 +682,18 @@ jobs:
                   echo "closure: $name.dll does NOT ride — the image ships it (src/platform-shipped.txt); bundling it would land a same-identity duplicate beside /app's copy"
                 fi
               done
+              # The SHELF rides: the builder resolved these additional libraries from the image's
+              # module-libraries shelf and derived the ride set from the shelf's own deps.json
+              # (minus everything the platform image supplies). module-libs.txt is the PROVENANCE —
+              # written by the builder, consumed here for the pack args and below by the
+              # inspection, so what ships and what is allowed cannot disagree.
+              if [ -f "$packdir/module-libs.txt" ]; then
+                while IFS= read -r ride; do
+                  [ -n "$ride" ] || continue
+                  printf '%s\n%s\n' --with "$ride" >> "$packargs\"
+                  echo "closure: $ride RIDES — module-libraries shelf (deps.json-derived; the image does not carry it)"
+                done < "$packdir/module-libs.txt"
+              fi
               # 🚨 WHY THERE IS NO --deps-closure HERE, stated every run so nobody reads its absence
               # as an oversight. That flag derives the module's private closure from the deps.json
               # the SDK emits, and there is no SDK on this path. The closure is complete BY
@@ -689,7 +701,7 @@ jobs:
               # does not supply, and this lane passes no --extra-refs — so every assembly the module
               # binds is one the image it lands into already carries.
               echo "closure: NO --deps-closure on the container path — there is no SDK deps.json to derive one from."
-              echo "closure: complete BY CONSTRUCTION instead — the builder refuses BY NAME any PackageReference the image does not supply, and this lane passes no --extra-refs, so every assembly $MODULE binds is one the image it lands into already carries."
+              echo "closure: complete BY RECORD instead — every reference resolved from the image, its shared frameworks, or the module-libraries shelf (whose deps.json IS the ride record); the builder refuses BY NAME anything none of them supplies, and this lane passes no --extra-refs."
               # 🚨 THE BINDING IDENTITY, CHECKED. AssemblyVersion is emitted by the SDK's
               # GenerateAssemblyInfo target, and build-project runs no targets — so a module built
               # here carries whatever Roslyn defaulted to unless the builder learns to stamp it.
@@ -808,10 +820,20 @@ jobs:
           # refusal, not a curiosity. The SDK path is untouched: its private closure legitimately
           # carries package assemblies.
           if [ "$COMPILER" = "container" ]; then
-            jq -e '[.module.assemblies[] | select(startswith("MeshWeaver.") | not)] | length == 0' \
+            # A non-MeshWeaver assembly is allowed ONLY with shelf provenance: the builder's
+            # module-libs.txt names every ride it derived from the shelf's deps.json. Anything
+            # else has no accountable closure and must fail — the 2026-08-19/20 outage shape.
+            shelf_manifest="$RUNNER_TEMP/module-build/$MODULE/module-libs.txt"
+            allowed="$( [ -f "$shelf_manifest" ] && tr '\n' ';' < "$shelf_manifest" || true )"
+            jq -e --arg allowed "$allowed" \
+              '($allowed | split(";") | map(select(length > 0))) as $shelf
+               | [.module.assemblies[]
+                  | select(startswith("MeshWeaver.") | not)
+                  | select(. as $a | $shelf | index($a) | not)]
+               | length == 0' \
               "$manifest" > /dev/null \
-              || { echo "::error::the container-built bundle carries a non-MeshWeaver assembly, which contradicts the reason it needs no --deps-closure: every reference was supposed to resolve from the image's /app"; exit 1; }
-            echo "container path: closure is entry + module-owned MeshWeaver siblings only, as derived"
+              || { echo "::error::the container-built bundle carries a non-MeshWeaver assembly with NO shelf provenance (not in the builder's module-libs.txt) — its closure cannot be accounted for, so the pack fails rather than landing a module that faults at first use"; exit 1; }
+            echo "container path: closure is entry + module-owned MeshWeaver siblings + shelf-manifested rides, as recorded"
             # 🚨 The STATIC-ASSET half, asserted — because its absence is the one failure with no
             # symptom at any later gate: the publish 200s, the module lands and loads, every page
             # renders, only UNSTYLED (#2221's exact signature; PluginBundlePublishAssetsTest names

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -690,7 +690,7 @@ jobs:
               if [ -f "$packdir/module-libs.txt" ]; then
                 while IFS= read -r ride; do
                   [ -n "$ride" ] || continue
-                  printf '%s\n%s\n' --with "$ride" >> "$packargs\"
+                  printf '%s\n%s\n' --with "$ride" >> "$packargs"
                   echo "closure: $ride RIDES — module-libraries shelf (deps.json-derived; the image does not carry it)"
                 done < "$packdir/module-libs.txt"
               fi

--- a/test/MeshWeaver.PluginTester.Test/ModuleLibrariesShelfTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ModuleLibrariesShelfTest.cs
@@ -1,0 +1,87 @@
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// The module-libraries shelf: additional libraries resolve from a curated, deps.json-recorded
+/// publish — and every ride is DERIVED from that record, minus what the landing image supplies.
+/// The 2026-08-19/20 outage was a guessed closure; these tests pin the property that replaces the
+/// guessing.
+/// </summary>
+public class ModuleLibrariesShelfTest : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"mw-shelf-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>A shelf with one provider package chaining to a transitive and to a platform lib.</summary>
+    private string Shelf()
+    {
+        Directory.CreateDirectory(_root);
+        foreach (var name in new[] { "Provider.Sdk", "Provider.Transitive", "Azure.Core" })
+            File.WriteAllBytes(Path.Combine(_root, name + ".dll"), [0x4D, 0x5A]);
+        File.WriteAllText(Path.Combine(_root, "MeshWeaver.ModuleLibraries.deps.json"), """
+            {
+              "targets": {
+                "net10.0": {
+                  "Provider.Sdk/2.0.0": {
+                    "runtime": { "lib/net10.0/Provider.Sdk.dll": {} },
+                    "dependencies": { "Provider.Transitive": "1.0.0", "Azure.Core": "1.60.0" }
+                  },
+                  "Provider.Transitive/1.0.0": {
+                    "runtime": { "lib/net10.0/Provider.Transitive.dll": {} }
+                  },
+                  "Azure.Core/1.60.0": {
+                    "runtime": { "lib/net10.0/Azure.Core.dll": {} }
+                  }
+                }
+              }
+            }
+            """);
+        return _root;
+    }
+
+    [Fact]
+    public void ARideIsTheDepsRecordedClosureMinusWhatTheImageSupplies()
+    {
+        var shelf = ModuleLibrariesShelf.Read(Shelf());
+
+        // Azure.Core is in the landing image — it must never ride (a same-identity duplicate
+        // beside the platform's copy is the #143 binding trap, not a convenience).
+        var resolution = shelf.Resolve(
+            "Provider.Sdk",
+            suppliedByContainer: n => n.Equals("Azure.Core", StringComparison.OrdinalIgnoreCase));
+
+        resolution.Should().NotBeNull();
+        resolution!.Version.Should().Be("2.0.0", "the shelf's pin is the same central pin the SDK path used");
+        resolution.ReferenceFiles.Select(Path.GetFileName).Order(StringComparer.Ordinal)
+            .Should().Equal("Provider.Sdk.dll");
+        resolution.RideFiles.Select(Path.GetFileName).Order(StringComparer.Ordinal)
+            .Should().Equal(["Provider.Sdk.dll", "Provider.Transitive.dll"],
+                "the transitive shelf closure rides; the image-supplied dependency does not");
+    }
+
+    [Fact]
+    public void APackageTheShelfDoesNotCarryResolvesToNull_neverToAGuess()
+        => ModuleLibrariesShelf.Read(Shelf())
+            .Resolve("Some.Unknown.Package", _ => false)
+            .Should().BeNull("the unresolved-package refusal stays the answer for everything uncurated");
+
+    [Fact]
+    public void AShelfWithoutItsDepsRecordIsARefusal()
+    {
+        Directory.CreateDirectory(_root);
+        File.WriteAllBytes(Path.Combine(_root, "Whatever.dll"), [0x4D, 0x5A]);
+
+        Action act = () => ModuleLibrariesShelf.Read(_root);
+
+        act.Should().Throw<InvalidOperationException>().WithMessage("*deps.json*",
+            "a shelf that silently resolves nothing turns every consumer's failure into a lie");
+    }
+}

--- a/tools/MeshWeaver.ModuleLibraries/MeshWeaver.ModuleLibraries.csproj
+++ b/tools/MeshWeaver.ModuleLibraries/MeshWeaver.ModuleLibraries.csproj
@@ -1,0 +1,57 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- ═══════════════════ THE MODULE-LIBRARIES SHELF ═══════════════════
+       The curated ADDITIONAL libraries a container-built module may bind: packages its module
+       needs that the portal image deliberately does not load (provider SDKs, import/export
+       helpers). `mw-plugin-test build-project` resolves an otherwise-unsupplied PackageReference
+       from this shelf and makes the assemblies RIDE the bundle — with a closure DERIVED from this
+       project's own deps.json, which is the whole reason this is a csproj and not a folder of
+       DLLs: the 2026-08-19/20 outage was a bundle whose closure was guessed, and the lane's
+       no-extra-refs stance exists to make that impossible. One publish of this project is the
+       shelf, its deps.json is the provenance, and the central pins in Directory.Packages.props
+       are the single version decision (the same pins every SDK-path module compiled against).
+
+       🚨 CURATED, not open: a package joins this list with the module family that needs it,
+       named in the commit. Everything here is either already a platform pin or was one before
+       the SDK path smuggled it inside per-bundle closures.
+
+       Staged into the tester image as module-libs/ beside the builder by the plugin-test-image
+       CD job (the same handover pattern as razor-generators/ and sdk-generators/); a dev build
+       without the staging simply has no shelf, and a shelf-needing module then fails BY NAME
+       exactly as before. -->
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <!-- No source of its own: the references ARE the content. -->
+    <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+    <!-- Every referenced assembly lands in the publish output — the publish IS the shelf. -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- MeshWeaver.Import + MeshWeaver.Markdown.Export -->
+    <PackageReference Include="ClosedXML" />
+    <PackageReference Include="CsvHelper" />
+    <!-- MeshWeaver.AI.OpenAI -->
+    <PackageReference Include="OpenAI" />
+    <PackageReference Include="Azure.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Agents.AI.OpenAI" />
+    <PackageReference Include="Microsoft.Extensions.AI.OpenAI" />
+    <!-- MeshWeaver.AI.AzureFoundry -->
+    <PackageReference Include="Azure.AI.Inference" />
+    <PackageReference Include="Microsoft.Agents.AI.AzureAI" />
+    <PackageReference Include="Azure.AI.Agents.Persistent" />
+    <PackageReference Include="Microsoft.Extensions.AI.AzureAIInference" />
+    <!-- MeshWeaver.AI.ClaudeCode -->
+    <PackageReference Include="ClaudeAgentSdk" />
+    <!-- MeshWeaver.AI.Copilot -->
+    <PackageReference Include="GitHub.Copilot.SDK" />
+    <!-- MeshWeaver.Mail.MicrosoftGraph -->
+    <PackageReference Include="Microsoft.Graph" />
+    <!-- MeshWeaver.Blazor.Radzen -->
+    <PackageReference Include="Radzen.Blazor" />
+  </ItemGroup>
+
+</Project>

--- a/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
+++ b/tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj
@@ -161,6 +161,30 @@
     </ItemGroup>
   </Target>
 
+  <!-- ═══ The MODULE-LIBRARIES shelf (tools/MeshWeaver.ModuleLibraries) ═══
+       CD publishes the shelf project and hands its output root over here, and it ships as
+       module-libs/ beside the builder — the same handover pattern as the Razor generators, minus
+       the per-RID split (the shelf is AnyCPU IL). A build WITHOUT the property simply ships no
+       shelf: a dev build then resolves no additional libraries, and a shelf-needing module fails
+       BY NAME exactly as before — absence is visible, never wrong. The deps.json ships with it:
+       it IS the record every shelf ride's closure is derived from (ModuleLibrariesShelf). -->
+  <Target Name="StageModuleLibraries" BeforeTargets="AssignTargetPaths"
+          Condition="'$(MeshWeaverModuleLibrariesRoot)' != ''">
+    <ItemGroup>
+      <_MeshWeaverModuleLibrary Include="$(MeshWeaverModuleLibrariesRoot)/**/*" />
+    </ItemGroup>
+    <Error Condition="'@(_MeshWeaverModuleLibrary)' == ''"
+           Text="MeshWeaverModuleLibrariesRoot '$(MeshWeaverModuleLibrariesRoot)' staged nothing — an empty shelf ships an image where every shelf-resolved module reds on 'the container does not supply', indistinguishable from a module defect." />
+    <ItemGroup>
+      <Content Include="@(_MeshWeaverModuleLibrary)"
+               Link="module-libs/%(RecursiveDir)%(Filename)%(Extension)"
+               CopyToOutputDirectory="PreserveNewest"
+               CopyToPublishDirectory="PreserveNewest"
+               Pack="false"
+               Visible="false" />
+    </ItemGroup>
+  </Target>
+
   <ItemGroup>
     <!-- GateDiscoveryEqualsBakeDiscoveryTest pins PluginGateRunner.DiscoverNodeTypes equal to the
          compiler-driven bake's discovery (#2063). The two halves disagreeing IS the defect, and

--- a/tools/MeshWeaver.PluginTester/ModuleLibrariesShelf.cs
+++ b/tools/MeshWeaver.PluginTester/ModuleLibrariesShelf.cs
@@ -1,0 +1,191 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// The curated ADDITIONAL-libraries shelf (<c>module-libs/</c> beside the builder — the publish of
+/// <c>tools/MeshWeaver.ModuleLibraries</c>, staged into the tester image by CD like
+/// <c>razor-generators/</c> and <c>sdk-generators/</c>). A container build resolves an
+/// otherwise-unsupplied <c>PackageReference</c> here, and the package's assemblies RIDE the bundle
+/// together with their transitive shelf closure — every ride derived from the shelf's own
+/// <c>deps.json</c>, never guessed (the 2026-08-19/20 outage was a guessed closure, and the lane's
+/// no-extra-refs stance exists so that cannot recur).
+///
+/// <para>🚨 <b>The container still wins.</b> An assembly the platform image supplies (its
+/// <c>/app</c>, its shared frameworks) never rides from the shelf — a same-identity duplicate
+/// beside the platform's copy is the #143-family binding trap. The shelf contributes only what the
+/// landing image does not have, which is the definition of an additional library.</para>
+/// </summary>
+public sealed class ModuleLibrariesShelf
+{
+    /// <summary>The directory, beside the builder, that carries the shelf.</summary>
+    public const string DirectoryName = "module-libs";
+
+    private readonly ImmutableDictionary<string, ImmutableArray<string>> _assembliesByPackage;
+    private readonly ImmutableDictionary<string, ImmutableArray<string>> _dependenciesByPackage;
+    private readonly ImmutableDictionary<string, string> _versionsByPackage;
+    private readonly ImmutableDictionary<string, string> _filesByName;
+
+    private ModuleLibrariesShelf(
+        string directory,
+        ImmutableDictionary<string, ImmutableArray<string>> assembliesByPackage,
+        ImmutableDictionary<string, ImmutableArray<string>> dependenciesByPackage,
+        ImmutableDictionary<string, string> versionsByPackage,
+        ImmutableDictionary<string, string> filesByName)
+    {
+        Directory = directory;
+        _assembliesByPackage = assembliesByPackage;
+        _dependenciesByPackage = dependenciesByPackage;
+        _versionsByPackage = versionsByPackage;
+        _filesByName = filesByName;
+    }
+
+    /// <summary>Where the shelf was read from.</summary>
+    public string Directory { get; }
+
+    /// <summary>The packages the shelf carries, for the build log.</summary>
+    public int PackageCount => _assembliesByPackage.Count;
+
+    /// <summary>
+    /// Locates the shelf: <c>module-libs/</c> beside the builder first (the in-image layout), then
+    /// under the reference container's directory. Null when no shelf ships — a dev build without
+    /// the staging; a shelf-needing module then fails by name exactly as before.
+    /// </summary>
+    public static ModuleLibrariesShelf? Locate(string appDirectory)
+    {
+        foreach (var candidate in new[]
+                 {
+                     Path.Combine(AppContext.BaseDirectory, DirectoryName),
+                     Path.Combine(appDirectory, DirectoryName),
+                 })
+        {
+            var full = Path.GetFullPath(candidate);
+            if (System.IO.Directory.Exists(full)
+                && System.IO.Directory.GetFiles(full, "*.deps.json").Length == 1)
+                return Read(full);
+        }
+        return null;
+    }
+
+    /// <summary>
+    /// Reads a shelf directory: exactly one <c>*.deps.json</c> (the closure record), assemblies on
+    /// disk beside it. A shelf whose record is unreadable is a FAILURE — a shelf that silently
+    /// resolves nothing turns every consumer into the unresolved-package refusal with a lie
+    /// attached ("the shelf has no such package" when really the shelf could not be read).
+    /// </summary>
+    public static ModuleLibrariesShelf Read(string directory)
+    {
+        var full = Path.GetFullPath(directory);
+        var depsFiles = System.IO.Directory.GetFiles(full, "*.deps.json");
+        if (depsFiles.Length != 1)
+            throw new InvalidOperationException(
+                $"'{full}' holds {depsFiles.Length} *.deps.json files — the shelf needs exactly one: "
+                + "it IS the closure record every ride is derived from.");
+
+        using var document = JsonDocument.Parse(File.ReadAllText(depsFiles[0]));
+        var assemblies = ImmutableDictionary.CreateBuilder<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase);
+        var dependencies = ImmutableDictionary.CreateBuilder<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase);
+        var versions = ImmutableDictionary.CreateBuilder<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        if (!document.RootElement.TryGetProperty("targets", out var targets))
+            throw new InvalidOperationException($"'{depsFiles[0]}' has no 'targets' — not a deps.json.");
+        foreach (var target in targets.EnumerateObject())
+        {
+            foreach (var library in target.Value.EnumerateObject())
+            {
+                var slash = library.Name.IndexOf('/');
+                if (slash <= 0) continue;
+                var id = library.Name[..slash];
+                var version = library.Name[(slash + 1)..];
+                versions[id] = version;
+
+                if (library.Value.TryGetProperty("runtime", out var runtime))
+                {
+                    var names = runtime.EnumerateObject()
+                        .Select(r => Path.GetFileNameWithoutExtension(r.Name))
+                        .Where(n => n.Length > 0)
+                        .ToImmutableArray();
+                    if (!names.IsEmpty)
+                        assemblies[id] = names;
+                }
+                if (library.Value.TryGetProperty("dependencies", out var deps))
+                    dependencies[id] = [.. deps.EnumerateObject().Select(d => d.Name)];
+            }
+        }
+
+        var files = System.IO.Directory.GetFiles(full, "*.dll")
+            .ToImmutableDictionary(
+                p => Path.GetFileNameWithoutExtension(p),
+                p => p,
+                StringComparer.OrdinalIgnoreCase);
+
+        return new ModuleLibrariesShelf(
+            full, assemblies.ToImmutable(), dependencies.ToImmutable(),
+            versions.ToImmutable(), files);
+    }
+
+    /// <summary>One shelf resolution: the package's own assemblies plus its transitive ride set.</summary>
+    /// <param name="PackageId">The package.</param>
+    /// <param name="Version">The shelf's pinned version — the same central pin the SDK path used.</param>
+    /// <param name="ReferenceFiles">The package's own assembly files, for the compile.</param>
+    /// <param name="RideFiles">Every file that must travel with the bundle: the package's
+    /// assemblies plus its transitive shelf dependencies, MINUS anything the container already
+    /// supplies (a duplicate beside the platform's copy is the binding trap, not a convenience).</param>
+    public sealed record Resolution(
+        string PackageId, string Version,
+        ImmutableArray<string> ReferenceFiles,
+        ImmutableArray<string> RideFiles);
+
+    /// <summary>
+    /// Resolves one package from the shelf, or null when the shelf does not carry it.
+    /// </summary>
+    /// <param name="packageId">The package id.</param>
+    /// <param name="suppliedByContainer">Filter: an assembly simple name the landing image already
+    /// supplies (its /app, its shared frameworks) — those never ride.</param>
+    public Resolution? Resolve(string packageId, Func<string, bool> suppliedByContainer)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(packageId);
+        ArgumentNullException.ThrowIfNull(suppliedByContainer);
+        if (!_assembliesByPackage.TryGetValue(packageId, out var own))
+            return null;
+
+        var referenceFiles = own
+            .Where(_filesByName.ContainsKey)
+            .Select(n => _filesByName[n])
+            .ToImmutableArray();
+        if (referenceFiles.IsEmpty)
+            return null;
+
+        // The transitive shelf closure: packages reachable from this one whose assemblies are on
+        // the shelf and NOT supplied by the landing image. Walked over the deps.json graph — the
+        // record, not a guess.
+        var rides = ImmutableArray.CreateBuilder<string>();
+        var seenPackages = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seenFiles = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var pending = new Stack<string>();
+        pending.Push(packageId);
+        while (pending.Count > 0)
+        {
+            var current = pending.Pop();
+            if (!seenPackages.Add(current)) continue;
+            if (_assembliesByPackage.TryGetValue(current, out var names))
+                foreach (var name in names)
+                {
+                    if (suppliedByContainer(name)) continue;
+                    if (!_filesByName.TryGetValue(name, out var file)) continue;
+                    if (seenFiles.Add(name))
+                        rides.Add(file);
+                }
+            if (_dependenciesByPackage.TryGetValue(current, out var next))
+                foreach (var dependency in next)
+                    pending.Push(dependency);
+        }
+
+        return new Resolution(
+            packageId,
+            _versionsByPackage.GetValueOrDefault(packageId, "unknown"),
+            referenceFiles,
+            rides.ToImmutable());
+    }
+}

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -288,6 +288,10 @@ public static class ProjectBuild
 
         var extraReferences = ResolveExtraReferences(options, sink);
         var generators = ResolveGenerators(options, sink);
+        var shelf = ModuleLibrariesShelf.Locate(container.AppDirectory);
+        if (shelf is not null)
+            sink.Info($"module-libraries shelf: {shelf.PackageCount} package(s) from {shelf.Directory} "
+                + "(an additional library resolves here and RIDES the bundle with its deps.json-derived closure)");
 
         return Cascade.Run<ProjectResult>(
                 graph.Order,
@@ -295,7 +299,7 @@ public static class ProjectBuild
                 (id, deps) =>
                 {
                     var result = Compile(
-                        graph.Models[id], graph, container, extraReferences, generators, options, sink, workRoot,
+                        graph.Models[id], graph, container, extraReferences, generators, shelf, options, sink, workRoot,
                         deps.Where(d => d.Result is not null).Select(d => d.Result!).ToArray());
                     return (result, result.IsGreen);
                 },
@@ -500,6 +504,7 @@ public static class ProjectBuild
         ContainerReferenceSet container,
         ImmutableArray<string> extraReferences,
         ImmutableArray<string> generators,
+        ModuleLibrariesShelf? shelf,
         Options options,
         Sink sink,
         string workRoot,
@@ -534,6 +539,7 @@ public static class ProjectBuild
         // Packages: the container is authoritative for what the container HAS. Anything it does not
         // have is an ADDITIONAL library, and this mode cannot invent one.
         var unresolved = ImmutableArray.CreateBuilder<string>();
+        var shelfResolutions = new List<ModuleLibrariesShelf.Resolution>();
         var extraByName = extraReferences.ToDictionary(
             p => Path.GetFileNameWithoutExtension(p)!, p => p, StringComparer.OrdinalIgnoreCase);
         foreach (var package in model.PackageReferences)
@@ -550,6 +556,14 @@ public static class ProjectBuild
                 sink.Info($"[{name}] package {package.Id} → --extra-refs");
                 continue;
             }
+            if (shelf?.Resolve(package.Id, n => container.FindAssembly(n) is not null)
+                is { } fromShelf)
+            {
+                shelfResolutions.Add(fromShelf);
+                sink.Info($"[{name}] package {package.Id} → the module-libraries shelf "
+                    + $"({fromShelf.Version}); {fromShelf.RideFiles.Length} file(s) ride the bundle");
+                continue;
+            }
             unresolved.Add(package.Id);
         }
         if (unresolved.Count > 0)
@@ -557,10 +571,11 @@ public static class ProjectBuild
             var message =
                 $"{unresolved.Count} PackageReference(s) the container does not supply: "
                 + string.Join(", ", unresolved)
-                + ". This mode resolves references from the image and from --extra-refs only — there is "
-                + "no NuGet here. Only libraries ADDITIONAL to the platform have to be specified, and "
-                + "these are they: pass --extra-refs <dir> holding their assemblies, or build against an "
-                + "image that carries them.";
+                + ". This mode resolves references from the image, the module-libraries shelf and "
+                + "--extra-refs only — there is no NuGet here. Only libraries ADDITIONAL to the platform "
+                + "have to be specified, and these are they: add the package to the curated shelf "
+                + "(tools/MeshWeaver.ModuleLibraries — its deps.json is the ride closure), pass "
+                + "--extra-refs <dir>, or build against an image that carries them.";
             sink.Error($"[{name}] {message}");
             return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
                 model.CompileItems.Length, 0, 0, null, unresolved.ToImmutable(), message);
@@ -579,6 +594,9 @@ public static class ProjectBuild
         }
         foreach (var extra in extraReferences)
             references.Add(MetadataReference.CreateFromFile(extra));
+        foreach (var fromShelf in shelfResolutions)
+            foreach (var file in fromShelf.ReferenceFiles)
+                references.Add(MetadataReference.CreateFromFile(file));
         foreach (var dependency in dependencies)
             if (dependency.AssemblyPath is { Length: > 0 } dll)
                 references.Add(MetadataReference.CreateFromFile(dll));
@@ -802,6 +820,7 @@ public static class ProjectBuild
                     model.CompileItems.Length, 0, warnings, null, [], reason);
             }
             NameTheDocumentationFile(outputDirectory, model);
+            EmitShelfRides(outputDirectory, model, shelfResolutions, sink, name);
             var scopedCssCount = EmitStaticAssets(outputDirectory, model, sink, name);
             sink.Info(
                 $"[{name}] OK — {model.CompileItems.Length} source file(s)"
@@ -887,6 +906,41 @@ public static class ProjectBuild
         sink.Info($"[{name}] css isolation: {scoped.Length} scoped stylesheet(s) → "
             + $"wwwroot/{model.AssemblyName}.styles.css (scopes match the generated markup)");
         return scoped.Length;
+    }
+
+    /// <summary>
+    /// The file, beside the built module, that names every shelf-supplied assembly riding the
+    /// bundle. 🚨 It is the PROVENANCE the lane's inspection keys on: a container bundle may carry
+    /// a non-MeshWeaver assembly ONLY when this manifest names it — anything else still means the
+    /// closure cannot be accounted for and the pack must fail.
+    /// </summary>
+    public const string ShelfManifestName = "module-libs.txt";
+
+    /// <summary>
+    /// Copies every shelf ride beside the module and writes <see cref="ShelfManifestName"/>. The
+    /// rides were derived from the shelf's deps.json minus everything the landing image supplies
+    /// (<see cref="ModuleLibrariesShelf.Resolve"/>), so the bundle's closure stays complete BY
+    /// RECORD — the property the lane's no-extra-refs stance protects.
+    /// </summary>
+    private static void EmitShelfRides(
+        string outputDirectory, ProjectFile.Model model,
+        List<ModuleLibrariesShelf.Resolution> shelfResolutions, Sink sink, string name)
+    {
+        if (shelfResolutions.Count == 0)
+            return;
+        var manifest = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var resolution in shelfResolutions)
+            foreach (var file in resolution.RideFiles)
+            {
+                var fileName = Path.GetFileName(file);
+                if (fileName.Equals(model.AssemblyName + ".dll", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                File.Copy(file, Path.Combine(outputDirectory, fileName), overwrite: true);
+                manifest.Add(fileName);
+            }
+        File.WriteAllLines(Path.Combine(outputDirectory, ShelfManifestName), manifest);
+        sink.Info($"[{name}] shelf rides: {manifest.Count} assembl(y|ies) beside the module "
+            + $"({ShelfManifestName} is the provenance the pack inspection keys on)");
     }
 
     /// <summary>How many resource names a build lists before it counts the rest instead.</summary>


### PR DESCRIPTION
The last compile-blocker class on the road to 100% container builds (maintainer directive). Eight modules bind provider SDKs the portal image deliberately does not load; the SDK path smuggled them inside per-bundle closures, which is the duplication the container path removes — but the lane's no-`--extra-refs` stance (correct: no deps.json = no accountable closure) left them stranded.

**The shelf makes the closure a record instead of a guess:**
- `tools/MeshWeaver.ModuleLibraries` — a curated csproj over the same central pins every SDK-path module compiled against; its **publish is the shelf and its `deps.json` is the ride record**.
- CD stages it into the tester image as `module-libs/` beside the builder (the razor-generators/sdk-generators handover; AnyCPU, one copy for both architectures; fail-closed staging checks).
- `build-project` resolves an unsupplied `PackageReference` from the shelf; rides = the package + its transitive shelf closure **minus anything the landing image supplies** (`/app` + shared frameworks — the #143 duplicate trap). `module-libs.txt` is written beside the module as provenance.
- The lane packs exactly the manifested rides (`--with`), and the container inspection now allows a non-MeshWeaver assembly **only when the manifest names it** — everything else still fails as unaccountable.

Proven: `MeshWeaver.AI.OpenAI` builds GREEN against the portal `/app`+frameworks with 4 shelf packages (versions logged), exactly 4 rides, `Azure.Core`-class transitives correctly excluded. Unit tests pin ride derivation, the unknown-package refusal, and the missing-record refusal. 280/280 suite; three projects build Release `-warnaserror`.

Unblocks: AI.{OpenAI,AzureFoundry,ClaudeCode,Copilot}, Mail.MicrosoftGraph, Import, Markdown.Export, Blazor.Radzen → with these, 30/31 Plugins modules compile in-container (Northwind flips via its named accept).

🤖 Generated with [Claude Code](https://claude.com/claude-code)