### PR TITLE
feat(layout): NavigateToSidePanel — a click can open a thread beside the page

### DIFF
--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -1533,13 +1533,34 @@ public record LayoutAreaHost : IDisposable
     /// <param name="forceLoad">Whether to force a full page reload.</param>
     /// <param name="replace">Whether to replace the current history entry instead of adding a new one.</param>
     public void NavigateTo(string uri, bool forceLoad = false, bool replace = false)
+        => PostNavigation(new NavigationRequest(uri) { ForceLoad = forceLoad, Replace = replace });
+
+    /// <summary>
+    /// Opens the specified URI in the portal's side panel — the page the viewer is on stays where
+    /// it is. This is the missing first link of a chain the framework already carries end to end:
+    /// <see cref="NavigationRequest.Target"/> → the portal's handler → the navigation service's
+    /// side-panel event → the layout opens the chat panel on the path. Use it wherever a click
+    /// creates or references a thread the viewer should see BESIDE their work — an embedded
+    /// exercise composer navigating the whole page to the thread it just opened loses the very
+    /// page the exercise told the viewer to come back to.
+    ///
+    /// <para>A NEW method rather than an optional parameter on <see cref="NavigateTo"/>: adding a
+    /// parameter replaces that method's signature, and module DLLs compiled against
+    /// <c>NavigateTo(string, bool, bool)</c> would throw <c>MissingMethodException</c> at runtime
+    /// — the image/module atomicity hazard.</para>
+    /// </summary>
+    /// <param name="uri">The URI to open in the side panel.</param>
+    public void NavigateToSidePanel(string uri)
+        => PostNavigation(new NavigationRequest(uri) { Target = "SidePanel" });
+
+    private void PostNavigation(NavigationRequest request)
     {
         var subscriber = Stream.Get<Address>(nameof(SubscribeRequest.Subscriber));
         if (subscriber != null)
         {
             if (subscriber.Host is { })
                 subscriber = subscriber.Host;
-            Stream.Hub.Post(new NavigationRequest(uri) { ForceLoad = forceLoad, Replace = replace }, o => o.WithTarget(subscriber));
+            Stream.Hub.Post(request, o => o.WithTarget(subscriber));
         }
         else
         {

--- a/src/MeshWeaver.Layout/UiActionContext.cs
+++ b/src/MeshWeaver.Layout/UiActionContext.cs
@@ -29,4 +29,16 @@ public static class UiActionContextExtensions
     {
         context.Host.NavigateTo(uri, forceLoad, replace);
     }
+
+    /// <summary>
+    /// Opens the URI in the portal's side panel, leaving the page the viewer is on in place —
+    /// see <see cref="Composition.LayoutAreaHost.NavigateToSidePanel"/> for when to prefer this
+    /// over <see cref="NavigateTo"/>.
+    /// </summary>
+    /// <param name="context">The action context of the click.</param>
+    /// <param name="uri">The URI to open in the side panel.</param>
+    public static void NavigateToSidePanel(this UiActionContext context, string uri)
+    {
+        context.Host.NavigateToSidePanel(uri);
+    }
 }

--- a/test/MeshWeaver.Layout.Test/NavigateToSidePanelTest.cs
+++ b/test/MeshWeaver.Layout.Test/NavigateToSidePanelTest.cs
@@ -1,0 +1,87 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Messaging;
+using MeshWeaver.Utils;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// 🚨 <b>A layout area must be able to open a thread BESIDE the page, not only instead of it.</b>
+///
+/// <para>The framework has carried the whole side-panel navigation chain for a while —
+/// <c>NavigationRequest.Target</c>, the portal handler that forwards it, the
+/// <c>SidePanelNavigationRequested</c> event, and the layout that opens the chat panel on it. But
+/// <see cref="LayoutAreaHost"/> exposed only <c>NavigateTo(uri, forceLoad, replace)</c>, which
+/// posts the request with no target — so server-side area code could reach the chain's every link
+/// EXCEPT the first one, and an embedded course composer had no choice but to navigate the whole
+/// page to the thread it created. A learner mid-exercise lost the exercise (AgenticBusiness
+/// lesson 3, reported 2026-08-31): the chat "took over the entire screen".</para>
+///
+/// <para>Added as a NEW method rather than an optional parameter on the existing one: adding a
+/// parameter replaces the method's signature, and compiled module DLLs calling
+/// <c>NavigateTo(string, bool, bool)</c> would throw <c>MissingMethodException</c> at runtime —
+/// the exact image/module atomicity hazard the plugins repo documents.</para>
+/// </summary>
+public class NavigateToSidePanelTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string SendView = nameof(SendView);
+
+    /// <summary>What the click posted back to the subscriber — completed by the client handler.</summary>
+    private readonly ReplaySubject<NavigationRequest> received = new(1);
+
+    private static IObservable<UiControl?> Send(LayoutAreaHost host, RenderingContext ctx) =>
+        Observable.Return<UiControl?>(
+            Controls.Stack.WithView(
+                Controls.Button("open")
+                    .WithClickAction(click =>
+                    {
+                        click.Host.NavigateToSidePanel("/acme/_Thread/t-1");
+                        return Task.CompletedTask;
+                    }),
+                "Open"));
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration) =>
+        base.ConfigureHost(configuration)
+            .WithRoutes(r => r.RouteAddress(ClientType, (_, d) => d.Package()))
+            .AddLayout(layout => layout.WithView(SendView, Send));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration) =>
+        base.ConfigureClient(configuration)
+            .AddLayoutClient(d => d)
+            .WithHandler<NavigationRequest>((_, delivery) =>
+            {
+                received.OnNext(delivery.Message);
+                return delivery.Processed();
+            });
+
+    [HubFact]
+    public async Task AClick_CanOpenAPathInTheSidePanel_InsteadOfNavigatingThePage()
+    {
+        var reference = new LayoutAreaReference(SendView);
+        var client = GetClient();
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(CreateHostAddress(), reference);
+
+        await stream.GetControlStream($"{reference.Area}/Open")
+            .Should().Within(10.Seconds()).Match(x => x != null, "the button must render first");
+
+        client.Post(
+            new ClickedEvent($"{reference.Area}/Open", stream.StreamId),
+            o => o.WithTarget(CreateHostAddress()));
+
+        var request = await received
+            .Should().Within(10.Seconds()).Emit("the click posts a NavigationRequest to the subscriber");
+
+        request.Uri.Should().Be("/acme/_Thread/t-1");
+        request.Target.Should().Be("SidePanel",
+            "an untargeted request navigates the whole page — the take-over this API exists to avoid");
+    }
+}


### PR DESCRIPTION
## The defect this enables fixing

In AgenticBusiness lesson 3 (and every TryIt embed), sending a prompt to the agent **navigates the whole page** to the newly created thread — "the AI chat takes over the entire screen" — losing the exercise page that told the learner to come back and compare results. Reported 2026-08-31.

The embed had no alternative. The framework carries the complete side-panel navigation chain end to end — `NavigationRequest.Target`, the portal handler forwarding it into `NavigationOptions`, `NavigationService` firing `SidePanelNavigationRequested` on `Target == "SidePanel"`, and `PortalLayoutBase` opening the chat panel on the path — but `LayoutAreaHost` exposed only `NavigateTo(uri, forceLoad, replace)`, which posts the request with **no Target**. Server-side area code could reach every link of the chain except the first one.

## The change

1. `LayoutAreaHost.NavigateToSidePanel(uri)` — posts the `NavigationRequest` with `Target = "SidePanel"`; the existing `NavigateTo` is refactored onto a shared private `PostNavigation`, behaviour unchanged.
2. A matching `UiActionContext.NavigateToSidePanel` extension beside the existing `NavigateTo`.

**Deliberately a new method, not an optional parameter on the existing one:** adding a parameter replaces the method's signature, and module DLLs compiled against `NavigateTo(string, bool, bool)` would throw `MissingMethodException` at runtime — the image/module atomicity hazard the plugins repo documents ("the image and the full set of landed modules must move atomically").

## Verification

`NavigateToSidePanelTest` pins the behaviour with a **real hub round-trip** (no mocking): a rendered button whose click calls the new API, a real `ClickedEvent` posted from the client, and the assertion that the `NavigationRequest` arriving at the subscriber carries `Target = "SidePanel"`.

TDD, all three colours:
- **RED** before the API existed (`CS1061`).
- **GREEN** with it.
- **RED under mutation** — dropping `Target` from the implementation fails the test with its own message: *"an untargeted request navigates the whole page — the take-over this API exists to avoid"*.

Full `MeshWeaver.Layout.Test` suite: **437/437** under `-c Release -warnaserror`, 0 warnings.

## Follow-up (dependency order)

The consumer lands in `MeshWeaver.Education` after this merges: `TryItAreas.Send` switches `click.NavigateTo("/" + created.Path)` → `click.NavigateToSidePanel(...)`, fixing every TryIt embed in one call site. That PR carries the user-facing What's New entry; this one is API-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
