### PR TITLE
perf(builder): one Roslyn workspace, single body pass, fail-fast — gates compile against implementation frameworks

### DIFF
--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -199,8 +199,17 @@ jobs:
           id=$(docker create "$IMAGE")
           mkdir -p refs
           docker cp "$id:/app/." refs/ >/dev/null
+          # 🚨 The platform's SHARED FRAMEWORKS ride into the reference set too. A container-built
+          # module (mw-plugin-test build-project compiles against /app) references
+          # System.Private.CoreLib's identity DIRECTLY — the SDK ref pack cannot resolve it, and
+          # the first run whose floor bundles were container-built failed 11 NodeTypes with
+          # CS0012 'System.Private.CoreLib not referenced' (Plugins#1032, 2026-09-01). With these
+          # present, compile-check.py switches itself to implementation-framework mode and
+          # compiles exactly the way the mesh does.
+          mkdir -p refs/shared-frameworks
+          docker cp "$id:/usr/share/dotnet/shared/." refs/shared-frameworks/ >/dev/null
           docker rm -v "$id" >/dev/null
-          echo "framework assemblies: $(find refs -name 'MeshWeaver.*.dll' | wc -l)"
+          echo "framework assemblies: $(find refs -maxdepth 1 -name 'MeshWeaver.*.dll' | wc -l) from /app; $(find refs/shared-frameworks -name '*.dll' | wc -l) implementation-framework assemblies"
           # The identity that addresses an upstream's sealed publication — only when one is seeded.
           if [ -n "${UPSTREAM_SEED:-}" ]; then
             line=$(docker run --rm --init --entrypoint /app/mw-plugin-test "$IMAGE" --print-framework-identity)

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -544,7 +544,7 @@ jobs:
           case "${IMAGE##*/}" in *:*) NOTAG="${IMAGE%:*}" ;; *) NOTAG="$IMAGE" ;; esac
           pinned="${NOTAG}@${DIGEST}"
           if [ "$IMAGE_HIT" != "true" ] || [ "$REFS_HIT" != "true" ]; then
-            docker pull --platform linux/amd64 "$pinned"
+            docker pull -q --platform linux/amd64 "$pinned"
           fi
           if [ "$IMAGE_HIT" != "true" ]; then
             mkdir -p "$RUNNER_TEMP/platform-image"
@@ -566,7 +566,7 @@ jobs:
           if [ -n "$TESTER_DIGEST" ] && [ "$TESTER_HIT" != "true" ]; then
             case "${TESTER_IMAGE##*/}" in *:*) TNOTAG="${TESTER_IMAGE%:*}" ;; *) TNOTAG="$TESTER_IMAGE" ;; esac
             tester_pinned="${TNOTAG}@${TESTER_DIGEST}"
-            docker pull --platform linux/amd64 "$tester_pinned"
+            docker pull -q --platform linux/amd64 "$tester_pinned"
             rm -rf "$RUNNER_TEMP/tester-app"
             tcid=$(docker create --platform linux/amd64 "$tester_pinned")
             docker cp -q "$tcid:/app" "$RUNNER_TEMP/tester-app"
@@ -926,7 +926,7 @@ jobs:
               else
                 echo "platform image: cache MISS for $DIGEST — pulling from ACR (same bytes, only slower)"
                 echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
-                docker pull --platform linux/amd64 "$pinned"
+                docker pull -q --platform linux/amd64 "$pinned"
                 img="$pinned"
               fi
               # The BUILDER travels as files, not as an image: the tester image's /app (builder +
@@ -937,7 +937,7 @@ jobs:
               if [ ! -f "$tester_app/mw-plugin-test.dll" ]; then
                 echo "tester-app cache MISS for $TESTER_DIGEST — extracting once"
                 echo "$ACR_PASSWORD" | docker login "${TESTER_IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
-                docker pull --platform linux/amd64 "$tester_pinned"
+                docker pull -q --platform linux/amd64 "$tester_pinned"
                 rm -rf "$tester_app"
                 tcid=$(docker create --platform linux/amd64 "$tester_pinned")
                 docker cp -q "$tcid:/app" "$tester_app"
@@ -1221,6 +1221,7 @@ jobs:
         with:
           name: module-bundle-${{ matrix.entry.module }}
           path: ${{ runner.temp }}/bundles/*.module.nupkg
+          retention-days: 3
           if-no-files-found: error
 
       # ───────────── THE BUILT MARKER — "the bundle exists", and nothing more ─────────────
@@ -1243,6 +1244,7 @@ jobs:
         with:
           name: module-built-${{ matrix.entry.module }}
           path: ${{ runner.temp }}/built/*.json
+          retention-days: 1
           if-no-files-found: error
 
       # 🚨 Only when THIS diff reaches the module (or on a full run): a floor-only entry — built
@@ -1261,6 +1263,7 @@ jobs:
         with:
           name: module-dll-${{ matrix.entry.module }}
           path: |
+          retention-days: 1
             ${{ runner.temp }}/module-build/${{ matrix.entry.module }}/${{ matrix.entry.module }}.dll
             ${{ runner.temp }}/module-build/${{ matrix.entry.module }}/${{ matrix.entry.module }}.pdb
           if-no-files-found: error
@@ -1383,6 +1386,7 @@ jobs:
         with:
           name: module-pack-receipt-${{ matrix.entry.module }}
           path: ${{ runner.temp }}/receipts/*.json
+          retention-days: 1
           if-no-files-found: error
 
   # ═══════════════ THE COUNT GATE — one STABLE context, on every run ═══════════════

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -1,0 +1,90 @@
+---
+nodeType: Markdown
+name: Module Build Architecture
+category: Architecture
+description: The one shape every repo's module CI follows — the platform image is the compiler and the reference set, everything shared is staged once per run, one Roslyn workspace builds the whole graph fail-fast, and every gate compiles against implementation frameworks.
+icon: /static/NodeTypeIcons/code.svg
+---
+
+# Module Build Architecture
+
+**This is the shape every repo follows** (maintainer directives, 2026-08-31/09-01). The platform
+repo carries the reusable lanes and the builder; a satellite carries only its policy. A repo whose
+CI deviates from this page is behind, not different.
+
+## The compiler is the platform image
+
+A module never runs against a source tree or a NuGet feed: it is loaded into the platform IMAGE and
+bound by the assemblies in there. So the honest compiler is that image's own —
+`mw-plugin-test build-project` runs INSIDE the pinned platform container, its `/app` is the
+reference set, its runtime is the shared-framework surface. No .NET SDK, no restore, no platform
+source checkout. A declared mode that cannot run FAILS; there is deliberately no SDK fallback
+(a fallback would make "the container built it" and "the SDK built it" indistinguishable in a
+green log).
+
+An additional library resolves from the curated **module-libraries shelf**, and a
+`PackageReference`'s compile surface is its **transitive closure** from the shelf's deps.json —
+exactly what the SDK hands a consumer (`PackageReference Microsoft.Graph` lets code
+`using Microsoft.Kiota…`; offering only the package's own assemblies re-created that gap as a
+CS0234 wall on Plugins#1032).
+
+## Everything shared is staged ONCE per run
+
+"Update once at the beginning for everyone, and not by module." A `prepare` job stages what every
+pack job consumes identically:
+
+* the **platform image as a per-digest zstd tarball in the actions cache** (GitHub's blob storage,
+  colocated with the runners) — pack jobs `docker load` it and touch NO registry on a warm digest.
+  The per-job ACR pulls (~52s × N jobs, all at once on a fresh digest) were the stampede that
+  helped beat the registry into `connection refused` on 2026-08-31;
+* the platform `/app` and tester-app extractions (per-digest caches);
+* the **module-pack tool**, published once per platform pin and downloaded per job (~5s) instead of
+  `dotnet build` in every job (48–79s measured).
+
+A cache miss in a pack job falls back to pulling the SAME digest-pinned bytes, loudly — a perf
+fallback, never a verification fallback.
+
+## One Roslyn workspace, one pass, fail-fast
+
+The builder creates **one reference universe for the whole run**: every project shares the same
+`PortableExecutableReference` instance per path, so each assembly is read from the filesystem and
+its metadata decoded once. Siblings already built in this run ride `--prebuilt` artifacts — the
+mesh is never rebuilt per dependent.
+
+The compile itself is **one body pass, like csc**: parse + declaration diagnostics up front, body
+diagnostics from the single `Emit`. (`GetDiagnostics()` before `Emit()` analyzed every method body
+twice — measured on MeshWeaver.AI: 82s + 79s for work csc does once. The remaining cost is real:
+~97% of that project's compile is Roslyn's nullable flow analysis, dominated by a few very large
+methods — an argument for smaller methods, not a builder defect.)
+
+**When a build fails, the run exits**: dependents report `blocked by <it>`, and independent nodes
+that have not started refuse their slot naming the first failure. Nothing keeps earning minutes
+after the verdict is red.
+
+## Gates compile against IMPLEMENTATION frameworks
+
+`compile-check` extracts the image's `/usr/share/dotnet/shared` beside `/app` and, seeing
+`System.Private.CoreLib.dll`, switches to implementation-framework mode: no SDK ref pack, no
+`FrameworkReference` — the check compiles exactly what the mesh compiles. This is not a
+preference: a container-built module references `System.Private.CoreLib`'s identity directly, and
+the ref pack cannot resolve it (11 NodeTypes failed CS0012 the moment the floor bundles were
+container-built, while the portal compiled the same nodes fine). Measured: 80/80 in 44s vs 161s
+with 11 false regressions on the ref-pack path.
+
+## Roadmap (agreed, not yet landed)
+
+* **After the global build, run tests** — one build job builds the whole graph in the one
+  workspace; test jobs consume its artifacts instead of rebuilding.
+* **Self-hosted runners with a mounted mirror volume** — a bare git mirror on a persistent drive,
+  `git worktree add` per run at the release ref, worktree deleted at the end; docker layer store
+  warm on the node so even the once-per-digest pull disappears.
+* **`pack-module` and test verbs in the tester** — the last `dotnet` uses on a runner
+  (the packer runtime, `dotnet test`) move inside the image.
+
+## Rolling it out
+
+The lanes are `workflow_call` reusables in this repo (`node-repo-module-pack.yml`,
+`node-repo-compile-check.yml`, …) — a satellite adopts the shape by bumping its pinned lane SHA
+and syncing its `scripts/compile-check.py` copy. Never hand-roll a repo's CI; policy lives in the
+caller, mechanics live here. See [ModuleVersioning](ModuleVersioning) and
+[NodeTypeCompilation](NodeTypeCompilation) for the versioning and runtime-compilation halves.

--- a/test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj
+++ b/test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj
@@ -1,5 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Orleans logs 'Silo not running with ServerGC turned on' as a WARNING on every silo
+         start, and this suite starts one per cluster — dozens of identical warn lines per run
+         ("we get tons of this", maintainer, 2026-09-01). Server GC is what Orleans actually
+         recommends for a silo host, so turn it ON rather than filtering the message. -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
     <ProjectGuid>{bd553448-e2b5-4e44-8e91-fff0884a0b28}</ProjectGuid>
   </PropertyGroup>
     <ItemGroup>

--- a/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
@@ -76,6 +76,31 @@ public class CascadeTest
     }
 
     [Fact]
+    public async Task StopOnFirstFailure_AnIndependentNodeThatHasNotStartedIsBlockedByTheFirstRed()
+    {
+        // maxParallel: 1 makes the order deterministic: "AAA" (ordinal-first) runs and fails
+        // before "ZZZ" ever gets the slot. With the target-directed option, ZZZ must refuse the
+        // slot and name AAA — "when build fails => exit" (maintainer, 2026-09-01). The default
+        // (sweep) contract is pinned by OnRedWeBreak…: independents still run.
+        var ran = new ConcurrentBag<string>();
+        var results = await Cascade.Run<string>(
+            ["AAA", "ZZZ"], _ => [],
+            (id, _) =>
+            {
+                ran.Add(id);
+                return (id, id != "AAA"); // the first node fails
+            },
+            maxParallel: 1,
+            stopOnFirstFailure: true).Await(TestContext.Current.CancellationToken);
+
+        var byId = results.ToDictionary(r => r.Id, StringComparer.Ordinal);
+        Assert.Equal(Cascade.NodeOutcome.Red, byId["AAA"].Outcome);
+        Assert.Equal(Cascade.NodeOutcome.Blocked, byId["ZZZ"].Outcome);
+        Assert.Equal("AAA", byId["ZZZ"].BlockedBy); // the refusal names the first failure
+        Assert.DoesNotContain("ZZZ", ran); // its work never ran
+    }
+
+    [Fact]
     public async Task AFaultingWorkFunctionIsReportedAsFaulted_NotAsACrashOfTheWholeBuild()
     {
         var results = await Cascade.Run<string>(

--- a/tools/MeshWeaver.PluginTester/Cascade.cs
+++ b/tools/MeshWeaver.PluginTester/Cascade.cs
@@ -99,12 +99,18 @@ public static class Cascade
     /// <param name="maxParallel">Concurrency cap for the work function. Blocking a node costs no slot.</param>
     /// <param name="scheduler">Where the work runs; the task pool by default.</param>
     /// <typeparam name="T">The work's payload type.</typeparam>
+    /// <param name="stopOnFirstFailure">When set, the first red/faulted node also blocks every
+    /// node that has not yet STARTED — independents included ("when build fails => exit",
+    /// maintainer, 2026-09-01). Off by default: a SWEEP exists to enumerate every verdict, and
+    /// one module's failure must not hide the rest — only a target-directed build wants the
+    /// early exit.</param>
     public static IObservable<ImmutableArray<NodeResult<T>>> Run<T>(
         IReadOnlyCollection<string> ids,
         Func<string, IReadOnlyList<string>> dependenciesOf,
         Func<string, IReadOnlyList<NodeResult<T>>, (T Result, bool Green)> run,
         int maxParallel,
-        IScheduler? scheduler = null)
+        IScheduler? scheduler = null,
+        bool stopOnFirstFailure = false)
     {
         ArgumentNullException.ThrowIfNull(ids);
         ArgumentNullException.ThrowIfNull(dependenciesOf);
@@ -125,13 +131,9 @@ public static class Cascade
             var clock = Stopwatch.StartNew();
             var pool = scheduler ?? TaskPoolScheduler.Default;
 
-            // 🚨 FAIL-FAST across the whole graph ("when build fails => exit", maintainer,
-            // 2026-09-01): dependents were always Blocked on a red dependency, but INDEPENDENT
-            // nodes kept earning slots after the run's verdict was already RED — on CI that is
-            // minutes of work whose only possible outcome is a redder red. The first failure
-            // stamps itself here; a work item that reaches the gate afterwards refuses its slot
-            // and reports Blocked by that first failure. Nodes already RUNNING finish (their
-            // verdicts are real); nothing new starts.
+            // FAIL-FAST (opt-in, see the parameter doc): the first failure stamps itself here; a
+            // work item that reaches the gate afterwards refuses its slot and reports Blocked by
+            // that first failure. Nodes already RUNNING finish — their verdicts are real.
             var firstFailure = new string[1];
 
             // The concurrency gate. Every node hands its work here when it becomes ready;
@@ -176,14 +178,14 @@ public static class Cascade
                         var work = Observable.Defer(() => Observable.Start(() =>
                             {
                                 var started = clock.Elapsed;
-                                if (Volatile.Read(ref firstFailure[0]) is { } failedFirst)
+                                if (stopOnFirstFailure && Volatile.Read(ref firstFailure[0]) is { } failedFirst)
                                     return new NodeResult<T>(
                                         id, NodeOutcome.Blocked, default, failedFirst, null,
                                         ready, started, clock.Elapsed);
                                 try
                                 {
                                     var (payload, green) = run(id, ordered);
-                                    if (!green)
+                                    if (!green && stopOnFirstFailure)
                                         Interlocked.CompareExchange(ref firstFailure[0], id, null);
                                     return new NodeResult<T>(
                                         id, green ? NodeOutcome.Green : NodeOutcome.Red, payload, null, null,
@@ -191,7 +193,8 @@ public static class Cascade
                                 }
                                 catch (Exception ex)
                                 {
-                                    Interlocked.CompareExchange(ref firstFailure[0], id, null);
+                                    if (stopOnFirstFailure)
+                                        Interlocked.CompareExchange(ref firstFailure[0], id, null);
                                     return new NodeResult<T>(
                                         id, NodeOutcome.Faulted, default, null,
                                         $"{ex.GetType().Name}: {ex.Message}", ready, started, clock.Elapsed);

--- a/tools/MeshWeaver.PluginTester/Cascade.cs
+++ b/tools/MeshWeaver.PluginTester/Cascade.cs
@@ -125,6 +125,15 @@ public static class Cascade
             var clock = Stopwatch.StartNew();
             var pool = scheduler ?? TaskPoolScheduler.Default;
 
+            // 🚨 FAIL-FAST across the whole graph ("when build fails => exit", maintainer,
+            // 2026-09-01): dependents were always Blocked on a red dependency, but INDEPENDENT
+            // nodes kept earning slots after the run's verdict was already RED — on CI that is
+            // minutes of work whose only possible outcome is a redder red. The first failure
+            // stamps itself here; a work item that reaches the gate afterwards refuses its slot
+            // and reports Blocked by that first failure. Nodes already RUNNING finish (their
+            // verdicts are real); nothing new starts.
+            var firstFailure = new string[1];
+
             // The concurrency gate. Every node hands its work here when it becomes ready;
             // Merge(maxParallel) subscribes at most that many at a time and takes the next as one
             // completes. The gate is subscribed BEFORE any node, so nothing is handed to a queue
@@ -167,15 +176,22 @@ public static class Cascade
                         var work = Observable.Defer(() => Observable.Start(() =>
                             {
                                 var started = clock.Elapsed;
+                                if (Volatile.Read(ref firstFailure[0]) is { } failedFirst)
+                                    return new NodeResult<T>(
+                                        id, NodeOutcome.Blocked, default, failedFirst, null,
+                                        ready, started, clock.Elapsed);
                                 try
                                 {
                                     var (payload, green) = run(id, ordered);
+                                    if (!green)
+                                        Interlocked.CompareExchange(ref firstFailure[0], id, null);
                                     return new NodeResult<T>(
                                         id, green ? NodeOutcome.Green : NodeOutcome.Red, payload, null, null,
                                         ready, started, clock.Elapsed);
                                 }
                                 catch (Exception ex)
                                 {
+                                    Interlocked.CompareExchange(ref firstFailure[0], id, null);
                                     return new NodeResult<T>(
                                         id, NodeOutcome.Faulted, default, null,
                                         $"{ex.GetType().Name}: {ex.Message}", ready, started, clock.Elapsed);

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -174,6 +174,7 @@ static async Task<int> RunBuildProject(string[] args)
     var app = ContainerReferenceSet.DefaultAppDirectory;
     string? sharedFrameworks = null;
     var prebuilt = new List<string>();
+    var verbose = false;
     var extraRefs = new List<string>();
     var generatorPaths = new List<string>();
     string? razorGenerators = null;
@@ -224,6 +225,9 @@ static async Task<int> RunBuildProject(string[] args)
                 break;
             case "--accept" when i + 1 < args.Length:
                 accept.Add(args[++i]);
+                break;
+            case "--verbose":
+                verbose = true;
                 break;
             // The no-warn policy is ON by default; both spellings of the opt-out are accepted
             // because both are documented, and a flag that silently means nothing is worse than a
@@ -278,6 +282,7 @@ static async Task<int> RunBuildProject(string[] args)
         Accept = accept,
         Properties = properties,
         AllowWarnings = allowWarnings,
+        Verbose = verbose,
         MaxParallel = maxParallel,
     }).Await(CancellationToken.None);
     return projectReport.ExitCode;

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -93,6 +93,14 @@ public static class ProjectBuild
         /// <summary>False (the default) fails the build on any warning the project did not suppress.</summary>
         public bool AllowWarnings { get; init; }
 
+        /// <summary>
+        /// Per-item narration (resource names, per-package resolutions). OFF by default — "ci
+        /// should be silent, only warn / error" plus the basic progress verdicts (maintainer,
+        /// 2026-09-01); the detail returns with <c>--verbose</c> when a name mismatch or a
+        /// resolution question actually needs it.
+        /// </summary>
+        public bool Verbose { get; init; }
+
         /// <summary>The <c>--accept</c> tokens acknowledging constructs the evaluator cannot reproduce.</summary>
         public IReadOnlyList<string> Accept { get; init; } = [];
 
@@ -588,16 +596,17 @@ public static class ProjectBuild
                   + $"nullable {model.NullableOptions}, "
                   + $"warnings-as-errors {(model.TreatWarningsAsErrors ? "on" : "off")}");
 
-        // 🚨 Say the NAMES, not the count. A manifest resource is asked for BY NAME in some other
-        // process, months later, and a wrong name is a null stream rather than an error — so the
-        // names this build committed to belong in the log, where a reader can compare them against
-        // what the code asks for. Capped: MeshWeaver.Documentation embeds hundreds.
+        // The NAMES matter (a manifest resource is asked for BY NAME months later, and a wrong
+        // name is a null stream, not an error) — but 37 lines per project is CI spam, so the
+        // count is the default and the names come back with --verbose when a mismatch needs
+        // comparing. Capped even then: MeshWeaver.Documentation embeds hundreds.
         if (!model.EmbeddedResources.IsEmpty)
         {
-            sink.Info($"[{name}] embedded resources: {model.EmbeddedResources.Length}");
-            foreach (var resource in model.EmbeddedResources.Take(MaxListedResources))
+            sink.Info($"[{name}] embedded resources: {model.EmbeddedResources.Length}"
+                + (options.Verbose ? "" : " (names with --verbose)"));
+            foreach (var resource in (options.Verbose ? model.EmbeddedResources.Take(MaxListedResources) : []))
                 sink.Info($"[{name}]   {resource.ManifestName}  ({resource.Origin})");
-            if (model.EmbeddedResources.Length > MaxListedResources)
+            if (options.Verbose && model.EmbeddedResources.Length > MaxListedResources)
                 sink.Info($"[{name}]   … and {model.EmbeddedResources.Length - MaxListedResources} more");
         }
         // A resource the operator ACCEPTED away is still missing from the assembly, so it is a
@@ -609,6 +618,7 @@ public static class ProjectBuild
         // have is an ADDITIONAL library, and this mode cannot invent one.
         var unresolved = ImmutableArray.CreateBuilder<string>();
         var shelfResolutions = new List<ModuleLibrariesShelf.Resolution>();
+        var containerResolved = 0;
         var extraByName = extraReferences.ToDictionary(
             p => Path.GetFileNameWithoutExtension(p)!, p => p, StringComparer.OrdinalIgnoreCase);
         foreach (var package in model.PackageReferences)
@@ -616,8 +626,10 @@ public static class ProjectBuild
             var resolution = container.Resolve(package.Id);
             if (resolution.Supplied)
             {
-                sink.Info($"[{name}] package {package.Id} → the container "
-                          + $"({resolution.Version ?? package.Version ?? "version unknown"})");
+                if (options.Verbose)
+                    sink.Info($"[{name}] package {package.Id} → the container "
+                              + $"({resolution.Version ?? package.Version ?? "version unknown"})");
+                containerResolved++;
                 continue;
             }
             if (extraByName.ContainsKey(package.Id))
@@ -635,6 +647,8 @@ public static class ProjectBuild
             }
             unresolved.Add(package.Id);
         }
+        if (containerResolved > 0 && !options.Verbose)
+            sink.Info($"[{name}] {containerResolved} package(s) resolved from the container (per-package detail with --verbose)");
         if (unresolved.Count > 0)
         {
             var message =

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reactive.Linq;
@@ -456,6 +457,21 @@ public static class ProjectBuild
         public ImmutableDictionary<string, string> PrebuiltReferences { get; init; } =
             ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// One Roslyn reference universe for the whole run — "one workspace": every project in the
+        /// graph shares the SAME <see cref="PortableExecutableReference"/> instance per path, so a
+        /// reference assembly is opened and its metadata decoded from the filesystem ONCE, and
+        /// Roslyn's metadata-keyed symbol caches carry across the graph instead of every project
+        /// re-materializing 200+ assemblies (maintainer, 2026-09-01: "create *one* roslyn
+        /// workspace with all projects at beginning … and you read from file system directly").
+        /// Run-scoped instance state, deliberately not static.
+        /// </summary>
+        public ConcurrentDictionary<string, PortableExecutableReference> SharedReferences { get; } =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        internal PortableExecutableReference Reference(string path) =>
+            SharedReferences.GetOrAdd(path, static p => MetadataReference.CreateFromFile(p));
+
         internal IReadOnlyList<string> DependenciesOf(string id) =>
             Edges.TryGetValue(id, out var deps) ? deps : [];
 
@@ -640,21 +656,21 @@ public static class ProjectBuild
         {
             if (graph.ShadowedAssemblyNames.Contains(assemblyName)) continue;
             if (extraByName.ContainsKey(assemblyName)) continue;
-            references.Add(MetadataReference.CreateFromFile(path));
+            references.Add(graph.Reference(path));
         }
         foreach (var extra in extraReferences)
-            references.Add(MetadataReference.CreateFromFile(extra));
+            references.Add(graph.Reference(extra));
         foreach (var prebuiltDll in graph.PrebuiltReferences.Values)
-            references.Add(MetadataReference.CreateFromFile(prebuiltDll));
+            references.Add(graph.Reference(prebuiltDll));
         // Two shelf packages can share a transitive; each names the full closure, so dedupe by path.
         var shelfReferencePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var fromShelf in shelfResolutions)
             foreach (var file in fromShelf.ReferenceFiles)
                 if (shelfReferencePaths.Add(file))
-                    references.Add(MetadataReference.CreateFromFile(file));
+                    references.Add(graph.Reference(file));
         foreach (var dependency in dependencies)
             if (dependency.AssemblyPath is { Length: > 0 } dll)
-                references.Add(MetadataReference.CreateFromFile(dll));
+                references.Add(graph.Reference(dll));
 
         var parseOptions = new CSharpParseOptions(
                 model.LanguageVersion,
@@ -787,15 +803,31 @@ public static class ProjectBuild
             }
         }
 
+        // Phase timing: the CI receipt for MeshWeaver.AI read "OK … in 558956 ms" with nine silent
+        // minutes between the identity line and the verdict — a duration with no phases is a
+        // number nobody can act on. Each phase now reports itself.
+        var phase = System.Diagnostics.Stopwatch.StartNew();
         if (!generators.IsEmpty)
+        {
             compilation = GeneratorPipeline.RunSourceGenerators(
                 compilation, generators, sink.Logger, CancellationToken.None);
+            sink.Info($"[{name}] phase: source generators {phase.ElapsedMilliseconds} ms");
+        }
 
+        phase.Restart();
         var errors = 0;
         var warnings = 0;
         var missingGeneratorPartials = 0;
         var missingComponentOverrides = 0;
-        foreach (var diagnostic in compilation.GetDiagnostics())
+        // 🚨 ONE body pass, like csc. GetDiagnostics() binds and flow-analyzes every method body,
+        // and the Emit below then lowers them ALL AGAIN — measured on MeshWeaver.AI (168
+        // nullable-heavy files): 82s analysis + 79s emit locally, 559s inside the CI container,
+        // for work csc does once. So the upfront pass reads only parse + declaration diagnostics
+        // (imports, signatures, partials — including the CS8795/CS0115 generator signatures
+        // classified below); body diagnostics surface from the emit itself, whose EmitResult
+        // carries every one.
+        foreach (var diagnostic in compilation.GetParseDiagnostics()
+                     .Concat(compilation.GetDeclarationDiagnostics()))
         {
             switch (diagnostic.Severity)
             {
@@ -818,6 +850,9 @@ public static class ProjectBuild
                     break;
             }
         }
+
+        sink.Info($"[{name}] phase: declaration analysis {phase.ElapsedMilliseconds} ms");
+        phase.Restart();
 
         if (errors > 0)
         {
@@ -868,11 +903,27 @@ public static class ProjectBuild
             var artifact = EmitPipeline.EmitCompilationToDirectory(
                 compilation, model.AssemblyName, model.ProjectPath, outputDirectory,
                 ManifestResources(model), CancellationToken.None);
+            sink.Info($"[{name}] phase: emit {phase.ElapsedMilliseconds} ms");
             if (!artifact.MatchesFileOnDisk(out var reason))
             {
                 sink.Error($"[{name}] RED — the emitted assembly did not survive the write: {reason}");
                 return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
                     model.CompileItems.Length, 0, warnings, null, [], reason);
+            }
+            // Body-level warnings arrive from the emit (the single body pass); under
+            // warnings-as-errors they were already escalated inside the Emit and threw. This is
+            // the same no-warn policy gate as the declaration pass above, applied to the rest.
+            foreach (var bodyWarning in artifact.Warnings)
+                sink.Warn($"[{name}] {bodyWarning}");
+            warnings += artifact.Warnings.Count;
+            if (artifact.Warnings.Count > 0 && !options.AllowWarnings)
+            {
+                sink.Error(
+                    $"[{name}] RED — {warnings} warning(s), and the no-warn policy is on. Fix them, add them "
+                    + "to the project's NoWarn, or pass --allow-warnings to build anyway.");
+                return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
+                    model.CompileItems.Length, 0, warnings, null, [],
+                    $"{warnings} warning(s) under the no-warn policy");
             }
             NameTheDocumentationFile(outputDirectory, model);
             EmitShelfRides(outputDirectory, model, shelfResolutions, sink, name);
@@ -890,6 +941,14 @@ public static class ProjectBuild
                 RazorCount = razorGenerated,
                 ResourceCount = model.EmbeddedResources.Length,
             };
+        }
+        catch (CompilationException ex)
+        {
+            // Body-level compile errors surface HERE now (the emit is the single body pass); the
+            // message already carries every formatted diagnostic.
+            sink.Error($"[{name}] RED — {ex.Message}");
+            return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
+                model.CompileItems.Length, 1, warnings, null, [], ex.Message);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -315,7 +315,10 @@ public static class ProjectBuild
                         deps.Where(d => d.Result is not null).Select(d => d.Result!).ToArray());
                     return (result, result.IsGreen);
                 },
-                options.MaxParallel)
+                options.MaxParallel,
+                // Target-directed build: the first failure ends the run ("when build fails =>
+                // exit") — a red here dooms the job, so independents must not keep earning slots.
+                stopOnFirstFailure: true)
             .Select(results =>
             {
                 var report = new Report(


### PR DESCRIPTION
The answer to *"why is AI so slow? this cannot be real timing"* — measured, fixed, and documented as the shape every repo follows.

## The analysis (MeshWeaver.AI, 168 files)

| | before | after |
|---|---|---|
| local builder compile | 161s (82s GetDiagnostics + 79s Emit — the same bodies twice) | **80.6s** (single pass) |
| CI container | 559s | projected ~½ |
| with nullable flow analysis off | — | 2.6s |

~97% of the remaining compile is Roslyn's **nullable flow analysis**, single-threaded because a few very large methods dominate (`ThreadExecution.cs` ~4000 lines) — the same cost csc pays (the SDK job's 309s agrees). That's source-side work in Plugins, tracked separately.

## What ships

1. **One body pass, like csc** — parse+declaration diagnostics upfront, body diagnostics from the single `Emit` (its `EmitResult`/`CompilationException` carries them all).
2. **One Roslyn workspace per run** — shared `PortableExecutableReference` per path; 200+ assemblies decoded once, not once per project.
3. **Fail-fast** — *"when build fails => exit"*: first red blocks every not-yet-started node by name.
4. **Implementation-framework gates** — `node-repo-compile-check` extracts the image's `shared/` beside `/app`; `compile-check.py` (caller-side, landing on Plugins#1032) then drops the SDK ref pack. Container-built modules reference `System.Private.CoreLib` directly; the ref pack reds them falsely (11× CS0012 on #1032). Validated locally: **80/80 NodeTypes in 44s** vs 161s + 11 false regressions.
5. **`Doc/Architecture/ModuleBuildArchitecture`** — the shape, its measurements, and the agreed roadmap (tests after global build; self-hosted mirror volume + per-run worktree deleted at end; pack/test verbs in-image), for every repo to follow.

282/282 tester tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)