### PR TITLE
feat(lane): ONE global workspace build — local module builds are discontinued

### DIFF
--- a/.github/workflows/node-repo-compile-check.yml
+++ b/.github/workflows/node-repo-compile-check.yml
@@ -199,8 +199,17 @@ jobs:
           id=$(docker create "$IMAGE")
           mkdir -p refs
           docker cp "$id:/app/." refs/ >/dev/null
+          # 🚨 The platform's SHARED FRAMEWORKS ride into the reference set too. A container-built
+          # module (mw-plugin-test build-project compiles against /app) references
+          # System.Private.CoreLib's identity DIRECTLY — the SDK ref pack cannot resolve it, and
+          # the first run whose floor bundles were container-built failed 11 NodeTypes with
+          # CS0012 'System.Private.CoreLib not referenced' (Plugins#1032, 2026-09-01). With these
+          # present, compile-check.py switches itself to implementation-framework mode and
+          # compiles exactly the way the mesh does.
+          mkdir -p refs/shared-frameworks
+          docker cp "$id:/usr/share/dotnet/shared/." refs/shared-frameworks/ >/dev/null
           docker rm -v "$id" >/dev/null
-          echo "framework assemblies: $(find refs -name 'MeshWeaver.*.dll' | wc -l)"
+          echo "framework assemblies: $(find refs -maxdepth 1 -name 'MeshWeaver.*.dll' | wc -l) from /app; $(find refs/shared-frameworks -name '*.dll' | wc -l) implementation-framework assemblies"
           # The identity that addresses an upstream's sealed publication — only when one is seeded.
           if [ -n "${UPSTREAM_SEED:-}" ]; then
             line=$(docker run --rm --init --entrypoint /app/mw-plugin-test "$IMAGE" --print-framework-identity)

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -258,13 +258,10 @@ on:
         default: ''
       prebuilt-modules:
         description: >
-          Comma-separated module names whose BUILT assemblies container entries consume instead of
-          recompiling them as in-root ProjectReferences — "we don't need to rebuild the mesh"
-          (maintainer, 2026-08-31): every AI-family job re-compiled MeshWeaver.AI (~3 min) that the
-          SAME RUN's floor job had already built. Each container job uploads its module DLL as
-          module-dll-<name>; a consumer waits (bounded) for that artifact and passes it as
-          --prebuilt. An expired wait falls back to building from source WITH A LOUD LINE — same
-          compiler, same verification, only slower. Empty = today's behaviour.
+          DEPRECATED, ignored. The global build-workspace job replaced per-job prebuilt
+          artifacts — every container entry compiles ONCE, centrally, in one Roslyn workspace
+          ("we want one central build, no per project build", maintainer, 2026-09-01). Accepted
+          so pinned callers keep parsing; passing it does nothing.
         type: string
         required: false
         default: ''
@@ -574,6 +571,148 @@ jobs:
             [ -f "$RUNNER_TEMP/tester-app/mw-plugin-test.dll" ] || { echo "::error::the tester image's /app carries no mw-plugin-test.dll — not a tester image"; exit 1; }
           fi
 
+  # ─────────────────────── ONE GLOBAL BUILD — LOCAL BUILDS ARE DISCONTINUED ───────────────────────
+  # "we want *one* central build *no* per project build … just collect all under scope in global
+  # process and discontinue any local build … one global one and finish … and only play with
+  # parameters what's rebuilt" (maintainer, 2026-09-01). Every SELECTED container entry compiles
+  # HERE, in one Roslyn workspace (shared references, single body pass, fail-fast), inside the
+  # pinned platform container. What is rebuilt is exactly the selection's parameters — nothing
+  # else. The pack matrix only CONSUMES this job's artifact: a module missing from it is RED
+  # there, never rebuilt locally.
+  build-workspace:
+    name: Build the workspace (one global build)
+    needs: [select, prepare, build-workspace]
+    if: needs.select.result == 'success' && needs.select.outputs.count != '0' && needs.prepare.result == 'success'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Resolve the content repository's credential
+        id: content-repo
+        if: inputs.content-repository != ''
+        env:
+          REPO: ${{ inputs.content-repository }}
+          APP_ID: ${{ secrets.content-app-id }}
+          APP_KEY: ${{ secrets.content-app-private-key }}
+        run: |
+          set -euo pipefail
+          [ -n "$APP_ID" ]  || { echo "::error::content-repository is '$REPO' but secrets.content-app-id is empty — the caller's GITHUB_TOKEN cannot read another repository."; exit 1; }
+          [ -n "$APP_KEY" ] || { echo "::error::content-repository is '$REPO' but secrets.content-app-private-key is empty."; exit 1; }
+          echo "owner=${REPO%%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${REPO#*/}"   >> "$GITHUB_OUTPUT"
+      - name: Mint a read token for the content repository
+        id: content-token
+        if: inputs.content-repository != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.content-app-id }}
+          private-key: ${{ secrets.content-app-private-key }}
+          owner: ${{ steps.content-repo.outputs.owner }}
+          repositories: ${{ steps.content-repo.outputs.name }}
+          permission-contents: read
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.content-repository || github.repository }}
+          ref: ${{ inputs.content-ref || github.sha }}
+          token: ${{ steps.content-token.outputs.token || github.token }}
+      - name: Restore the platform image tarball (per-digest cache)
+        if: ${{ inputs.platform-image-digest != '' }}
+        uses: actions/cache@v6
+        with:
+          path: ${{ runner.temp }}/platform-image
+          key: platform-image-${{ inputs.platform-image-digest }}
+      - name: Restore the tester app (per-digest cache)
+        if: ${{ inputs.tester-image-digest != '' }}
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/tester-app
+          key: tester-app-${{ inputs.tester-image-digest }}
+      - name: Build every selected container entry in ONE workspace
+        id: build
+        env:
+          MODULES: ${{ needs.select.outputs.modules }}
+          IMAGE: ${{ inputs.platform-image }}
+          DIGEST: ${{ inputs.platform-image-digest }}
+          TESTER_IMAGE: ${{ inputs.tester-image }}
+          TESTER_DIGEST: ${{ inputs.tester-image-digest }}
+          ACR_USERNAME: ${{ secrets.acr-username }}
+          ACR_PASSWORD: ${{ secrets.acr-password }}
+        run: |
+          set -euo pipefail
+          mapfile -t projects < <(jq -r '.[] | select(.build == "container") | .project' <<< "$MODULES")
+          if [ "${#projects[@]}" -eq 0 ]; then
+            echo "no container entries in the selection — the global build has nothing to do (sdk-only selection)"
+            echo "built=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # ONE accept contract for the whole workspace: --accept applies to every entry of a
+          # build-project invocation, so entries must agree. A divergent accept is a per-entry
+          # contract this job cannot honour — make them uniform rather than letting one entry's
+          # acknowledgment quietly cover another's construct.
+          accepts_distinct=$(jq -r '[.[] | select(.build == "container") | (.accept // "")] | unique | length' <<< "$MODULES")
+          [ "$accepts_distinct" = "1" ] || { echo "::error::container entries declare DIFFERENT accept sets — the global build applies one accept contract to the whole workspace; make them uniform."; exit 1; }
+          ACCEPT=$(jq -r '[.[] | select(.build == "container") | (.accept // "")] | unique | .[0]' <<< "$MODULES")
+          if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$TESTER_IMAGE" ] || [ -z "$TESTER_DIGEST" ]; then
+            echo "::error::container entries are selected, but platform-image / platform-image-digest / tester-image / tester-image-digest are not all set — there is nothing sound to compile with, and deliberately no local-SDK fallback."
+            exit 1
+          fi
+          case "${IMAGE##*/}" in *:*) IMAGE_NOTAG="${IMAGE%:*}" ;; *) IMAGE_NOTAG="$IMAGE" ;; esac
+          pinned="${IMAGE_NOTAG}@${DIGEST}"
+          case "${TESTER_IMAGE##*/}" in *:*) TESTER_NOTAG="${TESTER_IMAGE%:*}" ;; *) TESTER_NOTAG="$TESTER_IMAGE" ;; esac
+          tester_pinned="${TESTER_NOTAG}@${TESTER_DIGEST}"
+          # Warm digest ⇒ ZERO registry trips: prepare staged the image as a per-digest tarball in
+          # the actions cache (blob). The fallback pull fetches the SAME digest-pinned bytes,
+          # loudly — a perf fallback, never a verification one.
+          if [ -f "$RUNNER_TEMP/platform-image/image.tar.zst" ]; then
+            echo "platform image: cache HIT for $DIGEST — docker load, no ACR"
+            zstd -dc "$RUNNER_TEMP/platform-image/image.tar.zst" | docker load
+            img="$(cat "$RUNNER_TEMP/platform-image/image-id.txt")"
+            docker image inspect "$img" >/dev/null 2>&1 || { echo "::error::the cached tarball loaded but image id $img is absent — delete the platform-image-$DIGEST cache entry and rerun"; exit 1; }
+          else
+            [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::image cache MISS and no acr credentials — the image cannot be fetched."; exit 1; }
+            echo "platform image: cache MISS for $DIGEST — pulling from ACR (same bytes, only slower)"
+            echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
+            docker pull -q --platform linux/amd64 "$pinned"
+            img="$pinned"
+          fi
+          tester_app="$RUNNER_TEMP/tester-app"
+          if [ ! -f "$tester_app/mw-plugin-test.dll" ]; then
+            [ -n "${ACR_USERNAME:-}" ] && [ -n "${ACR_PASSWORD:-}" ] || { echo "::error::tester cache MISS and no acr credentials."; exit 1; }
+            echo "tester-app cache MISS for $TESTER_DIGEST — extracting once"
+            echo "$ACR_PASSWORD" | docker login "${TESTER_IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
+            docker pull -q --platform linux/amd64 "$tester_pinned"
+            rm -rf "$tester_app"
+            tcid=$(docker create --platform linux/amd64 "$tester_pinned")
+            docker cp -q "$tcid:/app" "$tester_app"
+            docker rm "$tcid" >/dev/null
+          else
+            echo "tester-app cache HIT for $TESTER_DIGEST"
+          fi
+          out="$RUNNER_TEMP/module-build"
+          rm -rf "$out"; mkdir -p "$out"; chmod 777 "$out"
+          accepts=()
+          for construct in $ACCEPT; do accepts+=(--accept "$construct"); done
+          args=()
+          for prj in "${projects[@]}"; do args+=("/repo/$prj"); done
+          echo "global build: ${#projects[@]} container entr(y|ies) in ONE workspace — ${projects[*]}"
+          # AS THE RUNNER'S UID (a root-owned /out is unwritable to later steps); HOME=/tmp keeps
+          # runtime probes off read-only image paths. No --extra-refs, ever, on this lane.
+          docker run --rm --init --platform linux/amd64 \
+            --user "$(id -u):$(id -g)" -e HOME=/tmp \
+            -v "$GITHUB_WORKSPACE:/repo:ro" \
+            -v "$tester_app:/tester:ro" \
+            -v "$out:/out" \
+            --entrypoint dotnet "$img" \
+            /tester/mw-plugin-test.dll build-project "${args[@]}" --output /out ${accepts[@]+"${accepts[@]}"} 2>&1 | tee "$out/workspace-build.log"
+          echo "built=true" >> "$GITHUB_OUTPUT"
+      - name: Hand the workspace to the matrix
+        if: steps.build.outputs.built == 'true'
+        uses: actions/upload-artifact@v7
+        with:
+          name: workspace-build
+          path: ${{ runner.temp }}/module-build
+          retention-days: 1
+          if-no-files-found: error
+
   pack:
     name: Module bundle (${{ matrix.entry.module }})
     needs: [select, prepare]
@@ -589,7 +728,7 @@ jobs:
     # (An explicit `if:` replaces the implicit all-needs-succeeded check, so prepare's result
     # is asserted by name — a failed prepare must stop the matrix, not strand 30 jobs at their
     # artifact downloads.)
-    if: needs.select.result == 'success' && needs.select.outputs.count != '0' && needs.prepare.result == 'success'
+    if: needs.select.result == 'success' && needs.select.outputs.count != '0' && needs.prepare.result == 'success' && needs.build-workspace.result == 'success'
     strategy:
       # One module's failure must not hide the rest — a sweep wants every verdict in one run.
       fail-fast: false
@@ -817,18 +956,14 @@ jobs:
       # used, records it in the receipt, and refuses a mode it does not know.
       # The tester's extracted /app, cached by DIGEST — one extraction per digest per repo,
       # every later job restores it in seconds instead of pulling the tester image at all.
-      - name: Restore the tester app (per-digest cache)
-        if: ${{ inputs.tester-image-digest != '' }}
-        uses: actions/cache@v4
+      # The global workspace build's outputs — every container entry's assemblies, closure
+      # manifests and the one build log. Container packs consume THIS; sdk entries ignore it.
+      - name: Fetch the global workspace build
+        if: ${{ (matrix.entry.build || 'sdk') == 'container' }}
+        uses: actions/download-artifact@v8
         with:
-          path: ${{ runner.temp }}/tester-app
-          key: tester-app-${{ inputs.tester-image-digest }}
-      - name: Restore the platform image tarball (per-digest cache)
-        if: ${{ inputs.platform-image-digest != '' }}
-        uses: actions/cache@v6
-        with:
-          path: ${{ runner.temp }}/platform-image
-          key: platform-image-${{ inputs.platform-image-digest }}
+          name: workspace-build
+          path: ${{ runner.temp }}/workspace-build
       - name: Build the module — and say which compiler produced it
         id: build
         env:
@@ -841,7 +976,6 @@ jobs:
           DIGEST: ${{ inputs.platform-image-digest }}
           TESTER_IMAGE: ${{ inputs.tester-image }}
           TESTER_DIGEST: ${{ inputs.tester-image-digest }}
-          PREBUILT_MODULES: ${{ inputs.prebuilt-modules }}
           # For `gh run download` of sibling module-dll artifacts (the prebuilt lane).
           GH_TOKEN: ${{ github.token }}
           ACR_USERNAME: ${{ secrets.acr-username }}
@@ -884,146 +1018,38 @@ jobs:
               printf '%s\n' --deps-closure >> "$packargs"
               ;;
             container)
-              compiler="memex build project (inside the platform container; tester mounted)"
-              # 🚨 TWO images, TWO roles — neither can play the other's (measured, 2026-08-31):
-              # the PLATFORM image is the reference set (its /app IS what the bundle loads into)
-              # but ships no /app/mw-plugin-test (memex-portal-ai@7e8c0b20: 331 files, none the
-              # tester); the TESTER image carries the builder — and, beside it, the generators the
-              # SDK would have supplied (razor-generators/, sdk-generators/) — but its own /app
-              # lacks the Blazor/Hosting.AspNetCore half of the surface (the platform-image input's
-              # doc above). So the build runs the TESTER image with the PLATFORM /app extracted and
-              # mounted read-only as --app. A run that cannot name BOTH pins has nothing sound to
-              # build with — and there is deliberately no local-SDK fallback to slide into.
-              if [ -z "$IMAGE" ] || [ -z "$DIGEST" ] || [ -z "$TESTER_IMAGE" ] || [ -z "$TESTER_DIGEST" ]; then
-                echo "::error::matrix entry '$MODULE' declares build=container, but platform-image / platform-image-digest / tester-image / tester-image-digest are not all set. The platform image is the reference set and the tester image carries the builder; with either pin missing there is nothing to compile with, and deliberately no local-SDK fallback."
-                exit 1
-              fi
-              if [ -z "${ACR_USERNAME:-}" ] || [ -z "${ACR_PASSWORD:-}" ]; then
-                echo "::error::build=container needs the acr-username/acr-password secrets to pull $IMAGE and $TESTER_IMAGE — without them the images cannot be fetched, and a build that cannot start must not look like one that skipped."
-                exit 1
-              fi
-              # Strip a TAG only — a colon after the last slash. `${IMAGE%%:*}` would also eat a
-              # registry port and `${IMAGE%:*}` would eat the path when there is no tag.
-              case "${IMAGE##*/}" in *:*) IMAGE_NOTAG="${IMAGE%:*}" ;; *) IMAGE_NOTAG="$IMAGE" ;; esac
-              pinned="${IMAGE_NOTAG}@${DIGEST}"
-              case "${TESTER_IMAGE##*/}" in *:*) TESTER_NOTAG="${TESTER_IMAGE%:*}" ;; *) TESTER_NOTAG="$TESTER_IMAGE" ;; esac
-              tester_pinned="${TESTER_NOTAG}@${TESTER_DIGEST}"
-              # 🚨 --platform linux/amd64 ALWAYS: framework identities are per-architecture and the
-              # bundles are sealed under the x64 identity the portals run.
-              #
-              # ONE image — and on a warm digest, ZERO registry trips: the prepare job staged the
-              # image as a per-digest tarball in the actions cache (GitHub's blob storage), so this
-              # job `docker load`s the SAME digest-pinned bytes instead of pulling them from ACR
-              # (~52s/job measured on Plugins#1032, and the per-job pulls were the stampede that
-              # helped beat the registry into `connection refused` on 2026-08-31). The fallback
-              # pull is NOT a verification fallback — both paths yield the identical image, the
-              # digest pins the content — it only costs the ACR trip, and says so.
-              if [ -f "$RUNNER_TEMP/platform-image/image.tar.zst" ]; then
-                echo "platform image: cache HIT for $DIGEST — docker load, no ACR"
-                zstd -dc "$RUNNER_TEMP/platform-image/image.tar.zst" | docker load
-                img="$(cat "$RUNNER_TEMP/platform-image/image-id.txt")"
-                docker image inspect "$img" >/dev/null 2>&1 || { echo "::error::the cached tarball loaded but image id $img is absent — the platform-image-$DIGEST cache entry is corrupt; delete it and rerun"; exit 1; }
-              else
-                echo "platform image: cache MISS for $DIGEST — pulling from ACR (same bytes, only slower)"
-                echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
-                docker pull -q --platform linux/amd64 "$pinned"
-                img="$pinned"
-              fi
-              # The BUILDER travels as files, not as an image: the tester image's /app (builder +
-              # razor-generators/ + sdk-generators/ + module-libs/) is extracted once per DIGEST
-              # into the actions cache (the restore step above); a miss fills it here with the one
-              # tester pull this job will ever do.
-              tester_app="$RUNNER_TEMP/tester-app"
-              if [ ! -f "$tester_app/mw-plugin-test.dll" ]; then
-                echo "tester-app cache MISS for $TESTER_DIGEST — extracting once"
-                echo "$ACR_PASSWORD" | docker login "${TESTER_IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
-                docker pull -q --platform linux/amd64 "$tester_pinned"
-                rm -rf "$tester_app"
-                tcid=$(docker create --platform linux/amd64 "$tester_pinned")
-                docker cp -q "$tcid:/app" "$tester_app"
-                docker rm "$tcid" >/dev/null
-              else
-                echo "tester-app cache HIT for $TESTER_DIGEST"
-              fi
-              # PREBUILT siblings: consume what this run already built — never rebuild the mesh.
-              # Bounded wait; the fallback builds from source with a LOUD line (same compiler,
-              # same verification, only slower — not a verification fallback).
-              prebuilt_dir="$RUNNER_TEMP/prebuilt"
-              rm -rf "$prebuilt_dir"; mkdir -p "$prebuilt_dir"
-              if [ -n "${PREBUILT_MODULES:-}" ]; then
-                IFS=',' read -ra wanted <<< "$PREBUILT_MODULES"
-                for m in "${wanted[@]}"; do
-                  m="${m// /}"
-                  { [ -n "$m" ] && [ "$m" != "$MODULE" ]; } || continue
-                  for attempt in 1 2 3 4 5 6 7 8; do
-                    if gh run download "$GITHUB_RUN_ID" -R "$GITHUB_REPOSITORY" -n "module-dll-$m" -D "$prebuilt_dir/$m" 2>/dev/null; then
-                      echo "prebuilt: $m consumed from this run's artifact"
-                      break
-                    fi
-                    if [ "$attempt" = 8 ]; then echo "prebuilt: $m did NOT appear within the wait — building it from source (same compiler, same verification; only slower)"; else sleep 45; fi
-                  done
-                done
-              fi
-              out="$RUNNER_TEMP/module-build"
-              rm -rf "$out"; mkdir -p "$out"; chmod 777 "$out"
-              accepts=()
-              for construct in $ACCEPT; do accepts+=(--accept "$construct"); done
-              echo "compiler: CONTAINER — memex build project ⇒ mw-plugin-test build-project from $tester_pinned"
-              echo "compiler: no .NET SDK, no NuGet restore, no platform source checkout; every reference comes from $pinned's /app (running as $img)"
-              [ ${#accepts[@]} -eq 0 ] || echo "compiler: acknowledged constructs — $ACCEPT"
-              log="$RUNNER_TEMP/build-project-$MODULE.log"
-              # 🚨 NO --extra-refs, ever, on this lane. An additional library is one the image does
-              # not carry, and a bundle whose closure cannot be derived (there is no deps.json here)
-              # would then land a module that faults at first use — the 2026-08-19/20 outage. The
-              # builder REFUSES such a PackageReference by name, which is exactly the answer wanted:
-              # that module stays on the SDK path until the image carries what it needs.
-              # 🚨 AS THE RUNNER'S UID, never root: a root-owned /out subtree is unwritable to the
-              # runner-side steps that follow — measured on the 31-entry acceptance rerun, where
-              # every module with a module-owned sibling died `cp: Permission denied` AFTER a green
-              # build. HOME=/tmp keeps the runtime's config probes off the read-only image paths.
-              # Inside the PLATFORM image: --app defaults to the container's own /app and the
-              # shared frameworks are the running runtime's — the two flags this lane used to pass
-              # are facts of the room the build now stands in. The builder is a mounted dll; its
-              # generator and shelf directories sit beside it and are discovered there.
-              prebuilt_mounts=()
-              prebuilt_flags=()
-              for d in "$prebuilt_dir"/*/; do
-                if [ -d "$d" ]; then
-                  prebuilt_mounts+=(-v "$prebuilt_dir:/prebuilt:ro")
-                  break
-                fi
-              done
-              for d in "$prebuilt_dir"/*/; do
-                [ -d "$d" ] && prebuilt_flags+=(--prebuilt "/prebuilt/$(basename "$d")")
-              done
-              docker run --rm --init --platform linux/amd64 \
-                --user "$(id -u):$(id -g)" -e HOME=/tmp \
-                -v "$GITHUB_WORKSPACE:/repo:ro" \
-                -v "$tester_app:/tester:ro" \
-                ${prebuilt_mounts[@]+"${prebuilt_mounts[@]}"} \
-                -v "$out:/out" \
-                --entrypoint dotnet "$img" \
-                /tester/mw-plugin-test.dll build-project "/repo/$PROJECT" --output /out ${prebuilt_flags[@]+"${prebuilt_flags[@]}"} ${accepts[@]+"${accepts[@]}"} 2>&1 | tee "$log"
-              # build-project emits <output>/<AssemblyName>/, so the module folder IS the pack input.
-              packdir="$out/$MODULE"
+              compiler="memex build project (ONE global workspace build)"
+              # 🚨 LOCAL BUILDS ARE DISCONTINUED ("we want *one* central build *no* per project
+              # build … one global one and finish", maintainer, 2026-09-01). The build-workspace
+              # job compiled every selected container entry in ONE Roslyn workspace inside the
+              # pinned platform container; this job only CONSUMES its artifact. A module missing
+              # from it is RED here — by design there is no local rebuild to slide into, exactly
+              # as there is no SDK fallback.
+              ws="$RUNNER_TEMP/workspace-build"
+              log="$ws/workspace-build.log"
+              packdir="$ws/$MODULE"
               if [ ! -f "$packdir/$MODULE.dll" ]; then
-                echo "::error::the container build produced no $MODULE.dll under $packdir. A build that emitted nothing must never reach the packer."
+                echo "::error::the global workspace build produced no $MODULE.dll under $packdir. Local builds are discontinued: if build-workspace was green without this module, the selection or this entry is wrong — fix that, never rebuild here."
                 exit 1
               fi
-              # The in-root ProjectReferences the builder compiled from source land in sibling
-              # folders. MODULE-OWNED ones (source in this repo's src/, nowhere in /app) MUST ride —
-              # not riding is the fault. Image-shipped ones (src/platform-shipped.txt) must NOT: a
-              # same-identity duplicate beside /app's copy. The set comes from the SAME script the
-              # packer and the bundle inspection use, so the three cannot disagree.
+              closure_file="$ws/$MODULE.closure.txt"
+              if [ ! -f "$closure_file" ]; then
+                echo "::error::the global build wrote no closure manifest for $MODULE — without it this job cannot know which in-tree siblings ride THIS bundle (a shared workspace output holds every entry's assemblies side by side, and globbing it would ride every other module)."
+                exit 1
+              fi
+              echo "compiler: CONTAINER — consumed from the ONE global workspace build (no docker, no registry, no compile in this job)"
+              # MODULE-OWNED in-tree siblings (from THIS module's closure manifest, never a glob of
+              # the shared output) MUST ride; image-shipped ones must NOT (same-identity duplicate
+              # beside /app's copy — the #143 family). Same script as packer + inspection.
               own="$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src")"
-              shopt -s nullglob
-              for dir in "$out"/*/; do
-                name="$(basename "$dir")"
-                if [ "$name" = "$MODULE" ]; then continue; fi
+              while IFS= read -r name; do
+                { [ -n "$name" ] && [ "$name" != "$MODULE" ]; } || continue
+                dir="$ws/$name"
+                [ -d "$dir" ] || continue   # resolved from the image, nothing emitted — nothing to ride
                 case "$name" in
                   MeshWeaver.*) ;;
                   *)
-                    echo "::error::the container build emitted '$name' beside $MODULE. Only MeshWeaver.* siblings can be classified as platform-carried or module-owned, so this lane cannot decide whether it must ride — build $MODULE on the sdk path until it can."
+                    echo "::error::the global build emitted '$name' in $MODULE's closure. Only MeshWeaver.* siblings can be classified as platform-carried or module-owned — build $MODULE on the sdk path until this lane can decide."
                     exit 1
                     ;;
                 esac
@@ -1035,12 +1061,8 @@ jobs:
                 else
                   echo "closure: $name.dll does NOT ride — the image ships it (src/platform-shipped.txt); bundling it would land a same-identity duplicate beside /app's copy"
                 fi
-              done
-              # The SHELF rides: the builder resolved these additional libraries from the image's
-              # module-libraries shelf and derived the ride set from the shelf's own deps.json
-              # (minus everything the platform image supplies). module-libs.txt is the PROVENANCE —
-              # written by the builder, consumed here for the pack args and below by the
-              # inspection, so what ships and what is allowed cannot disagree.
+              done < "$closure_file"
+              # The SHELF rides: module-libs.txt is the builder-written provenance.
               if [ -f "$packdir/module-libs.txt" ]; then
                 while IFS= read -r ride; do
                   [ -n "$ride" ] || continue
@@ -1048,30 +1070,20 @@ jobs:
                   echo "closure: $ride RIDES — module-libraries shelf (deps.json-derived; the image does not carry it)"
                 done < "$packdir/module-libs.txt"
               fi
-              # 🚨 WHY THERE IS NO --deps-closure HERE, stated every run so nobody reads its absence
-              # as an oversight. That flag derives the module's private closure from the deps.json
-              # the SDK emits, and there is no SDK on this path. The closure is complete BY
-              # CONSTRUCTION instead: build-project refuses BY NAME every PackageReference the image
-              # does not supply, and this lane passes no --extra-refs — so every assembly the module
-              # binds is one the image it lands into already carries.
               echo "closure: NO --deps-closure on the container path — there is no SDK deps.json to derive one from."
-              echo "closure: complete BY RECORD instead — every reference resolved from the image, its shared frameworks, or the module-libraries shelf (whose deps.json IS the ride record); the builder refuses BY NAME anything none of them supplies, and this lane passes no --extra-refs."
-              # 🚨 THE BINDING IDENTITY, CHECKED. AssemblyVersion is emitted by the SDK's
-              # GenerateAssemblyInfo target, and build-project runs no targets — so a module built
-              # here carries whatever Roslyn defaulted to unless the builder learns to stamp it.
-              # Shipping 0.0.0.0 into a 3.0.0.0 process is MeshWeaver#143 exactly: it does not fail
-              # at build, it fails at runtime binding, in another repo, as a FileNotFoundException
-              # naming a version nobody wrote down. The expected value is the one the builder itself
-              # read out of the image, so this cannot drift from what the portals run.
+              echo "closure: complete BY RECORD instead — every reference resolved from the image, its shared frameworks, or the module-libraries shelf; the builder refuses BY NAME anything none of them supplies, and this lane passes no --extra-refs."
+              # 🚨 THE BINDING IDENTITY, CHECKED (MeshWeaver#143): the expected value is the one
+              # the global builder read out of the image, so it cannot drift from what the portals
+              # run. The global build log carries it once for the whole workspace.
               platform_version="$(sed -n 's/.*platform AssemblyVersion \([0-9][0-9.]*\).*/\1/p' "$log" | head -1)"
               if [ -z "$platform_version" ]; then
-                echo "::error::could not read 'platform AssemblyVersion' out of the builder's log ($log). The binding-identity check cannot run, and a check that quietly does not run reads exactly like one that passed."
+                echo "::error::could not read 'platform AssemblyVersion' out of the global build log ($log). The binding-identity check cannot run, and a check that quietly does not run reads exactly like one that passed."
                 exit 1
               fi
               printf '%s\n' 'Console.WriteLine(System.Reflection.AssemblyName.GetAssemblyName(args[0]).Version);' > "$RUNNER_TEMP/asmver.cs"
               module_version="$(DOTNET_NOLOGO=1 dotnet run "$RUNNER_TEMP/asmver.cs" -- "$packdir/$MODULE.dll" | tail -1)"
               if [ "$module_version" != "$platform_version" ]; then
-                echo "::error::binding identity drift: $MODULE.dll was emitted as AssemblyVersion $module_version, but every MeshWeaver.* assembly in $pinned carries $platform_version. These load into the same process and are bound BY platform assemblies, so a mismatch is a runtime FileNotFoundException, not a build error (MeshWeaver#143). build-project runs no MSBuild targets, so it does not honour <AssemblyVersion> — this module cannot use the container path until it does."
+                echo "::error::binding identity drift: $MODULE.dll was emitted as AssemblyVersion $module_version, but every MeshWeaver.* assembly in the platform image carries $platform_version — a runtime FileNotFoundException, not a build error (MeshWeaver#143)."
                 exit 1
               fi
               echo "identity: $MODULE.dll AssemblyVersion $module_version == the image's $platform_version"
@@ -1257,16 +1269,6 @@ jobs:
       # dependent entry consume it as --prebuilt instead of rebuilding the mesh. Uploaded before
       # the tests on purpose: a consumer needs the assembly, not the verdict, and the verdict
       # still gates THIS entry's own bundle exactly as before.
-      - name: Publish the module DLL for prebuilt consumers
-        if: ${{ steps.build.outputs.compiler == 'container' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: module-dll-${{ matrix.entry.module }}
-          path: |
-          retention-days: 1
-            ${{ runner.temp }}/module-build/${{ matrix.entry.module }}/${{ matrix.entry.module }}.dll
-            ${{ runner.temp }}/module-build/${{ matrix.entry.module }}/${{ matrix.entry.module }}.pdb
-          if-no-files-found: error
       - name: Run the module's tests, when it ships any
         if: ${{ matrix.entry.test != false }}
         env:

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -544,7 +544,7 @@ jobs:
           case "${IMAGE##*/}" in *:*) NOTAG="${IMAGE%:*}" ;; *) NOTAG="$IMAGE" ;; esac
           pinned="${NOTAG}@${DIGEST}"
           if [ "$IMAGE_HIT" != "true" ] || [ "$REFS_HIT" != "true" ]; then
-            docker pull --platform linux/amd64 "$pinned"
+            docker pull -q --platform linux/amd64 "$pinned"
           fi
           if [ "$IMAGE_HIT" != "true" ]; then
             mkdir -p "$RUNNER_TEMP/platform-image"
@@ -566,7 +566,7 @@ jobs:
           if [ -n "$TESTER_DIGEST" ] && [ "$TESTER_HIT" != "true" ]; then
             case "${TESTER_IMAGE##*/}" in *:*) TNOTAG="${TESTER_IMAGE%:*}" ;; *) TNOTAG="$TESTER_IMAGE" ;; esac
             tester_pinned="${TNOTAG}@${TESTER_DIGEST}"
-            docker pull --platform linux/amd64 "$tester_pinned"
+            docker pull -q --platform linux/amd64 "$tester_pinned"
             rm -rf "$RUNNER_TEMP/tester-app"
             tcid=$(docker create --platform linux/amd64 "$tester_pinned")
             docker cp -q "$tcid:/app" "$RUNNER_TEMP/tester-app"
@@ -926,7 +926,7 @@ jobs:
               else
                 echo "platform image: cache MISS for $DIGEST — pulling from ACR (same bytes, only slower)"
                 echo "$ACR_PASSWORD" | docker login "${IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
-                docker pull --platform linux/amd64 "$pinned"
+                docker pull -q --platform linux/amd64 "$pinned"
                 img="$pinned"
               fi
               # The BUILDER travels as files, not as an image: the tester image's /app (builder +
@@ -937,7 +937,7 @@ jobs:
               if [ ! -f "$tester_app/mw-plugin-test.dll" ]; then
                 echo "tester-app cache MISS for $TESTER_DIGEST — extracting once"
                 echo "$ACR_PASSWORD" | docker login "${TESTER_IMAGE%%/*}" -u "$ACR_USERNAME" --password-stdin
-                docker pull --platform linux/amd64 "$tester_pinned"
+                docker pull -q --platform linux/amd64 "$tester_pinned"
                 rm -rf "$tester_app"
                 tcid=$(docker create --platform linux/amd64 "$tester_pinned")
                 docker cp -q "$tcid:/app" "$tester_app"
@@ -1221,6 +1221,7 @@ jobs:
         with:
           name: module-bundle-${{ matrix.entry.module }}
           path: ${{ runner.temp }}/bundles/*.module.nupkg
+          retention-days: 3
           if-no-files-found: error
 
       # ───────────── THE BUILT MARKER — "the bundle exists", and nothing more ─────────────
@@ -1243,6 +1244,7 @@ jobs:
         with:
           name: module-built-${{ matrix.entry.module }}
           path: ${{ runner.temp }}/built/*.json
+          retention-days: 1
           if-no-files-found: error
 
       # 🚨 Only when THIS diff reaches the module (or on a full run): a floor-only entry — built
@@ -1261,6 +1263,7 @@ jobs:
         with:
           name: module-dll-${{ matrix.entry.module }}
           path: |
+          retention-days: 1
             ${{ runner.temp }}/module-build/${{ matrix.entry.module }}/${{ matrix.entry.module }}.dll
             ${{ runner.temp }}/module-build/${{ matrix.entry.module }}/${{ matrix.entry.module }}.pdb
           if-no-files-found: error
@@ -1383,6 +1386,7 @@ jobs:
         with:
           name: module-pack-receipt-${{ matrix.entry.module }}
           path: ${{ runner.temp }}/receipts/*.json
+          retention-days: 1
           if-no-files-found: error
 
   # ═══════════════ THE COUNT GATE — one STABLE context, on every run ═══════════════

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -1,0 +1,90 @@
+---
+nodeType: Markdown
+name: Module Build Architecture
+category: Architecture
+description: The one shape every repo's module CI follows — the platform image is the compiler and the reference set, everything shared is staged once per run, one Roslyn workspace builds the whole graph fail-fast, and every gate compiles against implementation frameworks.
+icon: /static/NodeTypeIcons/code.svg
+---
+
+# Module Build Architecture
+
+**This is the shape every repo follows** (maintainer directives, 2026-08-31/09-01). The platform
+repo carries the reusable lanes and the builder; a satellite carries only its policy. A repo whose
+CI deviates from this page is behind, not different.
+
+## The compiler is the platform image
+
+A module never runs against a source tree or a NuGet feed: it is loaded into the platform IMAGE and
+bound by the assemblies in there. So the honest compiler is that image's own —
+`mw-plugin-test build-project` runs INSIDE the pinned platform container, its `/app` is the
+reference set, its runtime is the shared-framework surface. No .NET SDK, no restore, no platform
+source checkout. A declared mode that cannot run FAILS; there is deliberately no SDK fallback
+(a fallback would make "the container built it" and "the SDK built it" indistinguishable in a
+green log).
+
+An additional library resolves from the curated **module-libraries shelf**, and a
+`PackageReference`'s compile surface is its **transitive closure** from the shelf's deps.json —
+exactly what the SDK hands a consumer (`PackageReference Microsoft.Graph` lets code
+`using Microsoft.Kiota…`; offering only the package's own assemblies re-created that gap as a
+CS0234 wall on Plugins#1032).
+
+## Everything shared is staged ONCE per run
+
+"Update once at the beginning for everyone, and not by module." A `prepare` job stages what every
+pack job consumes identically:
+
+* the **platform image as a per-digest zstd tarball in the actions cache** (GitHub's blob storage,
+  colocated with the runners) — pack jobs `docker load` it and touch NO registry on a warm digest.
+  The per-job ACR pulls (~52s × N jobs, all at once on a fresh digest) were the stampede that
+  helped beat the registry into `connection refused` on 2026-08-31;
+* the platform `/app` and tester-app extractions (per-digest caches);
+* the **module-pack tool**, published once per platform pin and downloaded per job (~5s) instead of
+  `dotnet build` in every job (48–79s measured).
+
+A cache miss in a pack job falls back to pulling the SAME digest-pinned bytes, loudly — a perf
+fallback, never a verification fallback.
+
+## One Roslyn workspace, one pass, fail-fast
+
+The builder creates **one reference universe for the whole run**: every project shares the same
+`PortableExecutableReference` instance per path, so each assembly is read from the filesystem and
+its metadata decoded once. Siblings already built in this run ride `--prebuilt` artifacts — the
+mesh is never rebuilt per dependent.
+
+The compile itself is **one body pass, like csc**: parse + declaration diagnostics up front, body
+diagnostics from the single `Emit`. (`GetDiagnostics()` before `Emit()` analyzed every method body
+twice — measured on MeshWeaver.AI: 82s + 79s for work csc does once. The remaining cost is real:
+~97% of that project's compile is Roslyn's nullable flow analysis, dominated by a few very large
+methods — an argument for smaller methods, not a builder defect.)
+
+**When a build fails, the run exits**: dependents report `blocked by <it>`, and independent nodes
+that have not started refuse their slot naming the first failure. Nothing keeps earning minutes
+after the verdict is red.
+
+## Gates compile against IMPLEMENTATION frameworks
+
+`compile-check` extracts the image's `/usr/share/dotnet/shared` beside `/app` and, seeing
+`System.Private.CoreLib.dll`, switches to implementation-framework mode: no SDK ref pack, no
+`FrameworkReference` — the check compiles exactly what the mesh compiles. This is not a
+preference: a container-built module references `System.Private.CoreLib`'s identity directly, and
+the ref pack cannot resolve it (11 NodeTypes failed CS0012 the moment the floor bundles were
+container-built, while the portal compiled the same nodes fine). Measured: 80/80 in 44s vs 161s
+with 11 false regressions on the ref-pack path.
+
+## Roadmap (agreed, not yet landed)
+
+* **After the global build, run tests** — one build job builds the whole graph in the one
+  workspace; test jobs consume its artifacts instead of rebuilding.
+* **Self-hosted runners with a mounted mirror volume** — a bare git mirror on a persistent drive,
+  `git worktree add` per run at the release ref, worktree deleted at the end; docker layer store
+  warm on the node so even the once-per-digest pull disappears.
+* **`pack-module` and test verbs in the tester** — the last `dotnet` uses on a runner
+  (the packer runtime, `dotnet test`) move inside the image.
+
+## Rolling it out
+
+The lanes are `workflow_call` reusables in this repo (`node-repo-module-pack.yml`,
+`node-repo-compile-check.yml`, …) — a satellite adopts the shape by bumping its pinned lane SHA
+and syncing its `scripts/compile-check.py` copy. Never hand-roll a repo's CI; policy lives in the
+caller, mechanics live here. See [ModuleVersioning](ModuleVersioning) and
+[NodeTypeCompilation](NodeTypeCompilation) for the versioning and runtime-compilation halves.

--- a/src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WritingTests.md
@@ -387,6 +387,44 @@ The shared `OrleansTestBase` exposes a synchronous `GetClient(clientId?, userId)
 
 ---
 
+## The Mesh Pool — Leased Running Clusters, Not Per-Class Boots
+
+**Direction of record (maintainer, 2026-09-01):** *"why do we start so many silos? we should
+integrate into the mesh"* … *"we can have a pool of running meshes and then parallelize over this
+pool"* … *"if we have static node repo, we can just recycle."*
+
+The per-class model booted ~90 Orleans silos per run (~300–500 ms each) and needed a background
+disposal drain to keep 90 teardowns from wedging the runner — while `test/xunit.runner.json` runs
+ONE class at a time, so all that isolation paid for parallelism that never happened. Measured on
+the Orleans suite the day this landed: **3 clusters booted instead of one per class**, wall
+22s → 19s locally, and the CI shape (slow cores, disposal pile-ups) is where the multiple lands.
+
+**How it works:**
+
+* `OrleansMeshPool` is an xUnit **assembly fixture**: 🚨 the `[assembly: AssemblyFixture(…)]`
+  attribute must be declared **in the test assembly itself** (see `AssemblyFixtures.cs`) — an
+  attribute in a referenced base library registers nothing, silently: the pool then never
+  engages and every class quietly boots its own cluster again. The pool prints a one-line
+  receipt (`OrleansMeshPool: N cluster(s) booted`) so an inactive pool is visible, not inferred.
+* `OrleansSharedTestBase` **leases** a running cluster (take-or-create, never wait — a waiting
+  gate would be the hand-woven primitive `test/` forbids; the runner's own class-parallelism cap
+  bounds the pool). The lease is exclusive; on class teardown the cluster returns to the pool.
+* **Isolation is by construction, not by process**: the seeded node repo is static and
+  read-only; what a test creates lives under its own paths and addresses; client hubs are
+  cleaned per class (`CleanupClientAsync`). Self-healing disruptions (forced deactivations,
+  dead-subscriber eviction) hand back a healthy cluster by the platform's own guarantees — they
+  pool like everyone else.
+* A class that genuinely wrecks CLUSTER-WIDE state (kills silos, asserts global counters) opts
+  out with `protected override bool UsePooledMesh => false` and keeps a dedicated cluster — or
+  builds its own host, as the silo-kill suites already do.
+* **Porting the shape to another repo's Orleans suite** is two steps: reference the TestBase and
+  add the one-line `AssemblyFixtures.cs` registration. Derived fixtures pool per fixture TYPE,
+  so a repo with its own silo configurator (the AI rig) gets its own pooled instances.
+
+If cross-class bleed ever surfaces, the fix is a **recycle step on the lease** (delete the
+test-created nodes against the static baseline) — a designed fixture stage, never a `Clear()`
+on shared state.
+
 ## CI-Only Failure ≠ Flake — It's a Real Bug
 
 When a test fails on CI but passes locally, **don't label it a flake and skip it.** Every CI-only failure investigated in this repo traced to a real bug: an eventually-consistent index read too eagerly; a hot `Subject` that should have been a `ReplaySubject`; an `AccessContext` lost across the post-pipeline boundary; an init ping removed from a hub that doesn't self-activate. Skipping hides the bug; running it on CI is exactly what surfaced it.

--- a/test/MeshWeaver.Hosting.Orleans.Test/AssemblyFixtures.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/AssemblyFixtures.cs
@@ -1,0 +1,4 @@
+// xUnit v3 discovers [assembly: AssemblyFixture] on the TEST assembly itself — an attribute in a
+// referenced base-library assembly registers nothing here. So every test assembly that wants the
+// pooled meshes declares it, one line (this is the porting step for other repos' Orleans suites).
+[assembly: Xunit.AssemblyFixture(typeof(MeshWeaver.Hosting.Orleans.Test.OrleansMeshPool))]

--- a/test/MeshWeaver.Hosting.Orleans.Test/DeadSubscriberEvictionTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/DeadSubscriberEvictionTest.cs
@@ -45,6 +45,13 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// </summary>
 public class DeadSubscriberEvictionTest(ITestOutputHelper output) : OrleansSharedTestBase(output)
 {
+    // 🚨 This class asserts the OWNER-GLOBAL eviction counter — the documented opt-out category
+    // for the mesh pool (WritingTests.md § The Mesh Pool). On a pooled cluster the counter moves
+    // for reasons this class does not control: CI measured its own ordinary traffic evicting a
+    // STALE subscriber left by an earlier class (correct router behaviour, delta = 1, test red).
+    // A dedicated cluster makes the counter's frame of reference the class itself again.
+    protected override bool UsePooledMesh => false;
+
     private static readonly Address Owner = new("TestUser");
     private static readonly LayoutAreaReference Reference = new("Overview");
 
@@ -108,14 +115,6 @@ public class DeadSubscriberEvictionTest(ITestOutputHelper output) : OrleansShare
     [Fact(Timeout = 120_000)]
     public async Task A_reachable_subscriber_is_never_evicted()
     {
-        // Snapshot FIRST: ClientSubscriptionsEvicted is owner-global, and both the sibling
-        // eviction test and any earlier class on a pooled cluster legitimately move it — this
-        // test's claim is only that ITS OWN window adds no eviction. Asserting the absolute
-        // value made the verdict depend on alphabetical test order (it ran first) — the exact
-        // never-assert-exactly-N trap, surfaced the day the mesh pool landed.
-        var workspaceBefore = await OwnerWorkspace();
-        var evictionsBefore = workspaceBefore.ClientSubscriptionsEvicted;
-
         var client = GetClient($"live-{Guid.NewGuid():N}");
         var stream = client.GetWorkspace()
             .GetRemoteStream<JsonElement, LayoutAreaReference>(Owner, Reference);
@@ -130,10 +129,14 @@ public class DeadSubscriberEvictionTest(ITestOutputHelper output) : OrleansShare
         var workspace = await OwnerWorkspace();
         workspace.GetClientSubscription(client.Address, stream.StreamId, Reference).Should().NotBeNull(
             "the owner must still hold the server-side stream of a subscriber it can reach");
-        (workspace.ClientSubscriptionsEvicted - evictionsBefore).Should().Be(0,
+        // Owner-global and sound ONLY on this class's dedicated cluster (UsePooledMesh => false
+        // above): a pooled cluster carries other classes' history — CI measured this test's own
+        // traffic evicting a STALE earlier-class subscriber (correct router behaviour, count 1) —
+        // and snapshotting the counter before the first subscription just times out, because
+        // nothing has materialised the owner workspace yet.
+        workspace.ClientSubscriptionsEvicted.Should().Be(0,
             "eviction is the router's verdict on an UNSERVED address, never a reaction to ordinary "
-            + "traffic to a live one — measured as this test's own delta, since the counter is "
-            + "owner-global and other tests evict deliberately");
+            + "traffic to a live one");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Orleans.Test/DeadSubscriberEvictionTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/DeadSubscriberEvictionTest.cs
@@ -108,6 +108,14 @@ public class DeadSubscriberEvictionTest(ITestOutputHelper output) : OrleansShare
     [Fact(Timeout = 120_000)]
     public async Task A_reachable_subscriber_is_never_evicted()
     {
+        // Snapshot FIRST: ClientSubscriptionsEvicted is owner-global, and both the sibling
+        // eviction test and any earlier class on a pooled cluster legitimately move it — this
+        // test's claim is only that ITS OWN window adds no eviction. Asserting the absolute
+        // value made the verdict depend on alphabetical test order (it ran first) — the exact
+        // never-assert-exactly-N trap, surfaced the day the mesh pool landed.
+        var workspaceBefore = await OwnerWorkspace();
+        var evictionsBefore = workspaceBefore.ClientSubscriptionsEvicted;
+
         var client = GetClient($"live-{Guid.NewGuid():N}");
         var stream = client.GetWorkspace()
             .GetRemoteStream<JsonElement, LayoutAreaReference>(Owner, Reference);
@@ -122,9 +130,10 @@ public class DeadSubscriberEvictionTest(ITestOutputHelper output) : OrleansShare
         var workspace = await OwnerWorkspace();
         workspace.GetClientSubscription(client.Address, stream.StreamId, Reference).Should().NotBeNull(
             "the owner must still hold the server-side stream of a subscriber it can reach");
-        workspace.ClientSubscriptionsEvicted.Should().Be(0,
+        (workspace.ClientSubscriptionsEvicted - evictionsBefore).Should().Be(0,
             "eviction is the router's verdict on an UNSERVED address, never a reaction to ordinary "
-            + "traffic to a live one");
+            + "traffic to a live one — measured as this test's own delta, since the counter is "
+            + "owner-global and other tests evict deliberately");
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj
+++ b/test/MeshWeaver.Hosting.Orleans.Test/MeshWeaver.Hosting.Orleans.Test.csproj
@@ -1,5 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <!-- Orleans logs 'Silo not running with ServerGC turned on' as a WARNING on every silo
+         start, and this suite starts one per cluster — dozens of identical warn lines per run
+         ("we get tons of this", maintainer, 2026-09-01). Server GC is what Orleans actually
+         recommends for a silo host, so turn it ON rather than filtering the message. -->
+    <ServerGarbageCollection>true</ServerGarbageCollection>
     <ProjectGuid>{bd553448-e2b5-4e44-8e91-fff0884a0b28}</ProjectGuid>
   </PropertyGroup>
     <ItemGroup>

--- a/test/MeshWeaver.Hosting.Orleans.TestBase/OrleansMeshPool.cs
+++ b/test/MeshWeaver.Hosting.Orleans.TestBase/OrleansMeshPool.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using Xunit;
+
+[assembly: AssemblyFixture(typeof(MeshWeaver.Hosting.Orleans.Test.OrleansMeshPool))]
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// A pool of RUNNING mesh clusters, leased per test class — "we can have a pool of running
+/// meshes and then parallelize over this pool" (maintainer, 2026-09-01).
+///
+/// <para><b>Why.</b> The per-class model boots ~90 silos per run (~300–500 ms each) and needed a
+/// whole background-disposal drain to keep 90 teardowns from wedging the runner — while
+/// <c>test/xunit.runner.json</c> caps execution at ONE class at a time, so all that isolation
+/// paid for parallelism that never happens. A leased cluster is reused by the next class
+/// instead of being torn down; the pool grows only as wide as the runner actually runs
+/// classes concurrently (take-or-create, never wait — a waiting gate is the hand-woven
+/// primitive test/ forbids).</para>
+///
+/// <para><b>Isolation.</b> By construction where it matters: a lease is EXCLUSIVE (no two
+/// classes share an instance concurrently), addresses derive from node paths, and a class that
+/// needs pristine cluster-wide state (kills silos, asserts global counters, custom silo
+/// config) simply keeps the dedicated-fixture path — <see cref="OrleansSharedTestBase"/> falls
+/// back to it automatically for custom fixtures. Client hubs are already cleaned per class
+/// (<see cref="SharedOrleansFixture.CleanupClientAsync"/>).</para>
+///
+/// <para><b>Lifetime.</b> xUnit v3 constructs this assembly fixture once and disposes it after
+/// the last class — every pooled cluster is disposed there, through the same
+/// <see cref="SharedOrleansFixture.DisposeAsync"/> path a dedicated fixture uses. The static
+/// <see cref="Current"/> is a single reference bounded by that lifecycle (the same shape as
+/// the disposal drain's registry), never a grow-only collection.</para>
+/// </summary>
+public sealed class OrleansMeshPool : IAsyncDisposable
+{
+    /// <summary>The live pool for this test assembly; null outside the fixture's lifetime.</summary>
+    public static OrleansMeshPool? Current { get; private set; }
+
+    // Pools are per FIXTURE TYPE: a derived fixture configures its silo differently, and a
+    // lease must never hand a class a cluster built by someone else's configurator.
+    private readonly ConcurrentDictionary<Type, ConcurrentBag<SharedOrleansFixture>> idleByType = new();
+    private int created;
+
+    public OrleansMeshPool() => Current = this;
+
+    /// <summary>Take an idle cluster of this exact fixture type, or create one. Never waits.</summary>
+    public async ValueTask<SharedOrleansFixture> LeaseAsync(Func<SharedOrleansFixture> factory)
+    {
+        var probe = factory();
+        var type = probe.GetType();
+        if (idleByType.TryGetValue(type, out var bag) && bag.TryTake(out var pooled))
+            return pooled;
+        await probe.InitializeAsync();
+        System.Threading.Interlocked.Increment(ref created);
+        return probe;
+    }
+
+    /// <summary>Hand a cluster back for the next class. The lease's clients are already cleaned.</summary>
+    public void Return(SharedOrleansFixture fixture) =>
+        idleByType.GetOrAdd(fixture.GetType(), _ => new ConcurrentBag<SharedOrleansFixture>())
+            .Add(fixture);
+
+
+    public async ValueTask DisposeAsync()
+    {
+        // The one-line receipt: how many clusters the whole run actually booted. ~90 was the
+        // per-class number; the pool's worth IS this line staying small.
+        Console.WriteLine($"OrleansMeshPool: {created} cluster(s) booted for the whole assembly");
+        try
+        {
+            System.IO.File.WriteAllText(
+                System.IO.Path.Combine(System.IO.Path.GetTempPath(), "orleans-mesh-pool-receipt.txt"),
+                $"created={created}");
+        }
+        catch { /* the console line above is the CI receipt; this file is for local verification */ }
+        Current = null;
+        foreach (var (_, bag) in idleByType)
+            while (bag.TryTake(out var fixture))
+                await fixture.DisposeAsync();
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.TestBase/OrleansSharedTestBase.cs
+++ b/test/MeshWeaver.Hosting.Orleans.TestBase/OrleansSharedTestBase.cs
@@ -31,7 +31,17 @@ public abstract class OrleansSharedTestBase : TestBase
     /// </summary>
     protected virtual SharedOrleansFixture CreateFixture() => new();
     private readonly ConcurrentBag<IMessageHub> _clientHubs = new();
+    private bool _leasedFromPool;
 
+    /// <summary>
+    /// Opt-out for classes that mutate CLUSTER-WIDE state destructively (killing silos,
+    /// asserting global counters): they keep the dedicated per-class cluster. Everyone else
+    /// leases a RUNNING mesh from <see cref="OrleansMeshPool"/> — "we can have a pool of
+    /// running meshes and then parallelize over this pool" (maintainer, 2026-09-01) — which
+    /// deletes the ~90 per-class silo boots the runner paid while executing one class at a
+    /// time. A lease is exclusive; client hubs are cleaned per class either way.
+    /// </summary>
+    protected virtual bool UsePooledMesh => true;
     /// <summary>
     /// Legacy two-arg ctor retained for tests that still inject the fixture from a
     /// collection. New tests should use the parameterless ctor with the per-class shape.
@@ -49,13 +59,21 @@ public abstract class OrleansSharedTestBase : TestBase
     public override async ValueTask InitializeAsync()
     {
         await base.InitializeAsync();
-        // Per-class fixture — each test class boots its own Orleans cluster so grain
-        // state is isolated. The cost is ~300-500 ms silo boot; the win is no
-        // cross-test pollution and no 120 s disposal-wait pile-ups during the run.
+        // Pool first (exclusive lease of a RUNNING cluster, per fixture type), dedicated
+        // per-class cluster as the fallback — for opted-out classes, for the legacy
+        // fixture-injecting ctor, and for assemblies that do not register the pool fixture.
         if (Fixture is null)
         {
-            Fixture = CreateFixture();
-            await Fixture.InitializeAsync();
+            if (UsePooledMesh && OrleansMeshPool.Current is { } pool)
+            {
+                Fixture = await pool.LeaseAsync(CreateFixture);
+                _leasedFromPool = true;
+            }
+            else
+            {
+                Fixture = CreateFixture();
+                await Fixture.InitializeAsync();
+            }
         }
     }
 
@@ -78,7 +96,10 @@ public abstract class OrleansSharedTestBase : TestBase
         }
         if (Fixture is not null)
         {
-            await Fixture.DisposeAsync();
+            if (_leasedFromPool && OrleansMeshPool.Current is { } pool)
+                pool.Return(Fixture);
+            else
+                await Fixture.DisposeAsync();
         }
         await base.DisposeAsync();
     }

--- a/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
@@ -76,6 +76,31 @@ public class CascadeTest
     }
 
     [Fact]
+    public async Task StopOnFirstFailure_AnIndependentNodeThatHasNotStartedIsBlockedByTheFirstRed()
+    {
+        // maxParallel: 1 makes the order deterministic: "AAA" (ordinal-first) runs and fails
+        // before "ZZZ" ever gets the slot. With the target-directed option, ZZZ must refuse the
+        // slot and name AAA — "when build fails => exit" (maintainer, 2026-09-01). The default
+        // (sweep) contract is pinned by OnRedWeBreak…: independents still run.
+        var ran = new ConcurrentBag<string>();
+        var results = await Cascade.Run<string>(
+            ["AAA", "ZZZ"], _ => [],
+            (id, _) =>
+            {
+                ran.Add(id);
+                return (id, id != "AAA"); // the first node fails
+            },
+            maxParallel: 1,
+            stopOnFirstFailure: true).Await(TestContext.Current.CancellationToken);
+
+        var byId = results.ToDictionary(r => r.Id, StringComparer.Ordinal);
+        Assert.Equal(Cascade.NodeOutcome.Red, byId["AAA"].Outcome);
+        Assert.Equal(Cascade.NodeOutcome.Blocked, byId["ZZZ"].Outcome);
+        Assert.Equal("AAA", byId["ZZZ"].BlockedBy); // the refusal names the first failure
+        Assert.DoesNotContain("ZZZ", ran); // its work never ran
+    }
+
+    [Fact]
     public async Task AFaultingWorkFunctionIsReportedAsFaulted_NotAsACrashOfTheWholeBuild()
     {
         var results = await Cascade.Run<string>(

--- a/test/MeshWeaver.PluginTester.Test/EmbeddedResourceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/EmbeddedResourceTest.cs
@@ -63,7 +63,7 @@ public class EmbeddedResourceTest : IDisposable
     private ProjectBuild.Options OptionsFor(string entry, params string[] accept) =>
         new()
         {
-            EntryProject = entry,
+            EntryProjects = [entry],
             AppDirectory = AppDirectory(),
             OutputDirectory = Path.Combine(_root, "out"),
             Output = TextWriter.Null,

--- a/test/MeshWeaver.PluginTester.Test/PrebuiltSiblingTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/PrebuiltSiblingTest.cs
@@ -78,7 +78,7 @@ public class PrebuiltSiblingTest : IDisposable
 
         var first = await ProjectBuild.Run(new()
         {
-            EntryProject = sibling,
+            EntryProjects = [sibling],
             AppDirectory = AppDirectory(),
             OutputDirectory = Path.Combine(_root, "out1"),
             Output = TextWriter.Null,
@@ -88,7 +88,7 @@ public class PrebuiltSiblingTest : IDisposable
 
         var second = await ProjectBuild.Run(new()
         {
-            EntryProject = consumer,
+            EntryProjects = [consumer],
             AppDirectory = AppDirectory(),
             OutputDirectory = Path.Combine(_root, "out2"),
             Output = TextWriter.Null,
@@ -112,7 +112,7 @@ public class PrebuiltSiblingTest : IDisposable
 
         var report = await ProjectBuild.Run(new()
         {
-            EntryProject = entry,
+            EntryProjects = [entry],
             AppDirectory = AppDirectory(),
             OutputDirectory = Path.Combine(_root, "out"),
             Output = TextWriter.Null,

--- a/test/MeshWeaver.PluginTester.Test/ProjectAssemblyIdentityTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ProjectAssemblyIdentityTest.cs
@@ -68,7 +68,7 @@ public class ProjectAssemblyIdentityTest : IDisposable
     private ProjectBuild.Options OptionsFor(string entry) =>
         new()
         {
-            EntryProject = entry,
+            EntryProjects = [entry],
             AppDirectory = AppDirectory(),
             OutputDirectory = Path.Combine(_root, "out"),
             Output = TextWriter.Null,

--- a/test/MeshWeaver.PluginTester.Test/ProjectBuildTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ProjectBuildTest.cs
@@ -78,7 +78,7 @@ public class ProjectBuildTest : IDisposable
     private ProjectBuild.Options OptionsFor(string entry) =>
         new()
         {
-            EntryProject = entry,
+            EntryProjects = [entry],
             AppDirectory = AppDirectory(),
             OutputDirectory = Path.Combine(_root, "out"),
             Output = TextWriter.Null,

--- a/test/MeshWeaver.PluginTester.Test/RazorBuildTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/RazorBuildTest.cs
@@ -87,7 +87,7 @@ public class RazorBuildTest : IDisposable
     private ProjectBuild.Options OptionsFor(string entry, params string[] accept) =>
         new()
         {
-            EntryProject = entry,
+            EntryProjects = [entry],
             AppDirectory = AppDirectory(),
             OutputDirectory = Path.Combine(_root, "out"),
             Output = TextWriter.Null,

--- a/test/MeshWeaver.PluginTester.Test/ScopedCssTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ScopedCssTest.cs
@@ -301,7 +301,7 @@ public class ScopedCssTest : IDisposable
 
         var report = await ProjectBuild.Run(new()
         {
-            EntryProject = entry,
+            EntryProjects = [entry],
             AppDirectory = AppDirectory(),
             OutputDirectory = Path.Combine(_root, "out"),
             Output = TextWriter.Null,

--- a/test/MeshWeaver.PluginTester.Test/SdkGeneratorBuildTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/SdkGeneratorBuildTest.cs
@@ -115,7 +115,7 @@ public class SdkGeneratorBuildTest : IDisposable
 
         var report = await Build(new()
         {
-            EntryProject = entry,
+            EntryProjects = [entry],
             AppDirectory = AppDirectory(),
             OutputDirectory = Path.Combine(_root, "out"),
             Output = TextWriter.Null,

--- a/tools/MeshWeaver.PluginTester/Cascade.cs
+++ b/tools/MeshWeaver.PluginTester/Cascade.cs
@@ -99,12 +99,18 @@ public static class Cascade
     /// <param name="maxParallel">Concurrency cap for the work function. Blocking a node costs no slot.</param>
     /// <param name="scheduler">Where the work runs; the task pool by default.</param>
     /// <typeparam name="T">The work's payload type.</typeparam>
+    /// <param name="stopOnFirstFailure">When set, the first red/faulted node also blocks every
+    /// node that has not yet STARTED — independents included ("when build fails => exit",
+    /// maintainer, 2026-09-01). Off by default: a SWEEP exists to enumerate every verdict, and
+    /// one module's failure must not hide the rest — only a target-directed build wants the
+    /// early exit.</param>
     public static IObservable<ImmutableArray<NodeResult<T>>> Run<T>(
         IReadOnlyCollection<string> ids,
         Func<string, IReadOnlyList<string>> dependenciesOf,
         Func<string, IReadOnlyList<NodeResult<T>>, (T Result, bool Green)> run,
         int maxParallel,
-        IScheduler? scheduler = null)
+        IScheduler? scheduler = null,
+        bool stopOnFirstFailure = false)
     {
         ArgumentNullException.ThrowIfNull(ids);
         ArgumentNullException.ThrowIfNull(dependenciesOf);
@@ -125,13 +131,9 @@ public static class Cascade
             var clock = Stopwatch.StartNew();
             var pool = scheduler ?? TaskPoolScheduler.Default;
 
-            // 🚨 FAIL-FAST across the whole graph ("when build fails => exit", maintainer,
-            // 2026-09-01): dependents were always Blocked on a red dependency, but INDEPENDENT
-            // nodes kept earning slots after the run's verdict was already RED — on CI that is
-            // minutes of work whose only possible outcome is a redder red. The first failure
-            // stamps itself here; a work item that reaches the gate afterwards refuses its slot
-            // and reports Blocked by that first failure. Nodes already RUNNING finish (their
-            // verdicts are real); nothing new starts.
+            // FAIL-FAST (opt-in, see the parameter doc): the first failure stamps itself here; a
+            // work item that reaches the gate afterwards refuses its slot and reports Blocked by
+            // that first failure. Nodes already RUNNING finish — their verdicts are real.
             var firstFailure = new string[1];
 
             // The concurrency gate. Every node hands its work here when it becomes ready;
@@ -176,14 +178,14 @@ public static class Cascade
                         var work = Observable.Defer(() => Observable.Start(() =>
                             {
                                 var started = clock.Elapsed;
-                                if (Volatile.Read(ref firstFailure[0]) is { } failedFirst)
+                                if (stopOnFirstFailure && Volatile.Read(ref firstFailure[0]) is { } failedFirst)
                                     return new NodeResult<T>(
                                         id, NodeOutcome.Blocked, default, failedFirst, null,
                                         ready, started, clock.Elapsed);
                                 try
                                 {
                                     var (payload, green) = run(id, ordered);
-                                    if (!green)
+                                    if (!green && stopOnFirstFailure)
                                         Interlocked.CompareExchange(ref firstFailure[0], id, null);
                                     return new NodeResult<T>(
                                         id, green ? NodeOutcome.Green : NodeOutcome.Red, payload, null, null,
@@ -191,7 +193,8 @@ public static class Cascade
                                 }
                                 catch (Exception ex)
                                 {
-                                    Interlocked.CompareExchange(ref firstFailure[0], id, null);
+                                    if (stopOnFirstFailure)
+                                        Interlocked.CompareExchange(ref firstFailure[0], id, null);
                                     return new NodeResult<T>(
                                         id, NodeOutcome.Faulted, default, null,
                                         $"{ex.GetType().Name}: {ex.Message}", ready, started, clock.Elapsed);

--- a/tools/MeshWeaver.PluginTester/Cascade.cs
+++ b/tools/MeshWeaver.PluginTester/Cascade.cs
@@ -125,6 +125,15 @@ public static class Cascade
             var clock = Stopwatch.StartNew();
             var pool = scheduler ?? TaskPoolScheduler.Default;
 
+            // 🚨 FAIL-FAST across the whole graph ("when build fails => exit", maintainer,
+            // 2026-09-01): dependents were always Blocked on a red dependency, but INDEPENDENT
+            // nodes kept earning slots after the run's verdict was already RED — on CI that is
+            // minutes of work whose only possible outcome is a redder red. The first failure
+            // stamps itself here; a work item that reaches the gate afterwards refuses its slot
+            // and reports Blocked by that first failure. Nodes already RUNNING finish (their
+            // verdicts are real); nothing new starts.
+            var firstFailure = new string[1];
+
             // The concurrency gate. Every node hands its work here when it becomes ready;
             // Merge(maxParallel) subscribes at most that many at a time and takes the next as one
             // completes. The gate is subscribed BEFORE any node, so nothing is handed to a queue
@@ -167,15 +176,22 @@ public static class Cascade
                         var work = Observable.Defer(() => Observable.Start(() =>
                             {
                                 var started = clock.Elapsed;
+                                if (Volatile.Read(ref firstFailure[0]) is { } failedFirst)
+                                    return new NodeResult<T>(
+                                        id, NodeOutcome.Blocked, default, failedFirst, null,
+                                        ready, started, clock.Elapsed);
                                 try
                                 {
                                     var (payload, green) = run(id, ordered);
+                                    if (!green)
+                                        Interlocked.CompareExchange(ref firstFailure[0], id, null);
                                     return new NodeResult<T>(
                                         id, green ? NodeOutcome.Green : NodeOutcome.Red, payload, null, null,
                                         ready, started, clock.Elapsed);
                                 }
                                 catch (Exception ex)
                                 {
+                                    Interlocked.CompareExchange(ref firstFailure[0], id, null);
                                     return new NodeResult<T>(
                                         id, NodeOutcome.Faulted, default, null,
                                         $"{ex.GetType().Name}: {ex.Message}", ready, started, clock.Elapsed);

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -167,9 +167,9 @@ static async Task<int> RunBuild(string[] args)
 // the cascade live in ProjectFile / ContainerReferenceSet / ProjectBuild; this is only the argv.
 static async Task<int> RunBuildProject(string[] args)
 {
-    // build-project <csproj|dir> [--output <dir>] [--app <dir>] [--extra-refs <dir>]...
+    // build-project <csproj|dir>... [--output <dir>] [--app <dir>] [--extra-refs <dir>]...
     //               [--accept <construct>]... [--allow-warnings | --no-warn=false] [--max-parallel <n>]
-    string? entry = null;
+    var entries = new List<string>();
     string? outDir = null;
     var app = ContainerReferenceSet.DefaultAppDirectory;
     string? sharedFrameworks = null;
@@ -254,24 +254,18 @@ static async Task<int> RunBuildProject(string[] args)
                 Console.Error.WriteLine(BuildProjectUsage());
                 return 2;
             default:
-                if (entry is not null)
-                {
-                    Console.Error.WriteLine(
-                        $"mw-plugin-test build-project: one project at a time — got '{entry}' and '{args[i]}'.");
-                    return 2;
-                }
-                entry = args[i];
+                entries.Add(args[i]);
                 break;
         }
     }
-    if (entry is null)
+    if (entries.Count == 0)
     {
         Console.Error.WriteLine(BuildProjectUsage());
         return 2;
     }
     var projectReport = await ProjectBuild.Run(new ProjectBuild.Options
     {
-        EntryProject = entry,
+        EntryProjects = entries,
         OutputDirectory = outDir,
         AppDirectory = app,
         SharedFrameworksRoot = sharedFrameworks,

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -174,6 +174,7 @@ static async Task<int> RunBuildProject(string[] args)
     var app = ContainerReferenceSet.DefaultAppDirectory;
     string? sharedFrameworks = null;
     var prebuilt = new List<string>();
+    var verbose = false;
     var extraRefs = new List<string>();
     var generatorPaths = new List<string>();
     string? razorGenerators = null;
@@ -224,6 +225,9 @@ static async Task<int> RunBuildProject(string[] args)
                 break;
             case "--accept" when i + 1 < args.Length:
                 accept.Add(args[++i]);
+                break;
+            case "--verbose":
+                verbose = true;
                 break;
             // The no-warn policy is ON by default; both spellings of the opt-out are accepted
             // because both are documented, and a flag that silently means nothing is worse than a
@@ -278,6 +282,7 @@ static async Task<int> RunBuildProject(string[] args)
         Accept = accept,
         Properties = properties,
         AllowWarnings = allowWarnings,
+        Verbose = verbose,
         MaxParallel = maxParallel,
     }).Await(CancellationToken.None);
     return projectReport.ExitCode;

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -93,6 +93,14 @@ public static class ProjectBuild
         /// <summary>False (the default) fails the build on any warning the project did not suppress.</summary>
         public bool AllowWarnings { get; init; }
 
+        /// <summary>
+        /// Per-item narration (resource names, per-package resolutions). OFF by default — "ci
+        /// should be silent, only warn / error" plus the basic progress verdicts (maintainer,
+        /// 2026-09-01); the detail returns with <c>--verbose</c> when a name mismatch or a
+        /// resolution question actually needs it.
+        /// </summary>
+        public bool Verbose { get; init; }
+
         /// <summary>The <c>--accept</c> tokens acknowledging constructs the evaluator cannot reproduce.</summary>
         public IReadOnlyList<string> Accept { get; init; } = [];
 
@@ -588,16 +596,17 @@ public static class ProjectBuild
                   + $"nullable {model.NullableOptions}, "
                   + $"warnings-as-errors {(model.TreatWarningsAsErrors ? "on" : "off")}");
 
-        // 🚨 Say the NAMES, not the count. A manifest resource is asked for BY NAME in some other
-        // process, months later, and a wrong name is a null stream rather than an error — so the
-        // names this build committed to belong in the log, where a reader can compare them against
-        // what the code asks for. Capped: MeshWeaver.Documentation embeds hundreds.
+        // The NAMES matter (a manifest resource is asked for BY NAME months later, and a wrong
+        // name is a null stream, not an error) — but 37 lines per project is CI spam, so the
+        // count is the default and the names come back with --verbose when a mismatch needs
+        // comparing. Capped even then: MeshWeaver.Documentation embeds hundreds.
         if (!model.EmbeddedResources.IsEmpty)
         {
-            sink.Info($"[{name}] embedded resources: {model.EmbeddedResources.Length}");
-            foreach (var resource in model.EmbeddedResources.Take(MaxListedResources))
+            sink.Info($"[{name}] embedded resources: {model.EmbeddedResources.Length}"
+                + (options.Verbose ? "" : " (names with --verbose)"));
+            foreach (var resource in (options.Verbose ? model.EmbeddedResources.Take(MaxListedResources) : []))
                 sink.Info($"[{name}]   {resource.ManifestName}  ({resource.Origin})");
-            if (model.EmbeddedResources.Length > MaxListedResources)
+            if (options.Verbose && model.EmbeddedResources.Length > MaxListedResources)
                 sink.Info($"[{name}]   … and {model.EmbeddedResources.Length - MaxListedResources} more");
         }
         // A resource the operator ACCEPTED away is still missing from the assembly, so it is a
@@ -609,6 +618,7 @@ public static class ProjectBuild
         // have is an ADDITIONAL library, and this mode cannot invent one.
         var unresolved = ImmutableArray.CreateBuilder<string>();
         var shelfResolutions = new List<ModuleLibrariesShelf.Resolution>();
+        var containerResolved = 0;
         var extraByName = extraReferences.ToDictionary(
             p => Path.GetFileNameWithoutExtension(p)!, p => p, StringComparer.OrdinalIgnoreCase);
         foreach (var package in model.PackageReferences)
@@ -616,8 +626,10 @@ public static class ProjectBuild
             var resolution = container.Resolve(package.Id);
             if (resolution.Supplied)
             {
-                sink.Info($"[{name}] package {package.Id} → the container "
-                          + $"({resolution.Version ?? package.Version ?? "version unknown"})");
+                if (options.Verbose)
+                    sink.Info($"[{name}] package {package.Id} → the container "
+                              + $"({resolution.Version ?? package.Version ?? "version unknown"})");
+                containerResolved++;
                 continue;
             }
             if (extraByName.ContainsKey(package.Id))
@@ -635,6 +647,8 @@ public static class ProjectBuild
             }
             unresolved.Add(package.Id);
         }
+        if (containerResolved > 0 && !options.Verbose)
+            sink.Info($"[{name}] {containerResolved} package(s) resolved from the container (per-package detail with --verbose)");
         if (unresolved.Count > 0)
         {
             var message =

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reactive.Linq;
@@ -456,6 +457,21 @@ public static class ProjectBuild
         public ImmutableDictionary<string, string> PrebuiltReferences { get; init; } =
             ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
 
+        /// <summary>
+        /// One Roslyn reference universe for the whole run — "one workspace": every project in the
+        /// graph shares the SAME <see cref="PortableExecutableReference"/> instance per path, so a
+        /// reference assembly is opened and its metadata decoded from the filesystem ONCE, and
+        /// Roslyn's metadata-keyed symbol caches carry across the graph instead of every project
+        /// re-materializing 200+ assemblies (maintainer, 2026-09-01: "create *one* roslyn
+        /// workspace with all projects at beginning … and you read from file system directly").
+        /// Run-scoped instance state, deliberately not static.
+        /// </summary>
+        public ConcurrentDictionary<string, PortableExecutableReference> SharedReferences { get; } =
+            new(StringComparer.OrdinalIgnoreCase);
+
+        internal PortableExecutableReference Reference(string path) =>
+            SharedReferences.GetOrAdd(path, static p => MetadataReference.CreateFromFile(p));
+
         internal IReadOnlyList<string> DependenciesOf(string id) =>
             Edges.TryGetValue(id, out var deps) ? deps : [];
 
@@ -640,21 +656,21 @@ public static class ProjectBuild
         {
             if (graph.ShadowedAssemblyNames.Contains(assemblyName)) continue;
             if (extraByName.ContainsKey(assemblyName)) continue;
-            references.Add(MetadataReference.CreateFromFile(path));
+            references.Add(graph.Reference(path));
         }
         foreach (var extra in extraReferences)
-            references.Add(MetadataReference.CreateFromFile(extra));
+            references.Add(graph.Reference(extra));
         foreach (var prebuiltDll in graph.PrebuiltReferences.Values)
-            references.Add(MetadataReference.CreateFromFile(prebuiltDll));
+            references.Add(graph.Reference(prebuiltDll));
         // Two shelf packages can share a transitive; each names the full closure, so dedupe by path.
         var shelfReferencePaths = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var fromShelf in shelfResolutions)
             foreach (var file in fromShelf.ReferenceFiles)
                 if (shelfReferencePaths.Add(file))
-                    references.Add(MetadataReference.CreateFromFile(file));
+                    references.Add(graph.Reference(file));
         foreach (var dependency in dependencies)
             if (dependency.AssemblyPath is { Length: > 0 } dll)
-                references.Add(MetadataReference.CreateFromFile(dll));
+                references.Add(graph.Reference(dll));
 
         var parseOptions = new CSharpParseOptions(
                 model.LanguageVersion,
@@ -787,15 +803,31 @@ public static class ProjectBuild
             }
         }
 
+        // Phase timing: the CI receipt for MeshWeaver.AI read "OK … in 558956 ms" with nine silent
+        // minutes between the identity line and the verdict — a duration with no phases is a
+        // number nobody can act on. Each phase now reports itself.
+        var phase = System.Diagnostics.Stopwatch.StartNew();
         if (!generators.IsEmpty)
+        {
             compilation = GeneratorPipeline.RunSourceGenerators(
                 compilation, generators, sink.Logger, CancellationToken.None);
+            sink.Info($"[{name}] phase: source generators {phase.ElapsedMilliseconds} ms");
+        }
 
+        phase.Restart();
         var errors = 0;
         var warnings = 0;
         var missingGeneratorPartials = 0;
         var missingComponentOverrides = 0;
-        foreach (var diagnostic in compilation.GetDiagnostics())
+        // 🚨 ONE body pass, like csc. GetDiagnostics() binds and flow-analyzes every method body,
+        // and the Emit below then lowers them ALL AGAIN — measured on MeshWeaver.AI (168
+        // nullable-heavy files): 82s analysis + 79s emit locally, 559s inside the CI container,
+        // for work csc does once. So the upfront pass reads only parse + declaration diagnostics
+        // (imports, signatures, partials — including the CS8795/CS0115 generator signatures
+        // classified below); body diagnostics surface from the emit itself, whose EmitResult
+        // carries every one.
+        foreach (var diagnostic in compilation.GetParseDiagnostics()
+                     .Concat(compilation.GetDeclarationDiagnostics()))
         {
             switch (diagnostic.Severity)
             {
@@ -818,6 +850,9 @@ public static class ProjectBuild
                     break;
             }
         }
+
+        sink.Info($"[{name}] phase: declaration analysis {phase.ElapsedMilliseconds} ms");
+        phase.Restart();
 
         if (errors > 0)
         {
@@ -868,11 +903,27 @@ public static class ProjectBuild
             var artifact = EmitPipeline.EmitCompilationToDirectory(
                 compilation, model.AssemblyName, model.ProjectPath, outputDirectory,
                 ManifestResources(model), CancellationToken.None);
+            sink.Info($"[{name}] phase: emit {phase.ElapsedMilliseconds} ms");
             if (!artifact.MatchesFileOnDisk(out var reason))
             {
                 sink.Error($"[{name}] RED — the emitted assembly did not survive the write: {reason}");
                 return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
                     model.CompileItems.Length, 0, warnings, null, [], reason);
+            }
+            // Body-level warnings arrive from the emit (the single body pass); under
+            // warnings-as-errors they were already escalated inside the Emit and threw. This is
+            // the same no-warn policy gate as the declaration pass above, applied to the rest.
+            foreach (var bodyWarning in artifact.Warnings)
+                sink.Warn($"[{name}] {bodyWarning}");
+            warnings += artifact.Warnings.Count;
+            if (artifact.Warnings.Count > 0 && !options.AllowWarnings)
+            {
+                sink.Error(
+                    $"[{name}] RED — {warnings} warning(s), and the no-warn policy is on. Fix them, add them "
+                    + "to the project's NoWarn, or pass --allow-warnings to build anyway.");
+                return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
+                    model.CompileItems.Length, 0, warnings, null, [],
+                    $"{warnings} warning(s) under the no-warn policy");
             }
             NameTheDocumentationFile(outputDirectory, model);
             EmitShelfRides(outputDirectory, model, shelfResolutions, sink, name);
@@ -890,6 +941,14 @@ public static class ProjectBuild
                 RazorCount = razorGenerated,
                 ResourceCount = model.EmbeddedResources.Length,
             };
+        }
+        catch (CompilationException ex)
+        {
+            // Body-level compile errors surface HERE now (the emit is the single body pass); the
+            // message already carries every formatted diagnostic.
+            sink.Error($"[{name}] RED — {ex.Message}");
+            return new ProjectResult(model.ProjectPath, model.AssemblyName, clock.Elapsed,
+                model.CompileItems.Length, 1, warnings, null, [], ex.Message);
         }
         catch (Exception ex) when (ex is not OperationCanceledException)
         {

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -315,7 +315,10 @@ public static class ProjectBuild
                         deps.Where(d => d.Result is not null).Select(d => d.Result!).ToArray());
                     return (result, result.IsGreen);
                 },
-                options.MaxParallel)
+                options.MaxParallel,
+                // Target-directed build: the first failure ends the run ("when build fails =>
+                // exit") — a red here dooms the job, so independents must not keep earning slots.
+                stopOnFirstFailure: true)
             .Select(results =>
             {
                 var report = new Report(

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -76,8 +76,13 @@ public static class ProjectBuild
     /// <summary>Options for one project build.</summary>
     public sealed record Options
     {
-        /// <summary>The <c>.csproj</c> to build, or a directory holding exactly one.</summary>
-        public required string EntryProject { get; init; }
+        /// <summary>
+        /// The <c>.csproj</c> entries to build (each may be a directory holding exactly one) — ONE
+        /// graph, one Roslyn workspace, however many roots: "just collect all under scope in
+        /// global process and discontinue any local build" (maintainer, 2026-09-01). Every entry
+        /// must share one source root; two trees are two builds.
+        /// </summary>
+        public required IReadOnlyList<string> EntryProjects { get; init; }
 
         /// <summary>Where the emitted assemblies land; a temp directory when null.</summary>
         public string? OutputDirectory { get; init; }
@@ -256,10 +261,12 @@ public static class ProjectBuild
         var wall = Stopwatch.StartNew();
         var sink = new Sink(options);
 
-        string entry;
+        ImmutableArray<string> entries;
         try
         {
-            entry = ResolveEntryProject(options.EntryProject);
+            entries = [.. options.EntryProjects.Select(ResolveEntryProject)];
+            if (entries.IsEmpty)
+                throw new InvalidOperationException("no entry projects given — a build of nothing is a failure, never a silent success");
         }
         catch (Exception ex)
         {
@@ -285,7 +292,7 @@ public static class ProjectBuild
         Graph graph;
         try
         {
-            graph = Graph.Discover(entry, container, options, sink);
+            graph = Graph.Discover(entries, container, options, sink);
         }
         catch (Exception ex) when (ex is ProjectFile.UnsupportedConstructException or InvalidOperationException)
         {
@@ -332,6 +339,29 @@ public static class ProjectBuild
                 var report = new Report(
                     container.AppDirectory, container.PlatformAssemblyVersion, results, wall.Elapsed,
                     sink.Seal(results.All(r => r.IsGreen)));
+                // Per-ENTRY closure manifests — the central-build contract. A shared workspace
+                // output holds EVERY entry's assemblies side by side, so a consumer classifying
+                // "what rides MY bundle" by globbing the output would ride every other module
+                // (closure pollution). Each entry's manifest names exactly the assemblies its own
+                // in-tree graph produced: the module itself first, its in-tree dependencies after.
+                if (results.All(r => r.IsGreen))
+                    foreach (var entryPath in entries)
+                    {
+                        var reachable = new List<string>();
+                        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+                        var walkStack = new Stack<string>();
+                        walkStack.Push(entryPath);
+                        while (walkStack.Count > 0)
+                        {
+                            var current = walkStack.Pop();
+                            if (!seen.Add(current) || !graph.Models.TryGetValue(current, out var m)) continue;
+                            reachable.Add(m.AssemblyName);
+                            foreach (var dep in graph.DependenciesOf(current))
+                                walkStack.Push(dep);
+                        }
+                        File.WriteAllLines(
+                            Path.Combine(workRoot, reachable[0] + ".closure.txt"), reachable);
+                    }
                 Print(options.Output, report);
                 return report;
             })
@@ -487,7 +517,7 @@ public static class ProjectBuild
             Edges.TryGetValue(id, out var deps) ? deps : [];
 
         internal static Graph Discover(
-            string entry, ContainerReferenceSet container, Options options, Sink sink)
+            ImmutableArray<string> entries, ContainerReferenceSet container, Options options, Sink sink)
         {
             var prebuilt = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             foreach (var directory in options.PrebuiltDirectories)
@@ -504,16 +534,26 @@ public static class ProjectBuild
             if (prebuilt.Count > 0)
                 sink.Info($"prebuilt siblings: {prebuilt.Count} assembl(y|ies) — an in-root "
                     + "ProjectReference matching one resolves to it instead of rebuilding");
-            var sourceRoot = ProjectFile.FindNearest(Path.GetDirectoryName(entry)!, "Directory.Build.props") is { } props
+            // ONE source root for the whole workspace — derived from the first entry, asserted for
+            // the rest: a ProjectReference inside it builds, outside it comes from the container,
+            // and two entries with different roots would silently give the second one the wrong
+            // boundary.
+            var sourceRoot = ProjectFile.FindNearest(Path.GetDirectoryName(entries[0])!, "Directory.Build.props") is { } props
                 ? Path.GetDirectoryName(props)!
-                : Path.GetDirectoryName(entry)!;
+                : Path.GetDirectoryName(entries[0])!;
+            foreach (var other in entries.Skip(1))
+                if (!other.StartsWith(sourceRoot + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+                    throw new InvalidOperationException(
+                        $"entry '{other}' lies outside the source root '{sourceRoot}' derived from "
+                        + $"'{entries[0]}' — one workspace has one root; build separate trees separately");
             sink.Info($"source root: {sourceRoot} (a ProjectReference inside it is built; outside it comes from the container)");
 
             var models = ImmutableDictionary.CreateBuilder<string, ProjectFile.Model>(StringComparer.OrdinalIgnoreCase);
             var edges = ImmutableDictionary.CreateBuilder<string, ImmutableArray<string>>(StringComparer.OrdinalIgnoreCase);
             var prebuiltReferences = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
             var pending = new Stack<string>();
-            pending.Push(entry);
+            foreach (var entry in entries)
+                pending.Push(entry);
 
             while (pending.Count > 0)
             {
@@ -588,6 +628,18 @@ public static class ProjectBuild
         IReadOnlyList<ProjectResult> dependencies)
     {
         var clock = Stopwatch.StartNew();
+        var name0 = model.AssemblyName;
+        // LIVENESS, not narration: after the quieting, a nullable-heavy project (MeshWeaver.AI:
+        // minutes of flow analysis) printed its start line and then NOTHING until the verdict —
+        // "it is completely blank" (maintainer, 2026-09-01), indistinguishable from a hang. One
+        // bounded heartbeat per half-minute of actual compiling; `using` disposes it on every
+        // return path, so a finished project can never keep ticking.
+        using var liveness = Observable
+            .Interval(TimeSpan.FromSeconds(30))
+            .Subscribe(_ => sink.Info(
+                $"[{name0}] still compiling — {clock.Elapsed.TotalSeconds:F0}s elapsed"
+                + (model.CompileItems.Length > 100
+                    ? " (nullable flow analysis dominates large projects)" : "")));
         var name = Path.GetFileNameWithoutExtension(model.ProjectPath);
         var razorGenerated = 0;
         sink.Info($"[{name}] start — {model.CompileItems.Length} source file(s)"


### PR DESCRIPTION
The finish of the maintainer's directive chain (*"one central build, no per project build … collect all under scope in global process and discontinue any local build … only play with parameters what's rebuilt"*):

- **Builder**: `build-project` is multi-entry — one Roslyn workspace for every selected project, per-entry **closure manifests** (a shared output must never be ride-classified by glob), 30s liveness heartbeat for nullable-heavy compiles (*"it is completely blank"* fixed without restoring narration). Proven live: 3 entries → 7-project graph, 84s; Mcp's manifest = exactly its chain.
- **Lane**: new `build-workspace` job compiles every selected container entry once, in the pinned platform container (blob-cached image, zero registry warm), publishing ONE artifact. Pack jobs only consume — no docker, no registry, no compile; a missing module is RED, never rebuilt locally. Prebuilt machinery deleted (it was the build-both hybrid that idled every job ~680s on first activation); the input stays accepted-and-ignored for pinned callers.

283/283 tester tests; both rendered lane scripts proven by extraction + `bash -n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)