### PR TITLE
fix(lane): untangle the needs cycle that startup-failed every caller of the global build

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -581,7 +581,7 @@ jobs:
   # there, never rebuilt locally.
   build-workspace:
     name: Build the workspace (one global build)
-    needs: [select, prepare, build-workspace]
+    needs: [select, prepare]
     if: needs.select.result == 'success' && needs.select.outputs.count != '0' && needs.prepare.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -715,7 +715,7 @@ jobs:
 
   pack:
     name: Module bundle (${{ matrix.entry.module }})
-    needs: [select, prepare]
+    needs: [select, prepare, build-workspace]
     runs-on: ubuntu-latest
     # 🚨 This is a MODE SWITCH on the selection's own output, not a skip-trapdoor: GitHub refuses
     # a matrix with no vectors, so an empty selection has to express itself as "this job does not


### PR DESCRIPTION
`build-workspace` needed itself (first-occurrence replace hit the freshly inserted job) and `pack` never gained the need its `if:` references — GitHub refuses the cycle at workflow-validation time, so Plugins#1042's lap died with zero jobs. Two-line fix; lint gate now reads actionlint's full output + exit code (the original findings didn't contain the word 'error' my filter grepped for).

🤖 Generated with [Claude Code](https://claude.com/claude-code)