### PR TITLE
fix(memex-local): discovery never serves a linked worktree beside its primary

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -1146,6 +1146,13 @@ plugin_repo_paths() {
   for d in "$parent"/*/; do
     d="${d%/}"
     [ -d "$d" ] || continue
+    # 🚨 Never a LINKED WORKTREE. A worktree of a node repo is a node repo by content and derives
+    # the SAME source name from its origin, so discovering it beside its primary mounts the same
+    # /plugin-repos/<name> twice and the helm upgrade dies on the duplicate ("duplicate entries
+    # for key [mountPath=/plugin-repos/Education]", 2026-09-01). A linked worktree is the
+    # directory whose `.git` is a FILE (a gitdir pointer); auto-discovery serves primaries only,
+    # and serving a worktree deliberately stays one MEMEX_PLUGIN_REPOS away.
+    [ -f "$d/.git" ] && continue
     is_node_repo "$d" && printf '%s\n' "$d"
   done
   return 0

--- a/test/MeshWeaver.Documentation.Test/MemexLocalDiscoversNodeRepoSiblingsGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/MemexLocalDiscoversNodeRepoSiblingsGuard.cs
@@ -69,6 +69,19 @@ public class MemexLocalDiscoversNodeRepoSiblingsGuard : IDisposable
 
         // Right depth, wrong node type — a content node, not a package root.
         NodeRepo("Not.A.Repo", "Thing", "Markdown");
+
+        // 🚨 A LINKED WORKTREE of a node repo. By content it IS a node repo — same course roots —
+        // and by git-origin it derives the SAME source name, so discovering both produced
+        // duplicate volumeMounts and a failed helm upgrade ("duplicate entries for key
+        // [mountPath=/plugin-repos/Education]", observed 2026-09-01). A linked worktree is
+        // identified by its `.git` being a FILE (a gitdir pointer), not a directory; auto-discovery
+        // serves primaries only, and serving a worktree stays possible via MEMEX_PLUGIN_REPOS.
+        NodeRepo("Acme.Courses-wt", "Course", "Store/Plugin");
+        File.WriteAllText(Path.Combine(root, "Acme.Courses-wt", ".git"),
+            "gitdir: ../Acme.Courses/.git/worktrees/wt\n");
+        // The primaries get a real .git DIRECTORY, as on disk.
+        Directory.CreateDirectory(Path.Combine(root, "Acme.Courses", ".git"));
+        Directory.CreateDirectory(Path.Combine(root, "Acme.Views", ".git"));
     }
 
     private void NodeRepo(string repo, string package, string nodeType)
@@ -136,6 +149,16 @@ public class MemexLocalDiscoversNodeRepoSiblingsGuard : IDisposable
 
         Assert.DoesNotContain("Platform", discovered);
         Assert.DoesNotContain("Platform-wt", discovered);
+    }
+
+    /// <summary>
+    /// 🚨 A node repo's linked worktree must not be discovered beside its primary: both derive the
+    /// same source name, and the duplicate mount fails the helm upgrade — the whole update dies.
+    /// </summary>
+    [Fact]
+    public void ALinkedWorktreeOfANodeRepo_IsNeverDiscoveredBesideItsPrimary()
+    {
+        Assert.DoesNotContain("Acme.Courses-wt", Discovered());
     }
 
     /// <summary>


### PR DESCRIPTION
## The defect

Node-repo discovery (#2904) selects by content — and a linked **worktree** of a node repo is a node repo by content, with the same course roots and, via its git origin, the **same derived source name** as its primary. Discovering both mounted `/plugin-repos/Education` twice, and the helm upgrade died on the duplicate key, taking the whole `memex-local update` with it. Observed 2026-09-01, on the first update run beside an Education fix worktree:

```
serving plugin repo 'Education' from .../MeshWeaver.Education
serving plugin repo 'Education' from .../MWE-tryit
Error: UPGRADE FAILED: … duplicate entries for key [mountPath="/plugin-repos/Education"]
```

## The fix

A linked worktree is the directory whose `.git` is a **file** (a gitdir pointer), never a directory — the one property separating it from a primary without any name list. Discovery skips those; serving a worktree deliberately stays one `MEMEX_PLUGIN_REPOS` away, unchanged.

## Verification

The guard's fixture gains exactly the observed shape — a node-repo worktree beside its primary. **RED** on the unfixed script (the worktree was discovered; two tests failing), **GREEN** with the fix, plus a behavioural run against the real sibling tree: six primaries resolved, the live `MWE-tryit` worktree skipped. `MeshWeaver.Documentation.Test` 148/148 under `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)