### PR TITLE
An Editor can now delete the satellite it was allowed to publish — one rule, one answer (#2913)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -1215,6 +1215,11 @@ statement about the caller's rights (`Unavailable`, above). There is deliberatel
 `.Catch(_ => true)` on this path: the identical instinct on the security-fold twin is what made a
 group deny fail OPEN.
 
+The caller-visible detail names the exception **type** and never its **message**. A rule is arbitrary
+code, and its exception text can carry an internal path, a connection string or another tenant's
+identifier — while the type is all a caller can act on ("retry, or ask an operator"). The full
+exception, message and stack, goes to the log where only an operator sees it.
+
 **What is still NOT routed through the rule, on purpose.** `DeleteNodeRequest` and
 `ValidateDeleteRequest` carry `[RequiresPermission(Permission.Delete)]`, so on a route that passes
 through a hub with the `AccessControlPipeline` (a per-node hub) the delivery gate still demands

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -1159,6 +1159,74 @@ For the common "predicate over `(context, userId)`" case you don't write a class
 - Other identities are denied — the standard AccessAssignment check is **not** performed for VUser nodes.
 - Delete operations are not covered by this rule and fall through to standard RLS.
 
+## 🚨 One question, ONE answer — every gate resolves the rule through `NodeTypeAccessRuleSet`
+
+**A rule only governs a node type if EVERY path that decides that node type's access consults it.**
+Until #2913 one did not, and the gap was invisible from either side.
+
+- `RlsNodeValidator` built its own `nodeType → rule` dictionary and routed Read / Create / Update /
+  **Delete** through it.
+- The delete handler's **pre-flight** — `MeshExtensions.CheckDeletePermissionForNode`, the first gate
+  a `DeleteNodeRequest` meets — demanded `Permission.Delete` on `MainNode ?? Path` outright and never
+  looked at a rule at all.
+
+Both are correct in isolation and both are on the same request. The effective policy was their
+**conjunction**, so wherever a rule was *more permissive* than `Permission.Delete` the rule silently
+did not apply. `SatelliteAccessRule` maps a satellite's Delete to `Permission.Update` on its
+`MainNode` — creating a satellite is a modification of its main node, and so is removing it — and
+`Role.Editor` holds Update and **not** Delete. So an Editor could **publish a satellite onto a node
+and then be refused when erasing it**: "I can turn it on but not off", the exact state a
+revocable-consent feature exists to prevent, reachable by an ordinary Editor. It surfaced only when
+someone *ran* the writer (session presence, MeshWeaver.Plugins#1031), never by reading either file.
+
+The fix is structural, not a second copy of the lookup: **`NodeTypeAccessRuleSet`
+(`src/MeshWeaver.Mesh.Contract/Services/NodeTypeAccessRuleSet.cs`) is the one index**, a mesh-scoped
+singleton registered in `MeshBuilder`, and both `RlsNodeValidator` and the delete pre-flight resolve
+their rule from it. Selection semantics live in one place: keyed by node type, case-insensitive,
+last registration wins, and a rule applies only when its `SupportedOperations` is empty or contains
+the operation.
+
+**What that widened, precisely — and what it did not:**
+
+| Case | Before | After |
+|---|---|---|
+| Node type with a Delete-supporting rule that ALLOWS | rule ∧ `Permission.Delete` | the rule (this is the fix) |
+| Node type with NO rule | `Permission.Delete` | `Permission.Delete` — unchanged, closed by default |
+| Rule that DENIES | refused | refused (now at the pre-flight, so `Unauthorized` rather than `ValidationFailed`) |
+| Rule that FAULTS or reaches no verdict | n/a | refused as `Unavailable` — **fail-closed** |
+| `WellKnownUsers.System` | allowed via the fold's `Permission.All` | allowed before any rule is consulted |
+
+The only types that gained anything are those whose rule *chose* a lighter demand: the
+`SatelliteAccessRule` family (`Comment`, `TrackedChange`, `Kernel`, `Activity`, `UserActivity`,
+`ActivityLogSegment`, and in MeshWeaver.Plugins `Thread`, `ThreadMessage`, `TokenUsage`, `Portal`),
+whose Delete is Update-on-`MainNode` by design. `Space` and `Partition` also carried
+`Update`-for-Delete in their rules — nobody could reach that, because the pre-flight's own
+`Permission.Delete` demand sat in front of it — so making the rule authoritative would have widened
+them. Both rules now say `Permission.Delete` for Delete explicitly, which is exactly the policy that
+was enforced before. **A disagreement between two gates resolves to the STRICTER of the two unless
+there is a stated reason for the looser one** — and for satellites the issue states it: publishing
+and erasing a satellite are the same act on its main node.
+
+**Fail-closed is not optional here.** A rule reaches the same starve-able permission fold every other
+check does, so it can fault or complete without emitting. Neither is permission to proceed: both
+produce `DeletePreflight.Unestablished`, the delete is refused, and the response says
+`NodeDeletionRejectionReason.Unavailable` rather than `Unauthorized` — an availability failure, not a
+statement about the caller's rights (`Unavailable`, above). There is deliberately no
+`.Catch(_ => true)` on this path: the identical instinct on the security-fold twin is what made a
+group deny fail OPEN.
+
+**What is still NOT routed through the rule, on purpose.** `DeleteNodeRequest` and
+`ValidateDeleteRequest` carry `[RequiresPermission(Permission.Delete)]`, so on a route that passes
+through a hub with the `AccessControlPipeline` (a per-node hub) the delivery gate still demands
+`Permission.Delete` on the *receiving hub's own path* before the handler runs. The off-router
+node-operation execution hub — where `IMeshService.DeleteNode` lands — carries no such pipeline, and
+that is the route the pre-flight governs. Widening the message-level gate is a separate decision with
+a much larger blast radius; it has not been made.
+
+Pinned by `DeleteHonoursNodeTypeAccessRuleTest` (`test/MeshWeaver.Security.Test`), whose four cases
+are the four rows of the table above — including the one that matters most, that an Editor still
+cannot delete a node whose type has no rule.
+
 ## End-to-end: portal hub creating a VUser
 
 ```mermaid

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-you-can-remove-what-you-were-allowed-to-add.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-you-can-remove-what-you-were-allowed-to-add.md
@@ -1,0 +1,29 @@
+---
+Name: You can remove what you were allowed to add
+Category: Fix
+Description: Editors can now delete the comments, activity rows and presence entries they are allowed to create — the delete check no longer disagrees with the one that let them write it.
+Icon: Sparkle
+Order: -20260901
+---
+
+# You can remove what you were allowed to add
+
+Some things attached to a node — a comment, an activity entry, a live-presence row, a thread — are
+governed by the node they hang off: if you may edit the node, you may add them, and if you may edit
+the node, you may take them away again. That is what the platform's rule for them has always said.
+
+The delete path, however, was asking a different question. Before removing anything it demanded a
+full delete permission on the node, without consulting that rule — so an **Editor** could add one of
+these and then be told they were not allowed to remove it. You could turn something on and not turn
+it off, which is the one thing an "off" switch has to be able to do. It showed up wherever a feature
+publishes ongoing state on your behalf and expects you to be able to withdraw it.
+
+Deleting now asks the same question the rest of the platform asks, so both answers agree. If the
+node type has its own rule, that rule decides; if it does not, the delete permission is required
+exactly as before — nothing else became easier to delete. Deleting a **space** or a **partition**
+still requires delete rights, unchanged.
+
+Two smaller improvements come with it. A delete that could not be *evaluated* — because a check it
+depends on did not answer — now says so plainly instead of reporting it as "permission denied", so
+you are not sent off to request rights you already hold. And a delete is never allowed by default
+when its check cannot reach an answer: it is refused, and says why.

--- a/src/MeshWeaver.Graph/Configuration/PartitionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/PartitionNodeType.cs
@@ -86,7 +86,9 @@ public static class PartitionNodeType
     };
 
     /// <summary>
-    /// Access rule: Read for all authenticated users, Create/Update/Delete for Admin only.
+    /// Access rule: Read for all authenticated users; Create/Update require
+    /// <see cref="Permission.Update"/> and Delete requires <see cref="Permission.Delete"/> —
+    /// i.e. admins only.
     /// </summary>
     private class PartitionAccessRule(IMessageHub hub) : INodeTypeAccessRule
     {
@@ -103,7 +105,14 @@ public static class PartitionNodeType
             if (string.IsNullOrEmpty(userId))
                 return Observable.Return(false);
 
-            // Only admins can create/update/delete partitions
+            // 🚨 Delete demands Permission.Delete, not Update — the same demand the delete
+            // handler's pre-flight used to add on top of this rule. Now that the pre-flight routes
+            // THROUGH the rule (#2913) the rule is the only place the decision is taken, so it has
+            // to carry it. Unchanged outcome for every caller.
+            if (context.Operation == NodeOperation.Delete)
+                return hub.CheckPermission(context.Node.Path, userId, Permission.Delete);
+
+            // Only admins can create/update partitions
             return hub.CheckPermission(context.Node.Path, userId, Permission.Update);
         }
     }

--- a/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs
@@ -343,8 +343,9 @@ public static class SpaceNodeType
 
     /// <summary>
     /// DI-registered access rule for Space nodes.
-    /// Read: requires partition Read permission. Create/Update/Delete: requires
-    /// appropriate permission (via <c>SecurityService</c>).
+    /// Read: requires partition Read permission. Create: any authenticated identity for a
+    /// top-level Space (the creator becomes its Admin), parent Create otherwise. Update: requires
+    /// <see cref="Permission.Update"/>; Delete: requires <see cref="Permission.Delete"/>.
     /// </summary>
     private class SpaceAccessRule(IMessageHub hub) : INodeTypeAccessRule
     {
@@ -378,8 +379,20 @@ public static class SpaceNodeType
                 return hub.CheckPermission(parentPath, userId, Permission.Create);
             }
 
-            if (context.Operation is NodeOperation.Update or NodeOperation.Delete)
+            if (context.Operation == NodeOperation.Update)
                 return hub.CheckPermission(context.Node.Path, userId, Permission.Update);
+
+            // 🚨 DELETE IS NOT UPDATE, and this rule is now the ONLY thing that says so.
+            // Deleting a Space tears down a partition and drops its backing store
+            // (SpacePostDeletionHandler), so it has always required Permission.Delete in practice —
+            // but that demand lived in the delete handler's pre-flight, NOT here, and this rule said
+            // Update. Nothing could reach the gap while the pre-flight ran its own
+            // Permission.Delete check on every node; routing that pre-flight through this rule
+            // (#2913) makes the rule authoritative, so the demand has to be written down where the
+            // decision is taken. Same permission, same outcome for every caller — the second
+            // opinion is simply gone.
+            if (context.Operation == NodeOperation.Delete)
+                return hub.CheckPermission(context.Node.Path, userId, Permission.Delete);
 
             return Observable.Return(false);
         }

--- a/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
+++ b/src/MeshWeaver.Graph/Security/RlsNodeValidator.cs
@@ -16,7 +16,7 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
 {
     private readonly IMessageHub _hub;
     private readonly ILogger<RlsNodeValidator> _logger;
-    private readonly IReadOnlyDictionary<string, INodeTypeAccessRule> _accessRules;
+    private readonly NodeTypeAccessRuleSet _accessRules;
     private readonly TimeSpan _establishmentBudget;
 
     /// <summary>
@@ -24,17 +24,20 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
     /// </summary>
     /// <param name="hub">The message hub used for permission checks.</param>
     /// <param name="logger">The logger used to record access grants and denials.</param>
-    /// <param name="accessRules">The per-node-type access rules, indexed by node type (last registration wins per type).</param>
+    /// <param name="accessRules">
+    /// The mesh's per-node-type access rules. 🚨 The INDEX, not the raw enumerable — this validator
+    /// used to build its own dictionary while the delete handler's pre-flight consulted NO rule at
+    /// all, which is how a satellite's Delete came to be governed by two disagreeing answers
+    /// (#2913). Sharing the index is what makes them one.
+    /// </param>
     public RlsNodeValidator(
         IMessageHub hub,
         ILogger<RlsNodeValidator> logger,
-        IEnumerable<INodeTypeAccessRule> accessRules)
+        NodeTypeAccessRuleSet accessRules)
     {
         _hub = hub;
         _logger = logger;
-        _accessRules = accessRules
-            .GroupBy(r => r.NodeType, StringComparer.OrdinalIgnoreCase)
-            .ToDictionary(g => g.Key, g => g.Last(), StringComparer.OrdinalIgnoreCase);
+        _accessRules = accessRules;
         // 🚨 DERIVED from the enclosing mesh-operation budget, never configured on its own — issue
         // #1198. This bound only earns its keep by firing BEFORE the operation that encloses it,
         // and the previous shape (its own options class, its own 30 s default) made that ordering
@@ -251,10 +254,7 @@ public class RlsNodeValidator : INodeValidator, IOwnerEnforcedNodeValidator
 
     private IObservable<NodeValidationResult?> CheckCustomRule(NodeValidationContext context, string? userId)
     {
-        if (string.IsNullOrEmpty(context.Node.NodeType)
-            || !_accessRules.TryGetValue(context.Node.NodeType, out var accessRule)
-            || (accessRule.SupportedOperations.Count != 0
-                && !accessRule.SupportedOperations.Contains(context.Operation)))
+        if (_accessRules.Find(context.Node.NodeType, context.Operation) is not { } accessRule)
             return Observable.Return<NodeValidationResult?>(null);
 
         return accessRule.HasAccess(context, userId).Select<bool, NodeValidationResult?>(hasAccess =>

--- a/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshBuilder.cs
@@ -552,6 +552,13 @@ public record MeshBuilder
             // ever opened a scope on and silently passed every write under a subtree
             // being deleted (#839's write-guard test caught it).
             .AddSingleton<Services.RecentlyDeletedRegistry>()
+            // The mesh's INodeTypeAccessRule index — the ONE answer to "does a rule govern this
+            // (node type, operation)?", shared by RlsNodeValidator and the delete handler's
+            // pre-flight so the two cannot disagree again (#2913). Registered at the ROOT for the
+            // same reason the tombstone registry above is: the delete handler resolves it off a hub
+            // ServiceProvider that chains here, while the validator resolves it from its own scope,
+            // and every access rule in the fleet is registered on the MESH service collection.
+            .AddSingleton<Services.NodeTypeAccessRuleSet>()
             // The SAME instance, surfaced to the message pipeline (which sits below
             // MeshWeaver.Mesh.Contract in the reference graph and therefore cannot see the
             // registry type). MessageService reads it to classify a delivery abandoned by a

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -3438,9 +3438,15 @@ public static class MeshExtensions
                     "[DeleteNode] the {NodeType} access rule for {Path} could not reach a verdict for "
                     + "{User} — refusing the delete and reporting an availability failure, not a denial",
                     node.NodeType, node.Path, userId);
+                // 🚨 The TYPE, never the exception's MESSAGE. This detail is echoed to the CALLER
+                // in the DeleteNodeResponse, and an arbitrary rule's exception text can carry
+                // internal paths, connection strings or another tenant's identifiers. The type
+                // names the condition, which is all a caller can act on ("retry, or ask an
+                // operator"); the full exception — message and stack — is on the LogWarning above,
+                // where only an operator sees it. (Copilot review, #2945.)
                 return Observable.Return<(DeletePreflight Verdict, string? Detail)?>(
                     (DeletePreflight.Unestablished,
-                        $"the '{node.NodeType}' access rule failed ({ex.GetType().Name}: {ex.Message})"));
+                        $"the '{node.NodeType}' access rule failed ({ex.GetType().Name})"));
             })
             // 🚨 THE THIRD TERMINAL — a chain can also COMPLETE WITHOUT EMITTING (the shape that
             // made RlsNodeValidator's own fold read as "nothing objected", #2742). Built LAZILY via

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -2336,20 +2336,42 @@ public static class MeshExtensions
                 //    operation). Descendants are validated by their own per-node
                 //    hub when fan-out fires a non-recursive DeleteNodeRequest at
                 //    each leaf's address — never load all descendant nodes upfront.
-                return CheckDeletePermissionForNode(hub, senderUserId, rootNode, logger)
+                return CheckDeletePermissionForNode(
+                        hub, senderUserId, rootNode, capturedRequest, request.AccessContext, logger)
                     .TimeoutAtStage(budget, () => DeleteStageTimeout(
                         DeleteStage.CheckPermission,
                         $"the effective-permission fold for '{path}' did not settle within "
                         + $"{budget.TotalSeconds:0}s (user '{senderUserId}')"))
-                    .SelectMany(denied =>
+                    .SelectMany(preflight =>
                     {
-                        if (denied)
+                        if (preflight.Verdict is DeletePreflight.Denied)
                         {
                             logger.LogWarning("[DeleteNode] permission-denied path={Path}", path);
                             PostFailed(
                                 $"Delete permission denied for '{path}'",
                                 NodeDeletionRejectionReason.Unauthorized,
                                 [new LogMessage($"Delete permission denied for '{path}'", LogLevel.Error)],
+                                ImmutableList.Create(path));
+                            return Observable.Empty<System.Reactive.Unit>();
+                        }
+
+                        // 🚨 NOT a denial — no verdict was reached at all. Refused all the same
+                        // (fail-closed), but reported as Unavailable so nobody reads an availability
+                        // failure as a statement about the caller's rights and sends a
+                        // correctly-entitled user to request permissions they already hold (#1446).
+                        if (preflight.Verdict is DeletePreflight.Unestablished)
+                        {
+                            var unestablished =
+                                $"The delete permission check for '{path}' could not be established: "
+                                + $"{preflight.Detail}. This is an availability failure, NOT a decision "
+                                + "about your access — the delete was not evaluated and may be retried.";
+                            logger.LogWarning(
+                                "[DeleteNode] permission-unestablished path={Path}: {Detail}",
+                                path, preflight.Detail);
+                            PostFailed(
+                                unestablished,
+                                NodeDeletionRejectionReason.Unavailable,
+                                [new LogMessage(unestablished, LogLevel.Error)],
                                 ImmutableList.Create(path));
                             return Observable.Empty<System.Reactive.Unit>();
                         }
@@ -3300,10 +3322,142 @@ public static class MeshExtensions
     }
 
     /// <summary>
-    /// Check <see cref="Permission.Delete"/> for a single node's primary path.
-    /// Returns <c>true</c> if delete is denied.
+    /// What the delete pre-flight concluded for ONE node. Deliberately TRI-state: a check that
+    /// could not be established is neither a grant (unsafe) nor a denial (a lie that files an
+    /// availability incident as a policy decision) — same vocabulary and the same reasoning as
+    /// <see cref="NodeRejectionReason.Unavailable"/> and <c>PermissionCheckOutcome.Undetermined</c>.
+    /// Both non-<see cref="Allowed"/> verdicts refuse the delete; only the REPORT differs.
     /// </summary>
-    private static IObservable<bool> CheckDeletePermissionForNode(
+    private enum DeletePreflight
+    {
+        /// <summary>The caller may delete this node.</summary>
+        Allowed,
+
+        /// <summary>A verdict was reached and it is NO.</summary>
+        Denied,
+
+        /// <summary>No verdict was reached — the check faulted or produced nothing. Fail-CLOSED.</summary>
+        Unestablished
+    }
+
+    /// <summary>
+    /// The delete pre-flight for a single node: may <paramref name="userId"/> delete
+    /// <paramref name="node"/>?
+    ///
+    /// <para>🚨 <b>The node type's registered <see cref="INodeTypeAccessRule"/> decides when there is
+    /// one</b> — the SAME rule, resolved through the SAME <see cref="NodeTypeAccessRuleSet"/>, that
+    /// <c>RlsNodeValidator</c> consults for Read/Create/Update/Delete (issue #2913). This used to
+    /// demand <see cref="Permission.Delete"/> outright and never look at a rule, so a satellite's
+    /// lifecycle was governed by two disagreeing answers: <c>SatelliteAccessRule</c> maps a
+    /// satellite's Delete to <see cref="Permission.Update"/> on its <see cref="MeshNode.MainNode"/>
+    /// (creating a satellite is a modification of its main node, and so is removing it), while this
+    /// pre-flight demanded Delete. An <c>Editor</c> holds Update and not Delete — so an Editor
+    /// could PUBLISH a satellite and then be refused when erasing it. "I can turn it on but not
+    /// off" is the exact failure a revocable-consent feature exists to prevent.</para>
+    ///
+    /// <para><b>Nothing widens for a node type that has no rule.</b>
+    /// <see cref="NodeTypeAccessRuleSet.Find"/> returning null means "no rule has an opinion", and
+    /// the fallback below is byte-for-byte the previous check — <see cref="Permission.Delete"/> on
+    /// <see cref="MeshNode.MainNode"/> (or the node's own path). Closed by default, unchanged.</para>
+    ///
+    /// <para><b>A rule that faults denies.</b> Its fault becomes
+    /// <see cref="DeletePreflight.Unestablished"/> — the delete is refused. There is deliberately no
+    /// <c>.Catch(_ =&gt; true)</c> shape anywhere on this path: the identical instinct on the
+    /// security-fold twin is what made a group deny fail OPEN (#2011).</para>
+    ///
+    /// <para>The SYSTEM identity is decided before any rule is consulted, exactly as
+    /// <c>RlsNodeValidator.Validate</c> does — so a rule never sees, and can never refuse, the
+    /// cascade commit that runs as infrastructure. Behaviour is unchanged: the permission fold
+    /// already short-circuits System to <see cref="Permission.All"/>.</para>
+    /// </summary>
+    private static IObservable<(DeletePreflight Verdict, string? Detail)> CheckDeletePermissionForNode(
+        IMessageHub hub,
+        string userId,
+        MeshNode node,
+        DeleteNodeRequest request,
+        AccessContext? deliveryAccessContext,
+        ILogger logger)
+    {
+        if (userId == WellKnownUsers.System)
+            return Observable.Return((DeletePreflight.Allowed, (string?)null));
+
+        var accessRule = hub.ServiceProvider.GetService<NodeTypeAccessRuleSet>()
+            ?.Find(node.NodeType, NodeOperation.Delete);
+
+        return accessRule is null
+            ? CheckDeletePermissionByPath(hub, userId, node, logger)
+            : CheckDeletePermissionByRule(hub, userId, node, request, deliveryAccessContext, accessRule, logger);
+    }
+
+    /// <summary>
+    /// The rule-governed leg of <see cref="CheckDeletePermissionForNode"/>. The context is built
+    /// exactly as <see cref="RunDeletionValidatorsWithWarningsObs"/> builds it, so the rule sees the
+    /// same inputs on both paths — including the DELIVERY's AccessContext, which is the only copy
+    /// that survives the scheduler hops between handler entry and here.
+    /// </summary>
+    private static IObservable<(DeletePreflight Verdict, string? Detail)> CheckDeletePermissionByRule(
+        IMessageHub hub,
+        string userId,
+        MeshNode node,
+        DeleteNodeRequest request,
+        AccessContext? deliveryAccessContext,
+        INodeTypeAccessRule accessRule,
+        ILogger logger)
+    {
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        var context = new NodeValidationContext
+        {
+            Operation = NodeOperation.Delete,
+            Node = node,
+            Request = request,
+            AccessContext = deliveryAccessContext ?? accessService?.Context ?? accessService?.CircuitContext,
+            DeleteCascadeRootPath = request.CascadeRootPath ?? request.Path
+        };
+
+        return accessRule.HasAccess(context, userId)
+            // TakeDecisionOutsideGate for the reason spelled out in CheckDeletePermissionByPath:
+            // the rules reach the very same permission fold (SatelliteAccessRule calls
+            // hub.CheckPermission), and the caller chains the entire delete pipeline onto this.
+            .TakeDecisionOutsideGate()
+            .Select(allowed =>
+            {
+                if (!allowed)
+                    logger.LogDebug(
+                        "[DeleteNode] rule-denied for {User} on {Path} (the {NodeType} access rule refused)",
+                        userId, node.Path, node.NodeType);
+                return ((DeletePreflight Verdict, string? Detail)?)
+                    (allowed ? DeletePreflight.Allowed : DeletePreflight.Denied, null);
+            })
+            // 🚨 FAIL CLOSED, and say WHICH failure it was. A rule reaches the same starve-able
+            // permission fold every other check does, so it can fault — and a fault is not a
+            // refusal. Answering Unestablished refuses the delete (the caller posts a failure) while
+            // reporting an availability problem rather than a decision about the caller's rights.
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex,
+                    "[DeleteNode] the {NodeType} access rule for {Path} could not reach a verdict for "
+                    + "{User} — refusing the delete and reporting an availability failure, not a denial",
+                    node.NodeType, node.Path, userId);
+                return Observable.Return<(DeletePreflight Verdict, string? Detail)?>(
+                    (DeletePreflight.Unestablished,
+                        $"the '{node.NodeType}' access rule failed ({ex.GetType().Name}: {ex.Message})"));
+            })
+            // 🚨 THE THIRD TERMINAL — a chain can also COMPLETE WITHOUT EMITTING (the shape that
+            // made RlsNodeValidator's own fold read as "nothing objected", #2742). Built LAZILY via
+            // nullable + DefaultIfEmpty() + Select so the message is only ever composed when it is
+            // actually used.
+            .DefaultIfEmpty()
+            .Select(outcome => outcome
+                ?? (DeletePreflight.Unestablished,
+                    $"the '{node.NodeType}' access rule completed without producing a verdict"));
+    }
+
+    /// <summary>
+    /// The default leg of <see cref="CheckDeletePermissionForNode"/> — used when NO
+    /// <see cref="INodeTypeAccessRule"/> governs the node type. Demands
+    /// <see cref="Permission.Delete"/> on the node's primary path, i.e. closed by default.
+    /// </summary>
+    private static IObservable<(DeletePreflight Verdict, string? Detail)> CheckDeletePermissionByPath(
         IMessageHub hub,
         string userId,
         MeshNode node,
@@ -3316,7 +3470,7 @@ public static class MeshExtensions
         // Take(1) is still required (GetEffectivePermissions rides the live AccessAssignment
         // synced query and is hot, so without it the chain never completes and the handler
         // hangs), but it is NOT sufficient. HandleDeleteNodeRequest chains
-        // `.SelectMany(denied => <the entire delete pipeline>)` onto this, and on a warm
+        // `.SelectMany(verdict => <the entire delete pipeline>)` onto this, and on a warm
         // permission cache the fold emits synchronously during Subscribe while holding its
         // CombineLatest gate — so the validator run, the storage delete, the cache
         // invalidation and the change-feed publish ALL ran inside that lock. Two per-node
@@ -3336,8 +3490,19 @@ public static class MeshExtensions
                     logger.LogDebug(
                         "[DeleteNode] permission-denied for {User} on {Path} (effective={Perms})",
                         userId, node.Path, perms);
-                return denied;
-            });
+                return ((DeletePreflight Verdict, string? Detail)?)
+                    (denied ? DeletePreflight.Denied : DeletePreflight.Allowed, null);
+            })
+            // 🚨 A fold that COMPLETES WITHOUT EMITTING is not a grant — and it was not even a
+            // response: with no emission the caller's SelectMany ran nothing, so the delete posted
+            // NEITHER a DeleteNodeResponse nor a failure and the caller waited out its own timeout.
+            // Same third terminal RlsNodeValidator grew for the same fold (#2742). Lazy by
+            // construction so the message is composed only when it is used.
+            .DefaultIfEmpty()
+            .Select(outcome => outcome
+                ?? (DeletePreflight.Unestablished,
+                    $"the effective-permission read of '{pathToCheck}' completed without producing a "
+                    + "verdict (a source of the permission fold emitted nothing)"));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/Services/NodeTypeAccessRuleSet.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/NodeTypeAccessRuleSet.cs
@@ -1,0 +1,71 @@
+using System.Collections.Immutable;
+using MeshWeaver.Mesh.Security;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// The mesh's registered <see cref="INodeTypeAccessRule"/>s indexed by node type — the ONE place
+/// the question "does a rule govern this (node type, operation), and which one?" is answered.
+///
+/// <para>🚨 <b>This type exists because that question used to have TWO answers</b> (issue #2913).
+/// <c>RlsNodeValidator</c> built its own dictionary and routed Read/Create/Update/Delete through the
+/// matching rule, while the delete handler's pre-flight
+/// (<c>MeshExtensions.CheckDeletePermissionForNode</c>) demanded <see cref="Permission.Delete"/>
+/// outright and never looked at a rule. The two disagreed on every satellite:
+/// <c>SatelliteAccessRule</c> maps a satellite's Delete to <see cref="Permission.Update"/> on its
+/// <see cref="MeshNode.MainNode"/>, so an <c>Editor</c> (Update, no Delete) could PUBLISH a satellite
+/// and then be refused when removing it — "you may turn it on but not off", the exact state a
+/// revocable-consent feature exists to prevent. Both callers now resolve the rule HERE, so the two
+/// paths cannot drift apart again.</para>
+///
+/// <para><b>Selection semantics</b> (unchanged from the dictionary this replaced): keyed by node
+/// type, case-insensitive, LAST registration wins per type, and a rule applies only when its
+/// <see cref="INodeTypeAccessRule.SupportedOperations"/> is empty (= all operations) or contains the
+/// operation being decided. <see cref="Find"/> returning <c>null</c> means "no rule governs this" —
+/// the caller falls back to its own standard permission check, which is where the closed-by-default
+/// behaviour lives. It never means "allowed".</para>
+///
+/// <para>Registered as a mesh-scoped SINGLETON in <c>MeshBuilder</c> (never a static — see
+/// Doc/Architecture/NoStaticState), for the same reason <c>RecentlyDeletedRegistry</c> is: the
+/// delete handler resolves it off a hub <c>ServiceProvider</c> that chains to the mesh root, and
+/// every <see cref="INodeTypeAccessRule"/> in the fleet is registered on the MESH service
+/// collection (<c>builder.ConfigureServices</c>), so root resolution sees the complete set.</para>
+/// </summary>
+public sealed class NodeTypeAccessRuleSet
+{
+    private readonly ImmutableDictionary<string, INodeTypeAccessRule> rules;
+
+    /// <summary>
+    /// Indexes the mesh's registered access rules by node type.
+    /// </summary>
+    /// <param name="accessRules">Every <see cref="INodeTypeAccessRule"/> registered on the mesh.</param>
+    public NodeTypeAccessRuleSet(IEnumerable<INodeTypeAccessRule> accessRules)
+    {
+        ArgumentNullException.ThrowIfNull(accessRules);
+        rules = accessRules
+            .GroupBy(r => r.NodeType, StringComparer.OrdinalIgnoreCase)
+            .ToImmutableDictionary(g => g.Key, g => g.Last(), StringComparer.OrdinalIgnoreCase);
+    }
+
+    /// <summary>
+    /// The rule that governs <paramref name="operation"/> for <paramref name="nodeType"/>, or
+    /// <c>null</c> when none does.
+    ///
+    /// <para>🚨 <c>null</c> is "no rule has an opinion", NOT "allowed". Every caller must fall back
+    /// to its own standard permission check on a null — that fallback is the closed-by-default
+    /// behaviour, and short-circuiting it to an allow would grant delete rights to every node type
+    /// that has no rule.</para>
+    /// </summary>
+    /// <param name="nodeType">The node's <see cref="MeshNode.NodeType"/>; null/empty yields null.</param>
+    /// <param name="operation">The operation being decided.</param>
+    /// <returns>The governing rule, or null.</returns>
+    public INodeTypeAccessRule? Find(string? nodeType, NodeOperation operation)
+    {
+        if (string.IsNullOrEmpty(nodeType) || !rules.TryGetValue(nodeType, out var rule))
+            return null;
+
+        return rule.SupportedOperations.Count == 0 || rule.SupportedOperations.Contains(operation)
+            ? rule
+            : null;
+    }
+}

--- a/test/MeshWeaver.Security.Test/DeleteHonoursNodeTypeAccessRuleTest.cs
+++ b/test/MeshWeaver.Security.Test/DeleteHonoursNodeTypeAccessRuleTest.cs
@@ -1,0 +1,253 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Security;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Security.Test;
+
+/// <summary>
+/// Issue #2913 — <b>the delete pipeline used to answer the permission question TWICE, and the two
+/// answers disagreed.</b> <c>RlsNodeValidator</c> routed Delete through the node type's registered
+/// <see cref="INodeTypeAccessRule"/>; the delete handler's pre-flight
+/// (<c>MeshExtensions.CheckDeletePermissionForNode</c>) demanded <see cref="Permission.Delete"/>
+/// outright and never looked at a rule. <c>SatelliteAccessRule</c> maps a satellite's Delete to
+/// <see cref="Permission.Update"/> on its <c>MainNode</c>, and <c>Role.Editor</c> holds Update and
+/// NOT Delete — so an Editor could PUBLISH a satellite onto a node and then be refused when erasing
+/// it. "I can turn it on but not off" is the exact state a revocable-consent feature exists to
+/// prevent, and it was reachable by an ordinary Editor.
+///
+/// <para>These four tests pin the whole decision, not just the happy half — the fix is only correct
+/// if it widened EXACTLY the rule-governed case:</para>
+/// <list type="number">
+/// <item>An Editor CAN now delete a satellite it may publish (the issue's case).</item>
+/// <item>The same Editor still CANNOT delete a node whose type has NO rule — the default is still
+/// <see cref="Permission.Delete"/>, closed by default. <b>This is the test that matters most.</b></item>
+/// <item>A rule that FAULTS denies (<see cref="NodeDeletionRejectionReason.Unavailable"/>), never
+/// falls through to allow — the fail-open shape that bit #2011.</item>
+/// <item>A rule that says NO denies even a caller who holds <see cref="Permission.Delete"/>: the
+/// rule is the decision, not a second opinion that a raw permission can outvote.</item>
+/// </list>
+///
+/// <para>The delete is issued at <c>NodeOperationTarget()</c> — the mesh's off-router node-operation
+/// execution hub, which is where <c>IMeshService.DeleteNode</c> lands and which carries NO
+/// per-node <c>AccessControlPipeline</c>. That is deliberate: on THAT route the handler's pre-flight
+/// IS the gate, so these tests exercise the code the fix changed rather than a delivery gate in
+/// front of it.</para>
+/// </summary>
+public class DeleteHonoursNodeTypeAccessRuleTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Editor = "editor-2913";
+    private const string Space = TestPartition + "/space-2913";
+    private const string MainNode = Space + "/doc";
+
+    /// <summary>A satellite type whose access rule delegates every write to its MainNode.</summary>
+    private const string SatelliteType = "SatelliteUnderTest2913";
+
+    /// <summary>A type whose rule cannot answer — it faults.</summary>
+    private const string FaultingType = "FaultingRuleType2913";
+
+    /// <summary>A type whose rule answers NO, unconditionally.</summary>
+    private const string DenyingType = "DenyingRuleType2913";
+
+    /// <summary>
+    /// The xunit wedge backstop. It must DOMINATE the inner waits below, which are
+    /// <see cref="TestTimeouts.Convergence"/> — 36 s locally and 108 s on CI (the 3× CI factor).
+    /// Written as a constant only because an attribute argument has to be one; the value is
+    /// <c>TestTimeouts.Convergence × 2</c> at the CI factor, i.e. the same margin
+    /// <c>TestTimeouts.TestMilliseconds</c> applies. A test whose outer bound does not dominate its
+    /// inner wait can only ever fail anonymously (#2819).
+    /// </summary>
+    private const int FactTimeoutMs = 240_000;
+
+    private IStorageAdapter Storage => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+
+    /// <summary>
+    /// No <c>PublicAdminAccess</c> — a security test must be able to observe a denial. The DevLogin
+    /// admin keeps the static root Admin grant <c>ConfigureMeshBase</c> installs, so the fixtures
+    /// below are created by an authorised identity.
+    /// </summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                PlainType(SatelliteType, "Satellite Under Test"),
+                PlainType(FaultingType, "Faulting Rule Type"),
+                PlainType(DenyingType, "Denying Rule Type"))
+            .ConfigureServices(services =>
+            {
+                // The REAL SatelliteAccessRule — the production rule the issue is about, not a
+                // stand-in: Delete on a satellite requires Update on its MainNode.
+                services.AddSingleton<INodeTypeAccessRule>(sp =>
+                    new SatelliteAccessRule(SatelliteType, sp.GetRequiredService<IMessageHub>()));
+                services.AddSingleton<INodeTypeAccessRule>(new ScriptedAccessRule(
+                    FaultingType,
+                    () => Observable.Throw<bool>(new InvalidOperationException("the rule could not answer"))));
+                services.AddSingleton<INodeTypeAccessRule>(new ScriptedAccessRule(
+                    DenyingType, () => Observable.Return(false)));
+                return services;
+            });
+
+    /// <summary>A minimal NodeType definition — enough for the create handler's type-exists gate.</summary>
+    private static MeshNode PlainType(string nodeType, string name) => new(nodeType)
+    {
+        Name = name,
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source.WithContentType<AccessObject>())
+    };
+
+    /// <summary>An <see cref="INodeTypeAccessRule"/> whose Delete answer is supplied by the test.</summary>
+    private sealed class ScriptedAccessRule(string nodeType, Func<IObservable<bool>> answer) : INodeTypeAccessRule
+    {
+        public string NodeType => nodeType;
+
+        public IReadOnlyCollection<NodeOperation> SupportedOperations => [NodeOperation.Delete];
+
+        public IObservable<bool> HasAccess(NodeValidationContext context, string? userId) => answer();
+    }
+
+    private async Task SeedFixtureAsync()
+    {
+        await NodeFactory.CreateNode(new MeshNode("space-2913", TestPartition)
+        { Name = "Space 2913", NodeType = "Group" }).Should().Within(TestTimeouts.Convergence).Emit();
+        await NodeFactory.CreateNode(new MeshNode("doc", Space)
+        { Name = "Doc", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        // The Editor's ONLY grant: Editor on the space. Read | Create | Update | Comment | … and
+        // deliberately NOT Delete — see Role.Editor.
+        await NodeFactory.CreateNode(AssignmentNodeFactory.UserRole(Editor, "Editor", Space))
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        // Wait until the live permission fold — the same fold every gate reads — sees the grant,
+        // so the delete below races nothing. Assert BOTH halves: the Editor holds Update (which is
+        // what the satellite rule delegates to) and does NOT hold Delete (which is what the
+        // pre-flight used to demand). Without the second half this fixture could silently drift
+        // into granting Delete and every assertion below would pass for the wrong reason.
+        await Mesh.GetEffectivePermissions(MainNode, Editor)
+            .Should().Within(TestTimeouts.Convergence)
+            .Match(p => p.HasFlag(Permission.Update) && !p.HasFlag(Permission.Delete));
+    }
+
+    private Task<DeleteNodeResponse> DeleteAs(string path, AccessContext identity) =>
+        RequestHub
+            .Observe(new DeleteNodeRequest(path) { Recursive = true, ConfirmWarnings = true },
+                o => o.WithTarget(RequestHub.NodeOperationTarget()).WithAccessContext(identity))
+            .Select(d => d.Message)
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+    private static AccessContext As(string userId) => new() { ObjectId = userId, Name = userId };
+
+    // ─── 1. The issue: an Editor may PUBLISH a satellite, so it may ERASE it ───
+
+    [Fact(Timeout = FactTimeoutMs)]
+    public async Task Editor_CanDelete_ASatelliteItMayPublish()
+    {
+        await SeedFixtureAsync();
+
+        // A satellite of the doc: its MainNode is the doc, exactly as a presence / activity /
+        // thread row written onto a node is. Creating it requires Update on the MainNode — which
+        // the Editor holds — so removing it must too.
+        var satellite = $"{MainNode}/presence";
+        await NodeFactory.CreateNode(new MeshNode("presence", MainNode)
+        { Name = "Presence", NodeType = SatelliteType, MainNode = MainNode })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        var response = await DeleteAs(satellite, As(Editor));
+
+        response.Success.Should().BeTrue(
+            "SatelliteAccessRule maps a satellite's Delete to Update on its MainNode and the Editor "
+            + "holds Update there, so the delete pre-flight must reach the SAME verdict the RLS "
+            + $"validator does (#2913) — got: {response.Error}");
+
+        // AUTHORITATIVE: storage, below the security layer.
+        (await Storage.Read(satellite, Mesh.JsonSerializerOptions).Should().Within(TestTimeouts.Convergence).Emit())
+            .Should().BeNull("the satellite must actually be gone, not merely reported as deleted");
+    }
+
+    // ─── 2. 🚨 THE ONE THAT MATTERS: nothing widened for a type with NO rule ───
+
+    [Fact(Timeout = FactTimeoutMs)]
+    public async Task Editor_StillCannotDelete_APlainNodeWithNoAccessRule()
+    {
+        await SeedFixtureAsync();
+
+        // Same partition, same Editor, same Update-without-Delete grant — the ONLY difference from
+        // the test above is that "Markdown" has no INodeTypeAccessRule. The fallback must still be
+        // Permission.Delete, i.e. closed by default.
+        var plain = $"{Space}/plain";
+        await NodeFactory.CreateNode(new MeshNode("plain", Space)
+        { Name = "Plain", NodeType = "Markdown" }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        var response = await DeleteAs(plain, As(Editor));
+
+        response.Success.Should().BeFalse(
+            "no rule governs 'Markdown', so the delete must still demand Permission.Delete — "
+            + "routing the pre-flight through the rule chain must not widen anything else");
+        response.RejectionReason.Should().Be(NodeDeletionRejectionReason.Unauthorized,
+            $"this is a decision about the caller's rights, not an availability failure: {response.Error}");
+
+        (await Storage.Read(plain, Mesh.JsonSerializerOptions).Should().Within(TestTimeouts.Convergence).Emit())
+            .Should().NotBeNull("a denied delete must remove nothing");
+    }
+
+    // ─── 3. A rule that faults DENIES — it never falls through to allow ───
+
+    [Fact(Timeout = FactTimeoutMs)]
+    public async Task AFaultingRule_RefusesTheDelete_AndReportsUnavailableNotDenied()
+    {
+        await SeedFixtureAsync();
+
+        var faulty = $"{Space}/faulty";
+        await NodeFactory.CreateNode(new MeshNode("faulty", Space)
+        { Name = "Faulty", NodeType = FaultingType, MainNode = Space })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        // The DevLogin admin — who holds Permission.Delete outright — so a pass here could only
+        // mean the rule was bypassed rather than that the caller was entitled.
+        var response = await DeleteAs(faulty, TestUsers.Admin);
+
+        response.Success.Should().BeFalse(
+            "a registered rule that cannot answer must FAIL CLOSED — an exception on the way to a "
+            + "verdict is not permission to proceed (the fail-open shape of #2011)");
+        response.RejectionReason.Should().Be(NodeDeletionRejectionReason.Unavailable,
+            "no verdict was reached, so the honest report is an availability failure — collapsing it "
+            + "into Unauthorized would send a correctly-entitled caller to request rights they hold");
+        response.Error.Should().Contain("could not be established",
+            $"the refusal must say WHICH failure it was: {response.Error}");
+
+        (await Storage.Read(faulty, Mesh.JsonSerializerOptions).Should().Within(TestTimeouts.Convergence).Emit())
+            .Should().NotBeNull("a delete that could not be authorised must remove nothing");
+    }
+
+    // ─── 4. A rule that says NO outranks a raw Permission.Delete ───
+
+    [Fact(Timeout = FactTimeoutMs)]
+    public async Task ADenyingRule_RefusesTheDelete_EvenForACallerHoldingDelete()
+    {
+        await SeedFixtureAsync();
+
+        var denied = $"{Space}/denied";
+        await NodeFactory.CreateNode(new MeshNode("denied", Space)
+        { Name = "Denied", NodeType = DenyingType, MainNode = Space })
+            .Should().Within(TestTimeouts.Convergence).Emit();
+
+        var response = await DeleteAs(denied, TestUsers.Admin);
+
+        response.Success.Should().BeFalse(
+            "the node type's rule IS the decision — it must not be outvoted by the caller happening "
+            + "to hold Permission.Delete, which is the direction the old pre-flight could widen in");
+        response.RejectionReason.Should().Be(NodeDeletionRejectionReason.Unauthorized,
+            $"the rule reached a verdict and it was NO: {response.Error}");
+
+        (await Storage.Read(denied, Mesh.JsonSerializerOptions).Should().Within(TestTimeouts.Convergence).Emit())
+            .Should().NotBeNull("a rule-denied delete must remove nothing");
+    }
+}

--- a/test/MeshWeaver.Security.Test/DeleteHonoursNodeTypeAccessRuleTest.cs
+++ b/test/MeshWeaver.Security.Test/DeleteHonoursNodeTypeAccessRuleTest.cs
@@ -69,6 +69,13 @@ public class DeleteHonoursNodeTypeAccessRuleTest(ITestOutputHelper output) : Mon
     /// </summary>
     private const int FactTimeoutMs = 240_000;
 
+    /// <summary>
+    /// Stand-in for whatever a real rule's exception might carry — an internal path, a connection
+    /// string, another tenant's identifier. The caller-visible refusal must name the exception TYPE
+    /// and NOT this text; the full exception belongs in the operator's log only.
+    /// </summary>
+    private const string SecretInFaultMessage = "internal-detail-that-must-not-reach-the-caller";
+
     private IStorageAdapter Storage => Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
 
     /// <summary>
@@ -90,7 +97,7 @@ public class DeleteHonoursNodeTypeAccessRuleTest(ITestOutputHelper output) : Mon
                     new SatelliteAccessRule(SatelliteType, sp.GetRequiredService<IMessageHub>()));
                 services.AddSingleton<INodeTypeAccessRule>(new ScriptedAccessRule(
                     FaultingType,
-                    () => Observable.Throw<bool>(new InvalidOperationException("the rule could not answer"))));
+                    () => Observable.Throw<bool>(new InvalidOperationException(SecretInFaultMessage))));
                 services.AddSingleton<INodeTypeAccessRule>(new ScriptedAccessRule(
                     DenyingType, () => Observable.Return(false)));
                 return services;
@@ -222,6 +229,12 @@ public class DeleteHonoursNodeTypeAccessRuleTest(ITestOutputHelper output) : Mon
             + "into Unauthorized would send a correctly-entitled caller to request rights they hold");
         response.Error.Should().Contain("could not be established",
             $"the refusal must say WHICH failure it was: {response.Error}");
+        response.Error.Should().Contain(nameof(InvalidOperationException),
+            "the exception TYPE names the condition and is what a caller can act on");
+        response.Error.Should().NotContain(SecretInFaultMessage,
+            "a rule's raw exception MESSAGE must never be echoed to the caller — it can carry "
+            + "internal paths or another tenant's identifiers; it belongs in the operator's log "
+            + "only (Copilot review, #2945)");
 
         (await Storage.Read(faulty, Mesh.JsonSerializerOptions).Should().Within(TestTimeouts.Convergence).Emit())
             .Should().NotBeNull("a delete that could not be authorised must remove nothing");


### PR DESCRIPTION
Closes #2913

## The defect: one question, two answers, both on the same request

`Role.Editor` holds `Update` and **not** `Delete`. `SatelliteAccessRule` maps a satellite's Delete to `Permission.Update` on its `MainNode` — creating a satellite is a modification of its main node, and so is removing it. So an Editor may publish a satellite. But it could not erase one:

- `RlsNodeValidator` routes Read / Create / Update / **Delete** through the node type's registered `INodeTypeAccessRule`.
- `HandleDeleteNodeRequest`'s **pre-flight** — `MeshExtensions.CheckDeletePermissionForNode`, the first gate a `DeleteNodeRequest` meets on the off-router node-operation hub where `IMeshService.DeleteNode` lands — demanded `Permission.Delete` on `MainNode ?? Path` outright and **never looked at a rule**.

Both are correct in isolation. The effective policy was their **conjunction**, so wherever a rule was *more permissive* than `Permission.Delete` the rule silently did not apply. "I can turn it on but not off" is the exact state a revocable-consent feature exists to prevent, and it was reachable by an ordinary Editor. It surfaced only when someone *ran* the writer (session presence, MeshWeaver.Plugins#1031) — never by reading either file.

## The fix is structural, not a second copy of the lookup

`NodeTypeAccessRuleSet` (`src/MeshWeaver.Mesh.Contract/Services/NodeTypeAccessRuleSet.cs`) is now **the one index** — a mesh-scoped singleton registered in `MeshBuilder`, holding the selection semantics in one place (keyed by node type, case-insensitive, last registration wins, `SupportedOperations` honoured). Both `RlsNodeValidator` and the delete pre-flight resolve their rule from it, so the two paths cannot drift apart again. Two code paths answering one question was the actual defect; fixing only the symptom would have left it live.

## What widened — precisely — and what did not

| Case | Before | After |
|---|---|---|
| Type with a Delete-supporting rule that **allows** | rule ∧ `Permission.Delete` | the rule — **this is the fix** |
| Type with **no rule** | `Permission.Delete` | `Permission.Delete` — byte-for-byte, closed by default |
| Rule that **denies** | refused | refused (now at the pre-flight, so `Unauthorized` rather than `ValidationFailed`) |
| Rule that **faults** / reaches no verdict | n/a | refused as `Unavailable` — **fail-closed** |
| `WellKnownUsers.System` | allowed via the fold's `Permission.All` | allowed before any rule is consulted (unchanged outcome) |

The only types that gained anything are those whose rule *chose* a lighter demand: the `SatelliteAccessRule` family — `Comment`, `TrackedChange`, `Kernel`, `Activity`, `UserActivity`, `ActivityLogSegment`, and in MeshWeaver.Plugins `Thread`, `ThreadMessage`, `TokenUsage`, `Portal`.

🚨 **`Space` and `Partition` were the trap.** Their rules also said `Update` for Delete — unreachable, because the pre-flight's own `Permission.Delete` demand sat in front of it. Making the rule authoritative would have let anyone with `Update` on a Space **delete the Space and drop its backing store**. Both rules now state `Permission.Delete` for Delete explicitly, which is exactly the policy that was already enforced. **A disagreement between two gates resolves to the STRICTER of the two unless there is a stated reason for the looser one** — and for satellites the issue states it.

## Fail-closed, deliberately

A rule reaches the same starve-able permission fold every other check does, so it can fault or complete without emitting. Neither is permission to proceed: both yield `DeletePreflight.Unestablished`, the delete is refused, and the response says `NodeDeletionRejectionReason.Unavailable` — an availability failure, not a statement about the caller's rights (#1446). There is deliberately **no `.Catch(_ => true)`** on this path; the identical instinct on the security-fold twin is what made a group deny fail OPEN (#2011). The same third terminal is added to the no-rule leg, where an empty fold previously posted **no response at all** and the caller waited out its own timeout (the #2742 shape).

## Not changed, on purpose

`DeleteNodeRequest` / `ValidateDeleteRequest` carry `[RequiresPermission(Permission.Delete)]`, so on a route through a hub with the `AccessControlPipeline` (a per-node hub) the delivery gate still demands `Permission.Delete` on the receiving hub's own path. Widening the message-level gate is a separate decision with a much larger blast radius; it has not been made.

## Verification

`test/MeshWeaver.Security.Test/DeleteHonoursNodeTypeAccessRuleTest.cs` pins all four rows of the table, using the **real** `SatelliteAccessRule`. **Each was proven falsifiable**:

- rule lookup removed from the pre-flight (the pre-fix behaviour) → tests 1, 3, 4 red;
- the no-rule fallback relaxed from `Delete` to `Update` (an over-permissive fix) → test 2 red — the no-widening test, the one that matters most.

Green locally, Release + `-warnaserror`, `0 Error(s)` on every touched project: Graph 1578/1578 · Security 378/378 · NodeOperations 76/76 · Hosting 269/269 · AccessControl 21/21 · Documentation 147/147 (link integrity + the timeout ratchet — the new test adopts `TestTimeouts`, it does not re-seed the baseline) · Hosting.Monolith delete + node-operation-target suite 37/37.

## Work product conserved

The two-paths-one-question finding, the widening table and the still-unrouted message gate are committed to `Doc/Architecture/AccessControl` → *"One question, ONE answer"*. What's New entry: `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kwar1ZGt5FMEpHiXmkzKCm