### PR TITLE
fix(data): a faulted data-source load could wedge its node — the stream's sub-hub outran its own constructor (#2625)

### DIFF
--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -351,9 +351,37 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
 
 
     /// <summary>
-    /// The actual synchronization hub
+    /// The actual synchronization hub.
+    ///
+    /// <para>🚨 <b>Bound BEFORE the hub can process its own initialization, not after
+    /// <c>GetHostedHub</c> returns</b> (#2625). <c>MessageHubConfiguration.Build</c> ends with
+    /// <c>StartMessageProcessing()</c>, which POSTS <c>InitializeHubRequest</c> — so the sub-hub's
+    /// BuildupActions run on its turn scheduler while this constructor is still inside
+    /// <c>GetHostedHub</c>. A data source whose initial load faults synchronously
+    /// (<c>Observable.Throw</c>) reaches <see cref="OnError"/> in that window, and with the
+    /// assignment done only on the constructor's return path that call found <c>Hub</c> null and
+    /// SILENTLY skipped <c>FailStartup</c> + <c>OpenGate(SynchronizationGate)</c>: the sub-hub
+    /// stayed <c>Starting</c> forever, its <c>Started</c> task never settled, so
+    /// <c>IDataSource.Initialized</c> hung and the owning <c>DataContext</c>'s gate was never
+    /// given its answer — every request to that hub deferred until an unrelated deadline
+    /// expired.</para>
+    ///
+    /// <para>So the binding is a SYNCHRONOUS buildup action (<see cref="BindHub"/>), which
+    /// <c>Build</c> runs BEFORE <c>StartMessageProcessing</c>. There is then no window at all:
+    /// every message handler and every BuildupAction on the sub-hub sees a bound
+    /// <c>Hub</c>, on the same thread that is still running this constructor. The constructor's
+    /// own assignment below remains for the path where <c>GetHostedHub</c> hands back a
+    /// PRE-EXISTING sub-hub, in which case the configuration lambda — and therefore
+    /// <see cref="BindHub"/> — never runs (and no BuildupAction runs either, so nothing can
+    /// observe the gap).</para>
     /// </summary>
-    public IMessageHub Hub { get; }
+    public IMessageHub Hub { get; private set; } = null!;
+
+    /// <summary>
+    /// Binds <see cref="Hub"/> from the sub-hub's synchronous buildup action — see the remarks
+    /// on <see cref="Hub"/> for why this cannot wait for the constructor's return path.
+    /// </summary>
+    private void BindHub(IMessageHub syncHub) => Hub = syncHub;
 
     /// <summary>
     /// The host of the synchronization stream.
@@ -911,13 +939,31 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
             {
                 logger.LogDebug(ex, "[SYNC_STREAM] Exception from Store.OnError propagation for {StreamId}", StreamId);
             }
-            // Always fault startup and open gate, even if Store.OnError throws.
-            // (Hub is non-null on every constructed stream — the ctor refuses rather
-            // than fabricating a hub-less one; the guard is belt-and-braces.)
+            // Always fault startup and open gate, even if Store.OnError throws. These two calls
+            // are the ONLY thing that lets a faulted initial load settle
+            // IDataSource.Initialized — FailStartup faults the sub-hub's Started task, which
+            // DataContext's gate is a WhenAll over.
+            //
+            // 🚨 SKIPPING THEM IS A WEDGE, NEVER A NO-OP (#2625). Hub is bound by a SYNCHRONOUS
+            // buildup action now (see the remarks on Hub), so it is non-null for every
+            // BuildupAction and every handler and this branch cannot be taken from the init
+            // path. It stays as a guard because the constructor's refusal path leaves a
+            // stream whose Hub was never bound — but it must be LOUD: the silent version cost
+            // #2625 two months of an unreproducible CI flake, because everything downstream
+            // simply waited forever with nothing logged.
             if (Hub is not null)
             {
                 Hub.FailStartup(error);
                 Hub.OpenGate(SynchronizationGate);
+            }
+            else
+            {
+                logger.LogError(error,
+                    "[SYNC_STREAM] OnError for {StreamId} (Reference={Reference}, Owner={Owner}) "
+                    + "could not fault its sub-hub's startup: the stream has no Hub bound. Anything "
+                    + "waiting on that hub's Started task — IDataSource.Initialized, and therefore "
+                    + "the owning DataContext's initialization gate — will never be settled by this "
+                    + "fault.", StreamId, Reference, Owner);
             }
         }
         else
@@ -1208,6 +1254,12 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
     private MessageHubConfiguration ConfigureSynchronizationHub(MessageHubConfiguration config)
     {
         config = config
+            // 🚨 FIRST, and the SYNCHRONOUS overload on purpose (#2625): SyncBuildupActions run
+            // inside Build() BEFORE StartMessageProcessing posts InitializeHubRequest, so this
+            // binds the stream's Hub before ANY message — including this hub's own init, whose
+            // fault path calls OnError → Hub.FailStartup — can reach code that reads it. See the
+            // remarks on Hub.
+            .WithInitialization(BindHub)
             // Inherit the owning Host's posting identity (feedback_access_context_always_set). In
             // prod the Host is a User hub (= the default) so this is a no-op; in plumbing tests the
             // Host is a System hub and the sync hub must be System too, else its own

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubInitializationFailure.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubInitializationFailure.md
@@ -70,6 +70,74 @@ This **generalizes** the per-context guard that already lived in `DataContext.Op
 (which opens its own `DataContextInit` gate even on fault) up to the hub level, so **every**
 BuildupAction — not just the DataContext one — fails gracefully.
 
+## 🚨 A hub's init runs BEFORE its creator's constructor has returned
+
+`MessageHubConfiguration.Build` ends with `StartMessageProcessing()`, and that method **posts
+`InitializeHubRequest`**. So a hub is already draining its own init turn — on its own turn
+scheduler, i.e. another thread — while the code that asked for it is still inside
+`GetHostedHub(...)`.
+
+Anything the BuildupActions reach back into must therefore be **fully bound before `Build`
+starts message processing**, not on the creator's return path. There are exactly two safe
+places:
+
+| Where | Runs | Use it for |
+|---|---|---|
+| a **synchronous** `WithInitialization(Action<IMessageHub>)` | inside `Build`, *before* `StartMessageProcessing` | binding the creator's own fields onto the new hub |
+| the creator, after `WithDeferredInitialization()` + an explicit `Post(new InitializeHubRequest())` | whenever the creator says so | when the creator cannot finish before `Build` (e.g. `LayoutAreaHost`, whose init lambda reads a property assigned after the constructor returns) |
+
+**Assigning on the return path is a race, and it fails SILENTLY.** `SynchronizationStream`'s
+constructor used to do exactly that:
+
+```csharp
+var syncHub = Host.GetHostedHub(SynchronizationAddress.Create(ClientId), ConfigureSynchronizationHub, …);
+…
+Hub = syncHub;              // ← too late: the sub-hub's init may already have faulted
+```
+
+A data source whose initial load faults *synchronously* (`Observable.Throw`) reaches
+`SynchronizationStream.OnError` inside that window. `OnError`'s `if (Hub is not null)` guard then
+skipped **both** `Hub.FailStartup(error)` and `Hub.OpenGate(SynchronizationGate)` — so:
+
+* `SynchronizationGate` never opened ⇒ the sub-hub never reached `Started`;
+* `Hub.Started` never settled ⇒ `IDataSource.Initialized` (a `WhenAll` over those tasks) hung;
+* `DataContext`'s `DataContextInit` gate was never given its answer ⇒ **every** request to the
+  owning hub deferred until an unrelated deadline expired.
+
+The tell is a log that says the hub failed and then goes quiet: `sync/… initialization failed —
+a BuildupAction faulted` at ~4 ms, followed by **no** `DataContext initialization failed for …`
+and a caller that waits out its whole budget. That was CI flake
+[#2625](https://github.com/Systemorph/MeshWeaver/issues/2625), unreproducible in 25 local runs
+because the window is a few instructions wide and only CI-shard thread pressure lands in it.
+
+The fix is the first row of the table: `ConfigureSynchronizationHub` now starts with
+`.WithInitialization(BindHub)`, so `Hub` is bound on the constructing thread before the sub-hub
+can process anything. The same window was a latent `NullReferenceException` on the *success*
+path too — `Initialize`'s `SetCurrent(hub, new ChangeItem<TStream>(init, StreamId, OwnerVersion()))`
+reads `Hub.Version` for an owner-side stream.
+
+**The general rule: a "not yet available, skip it" guard on an initialization path is a wedge,
+never a no-op.** Skipping `FailStartup` does not degrade the failure — it converts a fast, typed
+rejection into an unbounded wait with nothing logged. Where such a guard must stay (here: a
+stream whose constructor refused before binding a hub), it logs at **Error** and names what will
+never be settled.
+
+### How to reproduce an ordering like this deterministically
+
+`HostedHubsCollection` publishes `HubAdded` **twice** per hosted hub, and the two emissions
+straddle exactly this window:
+
+1. from `HostedHubsCollection.Add`, called by `Build` *before* `SyncBuildupActions` and before
+   `StartMessageProcessing` — nothing can have faulted yet;
+2. from `GetHub`'s creation `Lazy`, called *after* `Build` returned (so after the init request was
+   posted) and *before* `GetHostedHub` returns to the caller's constructor.
+
+Subscribing on the second emission and holding that thread until the sub-hub records its
+`InitializationError` pins the interleaving with no timing luck at all — see
+`DataContextFaultedInitBeforeStreamHubBoundTest`. This beats a repeat-until-it-flakes loop: 25
+runs at `DOTNET_PROCESSOR_COUNT=4` produced 0 failures, the parked run produces the defect every
+time.
+
 ## How it shows on the GUI
 
 Because the failure is now a `DeliveryFailure` flowing back through the subscriber rather than a silent
@@ -102,6 +170,11 @@ handler. That is an ordinary wedge — see
 faulting BuildupAction answers a probe request with a `DeliveryFailureException` carrying
 `"initialization failed: <reason>"` **fast** (a `TimeoutException` would mean the gate never opened —
 the regression), and exposes the `InitializationError` status marker.
+
+`test/MeshWeaver.Data.Test/DataContextInitWatchdogTest.cs` pins the DataContext side — the
+watchdog's four terminal outcomes, plus
+`DataContextFaultedInitBeforeStreamHubBoundTest`, which stages the construction-window ordering
+above deterministically and asserts that the faulted arm still settles the gate.
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-data-source-that-fails-to-load-no-longer-freezes-its-node.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-data-source-that-fails-to-load-no-longer-freezes-its-node.md
@@ -1,0 +1,23 @@
+---
+Name: A data source that fails to load no longer freezes its node
+Category: Fix
+Description: A node whose data failed to load could stop answering entirely instead of reporting the error, leaving every page and request on it waiting for its full timeout.
+Icon: Sparkle
+Order: -20260901
+---
+
+# A data source that fails to load no longer freezes its node
+
+When a node's data failed to load, it was supposed to say so immediately: every request got a
+clear "initialization failed — here is why" answer within milliseconds, and the page showed the
+real reason.
+
+Occasionally it did the opposite. The node recorded the failure internally and then went silent:
+requests were held back waiting for a load that had already given up, and callers waited out
+their whole budget — up to 30 seconds — before getting a generic timeout with no explanation.
+Whether it happened came down to which of two things finished first on a busy machine, so the
+same node could behave correctly one moment and freeze the next.
+
+The two are no longer in a race. A data load that fails now always reaches the code that reports
+it, so the node reports the error immediately every time, and the message you see names the
+actual problem instead of a timeout.

--- a/test/MeshWeaver.Data.Test/DataContextInitWatchdogTest.cs
+++ b/test/MeshWeaver.Data.Test/DataContextInitWatchdogTest.cs
@@ -277,8 +277,10 @@ public class DataContextFaultedInitBeforeStreamHubBoundTest(ITestOutputHelper ou
         => configuration.WithTypes(typeof(ProbeRequest), typeof(ProbeResponse));
 
     /// <summary>What the park actually observed — written to test output so a future red says
-    /// whether the window was staged at all, not merely that the probe was slow.</summary>
-    private string parkDiagnostics = "(never parked)";
+    /// whether the window was staged at all, not merely that the probe was slow. Volatile: it is
+    /// written on the hosted-hub CONSTRUCTION thread and read on the test thread, and a stale read
+    /// would make the one diagnostic that explains a future red untrustworthy.</summary>
+    private volatile string parkDiagnostics = "(never parked)";
 
     /// <summary>
     /// The address of the first <c>sync/…</c> sub-hub seen — the data source's own stream hub.

--- a/test/MeshWeaver.Data.Test/DataContextInitWatchdogTest.cs
+++ b/test/MeshWeaver.Data.Test/DataContextInitWatchdogTest.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Reactive.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 
 namespace MeshWeaver.Data.Test;
@@ -194,5 +196,180 @@ public class DataContextInitFaultedTest(ITestOutputHelper output) : HubTestBase(
             "the hub must expose the FAILED status marker after a faulted init");
         initError!.ToString().Should().Contain(InitFaultMarker,
             "the recorded failure must carry the SPECIFIC init fault for diagnosis");
+    }
+}
+
+/// <summary>
+/// The DETERMINISTIC repro of the #2625 flake, and the regression guard for its fix.
+///
+/// <para><b>The race.</b> <c>SynchronizationStream</c>'s constructor asks
+/// <c>Host.GetHostedHub(sync/…, HostedHubCreation.Always)</c> for its sub-hub, and
+/// <c>MessageHubConfiguration.Build</c> STARTS that hub — it posts <c>InitializeHubRequest</c> —
+/// before <c>GetHostedHub</c> returns. So the sub-hub's BuildupActions can run on the action
+/// block WHILE the constructor is still executing, i.e. before the constructor has assigned the
+/// stream's <c>Hub</c> field. A data source whose initial load faults SYNCHRONOUSLY
+/// (<c>Observable.Throw</c>) does exactly that in ~zero time.</para>
+///
+/// <para><b>What that used to cost.</b> The fault reached
+/// <c>SynchronizationStream.OnError</c>, whose <c>if (Hub is not null)</c> guard then SKIPPED
+/// both <c>Hub.FailStartup(error)</c> and <c>Hub.OpenGate(SynchronizationGate)</c> — silently.
+/// The sync hub therefore never reached <c>Started</c> and its <c>Started</c> task never
+/// settled, so <c>IDataSource.Initialized</c> (a <c>WhenAll</c> over those tasks) hung, so
+/// <see cref="DataContext"/>'s gate was never settled and every request to the owning hub sat
+/// behind <c>DataContextInit</c> until an unrelated deadline expired. The hub logged
+/// "initialization failed … FAILED state" in 4 ms and answered nothing for the rest of the
+/// test's budget — the exact signature in the issue.</para>
+///
+/// <para><b>Why this test is deterministic where a 25-run loop was not.</b>
+/// <c>HostedHubsCollection</c> publishes <c>HubAdded</c> on the CONSTRUCTING thread, inside the
+/// creation <c>Lazy</c> — after <c>Build</c> has posted the init request and before
+/// <c>GetHostedHub</c> returns to the stream's constructor. Parking that thread there until the
+/// sub-hub has recorded its init failure pins the CI interleaving with no timing luck at all.
+/// The park is the SUBJECT of the test, so it is a bounded <c>SpinWait.SpinUntil</c> over a
+/// value another worker writes (AGENTS.md's sanctioned shape) — not a gate.</para>
+/// </summary>
+public class DataContextFaultedInitBeforeStreamHubBoundTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string InitFaultMarker = "boom before the stream bound its hub";
+
+    private record FaultyItem(string Id);
+
+    // NOT PingRequest — the gate exempts liveness pings; see DataContextInitTimeoutTest.
+    private record ProbeRequest : IRequest<ProbeResponse>;
+
+    private record ProbeResponse;
+
+    /// <summary>
+    /// Set once, so only the FIRST hosted sub-hub — the data source's own
+    /// <c>sync/…</c> stream hub — is parked; later ones (reduced streams) run free.
+    /// </summary>
+    private int parkClaimed;
+
+    /// <summary>True once the park has actually been taken, so the test can assert it staged.</summary>
+    private volatile bool parkStaged;
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => configuration
+            .WithTypes(typeof(ProbeRequest), typeof(ProbeResponse))
+            // The handler WOULD answer, so a pass can only come from the FAILED-state
+            // rejection — never from the request quietly being served after all.
+            .WithHandler<ProbeRequest>((hub, request) =>
+            {
+                hub.Post(new ProbeResponse(), o => o.ResponseFor(request));
+                return request.Processed();
+            })
+            // 🚨 The SYNCHRONOUS WithInitialization overload on purpose: SyncBuildupActions run
+            // inside Build(), BEFORE the host starts message processing — so this subscription is
+            // guaranteed to be in place before the init turn creates any data-source stream. The
+            // observable overload would run on the init turn itself and could miss the emission.
+            .WithInitialization(hub => hub.RegisterForDisposal(
+                hub.ServiceProvider.GetRequiredService<HostedHubsCollection>()
+                    .HubAdded
+                    .Subscribe(ParkConstructionUntilChildInitFailed)))
+            .AddData(data => data
+                .AddSource(src => src.WithType<FaultyItem>(t => t
+                    .WithKey(i => i.Id)
+                    .WithInitialData(() =>
+                        Observable.Throw<IEnumerable<FaultyItem>>(
+                            new InvalidOperationException(InitFaultMarker))))));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => configuration.WithTypes(typeof(ProbeRequest), typeof(ProbeResponse));
+
+    /// <summary>What the park actually observed — written to test output so a future red says
+    /// whether the window was staged at all, not merely that the probe was slow.</summary>
+    private string parkDiagnostics = "(never parked)";
+
+    /// <summary>
+    /// The address of the first <c>sync/…</c> sub-hub seen — the data source's own stream hub.
+    /// Written and read only on the constructing thread.
+    /// </summary>
+    private Address? firstSyncAddress;
+
+    private void ParkConstructionUntilChildInitFailed(IMessageHub child)
+    {
+        if (child is not MessageHub concrete
+            || concrete.Address.Type != MeshWeaver.Data.SynchronizationAddress.AddressType)
+            return;
+
+        // 🚨 HubAdded fires TWICE per hosted hub, and only the SECOND one is the window.
+        //   1. HostedHubsCollection.Add — called from MessageHubConfiguration.Build BEFORE
+        //      SyncBuildupActions and BEFORE StartMessageProcessing, so the hub has not yet
+        //      been handed its InitializeHubRequest and nothing can fault.
+        //   2. HostedHubsCollection.GetHub's creation Lazy — called AFTER Build returned, i.e.
+        //      after StartMessageProcessing posted InitializeHubRequest, and BEFORE
+        //      GetHostedHub returns to SynchronizationStream's constructor. That is exactly
+        //      the interval in which the constructor has NOT yet assigned its Hub field.
+        if (firstSyncAddress is null)
+        {
+            firstSyncAddress = concrete.Address;
+            return;
+        }
+        if (!firstSyncAddress.Equals(concrete.Address))
+            return;
+        if (Interlocked.Exchange(ref parkClaimed, 1) != 0)
+            return;
+
+        parkStaged = true;
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        try
+        {
+            // Bounded, and the bound is a DIAGNOSTIC rather than a budget: the sub-hub's init
+            // faults synchronously on its own turn scheduler, so this releases in milliseconds.
+            // Written in the shape AGENTS.md sanctions for a park that IS the subject of the
+            // test — a bounded SpinUntil over a value another worker writes, never a gate.
+            SpinWait.SpinUntil(() => concrete.InitializationError is not null, TimeSpan.FromSeconds(10));
+        }
+        finally
+        {
+            parkDiagnostics =
+                $"parked on {concrete.Address} for {sw.ElapsedMilliseconds}ms, "
+                + $"RunLevel={concrete.RunLevel}, InitializationError={concrete.InitializationError?.Message ?? "(null)"}";
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task StreamFaultingBeforeItsHubIsBound_StillFailsTheDataContextGateFast()
+    {
+        var host = GetHost();
+        var client = GetClient();
+
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        // Generous WAIT / asserted ELAPSED, exactly as DataContextInitFaultedTest separates them
+        // (#2700): the wait must be long enough that a timeout means NEVER, the elapsed assertion
+        // is what carries "…Fast".
+        var act = () => client
+            .Observe(new ProbeRequest(), o => o.WithTarget(host.Address))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(45)).Await();
+
+        var ex = (await act.Should().ThrowAsync<Exception>(
+            "a hub whose data-source init threw must answer requests with an error")).Which;
+        stopwatch.Stop();
+
+        Output.WriteLine($"PARK: {parkDiagnostics}");
+        parkStaged.Should().BeTrue(
+            "the repro only means anything if the stream's construction was actually parked at "
+            + "HubAdded — a HubAdded that never fired would make this test a tautology");
+
+        ex.Should().NotBeOfType<TimeoutException>(
+            "a faulted init must be ANSWERED by the rejection handler even when the sub-hub's init "
+            + "turn beat the stream's constructor to the Hub assignment — a timeout here is the "
+            + "#2625 wedge: OnError skipped FailStartup, so Started never settled and the "
+            + "DataContextInit gate was never given its answer");
+
+        stopwatch.Elapsed.Should().BeLessThan(TimeSpan.FromSeconds(25),
+            $"the rejection handler answers in milliseconds; this took {stopwatch.Elapsed.TotalSeconds:F1}s, "
+            + "which is a request that fell through to a deferral/time-box deadline rather than one "
+            + "the faulted arm rejected");
+
+        ex.ToString().Should().Contain("initialization failed",
+            "the rejection must be reported as an initialization failure");
+
+        var initError = host.GetWorkspace().DataContext.InitializationError;
+        initError.Should().NotBeNull(
+            "the DataContext must reach its terminal FAILED state, not sit un-settled");
+        initError!.ToString().Should().Contain(InitFaultMarker,
+            "the recorded failure must carry the SPECIFIC init fault — a TimeoutException here "
+            + "would mean the time-box settled the gate instead of the fault");
     }
 }


### PR DESCRIPTION
## Root cause — proven, not narrowed

`MessageHubConfiguration.Build` ends with `StartMessageProcessing()`, and that method **posts
`InitializeHubRequest`**. So a hosted hub is already draining its own init turn — on its own turn
scheduler, i.e. another thread — while the code that asked for it is still inside `GetHostedHub`.

`SynchronizationStream`'s constructor bound its `Hub` only on the **return path** from that call:

```csharp
var syncHub = Host.GetHostedHub(SynchronizationAddress.Create(ClientId), ConfigureSynchronizationHub, …);
…
Hub = syncHub;              // ← too late: the sub-hub's init may already have faulted
```

A data source whose initial load faults **synchronously** (`Observable.Throw`) reaches
`SynchronizationStream.OnError` inside that window. `OnError`'s `if (Hub is not null)` guard then
skipped **both** `Hub.FailStartup(error)` and `Hub.OpenGate(SynchronizationGate)` — silently:

* `SynchronizationGate` never opened ⇒ the sub-hub never reached `Started`;
* `Hub.Started` never settled ⇒ `IDataSource.Initialized` (a `WhenAll` over those tasks) hung;
* `DataContext`'s `DataContextInit` gate was never given its answer ⇒ **every** request to the
  owning hub deferred until an unrelated deadline expired.

That is exactly the signature in the issue: `sync/… initialization failed — a BuildupAction faulted`
at ~4 ms, then **no** `DataContext initialization failed for …` at all, and a probe request answered
by nothing for the rest of its budget.

This is the issue's candidate **(b)** — "the child's `Started` never settles". Candidate (a) (an
empty `Streams` snapshot) is not what happens: `TypeSourceBasedUnpartitionedDataSource.Initialize`
creates the stream eagerly, before `DataContext.InitializeDataSources` reads `Initialized`.

## The fix

`ConfigureSynchronizationHub` now begins with `.WithInitialization(BindHub)` — the **synchronous**
`WithInitialization(Action<IMessageHub>)` overload, which `Build` runs BEFORE
`StartMessageProcessing`. There is then no window at all: every BuildupAction and every handler on
the sub-hub sees a bound `Hub`, assigned on the same thread that is still running the constructor.
The constructor's own assignment stays for the path where `GetHostedHub` hands back a
**pre-existing** sub-hub — there the configuration lambda never runs, and neither does any
BuildupAction, so nothing can observe the gap.

The same window was a latent `NullReferenceException` on the **success** path too — `Initialize`'s
`SetCurrent(hub, new ChangeItem<TStream>(init, StreamId, OwnerVersion()))` reads `Hub.Version` for
an owner-side stream.

The residual null-`Hub` branch in `OnError` stays as a guard for the constructor's refusal path, but
it is now **loud** (Error, naming what will never be settled). Skipping `FailStartup` is a wedge,
never a no-op — the silent version is precisely why this cost two months of an unreproducible flake.

**No band-aid:** no timeout widened, no watchdog, no retry, no `catch {}`. The 15 s / 30 s / 60 s
bounds are untouched, and the `DataContext` time-box stays exactly where it was.

## Deterministic repro

25 local runs at `DOTNET_PROCESSOR_COUNT=4` had produced 0 failures — the window is a few
instructions wide. So the ordering is **staged**, not waited for.

`HostedHubsCollection` publishes `HubAdded` **twice** per hosted hub, and the two emissions straddle
the window:

1. from `HostedHubsCollection.Add`, called by `Build` *before* `SyncBuildupActions` and before
   `StartMessageProcessing` — nothing can have faulted yet;
2. from `GetHub`'s creation `Lazy`, called *after* `Build` returned (so after the init request was
   posted) and *before* `GetHostedHub` returns to the constructor.

`DataContextFaultedInitBeforeStreamHubBoundTest` subscribes on the second emission and holds that
thread until the sub-hub records its `InitializationError` (a bounded `SpinWait.SpinUntil` over a
value another worker writes — the shape AGENTS.md sanctions for a park that IS the subject of the
test, written in a `finally`). It also asserts `parkStaged`, so a `HubAdded` that stopped firing
turns the test red rather than tautologically green.

| | elapsed | outcome |
|---|---|---|
| before the fix | **30.02 s** (fell through to the hub's own deferral timeout), `RunLevel=Starting` at park release | ❌ FAIL |
| after the fix | **69 ms**, `RunLevel=Started` at park release | ✅ PASS |

## Verified

* `DataContextFaultedInitBeforeStreamHubBoundTest` — RED on unmodified `src/` (30.0 s), GREEN after (69 ms).
* `MeshWeaver.Data.Test` — **414/414** at `DOTNET_PROCESSOR_COUNT=4`, including all five DataContext
  init-watchdog outcomes.
* `MeshWeaver.Layout.Test` **437/437** · `MeshWeaver.Messaging.Hub.Test` **341/341** ·
  `MeshWeaver.Documentation.Test` **147/147**.
* Every touched project built one-per-invocation with `-c Release -warnaserror`: **0 Error(s), 0 Warning(s)**.
* `scripts/check-record-signatures.py --base origin/main` — clean.

## Work product conserved

`Doc/Architecture/HubInitializationFailure` gains a section — *"A hub's init runs BEFORE its
creator's constructor has returned"* — with the two safe binding points (a synchronous buildup
action; or `WithDeferredInitialization()` + an explicit `Post(new InitializeHubRequest())`, which is
what `LayoutAreaHost` already does), the failure chain above, and the `HubAdded`-twice recipe for
staging this ordering deterministically.

What's New: `Category: Fix` — *A data source that fails to load no longer freezes its node*.

Closes #2625

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kwar1ZGt5FMEpHiXmkzKCm