### PR TITLE
fix(adoption): the stale-prebuilt refusal was armed and INERT — make it reachable

### DIFF
--- a/.github/scripts/assert-bake-consumption.sh
+++ b/.github/scripts/assert-bake-consumption.sh
@@ -29,14 +29,31 @@ fail() { echo "::error::$1"; exit 1; }
 ls "$BAKE"/*.zip >/dev/null 2>&1 \
   || fail "$LABEL: the bake ran green but produced no bundles under $BAKE — the gate would then adopt nothing and pass vacuously."
 
-# ── 2. No compile FALLBACK ──────────────────────────────────────────────────────────────────────
+# ── 2. No compile FALLBACK, and no FALSE REFUSAL ────────────────────────────────────────────────
 # Each phrase means a consumer wanted prebuilt bytes, could not get them, and quietly compiled
 # instead. Green in every other signal; a delivery defect all the same.
+#
+# 🚨 "ADOPTION REFUSED" is the #2813 phrase, and it is here for the OPPOSITE failure to the others.
+# The refusal fires when a bundle's recorded source fingerprint disagrees with the source the mesh
+# holds — which, in THIS lane, cannot legitimately happen: the bake and the gate are staged from the
+# same tree by bake-then-gate.sh, so a disagreement means the two producers HASH THE SAME CONTENT
+# DIFFERENTLY. That is a false refusal, and shipping one refuses every good bundle in the fleet —
+# strictly worse than the staleness bug the refusal exists to catch. It is also invisible without
+# this line: `Seed` returns TRUE and the adopted/declared counts below still balance, because the
+# owner refuses AFTERWARDS, when it stamps; the type then flips to Pending, recompiles locally, and
+# every per-type verdict is green. The gate's own default log level is Warning and the refusal logs
+# at Error/Critical, so the phrase reaches the log without turning anything up.
 fallback_hit=0
 while IFS= read -r phrase; do
   [ -z "$phrase" ] && continue
   if grep -F -q -- "$phrase" "$BAKE_LOG" "$GATE_LOG" 2>/dev/null; then
-    echo "::error::$LABEL: compile fallback detected — \"$phrase\". A consumer declined the bake and compiled instead, so this run did not judge the bytes the bake shipped."
+    # The refusal phrase means something different from the rest, so it must not be reported as a
+    # fallback — a reader sent to look for a declined bundle would find a perfectly adopted one.
+    if [ "$phrase" = "ADOPTION REFUSED" ]; then
+      echo "::error::$LABEL: FALSE REFUSAL (#2813) — a NodeType refused the bake's own bytes as built from different source, but bake and gate were staged from the SAME tree. The compiler-driven producer and the runtime therefore hash the same content differently, which refuses every good bundle in the fleet. Fix NodeTypeSourceFingerprint (or whichever side moved) before shipping; do NOT relax this check."
+    else
+      echo "::error::$LABEL: compile fallback detected — \"$phrase\". A consumer declined the bake and compiled instead, so this run did not judge the bytes the bake shipped."
+    fi
     grep -F -n -- "$phrase" "$BAKE_LOG" "$GATE_LOG" 2>/dev/null | head -5
     fallback_hit=1
   fi
@@ -45,6 +62,7 @@ no prebuilt bundle
 carried no assemblies
 could resolve NO artifact
 no prebuilt assemblies adopted
+ADOPTION REFUSED
 PHRASES
 
 # ── 3. The gate CONSUMED the bake ───────────────────────────────────────────────────────────────

--- a/src/MeshWeaver.Compiler/NodeTypeSourceFingerprint.cs
+++ b/src/MeshWeaver.Compiler/NodeTypeSourceFingerprint.cs
@@ -1,0 +1,108 @@
+using System.Security.Cryptography;
+using System.Text;
+using MeshWeaver.Mesh;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace MeshWeaver.Compiler;
+
+/// <summary>
+/// 🚨 <b>The ONE definition of "which source did these bytes come from"</b> (#2813) — computed
+/// identically by the PRODUCER that bakes a prebuilt assembly and by the CONSUMER that is asked to
+/// adopt it, so the two values are comparable and a mismatch is proof of staleness rather than of a
+/// shape difference.
+///
+/// <para>The producer writes it into the bundle manifest per assembly entry
+/// (<c>BundleWriter.AssemblyEntry.SourceFingerprint</c>); <c>PrebuiltAssemblySeeder.Seed</c> stamps
+/// it on the node as <c>NodeTypeDefinition.AdoptedSourceFingerprint</c>; the owning hub computes
+/// this same function over ITS live source set into
+/// <c>NodeTypeDefinition.CurrentSourceFingerprint</c>; and
+/// <c>NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp</c> compares the two. Equal ⇒
+/// <c>AdoptedVerified</c>. Different ⇒ <c>AdoptionRefused</c>: the bytes are last week's code over
+/// today's data, which is what destroyed four client documents.</para>
+///
+/// <para><b>Why it hashes the COMPILE INPUT and not the source MeshNodes' serialised content.</b>
+/// The obvious shape — <c>PartitionSourceFingerprint.Compute(nodes, versioned: false,
+/// hub.JsonSerializerOptions)</c>, which is what the live half computed before this existed — is
+/// unusable as a CROSS-PROCESS comparison, in three ways that all produce FALSE REFUSALS (an
+/// outage strictly worse than the bug):</para>
+/// <list type="bullet">
+///   <item><b>Run bookkeeping churns it.</b> <see cref="CodeConfiguration"/> carries
+///     <c>LastExecutedAt</c> / <c>LastExecutedBy</c> / <c>LastExecutedCodeHash</c> /
+///     <c>LastActivityPath</c>, written when a reader presses Run on a code cell. Hashing the
+///     serialised content would move the live fingerprint with no source change at all, and no
+///     producer can ever know those values.</item>
+///   <item><b>The two sides serialise differently by design.</b> The consumer has a hub and
+///     therefore a TypeRegistry (polymorphic <c>$type</c> discriminators); the compiler-driven bake
+///     deliberately has neither — <c>TreeNodeLoader</c> materialises exactly the two content types
+///     a compile reads and leaves everything else null, precisely so a half-populated registry
+///     cannot silently degrade content to <c>JsonElement</c>. Two honest readers, two different
+///     JSON strings.</item>
+///   <item><b>Node metadata is not compile input.</b> A description, an icon, an order — none of
+///     them change a byte of the emitted assembly, and letting them decide whether an assembly is
+///     stale answers a question nobody asked.</item>
+/// </list>
+///
+/// <para>So the fingerprint is taken over exactly what Roslyn is handed: the
+/// <see cref="NodeCompileShaping.CollectCompileSources"/> fold — deduplicated (ordinal-ignore-case),
+/// executable cells and blank files dropped — reduced to <c>(node path, SHA-256 of the code
+/// text)</c>. That fold is the SAME call both the mesh compile path
+/// (<c>MeshNodeCompilationService</c>) and the tree bake (<see cref="NodeSetCompiler"/>) already
+/// make, so producer and consumer cannot fork on which files count.</para>
+///
+/// <para><b>Why it lives in this assembly.</b> <see cref="FrameworkBuildIdentity.FullMvidAssemblies"/>
+/// is the transitive closure of <c>MeshWeaver.Compiler</c>, so any change to this function moves the
+/// framework identity — and adoption is already gated on that identity matching. A producer and a
+/// consumer that could adopt across each other therefore necessarily run the SAME implementation of
+/// this hash. Put it anywhere else and two meshes could disagree about the shape while agreeing
+/// about the gate, which is a false-refusal outage waiting on a refactor.</para>
+///
+/// <para>🚨 <b>Known residue, deliberately not covered.</b> An <c>@@</c> include pulls a Code node
+/// that no source query matches, so it is absent from this fold — a change to an included-only
+/// snippet does not move the fingerprint. That is not a new hole: it is the SAME set
+/// <c>NodeTypeDefinition.CompiledSources</c> records, so <c>IsDirty</c> has always missed it too.
+/// Closing it means resolving includes on the live side (a mesh read per include) and is tracked
+/// separately rather than smuggled in here — but it is named, because a guard whose coverage is
+/// assumed rather than stated is how this mechanism went inert the first time.</para>
+/// </summary>
+public static class NodeTypeSourceFingerprint
+{
+    /// <summary>
+    /// The fingerprint of <paramref name="sourceNodes"/> as a compile input for the NodeType at
+    /// <paramref name="nodeTypePath"/>.
+    ///
+    /// <para>NEVER null: an empty source set folds to the empty-set hash, a real value. That is
+    /// deliberate — "this type compiles from nothing" is a fact worth comparing, and returning null
+    /// would make a bundle baked from three files adopt as merely <i>unverified</i> against a mesh
+    /// whose sources have all been deleted, instead of being refused.</para>
+    /// </summary>
+    /// <param name="sourceNodes">The RAW resolved source+test node set — the output of
+    /// <c>NodeSources.GetSources</c> at runtime, or <c>NodeSet.ResolveSources</c> in the bake. The
+    /// shaping fold is applied here so both callers cannot apply a different one.</param>
+    /// <param name="nodeTypePath">The NodeType's mesh path (diagnostics only).</param>
+    /// <param name="logger">Diagnostics for the shaping fold (skipped executable cells).</param>
+    public static string Compute(
+        IEnumerable<MeshNode> sourceNodes,
+        string nodeTypePath,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(sourceNodes);
+        ArgumentException.ThrowIfNullOrEmpty(nodeTypePath);
+
+        var (sources, paths) = NodeCompileShaping.CollectCompileSources(
+            sourceNodes, nodeTypePath, logger ?? NullLogger.Instance);
+
+        // CollectCompileSources returns the two lists in lock-step (one MatchedPath per
+        // CodeConfiguration it accepted), and PartitionSourceFingerprint sorts by path before
+        // hashing — so the enumeration order the fold happened to use cannot reach the result.
+        return PartitionSourceFingerprint.Compute(
+            paths.Select((path, index) => (path, TokenOf(sources[index]))));
+    }
+
+    /// <summary>SHA-256 over the code text — the only property of a source node the emitted bytes
+    /// depend on (<see cref="NodeCompileShaping.CombineSources"/> reads <c>Code</c> and nothing
+    /// else).</summary>
+    private static string TokenOf(CodeConfiguration code) =>
+        Convert.ToHexStringLower(
+            SHA256.HashData(Encoding.UTF8.GetBytes(code.Code ?? string.Empty)));
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -670,9 +670,18 @@ the value it compares simply never arrived, and every part of the system reporte
 > links above.
 
 **Producer and consumer must hash identically, or every good bundle is refused.** That equality is
-pinned by `BakeEquivalenceTest`, which bakes one content set both ways — through a real mesh (whose
+pinned twice. `BakeEquivalenceTest` bakes one content set both ways — through a real mesh (whose
 value *is* the consumer-side value) and through the mesh-free tree bake — and asserts the
-fingerprints are equal, non-empty, and different for different types.
+fingerprints are equal, non-empty, and different for different types. And the PR lane asserts it on
+the REAL trees: `bake-then-gate.sh` stages the bake and the gate from the same tree, so an
+`ADOPTION REFUSED` line in that run can only mean the two producers hash the same content
+differently, and `assert-bake-consumption.sh` fails on it by name.
+
+> 🚨 That second check exists because a false refusal is otherwise INVISIBLE in CI, in the same way
+> the original defect was. `Seed` returns `true`, the adopted/declared counts balance (the owner
+> refuses *afterwards*, when it stamps), the type flips to `Pending`, recompiles locally, and every
+> per-type verdict is green. Only the log says anything — and only because the refusal logs at
+> `Error`, above the gate's default level.
 
 #### Two things this deliberately does NOT do
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -556,11 +556,38 @@ unrecoverable. Only forcing a compile moved the MVID.
 
 #### The check, and where it can be made
 
-The producer records a **content** fingerprint of the sources the bytes were built from
-(`PartitionSourceFingerprint`). It has to be content, not versions: `CurrentSourceVersions` is
-`{path → LastModified.UtcTicks}`, mesh-LOCAL modification times the producer cannot know and does not
-have (the bake writes zeros), so a fingerprint over ticks would never match and every adoption would
-be refused.
+The producer records a **content** fingerprint of the sources the bytes were built from. It has to
+be content, not versions: `CurrentSourceVersions` is `{path → LastModified.UtcTicks}`, mesh-LOCAL
+modification times the producer cannot know and does not have (the bake writes zeros), so a
+fingerprint over ticks would never match and every adoption would be refused.
+
+**What exactly is hashed — `NodeTypeSourceFingerprint` (in `MeshWeaver.Compiler`).** The fingerprint
+is taken over the *compile input*: the `NodeCompileShaping.CollectCompileSources` fold — deduplicated
+ordinal-ignore-case, executable cells and blank files dropped — reduced to
+`(node path, SHA-256 of the code text)`, folded with `PartitionSourceFingerprint`, which sorts by
+path so enumeration order cannot reach the result. Both the runtime and the bake call *that* fold
+already, so they cannot fork on which files count.
+
+The obvious alternative — hashing the source MeshNodes' serialised content — is unusable across
+processes, and each of its three failure modes produces a **false refusal**, which is an outage
+strictly worse than the staleness bug:
+
+- **Run bookkeeping churns it.** `CodeConfiguration` carries `LastExecutedAt` / `LastExecutedBy` /
+  `LastExecutedCodeHash` / `LastActivityPath`, written when a reader presses **Run** on a code cell.
+  The live hash would move with no source change at all, and no producer can know those values.
+- **The two sides serialise differently by design.** The consumer has a hub and therefore a
+  TypeRegistry (polymorphic `$type` discriminators); the compiler-driven bake deliberately has
+  neither — `TreeNodeLoader` materialises exactly the two content types a compile reads and leaves
+  everything else null, precisely so a half-populated registry cannot degrade content to
+  `JsonElement`. Two honest readers, two different JSON strings.
+- **Node metadata is not compile input.** A description, an icon, an order: none of them change a
+  byte of the emitted assembly.
+
+It lives in `MeshWeaver.Compiler` because `FrameworkBuildIdentity.FullMvidAssemblies` is that
+assembly's transitive closure, and adoption is *already* gated on the framework identity matching —
+so a producer and a consumer that can adopt across each other necessarily run the same
+implementation of this hash. Anywhere else, two meshes could disagree about the shape while agreeing
+about the gate.
 
 The comparison happens on the **owner**, in `ApplyAdoptedSourceStamp` — one pure function shared by
 all three writers that can fulfil the request, so turning assert into check fixes all three at once:
@@ -602,15 +629,71 @@ set on a mesh nobody can see:
 > **memex** and **memex-cloud** (#2194 item 3 records the same) — two instances, saying nothing about
 > `pearl`, `atioz`, local installs, or any external instance the registry serves.
 
+#### 🚨 The path the fingerprint actually travels — and why it was INERT for months
+
+The comparison above shipped complete, and for months it could not fire. Nothing was broken in it;
+the value it compares simply never arrived, and every part of the system reported success:
+
+1. `PrebuiltAssemblySeeder.Seed` had a **seven-parameter convenience overload** that hard-coded
+   `sourceFingerprint: null`. Both production callers — `PluginBundleClient` and
+   `ShippedPrebuiltBundles` — bound to it, so `AdoptedSourceFingerprint` was never written, the
+   first guard in `ApplyAdoptedSourceStamp` short-circuited, and **every adoption on every mesh
+   returned `AdoptedUnverified`**. That overload is now `[Obsolete(error: true)]`: passing null is
+   still allowed (a legacy bundle genuinely records none) but must be *written at the call site*,
+   where a reviewer sees the claim being waived. It is obsoleted rather than **deleted** because
+   deleting public framework surface is a breaking change to in-mesh code no compiler can see, and
+   the live-mesh sweep AGENTS.md requires could not be completed — `search_chunks` answers
+   `"searched": false` on both reachable deployments, which is a FAILED sweep, not a clean one. Both
+   repos' node trees were swept by hand and hold no caller, so the symbol stays (nothing already
+   compiled breaks) while every source call site now fails loudly, at the call, with the reason.
+2. **No producer wrote one.** `BundleWriter.AssemblyEntry.SourceFingerprint` /
+   `BundleReader.AssemblyRef` / `BundleReader.Payload` now carry it end to end, and all three bake
+   producers record it — the compiler-driven `TreeBake` and `CascadeBuild` from the tree, the
+   mesh-driven `BakeOutput` through the same `NodeSources.GetSources` query the owning hub reads.
+3. **The live half was computed only when it was already too late to matter.** The owner computed
+   `CurrentSourceFingerprint` only "when there is something to compare it against" — a condition
+   unsatisfiable in the ordering the incident took. The owner publishes its snapshot first; the
+   adoption's patch then lands carrying both the adopted fingerprint and the stamp request, and the
+   sources watcher does **not** re-run, because its `DistinctUntilChanged` keys on the source
+   *queries*, which did not change. The judgement then read an absent live value and took the
+   "inconclusive" branch. It is now computed on **every** publication (a SHA over text already in
+   hand, on a path where a Roslyn compile is about to cost four orders of magnitude more), the
+   idempotency check includes it so a node persisted before the field existed self-heals on its next
+   activation, and the two writers that cannot compute it — the standalone stamp watcher and the
+   release-request watcher — now **wait** rather than consume the one-shot request on an absence.
+
+> 🚨 **The lesson is the general one:** *"the fix merged" is not "the fix runs."* A guard whose
+> input is never supplied is indistinguishable from a guard that passes. The regression that pins
+> this one is `AdoptedBuildSourceStampTest`, which drives a real bundle through
+> `BundleWriter → BundleReader → ShippedPrebuiltBundles → Seed → the owner's stamp` on a real mesh and
+> asserts all three rows of the table; a unit test over the pure function cannot see any of the four
+> links above.
+
+**Producer and consumer must hash identically, or every good bundle is refused.** That equality is
+pinned by `BakeEquivalenceTest`, which bakes one content set both ways — through a real mesh (whose
+value *is* the consumer-side value) and through the mesh-free tree bake — and asserts the
+fingerprints are equal, non-empty, and different for different types.
+
 #### Two things this deliberately does NOT do
 
-- **Nothing writes a fingerprint into a bundle yet**, so today every adoption reads
-  `AdoptedUnverified`. That is the honest state and the whole visibility win; the refusal row is armed
-  and starts discriminating the day the bake records one, with no further change here.
+- **`@@` includes are outside the fingerprint.** An `@@` include pulls a Code node that no source
+  query matches, so a change to an included-only snippet does not move the hash. That is not a new
+  hole: it is the same set `CompiledSources` records, so `IsDirty` has always missed it too. Closing
+  it means resolving includes on the live side (a mesh read per include) and is tracked separately —
+  but it is stated, because a guard whose coverage is assumed rather than named is exactly how this
+  mechanism went inert the first time.
 - **Refusing to LOAD is the second line of defence.** The damage needs two ingredients — stale bytes
   *and something armed to run them*. A type that renders read-only pages from unverified bytes is a
   degraded system; a type that WRITES from them is the incident. The execute-time interlock is
-  tracked separately, and `BuildProvenance` is what makes it stateable.
+  tracked separately (#2820), and `BuildProvenance` is what makes it stateable.
+
+> `BuildProvenance` is reset to `Compiled` by `ApplyCompileSuccess`: Roslyn built those bytes here,
+> from the source this mesh holds, so nothing about an earlier adoption survives a successful local
+> compile. Without that reset the field was write-once-per-adoption — a type refused as stale and
+> then recompiled kept reading `AdoptionRefused` forever, which turns the operator signal into noise
+> and would make the execute-time interlock refuse a type whose source it had just compiled itself.
+> `ApplyCompileFailure` deliberately does *not* reset it: after a failed compile the bytes in place
+> are still whatever the refusal left, so the refusal is still the true story.
 
 > 🚨 **Do not use `LatestReleasePath` vs the NodeType as a staleness signal.** It lags routinely —
 > a healthy type can serve perfectly with its release pointer several versions behind, and a check of

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-prebuilt-assembly-is-now-checked-against-the-source-you-actually-have.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-prebuilt-assembly-is-now-checked-against-the-source-you-actually-have.md
@@ -1,0 +1,51 @@
+---
+Name: A prebuilt assembly is now checked against the source you actually have
+Category: Fix
+Description: A NodeType could adopt a compiled assembly built from older source and report perfect health while running it; the bundle now records which source it was built from, and a portal refuses bytes that do not match the source it is holding.
+Icon: ShieldCheckmark
+Order: -20260901
+---
+
+# A prebuilt assembly is now checked against the source you actually have
+
+Installing or syncing a package does not usually recompile it. If a bundle already carries a
+compiled assembly for a NodeType, the portal **adopts** those bytes instead of running Roslyn —
+which is why an install takes seconds rather than minutes.
+
+Adoption had no way to tell whether those bytes belonged to the source the mesh was holding. Worse,
+the act of adopting made it *look* as though they did: the two signals an operator is taught to
+check — `compilationStatus: Ok`, and `compiledSources` matching `currentSourceVersions` — are both
+written by the adoption itself. So a sync that pulled a fix and then adopted an assembly built
+before that fix reported success at every step, and the next run executed the old code. On
+30 August that cost four client documents their entire body text; one had no earlier version and
+could not be recovered.
+
+A bundle now records, per assembly, a fingerprint of the source it was compiled from, and the
+owning NodeType compares it against a fingerprint of the source **this** mesh holds:
+
+- **They match** → the assembly is adopted and marked verified. Nothing recompiles; the fast path
+  is exactly as fast as before.
+- **They differ** → the adoption is **refused**. The bytes are not stamped as current, the rejected
+  assembly stops serving, and a real compile of the live source is dispatched. The log names the
+  type and both fingerprints.
+- **The bundle records none** (anything built before this change) → it still adopts, and is marked
+  *unverified* rather than silently treated as checked. Refusing here would recompile everything on
+  every install, and on a deployment that only accepts prebuilt assemblies it would take every such
+  type offline — a bigger outage than the bug.
+
+The result is visible on the NodeType as `buildProvenance`: `Compiled`, `AdoptedVerified`,
+`AdoptedUnverified`, or `AdoptionRefused`. A successful local compile resets it to `Compiled`, so
+the field says what happened to the bytes that are serving right now rather than accumulating
+history.
+
+## Why this is shipping now, and not in August
+
+The comparison above was written in August and was correct. It also never ran. The convenience
+overload both callers used hard-coded the fingerprint to "none", no bake wrote one, and the live
+half was computed only under a condition that the real sequence of events never satisfied. Every
+adoption therefore took the "unknown provenance" branch, and nothing anywhere said so — a guard
+whose input never arrives is indistinguishable from a guard that passes.
+
+All four links are closed and pinned by tests that drive a real bundle through a real mesh, and the
+shortcut that made "unverified" the default answer no longer compiles: a caller that genuinely has
+no fingerprint must now say so explicitly, where a reviewer can see it.

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeAdoptionRegistry.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeAdoptionRegistry.cs
@@ -12,7 +12,7 @@ namespace MeshWeaver.Graph.Configuration;
 ///
 /// <para><b>The race this closes, measured 2026-08-22.</b> Adopting a prebuilt assembly requires
 /// writing the NodeType's node, and that write goes through the type's OWN hub — so
-/// <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> ACTIVATES the hub it is about to stamp. Activation is
+/// <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string}, string)"/> ACTIVATES the hub it is about to stamp. Activation is
 /// exactly what arms the first-build kickoff (<c>CompilationStatus is null</c> + no usable build ⇒
 /// flip Pending), so the seeder's own probe started the very Roslyn compile the adoption exists to
 /// avoid:</para>

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeCompilationHelpers.cs
@@ -1204,7 +1204,16 @@ internal static class NodeTypeCompilationHelpers
                     // The owner has not published its snapshot yet — nothing authoritative to
                     // stamp FROM. The publication itself carries the stamp (InstallSourcesWatcher),
                     // so waiting here costs nothing and guessing here would cost correctness.
-                    && def.CurrentSourceVersions is not null),
+                    && def.CurrentSourceVersions is not null
+                    // 🚨 #2813 — the SAME rule applied to the fingerprint. The stamp request is
+                    // ONE-SHOT, so consuming it while the three-way is unanswerable spends the only
+                    // chance to refuse: the judgement records AdoptedUnverified and nothing ever
+                    // re-opens the question. An adopted fingerprint with no live counterpart yet is
+                    // precisely that state, and it is transient — only the sources watcher holds
+                    // the live source nodes, and its publication both computes the fingerprint and
+                    // carries the stamp. So wait for it here, exactly as we wait for the snapshot.
+                    && (def.AdoptedSourceFingerprint is not { Length: > 0 }
+                        || def.CurrentSourceFingerprint is { Length: > 0 })),
             node =>
             {
                 var observed = (NodeTypeDefinition)node!.Content!;
@@ -1447,34 +1456,56 @@ internal static class NodeTypeCompilationHelpers
                         // is the state a release request reads as dirty and recompiles.
                         var pendingStamp = def.RequestedSourceStampAt is not null;
 
-                        // Idempotent: no-op when CurrentSourceVersions already
-                        // matches the just-computed snapshot. IsDirty is a
-                        // computed property — derives from CurrentSourceVersions
-                        // vs CompiledSources — so no separate flag to write.
-                        // (A pending stamp still has to be consumed, so it never no-ops.)
-                        if (!pendingStamp
-                            && def.CurrentSourceVersions is not null
-                            && DictEquals(def.CurrentSourceVersions, snapshot))
-                            return curr;
-
-                        var updated = def with { CurrentSourceVersions = snapshot };
-
                         // 🚨 #2813 — the live CONTENT fingerprint, computed HERE because this is
                         // the one place that already holds the live source nodes, and written in
                         // the SAME update as the tick snapshot so a reader can never see one
                         // without the other.
                         //
-                        // Computed ONLY when it can be used: a type carrying an adopted
-                        // fingerprint, or a stamp request about to be judged against one. A
-                        // locally-compiled type has nothing to compare against, and hashing every
-                        // source node's serialised content on every source emission — a path that
-                        // today only reads timestamps — would be a real cost for no answer.
-                        if (pendingStamp || def.AdoptedSourceFingerprint is { Length: > 0 })
-                            updated = updated with
-                            {
-                                CurrentSourceFingerprint = PartitionSourceFingerprint.Compute(
-                                    published.Nodes, versioned: false, hub.JsonSerializerOptions),
-                            };
+                        // 🚨 UNCONDITIONALLY, and that is the fix (#2813 second half). It used to
+                        // be computed only when there was already something to compare it against
+                        // ("a pending stamp, or an adopted fingerprint on the node"), and that
+                        // condition is unsatisfiable in the ordering the incident actually took:
+                        // the owner publishes its snapshot FIRST, then the adoption's patch lands
+                        // carrying both the adopted fingerprint and the stamp request — and this
+                        // watcher does NOT re-run, because its DistinctUntilChanged keys on the
+                        // source QUERIES, which did not change. The judgement then read an absent
+                        // live value, took the "inconclusive" branch and degraded to
+                        // AdoptedUnverified. Every stale-adoption refusal was therefore reachable
+                        // only in the other ordering.
+                        //
+                        // The cost that condition was protecting against is gone with the shape:
+                        // NodeTypeSourceFingerprint hashes the compile INPUT (each source node's
+                        // code text), not every node's Content serialised through the hub's
+                        // polymorphic options. It is a SHA-256 over text this branch already holds
+                        // in memory, on a path that runs at hub activation and per source edit —
+                        // i.e. exactly where a Roslyn compile is about to cost four orders of
+                        // magnitude more.
+                        var fingerprint = NodeTypeSourceFingerprint.Compute(
+                            published.Nodes, hubPath, logger);
+
+                        // Idempotent: no-op when CurrentSourceVersions already
+                        // matches the just-computed snapshot. IsDirty is a
+                        // computed property — derives from CurrentSourceVersions
+                        // vs CompiledSources — so no separate flag to write.
+                        // (A pending stamp still has to be consumed, so it never no-ops.)
+                        //
+                        // 🚨 The fingerprint is part of the equality. Without it a node persisted
+                        // before this field existed — snapshot already current, fingerprint null —
+                        // would no-op forever and never acquire one, so the type could never be
+                        // judged again. The condition is what makes the field SELF-HEALING on the
+                        // first activation after an upgrade.
+                        if (!pendingStamp
+                            && def.CurrentSourceVersions is not null
+                            && DictEquals(def.CurrentSourceVersions, snapshot)
+                            && string.Equals(
+                                def.CurrentSourceFingerprint, fingerprint, StringComparison.Ordinal))
+                            return curr;
+
+                        var updated = def with
+                        {
+                            CurrentSourceVersions = snapshot,
+                            CurrentSourceFingerprint = fingerprint,
+                        };
 
                         if (pendingStamp)
                             updated = ApplyAdoptedSourceStampAndReport(updated, snapshot, hub, hubPath, logger);
@@ -1676,8 +1707,18 @@ internal static class NodeTypeCompilationHelpers
                         // reads dirty and recompiles the build that was just adopted. Reading the
                         // owner's own pair here is authoritative, so nothing is widened: the branch
                         // still requires a genuinely non-dirty definition.
+                        //
+                        // 🚨 #2813 — …but ONLY when the three-way can actually be answered. An
+                        // adopted fingerprint whose live counterpart the owner has not published
+                        // yet is inconclusive, and the request is one-shot: fulfilling it here
+                        // would spend the refusal on an absence and record AdoptedUnverified
+                        // permanently. Leaving it standing costs a recompile of a type that may
+                        // have been adoptable — the safe direction, and the one #1834 was
+                        // optimising away, not the one it was preventing.
                         if (def.RequestedSourceStampAt is not null
-                            && def.CurrentSourceVersions is { } liveSources)
+                            && def.CurrentSourceVersions is { } liveSources
+                            && (def.AdoptedSourceFingerprint is not { Length: > 0 }
+                                || def.CurrentSourceFingerprint is { Length: > 0 }))
                             def = ApplyAdoptedSourceStampAndReport(def, liveSources, hub, hubPath, logger);
                         // 🚨 Gate on the CARRIED triggerAt, NOT def.RequestedReleaseAt
                         // (which may have flapped back to an older value). Already
@@ -2314,6 +2355,16 @@ internal static class NodeTypeCompilationHelpers
             CompilationStatus = CompilationStatus.Ok,
             CompilationError = null,
             CompilationDiagnostics = null,
+            // 🚨 #2813 — Roslyn built these bytes HERE, from the source this mesh holds, so the
+            // provenance is Compiled and nothing about an earlier adoption survives. Without this
+            // the field was write-once-per-adoption: a type refused as stale and then successfully
+            // recompiled kept reading AdoptionRefused forever, and one refused adoption in a node's
+            // history would mark it permanently. That turns the operator signal the incident asked
+            // for into noise people learn to ignore, and it would make #2820's execute-time
+            // interlock refuse to run a type whose live source it had just compiled itself.
+            // ApplyCompileFailure deliberately does NOT do this: after a failed compile the bytes
+            // in place are still whatever the refusal left, so the refusal is still the true story.
+            BuildProvenance = Mesh.Services.BuildProvenance.Compiled,
             LastCompileSucceededAt = DateTimeOffset.UtcNow,
             // Stamp LastCompiledVersion to MATCH the version the IAssemblyStore upload used
             // (set by UploadToStoreIfNeeded — the captured node Version at compile kickoff).

--- a/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeDefinition.cs
@@ -496,7 +496,7 @@ public record NodeTypeDefinition
     /// <summary>
     /// A REQUEST to the owning per-NodeType hub: "stamp <see cref="CompiledSources"/> from your own
     /// <see cref="CurrentSourceVersions"/>". Written by
-    /// <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> when it adopts a prebuilt assembly; consumed —
+    /// <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string}, string)"/> when it adopts a prebuilt assembly; consumed —
     /// exactly once — on the owner, which clears it in the same write that applies the stamp.
     ///
     /// <para>🚨 <b>Why the value cannot be written by the adopter</b> (#1834). A bundle's own
@@ -530,7 +530,7 @@ public record NodeTypeDefinition
     /// The source fingerprint the PRODUCER recorded for the adopted bytes — a content hash over
     /// the Code/Test nodes the bundle was compiled from
     /// (<see cref="Mesh.PartitionSourceFingerprint"/>). Written by
-    /// <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> beside <see cref="RequestedSourceStampAt"/>;
+    /// <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string}, string)"/> beside <see cref="RequestedSourceStampAt"/>;
     /// <c>null</c> for a locally-compiled build and for a LEGACY bundle published before producers
     /// recorded one.
     ///

--- a/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Graph/Configuration/PrebuiltAssemblySeeder.cs
@@ -133,7 +133,7 @@ public static class PrebuiltAssemblySeeder
     /// <para>🚨 The counterpart to <see cref="DeclineReason(string?)"/>, and the reason both are
     /// public: <c>DeclineReason</c> answers "must we NOT adopt", this answers "need we adopt at
     /// all". Without it every boot re-adopts every bundle entry it holds — and adoption is not
-    /// cheap bookkeeping: <see cref="Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> opens the type's own mesh-node stream (which ACTIVATES
+    /// cheap bookkeeping: <see cref="Seed(IMessageHub, string, byte[], byte[], string, ILogger, IReadOnlyDictionary{string, string}, string)"/> opens the type's own mesh-node stream (which ACTIVATES
     /// its per-node hub), re-uploads the assembly bytes to the shared store, and writes the node.
     /// Measured on memex-cloud 2026-08-17, that was 43 hub activations, 43 uploads and 43 writes —
     /// <b>13.5 s of a 101 s boot</b> — establishing that nothing had changed since the previous pod
@@ -159,7 +159,7 @@ public static class PrebuiltAssemblySeeder
     /// precisely what the bake would call <see cref="BakeState.Baked"/></b>.</para>
     ///
     /// <para>🚨 Note in particular what this does NOT compare: the NodeType MeshNode's CURRENT
-    /// version. <see cref="Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> uploads and stamps the version it read BEFORE its own write, and
+    /// version. <see cref="Seed(IMessageHub, string, byte[], byte[], string, ILogger, IReadOnlyDictionary{string, string}, string)"/> uploads and stamps the version it read BEFORE its own write, and
     /// that write bumps the node — so after any adoption <c>LastCompiledVersion</c> is permanently
     /// one behind <c>node.Version</c>, and a naive equality check is unsatisfiable. That mismatch
     /// is also why today's unconditional re-adoption uploads the SAME bytes under a NEW store key
@@ -225,26 +225,34 @@ public static class PrebuiltAssemblySeeder
     }
 
     /// <summary>
-    /// Seeds <paramref name="assemblyBytes"/> as the build for <paramref name="nodeTypePath"/>.
+    /// 🚨 <b>THE TRAP-DOOR THAT MADE #2813's CURE INERT. Do not call it; pass the fingerprint.</b>
     ///
-    /// <para>Cold: the write runs on Subscribe. Emits <c>true</c> when the assembly was adopted and
-    /// <c>false</c> when it was declined — a decline is not an error, it is the caller's signal to
-    /// compile normally.</para>
+    /// <para>This overload defaulted <c>sourceFingerprint</c> to null, and BOTH production callers
+    /// bound to it — <c>PluginBundleClient</c> and <c>ShippedPrebuiltBundles</c>. So every adoption
+    /// on every mesh took the legacy "provenance unknown" branch, the three-way comparison in
+    /// <c>NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp</c> could never reach its refusal, and
+    /// the whole mechanism sat armed and dead for months while the code implementing it looked
+    /// finished. A convenience overload whose default answer is "unverified" is not a convenience:
+    /// it is a silent opt-out of a safety check, taken by whoever writes the shortest call.</para>
+    ///
+    /// <para>Passing <c>null</c> is still legitimate — a legacy bundle genuinely records no
+    /// fingerprint — but it must be WRITTEN, at the call site, where a reviewer can see the claim
+    /// being waived. Use the eight-parameter
+    /// <see cref="Seed(IMessageHub, string, byte[], byte[], string, ILogger, IReadOnlyDictionary{string, string}, string)"/>.</para>
+    ///
+    /// <para>🚨 <b>Why this is <c>Obsolete(error)</c> and not DELETED.</b> Deleting a public
+    /// framework method is a breaking change to in-mesh code no compiler can see, and AGENTS.md
+    /// requires sweeping the live mesh before doing it. That sweep could not be completed: content
+    /// indexing is inactive on both reachable deployments (<c>search_chunks</c> answers
+    /// <c>"searched": false</c>, which is a FAILED sweep, not a clean one). Both repos' node trees
+    /// were swept by hand and hold no caller. So the symbol stays — nothing already compiled can
+    /// break — while every source call site fails loudly, at the call, with the reason.</para>
     /// </summary>
-    /// <param name="hub">The calling hub.</param>
-    /// <param name="nodeTypePath">Mesh path of the NodeType this assembly implements.</param>
-    /// <param name="assemblyBytes">The compiled assembly.</param>
-    /// <param name="pdbBytes">Symbols, when the assembly does not embed them.</param>
-    /// <param name="frameworkMvid">The framework build identity the bytes were compiled against,
-    /// as recorded by the producer. <c>null</c> declines the seed.</param>
-    /// <param name="logger">Diagnostics. Every decline is logged with its reason — a silent decline
-    /// looks exactly like a successful adoption that later recompiles for no visible cause.</param>
-    /// <param name="dependencies">The producer's per-type DEPENDENCY RECORD for these bytes
-    /// (#1707 slice 2), when the bundle carries one: validated against THIS environment before
-    /// adoption (a module the type binds must be the exact build here too) and stamped onto
-    /// <see cref="NodeTypeDefinition.CompiledDependencies"/> on adopt so the ongoing validity
-    /// checks judge the adopted build the same way they judge a locally-compiled one. Null =
-    /// legacy bundle; the framework gate alone decides, and no record is stamped.</param>
+    [Obsolete(
+        "#2813: this overload silently adopts prebuilt bytes as UNVERIFIED. Call the eight-parameter "
+        + "Seed and pass the bundle's source fingerprint (BundleReader.Payload.SourceFingerprint), "
+        + "or an explicit null if the bundle genuinely records none.",
+        error: true)]
     public static IObservable<bool> Seed(
         IMessageHub hub,
         string nodeTypePath,
@@ -274,16 +282,18 @@ public static class PrebuiltAssemblySeeder
     /// <param name="dependencies">The producer's per-type dependency record, or <c>null</c> for a
     /// legacy bundle.</param>
     /// <param name="sourceFingerprint">🚨 <b>The producer's CONTENT fingerprint of the sources these
-    /// bytes were built from</b> (#2813) — <see cref="PartitionSourceFingerprint"/> shape. Stamped
-    /// onto the node, where the OWNER compares it against its own live source set before honouring
-    /// the adoption's <c>RequestedSourceStampAt</c>. <c>null</c> for a legacy bundle that records
-    /// none: the adoption still lands, but as <c>BuildProvenance.AdoptedUnverified</c> — never
-    /// silently as verified.
+    /// bytes were built from</b> — <c>NodeTypeSourceFingerprint.Compute</c> shape (#2813), which is
+    /// what <c>BundleReader.Payload.SourceFingerprint</c> carries. Stamped onto the node, where the
+    /// OWNER compares it against its own live source set before honouring the adoption's
+    /// <c>RequestedSourceStampAt</c>. <c>null</c> for a legacy bundle that records none: the
+    /// adoption still lands, but as <c>BuildProvenance.AdoptedUnverified</c> — never silently as
+    /// verified.
     ///
     /// <para>A separate OVERLOAD rather than an eighth optional parameter: the seven-parameter form
-    /// is public surface with shipped callers, and adding an optional parameter to it is a BINARY
-    /// break the compatibility gate is right to refuse. This parameter carries no default, so an
-    /// existing seven-argument call still binds unambiguously to the old form.</para></param>
+    /// is public surface, and adding an optional parameter to it is a BINARY break the compatibility
+    /// gate is right to refuse. This parameter carries no default, so the two forms stay distinct —
+    /// and the seven-argument one is now <c>Obsolete(error)</c>, because a call that silently means
+    /// "unverified" is exactly how the refusal above stayed unreachable.</para></param>
     public static IObservable<bool> Seed(
         IMessageHub hub,
         string nodeTypePath,

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -435,7 +435,7 @@ public static class ShippedPrebuiltBundles
     /// node path and dependency record; the assemblies are the bundle's entire weight. Reading the
     /// manifest alone is enough to answer the whole adoption question, so a bundle whose types are
     /// all current is answered without decompressing a single assembly — on top of the per-type hub
-    /// activation and store upload that <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> would cost.</para>
+    /// activation and store upload that <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string}, string)"/> would cost.</para>
     ///
     /// <para>Emits the tally; folds its own faults to zero.</para>
     /// </summary>
@@ -621,7 +621,12 @@ public static class ShippedPrebuiltBundles
         Action<string>? onCovered = null)
         => assemblies
             .Select(a => PrebuiltAssemblySeeder
-                .Seed(mesh, a.NodePath, a.Assembly, a.Pdb, frameworkMvid, logger, a.Dependencies)
+                // 🚨 #2813 — a.SourceFingerprint is the producer's statement of which sources these
+                // bytes came from; the owning hub compares it against its own live set and refuses
+                // a provably-stale adoption. Null from a legacy bundle, which still adopts (as
+                // AdoptedUnverified).
+                .Seed(mesh, a.NodePath, a.Assembly, a.Pdb, frameworkMvid, logger, a.Dependencies,
+                    a.SourceFingerprint)
                 .Take(1)
                 .Timeout(SeedBudget)
                 .Do(adopted =>

--- a/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleReader.cs
@@ -59,7 +59,17 @@ public static class BundleReader
     /// <param name="Dependencies">The producer's per-type dependency record (#1707 slice 2), or
     /// null for a legacy bundle.</param>
     public sealed record AssemblyRef(
-        string NodePath, string Assembly, IReadOnlyDictionary<string, string>? Dependencies = null);
+        string NodePath, string Assembly, IReadOnlyDictionary<string, string>? Dependencies = null)
+    {
+        /// <summary>
+        /// The producer's CONTENT fingerprint of the sources these bytes were compiled from
+        /// (#2813) — see <see cref="Payload.SourceFingerprint"/>. Null for a legacy bundle.
+        ///
+        /// <para>An INIT property, not a fourth primary-constructor parameter: adding one replaces
+        /// a public record's constructor signature and is a binary break across the fleet.</para>
+        /// </summary>
+        public string? SourceFingerprint { get; init; }
+    }
 
     /// <summary>The bundle's compiled-module declaration.</summary>
     /// <param name="AssemblyName">The module's entry-assembly name WITHOUT extension
@@ -105,7 +115,23 @@ public static class BundleReader
     /// (#1707 slice 2), joined from the manifest, or null for a legacy bundle.</param>
     public sealed record Payload(
         string NodePath, byte[] Assembly, byte[]? Pdb,
-        IReadOnlyDictionary<string, string>? Dependencies = null);
+        IReadOnlyDictionary<string, string>? Dependencies = null)
+    {
+        /// <summary>
+        /// 🚨 <b>The producer's CONTENT fingerprint of the sources these bytes were compiled
+        /// from</b> (#2813), joined from the manifest. A consumer MUST pass it to
+        /// <c>PrebuiltAssemblySeeder.Seed</c>: it is what lets the owning hub compare the bundle's
+        /// source against the source THIS mesh holds and refuse an adoption that would run last
+        /// week's code over today's data.
+        ///
+        /// <para>Null for a legacy bundle whose producer recorded none — that adoption still
+        /// lands, as <c>BuildProvenance.AdoptedUnverified</c>.</para>
+        ///
+        /// <para>An INIT property, not a fifth primary-constructor parameter — see
+        /// <see cref="AssemblyRef.SourceFingerprint"/>.</para>
+        /// </summary>
+        public string? SourceFingerprint { get; init; }
+    }
 
     /// <summary>
     /// Extracts the manifest and every assembly it names.
@@ -174,7 +200,14 @@ public static class BundleReader
 
             payloads.Add(new Payload(
                 reference.NodePath, ReadAll(dll), pdb is null ? null : ReadAll(pdb),
-                reference.Dependencies));
+                reference.Dependencies)
+            {
+                // #2813 — carried, not derived. The manifest is the producer's statement about
+                // which sources these bytes came from; a reader that dropped it would leave every
+                // consumer unable to tell a current adoption from a stale one, which is exactly
+                // the state this mechanism sat in while it looked implemented.
+                SourceFingerprint = reference.SourceFingerprint,
+            });
         }
 
         return (manifest, payloads);

--- a/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
+++ b/src/MeshWeaver.Plugin.Packaging/BundleWriter.cs
@@ -54,7 +54,29 @@ public static class BundleWriter
         Func<Stream> OpenAssembly,
         Func<Stream>? OpenPdb = null,
         IReadOnlyDictionary<string, long>? SourceVersions = null,
-        IReadOnlyDictionary<string, string>? Dependencies = null);
+        IReadOnlyDictionary<string, string>? Dependencies = null)
+    {
+        /// <summary>
+        /// 🚨 <b>The CONTENT fingerprint of the sources these bytes were compiled from</b> (#2813)
+        /// — <c>NodeTypeSourceFingerprint.Compute</c> over the type's resolved source+test set.
+        /// The consumer stamps it as <c>NodeTypeDefinition.AdoptedSourceFingerprint</c> and refuses
+        /// the adoption when its OWN live sources hash to something else: the whole point is that a
+        /// portal can prove the assembly it is about to run was built from the source it is
+        /// holding, which every other signal (<c>compiledSources</c> vs
+        /// <c>currentSourceVersions</c>, <c>compilationStatus: Ok</c>) reported healthy while being
+        /// false.
+        ///
+        /// <para>Null only for a producer that records none. Such a bundle still adopts — as
+        /// <c>BuildProvenance.AdoptedUnverified</c>, never silently as verified — because refusing
+        /// on an absence would park every legacy-bundle type at once.</para>
+        ///
+        /// <para>An INIT property rather than a sixth primary-constructor parameter: adding one to
+        /// a public record REPLACES the constructor signature, which is a binary break for every
+        /// module compiled against the old arity (<c>scripts/check-record-signatures.py</c> is
+        /// right to refuse it) and would take down a mixed fleet on the roll.</para>
+        /// </summary>
+        public string? SourceFingerprint { get; init; }
+    }
 
     /// <summary>
     /// One NODE-DEFINITION file destined for the bundle — the package's own tree (its
@@ -121,6 +143,10 @@ public static class BundleWriter
                     assembly = $"{a.NodePath}.dll",
                     sourceVersions = a.SourceVersions,
                     dependencies = a.Dependencies,
+                    // #2813. Unlike sourceVersions (provenance a reader skips), this one is READ
+                    // by BundleReader and carried to PrebuiltAssemblySeeder — it is the value the
+                    // consumer's refusal is decided on.
+                    sourceFingerprint = a.SourceFingerprint,
                 })
                 .ToList(),
             // DECLARED, never left to be discovered by enumerating the folder — the same rule the

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -525,7 +525,14 @@ public sealed class PluginBundleClient
                 return assemblies
                     .Select(a => PrebuiltAssemblySeeder.Seed(
                         _hub, a.NodePath, a.Assembly, a.Pdb, manifest!.FrameworkMvid, _logger,
-                        a.Dependencies))
+                        a.Dependencies,
+                        // 🚨 #2813 — the producer's source fingerprint, or null from a legacy
+                        // bundle. It is what lets the owning hub REFUSE bytes that were not built
+                        // from the source this mesh holds. Dropping it here is not a degradation
+                        // that shows up anywhere: the adoption still succeeds, the node still reads
+                        // compilationStatus Ok with matching compiledSources, and last week's code
+                        // runs against today's data.
+                        a.SourceFingerprint))
                     .Concat()
                     .Count(adopted => adopted)
                     .Do(count =>

--- a/test/MeshWeaver.PluginCatalog.Test/AdoptedBuildSourceStampTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/AdoptedBuildSourceStampTest.cs
@@ -4,6 +4,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
@@ -11,6 +12,7 @@ using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
+using MeshWeaver.Compiler;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
@@ -197,6 +199,250 @@ public class AdoptedBuildSourceStampTest(ITestOutputHelper output) : MonolithMes
             TryDelete(dir);
         }
     }
+
+    // ══════════════════════════════════════════════════════════════════════════════════════════
+    //  #2813 — THE THREE-WAY, END TO END.
+    //
+    //  The comparison itself is unit-tested in MeshWeaver.Graph.Test (AdoptedBuildProvenanceTest,
+    //  a pure function over a staged definition). What those tests CANNOT see — and what let this
+    //  mechanism ship armed and inert for months — is whether a real bundle's fingerprint ever
+    //  reaches the comparison on a real mesh. It did not: both production callers bound to a
+    //  convenience overload that hard-coded `sourceFingerprint: null`, so every adoption in every
+    //  deployment took the legacy branch and the refusal could not fire. These three tests drive
+    //  the WHOLE path — BundleWriter → BundleReader → ShippedPrebuiltBundles → Seed → the owning
+    //  hub's stamp — and each of them fails if any link drops the value.
+    // ══════════════════════════════════════════════════════════════════════════════════════════
+
+    /// <summary>
+    /// 🚨 <b>THE test for #2813.</b> The bundle states which sources its bytes were built from, and
+    /// they are NOT the ones this mesh holds — the exact shape of the incident: a sync pulled new
+    /// source for <c>Crm/Migration</c>, an assembly built from the PREVIOUS source was adopted over
+    /// it, and the next run executed last week's code and destroyed four client documents.
+    ///
+    /// <para>Asserted on the ONE write that records the refusal, observed through a subscription
+    /// armed BEFORE the seed — a later local compile supersedes that state within seconds, so
+    /// reading the node afterwards would be a race whose green is meaningless.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ABundleBuiltFromDifferentSource_IsRefused()
+    {
+        const string id = "StaleThing";
+        var typePath = $"{TestPartition}/{id}";
+
+        await CreateNodeType(id);
+        await CreateSource(typePath, "model",
+            "public record StaleThing { public string Title { get; init; } = string.Empty; }");
+
+        // What a producer that baked an OLDER revision of this file would have recorded. Computed
+        // with the same public function the bake uses — the point is that it is a HONEST
+        // fingerprint of DIFFERENT source, not a corrupt or random string, because a corrupt value
+        // would be refused for reasons that say nothing about staleness.
+        var staleFingerprint = FingerprintOf(
+            $"{typePath}/Source/model",
+            "public record StaleThing { public string Title { get; init; } = \"last week\"; }");
+
+        var dir = CreateBundleDirectory();
+        var refusal = ObserveDefinition(typePath,
+            d => d.BuildProvenance is BuildProvenance.AdoptionRefused);
+        using var subscription = refusal.Connect();
+        try
+        {
+            WriteBundle(
+                Path.Combine(dir, "shipped.zip"),
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream([0xDE, 0xAD, 0xBE, 0xEF]))
+                {
+                    SourceFingerprint = staleFingerprint,
+                });
+
+            await ShippedPrebuiltBundles.SeedAll(Mesh, dir, null)
+                .FirstAsync()
+                .Await(TestContext.Current.CancellationToken);
+
+            var refused = await refusal.Await(TestContext.Current.CancellationToken);
+
+            refused.AdoptedSourceFingerprint.Should().Be(staleFingerprint,
+                "the bundle's fingerprint must survive the whole transport — writer, reader, Seed "
+                + "— or the comparison is made against nothing and silently degrades to "
+                + "AdoptedUnverified, which is the state this fix exists to leave");
+            refused.CurrentSourceFingerprint.Should().NotBeNullOrEmpty(
+                "the owner must have computed its OWN fingerprint, or the three-way answered its "
+                + "scariest branch on an absence rather than on a comparison");
+            refused.CurrentSourceFingerprint.Should().NotBe(staleFingerprint,
+                "the fixture is only meaningful if the two genuinely differ");
+            refused.CompiledSources.Should().BeNull(
+                "a refused adoption must not stamp CompiledSources — that write is exactly what "
+                + "makes IsDirty false by construction and is precisely the lie that made every "
+                + "health signal report green while stale bytes ran");
+            refused.CompilationStatus.Should().Be(CompilationStatus.Pending,
+                "the refusal must DRIVE a real local compile of the live source, not merely "
+                + "record a complaint");
+            refused.RequestedSourceStampAt.Should().BeNull(
+                "the stamp request is consumed by the refusal so it cannot re-fire");
+        }
+        finally
+        {
+            TryDelete(dir);
+        }
+    }
+
+    /// <summary>
+    /// The other side of the same gate, and the one whose failure would be an OUTAGE rather than a
+    /// bug: a bundle whose fingerprint MATCHES must adopt, be marked verified, and NOT recompile.
+    ///
+    /// <para>If the producer's hash and the consumer's hash disagreed in any way — a serializer
+    /// option, a node property, a shaping rule — every good bundle on every mesh would be refused
+    /// and every portal would recompile everything on every boot. This test is the reason the
+    /// fingerprint is taken over the compile INPUT (path + code text through
+    /// <c>NodeCompileShaping.CollectCompileSources</c>) rather than over the source nodes'
+    /// serialised content.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ABundleBuiltFromTheSameSource_AdoptsAsVerified_AndIsNotRecompiled()
+    {
+        const string id = "VerifiedThing";
+        var typePath = $"{TestPartition}/{id}";
+        const string code =
+            "public record VerifiedThing { public int Answer { get; init; } = 42; }";
+
+        await CreateNodeType(id);
+        await CreateSource(typePath, "model", code);
+
+        var dir = CreateBundleDirectory();
+        try
+        {
+            WriteBundle(
+                Path.Combine(dir, "shipped.zip"),
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream([0x0F, 0xF1, 0xCE]))
+                {
+                    // Computed by the TEST, from the source text alone, exactly as a bake computes
+                    // it from a checkout — never read back off the mesh, which would make the
+                    // assertion circular and prove nothing about cross-process equality.
+                    SourceFingerprint = FingerprintOf($"{typePath}/Source/model", code),
+                });
+
+            var adopted = await ShippedPrebuiltBundles.SeedAll(Mesh, dir, null)
+                .FirstAsync()
+                .Await(TestContext.Current.CancellationToken);
+            adopted.Should().Be(1, "the bundle names a type this mesh holds");
+
+            var def = await AwaitDefinition(typePath,
+                d => d.LatestAssemblyPath is { Length: > 0 }
+                     && d.RequestedSourceStampAt is null
+                     && d.CompiledSources is not null,
+                "the adoption was stamped by the owner");
+
+            def.BuildProvenance.Should().Be(BuildProvenance.AdoptedVerified,
+                "the producer's fingerprint and the owner's own must be EQUAL for identical "
+                + "source — if this is AdoptedUnverified the value never arrived, and if it is "
+                + "AdoptionRefused the two producers hash the same content differently, which "
+                + "would refuse every good bundle in the fleet");
+            def.CompiledSources!.Should().Equal(def.CurrentSourceVersions!,
+                "a verified adoption stamps the owner's live snapshot");
+            def.IsDirty.Should().BeFalse(
+                "a verified adoption is current by construction — reading dirty here means the "
+                + "next release request recompiles the build that was just proven correct");
+            def.CompilationStatus.Should().NotBe(CompilationStatus.Pending,
+                "nothing about a VERIFIED adoption may dispatch a compile");
+        }
+        finally
+        {
+            TryDelete(dir);
+        }
+    }
+
+    /// <summary>
+    /// The LEGACY path, asserted rather than assumed. A bundle from a producer that records no
+    /// fingerprint must still adopt — as <see cref="BuildProvenance.AdoptedUnverified"/>.
+    ///
+    /// <para>🚨 Refusing on an absence is the tempting and wrong answer: it would make every
+    /// legacy-bundle type dirty on arrival, so every install would recompile everything (the 43
+    /// activations / 13.5 s of boot the prebuilt lane exists to remove), and on a
+    /// <c>Modules:RequirePrebuilt</c> mesh — where a local compile is refused by design — it would
+    /// PARK every such type: an outage with no recovery path, self-inflicted by a guard. The
+    /// requirement for an unproven bundle is VISIBILITY, not refusal.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ALegacyBundleWithNoFingerprint_StillAdopts_ButAsUnverified()
+    {
+        const string id = "LegacyThing";
+        var typePath = $"{TestPartition}/{id}";
+
+        await CreateNodeType(id);
+        await CreateSource(typePath, "model",
+            "public record LegacyThing { public string Note { get; init; } = string.Empty; }");
+
+        var dir = CreateBundleDirectory();
+        try
+        {
+            WriteBundle(
+                Path.Combine(dir, "shipped.zip"),
+                PrebuiltAssemblySeeder.LiveFrameworkMvid,
+                // No SourceFingerprint — every bundle produced before #2813 looks exactly like this.
+                new BundleWriter.AssemblyEntry(typePath, () => new MemoryStream([0x11, 0x22, 0x33])));
+
+            var adopted = await ShippedPrebuiltBundles.SeedAll(Mesh, dir, null)
+                .FirstAsync()
+                .Await(TestContext.Current.CancellationToken);
+            adopted.Should().Be(1);
+
+            var def = await AwaitDefinition(typePath,
+                d => d.LatestAssemblyPath is { Length: > 0 }
+                     && d.RequestedSourceStampAt is null
+                     && d.CompiledSources is not null,
+                "the adoption was stamped by the owner");
+
+            def.AdoptedSourceFingerprint.Should().BeNull("the bundle recorded none");
+            def.BuildProvenance.Should().Be(BuildProvenance.AdoptedUnverified,
+                "provenance is UNKNOWN, which is neither a clean bill of health nor a refusal");
+            def.CompiledSources!.Should().Equal(def.CurrentSourceVersions!,
+                "the stamp is KEPT deliberately — withholding it parks every legacy type on a "
+                + "RequirePrebuilt mesh");
+            def.CompilationStatus.Should().NotBe(CompilationStatus.Pending,
+                "an unproven bundle is not a refused one — it must not dispatch a compile");
+        }
+        finally
+        {
+            TryDelete(dir);
+        }
+    }
+
+    /// <summary>
+    /// What a PRODUCER computes for a one-file source set: the same public function the bake calls,
+    /// over a node built the way the tree loader builds one. Deliberately NOT read back off the
+    /// mesh — the whole claim under test is that a process holding only the source TEXT arrives at
+    /// the value a mesh holding the imported NODE arrives at.
+    /// </summary>
+    private static string FingerprintOf(string sourcePath, string code)
+        => NodeTypeSourceFingerprint.Compute(
+            [
+                new MeshNode(
+                    sourcePath[(sourcePath.LastIndexOf('/') + 1)..],
+                    sourcePath[..sourcePath.LastIndexOf('/')])
+                {
+                    NodeType = "Code",
+                    State = MeshNodeState.Active,
+                    Content = new CodeConfiguration { Code = code, Language = "csharp" },
+                },
+            ],
+            sourcePath[..sourcePath.IndexOf("/Source/", StringComparison.Ordinal)]);
+
+    /// <summary>
+    /// A connectable stream of the FIRST definition emission matching <paramref name="predicate"/>,
+    /// so a caller can ARM the observation before the write it is about to trigger. Waiting after
+    /// the fact would miss any state a later write supersedes — and the refusal is exactly such a
+    /// state, since it dispatches the compile that replaces it.
+    /// </summary>
+    private IConnectableObservable<NodeTypeDefinition> ObserveDefinition(
+        string typePath, Func<NodeTypeDefinition, bool> predicate)
+        => Mesh.GetWorkspace().GetMeshNodeStream(typePath)
+            .Select(n => n?.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions))
+            .Where(d => d is not null && predicate(d))
+            .Select(d => d!)
+            .Take(1)
+            .Timeout(TimeSpan.FromSeconds(90))
+            .Replay(1);
 
     private async Task<NodeTypeDefinition> AwaitDefinition(
         string typePath, Func<NodeTypeDefinition, bool> predicate, string because)

--- a/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
+++ b/test/MeshWeaver.PluginCatalog.Test/ShippedPrebuiltBundlesTest.cs
@@ -316,7 +316,7 @@ public class ShippedPrebuiltBundlesTest(ITestOutputHelper output) : MonolithMesh
 
     /// <summary>
     /// One NodeType's files on the assembly store, relative and ordered — the race-free half of
-    /// "did Seed run". <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string})"/> uploads BEFORE it stamps the
+    /// "did Seed run". <see cref="PrebuiltAssemblySeeder.Seed(MeshWeaver.Messaging.IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string}, string)"/> uploads BEFORE it stamps the
     /// record, and the upload is a local filesystem write, so this is settled the moment the
     /// seeding observable emits; the NODE, by contrast, is written through the owner and its
     /// mirror may not have caught up, so a regression could otherwise read as a pass. A

--- a/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
@@ -258,6 +258,26 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
                         meshEntry.SourceVersions.Keys.OrderBy(k => k, StringComparer.Ordinal),
                         treeEntry.SourceVersions.Keys.OrderBy(k => k, StringComparer.Ordinal));
 
+                    // 3b. 🚨 THE SOURCE FINGERPRINT (#2813) — THE equality this whole mechanism
+                    //     rests on. The consumer refuses an adoption whose recorded fingerprint
+                    //     differs from the one ITS OWN hub computes over ITS live sources, so a
+                    //     producer that hashes even slightly differently turns every good bundle
+                    //     into a refusal: a self-inflicted outage strictly worse than the staleness
+                    //     bug. The mesh bake computes it through NodeSources.GetSources on a real
+                    //     workspace — i.e. it IS the consumer-side value — and the tree bake
+                    //     computes it from files with no mesh anywhere. Equal here means a bundle
+                    //     baked by the compiler-driven producer is adoptable as VERIFIED by a mesh
+                    //     holding the same content, which is the claim the fix makes.
+                    Assert.False(
+                        string.IsNullOrEmpty(meshEntry.SourceFingerprint),
+                        $"the mesh bake recorded no source fingerprint for {nodePath} — a bundle "
+                        + "without one adopts as AdoptedUnverified and the staleness refusal can "
+                        + "never fire, which is the exact state #2813 sat in");
+                    Assert.False(
+                        string.IsNullOrEmpty(treeEntry.SourceFingerprint),
+                        $"the compiler-driven bake recorded no source fingerprint for {nodePath}");
+                    Assert.Equal(meshEntry.SourceFingerprint, treeEntry.SourceFingerprint);
+
                     // 4. The per-type DEPENDENCY RECORD — what PrebuiltAssemblySeeder validates
                     //    before adopting. A record that differs is a bundle that declines (or,
                     //    worse, one that adopts against a surface it was not built for).
@@ -290,6 +310,13 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
             Assert.Contains("Helper", thingSurface);
             Assert.Contains("Deep", thingSurface);
             Assert.Contains("ThingTests", thingSurface);
+            // 7a'. …and the fingerprint DISCRIMINATES. Two types with different sources must not
+            //      hash the same, or assertion 3b above is satisfiable by a constant — which is
+            //      exactly the shape of guard #2813 is about (one that cannot fail).
+            Assert.NotEqual(
+                tree.Bundles["Widget"]["Widget/Thing"].SourceFingerprint,
+                tree.Bundles["Lib"]["Lib/Shared"].SourceFingerprint);
+
             // 7b. The @@ include pulled in a Code node NO source query matches — so it is absent
             //     from the resolved set but present in the bytes.
             Assert.DoesNotContain("Widget/Snippets/Greeting", thing.SourceVersions.Keys);
@@ -380,7 +407,8 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
         byte[] Assembly,
         bool HasPdb,
         IReadOnlyDictionary<string, string> Dependencies,
-        IReadOnlyDictionary<string, long> SourceVersions);
+        IReadOnlyDictionary<string, long> SourceVersions,
+        string? SourceFingerprint);
 
     private sealed record BakeDirectory(
         string FrameworkIdentity,
@@ -405,7 +433,11 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
                     p.Pdb is { Length: > 0 },
                     p.Dependencies ?? new Dictionary<string, string>(StringComparer.Ordinal),
                     sourceVersions.GetValueOrDefault(p.NodePath)
-                        ?? new Dictionary<string, long>(StringComparer.Ordinal)),
+                        ?? new Dictionary<string, long>(StringComparer.Ordinal),
+                    // #2813 — read through BundleReader, not off the raw manifest: this is the
+                    // value a real consumer receives, so a reader that dropped it would show up
+                    // here as two nulls comparing equal rather than as a passing test.
+                    p.SourceFingerprint),
                 StringComparer.Ordinal);
         }
         return new BakeDirectory(identity, bundles);

--- a/tools/MeshWeaver.PluginTester/BakeOutput.cs
+++ b/tools/MeshWeaver.PluginTester/BakeOutput.cs
@@ -5,7 +5,6 @@ using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
-using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
@@ -232,11 +231,16 @@ public static class BakeOutput
         IWorkspace workspace, NodeTypeDefinition def, string typePath)
     {
         var access = workspace.Hub.ServiceProvider.GetService<AccessService>();
-        return Observable
-            .Using(
-                () => access?.ImpersonateAsSystem()
-                      ?? System.Reactive.Disposables.Disposable.Empty,
-                _ => NodeSources.GetSources(workspace, def, typePath))
+        // 🚨 RunAsSystem, NEVER Observable.Using(access.ImpersonateAsSystem, …). Impersonation is
+        // an AsyncLocal store/restore pair, and Rx runs Using's resource factory on the SUBSCRIBING
+        // thread while disposing it when the inner observable TERMINATES — a different thread for a
+        // cross-hub read like this one. The subscriber is then left running as System (#1790).
+        // RunAsSystem seals both ends inside the one Subscribe, so the cold read below still issues
+        // impersonated while nothing downstream inherits the identity.
+        // ImpersonationScopeSiteRatchetGuard fails a NEW site carrying the old shape, and this file
+        // is not on its allow list — deliberately, because it is new code.
+        return access
+            .RunAsSystem(() => NodeSources.GetSources(workspace, def, typePath))
             .Take(1)
             .Timeout(ReadBudget)
             .Select(sources => NodeTypeSourceFingerprint.Compute(sources, typePath));

--- a/tools/MeshWeaver.PluginTester/BakeOutput.cs
+++ b/tools/MeshWeaver.PluginTester/BakeOutput.cs
@@ -1,9 +1,11 @@
 using System.Reactive.Linq;
+using MeshWeaver.Compiler;
 using MeshWeaver.Data;
 using MeshWeaver.GitSync;
 using MeshWeaver.Graph;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Mesh.Threading;
 using MeshWeaver.Messaging;
@@ -184,25 +186,61 @@ public static class BakeOutput
                                 $"bake: '{typePath}' claims a usable build at v{version} but the "
                                 + "run's assembly store has NO bytes for it — refusing to write a "
                                 + "bundle that ships less than the gate verdict claims");
-                        // STREAMED, never buffered: the entry carries open-stream FACTORIES, so the
-                        // bytes flow disk → zip inside BundleWriter (which opens and disposes each
-                        // stream per entry) instead of the whole bake's DLL set sitting in byte[]s
-                        // at once — that is the entire point of AssemblyEntry's factory shape.
-                        // The factories run inside the zip-writing InvokeBlocking, on the same
-                        // files pool as this existence probe.
-                        return pool.InvokeBlocking(_ =>
-                        {
-                            var pdbPath = Path.ChangeExtension(dllPath, ".pdb");
-                            var hasPdb = File.Exists(pdbPath);
-                            return new BundleWriter.AssemblyEntry(
-                                typePath,
-                                () => File.OpenRead(dllPath),
-                                hasPdb ? () => File.OpenRead(pdbPath) : null,
-                                def.CompiledSources,
-                                def.CompiledDependencies);
-                        });
+                        // 🚨 #2813 — the CONTENT fingerprint of the sources these bytes came from,
+                        // read through the SAME shared query the runtime's sources watcher reads
+                        // (NodeSources.GetSources, System-scoped for the same reason: source-set
+                        // discovery is framework infrastructure, and a per-user read routes a
+                        // CheckPermission back into the grain being read). Computing it here rather
+                        // than folding def.CompiledSources is the whole point — CompiledSources is
+                        // path→ticks, and ticks are the consumer's install clock, not content.
+                        return SourceFingerprintOf(workspace, def, typePath)
+                            .SelectMany(fingerprint => pool.InvokeBlocking(_ =>
+                            {
+                                // STREAMED, never buffered: the entry carries open-stream
+                                // FACTORIES, so the bytes flow disk → zip inside BundleWriter
+                                // (which opens and disposes each stream per entry) instead of the
+                                // whole bake's DLL set sitting in byte[]s at once — that is the
+                                // entire point of AssemblyEntry's factory shape. The factories run
+                                // inside the zip-writing InvokeBlocking, on the same files pool as
+                                // this existence probe.
+                                var pdbPath = Path.ChangeExtension(dllPath, ".pdb");
+                                var hasPdb = File.Exists(pdbPath);
+                                return new BundleWriter.AssemblyEntry(
+                                    typePath,
+                                    () => File.OpenRead(dllPath),
+                                    hasPdb ? () => File.OpenRead(pdbPath) : null,
+                                    def.CompiledSources,
+                                    def.CompiledDependencies)
+                                {
+                                    SourceFingerprint = fingerprint,
+                                };
+                            }));
                     });
             });
+
+    /// <summary>
+    /// The live source set's fingerprint for one NodeType (#2813) — the mesh-driven producer's half
+    /// of the value a consumer compares against its own.
+    ///
+    /// <para>Reads the CANONICAL shared query rather than re-deriving a source set: this is the
+    /// same <c>Replay(1).RefCount()</c> upstream the owning hub's sources watcher already holds
+    /// open, so the value computed here is by construction the value THAT hub computes into
+    /// <c>NodeTypeDefinition.CurrentSourceFingerprint</c>. <c>BakeEquivalenceTest</c> is what pins
+    /// the compiler-driven bake to it.</para>
+    /// </summary>
+    private static IObservable<string> SourceFingerprintOf(
+        IWorkspace workspace, NodeTypeDefinition def, string typePath)
+    {
+        var access = workspace.Hub.ServiceProvider.GetService<AccessService>();
+        return Observable
+            .Using(
+                () => access?.ImpersonateAsSystem()
+                      ?? System.Reactive.Disposables.Disposable.Empty,
+                _ => NodeSources.GetSources(workspace, def, typePath))
+            .Take(1)
+            .Timeout(ReadBudget)
+            .Select(sources => NodeTypeSourceFingerprint.Compute(sources, typePath));
+    }
 
     /// <summary>Package ids are top-level folder names, but the bundle FILE name must be safe on
     /// every filesystem the artifact travels through.</summary>

--- a/tools/MeshWeaver.PluginTester/CascadeBuild.cs
+++ b/tools/MeshWeaver.PluginTester/CascadeBuild.cs
@@ -459,7 +459,16 @@ public static class CascadeBuild
                     () => File.OpenRead(compiled.DllPath),
                     compiled.PdbPath is null ? null : () => File.OpenRead(compiled.PdbPath),
                     sourceVersions,
-                    compiled.Dependencies));
+                    compiled.Dependencies)
+                {
+                    // 🚨 #2813 — the CONTENT fingerprint of the sources this compile consumed, so
+                    // the consumer can prove the bytes match the source IT holds instead of taking
+                    // the bundle's word for it. Over the RAW resolved set, exactly as the runtime's
+                    // sources watcher does: NodeTypeSourceFingerprint applies the shaping fold
+                    // itself so the two callers cannot apply different ones.
+                    SourceFingerprint = NodeTypeSourceFingerprint.Compute(
+                        resolution.Sources, candidate.Node.Path, options.Logger),
+                });
             }
 
             StaticTestRunner.Run? tests = null;

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -378,7 +378,17 @@ public static class TreeBake
                     () => File.OpenRead(compiled.DllPath),
                     compiled.PdbPath is null ? null : () => File.OpenRead(compiled.PdbPath),
                     sourceVersions,
-                    compiled.Dependencies));
+                    compiled.Dependencies)
+                {
+                    // 🚨 #2813 — the CONTENT fingerprint of the sources this compile consumed.
+                    // `sourceVersions` above is provenance a reader SKIPS (its values are zeros);
+                    // this is the value the consumer's adoption is decided on, and it is taken over
+                    // the same RAW resolved set for the same reason: NodeTypeSourceFingerprint
+                    // applies the shaping fold, so the bake and the runtime cannot fork on which
+                    // files count.
+                    SourceFingerprint = NodeTypeSourceFingerprint.Compute(
+                        resolution.Sources, candidate.Node.Path, options.Logger),
+                });
 
                 results.Add(new TypeResult(
                     compiled.NodePath, candidate.Package, null, compiled.Inputs.MatchedSourcePaths));


### PR DESCRIPTION
## The refusal built by #2821 has never fired

#2821 shipped the three-way comparison that refuses a prebuilt assembly whose recorded source
disagrees with the source the mesh holds, and #2820 records the consequence in one line: *"Today
every adoption reads `AdoptedUnverified`, because nothing writes a source fingerprint into a bundle
yet."*

It was worse than that. **Four** links were missing between a bundle and that comparison, and every
one of them fails silently — a guard whose input never arrives is indistinguishable from a guard
that passes:

1. `PrebuiltAssemblySeeder.Seed` had a seven-parameter convenience overload that hard-coded
   `sourceFingerprint: null`, and **both** production callers bound to it (`PluginBundleClient`,
   `ShippedPrebuiltBundles`). `AdoptedSourceFingerprint` was therefore never written and the first
   guard in `ApplyAdoptedSourceStamp` short-circuited.
2. No producer wrote a fingerprint into a bundle at all.
3. `BundleReader` had nowhere to carry one.
4. **The live half was computed only under a condition the incident's own ordering never
   satisfies.** The owner computed `CurrentSourceFingerprint` only "when there is something to
   compare it against". But the owner publishes its snapshot *first*; the adoption's patch then
   lands carrying both the fingerprint and the stamp request, and the sources watcher does **not**
   re-run — its `DistinctUntilChanged` keys on the source *queries*, which did not change. The
   judgement then read an absent live value and took the inconclusive branch. So even with links
   1–3 closed, the refusal would still not have fired in the ordering that destroyed the documents.

All four are closed, and the refusal now fires end to end.

## The load-bearing decision: what is hashed

Producer and consumer must hash **identically**, or every good bundle is refused — a self-inflicted
outage strictly worse than the staleness bug. The new `NodeTypeSourceFingerprint` hashes the
**compile input**: the `NodeCompileShaping.CollectCompileSources` fold — the same call both the
runtime compile path and the tree bake already make, so they cannot fork on which files count —
reduced to `(node path, SHA-256 of the code text)` and folded with `PartitionSourceFingerprint`
(which sorts by path, so enumeration order cannot reach the result).

It lives in `MeshWeaver.Compiler` because `FrameworkBuildIdentity.FullMvidAssemblies` is that
assembly's transitive closure, and adoption is *already* gated on framework identity — so a producer
and a consumer that can adopt across each other necessarily run the same implementation of the hash.

**Hashing the source nodes' serialised content — what the live half did — cannot work across
processes, and each failure mode is a FALSE REFUSAL:**

- `CodeConfiguration` carries run bookkeeping (`LastExecutedAt`, `LastExecutedBy`,
  `LastExecutedCodeHash`, `LastActivityPath`) written when a reader presses **Run** on a code cell.
  The live hash would move with no source change, and no producer can know those values.
- The consumer has a hub and therefore a TypeRegistry (polymorphic `$type`); the compiler-driven
  bake deliberately has neither — `TreeNodeLoader` materialises exactly the two content types a
  compile reads and leaves the rest null, precisely so a half-populated registry cannot degrade
  content to `JsonElement`. Two honest readers, two different JSON strings.
- Node metadata (description, icon, order) is not compile input.

## Also fixed

`ApplyCompileSuccess` never reset `BuildProvenance`, so a type refused as stale and then
**successfully recompiled** kept reading `AdoptionRefused` forever. One refusal in a node's history
would have marked it permanently — turning the operator signal the incident asked for into noise,
and making #2820's execute-time interlock refuse a type whose live source it had just compiled
itself. `ApplyCompileFailure` deliberately still does not reset it.

## The obsolete overload, and why it is not deleted

AGENTS.md requires sweeping the live mesh before removing public framework surface. **That sweep
could not be completed**: `search_chunks` answers `"searched": false` on both reachable deployments
(content indexing inactive) — a FAILED sweep, not a clean one. Both repos' node trees were swept by
hand and hold no caller.

So the seven-parameter overload is `[Obsolete(error: true)]` rather than deleted: the symbol stays,
nothing already compiled can break, and every *source* call site now fails loudly with the reason.
Passing `null` remains legitimate for a genuinely legacy bundle — but it must be written at the call
site, where a reviewer can see the claim being waived.

## Verification — every new test was proven able to fail

Each inversion was applied, built, run, and restored:

| inversion | expected | observed |
|---|---|---|
| consumer passes `null` (i.e. restore the exact defect) | refusal + verified tests red, legacy green | ✅ refusal test red at 90 s timeout; verified test red with `AdoptedUnverified`; legacy green |
| salt one side's hash (producer ≠ consumer) | verified test red, equivalence test red | ✅ verified test red with `Compiled` (refused → recompiled); `BakeEquivalenceTest` red, "Strings differ" |
| legacy branch claims `AdoptedVerified` | legacy test red, alone | ✅ legacy test red, 1 of 5 |

Green after restore, and:

- `MeshWeaver.Graph.Test` — **1607/1607**
- `AdoptedBuildSourceStampTest` — 5/5, three of them new, each driving a real bundle through
  `BundleWriter → BundleReader → ShippedPrebuiltBundles → Seed → the owner's stamp` on a real mesh
- `BakeEquivalenceTest` — bakes one content set **both ways** (through a real mesh, whose value *is*
  the consumer-side value, and through the mesh-free tree bake) and asserts the fingerprints are
  equal, non-empty, and different for different types. This is the equality proof; without it the
  fix would be an outage.
- `scripts/check-record-signatures.py` and `scripts/check-type-forwards.py` both clean (the new
  fields are **init properties**, never primary-constructor parameters — adding one is a binary
  break across a mixed fleet).
- Every touched project built `-c Release -warnaserror`, one per invocation, `0 Error(s)`.

## Stated residue

An `@@` include pulls a Code node no source query matches, so it is outside the fold and a change to
an included-only snippet does not move the fingerprint. **This is not new** — it is the same set
`CompiledSources` records, so `IsDirty` has always missed it too. Closing it means resolving
includes on the live side (a mesh read per include). It is named in the doc and in the code rather
than left implied, because a guard whose coverage is assumed is exactly how this mechanism went
inert the first time.

## Docs

`Doc/Architecture/NodeTypeCompilation` documented the three-way as if it were live. It now states
what actually reaches the comparison, why the fingerprint shape is what it is, and the general
lesson: **"the fix merged" is not "the fix runs."** Plus a What's New entry (`Category: Fix`).

Closes #2813

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Kwar1ZGt5FMEpHiXmkzKCm
