### PR TITLE
fix(mesh): ONE static-node precedence rule — the query seam and hub activation no longer disagree (#2908)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticNodeProviders.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticNodeProviders.md
@@ -92,6 +92,77 @@ foreach (var node in serviceProvider.EnumerateStaticNodes()) { … }
 
 `StaticMeshNodeListProvider.GetStaticNodes()` applies the same `GroupBy(Path).Last()` de-dup the old dictionary used at build time. The semantic is preserved — just deferred to iteration.
 
+## 🚨 One path, one static node — the precedence rule
+
+More than one contributor can offer a node at the same path: a host calls `AddMeshNodes` for a path
+a platform provider already claims, or a node type registers its declaration twice (several do, on
+purpose — `AddPartitionType` seeds `CreateMeshNode()` *and* registers a provider that yields it
+again). Something has to decide who wins, and **every reader has to decide it the same way**.
+
+There is exactly one rule, implemented once, in
+`StaticNodeProviderExtensions.ResolveStaticNodes(providers)`:
+
+1. the `MeshBuilder.AddMeshNodes(...)` **seed wins every tie** — it is the host's own declaration,
+   and it is the bucket that carries registration-node semantics (suppressed under `context:search`
+   / `is:content`) at the query seam;
+2. among the remaining providers, **first registered wins**;
+3. within one provider, its own `GetStaticNodes()` order decides (the seed provider applies
+   last-write-wins by path before it yields).
+
+A **definition-only** entry still *claims* its path — it is not skipped in favour of a
+lower-precedence provider's served node. The host declared that path DB-backed; a second provider
+must not win it back. `FindServedStaticNode` takes the winner first and applies the
+`IsDefinitionOnly` test second, in that order.
+
+Both readers of "which static node is at this path" call that one resolution:
+`StaticNodeQueryProvider` (queries, autocomplete) and `FindStaticNode` /
+`FindServedStaticNode` (hub activation via `MeshDataSource.WithMeshNodes`, the create path's
+already-exists check, the persistence-sampler gate, the plugin installer's pre-flight).
+
+### Why this is a rule and not a detail
+
+They used to differ. The query provider gave the seed priority and excluded every other provider's
+node at a seed-claimed path; `FindServedStaticNode` took a bare `FirstOrDefault` **in DI-registration
+order**. Registration order is not something a host controls — a provider registered by
+`AddPersistence` lands before the mesh builder's own deferred registrations — so appending a second
+static node at a platform seed's path was **served by one reader and not the other, in one live
+process**:
+
+| reader | served |
+|---|---|
+| `StaticNodeQueryProvider` | the appended node |
+| `POST /api/mesh/get` → hub activation → `FindServedStaticNode` | the platform's node |
+
+Nothing errored. No warning, no ambiguity diagnostic, no last-one-wins log. The path simply resolved
+to different content depending on which way you arrived at it, and it made "override a platform
+default by appending a node at its path" look like a supported pattern — the append was accepted, so
+the natural conclusion was that it had worked (#2908).
+
+### A contested path is loud
+
+Overriding another contributor's node by adding a second one at its path is **not supported**, so a
+duplicate registration says so:
+
+```csharp
+// One line per path claimed by more than one provider WITH DIFFERENT CONTENT.
+foreach (var line in serviceProvider.DescribeStaticProviderCollisions())
+    logger.LogWarning(line);
+```
+
+`StaticNodeQueryProvider` runs this once per mesh at construction and logs each line as a warning
+naming the contested path, the winner, and the claimant that is being dropped.
+`DescribeStaticServeCollision(path)` carries the same detail, so a create refused at that path names
+it too.
+
+The comparison is **content**, not claim count: two claimants offering byte-identical declarations
+are redundant, not a dropped contribution, and warning on those would fire for every built-in type
+and be ignored within a week. Equality is
+`PartitionSourceFingerprint.ComputeNodeToken` — the repo's deterministic per-node source token,
+which excludes the un-serialisable `HubConfiguration` delegate (two calls to one factory produce
+different delegates and would otherwise never compare equal).
+
+Regression guard: `test/MeshWeaver.Hosting.Test/StaticNodePrecedenceTest.cs`.
+
 ## Adding a new built-in node
 
 Two paths are available, and the right choice depends on complexity:

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-built-in-path-resolves-to-one-node-no-matter-who-asks.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-built-in-path-resolves-to-one-node-no-matter-who-asks.md
@@ -1,0 +1,33 @@
+---
+Name: A built-in path resolves to one node, no matter who asks
+Category: Fix
+Description: Two parts of the platform could serve different content for the same built-in path, silently. They now share one rule — and a duplicate registration says so instead of being half-honoured.
+Icon: Sparkle
+Order: -20260901
+---
+
+# A built-in path resolves to one node, no matter who asks
+
+Some content is built into the platform rather than stored: node-type declarations, the built-in
+roles, the partition entries, the shipped documentation. A deployment can add its own, and more than
+one contributor can end up offering something at the same address.
+
+Two parts of the platform resolved that differently. Search and autocomplete picked one; opening the
+address directly picked the other. In one running portal, the same address returned **different
+content depending on how you got to it** — and nothing said so. No error, no warning, nothing in the
+log. It also made "add my own version at the platform's address to override it" look like a
+supported way to customise a deployment: the addition was accepted, so the obvious conclusion was
+that it had worked, when in fact it had worked in one place and not the other.
+
+Both now use one rule, in one place, so the two can no longer drift apart: the deployment's own
+declaration wins, then contributors in the order they were registered. An address a deployment has
+deliberately handed to the database stays handed over — no contributor can quietly take it back.
+
+And a genuine clash is now **loud**. When two contributors offer *different* content at one address,
+the portal logs a warning at start-up naming the address, which one won and which one was dropped,
+and the refusal you get when something else tries to occupy that address says the same. Contributors
+offering the *same* declaration twice — which several built-in types do on purpose — stay silent, so
+the warning means something when you see it.
+
+Overriding a built-in by adding a second entry at its address is not a supported customisation. Give
+your own declaration its own address, or remove the one it was competing with.

--- a/src/MeshWeaver.Hosting/Persistence/Query/StaticNodeQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StaticNodeQueryProvider.cs
@@ -74,7 +74,11 @@ public class StaticNodeQueryProvider : IMeshQueryProvider
     /// </summary>
     /// <param name="providers">The static node providers (built-in roles, type definitions, etc.).</param>
     /// <param name="matches">Predicate deciding whether a scoped query's namespaces are owned by this provider.</param>
-    /// <param name="meshConfiguration">Optional mesh configuration supplying seed (<c>AddMeshNodes</c>) nodes and context-exclusion rules; may be <see langword="null"/>.</param>
+    /// <param name="meshConfiguration">Optional mesh configuration supplying the autocomplete /
+    /// context-exclusion rules; may be <see langword="null"/>. The seed (<c>AddMeshNodes</c>) nodes
+    /// come from <paramref name="providers"/> — <c>MeshBuilder</c> registers them as an
+    /// <see cref="IStaticNodeProvider"/> — so ONE resolution decides who serves a contested path
+    /// (<c>StaticNodeProviderExtensions.ResolveStaticNodes</c>, MeshWeaver#2908).</param>
     /// <param name="loggerFactory">Optional logger factory; diagnostics are suppressed when <see langword="null"/>.</param>
     public StaticNodeQueryProvider(
         IEnumerable<IStaticNodeProvider> providers,
@@ -88,28 +92,28 @@ public class StaticNodeQueryProvider : IMeshQueryProvider
 
         var providerList = providers as IList<IStaticNodeProvider> ?? providers.ToList();
 
-        // MeshConfiguration.Nodes (AddMeshNodes seed) wins the "config" bucket —
-        // bridge providers like MeshConfigurationStaticNodeProvider re-emit those
-        // same nodes via IStaticNodeProvider, but they retain config-node
-        // semantics (search-context excluded). Without this priority, the
-        // bridged config nodes leak through QueryAsync's _providerNodes path
-        // which has no isSearch guard (caught by
+        // 🚨 The AddMeshNodes-seed-wins rule is NOT implemented here. It lives in
+        // StaticNodeProviderExtensions.ResolveStaticNodeBuckets, which is also what
+        // FindServedStaticNode / FindStaticNode resolve through — that shared call is the whole
+        // point (MeshWeaver#2908): a second static node at a path another contributor already
+        // claimed used to be served by this reader and NOT by hub activation's, silently, because
+        // each seam applied its own rule. The buckets stay separate because the two are treated
+        // differently BELOW (seed nodes are registration declarations, suppressed under
+        // context:search / is:content); who WINS a contested path is decided in one place.
+        //
+        // Seed priority also keeps a bridged copy of a seed node out of the provider bucket, which
+        // has no isSearch guard (caught by
         // StaticNodeQueryContextTests.SearchContext_ExcludesStaticNodes).
-        var configPaths = new HashSet<string>(
-            ((meshConfiguration?.AddMeshNodesList ?? Enumerable.Empty<MeshNode>()))
-                .Select(n => n.Path)
-                .Where(p => !string.IsNullOrEmpty(p)),
-            StringComparer.OrdinalIgnoreCase);
+        var (seedNodes, providedNodes) =
+            StaticNodeProviderExtensions.ResolveStaticNodeBuckets(providerList);
 
-        _providerNodes = providerList
-            .SelectMany(p => p.GetStaticNodes())
-            // Definition-only nodes (a DB-synced NodeType catalog's in-memory type-def) are NOT
-            // queryable — Postgres owns the runtime node at their path. Excluding them keeps the
-            // bare partition path (e.g. path:Harness) resolving to exactly the PG nodeType:NodeType
-            // root, with no second claimant. See Doc/Architecture/NodeTypeCatalogs.md.
-            .Where(n => !n.IsDefinitionOnly)
-            .Where(n => !configPaths.Contains(n.Path))
-            .ToArray();
+        // Definition-only nodes (a DB-synced NodeType catalog's in-memory type-def) are NOT
+        // queryable — Postgres owns the runtime node at their path. Excluding them keeps the
+        // bare partition path (e.g. path:Harness) resolving to exactly the PG nodeType:NodeType
+        // root, with no second claimant. They still CLAIMED their path in the resolution above,
+        // so no lower-precedence provider slips a served node underneath them.
+        // See Doc/Architecture/NodeTypeCatalogs.md.
+        _providerNodes = providedNodes.Where(n => !n.IsDefinitionOnly).ToArray();
         _logger?.LogDebug(
             "[StaticNodeQueryProvider] ctor: {Providers} provider(s) -> {Count} nodes; byType=[{ByType}]; byNamespace(top)=[{ByNs}]",
             providerList.Count,
@@ -117,10 +121,17 @@ public class StaticNodeQueryProvider : IMeshQueryProvider
             string.Join(", ", _providerNodes.GroupBy(n => n.NodeType ?? "(null)").Select(g => $"{g.Key}={g.Count()}")),
             string.Join(", ", _providerNodes.GroupBy(n => n.Namespace ?? "(null)").OrderByDescending(g => g.Count()).Take(5).Select(g => $"{g.Key}={g.Count()}")));
 
-        _configNodes = ((meshConfiguration?.AddMeshNodesList ?? Enumerable.Empty<MeshNode>()))
-            // See _providerNodes: a definition-only catalog type-def is never a query result.
-            .Where(n => !n.IsDefinitionOnly)
-            .ToArray();
+        // See _providerNodes: a definition-only catalog type-def is never a query result.
+        _configNodes = seedNodes.Where(n => !n.IsDefinitionOnly).ToArray();
+
+        // 🚨 LOUD, once per mesh: two providers claiming one path with DIFFERENT content means one
+        // of them is being dropped. Registration order is not something a host controls, so
+        // "append a node at the platform's path to override it" is not a supported pattern — and
+        // before this warning existed it looked like one, because the append was accepted and only
+        // half-honoured (MeshWeaver#2908).
+        if (_logger is not null)
+            foreach (var collision in StaticNodeProviderExtensions.DescribeStaticProviderCollisions(providerList))
+                _logger.LogWarning("[StaticNodeQueryProvider] {Collision}", collision);
 
         _allNodes = _providerNodes.Concat(_configNodes).ToArray();
 

--- a/src/MeshWeaver.Mesh.Contract/Services/StaticNodeProviderExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/StaticNodeProviderExtensions.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.Mesh.Services;
@@ -8,31 +9,151 @@ namespace MeshWeaver.Mesh.Services;
 /// callers iterate the providers directly so any source of static nodes
 /// (built-in NodeTypes, per-organization providers, etc.) is consulted
 /// uniformly.
+///
+/// <para>🚨 <b>Every "which static node is at this path" question is answered by
+/// <see cref="ResolveStaticNodes"/> and nothing else.</b> Two readers of the same path used to
+/// implement their own resolution — <c>StaticNodeQueryProvider</c> gave the <c>AddMeshNodes</c>
+/// seed priority and excluded any other provider's node at a seed-claimed path, while
+/// <see cref="FindServedStaticNode"/> took a bare <c>FirstOrDefault</c> in DI-registration order.
+/// Registration order is not a property a host controls (a provider added by
+/// <c>AddPersistence</c> lands before the builder's own deferred registrations), so a second
+/// static node at a platform seed's path was served by one reader and not the other, with no
+/// error, no warning and no ambiguity diagnostic — the path simply resolved to different content
+/// depending on which way you arrived at it (MeshWeaver#2908). One rule, one implementation, both
+/// readers.</para>
 /// </summary>
 public static class StaticNodeProviderExtensions
 {
     /// <summary>
-    /// Enumerates every static <see cref="MeshNode"/> across every registered
-    /// <see cref="IStaticNodeProvider"/>. Order is not specified; callers
-    /// that need deterministic results should sort.
+    /// 🚨 <b>THE static-node precedence rule.</b> Flattens every registered
+    /// <see cref="IStaticNodeProvider"/> into <b>at most one node per path</b>:
+    ///
+    /// <list type="number">
+    ///   <item>the <c>MeshBuilder.AddMeshNodes(...)</c> <b>seed</b> wins every tie — it is the
+    ///     host's own declaration, and it is the bucket that carries config-node semantics
+    ///     (search-context exclusion) at the query seam, so a bridged copy emitted by another
+    ///     provider must never stand in for it;</item>
+    ///   <item>among the remaining providers, <b>first registered wins</b>;</item>
+    ///   <item>within one provider, its own <see cref="IStaticNodeProvider.GetStaticNodes"/> order
+    ///     decides (the seed provider applies last-write-wins by path before it yields).</item>
+    /// </list>
+    ///
+    /// <para>Definition-only entries are NOT filtered here: they still CLAIM their path (Postgres
+    /// owns the runtime node there, and a second provider must not sneak a served node underneath
+    /// a path the host declared DB-backed). <see cref="FindServedStaticNode"/> applies the
+    /// served/definition-only distinction on top of this resolution.</para>
+    ///
+    /// <para>Lazy on purpose — a <c>FirstOrDefault</c> over the result short-circuits, and the seed
+    /// (where nearly every <see cref="FindStaticNode"/> lookup lands) is walked first.</para>
     /// </summary>
-    public static IEnumerable<MeshNode> EnumerateStaticNodes(this IServiceProvider serviceProvider) =>
-        serviceProvider.GetServices<IStaticNodeProvider>().SelectMany(p => p.GetStaticNodes());
+    /// <param name="providers">The registered static node providers, in DI-registration order.</param>
+    /// <returns>Every static node, seed first, deduplicated by path (case-insensitive).</returns>
+    public static IEnumerable<MeshNode> ResolveStaticNodes(IEnumerable<IStaticNodeProvider> providers)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+        return Iterate(OrderByPrecedence(providers));
+
+        static IEnumerable<MeshNode> Iterate(IReadOnlyList<IStaticNodeProvider> ordered)
+        {
+            var claimed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var provider in ordered)
+            foreach (var node in provider.GetStaticNodes())
+            {
+                // A pathless node cannot be de-duplicated by path; it is passed through so this
+                // resolution can never silently DROP a contribution it has no key for.
+                if (string.IsNullOrEmpty(node.Path) || claimed.Add(node.Path))
+                    yield return node;
+            }
+        }
+    }
 
     /// <summary>
-    /// First static node whose <see cref="MeshNode.Path"/> matches
-    /// <paramref name="path"/> (case-insensitive). Returns null when no
-    /// provider offers a matching node.
+    /// The same resolution as <see cref="ResolveStaticNodes"/>, kept in its two buckets because the
+    /// query seam treats them differently: seed (<c>AddMeshNodes</c>) nodes are registration
+    /// declarations and are suppressed under <c>context:search</c> / <c>is:content</c>, while other
+    /// providers' nodes are not. Splitting here rather than at the query provider is what keeps
+    /// "who wins a contested path" from having a second implementation.
+    /// </summary>
+    internal static (IReadOnlyList<MeshNode> Seed, IReadOnlyList<MeshNode> Provided)
+        ResolveStaticNodeBuckets(IEnumerable<IStaticNodeProvider> providers)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+        var ordered = OrderByPrecedence(providers);
+        var claimed = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seed = new List<MeshNode>();
+        var provided = new List<MeshNode>();
+        foreach (var provider in ordered)
+        {
+            var bucket = IsSeedProvider(provider) ? seed : provided;
+            foreach (var node in provider.GetStaticNodes())
+                if (string.IsNullOrEmpty(node.Path) || claimed.Add(node.Path))
+                    bucket.Add(node);
+        }
+        return (seed, provided);
+    }
+
+    /// <summary>
+    /// Seed providers first, everything else in registration order — a STABLE partition, so a
+    /// host's registration order still decides among equals.
+    /// </summary>
+    private static IReadOnlyList<IStaticNodeProvider> OrderByPrecedence(
+        IEnumerable<IStaticNodeProvider> providers)
+    {
+        var list = providers as IReadOnlyList<IStaticNodeProvider> ?? providers.ToArray();
+        var seedCount = 0;
+        for (var i = 0; i < list.Count; i++)
+            if (IsSeedProvider(list[i]))
+                seedCount++;
+        // Nothing to reorder when the seed is absent, alone, or already the whole set.
+        if (seedCount == 0 || seedCount == list.Count)
+            return list;
+        var ordered = new List<IStaticNodeProvider>(list.Count);
+        foreach (var provider in list)
+            if (IsSeedProvider(provider))
+                ordered.Add(provider);
+        foreach (var provider in list)
+            if (!IsSeedProvider(provider))
+                ordered.Add(provider);
+        return ordered;
+    }
+
+    /// <summary>
+    /// The <c>MeshBuilder.AddMeshNodes(...)</c> seed — registered by <c>MeshBuilder.Register()</c>
+    /// as <c>StaticMeshNodeListProvider</c>. Type identity, not registration position: the
+    /// position is exactly what a host cannot control.
+    /// </summary>
+    internal static bool IsSeedProvider(IStaticNodeProvider provider) =>
+        provider is StaticMeshNodeListProvider;
+
+    /// <summary>
+    /// The display name for a provider in a diagnostic. The <c>AddMeshNodes</c> seed is by far the
+    /// most common claimant (every built-in NodeType declaration sits at a top-level path); name
+    /// the CALL, not the internal wrapper type.
+    /// </summary>
+    private static string ProviderName(IStaticNodeProvider provider) =>
+        IsSeedProvider(provider) ? "MeshBuilder.AddMeshNodes" : provider.GetType().Name;
+
+    /// <summary>
+    /// Enumerates every static <see cref="MeshNode"/> across every registered
+    /// <see cref="IStaticNodeProvider"/>, resolved by <see cref="ResolveStaticNodes"/> — seed
+    /// first, at most one node per path.
+    /// </summary>
+    public static IEnumerable<MeshNode> EnumerateStaticNodes(this IServiceProvider serviceProvider) =>
+        ResolveStaticNodes(serviceProvider.GetServices<IStaticNodeProvider>());
+
+    /// <summary>
+    /// The static node at <paramref name="path"/> (case-insensitive), or null when no provider
+    /// offers one. Resolution is <see cref="ResolveStaticNodes"/>'s, so this agrees with the query
+    /// seam by construction.
     /// </summary>
     public static MeshNode? FindStaticNode(this IServiceProvider serviceProvider, string path) =>
         serviceProvider.EnumerateStaticNodes()
             .FirstOrDefault(n => string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
-    /// The static node genuinely <b>SERVED</b> at <paramref name="path"/>: the first
-    /// non-<see cref="MeshNode.IsDefinitionOnly"/> static node across every registered
-    /// <see cref="IStaticNodeProvider"/> whose <see cref="MeshNode.Path"/> matches
-    /// (case-insensitive), or <c>null</c>.
+    /// The static node genuinely <b>SERVED</b> at <paramref name="path"/>: the
+    /// <see cref="ResolveStaticNodes"/> winner for that path when it is not
+    /// <see cref="MeshNode.IsDefinitionOnly"/>, else <c>null</c>.
     ///
     /// <para>Definition-only entries are skipped deliberately: a DB-synced NodeType catalog's
     /// in-memory type-def supplies its <c>HubConfiguration</c> BY NAME but is NOT the runtime node
@@ -42,39 +163,146 @@ public static class StaticNodeProviderExtensions
     /// persistence-sampler gate, the create path's already-exists check, and the plugin installer's
     /// shadowing pre-flight. Keeping them on one lookup is what guarantees "served static" ⇔ "not
     /// persistence-backed" can never drift apart.</para>
+    ///
+    /// <para>🚨 The winner is taken FIRST and the definition-only test applied SECOND, never the
+    /// other way round: a path the host declared DB-backed must resolve to "nothing static serves
+    /// this" even when a lower-precedence provider still offers a served node there. Scanning for
+    /// "the first served node" instead would let that provider's node win a path the seed had
+    /// deliberately handed to Postgres — the divergence in MeshWeaver#2908.</para>
     /// </summary>
     public static MeshNode? FindServedStaticNode(this IServiceProvider serviceProvider, string path) =>
-        serviceProvider.EnumerateStaticNodes()
-            .FirstOrDefault(n => !n.IsDefinitionOnly
-                && string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase));
+        serviceProvider.FindStaticNode(path) is { IsDefinitionOnly: false } served ? served : null;
 
     /// <summary>
     /// The type name of the <see cref="IStaticNodeProvider"/> that SERVES <paramref name="path"/>,
     /// or <c>null</c> when nothing does. Names the claimant in a collision diagnostic so the fix is
-    /// a lookup away instead of a bisect.
+    /// a lookup away instead of a bisect. Follows <see cref="ResolveStaticNodes"/>'s precedence, so
+    /// it names the provider whose node <see cref="FindServedStaticNode"/> actually returns.
     /// </summary>
     public static string? ServingStaticProviderName(this IServiceProvider serviceProvider, string path)
     {
-        foreach (var provider in serviceProvider.GetServices<IStaticNodeProvider>())
-        {
-            var served = provider.GetStaticNodes().FirstOrDefault(
-                n => !n.IsDefinitionOnly
-                     && string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase));
-            if (served is null)
-                continue;
-            // The AddMeshNodes seed is by far the most common claimant (every built-in NodeType
-            // definition sits at a top-level path); name the CALL, not the internal wrapper type.
-            return provider is StaticMeshNodeListProvider
-                ? "MeshBuilder.AddMeshNodes"
-                : provider.GetType().Name;
-        }
-        return null;
+        var claims = ClaimsAt(serviceProvider.GetServices<IStaticNodeProvider>(), path);
+        if (claims.Count == 0 || claims[0].Node.IsDefinitionOnly)
+            return null;
+        return ProviderName(claims[0].Provider);
     }
 
     /// <summary>
-    /// The ONE message describing a static-vs-durable claim collision at <paramref name="path"/> —
-    /// a registered <see cref="IStaticNodeProvider"/> SERVES the path while durable content is
-    /// trying to live there.
+    /// Every provider claiming <paramref name="path"/>, in precedence order (the winner first).
+    /// </summary>
+    private static IReadOnlyList<(IStaticNodeProvider Provider, MeshNode Node)> ClaimsAt(
+        IEnumerable<IStaticNodeProvider> providers, string path)
+    {
+        var claims = new List<(IStaticNodeProvider, MeshNode)>();
+        foreach (var provider in OrderByPrecedence(providers))
+        {
+            // Within one provider the first match is that provider's claim — the same
+            // within-provider order ResolveStaticNodes honours.
+            var node = provider.GetStaticNodes()
+                .FirstOrDefault(n => string.Equals(n.Path, path, StringComparison.OrdinalIgnoreCase));
+            if (node is not null)
+                claims.Add((provider, node));
+        }
+        return claims;
+    }
+
+    /// <summary>
+    /// Every path claimed by MORE THAN ONE static provider with <b>different</b> content — the
+    /// registration that <see cref="ResolveStaticNodes"/> resolves silently and that a host almost
+    /// certainly did not intend.
+    ///
+    /// <para>🚨 Why "different content" and not "more than one claimant": declaring a node type
+    /// registers the SAME declaration twice by design (<c>AddPartitionType</c> calls
+    /// <c>builder.AddMeshNodes(CreateMeshNode())</c> and registers a provider that yields
+    /// <c>CreateMeshNode()</c> again), so a bare duplicate count would fire on every built-in type
+    /// and be ignored within a week. Two claimants offering byte-identical declarations are
+    /// redundant; two claimants offering DIFFERENT declarations mean one of them is being dropped,
+    /// which is the failure this exists to name.</para>
+    ///
+    /// <para>Comparison is <see cref="PartitionSourceFingerprint.ComputeNodeToken"/> — the repo's
+    /// deterministic per-node source token, which excludes the un-serialisable
+    /// <c>HubConfiguration</c> delegate (two calls to one factory produce different delegates and
+    /// would otherwise never compare equal).</para>
+    /// </summary>
+    /// <param name="providers">The registered static node providers, in DI-registration order.</param>
+    /// <param name="options">Serializer options for the content token; the hub's when available.</param>
+    /// <returns>One human-readable line per contested path; empty when nothing collides.</returns>
+    public static IReadOnlyList<string> DescribeStaticProviderCollisions(
+        IEnumerable<IStaticNodeProvider> providers,
+        JsonSerializerOptions? options = null)
+    {
+        ArgumentNullException.ThrowIfNull(providers);
+        var ordered = OrderByPrecedence(providers);
+        // path -> claims, in precedence order. Built in ONE sweep: asking ClaimsAt per path would
+        // re-enumerate every provider once per path.
+        var byPath = new Dictionary<string, List<(IStaticNodeProvider Provider, MeshNode Node)>>(
+            StringComparer.OrdinalIgnoreCase);
+        foreach (var provider in ordered)
+        {
+            var seenHere = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var node in provider.GetStaticNodes())
+            {
+                if (string.IsNullOrEmpty(node.Path) || !seenHere.Add(node.Path))
+                    continue;
+                if (!byPath.TryGetValue(node.Path, out var claims))
+                    byPath[node.Path] = claims = new List<(IStaticNodeProvider, MeshNode)>();
+                claims.Add((provider, node));
+            }
+        }
+
+        var report = new List<string>();
+        foreach (var (path, claims) in byPath)
+        {
+            if (claims.Count < 2)
+                continue;
+            var shadowed = ShadowedClaims(claims, options);
+            if (shadowed.Count == 0)
+                continue;
+            report.Add(
+                $"Path '{path}' is claimed by {claims.Count} static node providers with DIFFERENT "
+                + $"content. '{ProviderName(claims[0].Provider)}' wins and "
+                + string.Join(", ", shadowed.Select(c => $"'{ProviderName(c.Provider)}'"))
+                + " is silently dropped. Static-node precedence is: the MeshBuilder.AddMeshNodes "
+                + "seed first, then providers in registration order — registration order is not "
+                + "something a host controls, so overriding another contributor's node by adding a "
+                + "second one at its path is NOT supported (MeshWeaver#2908). Remove one of the "
+                + "registrations, or give the host's own declaration its own path.");
+        }
+        report.Sort(StringComparer.Ordinal);
+        return report;
+    }
+
+    /// <summary>
+    /// <inheritdoc cref="DescribeStaticProviderCollisions(IEnumerable{IStaticNodeProvider}, JsonSerializerOptions)"/>
+    /// </summary>
+    public static IReadOnlyList<string> DescribeStaticProviderCollisions(
+        this IServiceProvider serviceProvider,
+        JsonSerializerOptions? options = null) =>
+        DescribeStaticProviderCollisions(serviceProvider.GetServices<IStaticNodeProvider>(), options);
+
+    /// <summary>
+    /// The claims after the winner whose content token differs from the winner's — i.e. the
+    /// contributions this resolution actually DROPS.
+    /// </summary>
+    private static IReadOnlyList<(IStaticNodeProvider Provider, MeshNode Node)> ShadowedClaims(
+        IReadOnlyList<(IStaticNodeProvider Provider, MeshNode Node)> claims,
+        JsonSerializerOptions? options)
+    {
+        var winnerToken = PartitionSourceFingerprint.ComputeNodeToken(claims[0].Node, options);
+        var shadowed = new List<(IStaticNodeProvider, MeshNode)>();
+        for (var i = 1; i < claims.Count; i++)
+            if (!string.Equals(
+                    PartitionSourceFingerprint.ComputeNodeToken(claims[i].Node, options),
+                    winnerToken,
+                    StringComparison.Ordinal))
+                shadowed.Add(claims[i]);
+        return shadowed;
+    }
+
+    /// <summary>
+    /// The ONE message describing a static claim collision at <paramref name="path"/> — a
+    /// registered <see cref="IStaticNodeProvider"/> SERVES the path while durable content is trying
+    /// to live there, and/or a second static provider claims the same path with different content.
     ///
     /// <para>🚨 Why this needs its own diagnostic (#1209): the static claim wins every serve seam,
     /// so the per-node hub at that path is seeded from a node that is BY DESIGN never persisted. It
@@ -88,23 +316,46 @@ public static class StaticNodeProviderExtensions
     /// <c>serveFromPartition</c>, which flips the static entry to
     /// <see cref="MeshNode.IsDefinitionOnly"/> so the durable row owns the path — and this message
     /// is what points at it.</para>
+    ///
+    /// <para>🚨 The second half (#2908): when more than one static provider claims the path, the
+    /// loser is dropped silently and the two seams that read the path used to disagree about which
+    /// one that was. The message names every claimant so a host that appended a node at a platform
+    /// seed's path learns that it did, instead of discovering it by comparing two views.</para>
     /// </summary>
     /// <param name="serviceProvider">Resolves the registered static node providers.</param>
     /// <param name="path">The contested path.</param>
-    /// <returns>The diagnostic, or <c>null</c> when nothing serves <paramref name="path"/> statically.</returns>
+    /// <returns>The diagnostic, or <c>null</c> when nothing claims <paramref name="path"/> statically.</returns>
     public static string? DescribeStaticServeCollision(this IServiceProvider serviceProvider, string path)
     {
-        // ONE sweep: the provider name is non-null on exactly the same condition as
-        // FindServedStaticNode, so resolving the claimant also answers "is there a collision".
-        if (serviceProvider.ServingStaticProviderName(path) is not { } claimant)
+        var claims = ClaimsAt(serviceProvider.GetServices<IStaticNodeProvider>(), path);
+        if (claims.Count == 0)
             return null;
         var partition = path.Split('/', 2)[0];
-        return $"Path '{path}' is SERVED BY A STATIC NODE PROVIDER ({claimant}), so durable content "
-               + $"cannot live there: the per-node hub at '{path}' is seeded from the static node and "
+        var shadowed = claims.Count > 1
+            ? ShadowedClaims(claims, options: null)
+            : Array.Empty<(IStaticNodeProvider Provider, MeshNode Node)>();
+        var contested = shadowed.Count > 0
+            ? $" It is ALSO claimed by {string.Join(", ", shadowed.Select(c => $"'{ProviderName(c.Provider)}'"))} "
+              + "with different content, which this resolution drops — static-node precedence is the "
+              + "MeshBuilder.AddMeshNodes seed first, then providers in registration order "
+              + "(MeshWeaver#2908)."
+            : string.Empty;
+        if (claims[0].Node.IsDefinitionOnly)
+            // Nothing is SERVED here — the winner handed the path to persistence. Only the
+            // multi-claimant half of the message can apply.
+            return shadowed.Count > 0
+                ? $"Path '{path}' is claimed by more than one static node provider."
+                  + $" '{ProviderName(claims[0].Provider)}' wins and marks the path definition-only"
+                  + $" (the durable row owns it).{contested}"
+                : null;
+        return $"Path '{path}' is SERVED BY A STATIC NODE PROVIDER ({ProviderName(claims[0].Provider)}), "
+               + "so durable content cannot live there: the per-node hub at "
+               + $"'{path}' is seeded from the static node and "
                + "has no persistence backing, which leaves the path unreadable, un-creatable and "
                + "un-writable (MeshWeaver#1209). Configure this host to serve the partition from the "
                + $"database instead — pass '{partition}' in serveFromPartition (e.g. "
                + $"AddAI(serveFromPartition: [\"{partition}\"]), or Features:StaticRepoSync:Partitions) "
-               + "— which marks the static entry definition-only and lets the durable row own the path.";
+               + "— which marks the static entry definition-only and lets the durable row own the path."
+               + contested;
     }
 }

--- a/test/MeshWeaver.Hosting.Test/StaticNodePrecedenceTest.cs
+++ b/test/MeshWeaver.Hosting.Test/StaticNodePrecedenceTest.cs
@@ -1,0 +1,182 @@
+using System.Text.Json;
+using MeshWeaver.Hosting.Persistence.Query;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// MeshWeaver#2908 — <b>two readers disagreeing about one path, silently</b>.
+///
+/// <para>A second static node at a path another contributor already claimed used to be served by
+/// <c>StaticNodeQueryProvider</c> and NOT by hub activation
+/// (<c>MeshDataSource.WithMeshNodes</c> → <see cref="StaticNodeProviderExtensions.FindServedStaticNode"/>),
+/// because each seam implemented its own resolution: the query provider gave the
+/// <c>AddMeshNodes</c> seed priority and excluded every other provider's node at a seed-claimed
+/// path, while <c>FindServedStaticNode</c> took a bare <c>FirstOrDefault</c> in DI-registration
+/// order. Registration order is not a property a host controls, so the same path resolved to
+/// different content depending on which way you arrived at it — with no error, no warning and no
+/// ambiguity diagnostic.</para>
+///
+/// <para>These tests pin the two halves of the fix: ONE resolution both readers call, and a LOUD
+/// diagnostic when two providers claim a path with different content.</para>
+/// </summary>
+public class StaticNodePrecedenceTest
+{
+    private const string Contested = "Admin/HomeConfig";
+    private static readonly JsonSerializerOptions Options = new();
+
+    /// <summary>A provider that is not the <c>AddMeshNodes</c> seed — a platform contributor.</summary>
+    private sealed class PlatformProvider(params MeshNode[] nodes) : IStaticNodeProvider
+    {
+        public IEnumerable<MeshNode> GetStaticNodes() => nodes;
+    }
+
+    private static MeshNode HomeConfig(string name, bool definitionOnly = false) =>
+        MeshNode.FromPath(Contested) with
+        {
+            NodeType = "Markdown",
+            Name = name,
+            IsDefinitionOnly = definitionOnly,
+        };
+
+    /// <summary>
+    /// The #2908 registration exactly: a platform provider registered FIRST (as an
+    /// <c>AddPersistence</c>-time provider is), the host's own <c>AddMeshNodes</c> seed second.
+    /// </summary>
+    private static IServiceProvider BuildContested(MeshNode platformNode, MeshNode seedNode) =>
+        new ServiceCollection()
+            .AddSingleton<IStaticNodeProvider>(new PlatformProvider(platformNode))
+            .AddSingleton<IStaticNodeProvider>(new StaticMeshNodeListProvider([seedNode]))
+            .BuildServiceProvider();
+
+    private static StaticNodeQueryProvider QueryProvider(
+        IServiceProvider sp, IReadOnlyList<MeshNode> seedNodes, ILoggerFactory? loggerFactory = null) =>
+        new(sp.GetServices<IStaticNodeProvider>(),
+            _ => true,
+            new MeshConfiguration(seedNodes),
+            loggerFactory);
+
+    private static IReadOnlyList<MeshNode> QueryPath(StaticNodeQueryProvider provider, string path)
+    {
+        // The static catalog is purely in-memory: Query returns a completed Observable.Return, so
+        // the single emission is already there. No polling, no bridge.
+        IReadOnlyList<MeshNode>? items = null;
+        using (provider.Query<MeshNode>(new MeshQueryRequest { Query = $"path:{path}" }, Options)
+                   .Subscribe(change => items = change.Items))
+        {
+        }
+        items.Should().NotBeNull("StaticNodeQueryProvider emits its snapshot synchronously");
+        return items!;
+    }
+
+    [Fact]
+    public void Both_readers_serve_the_SAME_node_at_a_contested_path()
+    {
+        var platform = HomeConfig("platform seed");
+        var seed = HomeConfig("host override");
+        var sp = BuildContested(platform, seed);
+
+        var throughActivation = sp.FindServedStaticNode(Contested);
+        var throughQuery = QueryPath(QueryProvider(sp, [seed]), Contested);
+
+        // The substance of #2908: one path, one answer. Before the fix the query seam served the
+        // seed while hub activation served the platform provider's node, and nothing said so.
+        throughQuery.Should().ContainSingle(
+            "a path resolves to exactly one static node, whichever reader asks");
+        throughActivation.Should().NotBeNull();
+        throughActivation!.Name.Should().Be(throughQuery[0].Name,
+            "hub activation and the query provider must resolve the same static node at one path");
+
+        // And the documented rule is that the AddMeshNodes seed wins — the one the host declared.
+        throughActivation.Name.Should().Be("host override");
+    }
+
+    [Fact]
+    public void The_precedence_holds_when_the_seed_hands_the_path_to_persistence()
+    {
+        // The host declared the path DB-backed (serveFromPartition flips the seed entry to
+        // definition-only). A lower-precedence provider still offers a served node there; it must
+        // not win the path back — on EITHER seam.
+        var platform = HomeConfig("platform seed");
+        var seed = HomeConfig("host override", definitionOnly: true);
+        var sp = BuildContested(platform, seed);
+
+        sp.FindServedStaticNode(Contested).Should().BeNull(
+            "the seed handed this path to the durable row; nothing static serves it");
+        sp.ServingStaticProviderName(Contested).Should().BeNull(
+            "the collision diagnostic must name the same winner FindServedStaticNode resolves");
+        QueryPath(QueryProvider(sp, [seed]), Contested).Should().BeEmpty(
+            "a definition-only claim is not a query result, and no provider may serve underneath it");
+    }
+
+    [Fact]
+    public void A_contested_path_is_reported_LOUD_naming_both_claimants()
+    {
+        var sp = BuildContested(HomeConfig("platform seed"), HomeConfig("host override"));
+
+        var collisions = sp.DescribeStaticProviderCollisions();
+
+        collisions.Should().ContainSingle("exactly one path is contested");
+        collisions[0].Should().Contain(Contested);
+        collisions[0].Should().Contain("MeshBuilder.AddMeshNodes", "the winner is named");
+        collisions[0].Should().Contain(nameof(PlatformProvider), "the DROPPED claimant is named");
+        collisions[0].Should().Contain("2908");
+
+        // …and the durable-collision message a create refusal surfaces says it too, so the append
+        // is visible from the seam a host actually hits.
+        sp.DescribeStaticServeCollision(Contested).Should()
+            .Contain(nameof(PlatformProvider))
+            .And.Contain("different content");
+    }
+
+    [Fact]
+    public void The_query_provider_WARNS_about_a_contested_path_at_construction()
+    {
+        var sp = BuildContested(HomeConfig("platform seed"), HomeConfig("host override"));
+        var factory = new CapturingLoggerFactory();
+
+        QueryProvider(sp, [HomeConfig("host override")], factory);
+
+        factory.Warnings.Should().ContainSingle(
+            "a duplicate registration must be LOUD once per mesh, not discovered by comparing views");
+        factory.Warnings[0].Should().Contain(Contested).And.Contain(nameof(PlatformProvider));
+    }
+
+    [Fact]
+    public void Two_providers_offering_the_SAME_declaration_are_redundant_not_contested()
+    {
+        // Declaring a node type registers it twice by design (AddPartitionType seeds
+        // CreateMeshNode() AND registers a provider yielding CreateMeshNode() again). A bare
+        // duplicate count would fire on every built-in type and be ignored within a week.
+        var sp = BuildContested(HomeConfig("Home"), HomeConfig("Home"));
+
+        sp.DescribeStaticProviderCollisions().Should().BeEmpty(
+            "byte-identical declarations are redundant, not a dropped contribution");
+    }
+
+    private sealed class CapturingLoggerFactory : ILoggerFactory
+    {
+        private readonly List<string> _warnings = [];
+        public IReadOnlyList<string> Warnings => _warnings;
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_warnings);
+        public void AddProvider(ILoggerProvider provider) { }
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(List<string> warnings) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => true;
+            public void Log<TState>(
+                LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel >= LogLevel.Warning)
+                    warnings.Add(formatter(state, exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The defect

Two readers of *"which static node is at this path"* implemented their own resolution:

| reader | rule |
|---|---|
| `StaticNodeQueryProvider` (queries, autocomplete) | the `AddMeshNodes` seed wins; every other provider's node at a seed-claimed path is excluded |
| `FindServedStaticNode` — hub activation (`MeshDataSource.WithMeshNodes`), the create path's already-exists check, the persistence-sampler gate, the plugin installer's pre-flight | a bare `FirstOrDefault` **in DI-registration order** |

Registration order is not a property a host controls — a provider registered from `AddPersistence` lands before the mesh builder's own deferred registrations — so a second static node at a platform seed's path was **served by one reader and not the other, in one live process**, with no error, no warning and no ambiguity diagnostic. It also made "override a platform default by appending a node at its path" look supported: the append was accepted, so the natural conclusion was that it had worked.

## The fix

One rule, one implementation: `StaticNodeProviderExtensions.ResolveStaticNodes(providers)` — seed first, then providers in registration order, **at most one node per path**. Both readers call it.

- The query provider goes through `ResolveStaticNodeBuckets`: it still needs the two buckets separately (seed nodes are registration declarations, suppressed under `context:search` / `is:content`), but *who wins a contested path* is no longer its business.
- `FindStaticNode` / `FindServedStaticNode` / `ServingStaticProviderName` go through `EnumerateStaticNodes`, which is now that resolution.
- A **definition-only** entry still CLAIMS its path: the winner is taken first and the `IsDefinitionOnly` test applied second, so a path the host handed to Postgres (`serveFromPartition`) cannot be won back by a lower-precedence provider offering a served node there.

## …and a duplicate registration is now LOUD

`DescribeStaticProviderCollisions` reports every path claimed by more than one provider **with different content**; `StaticNodeQueryProvider` logs one warning per contested path at construction, and `DescribeStaticServeCollision` names the shadowed claimant so a create refusal says it too.

Content, not claim count: declaring a node type registers the same declaration twice on purpose (`AddPartitionType` seeds `CreateMeshNode()` *and* registers a provider that yields it again), so a bare duplicate count would fire on every built-in type and be ignored within a week. Equality is `PartitionSourceFingerprint.ComputeNodeToken`, which excludes the un-serialisable `HubConfiguration` delegate (two calls to one factory produce different delegates and would otherwise never compare equal).

## Verification

`test/MeshWeaver.Hosting.Test/StaticNodePrecedenceTest.cs` — 5 tests, 40 ms, no mesh required.

**Proved they can fail.** The two core assertions were run against unmodified `src/` (tests kept, source reverted, restored after):

```
Failed Both_readers_serve_the_SAME_node_at_a_contested_path
   Expected value to be "host override", but found "platform seed".
Failed The_precedence_holds_when_the_seed_hands_the_path_to_persistence
   Expected value to be <null>, but found MeshNode { … Name = platform seed … }
```

That first line **is** issue #2908: the query seam served `host override` while hub activation served `platform seed`, in one process, silently. Both pass on this branch.

Regression suites (all green, Release):

| suite | result |
|---|---|
| `MeshWeaver.Hosting.Test` (full) | 274 / 274 |
| `MeshWeaver.Query.Test` → `StaticNodeQueryContextTests` | 3 / 3 |
| `MeshWeaver.Autocomplete.Test` (full) | 146 / 146 |
| `MeshWeaver.Hosting.Monolith.Test` → CreatableTypes / SelfTyping / UserActivity | 27 / 27 |
| `MeshWeaver.Documentation.Test` → link integrity + satellite guard | 5 / 5 |

`dotnet build … -c Release -warnaserror`, one project per invocation, `0 Error(s)`: `MeshWeaver.Mesh.Contract`, `MeshWeaver.Hosting`, `MeshWeaver.PluginCatalog`, `MeshWeaver.Hosting.Monolith`, `MeshWeaver.Hosting.Orleans`, and every test project run above.

**No public signature changed** — `EnumerateStaticNodes`, `FindStaticNode`, `FindServedStaticNode`, `ServingStaticProviderName` and `DescribeStaticServeCollision` keep their exact shapes; `ResolveStaticNodes` and `DescribeStaticProviderCollisions` are additions. Swept both repos' node trees and `MeshWeaver.Plugins` for callers: only test call sites, all on unchanged signatures.

## Work product conserved

- `Doc/Architecture/StaticNodeProviders` gains **"🚨 One path, one static node — the precedence rule"** — the rule, the definition-only edge, the two-reader divergence table, and why the collision report compares content rather than counting claims.
- What's New (`Category: Fix`): *A built-in path resolves to one node, no matter who asks*.

Closes #2908