### PR TITLE
fix(lane): a call's evidence is named and STAMPED with its own lane — a sibling's cannot answer bundles-built (Plugins#1077)

### DIFF
--- a/.github/scripts/node-repo-pack-verify.py
+++ b/.github/scripts/node-repo-pack-verify.py
@@ -34,6 +34,24 @@ the other call's receipts and reads them as "built but never selected". `--decla
 caller's own matrix (`inputs.modules`): a receipt for a module this call did not declare belongs
 to a sibling call and is set aside, NAMED, and never counted. Within the declared set the
 accounting is exactly as strict as before.
+
+🚨 …AND A NAME-ONLY SEPARATION IS NOT ENOUGH. `--declared` tells two calls apart only while their
+matrices are DISJOINT; the moment both declare the same module — one `always-modules` entry that
+also appears in the other call's list is all it takes — one call's evidence answers the other's
+question, and the answer a REQUIRED gate composes on (`bundles-built`) becomes truthy from
+evidence this call never produced (Plugins#1077). So the producer now STAMPS its lane into every
+marker and receipt and `--lane` checks it: evidence this call cannot attribute to itself is set
+aside and NAMED, and a SELECTED module left without attributable evidence reads as NOT BUILT.
+Fail closed — zero markers, an unstamped marker and a foreign marker are all `false`, never a
+silent true.
+
+🚨 AND THE MARKER MUST ASSERT WHAT THE CALLER ACTUALLY NEEDS. `bundles-built` is consumed by gates
+that only COMPOSE the bundles, so it has to mean "the set is complete and USABLE". A marker saying
+only "an artifact was uploaded" leaves "present but uncomposable" reading as true, so the marker
+carries the bundle it attests and the closure evidence its build resolved, and a marker missing
+either is refused here rather than trusted because of where its step happened to sit in the job.
+🚨 None of this touches the module's TESTS: the marker is still dropped BEFORE them (#2710,
+Plugins#937) so a red suite cannot read as "bundle missing" to a gate that only composes.
 """
 from __future__ import annotations
 
@@ -76,13 +94,27 @@ def _receipt_stem(broken_entry: str) -> str:
 
 def verify(expected: list[str], receipts: dict[str, dict], broken: list[str],
            pack_result: str, receipts_dir_exists: bool,
-           scope: str = "", declared: set[str] | None = None) -> tuple[int, list[str], list[str]]:
+           scope: str = "", declared: set[str] | None = None,
+           lane: str = "") -> tuple[int, list[str], list[str]]:
     """(exit code, error lines, note lines). `declared` is the caller's own matrix; when given,
     receipts for modules outside it are a SIBLING call's (artifacts are run-wide) and are set
-    aside rather than counted. `None` keeps the pre-#932 behaviour: every receipt is this call's."""
+    aside rather than counted. `None` keeps the pre-#932 behaviour: every receipt is this call's.
+    `lane` is this call's own lane key: a receipt stamped with any other lane — or with none —
+    is a sibling's STRUCTURALLY, whatever its module is called, and is set aside the same way."""
     errors: list[str] = []
     notes: list[str] = []
     want = set(expected)
+
+    # 🚨 STRUCTURAL ATTRIBUTION FIRST. `--declared` separates two calls in one run by module NAME,
+    # which holds only while their matrices are disjoint; the stamp the producer wrote holds
+    # always. Applied before anything is counted, so a foreign receipt can neither satisfy a
+    # selection nor be reported as "built but never selected".
+    if lane:
+        foreign = sorted(m for m, r in receipts.items() if r.get("lane") != lane)
+        if foreign:
+            receipts = {m: r for m, r in receipts.items() if r.get("lane") == lane}
+            notes.append(f"{len(foreign)} receipt(s) carry another lane's stamp (this call is "
+                         f"'{lane}') and are not this call's to count: " + ", ".join(foreign))
 
     if declared is not None:
         # 🚨 The selection is computed FROM the declared matrix, so a selected module the caller
@@ -165,35 +197,74 @@ def verify(expected: list[str], receipts: dict[str, dict], broken: list[str],
     return (1 if errors else 0), errors, notes
 
 
-def read_markers(directory: Path) -> set[str]:
-    """The modules with a well-formed built marker (`module-built-<module>` artifacts, merged)."""
+MARKER_CLAIMS = ("bundle", "closure")
+"""What a built marker must ASSERT, not merely imply from where its step sits in the job.
+
+`bundle` — the bundle file the upload step took; `closure` — how the build resolved this
+module's private closure (the `<Module>.closure.txt` manifest on the container path, the
+publish `deps.json` on the sdk path). `bundles-built` is what a REQUIRED gate composes bundles
+on, so it must mean "complete AND usable": a marker that attests only "an artifact exists"
+lets present-but-uncomposable read as true, which is the class Plugins#1077 sits in."""
+
+
+def read_markers(directory: Path, lane: str = "") -> tuple[set[str], list[str]]:
+    """(modules this call can attribute a complete built marker to, the markers it REFUSED and why).
+
+    🚨 EVERY REFUSAL IS FAIL-CLOSED. A marker that cannot be parsed, does not name its own file,
+    carries another call's lane stamp (or none at all), or does not record what it attests, is not
+    a marker — the module then reads as NOT built. A truthy answer derived from absent or foreign
+    evidence is the whole defect, so the refusals are returned and NAMED rather than dropped."""
     found: set[str] = set()
+    refused: list[str] = []
     if not directory.is_dir():
-        return found
+        return found, refused
     for path in sorted(directory.rglob("*.json")):
         try:
             doc = json.loads(path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
+            refused.append(f"{path.name} (unreadable as JSON)")
             continue
-        module = doc.get("module") if isinstance(doc, dict) else None
-        if isinstance(module, str) and module and path.stem == module:
-            found.add(module)
-    return found
+        if not isinstance(doc, dict):
+            refused.append(f"{path.name} (not a marker object)")
+            continue
+        module = doc.get("module")
+        if not isinstance(module, str) or not module or path.stem != module:
+            refused.append(f"{path.name} (claims module {doc.get('module')!r})")
+            continue
+        stamp = doc.get("lane")
+        if lane and stamp != lane:
+            refused.append(f"{module} (lane {stamp!r}, this call is {lane!r})")
+            continue
+        absent = [claim for claim in MARKER_CLAIMS
+                  if not isinstance(doc.get(claim), str) or not doc.get(claim)]
+        if absent:
+            refused.append(f"{module} (records no " + ", no ".join(absent) + ")")
+            continue
+        found.add(module)
+    return found, refused
 
 
-def bundles_built(expected: list[str], built: set[str], declared: set[str] | None) -> tuple[bool, str]:
-    """(every selected bundle exists as an artifact, one line saying so). Independent of the
-    receipts and of the pack job's result on purpose: this is the claim a caller's gate depends on
-    when it only COMPOSES the bundles, and a red suite or a failed hand-over must not turn it
-    false. A sibling call's markers are set aside the same way as its receipts."""
+def bundles_built(expected: list[str], built: set[str], declared: set[str] | None,
+                  refused: list[str] | None = None) -> tuple[bool, str]:
+    """(every selected bundle exists as a COMPOSABLE artifact of THIS call, one line saying so).
+
+    Independent of the receipts and of the pack job's result on purpose: this is the claim a
+    caller's gate depends on when it only COMPOSES the bundles, and a red suite or a failed
+    hand-over must not turn it false (#2710, Plugins#937). A sibling call's markers are set aside
+    the same way as its receipts — by lane stamp in `read_markers`, and by name here."""
     want = set(expected)
     if declared is not None:
         built = {m for m in built if m in declared}
+    refused = list(refused or [])
+    aside = (f" ({len(refused)} marker(s) refused: " + "; ".join(refused) + ")") if refused else ""
     missing = sorted(want - built)
     if missing:
         return False, (f"bundles-built: false — {len(missing)} of {len(want)} selected bundle(s) "
-                       f"never became an artifact: " + ", ".join(missing))
-    return True, f"bundles-built: true — {len(want)} of {len(want)} selected bundle(s) exist as artifacts"
+                       f"have no built marker this call can attribute to itself: "
+                       + ", ".join(missing) + aside)
+    return True, (f"bundles-built: true — {len(want)} of {len(want)} selected bundle(s) exist as "
+                  f"this call's artifacts, each recording the bundle and the closure it was "
+                  f"composed from" + aside)
 
 
 def parse_declared(text: str) -> set[str] | None:
@@ -233,9 +304,17 @@ def self_test() -> int:
             failures.append(name)
 
     def run(directory: Path, expected: list[str], result: str = "success", scope: str = "",
-            declared: set[str] | None = None):
+            declared: set[str] | None = None, lane: str = ""):
         receipts, broken = read_receipts(directory)
-        return verify(expected, receipts, broken, result, directory.is_dir(), scope, declared)
+        return verify(expected, receipts, broken, result, directory.is_dir(), scope, declared, lane)
+
+    def marker(module: str, lane: str = "floor-abc123", **overrides) -> str:
+        doc = {"lane": lane, "package": module.split(".")[-1], "module": module,
+               "version": "1.2.3", "compiler": "container",
+               "bundle": f"{module}.1.2.3.module.nupkg",
+               "closure": f"{module}.closure.txt (2 entries)"}
+        doc.update(overrides)
+        return json.dumps({k: v for k, v in doc.items() if v is not None})
 
     with tempfile.TemporaryDirectory() as tmp:
         d = Path(tmp) / "receipts"
@@ -321,24 +400,97 @@ def self_test() -> int:
         check("no receipts at all is a FAILURE, never a pass",
               code == 1 and any("no receipt directory" in e for e in errors), f"{errors}")
 
-        print("the built markers — 'the bundle exists' stays true through a red suite:")
+        # 🚨 The receipts' lane half: `--declared` separates two calls by NAME, which holds only
+        # while their matrices are disjoint. The stamp holds always (Plugins#1077).
+        print("the receipts' LANE stamp — the separation that survives two calls declaring the "
+              "same module:")
+        (d / "MeshWeaver.AI.json").write_text(json.dumps(
+            {"lane": "floor-abc123", "package": "AI", "module": "MeshWeaver.AI",
+             "published": True}), encoding="utf-8")
+        for m in three[1:]:
+            (d / f"{m}.json").write_text(json.dumps(
+                {"lane": "floor-abc123", "package": m.split(".")[-1], "module": m,
+                 "published": False}), encoding="utf-8")
+        code, errors, notes = run(d, three, lane="floor-abc123")
+        check("this call's own stamped receipts still add up", code == 0, f"{errors}")
+        # A module BOTH calls declare — the case --declared cannot see — must not be donated.
+        (d / "MeshWeaver.Mcp.json").write_text(json.dumps(
+            {"lane": "rest-def456", "package": "Mcp", "module": "MeshWeaver.Mcp"}),
+            encoding="utf-8")
+        code, errors, notes = run(d, three, declared=set(three), lane="floor-abc123")
+        check("a receipt this call DECLARED but a SIBLING LANE produced is set aside and the "
+              "module then reads as never built",
+              code == 1
+              and any("another lane's stamp" in n and "MeshWeaver.Mcp" in n for n in notes)
+              and any("NO receipt" in e and "MeshWeaver.Mcp" in e for e in errors),
+              f"{errors} {notes}")
+        (d / "MeshWeaver.Mcp.json").write_text(json.dumps(
+            {"lane": "floor-abc123", "package": "Mcp", "module": "MeshWeaver.Mcp"}),
+            encoding="utf-8")
+
+        print("the built markers — 'complete AND composable, from THIS lane', still surviving a "
+              "red suite:")
         b = Path(tmp) / "built"
         b.mkdir()
         for m in three:
-            (b / f"{m}.json").write_text(json.dumps({"module": m}), encoding="utf-8")
-        ok, line = bundles_built(three, read_markers(b), None)
-        check("every selected bundle has a marker ⇒ bundles-built true", ok and "true" in line, line)
-        code, errors, _ = run(d, three, "failure")
-        ok, _ = bundles_built(three, read_markers(b), None)
+            (b / f"{m}.json").write_text(marker(m), encoding="utf-8")
+        found, refused = read_markers(b, "floor-abc123")
+        ok, line = bundles_built(three, found, None, refused)
+        check("every selected bundle has a complete marker ⇒ bundles-built true",
+              ok and "true" in line and not refused, line)
+        code, errors, _ = run(d, three, "failure", lane="floor-abc123")
+        found, refused = read_markers(b, "floor-abc123")
+        ok, _ = bundles_built(three, found, None, refused)
         check("…and a FAILED pack job (its suite went red) keeps bundles-built TRUE while the "
-              "lane itself still fails", ok and code == 1, f"{errors}")
+              "lane itself still fails — #2710 is untouched", ok and code == 1, f"{errors}")
+
+        print("marker mutations — each must make bundles-built FALSE and name what it refused:")
         (b / "MeshWeaver.Mcp.json").unlink()
-        ok, line = bundles_built(three, read_markers(b), None)
-        check("a selected bundle with NO marker ⇒ bundles-built false, naming it",
+        found, refused = read_markers(b, "floor-abc123")
+        ok, line = bundles_built(three, found, None, refused)
+        check("a selected bundle with NO marker ⇒ false, naming it",
               not ok and "MeshWeaver.Mcp" in line, line)
-        (b / "MeshWeaver.Ghost.json").write_text(json.dumps({"module": "MeshWeaver.Ghost"}), encoding="utf-8")
-        ok, _ = bundles_built(["MeshWeaver.AI", "MeshWeaver.Teams"], read_markers(b), set(three))
-        check("a sibling call's marker is set aside like its receipt", ok)
+        # 🚨 THE DEFECT ITSELF: a sibling call's marker for a module THIS call also declared.
+        (b / "MeshWeaver.Mcp.json").write_text(marker("MeshWeaver.Mcp", lane="rest-def456"),
+                                               encoding="utf-8")
+        found, refused = read_markers(b, "floor-abc123")
+        ok, line = bundles_built(three, found, None, refused)
+        check("a marker from a FOREIGN LANE does not satisfy this one — false, and it says whose",
+              not ok and "MeshWeaver.Mcp" in line and "rest-def456" in line, line)
+        (b / "MeshWeaver.Mcp.json").write_text(marker("MeshWeaver.Mcp", lane=None),
+                                               encoding="utf-8")
+        found, refused = read_markers(b, "floor-abc123")
+        ok, line = bundles_built(three, found, None, refused)
+        check("an UNSTAMPED marker is not this call's either ⇒ false (fail closed, never a "
+              "silent true)", not ok and "MeshWeaver.Mcp" in line, line)
+        for claim in ("closure", "bundle"):
+            (b / "MeshWeaver.Mcp.json").write_text(
+                marker("MeshWeaver.Mcp", **{claim: None}), encoding="utf-8")
+            found, refused = read_markers(b, "floor-abc123")
+            ok, line = bundles_built(three, found, None, refused)
+            check(f"a marker recording no {claim} ⇒ false — 'the artifact exists' is not the "
+                  f"claim `bundles-built` makes", not ok and claim in line, line)
+        (b / "MeshWeaver.Mcp.json").write_text(marker("MeshWeaver.Mcp"), encoding="utf-8")
+        (b / "MeshWeaver.Mcp.json").write_text("{ not json", encoding="utf-8")
+        found, refused = read_markers(b, "floor-abc123")
+        ok, line = bundles_built(three, found, None, refused)
+        check("a CORRUPT marker is not a marker ⇒ false, naming the file",
+              not ok and "unreadable" in line, line)
+        (b / "MeshWeaver.Mcp.json").write_text(marker("MeshWeaver.Mcp"), encoding="utf-8")
+
+        found, refused = read_markers(Path(tmp) / "no-markers-at-all", "floor-abc123")
+        ok, line = bundles_built(three, found, None, refused)
+        check("ZERO markers with a non-empty selection ⇒ false, never a silent true",
+              not ok and not found, line)
+
+        (b / "MeshWeaver.Ghost.json").write_text(marker("MeshWeaver.Ghost"), encoding="utf-8")
+        found, refused = read_markers(b, "floor-abc123")
+        ok, _ = bundles_built(["MeshWeaver.AI", "MeshWeaver.Teams"], found, set(three), refused)
+        check("a sibling call's marker for an UNDECLARED module is set aside like its receipt", ok)
+        (b / "MeshWeaver.Ghost.json").unlink()
+        found, refused = read_markers(b)
+        ok, _ = bundles_built(three, found, None, refused)
+        check("no --lane ⇒ the pre-#1077 name-only behaviour still adds up", ok)
         ok, _ = bundles_built([], set(), None)
         check("an empty selection has every bundle it needs ⇒ true", ok)
 
@@ -372,8 +524,12 @@ def self_test() -> int:
               "skipped module bundle.")
         return 1
     print("\n✓ node-repo-pack-verify self-test: 2 green-run assertions, 10 mutations that must go "
-          "red, the two sibling-call receipts (well-formed and corrupt) that must NOT, 5 built-marker cases, and 5 empty-selection cases including the "
-          "scope=full contradiction lock — all green.")
+          "red, the two sibling-call receipts (well-formed and corrupt) that must NOT, the two "
+          "receipt LANE cases (own stamp counts, a sibling lane's does not — even for a module "
+          "both calls declared), 12 built-marker cases (foreign lane, unstamped, no closure, no "
+          "bundle, corrupt, zero markers — every one fail-closed — plus #2710's red-suite "
+          "survival), and 5 empty-selection cases including the scope=full contradiction lock — "
+          "all green.")
     return 0
 
 
@@ -391,9 +547,15 @@ def main() -> int:
                    help="the caller's own `modules:` input (JSON entries or names). Receipts for "
                         "modules outside it belong to a sibling call in the same run and are set "
                         "aside, not counted. Empty ⇒ every receipt is this call's.")
+    p.add_argument("--lane", default="",
+                   help="this call's lane key (select.outputs.lane). A marker or receipt stamped "
+                        "with any other lane — or with none — belongs to a sibling call in the "
+                        "same run and is set aside, NAMED, never counted. Empty ⇒ no lane check "
+                        "(name-based --declared separation only).")
     p.add_argument("--built", default="",
                    help="directory the module-built-* markers were merged into; with --github-output, "
-                        "writes bundles_built=true|false — the receipt-independent 'bundle exists' claim")
+                        "writes bundles_built=true|false — the receipt-independent 'this call built "
+                        "a complete, composable bundle' claim")
     p.add_argument("--github-output", default="", dest="github_output",
                    help="the $GITHUB_OUTPUT file to append bundles_built to")
     p.add_argument("--self-test", action="store_true", dest="self_test")
@@ -407,10 +569,11 @@ def main() -> int:
     expected = [m for m in args.expected.split() if m]
     receipts, broken = read_receipts(directory)
     code, errors, notes = verify(expected, receipts, broken, args.pack_result,
-                                 directory.is_dir(), args.scope, parse_declared(args.declared))
+                                 directory.is_dir(), args.scope, parse_declared(args.declared),
+                                 args.lane)
 
-    ok, line = bundles_built(expected, read_markers(Path(args.built)) if args.built else set(),
-                             parse_declared(args.declared))
+    markers, refused = read_markers(Path(args.built), args.lane) if args.built else (set(), [])
+    ok, line = bundles_built(expected, markers, parse_declared(args.declared), refused)
     if args.built:
         notes.append(line)
         if args.github_output:

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -258,11 +258,19 @@ on:
         default: ''
       lane-id:
         description: >
-          Distinguishes this CALL's global-build artifact when one workflow invokes the lane
-          more than once in the same run (floor + rest): both calls uploading 'workspace-build'
-          collide, and half the packs then download the OTHER call's workspace — measured on
-          Plugins#1044 (run 33475…, 'produced no MeshWeaver.Teams.dll' while the build had 35/35
-          ok). Callers with multiple invocations MUST set distinct values.
+          A HUMAN LABEL for this call, nothing more — it is a readability prefix on the lane key,
+          not the thing that makes the key unique. It exists because one workflow may invoke this
+          lane more than once in the same run (floor + rest) and artifacts are RUN-WIDE, so two
+          calls uploading 'workspace-build' collide and half the packs then download the OTHER
+          call's workspace — measured on Plugins#1044 (run 33475…, 'produced no
+          MeshWeaver.Teams.dll' while the build had 35/35 ok) and again on Plugins#1077 (run
+          33487032213 carried TWO artifacts named 'workspace-build', 25.8 MB and 950 kB, and the
+          floor's pack downloaded the other call's).
+          🚨 A DISCRIMINATOR WITH A SHARED DEFAULT IS NOT A DISCRIMINATOR: every caller that
+          forgot to set this got 'main' on both calls and collided exactly as before, silently.
+          So the lane KEY is now derived in `select` and always carries a fingerprint of this
+          call's own `modules:` matrix (`select.outputs.lane`), which is unique per call by
+          construction. Setting this input only makes the artifact names readable.
         type: string
         required: false
         default: 'main'
@@ -347,13 +355,18 @@ on:
     outputs:
       bundles-built:
         description: >
-          "true" when EVERY selected module bundle exists as an artifact — the module-built-<module>
-          markers, dropped right after the bundle upload and BEFORE the tests. This is the claim a
-          caller's gate should depend on when it only COMPOSES the bundles: a red suite in this call
-          must not read as "bundle missing" there (Plugins #937 — one AI flake turned both required
-          gates red). The lane's own stable context (`All selected bundles built`) still asserts the
-          receipts AND the pack job's result, so a failed suite keeps the lane red wherever the lane
-          itself is required.
+          "true" when EVERY selected module bundle of THIS CALL exists as a COMPOSABLE artifact —
+          a `module-built-<lane>-<module>` marker, dropped right after the bundle upload and BEFORE
+          the tests, recording the bundle it attests and the closure evidence the build resolved.
+          This is the claim a caller's gate should depend on when it only COMPOSES the bundles: a
+          red suite in this call must not read as "bundle missing" there (Plugins #937 — one AI
+          flake turned both required gates red). Nothing about the test run reaches it.
+          🚨 It FAILS CLOSED. Zero markers, a marker stamped with another call's lane, an unstamped
+          one, and one that does not record what it attests are all "not built" for the module in
+          question — a truthy answer derived from absent or foreign evidence is the defect this
+          output exists to not have (Plugins#1077). The lane's own stable context (`All selected
+          bundles built`) still asserts the receipts AND the pack job's result, so a failed suite
+          keeps the lane red wherever the lane itself is required.
         value: ${{ jobs.verify.outputs.bundles-built }}
 
 jobs:
@@ -368,7 +381,38 @@ jobs:
       count: ${{ steps.scope.outputs.count }}
       selected: ${{ steps.scope.outputs.selected }}
       scope: ${{ steps.scope.outputs.scope }}
+      lane: ${{ steps.lane.outputs.id }}
     steps:
+      # ───────────── THIS CALL'S ARTIFACT NAMESPACE — derived, never assumed ─────────────
+      # 🚨 ARTIFACTS ARE RUN-WIDE. A repo may invoke this reusable workflow more than once in one
+      # run (MeshWeaver.Plugins does, on every run: `modules-floor` and `modules-rest`), and every
+      # artifact either call uploads lands in ONE run-scoped namespace. `lane-id` was added for
+      # exactly this (#2934) — and did not close it, because its DEFAULT is the same literal for
+      # both calls and neither caller set it. Two artifacts named `workspace-build` therefore
+      # coexisted in Plugins run 33487032213 (25.8 MB and 950 kB), `download-artifact` resolved
+      # the name to ONE of them, and the floor's pack read the other call's workspace: "the global
+      # build wrote no closure manifest for MeshWeaver.Markdown.Collaboration" — a REQUIRED gate
+      # flipping green/red on main with no source change (Plugins#1077).
+      #
+      # So the key is DERIVED here rather than trusted from the caller: `lane-id` is only a
+      # readable prefix, and the part that discriminates is a fingerprint of this call's own
+      # `modules:` matrix. Two calls that build different sets fingerprint differently by
+      # construction — there is no input a caller can forget. It is also stamped INTO every
+      # marker and receipt this call drops, so the verifier can refuse a foreign lane's evidence
+      # even if the names ever collide again.
+      - name: This call's lane key
+        id: lane
+        env:
+          LANE: ${{ inputs.lane-id }}
+          DECLARED: ${{ inputs.modules }}
+        run: |
+          set -euo pipefail
+          # Artifact names may not carry " : < > | * ? \ / — keep the label to a safe alphabet.
+          slug="$(printf '%s' "$LANE" | tr -c 'A-Za-z0-9._-' '-' | cut -c1-24)"
+          fingerprint="$(printf '%s' "$DECLARED" | sha256sum | cut -c1-12)"
+          id="${slug:-lane}-$fingerprint"
+          echo "lane key: $id (label '${LANE:-<unset>}' + a fingerprint of this call's own modules: matrix)"
+          echo "id=$id" >> "$GITHUB_OUTPUT"
       # 🚨 The caller goes in its OWN directory, not the workspace root. Node packages are
       # discovered as "top-level dirs carrying an index.json", and the platform checkout below
       # lands INSIDE the workspace — clone core to the root beside the caller's content and the
@@ -501,10 +545,13 @@ jobs:
       - name: Publish the module-pack tool (once for every pack job)
         if: steps.tool-cache.outputs.cache-hit != 'true'
         run: dotnet publish meshweaver/src/MeshWeaver.Plugin.Build/MeshWeaver.Plugin.Build.csproj -c Release -o "$RUNNER_TEMP/pack-tool"
+      # Lane-scoped like every other artifact this workflow drops: two calls in one run publish
+      # the tool from their OWN platform pin, and a run-wide name lets one call's pack jobs pack
+      # with the other call's builder.
       - name: Hand the tool to the matrix
         uses: actions/upload-artifact@v7
         with:
-          name: module-pack-tool
+          name: module-pack-tool-${{ needs.select.outputs.lane }}
           path: ${{ runner.temp }}/pack-tool
           retention-days: 1
       - name: Restore the platform image tarball (per-digest cache)
@@ -718,7 +765,7 @@ jobs:
         if: steps.build.outputs.built == 'true'
         uses: actions/upload-artifact@v7
         with:
-          name: workspace-build-${{ inputs.lane-id }}
+          name: workspace-build-${{ needs.select.outputs.lane }}
           path: ${{ runner.temp }}/module-build
           retention-days: 1
           if-no-files-found: error
@@ -972,7 +1019,7 @@ jobs:
         if: ${{ (matrix.entry.build || 'sdk') == 'container' }}
         uses: actions/download-artifact@v8
         with:
-          name: workspace-build-${{ inputs.lane-id }}
+          name: workspace-build-${{ needs.select.outputs.lane }}
           path: ${{ runner.temp }}/workspace-build
       - name: Build the module — and say which compiler produced it
         id: build
@@ -1026,6 +1073,11 @@ jobs:
                 ${REFS:+-p:MeshWeaverRefs=$REFS}
               packdir="$GITHUB_WORKSPACE/$(dirname "$PROJECT")/bin/Release/net10.0/publish"
               printf '%s\n' --deps-closure >> "$packargs"
+              # What resolved this bundle's private closure — recorded, not merely implied. It is
+              # stamped into the built marker below and the verifier REFUSES a marker without it:
+              # "the bundle exists" and "the bundle is composable" must be one claim, not two
+              # facts that happen to be produced by adjacent steps (Plugins#1077).
+              closure_evidence="deps-closure (from the publish deps.json)"
               ;;
             container)
               compiler="memex build project (ONE global workspace build)"
@@ -1047,6 +1099,7 @@ jobs:
                 echo "::error::the global build wrote no closure manifest for $MODULE — without it this job cannot know which in-tree siblings ride THIS bundle (a shared workspace output holds every entry's assemblies side by side, and globbing it would ride every other module)."
                 exit 1
               fi
+              closure_evidence="$MODULE.closure.txt ($(wc -l < "$closure_file" | tr -d ' ') entr(y|ies)) from the global workspace build"
               echo "compiler: CONTAINER — consumed from the ONE global workspace build (no docker, no registry, no compile in this job)"
               # MODULE-OWNED in-tree siblings (from THIS module's closure manifest, never a glob of
               # the shared output) MUST ride; image-shipped ones must NOT (same-identity duplicate
@@ -1103,8 +1156,15 @@ jobs:
               exit 1
               ;;
           esac
-          echo "compiler=$MODE" >> "$GITHUB_OUTPUT"
-          echo "packdir=$packdir" >> "$GITHUB_OUTPUT"
+          # `closure` is never empty by the time we get here: both branches set it, and the only
+          # paths that leave it unset already exited 1 above. The built marker carries it so that
+          # the VERIFIER — not the order the steps happen to sit in — is what asserts this bundle
+          # was composable (Plugins#1077).
+          {
+            echo "compiler=$MODE"
+            echo "packdir=$packdir"
+            echo "closure=$closure_evidence"
+          } >> "$GITHUB_OUTPUT"
           {
             echo "### \`$MODULE\` — compiled by **$compiler**"
             echo
@@ -1119,7 +1179,7 @@ jobs:
       - name: Fetch the module-pack tool (built once by prepare)
         uses: actions/download-artifact@v8
         with:
-          name: module-pack-tool
+          name: module-pack-tool-${{ needs.select.outputs.lane }}
           path: ${{ runner.temp }}/pack-tool
 
       - name: Pack the module bundle
@@ -1251,25 +1311,52 @@ jobs:
           retention-days: 3
           if-no-files-found: error
 
-      # ───────────── THE BUILT MARKER — "the bundle exists", and nothing more ─────────────
+      # ───────── THE BUILT MARKER — "this bundle exists AND is composable", from THIS lane ─────────
       # Dropped the moment the bundle artifact is up, BEFORE the tests and the hand-over, so a
       # caller whose gates only COMPOSE this bundle can depend on the workflow's `bundles-built`
       # output instead of this job's result: a red suite here must not read as "bundle missing"
-      # there. The receipt further down stays LAST — it still means the whole leg, tests and
+      # there (#2710, Plugins#937). That intent is unchanged — NOTHING about the test run reaches
+      # this marker. The receipt further down stays LAST — it still means the whole leg, tests and
       # publish included, got here.
+      #
+      # 🚨 WHAT THE MARKER ASSERTS IS NOW WRITTEN DOWN, not inferred from where the step sits.
+      # `bundles-built` is the claim a REQUIRED gate composes bundles on, so it must mean "the set
+      # is complete and usable", and a marker that says only "an artifact was uploaded" leaves
+      # "present but uncomposable" reading as true. So the marker carries the two things the
+      # composing caller actually needs — the bundle file the upload above just took, and the
+      # closure evidence the build resolved (the closure manifest on the container path) — and the
+      # verifier REFUSES a marker missing either. An ordering guarantee that only a comment
+      # records is one refactor away from being gone; this one fails closed instead.
+      #
+      # 🚨 And it carries its LANE. Artifacts are run-wide, so a repo calling this workflow twice
+      # (Plugins: floor + rest) puts both calls' evidence in one namespace. The names below are
+      # lane-scoped AND the stamp inside is checked, so even a name collision cannot donate one
+      # call's marker to the other's answer (Plugins#1077).
       - name: Drop the built marker
+        env:
+          LANE: ${{ needs.select.outputs.lane }}
+          PACKAGE: ${{ matrix.entry.package }}
+          MODULE: ${{ matrix.entry.module }}
+          VERSION: ${{ steps.identity.outputs.version }}
+          COMPILER: ${{ steps.build.outputs.compiler }}
+          CLOSURE: ${{ steps.build.outputs.closure }}
+          BUNDLE: ${{ steps.bundle.outputs.path }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/built"
-          jq -n --arg p "${{ matrix.entry.package }}" --arg m "${{ matrix.entry.module }}" \
-                --arg v "${{ steps.identity.outputs.version }}" \
-                --arg c "${{ steps.build.outputs.compiler }}" \
-             '{package:$p, module:$m, version:$v, compiler:$c}' \
-             > "$RUNNER_TEMP/built/${{ matrix.entry.module }}.json"
+          [ -n "$LANE" ]    || { echo "::error::the lane key is empty — the select job did not produce one, so this marker could not be attributed to this call and the verifier would refuse it anyway. Failing here, where it is readable."; exit 1; }
+          [ -n "$CLOSURE" ] || { echo "::error::the build step recorded no closure evidence for $MODULE — the bundle may exist but nothing says it is composable, which is exactly the claim \`bundles-built\` makes. Failing rather than dropping a marker that overstates."; exit 1; }
+          [ -n "$BUNDLE" ]  || { echo "::error::no bundle path from the pack step for $MODULE — there is nothing for this marker to attest."; exit 1; }
+          jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
+                --arg v "$VERSION" --arg c "$COMPILER" \
+                --arg cl "$CLOSURE" --arg b "$(basename "$BUNDLE")" \
+             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, closure:$cl, bundle:$b}' \
+             > "$RUNNER_TEMP/built/$MODULE.json"
+          cat "$RUNNER_TEMP/built/$MODULE.json"
       - name: Upload the built marker
         uses: actions/upload-artifact@v7
         with:
-          name: module-built-${{ matrix.entry.module }}
+          name: module-built-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}
           path: ${{ runner.temp }}/built/*.json
           retention-days: 1
           if-no-files-found: error
@@ -1384,21 +1471,33 @@ jobs:
       # that failure mode reachable rather than theoretical. `verify` counts these against the
       # selection and names whatever is missing. It is the LAST step on purpose: a receipt means
       # the whole leg, publish included, got here.
+      # 🚨 Lane-stamped and lane-named, for the same reason as the marker: artifacts are run-wide,
+      # and `--declared` alone separates two calls only while their matrices are DISJOINT. The
+      # moment two calls in one run declare the same module — an `always-modules` floor entry that
+      # is also in the other call's list is all it takes — a name-only filter hands one call's
+      # receipt to the other's accounting. The stamp is what makes attribution structural.
       - name: Drop the receipt
+        env:
+          LANE: ${{ needs.select.outputs.lane }}
+          PACKAGE: ${{ matrix.entry.package }}
+          MODULE: ${{ matrix.entry.module }}
+          VERSION: ${{ steps.identity.outputs.version }}
+          COMPILER: ${{ steps.build.outputs.compiler }}
+          PUBLISHED: ${{ inputs.publish }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/receipts"
-          jq -n --arg p "${{ matrix.entry.package }}" --arg m "${{ matrix.entry.module }}" \
-                --arg v "${{ steps.identity.outputs.version }}" \
-                --arg c "${{ steps.build.outputs.compiler }}" \
-                --argjson pub '${{ inputs.publish }}' \
-             '{package:$p, module:$m, version:$v, compiler:$c, published:$pub}' \
-             > "$RUNNER_TEMP/receipts/${{ matrix.entry.module }}.json"
-          cat "$RUNNER_TEMP/receipts/${{ matrix.entry.module }}.json"
+          [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so this receipt could not be attributed to this call."; exit 1; }
+          jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
+                --arg v "$VERSION" --arg c "$COMPILER" \
+                --argjson pub "$PUBLISHED" \
+             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, published:$pub}' \
+             > "$RUNNER_TEMP/receipts/$MODULE.json"
+          cat "$RUNNER_TEMP/receipts/$MODULE.json"
       - name: Upload the receipt
         uses: actions/upload-artifact@v7
         with:
-          name: module-pack-receipt-${{ matrix.entry.module }}
+          name: module-pack-receipt-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}
           path: ${{ runner.temp }}/receipts/*.json
           retention-days: 1
           if-no-files-found: error
@@ -1432,18 +1531,31 @@ jobs:
           python-version: "3.12"
       # Absent receipts are the finding, so a download that matches nothing must NOT fail here —
       # it must reach the verifier, which says which module is missing. That is the whole point.
+      #
+      # 🚨 SCOPED TO THIS CALL'S LANE. These patterns used to be `module-pack-receipt-*` and
+      # `module-built-*`, and artifacts are RUN-WIDE: a repo calling this workflow twice in one
+      # run (Plugins: `modules-floor` + `modules-rest`) had each verifier download BOTH calls'
+      # evidence and then separate them by module NAME alone (`--declared`). That works only while
+      # the two matrices are disjoint, and `bundles-built` is what a REQUIRED gate composes on —
+      # so the failure mode was a truthy answer derived from a sibling's evidence (Plugins#1077).
+      # The lane key is unique per call by construction, so the glob no longer reaches a sibling;
+      # the lane stamp INSIDE each file is checked as well, because a pattern is one edit away
+      # from being widened again and this one must fail closed when it is.
+      #
+      # A pattern that matches nothing still reaches the verifier as ZERO evidence, which is
+      # `bundles-built=false` for any non-empty selection — never a silent true.
       - name: Collect the receipts
         uses: actions/download-artifact@v8
         continue-on-error: true
         with:
-          pattern: module-pack-receipt-*
+          pattern: module-pack-receipt-${{ needs.select.outputs.lane }}-*
           merge-multiple: true
           path: ${{ runner.temp }}/receipts
       - name: Collect the built markers
         uses: actions/download-artifact@v8
         continue-on-error: true
         with:
-          pattern: module-built-*
+          pattern: module-built-${{ needs.select.outputs.lane }}-*
           merge-multiple: true
           path: ${{ runner.temp }}/built
       - name: Exactly the selected bundles were built
@@ -1454,6 +1566,7 @@ jobs:
           SCOPE: ${{ needs.select.outputs.scope }}
           COUNT: ${{ needs.select.outputs.count }}
           DECLARED: ${{ inputs.modules }}
+          LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
           echo "scope=$SCOPE, selection named $COUNT module bundle(s); pack job: $PACK_RESULT"
@@ -1479,15 +1592,31 @@ jobs:
             echo "bundles_built=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
+          # 🚨 The lane key is what makes every download above THIS call's. Without it the two
+          # collectors fall back to name-only separation, which is exactly the state that let a
+          # sibling call's evidence answer this one (Plugins#1077) — so an empty key is refused
+          # here rather than silently degraded into the behaviour being fixed.
+          if [ -z "$LANE" ]; then
+            echo "::error title=Module bundles incomplete::the selection produced no lane key, so \
+          nothing downloaded above can be attributed to THIS call and bundles-built would be \
+          answerable from a sibling call's artifacts. Refusing to answer."
+            echo "bundles_built=false" >> "$GITHUB_OUTPUT"
+            exit 1
+          fi
           # 🚨 `--declared`: artifacts are RUN-wide, so when a repo calls this workflow twice in
           # one run (Plugins #932: a floor call the gates compose, and the rest) each verifier
           # downloads the OTHER call's receipts too. Only modules in THIS call's matrix count.
+          # 🚨 `--lane`: the structural half of the same answer. `--declared` separates two calls
+          # by module name; `--lane` separates them by the stamp the producer wrote, so a marker
+          # or receipt this call cannot attribute to itself is set aside and NAMED, and a
+          # SELECTED module left without one reads as not built.
           python3 meshweaver/.github/scripts/node-repo-pack-verify.py \
             --expected "$EXPECTED" \
             --receipts "$RUNNER_TEMP/receipts" \
             --pack-result "$PACK_RESULT" \
             --scope "$SCOPE" \
             --declared "$DECLARED" \
+            --lane "$LANE" \
             --built "$RUNNER_TEMP/built" \
             --github-output "$GITHUB_OUTPUT"
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -82,6 +82,50 @@ Two bugs that make a monitor lie, both hit in one session:
   of a PR with zero checks. Decide readiness by asserting the **required set is present and
   SUCCESS**, never by the absence of failures.
 
+## A green gate can be answering with evidence it did not produce
+
+The traps above are about a check that never *ran*. This one is worse: the check runs, does its
+accounting, and reports SUCCESS **from another job's evidence**.
+
+**Artifacts are RUN-wide, not call-wide.** A reusable workflow that a repo invokes twice in one run
+— `MeshWeaver.Plugins` calls `node-repo-module-pack.yml` as both `modules-floor` and `modules-rest`,
+on every run — puts both calls' artifacts in ONE namespace. Two uploads of the same name are
+*accepted*: Plugins run `33487032213` carried two artifacts literally named `workspace-build`
+(25.8 MB and 950 kB), and `download-artifact` resolved the name to one of them. The floor's pack job
+read the other call's workspace and died on *"the global build wrote no closure manifest for
+MeshWeaver.Markdown.Collaboration"* — a REQUIRED gate flipping green/red on `main` with **no source
+change**, alternating by which call won the name (Plugins#1077).
+
+**A discriminator with a shared default is not a discriminator.** The `lane-id` input existed for
+exactly this and did not close it, because its default was the same literal for both calls and
+neither caller set it. The fix is to *derive* the key rather than trust the caller: `select` now
+computes a lane key from the call's own `modules:` matrix — unique per call by construction, with no
+input a caller can forget — and every artifact the call drops is named and stamped with it.
+
+**Three rules generalise out of it:**
+
+1. **Name every artifact for the CALL, not the workflow.** If two invocations can coexist in one
+   run, the name must carry something that differs between them, derived — not an input someone
+   remembers to pass.
+2. **Scope the download to match, and check the stamp anyway.** A `pattern: foo-*` glob is one edit
+   from being widened back; the producer stamping its lane INTO the file means the consumer can
+   still refuse foreign evidence when it is.
+3. **An answer a gate composes must fail closed.** `bundles-built` is what a required gate depends
+   on, so zero evidence, foreign evidence and evidence that does not record what it attests are all
+   *false* — never a silent true. A marker saying "an artifact was uploaded" leaves
+   present-but-uncomposable reading as green, so the marker records the bundle it attests **and**
+   the closure the build resolved, and the verifier requires both.
+
+🚨 **Preserve the reason the evidence is dropped EARLY.** The built marker lands before the module's
+tests deliberately, so a red suite cannot read as "bundle missing" to a gate that only *composes*
+bundles (#2710, Plugins#937). Strengthening what the marker claims must not drag test results into
+it — "the bundle is complete and usable" and "the module's tests passed" are different questions,
+answered by different contexts.
+
+**And the acceptance criterion for a fix in this class is REPEATED green.** A defect that alternates
+run to run produces single greens by itself; one green run is what it looks like, not evidence it is
+gone.
+
 ## Reading a RED shard: the exit marker classifies it, the log text does not
 
 A red shard says *why* in exactly one place — the **exit marker** printed by "Fail on non-zero


### PR DESCRIPTION
Fixes the required-status-check flip reported in `Systemorph/MeshWeaver.Plugins#1077`.

## The collision, confirmed — and it is `workspace-build`, not the marker

`node-repo-module-pack.yml` is invoked **twice in one run** by MeshWeaver.Plugins (`modules-floor`, `modules-rest`), and **artifacts are RUN-wide**. Two uploads of the same name are *accepted*, not rejected:

```
$ gh api repos/.../actions/runs/33487032213/artifacts --jq '...workspace...'
{"id":9792427755,"name":"workspace-build","size_in_bytes":25792943}   # the REST call, 30 entries
{"id":9792412391,"name":"workspace-build","size_in_bytes":950533}     # the FLOOR call, 2 entries
```

`download-artifact` resolved the name to **one** of them. In run `33487032213` the floor's `MeshWeaver.Markdown.Collaboration` pack downloaded **id 9792427755 — the other call's workspace** (verbatim from its log) and died on *"the global build wrote no closure manifest"*. That error fires in the **build** step, ~200 lines before the marker, so no marker was dropped → `bundles-built=false` → the required gate went **red, correctly**.

`lane-id` (#2934) was added for exactly this and **did not close it**: its default is the same literal (`'main'`) for both calls, and neither caller sets it. **A discriminator with a shared default is not a discriminator.**

## Two corrections to the issue's diagnosis, from the logs

Both are worth recording because they change what "fixed" looks like:

1. **Run `33490117901`'s `Module bundle (MeshWeaver.AI)` did NOT fail on the closure manifest.** It failed on its **test suite** — `Failed: 1, Passed: 1640` (`MeshPluginContentAccessTest.Autocomplete_RoundTrip_LowercaseQuery_QuotedInsertText_GetsContent`), after the bundle upload and after the marker. So `bundles-built=true` there was the **documented, deliberate #2710 / Plugins#937 behaviour**, and `Compile every NodeType (vs core)` reporting SUCCESS on a real, complete bundle set was correct. The alternation in the issue's table is one genuine collision plus one unrelated AI flake, not one defect firing twice.
2. **The marker/receipt name collision is real but was *latent* for Plugins**, because the two calls' declared matrices are disjoint and `--declared` filters by module name. It becomes live the moment two calls in one run declare the same module — one `always-modules` floor entry that also appears in the other call's list is all it takes. Confirmed run-wide from the floor `verify` job log: it downloaded **all 30** of the sibling call's receipts and **all 31** of its markers under `module-pack-receipt-*` / `module-built-*`.

## What changed

- **The lane key is DERIVED, not trusted.** `select` emits `lane` = the `lane-id` label + a fingerprint of *this call's own* `modules:` matrix — unique per call by construction, no input a caller can forget. Against the real Plugins matrices, the two calls that both leave `lane-id` at its default now key as `main-27ced244ed9c` and `main-e42e45b20d86`.
- **Every artifact this call drops is lane-named**: `workspace-build-<lane>`, `module-pack-tool-<lane>`, `module-built-<lane>-<module>`, `module-pack-receipt-<lane>-<module>`. **`module-bundle-<module>` is unchanged** — it is the cross-workflow contract every caller composes.
- **`verify`'s collectors are scoped to this call's lane**, *and* the lane is stamped inside every marker and receipt so the verifier refuses foreign evidence even if a pattern is widened again.
- **The claim is stronger**: `bundles-built` must mean *complete **and usable***. The marker now records the bundle it attests **and** the closure evidence the build resolved (`<Module>.closure.txt` on the container path, publish deps.json on the sdk path), and the verifier refuses a marker missing either — an ordering guarantee that only a comment records is one refactor from being gone.
- **Fail closed, everywhere**: zero markers, a foreign-lane marker, an unstamped one, a corrupt one, and one that does not record what it attests are each "not built". An empty lane key in `verify` is refused rather than degraded back into name-only separation.

🚨 **#2710 is untouched.** The marker is still dropped BEFORE the module's tests and nothing about the test run reaches it, so a red suite still cannot read as "bundle missing" to a gate that only composes bundles.

## What I ran vs. what I read

**Executed:**
- `node-repo-pack-verify.py --self-test` — 24 → **34 cases**, all green.
- An **end-to-end dry run** of the verifier on a synthesised run-wide directory (both lanes' evidence merged, the floor's AI leg with no marker of its own, the rest lane donating one): **`bundles_built=false` with `--lane`, `bundles_built=true` without it** — the false pass and its closure, side by side.
- The lane-key shell, against the two real Plugins matrices → two distinct keys with no caller change.
- `actionlint` — findings **identical** to `origin/main` (`diff` on the normalised output); `bash -n` on every `run:` block; YAML parses.

**Read, not executed:** the collision itself. I cannot stage two concurrent reusable-workflow calls locally, so the artifact-name and download-pattern reasoning is a reading of the workflow plus the **artifact and job logs of the two real runs** (ids and sizes quoted above) — not a live reproduction.

## Acceptance — one green proves nothing

Per #1077: this defect *produces* single greens. Acceptance is **both floor entries producing a closure manifest and a bundle in the same run, repeatedly**. Suggested check after this lands and Plugins bumps its pin: several consecutive `main` runs with both floor bundles green and `Compile every NodeType (vs core)` green.

## Blast radius

`main-cd.yml` calls this workflow **once** (relative ref) and consumes only `module-bundle-*` — unaffected. MeshWeaver.Plugins and the four satellites pin by SHA; **MeshWeaver.Plugins currently pins `0a1eabdc` (pre-#2934) and must bump to pick this up** — that bump is a separate one-line PR on that repo. The inputs/outputs contract is unchanged, so no satellite needs an edit of its own.

Work product conserved in `Doc/Architecture/ReadingCiSignals` — a new section on a gate answering from evidence it did not produce.

Not merged and auto-merge not armed, as instructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
