### PR TITLE
test(static lane): a skip is its own outcome — Skip, TestLog and TestContext were landed and dead

### DIFF
--- a/test/MeshWeaver.MathDemo.Test/MatrixViewsTest.cs
+++ b/test/MeshWeaver.MathDemo.Test/MatrixViewsTest.cs
@@ -75,7 +75,13 @@ public class MatrixViewsTest(ITestOutputHelper output) : MonolithMeshTestBase(ou
     [Fact(Timeout = 120_000)]
     public async Task Inverse_ShouldRenderForMatrixExample()
     {
-        if (ShouldSkip) return;
+        // 🚨 Assert.SkipWhen, never `if (…) return;`. A bare return reports the case as
+        // PASSED — the run then claims a NuGet-restoring render was proven on a machine where it
+        // never executed, which is the absence-of-evidence-reads-as-green failure the estate keeps
+        // paying for. xUnit v3 has the primitive; this repo already uses it everywhere else.
+        Assert.SkipWhen(ShouldSkip,
+            "MESHWEAVER_SKIP_NUGET=1 — this case restores MathNet.Numerics from api.nuget.org "
+            + "on first run and cannot be executed offline");
 
         var client = GetClient();
         var address = new Address("MathDemo/Matrix/Example");

--- a/test/MeshWeaver.PluginTester.Test/StaticTestRunnerTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/StaticTestRunnerTest.cs
@@ -1,0 +1,469 @@
+using System.Collections.Immutable;
+using System.Text;
+using MeshWeaver.PluginTester;
+using MeshWeaver.Testing;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+// 🚨 xUnit v3 ships its OWN Xunit.TestContext — the very type the static lane's shim imitates.
+// Aliased rather than disambiguated at each use, so this file can never assert against the wrong one.
+using MeshTestContext = MeshWeaver.Testing.TestContext;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// The STATIC lane's case surface, executed rather than described: a probe assembly is compiled to
+/// disk and handed to <see cref="StaticTestRunner.Execute"/>, exactly as a NodeType's emitted
+/// <c>Test/*.cs</c> is on a build run.
+///
+/// <para>🚨 <b>Why the counting assertions are the point.</b> <c>SkipException</c>,
+/// <c>TestContext</c> and <c>TestLog</c> shipped in <c>Testing/TestContext.cs</c> and the runner
+/// referenced NONE of them — a landed, dead surface. Wiring them in is only half the job: the half
+/// that bites is a skip folded into the pass count, which makes a verdict line say <c>12/12
+/// passed</c> over a suite where three cases declined to assert anything. That is the
+/// absence-of-evidence-reads-as-green failure this estate has paid for repeatedly, so every count
+/// here is asserted as a SPLIT, never as a total.</para>
+/// </summary>
+public class StaticTestRunnerTest
+{
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// One case per outcome the runner can produce, in one assembly — a pass, a decline, a
+    /// failure, and a hosted case the mesh lane owns.
+    /// </summary>
+    private const string OutcomesProbe = """
+        using System;
+        using MeshWeaver.Testing;
+
+        public static class ProbeOutcomesTests
+        {
+            public static void APassingCase() { }
+
+            public static void ADecliningCase() =>
+                throw new SkipException("no credential on this host");
+
+            public static void AFailingCase() =>
+                throw new InvalidOperationException("boom");
+
+            public static void AHostedCase(object host) { }
+        }
+        """;
+
+    [Fact]
+    public void ASkipIsItsOwnOutcome_CarriesItsReason_AndIsNeverCountedAsAPass()
+    {
+        var directory = TempDirectory("skip-outcome");
+        try
+        {
+            var log = new StringWriter();
+            var run = StaticTestRunner.Execute(
+                Emit(directory, "Probe.Outcomes", OutcomesProbe), [], Budget, log);
+
+            Assert.Null(run.LoadError);
+            Assert.Equal(4, run.Cases.Length);
+
+            var skipped = Assert.Single(run.Cases.Where(c => c.Name == "ProbeOutcomesTests.ADecliningCase"));
+            Assert.Equal(StaticTestRunner.Outcome.Skipped, skipped.Outcome);
+
+            // The reason REACHES the verdict. A skip whose reason is dropped is indistinguishable
+            // from a case that was never discovered.
+            Assert.Equal("no credential on this host", skipped.Error);
+
+            // 🚨 The split, member by member. `Passed` counting 2 here would be the whole defect.
+            Assert.Equal(1, run.Passed);
+            Assert.Equal(1, run.Failed);
+            Assert.Equal(1, run.Skipped);
+            Assert.Equal(1, run.NeedsMesh);
+            Assert.Equal(run.Cases.Length, run.Passed + run.Failed + run.Skipped + run.NeedsMesh);
+
+            // A skip does not turn the run red on its own — but this run has a real failure, so it
+            // is red for that reason and only that reason.
+            Assert.False(run.IsGreen);
+
+            // …and the printed line gets its own token, because the table a reader actually looks
+            // at is where a skip would otherwise disappear into `ok`.
+            var printed = log.ToString();
+            Assert.Contains("SKIP  ProbeOutcomesTests.ADecliningCase", printed, StringComparison.Ordinal);
+            Assert.Contains("no credential on this host", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("ok    ProbeOutcomesTests.ADecliningCase", printed, StringComparison.Ordinal);
+        }
+        finally { Cleanup(directory); }
+    }
+
+    /// <summary>A suite whose only non-passing case declines: green, and honest about it.</summary>
+    private const string AllSkippedProbe = """
+        using MeshWeaver.Testing;
+
+        public static class ProbeDeclineTests
+        {
+            public static void One() => throw new SkipException("not on this platform");
+            public static void Two() => throw new SkipException("not on this platform");
+        }
+        """;
+
+    [Fact]
+    public void ARunOfNothingButSkipsIsGreen_AndReportsZeroPassed()
+    {
+        var directory = TempDirectory("all-skipped");
+        try
+        {
+            var run = StaticTestRunner.Execute(
+                Emit(directory, "Probe.Decline", AllSkippedProbe), [], Budget, null);
+
+            // Green — declining is a legitimate answer and must not turn a build red…
+            Assert.True(run.IsGreen);
+            // …but it proved NOTHING, and the numbers say so.
+            Assert.Equal(0, run.Passed);
+            Assert.Equal(2, run.Skipped);
+            Assert.Equal(0, run.Failed);
+        }
+        finally { Cleanup(directory); }
+    }
+
+    private const string LogProbe = """
+        using System;
+        using MeshWeaver.Testing;
+
+        public static class ProbeLogTests
+        {
+            public static void AFailureNarratesItself()
+            {
+                TestLog.WriteLine("opened the door");
+                TestLog.WriteLine("read {0} rows", 7);
+                throw new InvalidOperationException("then it broke");
+            }
+
+            public static void APassIsQuietInTheLogButKeepsItsLines()
+            {
+                TestLog.WriteLine("nothing to see");
+            }
+        }
+        """;
+
+    [Fact]
+    public void TestLogIsCapturedPerCase_AttachedToItsResult_AndPrintedForFailuresOnly()
+    {
+        var directory = TempDirectory("testlog");
+        try
+        {
+            var log = new StringWriter();
+            var run = StaticTestRunner.Execute(
+                Emit(directory, "Probe.Log", LogProbe), [], Budget, log);
+
+            Assert.Null(run.LoadError);
+            var failed = Assert.Single(run.Cases.Where(c => c.Name == "ProbeLogTests.AFailureNarratesItself"));
+            var passed = Assert.Single(run.Cases.Where(c => c.Name == "ProbeLogTests.APassIsQuietInTheLogButKeepsItsLines"));
+
+            // Attached to the CASE, not smeared across the build log: each case's lines are its own,
+            // prefixed with its own name.
+            Assert.Equal(2, failed.Log.Length);
+            Assert.Contains("[ProbeLogTests.AFailureNarratesItself] opened the door", failed.Log[0], StringComparison.Ordinal);
+            Assert.Contains("[ProbeLogTests.AFailureNarratesItself] read 7 rows", failed.Log[1], StringComparison.Ordinal);
+            Assert.Equal(
+                ["      [ProbeLogTests.APassIsQuietInTheLogButKeepsItsLines] nothing to see"],
+                passed.Log);
+
+            // Printed with the failure — that is the point of capturing it — and NOT with the pass,
+            // which would bury the failure's neighbourhood in noise.
+            var printed = log.ToString();
+            Assert.Contains("opened the door", printed, StringComparison.Ordinal);
+            Assert.DoesNotContain("nothing to see", printed, StringComparison.Ordinal);
+        }
+        finally { Cleanup(directory); }
+    }
+
+    private const string ContextProbe = """
+        using System;
+        using System.Threading;
+        using MeshWeaver.Testing;
+
+        public static class ProbeContextTests
+        {
+            public static void SeesItsOwnName()
+            {
+                var name = TestContext.Current.CaseName;
+                if (name != "ProbeContextTests.SeesItsOwnName")
+                    throw new InvalidOperationException("CaseName was '" + name + "'");
+            }
+
+            public static void SeesACancellableBudget()
+            {
+                var token = TestContext.Current.CancellationToken;
+                if (!token.CanBeCanceled)
+                    throw new InvalidOperationException("the case budget was CancellationToken.None");
+                if (token.IsCancellationRequested)
+                    throw new InvalidOperationException("the budget was already spent on entry");
+            }
+        }
+        """;
+
+    [Fact]
+    public void TestContextCurrentIsPopulatedForTheCase()
+    {
+        var directory = TempDirectory("context");
+        try
+        {
+            var run = StaticTestRunner.Execute(
+                Emit(directory, "Probe.Context", ContextProbe), [], Budget, null);
+
+            Assert.Null(run.LoadError);
+            Assert.All(run.Cases, c => Assert.Equal(StaticTestRunner.Outcome.Passed, c.Outcome));
+            Assert.Equal(2, run.Passed);
+        }
+        finally { Cleanup(directory); }
+    }
+
+    private const string CooperativeHangProbe = """
+        using System;
+        using MeshWeaver.Testing;
+
+        public static class ProbeBudgetTests
+        {
+            public static void WaitsOnItsOwnBudget()
+            {
+                TestLog.WriteLine("about to wait on the budget");
+                TestContext.Current.CancellationToken.WaitHandle.WaitOne();
+                TestContext.Current.CancellationToken.ThrowIfCancellationRequested();
+            }
+        }
+        """;
+
+    [Fact]
+    public void TheBudgetTokenTripsInsideTheCap_SoACooperativeCaseEndsNamedRatherThanAbandoned()
+    {
+        var directory = TempDirectory("budget");
+        try
+        {
+            var log = new StringWriter();
+            var run = StaticTestRunner.Execute(
+                Emit(directory, "Probe.Budget", CooperativeHangProbe), [],
+                TimeSpan.FromSeconds(2), log);
+
+            var c = Assert.Single(run.Cases);
+            Assert.Equal(StaticTestRunner.Outcome.Failed, c.Outcome);
+
+            // The token fired, so the case ended by NAME — not with the runner's "did not return"
+            // verdict, which means the thread was abandoned and the build carried a live thread on.
+            Assert.Contains("OperationCanceledException", c.Error!, StringComparison.Ordinal);
+            Assert.DoesNotContain("did not return within", c.Error!, StringComparison.Ordinal);
+
+            // …and the verdict NAMES the budget rather than repeating the framework's
+            // "The operation was canceled.", which tells a reader nothing about why.
+            Assert.Contains("the case budget (2s) expired", c.Error!, StringComparison.Ordinal);
+
+            // …and the lines it wrote before it blocked survived into the report.
+            Assert.Contains("about to wait on the budget", string.Join("\n", c.Log), StringComparison.Ordinal);
+            Assert.Contains("about to wait on the budget", log.ToString(), StringComparison.Ordinal);
+        }
+        finally { Cleanup(directory); }
+    }
+
+    private const string ParallelProbeTemplate = """
+        using MeshWeaver.Testing;
+
+        public static class Probe{0}Tests
+        {{
+            public static void Case() => TestLog.WriteLine("marker-{0}");
+        }}
+        """;
+
+    [Fact]
+    public async Task ConcurrentRunsDoNotSmearEachOthersLog()
+    {
+        // The cascade builds packages in PARALLEL, so two Execute calls are routinely in flight at
+        // once. A process-wide TestLog sink would attribute one package's output to another; the
+        // capture hangs off the [ThreadStatic] context instead, and this is what proves it.
+        var directory = TempDirectory("parallel");
+        try
+        {
+            var assemblies = Enumerable.Range(0, 8)
+                .Select(i => Emit(
+                    directory,
+                    $"Probe.Parallel{i}",
+                    string.Format(System.Globalization.CultureInfo.InvariantCulture, ParallelProbeTemplate, i)))
+                .ToArray();
+
+            var runs = await Task.WhenAll(assemblies.Select((path, i) =>
+                Task.Run(() => (Index: i, Run: StaticTestRunner.Execute(path, [], Budget, null)))));
+
+            Assert.All(runs, r =>
+            {
+                var c = Assert.Single(r.Run.Cases);
+                Assert.Equal(StaticTestRunner.Outcome.Passed, c.Outcome);
+                var line = Assert.Single(c.Log);
+                Assert.Contains($"marker-{r.Index}", line, StringComparison.Ordinal);
+                Assert.Contains($"Probe{r.Index}Tests.Case", line, StringComparison.Ordinal);
+            });
+        }
+        finally { Cleanup(directory); }
+    }
+
+    [Fact]
+    public void EnteringACaseContextInstallsItAndDisposingRestoresTheOneBefore()
+    {
+        Assert.Equal("(no case)", MeshTestContext.Current.CaseName);
+        using (MeshTestContext.Enter("Outer.Case", CancellationToken.None))
+        {
+            Assert.Equal("Outer.Case", MeshTestContext.Current.CaseName);
+            using (MeshTestContext.Enter("Inner.Case", CancellationToken.None))
+                Assert.Equal("Inner.Case", MeshTestContext.Current.CaseName);
+            Assert.Equal("Outer.Case", MeshTestContext.Current.CaseName);
+        }
+
+        // Cleared after — a leaked context would name the wrong case in every later TestLog line
+        // this thread emits, and the thread is reused for the next case.
+        Assert.Equal("(no case)", MeshTestContext.Current.CaseName);
+    }
+
+    [Fact]
+    public void DisposingAnotherThreadsScopeCannotClearThisThreadsContext()
+    {
+        // The context is [ThreadStatic]. A scope disposed from a foreign thread must NOT reach into
+        // that thread's slot — doing so would silently unset a different, concurrently running case.
+        IDisposable? foreign = null;
+        var owner = new Thread(() => foreign = MeshTestContext.Enter("Foreign.Case", CancellationToken.None));
+        owner.Start();
+        owner.Join();
+
+        using (MeshTestContext.Enter("Mine.Case", CancellationToken.None))
+        {
+            foreign!.Dispose();
+            Assert.Equal("Mine.Case", MeshTestContext.Current.CaseName);
+        }
+        Assert.Equal("(no case)", MeshTestContext.Current.CaseName);
+    }
+
+    [Fact]
+    public void TestLogOutsideACaseFallsBackToTheProcessSink()
+    {
+        var seen = new List<string>();
+        var previous = TestLog.Sink;
+        try
+        {
+            TestLog.Sink = seen.Add;
+            TestLog.WriteLine("orphan line");
+            Assert.Equal(["      [(no case)] orphan line"], seen);
+        }
+        finally { TestLog.Sink = previous; }
+    }
+
+    [Fact]
+    public void APackageRollUpKeepsSkipsOutOfItsPassCount()
+    {
+        // The counting seam one level up: CascadeBuild's package roll-up is where a per-case skip
+        // would be laundered into "N passed" for the table and the JSON report.
+        var run = new StaticTestRunner.Run("x.dll",
+        [
+            new StaticTestRunner.Case("T.A", StaticTestRunner.Outcome.Passed, TimeSpan.Zero, null),
+            new StaticTestRunner.Case("T.B", StaticTestRunner.Outcome.Skipped, TimeSpan.Zero, "why"),
+            new StaticTestRunner.Case("T.C", StaticTestRunner.Outcome.Skipped, TimeSpan.Zero, "why"),
+            new StaticTestRunner.Case("T.D", StaticTestRunner.Outcome.NeedsMesh, TimeSpan.Zero, "host"),
+        ], null);
+
+        var package = new CascadeBuild.PackageBuild(
+            "Probe",
+            [new CascadeBuild.TypeBuild("Probe/T", "Probe", null, TimeSpan.Zero, 1, "x.dll", run, [])],
+            [], TimeSpan.Zero, TimeSpan.Zero, []);
+
+        Assert.Equal(1, package.TestsPassed);
+        Assert.Equal(2, package.TestsSkipped);
+        Assert.Equal(0, package.TestsFailed);
+        Assert.Equal(1, package.TestsNeedMesh);
+        Assert.True(package.IsGreen);
+    }
+
+    [Fact]
+    public void TheSummaryTableCarriesASkipColumn_AlignedWithItsHeader()
+    {
+        // 🚨 The one table a reader actually looks at. Before this facility it had no `skip` column
+        // at all, so a declining case simply was not in the picture; and the header had already
+        // drifted out of alignment with the row format, which is how a column quietly stops meaning
+        // what its heading says.
+        var run = new StaticTestRunner.Run("x.dll",
+        [
+            new StaticTestRunner.Case("T.A", StaticTestRunner.Outcome.Passed, TimeSpan.Zero, null),
+            new StaticTestRunner.Case("T.B", StaticTestRunner.Outcome.Skipped, TimeSpan.Zero, "why"),
+            new StaticTestRunner.Case("T.C", StaticTestRunner.Outcome.Skipped, TimeSpan.Zero, "why"),
+            new StaticTestRunner.Case("T.D", StaticTestRunner.Outcome.Skipped, TimeSpan.Zero, "why"),
+        ], null);
+        var package = new CascadeBuild.PackageBuild(
+            "Probe",
+            [new CascadeBuild.TypeBuild("Probe/T", "Probe", null, TimeSpan.Zero, 1, "x.dll", run, [])],
+            [], TimeSpan.Zero, TimeSpan.Zero, []);
+        var report = new CascadeBuild.Report(
+            "identity",
+            [new Cascade.NodeResult<CascadeBuild.PackageBuild>(
+                "Probe", Cascade.NodeOutcome.Green, package, null, null,
+                TimeSpan.Zero, TimeSpan.Zero, TimeSpan.Zero)],
+            ["Probe"], TimeSpan.FromSeconds(1), []);
+
+        var output = new StringWriter();
+        CascadeBuild.Print(output, report, _ => []);
+        var lines = output.ToString().Split('\n');
+
+        var header = Assert.Single(lines, l => l.StartsWith("package", StringComparison.Ordinal));
+        var row = Assert.Single(lines, l => l.StartsWith("Probe ", StringComparison.Ordinal));
+
+        var skip = header.IndexOf("skip", StringComparison.Ordinal);
+        var passed = header.IndexOf("passed", StringComparison.Ordinal);
+        Assert.True(skip > 0, $"the summary table has no `skip` column: {header}");
+        Assert.True(passed > 0 && passed < skip, "passed and skip are separate columns, in that order");
+
+        // The numbers land UNDER their own headings — one pass, three declines, and the pass count
+        // is 1 rather than 4.
+        // `passed` is right-aligned in a 6-wide field it exactly fills; `skip` is right-aligned in
+        // a 5-wide one, so its field starts one column left of the heading.
+        Assert.Equal("1", row[passed..(passed + 6)].Trim());
+        Assert.Equal("3", row[(skip - 1)..(skip + 4)].Trim());
+        Assert.Equal(1, package.TestsPassed);
+        Assert.Equal(3, package.TestsSkipped);
+    }
+
+    /// <summary>
+    /// Compiles <paramref name="source"/> to a real assembly on disk, referencing this process's
+    /// core assemblies plus <c>mw-plugin-test</c> itself — which is how a case reaches
+    /// <c>MeshWeaver.Testing</c>. The runner loads it into a collectible context that defers every
+    /// already-loaded assembly to the default one, so <c>SkipException</c> thrown in there IS the
+    /// <c>SkipException</c> the runner catches; a second copy would silently classify every skip as
+    /// a failure.
+    /// </summary>
+    private static string Emit(string directory, string name, string source)
+    {
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, name + ".dll");
+        var compilation = CSharpCompilation.Create(
+            name,
+            [CSharpSyntaxTree.ParseText(source)],
+            References(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        var emit = compilation.Emit(path);
+        Assert.True(
+            emit.Success,
+            "the probe assembly did not compile: "
+            + string.Join("; ", emit.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error)));
+        return path;
+    }
+
+    private static ImmutableArray<MetadataReference> References() =>
+    [
+        MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+        MetadataReference.CreateFromFile(typeof(SkipException).Assembly.Location),
+        .. ((AppContext.GetData("TRUSTED_PLATFORM_ASSEMBLIES") as string ?? string.Empty)
+            .Split(Path.PathSeparator)
+            .Where(p => !string.IsNullOrEmpty(p) && File.Exists(p))
+            .Where(p => Path.GetFileName(p)
+                is "System.Runtime.dll" or "netstandard.dll" or "System.Threading.dll"
+                or "System.Console.dll")
+            .Select(p => (MetadataReference)MetadataReference.CreateFromFile(p))),
+    ];
+
+    private static string TempDirectory(string prefix) =>
+        Path.Combine(Path.GetTempPath(), "static-test-runner-" + prefix + "-" + Guid.NewGuid().ToString("N"));
+
+    private static void Cleanup(string directory)
+    {
+        try { if (Directory.Exists(directory)) Directory.Delete(directory, recursive: true); }
+        catch { /* best effort — a locked temp dir must not fail the test */ }
+    }
+}

--- a/tools/MeshWeaver.PluginTester/CascadeBuild.cs
+++ b/tools/MeshWeaver.PluginTester/CascadeBuild.cs
@@ -136,6 +136,13 @@ public static class CascadeBuild
 
         /// <summary>Cases left to the mesh lane.</summary>
         public int TestsNeedMesh => Types.Sum(t => t.Tests?.NeedsMesh ?? 0);
+
+        /// <summary>
+        /// Cases that ran and DECLINED. 🚨 Its own number, never added to
+        /// <see cref="TestsPassed"/>: a package line reading "12 passed" over a suite where three
+        /// threw <c>SkipException</c> asserts evidence that was never produced.
+        /// </summary>
+        public int TestsSkipped => Types.Sum(t => t.Tests?.Skipped ?? 0);
     }
 
     /// <summary>The whole build.</summary>
@@ -495,7 +502,8 @@ public static class CascadeBuild
                 + $"{compiled.Inputs.MatchedSourcePaths.Length} source(s))"
                 + (tests is null ? "" : tests.Cases.IsEmpty
                     ? " tests: no test classes in the assembly"
-                    : $" tests: {tests.Cases.Length} case(s) — {tests.Passed} passed, {tests.Failed} failed, {tests.NeedsMesh} needs-mesh")
+                    : $" tests: {tests.Cases.Length} case(s) — {tests.Passed} passed, {tests.Failed} failed, "
+                      + $"{tests.Skipped} skipped, {tests.NeedsMesh} needs-mesh")
                 + (binds.IsEmpty ? "" : $" binds-dependency-assembly: {string.Join(", ", binds)}"));
         }
         compileClock.Stop();
@@ -506,14 +514,19 @@ public static class CascadeBuild
         options.Output.WriteLine(
             $"{Stamp()} [{id}] {(result.IsGreen ? "GREEN" : "RED")} — compile {result.Compile.TotalSeconds:F1}s, "
             + $"tests {result.Tests.TotalSeconds:F1}s ({result.TestsPassed} passed, {result.TestsFailed} failed, "
-            + $"{result.TestsNeedMesh} needs-mesh)");
+            + $"{result.TestsSkipped} skipped, {result.TestsNeedMesh} needs-mesh)");
         return result;
     }
 
     private static Report Fatal(string frameworkIdentity, Stopwatch wall, string error) =>
         new(frameworkIdentity, [], [], wall.Elapsed, [], error);
 
-    private static void Print(
+    /// <summary>
+    /// The summary table and the build line. 🚨 <c>internal</c> so the columns can be PINNED by a
+    /// test: the header drifted out of alignment with the row format once already, and a column
+    /// that silently disappears is how a skip gets read as a pass.
+    /// </summary>
+    internal static void Print(
         TextWriter output, Report report, Func<string, IReadOnlyList<string>> dependenciesOf)
     {
         output.WriteLine();
@@ -522,7 +535,9 @@ public static class CascadeBuild
             output.WriteLine($"FATAL: {report.FatalError}");
             return;
         }
-        output.WriteLine("package                        verdict   ready    queued    work   compile   tests   types  passed failed mesh  note");
+        // 🚨 `skip` is a column of its own. It used to have nowhere to go, which meant a
+        // declining case was invisible in the one table a reader actually looks at.
+        output.WriteLine("package                        verdict    ready   queued    work  compile   tests  types passed failed  skip  mesh  note");
         foreach (var p in report.Packages.OrderBy(p => p.Finished))
         {
             var b = p.Result;
@@ -540,7 +555,8 @@ public static class CascadeBuild
             output.WriteLine(
                 $"{p.Id,-30} {Verdict(p.Outcome),-8} {p.Ready.TotalSeconds,7:F1} {p.Queued.TotalSeconds,8:F1} "
                 + $"{p.Work.TotalSeconds,7:F1} {(b?.Compile.TotalSeconds ?? 0),8:F1} {(b?.Tests.TotalSeconds ?? 0),7:F1} "
-                + $"{(b?.Types.Length ?? 0),6} {(b?.TestsPassed ?? 0),6} {(b?.TestsFailed ?? 0),6} {(b?.TestsNeedMesh ?? 0),4}  {note}");
+                + $"{(b?.Types.Length ?? 0),6} {(b?.TestsPassed ?? 0),6} {(b?.TestsFailed ?? 0),6} "
+                + $"{(b?.TestsSkipped ?? 0),5} {(b?.TestsNeedMesh ?? 0),5}  {note}");
         }
         output.WriteLine();
         var green = report.Packages.Count(p => p.IsGreen);
@@ -599,6 +615,7 @@ public static class CascadeBuild
                         loadError = t.Tests.LoadError,
                         passed = t.Tests.Passed,
                         failed = t.Tests.Failed,
+                        skipped = t.Tests.Skipped,
                         needsMesh = t.Tests.NeedsMesh,
                         cases = t.Tests.Cases.Select(c => new
                         {
@@ -606,6 +623,7 @@ public static class CascadeBuild
                             outcome = c.Outcome.ToString(),
                             ms = c.Elapsed.TotalMilliseconds,
                             error = c.Error,
+                            log = c.Log,
                         }),
                     },
                 }),

--- a/tools/MeshWeaver.PluginTester/README.md
+++ b/tools/MeshWeaver.PluginTester/README.md
@@ -181,6 +181,26 @@ mw-compiler build <repo-root> [<package>... | all] [--module <dll>]... [--out <d
   host (a `Tests` layout-area aggregator, anything needing a hub) is COUNTED and NAMED as
   `needs-mesh`, never dropped: the gate (`mw-compiler <root> --seed <out>`) still runs those,
   seeded from `--out` so nothing is compiled twice.
+- **What a case may reach for — three things, and there is no xUnit in this process.**
+  `MeshWeaver.Testing` (in this assembly) supplies `TestContext.Current` — the case's name and a
+  `CancellationToken` that trips just inside `--case-timeout`, so a case that threads it through its
+  waits ends with a NAMED cancellation instead of being abandoned as a hung thread;
+  `SkipException(reason)`, which a case throws to decline (a platform it is not on, a credential it
+  does not have); and `TestLog.WriteLine`, captured per case and printed with that case when it
+  FAILS. It is deliberately not a second xUnit: no attributes, no fixtures, no theories, no
+  assertion library. Every one is installed on the case's own thread — packages build in parallel,
+  so anything process-wide would attribute one package's output to another.
+  🚨 These types live in `mw-plugin-test`, not in a framework assembly. In-mesh source reaches them
+  here only because `ContainerReferenceSet` folds this process's own closure into the reference set;
+  a PORTAL compiling the same `Test/*.cs` at runtime has no such assembly. So a node repo's test
+  source that literally names `SkipException` compiles in this lane and **fails to compile on a
+  portal** — moving the shim into a framework assembly is the prerequisite for using it there.
+- 🚨 **A skip is never a pass.** `skipped` is its own count next to `passed` / `failed` /
+  `needs-mesh` in the per-type line, the package line, the summary table and `--report` JSON, and
+  prints as `SKIP` with its reason rather than `ok`. It does not turn a build red — declining is a
+  legitimate answer — but a suite that declined proved nothing, and a verdict reading `12/12 passed`
+  over three declines is the absence-of-evidence-reads-as-green failure the node-repo CI policy
+  exists to forbid.
 - **Timings are the point.** Every package reports ready / queued / work, its compile and test
   splits and per-type compile times; the summary prints the critical path (the chain whose serial
   length is the wall-clock floor) and the parallel speed-up. `--report` writes all of it as JSON.

--- a/tools/MeshWeaver.PluginTester/StaticTestRunner.cs
+++ b/tools/MeshWeaver.PluginTester/StaticTestRunner.cs
@@ -20,6 +20,15 @@ namespace MeshWeaver.PluginTester;
 /// workload"; "do not try to import mesh nodes"), the hosted cases through the gate that seeds
 /// from this build's output.</para>
 ///
+/// <para><b>The xUnit-shaped surface a case may use.</b> There is no xUnit in this process, so the
+/// runner supplies the three things a migrated body actually reaches for, and nothing more:
+/// <see cref="Testing.TestContext"/><c>.Current</c> (the case's name and a token that trips just
+/// inside its budget), <see cref="Testing.SkipException"/> (reported as
+/// <see cref="Outcome.Skipped"/> with its reason — never as passed and never as failed), and
+/// <see cref="Testing.TestLog"/> (captured PER CASE and attached to
+/// <see cref="Case.Log"/>, printed with the case when it fails). Deliberately not a second xUnit:
+/// no attributes, no fixtures, no theories, no assertion library.</para>
+///
 /// <para><b>Resolution.</b> The emitted assembly binds the framework (already in this process —
 /// the tester's own closure is the image's <c>/app</c>) and the dependency packages' emitted
 /// assemblies, which are mapped by simple name into the context. Anything else is a missing
@@ -36,14 +45,32 @@ public static class StaticTestRunner
         Failed,
         /// <summary>Needs a host or hub — left to the mesh lane.</summary>
         NeedsMesh,
+        /// <summary>
+        /// Ran and declined: the body threw <see cref="Testing.SkipException"/>, naming a condition
+        /// it cannot meet here. 🚨 <b>Never folded into <see cref="Passed"/>.</b> A skip asserted
+        /// NOTHING, so counting it as a pass makes a verdict line claim evidence that was never
+        /// produced — the "absence of evidence reads as green" defect this estate keeps paying for.
+        /// It does not fail the run either: declining is a legitimate answer, and it is REPORTED
+        /// with its reason so a reader can see how much of a suite actually ran.
+        /// </summary>
+        Skipped,
     }
 
     /// <summary>One executed (or classified) case.</summary>
     /// <param name="Name"><c>Type.Method</c>.</param>
     /// <param name="Outcome">The verdict.</param>
     /// <param name="Elapsed">Wall time of the invocation (zero when not run).</param>
-    /// <param name="Error">The failure text, innermost exception first.</param>
-    public sealed record Case(string Name, Outcome Outcome, TimeSpan Elapsed, string? Error);
+    /// <param name="Error">The failure text, innermost exception first; the reason for a skip.</param>
+    public sealed record Case(string Name, Outcome Outcome, TimeSpan Elapsed, string? Error)
+    {
+        /// <summary>
+        /// What the case wrote through <see cref="Testing.TestLog"/> while it ran, in order.
+        /// Captured per case (never through a process-wide sink — packages build in parallel), and
+        /// printed with the case when it FAILS, including when it is abandoned for outliving its
+        /// budget: the lines up to the hang are usually the only evidence of where it got to.
+        /// </summary>
+        public ImmutableArray<string> Log { get; init; } = [];
+    }
 
     /// <summary>The run over one assembly.</summary>
     /// <param name="Assembly">The assembly path.</param>
@@ -60,7 +87,19 @@ public static class StaticTestRunner
         /// <summary>Cases that need the mesh lane.</summary>
         public int NeedsMesh => Cases.Count(c => c.Outcome == Outcome.NeedsMesh);
 
-        /// <summary>Green iff it loaded and nothing that ran failed. No cases is green, not a pass.</summary>
+        /// <summary>
+        /// Cases that ran and DECLINED (<see cref="Outcome.Skipped"/>). 🚨 Reported separately from
+        /// <see cref="Passed"/> everywhere, because a verdict of "12/12 passed" over a suite where
+        /// three declined is a false claim about what was proven.
+        /// </summary>
+        public int Skipped => Cases.Count(c => c.Outcome == Outcome.Skipped);
+
+        /// <summary>
+        /// Green iff it loaded and nothing that ran failed. No cases is green, not a pass — and
+        /// neither is a skip: <see cref="Skipped"/> does not turn the run red (declining is a
+        /// legitimate answer) but it is never counted as evidence, which is why it has its own
+        /// column in every report rather than being absorbed here.
+        /// </summary>
         public bool IsGreen => LoadError is null && Failed == 0;
     }
 
@@ -129,7 +168,7 @@ public static class StaticTestRunner
                         continue;
                     }
                     cases.Add(Invoke(name, method, perCaseTimeout));
-                    output?.WriteLine(Describe(cases[^1]));
+                    Report(output, cases[^1]);
                 }
             }
             return new Run(assemblyPath, cases.ToImmutable(), null);
@@ -140,21 +179,60 @@ public static class StaticTestRunner
         }
     }
 
+    /// <summary>
+    /// Writes one case's line to the build log, and — for a FAILURE only — whatever the case wrote
+    /// through <c>TestLog</c> before it died. A pass needs no narration and a skip already carries
+    /// its reason; a failure is the one place the neighbourhood earns its space.
+    /// </summary>
+    private static void Report(TextWriter? output, Case c)
+    {
+        if (output is null)
+            return;
+        output.WriteLine(Describe(c));
+        if (c.Outcome != Outcome.Failed)
+            return;
+        foreach (var line in c.Log)
+            output.WriteLine(line);
+    }
+
     private static string Describe(Case c) => c.Outcome switch
     {
         Outcome.Passed => $"      ok    {c.Name} ({c.Elapsed.TotalMilliseconds:F0} ms)",
         Outcome.Failed => $"      FAIL  {c.Name} ({c.Elapsed.TotalMilliseconds:F0} ms): {c.Error}",
+        // 🚨 Its own token. A skip printed as `ok` is a claim that the case proved something.
+        Outcome.Skipped => $"      SKIP  {c.Name} ({c.Elapsed.TotalMilliseconds:F0} ms): {c.Error}",
         _ => $"      mesh  {c.Name}: {c.Error}",
     };
 
     private static Case Invoke(string name, MethodInfo method, TimeSpan timeout)
     {
+        // Per-case capture, never a process-wide sink: the cascade builds packages in PARALLEL, so
+        // two cases are routinely in flight at once and a shared collector would attribute one's
+        // output to the other. Locked because the runner thread reads it while an ABANDONED case
+        // thread may still be writing to it (the hung-case path below).
+        var log = new List<string>();
+        void Capture(string line) { lock (log) log.Add(line); }
+        ImmutableArray<string> Captured() { lock (log) return [.. log]; }
+
+        // The budget as a token, so a case that threads TestContext.Current.CancellationToken
+        // through its waits ends with a NAMED cancellation instead of being abandoned. It trips a
+        // little before the join deadline for exactly that reason — a token that fires at the same
+        // instant Join gives up could never be acted on, and the hard cap stays at `timeout`.
+        var budget = new CancellationTokenSource();
+        var lead = timeout > TimeSpan.Zero
+            ? TimeSpan.FromMilliseconds(Math.Min(1000, timeout.TotalMilliseconds / 10))
+            : TimeSpan.Zero;
+
         var clock = Stopwatch.StartNew();
         // The case runs on its own thread so a hang can be reported by name rather than hanging
         // the whole build; the thread is background so it cannot keep the process alive.
         Exception? failure = null;
         var thread = new Thread(() =>
         {
+            // Entered and disposed on the CASE's thread — the context is [ThreadStatic], so this is
+            // the only place it can be installed and the only place it can be cleared.
+            using var _ = Testing.TestContext.Enter(
+                new Testing.TestContextData(name, budget.Token) { Log = Capture });
             try
             {
                 method.Invoke(null, null);
@@ -173,6 +251,8 @@ public static class StaticTestRunner
             Name = $"test:{name}",
         };
         thread.Start();
+        if (timeout > TimeSpan.Zero)
+            budget.CancelAfter(timeout - lead);
         // 🚨 Thread.Join(timeout), not a ManualResetEventSlim. It is the built-in primitive for
         // exactly this — "did that thread finish within the budget" — and it is STRICTER: the event
         // fired from a `finally` signalled before the thread had actually terminated, whereas Join
@@ -181,14 +261,38 @@ public static class StaticTestRunner
         // gate rather than exempt it, because the standard library already has this one.
         if (!thread.Join(timeout))
         {
+            // 🚨 `budget` is deliberately NOT disposed here. The abandoned thread is still running
+            // and still holds its token; disposing the source under it is a use-after-dispose, and
+            // in this estate that surfaces as an exit-139 nobody can reproduce. It is left to the
+            // GC, bounded by the timer CancelAfter already scheduled.
             return new Case(name, Outcome.Failed, clock.Elapsed,
                 $"did not return within {timeout.TotalSeconds:F0}s — a hung case; the thread is "
-                + "abandoned and the build continues");
+                + "abandoned and the build continues")
+            { Log = Captured() };
         }
         clock.Stop();
-        return failure is null
-            ? new Case(name, Outcome.Passed, clock.Elapsed, null)
-            : new Case(name, Outcome.Failed, clock.Elapsed, Innermost(failure));
+        var expired = budget.IsCancellationRequested;
+        // Safe only because Join returned: the case thread has really terminated, so nothing holds
+        // the token any more.
+        budget.Dispose();
+        var captured = Captured();
+        return failure switch
+        {
+            null => new Case(name, Outcome.Passed, clock.Elapsed, null) { Log = captured },
+            // A case that DID observe its budget: say so, because `Innermost` would otherwise
+            // report the framework's "The operation was canceled." — true and useless.
+            OperationCanceledException when expired =>
+                new Case(name, Outcome.Failed, clock.Elapsed,
+                    $"OperationCanceledException: the case budget ({timeout.TotalSeconds:F0}s) "
+                    + "expired and the case ended on TestContext.Current.CancellationToken")
+                { Log = captured },
+            // 🚨 The UNWRAPPED exception only — never a walk down the inner chain. A skip is
+            // something the case says about itself; an assertion failure that happens to carry a
+            // SkipException as an inner would otherwise be reported as a decision not to run.
+            Testing.SkipException skip =>
+                new Case(name, Outcome.Skipped, clock.Elapsed, skip.Reason) { Log = captured },
+            _ => new Case(name, Outcome.Failed, clock.Elapsed, Innermost(failure)) { Log = captured },
+        };
     }
 
     private static string Innermost(Exception ex)

--- a/tools/MeshWeaver.PluginTester/Testing/TestContext.cs
+++ b/tools/MeshWeaver.PluginTester/Testing/TestContext.cs
@@ -6,6 +6,20 @@ namespace MeshWeaver.Testing;
 /// <c>TestContext.Current.CancellationToken</c>. The runner sets it on the case's own thread
 /// before invoking the method; the token trips at the case budget, so a case that threads it
 /// through its waits ends with a named timeout instead of a hung build.
+///
+/// <para>🚨 <b>This is the STATIC lane's surface and nothing else.</b> It exists because
+/// <c>mw-plugin-test build</c> executes a NodeType's <c>Test/*.cs</c> with no xUnit anywhere in the
+/// process — <see cref="MeshWeaver.PluginTester.StaticTestRunner"/> reflects over the emitted
+/// assembly and invokes the methods itself. It is deliberately NOT a second xUnit: no fixtures, no
+/// attributes, no theories, no assertion library. The mesh lane, which has a real host, is free to
+/// run real xUnit; nothing here is meant to serve it.</para>
+///
+/// <para>🚨 <b>Thread affinity is the whole design.</b> The cascade builds packages in PARALLEL and
+/// every case gets its own thread, so anything shared process-wide is a data race between two
+/// unrelated cases. The context is <c>[ThreadStatic]</c> and the case's log sink hangs off the
+/// context (<see cref="TestContextData.Log"/>) rather than off a static — which is why
+/// <see cref="TestLog.Sink"/> is only ever the fallback for a write made when NO case is
+/// running.</para>
 /// </summary>
 public static class TestContext
 {
@@ -15,11 +29,30 @@ public static class TestContext
     public static TestContextData Current => current ??= new TestContextData("(no case)", CancellationToken.None);
 
     /// <summary>Installs the context for the case about to run on this thread.</summary>
-    public static IDisposable Enter(string caseName, CancellationToken token)
+    public static IDisposable Enter(string caseName, CancellationToken token) =>
+        Enter(new TestContextData(caseName, token));
+
+    /// <summary>
+    /// Installs <paramref name="data"/> as this thread's context and restores the previous one on
+    /// dispose.
+    ///
+    /// <para>🚨 <b>Enter and Dispose must happen on the SAME thread.</b> The context is
+    /// <c>[ThreadStatic]</c>, so a dispose from another thread would clear THAT thread's context —
+    /// silently unsetting a different, concurrently running case. Rather than corrupt a neighbour,
+    /// a cross-thread dispose is a no-op; the owning thread's slot is overwritten by its next
+    /// <see cref="Enter(TestContextData)"/> and dies with the thread.</para>
+    /// </summary>
+    public static IDisposable Enter(TestContextData data)
     {
+        ArgumentNullException.ThrowIfNull(data);
         var previous = current;
-        current = new TestContextData(caseName, token);
-        return new Restore(() => current = previous);
+        var owner = Environment.CurrentManagedThreadId;
+        current = data;
+        return new Restore(() =>
+        {
+            if (Environment.CurrentManagedThreadId == owner)
+                current = previous;
+        });
     }
 
     private sealed class Restore(Action undo) : IDisposable
@@ -31,7 +64,15 @@ public static class TestContext
 /// <summary>What a case may ask about itself.</summary>
 /// <param name="CaseName"><c>Type.Method</c> of the running case.</param>
 /// <param name="CancellationToken">Trips at the case budget.</param>
-public sealed record TestContextData(string CaseName, CancellationToken CancellationToken);
+public sealed record TestContextData(string CaseName, CancellationToken CancellationToken)
+{
+    /// <summary>
+    /// Where this case's <see cref="TestLog"/> lines go. The runner installs a per-case collector
+    /// so the lines can be ATTACHED to the case's result instead of being smeared across the build
+    /// log of whichever package happened to be writing at the same moment. Null outside a run.
+    /// </summary>
+    public Action<string>? Log { get; init; }
+}
 
 /// <summary>
 /// Thrown by a case that decides it cannot run here (a platform it is not on, a credential it
@@ -44,20 +85,28 @@ public sealed class SkipException(string reason) : Exception(reason)
 }
 
 /// <summary>
-/// Where a case writes what it wants a reader to see. Lines go to the runner's output (the build
-/// log) prefixed with the case name, so a failure's neighbourhood is readable without a debugger —
+/// Where a case writes what it wants a reader to see. Lines are captured against the running case
+/// and printed with its failure, so a failure's neighbourhood is readable without a debugger —
 /// the role <c>ITestOutputHelper</c> played in the suites this replaces.
 /// </summary>
 public static class TestLog
 {
-    /// <summary>Optional sink the runner installs; the console otherwise.</summary>
+    /// <summary>
+    /// Process-wide fallback for a line written when NO case is running; the console otherwise.
+    ///
+    /// <para>🚨 Not the per-case sink, and it must never become one: one static shared by every
+    /// concurrently building package would attribute one case's output to another. The runner
+    /// installs <see cref="TestContextData.Log"/> instead, which is reached through the
+    /// <c>[ThreadStatic]</c> context and so belongs to exactly one case.</para>
+    /// </summary>
     public static Action<string>? Sink { get; set; }
 
     /// <summary>Writes one line, prefixed with the running case.</summary>
     public static void WriteLine(string message)
     {
-        var line = $"      [{TestContext.Current.CaseName}] {message}";
-        (Sink ?? Console.WriteLine)(line);
+        var context = TestContext.Current;
+        var line = $"      [{context.CaseName}] {message}";
+        (context.Log ?? Sink ?? Console.WriteLine)(line);
     }
 
     /// <summary>Writes one formatted line.</summary>


### PR DESCRIPTION
`tools/MeshWeaver.PluginTester/Testing/TestContext.cs` shipped `TestContext.Current`, `SkipException` and `TestLog`, and `StaticTestRunner` referenced **none of them** — a working xunit-shim surface that nothing could reach. This wires it into the **static/build lane** (the lane that has no xunit anywhere in the process) and stops there. It is deliberately not a second xunit: no attributes, no fixtures, no theories, no assertion library.

## What a case can now do

| Surface | Behaviour |
|---|---|
| `throw new SkipException(reason)` | Reported as `Outcome.Skipped` — never failed, never passed — with the reason carried into `Case.Error` and printed as its own `SKIP` token. Classified off the **unwrapped** exception only: a walk down the inner chain would report an assertion failure that happens to carry a `SkipException` as a decision not to run. |
| `TestLog.WriteLine` | Captured **per case** and attached to `Case.Log`; printed with that case when it fails, including when it is abandoned for outliving its budget (the lines up to the hang are usually the only evidence of where it got to). |
| `TestContext.Current` | Installed on the case's own thread and cleared there; its `CancellationToken` is now real. |

**Concurrency.** The capture hangs off the `[ThreadStatic]` context, **not** off the landed process-wide `TestLog.Sink`: the cascade builds packages in PARALLEL, so a single static collector would attribute one package's output to another. `Sink` stays as the fallback for a write made outside any case. A scope disposed from a foreign thread is a no-op rather than a reach into that thread's slot, which would silently unset a different, concurrently running case.

**The budget token** trips just *inside* the join deadline, so a case that threads it through its waits ends with a named cancellation naming the budget instead of being abandoned as a hung thread. The hard cap is unchanged. On the abandoned path the `CancellationTokenSource` is deliberately **not** disposed — the thread is still running and still holds its token, and a use-after-dispose there surfaces in this estate as an exit-139 nobody can reproduce.

## 🚨 The half that actually bites: a skip must never be laundered into a pass

Every place the static lane FORMATS or COUNTS a verdict now carries `skipped` as its own number:

- `StaticTestRunner.Run.Skipped`
- `CascadeBuild.PackageBuild.TestsSkipped`
- the per-type `ok …` line
- the package `GREEN`/`RED` line
- a **`skip` column** in the summary table
- the `--report` JSON (which also gains each case's captured log)

A run of nothing but skips is **green** — declining is a legitimate answer — and reports `0 passed`, because it proved nothing. A verdict line reading `12/12 passed` over three declines is exactly the absence-of-evidence-reads-as-green failure the node-repo CI policy exists to forbid.

The summary table's header had **also** drifted out of alignment with its row format (`ready`, `compile`, `tests`, `types`, `passed`, `failed`, `mesh` were all off). It is regenerated to match, `Print` is now `internal`, and a test pins the columns.

## Tests

`test/MeshWeaver.PluginTester.Test/StaticTestRunnerTest.cs` — 11 cases that **compile probe assemblies to disk** and run them through `StaticTestRunner.Execute`, exactly as a NodeType's emitted `Test/*.cs` is on a build run:

- the four-way outcome split, and that `Passed + Failed + Skipped + NeedsMesh == Cases.Length`
- the skip reason reaching the verdict and the printed line
- an all-skips run being green **with zero passed**
- per-case log capture, attachment, and failures-only printing
- `TestContext.Current` carrying the case's own name and a live, un-spent budget
- the token tripping inside the cap so a cooperative case ends named, not abandoned
- **eight concurrent `Execute` runs not smearing each other's log**
- enter/restore nesting, and cross-thread dispose being a no-op
- `TestLog` outside a case falling back to the process sink
- the package roll-up and the summary table keeping skips out of the pass count

**Observed:** `MeshWeaver.PluginTester.Test` 294 passed / 0 failed (283 before this branch, +11). `MeshWeaver.Documentation.Test` architecture guards 128 passed / 0 failed — including `HandWovenGateRatchetGuard`, which scans `tools/`.

## 🚨 Known limit, deliberately not fixed here

`MeshWeaver.Testing` lives in `mw-plugin-test`, not in a framework assembly. In-mesh source reaches it in this lane only because `ContainerReferenceSet` folds the builder process's own closure into the reference set — a **portal** compiling the same `Test/*.cs` at runtime has no such assembly. So a node repo's test source that literally names `SkipException` would compile here and **fail to compile on a portal**. Moving the shim into a framework assembly is the prerequisite for using it there; the README now says so in as many words.

Scope note: this is the STATIC lane only. The mesh lane's execution host is a separate facility, and if it ends up hosting real xunit it gets skip and output capture natively rather than from this shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)