### PR TITLE
fix(cd): one run builds from ONE plugin commit — the sha `gate` resolved, not the branch

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -842,15 +842,26 @@ jobs:
       # 🚨 The portal HOST lives in MeshWeaver.Plugins (#2293 removed it from here). This checkout is
       # what makes the image buildable at all; without it the publish below has no project.
       #
-      # ref defaults to `main` and is overridable by a repo variable, mirroring the plugins lane's
-      # own MW_PLATFORM_REF. The variable does not decouple "which plugins commit shipped with which
-      # core commit" — it makes that coupling STEERABLE, so pinning to a known-good plugins commit
-      # during an incident is a variable change rather than editing this file under pressure.
+      # 🚨 THE COMMIT `gate` RESOLVED, NOT `main`. Exactly the rule the line above follows for
+      # core's own checkout — "build the EXACT commit, not whatever main is now" — applied to the
+      # other half of the pair. It used to read `vars.MW_PLUGINS_REF || 'main'`, resolved fresh by
+      # every job that wanted it: `gate` resolved X for the identity, this job checked out whatever
+      # main was seconds later, `migration-image` resolved again, and the two reusable calls at the
+      # bottom of this file resolved three more times inside their own graphs. A plugins merge
+      # landing mid-run therefore produced an image built from Y while `promote` tagged it
+      # `<core>-pX` — the pair key (#2622) asserting a provenance that was never true — and, worse,
+      # a portal image and the module bundles baked beside it could come from DIFFERENT plugins
+      # commits, which is precisely the mixed set no host can serve.
+      #
+      # MW_PLUGINS_REF still steers: `gate` resolves `refs/heads/$MW_PLUGINS_REF` (default `main`)
+      # ONCE and fails RED if it resolves to nothing, so the variable remains the incident lever and
+      # the run remains internally consistent. Steerable AND pinned, which is what it always claimed
+      # to be.
       - name: Check out MeshWeaver.Plugins (holds the portal host)
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver.Plugins
-          ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
+          ref: ${{ needs.gate.outputs.plugins_sha }}
           path: plugins-repo
           ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
           fetch-depth: 1
@@ -1017,11 +1028,15 @@ jobs:
       - uses: actions/checkout@v7
         with:
           ref: ${{ needs.gate.outputs.sha }}
+      # The plugins commit `gate` resolved — see the portal leg's comment. Both images MUST come
+      # from one plugins commit: helm derives the migration tag from the portal image's tag, so a
+      # migration built from a different tree than the portal it migrates for is the 2026-08-27
+      # failure (#2555) wearing a different mask.
       - name: Check out MeshWeaver.Plugins (holds the migration worker)
         uses: actions/checkout@v7
         with:
           repository: Systemorph/MeshWeaver.Plugins
-          ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
+          ref: ${{ needs.gate.outputs.plugins_sha }}
           path: plugins-repo
           ssh-key: ${{ secrets.PLUGINS_REPO_SSH_KEY }}
           fetch-depth: 1
@@ -2091,6 +2106,13 @@ jobs:
   # satellite wakes, the upstream it consumes is already sealed for the identity it is told to
   # bake against. Both legs are the platform's reusable workflows pointed at the Plugins checkout
   # (content-repository); a node repo calling them with no content-repository behaves as before.
+  #
+  # 🚨 "the same plugins-repo commit the portal image was built from" is now ENFORCED rather than
+  # hoped for: `content-ref` is the sha `gate` resolved, the identical value the two image legs
+  # check out. It used to be `vars.MW_PLUGINS_REF || 'main'`, re-resolved inside each reusable
+  # graph (node-repo-module-pack checks the content repo out THREE times), so a plugins merge
+  # landing mid-run could seal bundles from a tree the shipped image does not contain — the one
+  # thing this section exists to guarantee, quietly not guaranteed.
   plugins-modules:
     name: "Plugins: pack the module bundles the bake composes"
     needs: [preflight, gate, promote]
@@ -2100,7 +2122,7 @@ jobs:
     uses: ./.github/workflows/node-repo-module-pack.yml
     with:
       content-repository: Systemorph/MeshWeaver.Plugins
-      content-ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
+      content-ref: ${{ needs.gate.outputs.plugins_sha }}
       platform-ref: ${{ needs.gate.outputs.sha }}
       # The compose set the bake needs (the same two Plugins' own ci.yml passes as
       # module-artifacts); the rest of the catalog is content, baked below.
@@ -2173,7 +2195,7 @@ jobs:
     uses: ./.github/workflows/node-repo-publish-bake.yml
     with:
       content-repository: Systemorph/MeshWeaver.Plugins
-      content-ref: ${{ vars.MW_PLUGINS_REF || 'main' }}
+      content-ref: ${{ needs.gate.outputs.plugins_sha }}
       bake-source: plugins
       module-artifacts: module-bundle-MeshWeaver.{AI,Markdown.Collaboration}
       test-image: meshweaver.azurecr.io/mw-plugin-test:${{ needs.plugin-test-image.outputs.version }}

--- a/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
@@ -137,7 +137,13 @@ public class CdImageVersionsShareOneSourceGuard
             + $"repository in {Workflow}; found {pins.Count}. Either they were renamed or the "
             + "matcher no longer recognises them — in both cases this guard checks nothing.");
 
-        var offenders = pins.Where(x => !x.Ref.Contains("needs.gate.outputs.plugins_sha", StringComparison.Ordinal)).ToList();
+        // 🚨 EQUALITY, not Contains (Copilot, #2967). `Contains` would accept
+        // `${{ needs.gate.outputs.plugins_sha || 'main' }}` — the pinned sha with the branch
+        // restored as a fallback, which is the regression itself wearing the fix's name. A
+        // fallback is not a safety net here: `gate` already fails RED on an unresolvable ref, so
+        // the only way the sha is empty is a gate that did not run, and then the job must not run
+        // either. Quoting and inner whitespace are tolerated; a second expression is not.
+        var offenders = pins.Where(x => !PinnedExactly.IsMatch(x.Ref)).ToList();
 
         Assert.True(offenders.Count == 0,
             "main-cd.yml reaches into a plugin repository at a ref it resolved for itself:\n  "
@@ -148,6 +154,10 @@ public class CdImageVersionsShareOneSourceGuard
             + "module bundles be sealed from a third. Use ${{ needs.gate.outputs.plugins_sha }}; "
             + "MW_PLUGINS_REF keeps steering the run through `gate`, which resolves it ONCE.");
     }
+
+    /// <summary>The one accepted ref: the sha <c>gate</c> resolved, and nothing else beside it.</summary>
+    private static readonly Regex PinnedExactly =
+        new(@"^[""']?\$\{\{\s*needs\.gate\.outputs\.plugins_sha\s*\}\}[""']?$", RegexOptions.Compiled);
 
     /// <summary>
     /// Every place CD names a plugin repository, paired with the ref that checkout or reusable call

--- a/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CdImageVersionsShareOneSourceGuard.cs
@@ -102,6 +102,85 @@ public class CdImageVersionsShareOneSourceGuard
         return [.. matches.Select(m => m.Groups["project"].Value.Replace('\\', '/'))];
     }
 
+    /// <summary>
+    /// 🚨 <b>Every leg of a published set must be BUILT from the same plugin COMMIT</b> — the same
+    /// rule as the version above, one level down: not "tagged from one source of truth" but
+    /// "compiled from one tree".
+    ///
+    /// <para><b>What went wrong.</b> Each consumer resolved the plugins ref for itself.
+    /// <c>gate</c> resolved the HEAD of <c>MW_PLUGINS_REF</c> (default <c>main</c>) ONCE, minted the
+    /// image-set identity from it, and <c>promote</c> tagged the portal
+    /// <c>&lt;core-sha&gt;-p&lt;plugins-sha&gt;</c> with that value — while <c>portal-image</c>,
+    /// <c>migration-image</c> and the two reusable calls each checked out the BRANCH, seconds to
+    /// minutes later. <c>node-repo-module-pack</c> alone checks the content repo out three times.
+    /// A plugins merge landing mid-run therefore produced an image built from a commit the pair tag
+    /// does not name, and — the part that matters — a portal image and the module bundles sealed
+    /// beside it from DIFFERENT trees. There is no image that can serve a mixed set of module
+    /// builds; that is the whole reason the pair key (#2622) exists.</para>
+    ///
+    /// <para><b>Why it is silent.</b> Every leg succeeds. Every image pushes. The tags are
+    /// well-formed. Only the provenance they assert is false, and nothing compares a built tree to
+    /// the sha that named it — exactly the shape of #2555 one layer up.</para>
+    ///
+    /// <para>Asserted structurally: every checkout or reusable call in CD that names a plugin
+    /// repository must take its ref from <c>needs.gate.outputs.plugins_sha</c>, the value
+    /// <c>gate</c> resolved once. A branch name there — <c>main</c>, or the steering variable
+    /// unresolved — is the regression.</para>
+    /// </summary>
+    [Fact]
+    public void EveryPluginCheckoutUsesTheCommitTheGateResolved()
+    {
+        var pins = PluginRefs();
+
+        Assert.True(pins.Count >= 4,
+            $"Expected at least the two image legs and the two reusable calls to name a plugin "
+            + $"repository in {Workflow}; found {pins.Count}. Either they were renamed or the "
+            + "matcher no longer recognises them — in both cases this guard checks nothing.");
+
+        var offenders = pins.Where(x => !x.Ref.Contains("needs.gate.outputs.plugins_sha", StringComparison.Ordinal)).ToList();
+
+        Assert.True(offenders.Count == 0,
+            "main-cd.yml reaches into a plugin repository at a ref it resolved for itself:\n  "
+            + string.Join("\n  ", offenders.Select(x => $"line {x.Line}: {x.Repo} @ {x.Ref}"))
+            + "\nEvery leg of one run must build from ONE plugin commit — the sha `gate` already "
+            + "resolved and `promote` tags the image set with. Re-resolving a branch here lets a "
+            + "mid-run merge ship an image whose pair tag names a different tree, and lets the "
+            + "module bundles be sealed from a third. Use ${{ needs.gate.outputs.plugins_sha }}; "
+            + "MW_PLUGINS_REF keeps steering the run through `gate`, which resolves it ONCE.");
+    }
+
+    /// <summary>
+    /// Every place CD names a plugin repository, paired with the ref that checkout or reusable call
+    /// will use — the next <c>ref:</c>/<c>content-ref:</c> within the same <c>with:</c> block.
+    /// Comment lines are skipped: this workflow explains its own history in prose, and a matcher
+    /// that read a comment would report an edge that does not exist.
+    /// </summary>
+    private static IReadOnlyList<(int Line, string Repo, string Ref)> PluginRefs()
+    {
+        var lines = File.ReadAllLines(Path.Combine(FindRepoRoot(), Workflow));
+        var found = new List<(int, string, string)>();
+
+        for (var i = 0; i < lines.Length; i++)
+        {
+            if (Regex.IsMatch(lines[i], @"^\s*#")) continue;
+            var repo = Regex.Match(lines[i], @"^\s*(?:content-)?repository:\s*(?<repo>Systemorph/MeshWeaver\.[A-Za-z.]+)\s*$");
+            if (!repo.Success) continue;
+
+            // The ref sits within the same `with:` block — a handful of lines, never a whole job.
+            var refValue = "<none>";
+            for (var j = i + 1; j < Math.Min(i + 8, lines.Length); j++)
+            {
+                if (Regex.IsMatch(lines[j], @"^\s*#")) continue;
+                var m = Regex.Match(lines[j], @"^\s*(?:content-)?ref:\s*(?<ref>.+?)\s*$");
+                if (m.Success) { refValue = m.Groups["ref"].Value; break; }
+            }
+
+            found.Add((i + 1, repo.Groups["repo"].Value, refValue));
+        }
+
+        return found;
+    }
+
     private static string FindRepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
Found while inventorying core→Plugins couplings for the "core build does not do anything with plugins" directive (companion to #2965). This one is a **correctness bug**, not just a coupling.

## The defect

`gate` resolves the plugins HEAD **once**, mints the image-set identity from it, and `promote` tags the portal `<core-sha>-p<plugins-sha>` with that value. Its own comment says the sha must never be re-resolved downstream — re-resolving is what turned a correct publish red in #2622.

Four consumers re-resolved it anyway. Not by calling `ls-remote` again — by checking out the **branch**:

| Job | was |
|---|---|
| `portal-image` (`:853`) | `ref: ${{ vars.MW_PLUGINS_REF \|\| 'main' }}` |
| `migration-image` (`:1024`) | same |
| `plugins-modules` (`:2103`) | `content-ref:` same — and `node-repo-module-pack` checks the content repo out **three times** inside its own graph |
| `plugins-bake` (`:2176`) | `content-ref:` same |

Each resolves at its own moment, seconds to minutes apart.

**What that produces.** A plugins merge landing mid-run gives an image built from a commit the pair tag does not name — the tag asserting a provenance that was never true. And the half that actually breaks hosts: a portal image and the module bundles sealed beside it **from different trees**. There is no image that can serve a mixed set of module builds; that is the entire reason the pair key exists. The section comment above `plugins-modules` already *claimed* the bundles came "from the same plugins-repo commit the portal image was built from" — nothing enforced it.

**Why nobody saw it.** Every leg succeeds. Every image pushes. Every tag is well-formed. Only the provenance is false, and nothing compares a built tree to the sha that named it — the same silent shape as #2555 one layer up, which is why the guard lands in *that* file.

## The fix

All four now read `${{ needs.gate.outputs.plugins_sha }}`.

Mechanically identical to the line **two above** the portal checkout, where core already checks *itself* out by the sha `gate` resolved — *"build the EXACT commit the tests passed on — not whatever main is now."* The rule was already written down; it just wasn't applied to the other half of the pair. And the reusable workflows feed `content-ref` straight to `actions/checkout`'s `ref:` and **default it to `github.sha`**, so a sha is the shape they already expect.

**`MW_PLUGINS_REF` still steers.** `gate` resolves `refs/heads/$MW_PLUGINS_REF` (default `main`) once, with no `if:` and no `continue-on-error`, and fails RED if it resolves to nothing — so the variable stays the incident lever while the run becomes internally consistent. Steerable **and** pinned, which is what the old comment claimed it already was.

## The guard

`CdImageVersionsShareOneSourceGuard` gains the fact, one level down from the version rule it sits beside: every checkout or reusable call in CD that names a plugin repository must take its ref from `needs.gate.outputs.plugins_sha`. Non-vacuity floor of **four**, so a rename cannot empty the matcher and turn it green.

**Falsified:** reverting the two image legs to the branch fails it naming `line 863` and `line 1038`; reverting that goes silent.

## Verification

- YAML parses — 15 jobs
- `check-workflow-shell.py` → 0 live findings
- `test-cd-steps.py` → all cases pass against the **extracted** (not copied) `release` + `decide` steps
- `dotnet test test/MeshWeaver.Documentation.Test` → **151/151**

🤖 Generated with [Claude Code](https://claude.com/claude-code)