### PR TITLE
The portal reports the build it is running, and CD proves it before shipping

### DIFF
--- a/.github/scripts/check-image-build-identity.sh
+++ b/.github/scripts/check-image-build-identity.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Does the PUBLISHED portal image identify itself as the version this run built?
+#
+#   .github/scripts/check-image-build-identity.sh <tag> <expected-version> [<repository>]
+#   exit 0 = the image reports the expected version   exit 1 = it does not, or could not be read
+#
+# 🚨 A TAG IS NOT EVIDENCE ABOUT THE BYTES UNDER IT, and that gap shipped. Between 2026-08-25 and
+# 2026-09-01 every memex-portal-ai image was TAGGED 3.0.0-rc9.ci.<n> and REPORTED itself as 1.0.0.
+# The cause was one missing `-p:Version=` on the publish: the portal host had moved to
+# MeshWeaver.Plugins, whose src/Directory.Build.props does not import core's root props, so
+# $(Version) evaluated to the SDK default — and the csproj bakes $(Version) into the image config as
+# MESHWEAVER_PLATFORM_VERSION, which is the FIRST thing a running portal reads to identify itself.
+#
+# Nothing was red. `promote` applied a correct tag to an image that misreported itself; /api/version
+# still answered correctly (it reads a core-built assembly), so the one surface a monitor would
+# check looked fine. What broke was the self-updater: VersionSelect compares registry tags against
+# the REPORTED version, so with it pinned at 1.0.0 every tag was newer forever — the install could
+# never reach "up to date" and re-rolled on every check floor, and the About page and the header
+# build chip both lied about the running build.
+#
+# So this asserts the ARTIFACT, per the deployment doctrine "verify the IMAGE, never the green
+# tick". It reads the image CONFIG out of the registry — the same bytes the container runtime will
+# hand the process as an environment variable — and compares it to the version this run intended.
+#
+# 🚨 EVERY architecture is checked, not the index. The publish produces a manifest LIST over
+# linux/amd64 + linux/arm64; each entry carries its OWN config blob, so checking one proves nothing
+# about the other, and an arm64 node is exactly where nobody would look.
+#
+# 🚨 FAIL CLOSED. An unreadable manifest, an absent variable, a config without the key — every one
+# is exit 1. "Could not check" must never be reported as "checked and fine": that equivalence is
+# the whole reason the original defect survived a week of green runs.
+#
+# Runnable locally against the real registry, which is how it was verified:
+#   az login && .github/scripts/check-image-build-identity.sh 3.0.0-rc9.ci.7231 3.0.0-rc9.ci.7231
+set -uo pipefail
+
+TAG="${1:?usage: check-image-build-identity.sh <tag> <expected-version> [<repository>]}"
+EXPECTED="${2:?usage: check-image-build-identity.sh <tag> <expected-version> [<repository>]}"
+REPO="${3:-memex-portal-ai}"
+REGISTRY="${ACR_NAME:-meshweaver}"
+SERVER="$REGISTRY.azurecr.io"
+
+# The variable the portal reads first — MeshWeaver.Mesh.PlatformBuildInfo
+# .PlatformVersionEnvironmentVariable. Kept as a literal here because this script runs before (and
+# independently of) anything that could resolve it from the source tree.
+VAR="MESHWEAVER_PLATFORM_VERSION"
+
+summary() { [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "$1" >> "$GITHUB_STEP_SUMMARY"; return 0; }
+die()     { echo "::error::$1"; summary "- ❌ $1"; exit 1; }
+ok()      { echo "$1";          summary "- ✅ $1"; }
+
+summary "### Build identity baked into \`$REPO:$TAG\`"
+
+# An ACR refresh token from the ambient `az login` (ARM), exchanged for a pull-scoped access token.
+# `az acr login --expose-token` deliberately does NOT need a docker daemon — this reads blobs over
+# the registry's own REST API, exactly as check-image-set.sh reads manifests over ARM.
+REFRESH=$(az acr login --name "$REGISTRY" --expose-token --output tsv --query accessToken 2>/dev/null)
+[ -n "$REFRESH" ] || die "could not obtain an ACR token for $SERVER — is the job logged in to Azure?"
+
+BEARER=$(curl -fsS -u "00000000-0000-0000-0000-000000000000:$REFRESH" \
+  "https://$SERVER/oauth2/token?service=$SERVER&scope=repository:$REPO:pull" 2>/dev/null \
+  | jq -r '.access_token // empty')
+[ -n "$BEARER" ] || die "could not exchange the ACR token for a pull scope on $REPO"
+
+# Accepts both the OCI and the Docker spellings of index and manifest: the SDK's container publish
+# has emitted each at different times, and a 406 here would read as "image missing".
+ACCEPT='application/vnd.oci.image.index.v1+json,application/vnd.docker.distribution.manifest.list.v2+json,application/vnd.oci.image.manifest.v1+json,application/vnd.docker.distribution.manifest.v2+json'
+
+fetch() { curl -fsS -H "Authorization: Bearer $BEARER" -H "Accept: $ACCEPT" "https://$SERVER/v2/$REPO/manifests/$1" 2>/dev/null; }
+
+# 🚨 Blobs are NOT served by the registry — /v2/…/blobs/… answers 307 to a SAS-signed blob-storage
+# URL, so this needs -L where manifests do not. Without it curl returns the redirect's HTML body and
+# jq fails on it; measured against the live registry while writing this. The follow deliberately
+# does NOT use --location-trusted: curl drops the Authorization header on a cross-host redirect, and
+# blob storage REJECTS the request if it is forwarded.
+fetch_blob() { curl -fsSL -H "Authorization: Bearer $BEARER" "https://$SERVER/v2/$REPO/blobs/$1" 2>/dev/null; }
+
+INDEX=$(fetch "$TAG")
+[ -n "$INDEX" ] || die "could not read the manifest for $REPO:$TAG"
+
+# A manifest list names its children; a single manifest IS its own child. Normalising to a digest
+# list keeps the loop below identical for both shapes.
+DIGESTS=$(echo "$INDEX" | jq -r 'if .manifests then .manifests[] | select(.platform.os != "unknown") | .digest else empty end')
+if [ -z "$DIGESTS" ]; then
+  CONFIG_DIGEST=$(echo "$INDEX" | jq -r '.config.digest // empty')
+  [ -n "$CONFIG_DIGEST" ] || die "$REPO:$TAG is neither an image index nor an image manifest"
+  DIGESTS=""
+  CONFIGS="$CONFIG_DIGEST"
+else
+  CONFIGS=""
+  for digest in $DIGESTS; do
+    MANIFEST=$(fetch "$digest")
+    [ -n "$MANIFEST" ] || die "could not read the platform manifest $digest of $REPO:$TAG"
+    CONFIG_DIGEST=$(echo "$MANIFEST" | jq -r '.config.digest // empty')
+    [ -n "$CONFIG_DIGEST" ] || die "platform manifest $digest of $REPO:$TAG names no config blob"
+    CONFIGS="$CONFIGS $CONFIG_DIGEST"
+  done
+fi
+
+checked=0
+for config in $CONFIGS; do
+  BLOB=$(fetch_blob "$config")
+  [ -n "$BLOB" ] || die "could not read the config blob $config of $REPO:$TAG"
+
+  PLATFORM=$(echo "$BLOB" | jq -r '"\(.os // "?")/\(.architecture // "?")"')
+  # .config.Env is the runtime environment the container starts with — the exact channel the csproj
+  # ships the version on. `select` rather than a grep so a variable whose VALUE contains the name
+  # cannot match.
+  ACTUAL=$(echo "$BLOB" | jq -r --arg v "$VAR" '(.config.Env // [])[] | select(startswith($v + "=")) | sub("^" + $v + "=" ; "")')
+
+  [ -n "$ACTUAL" ] || die "$REPO:$TAG ($PLATFORM) ships no $VAR — the running portal would fall back to the entry assembly, which in MeshWeaver.Plugins is the SDK default 1.0.0"
+  [ "$ACTUAL" = "$EXPECTED" ] || die "$REPO:$TAG ($PLATFORM) reports $VAR=$ACTUAL but this run built $EXPECTED — the image would misreport itself and every registry tag would look newer to its self-updater"
+
+  ok "$PLATFORM reports $VAR=$ACTUAL"
+  checked=$((checked + 1))
+done
+
+# The loop can only be empty if the normalisation above produced nothing, which the guards already
+# refuse — but a check that silently examined zero images is the failure this file exists to
+# prevent, so it is asserted rather than assumed.
+[ "$checked" -gt 0 ] || die "no image config was examined for $REPO:$TAG — refusing to report a pass"
+
+ok "$REPO:$TAG identifies itself as $EXPECTED on all $checked architecture(s)"

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -875,8 +875,25 @@ jobs:
       # compares to decide a rollout — so it MUST be the monotonic $(Version) (Directory.Build.props
       # derives the .ci.<n> suffix from $GITHUB_RUN_NUMBER). -getProperty:Version prints the computed
       # version without building; CIRun=true so it matches the version baked into the binaries below.
-      # It is NOT applied here: this job only pushes the staging tag, and `promote` applies this
-      # version (job output) once every leg has succeeded.
+      #
+      # 🚨 IT IS TWO DIFFERENT THINGS AND ONLY ONE OF THEM IS A TAG. As a TAG it is not applied
+      # here — this job pushes the staging tag only, and `promote` applies the version tag once
+      # every leg has succeeded. As the BAKED version it is applied here, via `-p:Version=` on the
+      # publish below, and that half was missing for a week (2026-08-25 → 09-01).
+      #
+      # Why it cannot be left to the project: the portal host lives in MeshWeaver.Plugins, whose
+      # src/Directory.Build.props does not import core's root props, so $(Version) there is the SDK
+      # default 1.0.0. The csproj bakes $(Version) into the image config as
+      # MESHWEAVER_PLATFORM_VERSION, which is the FIRST thing the running portal reads to identify
+      # itself — so the image was tagged 3.0.0-rc9.ci.<n> and reported 1.0.0. VersionSelect.IsNewer
+      # then called every registry tag newer than the running build, forever: the install could
+      # never reach "up to date" and re-rolled on every check floor, and the About page said
+      # `Version: 1.0.0` while /api/version answered correctly off a core-built assembly.
+      #
+      # edge-images.yml and release-images.yml have always passed it, and say why in the same words
+      # ("BAKED, not just tagged"). The step after the publish below reads the variable back out of
+      # the pushed image, so a future omission fails the run instead of shipping a portal that
+      # misreports itself — a tag is not evidence about the bytes under it.
       - name: Compute image version
         id: vars
         run: |
@@ -986,6 +1003,7 @@ jobs:
                  -c Release --no-self-contained -t:PublishContainer -p:PublishProfile= \
                  -p:ContainerRuntimeIdentifiers='"linux-x64;linux-arm64"' \
                  -p:CIRun=true \
+                 -p:Version=${{ steps.vars.outputs.version }} \
                  -p:MeshWeaverRoot=${{ github.workspace }} \
                  -p:ContainerRegistry=${{ env.ACR }} \
                  -p:ContainerRepository=memex-portal-ai \
@@ -1015,6 +1033,17 @@ jobs:
           done
           echo "::error::portal-ai publish failed on all 3 attempts with no compiler diagnostics — read the LAST attempt's output above. A registry blob-upload failure there (the CONTAINER-10xx family) means the connection died three times running, which is no longer a transient and wants investigating rather than another retry (#2810)."
           exit 1
+      # 🚨 The publish SUCCEEDING is not evidence the image identifies itself correctly — that is
+      # exactly the state that shipped for a week (see the version note above). So the version is
+      # read back out of the pushed image config, per architecture, before anything selectable is
+      # applied to it: this runs BEFORE `promote`, so an image that misreports itself never gets a
+      # tag a consumer can roll to. Unconditional, and fail-closed on anything it cannot read — a
+      # skipped check and a passed one are indistinguishable in the UI.
+      - name: The published image must identify itself as this run's version
+        run: >
+          .github/scripts/check-image-build-identity.sh
+          "${{ needs.gate.outputs.staging_tag }}"
+          "${{ steps.vars.outputs.version }}"
 
   migration-image:
     name: "Build + push migration image"

--- a/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
+++ b/memex/Memex.Portal.Shared/ShippedReleaseSeed.cs
@@ -81,22 +81,20 @@ public static class ShippedReleaseSeed
     /// holds across CI jobs (#1660 WS3) — so this reads the
     /// <see cref="MeshWeaver.Mesh.PlatformBuildInfo.PlatformVersionEnvironmentVariable"/> the
     /// container publish injects FIRST (the self-updater's version comparison against registry
-    /// tags depends on the run number), then falls back to the entry assembly's
+    /// tags depends on the run number), then falls back to the build assembly's
     /// <see cref="AssemblyInformationalVersionAttribute"/> (<c>PlatformVersion+&lt;sha&gt;</c> on a
     /// CI build), the numeric assembly version, then <c>"unknown"</c>.
+    ///
+    /// <para>🚨 <b>Build assembly, not entry assembly.</b> Reading
+    /// <see cref="Assembly.GetEntryAssembly"/> here reported <c>1.0.0</c> on the deployed portal for
+    /// a week: the portal executable moved to MeshWeaver.Plugins (2026-08-25), which defines no
+    /// <c>Version</c>, so the host stopped being part of this build. Because
+    /// <c>VersionSelect.IsNewer</c> compares registry tags against THIS value, every tag then looked
+    /// newer forever — the install could never reach "up to date" and re-rolled on every check
+    /// floor. <see cref="MeshWeaver.Mesh.PlatformBuildInfo"/> owns the selection so this page and
+    /// <c>/api/version</c> cannot answer differently.</para>
     /// </summary>
-    public static string InstalledPlatformVersion
-    {
-        get
-        {
-            if (MeshWeaver.Mesh.PlatformBuildInfo.RuntimePlatformVersion is { } injected)
-                return injected;
-            var asm = Assembly.GetEntryAssembly() ?? typeof(ShippedReleaseSeed).Assembly;
-            return asm.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-                ?? asm.GetName().Version?.ToString()
-                ?? "unknown";
-        }
-    }
+    public static string InstalledPlatformVersion => MeshWeaver.Mesh.PlatformBuildInfo.PlatformVersion;
 
     /// <summary>The GitHub repository the platform is built from.</summary>
     public const string RepositoryUrl = "https://github.com/Systemorph/MeshWeaver";
@@ -106,17 +104,10 @@ public static class ShippedReleaseSeed
     /// by the <c>AddCommitHashMetadata</c> target in <c>Directory.Build.props</c> (from the SDK's
     /// <c>SourceRevisionId</c> or the CI <c>GITHUB_SHA</c>). Null when the build carried no source-control
     /// info (a git-less source drop) — the About page then falls back to the version string alone.
+    /// Read off the same build assembly the version comes from, so "which build" and "which commit"
+    /// can never name two different builds.
     /// </summary>
-    public static string? CommitHash
-    {
-        get
-        {
-            var asm = Assembly.GetEntryAssembly() ?? typeof(ShippedReleaseSeed).Assembly;
-            var sha = asm.GetCustomAttributes<AssemblyMetadataAttribute>()
-                .FirstOrDefault(a => string.Equals(a.Key, "CommitHash", StringComparison.OrdinalIgnoreCase))?.Value;
-            return string.IsNullOrWhiteSpace(sha) ? null : sha;
-        }
-    }
+    public static string? CommitHash => MeshWeaver.Mesh.PlatformBuildInfo.CommitHash;
 
     /// <summary>Link to the GitHub commit this build was produced from, or null when the SHA is unknown.</summary>
     public static string? CommitUrl => CommitHash is { } sha ? $"{RepositoryUrl}/commit/{sha}" : null;

--- a/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
+++ b/memex/aspire/Memex.Portal.ServiceDefaults/ServiceDefaults.cs
@@ -9,6 +9,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 using Microsoft.Extensions.Hosting;
 using MeshWeaver.Hosting;
+using MeshWeaver.Mesh;
 using Microsoft.Extensions.Logging;
 using OpenTelemetry;
 using OpenTelemetry.Metrics;
@@ -385,37 +386,23 @@ public static class ServiceDefaults
     /// constants baked into the assembly, so re-reading them per request would buy nothing.
     /// Immutable and never written after initialization (a constant, not a cache).
     /// </summary>
-    public static BuildIdentity Build { get; } = ReadBuildIdentity(SelectBuildAssembly());
+    public static BuildIdentity Build { get; } = ReadBuildIdentity(PlatformBuildInfo.BuildAssembly);
 
     /// <summary>Web defaults ⇒ camelCase, so the contract is <c>{"version":…,"commit":…}</c>.</summary>
     private static readonly JsonSerializerOptions VersionJsonOptions = new(JsonSerializerDefaults.Web);
 
     /// <summary>
-    /// The assembly that represents this build. In the portal this is the entry assembly — the
-    /// executable — which the root <c>Directory.Build.props</c> stamps with both the platform
-    /// version and the commit (<c>memex/Directory.Build.props</c> imports the root, so every
-    /// portal project inherits the stamps). Reading the entry assembly is what keeps this endpoint
-    /// and the About tab reporting the same build.
+    /// Projects an assembly's build stamps to the wire record. The About tab
+    /// (<c>ShippedReleaseSeed.InstalledPlatformVersion</c> / <c>.CommitHash</c>) reads the same two
+    /// attributes off the same assembly — the two readers are separate only because
+    /// <c>Memex.Portal.Shared</c> sits far above this infrastructure project and must not be pulled
+    /// into it, so the SELECTION of that assembly lives below both, in
+    /// <see cref="PlatformBuildInfo.SelectBuildAssembly"/>.
     ///
-    /// <para>When the process was launched by a host that is NOT part of this build, the entry
-    /// assembly carries no <c>CommitHash</c> and reading it would report the HOST's version — a
-    /// test runner's <c>1.0.0</c> with no commit. (<c>test/Directory.Build.props</c> deliberately
-    /// does not import the root props, so this is exactly the shape under test.) The fallback is
-    /// this assembly: the same build stamps every one of its assemblies with the same commit, so
-    /// the answer is the real one rather than a foreign host's.</para>
-    /// </summary>
-    internal static Assembly SelectBuildAssembly()
-    {
-        var entry = Assembly.GetEntryAssembly();
-        return entry is not null && CommitOf(entry) is not null ? entry : typeof(ServiceDefaults).Assembly;
-    }
-
-    /// <summary>
-    /// Projects an assembly's build stamps to the wire record. Mirrors the reflection behind the
-    /// About tab (<c>ShippedReleaseSeed.InstalledPlatformVersion</c> / <c>.CommitHash</c>) — the two
-    /// readers are separate only because <c>Memex.Portal.Shared</c> sits far above this
-    /// infrastructure project and must not be pulled into it; both read the SAME two attributes, so
-    /// the page and the endpoint report the same build.
+    /// <para>🚨 It used to be duplicated here instead, and only here — the About tab read
+    /// <c>GetEntryAssembly()</c> raw. When the portal executable moved to a repo that stamps no
+    /// version (2026-08-25) the copies diverged in production: this endpoint answered
+    /// <c>3.0.0-rc9+0a1eabdc…</c> and the page said <c>1.0.0</c>. One selection, one answer.</para>
     /// </summary>
     public static BuildIdentity ReadBuildIdentity(Assembly assembly) => new(
         assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion

--- a/src/MeshWeaver.Documentation/Data/Architecture/PlatformBuildIdentity.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PlatformBuildIdentity.md
@@ -1,0 +1,116 @@
+---
+NodeType: Markdown
+Name: "Platform Build Identity"
+Abstract: "How a running portal knows WHICH build it is: the two stamps (assembly metadata for the commit and base version, an image-config environment variable for the run number), the one selection rule both version surfaces share, the delivery contract that bakes the version rather than only tagging it, and the gate that reads it back out of the published image."
+Icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='24' height='24' rx='4' fill='#4338ca'/><path d='M12 4.2 19 8v8l-7 3.8L5 16V8z' fill='none' stroke='white' stroke-width='1.6' stroke-linejoin='round'/><path d='M12 11.4 19 8M12 11.4 5 8m7 3.4v8.4' fill='none' stroke='white' stroke-width='1.4' stroke-linejoin='round'/></svg>"
+Authors:
+  - "Samuel Glauser"
+Tags:
+  - "Architecture"
+  - "Release"
+  - "Deployment"
+  - "CI/CD"
+---
+
+# Platform Build Identity
+
+A running portal has to be able to answer **which build am I**. Three things depend on the answer,
+and only one of them is a display:
+
+1. **The self-updater.** `VersionSelect.IsNewer` compares registry tags against the running
+   version to decide whether a newer release exists. This is the load-bearing consumer.
+2. **Settings → About**, and the build chip beside the alerts bell in the header.
+3. **`/api/version`**, the anonymous endpoint that lets a deploy check, a monitor or a person
+   verify a rollout from outside the portal.
+
+They must all name the same build. This page is how that is arranged, and what happened when it
+was not.
+
+## The two stamps, and why there are two
+
+| What | Where it lives | Produced by |
+|---|---|---|
+| Base version + commit sha (`3.0.0-rc9+<sha>`) | **Assembly metadata** on every assembly of the build | `PlatformVersion` and the `AddCommitHashMetadata` target in the root `Directory.Build.props` |
+| Full run-numbered version (`3.0.0-rc9.ci.7231`) | **Container image config**, as `MESHWEAVER_PLATFORM_VERSION` | `-p:Version=` on the container publish → the `ContainerEnvironmentVariable` item in `Memex.Portal.Distributed.csproj` |
+
+The split is not incidental. CI compile inputs are **commit-deterministic** (#1660 WS3): the
+framework identity that lets CI-baked NodeType assemblies seed at boot must be equal between the
+run that bakes them and the run that builds the image, so the CI run number cannot be compiled into
+any assembly. It therefore rides the image configuration instead — which means it exists only if
+the publish is told what it is.
+
+## The one selection rule
+
+`MeshWeaver.Mesh.PlatformBuildInfo` owns it, and every version surface reads it:
+
+- `SelectBuildAssembly(entry)` — the entry assembly **if this build stamped it** (it carries a
+  `CommitHash`), otherwise an assembly that is part of this build.
+- `AssemblyVersion` / `CommitHash` — read off that assembly. `/api/version` reports exactly these,
+  because it promises assembly metadata and nothing else.
+- `PlatformVersion` — `MESHWEAVER_PLATFORM_VERSION` if the container publish supplied one, else
+  `AssemblyVersion`. This is what About shows and what the self-updater compares.
+
+> 🚨 **The entry assembly is not the build.** It is whatever host started the process, and on two
+> hosts that matter it is not part of the platform build at all: a test runner
+> (`test/Directory.Build.props` deliberately does not import the root props) and the deployed
+> portal executable, which lives in **MeshWeaver.Plugins**, whose `src/Directory.Build.props` does
+> not import core's root props either. Both report the SDK default `1.0.0` and no commit.
+
+## The delivery contract
+
+The version is **baked, not merely tagged**. `main-cd.yml` resolves `$(Version)` from a core
+project and passes it to the portal publish as `-p:Version=`; `edge-images.yml` and
+`release-images.yml` do the same, and say why in the same words. A tag is applied to an image; it
+is not a property of the bytes inside it, and the two can disagree.
+
+Because they can disagree, they are compared. `.github/scripts/check-image-build-identity.sh` reads
+`MESHWEAVER_PLATFORM_VERSION` back out of the **published image config**, for **every**
+architecture in the manifest list, and fails the run if it is absent or is not the version that run
+built. It runs in `portal-image` immediately after the push and **before `promote`**, so an image
+that misreports itself never receives a tag any install can roll to. It fails closed: an unreadable
+manifest, an absent variable and a config it cannot parse are all exit 1, because "could not check"
+must never render as "checked and fine".
+
+## The incident this page exists because of (2026-08-25 → 2026-09-01)
+
+The portal hosts moved to MeshWeaver.Plugins on 2026-08-25. `main-cd.yml` was repointed at the
+relocated project — and the `-p:Version=` half of the contract was not carried over. `$(Version)`
+in that repo is the SDK default, so every `memex-portal-ai` image published for a week was **tagged**
+`3.0.0-rc9.ci.<n>` and **reported itself** as `1.0.0`. Read straight out of the registry:
+
+```
+memex-portal-ai:3.0.0-rc9.ci.7231 (linux/amd64) MESHWEAVER_PLATFORM_VERSION=1.0.0
+memex-portal-ai:3.0.0-rc9.ci.7231 (linux/arm64) MESHWEAVER_PLATFORM_VERSION=1.0.0
+```
+
+At the same time the About page and the self-updater were reading `Assembly.GetEntryAssembly()`
+raw, while `/api/version` already had the fallback — so the same process answered
+`3.0.0-rc9+0a1eabdc…` on the endpoint and `Version: 1.0.0`, `Build commit: not recorded for this
+build` on the page.
+
+**Nothing was red.** Every CI gate passed, `promote` applied a correct tag, and the one surface a
+monitor would poll answered correctly. What broke was downstream of the number: with the running
+version pinned at `1.0.0`, every registry tag was newer forever. The install could never reach "up
+to date", it re-armed a roll on every check floor, and the header build chip stayed in its
+update-available state — where a click is a hard page reload rather than a link to About, so the
+page that would have shown the wrong version was the page the header could no longer reach.
+
+Two lessons are encoded above rather than left as narrative:
+
+- **A duplicated derivation drifts, and drifts silently.** The fallback existed in one of two
+  readers for three weeks and nobody could see the difference until a third thing (the repo move)
+  made the two branches diverge. The selection now lives below both readers, and a test asserts the
+  two surfaces report the same build.
+- **A relocation carries contracts, not just files.** This is the second time: `AssemblyVersion`
+  had already been left behind by the same move (relocated assemblies built `1.0.0.0` into a
+  `3.0.0.0` process, fixed 2026-08-21). Both halves were invisible to every gate because a version
+  that is merely *wrong* still builds, still runs, and still looks like a version.
+
+## Related
+
+- [Release & Self-Update Strategy](../ReleaseStrategy) — what the compared version is compared
+  *against*, and the policy that acts on the answer.
+- [Module Versioning](../ModuleVersioning) — the module half: what you author, what the build
+  derives.
+- [Deployment](../Deployment) — "verify the IMAGE, never the green tick", of which the gate above
+  is one instance.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-the-about-page-names-the-build-the-portal-is-actually-running.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-the-about-page-names-the-build-the-portal-is-actually-running.md
@@ -1,0 +1,37 @@
+---
+Name: The About page names the build the portal is actually running
+Category: Fix
+Description: Settings → About reported Version 1.0.0 and "no build commit recorded" on every deployed portal, and the header build chip was stuck offering a refresh because the install could never see itself as up to date.
+Icon: Info
+Order: -20260901
+---
+
+# The About page names the build the portal is actually running
+
+Settings → **About** exists to answer one question: which build is this, and is it current. Since
+25 August it had been answering the first half wrongly on every deployed portal — `Version: 1.0.0`,
+and `Build commit: not recorded for this build` — while `/api/version` on the very same host
+answered correctly. Two surfaces, one process, two different builds named.
+
+The consequences ran further than the page. The portal compares that same number against the
+release registry to decide whether it is current, so a version pinned at `1.0.0` made **every**
+published build look newer, permanently. An install could never reach "up to date"; it re-armed a
+roll on every check interval; and the build chip in the header — the small icon beside the alerts
+bell — stayed in its update-available state, where clicking it reloads the page instead of opening
+About. The one route from the header to the build identity was closed by the very defect you would
+have gone there to read about.
+
+The cause was a build stamp, not the page. A portal learns its own identity from two places: the
+commit and base version are compiled into the assemblies, and the full run-numbered version rides
+the container image as an environment variable. Both were being read off the *entry assembly* —
+the executable — which stopped being part of the platform build when the portal hosts moved to
+their own repository, and which therefore carried the toolchain's default `1.0.0` and no commit at
+all. `/api/version` was unaffected because it already refused an unstamped host and fell back to an
+assembly the build really did stamp.
+
+That refusal is now the platform's, not one endpoint's: both surfaces resolve the same build
+assembly through one place, so they cannot name different builds again. The delivery pipeline also
+bakes the run-numbered version into the image it publishes rather than only tagging it with one,
+and — because a tag says nothing about the bytes underneath it — the pipeline now reads the version
+back out of the published image, on every architecture, before that image is given a tag anyone can
+roll to. An image that misreports itself no longer reaches a portal.

--- a/src/MeshWeaver.Mesh.Contract/PlatformBuildInfo.cs
+++ b/src/MeshWeaver.Mesh.Contract/PlatformBuildInfo.cs
@@ -1,24 +1,48 @@
+using System.Reflection;
+
 namespace MeshWeaver.Mesh;
 
 /// <summary>
-/// How a RUNNING process learns its full, run-numbered platform version (e.g.
-/// <c>3.0.0-rc3.ci.3961</c>) now that compiled assemblies are COMMIT-DETERMINISTIC (issue #1660
-/// WS3): the run number must not be compiled in — it would fork the framework identity between the
-/// CI run that bakes NodeType assemblies and the CD run that builds the image — so the container
-/// publish injects it as an environment variable instead (image CONFIG, not assembly bytes; see
-/// the <c>ContainerEnvironmentVariable</c> item in <c>Memex.Portal.Distributed.csproj</c> and the
-/// version-channel note in <c>Directory.Build.props</c>).
+/// WHICH BUILD is this process — the one answer every version surface reads, so they cannot
+/// disagree.
+///
+/// <para>Two stamps carry the identity, and they are produced in different places on purpose. The
+/// run-numbered platform version (e.g. <c>3.0.0-rc3.ci.3961</c>) rides the container IMAGE CONFIG
+/// as an environment variable, because compiled assemblies are COMMIT-DETERMINISTIC (issue #1660
+/// WS3): baking the run number in would fork the framework identity between the CI run that bakes
+/// NodeType assemblies and the CD run that builds the image. The commit sha and the base version
+/// are ASSEMBLY metadata, stamped by <c>AddCommitHashMetadata</c> in the root
+/// <c>Directory.Build.props</c>.</para>
+///
+/// <para>🚨 <b>The entry assembly is not the build.</b> Reading <c>Assembly.GetEntryAssembly()</c>
+/// blindly reports whatever host happens to have started the process, and on two hosts that
+/// matter it is not part of this build at all: a test runner (<c>test/Directory.Build.props</c>
+/// deliberately does not import the root props) and — since the portal hosts moved to
+/// MeshWeaver.Plugins on 2026-08-25 — the deployed portal executable itself, which is built in a
+/// repo that defines no <c>Version</c>. Both report the SDK default <c>1.0.0</c> and no commit.
+/// <see cref="SelectBuildAssembly"/> is the guard: an entry assembly this build did not stamp is
+/// refused in favour of one it did.</para>
+///
+/// <para>That guard used to exist in exactly one of the two readers. <c>/api/version</c> had it;
+/// the About page and the self-updater did not — so the deployed portal answered
+/// <c>3.0.0-rc9+0a1eabdc…</c> on the endpoint and <c>1.0.0</c> on the page, and because
+/// <c>VersionSelect.IsNewer</c> compares against that number, every registry tag looked newer
+/// forever: the install could never reach "up to date" and re-rolled on every check floor. The
+/// selection lives here, below both readers, so there is no second copy to drift.</para>
 /// </summary>
 public static class PlatformBuildInfo
 {
     /// <summary>
     /// The environment variable carrying the deployment's run-numbered platform version. Consumers
     /// (the self-updater's current-version, the Admin/PlatformVersion node, version displays) read
-    /// it FIRST and fall back to the entry assembly's <c>AssemblyInformationalVersion</c> —
+    /// it FIRST and fall back to the build assembly's <c>AssemblyInformationalVersion</c> —
     /// which under CI determinism is the bare <c>PlatformVersion+&lt;sha&gt;</c>, still correct,
     /// just without the run number.
     /// </summary>
     public const string PlatformVersionEnvironmentVariable = "MESHWEAVER_PLATFORM_VERSION";
+
+    /// <summary>The assembly metadata key <c>AddCommitHashMetadata</c> writes the git sha to.</summary>
+    private const string CommitHashKey = "CommitHash";
 
     /// <summary>
     /// The injected run-numbered platform version, or null when the process runs without one
@@ -27,5 +51,57 @@ public static class PlatformBuildInfo
     public static string? RuntimePlatformVersion =>
         Environment.GetEnvironmentVariable(PlatformVersionEnvironmentVariable) is { Length: > 0 } v
             ? v
+            : null;
+
+    /// <summary>
+    /// The assembly that represents this build: the entry assembly when this build stamped it,
+    /// otherwise an assembly that IS part of this build. One build stamps every one of its
+    /// assemblies with the same commit, so the fallback answer is the real one rather than a
+    /// foreign host's.
+    /// </summary>
+    /// <param name="entry">
+    /// The process entry assembly — <c>null</c> is treated as "not part of this build" (a host
+    /// that reports none, e.g. an unmanaged launcher). Taken as a parameter so the selection is
+    /// testable without controlling the process.
+    /// </param>
+    public static Assembly SelectBuildAssembly(Assembly? entry) =>
+        entry is not null && CommitOf(entry) is not null ? entry : typeof(PlatformBuildInfo).Assembly;
+
+    /// <summary>
+    /// The build identity of THIS process, resolved once — the values are compile-time constants
+    /// baked into the assembly, so re-reading them per call would buy nothing.
+    /// </summary>
+    public static Assembly BuildAssembly { get; } = SelectBuildAssembly(Assembly.GetEntryAssembly());
+
+    /// <summary>
+    /// This build's version as the ASSEMBLY carries it: the informational version (<c>
+    /// PlatformVersion+&lt;sha&gt;</c> on a CI build), then the numeric assembly version, then
+    /// <c>"unknown"</c>. Deliberately does NOT consult the injected run number — a surface that
+    /// promises assembly metadata (<c>/api/version</c>) must report exactly that; the surfaces that
+    /// want the run number read <see cref="PlatformVersion"/>.
+    /// </summary>
+    public static string AssemblyVersion =>
+        BuildAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+        ?? BuildAssembly.GetName().Version?.ToString()
+        ?? "unknown";
+
+    /// <summary>
+    /// The version the platform IDENTIFIES ITSELF BY: the injected run-numbered version when the
+    /// container publish supplied one, else what the assembly carries. This is the value the
+    /// self-updater compares against registry tags, so the run number must be visible here.
+    /// </summary>
+    public static string PlatformVersion => RuntimePlatformVersion ?? AssemblyVersion;
+
+    /// <summary>
+    /// The git commit sha this build was produced from, or <c>null</c> when the build carried no
+    /// source-control information (a git-less source drop).
+    /// </summary>
+    public static string? CommitHash => CommitOf(BuildAssembly);
+
+    private static string? CommitOf(Assembly assembly) =>
+        assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => string.Equals(a.Key, CommitHashKey, StringComparison.OrdinalIgnoreCase))
+            ?.Value is { Length: > 0 } sha
+            ? sha
             : null;
 }

--- a/test/Memex.Portal.Shared.Test/PlatformBuildIdentityTest.cs
+++ b/test/Memex.Portal.Shared.Test/PlatformBuildIdentityTest.cs
@@ -1,0 +1,128 @@
+using System.Reflection;
+using MeshWeaver.Mesh;
+using Xunit;
+
+// The class and its namespace share the name "ServiceDefaults", so the bare name binds to the
+// namespace here — same aliasing as VersionEndpointTest.
+using Defaults = Memex.Portal.ServiceDefaults.ServiceDefaults;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The portal must report the build it is actually running, and every surface that reports it must
+/// report the SAME one.
+///
+/// <para><b>The incident these tests pin.</b> Until 2026-09-01 the About page and the self-updater
+/// read <c>Assembly.GetEntryAssembly()</c> with no fallback, while <c>/api/version</c> read the
+/// same two stamps through a selection that falls back to a stamped assembly when the entry
+/// assembly is not part of this build. That difference was invisible while the portal executable
+/// lived in this repo and was stamped. When the portal hosts moved to MeshWeaver.Plugins
+/// (2026-08-25) the executable stopped being stamped, and the two readers diverged on the deployed
+/// portal: <c>/api/version</c> answered <c>3.0.0-rc9+0a1eabdc…</c> while the About page said
+/// <c>Version: 1.0.0</c> and <c>Build commit: not recorded for this build</c>.</para>
+///
+/// <para>A version pinned at <c>1.0.0</c> is not a cosmetic defect: <c>VersionSelect.IsNewer</c>
+/// then reports EVERY registry tag as newer, so the install can never reach "up to date", the
+/// header build chip is permanently in its update-available state (where a click is a page reload
+/// rather than a link to About), and the deployment re-rolls on every check floor.</para>
+///
+/// <para>🚨 <b>This test run IS the failure case</b>, which is what gives the assertions teeth:
+/// <c>test/Directory.Build.props</c> deliberately does not import the root props, so
+/// <c>AddCommitHashMetadata</c> never runs for a test project and the entry assembly here — the
+/// runner — carries no <c>CommitHash</c>, exactly like the relocated portal executable. Each test
+/// states its own non-vacuity guard rather than assuming that.</para>
+/// </summary>
+public class PlatformBuildIdentityTest
+{
+    /// <summary>An assembly THIS build stamped — the platform half of the selection.</summary>
+    private static Assembly StampedAssembly => typeof(ShippedReleaseSeed).Assembly;
+
+    /// <summary>An assembly built outside this repo, so it carries no <c>CommitHash</c>.</summary>
+    private static Assembly UnstampedAssembly => typeof(object).Assembly;
+
+    private static string? CommitOf(Assembly assembly) =>
+        assembly.GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => string.Equals(a.Key, "CommitHash", StringComparison.OrdinalIgnoreCase))
+            ?.Value is { Length: > 0 } sha
+            ? sha
+            : null;
+
+    /// <summary>
+    /// A stamped entry assembly IS the build identity — the production branch. A portal executable
+    /// built in this repo must keep answering for itself; the fallback exists for the other case
+    /// and must never override a real answer.
+    /// </summary>
+    [Fact]
+    public void Select_keeps_the_entry_assembly_when_this_build_stamped_it()
+    {
+        // Non-vacuity: the assembly handed in really is stamped, so "it was kept" means something.
+        CommitOf(StampedAssembly).Should().NotBeNull(
+            "AddCommitHashMetadata stamps every assembly built from this repo");
+
+        PlatformBuildInfo.SelectBuildAssembly(StampedAssembly).Should().BeSameAs(StampedAssembly);
+    }
+
+    /// <summary>
+    /// An entry assembly that is not part of this build is REFUSED as the build identity — the case
+    /// a relocated portal executable and a test runner have in common. Reading it would report the
+    /// SDK default <c>1.0.0</c> and no commit at all.
+    /// </summary>
+    [Fact]
+    public void Select_falls_back_when_the_entry_assembly_is_not_part_of_this_build()
+    {
+        // Non-vacuity: the assembly handed in really is unstamped, so the fallback really is taken.
+        CommitOf(UnstampedAssembly).Should().BeNull(
+            "the framework's own assembly is built outside this repo");
+
+        var selected = PlatformBuildInfo.SelectBuildAssembly(UnstampedAssembly);
+
+        selected.Should().NotBeSameAs(UnstampedAssembly);
+        CommitOf(selected).Should().NotBeNull("the fallback must land on an assembly this build stamped");
+    }
+
+    /// <summary>
+    /// An absent entry assembly (a host that reports none) is the same case as an unstamped one.
+    /// </summary>
+    [Fact]
+    public void Select_falls_back_when_there_is_no_entry_assembly()
+        => CommitOf(PlatformBuildInfo.SelectBuildAssembly(null)).Should().NotBeNull();
+
+    /// <summary>
+    /// The About page's build identity is the REAL build, not the host's default — asserted on the
+    /// commit because that half is independent of the injected run number, so the assertion holds
+    /// whether or not a container variable is present in this process.
+    /// </summary>
+    [Fact]
+    public void The_about_page_reports_a_real_build_commit_under_an_unstamped_host()
+    {
+        // Non-vacuity: this process's entry assembly is the unstamped shape the fix is about.
+        CommitOf(Assembly.GetEntryAssembly()!).Should().BeNull(
+            "test projects do not import the root props, so the runner carries no CommitHash");
+
+        ShippedReleaseSeed.CommitHash.Should().NotBeNull(
+            "reading only the entry assembly reports 'not recorded for this build' on every " +
+            "deployment whose executable is built outside this repo");
+    }
+
+    /// <summary>
+    /// 🚨 The whole point: <c>/api/version</c> and the About page CANNOT disagree. They are separate
+    /// readers only because Memex.Portal.Shared sits far above the infrastructure project — they
+    /// must resolve the same assembly and read the same two stamps, and this is the assertion that
+    /// makes that structural rather than a coincidence of how each was written.
+    /// </summary>
+    [Fact]
+    public void The_about_page_and_the_version_endpoint_report_the_same_build()
+    {
+        // Non-vacuity, and a real assertion rather than a skip: with a run number injected the two
+        // surfaces legitimately differ (the endpoint reports assembly metadata only), so a host
+        // that sets the variable must fail here loudly instead of quietly proving nothing.
+        PlatformBuildInfo.RuntimePlatformVersion.Should().BeNull(
+            "no container variable is injected in a test process — see ShippedReleaseSeed");
+
+        ShippedReleaseSeed.InstalledPlatformVersion.Should().Be(Defaults.Build.Version,
+            "the deployed portal answered 3.0.0-rc9 on /api/version and 1.0.0 on the About page");
+
+        (ShippedReleaseSeed.CommitHash ?? "").Should().Be(Defaults.Build.Commit,
+            "one build produced this process — the two surfaces name the same commit or one is lying");
+    }
+}


### PR DESCRIPTION
## The symptom

Settings → About has said `Version: 1.0.0` / `Build commit: not recorded for this build` on every deployed portal since **2026-08-25**, while `/api/version` on the same host answers `3.0.0-rc9+0a1eabdc…`. Same process, two builds named.

The display is the least of it. `VersionSelect.IsNewer` compares registry tags against that number, so pinned at `1.0.0` every published build looks newer **permanently**: the install can never reach "up to date", it re-arms a roll on every check floor (`Admin/UpdatePolicy.lastCheckVerdict` on memex.meshweaver.cloud reads *"… is available but this install rolled 00:42:30 ago, inside the 01:00:00 floor — deferring"*), and the header build chip stays in its update-available state — where a click is `Navigation.Refresh(forceReload: true)`, not a link to About. The one route from the header to the build identity was closed by the very defect you would have gone there to read about.

## Root cause — two halves, both left behind by the portal-host move

Both were invisible to every gate, because a version that is merely *wrong* still builds, still runs, and still looks like a version.

**1. CD tags the version but does not bake it.** `main-cd.yml` publishes `plugins-repo/src/Memex.Portal.Distributed` with no `-p:Version=`. That repo's `src/Directory.Build.props` does not import core's root props, so `$(Version)` is the SDK default — and the csproj bakes `$(Version)` into the image config as `MESHWEAVER_PLATFORM_VERSION`, the first thing a running portal reads to identify itself. Read out of ACR, on both architectures:

```
memex-portal-ai:3.0.0-rc9.ci.7231 (linux/amd64) MESHWEAVER_PLATFORM_VERSION=1.0.0
memex-portal-ai:3.0.0-rc9.ci.7231 (linux/arm64) MESHWEAVER_PLATFORM_VERSION=1.0.0
```

`edge-images.yml` and `release-images.yml` have always passed it, and say why in the same words ("BAKED, not just tagged"). `MeshWeaver.Plugins/.github/workflows/portal-ai-image.yml` measured and wrote down this exact regression on 2026-08-25 — *"`-getProperty:Version` on Memex.Portal.Distributed returns **1.0.0** here against **3.0.0-rc8.ci.\<n\>** there. That is a MAJOR-version regression"* — but that lane is dispatch-only and was never promoted as the cutover, so `main-cd.yml` kept shipping.

**2. Only one of the two readers refused an unstamped host.** `ShippedReleaseSeed` read `Assembly.GetEntryAssembly()` raw; `ServiceDefaults` already fell back to a stamped assembly, which is why the endpoint alone stayed correct. That selection now lives in `PlatformBuildInfo`, below both readers, so there is no second copy to drift.

This is the second contract the same move left behind — `41520256` in the Plugins repo ("Relocated assemblies built 1.0.0.0 into a 3.0.0.0 process") was the `AssemblyVersion` half, fixed 2026-08-21.

## What this changes

1. `main-cd.yml` passes `-p:Version=` on the portal publish.
2. `PlatformBuildInfo` owns the build-assembly selection; `ShippedReleaseSeed` and `ServiceDefaults` both read it. A test asserts the About page and `/api/version` name the same build.
3. `.github/scripts/check-image-build-identity.sh` reads `MESHWEAVER_PLATFORM_VERSION` back out of the **published image config**, per architecture, in `portal-image` and **before `promote`** — so an image that misreports itself never receives a tag any install can roll to. Fail-closed: unreadable manifest, absent variable and unparseable config are all exit 1, because "could not check" rendered as "checked and fine" is how the original defect survived a week of green runs.
4. Doc page `Doc/Architecture/PlatformBuildIdentity` + a What's New entry (`Category: Fix`).

## Verification

- **TDD**: the new tests fail on `main` with exactly the production symptom — `Expected "3.0.0-rc9.ci.0+f9bb94bbc…" … but found "1.0.0+f9bb94bbc…"`, and `CommitHash` null — and pass after. The test run *is* the failure shape (an unstamped entry assembly), with a non-vacuity guard on each case.
- `Memex.Portal.Shared.Test` **495/495** green in Release; `dotnet build -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**; `DocumentationLinkIntegrityTest` green.
- **The gate, against the live registry**: fails on today's image naming the exact mismatch, and passes when told to expect what that image actually reports, examining both architectures.
- ⚠️ **Not verified on a running portal.** The dev Monolith (`MeshWeaver.Plugins/src/Memex.Portal.Monolith`) does not start in this environment — `EventSubscriptionRunner` cannot resolve `IMeshService` after `MeshDataSource: No persistence core`. That failure is independent of this diff (which touches no DI registration, and that constructor has taken `IMeshService` since 2026-07-05), but it means the About page itself was not observed rendering the corrected version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MTKdQ5r3L8NRpZzHT2bbo1