### PR TITLE
fix(security): an API token's authority is read live, never from the role snapshot taken at mint

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -822,6 +822,102 @@ exact fold it ran before.
 
 ---
 
+# API tokens and the `Api` capability
+
+An API token (`mw_…`, used by MCP and every programmatic client) authenticates as its **owner** and
+gets that person's permissions — no more. On top of that it must clear one extra gate, the
+**API-token clamp** in `PermissionEvaluator`:
+
+```csharp
+// a Bearer context that cannot reach the API surface here gets NOTHING here
+if (currentContext?.IsApiToken == true && !p.HasFlag(Permission.Api)
+    && !PublicSurfaceCarriesApi(publicGrant, permissionCap))
+    p = Permission.None;
+```
+
+It zeroes the **whole** permission set, not just the `Api` bit — "may not use the API here" is not a
+partial answer. There are exactly two ways past it, and both are read live off the target path on
+every evaluation:
+
+1. **The caller's own node permissions carry `Api`.** Every built-in role carries it (`Viewer`,
+   `Commenter`, `Editor`, `Admin`), so an ordinary grant is enough; a *custom* `Role` that omits
+   `Api` is the case where a real grant still leaves the token outside.
+2. **This path's PUBLIC surface carries it** — a `PartitionAccessPolicy.PublicRead` scope or a
+   declared [`NodeTypeGate`](#type-declared-subtree-gates-nodetypegate) segment — *and* no policy on
+   the scope chain caps `Api` out. A page every anonymous browser may read is not secret from an API
+   client. This is what keeps tokens working on `Doc/`, `Agent/` and every installed package
+   partition, which `PackageInstaller` publishes through exactly that policy rather than through an
+   `AccessAssignment`.
+
+`PartitionAccessPolicy { Api = false }` is therefore meaningful in its own right: **"readable in a
+browser, not reachable through the API."** The public grant is ORed in *after* the cap so the page
+stays readable; the capability it confers is *not*, so the API surface closes.
+
+## 🚨 Why the mint-time role snapshot existed — and why trusting it was the bug
+
+`ApiToken.Roles` is a list of role ids captured **when the token was created**. It rides
+`ValidateTokenResponse.Roles` and is stamped onto `AccessContext.Roles` by `UserContextMiddleware`.
+Until 2026-09-01 the clamp's second escape hatch was that snapshot (`ClaimsCarryApi`), and the
+comments around it gave a reason:
+
+> per-node hubs intentionally don't register the synced `AccessAssignment` query (recursion
+> avoidance), so without the stamp an API-token request sees 0 roles → 0 perms → the gate strips →
+> DENY.
+
+**That reason had been obsolete for months, and the comment outlived the mechanism it described.**
+Two things had changed underneath it:
+
+* The fold moved onto the **process-wide `IMeshNodeStreamCache`**. `AddRowLevelSecurity` registers
+  no synced query at all any more — the mesh hub and every per-node hub run the *same*
+  `PermissionEvaluator` over the *same* cached `$security-*` queries. There is no hub on which a
+  grant is invisible, so there was nothing left for the stamp to compensate for.
+* The **2026-08-05 paywall fix** removed claim roles from node permissions outright (they had made
+  every claim a global, undeniable grant). After it, the snapshot's only remaining effect was this
+  one capability hatch.
+
+A snapshot answers a question about **now** with a fact from **then**, so it was wrong in both
+directions at once:
+
+| | What a stale snapshot does | Consequence |
+|---|---|---|
+| **Too restrictive** | It cannot see a grant made after the mint | A token minted before its owner held anything `Api`-bearing could not read a publicly-readable partition the same person's browser renders fine — and **no later grant could fix it**, because no later grant rewrites a minted token. Most IdPs emit no role claims at all, so `ApiToken.Roles` is usually empty: re-minting produced the same empty list and changed nothing. |
+| **Too permissive** | It cannot lose a capability revoked after the mint | A token whose mint-time claims carried an `Api`-bearing role name kept the API surface open **forever**, over the top of a `PartitionAccessPolicy` written afterwards that said `api: false`. Withdrawing API reach could not withdraw it from the tokens that already existed. |
+
+The second row is the security half, and it is the one that decided the design: **the failure that
+must not ship is a token retaining authority someone took away.**
+
+## The fix, and why this shape
+
+The capability is now derived from `(publicGrant, permissionCap)` — two values the fold **already
+computes for this path on every emission**. Concretely that buys freshness for free:
+
+* **No new data source.** No extra query, no extra subscription, nothing added to the hot path.
+* **No cross-schema fan-out.** "Does this person hold an `Api`-bearing role *anywhere*?" is the
+  unanchored, all-partitions question that
+  [Cross-schema fan-out elimination](/Doc/Architecture/CrossSchemaFanOutElimination) exists to
+  forbid — a 188-schema `UNION` is a measured lock bomb. The question actually worth asking is
+  path-scoped, and the scope walk already answers it.
+* **No recursion.** Resolving the token's roles inside token validation would have put a permission
+  read inside the authentication bootstrap. Nothing here re-enters the evaluator.
+* **Undetermined is not a grant.** The predicate is only consulted on a fold *emission*, where both
+  inputs are known. A fold leg that cannot reach a verdict terminates with an **error**, which
+  surfaces as `Undetermined` / `ErrorType.Unavailable` and refuses the delivery — never as a
+  permissive default. See [The fold can produce NO answer](#-the-fold-can-produce-no-answer-and-that-is-a-third-outcome).
+
+`AccessContext.Roles` is now read **nowhere** in `PermissionEvaluator`. It is still carried on a
+Bearer context, for two non-authority reasons: it is a useful diagnostic, and `AccessControlPipeline`
+uses a non-empty `Roles` list as its cue to restore the sender's `AccessContext` on a receiving hub.
+Neither is a permission decision — a future "just check the claims" is a regression, not a shortcut.
+
+> 🚨 **The general rule this is an instance of.** A credential must not carry a *copy* of an
+> authorization fact. Copies go stale silently and in both directions, and the permissive direction
+> has no expiry: the moment authority is snapshotted onto a token, revoking it stops working for
+> every token already minted. Authority is read from the authority, at the point of use.
+
+Pinned by `ApiTokenCapabilityFreshnessTest` (core) and `PaywallRealGateShapeTests` (plugins).
+
+---
+
 # Hierarchical access pattern
 
 ```mermaid

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -909,6 +909,17 @@ Bearer context, for two non-authority reasons: it is a useful diagnostic, and `A
 uses a non-empty `Roles` list as its cue to restore the sender's `AccessContext` on a receiving hub.
 Neither is a permission decision — a future "just check the claims" is a regression, not a shortcut.
 
+> ⚠️ **Known gap, named rather than papered over — that second use is itself a defect.**
+> `AccessControlPipeline` restores the sender's context only when `delivery.AccessContext` carries a
+> **non-empty** `Roles` list. A token minted with no claims (the ordinary case) therefore reaches a
+> per-node hub with no restored context at all, so `capturedContext` is null, `IsApiToken` is
+> unknown, and the clamp **does not run** on that path. It is not a hole in the read path — the
+> exact-read gate (`MeshNodeStreamCache.GetStreamRaw` → `ProbeEffectivePermissions`) captures the
+> caller's context directly and clamps correctly — but a message-routed check on a per-node hub can
+> miss it. The cure is to make the restore unconditional rather than role-shaped; it is a
+> context-propagation defect, not a staleness one, and it is tracked separately (issue #2976) so it
+> gets its own measurement on a hot path rather than riding along here.
+
 > 🚨 **The general rule this is an instance of.** A credential must not carry a *copy* of an
 > authorization fact. Copies go stale silently and in both directions, and the permissive direction
 > has no expiry: the moment authority is snapshotted onto a token, revoking it stops working for

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-an-api-token-no-longer-remembers-what-you-used-to-be-allowed.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-an-api-token-no-longer-remembers-what-you-used-to-be-allowed.md
@@ -1,0 +1,43 @@
+---
+Name: An API token no longer remembers what you used to be allowed
+Category: Fix
+Description: API tokens carried a copy of your roles from the moment they were created. That copy could not see access granted later — and, worse, could not lose access taken away later. Tokens now read your access live, so a new grant works immediately and a withdrawal takes effect immediately.
+Icon: ShieldKeyhole
+Order: -20260901
+---
+
+# An API token no longer remembers what you used to be allowed
+
+An API token — the `mw_…` key that connects Claude, an MCP client or any script to your mesh — signs
+in as you. It should see what you see.
+
+Until now it carried something extra: a small copy of your roles, taken at the instant the token was
+created and never updated. That copy was consulted when deciding whether a token was allowed to use
+the API at all, and a copy of an access fact goes stale in both directions.
+
+**It could not see access granted later.** If someone shared a space with you after your token was
+made, the token did not learn about it. The page opened perfectly in your browser and the same read
+through the token was refused — the confusing shape where "it works on screen but not in the tool".
+Re-making the token was the usual advice, and it often did not help either: most sign-in providers
+attach no roles at all, so the copy was empty the first time and empty again on every re-make.
+
+**And it could not lose access taken away later.** This is the more serious half. A token created
+while you held a wide role kept the door open indefinitely, even after an administrator marked a
+partition as *not reachable through the API*. Closing that door closed it for new tokens and left
+every existing one untouched — a withdrawal that silently did not apply.
+
+## What changed
+
+Tokens no longer carry authority. Every request now resolves your access from the live records on
+the page being read, exactly the way your browser session does:
+
+- **A grant works the moment it is made.** No re-issuing a token, no signing out, nothing to wait
+  for.
+- **A withdrawal works the moment it is made.** Marking a partition as not reachable through the API
+  now applies to tokens that already exist, which is the only version of that setting worth having.
+- **Public pages are readable through the API.** Documentation, the agent catalog and installed
+  package content are published for everyone to read; a token can now read them without needing a
+  role of its own — while a partition explicitly closed to the API stays closed.
+
+Nothing became more visible. A token still sees exactly what its owner sees and never more; what
+changed is only *when* it finds out.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-an-api-token-no-longer-works-from-a-copy-of-your-old-permissions.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-an-api-token-no-longer-works-from-a-copy-of-your-old-permissions.md
@@ -1,12 +1,12 @@
 ---
-Name: An API token no longer remembers what you used to be allowed
+Name: An API token no longer works from a copy of your old permissions
 Category: Fix
 Description: API tokens carried a copy of your roles from the moment they were created. That copy could not see access granted later — and, worse, could not lose access taken away later. Tokens now read your access live, so a new grant works immediately and a withdrawal takes effect immediately.
 Icon: ShieldKeyhole
 Order: -20260901
 ---
 
-# An API token no longer remembers what you used to be allowed
+# An API token no longer works from a copy of your old permissions
 
 An API token — the `mw_…` key that connects Claude, an MCP client or any script to your mesh — signs
 in as you. It should see what you see.

--- a/src/MeshWeaver.Graph/Configuration/ApiTokenNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ApiTokenNodeType.cs
@@ -178,11 +178,11 @@ public static class ApiTokenNodeType
                     }
 
                     // Include the roles captured on the ApiToken at creation time.
-                    // UserContextMiddleware stamps these onto AccessContext.Roles so
-                    // SecurityService.GetEffectivePermissions can resolve them via
-                    // the claim-based role path on per-node hubs — where the
-                    // synced AccessAssignment query is intentionally not registered
-                    // (SecurityServiceExtensions:44-50, recursion avoidance).
+                    // 🚨 Diagnostic only — no permission decision reads them (see
+                    // ApiToken.Roles). Permissions and the Api capability are folded
+                    // live off the TARGET PATH on every request, so a token never
+                    // needs re-minting to see a grant, and a mint-time role can never
+                    // outlive the authority it was copied from.
                     var response = ValidateTokenResponse.Ok(
                         apiToken.UserId, apiToken.UserName, apiToken.UserEmail, apiToken.Roles);
                     hub.Post(response, o => o.ResponseFor(request));

--- a/src/MeshWeaver.Hosting.AspNetCore/Portal/UserContextMiddleware.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/Portal/UserContextMiddleware.cs
@@ -449,13 +449,27 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
                         ObjectId = response.UserId,
                         Name = response.UserName ?? "",
                         Email = response.UserEmail!,
-                        // Stamp the roles captured on the ApiToken at creation time so
-                        // SecurityService.GetEffectivePermissions can resolve permissions via
-                        // its claim-based role path (lines 166-174). Without this, API-token
-                        // requests against per-node hubs see 0 roles → 0 perms → the
-                        // IsApiToken gate strips → DENY — because per-node hubs intentionally
-                        // don't register the synced AccessAssignment query
-                        // (SecurityServiceExtensions:44-50, recursion avoidance).
+                        // 🚨 NOT AUTHORITY. These are the role ids captured on the ApiToken node
+                        // when the token was MINTED, and PermissionEvaluator reads them nowhere:
+                        // a token's permissions are folded from the live AccessAssignment /
+                        // PartitionAccessPolicy nodes on the target path exactly like a browser
+                        // session's, and its API capability from that path's own public grant and
+                        // policy cap (PermissionEvaluator.PublicSurfaceCarriesApi). They are
+                        // stamped only as a diagnostic and because AccessControlPipeline uses a
+                        // non-empty Roles list as its cue to restore the sender's AccessContext on
+                        // a receiving hub.
+                        //
+                        // The comment this replaces claimed the stamp was load-bearing — "per-node
+                        // hubs intentionally don't register the synced AccessAssignment query
+                        // (recursion avoidance), so without this a token sees 0 roles → 0 perms →
+                        // DENY". That stopped being true when the fold moved onto the process-wide
+                        // IMeshNodeStreamCache: AddRowLevelSecurity registers no synced query at
+                        // all any more, every hub (mesh and per-node alike) runs the SAME
+                        // PermissionEvaluator over the SAME cached queries, and claim roles were
+                        // removed from node permissions outright by the 2026-08-05 paywall fix.
+                        // The stale rationale outlived the mechanism it described by months and
+                        // kept a mint-time snapshot in the authority path — see
+                        // Doc/Architecture/AccessControl → "API tokens and the Api capability".
                         Roles = response.Roles,
                         IsApiToken = true,
                     }, null)

--- a/src/MeshWeaver.Mesh.Contract/Security/ApiToken.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/ApiToken.cs
@@ -35,16 +35,19 @@ public record ApiToken
     public bool IsRevoked { get; init; }
 
     /// <summary>
-    /// Role IDs (e.g. "Admin", "Editor") captured at token-creation time from
-    /// the creating user's <c>AccessContext.Roles</c>. Returned in
-    /// <see cref="ValidateTokenResponse.Roles"/> at validation and stamped onto
-    /// the request's <c>AccessContext.Roles</c> by the auth middleware so that
-    /// SecurityService.GetEffectivePermissions can resolve them via the
-    /// claim-based role path on per-node hubs (where the synced
-    /// AccessAssignment query is intentionally not registered — see
-    /// SecurityServiceExtensions:44-50). Without this, API-token-bound requests
-    /// against per-node hubs see 0 roles → 0 perms → API gate strips, even
-    /// when the user is admin on the target scope.
+    /// Role IDs (e.g. "Admin", "Editor") captured at token-creation time from the creating user's
+    /// <c>AccessContext.Roles</c>, returned in <see cref="ValidateTokenResponse.Roles"/> at
+    /// validation and stamped onto the request's <c>AccessContext.Roles</c> by the auth middleware.
+    ///
+    /// <para>🚨 <b>NOT AUTHORITY — a diagnostic breadcrumb.</b> Nothing in
+    /// <c>PermissionEvaluator</c> reads it. A token's data permissions are folded from the live
+    /// <c>AccessAssignment</c> / <c>PartitionAccessPolicy</c> nodes on the target path, exactly
+    /// like a browser session's, and its <see cref="Permission.Api"/> capability is derived from
+    /// that path's own public grant and policy cap. Do not reintroduce it into a permission
+    /// decision: a value written when the token was minted cannot see a grant made afterwards and
+    /// cannot lose a capability revoked afterwards, so trusting it makes both a lockout and a
+    /// standing privilege permanent. See Doc/Architecture/AccessControl →
+    /// "API tokens and the Api capability".</para>
     /// </summary>
     public IReadOnlyCollection<string> Roles { get; init; } = [];
 }

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -191,11 +191,14 @@ internal static class PermissionEvaluator
             // ObserveOn — when the .Select lambdas in the fold land on TaskPool
             // (because cache.GetQuery uses SubscribeOn(TaskPoolScheduler)),
             // accessService.Context is null or contaminated. CircuitContext is
-            // mesh-global so it survives, but Bearer-token Roles claims live in
-            // AccessContext.Roles and we need that snapshot here. The Public leg
-            // of the fold evaluates under the SAME captured viewer context — it
-            // is the same viewer's check, and its API-token gate is subsumed by
-            // the outer one (own | pub is gated on the combined value).
+            // mesh-global so it survives, but the request-scoped context carries
+            // the two flags the fold reads — IsApiToken (the API-token clamp) and
+            // IsHub (the hub-credential early return) — so it has to be snapshotted
+            // here. 🚨 AccessContext.Roles is NOT read: a Bearer token's Roles are a
+            // mint-time snapshot and carry no authority anywhere in this evaluator.
+            // The Public leg of the fold evaluates under the SAME captured viewer
+            // context — it is the same viewer's check, and its API-token gate is
+            // subsumed by the outer one (own | pub is gated on the combined value).
             accessService?.Context,
             accessService?.CircuitContext);
     }
@@ -349,13 +352,33 @@ internal static class PermissionEvaluator
                     // the Rx schedulers cache.GetQuery uses).
                     var currentContext = capturedContext ?? capturedCircuitContext;
                     // API-token capability: the token may use the API surface when its NODE
-                    // permissions carry Api (a real Viewer/Editor grant) OR its claim roles do —
-                    // this is the ONE place claim roles act, and it is a CAPABILITY gate, never a
-                    // data grant (claims are excluded from roleIds above; see ComputeRoleState).
-                    // Without the claims half, removing claims from node permissions would zero
-                    // every MCP token on PublicRead-policy content (p = Read only, no Api bit).
+                    // permissions carry Api (a real Viewer/Editor grant) or when THIS path's
+                    // public surface does (see PublicSurfaceCarriesApi). Both halves are
+                    // recomputed from the live fold on every emission — nothing here reads the
+                    // token's own claims.
+                    //
+                    // 🚨 IT USED TO READ THEM, and that was a staleness hole with a security
+                    // side: the escape hatch was `ClaimsCarryApi(ctx)` over AccessContext.Roles,
+                    // which for a Bearer request is the role list captured on the ApiToken node
+                    // at MINT time (ApiToken.Roles → ValidateTokenResponse.Roles →
+                    // UserContextMiddleware). A snapshot answers a question about NOW with a fact
+                    // from THEN, and it is wrong in both directions:
+                    //   • too RESTRICTIVE — a token minted before its owner was granted anything
+                    //     (the ordinary case: most IdPs emit no role claims at all, so
+                    //     ApiToken.Roles is empty) could not read a PublicRead partition that the
+                    //     same person's browser renders fine, and NO later grant could fix it
+                    //     because no later grant rewrites a minted token;
+                    //   • too PERMISSIVE — the hatch outlived whatever produced it. A token whose
+                    //     mint-time claims carried an Api-bearing role name kept the API surface
+                    //     open FOREVER, over the top of a PartitionAccessPolicy that later said
+                    //     `api: false`. Taking API reach away could not take it away from the
+                    //     tokens that already existed.
+                    // Deriving the capability from (publicGrant, permissionCap) — both live,
+                    // both anchored to THIS path's scope chain — needs no extra query, no
+                    // cross-schema fan-out (Doc/Architecture/CrossSchemaFanOutElimination) and no
+                    // re-entry into the fold, so freshness costs nothing per request.
                     if (currentContext?.IsApiToken == true && !p.HasFlag(Permission.Api)
-                        && !ClaimsCarryApi(currentContext))
+                        && !PublicSurfaceCarriesApi(publicGrant, permissionCap))
                         p = Permission.None;
                     logger?.LogTrace("User {UserId} has permissions {Permissions} on node {NodePath} (cap: {Cap})",
                         userId, p, nodePath, permissionCap);
@@ -702,22 +725,50 @@ internal static class PermissionEvaluator
         // The access model (AGENTS.md, "Global admin"): a platform role grants the PLATFORM
         // gates, deliberately NOT cross-partition data access — it must not read a course it has
         // not bought. So node data permissions come from AccessAssignment nodes and policies
-        // ONLY, matching the SQL path row for row. Claim roles keep their legitimate job at the
-        // API-token capability check in GetEffectivePermissions (ClaimsCarryApi) — they decide
-        // whether the token may use the API surface, never what data it may read.
-        // Pinned by PaywallRealGateShapeTests (DbRoleClaim_DoesNotGrantNodeRead and siblings).
+        // ONLY, matching the SQL path row for row.
+        //
+        // 🚨 Claim roles now have NO job here at all. They kept one until 2026-09-01 — the
+        // API-token capability hatch in GetEffectivePermissionsCore — and that last foothold was
+        // itself a staleness hole, because a Bearer context's Roles are the snapshot taken when
+        // the token was MINTED: it could not see a grant made afterwards, and it could not lose a
+        // capability revoked afterwards. The capability is now derived from this path's own live
+        // public grant and policy cap (PublicSurfaceCarriesApi). AccessContext.Roles is read
+        // NOWHERE in this file; a future "just check the claims" is a regression, not a shortcut.
+        // Pinned by PaywallRealGateShapeTests (DbRoleClaim_DoesNotGrantNodeRead and siblings) and
+        // by ApiTokenCapabilityFreshnessTest.
         return (roleIds, permissionCap, publicGrant);
     }
 
     /// <summary>
-    /// True when the context's claim roles include a built-in role carrying
-    /// <see cref="Permission.Api"/> (Viewer, Commenter, Editor, Admin, …). Backs the API-token
-    /// capability gate — the only effect claim roles have on permission evaluation.
+    /// True when the PUBLIC surface of the path being evaluated carries the API capability —
+    /// the API-token clamp's only escape hatch besides a real <see cref="Permission.Api"/> in the
+    /// caller's own node permissions.
+    ///
+    /// <para>A public surface is a <c>PartitionAccessPolicy.PublicRead</c> scope or a declared
+    /// <c>NodeTypeGate</c> segment: content every anonymous browser already reads. It is public on
+    /// EVERY surface — a page anyone may read is not secret from an API client — so a Bearer
+    /// context is admitted to it even with no role of its own. That is what keeps MCP tokens
+    /// working on <c>Doc/</c>, <c>Agent/</c> and every installed package partition, which
+    /// <c>PackageInstaller</c> makes readable through exactly this policy and not through an
+    /// <c>AccessAssignment</c>.</para>
+    ///
+    /// <para>🚨 <paramref name="permissionCap"/> is what makes this a DECISION rather than a hole.
+    /// The public grant is ORed in after the cap on purpose (a public page stays readable to a
+    /// browser even on a capped partition), but the API capability it confers is NOT: a scope on
+    /// the chain that sets <c>api: false</c> means "not reachable through the API", and that must
+    /// bind here or the policy is decorative. The old claim-based hatch could not honour it — a
+    /// mint-time role snapshot knows nothing about a policy written afterwards.</para>
+    ///
+    /// <para>Undetermined is NOT a grant: this predicate is only ever consulted on a fold emission,
+    /// where both inputs are known. A fold that cannot reach a verdict terminates with an error
+    /// (see the leg-seeding note in <see cref="GetEffectivePermissionsCore"/>), which surfaces as
+    /// <c>Undetermined</c> / <c>ErrorType.Unavailable</c> and refuses the delivery — never as a
+    /// permissive default.</para>
     /// </summary>
-    private static bool ClaimsCarryApi(AccessContext ctx)
-        => ctx.Roles is not null
-           && ctx.Roles.Any(r =>
-               BuiltInRolePerms.TryGetValue(r, out var rp) && rp.HasFlag(Permission.Api));
+    /// <param name="publicGrant">The public grant folded for this path (Read, or None).</param>
+    /// <param name="permissionCap">The AND of every policy cap on this path's scope chain.</param>
+    private static bool PublicSurfaceCarriesApi(Permission publicGrant, Permission permissionCap)
+        => publicGrant.HasFlag(Permission.Read) && permissionCap.HasFlag(Permission.Api);
 
     private static List<string> GetScopeHierarchy(string nodePath)
     {

--- a/src/MeshWeaver.Mesh.Contract/Security/ValidateTokenRequest.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/ValidateTokenRequest.cs
@@ -40,13 +40,14 @@ public record ValidateTokenResponse
     public string? UserEmail { get; init; }
 
     /// <summary>
-    /// Roles captured on the <see cref="ApiToken"/> at creation time. The auth
-    /// middleware copies these into <see cref="AccessContext.Roles"/> so
-    /// SecurityService can resolve permissions via the claim-based role path
-    /// even on per-node hubs (where the synced AccessAssignment query is
-    /// intentionally not registered — see SecurityServiceExtensions:44-50).
-    /// Empty for tokens created before this field existed — those tokens
-    /// must be re-created to pick up non-claim role data.
+    /// Roles captured on the <see cref="ApiToken"/> at creation time; the auth middleware copies
+    /// them into <see cref="AccessContext.Roles"/>.
+    ///
+    /// <para>🚨 <b>Carried, never trusted.</b> No permission decision reads this — see
+    /// <see cref="ApiToken.Roles"/>. It is deliberately harmless that the value is a snapshot,
+    /// and deliberately harmless that it is empty on tokens minted before the field existed: a
+    /// token NEVER needs re-creating to pick up a grant, because grants are read live off the
+    /// target path on every request.</para>
     /// </summary>
     public IReadOnlyCollection<string> Roles { get; init; } = [];
 
@@ -74,9 +75,9 @@ public record ValidateTokenResponse
         => new() { UserId = userId, UserName = userName, UserEmail = userEmail };
 
     /// <summary>
-    /// Creates a successful validation response carrying the token's role set so
-    /// the auth middleware can stamp <see cref="AccessContext.Roles"/> for
-    /// downstream permission checks.
+    /// Creates a successful validation response carrying the token's mint-time role set so the
+    /// auth middleware can stamp <see cref="AccessContext.Roles"/>. Diagnostic only — see
+    /// <see cref="Roles"/>.
     /// </summary>
     public static ValidateTokenResponse Ok(string userId, string userName, string userEmail,
         IReadOnlyCollection<string> roles)

--- a/test/MeshWeaver.Graph.Test/ApiTokenCapabilityFreshnessTest.cs
+++ b/test/MeshWeaver.Graph.Test/ApiTokenCapabilityFreshnessTest.cs
@@ -1,0 +1,242 @@
+using System.Reactive.Linq;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The API-token capability clamp must answer from LIVE data, never from the role snapshot taken
+/// when the token was minted.
+///
+/// <para><b>The defect.</b> <c>ApiToken.Roles</c> is captured at token-creation time, travels on
+/// <c>ValidateTokenResponse.Roles</c> and is stamped onto <c>AccessContext.Roles</c> by
+/// <c>UserContextMiddleware</c>. <c>PermissionEvaluator</c>'s clamp — which zeroes the WHOLE
+/// permission set for a Bearer context that lacks <see cref="Permission.Api"/> — used to consult
+/// that snapshot as its escape hatch (<c>ClaimsCarryApi</c>). A snapshot answers a question about
+/// NOW with a fact from THEN, and it was wrong in both directions:</para>
+/// <list type="bullet">
+/// <item><b>Too restrictive.</b> A token minted before its owner held anything Api-bearing could
+/// not reach a publicly-readable partition its owner's browser renders fine — and no later grant
+/// could fix it, because no later grant rewrites a minted token. Most IdPs emit no role claims at
+/// all, so this is the ORDINARY case, not an edge one.</item>
+/// <item><b>Too permissive — the security half.</b> The hatch outlived whatever produced it. A
+/// token whose mint-time claims carried an Api-bearing role name kept the API surface open
+/// forever, over the top of a <c>PartitionAccessPolicy</c> that later declared
+/// <c>api: false</c>. Taking API reach away could not take it away from the tokens that already
+/// existed.</item>
+/// </list>
+///
+/// <para><b>The fix.</b> The capability is derived from THIS path's own live public grant and
+/// policy cap (<c>PermissionEvaluator.PublicSurfaceCarriesApi</c>) — both already in the fold, so
+/// there is no extra query, no cross-schema fan-out and no re-entry into the evaluator. Nothing in
+/// the evaluator reads <c>AccessContext.Roles</c> any more.</para>
+///
+/// <para>🚨 Every case below is written so it CAN fail: <see cref="StaleClaimRoles_CannotDefeat"/>
+/// and <see cref="TokenWithNoClaims_ReadsAPubliclyReadablePartition"/> both FAIL on the pre-fix
+/// evaluator (verified by restoring the claim hatch), and the two "still works" cases fail if the
+/// clamp is simply deleted.</para>
+/// </summary>
+public class ApiTokenCapabilityFreshnessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The person the token belongs to. Deliberately NOT the DevLogin harness admin.</summary>
+    private const string TokenUser = "token-holder";
+
+    /// <summary>Publicly readable by policy — the shape <c>PackageInstaller</c> writes for
+    /// <c>Doc/</c>, <c>Agent/</c> and every installed package partition.</summary>
+    private const string PublicPartition = "PublicCatalog";
+
+    /// <summary>Publicly readable in a browser, explicitly NOT reachable through the API.</summary>
+    private const string ApiCappedPartition = "CappedCatalog";
+
+    /// <summary>No public surface; the token holder has a real Editor grant here.</summary>
+    private const string GrantedPartition = "GrantedSpace";
+
+    /// <summary>No public surface and no grant — the control arm.</summary>
+    private const string ForeignPartition = "ForeignSpace";
+
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
+
+    // 🚨 ConfigureMeshBase, not base.ConfigureMesh: the latter chains PublicAdminAccess(), which
+    // grants Public the Admin role in every default partition — under it every identity carries
+    // Admin (hence Api) everywhere and every assertion here would pass vacuously.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode(PublicPartition) { Name = "Public Catalog", NodeType = "Markdown" },
+                new MeshNode("Page", PublicPartition) { Name = "Public Page", NodeType = "Markdown" },
+                AssignmentNodeFactory.Policy(PublicPartition,
+                    new PartitionAccessPolicy { PublicRead = true }),
+
+                new MeshNode(ApiCappedPartition) { Name = "Capped Catalog", NodeType = "Markdown" },
+                new MeshNode("Page", ApiCappedPartition) { Name = "Capped Page", NodeType = "Markdown" },
+                // "Readable by anyone in a browser; not reachable through the API." The Api cap is
+                // the administrator's revocation of API reach — the thing a stale token defeated.
+                AssignmentNodeFactory.Policy(ApiCappedPartition,
+                    new PartitionAccessPolicy { PublicRead = true, Api = false }),
+
+                new MeshNode(GrantedPartition) { Name = "Granted Space", NodeType = "Markdown" },
+                new MeshNode("Page", GrantedPartition) { Name = "Granted Page", NodeType = "Markdown" },
+                AssignmentNodeFactory.UserRole(TokenUser, "Editor", GrantedPartition),
+
+                new MeshNode(ForeignPartition) { Name = "Foreign Space", NodeType = "Markdown" },
+                new MeshNode("Page", ForeignPartition) { Name = "Foreign Page", NodeType = "Markdown" });
+
+    private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
+
+    /// <summary>
+    /// A Bearer request as the middleware builds it. <paramref name="mintTimeRoles"/> is the
+    /// snapshot from <c>ApiToken.Roles</c>; the whole point of this suite is that it must not
+    /// change any answer.
+    ///
+    /// <para>🚨 BOTH contexts, deliberately: the evaluator snapshots
+    /// <c>Context ?? CircuitContext</c> on the caller's thread, so a circuit-only switch can be
+    /// shadowed by whatever last wrote <c>Context</c> and leave the test asserting as the wrong
+    /// principal.</para>
+    /// </summary>
+    private void BecomeToken(params string[] mintTimeRoles)
+    {
+        var ctx = new AccessContext
+        {
+            ObjectId = TokenUser,
+            Name = "Token Holder",
+            Roles = mintTimeRoles,
+            IsApiToken = true,
+        };
+        Access.SetContext(ctx);
+        Access.SetHostIdentity(ctx);
+    }
+
+    /// <summary>The same person in a browser — the surface the issue reports as "works fine".</summary>
+    private void BecomeBrowser()
+    {
+        var ctx = new AccessContext { ObjectId = TokenUser, Name = "Token Holder" };
+        Access.SetContext(ctx);
+        Access.SetHostIdentity(ctx);
+    }
+
+    private Task<Permission> Effective(string path) =>
+        Mesh.GetEffectivePermissions(path, TokenUser)
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+
+    /// <summary>
+    /// 🚨 THE SECURITY PIN. The administrator has said "this partition is not reachable through
+    /// the API" (<c>api: false</c>). A token minted while its owner's claims still carried an
+    /// Api-bearing role must NOT be able to spend that stale fact against the live policy.
+    ///
+    /// <para>Pre-fix this returned <c>Read</c>: the public grant is ORed in after the cap, so
+    /// <c>p</c> was <c>Read</c> without <c>Api</c>, and <c>ClaimsCarryApi(["Admin"])</c> answered
+    /// true and waved it through. The stale claim outranked the live policy, permanently and for
+    /// every token minted before the policy was written.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task StaleClaimRoles_CannotDefeat()
+    {
+        BecomeToken("Admin", "Editor");
+
+        (await Effective($"{ApiCappedPartition}/Page"))
+            .Should().Be(Permission.None,
+                "a policy that caps Api out means 'not reachable through the API' — a role " +
+                "snapshot taken when the token was minted must not outrank it");
+    }
+
+    /// <summary>
+    /// The companion measurement that makes the pin above meaningful rather than merely strict:
+    /// the SAME node, the SAME person, in a browser. The cap removes the Api bit and nothing else,
+    /// so the page stays readable — which is exactly what <c>PublicRead</c> means and why the
+    /// denial above is a capability decision, not a data one.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ApiCappedPartition_IsStillReadableInABrowser()
+    {
+        BecomeBrowser();
+
+        (await Effective($"{ApiCappedPartition}/Page"))
+            .HasFlag(Permission.Read).Should().BeTrue(
+                "capping Api withdraws the API surface, not the public page");
+    }
+
+    /// <summary>
+    /// 🚨 THE ISSUE'S DIRECTION. A token carrying NO claims at all — what every token minted
+    /// through an IdP that emits no role claims looks like — reads a publicly-readable partition.
+    ///
+    /// <para>Pre-fix this returned <c>Permission.None</c>: <c>p</c> was <c>Read</c> from the
+    /// public grant with no <c>Api</c> bit, the claims were empty, and the clamp zeroed the whole
+    /// set. The user's browser rendered the same page, and re-minting the token changed nothing
+    /// because the claim list was empty at every mint.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task TokenWithNoClaims_ReadsAPubliclyReadablePartition()
+    {
+        BecomeToken();
+
+        (await Effective($"{PublicPartition}/Page"))
+            .HasFlag(Permission.Read).Should().BeTrue(
+                "a page every anonymous browser may read is not secret from an API client — and " +
+                "no re-mint could have produced this, because the claim list is empty at every mint");
+    }
+
+    /// <summary>
+    /// The clamp is still a clamp. No grant, no public surface, and a mint-time claim list that
+    /// says "Admin": still nothing. Claim roles never were a data grant (the 2026-08-05 paywall
+    /// fix) and removing their last foothold must not have quietly restored one.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task StaleClaimRoles_GrantNothingWhereThereIsNoLiveAuthority()
+    {
+        BecomeToken("Admin");
+
+        (await Effective($"{ForeignPartition}/Page"))
+            .Should().Be(Permission.None,
+                "a platform role claim is not cross-partition data access, snapshot or not");
+    }
+
+    /// <summary>
+    /// The regression the mint-time stamp was introduced to prevent, pinned so it cannot come
+    /// back: a claimless token with a REAL <c>Editor</c> grant on the target scope reads it.
+    /// <c>Role.Editor</c> carries <see cref="Permission.Api"/>, so the clamp never fires — which
+    /// is why the "0 roles → 0 perms → DENY" story the old comments told stopped being true long
+    /// before this change.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task TokenWithNoClaims_ReadsWhatItsOwnGrantAllows()
+    {
+        BecomeToken();
+
+        var perms = await Effective($"{GrantedPartition}/Page");
+        perms.HasFlag(Permission.Read).Should().BeTrue(
+            "the grant is read live off the target path — a token never needs re-minting to see it");
+        perms.HasFlag(Permission.Api).Should().BeTrue(
+            "Editor carries Api, so the capability comes from the grant itself");
+    }
+
+    /// <summary>
+    /// The structural anti-regression: on the two paths where the old evaluator DID diverge on
+    /// claims, the verdict is now identical with and without them. <c>AccessContext.Roles</c> is
+    /// carried for diagnostics and for <c>AccessControlPipeline</c>'s context-restore cue — a
+    /// future "just check the claims" is a regression, not a shortcut.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ClaimRoles_ChangeNoVerdict()
+    {
+        BecomeToken();
+        var cappedWithout = await Effective($"{ApiCappedPartition}/Page");
+        var publicWithout = await Effective($"{PublicPartition}/Page");
+
+        BecomeToken("Admin", "Editor", "Viewer");
+        var cappedWith = await Effective($"{ApiCappedPartition}/Page");
+        var publicWith = await Effective($"{PublicPartition}/Page");
+
+        cappedWith.Should().Be(cappedWithout,
+            "the Api cap is decided by the live policy, not by what the token remembers");
+        publicWith.Should().Be(publicWithout,
+            "the public surface is decided by the live policy, not by what the token remembers");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ApiTokenCapabilityFreshnessTest.cs
+++ b/test/MeshWeaver.Graph.Test/ApiTokenCapabilityFreshnessTest.cs
@@ -67,7 +67,16 @@ public class ApiTokenCapabilityFreshnessTest(ITestOutputHelper output) : Monolit
     /// into a shared mesh.</summary>
     private const string LateGrantPartition = "LateGrantSpace";
 
-    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
+    /// <summary>
+    /// 🚨 <see cref="TestTimeouts.Quick"/>, never a literal. Every wait in this suite settles a
+    /// LOCAL, in-memory fold over cached queries — the case that property names — and the value is
+    /// CI-scaled, so the bound is not a guess about how fast one laptop is
+    /// (<c>TestTimeoutLiteralRatchetGuard</c>). It also stays strictly BELOW each case's
+    /// <c>[Fact(Timeout = 60_000)]</c> on CI as well as locally (12 s local / 36 s CI vs 60 s), so
+    /// a wait that does not converge loses first and reports WHAT it was waiting for, instead of
+    /// xunit killing the method and reporting an anonymous timeout.
+    /// </summary>
+    private static TimeSpan Budget => TestTimeouts.Quick;
 
     // 🚨 ConfigureMeshBase, not base.ConfigureMesh: the latter chains PublicAdminAccess(), which
     // grants Public the Admin role in every default partition — under it every identity carries

--- a/test/MeshWeaver.Graph.Test/ApiTokenCapabilityFreshnessTest.cs
+++ b/test/MeshWeaver.Graph.Test/ApiTokenCapabilityFreshnessTest.cs
@@ -37,10 +37,12 @@ namespace MeshWeaver.Graph.Test;
 /// there is no extra query, no cross-schema fan-out and no re-entry into the evaluator. Nothing in
 /// the evaluator reads <c>AccessContext.Roles</c> any more.</para>
 ///
-/// <para>🚨 Every case below is written so it CAN fail: <see cref="StaleClaimRoles_CannotDefeat"/>
-/// and <see cref="TokenWithNoClaims_ReadsAPubliclyReadablePartition"/> both FAIL on the pre-fix
-/// evaluator (verified by restoring the claim hatch), and the two "still works" cases fail if the
-/// clamp is simply deleted.</para>
+/// <para>🚨 Every case below is written so it CAN fail, and that was measured rather than assumed.
+/// Restoring the claim hatch reds exactly <see cref="StaleClaimRoles_CannotDefeat"/>,
+/// <see cref="TokenWithNoClaims_ReadsAPubliclyReadablePartition"/> and
+/// <see cref="ClaimRoles_ChangeNoVerdict"/> while the "must still work" cases stay green; deleting
+/// the clamp outright reds <see cref="StaleClaimRoles_CannotDefeat"/>, so the clamp is still
+/// load-bearing and this change did not merely neuter it.</para>
 /// </summary>
 public class ApiTokenCapabilityFreshnessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -59,6 +61,11 @@ public class ApiTokenCapabilityFreshnessTest(ITestOutputHelper output) : Monolit
 
     /// <summary>No public surface and no grant — the control arm.</summary>
     private const string ForeignPartition = "ForeignSpace";
+
+    /// <summary>Starts with no grant; one is WRITTEN AT RUNTIME, long after the token existed.
+    /// Its own partition so it cannot perturb the control arm above even if this suite ever opts
+    /// into a shared mesh.</summary>
+    private const string LateGrantPartition = "LateGrantSpace";
 
     private static readonly TimeSpan Budget = TimeSpan.FromSeconds(30);
 
@@ -85,7 +92,10 @@ public class ApiTokenCapabilityFreshnessTest(ITestOutputHelper output) : Monolit
                 AssignmentNodeFactory.UserRole(TokenUser, "Editor", GrantedPartition),
 
                 new MeshNode(ForeignPartition) { Name = "Foreign Space", NodeType = "Markdown" },
-                new MeshNode("Page", ForeignPartition) { Name = "Foreign Page", NodeType = "Markdown" });
+                new MeshNode("Page", ForeignPartition) { Name = "Foreign Page", NodeType = "Markdown" },
+
+                new MeshNode(LateGrantPartition) { Name = "Late Grant Space", NodeType = "Markdown" },
+                new MeshNode("Page", LateGrantPartition) { Name = "Late Grant Page", NodeType = "Markdown" });
 
     private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
 
@@ -215,6 +225,50 @@ public class ApiTokenCapabilityFreshnessTest(ITestOutputHelper output) : Monolit
             "the grant is read live off the target path — a token never needs re-minting to see it");
         perms.HasFlag(Permission.Api).Should().BeTrue(
             "Editor carries Api, so the capability comes from the grant itself");
+    }
+
+    /// <summary>
+    /// 🚨 THE ISSUE'S CASE, END TO END AND IN TIME ORDER: the token exists FIRST, the grant is
+    /// written AFTERWARDS, and the same token — never re-minted, never re-validated — sees it.
+    ///
+    /// <para>The negative half is asserted first and is what makes it a measurement rather than an
+    /// assumption: the very same read is refused before the grant lands. Nothing about the token
+    /// changes between the two reads; only the mesh does.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task AGrantWrittenAfterTheTokenExists_IsSeenWithoutReminting()
+    {
+        BecomeToken();
+
+        // Before: no grant anywhere on this path, no public surface.
+        (await Effective($"{LateGrantPartition}/Page"))
+            .Should().Be(Permission.None, "the control arm — this token is refused here");
+
+        // The grant lands, written by an administrator long after the token was minted.
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var assignment = AssignmentNodeFactory.UserRole(TokenUser, "Editor", LateGrantPartition);
+        await Observable.Create<MeshNode>(observer =>
+            {
+                // As System: writing an AccessAssignment is an administrative act, and the point
+                // under test is what the TOKEN sees afterwards, not who may write the grant.
+                using (Access.ImpersonateAsSystem())
+                    return meshService.CreateNode(assignment).Subscribe(observer);
+            })
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
+
+        // Re-assert the token identity: ImpersonateAsSystem above is scoped, but being explicit
+        // means a leaked System scope cannot make this pass while proving nothing.
+        BecomeToken();
+
+        // After: the SAME token, unchanged, on the SAME path. The fold re-emits when the grant
+        // lands, so this is a wait on the condition — never a sleep.
+        await Mesh.GetEffectivePermissions($"{LateGrantPartition}/Page", TokenUser)
+            .Where(p => p.HasFlag(Permission.Read))
+            .FirstAsync()
+            .Timeout(Budget)
+            .Await(TestContext.Current.CancellationToken);
     }
 
     /// <summary>


### PR DESCRIPTION
## The defect

`ApiToken.Roles` is a list of role ids captured **when the token was created**. It rides `ValidateTokenResponse.Roles` and is stamped onto `AccessContext.Roles` by `UserContextMiddleware`. `PermissionEvaluator`'s **API-token clamp** — which zeroes the *whole* permission set for a Bearer context that lacks `Permission.Api` — consulted that snapshot as its escape hatch (`ClaimsCarryApi`).

A snapshot answers a question about **now** with a fact from **then**, so it was wrong in both directions at once:

| | What a stale snapshot does | Consequence |
|---|---|---|
| **Too restrictive** | cannot see a grant made after the mint | A token minted before its owner held anything `Api`-bearing could not read a publicly-readable partition the same person's browser renders fine — and **no later grant could fix it**. Most IdPs emit no role claims at all, so `ApiToken.Roles` is usually empty and **re-minting produced the same empty list**. |
| **Too permissive** | cannot lose a capability revoked after the mint | A token whose mint-time claims carried an `Api`-bearing role name kept the API surface open **forever**, over the top of a `PartitionAccessPolicy` written afterwards saying `api: false`. **Withdrawing API reach could not withdraw it from tokens that already existed.** |

The second row is the security half and is what drove the design: the failure that must not ship is *a token retaining authority someone took away*.

### The rationale for the snapshot was obsolete

Four comments (`UserContextMiddleware`, `ApiToken.Roles`, `ValidateTokenResponse.Roles`, `ApiTokenNodeType`) justified the stamp with:

> per-node hubs intentionally don't register the synced `AccessAssignment` query (recursion avoidance), so without it an API-token request sees 0 roles → 0 perms → DENY.

That stopped being true months ago and nobody noticed:

* the fold moved onto the **process-wide `IMeshNodeStreamCache`** — `AddRowLevelSecurity` registers **no synced query at all**, and the mesh hub and every per-node hub run the *same* evaluator over the *same* cached `$security-*` queries. There is no hub on which a grant is invisible.
* the **2026-08-05 paywall fix** removed claim roles from node permissions outright. After it, the snapshot's only remaining effect was this one capability hatch.

Those comments are corrected here rather than left to mislead a third time.

## The fix

```csharp
if (currentContext?.IsApiToken == true && !p.HasFlag(Permission.Api)
    && !PublicSurfaceCarriesApi(publicGrant, permissionCap))
    p = Permission.None;

private static bool PublicSurfaceCarriesApi(Permission publicGrant, Permission permissionCap)
    => publicGrant.HasFlag(Permission.Read) && permissionCap.HasFlag(Permission.Api);
```

A publicly-readable scope (a `PartitionAccessPolicy.PublicRead`, or a declared `NodeTypeGate` segment) is public on **every** surface — a page anyone may read is not secret from an API client. That is what keeps tokens working on `Doc/`, `Agent/` and every installed package partition, which `PackageInstaller` publishes through exactly that policy rather than through an `AccessAssignment`. And `api: false` anywhere on the scope chain now genuinely means *"not reachable through the API"*, because the cap binds the capability the public grant confers.

`AccessContext.Roles` is now read **nowhere** in the evaluator.

### Why this shape — against the three constraints in the brief

* **Fresh, and freshness is free.** Both inputs are already computed by the fold for this path on every emission. No new query, no new subscription, nothing added to the hot path.
* **Not a fan-out.** *"Does this person hold an `Api`-bearing role anywhere?"* is the unanchored all-partitions question `Doc/Architecture/CrossSchemaFanOutElimination` (#2640) exists to forbid — a 188-schema `UNION` is a measured lock bomb. The question worth asking is path-scoped, and the scope walk already answers it.
* **No recursion.** Resolving roles inside token validation would put a permission read inside the authentication bootstrap. Nothing here re-enters the evaluator, so the recursion the per-node-hub story was built to avoid is not reintroduced.
* **The third state stays a third state.** The predicate is only consulted on a fold *emission*, where both inputs are known. A leg that cannot reach a verdict still terminates with an **error** → `Undetermined` / `ErrorType.Unavailable`, refusing the delivery. Undetermined never grants.

## Proof each test can fail (invert once, see red, restore)

`test/MeshWeaver.Graph.Test/ApiTokenCapabilityFreshnessTest.cs`, 6 cases, on a real monolith mesh with `ConfigureMeshBase` (no `PublicAdminAccess`, so nothing passes vacuously).

**Inversion 1 — restore the pre-fix claim hatch:** `Failed: 3, Passed: 3`
* `StaleClaimRoles_CannotDefeat` — *expected `None` … but found `Read`.* **This is the security defect, live**: `api: false` on the partition, and a token remembering `["Admin","Editor"]` reads it anyway.
* `TokenWithNoClaims_ReadsAPubliclyReadablePartition` — *expected `true` … but found `False`.* The lockout direction, on a token no re-mint can repair.
* `ClaimRoles_ChangeNoVerdict` — same node, same person, verdict differed on what the token remembered.
* The three "must still work" cases stayed **green**, so the suite is not merely asserting the new code.

**Inversion 2 — disable the clamp entirely (`if (false) …`):** `Failed: 1, Passed: 5` — `StaleClaimRoles_CannotDefeat` reds, proving the clamp is still load-bearing and the fix did not neuter it.

**Restored:** `Passed: 6, Failed: 0`.

## Verified

* `dotnet build … -c Release -warnaserror`, one project per invocation, `0 Error(s) / 0 Warning(s)`: `MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph`, `MeshWeaver.Hosting.AspNetCore`, `MeshWeaver.Documentation`, `test/MeshWeaver.Graph.Test`, `test/MeshWeaver.Documentation.Test`.
* `ApiTokenCapabilityFreshnessTest` — 6/6 green.
* `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` + `DocumentationEmbedIntegrityTest` — 12/12 green (the new doc section and What's New entry).

## Blast radius reviewed

* Core: the only other `IsApiToken` construction is `PermissionProbeCacheKeyTests`, which tests the cache-key builder directly and is unaffected.
* Plugins `PaywallRealGateShapeTests`: the public cover is granted by **Public/Anonymous `Viewer` `AccessAssignment` nodes**, and `Role.Viewer` carries `Api`, so `p` already holds `Api` and the clamp never fires — `ApiToken_WithClaimRoles_StillReadsPublicContent` stays green. The gated child carries explicit Public/Anonymous **denies**, so there is no public grant and `…_IsStillDeniedGatedContent`, `DbRoleClaim_DoesNotGrantNodeRead` and `ViewerClaim_DoesNotGrantNodeRead` stay red-on-read as intended.
* Plugins `McpAccessControlTests`: its `LoginWithToken` builds a context **without** `IsApiToken`, so the clamp is not on that path at all; its `Roles = ["Editor"]` comment is now stale but inert.

## Work product conserved

* `Doc/Architecture/AccessControl` → new section **"API tokens and the `Api` capability"**: what the clamp is, the two live ways past it, **why the mint-time snapshot existed**, why its rationale expired, and the general rule — *a credential must not carry a copy of an authorization fact; copies go stale in both directions and the permissive direction has no expiry.*
* What's New entry (`Category: Fix`).

## On SocialMedia#92

Refs Systemorph/MeshWeaver.SocialMedia#92 — deliberately **not** `Closes`. This fixes a real defect of exactly that issue's shape, but a live read of the mesh shows it is **not carson's cause**: `Profiles/_Access/carson_Access` grants `Editor`, `Role.Editor` carries `Permission.Api`, and there is no `PartitionAccessPolicy` anywhere under `Profiles` — so on that path `p` already holds `Api` and the clamp cannot fire, with or without claims. Details posted on the issue; it stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)