### PR TITLE
A module bundle carries its own closure — /app is one PORTAL, not a platform guarantee

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1125,16 +1125,24 @@ jobs:
                   echo "closure: $name.dll does NOT ride — the image ships it (src/platform-shipped.txt); bundling it would land a same-identity duplicate beside /app's copy"
                 fi
               done < "$closure_file"
-              # The SHELF rides: module-libs.txt is the builder-written provenance.
+              # The PRIVATE CLOSURE rides: module-libs.txt is the builder-written provenance —
+              # every non-framework assembly this module's own PackageReferences pull in, sourced
+              # from the image's /app and the module-libraries shelf.
+              # 🚨 "The image has it" is NOT a reason to leave one out. The reference image is a
+              # PORTAL, and a portal with a module compiled into it carries that module's private
+              # dependencies too: reading /app as a platform guarantee dropped Microsoft.Agents.AI
+              # out of the AI bundle and threw ReflectionTypeLoadException in every host that was
+              # not that exact image — this repo's bake gate and MeshWeaver.Reinsurance's trunk
+              # (MeshWeaver.Plugins#1043). The SHARED FRAMEWORK is the only sound omission.
               if [ -f "$packdir/module-libs.txt" ]; then
                 while IFS= read -r ride; do
                   [ -n "$ride" ] || continue
                   printf '%s\n%s\n' --with "$ride" >> "$packargs"
-                  echo "closure: $ride RIDES — module-libraries shelf (deps.json-derived; the image does not carry it)"
+                  echo "closure: $ride RIDES — the module's private closure (deps.json-derived, from the image or the shelf)"
                 done < "$packdir/module-libs.txt"
               fi
               echo "closure: NO --deps-closure on the container path — there is no SDK deps.json to derive one from."
-              echo "closure: complete BY RECORD instead — every reference resolved from the image, its shared frameworks, or the module-libraries shelf; the builder refuses BY NAME anything none of them supplies, and this lane passes no --extra-refs."
+              echo "closure: complete BY RECORD instead — the builder walked the module's own package references over the image's and the shelf's deps.json and copied everything the shared framework does not supply; it refuses BY NAME anything neither supplies, and this lane passes no --extra-refs."
               # 🚨 THE BINDING IDENTITY, CHECKED (MeshWeaver#143): the expected value is the one
               # the global builder read out of the image, so it cannot drift from what the portals
               # run. The global build log carries it once for the whole workspace.
@@ -1267,9 +1275,10 @@ jobs:
           # refusal, not a curiosity. The SDK path is untouched: its private closure legitimately
           # carries package assemblies.
           if [ "$COMPILER" = "container" ]; then
-            # A non-MeshWeaver assembly is allowed ONLY with shelf provenance: the builder's
-            # module-libs.txt names every ride it derived from the shelf's deps.json. Anything
-            # else has no accountable closure and must fail — the 2026-08-19/20 outage shape.
+            # A non-MeshWeaver assembly is allowed ONLY with builder provenance: the builder's
+            # module-libs.txt names every ride it derived from the image's and the shelf's
+            # deps.json. Anything else has no accountable closure and must fail — the
+            # 2026-08-19/20 outage shape.
             # 🚨 FROM THE BUILD STEP'S OWN packdir output — never a hard-coded layout. The global
             # workspace moved the pack input to workspace-build/<Module>; this path still reading
             # module-build/ made the allow-list EMPTY and failed all 8 shelf-consuming modules on
@@ -1283,8 +1292,8 @@ jobs:
                   | select(. as $a | $shelf | index($a) | not)]
                | length == 0' \
               "$manifest" > /dev/null \
-              || { echo "::error::the container-built bundle carries a non-MeshWeaver assembly with NO shelf provenance (not in the builder's module-libs.txt) — its closure cannot be accounted for, so the pack fails rather than landing a module that faults at first use"; exit 1; }
-            echo "container path: closure is entry + module-owned MeshWeaver siblings + shelf-manifested rides, as recorded"
+              || { echo "::error::the container-built bundle carries a non-MeshWeaver assembly with NO builder provenance (not in the builder's module-libs.txt) — its closure cannot be accounted for, so the pack fails rather than landing a module that faults at first use"; exit 1; }
+            echo "container path: closure is entry + module-owned MeshWeaver siblings + the manifested private closure, as recorded"
             # 🚨 The STATIC-ASSET half, asserted — because its absence is the one failure with no
             # symptom at any later gate: the publish 200s, the module lands and loads, every page
             # renders, only UNSTYLED (#2221's exact signature; PluginBundlePublishAssetsTest names

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -74,6 +74,15 @@ Additional libraries resolve from the curated **module-libraries shelf**, and a
 exactly what the SDK hands a consumer (`PackageReference Microsoft.Graph` lets code
 `using Microsoft.Kiota…`; anything less re-creates that gap as a CS0234 wall).
 
+🚨 **What a module COMPILES against and what its bundle CARRIES are two questions with two
+answers.** For the compile the image is authoritative — a module binds the assemblies of the host
+it is loaded into. For the bundle it is not: the image is a PORTAL, and a portal with a module
+compiled into it also carries that module's private package dependencies, so "`/app` has the file"
+is a fact about one host, never a platform guarantee. A bundle carries its own package closure
+minus the SHARED FRAMEWORK, exactly as the SDK lane's `--deps-closure` does — see
+[ModuleClosureAccounting](../ModuleClosureAccounting) for the rule and the two outages that came
+from conflating the two questions.
+
 ## Gates compile against IMPLEMENTATION frameworks
 
 Every compile-check extracts the image's `/usr/share/dotnet/shared` beside `/app` and, seeing
@@ -125,6 +134,7 @@ No component ever publishes from the mesh router — the router names a spokesma
 * **Self-hosted runners with a mounted git mirror + warm image store** (MeshWeaver#2926): bare
   mirror volume, `git worktree add` per run at the release ref, worktree deleted at job end.
 
-See also: [ModuleVersioning](../ModuleVersioning) ·
+See also: [ModuleClosureAccounting](../ModuleClosureAccounting) ·
+[ModuleVersioning](../ModuleVersioning) ·
 [NodeTypeCompilation](../NodeTypeCompilation) · [PluginBuildContract](../PluginBuildContract) ·
 [BuildProcess](../BuildProcess) · [InMeshBuildAndTest](../InMeshBuildAndTest).

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleClosureAccounting.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleClosureAccounting.md
@@ -1,0 +1,136 @@
+---
+nodeType: Markdown
+name: Module Closure Accounting
+category: Architecture
+description: What a module bundle must carry and what it may leave to its host — the one rule, why "the reference image has it" is not that rule, and the two fleet-wide outages that came from getting it wrong.
+icon: /static/NodeTypeIcons/code.svg
+---
+
+# Module Closure Accounting
+
+A module reaches a mesh as **bytes**. Whatever those bytes need at runtime and do not carry, the
+host must supply — so "what rides the bundle" is a claim about **every** host the bundle may land
+in, not about the one that happened to build it. Getting that claim wrong has now cost two
+fleet-wide outages, and both times it looked like the *consumer's* fault from the consumer's side.
+
+## The rule
+
+> **A module bundle carries the transitive closure of its own package references, minus the shared
+> framework. The shared framework is the only sound omission.**
+
+The shared framework (`Microsoft.NETCore.App`, `Microsoft.AspNetCore.App`) travels with every host
+that can load the module at all — a host without it cannot run the platform either. Everything
+else is a composition detail of one particular host, and a bundle that bets on it is a bundle that
+works exactly where it was built.
+
+Two corollaries, both deliberate:
+
+* **A diamond RIDES.** A package reachable from the module's own references *and* from the
+  platform's is bundled anyway. `Assembly.LoadFrom` resolves the app closure FIRST and only probes
+  the module directory for what the app does not have, so a duplicate costs bytes while an omission
+  costs a type load. Excluding diamonds instead couples every landed bundle to the platform's
+  transitive dependency whims: the platform sheds a dependency — the very point of the module
+  split — and every landed module that relied on it breaks until re-packed.
+* **`MeshWeaver.*` never rides.** Platform assemblies reach a module as `ProjectReference`s and
+  bind by a strictly synchronised `AssemblyVersion`; a bundled copy is the same-identity trap
+  (MeshWeaver#143). The deliberate exception is a **module-owned** `MeshWeaver.*` sibling — one
+  whose source lives in the module's own repo and is therefore nowhere in `/app` — which rides,
+  **and whose own package closure rides with it**.
+
+## Why `/app` is not the boundary
+
+The unified build compiles a module **inside the platform image**, and its `/app` is the reference
+set ([Module Build Architecture](../ModuleBuildArchitecture)). That is right for the *compile*: a
+module binds the assemblies of the image it is loaded into. It is wrong for the *bundle*, and the
+difference is not a nuance:
+
+**the reference image is a PORTAL, and a portal with a module compiled into it carries that
+module's private package dependencies.**
+
+Measured on `memex-portal-ai` (2026-09-01) — 334 assemblies in `/app`:
+
+```
+/app/MeshWeaver.AI.dll
+/app/Microsoft.Agents.AI.dll
+/app/Microsoft.Agents.AI.Abstractions.dll
+```
+
+`Microsoft.Agents.AI` is referenced by **no platform project at all**; it is in that image only
+because `MeshWeaver.AI` is built into it. The tester image from the same promoted wave carries 100
+assemblies and none of them. So a builder that reads "`/app` has the file" as "the platform
+supplies it" concludes that the AI module's own SDK need not ride — and the published manifest says
+exactly that:
+
+```json
+"module": {
+  "assemblyName": "MeshWeaver.AI",
+  "assemblies": ["MeshWeaver.AI.dll", "MeshWeaver.AI.pdb", "MeshWeaver.Markdown.Collaboration.dll"]
+}
+```
+
+Three files, no third-party closure. It loads on that one portal and throws everywhere else:
+
+```
+idempotence: re-install failed: ReflectionTypeLoadException: Unable to load one or more of the
+requested types.
+Could not load file or assembly 'Microsoft.Agents.AI, Version=1.17.0.0, …'
+```
+
+## The blast radius is the consumer's trunk, not the producer's gate
+
+That is the reason this page exists rather than a comment on a workflow. The bundle is published
+from one repo and **installed** in others, so an incomplete closure surfaces as a red gate in a
+repo that changed nothing:
+
+| Where | What it looked like |
+|---|---|
+| The producer's own bake-publish lane | `GATE FAILED — idempotence: Store, Feedback, Hosting, Providers, RemoteControl, RolePlay, Voice, Essentials` — 8 packages "re-bake differently" |
+| A satellite's `main` (MeshWeaver.Reinsurance) | `[FAIL] Store … idempotence: re-install failed` — its own trunk red for ~11 h, every other job green |
+
+On the satellite's failing run the ONLY failing job was `publish-bake`; `compile-check`,
+`test-repos` and the e2e enumeration all passed. Every gate that could see the repo's own content
+was green, and only the job installing the *external* bundle failed. **When one repo's gate fails
+on a bundle another repo publishes, look at the publisher's closure before looking at the
+consumer.**
+
+## Where the accounting lives
+
+One producer, one reader:
+
+1. **`PrivateClosure.Derive`** (in the builder) walks the module's declared `PackageReference`s over
+   the dependency records of the image's `/app` deps.json and the module-libraries shelf. For every
+   assembly it reaches: `MeshWeaver.*` is skipped, a shared-framework name is *recorded as
+   omitted*, and everything else must resolve to a file — the image's copy first (those are the
+   exact bytes the compile bound against), the shelf otherwise. An assembly neither source has is
+   reported, never silently dropped.
+2. **The union is taken over the module's in-tree graph**, not over the entry project alone. A
+   module-owned sibling rides the bundle, so its private dependencies ride with it — the same
+   omission one hop further out. (The SDK path got this for free: `dotnet publish` materialises the
+   whole project graph's package assets.)
+3. **`module-libs.txt`**, beside the built module, is the written provenance. The pack lane turns
+   each line into a `--with`, and the bundle inspection refuses any non-`MeshWeaver.*` assembly the
+   manifest does not name — so a bundle can never carry something the builder cannot account for.
+
+The SDK lane's `--deps-closure` derives the same set from a publish folder. **The two lanes agree
+by construction, and that is the point**: converting a module from `sdk` to `container` must not
+change what its bundle contains.
+
+## What this is not
+
+* **Not an allow-list.** Naming `Microsoft.Agents.AI` somewhere to quiet a gate leaves the bundle
+  incomplete and moves the failure to whoever installs it next.
+* **Not "the tester image should carry what the portal image carries".** That narrows one gate's
+  divergence and still publishes a bundle nobody else can install.
+* **Not "the compose step tops up from the portal image".** That fixes only the composers who
+  remember to, and a bundle fetched straight from the registry has no compose step.
+
+## The check that would have caught it
+
+An assertion that a bundle's manifest lists more than its entry DLL is not enough — three files is
+a plausible-looking manifest. The property is comparative: **the same module, packed by the SDK
+lane and by the container lane, must declare the same non-framework closure.** Anything else is a
+lane divergence pretending to be a build decision.
+
+See also: [Module Build Architecture](../ModuleBuildArchitecture) ·
+[Module Versioning](../ModuleVersioning) · [Plugin Build Contract](../PluginBuildContract) ·
+[NodeType Compilation](../NodeTypeCompilation)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-module-brings-its-own-dependencies-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-module-brings-its-own-dependencies-again.md
@@ -1,0 +1,33 @@
+---
+Name: A module brings its own dependencies again
+Category: Fix
+Description: Installed modules no longer fail to load with "Could not load file or assembly" — a module package now carries the libraries it needs instead of assuming the portal happens to have them.
+Icon: Sparkle
+Order: -20260901
+---
+
+# A module brings its own dependencies again
+
+A module — the AI engine, an import format, a provider connector — arrives at your portal as a
+small package of compiled files. Whatever it needs to run and does not bring with it, the portal
+has to already have. So the package has to be honest about what it needs.
+
+For a short window it was not. The build had started deciding "the portal already has this
+library, so the package need not carry it" by looking at *one particular portal* — the one that
+built it, which happened to have the module compiled in and therefore had all of that module's
+libraries lying around. On that portal everything worked. Anywhere else the same package landed
+without its own dependencies, and the first thing that touched them failed with
+
+```
+Could not load file or assembly 'Microsoft.Agents.AI' …
+```
+
+That is not a message anyone can act on: it names a library nobody asked for, on a machine that
+installed a package the publisher said was complete. It surfaced as installs that would not come
+up, and as red builds in projects that had changed nothing and merely *used* a published package.
+
+A package now carries the libraries its own code pulls in, always — and leaves out only what
+travels with every portal by definition (the .NET runtime itself). That is the same rule the older
+build path used, so a package's contents no longer depend on which builder produced it. Installs
+that were failing on a missing library work on the next published version, with nothing to change
+on your side.

--- a/test/MeshWeaver.PluginTester.Test/LaneClosuresAgreeTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/LaneClosuresAgreeTest.cs
@@ -1,0 +1,146 @@
+using MeshWeaver.Plugin.Build;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// THE check that was missing. Converting a module from <c>"build": "sdk"</c> to
+/// <c>"build": "container"</c> changes which compiler produces the bytes — it must not change what
+/// the bundle CONTAINS. Nothing enforced that, so the flip silently emptied eight bundles'
+/// closures and only surfaced as <c>ReflectionTypeLoadException</c> in other repositories'
+/// trunks (MeshWeaver.Plugins#1043).
+///
+/// <para>The two lanes derive the closure from different records — the SDK from the module's own
+/// publish <c>deps.json</c> (<see cref="DepsClosure"/>), the container from the image's and the
+/// shelf's (<see cref="PrivateClosure"/>) — so this describes ONE package graph both ways and
+/// holds the answers against each other. A future divergence fails here rather than in a satellite
+/// repo's bake gate.</para>
+/// </summary>
+public class LaneClosuresAgreeTest : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"mw-lane-closure-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private const string Module = "Widget.Module";
+
+    /// <summary>
+    /// One package graph, as the module's OWN publish records it: a direct provider package with a
+    /// transitive, a framework-provided package, and a platform reference the walk stops at.
+    /// </summary>
+    private const string ModuleDepsJson = """
+        {
+          "runtimeTarget": { "name": ".NETCoreApp,Version=v10.0" },
+          "targets": {
+            ".NETCoreApp,Version=v10.0": {
+              "Widget.Module/1.0.0": {
+                "dependencies": { "Provider.Sdk": "2.0.0", "MeshWeaver.Data": "3.0.0" },
+                "runtime": { "Widget.Module.dll": {} }
+              },
+              "Provider.Sdk/2.0.0": {
+                "dependencies": { "Provider.Transitive": "1.0.0", "Framework.Riding.Package": "10.0.0" },
+                "runtime": { "lib/net10.0/Provider.Sdk.dll": {} }
+              },
+              "Provider.Transitive/1.0.0": {
+                "runtime": { "lib/net10.0/Provider.Transitive.dll": {} }
+              },
+              "Framework.Riding.Package/10.0.0": {
+                "runtime": { "lib/net10.0/System.Framework.Thing.dll": {} }
+              },
+              "MeshWeaver.Data/3.0.0": {
+                "dependencies": { "Platform.Only.Lib": "7.0.0" },
+                "runtime": { "MeshWeaver.Data.dll": { "assemblyVersion": "3.0.0.0" } }
+              },
+              "Platform.Only.Lib/7.0.0": {
+                "runtime": { "lib/net10.0/Platform.Only.Lib.dll": {} }
+              }
+            }
+          },
+          "libraries": {
+            "Widget.Module/1.0.0": { "type": "project" },
+            "Provider.Sdk/2.0.0": { "type": "package" },
+            "Provider.Transitive/1.0.0": { "type": "package" },
+            "Framework.Riding.Package/10.0.0": { "type": "package" },
+            "MeshWeaver.Data/3.0.0": { "type": "package" },
+            "Platform.Only.Lib/7.0.0": { "type": "package" }
+          }
+        }
+        """;
+
+    /// <summary>The SAME graph as a PORTAL image would carry it: every assembly on disk in /app,
+    /// including the ones only there because a module was compiled into that portal.</summary>
+    private ContainerReferenceSet Image()
+    {
+        var app = Path.Combine(_root, "app");
+        Directory.CreateDirectory(app);
+        foreach (var name in new[]
+                 {
+                     "MeshWeaver.Data", "Provider.Sdk", "Provider.Transitive", "Platform.Only.Lib",
+                     "System.Framework.Thing",
+                 })
+            File.WriteAllBytes(Path.Combine(app, name + ".dll"), [0x4D, 0x5A]);
+        File.WriteAllText(Path.Combine(app, "Portal.deps.json"), ModuleDepsJson
+            .Replace("\"Widget.Module/1.0.0\": {", "\"Portal/1.0.0\": {", StringComparison.Ordinal)
+            .Replace("\"runtime\": { \"Widget.Module.dll\": {} }", "\"runtime\": { \"Portal.dll\": {} }",
+                StringComparison.Ordinal));
+
+        var shared = Path.Combine(_root, "shared", "Microsoft.AspNetCore.App", "10.0.0");
+        Directory.CreateDirectory(shared);
+        File.WriteAllBytes(Path.Combine(shared, "System.Framework.Thing.dll"), [0x4D, 0x5A]);
+
+        return ContainerReferenceSet.Read(
+            app, trustedPlatformAssemblies: string.Empty,
+            sharedFrameworksRoot: Path.Combine(_root, "shared"));
+    }
+
+    [Fact]
+    public void BothLanesDeriveTheSameNonFrameworkClosure()
+    {
+        var container = Image();
+
+        // The SDK lane: the module's own publish deps.json, minus what the shared framework
+        // supplies — the packer expresses that trim as "the file is absent from the publish
+        // folder", which is the same set by a different route.
+        var sdk = DepsClosure.Derive(ModuleDepsJson, Module)
+            .Files
+            .Where(f => !container.IsFrameworkSupplied(Path.GetFileNameWithoutExtension(f)))
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        // The container lane: the module's declared package references walked over the image's
+        // record.
+        var containerLane = PrivateClosure.Derive(["Provider.Sdk"], container, shelf: null)
+            .Rides
+            .Select(r => r.AssemblyName + ".dll")
+            .Order(StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+
+        containerLane.Should().Equal(sdk,
+            "the compiler that produced the bytes must not change what the bundle carries — the "
+            + "container flip made 'the image has it' mean 'the bundle need not', and eight "
+            + "packages shipped without their own closure (Plugins#1043)");
+        sdk.Should().Equal(["Provider.Sdk.dll", "Provider.Transitive.dll"],
+            "the module's own package closure rides, the shared framework does not, and the "
+            + "platform reference's private dependency (Platform.Only.Lib) is /app's business");
+    }
+
+    [Fact]
+    public void TheContainerLaneCarriesWhatTheImageAlreadyHas()
+    {
+        var container = Image();
+
+        var rides = PrivateClosure.Derive(["Provider.Sdk"], container, shelf: null)
+            .Rides.Select(r => r.AssemblyName).ToArray();
+
+        rides.Should().Contain("Provider.Sdk",
+            "every one of these files IS in the image — that is the whole trap: a portal that has "
+            + "a module compiled into it carries the module's private dependencies, so treating "
+            + "/app as a platform guarantee publishes a bundle only that portal can load");
+    }
+}

--- a/test/MeshWeaver.PluginTester.Test/MeshWeaver.PluginTester.Test.csproj
+++ b/test/MeshWeaver.PluginTester.Test/MeshWeaver.PluginTester.Test.csproj
@@ -15,6 +15,13 @@
          assembly PATH — the runner loads it into its own collectible context exactly as it loads a
          package's emitted assembly, so this is the real lane, not a simulation of it. -->
     <ProjectReference Include="..\MeshWeaver.Security.MeshTest\MeshWeaver.Security.MeshTest.csproj" />
+    <!-- The SDK lane's closure derivation (DepsClosure), so LaneClosuresAgreeTest can hold the two
+         lanes' answers against each other in one assertion. Converting a module from `sdk` to
+         `container` must not change what its bundle carries, and the only way to KNOW that is to
+         derive both from one package graph and compare — which is exactly the check that was
+         missing when the container flip emptied the AI bundle's closure (Plugins#1043).
+         🚨 The TEST project's references, not tools/MeshWeaver.PluginTester's own. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Plugin.Build\MeshWeaver.Plugin.Build.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MeshWeaver.PluginTester.Test/PrivateClosureTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/PrivateClosureTest.cs
@@ -1,0 +1,182 @@
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// What a container-built module BUNDLES, as opposed to what it COMPILED against — the accounting
+/// MeshWeaver.Plugins#1043 got wrong.
+///
+/// <para>The container flip made "the reference image has this file" mean "the platform supplies
+/// it, so the bundle need not". The reference image is a PORTAL, and a portal with a module
+/// compiled into it carries that module's private package dependencies too — so
+/// <c>Microsoft.Agents.AI</c> read as platform-supplied, left the <c>MeshWeaver.AI</c> bundle, and
+/// every host that was not that exact image (the bake gate, MeshWeaver.Reinsurance's trunk seeding
+/// the published Store bundle) threw <c>ReflectionTypeLoadException</c>.</para>
+///
+/// <para>These tests pin the replacement rule, which is the SDK path's rule: the module's own
+/// package closure rides, and the SHARED FRAMEWORK is the only sound omission.</para>
+/// </summary>
+public class PrivateClosureTest : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"mw-private-closure-{Guid.NewGuid():N}");
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            Directory.Delete(_root, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private static void Dll(string directory, string name) =>
+        File.WriteAllBytes(Path.Combine(directory, name + ".dll"), [0x4D, 0x5A]);
+
+    /// <summary>
+    /// A PORTAL image: it carries the platform AND a module compiled into it, so its <c>/app</c>
+    /// holds that module's private dependency (<c>Provider.Sdk</c> → <c>Provider.Transitive</c>)
+    /// exactly as <c>memex-portal-ai</c> holds <c>Microsoft.Agents.AI</c>.
+    /// </summary>
+    private ContainerReferenceSet Portal()
+    {
+        var app = Path.Combine(_root, "app");
+        Directory.CreateDirectory(app);
+        foreach (var name in new[]
+                 { "MeshWeaver.Data", "Provider.Sdk", "Provider.Transitive", "Platform.Lib" })
+            Dll(app, name);
+        File.WriteAllText(Path.Combine(app, "Portal.deps.json"), """
+            {
+              "runtimeTarget": { "name": "net10.0" },
+              "targets": {
+                "net10.0": {
+                  "Portal/1.0.0": {},
+                  "Provider.Sdk/2.0.0": {
+                    "runtime": { "lib/net10.0/Provider.Sdk.dll": { "assemblyVersion": "2.0.0.0" } },
+                    "dependencies": { "Provider.Transitive": "1.0.0", "Framework.Riding.Package": "10.0.0" }
+                  },
+                  "Provider.Transitive/1.0.0": {
+                    "runtime": { "lib/net10.0/Provider.Transitive.dll": { "assemblyVersion": "1.0.0.0" } }
+                  },
+                  "Framework.Riding.Package/10.0.0": {
+                    "runtime": { "lib/net10.0/System.Framework.Thing.dll": { "assemblyVersion": "10.0.0.0" } }
+                  },
+                  "Platform.Lib/3.0.0": {
+                    "runtime": { "lib/net10.0/Platform.Lib.dll": { "assemblyVersion": "3.0.0.0" } }
+                  },
+                  "MeshWeaver.Data/3.0.0": {
+                    "runtime": { "MeshWeaver.Data.dll": { "assemblyVersion": "3.0.0.0" } }
+                  }
+                }
+              },
+              "libraries": {
+                "Portal/1.0.0": { "type": "project" },
+                "Provider.Sdk/2.0.0": { "type": "package" },
+                "Provider.Transitive/1.0.0": { "type": "package" },
+                "Framework.Riding.Package/10.0.0": { "type": "package" },
+                "Platform.Lib/3.0.0": { "type": "package" },
+                "MeshWeaver.Data/3.0.0": { "type": "package" }
+              }
+            }
+            """);
+
+        // A shared framework, laid out the way a runtime is: <root>/<Framework>/<version>/*.dll.
+        var shared = Path.Combine(_root, "shared", "Microsoft.AspNetCore.App", "10.0.0");
+        Directory.CreateDirectory(shared);
+        Dll(shared, "System.Framework.Thing");
+
+        return ContainerReferenceSet.Read(
+            app, trustedPlatformAssemblies: string.Empty,
+            sharedFrameworksRoot: Path.Combine(_root, "shared"));
+    }
+
+    /// <summary>A shelf carrying one package the portal image does NOT have.</summary>
+    private ModuleLibrariesShelf Shelf()
+    {
+        var dir = Path.Combine(_root, "module-libs");
+        Directory.CreateDirectory(dir);
+        Dll(dir, "Additional.Lib");
+        File.WriteAllText(Path.Combine(dir, "MeshWeaver.ModuleLibraries.deps.json"), """
+            {
+              "targets": {
+                "net10.0": {
+                  "Additional.Lib/5.0.0": {
+                    "runtime": { "lib/net10.0/Additional.Lib.dll": {} }
+                  }
+                }
+              }
+            }
+            """);
+        return ModuleLibrariesShelf.Read(dir);
+    }
+
+    [Fact]
+    public void APackageTheREFERENCEIMAGECarriesStillRides()
+    {
+        var closure = PrivateClosure.Derive(["Provider.Sdk"], Portal(), shelf: null);
+
+        closure.Rides.Select(r => r.AssemblyName).Should()
+            .Contain("Provider.Sdk",
+                "the image holds it only because a module was compiled into that portal — reading "
+                + "that as a platform guarantee is what dropped Microsoft.Agents.AI out of the AI "
+                + "bundle and broke every consumer that was not that image (Plugins#1043)")
+            .And.Contain("Provider.Transitive",
+                "the SDK hands a consumer the package's TRANSITIVE closure, and a bundle that "
+                + "stops at the direct reference faults one hop later instead of at first use");
+        closure.Missing.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TheSharedFrameworkIsTheOneSoundOmission()
+    {
+        var closure = PrivateClosure.Derive(["Provider.Sdk"], Portal(), shelf: null);
+
+        closure.Rides.Select(r => r.AssemblyName).Should().NotContain("System.Framework.Thing");
+        closure.FrameworkResolved.Should().Contain("System.Framework.Thing",
+            "a shared framework travels with every host that can load the module at all, so it is "
+            + "the only thing a bundle may leave to the consumer — recorded, never merely dropped");
+    }
+
+    [Fact]
+    public void ThePlatformsOwnAssembliesNeverRide()
+    {
+        var closure = PrivateClosure.Derive(["MeshWeaver.Data", "Provider.Sdk"], Portal(), shelf: null);
+
+        closure.Rides.Select(r => r.AssemblyName).Should().NotContain("MeshWeaver.Data",
+            "MeshWeaver.* reaches a module as a ProjectReference and binds by a strict "
+            + "AssemblyVersion — a bundled copy is the #143 same-identity trap");
+    }
+
+    [Fact]
+    public void TheShelfSuppliesWhatTheImageDoesNotCarry()
+    {
+        var closure = PrivateClosure.Derive(["Additional.Lib"], Portal(), Shelf());
+
+        closure.Rides.Should().ContainSingle()
+            .Which.Source.Should().Be("the shelf",
+                "an ADDITIONAL library is by definition one the image does not have");
+        closure.Missing.Should().BeEmpty();
+    }
+
+    [Fact]
+    public void TheIMAGEsBytesWinWhenBothHaveIt_soTheRideIsWhatTheCompileBound()
+    {
+        var shelf = Shelf();
+        File.WriteAllBytes(Path.Combine(shelf.Directory, "Provider.Sdk.dll"), [0x4D, 0x5A]);
+
+        var closure = PrivateClosure.Derive(["Provider.Sdk"], Portal(), ModuleLibrariesShelf.Read(shelf.Directory));
+
+        closure.Rides.Single(r => r.AssemblyName == "Provider.Sdk").Source.Should().Be("the image",
+            "the compile referenced /app's copy (the container wins in the reference set), so the "
+            + "bundle must carry those same bytes rather than a second opinion");
+    }
+
+    [Fact]
+    public void AnAssemblyNeitherSourceHasIsREPORTED_neverSilentlyDropped()
+    {
+        var closure = PrivateClosure.Derive(["Nowhere.At.All"], Portal(), shelf: null);
+
+        closure.Rides.Should().BeEmpty();
+        closure.Missing.Should().Equal(["Nowhere.At.All"],
+            "a package that compiled but cannot be materialized is the shape of a bundle that "
+            + "faults at first use — the builder says so rather than packing silence");
+    }
+}

--- a/tools/MeshWeaver.PluginTester/ContainerReferenceSet.cs
+++ b/tools/MeshWeaver.PluginTester/ContainerReferenceSet.cs
@@ -42,13 +42,17 @@ public sealed class ContainerReferenceSet
         string appDirectory,
         ImmutableDictionary<string, string> packageVersions,
         ImmutableDictionary<string, ImmutableArray<string>> packageAssemblies,
+        ImmutableDictionary<string, ImmutableArray<string>> packageDependencies,
         ImmutableDictionary<string, string> assembliesByName,
+        ImmutableHashSet<string> frameworkAssemblyNames,
         string platformAssemblyVersion)
     {
         AppDirectory = appDirectory;
         PackageVersions = packageVersions;
         PackageAssemblies = packageAssemblies;
+        PackageDependencies = packageDependencies;
         AssembliesByName = assembliesByName;
+        FrameworkAssemblyNames = frameworkAssemblyNames;
         PlatformAssemblyVersion = platformAssemblyVersion;
     }
 
@@ -61,8 +65,27 @@ public sealed class ContainerReferenceSet
     /// <summary>Package id → the assembly simple names it contributes, per the image's deps.json.</summary>
     public ImmutableDictionary<string, ImmutableArray<string>> PackageAssemblies { get; }
 
+    /// <summary>Package id → the package ids it depends on, per the image's deps.json. The
+    /// record the private-closure walk follows (<see cref="PrivateClosure"/>) — never a guess.</summary>
+    public ImmutableDictionary<string, ImmutableArray<string>> PackageDependencies { get; }
+
     /// <summary>Assembly simple name → the file backing it (case-insensitive).</summary>
     public ImmutableDictionary<string, string> AssembliesByName { get; }
+
+    /// <summary>
+    /// The assembly simple names the container's SHARED FRAMEWORKS supply
+    /// (<c>Microsoft.NETCore.App</c>, <c>Microsoft.AspNetCore.App</c>, …).
+    ///
+    /// <para>🚨 This — and ONLY this — is what a module bundle may leave out of its own closure.
+    /// The shared framework travels with every host that can load the module at all, so an
+    /// assembly it supplies is a genuine platform guarantee. <c>/app</c> is NOT: it is one
+    /// PORTAL's composition, and a portal that happens to carry a module compiled in also carries
+    /// that module's private package dependencies. Reading <c>/app</c> as a guarantee is what
+    /// dropped <c>Microsoft.Agents.AI</c> out of the AI bundle and made every consumer that is not
+    /// that exact image fail with <c>ReflectionTypeLoadException</c>
+    /// (MeshWeaver.Plugins#1043).</para>
+    /// </summary>
+    public ImmutableHashSet<string> FrameworkAssemblyNames { get; }
 
     /// <summary>The one <c>AssemblyVersion</c> every <c>MeshWeaver.*</c> assembly in the image carries.</summary>
     public string PlatformAssemblyVersion { get; }
@@ -107,7 +130,7 @@ public sealed class ContainerReferenceSet
                 + "is a failure rather than an empty build.");
 
         var deps = DepsFile(app);
-        var (packageVersions, packageAssemblies, platformVersion) = ReadDeps(deps);
+        var (packageVersions, packageAssemblies, packageDependencies, platformVersion) = ReadDeps(deps);
 
         // The reference set is the union of three things the container supplies, in increasing
         // priority: the SHARED FRAMEWORKS installed in it, the assemblies this process was
@@ -121,8 +144,13 @@ public sealed class ContainerReferenceSet
         //    modules reported Microsoft.AspNetCore.Components.Web "not supplied" against an image
         //    that ships it. This is the C# form of Directory.PlatformRefs.targets'
         //    <FrameworkReference Include="Microsoft.AspNetCore.App" />.
+        var frameworkNames = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
         foreach (var path in SharedFrameworkAssemblies(sharedFrameworksRoot))
-            byName.TryAdd(Path.GetFileNameWithoutExtension(path), path);
+        {
+            var simple = Path.GetFileNameWithoutExtension(path);
+            frameworkNames.Add(simple);
+            byName.TryAdd(simple, path);
+        }
 
         // 2. This process's own closure.
         var tpa = trustedPlatformAssemblies
@@ -143,7 +171,9 @@ public sealed class ContainerReferenceSet
             app,
             packageVersions,
             packageAssemblies,
+            packageDependencies,
             byName.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
+            frameworkNames.ToImmutable(),
             platformVersion);
     }
 
@@ -216,6 +246,7 @@ public sealed class ContainerReferenceSet
 
     private static (ImmutableDictionary<string, string> Versions,
                     ImmutableDictionary<string, ImmutableArray<string>> Assemblies,
+                    ImmutableDictionary<string, ImmutableArray<string>> Dependencies,
                     string PlatformAssemblyVersion)
         ReadDeps(string path)
     {
@@ -260,14 +291,23 @@ public sealed class ContainerReferenceSet
 
             var assemblies = ImmutableDictionary.CreateBuilder<string, ImmutableArray<string>>(
                 StringComparer.OrdinalIgnoreCase);
+            var dependencies = ImmutableDictionary.CreateBuilder<string, ImmutableArray<string>>(
+                StringComparer.OrdinalIgnoreCase);
             var bindingIdentities = new SortedSet<string>(StringComparer.Ordinal);
             foreach (var entry in runtimeTarget.EnumerateObject())
             {
+                var entrySlash = entry.Name.IndexOf('/');
+                var entryId = entrySlash > 0 ? entry.Name[..entrySlash] : entry.Name;
+                // The dependency edges are read for EVERY node, runtime assets or not: a
+                // metapackage carries no runtime of its own and is exactly the node a closure walk
+                // has to pass THROUGH rather than stop at.
+                if (entry.Value.TryGetProperty("dependencies", out var edges)
+                    && edges.ValueKind == JsonValueKind.Object)
+                    dependencies[entryId] = [.. edges.EnumerateObject().Select(d => d.Name)];
                 if (!entry.Value.TryGetProperty("runtime", out var runtime)
                     || runtime.ValueKind != JsonValueKind.Object)
                     continue;
-                var slash = entry.Name.IndexOf('/');
-                var id = slash > 0 ? entry.Name[..slash] : entry.Name;
+                var id = entryId;
                 var names = ImmutableArray.CreateBuilder<string>();
                 foreach (var file in runtime.EnumerateObject())
                 {
@@ -291,7 +331,8 @@ public sealed class ContainerReferenceSet
                     + "). That is the drift the AssemblyVersion contract exists to prevent; refusing "
                     + "to emit a reference set.");
 
-            return (versions.ToImmutable(), assemblies.ToImmutable(), bindingIdentities.Single());
+            return (versions.ToImmutable(), assemblies.ToImmutable(), dependencies.ToImmutable(),
+                bindingIdentities.Single());
         }
     }
 
@@ -338,4 +379,31 @@ public sealed class ContainerReferenceSet
     /// <returns>The file path, or null.</returns>
     public string? FindAssembly(string assemblyName) =>
         AssembliesByName.GetValueOrDefault(assemblyName);
+
+    /// <summary>
+    /// Whether the container's SHARED FRAMEWORK supplies this assembly — the one thing a module
+    /// bundle may leave out of its own closure, because it travels with every host that can load
+    /// the module at all. Deliberately NOT "is it in <c>/app</c>": see
+    /// <see cref="FrameworkAssemblyNames"/>.
+    /// </summary>
+    /// <param name="assemblyName">The assembly's simple name.</param>
+    /// <returns>True when a shared framework in this container carries it.</returns>
+    public bool IsFrameworkSupplied(string assemblyName) =>
+        FrameworkAssemblyNames.Contains(assemblyName);
+
+    /// <summary>
+    /// The assembly simple names a package contributes, per the image's own deps.json — falling
+    /// back to <c>&lt;id&gt;</c> for a package the image never resolved, which is the same rule
+    /// <see cref="Resolve"/> applies.
+    /// </summary>
+    /// <param name="packageId">The package id.</param>
+    /// <returns>The simple names.</returns>
+    public ImmutableArray<string> AssembliesOf(string packageId) =>
+        PackageAssemblies.TryGetValue(packageId, out var names) ? names : [packageId];
+
+    /// <summary>The package ids a package depends on, per the image's deps.json.</summary>
+    /// <param name="packageId">The package id.</param>
+    /// <returns>The dependency ids, empty when the image does not know the package.</returns>
+    public ImmutableArray<string> DependenciesOf(string packageId) =>
+        PackageDependencies.TryGetValue(packageId, out var deps) ? deps : [];
 }

--- a/tools/MeshWeaver.PluginTester/ModuleLibrariesShelf.cs
+++ b/tools/MeshWeaver.PluginTester/ModuleLibrariesShelf.cs
@@ -12,10 +12,17 @@ namespace MeshWeaver.PluginTester;
 /// <c>deps.json</c>, never guessed (the 2026-08-19/20 outage was a guessed closure, and the lane's
 /// no-extra-refs stance exists so that cannot recur).
 ///
-/// <para>🚨 <b>The container still wins.</b> An assembly the platform image supplies (its
-/// <c>/app</c>, its shared frameworks) never rides from the shelf — a same-identity duplicate
-/// beside the platform's copy is the #143-family binding trap. The shelf contributes only what the
-/// landing image does not have, which is the definition of an additional library.</para>
+/// <para>🚨 <b>The container still wins — for the COMPILE.</b> An assembly the platform image
+/// supplies (its <c>/app</c>, its shared frameworks) is referenced from there, not from the shelf:
+/// two metadata references to one simple name is the CS0433 family.</para>
+///
+/// <para>🚨 <b>It does NOT decide what rides.</b> That is
+/// <see cref="PrivateClosure"/>'s job, and it deliberately does not ask whether <c>/app</c> has
+/// the file: the reference image is a PORTAL, so a module compiled into it puts its own private
+/// dependencies in <c>/app</c>, and treating that as a platform guarantee is what emptied the
+/// <c>MeshWeaver.AI</c> bundle's closure (MeshWeaver.Plugins#1043).
+/// <see cref="Resolution.RideFiles"/> answers the narrower question "what would ride from the
+/// shelf alone" and is no longer the bundle's ride set.</para>
 /// </summary>
 public sealed class ModuleLibrariesShelf
 {
@@ -124,6 +131,33 @@ public sealed class ModuleLibrariesShelf
             full, assemblies.ToImmutable(), dependencies.ToImmutable(),
             versions.ToImmutable(), files);
     }
+
+    /// <summary>Whether the shelf carries this package at all (its deps record names it).</summary>
+    /// <param name="packageId">The package id.</param>
+    /// <returns>True when the shelf's deps.json has a node for it.</returns>
+    public bool Knows(string packageId) => _assembliesByPackage.ContainsKey(packageId);
+
+    /// <summary>The assembly simple names this package contributes, per the shelf's deps record.</summary>
+    /// <param name="packageId">The package id.</param>
+    /// <returns>The simple names, empty when the shelf does not carry the package.</returns>
+    public ImmutableArray<string> AssembliesOf(string packageId) =>
+        _assembliesByPackage.TryGetValue(packageId, out var names) ? names : [];
+
+    /// <summary>The package ids this package depends on, per the shelf's deps record.</summary>
+    /// <param name="packageId">The package id.</param>
+    /// <returns>The dependency ids, empty when the shelf does not carry the package.</returns>
+    public ImmutableArray<string> DependenciesOf(string packageId) =>
+        _dependenciesByPackage.TryGetValue(packageId, out var deps) ? deps : [];
+
+    /// <summary>The shelf's pinned version for a package, or null.</summary>
+    /// <param name="packageId">The package id.</param>
+    /// <returns>The version string, or null.</returns>
+    public string? VersionOf(string packageId) => _versionsByPackage.GetValueOrDefault(packageId);
+
+    /// <summary>The file on the shelf backing an assembly simple name, or null.</summary>
+    /// <param name="assemblyName">The assembly's simple name.</param>
+    /// <returns>The path, or null.</returns>
+    public string? FileFor(string assemblyName) => _filesByName.GetValueOrDefault(assemblyName);
 
     /// <summary>One shelf resolution: the package's own assemblies plus its transitive ride set.</summary>
     /// <param name="PackageId">The package.</param>

--- a/tools/MeshWeaver.PluginTester/PrivateClosure.cs
+++ b/tools/MeshWeaver.PluginTester/PrivateClosure.cs
@@ -1,0 +1,134 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// A container-built module's PRIVATE runtime closure: the non-framework assemblies its own
+/// <c>PackageReference</c>s pull in, which therefore have to RIDE the bundle.
+///
+/// <para><b>Why this exists — MeshWeaver.Plugins#1043, the second fleet-wide closure-accounting
+/// outage.</b> The container build resolves references from the platform image's <c>/app</c>, and
+/// the flip to <c>"build": "container"</c> made "the image has this file" mean "the platform
+/// supplies it, so the bundle need not". That reading is false, and silently so: the reference
+/// image is a PORTAL, and a portal that has a module compiled into it also carries that module's
+/// private package dependencies. <c>memex-portal-ai</c>'s <c>/app</c> holds
+/// <c>Microsoft.Agents.AI.dll</c> only because <c>MeshWeaver.AI</c> is built into that image —
+/// core references it nowhere, and the tester image (100 assemblies, same promoted wave) has no
+/// copy. So the published <c>MeshWeaver.AI</c> bundle listed three assemblies and none of its own
+/// third-party closure; it loaded on that one portal and threw
+/// <c>ReflectionTypeLoadException: Microsoft.Agents.AI, Version=1.17.0.0</c> everywhere else —
+/// the bake gate here, and MeshWeaver.Reinsurance's trunk, which merely SEEDS the published Store
+/// bundle and had no way to see why.</para>
+///
+/// <para><b>The rule, and it is the SDK path's rule.</b> A bundle carries the transitive closure
+/// of the module's own package references, MINUS the shared framework. That is exactly what
+/// <c>DepsClosure</c> derives from a publish folder for <c>--deps-closure</c> — including the
+/// diamond ("a package reachable from the module's own references AND from its MeshWeaver.*
+/// references is bundled anyway"), because <c>Assembly.LoadFrom</c> resolves the app closure FIRST
+/// and only probes the module directory for what the app does not have. So a duplicate costs
+/// bytes, while an omission costs a type load. The shared framework is the one honest exemption:
+/// it travels with every host that can load the module at all.</para>
+///
+/// <para><b>Where the bytes come from.</b> The container's <c>/app</c> first — those are the exact
+/// assemblies the compile bound against — then the curated module-libraries shelf for anything the
+/// image does not carry. Both are recorded sources with a deps.json behind them; nothing is
+/// guessed, which is the property the lane's no-<c>--extra-refs</c> stance protects.</para>
+///
+/// <para>Pure data-in/data-out over the two records, so the derivation is unit-testable with no
+/// container and no shelf on disk.</para>
+/// </summary>
+public static class PrivateClosure
+{
+    /// <summary>One assembly riding the bundle.</summary>
+    /// <param name="AssemblyName">The assembly's simple name.</param>
+    /// <param name="SourcePath">The file to copy beside the module.</param>
+    /// <param name="PackageId">The package that contributed it.</param>
+    /// <param name="Source">Where the bytes came from — <c>the image</c> or <c>the shelf</c>.</param>
+    public sealed record Ride(string AssemblyName, string SourcePath, string PackageId, string Source);
+
+    /// <summary>The derived closure.</summary>
+    /// <param name="Rides">Every assembly that must travel with the bundle, ordered by name.</param>
+    /// <param name="FrameworkResolved">Assembly names left out because a shared framework supplies
+    /// them — the ONE sound omission, listed so a log can show it was a decision.</param>
+    /// <param name="Missing">Assembly names the walk reached that neither the image nor the shelf
+    /// has a file for. Never silently dropped: a package that compiled but cannot be materialized
+    /// is the shape of a bundle that faults at first use.</param>
+    public sealed record Result(
+        ImmutableArray<Ride> Rides,
+        ImmutableArray<string> FrameworkResolved,
+        ImmutableArray<string> Missing);
+
+    /// <summary>
+    /// Derives the private closure of a set of <c>PackageReference</c> ids.
+    /// </summary>
+    /// <param name="packageIds">The project's declared package references.</param>
+    /// <param name="container">The container reference set (its deps.json is the dependency record
+    /// and its <c>/app</c> the preferred byte source).</param>
+    /// <param name="shelf">The module-libraries shelf, when one is staged.</param>
+    /// <returns>The closure.</returns>
+    public static Result Derive(
+        IEnumerable<string> packageIds, ContainerReferenceSet container, ModuleLibrariesShelf? shelf)
+    {
+        ArgumentNullException.ThrowIfNull(packageIds);
+        ArgumentNullException.ThrowIfNull(container);
+
+        var rides = new Dictionary<string, Ride>(StringComparer.OrdinalIgnoreCase);
+        var frameworkResolved = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        var missing = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var pending = new Stack<string>(packageIds);
+
+        while (pending.Count > 0)
+        {
+            var id = pending.Pop();
+            if (!seen.Add(id))
+                continue;
+            // The platform's OWN assemblies are ProjectReferences, never rides: shipping one beside
+            // the module lands a same-identity duplicate of a strictly versioned binary (#143).
+            if (IsPlatform(id))
+                continue;
+
+            var knownToShelf = shelf?.Knows(id) == true;
+            var names = knownToShelf ? shelf!.AssembliesOf(id) : container.AssembliesOf(id);
+            foreach (var name in names)
+            {
+                if (IsPlatform(name))
+                    continue;
+                if (container.IsFrameworkSupplied(name))
+                {
+                    frameworkResolved.Add(name);
+                    continue;
+                }
+                if (rides.ContainsKey(name))
+                    continue;
+                // The image first: those are the exact bytes the compile bound against. The shelf
+                // supplies what the image does not carry — which is the definition of an
+                // ADDITIONAL library.
+                var fromImage = container.FindAssembly(name);
+                if (fromImage is not null)
+                    rides[name] = new Ride(name, fromImage, id, "the image");
+                else if (shelf?.FileFor(name) is { } fromShelf)
+                    rides[name] = new Ride(name, fromShelf, id, "the shelf");
+                else
+                    missing.Add(name);
+            }
+
+            // Both records are followed: the shelf pins additional libraries, the image pins
+            // everything it carries, and a package can be known to one and not the other.
+            foreach (var dependency in container.DependenciesOf(id))
+                pending.Push(dependency);
+            if (shelf is not null)
+                foreach (var dependency in shelf.DependenciesOf(id))
+                    pending.Push(dependency);
+        }
+
+        return new Result(
+            [.. rides.Values.OrderBy(r => r.AssemblyName, StringComparer.OrdinalIgnoreCase)],
+            [.. frameworkResolved],
+            [.. missing]);
+    }
+
+    private static bool IsPlatform(string name) =>
+        name.StartsWith("MeshWeaver.", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(name, "MeshWeaver", StringComparison.OrdinalIgnoreCase);
+}

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -214,6 +214,21 @@ public static class ProjectBuild
         /// </summary>
         public int ResourceCount { get; init; }
 
+        /// <summary>
+        /// The non-framework assemblies this project's own <c>PackageReference</c>s pull in — what
+        /// must RIDE a bundle built from it (<see cref="PrivateClosure"/>).
+        ///
+        /// <para>Carried on the result rather than written during the compile because a bundle's
+        /// closure is the union over its whole IN-TREE graph: a module-owned sibling rides the
+        /// bundle, so the sibling's private dependencies have to ride with it. The union is taken
+        /// once, after the cascade, where the graph is at hand.</para>
+        ///
+        /// <para>🚨 An <c>init</c> PROPERTY, not a primary-constructor parameter — adding a
+        /// parameter REPLACES the record's signature
+        /// (<c>scripts/check-record-signatures.py</c>).</para>
+        /// </summary>
+        public ImmutableArray<PrivateClosure.Ride> Rides { get; init; } = [];
+
         /// <summary>Compiled, emitted, and within the warning policy.</summary>
         public bool IsGreen => Failure is null && AssemblyPath is not null;
     }
@@ -345,23 +360,34 @@ public static class ProjectBuild
                 // (closure pollution). Each entry's manifest names exactly the assemblies its own
                 // in-tree graph produced: the module itself first, its in-tree dependencies after.
                 if (results.All(r => r.IsGreen))
+                {
+                    var byProject = results
+                        .Where(r => r.Result is not null)
+                        .ToDictionary(r => r.Result!.ProjectPath, r => r.Result!, StringComparer.Ordinal);
                     foreach (var entryPath in entries)
                     {
-                        var reachable = new List<string>();
-                        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-                        var walkStack = new Stack<string>();
-                        walkStack.Push(entryPath);
-                        while (walkStack.Count > 0)
-                        {
-                            var current = walkStack.Pop();
-                            if (!seen.Add(current) || !graph.Models.TryGetValue(current, out var m)) continue;
-                            reachable.Add(m.AssemblyName);
-                            foreach (var dep in graph.DependenciesOf(current))
-                                walkStack.Push(dep);
-                        }
+                        var reachableProjects = InTreeClosure(graph, entryPath);
+                        var reachable = reachableProjects
+                            .Select(path => graph.Models[path].AssemblyName)
+                            .ToList();
                         File.WriteAllLines(
                             Path.Combine(workRoot, reachable[0] + ".closure.txt"), reachable);
+                        // 🚨 THE PRIVATE CLOSURE IS A UNION OVER THE IN-TREE GRAPH, not just the
+                        // entry's own packages. A module-owned sibling RIDES the bundle
+                        // (MeshWeaver.Markdown.Collaboration rides MeshWeaver.AI's), so its own
+                        // package dependencies have to ride with it or the bundle faults the first
+                        // time the sibling touches one — the same shape as the entry's own missing
+                        // closure, one hop further out. The SDK path got this for free: `dotnet
+                        // publish` materializes the WHOLE project graph's package assets.
+                        EmitPrivateClosure(
+                            Path.Combine(workRoot, reachable[0]),
+                            reachable[0],
+                            [.. reachableProjects
+                                .Where(byProject.ContainsKey)
+                                .SelectMany(path => byProject[path].Rides)],
+                            sink);
                     }
+                }
                 Print(options.Output, report);
                 return report;
             })
@@ -716,6 +742,24 @@ public static class ProjectBuild
                 model.CompileItems.Length, 0, 0, null, unresolved.ToImmutable(), message);
         }
 
+        // 🚨 WHAT RIDES IS NOT WHAT RESOLVED. The loop above answered "can this compile", and for
+        // that the container is authoritative. The bundle's closure is a different question with a
+        // different answer: /app is ONE PORTAL's composition, and a portal with a module compiled
+        // into it carries that module's private dependencies — so reading "/app has it" as "the
+        // platform supplies it" drops them from the bundle and the module faults everywhere else
+        // (MeshWeaver.Plugins#1043). The shared framework is the only sound omission.
+        var privateClosure = PrivateClosure.Derive(
+            model.PackageReferences.Select(p => p.Id), container, shelf);
+        foreach (var absent in privateClosure.Missing)
+            sink.Warn($"[{name}] private closure: no file for '{absent}' in the image or on the "
+                + "shelf — it cannot ride, and a bundle missing part of its closure faults at first use");
+        if (!privateClosure.Rides.IsEmpty)
+            sink.Info($"[{name}] private closure: {privateClosure.Rides.Length} assembl(y|ies) ride "
+                + $"the bundle, {privateClosure.FrameworkResolved.Length} left to the shared framework"
+                + (options.Verbose
+                    ? " — " + string.Join(", ", privateClosure.Rides.Select(r => $"{r.AssemblyName} ({r.Source})"))
+                    : " (names with --verbose)"));
+
         // The reference set: the whole container, MINUS every assembly this run builds from source
         // (its own included) — two definitions of one type is the CS0433 family, and the local build
         // is the one under test. Plus the dependency projects' fresh outputs and any additional
@@ -995,7 +1039,6 @@ public static class ProjectBuild
                     $"{warnings} warning(s) under the no-warn policy");
             }
             NameTheDocumentationFile(outputDirectory, model);
-            EmitShelfRides(outputDirectory, model, shelfResolutions, sink, name);
             var scopedCssCount = EmitStaticAssets(outputDirectory, model, sink, name);
             sink.Info(
                 $"[{name}] OK — {model.CompileItems.Length} source file(s)"
@@ -1009,6 +1052,7 @@ public static class ProjectBuild
             {
                 RazorCount = razorGenerated,
                 ResourceCount = model.EmbeddedResources.Length,
+                Rides = privateClosure.Rides,
             };
         }
         catch (CompilationException ex)
@@ -1092,38 +1136,64 @@ public static class ProjectBuild
     }
 
     /// <summary>
-    /// The file, beside the built module, that names every shelf-supplied assembly riding the
-    /// bundle. 🚨 It is the PROVENANCE the lane's inspection keys on: a container bundle may carry
+    /// The file, beside the built module, that names every non-framework assembly riding the
+    /// bundle — its PRIVATE CLOSURE, sourced from the image's <c>/app</c> and the module-libraries
+    /// shelf. 🚨 It is the PROVENANCE the lane's inspection keys on: a container bundle may carry
     /// a non-MeshWeaver assembly ONLY when this manifest names it — anything else still means the
-    /// closure cannot be accounted for and the pack must fail.
+    /// closure cannot be accounted for and the pack must fail. (The name predates the widening
+    /// from "shelf rides" to "the whole private closure", MeshWeaver.Plugins#1043; it is kept
+    /// because pinned caller workflows read it by name.)
     /// </summary>
     public const string ShelfManifestName = "module-libs.txt";
 
     /// <summary>
-    /// Copies every shelf ride beside the module and writes <see cref="ShelfManifestName"/>. The
-    /// rides were derived from the shelf's deps.json minus everything the landing image supplies
-    /// (<see cref="ModuleLibrariesShelf.Resolve"/>), so the bundle's closure stays complete BY
-    /// RECORD — the property the lane's no-extra-refs stance protects.
+    /// Copies a module's private closure beside it and writes <see cref="ShelfManifestName"/>. The
+    /// rides were derived from the image's and the shelf's own deps.json records
+    /// (<see cref="PrivateClosure.Derive"/>), so the bundle's closure stays complete BY RECORD —
+    /// the property the lane's no-extra-refs stance protects.
     /// </summary>
-    private static void EmitShelfRides(
-        string outputDirectory, ProjectFile.Model model,
-        List<ModuleLibrariesShelf.Resolution> shelfResolutions, Sink sink, string name)
+    private static void EmitPrivateClosure(
+        string outputDirectory, string moduleName,
+        ImmutableArray<PrivateClosure.Ride> rides, Sink sink)
     {
-        if (shelfResolutions.Count == 0)
+        if (rides.IsEmpty || !Directory.Exists(outputDirectory))
             return;
         var manifest = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
-        foreach (var resolution in shelfResolutions)
-            foreach (var file in resolution.RideFiles)
-            {
-                var fileName = Path.GetFileName(file);
-                if (fileName.Equals(model.AssemblyName + ".dll", StringComparison.OrdinalIgnoreCase))
-                    continue;
-                File.Copy(file, Path.Combine(outputDirectory, fileName), overwrite: true);
-                manifest.Add(fileName);
-            }
+        foreach (var ride in rides)
+        {
+            var fileName = Path.GetFileName(ride.SourcePath);
+            if (fileName.Equals(moduleName + ".dll", StringComparison.OrdinalIgnoreCase))
+                continue;
+            File.Copy(ride.SourcePath, Path.Combine(outputDirectory, fileName), overwrite: true);
+            manifest.Add(fileName);
+        }
+        if (manifest.Count == 0)
+            return;
         File.WriteAllLines(Path.Combine(outputDirectory, ShelfManifestName), manifest);
-        sink.Info($"[{name}] shelf rides: {manifest.Count} assembl(y|ies) beside the module "
+        sink.Info($"[{moduleName}] private closure: {manifest.Count} assembl(y|ies) beside the module "
             + $"({ShelfManifestName} is the provenance the pack inspection keys on)");
+    }
+
+    /// <summary>
+    /// The projects reachable from <paramref name="entryPath"/> over IN-TREE
+    /// <c>ProjectReference</c> edges, the entry first. One walk, used for both the entry's closure
+    /// manifest and the union its bundle's private closure is taken over.
+    /// </summary>
+    private static List<string> InTreeClosure(Graph graph, string entryPath)
+    {
+        var reachable = new List<string>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        var walkStack = new Stack<string>();
+        walkStack.Push(entryPath);
+        while (walkStack.Count > 0)
+        {
+            var current = walkStack.Pop();
+            if (!seen.Add(current) || !graph.Models.ContainsKey(current)) continue;
+            reachable.Add(current);
+            foreach (var dep in graph.DependenciesOf(current))
+                walkStack.Push(dep);
+        }
+        return reachable;
     }
 
     /// <summary>How many resource names a build lists before it counts the rest instead.</summary>

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -363,7 +363,12 @@ public static class ProjectBuild
                 {
                     var byProject = results
                         .Where(r => r.Result is not null)
-                        .ToDictionary(r => r.Result!.ProjectPath, r => r.Result!, StringComparer.Ordinal);
+                        // 🚨 OrdinalIgnoreCase, like Graph.Models and the walk that produces the
+                        // keys looked up here. An Ordinal lookup would silently MISS a reachable
+                        // project whose path differs only in casing, and the symptom would be a
+                        // bundle quietly short of part of its closure — the very failure this
+                        // union exists to prevent.
+                        .ToDictionary(r => r.Result!.ProjectPath, r => r.Result!, StringComparer.OrdinalIgnoreCase);
                     foreach (var entryPath in entries)
                     {
                         var reachableProjects = InTreeClosure(graph, entryPath);


### PR DESCRIPTION
## The defect

The container flip (`"build": "container"`) made the builder read **"the reference image's `/app` has this file"** as **"the platform supplies it, so the bundle need not"**. That reading is false, and silently so: **the reference image is a PORTAL**, and a portal with a module compiled into it carries that module's private package dependencies too.

Measured on `memex-portal-ai` (334 assemblies in `/app`):

```
/app/MeshWeaver.AI.dll
/app/Microsoft.Agents.AI.dll
/app/Microsoft.Agents.AI.Abstractions.dll
```

`Microsoft.Agents.AI` is referenced by **no platform project at all** — it is in that image only because `MeshWeaver.AI` is built into it, and the tester image from the same promoted wave carries none of it. So the published bundle declared three files and no third-party closure:

```json
"assemblies": ["MeshWeaver.AI.dll", "MeshWeaver.AI.pdb", "MeshWeaver.Markdown.Collaboration.dll"]
```

It loads on that one portal and throws `ReflectionTypeLoadException: Microsoft.Agents.AI, Version=1.17.0.0` everywhere else — Plugins' bake-publish gate (8 packages "re-baking differently") and **MeshWeaver.Reinsurance's `main`, red for ~11 h with every other job green**, merely for SEEDING the published Store bundle.

Timeline: `MeshWeaver.AI` has referenced `Microsoft.Agents.AI` since the engine moved in; the AI matrix entry flipped to `"build": "container"` in Plugins#1032, and the first satellite main run after that merge is the first red. That is a strong lead rather than a proof of causation on its own — **the proof is the pre/post measurement below**, which shows the same builder source, same image, producing the two closures.

## The rule this restores

> A module bundle carries the transitive closure of its own package references, **minus the shared framework**.

The shared framework travels with every host that can load the module at all; everything else is one host's composition detail. This is exactly what the SDK lane's `--deps-closure` derives, so a module converted from `sdk` to `container` keeps the same bundle contents. A diamond rides deliberately (`Assembly.LoadFrom` resolves the app closure FIRST, so a duplicate costs bytes while an omission costs a type load); `MeshWeaver.*` never rides.

## What changed

- **`PrivateClosure.Derive`** (new) walks the module's declared `PackageReference`s over the dependency records of the image's `deps.json` and the module-libraries shelf. It takes the image's bytes when it has them (those are what the compile bound against), the shelf's otherwise, records what the shared framework supplied, and **reports** anything neither source can materialise.
- The closure is a **union over the module's in-tree graph**, not the entry project alone: a module-owned sibling rides the bundle, so its private dependencies ride with it. (The SDK lane got this for free — `dotnet publish` materialises the whole graph's package assets.)
- `ContainerReferenceSet` exposes the shared-framework assembly names and the package dependency edges it was already reading past.
- `module-libs.txt` keeps its name — pinned caller workflows read it by name — but is now the whole private-closure provenance, not just shelf rides. **No caller workflow change is required**: the pack lane already turns each line into a `--with` and the bundle inspection already allows exactly what the manifest names.

## Pre/post, same builder source base, same platform image

`mw-plugin-test build-project MeshWeaver.AI --app <memex-portal-ai /app> --shared-frameworks <its shared root>`:

| | pack input for `MeshWeaver.AI` |
|---|---|
| **PRE** (`origin/main` builder) | `MeshWeaver.AI.{dll,pdb,xml}` — **no `module-libs.txt`**. Reproduces the published manifest's three-file closure exactly. |
| **POST** (this branch) | the same, **plus 13 closure assemblies** — `Microsoft.Agents.AI`, `Microsoft.Agents.AI.Abstractions`, `Microsoft.Extensions.AI[.Abstractions,.Evaluation]`, `Microsoft.Extensions.{Compliance,VectorData}.Abstractions`, `Microsoft.ML.Tokenizers`, `Google.Protobuf`, `System.Numerics.Tensors`, `YamlDotNet`, `HtmlAgilityPack`, `Humanizer` — and `module-libs.txt` naming them. **2 left to the shared framework** (`Microsoft.Extensions.Http`, `Microsoft.Extensions.FileSystemGlobbing`), which is the correct trim. |

Both runs green; the POST compile is `169 source file(s) + 37 resource(s), 0 warning(s)` in 95 s.

The same run also shows the blast radius is wider than the AI module: `MeshWeaver.ContentCollections.Indexing` gains 12 rides (UglyToad.PdfPig family, DocSharp, DocumentFormat.OpenXml, Markdig, System.IO.Packaging), all previously dropped for being in `/app`.

## The check that was missing

`LaneClosuresAgreeTest` describes **one** package graph both ways and holds the two lanes' derivations against each other. A future divergence fails there rather than in a satellite repo's bake gate.

## Not done, deliberately

No allow-list entry for `Microsoft.Agents.AI`, no widened comparison, no `continue-on-error`. Nor "the tester image should carry what the portal image carries" (narrows one gate's divergence, still publishes a bundle nobody else can install) or "the compose step tops up from the portal image" (fixes only the composers who remember to; a bundle fetched from the registry has no compose step).

## Verification

- `dotnet build -c Release -warnaserror` clean on `tools/MeshWeaver.PluginTester`, `test/MeshWeaver.PluginTester.Test`, `test/MeshWeaver.Documentation.Test` (`0 Error(s)`, `0 Warning(s)`).
- `MeshWeaver.PluginTester.Test` — 45 passed, 0 failed (includes `PrivateClosureTest`, `LaneClosuresAgreeTest`, and the existing `ContainerReferenceSetTest` / `ModuleLibrariesShelfTest` / `ProjectBuildTest`).
- `DocumentationLinkIntegrityTest` green.
- `.github/scripts/check-workflow-shell.py` — 0 live findings.
- Core tip at branch point: `14e7e0644`.

## Follow-up (cross-repo, dependency order)

This is the platform half. MeshWeaver.Plugins then bumps its `tester-image-digest` to the CD wave carrying this builder and republishes the module bundles; that PR carries `Closes #1043`, and MeshWeaver.Reinsurance's `main` recovering is the acceptance test.

Work product conserved as `Doc/Architecture/ModuleClosureAccounting`.

Refs Systemorph/MeshWeaver.Plugins#1043

🤖 Generated with [Claude Code](https://claude.com/claude-code)