### PR TITLE
fix(lane): the global build asserts its OWN postcondition — one emitted assembly per selected module (Plugins#1051)

### DIFF
--- a/.github/scripts/workspace-build-verify.py
+++ b/.github/scripts/workspace-build-verify.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""workspace-build-verify.py — the ONE global workspace build asserts its OWN postcondition.
+
+    "the workspace build is allowed to report success while not having built something a
+     downstream job will require. A green there is not evidence that the set is complete."
+    — Plugins#1051
+
+WHAT THIS IS FOR
+----------------
+`build-workspace` compiles every SELECTED container entry once, centrally, and hands the result
+to the pack matrix as one artifact. The matrix then demands, per module:
+
+    <workspace>/<Module>/<Module>.dll        the emitted assembly
+    <workspace>/<Module>.closure.txt         which in-tree siblings ride THIS bundle
+    <workspace>/workspace-build.log          carrying `platform AssemblyVersion <v>`
+
+Until this script, NOTHING asserted that the build had produced them. The build's exit code says
+"the compiler did not fail"; it says nothing about the SET. So two enumerators — the projects the
+build was handed, and the modules the matrix demands — were free to disagree, and the
+disagreement surfaced N jobs later as seven red bundle jobs saying `the global workspace build
+produced no MeshWeaver.AI.OpenAI.dll`, on a PR whose whole diff was one XML doc comment
+(Plugins#1051, run 33480755857). The error was accurate and in the wrong place: the job that
+could have named the missing module was green.
+
+🚨 IT IS THE SAME ENUMERATOR ON BOTH SIDES, ON PURPOSE. This script is fed
+`needs.select.outputs.modules` — the exact JSON the pack matrix expands. A postcondition derived
+from anything else (a glob of the output, the caller's declared list, a re-derivation from the
+projects) would be a second enumerator, which is the defect one level up.
+
+🚨 A GLOB WOULD PASS THE CASE THIS EXISTS TO CATCH. The workspace holds every entry's assemblies
+side by side plus their in-tree dependencies, so "the output directory has .dlls in it" is true
+in exactly the failure being diagnosed. Only a per-selected-module check can see it — which is
+also why the self-test's headline mutation is a NON-EMPTY workspace missing one selected module.
+
+WHAT IT DELIBERATELY DOES NOT DO
+--------------------------------
+It never asks the reverse question. The workspace legitimately carries assemblies nobody
+selected — an in-tree `ProjectReference` of a selected module is emitted beside it and rides its
+bundle by way of the closure manifest — so "emitted but not selected" is normal and is not a
+finding.
+
+    workspace-build-verify.py --modules @matrix.json --output "$RUNNER_TEMP/module-build"
+    workspace-build-verify.py --self-test
+
+EXIT 0 only when every selected `build: container` entry has a non-empty assembly, a closure
+manifest, and a build log the binding-identity check downstream can actually read.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# The same value the pack job extracts with
+# `sed -n 's/.*platform AssemblyVersion \([0-9][0-9.]*\).*/\1/p'` — the expected side of the
+# MeshWeaver#143 binding-identity check. When it is unreadable EVERY pack job dies on
+# "a check that quietly does not run reads exactly like one that passed"; naming it here costs
+# one job instead of N.
+PLATFORM_VERSION = re.compile(r"platform AssemblyVersion ([0-9][0-9.]*)")
+
+
+def container_entries(modules: object) -> list[dict]:
+    """The selection's `build: container` entries — the ones this job actually compiles.
+
+    `sdk` entries are built by the pack job on the runner and are none of this job's business;
+    an entry with no `build` key defaults to `sdk`, exactly as the workflow reads it.
+    """
+    if not isinstance(modules, list):
+        return []
+    return [e for e in modules
+            if isinstance(e, dict) and (e.get("build") or "sdk") == "container"]
+
+
+def verify(entries: list[dict], out: Path) -> tuple[int, list[str], list[str]]:
+    """(exit code, errors, notes) for one workspace output directory."""
+    errors: list[str] = []
+    notes: list[str] = []
+
+    if not entries:
+        notes.append("the selection carries no `build: container` entry — the global build had "
+                     "nothing to emit, and there is no postcondition to assert.")
+        return 0, errors, notes
+
+    if not out.is_dir():
+        errors.append(
+            f"the global build reported success but wrote no output directory at {out}. Every "
+            f"pack job in this call downloads that directory as its ONLY input; without it all "
+            f"{len(entries)} of them would fail one job later, each blaming its own module.")
+        return 1, errors, notes
+
+    for entry in entries:
+        module = entry.get("module")
+        project = entry.get("project", "<no project>")
+        if not isinstance(module, str) or not module:
+            errors.append(f"a container entry building {project} declares no `module` name — the "
+                          "pack matrix keys every artifact on it, so it cannot be blank.")
+            continue
+        assembly = out / module / f"{module}.dll"
+        closure = out / f"{module}.closure.txt"
+        if not assembly.is_file():
+            errors.append(
+                f"{module}: the global build emitted no {module}/{module}.dll. It was handed "
+                f"{project} and returned success, so the ASSEMBLY NAME the matrix demands and the "
+                f"one the project emits disagree, or the entry was never compiled. Fix the "
+                f"selection or the entry — there is deliberately no local rebuild downstream to "
+                f"slide into.")
+            continue
+        if assembly.stat().st_size == 0:
+            errors.append(f"{module}: {module}/{module}.dll is ZERO BYTES — an emit that was "
+                          "truncated reads to the pack job as a file that is present.")
+            continue
+        if not closure.is_file():
+            errors.append(
+                f"{module}: the global build wrote no {module}.closure.txt. A shared workspace "
+                f"holds every entry's assemblies side by side, so without it the pack job cannot "
+                f"know which in-tree siblings ride THIS bundle and globbing would ride every "
+                f"other module's (Plugins#1077).")
+            continue
+
+    log = out / "workspace-build.log"
+    if not log.is_file():
+        errors.append(f"the global build left no workspace-build.log in {out}. The pack job reads "
+                      "the platform AssemblyVersion out of it for the MeshWeaver#143 "
+                      "binding-identity check, and a check that cannot run reads exactly like one "
+                      "that passed.")
+    else:
+        text = log.read_text(encoding="utf-8", errors="replace")
+        found = PLATFORM_VERSION.search(text)
+        if not found:
+            errors.append("workspace-build.log carries no `platform AssemblyVersion <v>` line. "
+                          "That value is the EXPECTED side of the binding-identity check every "
+                          "pack job runs (MeshWeaver#143); unreadable here, it reds all of them.")
+        else:
+            notes.append(f"the build log carries the platform AssemblyVersion "
+                         f"({found.group(1)}) the binding-identity check compares against")
+
+    if not errors:
+        named = ", ".join(sorted(e["module"] for e in entries if e.get("module")))
+        notes.insert(0, f"all {len(entries)} selected container entr(y|ies) emitted an assembly "
+                        f"AND a closure manifest: {named}")
+    return (1 if errors else 0), errors, notes
+
+
+# ─────────────────────────────── THE GATE'S OWN PROOF ───────────────────────────────
+# A postcondition that cannot fail is the very defect this script exists to remove, one level up.
+# Every case below starts from the GREEN fixture and mutates ONE thing, so a case that stops
+# firing is visible as a case that stopped firing rather than as a quiet pass.
+
+def _fixture(root: Path, modules: list[str], *, log: bool = True,
+             platform_version: str = "3.0.0.0") -> None:
+    root.mkdir(parents=True, exist_ok=True)
+    for module in modules:
+        (root / module).mkdir(exist_ok=True)
+        (root / module / f"{module}.dll").write_bytes(b"MZ\x90\x00")
+        (root / f"{module}.closure.txt").write_text(f"{module}\n", encoding="utf-8")
+    if log:
+        (root / "workspace-build.log").write_text(
+            "[MeshWeaver.AI] start — 168 source file(s)\n"
+            f"platform AssemblyVersion {platform_version}\n"
+            "ok\n", encoding="utf-8")
+
+
+def _matrix(modules: list[str], sdk: list[str] | None = None) -> list[dict]:
+    entries = [{"package": m.split(".")[-1], "module": m,
+                "project": f"src/{m}/{m}.csproj", "build": "container"} for m in modules]
+    entries += [{"package": m.split(".")[-1], "module": m,
+                 "project": f"src/{m}/{m}.csproj"} for m in (sdk or [])]
+    return entries
+
+
+def self_test() -> int:
+    import tempfile
+    failures: list[str] = []
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        print(f"  {'✓' if ok else '✗'} {name}{'' if ok else ': ' + detail}")
+        if not ok:
+            failures.append(name)
+
+    three = ["MeshWeaver.AI", "MeshWeaver.AI.OpenAI", "MeshWeaver.Mcp"]
+
+    with tempfile.TemporaryDirectory() as tmp:
+        out = Path(tmp) / "module-build"
+        _fixture(out, three)
+
+        print("the green run every mutation below is a mutation OF:")
+        code, errors, notes = verify(container_entries(_matrix(three)), out)
+        check("a workspace holding every selected entry ⇒ pass", code == 0, f"{errors}")
+        check("and it SAYS what it verified", any("closure manifest" in n for n in notes),
+              f"{notes}")
+
+        print("mutations — each must turn RED and NAME the module:")
+
+        # 🚨 THE HEADLINE CASE, and Plugins#1051 verbatim: the workspace is NOT empty — it holds
+        # MeshWeaver.AI and MeshWeaver.Mcp and their closure manifests — and the one module the
+        # matrix will demand is absent. Any glob-shaped or count-shaped postcondition passes here.
+        (out / "MeshWeaver.AI.OpenAI" / "MeshWeaver.AI.OpenAI.dll").unlink()
+        code, errors, _ = verify(container_entries(_matrix(three)), out)
+        check("a NON-EMPTY workspace missing ONE selected module's dll fails, naming it",
+              code == 1 and any("MeshWeaver.AI.OpenAI" in e and "emitted no" in e for e in errors),
+              f"{errors}")
+        check("…and the other two are not blamed for it",
+              code == 1 and len(errors) == 1, f"{errors}")
+        _fixture(out, three)
+
+        (out / "MeshWeaver.Mcp" / "MeshWeaver.Mcp.dll").write_bytes(b"")
+        code, errors, _ = verify(container_entries(_matrix(three)), out)
+        check("a ZERO-BYTE assembly fails (present is not the same as emitted)",
+              code == 1 and any("MeshWeaver.Mcp" in e and "ZERO BYTES" in e for e in errors),
+              f"{errors}")
+        _fixture(out, three)
+
+        (out / "MeshWeaver.AI.closure.txt").unlink()
+        code, errors, _ = verify(container_entries(_matrix(three)), out)
+        check("a missing closure manifest fails HERE instead of in the pack job",
+              code == 1 and any("MeshWeaver.AI" in e and "closure.txt" in e for e in errors),
+              f"{errors}")
+        _fixture(out, three)
+
+        (out / "workspace-build.log").unlink()
+        code, errors, _ = verify(container_entries(_matrix(three)), out)
+        check("no build log ⇒ the binding-identity check downstream cannot run ⇒ red",
+              code == 1 and any("workspace-build.log" in e for e in errors), f"{errors}")
+
+        _fixture(out, three, log=False)
+        (out / "workspace-build.log").write_text("[MeshWeaver.AI] start\nok\n", encoding="utf-8")
+        code, errors, _ = verify(container_entries(_matrix(three)), out)
+        check("a build log with no `platform AssemblyVersion` line ⇒ red",
+              code == 1 and any("binding-identity" in e for e in errors), f"{errors}")
+        _fixture(out, three)
+
+        code, errors, _ = verify(container_entries(_matrix(three)), Path(tmp) / "nowhere")
+        check("no output directory at all ⇒ red, naming every pack job that would have died",
+              code == 1 and any("no output directory" in e for e in errors), f"{errors}")
+
+        code, errors, _ = verify(
+            container_entries([{"package": "X", "project": "src/X/X.csproj",
+                                "build": "container"}]), out)
+        check("a container entry with no `module` name ⇒ red (the matrix keys artifacts on it)",
+              code == 1 and any("declares no `module`" in e for e in errors), f"{errors}")
+
+        print("cases that must NOT fire — the bias that keeps the assertion honest:")
+
+        # An `sdk` entry is built by the pack job on the runner; the workspace holds nothing for
+        # it and never should. Asserting one here would red every mixed selection.
+        code, errors, _ = verify(container_entries(_matrix(three, sdk=["MeshWeaver.Testing"])), out)
+        check("an `sdk` entry is not this job's to emit ⇒ pass", code == 0, f"{errors}")
+
+        # A `build` key that is absent means `sdk` — the workflow's own default. Reading it as
+        # container would red exactly the entries this job must ignore.
+        code, errors, notes = verify(container_entries(_matrix([], sdk=three)), out)
+        check("an entry with NO `build` key defaults to sdk ⇒ nothing asserted",
+              code == 0 and any("no `build: container` entry" in n for n in notes),
+              f"{errors} {notes}")
+
+        # The workspace carries in-tree dependencies of selected modules beside them. They ride
+        # their dependents' bundles by way of the closure manifest and are NOT selections.
+        (out / "MeshWeaver.Graph").mkdir(exist_ok=True)
+        (out / "MeshWeaver.Graph" / "MeshWeaver.Graph.dll").write_bytes(b"MZ")
+        code, errors, _ = verify(container_entries(_matrix(three)), out)
+        check("an emitted assembly nobody selected is a dependency, not a finding ⇒ pass",
+              code == 0, f"{errors}")
+
+        # An empty selection reaches this script only if the workflow's own short-circuit changed;
+        # it must not invent a failure out of nothing to assert.
+        code, errors, notes = verify(container_entries([]), out)
+        check("an empty selection asserts nothing and says so",
+              code == 0 and any("nothing to emit" in n for n in notes), f"{errors} {notes}")
+
+    if failures:
+        print(f"\n::error title=workspace-build-verify self-test failed::{len(failures)} case(s). "
+              "This is the only thing that makes the ONE global build's green mean 'the selected "
+              "set was emitted' rather than 'the compiler did not throw'.")
+        return 1
+    print("\n✓ workspace-build-verify self-test: 2 green-run assertions, 8 mutations that must go "
+          "red (headline: a NON-EMPTY workspace missing one selected module — the case a glob "
+          "passes), and 4 cases that must NOT fire (sdk entries, a defaulted `build` key, an "
+          "unselected in-tree dependency, an empty selection) — all green.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n", 1)[0])
+    p.add_argument("--modules", default="",
+                   help="the SELECTION the pack matrix expands (select.outputs.modules), as JSON "
+                        "or @path-to-a-file. The same enumerator on both sides, deliberately.")
+    p.add_argument("--output", default="",
+                   help="the global build's output directory (what gets uploaded as workspace-build-<lane>)")
+    p.add_argument("--self-test", action="store_true", dest="self_test")
+    args = p.parse_args()
+    if args.self_test:
+        return self_test()
+    if not args.modules or not args.output:
+        p.error("--modules and --output are required")
+
+    raw = args.modules
+    if raw.startswith("@"):
+        raw = Path(raw[1:]).read_text(encoding="utf-8")
+    try:
+        modules = json.loads(raw)
+    except json.JSONDecodeError as ex:
+        print(f"::error title=Workspace build incomplete::the selection could not be parsed as "
+              f"JSON ({ex}) — the postcondition cannot be asserted, and an assertion that cannot "
+              f"run reads exactly like one that passed.")
+        return 1
+
+    entries = container_entries(modules)
+    code, errors, notes = verify(entries, Path(args.output))
+    for note in notes:
+        print(f"✓ {note}")
+    for error in errors:
+        print(f"::error title=Workspace build incomplete::{error}")
+    if os.environ.get("GITHUB_STEP_SUMMARY"):
+        with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+            fh.write(f"### {'✅' if code == 0 else '❌'} The global build emitted what was selected\n\n")
+            fh.write(f"{len(entries)} container entr(y|ies) selected\n\n")
+            for line in notes + errors:
+                fh.write(f"- {line}\n")
+    return code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -636,6 +636,13 @@ jobs:
   # pinned platform container. What is rebuilt is exactly the selection's parameters — nothing
   # else. The pack matrix only CONSUMES this job's artifact: a module missing from it is RED
   # there, never rebuilt locally.
+  #
+  # 🚨 AND THIS JOB ASSERTS ITS OWN POSTCONDITION (Plugins#1051). "The compiler did not throw" is
+  # not "the selected set was emitted", and the difference used to be discovered N jobs later by
+  # the pack matrix. The last step before the upload checks, per SELECTED container entry, the
+  # three things every pack job demands — the assembly, the closure manifest, and a build log the
+  # binding-identity check can read — so this job is green only when the artifact it hands over is
+  # complete.
   build-workspace:
     name: Build the workspace (one global build)
     needs: [select, prepare]
@@ -761,6 +768,45 @@ jobs:
             --entrypoint dotnet "$img" \
             /tester/mw-plugin-test.dll build-project "${args[@]}" --output /out ${accepts[@]+"${accepts[@]}"} 2>&1 | tee "$out/workspace-build.log"
           echo "built=true" >> "$GITHUB_OUTPUT"
+      # 🚨 THE PLATFORM CHECKOUT LANDS **AFTER** THE BUILD, ON PURPOSE. This job mounts
+      # `$GITHUB_WORKSPACE` at `/repo:ro` for the container build, so anything checked out beside
+      # the content tree BEFORE that line is inside what the builder sees. The pack job checks
+      # core out at `path: meshweaver` up front because it has no such mount; here the order is
+      # inverted so the compile input stays exactly the content repository and nothing else.
+      - name: Check out Systemorph/MeshWeaver at the pinned ref
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.platform-ref }}
+          path: meshweaver
+      # ───────────── THE BUILD ASSERTS ITS OWN POSTCONDITION (Plugins#1051) ─────────────
+      # A green here used to mean "the compiler did not throw" and was read as "the selected set
+      # was emitted". Those are different claims, and the gap between them surfaced N JOBS LATER:
+      # seven bundle jobs red with `the global workspace build produced no MeshWeaver.AI.OpenAI.dll`
+      # on a PR whose entire diff was one XML doc comment, while THIS job reported success in the
+      # same run (Plugins#1051, run 33480755857). The downstream message was accurate and in the
+      # wrong place — the job that knew the selection was the one that stayed green.
+      #
+      # So the producer now checks what the consumers demand, against the SAME enumerator the pack
+      # matrix expands (`needs.select.outputs.modules`, not a re-derivation and not a glob of the
+      # output — a second enumerator is the defect one level up). One accurate failure here
+      # replaces N inaccurate ones there, and no SHORT workspace is ever handed to the matrix:
+      # this step sits BEFORE the upload.
+      #
+      # 🚨 NO `if:` ON IT. The sdk-only case is handled INSIDE the script (it asserts nothing and
+      # says so) rather than by a condition that would render as a grey tick indistinguishable
+      # from a pass. Its self-test runs FIRST and fails the job — an unproven postcondition is
+      # exactly the thing #1051 is about.
+      - name: The global build emitted every selected module (postcondition)
+        env:
+          MODULES: ${{ needs.select.outputs.modules }}
+        run: |
+          set -euo pipefail
+          python3 meshweaver/.github/scripts/workspace-build-verify.py --self-test
+          printf '%s' "$MODULES" > "$RUNNER_TEMP/selection.json"
+          python3 meshweaver/.github/scripts/workspace-build-verify.py \
+            --modules "@$RUNNER_TEMP/selection.json" \
+            --output "$RUNNER_TEMP/module-build"
       - name: Hand the workspace to the matrix
         if: steps.build.outputs.built == 'true'
         uses: actions/upload-artifact@v7
@@ -1091,7 +1137,13 @@ jobs:
               log="$ws/workspace-build.log"
               packdir="$ws/$MODULE"
               if [ ! -f "$packdir/$MODULE.dll" ]; then
-                echo "::error::the global workspace build produced no $MODULE.dll under $packdir. Local builds are discontinued: if build-workspace was green without this module, the selection or this entry is wrong — fix that, never rebuild here."
+                # 🚨 build-workspace now asserts this very file EXISTS for every selected entry
+                # before it uploads (Plugins#1051), so a green build can no longer be a short one.
+                # Reaching here therefore means this job read the WRONG workspace — a sibling
+                # call's artifact (Plugins#1077) or a torn download — not that the build skipped
+                # the module. Still never rebuild locally: that would paper over which artifact
+                # arrived.
+                echo "::error::the global workspace build produced no $MODULE.dll under $packdir — yet build-workspace asserted every selected entry's assembly before uploading. So the workspace this job downloaded is not the one this call built (a sibling call's artifact, or a torn download); the lane key is ${{ needs.select.outputs.lane }}. Local builds are discontinued: fix which artifact arrives, never rebuild here."
                 exit 1
               fi
               closure_file="$ws/$MODULE.closure.txt"

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -43,6 +43,47 @@ select ──► prepare (ONCE) ──► build (ONE workspace) ──► pack �
 5. **verify** — unconditionally pairs the selection against the receipts; a skipped pack with a
    non-zero selection is RED.
 
+## Every stage asserts its OWN postcondition — never the next one's
+
+A stage's exit code answers *"did my work throw?"*. It does not answer *"did I produce what the
+next stage requires?"*, and the two were read as one claim until it cost a day.
+
+**The build is where this bites.** `build` reported success and the pack matrix then died, seven
+jobs at once, with `the global workspace build produced no MeshWeaver.AI.OpenAI.dll` — on a pull
+request whose entire diff was one XML doc comment. The message was accurate and one job too late:
+the stage that knew the selection was the green one, and the stage that discovered the gap knew
+only its own module. Two enumerators — the projects handed to the build and the modules the matrix
+expands — were free to disagree, and nothing compared them.
+
+So the build now checks, before it uploads anything, exactly what its consumers demand, **per
+selected entry**:
+
+| the consumer demands | the producer now asserts |
+|---|---|
+| `<Module>/<Module>.dll` | present and non-empty (a truncated emit reads as "the file is there") |
+| `<Module>.closure.txt` | present — without it a pack job cannot know which in-tree siblings ride *this* bundle, and a glob would ride every other module's |
+| `platform AssemblyVersion` in the build log | readable — it is the expected side of the binding-identity check every pack job runs |
+
+Three properties make it a postcondition rather than a second opinion:
+
+* **The same enumerator on both sides.** It is fed the selection the matrix expands, not a
+  re-derivation and not a glob of the output directory. A postcondition derived from a *different*
+  enumerator is the original defect, one level up.
+* **A glob would pass the case it exists to catch.** The workspace legitimately holds every
+  entry's assemblies side by side, so "there are DLLs in there" is true in exactly the failure
+  being diagnosed. Only a per-selected-module check can see it.
+* **No `if:` on it, and its self-test runs first.** The selection-with-no-container-entries case
+  is handled *inside* the check (it asserts nothing and says so) rather than by a condition that
+  would render as a grey tick indistinguishable from a pass. An unproven postcondition is the
+  thing this section is about.
+
+It deliberately never asks the reverse question: the workspace carries in-tree dependencies of
+selected modules beside them, so "emitted but not selected" is normal and is not a finding.
+
+**The generalisation, for any stage you add to this lane:** name the artifacts the next stage
+opens, and assert them where they are produced. One accurate failure upstream is worth N accurate
+failures downstream, and a downstream failure can only ever describe its own shard.
+
 ## Content-addressed outputs in blob storage = incremental CI
 
 Build outputs are keyed by **(module source tree hash × tester-image digest × platform-image


### PR DESCRIPTION
## The defect

`Module bundles / Build the workspace (one global build)` reported **success** while emitting
nothing for modules the pack matrix then demanded. The disagreement surfaced **N jobs downstream**:

```
##[error]the global workspace build produced no MeshWeaver.AI.OpenAI.dll under
/home/runner/work/_temp/workspace-build/MeshWeaver.AI.OpenAI. Local builds are
discontinued: if build-workspace was green without this module, the selection or
this entry is wrong — fix that, never rebuild here.
```

Seven bundle jobs, on a PR whose entire diff was **one XML doc comment** (Plugins#1051, run
33480755857). The message was accurate and one job too late: the stage that *knew the selection*
was the green one, and each stage that discovered the gap knew only its own module.

Root cause of the *reporting* gap: a build's exit code answers "did the compiler throw?", and that
was being read as "the selected set was emitted". Two enumerators — the projects handed to the
build and the modules the matrix expands — were free to disagree, and nothing compared them.

(The *particular* disagreement in that run was the run-wide `workspace-build` artifact collision
fixed by #2958 / Plugins#1077. This change is the level above it: the producer can no longer be
green while short, whatever the cause.)

## The change

`build-workspace` now checks, **before it uploads anything**, exactly what its consumers demand,
per SELECTED container entry:

| the consumer demands | the producer now asserts |
|---|---|
| `<Module>/<Module>.dll` | present and non-empty (a truncated emit reads as "the file is there") |
| `<Module>.closure.txt` | present — without it a pack job cannot know which in-tree siblings ride *this* bundle |
| `platform AssemblyVersion` in the build log | readable — the expected side of the MeshWeaver#143 binding-identity check every pack job runs |

Three properties make it a postcondition rather than a second opinion:

* **The same enumerator on both sides.** It is fed `needs.select.outputs.modules` — the JSON the
  pack matrix expands — not a re-derivation and not a glob of the output. A postcondition derived
  from a different enumerator is the original defect one level up.
* **A glob would pass the case it exists to catch.** The workspace legitimately holds every entry's
  assemblies side by side, so "there are DLLs in there" is true in exactly the failure being
  diagnosed.
* **No `if:` on the step**, and its **self-test runs first and fails the job**. The
  selection-with-no-container-entries case is handled *inside* the script (asserts nothing, says
  so) rather than by a condition that renders as a grey tick indistinguishable from a pass.

It deliberately never asks the reverse question — the workspace carries in-tree dependencies of
selected modules beside them, so "emitted but not selected" is normal.

Also here:
* The platform checkout lands **after** the container build, so `-v $GITHUB_WORKSPACE:/repo:ro`
  stays exactly the content repository and nothing else. (The pack job checks core out up front
  because it has no such mount.)
* The pack job's downstream message is corrected: with the postcondition in place, a missing DLL
  *there* means the **wrong workspace arrived** (a sibling call's artifact — Plugins#1077 — or a
  torn download), not a build that skipped the module. It now says so and names the lane key.
* `Doc/Architecture/ModuleBuildArchitecture` gains **"Every stage asserts its OWN postcondition —
  never the next one's"**, with the generalisation for any stage added to this lane.

## Proven able to fail

An assertion that cannot fail is the defect this PR is about, one level up. Both arms, same
command, on a fixture reproducing #1051 exactly — the FLOOR call's workspace (2 modules, non-empty,
2 DLLs, closure manifests, a good build log) handed to the REST call's selection:

**RED arm**
```
$ python3 .github/scripts/workspace-build-verify.py --modules @selection.json --output module-build
✓ the build log carries the platform AssemblyVersion (3.0.0.0) the binding-identity check compares against
::error title=Workspace build incomplete::MeshWeaver.AI.OpenAI: the global build emitted no MeshWeaver.AI.OpenAI/MeshWeaver.AI.OpenAI.dll. …
::error title=Workspace build incomplete::MeshWeaver.AI.WebSearch: the global build emitted no MeshWeaver.AI.WebSearch/MeshWeaver.AI.WebSearch.dll. …
::error title=Workspace build incomplete::MeshWeaver.Mcp: the global build emitted no MeshWeaver.Mcp/MeshWeaver.Mcp.dll. …
EXIT=1
```
(the `sdk` entry in the same selection, `MeshWeaver.Testing`, is correctly **not** blamed)

**GREEN control arm** — same command, after the three assemblies are added:
```
✓ all 3 selected container entr(y|ies) emitted an assembly AND a closure manifest: MeshWeaver.AI.OpenAI, MeshWeaver.AI.WebSearch, MeshWeaver.Mcp
✓ the build log carries the platform AssemblyVersion (3.0.0.0) …
EXIT=0
```

**Self-test** — 2 green-run assertions, **8 mutations that must go red** (headline: a NON-EMPTY
workspace missing one selected module), **4 cases that must NOT fire** (sdk entries, a defaulted
`build` key, an unselected in-tree dependency, an empty selection):
```
$ python3 .github/scripts/workspace-build-verify.py --self-test
… 14/14 ✓ … EXIT=0
```

Also verified locally: `check-workflow-shell.py --self-test` all cases pass and the tree scan is
`0 live` findings; the workflow parses as YAML; `MeshWeaver.Documentation.Test` builds
`-c Release -warnaserror` with `0 Error(s)` and `DocumentationLinkIntegrityTest` passes 1/1.

## Follow-through

`MeshWeaver.Plugins` picks this up with a pin bump on its two `node-repo-module-pack.yml` calls;
that PR carries `Closes Systemorph/MeshWeaver.Plugins#1051`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)