### PR TITLE
docs(versioning): `MeshWeaver.*` is TWO rows — module-owned siblings RIDE, so the version is not byte-identity (Plugins#889)

### DIFF
--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -34,12 +34,24 @@ gate exists.
   * modules — the baseline a publishing run must diff against is its own PUBLICATION, never
     `github.event.before`, which silently under-builds after ANY run that did not publish
     (cancelled, superseded, red, re-run). The bake HAS such a marker (`source-commit.txt` sealed
-    beside its bundles; bake-scope.sh reads it). THE MODULE LANE HAS NONE: the registry is keyed
-    `{package}@{version}` from `manifest.lock`, and that version identifies only the CONTENT half
-    — a `src/`-only change repacks the same version with different bytes, so "the registry already
-    serves this version" is NOT evidence the published bundle matches HEAD. (That is the same
-    blind spot Plugins #878 records on the delivery side.) Until this lane stamps a source commit
-    into what it publishes, a push packs everything.
+    beside its bundles; bake-scope.sh reads it). THE MODULE LANE HAS NONE, and the registry's
+    `{package}@{version}` key is NOT a substitute for one.
+
+    🚨 The reason that key fails has MOVED, and reading the old one wastes a day. It used to be
+    "the version identifies only the CONTENT half" — true until Plugins#878 landed, after which
+    `gen-manifests.py` hashes a mixed package's own `src/` project into its `moduleVersion` too.
+    What remains is narrower and still fatal: the version covers the module's OWN project, while
+    the CONTAINER pack path copies every MODULE-OWNED `MeshWeaver.*` sibling INTO the bundle
+    (`module-owned-platform.sh`: in this repo's `src/`, absent from `src/platform-shipped.txt`,
+    therefore nowhere in the image's `/app`). Measured on MeshWeaver.Plugins 2026-09-01:
+    `MeshWeaver.Blazor` rides in SEVEN published bundles and not one of their `manifest.lock`s
+    hashes a byte of it. So version equality still does not imply byte equality, and "the registry
+    already serves this version" is still NOT evidence the published bundle matches HEAD.
+
+    Until this lane stamps a SOURCE COMMIT into what it publishes — the analogue of the bake's
+    marker, diffed with `project-closure.py`, which walks transitive in-repo ProjectReferences and
+    therefore sees riders for free — a push packs everything. Narrowing on the version instead
+    would under-publish exactly those seven. See Doc/Architecture/ModuleVersioning.
 
 So the whole win sits on `pull_request` / `merge_group`, which is exactly where the cost is: a PR
 pushes many times, a trunk commit lands once.
@@ -99,11 +111,12 @@ NARROWABLE = {"pull_request", "merge_group"}
 FULL_REASONS = {
     "modules": {
         "push": "a push PUBLISHES, and the only sound baseline is its own publication — which the "
-                "module lane does not record (the registry is keyed {package}@{version}, and a "
-                "version identifies only the CONTENT half, so a src/-only change repacks the same "
-                "version with different bytes). Diffing github.event.before instead would silently "
-                "skip every module whose commit belonged to a cancelled, superseded or red run. "
-                "Packing every module.",
+                "module lane does not record. The registry's {package}@{version} key is not a "
+                "substitute: the version covers the module's OWN project (Plugins#878), while the "
+                "container pack path copies every module-owned MeshWeaver.* sibling INTO the "
+                "bundle, so a sibling's change moves the bundle's bytes and not its version. "
+                "Diffing github.event.before instead would silently skip every module whose commit "
+                "belonged to a cancelled, superseded or red run. Packing every module.",
         "repository_dispatch": "a framework-release dispatch moves the platform pin every module is "
                                "built against — every bundle must be rebuilt and republished or "
                                "every portal reads FrameworkDeclined and adopts nothing "

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
@@ -98,16 +98,63 @@ So for a mixed package the hash should cover:
 | the module project's own sources | **yes** | they are the assembly |
 | the module's `.csproj` | **yes** | it pins package versions, and a NuGet bump changes the shipped bundle |
 | non-`MeshWeaver.*` transitive deps | **yes**, by resolved version | they are bundled alongside the module |
-| `MeshWeaver.*` project references | **no** | never bundled — they ship in their own bundles or come from `/app`, so changing one does not change this module's bytes |
+| **module-owned** `MeshWeaver.*` project references | **yes** — and today they are NOT | they RIDE in the bundle (see below), so changing one changes this module's bytes |
+| **image-shipped** `MeshWeaver.*` project references | **no** | never bundled — `/app` supplies them, so changing one does not change this module's bytes |
 
-That last row is the one worth stating out loud: **a change to `MeshWeaver.AI` does not require
-bumping `MeshWeaver.AI.OpenAI`.** Modules bind platform types by simple assembly name, so the
-dependent's bytes are unchanged; `MeshWeaver.AI` ships its own bundle at its own version. Bumping
-every dependent would be busywork that also destroys the signal in the version number.
+#### 🚨 `MeshWeaver.*` is not one row — the container lane split it in two
+
+The version derivation implemented for the fix above hashes the module's **own project alone**,
+on the reasoning that a `MeshWeaver.*` reference is never bundled. **That reasoning is only half
+true, and the half it misses is live.**
+
+`DepsClosure.Derive` does stop at `MeshWeaver.*`, and that is what the `sdk` pack path uses
+(`--deps-closure`). The **container** path — now the default for nearly every entry — does not use
+it. It reads the module's closure manifest and, for every `MeshWeaver.*` sibling in it, asks
+`module-owned-platform.sh` one question: *is this project's source in this repo's `src/` and
+absent from `src/platform-shipped.txt`?* If yes, the sibling **is copied into the bundle** and
+passed as `--with <Name>.dll`, and the job log says so:
+
+```
+closure: MeshWeaver.Blazor.dll RIDES — module-owned (its source is in this repo's src/,
+         so it is nowhere in the image's /app)
+```
+
+It must ride: nothing else would supply it at run time. But the version derivation does not know
+that, so **a bundle can change its bytes without moving its version** — the exact defect the
+`src/` fix above was written to remove, one hop out.
+
+**Measured on `MeshWeaver.Plugins`, 2026-09-01** (35 matrix entries, 119 module-owned
+`MeshWeaver.*` projects): `MeshWeaver.Blazor` is module-owned and rides in **7** published
+bundles — `Analysis`, `AppleMaps`, `EntityViews`, `GoogleMaps`, `GraphViews`, `OpenStreetMap`,
+`Radzen`. Not one of those seven `manifest.lock` files hashes a single `src/MeshWeaver.Blazor/`
+path. An edit there changes what all seven bundles ship and moves none of their versions, so every
+existing portal keeps the old copy — `SkipUpToDate`, before any bytes are read.
+
+The `MeshWeaver.AI` example in the row above is *currently* safe only by accident of a transition:
+`MeshWeaver.AI` is listed in that repo's `src/platform-shipped.txt` while `MeshWeaver.Blazor.Portal`
+still references the engine. That line is marked to leave with MeshWeaver#2599 — **and the moment
+it does, every AI-provider bundle joins the seven above.** Do not read "a change to
+`MeshWeaver.AI` does not require bumping `MeshWeaver.AI.OpenAI`" as a standing rule; it is a
+statement about one entry in one exclusion list on one day.
+
+**The correct scope is the RIDING closure, not the whole reference graph.** Hash the module's own
+project plus exactly the `MeshWeaver.*` siblings `module-owned-platform.sh` says ride in its
+bundle. That is neither "own project only" (which under-covers, as measured) nor "the whole
+closure" (which bumps every dependent on any change and destroys the signal in the number) — it is
+the set whose bytes are actually inside the artifact being versioned.
 
 The ProjectReference walker for this already exists — see `scripts/check-surface-manifest.py`
-(`assembly names reachable from start through ProjectReference`) and the floor rule in
-`scripts/check-module-floors.py`. Reuse one of those rather than writing a fourth.
+(`assembly names reachable from start through ProjectReference`), `scripts/project-closure.py`,
+and the floor rule in `scripts/check-module-floors.py`. Reuse one of those rather than writing a
+fourth; the module-owned/image-shipped split is `.github/scripts/module-owned-platform.sh`, the
+same script the pack step and the bundle inspection call, so the three cannot disagree.
+
+**Until that lands, `registry-version ≠ manifest-version` is NOT a sound publication baseline.**
+It is proposed periodically as a way to narrow the module lane on `push` (Plugins#889 option 3);
+version equality does not imply byte equality while any sibling rides, so narrowing on it would
+silently under-publish exactly the bundles above. A sound baseline has to be a **commit** — the
+analogue of the bake's `source-commit.txt` — diffed with `project-closure.py`, which walks
+transitive in-repo `ProjectReference`s and therefore sees riders for free.
 
 > **If you are reading this while that derivation is still landing:** bump `content.version`'s MINOR
 > by hand for any `src/`-only change to a mixed package, and say in the PR that you did so and why.
@@ -120,11 +167,18 @@ reads `FrameworkDeclined (built against <old>, live <new>)` and adopts nothing.
 
 So the two lanes differ deliberately:
 
-| trigger | scope |
-|---|---|
-| `pull_request` | the **affected** closure |
-| `push` to `main` | the **affected** closure, baselined on the PUBLICATION (`source-commit.txt`), never `github.event.before` |
-| `repository_dispatch` / `schedule` (release-follow) | **everything** |
+| trigger | bake lane | module lane |
+|---|---|---|
+| `pull_request` / `merge_group` | the **affected** closure | the **affected** closure |
+| `push` to `main` | the **affected** closure, baselined on the PUBLICATION (`source-commit.txt`), never `github.event.before` | **everything** — this lane records no publication marker, and the registry version is not one (see the riding-closure note above) |
+| `repository_dispatch` / `schedule` (release-follow) | **everything** | **everything** |
+| `workflow_dispatch` | **everything** | **everything** |
+
+The `push` row is the only one where the two lanes differ, and the difference is a **missing
+marker, not a policy**: `bake-scope.sh` reads a `source-commit.txt` sealed beside the bundles, so it
+knows the commit its own last publication covered. The module lane has no equivalent, so
+`node-repo-scope.py` answers FULL and says why in the log and the job summary. Closing that gap is
+Plugins#889 — and the baseline it needs is a **commit**, not a version.
 
 ## Before you open the PR
 


### PR DESCRIPTION
Two load-bearing statements in the versioning record were stale, and both point the next reader at
the wrong thing. Found while assessing Plugins#889 ("the module-pack lane does not narrow on push"),
whose most attractive option was to use `registry-version ≠ manifest-version` as a per-package
baseline. **That option is not sound**, and this PR records why, with the measurement.

## 1. The reason the registry key fails as a baseline has MOVED

`node-repo-scope.py` and `ModuleVersioning` both said: *a version identifies only the CONTENT half,
so a `src/`-only change repacks the same version with different bytes — the same blind spot
Plugins#878 records.*

**Plugins#878 landed** (`d588dabd`, 2026-08-29). `gen-manifests.py::module_source_files` now hashes
a mixed package's own `src/` project into its `moduleVersion`. That sentence has been true-then-false
for three days, and anyone reading it goes looking for a fixed bug.

## 2. `MeshWeaver.*` project references are not one row — the container lane split them

The doc's closure table said `MeshWeaver.*` project references are **never** in the hash, "never
bundled — they ship in their own bundles or come from `/app`", and stated it out loud: *a change to
`MeshWeaver.AI` does not require bumping `MeshWeaver.AI.OpenAI`.*

That is the **sdk** path (`--deps-closure`, `DepsClosure.Derive` stops at `MeshWeaver.*`). The
**container** path — now nearly every entry in every node repo — does the opposite for
**module-owned** siblings. `node-repo-module-pack.yml` asks `module-owned-platform.sh` one question
per closure entry (is this project in the repo's `src/` and absent from `src/platform-shipped.txt`?)
and, when the answer is yes, copies the assembly into the bundle:

```
closure: MeshWeaver.Blazor.dll RIDES — module-owned (its source is in this repo's src/,
         so it is nowhere in the image's /app)
```

It **must** ride — nothing else supplies it at run time. But the version derivation does not know
that.

### Measured, on MeshWeaver.Plugins @ `85466905`, 2026-09-01

35 matrix entries; 119 module-owned `MeshWeaver.*` projects (`module-owned-platform.sh src`);
closures via `scripts/project-closure.py`:

| module bundle | module-owned sibling it carries | `src/MeshWeaver.Blazor/` paths in its `manifest.lock` |
|---|---|---|
| `MeshWeaver.Blazor.Analysis` | `MeshWeaver.Blazor` | **0** |
| `MeshWeaver.Blazor.AppleMaps` | `MeshWeaver.Blazor` | **0** |
| `MeshWeaver.Blazor.EntityViews` | `MeshWeaver.Blazor` | **0** |
| `MeshWeaver.Blazor.GoogleMaps` | `MeshWeaver.Blazor` | **0** |
| `MeshWeaver.Blazor.Graph` | `MeshWeaver.Blazor` | **0** |
| `MeshWeaver.Blazor.OpenStreetMap` | `MeshWeaver.Blazor` | **0** |
| `MeshWeaver.Blazor.Radzen` | `MeshWeaver.Blazor` | **0** |

An edit under `src/MeshWeaver.Blazor/` changes what all seven bundles ship and moves none of their
versions — so every existing portal takes `SkipUpToDate` before reading a byte. That is the
Plugins#878 defect one hop out.

The `MeshWeaver.AI` example the doc chose is exempt **only** because `MeshWeaver.AI` sits in that
repo's `src/platform-shipped.txt` for the #2584 interim, marked to leave with #2599. When it leaves,
every AI-provider bundle joins the seven.

## 3. The trigger table described the bake lane as if it were the module lane

It said `push` to main narrows "baselined on the PUBLICATION (`source-commit.txt`)". `bake-scope.sh`
does that; `node-repo-scope.py` answers **FULL** for `push` in the module lane and always has. The
table now splits the two lanes and says the difference is a **missing marker, not a policy**.

## What this changes

Nothing executable — a log message and prose. What it buys is that the next person to look at
Plugins#889 does not adopt an unsound baseline:

* the correct **hashing** scope is the **riding closure** — own project plus exactly the siblings
  `module-owned-platform.sh` says ride — not "own project only" (under-covers, as measured) and not
  "the whole reference graph" (bumps every dependent on any change, destroying the signal);
* the correct **narrowing** baseline is a **commit**, the analogue of the bake's marker, diffed with
  `project-closure.py` — which walks transitive in-repo `ProjectReference`s and therefore sees
  riders for free.

## Verified

* `python3 .github/scripts/node-repo-scope.py --self-test` — **44/44 green** (the push-fallback case
  asserts the word `PUBLISHES` in the reason string; kept).
* `MeshWeaver.Documentation.Test` builds `-c Release -warnaserror`, `0 Error(s)`; **166/166 passed**
  in 8 s, including `DocumentationLinkIntegrityTest`, `PlatformReleaseNotifyGuard` and
  `ReleaseDeliveryChainGuard`.

## Follow-through

`MeshWeaver.Plugins` gets the same correction on its `ci.yml` comment (which still blamed #878) in
its own PR, and the residual delivery defect from §2 is filed there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)