### PR TITLE
fix(mcp): every ExecuteScript Error carries an errorType — and "Error" is not universally side-effect free (#2918 review)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/AI/ExecuteScript.md
+++ b/src/MeshWeaver.Documentation/Data/AI/ExecuteScript.md
@@ -128,19 +128,25 @@ messages and its terminal status.
 | Status | Meaning |
 |---|---|
 | `Dispatched` | The owning hub accepted the submission and created the run's `ActivityLog`. Watch `activityPath` for `Running → Succeeded / Warning / Failed`. |
-| `Error` | The run never started. `errorType` names the condition and `message` explains it — see below. **Nothing was executed**, so no side effects occurred. |
+| `Error` | The run did not start, **or it is not known whether it started**. `errorType` says which — read the table below before deciding whether a retry is safe. |
 
-### Failing fast: `errorType`
+### `errorType` — and whether a retry is safe
 
-Two of the three reasons a target cannot run a script are decidable **before** anything is
-dispatched, and are decided that way — from one bounded read of the target node, with the caller's
-own `timeoutSeconds` as the ceiling:
+**Every** `Error` reply carries an `errorType`, so a caller can always branch on it. Two of the
+conditions are decidable **before** anything is dispatched, and are decided that way — from one
+bounded read of the target node, with the caller's own `timeoutSeconds` as the ceiling:
 
-| `errorType` | Meaning | What to do |
-|---|---|---|
-| `NodeNotFound` | There is no readable node at that path. | Check the path. A denied read reports the same way on purpose — saying "denied" would disclose that a gated node exists there. |
-| `NotExecutable` | The node exists but carries no `CodeConfiguration`, or carries one with `isExecutable: false`. | Point at a `Code` node, or set `isExecutable: true` on it. |
-| *(an exception type name)* | The dispatch itself failed — undeliverable, refused by the owning hub, or the budget elapsed. | `message` and `detail` carry the type and stack; the owning hub has logged the full cause. |
+| `errorType` | Meaning | Side effects | What to do |
+|---|---|---|---|
+| `NodeNotFound` | There is no readable node at that path. | **None** — nothing was dispatched. | Check the path. A denied read reports the same way on purpose — saying "denied" would disclose that a gated node exists there. |
+| `NotExecutable` | The node exists but carries no `CodeConfiguration`, or carries one with `isExecutable: false`. | **None** — nothing was dispatched. | Point at a `Code` node, or set `isExecutable: true` on it. |
+| `DispatchRefused` | The owning hub was reached and said no (unreadable node, activity creation refused, a fault while starting the run). | **None** — the hub creates no `ActivityLog` on any refusal path. | `message` carries the hub's own verdict; the hub has logged the full cause. |
+| `NoActivityPath` | The hub **accepted** the submission but returned no activity path. | 🚨 **Possible** — the run may be under way, it simply cannot be observed. | Check the Code node's activity history before re-running; a blind retry can run the script twice. |
+| *(an exception type name)* | The dispatch itself failed — undeliverable, or the acknowledgement never arrived within the budget. | 🚨 **Unknown** — "no acknowledgement" is not "not delivered". | `message` and `detail` carry the type and stack. Check the activity history before retrying. |
+
+> 🚨 **"Error" does not universally mean "nothing happened."** The two pre-flight verdicts and a hub
+> refusal are genuinely side-effect free. The last two are not: an acknowledgement that never came
+> back says nothing about whether the submission landed, so a retry can run the script a second time.
 
 > 🚨 **The pre-flight refuses only on a DEFINITIVE answer.** A read that reaches no verdict inside
 > its budget is *unknown*, not *absent* — so it never refuses; the dispatch proceeds exactly as it

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -4644,7 +4644,13 @@ public class MeshOperations
                         {
                             status = "Error",
                             path = resolvedPath,
-                            submissionId,
+                            // EVERY Error reply carries an errorType, or the field is not a
+                            // discriminator at all — a caller cannot branch on a key that is
+                            // present on some refusals and absent on others. A stable token, like
+                            // the pre-flight's: the hub answered, so there is no exception here to
+                            // name, and inventing one would be a lie.
+                            errorType = "DispatchRefused",
+                            submissionId = response.SubmissionId ?? submissionId,
                             message = response.Error
                                 ?? "The Code node's hub refused the dispatch without a reason."
                         },
@@ -4660,9 +4666,16 @@ public class MeshOperations
                         {
                             status = "Error",
                             path = resolvedPath,
-                            submissionId,
+                            // 🚨 The one Error that is NOT side-effect free: the hub accepted the
+                            // submission, so a run may well be under way — it just cannot be
+                            // observed, because the path to its ActivityLog never came back. Named
+                            // distinctly so a caller does not retry it like a refusal.
+                            errorType = "NoActivityPath",
+                            submissionId = response.SubmissionId ?? submissionId,
                             message = "The dispatch succeeded but the Code node's hub "
-                                + "returned no activity path, so the run cannot be observed."
+                                + "returned no activity path, so the run cannot be observed. "
+                                + "The script MAY be running — check the node's activity history "
+                                + "before re-running it."
                         },
                         hub.JsonSerializerOptions);
 


### PR DESCRIPTION
Follow-up to #2979 (merged). Two Copilot review findings, both correct.

## 1. `errorType` was not actually a discriminator

#2979 introduced `errorType` as the field a caller branches on, and documented it that way — but
only the two pre-flight verdicts and the exception path carried it. The **hub-refusal** branch
(`ExecuteScriptResponse.Success = false`) and the **no-activity-path** branch emitted
`status: "Error"` with no `errorType` at all, so a caller reading that key got `undefined` on two of
the four refusals. A field present on some refusals and absent on others is not something you can
branch on.

Both now carry a stable token — `DispatchRefused` and `NoActivityPath` — for the same reason the
pre-flight does: the hub answered, so there is no exception to name, and inventing one would be a
lie. Both also prefer the hub's own `SubmissionId` when it sent one, matching the success branch.

## 2. "Error" did not universally mean "nothing happened"

The Status table said it did. That is true of the two pre-flight verdicts and of a hub refusal (the
hub creates no `ActivityLog` on any refusal path) — and **false** of the other two:

| `errorType` | Side effects |
|---|---|
| `NodeNotFound` / `NotExecutable` | none — nothing was dispatched |
| `DispatchRefused` | none — the hub said no before creating anything |
| `NoActivityPath` | 🚨 **possible** — the hub *accepted* the submission; the run may be under way and simply cannot be observed |
| *(exception type)* | 🚨 **unknown** — "no acknowledgement" is not "not delivered" |

An agent that treats all four alike can run a script twice. The table now carries a side-effects
column and per-condition retry advice, and `NoActivityPath`'s own **wire message** says so, not only
the docs.

## Why there is no new test

With the pre-flight in place, the two branches this touches are no longer reachable deterministically
from the tool surface — the pre-flight now answers the conditions the owning hub used to refuse.

I probed for one anyway: an executable Code node whose `ActivityParentPath` names a partition that
does not exist, expecting `CreateNode` of the `ActivityLog` to fail into `FaultDispatch`. **It did
not refuse** — the in-memory store created the activity under that namespace and the tool answered
`Dispatched` with an `activityPath` in a partition that had never existed. So that test is absent
from this PR rather than weakened until it passed. (Whether an activity should be creatable under an
arbitrary non-existent namespace is a separate question I did not chase; noted here so it is not
lost.)

The doc half **is** covered, and it is the half that changes what a caller does.

## Verification

`dotnet build … -c Release -warnaserror`, one project per invocation — `MeshWeaver.Mesh.Operations`,
`MeshWeaver.Documentation.Test`, `Memex.Portal.Shared.Test` — all `0 Warning(s) / 0 Error(s)`.
`DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` green (2/2).
`ExecuteScriptPreflightTest` still green unchanged (2/2).

Refs #2918

🤖 Generated with [Claude Code](https://claude.com/claude-code)