### PR TITLE
docs: the side-panel navigation API and the content-type registration rule get written down

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentTypeRegistration.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentTypeRegistration.md
@@ -73,10 +73,12 @@ repaired**. Two independent reasons, either sufficient:
 - **It destroys the content bake.** Resolving a compiled type's configurations loads its assembly,
   and `NodeAssemblyLoadContext.LoadNodeAssembly` **deletes the file** when the load throws
   `BadImageFormatException` ("deleting for regeneration",
-  `src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs`). Probing an adopted-but-not-yet-loadable
+  `src/MeshWeaver.Compiler.Pipeline/CompilationCacheService.cs`). Probing an adopted-but-not-yet-loadable
   bake therefore removes the store's bytes and forces a re-adoption on the next boot.
-  `ShippedPrebuiltBundlesTest` caught this to the tick — an unchanged bundle was restamped where
-  the boot contract requires it to be skipped.
+  `ShippedPrebuiltBundlesTest` (in `MeshWeaver.PluginCatalog.Test`, which lives in
+  `MeshWeaver.Plugins`) caught this to the tick — an unchanged bundle was restamped where the boot
+  contract requires it to be skipped. Note that it is NOT in this repo's solution: a core change
+  can break it without any local build saying so.
 - **It reintroduces per-NodeType boot cost.** Opening every compiled type's bytes at start is
   exactly what the CI content bake removed: 43 re-adopted assemblies cost 13.5 s of a 101 s boot
   before that work. See [NodeType Compilation](../NodeTypeCompilation).

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentTypeRegistration.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentTypeRegistration.md
@@ -1,0 +1,108 @@
+---
+Name: Content-Type Registration
+Category: Architecture
+Description: A NodeType's content type must register because the definition is known, never because an instance happens to exist — and why the compiled types are deliberately left out of that sweep.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 7h-9"/><path d="M14 17H5"/><circle cx="17" cy="17" r="3"/><circle cx="7" cy="7" r="3"/></svg>
+---
+
+# Content-Type Registration
+
+A NodeType declares the CLR shape of its content inside its own hub configuration:
+
+```csharp
+config.AddMeshDataSource(source => source.WithContentType<PluginContent>())
+```
+
+`WithContentType` records the mapping in the mesh-wide `IMeshContentTypeRegistry`, and every read
+seam consults that registry to turn a stored `$type` back into the CLR type. A type the registry
+has never heard of is not an error: the polymorphic converter degrades it to a raw `JsonElement`
+by design, because an unresolvable discriminator is indistinguishable from an unknown one. The
+value then reads as absent, the view renders empty, and a reactive wait never completes — with no
+exception and nothing to grep. See [Serialization](../Serialization) for that failure mode in
+general, and [CQRS and Content Access](../CqrsAndContentAccess) for reading content correctly.
+
+## The defect: registration used to follow the INSTANCE
+
+The configuration lambda above runs when an instance hub of that NodeType **cold-activates**. That
+makes registration a side effect of somebody having created a node — which is a coincidence, not a
+guarantee.
+
+**Measured on a local portal, 2026-09-01.** Not one node carried `nodeType: Store/Plugin`; an
+installed course root is re-typed to `Space`, and nothing else instantiates the type. So
+`PluginContent` was never registered, every Store cover computed **no action buttons** — no Get,
+no Install, no Update — and the Subscribe page reported the product was not for sale. With the
+Update lane gone, installed content could not be refreshed either. One missing registration
+disabled the whole commerce surface, and deployments that happened to hold a live instance escaped
+by luck, which is what let the gap hide.
+
+The lesson generalises past the Store: **any type whose nodes are all created by an installer, a
+migration or another partition can be defined, compiled and completely absent from the registry.**
+
+## The cure: registration follows the DEFINITION
+
+`ContentTypeRegistrationSweep` (`src/MeshWeaver.Graph/ContentTypeRegistrationSweep.cs`) is an
+`IHostedService` wired beside the root-hub reply stream in both transports
+(`MonolithRegistryExtensions`, `OrleansServerRegistryExtensions`). At start it walks every static
+node definition that carries a `HubConfiguration` and, for each one the registry does not yet know,
+builds a short-lived probe hub:
+
+```csharp
+meshHub.GetHostedHub(
+    new Address($"content-type-registration/{Guid.NewGuid():N}"),
+    c => hubConfig(c.WithNodeTypePath(nodeTypePath))
+        .AsTransientNodeProbe(startDataSources: false));
+```
+
+Two properties make this cheap and safe, and both are load-bearing:
+
+1. **Registration is a side effect of the configuration BUILD**, not of anything running. Building
+   the data context executes `WithContentType`, which is all that is needed.
+2. **`AsTransientNodeProbe(startDataSources: false)` starts nothing** — no sync streams, no control
+   plane. The probe is disposed immediately. This is the same mechanism the schema probes already
+   use; see `ReadFromContentType` in `MeshOperations`.
+
+`WithNodeTypePath` stamps the path so the registration lands under the NodeType the definition
+describes rather than under the probe's own address.
+
+## 🚨 Compiled NodeTypes are deliberately NOT swept
+
+The obvious extension — sweep the runtime-compiled types too, by loading each one's cached assembly
+and reading its configurations — was implemented, failed CI, and was **removed rather than
+repaired**. Two independent reasons, either sufficient:
+
+- **It destroys the content bake.** Resolving a compiled type's configurations loads its assembly,
+  and `NodeAssemblyLoadContext.LoadNodeAssembly` **deletes the file** when the load throws
+  `BadImageFormatException` ("deleting for regeneration",
+  `src/MeshWeaver.Graph/Configuration/CompilationCacheService.cs`). Probing an adopted-but-not-yet-loadable
+  bake therefore removes the store's bytes and forces a re-adoption on the next boot.
+  `ShippedPrebuiltBundlesTest` caught this to the tick — an unchanged bundle was restamped where
+  the boot contract requires it to be skipped.
+- **It reintroduces per-NodeType boot cost.** Opening every compiled type's bytes at start is
+  exactly what the CI content bake removed: 43 re-adopted assemblies cost 13.5 s of a 101 s boot
+  before that work. See [NodeType Compilation](../NodeTypeCompilation).
+
+The scope limit is also principled, not merely pragmatic: a compiled type registers the moment one
+of its instance hubs activates, and a compiled type with **zero** instances has no stored payload
+carrying its discriminator — so there is nothing for the registry's absence to degrade. The gap only
+bites built-in types, whose content is written by installers and other partitions, and those are
+precisely the static definitions the sweep covers.
+
+## Diagnosing a suspected miss
+
+1. **Symptom**: a view that should render structured content renders empty, or a `ContentAs<T>`
+   returns `null` for a node whose stored JSON plainly holds the fields. No exception is logged.
+2. **Confirm** the stored JSON carries a `$type` and that the type is declared by some NodeType's
+   `WithContentType`.
+3. **Ask where the read happens.** A payload read on a hub that never registered the type is
+   untyped by construction. The durable fix is often to move the read to the owning hub rather than
+   to register the type more widely — see [Serialization](../Serialization).
+4. **Count the instances.** If the answer is zero and the type is a built-in one, this page is your
+   defect; the sweep should have covered it, so check that the transport's registry extension calls
+   `AddContentTypeRegistrationSweep()`.
+
+## Related Topics
+
+- [Serialization](../Serialization) — `$type` discriminators and registering types on both ends
+- [CQRS and Content Access](../CqrsAndContentAccess) — reading a node's content correctly
+- [NodeType Compilation](../NodeTypeCompilation) — the bake, adoption, and why boot cost matters
+- [Static Node Providers](../StaticNodeProviders) — where the static definitions the sweep walks come from

--- a/src/MeshWeaver.Documentation/Data/Architecture/Serialization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Serialization.md
@@ -169,6 +169,8 @@ hub.WithTypes(typeof(Story), typeof(Task), typeof(Comment))
 
 A missing registration does not throw on write — the discriminator is simply absent, and the object deserializes as `JsonElement` or `object` instead of the expected CLR type. Register early; diagnose by inspecting stored JSON for a missing `$type`.
 
+For a NodeType, `WithContentType` lives in the type's own hub configuration, and **the registration must not depend on an instance of that type existing** — see [Content-Type Registration](../ContentTypeRegistration) for how the platform sweeps definitions at startup, and for the whole commerce surface that went dead when it did not.
+
 ### The `$type` discriminator is the SHORT name — register the type on BOTH ends
 
 The `$type` discriminator defaults to the **short** type name (`StackControl`, `LayoutStackSkin`), **not** the namespace-qualified full name (`MeshWeaver.Layout.StackControl`). A short name is **only** resolvable through the type registry — there is no `Type.GetType("StackControl")` reflection fallback the way there is for a full name. Two consequences, both non-negotiable:

--- a/src/MeshWeaver.Documentation/Data/GUI/SidePanel.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/SidePanel.md
@@ -123,6 +123,57 @@ Click **&#x2197;** to move the current thread from the side panel into the full 
 
 ---
 
+# Opening the Side Panel From a Layout Area
+
+Everything above is what the *viewer* does. An area can also open the side panel itself — and for
+an embedded chat that is almost always the right choice.
+
+A layout area has two ways to send a viewer somewhere:
+
+| Call | Effect |
+|---|---|
+| `Host.NavigateTo(uri)` | Replaces the page — the viewer leaves where they are |
+| `Host.NavigateToSidePanel(uri)` | Opens `uri` beside the page — the viewer stays put |
+
+Both are available on `LayoutAreaHost` and, as extension methods, on the `UiActionContext` a click
+handler receives:
+
+```csharp
+Controls.Button("Try it")
+    .WithClickAction(click =>
+    {
+        var threadPath = StartTheExerciseThread(click);
+        click.NavigateToSidePanel(threadPath);   // not NavigateTo — the lesson stays on screen
+        return Task.CompletedTask;
+    })
+```
+
+> **Use `NavigateToSidePanel` wherever a click creates or references a thread the viewer should see
+> *beside* their work.** An embedded exercise composer that navigates the whole page to the thread
+> it just opened destroys the very page the exercise told the viewer to come back to. This was a
+> real defect in a course's try-it exercise: sending a prompt replaced the lesson with the thread.
+
+## How it reaches the browser
+
+`NavigateToSidePanel` posts a `NavigationRequest` carrying `Target = "SidePanel"` to the area's
+subscriber. From there the chain is the one the portal already had end to end — the portal
+application's handler, the navigation service, its side-panel event, and the portal layout opening
+the panel on that path. The API is the first link; nothing downstream was added for it.
+
+## Two design notes worth knowing
+
+- **It is a separate method, not a parameter on `NavigateTo`.** Adding a parameter changes that
+  method's signature, and module DLLs compiled against `NavigateTo(string, bool, bool)` would throw
+  `MissingMethodException` at runtime. Framework surfaces that modules bind to are extended by
+  addition, never by amendment.
+- **The panel must be free to show it.** In presentation mode the panel is suppressed, and a
+  side-panel navigation arriving while it is suppressed used to be accepted and then silently
+  dropped (fixed in `MeshWeaver.Plugins`). On the `/next` React shell, server-driven
+  `NavigationRequest` is not handled at all yet, so this call — like every other server-driven
+  navigation — currently does nothing there.
+
+---
+
 # Main Panel
 
 The main panel occupies the full width when the side panel is closed, and shares space via the resizable splitter when it is open. Its content always reflects the current URL.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-click-can-open-a-thread-beside-the-page.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-click-can-open-a-thread-beside-the-page.md
@@ -1,0 +1,22 @@
+---
+Name: A click can open a thread beside the page instead of replacing it
+Category: Feature
+Description: Layout areas can now send the viewer to a thread in the side panel, so an embedded chat opens next to the lesson or report instead of navigating away from it.
+Icon: Sparkle
+Order: -20260902
+---
+
+# A click can open a thread beside the page instead of replacing it
+
+A page that embeds a chat had only one way to send the viewer to it: navigate. The whole page was
+replaced by the thread — which is right for a link that means "go there", and wrong for an exercise
+that means "try this here". Anyone following a lesson, a report or a walkthrough lost the page the
+exercise had just told them to stay on, and had to find their way back.
+
+Layout areas can now open a path in the side panel instead. The viewer stays exactly where they
+were, and the thread appears beside their work — the same panel the chat icon opens, so it is
+resizable, closable, and preserved across a reload like any other side-panel content.
+
+This is available to anyone authoring an area or a course: alongside the existing "navigate the
+page", there is now "open it beside the page". The first place it is used is the try-it exercise in
+the Agentic Business course, whose chat now opens next to the lesson.


### PR DESCRIPTION
## What & why

Three documentation follow-ups to work that merged without them. No code changes.

**1. A What's New entry for #2917.** `NavigateToSidePanel` shipped as a new public framework API
with no entry — the `Category: Feature` entry another course author would discover it by. The
user-visible behaviour entry does exist, but in `MeshWeaver.Education`, where a *platform*
capability is not findable.

**2. `Doc/GUI/SidePanel` gains an author-facing section.** The page documented only what the
*viewer* does (open, close, resize, promote). It now also answers "how do I open the panel from my
layout area":

- `NavigateTo` replaces the page; `NavigateToSidePanel` opens beside it — with the rule for
  choosing, since an embedded exercise that navigates away destroys the page it told the viewer to
  come back to.
- The `NavigationRequest` / `Target = "SidePanel"` chain, noting the API is the first link and
  nothing downstream was added for it.
- Why it is a **separate method rather than an optional parameter** on `NavigateTo`: a changed
  signature throws `MissingMethodException` in modules compiled against the old one.
- The two surfaces that cannot honour it: present mode (fixed in `MeshWeaver.Plugins`#1036) and the
  `/next` React shell, which handles no `NavigationRequest` at all (`MeshWeaver.Plugins`#1037).

**3. `Doc/Architecture/ContentTypeRegistration` records the #2969 investigation.** Registration
followed the *instance*: `WithContentType` runs when an instance hub cold-activates, so a NodeType
that is defined and compiled but has no live node never registered at all. Measured consequence —
zero `Store/Plugin`-typed nodes on a portal meant `PluginContent` was unknown, every Store cover
computed no Get/Install/Update button, and the Update lane for installed content was dead.

The part most worth keeping is the negative result: **compiled NodeTypes are deliberately NOT
swept.** That version was written, failed CI, and was removed rather than repaired, because
resolving a compiled type's configurations loads its assembly and
`NodeAssemblyLoadContext.LoadNodeAssembly` **deletes the file** on `BadImageFormatException` — so
probing an adopted-but-unloadable bake destroys the store's bytes. It also reintroduces the
per-NodeType boot cost the CI content bake removed. `Serialization.md` cross-links the new page
from its "Register every content type" section.

## Merge preconditions

- [x] **(a) Build is green with warnings-as-errors** — `dotnet build -c Release -warnaserror` on
      `MeshWeaver.Documentation.Test`: 0 warnings, 0 errors.
- [x] **(b) Tests are green** — `MeshWeaver.Documentation.Test` 166/166, `DocumentationLinkIntegrityTest`
      included (every link on the new page and the edited ones resolves).
- [ ] **(c) Reviewed**
- [ ] **(d) Review comments dealt with**

## Notes for reviewers

Documentation only — no `src/` behaviour changes, so the risk is wording and link resolution, both
covered by the link-integrity test. The claim I would most like checked is the scope limit in
`ContentTypeRegistration.md`: that a compiled type with zero instances has no stored payload
carrying its discriminator, and therefore nothing for the registry's absence to degrade. That is the
argument for the sweep covering static definitions only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
