### PR TITLE
fix(seo): Safari shows a page's own favicon — rasterize the node's svg mark

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -140,8 +140,26 @@
          packages and the base image stays as it is — the font is supplied from an embedded
          resource instead. linux-x64 AND linux-arm64 natives ship in the package, which the
          multi-arch portal image requires. -->
-    <PackageVersion Include="SkiaSharp" Version="3.116.1" />
-    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.116.1" />
+    <PackageVersion Include="SkiaSharp" Version="3.119.2" />
+    <PackageVersion Include="SkiaSharp.NativeAssets.Linux.NoDependencies" Version="3.119.2" />
+    <!-- 🚨 SkiaSharp DRAWS; it does not PARSE. The favicon rasterizer (IconRasterizer, issue
+         #2075) has to turn a node's AUTHORED &lt;svg&gt; mark into PNG bytes because Safari
+         renders no SVG favicon at all, so the whole per-content favicon feature was invisible on
+         that browser — and every one of the 56 store-package marks is inline svg, including the
+         issue's own repro (Chess's board). Drawing only the marks the portal GENERATES would have
+         shipped an endpoint that misses its own reproduction case.
+
+         Svg.Skia is MIT; its closure is MIT plus MS-PL (Svg.Custom, the SVG.NET fork), both on the
+         `Dependency licences` allowlist — see Doc/Architecture/DependencyLicensing.
+
+         🚨 It is what pins SkiaSharp at 3.119.2 (from 3.116.1): Svg.Skia 4.9.1 floors SkiaSharp at
+         3.119.2, and a lower central pin under a higher transitive floor is NU1605, not a silent
+         resolve. Moving Svg.Skia moves SkiaSharp with it — they are one decision.
+
+         The HarfBuzzSharp natives it brings are standalone (no fontconfig/freetype link), so the
+         NoDependencies posture above is preserved: the portal base image still needs no apt
+         packages. -->
+    <PackageVersion Include="Svg.Skia" Version="4.9.1" />
     <PackageVersion Include="System.CommandLine" Version="2.0.11" />
     <PackageVersion Include="System.Composition.AttributedModel" Version="10.0.10" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />

--- a/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
@@ -51,12 +51,19 @@ public static class SeoEndpoints
     /// Sink for an AUTHORED icon whose markup will not parse. The route answers 404 either way, so
     /// without this line a broken mark and a node with no mark are indistinguishable from outside —
     /// and the broken one is the only one anybody can fix.
+    ///
+    /// <para>🚨 <c>GetRequiredService</c>, unlike <see cref="LateFault"/> above, and the difference
+    /// is the point: this sink IS the diagnostic. A null-conditional logger would make the one
+    /// signal that a mark is broken silently optional — the exact failure the method exists to
+    /// prevent — so a host with no logger factory must say so loudly rather than serve 404s that
+    /// mean nothing. Resolved ONCE per request, before the reactive chain, so the cost is not paid
+    /// per emission and a missing registration cannot surface as a swallowed 404.</para>
     /// </summary>
     private static Action<Exception> UnrenderableIcon(IMessageHub hub, string nodePath)
     {
-        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
-            ?.CreateLogger(typeof(SeoEndpoints));
-        return ex => logger?.LogWarning(
+        var logger = hub.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(typeof(SeoEndpoints));
+        return ex => logger.LogWarning(
             ex, "The icon of '{Path}' is inline svg that will not render; serving no raster icon "
                 + "for it", nodePath);
     }
@@ -180,10 +187,11 @@ public static class SeoEndpoints
                     $"size must be one of {string.Join(", ", IconRasterizer.SupportedSizes)}"));
 
             var pixels = size;
+            var unrenderable = UnrenderableIcon(hub, nodePath);
             return SeoResolver.Resolve(hub, nodePath)
                 .Select(data => data is null
                     ? Results.NotFound()
-                    : IconResult(http, data.Node, pixels, UnrenderableIcon(hub, nodePath)))
+                    : IconResult(http, data.Node, pixels, unrenderable))
                 .Catch<IResult, Exception>(_ => Observable.Return(Results.NotFound()))
                 .FirstAsync()
                 .ObserveCompletion(LateFault(hub, $"/api/icon/{nodePath}"), ct)!;

--- a/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
@@ -47,6 +47,20 @@ public static class SeoEndpoints
             ex, "{Route}: faulted after its HTTP response had already settled", route);
     }
 
+    /// <summary>
+    /// Sink for an AUTHORED icon whose markup will not parse. The route answers 404 either way, so
+    /// without this line a broken mark and a node with no mark are indistinguishable from outside —
+    /// and the broken one is the only one anybody can fix.
+    /// </summary>
+    private static Action<Exception> UnrenderableIcon(IMessageHub hub, string nodePath)
+    {
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(SeoEndpoints));
+        return ex => logger?.LogWarning(
+            ex, "The icon of '{Path}' is inline svg that will not render; serving no raster icon "
+                + "for it", nodePath);
+    }
+
     /// <summary>Node types whose top-level mains are sitemap candidates.</summary>
     private static readonly string[] CandidateNodeTypes = ["Store/Plugin", "Store/Catalog", "Space"];
 
@@ -76,6 +90,7 @@ public static class SeoEndpoints
         }).AllowAnonymous();
 
         MapShareCard(app);
+        MapNodeIcon(app);
         return app;
     }
 
@@ -116,6 +131,107 @@ public static class SeoEndpoints
                 .FirstAsync()
                 .ObserveCompletion(LateFault(hub, $"/api/og/{nodePath}"), ct)!;
         }).AllowAnonymous();
+
+    /// <summary>
+    /// 🚨 THE RASTER FAVICON — <c>/api/icon/{node}.png?size=N</c>.
+    ///
+    /// <para><b>Why a portal serves its own favicon as PNG.</b> A node page declares the node's own
+    /// icon in its head, and every store-package mark is authored inline <c>&lt;svg&gt;</c>. Safari
+    /// renders no SVG favicon at all, so on macOS and iOS the per-content favicon was invisible —
+    /// every tab wore the portal mark (issue #2075, item 3). This route renders the SAME svg
+    /// <see cref="SeoResolver.ResolveIcon"/> puts in the head, so the two are pictures of one
+    /// thing, and <see cref="SeoResolver.ResolveIconLinks"/> declares it beside the svg rather than
+    /// instead of it.</para>
+    ///
+    /// <para><b>Gated identically to the SEO head and the share card.</b> It resolves through
+    /// <see cref="SeoResolver.Resolve"/>, which returns null for anything the fail-closed
+    /// <see cref="AnonymousGate"/> refuses — so a private node's MARK cannot be lifted out of this
+    /// route, and a missing node, a private one and a node with no mark all answer the same 404.
+    /// There is no parallel permission rule here to drift from the page's.</para>
+    ///
+    /// <para><b>404 is the fallback, and nothing ever points at it.</b> A node with no icon of its
+    /// own gets no icon link in its head either (<see cref="SeoResolver.ResolveIconLinks"/> returns
+    /// empty), so the portal favicon stays — the same honest answer the head has always given.
+    /// Redirecting to the site favicon here would look like a fix while telling every consumer that
+    /// this node's mark IS the portal's.</para>
+    ///
+    /// <para><b>Sizes are an allow-list, not a range</b> (<see cref="IconRasterizer.SupportedSizes"/>):
+    /// the route is anonymous and shared-cacheable, so a free-form size parameter is an unbounded
+    /// number of distinct renders. An unsupported size is a 400 rather than a silent snap to 32 —
+    /// a caller asking for something this cannot serve should be told so.</para>
+    /// </summary>
+    private static void MapNodeIcon(IEndpointRouteBuilder app) =>
+        app.MapGet("/api/icon/{**path}", (
+            IMessageHub hub, HttpContext http, string path, CancellationToken ct) =>
+        {
+            var nodePath = (path ?? "").Trim('/');
+            if (nodePath.EndsWith(".png", StringComparison.OrdinalIgnoreCase))
+                nodePath = nodePath[..^4];
+            if (nodePath.Length == 0)
+                return Task.FromResult(Results.NotFound());
+
+            var size = IconRasterizer.FaviconSize;
+            var requested = http.Request.Query["size"].ToString();
+            if (requested.Length > 0
+                && (!int.TryParse(requested, System.Globalization.NumberStyles.Integer,
+                        System.Globalization.CultureInfo.InvariantCulture, out size)
+                    || !IconRasterizer.IsSupportedSize(size)))
+                return Task.FromResult(Results.BadRequest(
+                    $"size must be one of {string.Join(", ", IconRasterizer.SupportedSizes)}"));
+
+            var pixels = size;
+            return SeoResolver.Resolve(hub, nodePath)
+                .Select(data => data is null
+                    ? Results.NotFound()
+                    : IconResult(http, data.Node, pixels, UnrenderableIcon(hub, nodePath)))
+                .Catch<IResult, Exception>(_ => Observable.Return(Results.NotFound()))
+                .FirstAsync()
+                .ObserveCompletion(LateFault(hub, $"/api/icon/{nodePath}"), ct)!;
+        }).AllowAnonymous();
+
+    /// <summary>
+    /// One node's rasterized mark, or 404 when it carries none this can draw. Internal so the
+    /// endpoint's own decision — not a re-implementation of it — is what the tests exercise.
+    /// </summary>
+    /// <param name="http">The request, for conditional-GET and response headers.</param>
+    /// <param name="node">The node, already gated as anonymous-readable by the caller.</param>
+    /// <param name="size">The square edge in pixels.</param>
+    /// <param name="onUnrenderable">Sink for markup that is present but cannot be drawn — an
+    /// AUTHORED icon that fails to parse is a content defect worth a line in the log, not something
+    /// to swallow into an indistinguishable 404.</param>
+    internal static IResult IconResult(
+        HttpContext http, MeshNode node, int size, Action<Exception>? onUnrenderable = null)
+    {
+        if (SeoResolver.ResolveIconSvg(node) is not { } svg)
+            return Results.NotFound();
+
+        byte[]? png;
+        try
+        {
+            png = IconRasterizer.Render(svg, size);
+        }
+        catch (Exception ex)
+        {
+            // Malformed authored markup is a 4xx-shaped fact about the CONTENT, not a fault in this
+            // route — but it is invisible from outside, so it is reported before the 404 is served.
+            onUnrenderable?.Invoke(ex);
+            return Results.NotFound();
+        }
+
+        if (png is null)
+            return Results.NotFound();
+
+        var etag = $"\"{Convert.ToBase64String(System.Security.Cryptography.SHA256.HashData(png))}\"";
+        if (string.Equals(http.Request.Headers.IfNoneMatch.ToString(), etag, StringComparison.Ordinal))
+            return Results.StatusCode(StatusCodes.Status304NotModified);
+
+        http.Response.Headers.ETag = etag;
+        // Shared-cacheable for the same reason the share card is: everything drawn here is already
+        // served to anonymous callers in the page's own head, and the strong ETag is the render's
+        // hash — so a node that changes its mark produces a new icon rather than a stale one.
+        http.Response.Headers.CacheControl = "public, max-age=86400";
+        return Results.File(png, "image/png");
+    }
 
     private static IResult CardResult(HttpContext http, OgCardRenderer renderer, SeoPageData data)
     {

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -128,6 +128,9 @@
          referenced here rather than only where the renderer is called. NoDependencies = no
          fontconfig/freetype link, so nothing has to be apt-installed into the portal base. -->
     <PackageReference Include="SkiaSharp.NativeAssets.Linux.NoDependencies" />
+    <!-- SkiaSharp draws but does not PARSE svg, and every node mark is authored svg — see
+         IconRasterizer and Doc/Architecture/ContentFaviconRasterization. -->
+    <PackageReference Include="Svg.Skia" />
   </ItemGroup>
 
   <ItemGroup>

--- a/memex/Memex.Portal.Shared/Seo/IconRasterizer.cs
+++ b/memex/Memex.Portal.Shared/Seo/IconRasterizer.cs
@@ -1,0 +1,124 @@
+using System.Collections.Immutable;
+using SkiaSharp;
+using Svg.Skia;
+
+namespace Memex.Portal.Shared.Seo;
+
+/// <summary>
+/// Turns a node's <c>&lt;svg&gt;</c> mark into PNG bytes, so the per-content favicon reaches the
+/// browsers that cannot read an SVG one.
+///
+/// <para><b>Why this exists (issue #2075, item 3).</b> The SEO head emits the node's own icon as an
+/// <c>image/svg+xml</c> <c>data:</c> URI (<see cref="SeoResolver.ResolveIcon"/>). <b>Safari renders
+/// no SVG favicon at all</b> — not from a data URI, not from a URL — so on macOS and iOS every node
+/// page wore the portal favicon and the whole feature was invisible to those users. A feature a
+/// whole browser cannot see is not shipped for them. The cure is the standards-based one: declare
+/// the SVG *and* a PNG, and let each browser take the one it can read.</para>
+///
+/// <para><b>Why an SVG parser, and why authored marks decide it.</b> SkiaSharp draws; it does not
+/// parse SVG. The portal's icon population is mixed — generated backplates (structured, drawable
+/// directly) and AUTHORED markup (arbitrary) — and a census of the store packages found every one
+/// of the 56 marks to be authored inline <c>&lt;svg&gt;</c>, the issue's own <c>Chess</c> board
+/// among them. Drawing only the generated half would have produced an endpoint Safari honours that
+/// still leaves the reported node showing the portal favicon. Hence <c>Svg.Skia</c> beside
+/// <c>SkiaSharp</c>; see Doc/Architecture/ContentFaviconRasterization.</para>
+///
+/// <para><b>No state, deliberately.</b> Unlike <see cref="OgCardRenderer"/> — which holds a decoded
+/// typeface — nothing here survives a call: the parse, the surface and the encode are all per
+/// request, so there is no instance to own and no cache to scope to a mesh. Repeat cost is carried
+/// by the endpoint's strong ETag and <c>max-age</c> instead of by memory the process never frees
+/// (AGENTS.md: no static collections, and an unbounded icon cache keyed by node path is exactly
+/// one).</para>
+/// </summary>
+public static class IconRasterizer
+{
+    /// <summary>The favicon size a browser actually paints in a tab strip.</summary>
+    public const int FaviconSize = 32;
+
+    /// <summary>The <c>apple-touch-icon</c> size — Safari's bookmark / Add-to-Dock tile.</summary>
+    public const int AppleTouchSize = 180;
+
+    /// <summary>
+    /// The sizes the endpoint will render, smallest first. An ALLOW-LIST rather than a clamped
+    /// range: the route is anonymous and cacheable, so an unbounded size parameter is an unbounded
+    /// number of distinct renders and cache entries for one node. A constant lookup — written once
+    /// at type init, never at runtime.
+    /// </summary>
+    public static readonly ImmutableArray<int> SupportedSizes =
+        [16, FaviconSize, 48, 64, 96, 128, AppleTouchSize, 192, 512];
+
+    /// <summary>Whether <paramref name="size"/> is one this rasterizer will render.</summary>
+    public static bool IsSupportedSize(int size) => SupportedSizes.Contains(size);
+
+    /// <summary>
+    /// Rasterizes <paramref name="svg"/> into a square PNG of <paramref name="size"/> pixels, or
+    /// null when the markup carries nothing drawable.
+    ///
+    /// <para>The mark is fitted to the square by its own <c>viewBox</c> — scaled by the smaller
+    /// axis and centred, so a non-square mark keeps its aspect ratio instead of being stretched.
+    /// The ground is left TRANSPARENT: a favicon is painted onto whatever the browser's tab strip
+    /// or bookmark bar uses, and every authored mark already paints its own plate
+    /// (<c>IconBackplate</c> guarantees it), so inventing a background here would draw a border
+    /// around a mark that already has one.</para>
+    ///
+    /// <para>Pure: same markup and size → same bytes, which is what makes the endpoint's strong
+    /// ETag meaningful.</para>
+    /// </summary>
+    /// <param name="svg">Inline <c>&lt;svg&gt;</c> markup — the node's icon, byte for byte.</param>
+    /// <param name="size">The square edge in pixels; see <see cref="SupportedSizes"/>.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The size is not positive.</exception>
+    public static byte[]? Render(string svg, int size)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(size);
+        if (string.IsNullOrWhiteSpace(svg))
+            return null;
+
+        using var document = SKSvg.CreateFromSvg(svg);
+        var picture = document?.Picture;
+        // A zero-extent cull rect would divide by zero below. Svg.Skia never actually produces one
+        // — an empty root reports 1×1 — so this is a guard against the arithmetic, NOT the
+        // "draws nothing" test; that one is made below, on the pixels, where it can be true.
+        if (picture is null || picture.CullRect.Width <= 0 || picture.CullRect.Height <= 0)
+            return null;
+
+        var info = new SKImageInfo(size, size, SKColorType.Rgba8888, SKAlphaType.Premul);
+        using var surface = SKSurface.Create(info);
+        var canvas = surface.Canvas;
+        canvas.Clear(SKColors.Transparent);
+
+        var bounds = picture.CullRect;
+        var scale = Math.Min(size / bounds.Width, size / bounds.Height);
+        canvas.Translate(
+            (size - (bounds.Width * scale)) / 2f,
+            (size - (bounds.Height * scale)) / 2f);
+        canvas.Scale(scale);
+        canvas.Translate(-bounds.Left, -bounds.Top);
+        canvas.DrawPicture(picture);
+        canvas.Flush();
+
+        // 🚨 An svg that PARSES but paints nothing — an empty root, a mark whose whole body was
+        // stripped, a viewBox that collapses — encodes a perfectly valid, perfectly invisible PNG.
+        // Served, that is a blank tab icon behind a 200, which reads as a working endpoint and is
+        // the one failure nobody can see. Answer "no icon" instead and let the caller 404.
+        if (IsFullyTransparent(surface))
+            return null;
+
+        using var image = surface.Snapshot();
+        using var data = image.Encode(SKEncodedImageFormat.Png, 100);
+        return data.ToArray();
+    }
+
+    /// <summary>Whether every pixel drawn is fully transparent — i.e. the mark painted nothing.</summary>
+    private static bool IsFullyTransparent(SKSurface surface)
+    {
+        using var pixels = surface.PeekPixels();
+        if (pixels is null)
+            return false;   // cannot read the buffer → do not CLAIM it is blank
+        var span = pixels.GetPixelSpan();
+        // Rgba8888: alpha is the fourth byte of every pixel.
+        for (var i = 3; i < span.Length; i += 4)
+            if (span[i] != 0)
+                return false;
+        return true;
+    }
+}

--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -19,13 +19,26 @@ namespace Memex.Portal.Shared.Seo;
 /// <param name="Type">The media type to declare, or null when the value alone does not pin one
 /// down — declaring the WRONG type is worse than declaring none, and a consumer that ranks icons
 /// by type would then rank this one on a lie.</param>
-/// <param name="Rel">The link relation — <c>icon</c> for the tab strip, <c>apple-touch-icon</c> for
-/// Safari's bookmark / Add-to-Dock tile, which is a SEPARATE channel and never falls back to the
-/// favicon.</param>
-/// <param name="Sizes">The <c>sizes</c> attribute, for a raster icon that has exactly one pixel
-/// size. Null for a scalable (SVG) icon, where declaring a size would tell a browser ranking icons
-/// by size something untrue.</param>
-public sealed record PageIcon(string Href, string? Type, string Rel = "icon", string? Sizes = null);
+public sealed record PageIcon(string Href, string? Type)
+{
+    /// <summary>
+    /// The link relation — <c>icon</c> for the tab strip, <c>apple-touch-icon</c> for Safari's
+    /// bookmark / Add-to-Dock tile, which is a SEPARATE channel and never falls back to the
+    /// favicon.
+    ///
+    /// <para>🚨 An <c>init</c> PROPERTY, deliberately not a third primary-constructor parameter.
+    /// A record's primary constructor is a BINARY contract with every module already compiled
+    /// against it — adding a parameter replaces the signature even when it carries a default, and
+    /// the host aborts at boot on the mismatch in both directions. A new property is additive, so
+    /// this cannot split an image; <c>scripts/check-record-signatures.py</c> is what says so.</para>
+    /// </summary>
+    public string Rel { get; init; } = "icon";
+
+    /// <summary>The <c>sizes</c> attribute, for a raster icon that has exactly one pixel size. Null
+    /// for a scalable (SVG) icon, where declaring a size would tell a browser that ranks icons by
+    /// size something untrue. Same <c>init</c> reasoning as <see cref="Rel"/>.</summary>
+    public string? Sizes { get; init; }
+}
 
 /// <summary>
 /// What the crawler-facing head needs to know about the requested page: the resolved node and
@@ -266,15 +279,15 @@ public static class SeoResolver
         return
         [
             icon,
-            new PageIcon(
-                RasterIconUrl(node.Path, IconRasterizer.FaviconSize),
-                "image/png",
-                Sizes: $"{IconRasterizer.FaviconSize}x{IconRasterizer.FaviconSize}"),
-            new PageIcon(
-                RasterIconUrl(node.Path, IconRasterizer.AppleTouchSize),
-                "image/png",
-                Rel: "apple-touch-icon",
-                Sizes: $"{IconRasterizer.AppleTouchSize}x{IconRasterizer.AppleTouchSize}"),
+            new PageIcon(RasterIconUrl(node.Path, IconRasterizer.FaviconSize), "image/png")
+            {
+                Sizes = $"{IconRasterizer.FaviconSize}x{IconRasterizer.FaviconSize}",
+            },
+            new PageIcon(RasterIconUrl(node.Path, IconRasterizer.AppleTouchSize), "image/png")
+            {
+                Rel = "apple-touch-icon",
+                Sizes = $"{IconRasterizer.AppleTouchSize}x{IconRasterizer.AppleTouchSize}",
+            },
         ];
     }
 

--- a/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
+++ b/memex/Memex.Portal.Shared/Seo/SeoResolver.cs
@@ -19,7 +19,13 @@ namespace Memex.Portal.Shared.Seo;
 /// <param name="Type">The media type to declare, or null when the value alone does not pin one
 /// down — declaring the WRONG type is worse than declaring none, and a consumer that ranks icons
 /// by type would then rank this one on a lie.</param>
-public sealed record PageIcon(string Href, string? Type);
+/// <param name="Rel">The link relation — <c>icon</c> for the tab strip, <c>apple-touch-icon</c> for
+/// Safari's bookmark / Add-to-Dock tile, which is a SEPARATE channel and never falls back to the
+/// favicon.</param>
+/// <param name="Sizes">The <c>sizes</c> attribute, for a raster icon that has exactly one pixel
+/// size. Null for a scalable (SVG) icon, where declaring a size would tell a browser ranking icons
+/// by size something untrue.</param>
+public sealed record PageIcon(string Href, string? Type, string Rel = "icon", string? Sizes = null);
 
 /// <summary>
 /// What the crawler-facing head needs to know about the requested page: the resolved node and
@@ -185,15 +191,15 @@ public static class SeoResolver
     /// <returns>Its own icon, or null when it carries none an <c>href</c> can point at.</returns>
     public static PageIcon? ResolveIcon(MeshNode node)
     {
-        var icon = MeshNodeImageHelper.ResolveContentPath(node.Icon, node.Path);
-        if (string.IsNullOrWhiteSpace(icon))
-            return null;
-
         // An inline <svg> is MARKUP, not a location, so it travels as a data URI — the same
         // mechanism App.razor already uses for the per-instance favicon. The svg itself is
         // untouched: it is the node's icon, byte for byte.
-        if (MeshNodeImageHelper.IsInlineSvg(icon))
-            return new PageIcon(SvgDataUri(icon), SvgMediaType);
+        if (ResolveIconSvg(node) is { } svg)
+            return new PageIcon(SvgDataUri(svg), SvgMediaType);
+
+        var icon = MeshNodeImageHelper.ResolveContentPath(node.Icon, node.Path);
+        if (string.IsNullOrWhiteSpace(icon))
+            return null;
 
         // A URL or data URI the node carries — used as written.
         if (MeshNodeImageHelper.IsImageUrl(icon))
@@ -202,6 +208,74 @@ public static class SeoResolver
         // Anything else (an emoji, a bare word) is a character, not a picture, and no href can
         // carry it. The portal favicon stays rather than inventing a graphic for it.
         return null;
+    }
+
+    /// <summary>
+    /// The node's own icon AS SVG SOURCE, or null when it carries none that is markup.
+    ///
+    /// <para>This is the exact value <see cref="ResolveIcon"/> percent-encodes into its
+    /// <c>data:image/svg+xml</c> href — one resolution, two consumers, so the
+    /// <see cref="PageIcon"/> in the head and the PNG the rasterizer serves for the SAME page can
+    /// never be pictures of different things.</para>
+    ///
+    /// <para>Only INLINE markup qualifies. An icon that is a URL (a content-collection file, a
+    /// shipped glyph) is a location this process would have to fetch — over its own
+    /// access-controlled route, from an anonymous request — to rasterize; a raster URL needs no
+    /// rasterizing at all, because Safari reads those already.</para>
+    /// </summary>
+    /// <param name="node">The node whose page is being served.</param>
+    public static string? ResolveIconSvg(MeshNode node)
+    {
+        var icon = MeshNodeImageHelper.ResolveContentPath(node.Icon, node.Path);
+        return MeshNodeImageHelper.IsInlineSvg(icon) ? icon : null;
+    }
+
+    /// <summary>The route the rasterized favicon of one node is served from.</summary>
+    /// <param name="nodePath">The node's mesh path, which is also its public URL path.</param>
+    /// <param name="size">The square edge in pixels.</param>
+    public static string RasterIconUrl(string nodePath, int size) =>
+        $"/api/icon/{nodePath}.png?size={size}";
+
+    /// <summary>
+    /// 🚨 EVERY icon link the page's head should carry, in declaration order.
+    ///
+    /// <para><b>Why more than one.</b> Safari renders no SVG favicon — not from a data URI, not
+    /// from a URL — so a page whose only icon link is the node's <c>&lt;svg&gt;</c> mark wore the
+    /// portal favicon on every Mac and iPhone, in and out of circuit (issue #2075, item 3). The
+    /// standards-based answer is not to give up the scalable icon: declare BOTH and let each
+    /// browser take the one it can read. A browser that understands SVG prefers it (scalable beats
+    /// a fixed 32 px on a retina tab strip); Safari skips it and takes the PNG.</para>
+    ///
+    /// <para><b>Why <c>apple-touch-icon</c> is separate.</b> It is a different channel with a
+    /// different job — the large bookmark / Start-Page / Add-to-Dock tile — and Safari does NOT
+    /// fall back to the favicon for it: with none declared it draws its own letter tile. So a node
+    /// with a mark needs one pointed at that mark, or its tile says nothing about it.</para>
+    ///
+    /// <para>Nothing is synthesised, exactly as <see cref="ResolveIcon"/> promises: a node with no
+    /// icon of its own yields NO links at all, and a node whose icon is already a raster image
+    /// yields the single link it always did — Safari reads those without help.</para>
+    /// </summary>
+    /// <param name="node">The node whose page is being served.</param>
+    /// <returns>The links to declare; empty when the node has no icon an <c>href</c> can carry.</returns>
+    public static IReadOnlyList<PageIcon> ResolveIconLinks(MeshNode node)
+    {
+        if (ResolveIcon(node) is not { } icon)
+            return [];
+        if (ResolveIconSvg(node) is null)
+            return [icon];
+        return
+        [
+            icon,
+            new PageIcon(
+                RasterIconUrl(node.Path, IconRasterizer.FaviconSize),
+                "image/png",
+                Sizes: $"{IconRasterizer.FaviconSize}x{IconRasterizer.FaviconSize}"),
+            new PageIcon(
+                RasterIconUrl(node.Path, IconRasterizer.AppleTouchSize),
+                "image/png",
+                Rel: "apple-touch-icon",
+                Sizes: $"{IconRasterizer.AppleTouchSize}x{IconRasterizer.AppleTouchSize}"),
+        ];
     }
 
     /// <summary>The media type an icon URL pins down by itself, or null when it does not — a

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentFaviconRasterization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentFaviconRasterization.md
@@ -87,6 +87,11 @@ an `/api/icon` endpoint Safari honours while leaving **the exact node in the bug
 showing the portal favicon. A fix that does not cover its own reproduction case is the shape worth
 refusing, so the dependency was taken.
 
+**Measured on the real population, not on a sample:** every one of the **56 authored store marks**
+was pushed through `IconRasterizer` at both declared sizes — **56/56 produced a valid PNG of the
+right dimensions, 0 blank, 0 parse failures.** That is the check worth repeating if a mark ever
+stops appearing; the marks are the input this was chosen for.
+
 🚨 **`Svg.Skia` and `SkiaSharp` are one decision, not two.** `Svg.Skia` 4.9.1 floors SkiaSharp at
 3.119.2; a lower central pin under a higher transitive floor is `NU1605`, not a silent resolve — so
 the central pin moved from 3.116.1 with it. Moving either version moves the other.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentFaviconRasterization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentFaviconRasterization.md
@@ -50,6 +50,16 @@ about it.
 The set is produced by **`SeoResolver.ResolveIconLinks`** (`memex/Memex.Portal.Shared/Seo/`).
 `ResolveIcon` — the single-icon accessor — is unchanged and still returns the first of them.
 
+🚨 **`PageIcon` gained `Rel` and `Sizes` as `init` PROPERTIES, not as primary-constructor
+parameters** — and that is not a style choice. A record's primary constructor is a **binary
+contract** with every module already compiled against it: adding a parameter replaces the
+signature *even when it carries a default*, so a published module calls a constructor the new
+platform no longer has and the host aborts at boot, in both directions. There is no image that can
+serve a mixed set. `scripts/check-record-signatures.py` is the gate that says so, and it caught the
+positional version of exactly this change — a red worth having, because nothing about
+`PageIcon(Href, Type, Rel = "icon", Sizes = null)` *looks* breaking from the call site. A new
+property is additive and cannot split an image.
+
 ## `/api/icon/{node}.png?size=N`
 
 `SeoEndpoints.MapNodeIcon`, beside `/api/og/{node}.png`. Four properties matter:

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentFaviconRasterization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentFaviconRasterization.md
@@ -1,0 +1,147 @@
+---
+Name: Content Favicon Rasterization
+Category: Architecture
+Description: Why a node page declares TWO favicons — the node's own svg mark and a PNG rendered from it — and why Safari is the reason. Covers /api/icon, the Svg.Skia decision, the scope boundary, and the cross-repo seam.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="14" rx="2"/><path d="M3 9h18"/><circle cx="6.5" cy="6.5" r=".6"/><path d="M8 13.5l2.5 2.5L15 12l3 3"/></svg>
+---
+
+# Content Favicon Rasterization
+
+A node page identifies itself in the browser tab: it declares **its own icon**, not the portal's.
+That has shipped since 2026-08-11 — [`SeoResolver.ResolveIcon`](/Doc/Architecture/LinkPreviews)
+emits the node's mark on the initial server response, before any Blazor circuit exists.
+
+**On Safari it did nothing at all.** This page is why, and what the fix is.
+
+## The defect
+
+`MeshNode.Icon` for every store package is authored inline `<svg>` — a census of the plugin
+repository found **56 of 56** marks in that form, the `Chess` board among them. The head therefore
+carried one link:
+
+```html
+<link rel="icon" href="data:image/svg+xml,%3Csvg…" type="image/svg+xml" />
+```
+
+**Safari renders no SVG favicon.** Not from a `data:` URI, not from a URL, not in a tab, not in a
+bookmark. So on every Mac and iPhone the per-content favicon was invisible — each tab wore the
+portal mark — in circuit and out of it alike. A feature a whole browser cannot see is not shipped
+for the people using it.
+
+## The fix: declare both, let the browser choose
+
+The head now declares three links for a node whose mark is svg:
+
+```html
+<link rel="icon" href="data:image/svg+xml,…" type="image/svg+xml" />
+<link rel="icon" type="image/png" sizes="32x32" href="/api/icon/Chess.png?size=32" />
+<link rel="apple-touch-icon" sizes="180x180" href="/api/icon/Chess.png?size=180" />
+```
+
+This is the standards-based shape, not a workaround. A browser that reads SVG prefers the scalable
+icon — which is worth keeping: a vector mark beats a fixed 32 px on a retina tab strip. Safari
+skips the one it cannot read and takes the PNG. Nothing is lost and one browser is gained.
+
+`apple-touch-icon` is a **separate channel**, not a fallback: it is Safari's large bookmark /
+Start-Page / Add-to-Dock tile, and with none declared Safari draws its own letter tile rather than
+consulting the favicon. A node with a mark needs one pointed at that mark or its tile says nothing
+about it.
+
+The set is produced by **`SeoResolver.ResolveIconLinks`** (`memex/Memex.Portal.Shared/Seo/`).
+`ResolveIcon` — the single-icon accessor — is unchanged and still returns the first of them.
+
+## `/api/icon/{node}.png?size=N`
+
+`SeoEndpoints.MapNodeIcon`, beside `/api/og/{node}.png`. Four properties matter:
+
+- **One resolution, two consumers.** The route rasterizes the value `SeoResolver.ResolveIconSvg`
+  returns — the same string `ResolveIcon` percent-encodes into the head's data URI. The tab's PNG
+  and the head's SVG can never become pictures of different things.
+- **Gated identically to the page.** It resolves through `SeoResolver.Resolve`, hence through the
+  fail-closed `AnonymousGate`. A private node's mark cannot be lifted out of this route, and a
+  missing node, a private one and a node with no mark all answer the same 404. There is no
+  parallel permission rule here to drift from the page's.
+- **Sizes are an allow-list**, not a clamped range (`IconRasterizer.SupportedSizes`). The route is
+  anonymous and shared-cacheable, so a free-form `size` is an unbounded number of distinct renders
+  and cache entries per node. An unsupported size answers 400 rather than snapping silently to 32.
+- **No server-side cache.** Repeat cost is carried by a strong ETag (the render's own SHA-256) plus
+  `Cache-Control: public, max-age=86400`, exactly as the share card does. An icon cache keyed by
+  node path is an unbounded dictionary the process never frees — see
+  [No Static State](/Doc/Architecture/NoStaticState).
+
+## Why `Svg.Skia`, and why it moved SkiaSharp
+
+SkiaSharp **draws**; it does not **parse** SVG. `OgCardRenderer` gets away with SkiaSharp alone
+because it composes its card from primitives it chooses itself. An icon is the opposite: the mark
+is arbitrary authored markup.
+
+That made the scope decision explicit rather than accidental:
+
+| option | covers | cost |
+|---|---|---|
+| draw generated backplates directly in Skia | generated marks only | no dependency — **but misses `Chess`, the reported case** |
+| add `Svg.Skia` | every mark, authored ones included | one dependency |
+
+The second option is tempting precisely because it avoids a dependency, and it would have shipped
+an `/api/icon` endpoint Safari honours while leaving **the exact node in the bug report** still
+showing the portal favicon. A fix that does not cover its own reproduction case is the shape worth
+refusing, so the dependency was taken.
+
+🚨 **`Svg.Skia` and `SkiaSharp` are one decision, not two.** `Svg.Skia` 4.9.1 floors SkiaSharp at
+3.119.2; a lower central pin under a higher transitive floor is `NU1605`, not a silent resolve — so
+the central pin moved from 3.116.1 with it. Moving either version moves the other.
+
+**Licensing** clears [the gate](/Doc/Architecture/DependencyLicensing) with nothing to add to the
+allowlist: `Svg.Skia`, `Svg.Model`, `Svg.SceneGraph`, `Svg.Animation`, `ShimSkiaSharp`, `ExCSS` and
+the `HarfBuzzSharp` natives are MIT; `Svg.Custom` (the SVG.NET fork) is MS-PL. Both are already
+permitted.
+
+**The `NoDependencies` posture survives.** The portal deliberately ships
+`SkiaSharp.NativeAssets.Linux.NoDependencies` so the image needs no `fontconfig`/`libfreetype` and
+no apt packages. The HarfBuzzSharp natives `Svg.Skia` brings are standalone and change nothing
+about that.
+
+## What is deliberately NOT rasterized
+
+Only **inline `<svg>`** is. Two exclusions, each for a reason:
+
+- **A mark that is already raster** (`.png`, a content-collection image, a `data:image/png` URI) —
+  Safari reads those unaided, so the head declares the single link it always did and this route
+  answers 404 for it. Redrawing it would add a hop and a second copy of one picture.
+- **A mark that is a URL** (a content-collection file, a shipped glyph) — a location this process
+  would have to fetch, over its own access-controlled route, from an anonymous request, to
+  rasterize. That is a different design with its own access story; it is not in this change and no
+  head advertises it.
+
+And, unchanged from the day the feature shipped: **a node with no mark of its own synthesises
+nothing.** No letter tile, no NodeType stand-in. `ResolveIconLinks` returns empty and the portal
+favicon stays — the honest answer for a page with no mark, and the reason the route's 404 is never
+reached from a page we serve. Redirecting to the site favicon there would *look* like a fix while
+telling every consumer that this node's mark **is** the portal's.
+
+## The cross-repo seam
+
+The policy and the endpoint live in **core** (`memex/Memex.Portal.Shared/`); the `<head>` that
+renders the links lives in **MeshWeaver.Plugins** (`Memex.Portal.Gui/Seo/SeoHead.razor`, and the
+in-circuit swap in `MeshWeaver.Blazor/Pages/ApplicationPage.razor`), because the portal shell moved
+there with the GUI split. So core decides *what* the links are and the shell renders them —
+`ResolveIconLinks` is the seam.
+
+That makes this a two-repo change in the ordinary direction: **core merges first**, and until the
+Plugins side lands the endpoint is live and correct but only one link is declared, i.e. exactly
+today's behaviour. Nothing half-lands.
+
+## Verifying it
+
+```bash
+# the head declares all three
+curl -s https://memex.meshweaver.cloud/Chess | grep -oE '<link rel="(icon|apple-touch-icon)"[^>]*>'
+
+# and the raster route really answers with a PNG of that size
+curl -s "https://memex.meshweaver.cloud/api/icon/Chess.png?size=180" | file -
+```
+
+A node with no mark answering 404 on that second command is the design, not a failure — check its
+head declares no icon link either. See also [Link Previews](../LinkPreviews) for the rest of the
+crawler-facing head, and [Dependency Licensing](../DependencyLicensing) for the gate the new packages
+pass.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentFaviconRasterization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentFaviconRasterization.md
@@ -131,6 +131,30 @@ That makes this a two-repo change in the ordinary direction: **core merges first
 Plugins side lands the endpoint is live and correct but only one link is declared, i.e. exactly
 today's behaviour. Nothing half-lands.
 
+### 🚨 The residue: the IN-CIRCUIT head is a separate, narrower channel
+
+`SeoHead` renders for **anonymous requests only** — it returns early when
+`HttpContext.User.Identity.IsAuthenticated`. A signed-in user's tab icon comes instead from
+`ApplicationPage`'s circuit-side `<HeadContent>`, which declares one link from
+`MeshNodeImageHelper.ResolveIconLink`. **That path still declares SVG only**, so a signed-in Safari
+user's tab keeps the portal mark.
+
+It is deliberately not fixed here, because it is not the same problem wearing a different hat:
+
+- `ResolveIconLink` is **total** — a node with no icon of its own resolves to its NodeType glyph
+  (`/static/NodeTypeIcons/*.svg`) and finally a neutral box. `SeoResolver.ResolveIcon` is
+  deliberately **not**: the node's own mark or nothing. So the two do not resolve the same value,
+  and a raster link for the in-circuit path would have to answer for shipped glyphs too — those are
+  embedded resources in `MeshWeaver.Graph`, readable without an HTTP hop, so it is tractable, but it
+  is a *policy* question (does a NodeType stand-in deserve a rasterized tab icon?) rather than a
+  mechanical extension.
+- Safari's handling of a favicon link **inserted after load** is unreliable in a way the initial
+  response's is not, so the same three links added from the circuit may buy nothing.
+
+The reported defect — the anonymous, server-rendered head that crawlers and first paint read, and
+that every shared link resolves through — is fully covered. This residue is named so the next person
+measures it rather than rediscovering it from a screenshot.
+
 ## Verifying it
 
 ```bash

--- a/src/MeshWeaver.Documentation/Data/Architecture/LinkPreviews.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LinkPreviews.md
@@ -40,6 +40,10 @@ Blazor circuit exists:
 3. **`SeoNoScriptBody`** serves the page's pre-rendered markdown inside `<noscript>`, so non-JS
    crawlers index actual content rather than an empty Blazor shell.
 
+The **node's own icon** is part of that head, and it is declared twice — as the node's `<svg>` mark
+and as a PNG rendered from it at `/api/icon/{path}.png`, because Safari renders no SVG favicon at
+all. See [Content Favicon Rasterization](../ContentFaviconRasterization).
+
 ## The one bit that decides everything: anonymous read
 
 **Only what an anonymous visitor may read gets a card.** `SeoResolver` gates every path through

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-safari-shows-the-page-icon.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-safari-shows-the-page-icon.md
@@ -1,0 +1,26 @@
+---
+Name: Safari now shows a page's own icon in the tab
+Category: Fix
+Description: Node pages served their icon as SVG, which Safari does not render — so on Mac and iPhone every tab wore the portal mark. Each page now also offers a PNG, and a bookmark tile to match.
+Icon: Sparkle
+Order: -20260901
+---
+
+# Safari now shows a page's own icon in the tab
+
+Open a package, a space or a document and the browser tab shows **that page's own mark** — the
+chess board for Chess, each plugin's own icon — instead of the portal logo repeated across every
+tab. That has been true since August, on Chrome, Edge and Firefox.
+
+**On Safari it was never true.** Pages offered their icon in SVG form, and Safari does not render
+an SVG favicon at all — so on every Mac and iPhone the tab quietly fell back to the portal mark,
+whether you were signed in or not.
+
+Each page now offers its icon **both ways**: the scalable original, and a PNG rendered from exactly
+the same artwork. Browsers that read SVG keep the crisp one, and Safari takes the PNG — so the tab
+strip finally reads the same everywhere. Safari's larger tile — the one you get bookmarking a page,
+adding it to the Dock, or pinning it to the Start Page — now carries the page's mark too, instead
+of Safari's own letter square.
+
+Nothing is invented for a page that has no mark of its own: it keeps the portal icon, exactly as
+before. And nothing changes for a page whose icon was already a picture file — those always worked.

--- a/test/Memex.Portal.Shared.Test/IconRasterizerTest.cs
+++ b/test/Memex.Portal.Shared.Test/IconRasterizerTest.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Linq;
+using Memex.Portal.Shared.Seo;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The raster favicon (issue #2075, item 3). Safari renders no SVG favicon at all, so the
+/// per-content favicon — which every node page has emitted server-side since 2026-08-11 — was
+/// invisible on macOS and iOS: every tab wore the portal mark.
+///
+/// <para>🚨 These assert on an AUTHORED mark, not on art the portal generates. That is the whole
+/// point of the dependency: the icon population is mixed, and drawing only the generated
+/// backplates would have shipped an endpoint Safari honours while leaving the issue's own
+/// reproduction case — the <c>Chess</c> package, whose mark is an authored board — still showing
+/// the portal favicon. A fix that does not cover its own repro is the shape worth refusing.</para>
+/// </summary>
+public class IconRasterizerTest
+{
+    /// <summary>
+    /// 🚨 THE ISSUE'S OWN REPRO, byte for byte as <c>Chess/index.json</c> carries it: an authored
+    /// board (the <c>#f0d9b5</c> / <c>#b58863</c> squares and the knight path), not something this
+    /// test made up to be easy to draw.
+    /// </summary>
+    private const string AuthoredMark =
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'>"
+        + "<rect width='48' height='48' rx='10' fill='#f0d9b5'/>"
+        + "<rect x='6' y='6' width='18' height='18' fill='#b58863'/>"
+        + "<rect x='24' y='24' width='18' height='18' fill='#b58863'/>"
+        + "<path d='M17 38h16v-3H17zM18 33h14c0-3-1.5-4.5-3-6.5-1.2-1.6-1.6-4-1-6l2.5 1.5c.8.4 1.8.2 "
+        + "2.3-.6.5-.9.2-2-.7-2.5L26 15.5c-.3-2-1.8-3.5-4-3.5-1 0-1.6.4-2.2 1.2l-4.3 6.2c-.6.9-.4 "
+        + "2.1.4 2.8l2.6 2.1c.7.6 1.7.6 2.4 0l1.6-1.3c.3 1.7-.2 3.5-1.5 5C19.5 30 18 31 18 33z' "
+        + "fill='#2b1c12' stroke='#f7ead2' stroke-width='1.1'/></svg>";
+
+    /// <summary>PNG magic + IHDR width/height, read straight out of the bytes — the same reading
+    /// a browser does, and the only one that proves this is a PNG rather than "some bytes came
+    /// back".</summary>
+    private static (int Width, int Height) PngSize(byte[] png)
+    {
+        Assert.True(png.Length > 24, "a file that short cannot be a PNG");
+        Assert.Equal(new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A }, png.Take(8).ToArray());
+        Assert.Equal("IHDR", System.Text.Encoding.ASCII.GetString(png, 12, 4));
+        int Be(int at) => (png[at] << 24) | (png[at + 1] << 16) | (png[at + 2] << 8) | png[at + 3];
+        return (Be(16), Be(20));
+    }
+
+    /// <summary>
+    /// The two sizes the head declares: the 32 px favicon Safari will actually read, and the 180 px
+    /// <c>apple-touch-icon</c> — a separate channel Safari does NOT fall back to the favicon for.
+    /// </summary>
+    [Theory]
+    [InlineData(32)]
+    [InlineData(180)]
+    public void AnAuthoredSvgMark_RastersToARealPngAtThatExactSize(int size)
+    {
+        var png = IconRasterizer.Render(AuthoredMark, size);
+
+        Assert.NotNull(png);
+        var (width, height) = PngSize(png);
+        Assert.Equal(size, width);
+        Assert.Equal(size, height);
+    }
+
+    /// <summary>
+    /// A PNG of the right dimensions could still be blank. The mark's own ground is
+    /// <c>#f0d9b5</c>, so the centre pixel must be opaque and light — proof the authored markup was
+    /// PARSED and drawn, not merely allocated as a transparent canvas.
+    /// </summary>
+    [Fact]
+    public void TheAuthoredMarkIsActuallyDrawn_NotABlankCanvasOfTheRightSize()
+    {
+        var png = IconRasterizer.Render(AuthoredMark, 64);
+
+        Assert.NotNull(png);
+        using var bitmap = SkiaSharp.SKBitmap.Decode(png);
+        Assert.Equal(64, bitmap.Width);
+        var corner = bitmap.GetPixel(32, 6);      // board ground, above the knight
+        Assert.Equal(255, corner.Alpha);
+        Assert.Equal(0xF0, corner.Red);
+        Assert.Equal(0xD9, corner.Green);
+        Assert.Equal(0xB5, corner.Blue);
+    }
+
+    /// <summary>
+    /// The endpoint serves a strong ETag computed from these bytes, so the same mark at the same
+    /// size must render identically — otherwise every refetch is a cache miss and the 304 path is
+    /// dead code.
+    /// </summary>
+    [Fact]
+    public void TheSameMarkAtTheSameSize_RendersByteIdentically()
+        => Assert.Equal(IconRasterizer.Render(AuthoredMark, 32), IconRasterizer.Render(AuthoredMark, 32));
+
+    /// <summary>A non-square mark keeps its aspect ratio, so the output is square by CANVAS, not by
+    /// stretching the artwork.</summary>
+    [Fact]
+    public void ANonSquareMark_IsFittedAndCentred_NotStretched()
+    {
+        const string wide =
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 16'>"
+            + "<rect width='64' height='16' fill='#2563eb'/></svg>";
+
+        var png = IconRasterizer.Render(wide, 32);
+
+        Assert.NotNull(png);
+        using var bitmap = SkiaSharp.SKBitmap.Decode(png);
+        // Scaled by the wider axis (32/64), so the band is 8 px tall and centred: the middle row is
+        // painted and the top row is not.
+        Assert.Equal(255, bitmap.GetPixel(16, 16).Alpha);
+        Assert.Equal(0, bitmap.GetPixel(16, 1).Alpha);
+    }
+
+    /// <summary>
+    /// 🚨 Markup that PARSES but paints nothing must say "no icon" rather than encode a fully
+    /// transparent PNG. A blank icon behind a 200 looks exactly like a working endpoint, so it is
+    /// the one failure nobody can see — and it is not hypothetical: an empty svg root parses
+    /// cleanly and reports a 1×1 cull rect, so a bounds check alone would pass it straight through.
+    /// </summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 0 0'></svg>")]
+    [InlineData("<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'></svg>")]
+    [InlineData("<svg></svg>")]
+    public void MarkupThatPaintsNothing_YieldsNoIconRatherThanABlankOne(string markup)
+        => Assert.Null(IconRasterizer.Render(markup, 32));
+
+    /// <summary>The blank test is on the PIXELS, not on the bounds — a mark that paints only a
+    /// speck still counts as an icon.</summary>
+    [Fact]
+    public void AMarkThatPaintsOnlyASpeck_IsStillAnIcon()
+        => Assert.NotNull(IconRasterizer.Render(
+            "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'>"
+            + "<circle cx='12' cy='12' r='0.4' fill='#000'/></svg>", 32));
+
+    /// <summary>
+    /// The size set is an ALLOW-LIST, not a clamped range: the route is anonymous and
+    /// shared-cacheable, so a free-form size is an unbounded number of distinct renders per node.
+    /// </summary>
+    [Fact]
+    public void TheSupportedSizes_AreAnAllowList_CoveringBothDeclaredLinks()
+    {
+        Assert.True(IconRasterizer.IsSupportedSize(IconRasterizer.FaviconSize));
+        Assert.True(IconRasterizer.IsSupportedSize(IconRasterizer.AppleTouchSize));
+        Assert.False(IconRasterizer.IsSupportedSize(33));
+        Assert.False(IconRasterizer.IsSupportedSize(4096));
+        Assert.False(IconRasterizer.IsSupportedSize(0));
+    }
+
+    /// <summary>A non-positive size is a caller bug, not an image — it must raise rather than
+    /// produce a degenerate canvas.</summary>
+    [Fact]
+    public void ANonPositiveSize_Raises()
+        => Assert.Throws<ArgumentOutOfRangeException>(() => IconRasterizer.Render(AuthoredMark, 0));
+}

--- a/test/Memex.Portal.Shared.Test/NodeIconEndpointTest.cs
+++ b/test/Memex.Portal.Shared.Test/NodeIconEndpointTest.cs
@@ -1,0 +1,141 @@
+using System;
+using System.Linq;
+using Memex.Portal.Shared.Api;
+using Memex.Portal.Shared.Seo;
+using MeshWeaver.Mesh;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.HttpResults;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// What <c>/api/icon/{node}.png</c> actually answers. These drive
+/// <see cref="SeoEndpoints.IconResult"/> — the endpoint's OWN decision, reached from the route —
+/// rather than a re-implementation of it beside the route, which could agree with itself while the
+/// shipped answer is wrong.
+///
+/// <para>The permission decision is not re-tested here on purpose: the route reaches this only
+/// through <see cref="SeoResolver.Resolve"/>, the same fail-closed <c>AnonymousGate</c> pass the
+/// page head and the share card go through, so there is no second permission rule to drift.</para>
+/// </summary>
+public class NodeIconEndpointTest
+{
+    private const string AuthoredMark =
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'>"
+        + "<rect width='48' height='48' rx='10' fill='#f0d9b5'/>"
+        + "<rect x='6' y='6' width='18' height='18' fill='#b58863'/></svg>";
+
+    private static MeshNode Node(string? icon, string path = "Chess") =>
+        new(path) { NodeType = "Store/Plugin", Name = "Chess", Icon = icon };
+
+    private static (int Width, int Height) PngSize(byte[] png)
+    {
+        Assert.Equal(new byte[] { 0x89, 0x50, 0x4E, 0x47 }, png.Take(4).ToArray());
+        int Be(int at) => (png[at] << 24) | (png[at + 1] << 16) | (png[at + 2] << 8) | png[at + 3];
+        return (Be(16), Be(20));
+    }
+
+    /// <summary>The node's authored mark, served as a real PNG of the requested size.</summary>
+    [Theory]
+    [InlineData(32)]
+    [InlineData(180)]
+    public void ANodeWithAnAuthoredMark_IsServedAsAPngOfThatSize(int size)
+    {
+        var http = new DefaultHttpContext();
+
+        var result = SeoEndpoints.IconResult(http, Node(AuthoredMark), size);
+
+        var file = Assert.IsType<FileContentHttpResult>(result);
+        Assert.Equal("image/png", file.ContentType);
+        var (width, height) = PngSize(file.FileContents.ToArray());
+        Assert.Equal(size, width);
+        Assert.Equal(size, height);
+    }
+
+    /// <summary>
+    /// 🚨 THE FALLBACK, STATED: a node that carries no mark of its own gets a 404, and nothing ever
+    /// requests it — <see cref="SeoResolver.ResolveIconLinks"/> emits no icon link for such a node,
+    /// so the portal favicon simply stays. Redirecting to the site favicon here would look like a
+    /// fix while telling every consumer that this node's mark IS the portal's, and synthesising a
+    /// letter tile would put a picture in the head that the node never chose.
+    /// </summary>
+    [Fact]
+    public void ANodeWithNoMarkOfItsOwn_Is404_AndItsHeadAdvertisesNothingToAskFor()
+    {
+        var http = new DefaultHttpContext();
+
+        Assert.IsType<NotFound>(SeoEndpoints.IconResult(http, Node(null), 32));
+        Assert.IsType<NotFound>(SeoEndpoints.IconResult(http, Node("   "), 32));
+        // An emoji and a legacy Fluent NAME are characters, not pictures — same answer.
+        Assert.IsType<NotFound>(SeoEndpoints.IconResult(http, Node("📊"), 32));
+        Assert.IsType<NotFound>(SeoEndpoints.IconResult(http, Node("Document"), 32));
+
+        Assert.Empty(SeoResolver.ResolveIconLinks(Node(null)));
+        Assert.Empty(SeoResolver.ResolveIconLinks(Node("📊")));
+    }
+
+    /// <summary>
+    /// A mark that is already a RASTER image needs no help — Safari reads those — so this route
+    /// does not duplicate it, and the head declares that one URL exactly as it always did.
+    /// </summary>
+    [Fact]
+    public void AMarkThatIsAlreadyRaster_IsNotRedrawnHere()
+    {
+        var node = Node("https://cdn.example.org/mark.png");
+
+        Assert.IsType<NotFound>(SeoEndpoints.IconResult(new DefaultHttpContext(), node, 32));
+        var link = Assert.Single(SeoResolver.ResolveIconLinks(node));
+        Assert.Equal("https://cdn.example.org/mark.png", link.Href);
+    }
+
+    /// <summary>
+    /// Inline svg that will not parse is a CONTENT defect. The route answers 404 like any other
+    /// "no icon", but the fault is reported — otherwise a broken authored mark and a node with no
+    /// mark are indistinguishable from outside, and the broken one is the only one anyone can fix.
+    /// </summary>
+    [Fact]
+    public void MalformedAuthoredMarkup_Is404_ButIsReported()
+    {
+        Exception? reported = null;
+
+        var result = SeoEndpoints.IconResult(
+            new DefaultHttpContext(), Node("<svg><rect fill='#fff'</svg>"), 32, ex => reported = ex);
+
+        Assert.IsType<NotFound>(result);
+        Assert.NotNull(reported);
+    }
+
+    /// <summary>
+    /// The strong ETag and the shared cache directive: crawlers and browsers refetch favicons
+    /// aggressively, and the tag is the render's own hash, so a node that changes its mark produces
+    /// a new icon rather than a stale one.
+    /// </summary>
+    [Fact]
+    public void TheResponse_CarriesAStrongEtagAndIsSharedCacheable()
+    {
+        var http = new DefaultHttpContext();
+
+        SeoEndpoints.IconResult(http, Node(AuthoredMark), 32);
+
+        var etag = http.Response.Headers.ETag.ToString();
+        Assert.StartsWith("\"", etag);
+        Assert.Equal("public, max-age=86400", http.Response.Headers.CacheControl.ToString());
+    }
+
+    /// <summary>A conditional GET whose tag still matches is answered 304, not re-sent.</summary>
+    [Fact]
+    public void AMatchingIfNoneMatch_Is304()
+    {
+        var first = new DefaultHttpContext();
+        SeoEndpoints.IconResult(first, Node(AuthoredMark), 32);
+        var etag = first.Response.Headers.ETag.ToString();
+
+        var second = new DefaultHttpContext();
+        second.Request.Headers.IfNoneMatch = etag;
+
+        var result = SeoEndpoints.IconResult(second, Node(AuthoredMark), 32);
+
+        Assert.Equal(StatusCodes.Status304NotModified, Assert.IsType<StatusCodeHttpResult>(result).StatusCode);
+    }
+}

--- a/test/Memex.Portal.Shared.Test/SeoIconLinksTest.cs
+++ b/test/Memex.Portal.Shared.Test/SeoIconLinksTest.cs
@@ -1,0 +1,128 @@
+using System.Linq;
+using Memex.Portal.Shared.Seo;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The set of <c>&lt;link&gt;</c> elements a node page's head should carry
+/// (<see cref="SeoResolver.ResolveIconLinks"/>).
+///
+/// <para>🚨 THE DEFECT (issue #2075, item 3): the head declared exactly one icon — the node's own
+/// mark as an <c>image/svg+xml</c> data URI — and <b>Safari renders no SVG favicon at all</b>. So
+/// on every Mac and iPhone the per-content favicon was invisible: each tab wore the portal mark,
+/// in and out of circuit. The cure is not to give up the scalable icon but to declare BOTH and let
+/// each browser take the one it can read.</para>
+/// </summary>
+public class SeoIconLinksTest
+{
+    private const string AuthoredMark =
+        "<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 48 48'>"
+        + "<rect width='48' height='48' rx='10' fill='#f0d9b5'/></svg>";
+
+    private static MeshNode Node(string? icon, string path = "Chess") =>
+        new(path) { NodeType = "Store/Plugin", Icon = icon };
+
+    /// <summary>
+    /// An svg mark yields three links: the scalable icon (unchanged, so a browser that reads SVG
+    /// still gets the crisp one), the PNG favicon Safari will actually take, and the
+    /// <c>apple-touch-icon</c> — a SEPARATE channel that Safari does not fall back to the favicon
+    /// for, so with none declared it draws its own letter tile instead of the node's mark.
+    /// </summary>
+    [Fact]
+    public void AnSvgMark_DeclaresTheScalableIcon_APngFallback_AndAnAppleTouchIcon()
+    {
+        var links = SeoResolver.ResolveIconLinks(Node(AuthoredMark));
+
+        Assert.Equal(3, links.Count);
+
+        var svg = links[0];
+        Assert.Equal("icon", svg.Rel);
+        Assert.Equal("image/svg+xml", svg.Type);
+        Assert.StartsWith("data:image/svg+xml,", svg.Href);
+        // A scalable icon declares no size: telling a browser that ranks icons by size that this
+        // one is 32 px would be a lie about the only thing that makes it worth preferring.
+        Assert.Null(svg.Sizes);
+
+        var png = links[1];
+        Assert.Equal("icon", png.Rel);
+        Assert.Equal("image/png", png.Type);
+        Assert.Equal("/api/icon/Chess.png?size=32", png.Href);
+        Assert.Equal("32x32", png.Sizes);
+
+        var touch = links[2];
+        Assert.Equal("apple-touch-icon", touch.Rel);
+        Assert.Equal("image/png", touch.Type);
+        Assert.Equal("/api/icon/Chess.png?size=180", touch.Href);
+        Assert.Equal("180x180", touch.Sizes);
+    }
+
+    /// <summary>
+    /// 🚨 The raster links point at the SAME svg the first link carries. One resolution
+    /// (<see cref="SeoResolver.ResolveIconSvg"/>) feeds both, so the tab's PNG and the head's data
+    /// URI can never become pictures of different things.
+    /// </summary>
+    [Fact]
+    public void ThePngAndTheDataUri_AreTheSameMark()
+    {
+        var node = Node(AuthoredMark);
+
+        var fromLink = System.Uri.UnescapeDataString(
+            SeoResolver.ResolveIconLinks(node)[0].Href["data:image/svg+xml,".Length..]);
+
+        Assert.Equal(AuthoredMark, fromLink);
+        Assert.Equal(AuthoredMark, SeoResolver.ResolveIconSvg(node));
+    }
+
+    /// <summary>A nested page keeps its full mesh path in the icon URL — publishing moves nothing,
+    /// and the route is a catch-all, so no separator is escaped.</summary>
+    [Fact]
+    public void ANestedNode_KeepsItsFullPath_Unescaped()
+    {
+        var links = SeoResolver.ResolveIconLinks(Node(AuthoredMark, "AgenticPrimer/01-TheMagicWish"));
+
+        Assert.Equal("/api/icon/AgenticPrimer/01-TheMagicWish.png?size=32", links[1].Href);
+    }
+
+    /// <summary>A mark that is already a raster image needs no PNG fallback — Safari reads it — so
+    /// the head declares the one link it always did.</summary>
+    [Fact]
+    public void ARasterMark_StillDeclaresExactlyOneLink()
+    {
+        var links = SeoResolver.ResolveIconLinks(Node("https://cdn.example.org/mark.png"));
+
+        var only = Assert.Single(links);
+        Assert.Equal("https://cdn.example.org/mark.png", only.Href);
+        Assert.Equal("icon", only.Rel);
+    }
+
+    /// <summary>
+    /// 🚨 Nothing is synthesised, exactly as before. A node with no mark of its own declares NO
+    /// icon links, so the portal favicon stays — the honest answer for a page with no mark, and the
+    /// reason the raster route's 404 is never reached from a page we serve.
+    /// </summary>
+    [Fact]
+    public void NoMarkOfItsOwn_DeclaresNothing()
+    {
+        Assert.Empty(SeoResolver.ResolveIconLinks(Node(null)));
+        Assert.Empty(SeoResolver.ResolveIconLinks(Node("")));
+        Assert.Empty(SeoResolver.ResolveIconLinks(Node("Document")));
+        Assert.Empty(SeoResolver.ResolveIconLinks(Node("📊")));
+    }
+
+    /// <summary>
+    /// The single-icon accessor the head has used since 2026-08-11 is unchanged — this change ADDS
+    /// links, it does not move the existing one.
+    /// </summary>
+    [Fact]
+    public void TheExistingSingleIconAccessor_StillAnswersTheSame()
+    {
+        var icon = SeoResolver.ResolveIcon(Node(AuthoredMark));
+
+        Assert.NotNull(icon);
+        Assert.Equal("image/svg+xml", icon.Type);
+        Assert.Equal(AuthoredMark, System.Uri.UnescapeDataString(icon.Href["data:image/svg+xml,".Length..]));
+        Assert.Equal(SeoResolver.ResolveIconLinks(Node(AuthoredMark)).First(), icon);
+    }
+}


### PR DESCRIPTION
## The defect

A node page has declared **its own icon** in its head since 2026-08-11, and every store-package
mark is authored inline `<svg>` — **56 of 56**, measured across the plugin repository, the `Chess`
board among them.

**Safari renders no SVG favicon at all** — not from a `data:` URI, not from a URL, not in a tab and
not in a bookmark. So on every Mac and iPhone the per-content favicon was invisible: each tab wore
the portal mark, in circuit and out of it alike. A feature a whole browser cannot see is not
shipped for the people using it.

This is **item 3 of #2075**.

## The fix — declare both, let the browser choose

Not a swap. `SeoResolver.ResolveIconLinks` now yields three links for a node whose mark is svg:

```html
<link rel="icon" href="data:image/svg+xml,…" type="image/svg+xml" />
<link rel="icon" type="image/png" sizes="32x32" href="/api/icon/Chess.png?size=32" />
<link rel="apple-touch-icon" sizes="180x180" href="/api/icon/Chess.png?size=180" />
```

A browser that reads SVG keeps the scalable one — a vector mark still beats a fixed 32 px on a
retina tab strip. Safari skips it and takes the PNG. `apple-touch-icon` is a **separate channel**,
not a fallback: it is Safari's large bookmark / Start-Page / Add-to-Dock tile, and with none
declared Safari draws its own letter tile rather than consulting the favicon.

`ResolveIcon` — the single-icon accessor the head has used since August — is unchanged and still
returns the first of them.

## `/api/icon/{node}.png?size=N`

`SeoEndpoints.MapNodeIcon`, beside `/api/og/{node}.png`:

- **One resolution, two consumers.** It rasterizes the value `SeoResolver.ResolveIconSvg` returns —
  the same string `ResolveIcon` percent-encodes into the head's data URI. The tab's PNG and the
  head's SVG can never become pictures of different things.
- **Gated identically to the page**, through `SeoResolver.Resolve` and hence the fail-closed
  `AnonymousGate`. A private node's mark cannot be lifted out of this route, and a missing node, a
  private one and a node with no mark all answer the same 404. No parallel permission rule to drift.
- **Sizes are an allow-list**, not a clamped range: the route is anonymous and shared-cacheable, so
  a free-form `size` is an unbounded number of distinct renders per node. An unsupported size is a
  400, not a silent snap to 32.
- **No server-side cache.** A strong ETag (the render's own SHA-256) plus `max-age=86400` carry
  repeat cost, rather than a dictionary keyed by node path that the process never frees.

**Nothing is synthesised**, exactly as the feature has always promised: a node with no mark of its
own declares **no** icon links and keeps the portal favicon. That is why the route's 404 is never
reached from a page we serve — and it is the stated fallback, rather than redirecting to the site
favicon, which would *look* like a fix while telling every consumer that this node's mark **is**
the portal's.

## The dependency, and why it was not avoidable

SkiaSharp **draws**; it does not **parse** SVG. The icon population is mixed — generated backplates
(drawable directly) and authored markup (arbitrary):

| option | covers | cost |
|---|---|---|
| draw generated backplates directly in Skia | generated marks only | no dependency — **but misses `Chess`, the reported case** |
| add `Svg.Skia` | every mark, authored ones included | one dependency |

The second column is the whole argument: the cheap option ships an `/api/icon` Safari honours while
leaving the exact node in the bug report still showing the portal favicon.

🚨 **`Svg.Skia` and `SkiaSharp` are one decision.** `Svg.Skia` 4.9.1 floors SkiaSharp at 3.119.2, and
a lower central pin under a higher transitive floor is `NU1605`, not a silent resolve — so the
central pin moved from 3.116.1 with it.

**Licensing** clears the gate with nothing added to the allowlist. `.github/scripts/check-licenses.py`
run locally: **181 shipping packages, green**; the new closure is MIT (`Svg.Skia`, `Svg.Model`,
`Svg.SceneGraph`, `Svg.Animation`, `ShimSkiaSharp`, `ExCSS`, the `HarfBuzzSharp` natives) plus MS-PL
(`Svg.Custom`), both already permitted. The `NoDependencies` native posture is preserved — the
HarfBuzzSharp natives are standalone, so the portal image still needs no apt packages.

## Verification

- `Memex.Portal.Shared.Test` — **523/523 green** (whole project, not a filter).
- `MeshWeaver.Documentation.Test` — **166/166 green** (includes `DocumentationLinkIntegrityTest`).
- `Memex.Portal.Shared`, `Memex.Portal.Shared.Test` and `MeshWeaver.Documentation.Test` each built
  `-c Release -warnaserror`, one project per invocation: **0 Error(s), 0 Warning(s)**.
- **Every one of the 26 new tests was shown RED by a deliberate mutation and restored** — four
  batches: wrong PNG size, single link, missing blank-icon guard, 200 instead of 404, dropped ETag,
  unreported parse failure, stretched fit, no `DrawPicture`, widened allow-list, altered svg.

🚨 The blank-icon guard is not decorative and it was not designed from the armchair: an empty
`<svg>` **parses cleanly and reports a 1×1 cull rect**, so the bounds check I wrote first passed it
straight through and encoded a valid, perfectly invisible PNG behind a 200 — a blank tab icon that
reads as a working endpoint. The first test run caught it; the guard is now on the pixels.

## Work product

`Doc/Architecture/ContentFaviconRasterization` — the Safari behaviour, the dual-link shape, the
`Svg.Skia` decision and the SkiaSharp bump it forces, the scope boundary (what is deliberately not
rasterized), and the cross-repo seam. Cross-linked from `Doc/Architecture/LinkPreviews`.
What's New entry: `Category: Fix`.

## What remains, and the follow-up

The `<head>` that renders these links lives in **MeshWeaver.Plugins**
(`Memex.Portal.Gui/Seo/SeoHead.razor`, plus the in-circuit swap in
`MeshWeaver.Blazor/Pages/ApplicationPage.razor`) — the portal shell moved there with the GUI split.
So core decides *what* the links are and the shell renders them; `ResolveIconLinks` is the seam.
Core merges first, and until the Plugins side lands the endpoint is live and correct while the head
declares the one link it does today. Nothing half-lands.

**Item 2 of that issue — inheriting the package mark for a node with no icon of its own — is
untouched here and stays open.** It is explicitly refused by design today
(`SeoResolver.cs`: *"No synthesised badge… A node that carries no icon of its own simply keeps the
portal favicon"*), and reversing that refusal is a product call about what a tab should show for a
lesson page under a course — not a bug fix, and not something to decide inside a defect fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)