### PR TITLE
feat(#2483): the mesh verifies GitHub's OIDC itself — the JWKS branch + a BuildPrincipal node

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -74,6 +74,10 @@ public static class PluginBundleEndpoints
     /// <summary><see cref="HttpContext.Items"/> key holding the authenticated caller.</summary>
     private const string CallerItemKey = "PluginBundle.Caller";
 
+    /// <summary><see cref="HttpContext.Items"/> key holding the authenticated BUILD principal — a
+    /// different caller class from an installation, so a different slot (#2483).</summary>
+    private const string BuildCallerItemKey = "PluginBundle.BuildCaller";
+
     /// <summary>Maps the instance-key-gated bundle routes. Call alongside <c>MapPluginRegistry</c>.</summary>
     public static IEndpointRouteBuilder MapPluginBundles(this IEndpointRouteBuilder endpoints)
     {
@@ -101,7 +105,13 @@ public static class PluginBundleEndpoints
                 return InstanceAuthResponses.Unavailable(http, outcome.UnavailableReason, logger);
 
             var caller = outcome.Instance;
-            if (caller is null)
+            var build = outcome.Build;
+            // 🚨 A BUILD principal (#2483) is admitted on the PREBUILT routes ONLY. It is a CI run,
+            // not an installation: it has no instance record, no plan and no PluginGrant, so every
+            // other bundle route — which decides per package against exactly those — keeps refusing
+            // it with the same 401 as before. Narrowing here rather than inside each handler means
+            // a route added later is refused by default rather than by remembering to.
+            if (caller is null && (build is null || !IsPrebuiltRoute(http.Request.Path)))
             {
                 // 🚨 Fails CLOSED, with no anonymous escape hatch — unlike /api/plugins, which
                 // keeps one for local dev. These are compiled assemblies for PAID modules; "open
@@ -114,7 +124,10 @@ public static class PluginBundleEndpoints
                     statusCode: StatusCodes.Status401Unauthorized);
             }
 
-            http.Items[CallerItemKey] = caller;
+            if (caller is not null)
+                http.Items[CallerItemKey] = caller;
+            if (build is not null)
+                http.Items[BuildCallerItemKey] = build;
             return await next(ctx);
         });
 
@@ -190,27 +203,28 @@ public static class PluginBundleEndpoints
     {
         group.MapGet($"/{PrebuiltSegment}/{{identity}}/{{source}}",
             (HttpContext http, string identity, string source) =>
-                PrebuiltIndex(http, identity, source, Caller(http)));
+                PrebuiltIndex(http, identity, source, Caller(http), BuildCaller(http)));
         group.MapGet($"/{PrebuiltSegment}/{{identity}}/{{source}}/{{bundle}}",
             (HttpContext http, string identity, string source, string bundle) =>
-                PrebuiltBundle(http, identity, source, bundle, Caller(http)));
+                PrebuiltBundle(http, identity, source, bundle, Caller(http), BuildCaller(http)));
         // The module set a publication was sealed against (MeshWeaver#2698) — a consumer pinned to
         // this identity composes THESE bytes, never the package endpoint's. The literal segment wins
         // over {bundle} above, so a NodeType bundle named "modules" is not served here.
         group.MapGet($"/{PrebuiltSegment}/{{identity}}/{{source}}/{PublishedBundleCatalogue.ModulesDirectoryName}",
             (HttpContext http, string identity, string source) =>
-                PrebuiltModuleSet(http, identity, source, Caller(http)));
+                PrebuiltModuleSet(http, identity, source, Caller(http), BuildCaller(http)));
         group.MapGet($"/{PrebuiltSegment}/{{identity}}/{{source}}/{PublishedBundleCatalogue.ModulesDirectoryName}/{{bundle}}",
             (HttpContext http, string identity, string source, string bundle) =>
-                PrebuiltModule(http, identity, source, bundle, Caller(http)));
+                PrebuiltModule(http, identity, source, bundle, Caller(http), BuildCaller(http)));
     }
 
     /// <summary>The sealed publication's bundle names, or 404 when none is sealed for that
     /// identity/source, or 403 when the caller holds no whole-source grant on it.</summary>
     private static IResult PrebuiltIndex(
-        HttpContext http, string identity, string source, AuthenticatedInstance? caller)
+        HttpContext http, string identity, string source,
+        AuthenticatedInstance? caller, AuthenticatedBuild? build)
     {
-        if (PrebuiltDecision(http, identity, source, caller) is { } refused)
+        if (PrebuiltDecision(http, identity, source, caller, build) is { } refused)
             return refused;
         var directory = PrebuiltDirectory(http, identity, source);
         var sealed_ = directory is null ? null : PublishedBundleCatalogue.SealedBundlesOf(directory, Log(http));
@@ -224,9 +238,10 @@ public static class PluginBundleEndpoints
     /// <summary>One sealed bundle's bytes. A name the seal does not list is 404 even if the file
     /// exists — an unsealed file is not part of the publication.</summary>
     private static IResult PrebuiltBundle(
-        HttpContext http, string identity, string source, string bundle, AuthenticatedInstance? caller)
+        HttpContext http, string identity, string source, string bundle,
+        AuthenticatedInstance? caller, AuthenticatedBuild? build)
     {
-        if (PrebuiltDecision(http, identity, source, caller) is { } refused)
+        if (PrebuiltDecision(http, identity, source, caller, build) is { } refused)
             return refused;
         var directory = PrebuiltDirectory(http, identity, source);
         var sealed_ = directory is null ? null : PublishedBundleCatalogue.SealedBundlesOf(directory, Log(http));
@@ -241,9 +256,10 @@ public static class PluginBundleEndpoints
     /// is torn, or predates module sealing (republish it); an EMPTY list when the bake composed
     /// nothing. Same grant as the bundle index: a whole-source grant on the source.</summary>
     private static IResult PrebuiltModuleSet(
-        HttpContext http, string identity, string source, AuthenticatedInstance? caller)
+        HttpContext http, string identity, string source,
+        AuthenticatedInstance? caller, AuthenticatedBuild? build)
     {
-        if (PrebuiltDecision(http, identity, source, caller) is { } refused)
+        if (PrebuiltDecision(http, identity, source, caller, build) is { } refused)
             return refused;
         var directory = PrebuiltDirectory(http, identity, source);
         var reading = directory is null
@@ -259,9 +275,10 @@ public static class PluginBundleEndpoints
     /// <summary>One sealed module bundle's bytes. A name the module index does not list is 404
     /// even if the file exists — an unlisted file is not part of the sealed set.</summary>
     private static IResult PrebuiltModule(
-        HttpContext http, string identity, string source, string bundle, AuthenticatedInstance? caller)
+        HttpContext http, string identity, string source, string bundle,
+        AuthenticatedInstance? caller, AuthenticatedBuild? build)
     {
-        if (PrebuiltDecision(http, identity, source, caller) is { } refused)
+        if (PrebuiltDecision(http, identity, source, caller, build) is { } refused)
             return refused;
         if (!IsBareName(bundle))
             return Results.Json(new { error = "bundle must be a bare name" },
@@ -283,14 +300,23 @@ public static class PluginBundleEndpoints
     /// ledger like every other bundle route, so a refused fetch is as visible as a refused serve.
     /// </summary>
     private static IResult? PrebuiltDecision(
-        HttpContext http, string identity, string source, AuthenticatedInstance? caller)
+        HttpContext http, string identity, string source,
+        AuthenticatedInstance? caller, AuthenticatedBuild? build)
     {
-        if (caller is null)
+        if (caller is null && build is null)
             return Results.Json(new { error = "a registered instance key is required" },
                 statusCode: StatusCodes.Status401Unauthorized);
         if (!IsBareName(identity) || !IsBareName(source))
             return Results.Json(new { error = "identity and source must be bare names" },
                 statusCode: StatusCodes.Status400BadRequest);
+
+        // 🚨 The BUILD leg (#2483). A verified GitHub Actions token establishes WHICH repository
+        // asked; the admin-owned BuildPrincipal node decides whether it may fetch THIS source, on
+        // THIS event. It is the same shape as the instance leg one line below — credential resolves
+        // to identity, admin-owned node decides — so there is one thing to keep honest, not two.
+        if (caller is null)
+            return BuildDecision(http, source, build!);
+
         // A PLAN-LESS whole-source entry, specifically: a sealed publication carries every plan's
         // bundles, so a plan-scoped `<source>/*@pro` — which licenses that source's packages one by
         // one, by tier — must never fetch the publication whole.
@@ -309,6 +335,42 @@ public static class PluginBundleEndpoints
             : Results.Json(
                 new { error = $"instance '{caller.Instance.InstanceId}' is not granted source '{source}'" },
                 statusCode: StatusCodes.Status403Forbidden);
+    }
+
+    /// <summary>
+    /// The build principal's half of <see cref="PrebuiltDecision"/>: <c>fetch:&lt;source&gt;</c> on
+    /// the repository's own <see cref="BuildPrincipal"/>, decided against the run's <c>event_name</c>
+    /// and <c>ref</c> (#2483).
+    ///
+    /// <para>🚨 The refusal BODY names the repository and the source and nothing else. The reason —
+    /// which check failed — goes to the log and the entitlement ledger, because the URL space here
+    /// is fully predictable and a reason that distinguishes "wrong event" from "no scope" from "no
+    /// such publication" is an inventory oracle over every source this registry holds.</para>
+    /// </summary>
+    private static IResult? BuildDecision(HttpContext http, string source, AuthenticatedBuild build)
+    {
+        var refusal = build.Refuse(BuildVerbs.Fetch, source, DateTimeOffset.UtcNow);
+        var allowed = refusal is null;
+        Ledger(http)?.Record(new EntitlementDecision(
+            $"{PrebuiltSegment}/{source}",
+            allowed ? EntitlementOutcome.Granted : EntitlementOutcome.Denied,
+            EntitlementAnchorKind.Registry,
+            source,
+            true,
+            allowed
+                ? $"build principal {build.PrincipalPath} holds '{BuildPrincipal.Scope(BuildVerbs.Fetch, source)}' "
+                  + $"for {build.Repository} on event '{build.Claims.EventName}'"
+                : $"build principal {build.PrincipalPath} ({build.Repository}, event "
+                  + $"'{build.Claims.EventName}'): {refusal}"));
+        if (allowed)
+            return null;
+
+        Log(http)?.LogWarning(
+            "Plugin bundles: build principal {Path} refused for source {Source} — {Reason}",
+            build.PrincipalPath, source, refusal);
+        return Results.Json(
+            new { error = $"repository '{build.Repository}' may not fetch source '{source}'" },
+            statusCode: StatusCodes.Status403Forbidden);
     }
 
     private static string? PrebuiltDirectory(HttpContext http, string identity, string source)
@@ -477,6 +539,16 @@ public static class PluginBundleEndpoints
     /// </summary>
     private static AuthenticatedInstance? Caller(HttpContext http) =>
         http.Items.TryGetValue(CallerItemKey, out var value) ? value as AuthenticatedInstance : null;
+
+    /// <summary>The authenticated BUILD principal the filter stamped, or <c>null</c> (#2483). Same
+    /// contract as <see cref="Caller"/>: null is "granted nothing", never "unscoped".</summary>
+    private static AuthenticatedBuild? BuildCaller(HttpContext http) =>
+        http.Items.TryGetValue(BuildCallerItemKey, out var value) ? value as AuthenticatedBuild : null;
+
+    /// <summary>Whether <paramref name="path"/> is one of the prebuilt-publication routes — the only
+    /// ones a build principal may reach.</summary>
+    private static bool IsPrebuiltRoute(PathString path) =>
+        path.StartsWithSegments($"{RoutePrefix}/{PrebuiltSegment}");
 
     /// <summary>
     /// 🚨 <b>THE PER-PACKAGE AUTHORIZATION</b> (#1772), now anchored on the REGISTRY (#1782 gap 2) —

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -929,6 +929,178 @@ Pinned by `ApiTokenCapabilityFreshnessTest` (core) and `PaywallRealGateShapeTest
 
 ---
 
+# Build principals — a repository the mesh trusts, with no secret to keep
+
+A `BuildPrincipal` node is the third caller class on the registry surface, beside a signed-in
+**user** and a registered **instance**. Its subject is a **GitHub repository's CI**, it presents a
+short-lived OIDC token GitHub mints for the run, and there is no credential anywhere to store,
+rotate or leak. Introduced by #2483; the surrounding delivery design is
+[Plugin build contract](/Doc/Architecture/PluginBuildContract) → *The build principal*.
+
+## Why it exists
+
+Fetching an upstream's sealed publication needed an Azure OIDC identity whose federated credentials
+live in the Entra tenant — four of them, every one scoped to `ref:refs/heads/main`, none for
+`pull_request`, so a gate could not fetch on the one event it exists for (`AADSTS700213`, measured
+2026-08-27 on `MeshWeaver.SocialMedia#84` and `MeshWeaver.Reinsurance#100`). Nothing in the mesh
+recorded that those credentials existed, which repositories held one, or who authorised them.
+
+That is the shape of the plaintext-provider-key incident: **a security fact with no record a reader
+can point at.** Here the rule IS a node — `search nodeType:BuildPrincipal` is the complete list of
+repositories this mesh trusts and exactly what each may do, and revoking one is a node write.
+
+|  | Azure OIDC federated credential | Build principal |
+|---|---|---|
+| what is stored | a subject rule, in Entra | a subject rule, on a mesh node |
+| who can see which repos may fetch | whoever has tenant access | `search nodeType:BuildPrincipal` |
+| PR vs main | one credential per event subject, per subject *format* | one node; `event_name` is a claim it reads |
+| secret in the repo | none (already) | none |
+| verified by | Azure | the mesh, the way it already verifies `mwa_` tokens |
+
+## One verifier, two issuers, a trust node per issuer
+
+`InstanceRegistryAuthenticator.AuthenticateToken` forks on the token's `iss` claim, read
+**unverified**, and that read only picks a verifier — it grants nothing, and every claim that
+matters (`iss` included) is re-read from the verified payload afterwards.
+
+| `iss` | verified against | resolves to |
+|---|---|---|
+| the registry itself | `SyncTokenSigningKeyService`'s HMAC material (HS256) | a `MeshWeaverInstance` + its `PluginGrant` |
+| `https://token.actions.githubusercontent.com` | GitHub's published JWKS (RS256) | a `BuildPrincipal` node |
+
+Neither leg ever honours a token's own `alg`. The HS256 leg accepts `HS256` and nothing else; the
+RS256 leg accepts `RS256` and nothing else, so `alg: none` and an RSA-public-key-as-HMAC-secret
+forgery are refused before a key is looked up at all.
+
+## 🚨 A verified signature is not an authorization
+
+**Every workflow run on GitHub carries a token signed by these same keys.** The signature establishes
+only *which repository, on which event, asked*. A verifier that checked it and stopped would
+authenticate the entire public GitHub's CI.
+
+So the token is checked on five things — signature, `iss`, `aud`, validity window, and a non-empty
+`repository` — and then resolved to a node. **No node ⇒ no caller ⇒ 401.**
+
+* **`aud` is mandatory and unconfigured means REFUSE.** A registry with no
+  `Plugins:Registry:BuildPrincipalAudience` has no build-principal surface at all, rather than one
+  that accepts any audience. The audience is the only claim that distinguishes a token minted for
+  *this* registry from one a workflow legitimately minted for Azure and someone replayed here.
+* **`iss` is pinned in code, never configurable.** A configurable issuer is a configurable trust
+  anchor: one overlay pointing it at another key set and every claim below is attacker-authored.
+* **The path is a routing hint; the record is the authority.** `Admin/_BuildPrincipal/{owner}--{repo}`
+  routes the read, and the node's own `repository` is then compared with the claim again. The match
+  is exact — never a prefix, or `Systemorph/MeshWeaver.Evil` authenticates as `Systemorph/MeshWeaver`.
+
+## The node
+
+It lives at `Admin/_BuildPrincipal/{owner}--{repo}`, in the **Admin partition** — the same place
+`PluginGrant` lives and for the same reason: *the subject of an access decision must not be able to
+write the decision*. The partition's own access control **is** the global-admin gate, not a second
+role check beside it that could drift.
+
+```json
+{
+  "$type": "BuildPrincipal",
+  "repository": "Systemorph/MeshWeaver.SocialMedia",
+  "repositoryId": "123456789",
+  "events":    { "push": ["publish", "fetch"], "pull_request": ["fetch"] },
+  "eventRefs": { "push": ["refs/heads/main"] },
+  "scopes":    ["publish:socialmedia", "fetch:plugins"],
+  "issuedBy": "…", "issuedAt": "2026-09-01T00:00:00Z"
+}
+```
+
+| field | meaning |
+|---|---|
+| `repository` | the `repository` claim it must match, exactly |
+| `repositoryId` / `repositoryOwnerId` | optional pins on GitHub's **immutable** numeric ids — a name can be renamed and re-registered, an id cannot |
+| `events` | which `event_name`s may act, with which verbs. An event that is not a key here may do nothing |
+| `eventRefs` | optional per-event pin on the run's `ref`, so "`push` **on main** may publish" is expressible rather than merely intended. An event with no entry is not ref-constrained — a `pull_request` ref is `refs/pull/<n>/merge` and cannot be enumerated in advance |
+| `scopes` | `verb:source`, matched exactly on both halves. **No wildcard**: `fetch:*` is a scope for a source literally named `*` |
+| `issuedBy` / `issuedAt` | the audit trail the Entra credentials could not answer |
+| `lastSeen` | advisory, and **nothing writes it yet** — stamping it on the authentication path is a write per request, so an absent value means *not recorded*, never *never used* |
+| `requestedAction` / `isRevoked` | the stop, below |
+
+**The scope split is the security tie.** The identity that publishes a source is the identity that
+may fetch what it depends on, and it can do neither outside its scopes: SocialMedia's principal holds
+`publish:socialmedia` + `fetch:plugins`, so it can never publish *as* Plugins and never fetch a
+source it does not declare in `requires`. Both facts on one node.
+
+### Creating and revoking one
+
+Both are ordinary node writes into the Admin partition — `create` the node, or write
+`requestedAction: "Revoke"` onto it. There is no bespoke request type and no service: `stream.Update`
+(and the `create`/`patch` tools that ride it) is the only mutation API, and the Admin partition is
+the gate.
+
+🚨 **The revoke is honoured immediately, not folded by a watcher.** `BuildPrincipal.IsActive` reads
+`requestedAction` itself, so a principal stops authenticating on the very next request, on every
+replica, with nothing running in between. `isRevoked: true` is the equivalent permanent form for an
+admin who wants the record to read as revoked rather than as *asked to be*. **A security stop that
+waits for a reactor is a security stop with a window.**
+
+## Both subject formats, or a valid principal silently stops working
+
+This fleet's federated credentials already carry two forms — `repo:Systemorph/<repo>:ref:…` and the
+immutable `repo:Systemorph@<orgId>/<repo>@<repoId>:ref:…`. Matching is therefore done on a
+**normalized** `owner/name`: an `@<all-digits>` suffix is stripped from either half, which is
+unambiguous because neither a GitHub login nor a repository name may contain `@`. Both forms also
+resolve to the **same** node path. Without this, the day GitHub moves an organisation onto immutable
+ids is the day every build principal in the fleet stops authenticating and nobody changed anything.
+
+## JWKS: cached, bounded, and fail-closed
+
+`GitHubOidcKeyService` is a **mesh-scoped singleton holding the key set on an instance field** — never
+a static cache, which would outlive the mesh and bleed across tests and deployments. The HTTP read
+runs through `IIoPool`, and the promise is held so concurrent callers share one round trip; a failure
+nulls it, so the next caller starts a genuinely new attempt rather than replaying a latched
+`OnError`.
+
+* **Discovery may move the path, never the host.** The `jwks_uri` a discovery document advertises is
+  accepted only when it is HTTPS on the pinned issuer's own host; otherwise the pinned
+  `/.well-known/jwks` is used.
+* **Refresh is bounded twice.** The set is re-read when older than an hour; an unknown `kid` — the
+  signal of a GitHub key rotation — may force **one** early re-read, but only past a one-minute
+  floor. Without that floor a caller presenting invented key ids turns every unauthenticated request
+  into an outbound fetch.
+
+### 🚨 Undetermined is a third state, and it must not authenticate
+
+A key set that cannot be read is **not** a denial and certainly not an admission. The read errors,
+the authenticator answers `InstanceAuthResult.Unavailable`, and the endpoint answers **503 +
+`Retry-After`** — never the 401 a genuinely bad token gets. This is the same distinction the
+instance-key leg adopted in #2695 and the same rule core #2901 states generally: *collapsing an
+unreachable check into a boolean is a defect.* A build told "your identity is unknown" goes hunting
+for a credential that was never the problem.
+
+The unknown-`kid` case is graded rather than flattened:
+
+| what happened | answer |
+|---|---|
+| the key set was re-read and still does not hold the key | **401** — GitHub does not publish it. A verdict |
+| the refresh floor suppressed the re-read | **503** — nothing was established; ask again past the floor |
+
+## The node is read on every request — only the JWKS is cached
+
+The instance leg caches its verdict for a minute because an install *polls*; a build asks a handful
+of times per run, so there is nothing to buy by caching it and a revocation window to lose. Reading
+the node every time is what makes `requestedAction: Revoke` take effect at once rather than when a
+verdict cache expires.
+
+## Where a build principal is admitted
+
+Only the **prebuilt-publication routes** (`/api/plugins/bundles/prebuilt/…`), requiring
+`fetch:<source>`. A build is not an installation: it has no instance record, no plan and no
+`PluginGrant`, so every other bundle route — which decides per package against exactly those — keeps
+refusing it with the same 401 as before. The narrowing is expressed once, in the group filter, so a
+route added later is refused by default rather than by remembering to.
+
+Pinned by `GitHubBuildTokenTest`, `BuildPrincipalDecisionTest` and `BuildPrincipalAuthenticationTest`
+(core, `Memex.Portal.Shared.Test`). Every refusal there starts from a token that WOULD be accepted
+and moves exactly one thing, so a passing assertion can only mean that one thing was checked.
+
+---
+
 # Hierarchical access pattern
 
 ```mermaid

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginBuildContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginBuildContract.md
@@ -215,19 +215,28 @@ published JWKS instead of the mesh's own keys. The portal already references
 `Microsoft.Identity.Web`, so the JWKS fetch and signature check are library calls, not new
 dependencies.
 
-**The rule lives on `Store/BuildPrincipal`** — a control node in the shape every admin action here
+**The rule lives on a `BuildPrincipal` node** — a control node in the shape every admin action here
 already takes (`Store/Provision`, `Store/Enrollment`). It records what a stored secret never could:
 
 | field | meaning |
 |---|---|
-| `repository` | `Systemorph/MeshWeaver.SocialMedia` — the `repository` claim it must match |
-| `events` | which `event_name`s may act — `push` on `main` may *publish*; `pull_request` may only *fetch* |
+| `repository` | `Systemorph/MeshWeaver.SocialMedia` — the `repository` claim it must match, exactly |
+| `repositoryId` | optional pin on GitHub's IMMUTABLE numeric id — a name can be renamed and re-registered, an id cannot |
+| `events` | which `event_name`s may act — `push` may *publish*; `pull_request` may only *fetch* |
+| `eventRefs` | optional per-event `ref` pin, so "`push` **on main** may publish" is expressible rather than merely intended |
 | `scopes` | `publish:socialmedia`, `fetch:plugins` — what this repo may bake INTO the registry and install FROM it |
 | `issuedBy` / `issuedAt` / `lastSeen` | the audit trail |
 
-A global admin `create`s it; `requestedAction: Revoke` ends it. `search nodeType:Store/BuildPrincipal`
+A global admin `create`s it; `requestedAction: Revoke` ends it. `search nodeType:BuildPrincipal`
 lists every repo the mesh trusts and exactly what each may do. There is no key to lose because
 there is no key.
+
+> 🚨 **It is a CORE node type, `BuildPrincipal`, at `Admin/_BuildPrincipal/{owner}--{repo}` — not a
+> `Store/…` one.** The issue drafted it under `Store/` beside the other control nodes, but the
+> verifier that reads it is the registry's own `InstanceRegistryAuthenticator`, which is platform C#
+> and cannot depend on a package's in-mesh node type. It sits in the **Admin partition** for the same
+> reason `PluginGrant` does: the subject of an access decision must not be able to write the
+> decision, and that partition's access control IS the global-admin gate.
 
 **The security tie is the scope split.** The identity that publishes a source is the identity that
 may fetch what it depends on, and it can do neither outside its scopes: SocialMedia's principal
@@ -258,9 +267,18 @@ The two are the same idea; the difference is **where the rule lives and who can 
 mesh owns is a rule the mesh can audit, list, and revoke as a node — and it cannot silently drift
 into the state the first `upstream-seed` run found, where every credential covered the wrong event.
 
-**Until this lands** the Azure route in `upstream-seed` works on `main` and fails on PRs
-(`AADSTS700213`); that is recorded on the PRs that hit it. Provisioning a `pull_request` credential
-in Entra would make it work — and would be one more rule in the wrong place.
+**What has landed.** The registry serves publications under its own authenticator (#2487), the
+verifier's GitHub leg and the `BuildPrincipal` node type shipped with #2483, and a build principal is
+admitted on the prebuilt routes requiring `fetch:<source>` — the full mechanics, the refusal matrix
+and the fail-closed rules are in
+[Access control](/Doc/Architecture/AccessControl) → *Build principals*.
+
+**What has not.** `upstream-seed` still logs in to Azure rather than presenting its run's OIDC token,
+so on a pull request it still hits `AADSTS700213`; that is recorded on the PRs that hit it. The
+workflow change is a satellite-repo edit (`ACTIONS_ID_TOKEN_REQUEST_URL` with
+`audience=<registry>` → `Authorization: Bearer` → the prebuilt GET), and the registry side is now
+waiting for it rather than the other way round. Provisioning a `pull_request` credential in Entra
+would also make it work — and would be one more rule in the wrong place.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-the-mesh-trusts-a-build-without-holding-a-secret.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-the-mesh-trusts-a-build-without-holding-a-secret.md
@@ -1,0 +1,45 @@
+---
+Name: The mesh trusts a build without holding a secret
+Category: Feature
+Description: A repository's CI can now authenticate to the registry with the OIDC token GitHub already mints for the run, checked against a Build Principal node an admin can list and revoke — no key stored anywhere, and no rule left in a cloud tenant nobody can query.
+Icon: ShieldCheckmark
+Order: -20260901
+---
+
+# The mesh trusts a build without holding a secret
+
+Until now, a build that needed something from the registry had to prove itself with a credential
+somebody had provisioned: an identity in a cloud tenant, with a matching rule alongside it. The
+result was a security fact nobody in the mesh could see. Which repositories were trusted, on which
+events, by whose decision — the only way to find out was to have access to the tenant, and the only
+way to discover that a rule covered the wrong event was to run a build and read the error.
+
+**A GitHub Actions run already carries a passkey for services.** It can ask GitHub for a short-lived,
+signed token describing itself — which repository, which event, which branch. Verifying that token is
+all a federated credential ever did. So the mesh does it itself, and the rule that decides what the
+build may do now lives on a node:
+
+```
+search nodeType:BuildPrincipal
+```
+
+That is the complete list of repositories this deployment trusts and exactly what each may do —
+readable, auditable, and revocable the way every other record is. Nothing is minted, rotated, pasted
+into a repository's secrets, or able to leak, **because there is no key**.
+
+A principal records the repository, which events may act and with which verbs, and the sources it may
+fetch from or publish to. The scope split is the security tie: the identity that publishes a source is
+the identity that may fetch what it depends on, and it can do neither outside its scopes. A global
+admin creates one; writing `requestedAction: Revoke` ends it, and the stop takes effect on the very
+next request rather than when something notices.
+
+**A verified signature is deliberately not enough.** Every workflow run on GitHub carries a token
+signed by the same keys, so the signature says only *which* repository asked; a repository with no
+node is refused like any stranger, and the repository is matched exactly — never as a prefix. The
+audience is mandatory, so a deployment that has not configured one has no build-principal surface at
+all rather than one that accepts anything. And when GitHub's signing keys cannot be read, the answer
+is **"try again", not "your identity is unknown"** — an unreachable check is a third state, and a
+build sent hunting for a credential that was never the problem is a wasted afternoon.
+
+Build principals are admitted on the sealed-publication routes only. A build is not an installation:
+it holds no licence and no plan, so every other route refuses it exactly as before.

--- a/src/MeshWeaver.Graph/Configuration/MeshWeaverInstanceNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/MeshWeaverInstanceNodeType.cs
@@ -61,6 +61,15 @@ public static class MeshWeaverInstanceNodeType
     public const string ConsentPath = $"{ConsentNamespace}/{ConsentId}";
 
     /// <summary>
+    /// The node-type identifier for BUILD principals (<see cref="BuildPrincipal"/>) — the repository
+    /// rules a GitHub Actions OIDC token is checked against (#2483). Lives in the <b>Admin</b>
+    /// partition (<see cref="BuildPrincipal.Namespace"/>) for the same reason
+    /// <see cref="PluginGrant"/> does: the subject of an access decision must not be able to write
+    /// the decision, and the Admin partition IS the global-admin gate.
+    /// </summary>
+    public const string BuildPrincipalNodeType = "BuildPrincipal";
+
+    /// <summary>
     /// Registers both node types on the mesh builder and puts their content types in the hub's
     /// type registry so they serialize across silos (without this, a cross-silo create fails with
     /// "NodeType 'MeshWeaverInstance' is not registered" — same trap ApiToken hit).
@@ -69,10 +78,12 @@ public static class MeshWeaverInstanceNodeType
         where TBuilder : MeshBuilder
     {
         builder.AddMeshNodes(
-            CreateMeshNode(), CreateGrantMeshNode(), CreateRegistrationKeyMeshNode(), CreateConsentMeshNode());
+            CreateMeshNode(), CreateGrantMeshNode(), CreateRegistrationKeyMeshNode(), CreateConsentMeshNode(),
+            CreateBuildPrincipalMeshNode());
         // An instance is infrastructure identity, not content — keep all of these out of
         // autocomplete so they never surface as pickable nodes in the composer.
-        builder.AddAutocompleteExcludedTypes(NodeType, GrantNodeType, RegistrationKeyNodeType, ConsentNodeType);
+        builder.AddAutocompleteExcludedTypes(
+            NodeType, GrantNodeType, RegistrationKeyNodeType, ConsentNodeType, BuildPrincipalNodeType);
         builder.ConfigureHub(config => config
             .WithType<MeshWeaverInstance>(nameof(MeshWeaverInstance))
             .WithType<MeshWeaverInstanceIndex>(nameof(MeshWeaverInstanceIndex))
@@ -80,9 +91,27 @@ public static class MeshWeaverInstanceNodeType
             .WithType<PluginGrantEntry>(nameof(PluginGrantEntry))
             .WithType<RegistrationKey>(nameof(RegistrationKey))
             .WithType<RegistrationKeyIndex>(nameof(RegistrationKeyIndex))
-            .WithType<InstanceConsent>(nameof(InstanceConsent)));
+            .WithType<InstanceConsent>(nameof(InstanceConsent))
+            .WithType<BuildPrincipal>(nameof(BuildPrincipal)));
         return builder;
     }
+
+    /// <summary>
+    /// The <see cref="BuildPrincipal"/> node definition — one node per repository this mesh trusts
+    /// to act as a build, in the Admin partition so only a global admin can create or revoke one.
+    /// <c>search nodeType:BuildPrincipal</c> is the complete list, which is precisely what the Entra
+    /// federated credentials it replaces could not answer.
+    /// </summary>
+    /// <returns>The node definition.</returns>
+    public static MeshNode CreateBuildPrincipalMeshNode() => new(BuildPrincipalNodeType)
+    {
+        Name = "Build Principal",
+        IsSatelliteType = false,
+        ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source
+                .WithContentType<BuildPrincipal>())
+    };
 
     /// <summary>The <see cref="InstanceConsent"/> node definition. One record in the Admin
     /// partition; the partition's access control is what keeps everyone but a global admin from

--- a/src/MeshWeaver.Mesh.Contract/Security/BuildPrincipal.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/BuildPrincipal.cs
@@ -1,0 +1,313 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// A repository the mesh trusts to act as a BUILD — the rule GitHub's OIDC token is checked against
+/// (#2483), and the whole reason there is no secret to keep.
+///
+/// <para><b>What this replaces.</b> Fetching an upstream's sealed publication used to need an Azure
+/// OIDC identity whose federated credentials live in the Entra tenant: four of them, every one scoped
+/// to <c>ref:refs/heads/main</c>, none for <c>pull_request</c> — so a gate could not fetch on the one
+/// event it exists for (<c>AADSTS700213</c>, measured 2026-08-27). Nothing in the mesh recorded that
+/// those credentials existed, which repos held one, or who authorised them. That is the shape of the
+/// plaintext-provider-key incident: a security fact with no record a reader can point at. Here the
+/// rule IS a node — <c>search nodeType:BuildPrincipal</c> is the complete list of repositories this
+/// mesh trusts and exactly what each may do.</para>
+///
+/// <para>🚨 <b>It lives in the Admin partition</b> (<see cref="Namespace"/>), exactly like
+/// <see cref="PluginGrant"/> and for exactly the same reason: the subject of an access decision must
+/// not be able to write the decision. Only a global admin can write there
+/// (<c>Doc/Architecture/AccessControl</c> → "The Admin partition"), which IS the gating — not a
+/// second role check beside it that could drift.</para>
+///
+/// <para>🚨 <b>The path is a routing hint; the record is the authority.</b> A principal is looked up
+/// at <see cref="BuildPrincipal.NodeId"/> of the token's <c>repository</c> claim, and then
+/// <see cref="Repository"/> on the node it found is compared with the claim again
+/// (<see cref="GitHubActionsToken.RepositoryEquals"/>). The match is EXACT — never a prefix, never a
+/// wildcard. Same discipline as <see cref="MeshWeaverInstanceIndex"/>, and for the same reason: an
+/// index that has drifted must not authenticate anybody.</para>
+///
+/// <para><b>Revocation is immediate, not deferred.</b> Setting <see cref="RequestedAction"/> to
+/// <see cref="BuildPrincipalActions.Revoke"/> stops this principal authenticating on the very next
+/// request, on every replica, before any watcher has folded it into <see cref="IsRevoked"/>. A
+/// security stop that waits for a reactor is a security stop with a window.</para>
+/// </summary>
+public record BuildPrincipal
+{
+    /// <summary>The <c>_BuildPrincipal</c> namespace under the <b>Admin</b> partition. Mirrors
+    /// <c>Admin/_PluginGrant</c>: an access decision, in the one partition its subject cannot
+    /// write.</summary>
+    public const string Namespace = "Admin/_BuildPrincipal";
+
+    /// <summary>
+    /// The repository this principal speaks for, as GitHub's <c>repository</c> claim names it —
+    /// <c>Systemorph/MeshWeaver.SocialMedia</c>. Compared with
+    /// <see cref="GitHubActionsToken.RepositoryEquals"/>, so an admin may write either the classic
+    /// form or GitHub's immutable <c>owner@id/name@id</c> form and both keep matching.
+    /// </summary>
+    public string Repository { get; init; } = "";
+
+    /// <summary>
+    /// Optional pin on GitHub's immutable numeric repository id (<c>repository_id</c>). When set it
+    /// must match exactly. Names can be renamed and re-registered; an id cannot — so pinning it is
+    /// the strongest form of this rule, and leaving it null is the ordinary one.
+    /// </summary>
+    public string? RepositoryId { get; init; }
+
+    /// <summary>Optional pin on the owner's immutable numeric id (<c>repository_owner_id</c>). Same
+    /// contract as <see cref="RepositoryId"/>.</summary>
+    public string? RepositoryOwnerId { get; init; }
+
+    /// <summary>
+    /// Which <c>event_name</c>s may act, and with which verbs — <c>{ "push": ["publish", "fetch"],
+    /// "pull_request": ["fetch"] }</c>. An event that is not a key here may do nothing at all, so
+    /// this is also the list of events this repository is trusted on. Verbs are
+    /// <see cref="BuildVerbs"/> values, matched case-insensitively.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyCollection<string>> Events { get; init; } =
+        ImmutableDictionary<string, IReadOnlyCollection<string>>.Empty;
+
+    /// <summary>
+    /// Optional per-event pin on the run's <c>ref</c> claim — <c>{ "push": ["refs/heads/main"] }</c>
+    /// — so "<c>push</c> on <c>main</c> may publish" is expressible rather than merely intended. An
+    /// event with no entry here (or an empty list) is NOT ref-constrained, which is the right default
+    /// for <c>pull_request</c>: its ref is <c>refs/pull/&lt;n&gt;/merge</c> and cannot be enumerated
+    /// in advance. Matched ordinally — a git ref is a wire identifier, not operator prose.
+    /// </summary>
+    public IReadOnlyDictionary<string, IReadOnlyCollection<string>> EventRefs { get; init; } =
+        ImmutableDictionary<string, IReadOnlyCollection<string>>.Empty;
+
+    /// <summary>
+    /// What this repository may do, as <c>verb:source</c> — <c>publish:socialmedia</c>,
+    /// <c>fetch:plugins</c>. This is the security tie: the identity that publishes a source is the
+    /// identity that may fetch what it depends on, and it can do neither outside this list. Matched
+    /// EXACTLY on both halves — no wildcard, no prefix. A <c>fetch:*</c> would be an all-sources
+    /// grant written to look like a scope.
+    /// </summary>
+    public IReadOnlyCollection<string> Scopes { get; init; } = [];
+
+    /// <summary>ObjectId of the global admin who created this principal. Part of the record because
+    /// "who authorised this" is exactly what the Entra credentials could not answer.</summary>
+    public string IssuedBy { get; init; } = "";
+
+    /// <summary>When it was created.</summary>
+    public DateTimeOffset IssuedAt { get; init; }
+
+    /// <summary>Optional end of term. Null = until revoked. A build principal for a one-off
+    /// migration should carry one.</summary>
+    public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// Last time a run authenticated against this principal. Advisory — never consulted by a
+    /// decision.
+    ///
+    /// <para>🚨 <b>Nothing writes it yet, deliberately.</b> Stamping it on the authentication path
+    /// is a write per request, and the instance side only does it under a single-flight freshness
+    /// discipline (<c>ApiToken.LastUsedAt</c>) that this leg has not needed yet. The field is here
+    /// because the design names it and an admin may set it by hand; read an ABSENT value as "not
+    /// recorded", never as "never used".</para>
+    /// </summary>
+    public DateTimeOffset? LastSeen { get; init; }
+
+    /// <summary>
+    /// The control-plane verb, in the shape every admin action here already takes
+    /// (<c>Store/Provision</c>, <c>Store/Enrollment</c>): write
+    /// <see cref="BuildPrincipalActions.Revoke"/> and this principal stops authenticating
+    /// immediately. Never a request message — the field IS the request
+    /// (<c>Doc/Architecture/RequestViaStreamUpdate</c>).
+    /// </summary>
+    public string? RequestedAction { get; init; }
+
+    /// <summary>
+    /// The permanent form of a revocation, for an admin who wants the record to read as revoked
+    /// rather than as "asked to be". <see cref="RequestedAction"/> and this field are EQUIVALENT to
+    /// the decision — <see cref="IsActive"/> refuses on either — so nothing has to run in between
+    /// for a revoke to take effect.
+    /// </summary>
+    public bool IsRevoked { get; init; }
+
+    /// <summary>When it was revoked.</summary>
+    public DateTimeOffset? RevokedAt { get; init; }
+
+    /// <summary>ObjectId of the admin who revoked it.</summary>
+    public string? RevokedBy { get; init; }
+
+    /// <summary>Why this principal exists, in the issuer's words — a ticket, a repo owner, the
+    /// upstream it seeds. Free text and advisory.</summary>
+    public string? Notes { get; init; }
+
+    /// <summary>
+    /// Whether this principal is live at <paramref name="now"/> — not revoked, not asked to be
+    /// revoked, within its term.
+    /// </summary>
+    /// <param name="now">The instant to judge.</param>
+    /// <returns>True when it may still authenticate anything.</returns>
+    public bool IsActive(DateTimeOffset now) =>
+        !IsRevoked
+        && !string.Equals(RequestedAction, BuildPrincipalActions.Revoke, StringComparison.OrdinalIgnoreCase)
+        && (ExpiresAt is null || ExpiresAt > now);
+
+    /// <summary>
+    /// Whether the run described by <paramref name="claims"/> may perform <paramref name="verb"/> on
+    /// registry source <paramref name="source"/> at <paramref name="now"/>.
+    ///
+    /// <para>🚨 <paramref name="now"/> is an ARGUMENT, never the ambient clock: this is an
+    /// authorization decision, so it has to be reproducible in a test at a chosen instant. Same rule
+    /// as <see cref="PluginGrant.Allows(string,string,DateTimeOffset)"/>.</para>
+    /// </summary>
+    /// <param name="claims">The verified token claims.</param>
+    /// <param name="verb">A <see cref="BuildVerbs"/> value.</param>
+    /// <param name="source">The registry source name.</param>
+    /// <param name="now">The instant to decide at.</param>
+    /// <returns>True when every check passes.</returns>
+    public bool Allows(GitHubBuildClaims? claims, string? verb, string? source, DateTimeOffset now) =>
+        Refuse(claims, verb, source, now) is null;
+
+    /// <summary>
+    /// The reason this principal refuses the run, or null when it allows it — one implementation
+    /// behind <see cref="Allows"/> so the log line and the decision cannot disagree.
+    ///
+    /// <para>🚨 The reason is for the LOG and the entitlement ledger, never for the HTTP body. A
+    /// refusal that says which check failed is an oracle over a fully predictable URL space — the
+    /// same reasoning that makes a refused bundle byte-identical to "no such bundle".</para>
+    /// </summary>
+    /// <param name="claims">The verified token claims.</param>
+    /// <param name="verb">A <see cref="BuildVerbs"/> value.</param>
+    /// <param name="source">The registry source name.</param>
+    /// <param name="now">The instant to decide at.</param>
+    /// <returns>The refusal reason, or null when allowed.</returns>
+    public string? Refuse(GitHubBuildClaims? claims, string? verb, string? source, DateTimeOffset now)
+    {
+        if (claims is null)
+            return "no verified claims";
+        if (string.IsNullOrWhiteSpace(verb) || string.IsNullOrWhiteSpace(source))
+            return "the request named no verb or no source";
+        if (!IsActive(now))
+            return IsRevoked
+                || string.Equals(RequestedAction, BuildPrincipalActions.Revoke, StringComparison.OrdinalIgnoreCase)
+                ? "the build principal is revoked"
+                : "the build principal's term has ended";
+
+        // The path routed us here; the RECORD decides. A drifted or hand-edited index must not
+        // authenticate a repository the node does not name.
+        if (!GitHubActionsToken.RepositoryEquals(Repository, claims.Repository))
+            return $"the node declares repository '{Repository}' but the token claims '{claims.Repository}'";
+
+        // Optional immutable pins. Absent means "not pinned"; present means EXACT.
+        if (!string.IsNullOrWhiteSpace(RepositoryId)
+            && !string.Equals(RepositoryId.Trim(), claims.RepositoryId, StringComparison.Ordinal))
+            return "the pinned repository id does not match the token";
+        if (!string.IsNullOrWhiteSpace(RepositoryOwnerId)
+            && !string.Equals(RepositoryOwnerId.Trim(), claims.RepositoryOwnerId, StringComparison.Ordinal))
+            return "the pinned repository owner id does not match the token";
+
+        if (string.IsNullOrWhiteSpace(claims.EventName))
+            return "the token carries no event_name";
+        var verbs = Lookup(Events, claims.EventName);
+        if (verbs is null)
+            return $"event '{claims.EventName}' is not listed on this principal";
+        if (!verbs.Any(v => string.Equals(v, verb, StringComparison.OrdinalIgnoreCase)))
+            return $"event '{claims.EventName}' may not '{verb}'";
+
+        // A ref pin applies only to the events that declare one — see EventRefs.
+        var refs = Lookup(EventRefs, claims.EventName);
+        if (refs is { Count: > 0 }
+            && !refs.Any(r => string.Equals(r, claims.Ref, StringComparison.Ordinal)))
+            return $"ref '{claims.Ref}' is not permitted for event '{claims.EventName}'";
+
+        var wanted = Scope(verb, source);
+        return Scopes.Any(s => string.Equals(NormalizeScope(s), wanted, StringComparison.Ordinal))
+            ? null
+            : $"the principal holds no '{wanted}' scope";
+    }
+
+    /// <summary>The canonical <c>verb:source</c> scope string for a request.</summary>
+    /// <param name="verb">A <see cref="BuildVerbs"/> value.</param>
+    /// <param name="source">The registry source name.</param>
+    /// <returns>The normalized scope string.</returns>
+    public static string Scope(string? verb, string? source) =>
+        $"{(verb ?? "").Trim().ToLowerInvariant()}:{(source ?? "").Trim().ToLowerInvariant()}";
+
+    /// <summary>
+    /// The node id a repository resolves to — lowercase, <c>/</c> folded to <c>--</c>, and every
+    /// character outside <c>[a-z0-9._-]</c> replaced, so the id is deterministic and path-safe.
+    /// GitHub owner and repository names are case-insensitive, so lowercasing cannot collide two
+    /// distinct repositories.
+    /// </summary>
+    /// <param name="repository">A <c>repository</c> claim or a declared repository.</param>
+    /// <returns>The node id, or an empty string when the repository is blank.</returns>
+    public static string NodeId(string? repository)
+    {
+        var normalized = GitHubActionsToken.NormalizeRepository(repository);
+        if (normalized.Length == 0)
+            return "";
+        var builder = new System.Text.StringBuilder(normalized.Length + 1);
+        foreach (var c in normalized.ToLowerInvariant())
+            builder.Append(c switch
+            {
+                '/' => "--",
+                >= 'a' and <= 'z' => c.ToString(),
+                >= '0' and <= '9' => c.ToString(),
+                '.' or '_' or '-' => c.ToString(),
+                _ => "-",
+            });
+        return builder.ToString();
+    }
+
+    /// <summary>The full node path a repository's principal is read from.</summary>
+    /// <param name="repository">A <c>repository</c> claim or a declared repository.</param>
+    /// <returns>The path, or an empty string when the repository is blank.</returns>
+    public static string PathFor(string? repository)
+    {
+        var id = NodeId(repository);
+        return id.Length == 0 ? "" : $"{Namespace}/{id}";
+    }
+
+    private static string NormalizeScope(string? scope)
+    {
+        if (string.IsNullOrWhiteSpace(scope))
+            return "";
+        var colon = scope.IndexOf(':');
+        return colon <= 0 || colon == scope.Length - 1
+            ? ""
+            : Scope(scope[..colon], scope[(colon + 1)..]);
+    }
+
+    /// <summary>Case-insensitive lookup — an event name is a GitHub wire identifier, but a
+    /// hand-authored node routinely carries <c>Push</c> where the claim says <c>push</c>, and a
+    /// principal that silently matches nothing is the worst possible failure mode for an admin.</summary>
+    private static IReadOnlyCollection<string>? Lookup(
+        IReadOnlyDictionary<string, IReadOnlyCollection<string>>? map, string key)
+    {
+        if (map is null or { Count: 0 })
+            return null;
+        if (map.TryGetValue(key, out var exact))
+            return exact;
+        foreach (var pair in map)
+            if (string.Equals(pair.Key, key, StringComparison.OrdinalIgnoreCase))
+                return pair.Value;
+        return null;
+    }
+}
+
+/// <summary>The verbs a <see cref="BuildPrincipal"/> scope can carry.</summary>
+public static class BuildVerbs
+{
+    /// <summary>Read a source's sealed publication from this registry — what an
+    /// <c>upstream-seed</c> gate needs.</summary>
+    public const string Fetch = "fetch";
+
+    /// <summary>Write a source's bytes INTO this registry.</summary>
+    public const string Publish = "publish";
+}
+
+/// <summary>The control-plane verbs <see cref="BuildPrincipal.RequestedAction"/> accepts.</summary>
+public static class BuildPrincipalActions
+{
+    /// <summary>End this principal. Honoured the moment it is written — <see cref="BuildPrincipal.IsActive"/>
+    /// reads this field itself, so nothing has to observe the node and fold it into
+    /// <see cref="BuildPrincipal.IsRevoked"/> first. A security stop that waits for a reactor is a
+    /// security stop with a window.</summary>
+    public const string Revoke = "Revoke";
+}

--- a/src/MeshWeaver.Mesh.Contract/Security/GitHubActionsToken.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/GitHubActionsToken.cs
@@ -1,0 +1,548 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace MeshWeaver.Mesh.Security;
+
+/// <summary>
+/// The SECOND issuer on the registry's token path (#2483): GitHub Actions' OIDC token, verified by
+/// the mesh itself against GitHub's published JWKS.
+///
+/// <para><b>Why a second issuer instead of a second credential.</b> Every GitHub Actions run can
+/// already ask for a short-lived, signed JWT describing itself — <c>repository</c>, <c>ref</c>,
+/// <c>event_name</c>, <c>job_workflow_ref</c> — with no secret stored anywhere. Azure's federated
+/// credential is nothing more than Azure verifying that token against a rule; the mesh can verify it
+/// too, and then the rule lives on a node the mesh owns (<see cref="BuildPrincipal"/>) rather than in
+/// a cloud tenant no query can join. That is the whole of <c>Doc/Architecture/PluginBuildContract</c>
+/// → "The build principal".</para>
+///
+/// <para>🚨 <b>One verifier, two issuers, a trust node per issuer.</b> The fork is on the token's
+/// <c>iss</c> claim, read UNVERIFIED and used only to pick a verifier — never to grant anything:
+/// <see cref="SyncAccessToken"/>'s HMAC leg for the registry's own tokens, this leg for GitHub's. The
+/// HS256 leg still never honours a token's own <c>alg</c>, and neither does this one:
+/// <see cref="Algorithm"/> is the only algorithm accepted here, so an <c>alg: none</c> or an
+/// HMAC-shaped forgery replayed against an RSA public key is refused before any key is touched.</para>
+///
+/// <para>🚨 <b>A verified signature is not an authorization.</b> Every GitHub Actions run in the world
+/// gets a token signed by these same keys. What this class establishes is only <i>which repository, on
+/// which event, asked</i>; whether that repository may do anything here is decided against a
+/// <see cref="BuildPrincipal"/> node. A verifier that checked the signature and stopped would
+/// authenticate the entire public GitHub.</para>
+/// </summary>
+public static class GitHubActionsToken
+{
+    /// <summary>
+    /// The one issuer accepted here — pinned, never configurable. A configurable issuer is a
+    /// configurable trust anchor: an operator (or a misapplied overlay) could point the verifier at a
+    /// key set an attacker controls, and every claim below would then be attacker-authored.
+    /// </summary>
+    public const string Issuer = "https://token.actions.githubusercontent.com";
+
+    /// <summary>The <c>alg</c> a token must declare. Nothing else is accepted — in particular not
+    /// <c>none</c>, and never the token's own choice.</summary>
+    public const string Algorithm = "RS256";
+
+    /// <summary>GitHub's OpenID discovery document, under the pinned <see cref="Issuer"/>.</summary>
+    public const string OpenIdConfigurationUri = Issuer + "/.well-known/openid-configuration";
+
+    /// <summary>GitHub's documented JWKS endpoint — the fallback when discovery yields nothing
+    /// usable, and the shape a discovered <c>jwks_uri</c> is checked against.</summary>
+    public const string JwksUri = Issuer + "/.well-known/jwks";
+
+    /// <summary>
+    /// Tolerance applied to <c>exp</c> and <c>nbf</c>. Two minutes, deliberately tighter than the
+    /// five minutes token libraries default to: these tokens live for minutes and a build that
+    /// retries costs nothing, whereas every second of slack is a second an intercepted token still
+    /// works.
+    /// </summary>
+    public static readonly TimeSpan ClockSkew = TimeSpan.FromMinutes(2);
+
+    /// <summary>Largest token considered, in characters. A GitHub OIDC token is ~1–2 KB; the bound
+    /// keeps a hostile header from costing a large decode on an UNAUTHENTICATED request.</summary>
+    public const int MaxTokenChars = 8192;
+
+    /// <summary>Smallest RSA modulus accepted from the key set, in bytes (RSA-2048). A short key is
+    /// a forgeable signature, so it is dropped at parse time rather than trusted at verify time.</summary>
+    public const int MinimumModulusBytes = 256;
+
+    private static readonly JsonSerializerOptions Json = new(JsonSerializerDefaults.Web)
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    /// <summary>
+    /// The <c>iss</c> claim of <paramref name="token"/>, read WITHOUT verifying anything.
+    ///
+    /// <para>🚨 This is a ROUTING read and nothing else. It selects which verifier runs; it can only
+    /// ever send a forged token to a verifier that will reject it, and it grants nothing on its own.
+    /// Every claim that matters — including <c>iss</c> itself — is re-read from the verified payload
+    /// in <see cref="Verify"/>.</para>
+    /// </summary>
+    /// <param name="token">The raw bearer value.</param>
+    /// <returns>The unverified issuer, or null when the value is not a readable JWT.</returns>
+    public static string? PeekIssuer(string? token)
+    {
+        if (string.IsNullOrWhiteSpace(token) || token.Length > MaxTokenChars)
+            return null;
+        var parts = token.Trim().Split('.');
+        if (parts.Length != 3 || parts.Any(p => p.Length == 0))
+            return null;
+        return Read<Payload>(parts[1])?.Issuer;
+    }
+
+    /// <summary>Whether <paramref name="token"/> claims to come from GitHub Actions — the fork that
+    /// picks this verifier over the registry's HMAC one.</summary>
+    /// <param name="token">The raw bearer value.</param>
+    /// <returns>True when the unverified <c>iss</c> is exactly <see cref="Issuer"/>.</returns>
+    public static bool IsGitHubIssued(string? token) =>
+        string.Equals(PeekIssuer(token), Issuer, StringComparison.Ordinal);
+
+    /// <summary>
+    /// Verifies <paramref name="token"/>'s signature, issuer, audience and validity window against
+    /// <paramref name="keys"/>, and returns what it claims.
+    ///
+    /// <para>The result has THREE shapes, not two, and the third is the point: a token whose
+    /// <c>kid</c> is absent from the presented key set is <see cref="GitHubTokenVerification.Undetermined"/>
+    /// — nothing was established, and the caller may refresh the key set once and ask again. Folding
+    /// that into "rejected" is how a routine GitHub key rotation becomes a fleet-wide outage; folding
+    /// it into "accepted" would be a hole. Everything else that fails is a flat rejection, with no
+    /// hint about which check failed: telling a caller how their forgery failed helps only the
+    /// forger.</para>
+    /// </summary>
+    /// <param name="token">The raw bearer value.</param>
+    /// <param name="now">The instant to judge <c>exp</c>/<c>nbf</c> against.</param>
+    /// <param name="audiences">The audiences this registry accepts. EMPTY REFUSES EVERYTHING — a
+    /// registry that does not know which audience its builds request cannot tell a token minted for
+    /// it from one minted for any other service on the internet.</param>
+    /// <param name="keys">GitHub's current signing keys, by <c>kid</c>.</param>
+    /// <returns>The verification outcome.</returns>
+    public static GitHubTokenVerification Verify(
+        string? token,
+        DateTimeOffset now,
+        IReadOnlyCollection<string> audiences,
+        IReadOnlyDictionary<string, GitHubSigningKey> keys)
+    {
+        // Fail closed on an unconfigured audience. A token from ANY workflow on GitHub verifies
+        // against these keys; the audience is what says "this one was minted for us".
+        if (audiences is not { Count: > 0 } || keys is not { Count: > 0 })
+            return GitHubTokenVerification.Rejected;
+        if (string.IsNullOrWhiteSpace(token) || token.Length > MaxTokenChars)
+            return GitHubTokenVerification.Rejected;
+
+        var parts = token.Trim().Split('.');
+        if (parts.Length != 3 || parts.Any(p => p.Length == 0))
+            return GitHubTokenVerification.Rejected;
+
+        // The header is checked BEFORE any key is looked up: `alg` must be the one algorithm this
+        // issuer signs with. Honouring the token's own `alg` is the classic JWT hole.
+        var header = Read<Header>(parts[0]);
+        if (header is null
+            || !string.Equals(header.Algorithm, Algorithm, StringComparison.Ordinal)
+            || (header.Type is not null && !string.Equals(header.Type, "JWT", StringComparison.OrdinalIgnoreCase))
+            || string.IsNullOrWhiteSpace(header.KeyId))
+            return GitHubTokenVerification.Rejected;
+
+        if (!keys.TryGetValue(header.KeyId, out var key) || key is null)
+            return GitHubTokenVerification.Undetermined;
+
+        var signature = Decode(parts[2]);
+        if (signature is null)
+            return GitHubTokenVerification.Rejected;
+
+        using var rsa = RSA.Create();
+        try
+        {
+            rsa.ImportParameters(new RSAParameters { Modulus = key.Modulus, Exponent = key.Exponent });
+        }
+        catch (CryptographicException)
+        {
+            // A key the JWKS offered but this platform cannot import is not a reason to admit the
+            // caller. Same discipline as everywhere else on this path: no verification, no entry.
+            return GitHubTokenVerification.Rejected;
+        }
+
+        // The JWS signing input is the ASCII of "header.payload" — the base64url segments verbatim,
+        // never a re-serialization of the decoded JSON.
+        var signingInput = Encoding.ASCII.GetBytes(parts[0] + "." + parts[1]);
+        if (!rsa.VerifyData(signingInput, signature, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1))
+            return GitHubTokenVerification.Rejected;
+
+        var payload = Read<Payload>(parts[1]);
+        if (payload is null)
+            return GitHubTokenVerification.Rejected;
+
+        // Issuer, re-read from the VERIFIED payload — the unverified peek above only chose a verifier.
+        if (!string.Equals(payload.Issuer, Issuer, StringComparison.Ordinal))
+            return GitHubTokenVerification.Rejected;
+
+        var audience = MatchedAudience(payload.Audience, audiences);
+        if (audience is null)
+            return GitHubTokenVerification.Rejected;
+
+        if (payload.ExpiresAt <= 0)
+            return GitHubTokenVerification.Rejected;
+        var expiresAt = DateTimeOffset.FromUnixTimeSeconds(payload.ExpiresAt);
+        if (now - ClockSkew >= expiresAt)
+            return GitHubTokenVerification.Rejected;
+        if (payload.NotBefore > 0
+            && now + ClockSkew < DateTimeOffset.FromUnixTimeSeconds(payload.NotBefore))
+            return GitHubTokenVerification.Rejected;
+
+        // A token with no repository claim describes no build. Nothing downstream could match it,
+        // and an empty string must never fall through to an empty declared repository on a node.
+        if (string.IsNullOrWhiteSpace(payload.Repository))
+            return GitHubTokenVerification.Rejected;
+
+        return GitHubTokenVerification.Verified(new GitHubBuildClaims
+        {
+            Repository = payload.Repository.Trim(),
+            RepositoryId = Blank(payload.RepositoryId),
+            RepositoryOwner = Blank(payload.RepositoryOwner),
+            RepositoryOwnerId = Blank(payload.RepositoryOwnerId),
+            EventName = (payload.EventName ?? "").Trim(),
+            Ref = Blank(payload.Ref),
+            Subject = Blank(payload.Subject),
+            JobWorkflowRef = Blank(payload.JobWorkflowRef),
+            Workflow = Blank(payload.Workflow),
+            Actor = Blank(payload.Actor),
+            RunId = Blank(payload.RunId),
+            Audience = audience,
+            ExpiresAt = expiresAt,
+        });
+    }
+
+    /// <summary>
+    /// Reads a JWKS document into the RSA signing keys it offers, skipping every entry this verifier
+    /// would not use anyway — a non-RSA key type, an <c>alg</c> that is not <see cref="Algorithm"/>,
+    /// a <c>use</c> that is not <c>sig</c>, a missing <c>kid</c>, an undersized modulus. Never
+    /// throws: the document is fetched over the network, so a malformed one must be an empty key set
+    /// (which refuses everything) rather than an exception on an unauthenticated request path.
+    /// </summary>
+    /// <param name="json">The raw JWKS document.</param>
+    /// <returns>The usable keys, by <c>kid</c>. Empty when nothing usable was found.</returns>
+    public static IReadOnlyDictionary<string, GitHubSigningKey> ParseJwks(string? json)
+    {
+        var result = new Dictionary<string, GitHubSigningKey>(StringComparer.Ordinal);
+        if (string.IsNullOrWhiteSpace(json))
+            return result;
+
+        JsonDocument document;
+        try
+        {
+            document = JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return result;
+        }
+
+        using (document)
+        {
+            if (document.RootElement.ValueKind != JsonValueKind.Object
+                || !document.RootElement.TryGetProperty("keys", out var keys)
+                || keys.ValueKind != JsonValueKind.Array)
+                return result;
+
+            foreach (var entry in keys.EnumerateArray())
+            {
+                if (entry.ValueKind != JsonValueKind.Object)
+                    continue;
+                if (Text(entry, "kty") is not "RSA")
+                    continue;
+                if (Text(entry, "alg") is { } alg && !string.Equals(alg, Algorithm, StringComparison.Ordinal))
+                    continue;
+                if (Text(entry, "use") is { } use && !string.Equals(use, "sig", StringComparison.Ordinal))
+                    continue;
+                if (Text(entry, "kid") is not { Length: > 0 } kid)
+                    continue;
+                if (Text(entry, "n") is not { Length: > 0 } n || Text(entry, "e") is not { Length: > 0 } e)
+                    continue;
+                if (Decode(n) is not { } modulus || Decode(e) is not { } exponent)
+                    continue;
+                if (modulus.Length < MinimumModulusBytes || exponent.Length is 0)
+                    continue;
+                // A duplicate kid is a document we cannot reason about — keep the first and ignore
+                // the rest rather than letting a later entry silently replace a key already in use.
+                result.TryAdd(kid, new GitHubSigningKey { KeyId = kid, Modulus = modulus, Exponent = exponent });
+            }
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// The <c>jwks_uri</c> a discovery document advertises, accepted only when it is HTTPS on the
+    /// SAME host as <see cref="Issuer"/>. Anything else — a different host, plain HTTP, an
+    /// unparseable document — yields null and the caller falls back to the pinned
+    /// <see cref="JwksUri"/>. Discovery is a convenience so a moved endpoint does not become an
+    /// outage; it is never allowed to move the trust anchor.
+    /// </summary>
+    /// <param name="json">The raw OpenID configuration document.</param>
+    /// <returns>The accepted JWKS URI, or null.</returns>
+    public static string? JwksUriFromDiscovery(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+            return null;
+        try
+        {
+            using var document = JsonDocument.Parse(json);
+            if (document.RootElement.ValueKind != JsonValueKind.Object)
+                return null;
+            var advertised = Text(document.RootElement, "jwks_uri");
+            if (advertised is not { Length: > 0 }
+                || !Uri.TryCreate(advertised, UriKind.Absolute, out var uri)
+                || !string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.Ordinal))
+                return null;
+            var issuer = new Uri(Issuer);
+            return string.Equals(uri.Host, issuer.Host, StringComparison.OrdinalIgnoreCase)
+                ? uri.AbsoluteUri
+                : null;
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// A repository claim reduced to its <c>owner/name</c> form, so a principal keeps matching when
+    /// GitHub moves an organisation onto the IMMUTABLE claim format.
+    ///
+    /// <para>Both shapes occur in this fleet's federated credentials today:
+    /// <c>Systemorph/MeshWeaver.SocialMedia</c> and
+    /// <c>Systemorph@12345/MeshWeaver.SocialMedia@67890</c>. Stripping is unambiguous because neither
+    /// a GitHub login nor a repository name may contain <c>@</c>, and only an all-digit suffix is
+    /// removed — so no real name can be truncated by this.</para>
+    /// </summary>
+    /// <param name="repository">A <c>repository</c> claim or a declared repository.</param>
+    /// <returns>The normalized <c>owner/name</c>, or an empty string.</returns>
+    public static string NormalizeRepository(string? repository)
+    {
+        if (string.IsNullOrWhiteSpace(repository))
+            return "";
+        var trimmed = repository.Trim();
+        var slash = trimmed.IndexOf('/');
+        if (slash <= 0 || slash == trimmed.Length - 1)
+            return StripImmutableId(trimmed);
+        return StripImmutableId(trimmed[..slash]) + "/" + StripImmutableId(trimmed[(slash + 1)..]);
+    }
+
+    /// <summary>Whether two repository references name the same repository, compared on their
+    /// normalized <c>owner/name</c> form. Exact — never a prefix, never a wildcard: a prefix match
+    /// would let <c>Systemorph/MeshWeaver.Evil</c> authenticate as <c>Systemorph/MeshWeaver</c>.</summary>
+    /// <param name="left">One reference.</param>
+    /// <param name="right">The other.</param>
+    /// <returns>True when they name the same repository.</returns>
+    public static bool RepositoryEquals(string? left, string? right)
+    {
+        var a = NormalizeRepository(left);
+        var b = NormalizeRepository(right);
+        // GitHub owner/repo names are case-insensitive but case-preserving, so an ordinal compare
+        // would refuse a principal an admin typed with different casing than the claim carries.
+        return a.Length > 0 && string.Equals(a, b, StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static string StripImmutableId(string segment)
+    {
+        var at = segment.IndexOf('@');
+        if (at <= 0 || at == segment.Length - 1)
+            return segment;
+        var suffix = segment[(at + 1)..];
+        return suffix.All(char.IsAsciiDigit) ? segment[..at] : segment;
+    }
+
+    /// <summary>The configured audience the token's <c>aud</c> matches, or null. Handles both JWT
+    /// shapes — a single string and an array — because the claim is defined as either.</summary>
+    private static string? MatchedAudience(JsonElement audience, IReadOnlyCollection<string> accepted)
+    {
+        switch (audience.ValueKind)
+        {
+            case JsonValueKind.String:
+                return Accepted(audience.GetString());
+            case JsonValueKind.Array:
+                foreach (var item in audience.EnumerateArray())
+                    if (item.ValueKind == JsonValueKind.String && Accepted(item.GetString()) is { } hit)
+                        return hit;
+                return null;
+            default:
+                return null;
+        }
+
+        string? Accepted(string? candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+                return null;
+            var normalized = candidate.Trim().TrimEnd('/');
+            return accepted.Any(a =>
+                !string.IsNullOrWhiteSpace(a)
+                && string.Equals(a.Trim().TrimEnd('/'), normalized, StringComparison.OrdinalIgnoreCase))
+                ? candidate.Trim()
+                : null;
+        }
+    }
+
+    private static string? Blank(string? value) => string.IsNullOrWhiteSpace(value) ? null : value.Trim();
+
+    private static string? Text(JsonElement element, string property) =>
+        element.TryGetProperty(property, out var value) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+
+    private static byte[]? Decode(string segment)
+    {
+        var padded = segment.Replace('-', '+').Replace('_', '/');
+        var buffer = new byte[(padded.Length + 3) / 4 * 3];
+        return Convert.TryFromBase64String(
+            padded.PadRight((padded.Length + 3) / 4 * 4, '='), buffer, out var written)
+            ? buffer[..written]
+            : null;
+    }
+
+    /// <summary>A segment as JSON, or null — never a throw on the unauthenticated path.</summary>
+    private static T? Read<T>(string segment) where T : class
+    {
+        var bytes = Decode(segment);
+        if (bytes is null)
+            return null;
+        try
+        {
+            return JsonSerializer.Deserialize<T>(bytes, Json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+
+    private sealed record Header
+    {
+        [JsonPropertyName("alg")] public string? Algorithm { get; init; }
+        [JsonPropertyName("typ")] public string? Type { get; init; }
+        [JsonPropertyName("kid")] public string? KeyId { get; init; }
+    }
+
+    private sealed record Payload
+    {
+        [JsonPropertyName("iss")] public string? Issuer { get; init; }
+        [JsonPropertyName("sub")] public string? Subject { get; init; }
+        // `aud` is defined as either a string or an array of strings; both shapes are handled.
+        [JsonPropertyName("aud")] public JsonElement Audience { get; init; }
+        [JsonPropertyName("exp")] public long ExpiresAt { get; init; }
+        [JsonPropertyName("nbf")] public long NotBefore { get; init; }
+        [JsonPropertyName("repository")] public string? Repository { get; init; }
+        [JsonPropertyName("repository_id")] public string? RepositoryId { get; init; }
+        [JsonPropertyName("repository_owner")] public string? RepositoryOwner { get; init; }
+        [JsonPropertyName("repository_owner_id")] public string? RepositoryOwnerId { get; init; }
+        [JsonPropertyName("event_name")] public string? EventName { get; init; }
+        [JsonPropertyName("ref")] public string? Ref { get; init; }
+        [JsonPropertyName("job_workflow_ref")] public string? JobWorkflowRef { get; init; }
+        [JsonPropertyName("workflow")] public string? Workflow { get; init; }
+        [JsonPropertyName("actor")] public string? Actor { get; init; }
+        [JsonPropertyName("run_id")] public string? RunId { get; init; }
+    }
+}
+
+/// <summary>
+/// The outcome of verifying a GitHub Actions token — THREE shapes, because collapsing the third into
+/// a boolean is the defect core #2901 exists to name.
+/// </summary>
+public sealed record GitHubTokenVerification
+{
+    /// <summary>What the token claims, when it verified. Null otherwise.</summary>
+    public GitHubBuildClaims? Claims { get; init; }
+
+    /// <summary>True when the token's <c>kid</c> was not in the presented key set — NOTHING was
+    /// established, and a caller holding a possibly-stale key set may refresh once and re-verify.
+    /// This is not an acceptance and not a rejection.</summary>
+    public bool KeyUnknown { get; init; }
+
+    /// <summary>True when the token verified.</summary>
+    public bool IsVerified => Claims is not null;
+
+    /// <summary>The token did not verify, and the answer is final.</summary>
+    public static GitHubTokenVerification Rejected { get; } = new();
+
+    /// <summary>The signing key was not in the presented set — undetermined, not refused.</summary>
+    public static GitHubTokenVerification Undetermined { get; } = new() { KeyUnknown = true };
+
+    /// <summary>The token verified; <paramref name="claims"/> is what it says.</summary>
+    /// <param name="claims">The verified claims.</param>
+    /// <returns>A verified outcome.</returns>
+    public static GitHubTokenVerification Verified(GitHubBuildClaims claims) => new() { Claims = claims };
+}
+
+/// <summary>One RSA signing key from GitHub's JWKS, reduced to what a verification needs.</summary>
+public sealed record GitHubSigningKey
+{
+    /// <summary>The key's <c>kid</c> — how a token names the key it was signed with.</summary>
+    public string KeyId { get; init; } = "";
+
+    /// <summary>RSA modulus (the JWK's <c>n</c>, base64url-decoded).</summary>
+    public byte[] Modulus { get; init; } = [];
+
+    /// <summary>RSA public exponent (the JWK's <c>e</c>, base64url-decoded).</summary>
+    public byte[] Exponent { get; init; } = [];
+}
+
+/// <summary>
+/// GitHub's current signing keys, with the instant they were read. The instant is what bounds a
+/// forced refresh: an unknown <c>kid</c> may re-read the set, but only if the one in hand is old
+/// enough — so a caller spraying invented key ids cannot turn every request into an outbound fetch.
+/// </summary>
+/// <param name="ByKeyId">The usable keys, by <c>kid</c>.</param>
+/// <param name="FetchedAt">When this set was read.</param>
+public sealed record GitHubSigningKeys(
+    IReadOnlyDictionary<string, GitHubSigningKey> ByKeyId, DateTimeOffset FetchedAt);
+
+/// <summary>
+/// What a VERIFIED GitHub Actions token claims about the run that presented it. Identity and
+/// context only — never authority: what the run may do is decided against a
+/// <see cref="BuildPrincipal"/>.
+/// </summary>
+public sealed record GitHubBuildClaims
+{
+    /// <summary>The <c>repository</c> claim — <c>owner/name</c>, possibly in GitHub's immutable
+    /// <c>owner@id/name@id</c> form. Compare it with
+    /// <see cref="GitHubActionsToken.RepositoryEquals"/>, never with a raw string compare.</summary>
+    public string Repository { get; init; } = "";
+
+    /// <summary>The <c>repository_id</c> claim — GitHub's immutable numeric id for the repository.
+    /// A principal may pin it, which survives a rename and defeats a name re-registration.</summary>
+    public string? RepositoryId { get; init; }
+
+    /// <summary>The <c>repository_owner</c> claim.</summary>
+    public string? RepositoryOwner { get; init; }
+
+    /// <summary>The <c>repository_owner_id</c> claim — the owner's immutable numeric id.</summary>
+    public string? RepositoryOwnerId { get; init; }
+
+    /// <summary>The <c>event_name</c> claim (<c>push</c>, <c>pull_request</c>, …) — what the
+    /// principal's event map is keyed by.</summary>
+    public string EventName { get; init; } = "";
+
+    /// <summary>The <c>ref</c> claim (<c>refs/heads/main</c>, <c>refs/pull/12/merge</c>, …).</summary>
+    public string? Ref { get; init; }
+
+    /// <summary>The <c>sub</c> claim, verbatim — recorded for the audit trail. Both the classic and
+    /// the immutable subject formats appear here; nothing is matched on it.</summary>
+    public string? Subject { get; init; }
+
+    /// <summary>The <c>job_workflow_ref</c> claim — which workflow file ran.</summary>
+    public string? JobWorkflowRef { get; init; }
+
+    /// <summary>The <c>workflow</c> claim — the workflow's name.</summary>
+    public string? Workflow { get; init; }
+
+    /// <summary>The <c>actor</c> claim — who triggered the run.</summary>
+    public string? Actor { get; init; }
+
+    /// <summary>The <c>run_id</c> claim — which run, for correlating a decision with a build log.</summary>
+    public string? RunId { get; init; }
+
+    /// <summary>The configured audience this token matched.</summary>
+    public string Audience { get; init; } = "";
+
+    /// <summary>When the token stops verifying.</summary>
+    public DateTimeOffset ExpiresAt { get; init; }
+}

--- a/src/MeshWeaver.PluginCatalog/BuildPrincipalConfiguration.cs
+++ b/src/MeshWeaver.PluginCatalog/BuildPrincipalConfiguration.cs
@@ -1,0 +1,61 @@
+using MeshWeaver.Mesh.Security;
+using Microsoft.Extensions.Configuration;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// The one deployment-level knob the build-principal leg has: which <c>aud</c> a GitHub Actions
+/// token must carry to be considered minted for THIS registry (#2483).
+///
+/// <para>🚨 <b>Unconfigured means REFUSE, not "accept anything".</b> Every GitHub Actions run on
+/// earth can mint a token signed by the same keys; the audience is the only claim that says "this
+/// one was minted for us". A registry with no audience configured therefore has no build-principal
+/// surface — the same shape as <see cref="ModulePublish.TokenConfigKey"/>, and for the same reason
+/// the anonymous-when-unset registry of 2026-08-06 is not repeated here.</para>
+///
+/// <para>🚨 <b>The ISSUER is deliberately NOT configurable</b> (<see cref="GitHubActionsToken.Issuer"/>).
+/// A configurable issuer is a configurable trust anchor: one overlay pointing it at another key set
+/// and every claim below becomes attacker-authored. Only the audience — a value that can merely
+/// widen or narrow which tokens are considered ours — is an operator's to set.</para>
+///
+/// <para>A workflow asks for a token with <c>curl "$ACTIONS_ID_TOKEN_REQUEST_URL&amp;audience=&lt;this
+/// value&gt;"</c>, so the two sides carry the same string and neither holds a secret.</para>
+/// </summary>
+public static class BuildPrincipalConfiguration
+{
+    /// <summary>Configuration key holding the single accepted audience — usually the registry's own
+    /// public URL (<c>https://memex.meshweaver.cloud</c>).</summary>
+    public const string AudienceConfigKey = "Plugins:Registry:BuildPrincipalAudience";
+
+    /// <summary>Configuration section holding several accepted audiences
+    /// (<c>…:BuildPrincipalAudiences:0</c>, <c>:1</c>, …), for a registry reachable under more than
+    /// one name. Folded together with <see cref="AudienceConfigKey"/>.</summary>
+    public const string AudiencesConfigSection = "Plugins:Registry:BuildPrincipalAudiences";
+
+    /// <summary>
+    /// The audiences this registry accepts, de-duplicated and trimmed. EMPTY disables the
+    /// build-principal leg entirely — which is the safe default, not a degraded one.
+    /// </summary>
+    /// <param name="configuration">The deployment's configuration, or null.</param>
+    /// <returns>The accepted audiences; empty when none is configured.</returns>
+    public static IReadOnlyCollection<string> Audiences(IConfiguration? configuration)
+    {
+        if (configuration is null)
+            return [];
+
+        var accepted = new List<string>();
+        Add(configuration[AudienceConfigKey]);
+        foreach (var child in configuration.GetSection(AudiencesConfigSection).GetChildren())
+            Add(child.Value);
+        return accepted;
+
+        void Add(string? candidate)
+        {
+            if (string.IsNullOrWhiteSpace(candidate))
+                return;
+            var value = candidate.Trim();
+            if (!accepted.Any(a => string.Equals(a, value, StringComparison.OrdinalIgnoreCase)))
+                accepted.Add(value);
+        }
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/GitHubOidcKeyService.cs
+++ b/src/MeshWeaver.PluginCatalog/GitHubOidcKeyService.cs
@@ -1,0 +1,215 @@
+using System.Net.Http;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// GitHub's OIDC signing keys, fetched once and shared — the key source behind the build-principal
+/// leg of <see cref="InstanceRegistryAuthenticator"/> (#2483).
+///
+/// <para>🚨 <b>Mesh-scoped singleton, instance field, never a static cache.</b> Process-wide static
+/// state survives mesh disposal, so it bleeds across tests and across deployments sharing a host
+/// (<c>Doc/Architecture/NoStaticState</c>). The cache here dies with the mesh that owns it.</para>
+///
+/// <para>🚨 <b>A fetch that fails FAILS CLOSED and says so.</b> The observable ERRORS; it never
+/// yields an empty key set that would read as "no key matched" and never yields a stale-but-present
+/// set on the strength of a failure. The authenticator turns that error into
+/// <see cref="InstanceAuthResult.Unavailable"/> — a <c>503 Retry-After</c>, distinguishable from the
+/// <c>401</c> a genuinely bad token gets — because "I could not find out" is a third state, not a
+/// denial and certainly not an admission (core #2901).</para>
+///
+/// <para><b>Refresh is bounded twice.</b> The set is re-read when it is older than
+/// <see cref="CacheDuration"/>; and an unknown <c>kid</c> — the signal of a GitHub key rotation — may
+/// force ONE early re-read, but only if the set in hand is older than
+/// <see cref="MinimumRefreshInterval"/>. Without that floor a caller presenting invented key ids
+/// would turn every unauthenticated request into an outbound fetch.</para>
+///
+/// <para>Same promise-cache shape as <c>GitHubAppTokenService</c>: the in-flight fetch observable is
+/// held on an instance field so concurrent callers share ONE round trip, and a failure nulls it so
+/// the next caller starts a genuinely new attempt rather than replaying a latched
+/// <c>OnError</c>.</para>
+/// </summary>
+public sealed class GitHubOidcKeyService
+{
+    /// <summary>How long a fetched key set is reused before it is re-read.</summary>
+    public static readonly TimeSpan CacheDuration = TimeSpan.FromHours(1);
+
+    /// <summary>Floor between forced re-reads. An unknown <c>kid</c> may trigger one early fetch;
+    /// this is what keeps a hostile caller from turning that into a fetch per request.</summary>
+    public static readonly TimeSpan MinimumRefreshInterval = TimeSpan.FromMinutes(1);
+
+    /// <summary>Largest JWKS document read, in bytes. GitHub's is a few kilobytes; the bound keeps a
+    /// compromised or misrouted endpoint from streaming an unbounded body into the portal.</summary>
+    public const int MaxDocumentBytes = 256 * 1024;
+
+    // Shared fallback when no IHttpClientFactory is registered — HttpClient is designed to be
+    // long-lived and shared; a per-call `new HttpClient()` leaks sockets. Immutable shared resource,
+    // not a cache, so it does not fall under the no-static-state rule (same reasoning, same words,
+    // as RegistryPackageSource.SharedHttp).
+    private static readonly HttpClient SharedHttp = new();
+
+    private readonly IIoPool pool;
+    private readonly HttpClient http;
+    private readonly ILogger<GitHubOidcKeyService>? logger;
+
+    // The promise-cache: the current fetch, replayed to every caller. Instance fields, never static.
+    private readonly object gate = new();
+    private IObservable<GitHubSigningKeys>? cached;
+
+    /// <summary>Creates the service against the mesh's HTTP I/O pool.</summary>
+    /// <param name="hub">The hub whose service provider carries the pool registry and HTTP factory.</param>
+    /// <param name="logger">Optional logger.</param>
+    public GitHubOidcKeyService(IMessageHub hub, ILogger<GitHubOidcKeyService>? logger = null)
+    {
+        this.logger = logger;
+        pool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
+        http = hub.ServiceProvider.GetService<IHttpClientFactory>()
+            ?.CreateClient(InstanceRegistrationClient.HttpClientName) ?? SharedHttp;
+    }
+
+    /// <summary>
+    /// The fetch leaf, injectable so the CACHE and REFRESH rules can be driven without reaching
+    /// GitHub. Production is the HTTP read below; a test supplies a document (or a fault) directly.
+    /// </summary>
+    internal Func<CancellationToken, Task<string>>? FetchOverride { get; init; }
+
+    /// <summary>
+    /// GitHub's current signing keys — the cached set when it is fresh, a new fetch when it is not.
+    /// Errors when the keys cannot be read: the caller must answer retryable, never "unknown key".
+    /// </summary>
+    /// <param name="now">The instant freshness is judged against.</param>
+    /// <returns>A cold observable of the key set.</returns>
+    public IObservable<GitHubSigningKeys> Keys(DateTimeOffset now)
+    {
+        IObservable<GitHubSigningKeys> source;
+        lock (gate)
+            source = cached ??= CreateFetch();
+
+        return source.SelectMany(keys =>
+            now - keys.FetchedAt < CacheDuration
+                ? Observable.Return(keys)
+                : Swap(source));
+    }
+
+    /// <summary>
+    /// Re-reads the key set because a token named a <c>kid</c> the current set does not hold — the
+    /// signal of a GitHub key rotation. Bounded by <see cref="MinimumRefreshInterval"/>: when the set
+    /// in hand is younger than that, it is returned UNCHANGED and the caller refuses on it. That
+    /// keeps a caller inventing key ids from becoming an outbound fetch amplifier.
+    /// </summary>
+    /// <param name="stale">The set that did not contain the key.</param>
+    /// <param name="now">The current instant.</param>
+    /// <returns>A cold observable of the (possibly unchanged) key set.</returns>
+    public IObservable<GitHubSigningKeys> Refresh(GitHubSigningKeys stale, DateTimeOffset now)
+    {
+        if (now - stale.FetchedAt < MinimumRefreshInterval)
+            return Observable.Return(stale);
+
+        logger?.LogInformation(
+            "GitHub OIDC: a token named a signing key absent from the set read at {FetchedAt} — re-reading the JWKS",
+            stale.FetchedAt);
+
+        IObservable<GitHubSigningKeys> source;
+        lock (gate)
+            source = cached ?? CreateFetch();
+        return Swap(source);
+    }
+
+    /// <summary>Replaces a settled promise with a fresh fetch — once; concurrent refreshers share
+    /// the replacement rather than each starting a round trip of their own.</summary>
+    private IObservable<GitHubSigningKeys> Swap(IObservable<GitHubSigningKeys> settled)
+    {
+        lock (gate)
+        {
+            if (ReferenceEquals(cached, settled))
+                cached = CreateFetch();
+            return cached!;
+        }
+    }
+
+    private IObservable<GitHubSigningKeys> CreateFetch() =>
+        pool.Run(FetchAsync)
+            .Catch((Exception ex) =>
+            {
+                lock (gate)
+                    cached = null;   // never cache a failure — the next caller starts a new attempt
+                logger?.LogWarning(ex,
+                    "GitHub OIDC: could not read the signing keys — build-principal tokens are "
+                    + "UNDETERMINED (retryable), never accepted");
+                return Observable.Throw<GitHubSigningKeys>(ex);
+            });
+
+    // ── the HTTP leaf (runs inside the I/O pool) ─────────────────────────────
+
+    private async Task<GitHubSigningKeys> FetchAsync(CancellationToken ct)
+    {
+        var now = DateTimeOffset.UtcNow;
+        if (FetchOverride is { } test)
+            return Materialize(await test(ct).ConfigureAwait(false), now);
+
+        // Discovery first, so a moved endpoint is not an outage — but the discovered URI is accepted
+        // only when it is HTTPS on the pinned issuer's own host (JwksUriFromDiscovery). Discovery is
+        // a convenience; it is never allowed to move the trust anchor.
+        string? discovered = null;
+        try
+        {
+            discovered = GitHubActionsToken.JwksUriFromDiscovery(
+                await ReadAsync(GitHubActionsToken.OpenIdConfigurationUri, ct).ConfigureAwait(false));
+        }
+        catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
+        {
+            // A discovery blip must not fail the whole read: the pinned path below is the documented
+            // endpoint and is what every federation guide uses.
+            logger?.LogDebug(ex, "GitHub OIDC: discovery unavailable — using the pinned JWKS endpoint");
+        }
+
+        var uri = discovered ?? GitHubActionsToken.JwksUri;
+        return Materialize(await ReadAsync(uri, ct).ConfigureAwait(false), now);
+    }
+
+    private GitHubSigningKeys Materialize(string document, DateTimeOffset now)
+    {
+        var keys = GitHubActionsToken.ParseJwks(document);
+        if (keys.Count == 0)
+            // An empty set would refuse every token — correct, but it must not be REMEMBERED for an
+            // hour as if it were a valid answer. Throwing keeps it uncached and retryable.
+            throw new InvalidOperationException(
+                "GitHub's JWKS carried no usable RS256 signing key.");
+        logger?.LogInformation("GitHub OIDC: read {Count} signing key(s)", keys.Count);
+        return new GitHubSigningKeys(keys, now);
+    }
+
+    private async Task<string> ReadAsync(string uri, CancellationToken ct)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, uri);
+        request.Headers.Accept.ParseAdd("application/json");
+        using var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct)
+            .ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+            throw new HttpRequestException(
+                $"GET {uri} failed ({(int)response.StatusCode} {response.ReasonPhrase}).");
+        if (response.Content.Headers.ContentLength is { } declared && declared > MaxDocumentBytes)
+            throw new InvalidOperationException(
+                $"GET {uri} declared {declared} bytes, over the {MaxDocumentBytes}-byte bound.");
+
+        await using var stream = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        var buffer = new byte[MaxDocumentBytes + 1];
+        var read = 0;
+        while (read < buffer.Length)
+        {
+            var chunk = await stream.ReadAsync(buffer.AsMemory(read), ct).ConfigureAwait(false);
+            if (chunk == 0)
+                break;
+            read += chunk;
+        }
+        if (read > MaxDocumentBytes)
+            throw new InvalidOperationException(
+                $"GET {uri} returned more than the {MaxDocumentBytes}-byte bound.");
+        return System.Text.Encoding.UTF8.GetString(buffer, 0, read);
+    }
+}

--- a/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceRegistryAuthenticator.cs
@@ -5,6 +5,7 @@ using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
@@ -147,6 +148,13 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
         if (rawToken is null)
             return Observable.Return(InstanceAuthResult.Resolved(null));
 
+        // 🚨 ONE verifier, TWO issuers, a trust node per issuer (#2483). The fork is on the token's
+        // `iss`, read UNVERIFIED — it can only send a forged token to a verifier that will reject
+        // it, and it grants nothing on its own. Everything below this line is unchanged: the HMAC
+        // leg still never honours a token's own `alg`, and the GitHub leg never sees the HMAC key.
+        if (GitHubActionsToken.IsGitHubIssued(rawToken))
+            return AuthenticateBuild(rawToken);
+
         var keys = hub.ServiceProvider.GetService<SyncTokenSigningKeyService>();
         if (keys is null)
         {
@@ -195,6 +203,169 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
                 logger.LogWarning(ex, "Sync access token resolution UNAVAILABLE");
                 return Observable.Return(InstanceAuthResult.Unavailable(ex.Message));
             });
+    }
+
+    /// <summary>
+    /// The BUILD-PRINCIPAL leg (#2483): a GitHub Actions OIDC token, verified against GitHub's own
+    /// JWKS and then resolved to the <see cref="BuildPrincipal"/> node that says whether this mesh
+    /// trusts that repository at all.
+    ///
+    /// <para>🚨 <b>A verified signature is not an authorization.</b> Every workflow run on GitHub
+    /// carries a token signed by these same keys, so the signature establishes only WHICH repository
+    /// asked. No <see cref="BuildPrincipal"/> node ⇒ no caller ⇒ 401. This is the same shape as the
+    /// instance leg — the token is identity, the admin-owned node is authority — and it is why the
+    /// repository claim is re-compared against the record the path routed to.</para>
+    ///
+    /// <para><b>The NODE is read on every request — only the JWKS is cached.</b> That is what makes
+    /// a <see cref="BuildPrincipalActions.Revoke"/> take effect at once instead of when a verdict
+    /// cache expires. The instance leg caches its verdict for a minute because an install polls; a
+    /// build asks a handful of times per run, so there is nothing to buy and a revocation window to
+    /// lose.</para>
+    ///
+    /// <para>🚨 <b>Three outcomes, not two.</b> A key set that cannot be read is
+    /// <see cref="InstanceAuthResult.Unavailable"/> — a retryable 503, never "unknown token" and
+    /// never an admission. Collapsing an unreachable check into a boolean is the defect core #2901
+    /// exists to name; on an authentication path it is the difference between a build that retries
+    /// and a build that is told its perfectly good identity is unknown.</para>
+    /// </summary>
+    private IObservable<InstanceAuthResult> AuthenticateBuild(string rawToken)
+    {
+        var now = DateTimeOffset.UtcNow;
+        var audiences = BuildPrincipalConfiguration.Audiences(
+            hub.ServiceProvider.GetService<IConfiguration>());
+        if (audiences.Count == 0)
+        {
+            // A CONFIGURATION verdict, not a transient one — retrying will not configure an
+            // audience — so it stays a denial. Accepting any audience here would trust every
+            // GitHub Actions run that ever pointed a token at anything.
+            logger.LogWarning(
+                "A GitHub Actions token was presented but no build-principal audience is configured "
+                + "({Key}) — refusing.", BuildPrincipalConfiguration.AudienceConfigKey);
+            return Observable.Return(InstanceAuthResult.Resolved(null));
+        }
+
+        var keyService = hub.ServiceProvider.GetService<GitHubOidcKeyService>();
+        if (keyService is null)
+        {
+            // Same rule as the sync-token leg: a registry that cannot verify a signature must refuse
+            // the token, never accept it unverified.
+            logger.LogWarning(
+                "A GitHub Actions token was presented but no {Service} is registered — refusing.",
+                nameof(GitHubOidcKeyService));
+            return Observable.Return(InstanceAuthResult.Resolved(null));
+        }
+
+        return keyService.Keys(now)
+            .SelectMany(keys =>
+            {
+                var verified = GitHubActionsToken.Verify(rawToken, now, audiences, keys.ByKeyId);
+                if (!verified.KeyUnknown)
+                    return BuildOutcome(verified, keys, keys, now);
+
+                // An unknown `kid` is the signal of a GitHub key rotation, so re-read ONCE. The
+                // service's own floor decides whether that re-read actually happens; when it does
+                // not, the set comes back unchanged and the verdict below stays UNDETERMINED rather
+                // than becoming a denial we did not earn.
+                return keyService.Refresh(keys, now)
+                    .SelectMany(refreshed => BuildOutcome(
+                        GitHubActionsToken.Verify(rawToken, now, audiences, refreshed.ByKeyId),
+                        keys, refreshed, now));
+            })
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex,
+                    "GitHub build-principal resolution UNAVAILABLE — answering retryable, never "
+                    + "'unknown token'");
+                return Observable.Return(InstanceAuthResult.Unavailable(ex.Message));
+            });
+    }
+
+    /// <summary>Turns a verification into the authenticator's outcome, keeping "the key set was
+    /// never re-read" apart from "GitHub does not publish that key".</summary>
+    private IObservable<InstanceAuthResult> BuildOutcome(
+        GitHubTokenVerification verified,
+        GitHubSigningKeys before,
+        GitHubSigningKeys after,
+        DateTimeOffset now)
+    {
+        if (verified.KeyUnknown)
+        {
+            // ReferenceEquals, not a value compare: a suppressed refresh hands back the very set it
+            // was given, so identity is the exact answer to "was anything re-read".
+            if (ReferenceEquals(before, after))
+            {
+                // The refresh floor suppressed the re-read, so NOTHING was established about this
+                // token. Retryable — the build asks again once the floor elapses.
+                logger.LogWarning(
+                    "A GitHub Actions token named a signing key absent from the set read at "
+                    + "{FetchedAt}, and the refresh floor suppressed a re-read — answering retryable",
+                    before.FetchedAt);
+                return Observable.Return(InstanceAuthResult.Unavailable(
+                    "GitHub's signing keys were not re-read within the refresh floor"));
+            }
+            // The set WAS re-read and still does not hold the key: GitHub does not publish it.
+            // That is a verdict.
+            logger.LogWarning(
+                "A GitHub Actions token named a signing key GitHub does not publish — refusing.");
+            return Observable.Return(InstanceAuthResult.Resolved(null));
+        }
+
+        return verified.Claims is { } claims
+            ? ResolveBuildPrincipal(claims, now)
+            : Observable.Return(InstanceAuthResult.Resolved(null));
+    }
+
+    /// <summary>
+    /// Resolves verified claims to the <see cref="BuildPrincipal"/> the mesh holds for that
+    /// repository. The path is a routing hint; the RECORD is the authority, so the repository claim
+    /// is compared again against what the node declares — exactly, never as a prefix.
+    /// </summary>
+    private IObservable<InstanceAuthResult> ResolveBuildPrincipal(
+        GitHubBuildClaims claims, DateTimeOffset now)
+    {
+        var path = BuildPrincipal.PathFor(claims.Repository);
+        if (path.Length == 0)
+            return Observable.Return(InstanceAuthResult.Resolved(null));
+
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+        // One sealed System scope around the read, for the same reason as Resolve above: this IS
+        // the step that turns an anonymous HTTP caller into a known principal, so there is no
+        // identity to read with yet — and nothing downstream may inherit System.
+        return accessService.RunAsSystem(() => Read(path)
+            .Select(read =>
+            {
+                if (Unavailable(read, path, "GitHub build-principal resolution") is { } unavailable)
+                    return unavailable;
+
+                var principal = Content<BuildPrincipal>(read.Node);
+                if (principal is null)
+                {
+                    // The NORMAL negative: this mesh does not trust that repository. Definitive,
+                    // so the endpoint answers 401.
+                    logger.LogWarning(
+                        "A verified GitHub Actions token for {Repository} has no build principal at "
+                        + "{Path} — refusing.", claims.Repository, path);
+                    return InstanceAuthResult.Resolved(null);
+                }
+
+                if (!GitHubActionsToken.RepositoryEquals(principal.Repository, claims.Repository))
+                {
+                    logger.LogWarning(
+                        "Build principal {Path} declares repository {Declared} but the token claims "
+                        + "{Claimed} — refusing.", path, principal.Repository, claims.Repository);
+                    return InstanceAuthResult.Resolved(null);
+                }
+
+                if (!principal.IsActive(now))
+                {
+                    logger.LogWarning(
+                        "Build principal {Path} for {Repository} is revoked or out of term — refusing.",
+                        path, claims.Repository);
+                    return InstanceAuthResult.Resolved(null);
+                }
+
+                return InstanceAuthResult.ResolvedBuild(new AuthenticatedBuild(principal, claims, path));
+            }));
     }
 
     private IObservable<InstanceAuthResult> Resolve(string hash)
@@ -278,14 +449,15 @@ public sealed class InstanceRegistryAuthenticator(IMessageHub hub, ILogger<Insta
     /// <summary>The unavailable result for a read that reached no verdict, or null when it did.
     /// <see cref="NodeReadStatus.DeleteInProgress"/> counts as a verdict — the record is going away,
     /// so "unknown key" is the right answer and retrying would only delay it.</summary>
-    private InstanceAuthResult? Unavailable(NodeReadOutcome read, string path)
+    private InstanceAuthResult? Unavailable(
+        NodeReadOutcome read, string path, string what = "Instance key resolution")
     {
         if (read.Status != NodeReadStatus.Unavailable)
             return null;
         var reason = read.Failure?.Message ?? "the read reached no verdict";
         logger.LogWarning(
-            "Instance key resolution: {Path} was UNAVAILABLE ({Reason}) — answering retryable, "
-            + "never 'unknown key', and caching nothing", path, reason);
+            "{What}: {Path} was UNAVAILABLE ({Reason}) — answering retryable, "
+            + "never 'unknown key', and caching nothing", what, path, reason);
         return InstanceAuthResult.Unavailable($"{path}: {reason}");
     }
 
@@ -341,6 +513,15 @@ public sealed record InstanceAuthResult
     /// resolved, and carries no meaning at all when <see cref="IsUnavailable"/>.</summary>
     public AuthenticatedInstance? Instance { get; init; }
 
+    /// <summary>
+    /// The authenticated BUILD, when the caller presented a GitHub Actions OIDC token rather than an
+    /// instance credential (#2483). A build is a different CALLER CLASS from an installation — it
+    /// has no instance record, no plan and no <see cref="PluginGrant"/> — so it is a separate
+    /// property rather than an <see cref="AuthenticatedInstance"/> with empty fields, and every
+    /// surface that needs an installation keeps refusing it unchanged.
+    /// </summary>
+    public AuthenticatedBuild? Build { get; init; }
+
     /// <summary>Why no verdict was reached, or <c>null</c> when one was.</summary>
     public string? UnavailableReason { get; init; }
 
@@ -352,9 +533,60 @@ public sealed record InstanceAuthResult
     public static InstanceAuthResult Resolved(AuthenticatedInstance? instance) =>
         new() { Instance = instance };
 
+    /// <summary>The resolution completed and the caller is a trusted BUILD.</summary>
+    /// <param name="build">The authenticated build principal.</param>
+    /// <returns>A resolved outcome carrying <paramref name="build"/>.</returns>
+    public static InstanceAuthResult ResolvedBuild(AuthenticatedBuild build) =>
+        new() { Build = build };
+
     /// <summary>The resolution reached no verdict — answer retryable, and cache nothing.</summary>
     public static InstanceAuthResult Unavailable(string reason) =>
         new() { UnavailableReason = reason };
+}
+
+/// <summary>
+/// An authenticated BUILD: a GitHub Actions run whose OIDC token verified against GitHub's JWKS,
+/// together with the <see cref="Mesh.Security.BuildPrincipal"/> node this mesh holds for its
+/// repository (#2483).
+///
+/// <para>🚨 The claims contribute IDENTITY and CONTEXT, never authority. What the run may do is read
+/// from the live node on every request — so a <see cref="BuildPrincipalActions.Revoke"/> written a
+/// second ago takes effect now rather than when the token expires. Exactly the property the
+/// short-lived-token leg has, and for the same reason.</para>
+/// </summary>
+/// <param name="Principal">The admin-owned rule the repository resolved to.</param>
+/// <param name="Claims">The verified token claims.</param>
+/// <param name="PrincipalPath">Where the rule was read from — for the log and the ledger.</param>
+public sealed record AuthenticatedBuild(
+    BuildPrincipal Principal, GitHubBuildClaims Claims, string PrincipalPath)
+{
+    /// <summary>The repository this build speaks for, normalized to <c>owner/name</c>.</summary>
+    public string Repository => GitHubActionsToken.NormalizeRepository(Claims.Repository);
+
+    /// <summary>Whether this build may perform <paramref name="verb"/> on registry source
+    /// <paramref name="source"/> at <paramref name="now"/>.</summary>
+    /// <param name="verb">A <see cref="BuildVerbs"/> value.</param>
+    /// <param name="source">The registry source name.</param>
+    /// <param name="now">The instant to decide at.</param>
+    /// <returns>True when the principal allows it.</returns>
+    public bool Allows(string verb, string source, DateTimeOffset now) =>
+        Principal.Allows(Claims, verb, source, now);
+
+    /// <summary><see cref="Allows(string,string,DateTimeOffset)"/> right now — what a live request
+    /// means.</summary>
+    /// <param name="verb">A <see cref="BuildVerbs"/> value.</param>
+    /// <param name="source">The registry source name.</param>
+    /// <returns>True when the principal allows it.</returns>
+    public bool Allows(string verb, string source) => Allows(verb, source, DateTimeOffset.UtcNow);
+
+    /// <summary>Why the principal refuses, or null when it allows — for the LOG and the entitlement
+    /// ledger only, never for the HTTP body.</summary>
+    /// <param name="verb">A <see cref="BuildVerbs"/> value.</param>
+    /// <param name="source">The registry source name.</param>
+    /// <param name="now">The instant to decide at.</param>
+    /// <returns>The refusal reason, or null.</returns>
+    public string? Refuse(string verb, string source, DateTimeOffset now) =>
+        Principal.Refuse(Claims, verb, source, now);
 }
 
 /// <summary>An authenticated caller: which instance presented the key, and what it may pull.</summary>

--- a/src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj
+++ b/src/MeshWeaver.PluginCatalog/MeshWeaver.PluginCatalog.csproj
@@ -18,6 +18,10 @@
          MeshWeaver.AI.Test travels to MeshWeaver.Plugins. -->
     <InternalsVisibleTo Include="MeshWeaver.AI.Test" />
     <InternalsVisibleTo Include="MeshWeaver.Auth.Test" />
+    <!-- The build-principal suite (#2483) drives GitHubOidcKeyService's FETCH leaf directly, so the
+         cache / refresh-floor / fail-closed rules are exercised without reaching GitHub over the
+         network. Same white-box grant, same reason, as the three above. -->
+    <InternalsVisibleTo Include="Memex.Portal.Shared.Test" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -77,6 +77,12 @@ public static class PluginCatalogConfigurationExtensions
                 // Mints (once, per registry) and rotates the key that signs short-lived sync access
                 // tokens. Mesh-scoped so its cache dies with the mesh, like the authenticator.
                 .AddSingleton<SyncTokenSigningKeyService>()
+                // The SECOND issuer's key source (#2483): GitHub's OIDC JWKS, read once an hour and
+                // shared. Mesh-scoped for the same reason as everything above — a key set held in a
+                // static field would outlive the mesh and bleed across tests and deployments. A
+                // fetch that fails FAILS CLOSED: the observable errors, so the authenticator answers
+                // "undetermined" (503 + Retry-After) rather than "unknown token", and never accepts.
+                .AddSingleton<GitHubOidcKeyService>()
                 // The plan ladder (Admin/Tiers/*) a plan-scoped grant entry is decided against —
                 // read once per minute, on the caller, by the authenticator above. Mesh-scoped so
                 // the cache dies with the mesh.

--- a/test/Memex.Portal.Shared.Test/BuildPrincipalAuthenticationTest.cs
+++ b/test/Memex.Portal.Shared.Test/BuildPrincipalAuthenticationTest.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Api;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The build principal end to end (#2483): a GitHub Actions OIDC token, verified against a JWKS this
+/// test controls, resolved to a <c>BuildPrincipal</c> node in the Admin partition, and finally
+/// decided at the prebuilt-publication routes.
+///
+/// <para>🚨 <b>The refusal matrix is the point.</b> Every negative below starts from a token that
+/// WOULD be accepted and moves exactly one thing — the repository, the audience, the expiry, the
+/// node, the scope — so a passing assertion can only mean that one thing was checked. A verifier
+/// that checked the signature and stopped would authenticate every workflow run on GitHub.</para>
+///
+/// <para>🚨 <b>And the third state.</b> An unreadable JWKS answers <c>503</c>, never <c>401</c>:
+/// "I could not find out" is not a denial and certainly not an admission (core #2901). The test
+/// asserts the STATUS, because a build told "your identity is unknown" goes looking for a
+/// credential that was never the problem.</para>
+/// </summary>
+public class BuildPrincipalAuthenticationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Audience = "https://registry.build-principal.test";
+    private const string Repository = "Systemorph/MeshWeaver.SocialMedia";
+    private const string Identity = "s0123456789abcdef0123456789abcdef";
+    private const string Source = "plugins";
+
+    private readonly GitHubTokenFactory tokens = new();
+
+    /// <inheritdoc />
+    public override async ValueTask DisposeAsync()
+    {
+        tokens.Dispose();
+        await base.DisposeAsync();
+    }
+
+    /// <summary>What the JWKS leaf answers next. A test swaps it to stage a rotation or an outage.
+    /// Instance state, so it dies with the test class — never a static.</summary>
+    private volatile Func<string> jwks = () => "";
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddPluginCatalog()
+            .ConfigureServices(services => services
+                // The audience is the one deployment knob the build-principal leg has, and an
+                // unconfigured one refuses everything — so a test that wants the leg live has to
+                // name it, exactly as an operator does.
+                .AddSingleton<IConfiguration>(new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        [BuildPrincipalConfiguration.AudienceConfigKey] = Audience,
+                    })
+                    .Build())
+                // 🚨 TRANSIENT here, singleton in production. The service caches a key set for an
+                // hour on purpose; a per-request instance lets each fact stage its own JWKS (a
+                // rotation, an outage) without a Clear() for test isolation, which would be the tell
+                // of an unfixed root cause. The cache and refresh-floor rules are pinned separately
+                // below, against one instance driven directly.
+                .AddTransient(sp => new GitHubOidcKeyService(
+                    sp.GetRequiredService<IMessageHub>(),
+                    sp.GetRequiredService<ILogger<GitHubOidcKeyService>>())
+                {
+                    FetchOverride = _ => Task.FromResult(jwks()),
+                }));
+
+    private InstanceRegistryAuthenticator Authenticator() => new(
+        Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>());
+
+    private Task<InstanceAuthResult> Authenticate(string token) =>
+        Authenticator().AuthenticateOutcome($"Bearer {token}")
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+
+    /// <summary>Writes a build principal into the Admin partition — the create a global admin
+    /// makes. As System, because the Admin partition is exactly what an ordinary identity cannot
+    /// write.</summary>
+    private Task<MeshNode> Grant(BuildPrincipal principal, string? repository = null)
+    {
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var id = BuildPrincipal.NodeId(repository ?? principal.Repository);
+        var node = new MeshNode(id, BuildPrincipal.Namespace)
+        {
+            Name = $"Build principal: {principal.Repository}",
+            NodeType = MeshWeaverInstanceNodeType.BuildPrincipalNodeType,
+            State = MeshNodeState.Active,
+            Content = principal,
+        };
+        return access.RunAsSystem(() => meshService.CreateOrUpdateNode(node))
+            .Timeout(TestTimeouts.Convergence).Await();
+    }
+
+    private static BuildPrincipal Principal(string repository = Repository) => new()
+    {
+        Repository = repository,
+        Scopes = [$"{BuildVerbs.Fetch}:{Source}", $"{BuildVerbs.Publish}:socialmedia"],
+        Events = new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["push"] = [BuildVerbs.Fetch, BuildVerbs.Publish],
+            ["pull_request"] = [BuildVerbs.Fetch],
+        },
+        IssuedBy = "admin",
+        IssuedAt = DateTimeOffset.UtcNow.AddDays(-1),
+    };
+
+    // ── the authenticator ────────────────────────────────────────────────────
+
+    [Fact(Timeout = 240_000)]
+    public async Task AVerifiedToken_ResolvesToItsPrincipal_AndOnlyWhenOneExists()
+    {
+        jwks = () => tokens.Jwks();
+        var repository = "Systemorph/MeshWeaver.NoPrincipalYet";
+
+        // 1. No node for the repository → a DEFINITIVE negative. A verified signature is not an
+        //    authorization: this is the "no node = 401" the design names.
+        var stranger = await Authenticate(tokens.Mint(Audience, repository: repository));
+        Assert.False(stranger.IsUnavailable);
+        Assert.Null(stranger.Instance);
+        Assert.Null(stranger.Build);
+
+        // 2. Same token, once a global admin has written the rule → authenticated.
+        await Grant(Principal(repository));
+        var trusted = await Authenticate(tokens.Mint(Audience, repository: repository));
+        Assert.False(trusted.IsUnavailable);
+        Assert.NotNull(trusted.Build);
+        Assert.Equal(repository, trusted.Build!.Repository);
+        // 🚨 …and it is NOT an instance. Every surface that needs an installation keeps refusing it.
+        Assert.Null(trusted.Instance);
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task ANodeThatNamesAnotherRepository_DoesNotAuthenticateTheToken()
+    {
+        // The path is a routing hint; the RECORD is the authority. A node hand-edited (or migrated)
+        // so its path and its declared repository disagree must authenticate nobody.
+        jwks = () => tokens.Jwks();
+        var repository = "Systemorph/MeshWeaver.PathDrift";
+        await Grant(Principal("Systemorph/SomethingElse"), repository);
+
+        var result = await Authenticate(tokens.Mint(Audience, repository: repository));
+
+        Assert.False(result.IsUnavailable);
+        Assert.Null(result.Build);
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task ARevokedPrincipal_StopsAuthenticatingAtOnce()
+    {
+        jwks = () => tokens.Jwks();
+        var repository = "Systemorph/MeshWeaver.Revoked";
+        await Grant(Principal(repository));
+        Assert.NotNull((await Authenticate(tokens.Mint(Audience, repository: repository))).Build);
+
+        // The control-plane verb — no watcher stands between writing it and the refusal.
+        await Grant(Principal(repository) with { RequestedAction = BuildPrincipalActions.Revoke });
+
+        var result = await Authenticate(tokens.Mint(Audience, repository: repository));
+        Assert.False(result.IsUnavailable);
+        Assert.Null(result.Build);
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task AWrongAudienceOrAnExpiredToken_IsRefused_NotUnavailable()
+    {
+        jwks = () => tokens.Jwks();
+        await Grant(Principal());
+
+        foreach (var token in new[]
+                 {
+                     tokens.Mint("api://AzureADTokenExchange"),
+                     tokens.Mint(Audience, issuedAt: DateTimeOffset.UtcNow.AddHours(-2)),
+                     tokens.Mint(Audience, issuer: "https://evil.example"),
+                 })
+        {
+            var result = await Authenticate(token);
+            Assert.False(result.IsUnavailable, "a bad token is a VERDICT, not an outage");
+            Assert.Null(result.Build);
+        }
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task AnUnreachableKeySet_IsUNDETERMINED_NeverUnknownToken()
+    {
+        // 🚨 Fail closed AND distinguishable. The build is told "retry", not "your identity is
+        // unknown" — the latter sends an operator hunting a credential that was never the problem
+        // (the #2695 shape, on the leg that did not exist yet).
+        jwks = () => throw new HttpRequestException("JWKS unreachable");
+        await Grant(Principal());
+
+        var result = await Authenticate(tokens.Mint(Audience));
+
+        Assert.True(result.IsUnavailable);
+        Assert.Null(result.Build);
+        Assert.Null(result.Instance);
+    }
+
+    [Fact(Timeout = 240_000)]
+    public async Task AKeySetThatPublishesNothingUsable_IsUNDETERMINED_NotAnAdmission()
+    {
+        // An empty key set would refuse everything, which is correct — but it must not be REMEMBERED
+        // for an hour as if it were a valid answer, so the read throws and stays retryable.
+        jwks = () => """{"keys":[]}""";
+        await Grant(Principal());
+
+        var result = await Authenticate(tokens.Mint(Audience));
+
+        Assert.True(result.IsUnavailable);
+        Assert.Null(result.Build);
+    }
+
+    // ── the key service's own cache ──────────────────────────────────────────
+
+    [Fact(Timeout = 240_000)]
+    public async Task TheKeySetIsReadOnce_AFaultIsNeverCached_AndTheRefreshFloorBoundsRe_Reads()
+    {
+        var reads = 0;
+        var document = tokens.Jwks();
+        var fail = true;
+        var service = new GitHubOidcKeyService(
+            Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<GitHubOidcKeyService>>())
+        {
+            FetchOverride = _ =>
+            {
+                Interlocked.Increment(ref reads);
+                return fail
+                    ? Task.FromException<string>(new HttpRequestException("down"))
+                    : Task.FromResult(document);
+            },
+        };
+        var now = DateTimeOffset.UtcNow;
+
+        // A failure propagates AND is not cached — the next caller starts a genuinely new attempt
+        // rather than replaying a latched OnError (the ReplaySubject trap, #1369).
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            service.Keys(now).FirstAsync().Timeout(TestTimeouts.Convergence).Await());
+        await Assert.ThrowsAnyAsync<Exception>(() =>
+            service.Keys(now).FirstAsync().Timeout(TestTimeouts.Convergence).Await());
+        Assert.Equal(2, reads);
+
+        fail = false;
+        var first = await service.Keys(now).FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        Assert.Single(first.ByKeyId);
+        Assert.Equal(3, reads);
+
+        // A success is shared: a second caller inside the window costs no round trip.
+        await service.Keys(now).FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        Assert.Equal(3, reads);
+
+        // 🚨 The refresh floor. An unknown kid may force ONE early re-read; inside the floor it
+        // returns the set unchanged, so a caller inventing key ids cannot amplify into a fetch per
+        // request.
+        var suppressed = await service.Refresh(first, now).FirstAsync()
+            .Timeout(TestTimeouts.Convergence).Await();
+        Assert.Equal(3, reads);
+        Assert.Equal(first.FetchedAt, suppressed.FetchedAt);
+
+        // Past the floor it really does re-read — a rotation is recoverable without a restart.
+        await service.Refresh(first, now + GitHubOidcKeyService.MinimumRefreshInterval + TimeSpan.FromSeconds(1))
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        Assert.Equal(4, reads);
+
+        // And a stale set is re-read on the ordinary path too.
+        await service.Keys(now + GitHubOidcKeyService.CacheDuration + TimeSpan.FromMinutes(1))
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        Assert.Equal(5, reads);
+    }
+
+    // ── the endpoint ─────────────────────────────────────────────────────────
+
+    [Fact(Timeout = 240_000)]
+    public async Task ThePrebuiltRoutesServeATrustedBuild_AndRefuseEveryoneElse()
+    {
+        jwks = () => tokens.Jwks();
+        var root = Path.Combine(Path.GetTempPath(), "mw-buildprincipal-" + Guid.NewGuid().ToString("N"));
+        var dir = Path.Combine(root, Identity, Source);
+        Directory.CreateDirectory(dir);
+        try
+        {
+            WriteBundle(Path.Combine(dir, "Store.zip"));
+            File.WriteAllText(
+                Path.Combine(dir, ShippedPrebuiltBundles.CompletionSentinelFileName), "Store.zip\n");
+
+            await Grant(Principal());
+            await using var app = await StartHost(root);
+            var route = $"/api/plugins/bundles/prebuilt/{Identity}/{Source}";
+
+            // 1. the designed case — a push from the trusted repo, holding fetch:plugins
+            var ok = await Get(app, route, tokens.Mint(Audience));
+            Assert.Equal(HttpStatusCode.OK, ok.StatusCode);
+            Assert.Contains("Store.zip", await ok.Content.ReadAsStringAsync());
+            var bytes = await Get(app, route + "/Store.zip", tokens.Mint(Audience));
+            Assert.Equal(HttpStatusCode.OK, bytes.StatusCode);
+
+            // 2. 🚨 a valid signature from ANOTHER repository — 401, because no rule names it
+            var other = await Get(app, route, tokens.Mint(Audience, repository: "Systemorph/Evil"));
+            Assert.Equal(HttpStatusCode.Unauthorized, other.StatusCode);
+
+            // 3. the right repository on an event its rule does not carry → 403, never the bytes
+            var wrongEvent = await Get(app, route, tokens.Mint(Audience, eventName: "workflow_dispatch"));
+            Assert.Equal(HttpStatusCode.Forbidden, wrongEvent.StatusCode);
+
+            // 4. a source the principal holds no fetch scope for → 403
+            var otherSource = await Get(
+                app, $"/api/plugins/bundles/prebuilt/{Identity}/education", tokens.Mint(Audience));
+            Assert.Equal(HttpStatusCode.Forbidden, otherSource.StatusCode);
+
+            // 5. 🚨 a build principal is NOT an installation: every other bundle route still 401s,
+            //    because it decides per package against a grant and a plan a build does not have.
+            var index = await Get(app, "/api/plugins/bundles/index.json", tokens.Mint(Audience));
+            Assert.Equal(HttpStatusCode.Unauthorized, index.StatusCode);
+
+            // 6. an unreadable key set is 503 + Retry-After, never the 401 a bad token gets
+            jwks = () => throw new HttpRequestException("JWKS unreachable");
+            var unavailable = await Get(app, route, tokens.Mint(Audience));
+            Assert.Equal(HttpStatusCode.ServiceUnavailable, unavailable.StatusCode);
+        }
+        finally
+        {
+            try { Directory.Delete(root, recursive: true); } catch { /* best effort */ }
+        }
+    }
+
+    private static void WriteBundle(string path)
+    {
+        using var zip = ZipFile.Open(path, ZipArchiveMode.Create);
+        using var writer = new StreamWriter(zip.CreateEntry("meshweaver/manifest.json").Open());
+        writer.Write("""{"plugin":"Store"}""");
+    }
+
+    private async Task<WebApplication> StartHost(string publishedRoot)
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Configuration.AddInMemoryCollection(new Dictionary<string, string?>
+        {
+            [PublishedBundleCatalogue.PublishedRootConfigKey] = publishedRoot,
+        });
+        builder.Services.AddSingleton<IMessageHub>(Mesh);
+        builder.Services.AddSingleton(new InstanceRegistryAuthenticator(
+            Mesh, Mesh.ServiceProvider.GetRequiredService<ILogger<InstanceRegistryAuthenticator>>()));
+        var app = builder.Build();
+        app.MapPluginBundles();
+        await app.StartAsync();
+        return app;
+    }
+
+    private static async Task<HttpResponseMessage> Get(WebApplication app, string route, string token)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, route);
+        request.Headers.TryAddWithoutValidation("Authorization", $"Bearer {token}");
+        return await app.GetTestClient().SendAsync(request);
+    }
+}

--- a/test/Memex.Portal.Shared.Test/BuildPrincipalDecisionTest.cs
+++ b/test/Memex.Portal.Shared.Test/BuildPrincipalDecisionTest.cs
@@ -1,0 +1,185 @@
+using System;
+using System.Collections.Generic;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The AUTHORIZATION half of the build principal (#2483) — the rule a verified GitHub Actions token
+/// is decided against, once the signature has established only WHICH repository asked.
+///
+/// <para>The three steps the design names, pinned one at a time: <c>repository</c> claim → node,
+/// <c>event_name</c> claim → allowed verbs, requested <c>verb:source</c> ∈ <c>scopes</c>. Every
+/// refusal below starts from the allowed case and moves exactly one thing, so a passing assertion
+/// can only mean that one thing was checked.</para>
+/// </summary>
+public class BuildPrincipalDecisionTest
+{
+    private static readonly DateTimeOffset Now = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+    private const string Repository = "Systemorph/MeshWeaver.SocialMedia";
+
+    private static BuildPrincipal Principal(
+        string repository = Repository,
+        string[]? scopes = null,
+        IReadOnlyDictionary<string, IReadOnlyCollection<string>>? events = null,
+        IReadOnlyDictionary<string, IReadOnlyCollection<string>>? eventRefs = null) =>
+        new()
+        {
+            Repository = repository,
+            Scopes = scopes ?? ["publish:socialmedia", "fetch:plugins"],
+            Events = events ?? new Dictionary<string, IReadOnlyCollection<string>>
+            {
+                ["push"] = ["publish", "fetch"],
+                ["pull_request"] = ["fetch"],
+            },
+            EventRefs = eventRefs ?? new Dictionary<string, IReadOnlyCollection<string>>(),
+            IssuedBy = "admin",
+            IssuedAt = Now.AddDays(-1),
+        };
+
+    private static GitHubBuildClaims Claims(
+        string repository = Repository,
+        string eventName = "push",
+        string gitRef = "refs/heads/main",
+        string? repositoryId = "123456789") =>
+        new()
+        {
+            Repository = repository,
+            RepositoryId = repositoryId,
+            RepositoryOwnerId = "9999",
+            EventName = eventName,
+            Ref = gitRef,
+        };
+
+    [Fact]
+    public void TheDesignedCase_Allows()
+    {
+        Assert.True(Principal().Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+        Assert.True(Principal().Allows(Claims(), BuildVerbs.Publish, "socialmedia", Now));
+    }
+
+    [Fact]
+    public void AnotherRepositorysToken_IsRefused()
+    {
+        // 🚨 THE assertion this whole file exists for. Every workflow on GitHub holds a token with a
+        // valid signature; only the repository claim tells them apart. A prefix or wildcard match
+        // here would authorize any repository whose name merely starts the same way.
+        Assert.False(Principal().Allows(Claims("Systemorph/MeshWeaver.Evil"), BuildVerbs.Fetch, "plugins", Now));
+        Assert.False(Principal().Allows(Claims("Evil/MeshWeaver.SocialMedia"), BuildVerbs.Fetch, "plugins", Now));
+        Assert.Contains("repository", Principal().Refuse(
+            Claims("Systemorph/MeshWeaver.Evil"), BuildVerbs.Fetch, "plugins", Now)!);
+    }
+
+    [Fact]
+    public void TheImmutableClaimFormatStillMatchesAClassicallyWrittenPrincipal()
+    {
+        // The migration hazard: GitHub moving the org to immutable ids must not silently stop every
+        // build principal in the fleet from authenticating.
+        Assert.True(Principal().Allows(
+            Claims("Systemorph@12345/MeshWeaver.SocialMedia@67890"), BuildVerbs.Fetch, "plugins", Now));
+    }
+
+    [Fact]
+    public void AnUnlistedEvent_IsRefused()
+    {
+        Assert.False(Principal().Allows(Claims(eventName: "workflow_dispatch"), BuildVerbs.Fetch, "plugins", Now));
+        Assert.False(Principal().Allows(Claims(eventName: ""), BuildVerbs.Fetch, "plugins", Now));
+    }
+
+    [Fact]
+    public void AVerbTheEventDoesNotCarry_IsRefused()
+    {
+        // The design's whole point: `push` on main may publish; a pull request may only fetch.
+        Assert.True(Principal().Allows(Claims(eventName: "pull_request"), BuildVerbs.Fetch, "plugins", Now));
+        Assert.False(Principal().Allows(
+            Claims(eventName: "pull_request"), BuildVerbs.Publish, "socialmedia", Now));
+    }
+
+    [Fact]
+    public void AScopeForAnotherSource_IsRefused_AndThereIsNoWildcard()
+    {
+        Assert.False(Principal().Allows(Claims(), BuildVerbs.Fetch, "education", Now));
+        // A principal cannot buy itself every source by writing a star: `fetch:*` is a literal
+        // scope for a source literally named "*", which no registry has.
+        Assert.False(Principal(scopes: ["fetch:*"]).Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+        // …and publishing is not implied by fetching.
+        Assert.False(Principal(scopes: ["fetch:plugins"]).Allows(Claims(), BuildVerbs.Publish, "plugins", Now));
+    }
+
+    [Fact]
+    public void AScopeIsCaseInsensitiveOnBothHalves()
+    {
+        // Source names are operator-typed config values, matched case-insensitively everywhere else
+        // in the grant model (PluginGrantEntry.Source) — this must not be the one place they are not.
+        Assert.True(Principal(scopes: ["Fetch:Plugins"]).Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+        Assert.True(Principal().Allows(Claims(), "FETCH", "PLUGINS", Now));
+    }
+
+    [Fact]
+    public void ARefPin_AppliesToTheEventThatDeclaresIt_AndOnlyThat()
+    {
+        var pinned = Principal(eventRefs: new Dictionary<string, IReadOnlyCollection<string>>
+        {
+            ["push"] = ["refs/heads/main"],
+        });
+
+        Assert.True(pinned.Allows(Claims(), BuildVerbs.Publish, "socialmedia", Now));
+        // A push to somebody's feature branch is not a push to main.
+        Assert.False(pinned.Allows(
+            Claims(gitRef: "refs/heads/feat/anything"), BuildVerbs.Publish, "socialmedia", Now));
+        // The pull_request event declares no pin — its ref is refs/pull/<n>/merge and cannot be
+        // enumerated in advance, so it must stay unconstrained rather than silently refuse.
+        Assert.True(pinned.Allows(
+            Claims(eventName: "pull_request", gitRef: "refs/pull/17/merge"), BuildVerbs.Fetch, "plugins", Now));
+    }
+
+    [Fact]
+    public void RevocationTakesEffectImmediately_OnEitherForm()
+    {
+        // 🚨 No watcher stands between writing the revoke and the refusal. A security stop that
+        // waits for a reactor is a security stop with a window.
+        Assert.False((Principal() with { RequestedAction = BuildPrincipalActions.Revoke })
+            .Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+        Assert.False((Principal() with { RequestedAction = "revoke" })
+            .Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+        Assert.False((Principal() with { IsRevoked = true })
+            .Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+    }
+
+    [Fact]
+    public void AnEndedTerm_IsRefused()
+    {
+        Assert.False((Principal() with { ExpiresAt = Now.AddMinutes(-1) })
+            .Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+        Assert.True((Principal() with { ExpiresAt = Now.AddMinutes(1) })
+            .Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+    }
+
+    [Fact]
+    public void AnImmutableIdPin_MustMatchExactly_WhenSet()
+    {
+        var pinned = Principal() with { RepositoryId = "123456789" };
+
+        Assert.True(pinned.Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+        // A repository renamed away and its name re-registered by someone else carries a different
+        // immutable id — which is the entire reason the pin exists.
+        Assert.False(pinned.Allows(Claims(repositoryId: "987654321"), BuildVerbs.Fetch, "plugins", Now));
+        Assert.False(pinned.Allows(Claims(repositoryId: null), BuildVerbs.Fetch, "plugins", Now));
+        // Unpinned stays unpinned — the ordinary case must not start demanding an id.
+        Assert.True(Principal().Allows(Claims(repositoryId: null), BuildVerbs.Fetch, "plugins", Now));
+    }
+
+    [Fact]
+    public void AnEmptyPrincipal_GrantsNothing()
+    {
+        // The default-constructed shape — what a half-written node deserializes to — must authorize
+        // nothing at all rather than everything.
+        var empty = new BuildPrincipal { Repository = Repository };
+
+        Assert.False(empty.Allows(Claims(), BuildVerbs.Fetch, "plugins", Now));
+        Assert.False(empty.Allows(null, BuildVerbs.Fetch, "plugins", Now));
+        Assert.False(Principal().Allows(Claims(), "", "plugins", Now));
+        Assert.False(Principal().Allows(Claims(), BuildVerbs.Fetch, "", Now));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/GitHubBuildTokenTest.cs
+++ b/test/Memex.Portal.Shared.Test/GitHubBuildTokenTest.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using MeshWeaver.Mesh.Security;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The verifier half of the build principal (#2483): what a GitHub Actions OIDC token has to prove
+/// before the mesh will even look up a rule for it.
+///
+/// <para>🚨 <b>Signature-only is the failure this file exists to make impossible.</b> Every workflow
+/// run on GitHub carries a token signed by the same keys, so a verifier that checks the signature and
+/// stops authenticates the entire public internet's CI. Each refusal below is therefore asserted with
+/// an otherwise VALID token — same key, same signature, one claim moved — so a passing test can only
+/// mean the claim itself was checked.</para>
+///
+/// <para>The third state is asserted too: an unknown <c>kid</c> is
+/// <see cref="GitHubTokenVerification.KeyUnknown"/>, neither accepted nor refused, because a routine
+/// GitHub key rotation must become a re-read rather than a fleet-wide outage — and must never become
+/// an admission.</para>
+/// </summary>
+public class GitHubBuildTokenTest
+{
+    private const string Audience = "https://registry.example.test";
+    private const string Repository = "Systemorph/MeshWeaver.SocialMedia";
+    private static readonly DateTimeOffset Now = new(2026, 9, 1, 12, 0, 0, TimeSpan.Zero);
+    private static readonly string[] Audiences = [Audience];
+
+    private static GitHubTokenVerification Verify(
+        GitHubTokenFactory factory, string token, DateTimeOffset? now = null,
+        IReadOnlyCollection<string>? audiences = null,
+        IReadOnlyDictionary<string, GitHubSigningKey>? keys = null) =>
+        GitHubActionsToken.Verify(token, now ?? Now, audiences ?? Audiences, keys ?? factory.Keys());
+
+    [Fact]
+    public void AGenuineTokenVerifies_AndCarriesTheClaimsADecisionNeeds()
+    {
+        using var factory = new GitHubTokenFactory();
+
+        var result = Verify(factory, factory.Mint(Audience, issuedAt: Now));
+
+        Assert.True(result.IsVerified);
+        Assert.Equal(Repository, result.Claims!.Repository);
+        Assert.Equal("push", result.Claims.EventName);
+        Assert.Equal("refs/heads/main", result.Claims.Ref);
+        Assert.Equal("123456789", result.Claims.RepositoryId);
+        Assert.Equal(Audience, result.Claims.Audience);
+    }
+
+    [Fact]
+    public void NoConfiguredAudience_RefusesAPerfectlyValidToken()
+    {
+        // The whole build-principal leg is off until an operator names an audience. "Unconfigured"
+        // must never read as "accept anything": every GitHub run in the world verifies here.
+        using var factory = new GitHubTokenFactory();
+
+        var result = Verify(factory, factory.Mint(Audience, issuedAt: Now), audiences: []);
+
+        Assert.False(result.IsVerified);
+        Assert.False(result.KeyUnknown);
+    }
+
+    [Fact]
+    public void AnotherServicesAudienceIsRefused()
+    {
+        // The exact attack the audience exists to stop: a token a workflow legitimately minted for
+        // Azure, replayed here.
+        using var factory = new GitHubTokenFactory();
+
+        var result = Verify(factory, factory.Mint("api://AzureADTokenExchange", issuedAt: Now));
+
+        Assert.False(result.IsVerified);
+    }
+
+    [Fact]
+    public void AnAudienceArrayIsHonoured_WhenItContainsOurs()
+    {
+        using var factory = new GitHubTokenFactory();
+        var token = factory.Mint(
+            Audience, issuedAt: Now, audienceJson: $"[\"api://other\",\"{Audience}\"]");
+
+        Assert.True(Verify(factory, token).IsVerified);
+        // …and not when it does not.
+        var other = factory.Mint(Audience, issuedAt: Now, audienceJson: "[\"api://other\"]");
+        Assert.False(Verify(factory, other).IsVerified);
+    }
+
+    [Fact]
+    public void AnotherIssuerIsRefused()
+    {
+        using var factory = new GitHubTokenFactory();
+
+        var result = Verify(factory, factory.Mint(Audience, issuedAt: Now, issuer: "https://evil.example"));
+
+        Assert.False(result.IsVerified);
+        // …and the routing peek agrees it was never ours to verify in the first place.
+        Assert.False(GitHubActionsToken.IsGitHubIssued(
+            factory.Mint(Audience, issuedAt: Now, issuer: "https://evil.example")));
+    }
+
+    [Fact]
+    public void AnIssuerThatMerelySTARTSWithGitHubsIsRefused()
+    {
+        // A prefix match here would trust https://token.actions.githubusercontent.com.evil.example.
+        using var factory = new GitHubTokenFactory();
+        var token = factory.Mint(
+            Audience, issuedAt: Now, issuer: GitHubActionsToken.Issuer + ".evil.example");
+
+        Assert.False(Verify(factory, token).IsVerified);
+        Assert.False(GitHubActionsToken.IsGitHubIssued(token));
+    }
+
+    [Fact]
+    public void AnExpiredTokenIsRefused()
+    {
+        using var factory = new GitHubTokenFactory();
+        var token = factory.Mint(Audience, issuedAt: Now.AddHours(-2), lifetime: TimeSpan.FromMinutes(10));
+
+        Assert.False(Verify(factory, token).IsVerified);
+        // …and the same token verified at its own issue instant does, so only the clock moved.
+        Assert.True(Verify(factory, token, now: Now.AddHours(-2)).IsVerified);
+    }
+
+    [Fact]
+    public void ATokenThatIsNotYetValidIsRefused()
+    {
+        using var factory = new GitHubTokenFactory();
+        var token = factory.Mint(Audience, issuedAt: Now.AddHours(1));
+
+        Assert.False(Verify(factory, token).IsVerified);
+    }
+
+    [Fact]
+    public void TheTokensOwnAlgIsNeverHonoured()
+    {
+        using var factory = new GitHubTokenFactory();
+
+        // `none` — the classic forgery.
+        Assert.False(Verify(factory, factory.Mint(Audience, issuedAt: Now, algorithm: "none")).IsVerified);
+        // …and an HMAC claim over the same bytes: the header decides which verifier runs, and this
+        // one only ever runs RS256.
+        Assert.False(Verify(factory, factory.Mint(Audience, issuedAt: Now, algorithm: "HS256")).IsVerified);
+    }
+
+    [Fact]
+    public void ASignatureFromAnotherKeyIsRefused()
+    {
+        using var factory = new GitHubTokenFactory();
+        using var stranger = RSA.Create(2048);
+
+        var token = factory.Mint(Audience, issuedAt: Now, signWith: stranger);
+
+        Assert.False(Verify(factory, token).IsVerified);
+    }
+
+    [Fact]
+    public void AKeySetPublishingSomeoneElsesKeyUnderTheSameKidIsRefused()
+    {
+        // The JWKS is the trust anchor; a token signed by us must not verify against a key set that
+        // merely REUSES our kid.
+        using var factory = new GitHubTokenFactory();
+        var keys = GitHubActionsToken.ParseJwks(factory.JwksOfAStranger());
+
+        var result = Verify(factory, factory.Mint(Audience, issuedAt: Now), keys: keys);
+
+        Assert.False(result.IsVerified);
+        Assert.False(result.KeyUnknown, "the kid WAS published — this is a rejection, not an unknown key");
+    }
+
+    [Fact]
+    public void ASwappedPayloadIsRefused()
+    {
+        // A valid signature over DIFFERENT bytes: the only forgery left once `alg` and the key are
+        // pinned, and the one that would hand another repository's identity to this one.
+        using var factory = new GitHubTokenFactory();
+
+        var token = factory.MintWithSwappedPayload(Audience, Repository, "Systemorph/Evil");
+
+        Assert.False(Verify(factory, token).IsVerified);
+    }
+
+    [Fact]
+    public void AnUnknownKidIsUNDETERMINED_NeitherAcceptedNorRefused()
+    {
+        // 🚨 The third state (core #2901). GitHub rotates these keys; folding "I do not hold that
+        // key" into "rejected" turns a routine rotation into a fleet-wide outage, and folding it
+        // into "accepted" is a hole. It is neither: the caller re-reads the set and asks again.
+        using var factory = new GitHubTokenFactory();
+
+        var result = Verify(factory, factory.Mint(Audience, issuedAt: Now, keyId: "rotated-away"));
+
+        Assert.False(result.IsVerified);
+        Assert.True(result.KeyUnknown);
+    }
+
+    [Fact]
+    public void ATokenWithNoRepositoryClaimIsRefused()
+    {
+        using var factory = new GitHubTokenFactory();
+
+        Assert.False(Verify(factory, factory.Mint(Audience, issuedAt: Now, repository: "")).IsVerified);
+    }
+
+    [Fact]
+    public void GarbageIsRefusedWithoutThrowing()
+    {
+        // This runs on an UNAUTHENTICATED request with attacker-controlled input: a throwing parse
+        // would let anyone make the registry raise and unwind an exception per request.
+        using var factory = new GitHubTokenFactory();
+
+        foreach (var candidate in new[] { null, "", "   ", "a.b", "a.b.c", "...", new string('x', 20_000) })
+            Assert.False(GitHubActionsToken.Verify(candidate, Now, Audiences, factory.Keys()).IsVerified);
+    }
+
+    // ── the JWKS reader ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void TheKeySetSkipsEveryEntryThisVerifierWouldNotUse()
+    {
+        using var factory = new GitHubTokenFactory();
+        var keys = GitHubActionsToken.ParseJwks(factory.Jwks(
+            """{"kty":"EC","use":"sig","kid":"ec","crv":"P-256","x":"AA","y":"BB"}""",
+            """{"kty":"RSA","use":"enc","alg":"RS256","kid":"enc","n":"AQAB","e":"AQAB"}""",
+            """{"kty":"RSA","use":"sig","alg":"RS512","kid":"rs512","n":"AQAB","e":"AQAB"}""",
+            // RSA-1024: a modulus short enough to be forgeable is dropped at PARSE time rather
+            // than trusted at verify time.
+            $$"""{"kty":"RSA","use":"sig","alg":"RS256","kid":"short","n":"{{new string('A', 171)}}","e":"AQAB"}"""));
+
+        Assert.Equal([factory.KeyId], keys.Keys);
+    }
+
+    [Fact]
+    public void AMalformedKeySetIsEmpty_NeverAThrow()
+    {
+        foreach (var document in new[] { null, "", "not json", "[]", """{"keys":{}}""", """{"keys":[1,2]}""" })
+            Assert.Empty(GitHubActionsToken.ParseJwks(document));
+    }
+
+    [Fact]
+    public void DiscoveryMayMoveThePath_NeverTheHost()
+    {
+        Assert.Equal(
+            "https://token.actions.githubusercontent.com/somewhere/else",
+            GitHubActionsToken.JwksUriFromDiscovery(
+                """{"jwks_uri":"https://token.actions.githubusercontent.com/somewhere/else"}"""));
+
+        // 🚨 A discovery document is fetched over the network. It is allowed to move the PATH; it is
+        // never allowed to move the trust anchor.
+        Assert.Null(GitHubActionsToken.JwksUriFromDiscovery("""{"jwks_uri":"https://evil.example/jwks"}"""));
+        Assert.Null(GitHubActionsToken.JwksUriFromDiscovery(
+            """{"jwks_uri":"http://token.actions.githubusercontent.com/jwks"}"""));
+        Assert.Null(GitHubActionsToken.JwksUriFromDiscovery("""{"jwks_uri":"/relative"}"""));
+        Assert.Null(GitHubActionsToken.JwksUriFromDiscovery("not json"));
+    }
+
+    // ── repository matching, classic and immutable ───────────────────────────
+
+    [Fact]
+    public void TheImmutableSubjectFormatMatchesTheClassicOne()
+    {
+        // 🚨 The migration hazard: when GitHub moves an org onto immutable ids, a principal written
+        // in the classic form must keep matching — or every build principal in the fleet silently
+        // stops authenticating on a day nobody changed anything.
+        Assert.True(GitHubActionsToken.RepositoryEquals(
+            "Systemorph/MeshWeaver.SocialMedia", "Systemorph@12345/MeshWeaver.SocialMedia@67890"));
+        Assert.True(GitHubActionsToken.RepositoryEquals(
+            "Systemorph@12345/MeshWeaver.SocialMedia@67890", "Systemorph/MeshWeaver.SocialMedia"));
+        Assert.Equal(
+            "Systemorph/MeshWeaver.SocialMedia",
+            GitHubActionsToken.NormalizeRepository("Systemorph@12345/MeshWeaver.SocialMedia@67890"));
+    }
+
+    [Fact]
+    public void RepositoryMatchingIsExact_NeverAPrefix()
+    {
+        Assert.False(GitHubActionsToken.RepositoryEquals(
+            "Systemorph/MeshWeaver", "Systemorph/MeshWeaver.Evil"));
+        Assert.False(GitHubActionsToken.RepositoryEquals(
+            "Systemorph/MeshWeaver", "Evil/MeshWeaver"));
+        Assert.False(GitHubActionsToken.RepositoryEquals("Systemorph/MeshWeaver", null));
+        Assert.False(GitHubActionsToken.RepositoryEquals("", ""));
+        // GitHub names are case-insensitive, so an admin's casing must not lock a repo out.
+        Assert.True(GitHubActionsToken.RepositoryEquals(
+            "systemorph/meshweaver.socialmedia", "Systemorph/MeshWeaver.SocialMedia"));
+        // …and a non-numeric suffix after '@' is NOT an immutable id, so it is not stripped.
+        Assert.False(GitHubActionsToken.RepositoryEquals(
+            "Systemorph/MeshWeaver", "Systemorph/MeshWeaver@evil"));
+    }
+
+    [Fact]
+    public void ARepositoryResolvesToOneDeterministicNodePath()
+    {
+        Assert.Equal(
+            "Admin/_BuildPrincipal/systemorph--meshweaver.socialmedia",
+            BuildPrincipal.PathFor("Systemorph/MeshWeaver.SocialMedia"));
+        // Both claim formats route to the SAME node — the path is derived from the normalized form.
+        Assert.Equal(
+            BuildPrincipal.PathFor("Systemorph/MeshWeaver.SocialMedia"),
+            BuildPrincipal.PathFor("Systemorph@1/MeshWeaver.SocialMedia@2"));
+        Assert.Equal("", BuildPrincipal.PathFor(""));
+    }
+}

--- a/test/Memex.Portal.Shared.Test/GitHubTokenFactory.cs
+++ b/test/Memex.Portal.Shared.Test/GitHubTokenFactory.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using MeshWeaver.Mesh.Security;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Mints GitHub-Actions-shaped OIDC tokens and the JWKS that verifies them, so the build-principal
+/// leg (#2483) can be exercised against REAL RSA signatures rather than a stubbed verifier.
+///
+/// <para>🚨 This is the producer half of the contract under test, written independently of
+/// <see cref="GitHubActionsToken"/>: it signs with <see cref="RSA"/> directly and lays the JWKS out
+/// the way GitHub does. A helper that reused the verifier's own encoder could agree with a broken
+/// one — the classic gate-that-tests-its-own-input.</para>
+/// </summary>
+internal sealed class GitHubTokenFactory : IDisposable
+{
+    private readonly RSA key = RSA.Create(2048);
+
+    /// <summary>The <c>kid</c> this factory's key is published under.</summary>
+    public string KeyId { get; init; } = "test-key-1";
+
+    /// <summary>The JWKS document publishing this factory's public key, exactly as GitHub lays one
+    /// out — plus, deliberately, entries this verifier must skip.</summary>
+    /// <param name="extras">Extra raw JWK JSON objects to include beside the real key.</param>
+    /// <returns>The JWKS document.</returns>
+    public string Jwks(params string[] extras)
+    {
+        var parameters = key.ExportParameters(includePrivateParameters: false);
+        var entries = new List<string>
+        {
+            $$"""
+            {"kty":"RSA","use":"sig","alg":"RS256","kid":"{{KeyId}}",
+             "n":"{{Base64Url(parameters.Modulus!)}}","e":"{{Base64Url(parameters.Exponent!)}}"}
+            """,
+        };
+        entries.AddRange(extras);
+        return $$"""{"keys":[{{string.Join(",", entries)}}]}""";
+    }
+
+    /// <summary>A JWKS that publishes a DIFFERENT key under the same <c>kid</c> — the shape a
+    /// signature forged with a key of the attacker's own choosing has to fail against.</summary>
+    /// <returns>The JWKS document.</returns>
+    public string JwksOfAStranger()
+    {
+        using var stranger = RSA.Create(2048);
+        var parameters = stranger.ExportParameters(includePrivateParameters: false);
+        return $$"""
+            {"keys":[{"kty":"RSA","use":"sig","alg":"RS256","kid":"{{KeyId}}",
+             "n":"{{Base64Url(parameters.Modulus!)}}","e":"{{Base64Url(parameters.Exponent!)}}"}]}
+            """;
+    }
+
+    /// <summary>The parsed key set this factory's tokens verify against.</summary>
+    /// <returns>Keys by <c>kid</c>.</returns>
+    public IReadOnlyDictionary<string, GitHubSigningKey> Keys() => GitHubActionsToken.ParseJwks(Jwks());
+
+    /// <summary>
+    /// Mints a token. Every claim has a realistic default so a test names only what it is varying.
+    /// </summary>
+    /// <param name="audience">The <c>aud</c> claim.</param>
+    /// <param name="repository">The <c>repository</c> claim.</param>
+    /// <param name="eventName">The <c>event_name</c> claim.</param>
+    /// <param name="gitRef">The <c>ref</c> claim.</param>
+    /// <param name="issuer">The <c>iss</c> claim.</param>
+    /// <param name="issuedAt">Issue instant; <c>nbf</c>/<c>iat</c> come from here.</param>
+    /// <param name="lifetime">How long after <paramref name="issuedAt"/> the token expires.</param>
+    /// <param name="algorithm">The <c>alg</c> header — vary it to forge.</param>
+    /// <param name="keyId">The <c>kid</c> header — vary it to name a key nobody publishes.</param>
+    /// <param name="repositoryId">The <c>repository_id</c> claim.</param>
+    /// <param name="signWith">Sign with this key instead of the factory's own.</param>
+    /// <param name="audienceJson">Raw JSON for <c>aud</c> (e.g. an array), overriding
+    /// <paramref name="audience"/>.</param>
+    /// <returns>The token string.</returns>
+    public string Mint(
+        string audience,
+        string repository = "Systemorph/MeshWeaver.SocialMedia",
+        string eventName = "push",
+        string gitRef = "refs/heads/main",
+        string issuer = GitHubActionsToken.Issuer,
+        DateTimeOffset? issuedAt = null,
+        TimeSpan? lifetime = null,
+        string algorithm = "RS256",
+        string? keyId = null,
+        string repositoryId = "123456789",
+        RSA? signWith = null,
+        string? audienceJson = null)
+    {
+        var start = issuedAt ?? DateTimeOffset.UtcNow;
+        var expires = start.Add(lifetime ?? TimeSpan.FromMinutes(10));
+        var header = $$"""{"alg":"{{algorithm}}","typ":"JWT","kid":"{{keyId ?? KeyId}}","x5t":"ignored"}""";
+        var payload = $$"""
+            {"iss":{{Json(issuer)}},"sub":"repo:{{repository}}:ref:{{gitRef}}",
+             "aud":{{audienceJson ?? Json(audience)}},
+             "iat":{{start.ToUnixTimeSeconds()}},"nbf":{{start.ToUnixTimeSeconds()}},
+             "exp":{{expires.ToUnixTimeSeconds()}},"jti":"{{Guid.NewGuid():N}}",
+             "repository":{{Json(repository)}},"repository_id":{{Json(repositoryId)}},
+             "repository_owner":{{Json(repository.Split('/')[0])}},"repository_owner_id":"9999",
+             "event_name":{{Json(eventName)}},"ref":{{Json(gitRef)}},
+             "workflow":"CI","actor":"rbuergi","run_id":"42",
+             "job_workflow_ref":"{{repository}}/.github/workflows/ci.yml@{{gitRef}}"}
+            """;
+
+        var signingInput = Base64Url(Encoding.UTF8.GetBytes(Compact(header)))
+                           + "." + Base64Url(Encoding.UTF8.GetBytes(Compact(payload)));
+        var signature = (signWith ?? key).SignData(
+            Encoding.ASCII.GetBytes(signingInput), HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
+        return $"{signingInput}.{Base64Url(signature)}";
+    }
+
+    /// <summary>A token whose PAYLOAD was swapped after signing — a valid signature over different
+    /// bytes, which is the only interesting forgery once `alg` is pinned.</summary>
+    /// <param name="audience">The <c>aud</c> of the honest token.</param>
+    /// <param name="honestRepository">The repository actually signed for.</param>
+    /// <param name="swappedRepository">The repository substituted afterwards.</param>
+    /// <returns>The tampered token.</returns>
+    public string MintWithSwappedPayload(
+        string audience, string honestRepository, string swappedRepository)
+    {
+        var honest = Mint(audience, honestRepository);
+        var forged = Mint(audience, swappedRepository);
+        var honestParts = honest.Split('.');
+        var forgedParts = forged.Split('.');
+        // header + payload from the forgery, signature from the honest token.
+        return $"{forgedParts[0]}.{forgedParts[1]}.{honestParts[2]}";
+    }
+
+    /// <inheritdoc />
+    public void Dispose() => key.Dispose();
+
+    private static string Compact(string json) =>
+        string.Concat(json.Where(c => c is not ('\n' or '\r' or ' ')));
+
+    private static string Json(string value) => JsonSerializer.Serialize(value);
+
+    private static string Base64Url(byte[] bytes) =>
+        Convert.ToBase64String(bytes).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+}


### PR DESCRIPTION
Closes #2483.

Items 1 and 2 of the issue as the maintainer's 2026-08-30 comment narrowed it. Item 3 (the registry
serving publications) shipped in #2487; item 4 (`upstream-seed` presenting its run token instead of
logging in to Azure) is a satellite-repo workflow edit and is now unblocked rather than done — that
is stated in `PluginBuildContract` so a later reader is not misled.

Prerequisite check: the parallel consumer-JWT effort (#2804 → #2811, "the licence lives on the
instance") **merged 2026-08-30**, so this builds on top of it as the comment sequenced. No collision:
this leg touches only the `iss != registry` branch, and the HS256 leg is byte-for-byte unchanged.

## What landed

**One verifier, two issuers, a trust node per issuer.** `InstanceRegistryAuthenticator.AuthenticateToken`
forks on the token's `iss`, read *unverified* — that read only picks a verifier and grants nothing;
every claim, `iss` included, is re-read from the verified payload.

| `iss` | verified against | resolves to |
|---|---|---|
| the registry | `SyncTokenSigningKeyService`'s HMAC material (HS256) | a `MeshWeaverInstance` + its `PluginGrant` |
| `token.actions.githubusercontent.com` | GitHub's published JWKS (RS256) | a `BuildPrincipal` node |

Neither leg honours a token's own `alg`.

**`BuildPrincipal`, at `Admin/_BuildPrincipal/{owner}--{repo}`.** In the Admin partition, exactly like
`PluginGrant` and for the same reason: the subject of an access decision must not be able to write the
decision, and that partition's access control **is** the global-admin gate rather than a second role
check that could drift. `search nodeType:BuildPrincipal` is the complete list of repositories this mesh
trusts. Create it with `create`; end it by writing `requestedAction: \"Revoke\"`.

> 🚨 **Deliberate deviation from the issue's wording:** the issue drafted this as `Store/BuildPrincipal`.
> `Store/*` node types are **in-mesh** NodeTypes owned by the Store package, and the verifier that reads
> this one is platform C# that cannot depend on a package's compiled-at-runtime type. It is therefore a
> core node type. Every security property the issue asked for is preserved; only the prefix moved, and
> the reasoning is recorded in `PluginBuildContract`.

**Wired, not merely armed.** A build principal is admitted on the prebuilt-publication routes, requiring
`fetch:<source>`. Every other bundle route keeps refusing it with the same 401 — a build is not an
installation, so it has no instance record, plan or grant to decide against. The narrowing lives once,
in the group filter, so a route added later is refused by default.

## The security bar

- **A verified signature is not an authorization.** Every workflow run on GitHub carries a token signed
  by these same keys. Checked: signature, `iss`, `aud`, validity window, non-empty `repository` — then
  resolved to a node. **No node ⇒ 401.**
- **`aud` is mandatory; unconfigured refuses everything.** A registry with no
  `Plugins:Registry:BuildPrincipalAudience` has no build-principal surface at all rather than one that
  accepts any audience. The **issuer is pinned in code, never configurable** — a configurable issuer is
  a configurable trust anchor.
- **The path is a routing hint; the record is the authority.** The node's own `repository` is compared
  with the claim again, exactly — never a prefix, never a wildcard. Scopes match exactly on both halves,
  so `fetch:*` is a scope for a source literally named `*`.
- **Both subject formats.** Classic and immutable (`Systemorph@<orgId>/<repo>@<repoId>`) normalize to the
  same `owner/name` and the same node path, so the day GitHub migrates an org is not the day every build
  principal silently stops authenticating. A principal may additionally pin the immutable numeric id.
- **Undetermined is a third state (core #2901).** An unreadable JWKS answers **503 + Retry-After**, never
  the 401 a bad token gets. An unknown `kid` re-reads the key set once behind a refresh floor, and is a
  *verdict* only when the set was actually re-read. The JWKS cache is a **mesh-scoped singleton with an
  instance field** — never static — and a fetch failure is never cached.
- **Revocation is immediate.** `IsActive` reads `requestedAction` itself; nothing has to observe the node
  and fold it first. The node is read on **every** request — only the JWKS is cached — so there is no
  revocation window to lose.

## The refusal matrix, proved

41 new tests (`GitHubBuildTokenTest`, `BuildPrincipalDecisionTest`, `BuildPrincipalAuthenticationTest`).
Every negative starts from a token that WOULD be accepted and moves exactly one thing. The end-to-end
suite runs a real monolith mesh, real RSA signatures, and a real HTTP pipeline over the routes.

| presented | answer |
|---|---|
| valid signature, matching repository, principal grants `fetch:<source>` | **200** |
| valid signature, **another repository** | **401** — no rule names it |
| valid signature, right repository, event not on the principal | **403** |
| valid signature, source outside `scopes` | **403** |
| valid signature, principal revoked / out of term | **401** |
| node declares a different repository than the path routed to | **401** |
| another service's `aud` · another `iss` · an issuer that merely *starts with* GitHub's | **401** |
| expired · not yet valid · `alg: none` · `alg: HS256` · swapped payload · stranger's key | **401** |
| **JWKS unreachable / publishes nothing usable** | **503 + Retry-After** |
| a build principal on any non-prebuilt bundle route | **401** |

**Falsified, not assumed.** Five guards were inverted one batch at a time and the intended tests went
red, then were restored:

| inverted | red |
|---|---|
| the repository match in `BuildPrincipal.Refuse` | `AnotherRepositorysToken_IsRefused` |
| the repository re-check in the authenticator | `ANodeThatNamesAnotherRepository_DoesNotAuthenticateTheToken` |
| the `exp` check | `AnExpiredTokenIsRefused`, `AWrongAudienceOrAnExpiredToken_IsRefused_NotUnavailable` |
| the audience match | `AnotherServicesAudienceIsRefused`, `AnAudienceArrayIsHonoured…`, + the endpoint matrix |
| a JWKS failure swallowed into an empty key set | `AnUnreachableKeySet_IsUNDETERMINED_NeverUnknownToken`, `AKeySetThatPublishesNothingUsable…`, `TheKeySetIsReadOnce…` |
| a missing node accepted anyway | `AVerifiedToken_ResolvesToItsPrincipal_AndOnlyWhenOneExists`, `ThePrebuiltRoutesServeATrustedBuild_AndRefuseEveryoneElse` |

## Verified locally

- `dotnet build -c Release -warnaserror`, one project per invocation, `0 Error(s)`:
  `MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph`, `MeshWeaver.PluginCatalog`,
  `MeshWeaver.Documentation`, `Memex.Portal.Shared`, and both touched test projects.
- `Memex.Portal.Shared.Test` — **538 passed, 0 failed** (whole project, no `--filter`).
- `MeshWeaver.Documentation.Test` — **166 passed, 0 failed**, including
  `DocumentationLinkIntegrityTest` and the ratchet guards (the new tests use `TestTimeouts.Convergence`,
  not a literal, so `TestTimeoutLiteralRatchetGuard` stays at its baseline).

## Notes

- No public surface was deleted or renamed — additive only — so nothing the compiler cannot see can
  break. `search nodeType:NodeType name:*Build*` on memex confirms no existing `BuildPrincipal` type to
  collide with.
- No new user-visible portal strings, so no i18n keys (the HTTP API bodies match the existing
  unlocalized registry style).
- `scripts/type-forwards.allow` untouched.
- No new package reference: the RS256 verification uses `System.Security.Cryptography` directly, in the
  same house style as the existing HS256 `SyncAccessToken`, rather than pulling
  `ConfigurationManager<OpenIdConnectConfiguration>` (whose async surface fights the no-async rule) into
  `Mesh.Contract`, which deliberately carries almost no dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)