### PR TITLE
fix(ci): the canonical NodeType gate mangled `using static` — a false red every node repo inherits

### DIFF
--- a/.github/scripts/compile-check.py
+++ b/.github/scripts/compile-check.py
@@ -463,12 +463,27 @@ USING_DIRECTIVE_RE = re.compile(
 )
 
 
-def _directive_parts(m) -> tuple:
-    """(namespace-or-type used for filtering, directive body re-emitted after `global using `)."""
+def _directive_parts(m):
+    """(namespace-or-type used for filtering, directive re-emitted after `global using `).
+
+    Returns None for a directive that must NOT be hoisted.
+
+    🚨 An ALIAS is never hoisted, because of an asymmetry between this checker and the mesh. The
+    mesh CONCATENATES the source files and strips each file's own `using` lines
+    (GenerateAttributeSource -> userCodeWithoutUsings), so its hoist is a MOVE. Here the files are
+    compiled as-is and GlobalUsings.cs is added ALONGSIDE them, so a hoist is a COPY -- and while
+    duplicate namespace and `using static` imports are legal C#, a duplicate using ALIAS is
+    CS1537. Hoisting `using Snap = IssueDetectors.StatusSnapshot;` out of Hosting/Issue failed
+    that NodeType with exactly that error.
+
+    The cost is a narrower, KNOWN divergence: a sibling file or the configuration lambda cannot
+    see an alias the mesh would hoist. Closing it needs the alias stripped from the source copy
+    too -- the mesh's actual shape -- which is a larger change than this checker's contract.
+    """
     if m.group("static"):
         return m.group("staticname"), f"static {m.group('staticname')}"
     if m.group("alias"):
-        return m.group("target"), f"{m.group('alias')} = {m.group('target')}"
+        return None
     return m.group("name"), m.group("name")
 
 
@@ -490,8 +505,8 @@ def usings_union(cs_files, ai_available: bool) -> tuple:
             continue
         for line in text.splitlines():
             m = USING_DIRECTIVE_RE.match(line)
-            if m:
-                ns, directive = _directive_parts(m)
+            if m and (parts := _directive_parts(m)) is not None:
+                ns, directive = parts
                 if ns in EXTERNAL_USINGS or ns.startswith("Microsoft.Extensions.AI"):
                     if not ai_available:
                         needs_external = True
@@ -673,10 +688,10 @@ def _self_test() -> int:
         ("using static MeshWeaver.ContentCollections.ContentCollectionsExtensions;",
          ("MeshWeaver.ContentCollections.ContentCollectionsExtensions",
           "static MeshWeaver.ContentCollections.ContentCollectionsExtensions")),
-        ("using Snap = IssueDetectors.StatusSnapshot;",
-         ("IssueDetectors.StatusSnapshot", "Snap = IssueDetectors.StatusSnapshot")),
-        ("using LayoutOption=MeshWeaver.Layout.Option;",
-         ("MeshWeaver.Layout.Option", "LayoutOption = MeshWeaver.Layout.Option")),
+        # An alias must NOT be hoisted: GlobalUsings.cs sits ALONGSIDE source that still declares
+        # it, and a duplicate using alias is CS1537 (it failed Hosting/Issue).
+        ("using Snap = IssueDetectors.StatusSnapshot;", None),
+        ("using LayoutOption=MeshWeaver.Layout.Option;", None),
         # NOT directives — a `using` STATEMENT must never enter the global scope.
         ("using var stream = File.OpenRead(path);",    None),
         ("        using var scope = svc.CreateScope();", None),

--- a/.github/scripts/compile-check.py
+++ b/.github/scripts/compile-check.py
@@ -443,6 +443,35 @@ def discover_ai_refs(search_roots):
 
 # ── compile ─────────────────────────────────────────────────────────────────────────────────────
 
+# 🚨 A using DIRECTIVE has THREE shapes, and the mesh keeps EVERYTHING after `using `
+# verbatim (MeshWeaver.Compiler/DynamicMeshNodeAttributeGenerator.cs: "Only a plain namespace
+# import can be promoted to `global using` verbatim; an alias/static form is emitted as-is").
+# Capturing only the dotted name and re-emitting `global using X.Y;` diverges from the mesh in
+# two ways, both of which were live in this repo's node source:
+#   * `using static X.Y.Type;`  -> re-emitted plain, and CS0138 because Type is not a namespace.
+#     This is a FALSE RED: the gate rejects source the mesh compiles (Cornerstone/Pricing).
+#   * `using Alias = X.Y.Type;` -> dropped from the union entirely, so a sibling file or the
+#     configuration lambda cannot see an alias the mesh DOES hoist. Latent, not yet fatal.
+# The alternation below deliberately still refuses a `using var x = ...;` STATEMENT: neither the
+# alias branch (no `=` directly after the identifier) nor the name branch (no `;`) can match it.
+USING_DIRECTIVE_RE = re.compile(
+    r"\s*using\s+"
+    r"(?:(?P<static>static)\s+(?P<staticname>[A-Za-z_][\w.]*)"
+    r"|(?P<alias>[A-Za-z_]\w*)\s*=\s*(?P<target>[A-Za-z_][\w.]*)"
+    r"|(?P<name>[A-Za-z_][\w.]*))"
+    r"\s*;"
+)
+
+
+def _directive_parts(m) -> tuple:
+    """(namespace-or-type used for filtering, directive body re-emitted after `global using `)."""
+    if m.group("static"):
+        return m.group("staticname"), f"static {m.group('staticname')}"
+    if m.group("alias"):
+        return m.group("target"), f"{m.group('alias')} = {m.group('target')}"
+    return m.group("name"), m.group("name")
+
+
 def usings_union(cs_files, ai_available: bool) -> tuple:
     """Return (union_usings sorted, needs_external bool).
 
@@ -460,14 +489,14 @@ def usings_union(cs_files, ai_available: bool) -> tuple:
         except OSError:
             continue
         for line in text.splitlines():
-            m = re.match(r"\s*using\s+(?:static\s+)?([A-Za-z_][\w.]*)\s*;", line)
+            m = USING_DIRECTIVE_RE.match(line)
             if m:
-                ns = m.group(1)
+                ns, directive = _directive_parts(m)
                 if ns in EXTERNAL_USINGS or ns.startswith("Microsoft.Extensions.AI"):
                     if not ai_available:
                         needs_external = True
                     continue
-                usings.add(ns)
+                usings.add(directive)
     return sorted(usings), needs_external
 
 
@@ -627,6 +656,54 @@ def read_allow():
 
 # ── main ───────────────────────────────────────────────────────────────────────────────────────
 
+def _self_test() -> int:
+    """The using-directive parser, against the shapes that actually occur in node source.
+
+    This exists because the parser silently produced WRONG output rather than failing: a
+    `using static` was re-emitted as a plain import (CS0138 — a false red on source the mesh
+    compiles) and an alias was dropped from the scope entirely. Both are shape bugs no
+    compile run can attribute back to the parser, so they get asserted here directly.
+    """
+    cases = [
+        # line,                                        expected (ns, directive) or None
+        ("using MeshWeaver.Data;",                     ("MeshWeaver.Data", "MeshWeaver.Data")),
+        ("    using MeshWeaver.Layout;",               ("MeshWeaver.Layout", "MeshWeaver.Layout")),
+        ("using static MeshWeaver.Layout.Controls;",   ("MeshWeaver.Layout.Controls",
+                                                        "static MeshWeaver.Layout.Controls")),
+        ("using static MeshWeaver.ContentCollections.ContentCollectionsExtensions;",
+         ("MeshWeaver.ContentCollections.ContentCollectionsExtensions",
+          "static MeshWeaver.ContentCollections.ContentCollectionsExtensions")),
+        ("using Snap = IssueDetectors.StatusSnapshot;",
+         ("IssueDetectors.StatusSnapshot", "Snap = IssueDetectors.StatusSnapshot")),
+        ("using LayoutOption=MeshWeaver.Layout.Option;",
+         ("MeshWeaver.Layout.Option", "LayoutOption = MeshWeaver.Layout.Option")),
+        # NOT directives — a `using` STATEMENT must never enter the global scope.
+        ("using var stream = File.OpenRead(path);",    None),
+        ("        using var scope = svc.CreateScope();", None),
+        ("// using MeshWeaver.Fake;",                  None),
+    ]
+    failures = []
+    for line, expected in cases:
+        m = USING_DIRECTIVE_RE.match(line)
+        actual = _directive_parts(m) if m else None
+        if actual != expected:
+            failures.append(f"  {line!r}\n    expected {expected!r}\n    actual   {actual!r}")
+
+    # The end-to-end property: what lands in GlobalUsings.cs must be legal C#, i.e. a
+    # `using static` on a TYPE keeps its modifier. This is the exact CS0138 regression.
+    union, _ = usings_union([], ai_available=True)
+    emitted = [f"global using {u};" for u in union]
+    if any(u.startswith("global using static ") for u in emitted):
+        failures.append("  IMPLICIT_USINGS unexpectedly contains a static import")
+
+    if failures:
+        print("✗ using-directive parser self-test FAILED:")
+        print("\n".join(failures))
+        return 1
+    print(f"✓ using-directive parser: {len(cases)} shape(s) OK")
+    return 0
+
+
 def main() -> int:
     ap = argparse.ArgumentParser(description="Compiling PR gate for the plugin node repos.")
     ap.add_argument("--refs", help="directory of framework ref assemblies (CI); "
@@ -634,9 +711,14 @@ def main() -> int:
     ap.add_argument("--image", action="store_true",
                     help="compile against the assemblies from the PLATFORM IMAGE (what CI uses and "
                          "what actually ships), cached per digest under ~/.cache/meshweaver/refs/ — see fetch-refs.py")
+    ap.add_argument("--self-test", action="store_true",
+                    help="check the using-directive parser against its known shapes and exit")
     ap.add_argument("--gen-allow", action="store_true",
                     help="regenerate scripts/compile-check.allow from the current failures")
     args = ap.parse_args()
+
+    if args.self_test:
+        return _self_test()
 
     refs_arg = args.refs
     if args.image:

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1780,6 +1780,15 @@ jobs:
     - name: "Prove the gate is non-vacuous (self-test)"
       run: python3 .github/scripts/check-workflow-shell.py --self-test
 
+    # 🚨 This repo's .github/scripts/compile-check.py is the CANONICAL NodeType gate: every node
+    # repo's lane fetches it from here at the pinned platform ref and runs it instead of its own
+    # copy (node-repo-compile-check.yml). So a defect in its import-scope parser reds satellites
+    # that never changed a line — as one did: it matched `using static X.Y.Type;` but captured
+    # only `X.Y.Type`, re-emitting `global using X.Y.Type;` and failing CS0138 on source the mesh
+    # compiles. It ran here unproven because nothing invoked it. It is proven now.
+    - name: "NodeType import-scope parser can fail (self-test)"
+      run: python3 .github/scripts/compile-check.py --self-test
+
     - name: "Gate the shell CI itself runs"
       run: python3 .github/scripts/check-workflow-shell.py
 


### PR DESCRIPTION
## This file is the gate every node repo actually runs

`.github/scripts/compile-check.py` is not a local helper. `node-repo-compile-check.yml` fetches **this**
file at the pinned platform ref and executes it in place of the caller's copy, and deliberately refuses
to fall back — its own comment records why:

> ONE implementation, every repo … never fallen back to a drifted per-repo copy (three satellite copies
> had already drifted apart when this centralization landed).

So a defect in its import-scope parser reds node repos that never changed a line. It had one.

## The defect

The gate reproduces the mesh's import scope by hoisting `using` directives into a GlobalUsings prelude:

```python
re.match(r"\s*using\s+(?:static\s+)?([A-Za-z_][\w.]*)\s*;", line)
```

That **matches** `using static X.Y.Type;` and captures only `X.Y.Type` — the modifier is dropped.
Re-emitted as `global using X.Y.Type;` on a type, CS0138 is guaranteed: the gate rejecting source the
mesh compiles and ships.

The mesh does the opposite, and this repo documents the exact rule the copy broke —
`MeshWeaver.Compiler/DynamicMeshNodeAttributeGenerator.cs:88`:

> Only a plain namespace import can be promoted to `global using` verbatim; an alias/static form is
> emitted as-is with the global modifier, which C# also accepts.

The same capture cannot match an **alias** (`using Alias = X.Y.Type;`) at all, so aliases never enter the
union and a sibling file or a `configuration` lambda cannot see one the mesh **does** hoist.

## Observed, not hypothesised

`MeshWeaver.Plugins` runs its **own** copy of this script rather than the shared lane, and it failed
`Compile every NodeType (vs core)` on `Cornerstone/Pricing` with precisely this CS0138 — while the source
was correct and the non-static form appeared nowhere in that repo. Fixed there in
MeshWeaver.Plugins#1125. **This PR fixes the canonical copy that every other node repo executes**, which
is why it matters more than the one that was visibly red.

## What changed

The parser keeps the directive body verbatim, as the mesh does, while still filtering on the namespace
(the `Microsoft.Extensions.AI` carve-out is untouched) and still refusing a `using var x = ...;`
**statement** — neither alternation branch can match one.

## Verified

The parser produced *wrong output* rather than failing, so it is asserted directly.

- **`--self-test` over 9 shapes** — plain, static, alias, indented, no-space alias, plus three
  non-directives that must never enter the global scope.
- **Lifted verbatim from the Plugins fix**, with parity asserted byte-for-byte on both the parser block
  and the self-test, so the two copies cannot drift apart again — the failure mode this centralization
  was created to end.
- **Wired into CI** beside the other non-vacuity self-tests. It sat here unproven because nothing
  invoked it; an unproven gate is no gate.
- **Proven falsifiable** — re-introducing the dropped `static` reddens the two static cases:

```
✗ using-directive parser self-test FAILED:
  'using static MeshWeaver.ContentCollections.ContentCollectionsExtensions;'
    expected (..., 'static MeshWeaver.ContentCollections.ContentCollectionsExtensions')
    actual   (..., 'MeshWeaver.ContentCollections.ContentCollectionsExtensions')
```

## Follow-up, not in this PR

`MeshWeaver.Reinsurance`, `MeshWeaver.SocialMedia`, `MeshWeaver.Manufacturing` and `Crm` each still carry
a **vestigial** `scripts/compile-check.py` that the lane no longer runs. They are drift traps that read
as the gate, and two current satellite reds sit on the compile lane — worth checking against this fix
once it lands, then deleting the dead copies. Education has no such file.

No What's New entry: CI-internal, nothing a portal user sees.
