### PR TITLE
fix(#841): the ExecuteScript pre-flight refuses in silence — restore the operator's trace

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-refused-script-run-is-visible-to-operators-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-refused-script-run-is-visible-to-operators-again.md
@@ -1,0 +1,33 @@
+---
+Name: A refused script run is visible to operators again
+Category: Fix
+Description: When ExecuteScript refuses a target up front, the portal now writes a warning naming the path and the reason — so a run that never started leaves a trace an operator can find, not just a reply the caller alone can see.
+Icon: Bug
+Order: -20260901
+---
+
+# A refused script run is visible to operators again
+
+Two things are supposed to happen when a script run is refused: the **caller** is told why, and the
+**operator** gets a trace. Both matter, and for different people — the caller can fix a mistyped
+path, but only the log tells whoever is looking after the deployment that a run was asked for and
+never happened.
+
+The up-front check that now answers `NodeNotFound` and `NotExecutable` immediately, instead of
+waiting out the request budget, only carried the first half over. The node's own hub had always
+written a warning before refusing; the new check answers before the request ever reaches that hub,
+so from the moment it landed the two commonest refusals produced a reply for the caller and
+**nothing at all** in the log — the exact silence the original report was about.
+
+The check now writes that warning itself, naming the path, the condition and the fact that no
+activity node was created:
+
+```
+ExecuteScript refused for Acme/Reports/Monthly (NotExecutable): Not executable:
+'Acme/Reports/Monthly' has CodeConfiguration.IsExecutable = false. Set it to true on the
+Code node to make it runnable. No Activity node was created.
+```
+
+It sits on the single place every up-front refusal passes through, so a refusal added later cannot
+be silent by omission — the same shape the hub-side refusal already uses. Nothing about what the
+caller receives has changed.

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -4608,11 +4608,31 @@ public class MeshOperations
     /// (<c>status</c> / <c>path</c> / <c>errorType</c> / <c>message</c>) so a caller has one shape
     /// to read regardless of which side answered. <c>errorType</c> is a stable token here rather
     /// than an exception type name — there is no exception, and inventing one would be a lie.
+    ///
+    /// <para>🚨 #841 — IT ALSO LEAVES THE TRACE. The refusal envelope is only half of that issue's
+    /// contract: a dispatch that ends without an Activity node must reach the CALLER <b>and</b> the
+    /// OPERATOR, which is why <c>CodeNodeType.HandleExecuteScript</c>'s own sink (<c>RefuseDispatch</c>)
+    /// does both things in one place. The pre-flight (#2918) moved two of those three verdicts —
+    /// "no readable node" and "not a runnable Code node" — from the owning hub to here, where the
+    /// answer is cheaper; it did not bring the log line with it, so from that change onward exactly
+    /// the picture #841 exists to prevent came back for the commonest refusals: the caller is told,
+    /// and the pod emits nothing at Warning or above. The level is the one the hub-side sink already
+    /// uses, for the same reason: an operation the caller asked for and was denied is a Warning, and
+    /// operators grep this channel for refused runs.</para>
+    ///
+    /// <para>The log lives on this funnel rather than on each branch of
+    /// <see cref="DescribeUnrunnableTarget"/> so that a verdict added there cannot be silent — the
+    /// same reason the hub keeps one sink instead of logging at each <c>return</c>.</para>
     /// </summary>
-    private string PreflightError(string resolvedPath, string errorType, string message) =>
-        JsonSerializer.Serialize(
+    private string PreflightError(string resolvedPath, string errorType, string message)
+    {
+        logger.LogWarning(
+            "ExecuteScript refused for {Path} ({ErrorType}): {Error} No Activity node was created.",
+            resolvedPath, errorType, message);
+        return JsonSerializer.Serialize(
             new { status = "Error", path = resolvedPath, errorType, message },
             hub.JsonSerializerOptions);
+    }
 
     /// <summary>
     /// The dispatch itself — unchanged behaviour, lifted out of <see cref="ExecuteScript"/> so the

--- a/test/Memex.Portal.Shared.Test/ExecuteScriptPreflightTest.cs
+++ b/test/Memex.Portal.Shared.Test/ExecuteScriptPreflightTest.cs
@@ -1,13 +1,19 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract (#2370)
 using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Memex.Portal.Shared.Test;
@@ -31,9 +37,26 @@ namespace Memex.Portal.Shared.Test;
 /// generous dispatch budget and asserts the answer arrives in a small fraction of it: on the old
 /// code the observable emits only when the budget elapses, so the stopwatch is the discriminator.
 /// </para>
+///
+/// <para><b>And what the pre-flight must not lose.</b> Answering the caller is only half of what
+/// the dispatch it replaced did: #841's contract is that a run which ends without an Activity node
+/// is visible to the OPERATOR too. That half is pinned by
+/// <see cref="ExecuteScript_PreflightRefusal_IsVisibleToTheOperator_NotJustToTheCaller"/>, which
+/// asserts on the mesh's own logger rather than on elapsed time.</para>
 /// </summary>
 public class ExecuteScriptPreflightTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
+    /// <summary>
+    /// Captures what the mesh's own <see cref="ILoggerFactory"/> emits, so "the refusal is visible
+    /// at Warning+" is an assertion rather than a claim. Instance-owned — its lifetime is this
+    /// test's mesh — never static state.
+    /// </summary>
+    private readonly CapturingLoggerProvider logs = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<ILoggerProvider>(logs));
+
     /// <summary>
     /// The dispatch budget handed to <c>ExecuteScript</c>. Large enough that "waited it out" and
     /// "answered from the pre-flight" cannot be confused for one another.
@@ -100,6 +123,54 @@ public class ExecuteScriptPreflightTest(ITestOutputHelper output) : MonolithMesh
             $"the refusal must say WHAT is wrong with the target. Got: {result}");
     }
 
+    /// <summary>
+    /// 🚨 #841's OTHER half, which the pre-flight silently dropped.
+    ///
+    /// <para>A dispatch that ends without an Activity node must reach the CALLER <b>and</b> the
+    /// OPERATOR — that is why <c>CodeNodeType.HandleExecuteScript</c>'s refusal sink does both
+    /// things in one place, and why every test in the engine's dispatch-diagnostics suite asserts
+    /// the Warning+ trace as well as the verdict. The pre-flight above moved two of those three
+    /// verdicts — "no readable node" and "not a runnable Code node" — from the owning hub to the
+    /// caller, where the answer is cheaper; the log line did not come with them. From that change
+    /// onward the commonest refusals reproduced #841's reported picture exactly: the caller is
+    /// told, and the pod emits NOTHING at Warning or above.</para>
+    ///
+    /// <para>Both pre-flight branches are exercised, because they are two <c>return</c>s in
+    /// <c>DescribeUnrunnableTarget</c> and a trace on one says nothing about the other. The
+    /// assertion is on the mesh's own <see cref="ILoggerFactory"/>, not on test output, so it
+    /// measures what an operator would actually see in Loki.</para>
+    /// </summary>
+    [Theory(Timeout = 180000)]
+    [InlineData(true)]
+    [InlineData(false)]
+    public async Task ExecuteScript_PreflightRefusal_IsVisibleToTheOperator_NotJustToTheCaller(
+        bool absentPath)
+    {
+        var path = absentPath
+            ? $"{TestPartition}/NoSuchScript-{Guid.NewGuid():N}"
+            : TestPartition;
+
+        var (result, _) = await Run(path);
+        result.GetProperty("status").GetString().Should().Be("Error", result.ToString());
+
+        var refusals = logs.Records
+            .Where(r => r.Level >= LogLevel.Warning
+                && r.Message.Contains("ExecuteScript refused", StringComparison.Ordinal))
+            .ToArray();
+
+        refusals.Should().NotBeEmpty(
+            "a refused dispatch must leave a Warning+ trace naming the target — the caller's JSON "
+            + "is not evidence anybody but the caller can see, and an operator with no trace is "
+            + "the whole of #841. Captured at Warning+: [{0}]",
+            string.Join(" | ", logs.Records
+                .Where(r => r.Level >= LogLevel.Warning)
+                .Select(r => $"{r.Level} {r.Category}: {r.Message}")));
+
+        refusals.Should().Contain(r => r.Message.Contains(path, StringComparison.Ordinal),
+            "the trace must name the PATH that was refused, or an operator reading it cannot tell "
+            + "which run died");
+    }
+
     // ── helpers ──
 
     /// <summary>
@@ -120,5 +191,38 @@ public class ExecuteScriptPreflightTest(ITestOutputHelper output) : MonolithMesh
 
         Output.WriteLine($"ExecuteScript('{path}') answered in {stopwatch.Elapsed.TotalSeconds:F2}s: {json}");
         return (JsonDocument.Parse(json).RootElement.Clone(), stopwatch.Elapsed);
+    }
+
+    // ── log capture ──
+
+    private sealed record CapturedLog(
+        LogLevel Level, string Category, string Message, Exception? Exception);
+
+    /// <summary>
+    /// An <see cref="ILoggerProvider"/> that keeps every record the mesh emits. The backing queue
+    /// is an INSTANCE field on an instance the test's mesh owns — the no-static-state rule applies
+    /// to test infrastructure exactly as it does to <c>src/</c>.
+    /// </summary>
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<CapturedLog> records = new();
+
+        public IReadOnlyList<CapturedLog> Records => records.ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, records);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(string category, ConcurrentQueue<CapturedLog> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+                => sink.Enqueue(new CapturedLog(
+                    logLevel, category, formatter(state, exception), exception));
+        }
     }
 }

--- a/test/Memex.Portal.Shared.Test/ExecuteScriptPreflightTest.cs
+++ b/test/Memex.Portal.Shared.Test/ExecuteScriptPreflightTest.cs
@@ -199,9 +199,14 @@ public class ExecuteScriptPreflightTest(ITestOutputHelper output) : MonolithMesh
         LogLevel Level, string Category, string Message, Exception? Exception);
 
     /// <summary>
-    /// An <see cref="ILoggerProvider"/> that keeps every record the mesh emits. The backing queue
-    /// is an INSTANCE field on an instance the test's mesh owns — the no-static-state rule applies
-    /// to test infrastructure exactly as it does to <c>src/</c>.
+    /// An <see cref="ILoggerProvider"/> that keeps every record the mesh's <c>ILoggerFactory</c>
+    /// routes to it at <see cref="LogLevel.Debug"/> or above — the factory's own filter rules apply
+    /// first, so what lands here is what a deployment's sink would receive, minus <c>Trace</c>.
+    /// That is deliberate: the assertion is about Warning+, and the failure dump is more useful
+    /// without per-message trace chatter buried in it.
+    ///
+    /// <para>The backing queue is an INSTANCE field on an instance the test's mesh owns — the
+    /// no-static-state rule applies to test infrastructure exactly as it does to <c>src/</c>.</para>
     /// </summary>
     private sealed class CapturingLoggerProvider : ILoggerProvider
     {


### PR DESCRIPTION
## What was broken

#841's contract has two halves, for two different people: the **caller** is told why a run was
refused, and the **operator** gets a Warning+ trace saying a run was asked for and never happened.
That is why `CodeNodeType.HandleExecuteScript` keeps ONE refusal sink (`RefuseDispatch`) that does
both in one place.

#2918's pre-flight moved two of that handler's three verdicts — *no readable node* and *not a
runnable Code node* — into `MeshOperations`, where they are decidable from a single bounded read.
It carried the caller's half over and left the log line behind. So from that change onward the two
**commonest** refusals reproduced #841's reported picture exactly: a structured error for the
caller, and nothing at Warning or above in the pod.

Measured, not inferred — `MeshWeaver.AI.Test.ExecuteScriptDispatchDiagnosticsTest.Dispatch_NonExecutableNode_SurfacesRefusalToCaller`
red on Plugins main (run `33523800964`, job `99911922886`). The refusal itself works; the captured
Warning+ set contained three unrelated lines and not one from the refusal.

## The fix

`PreflightError` writes the Warning before it serialises the envelope. It is the single funnel every
pre-flight refusal passes through, so a verdict added later to `DescribeUnrunnableTarget` cannot be
silent by omission — the same reason the hub keeps one sink instead of logging at each `return`.

```
ExecuteScript refused for Acme/Reports/Monthly (NotExecutable): Not executable:
'Acme/Reports/Monthly' has CodeConfiguration.IsExecutable = false. Set it to true on the
Code node to make it runnable. No Activity node was created.
```

The level is the hub-side sink's, for the hub-side sink's reason: an operation the caller asked for
and was denied is a Warning. **Nothing the caller receives changed.**

## Why the regression merged green

`ExecuteScriptPreflightTest`'s existing cases pin ELAPSED TIME and `errorType`. Neither can see a
missing log line. The new theory closes that: it asserts on the mesh's own `ILoggerFactory` — an
`ILoggerProvider` registered through `MeshBuilder.ConfigureServices`, so it measures what a
deployment's log sink receives, not test output — and it covers **both** pre-flight branches,
because they are two `return`s and a trace on one says nothing about the other.

## Verification

- `dotnet build src/MeshWeaver.Mesh.Operations -c Release -warnaserror` → `0 Error(s) 0 Warning(s)`;
  same for `test/Memex.Portal.Shared.Test`, `src/MeshWeaver.Documentation`,
  `test/MeshWeaver.Documentation.Test`.
- **Whole** `Memex.Portal.Shared.Test`: `Passed: 525, Failed: 0` (both new cases present in the trx).
- **Whole** `MeshWeaver.Documentation.Test` (the ratchet guards + link integrity, for the What's New
  page): `Passed: 166, Failed: 0`.
- **Inverted once, seen red, restored.** With the `LogWarning` removed both new cases fail on
  *"Expected collection not to be empty because a refused dispatch must leave a Warning+ trace…"*
  while the two elapsed-time cases stay green — so the new assertion measures the log line and only
  the log line.
- **Cross-repo**: the whole `MeshWeaver.AI.Test` project (Plugins) built against this worktree
  (`-p:MeshWeaverRoot=…`) goes `Failed: 2, Passed: 1663` → `Failed: 0, Passed: 1665`.
  (The second of those two was a stale content pin, fixed separately in Plugins.)

## Filed, not patched here

**#2990** — the boot-time content-type sweep builds a throwaway probe hub with
`AsTransientNodeProbe(startDataSources: false)`; for an Activity-shaped NodeType that starts an
ActivityControlPlane watcher, `ReduceLocalStream` answers with a causeless
`InvalidOperationException("Failed to create stream")`, and because that is neither a
`HubDisposingException` nor a routing NotFound the watcher classifies routine probe teardown as a
*transient* fault — an ERROR line plus a re-establish timer, at every portal boot. Surfaced in this
test's captured-log dump; it is a design question about the probe, not a line to patch inside an
unrelated change.

Relates to #841, #2918.
