### PR TITLE
fix(#2483): a JWKS refresh after a FAULT handed back a null observable

### DIFF
--- a/src/MeshWeaver.PluginCatalog/GitHubOidcKeyService.cs
+++ b/src/MeshWeaver.PluginCatalog/GitHubOidcKeyService.cs
@@ -29,9 +29,9 @@ namespace MeshWeaver.PluginCatalog;
 /// <see cref="MinimumRefreshInterval"/>. Without that floor a caller presenting invented key ids
 /// would turn every unauthenticated request into an outbound fetch.</para>
 ///
-/// <para>Same promise-cache shape as <c>GitHubAppTokenService</c>: the in-flight fetch observable is
-/// held on an instance field so concurrent callers share ONE round trip, and a failure nulls it so
-/// the next caller starts a genuinely new attempt rather than replaying a latched
+/// <para>Same promise-cache shape as <c>GitHubAppTokenService</c>: the in-flight read is held on an
+/// instance field so concurrent callers share ONE round trip, and a failure evicts it — pair-exactly
+/// — so the next caller starts a genuinely new attempt rather than replaying a latched
 /// <c>OnError</c>.</para>
 /// </summary>
 public sealed class GitHubOidcKeyService
@@ -57,9 +57,25 @@ public sealed class GitHubOidcKeyService
     private readonly HttpClient http;
     private readonly ILogger<GitHubOidcKeyService>? logger;
 
-    // The promise-cache: the current fetch, replayed to every caller. Instance fields, never static.
+    // The promise-cache: the current read, replayed to every caller. Instance fields, never static.
     private readonly object gate = new();
-    private IObservable<GitHubSigningKeys>? cached;
+    private Attempt? attempt;
+
+    /// <summary>
+    /// One read of the key set: the promise, and the value it produced once it did.
+    ///
+    /// <para>The VALUE is what makes a refresh decidable. <see cref="Refresh"/> is handed the set a
+    /// caller found unusable and has to answer "has anyone already replaced this?" — a question about
+    /// a value, asked of a cache that holds a promise. Pairing the two on one holder answers it
+    /// without a second field that could drift, and it makes fault eviction PAIR-EXACT: a fault
+    /// removes the attempt that faulted, never a healthy replacement that started while it was
+    /// unwinding (the <c>PromiseCache</c> contract, in its single-slot form).</para>
+    /// </summary>
+    private sealed class Attempt
+    {
+        public IObservable<GitHubSigningKeys> Promise = null!;
+        public GitHubSigningKeys? Value;
+    }
 
     /// <summary>Creates the service against the mesh's HTTP I/O pool.</summary>
     /// <param name="hub">The hub whose service provider carries the pool registry and HTTP factory.</param>
@@ -88,12 +104,12 @@ public sealed class GitHubOidcKeyService
     {
         IObservable<GitHubSigningKeys> source;
         lock (gate)
-            source = cached ??= CreateFetch();
+            source = (attempt ??= CreateAttempt()).Promise;
 
         return source.SelectMany(keys =>
             now - keys.FetchedAt < CacheDuration
                 ? Observable.Return(keys)
-                : Swap(source));
+                : Replace(keys));
     }
 
     /// <summary>
@@ -114,35 +130,62 @@ public sealed class GitHubOidcKeyService
             "GitHub OIDC: a token named a signing key absent from the set read at {FetchedAt} — re-reading the JWKS",
             stale.FetchedAt);
 
-        IObservable<GitHubSigningKeys> source;
-        lock (gate)
-            source = cached ?? CreateFetch();
-        return Swap(source);
+        return Replace(stale);
     }
 
-    /// <summary>Replaces a settled promise with a fresh fetch — once; concurrent refreshers share
-    /// the replacement rather than each starting a round trip of their own.</summary>
-    private IObservable<GitHubSigningKeys> Swap(IObservable<GitHubSigningKeys> settled)
+    /// <summary>
+    /// Starts a fresh read of the key set — unless someone has ALREADY replaced the set
+    /// <paramref name="settled"/> came from, in which case the caller joins that attempt instead of
+    /// opening a round trip of its own.
+    ///
+    /// <para>🚨 It always returns a real observable. The predecessor of this method could hand back
+    /// <c>null</c> when the cache had been evicted by a previous FAULT — precisely the moment a
+    /// refresh is most likely — and that null escaped into the authenticator's <c>SelectMany</c>,
+    /// where the failure surfaces nowhere near its cause. Creating the attempt and storing it are
+    /// one step under one lock, so there is no state in which a caller is handed nothing.</para>
+    /// </summary>
+    /// <param name="settled">The set the caller found unusable.</param>
+    /// <returns>The shared promise for the current attempt.</returns>
+    private IObservable<GitHubSigningKeys> Replace(GitHubSigningKeys settled)
     {
         lock (gate)
         {
-            if (ReferenceEquals(cached, settled))
-                cached = CreateFetch();
-            return cached!;
+            // An attempt is live AND it is not the one that produced `settled` — either it is still
+            // in flight (Value is null) or it already produced something newer. Either way the work
+            // this caller wants is already happening; joining it is the whole point of the promise.
+            if (attempt is { } live && !ReferenceEquals(live.Value, settled))
+                return live.Promise;
+            attempt = CreateAttempt();
+            return attempt.Promise;
         }
     }
 
-    private IObservable<GitHubSigningKeys> CreateFetch() =>
-        pool.Run(FetchAsync)
-            .Catch((Exception ex) =>
+    private Attempt CreateAttempt()
+    {
+        var created = new Attempt();
+        created.Promise = pool.Run(FetchAsync)
+            .Do(keys =>
             {
                 lock (gate)
-                    cached = null;   // never cache a failure — the next caller starts a new attempt
+                    created.Value = keys;
+            })
+            .Catch((Exception ex) =>
+            {
+                // Never cache a failure — the next caller starts a genuinely new attempt rather than
+                // replaying a latched OnError. PAIR-EXACT: only this attempt is dropped, so a
+                // healthy replacement that started while this one was unwinding survives.
+                lock (gate)
+                {
+                    if (ReferenceEquals(attempt, created))
+                        attempt = null;
+                }
                 logger?.LogWarning(ex,
                     "GitHub OIDC: could not read the signing keys — build-principal tokens are "
                     + "UNDETERMINED (retryable), never accepted");
                 return Observable.Throw<GitHubSigningKeys>(ex);
             });
+        return created;
+    }
 
     // ── the HTTP leaf (runs inside the I/O pool) ─────────────────────────────
 

--- a/src/MeshWeaver.PluginCatalog/GitHubOidcKeyService.cs
+++ b/src/MeshWeaver.PluginCatalog/GitHubOidcKeyService.cs
@@ -73,7 +73,16 @@ public sealed class GitHubOidcKeyService
     /// </summary>
     private sealed class Attempt
     {
-        public IObservable<GitHubSigningKeys> Promise = null!;
+        /// <summary>
+        /// LAZY on purpose. <c>IIoPool.Run</c> is EAGER — it subscribes and schedules the round trip
+        /// at CONSTRUCTION — so building it inside <see cref="gate"/> would start I/O from inside the
+        /// very lock its own fault handler has to take. Deferring means the slot is claimed under the
+        /// lock (cheap, allocation only) and the read starts after it is released, with
+        /// <see cref="Lazy{T}"/>'s default publication mode still guaranteeing exactly one execution.
+        /// Same reason <c>PromiseCache</c> wraps its entries in a <c>Lazy</c>.
+        /// </summary>
+        public Lazy<IObservable<GitHubSigningKeys>> Promise = null!;
+
         public GitHubSigningKeys? Value;
     }
 
@@ -102,11 +111,13 @@ public sealed class GitHubOidcKeyService
     /// <returns>A cold observable of the key set.</returns>
     public IObservable<GitHubSigningKeys> Keys(DateTimeOffset now)
     {
-        IObservable<GitHubSigningKeys> source;
+        Attempt live;
         lock (gate)
-            source = (attempt ??= CreateAttempt()).Promise;
+            live = attempt ??= CreateAttempt();
 
-        return source.SelectMany(keys =>
+        // 🚨 Forced OUTSIDE the lock — claiming the slot and starting the round trip are separate
+        // steps precisely so no I/O is scheduled while `gate` is held.
+        return live.Promise.Value.SelectMany(keys =>
             now - keys.FetchedAt < CacheDuration
                 ? Observable.Return(keys)
                 : Replace(keys));
@@ -148,22 +159,25 @@ public sealed class GitHubOidcKeyService
     /// <returns>The shared promise for the current attempt.</returns>
     private IObservable<GitHubSigningKeys> Replace(GitHubSigningKeys settled)
     {
+        Attempt live;
         lock (gate)
         {
-            // An attempt is live AND it is not the one that produced `settled` — either it is still
-            // in flight (Value is null) or it already produced something newer. Either way the work
-            // this caller wants is already happening; joining it is the whole point of the promise.
-            if (attempt is { } live && !ReferenceEquals(live.Value, settled))
-                return live.Promise;
-            attempt = CreateAttempt();
-            return attempt.Promise;
+            // An attempt is present AND it is not the one that produced `settled` — either it is
+            // still in flight (Value is null) or it already produced something newer. Either way the
+            // work this caller wants is already happening; joining it is the point of the promise.
+            live = attempt is { } existing && !ReferenceEquals(existing.Value, settled)
+                ? existing
+                : attempt = CreateAttempt();
         }
+
+        // Outside the lock, as in Keys: the slot is claimed under `gate`, the round trip is not.
+        return live.Promise.Value;
     }
 
     private Attempt CreateAttempt()
     {
         var created = new Attempt();
-        created.Promise = pool.Run(FetchAsync)
+        created.Promise = new Lazy<IObservable<GitHubSigningKeys>>(() => pool.Run(FetchAsync)
             .Do(keys =>
             {
                 lock (gate)
@@ -183,7 +197,7 @@ public sealed class GitHubOidcKeyService
                     "GitHub OIDC: could not read the signing keys — build-principal tokens are "
                     + "UNDETERMINED (retryable), never accepted");
                 return Observable.Throw<GitHubSigningKeys>(ex);
-            });
+            }));
         return created;
     }
 

--- a/test/Memex.Portal.Shared.Test/BuildPrincipalAuthenticationTest.cs
+++ b/test/Memex.Portal.Shared.Test/BuildPrincipalAuthenticationTest.cs
@@ -259,9 +259,21 @@ public class BuildPrincipalAuthenticationTest(ITestOutputHelper output) : Monoli
             service.Keys(now).FirstAsync().Timeout(TestTimeouts.Convergence).Await());
         Assert.Equal(2, reads);
 
+        // 🚨 A ROTATION ARRIVING WHILE THE CACHE IS EMPTY. The fault above evicted the promise, so
+        // this refresh has nothing to replace — and must still start a real read rather than letting
+        // a null observable escape into the authenticator's SelectMany, where the failure would
+        // surface far from its cause (Copilot review, PR #2988).
         fail = false;
+        var afterFault = await service
+            .Refresh(new GitHubSigningKeys(
+                new Dictionary<string, GitHubSigningKey>(), now - TimeSpan.FromHours(1)), now)
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        Assert.Single(afterFault.ByKeyId);
+        Assert.Equal(3, reads);
+
         var first = await service.Keys(now).FirstAsync().Timeout(TestTimeouts.Convergence).Await();
         Assert.Single(first.ByKeyId);
+        // …and it was SHARED with the refresh above rather than starting a round trip of its own.
         Assert.Equal(3, reads);
 
         // A success is shared: a second caller inside the window costs no round trip.

--- a/test/MeshWeaver.Documentation.Test/TestTimeoutLiteralRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/TestTimeoutLiteralRatchetGuard.cs
@@ -80,8 +80,15 @@ public class TestTimeoutLiteralRatchetGuard
     /// <para>🚨 It is not a budget to spend. <see cref="TheBaselineStaysCloseToTheTree"/> caps the
     /// slack, so the allowance cannot quietly become permanent; the correct next edit to this
     /// number is DOWNWARD, in whichever change first converts a batch.</para>
+    ///
+    /// <para><b>2026-09-01 — 387 → 386 by CONVERSION.</b> <c>EditorTest.TestEditorWithDelayed</c>
+    /// waited on five sequential remote round-trips behind a literal <c>30.Seconds()</c> and failed
+    /// on MeshWeaver#2994 shard 5 with "the observable emitted nothing at all" — the anonymous
+    /// failure this guard's message predicts verbatim, at exactly 30 s. Converted to
+    /// <c>TestTimeouts.Convergence</c>. This is what a downward edit looks like: one site cured, one
+    /// off the count.</para>
     /// </summary>
-    private const int Baseline = 387;
+    private const int Baseline = 386;
 
     [Fact]
     public void TheHandWrittenTimeoutCountOnlyEverGoesDown()

--- a/test/MeshWeaver.Layout.Test/EditorTest.cs
+++ b/test/MeshWeaver.Layout.Test/EditorTest.cs
@@ -172,10 +172,18 @@ public class EditorTest(ITestOutputHelper output) : HubTestBase(output)
             area.UpdatePointer(i, editor.DataContext!, new("x"));
         }
 
-        // Wait up to the method timeout for the stream to reach the final "5" render — five sequential
-        // UpdatePointer round-trips through the remote JsonElement sync stream, each render blocked by
-        // Thread.Sleep(100) plus serialization, can take several seconds on a slow CI runner.
-        var controls = await controlStream.Where(x => x is not null).ToArray().Should().Within(30.Seconds()).Emit();
+        // Wait for the stream to reach the final "5" render — five sequential UpdatePointer
+        // round-trips through the remote JsonElement sync stream, each render blocked by
+        // Thread.Sleep(100) plus serialization.
+        //
+        // 🚨 TestTimeouts.Convergence, never a 30 s literal (#2819). This test HAD one, and it is the
+        // failure the ratchet guard's own docstring predicts: 30 s is below the framework's write
+        // bound (LateResponseWatchBound 30 s + VerdictBoundGrace 1 s), and CI is ~1.7× slower than
+        // the box the number was chosen on — so under runner contention it gave up at exactly 30 s
+        // with "the observable emitted nothing at all", a failure that cannot say why. Observed on
+        // MeshWeaver#2994, shard 5.
+        var controls = await controlStream.Where(x => x is not null).ToArray()
+            .Should().Within(TestTimeouts.Convergence).Emit();
         // The NUMBER of intermediate emissions is timing-dependent: the delayed editor coalesces updates
         // that arrive during a render, so a fast box sees ~2 while a slow CI runner — where the updates
         // spread past the 100ms render window — sees more. Asserting a count (was `<= 3`) races CI load;


### PR DESCRIPTION
Follow-up to #2988. Refs #2483.

The automatic Copilot review on #2988 found a **real defect**, and it landed on main before I had
finished checking it. Fixing it rather than noting it.

## The bug

`GitHubOidcKeyService.Refresh` could return `null`, and the moment it did was the worst possible one.

A previous fetch fault evicts the cached promise (`cached = null` — deliberate, so a transient
failure is never remembered). The very next **forced re-read** — the GitHub-key-rotation path — then
did:

```csharp
lock (gate) source = cached ?? CreateFetch();   // cached is null → a NEW observable, not stored
return Swap(source);                            // ReferenceEquals(null, source) → false
                                                //   → returns cached!  → null
```

That `null` escaped into the authenticator's `SelectMany`, where the failure surfaces nowhere near
its cause. It also fired a **wasted eager fetch** on the way out, because `pool.Run` schedules its
work at construction rather than at subscribe.

The two states compose badly on purpose: the cache is empty *exactly* when a fetch has just failed,
which is when a refresh is most likely to be asked for.

**Not reachable in production today** — no deployment configures
`Plugins:Registry:BuildPrincipalAudience`, so the build-principal leg is inert everywhere. That is
why this is a follow-up rather than a revert, not a reason to leave it.

## The fix

A single-slot promise holder that pairs the promise with the value it produced:

- *"Has anyone already replaced the set I was handed?"* is a question about a **value**, asked of a
  cache that holds a **promise**. Pairing them on one holder answers it in one lock, instead of via a
  second field that could drift out of step with the first.
- **Creation and storage are one step under one lock**, so there is no state in which a caller is
  handed nothing.
- **Fault eviction is pair-exact** — a fault drops only the attempt that faulted, never a healthy
  replacement that started while it was unwinding. Same contract as `PromiseCache`, in its
  single-slot form.

Everything the previous shape bought is preserved: concurrent callers still share one round trip, a
failure is still never cached, and the refresh floor still bounds forced re-reads.

## Verification

**The regression test was written first and confirmed RED against the merged code**, before the fix
existed:

```
Failed  BuildPrincipalAuthenticationTest.TheKeySetIsReadOnce_AFaultIsNeverCached_AndTheRefreshFloorBoundsRe_Reads
Failed! - Failed: 1, Passed: 537, Total: 538
```

It asserts that a refresh issued while the cache is empty starts a **real** read and that the next
`Keys()` caller **shares** it rather than opening a second round trip — so it catches both halves
(the null escape and the wasted eager fetch).

After the fix:

- `Memex.Portal.Shared.Test` — **564 passed, 0 failed** (whole project, no `--filter`)
- `MeshWeaver.Documentation.Test` — **166 passed, 0 failed** (link integrity + ratchet guards)
- `dotnet build -c Release -warnaserror`, one project per invocation, `0 Error(s)`:
  `MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`, both test projects

## The other two review comments

Replied on #2988 and resolved; both are the rule read one level too broadly, and the reasoning is on
the threads so it is not re-litigated.

- **`Func<CancellationToken, Task<string>>` test hook** — that is `IIoPool.Invoke`'s own leaf
  signature, and the hook substitutes the leaf that runs *inside* the pool. The service's public
  surface is `IObservable<T>` throughout. Making it `IObservable<string>` would need converting back
  at the boundary, since the production leaf must be a Task — two shapes for one seam, and the
  reactive one would be the fake.
- **`await` inside the pool leaf** — AGENTS.md's positive form is *"every async / blocking / IO edge
  goes through `IIoPool`; public surfaces return `IObservable<T>`"*, which is exactly this. Merged
  precedent: `GitHubAppTokenService.FetchInstallationTokenAsync`, `RegistryPackageSource`,
  `PluginBundleClient`. `HttpClient` has no non-Task API, so the broader reading would forbid HTTP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)