### PR TITLE
The ExecuteScript pre-flight keeps #841's Warning trace

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-refused-script-still-leaves-a-trace.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-a-refused-script-still-leaves-a-trace.md
@@ -1,0 +1,23 @@
+---
+Name: A script refused before it starts still leaves a trace
+Category: Fix
+Description: The fast refusal for a script that cannot run now writes the same warning the slow path always did, so an operator can still find out why a run never happened.
+Icon: Sparkle
+Order: -20260901
+---
+
+# A script refused before it starts still leaves a trace
+
+Asking to run a script on something that cannot run one — a page that is not a script, a path with
+nothing behind it, a script switched off — now answers immediately instead of waiting out the whole
+dispatch budget. That is a good change, and it stays.
+
+It had one cost nobody could see. The slow path used to leave a **warning in the log** on its way
+past, and that warning is the only evidence anywhere that a run was asked for and never happened:
+no run means no activity to look at afterwards. Answering earlier skipped the place the warning was
+written, so the caller got a clear message and the server went quiet — which is precisely the
+situation the warning was added for in the first place.
+
+The fast refusal now writes the same warning, naming the path and what was wrong with it. Nothing
+changes for the person who made the call; what changes is that whoever looks at the logs afterwards
+can still see it happened.

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -4609,10 +4609,26 @@ public class MeshOperations
     /// to read regardless of which side answered. <c>errorType</c> is a stable token here rather
     /// than an exception type name — there is no exception, and inventing one would be a lie.
     /// </summary>
-    private string PreflightError(string resolvedPath, string errorType, string message) =>
-        JsonSerializer.Serialize(
+    private string PreflightError(string resolvedPath, string errorType, string message)
+    {
+        // 🚨 #841's guarantee is not "the caller is told" — it is "the caller is told AND the pod
+        // leaves a Warning+ trace", because a dispatch that produced no Activity node produced no
+        // evidence anywhere, and that is what made the original issue undiagnosable in production.
+        // Both branches that used to answer these three refusals carry that trace
+        // (CodeNodeType.RefuseDispatch's "ExecuteScript refused on {Hub}", and DispatchScript's
+        // "ExecuteScript dispatch refused for {Path}"). This pre-flight now answers BEFORE either
+        // of them, so it has to carry it too — otherwise making the guaranteed failure FAST
+        // silently made the pod go quiet again for exactly the cases #841 was about. Caught by
+        // MeshWeaver.Plugins' ExecuteScriptDispatchDiagnosticsTest, which asserts the trace rather
+        // than the verdict.
+        logger.LogWarning(
+            "ExecuteScript refused for {Path}: {ErrorType}: {Error} No Activity node was created "
+            + "(refused before dispatch).",
+            resolvedPath, errorType, message);
+        return JsonSerializer.Serialize(
             new { status = "Error", path = resolvedPath, errorType, message },
             hub.JsonSerializerOptions);
+    }
 
     /// <summary>
     /// The dispatch itself — unchanged behaviour, lifted out of <see cref="ExecuteScript"/> so the

--- a/test/Memex.Portal.Shared.Test/ExecuteScriptPreflightTest.cs
+++ b/test/Memex.Portal.Shared.Test/ExecuteScriptPreflightTest.cs
@@ -1,13 +1,19 @@
 #pragma warning disable CS1591
 
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using MeshWeaver.AI;   // MeshOperations — its namespace is a frozen binary contract (#2370)
 using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace Memex.Portal.Shared.Test;
@@ -39,6 +45,17 @@ public class ExecuteScriptPreflightTest(ITestOutputHelper output) : MonolithMesh
     /// "answered from the pre-flight" cannot be confused for one another.
     /// </summary>
     private const int DispatchBudgetSeconds = 45;
+
+    /// <summary>
+    /// Captures what the mesh's own <see cref="ILoggerFactory"/> emits, so "the refusal is visible
+    /// at Warning+" is an assertion rather than a claim. Instance-owned — its lifetime is this
+    /// test's mesh — never static.
+    /// </summary>
+    private readonly CapturingLoggerProvider logs = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<ILoggerProvider>(logs));
 
     /// <summary>
     /// The bar the answer must beat. The pre-flight's own read is bounded at 10 s (and only
@@ -100,6 +117,41 @@ public class ExecuteScriptPreflightTest(ITestOutputHelper output) : MonolithMesh
             $"the refusal must say WHAT is wrong with the target. Got: {result}");
     }
 
+    /// <summary>
+    /// 🚨 THE PRE-FLIGHT MUST NOT MAKE THE POD GO QUIET. #841's guarantee is not "the caller is
+    /// told" — it is "the caller is told AND a Warning+ trace is left", because a dispatch that
+    /// creates no Activity node otherwise produces no evidence anywhere, which is what made that
+    /// issue undiagnosable in production. Both branches this pre-flight now answers BEFORE carry
+    /// that trace (<c>CodeNodeType.RefuseDispatch</c>'s <c>ExecuteScript refused on {Hub}</c>, and
+    /// the dispatch's own <c>ExecuteScript dispatch refused for {Path}</c>) — so making the
+    /// guaranteed failure FAST must not also make it silent.
+    ///
+    /// <para>Measured rather than assumed: without the log line in <c>PreflightError</c> this
+    /// verdict comes back correctly and the pod emits nothing at Warning or above, which is
+    /// exactly the pre-#841 condition. MeshWeaver.Plugins'
+    /// <c>ExecuteScriptDispatchDiagnosticsTest</c> caught it from the satellite side; this pins it
+    /// where the code lives.</para>
+    /// </summary>
+    [Fact(Timeout = 180000)]
+    public async Task APreflightRefusal_LeavesAWarningTrace_notOnlyACallerVerdict()
+    {
+        var absent = $"{TestPartition}/NoSuchScript-{Guid.NewGuid():N}";
+
+        var (result, _) = await Run(absent);
+
+        result.GetProperty("status").GetString().Should().Be("Error");
+
+        logs.Records
+            .FirstOrDefault(r => r.Level >= LogLevel.Warning
+                                 && r.Message.Contains("ExecuteScript refused", StringComparison.Ordinal))
+            .Should().NotBeNull(
+                "a dispatch that creates no Activity node must leave a Warning+ trace containing "
+                + "'ExecuteScript refused' — answering from the pre-flight skips the two sinks "
+                + "that carried that guarantee (#841), so it has to carry it itself. Captured: ["
+                + string.Join(" | ", logs.Records.Select(r => $"{r.Level} {r.Category}: {r.Message}"))
+                + "]");
+    }
+
     // ── helpers ──
 
     /// <summary>
@@ -120,5 +172,30 @@ public class ExecuteScriptPreflightTest(ITestOutputHelper output) : MonolithMesh
 
         Output.WriteLine($"ExecuteScript('{path}') answered in {stopwatch.Elapsed.TotalSeconds:F2}s: {json}");
         return (JsonDocument.Parse(json).RootElement.Clone(), stopwatch.Elapsed);
+    }
+
+    private sealed record CapturedLog(LogLevel Level, string Category, string Message);
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        // Instance field on an instance owned by the test's mesh — never static state.
+        private readonly ConcurrentQueue<CapturedLog> records = new();
+
+        public IReadOnlyList<CapturedLog> Records => records.ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(categoryName, records);
+
+        public void Dispose() { }
+
+        private sealed class CapturingLogger(string category, ConcurrentQueue<CapturedLog> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Debug;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+                => sink.Enqueue(new CapturedLog(logLevel, category, formatter(state, exception)));
+        }
     }
 }


### PR DESCRIPTION
## What happened

#2918's pre-flight (`DescribeUnrunnableTarget` → `PreflightError`) answers a guaranteed-unrunnable target **before** dispatching. That is the right change and it stays. But it answers before the two sinks that carried the *other half* of #841.

> #841's guarantee is not "the caller is told" — it is **"the caller is told AND the pod leaves a Warning+ trace"**, because a dispatch that creates no Activity node produces no evidence anywhere afterwards.

Both branches the pre-flight now front-runs log it:

* `CodeNodeType.RefuseDispatch` → `ExecuteScript refused on {Hub}: {Error} No Activity node was created.`
* `MeshOperations.DispatchScript` → `ExecuteScript dispatch refused for {Path}: {Error}`

`PreflightError` logged nothing. So making the guaranteed failure **fast** silently made it **silent**, for exactly the three conditions the pre-flight recognises (`NodeNotFound`, and both `NotExecutable` shapes) — the pre-#841 condition, restored by a fix for something else. The caller-visible verdict was correct throughout, which is why nothing else noticed.

## How it surfaced

From the satellite side. MeshWeaver.Plugins' `ExecuteScriptDispatchDiagnosticsTest.Dispatch_NonExecutableNode_SurfacesRefusalToCaller` asserts the **trace**, not the verdict:

```
Expected value not to be <null> because a dispatch failure must leave a Warning+ trace containing
'ExecuteScript refused' — the whole point of #841 is that the pod emitted NOTHING at Warning or above.
Captured: [Warning HostedHubsCollection: … | Warning HostedHubsCollection: … | Error KernelContainer: …]
```

while the verdict came back perfectly:

```json
{"status":"Error","errorType":"NotExecutable",
 "message":"Not executable: '…' has CodeConfiguration.IsExecutable = false. Set it to true…"}
```

That message text exists only in `MeshOperations.DescribeUnrunnableTarget` — it is the pre-flight answering, not the hub.

**It is also load-bearing right now.** That suite runs inside Plugins' `Module bundle (MeshWeaver.AI)` job, which packs and inspects the bundle and then **refuses to hand it to the registry while the suite is red**. So this failure is one of the two things keeping every satellite on yesterday's module bytes (the other is a stale content pin, fixed in MeshWeaver.Plugins#1124) — including MeshWeaver.Reinsurance's trunk, which is waiting on the module-closure fix in #2977.

## The fix

`PreflightError` writes the same warning the sinks it replaced do, naming the path and the `errorType`. One place, so all three refusal shapes carry it.

## The guard

`APreflightRefusalLeavesAWarningTrace…` in `ExecuteScriptPreflightTest`, beside the two elapsed-time tests, using the same instance-owned `ILoggerProvider` capture pattern the Plugins suite uses.

**Verified it can fail**: with the `LogWarning` removed the test is `Failed: 1, Passed: 0`; with it, `Passed: 3` for the file. A gate that cannot fail is not a gate.

## Verification

- `dotnet build -c Release -warnaserror` clean on `src/MeshWeaver.Mesh.Operations` and `test/Memex.Portal.Shared.Test` (`0 Error(s)`, `0 Warning(s)`).
- `ExecuteScriptPreflightTest` — 3 passed, 0 failed; falsification run as above.
- `DocumentationLinkIntegrityTest` green (What's New entry added).
- Core tip at branch point: `861f1a015`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)