### PR TITLE
fix(compile): the adopted-source fingerprint now covers @@ includes

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -1306,6 +1306,9 @@ internal static class NodeTypeCompilationHelpers
         // changed" path). Same mesh-scoped singleton the compile watcher's parked short-circuit
         // uses; null in the rare host that does not register it (no auto-retry, unchanged before).
         var parkRegistry = hub.ServiceProvider.GetService<NodeTypeCompileParkRegistry>();
+        // #2948 — the mesh read the source fingerprint's `@@`-include walk needs. Built once per
+        // watcher; it issues nothing at all for a source set with no `@@` in it.
+        var includeReader = SourceFingerprintIncludeReader.For(hub, logger);
 
         // Outer subscription: discover the source path set via the shared
         // synced query (NodeSources.GetSources). When the path set changes
@@ -1400,7 +1403,36 @@ internal static class NodeTypeCompilationHelpers
                 // adopted fingerprint to compare it against. The nodes are already materialised
                 // here; the hash is what costs, and it is paid only where it is used.
                 return (Snapshot: (IReadOnlyDictionary<string, long>)snap, Nodes: sources);
-            }),
+            })
+            // 🚨 #2948 — the CONTENT fingerprint now covers the `@@`-include closure, and resolving
+            // that needs mesh READS, so it happens HERE (an observable step) rather than inside the
+            // pure Update lambda below. Cost: `CollectIncludeClosure` scans each source's text for
+            // "@@" and issues NOTHING when there is none — which is nearly every type — so the
+            // reads are paid only by the types that actually have includes.
+            //
+            // 🚨 Switch(), not SelectMany: a newer source set must SUPERSEDE an in-flight include
+            // resolution, or a slow read could publish a fingerprint for a set that is already gone.
+            //
+            // 🚨 An include the mesh could not READ (a stall, an unavailable owner) is INCONCLUSIVE,
+            // never "absent". Degrading it to absence shortens the hashed set, which is
+            // indistinguishable from a stale bundle and refuses a perfectly good adoption — on a
+            // Modules:RequirePrebuilt mesh that is terminal. So the fingerprint is dropped for this
+            // emission (null) and the previously published value stands; the judgement then takes
+            // ApplyAdoptedSourceStamp's "nothing has been compared" branch (AdoptedUnverified),
+            // which is the honest answer and the same #890 rule the emit canary follows.
+            .Select(published => NodeTypeSourceFingerprint
+                .Compute(published.Nodes, hubPath, includeReader, logger)
+                .Select(fingerprint => (published.Snapshot, Fingerprint: (string?)fingerprint))
+                .Catch((SourceIncludeUnavailableException ex) =>
+                {
+                    logger?.LogWarning(ex,
+                        "SourcesWatcher: the @@-include closure for {HubPath} could not be "
+                        + "established, so CurrentSourceFingerprint is left at its previous value "
+                        + "for this emission — an unreadable include must never read as an absent "
+                        + "one", hubPath);
+                    return Observable.Return((published.Snapshot, Fingerprint: (string?)null));
+                }))
+            .Switch(),
                 published =>
                 {
                     var snapshot = published.Snapshot;
@@ -1479,8 +1511,13 @@ internal static class NodeTypeCompilationHelpers
                         // in memory, on a path that runs at hub activation and per source edit —
                         // i.e. exactly where a Roslyn compile is about to cost four orders of
                         // magnitude more.
-                        var fingerprint = NodeTypeSourceFingerprint.Compute(
-                            published.Nodes, hubPath, logger);
+                        //
+                        // 🚨 #2948 — it is now resolved UPSTREAM (the include closure needs mesh
+                        // reads, which cannot happen inside this pure lambda), and it can be NULL:
+                        // null means the closure could not be established, NOT that there is
+                        // nothing to hash. The previous value stands in that case — inventing one
+                        // from a short closure is a false refusal.
+                        var fingerprint = published.Fingerprint;
 
                         // Idempotent: no-op when CurrentSourceVersions already
                         // matches the just-computed snapshot. IsDirty is a
@@ -1492,18 +1529,22 @@ internal static class NodeTypeCompilationHelpers
                         // before this field existed — snapshot already current, fingerprint null —
                         // would no-op forever and never acquire one, so the type could never be
                         // judged again. The condition is what makes the field SELF-HEALING on the
-                        // first activation after an upgrade.
+                        // first activation after an upgrade. An INCONCLUSIVE emission (fingerprint
+                        // null) drops out of the comparison entirely: it has nothing to say about
+                        // the field, so it must neither force a write nor block the snapshot's.
                         if (!pendingStamp
                             && def.CurrentSourceVersions is not null
                             && DictEquals(def.CurrentSourceVersions, snapshot)
-                            && string.Equals(
-                                def.CurrentSourceFingerprint, fingerprint, StringComparison.Ordinal))
+                            && (fingerprint is null
+                                || string.Equals(
+                                    def.CurrentSourceFingerprint, fingerprint,
+                                    StringComparison.Ordinal)))
                             return curr;
 
                         var updated = def with
                         {
                             CurrentSourceVersions = snapshot,
-                            CurrentSourceFingerprint = fingerprint,
+                            CurrentSourceFingerprint = fingerprint ?? def.CurrentSourceFingerprint,
                         };
 
                         if (pendingStamp)

--- a/src/MeshWeaver.Compiler.Pipeline/SourceFingerprintIncludeReader.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/SourceFingerprintIncludeReader.cs
@@ -1,0 +1,153 @@
+using System.Reactive.Linq;
+using MeshWeaver.Compiler;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The mesh-actor half of the <c>@@</c>-include walk that
+/// <see cref="NodeTypeSourceFingerprint"/> runs (#2948) — the System-impersonated, bounded read
+/// <see cref="NodeCompileShaping.CollectIncludeClosure"/> is handed so it can find out what an
+/// included-only snippet says TODAY.
+///
+/// <para><b>Why this is not simply <c>MeshNodeCompilationService.ReadIncludeNode</c>.</b> The
+/// anchoring, the anchored-then-authored fallback ORDER and the cycle brake are shared — they live
+/// in <see cref="NodeCompileShaping"/> and neither reader gets to have an opinion about them. What
+/// differs is what a read that could not be COMPLETED means, and it differs in opposite
+/// directions:</para>
+/// <list type="bullet">
+///   <item><b>The compile</b> degrades a stall to "unresolved": the directive stays VERBATIM, Roslyn
+///     reports on the <c>@@</c> line, the type parks with a diagnostic a human can read. Turning a
+///     transient stall into a hard fault there would park the type on the ACTIVATION path, which is
+///     worse than a compile error you can see.</item>
+///   <item><b>The fingerprint</b> must NOT degrade it. A stalled read that reads as "absent"
+///     shortens the include closure, the hash then differs from the producer's, and the adoption is
+///     REFUSED — a false refusal, which on a <c>Modules:RequirePrebuilt</c> mesh is terminal and
+///     needs a human to rebake. The honest answer is INCONCLUSIVE: this reader faults, the caller
+///     leaves the previous fingerprint standing, and the adoption judgement degrades to
+///     <c>AdoptedUnverified</c> — the branch that exists precisely for "nothing has been compared".
+///     Same rule as the emit canary (#890): a probe must not answer its scariest branch on its own
+///     inability to run.</item>
+/// </list>
+///
+/// <para>🚨 <b>ABSENT is not a failure and must keep being an answer.</b> An <c>@@</c> match that
+/// resolves to nothing is ordinary — the scanner runs over raw C# and a path-shaped fragment that
+/// names no node is a legitimate outcome, and an include the mesh genuinely does not hold
+/// contributes nothing to the bytes either. Both producer and consumer therefore record nothing
+/// for it and agree. Only <see cref="NodeReadStatus.Unavailable"/> /
+/// <see cref="NodeReadStatus.DeleteInProgress"/> and a timeout are inconclusive.</para>
+/// </summary>
+public static class SourceFingerprintIncludeReader
+{
+    /// <summary>The per-read budget — the same 15s the compile path spends on an include, so a
+    /// fingerprint can never be the slower of the two on the same mesh.</summary>
+    public static readonly TimeSpan ReadBudget = TimeSpan.FromSeconds(15);
+
+    /// <summary>
+    /// Builds the reader for <paramref name="hub"/>: anchored path first, authored path as the
+    /// fallback only when the anchored one is genuinely ABSENT, reporting the path that actually
+    /// produced the node so nested includes anchor there.
+    ///
+    /// <para>🚨 <c>RunAsSystem</c>, never <c>Observable.Using(access.ImpersonateAsSystem, …)</c>.
+    /// Impersonation is an <c>AsyncLocal</c> store/restore pair and Rx disposes <c>Using</c>'s
+    /// resource when the inner observable TERMINATES — a different thread for a cross-hub read —
+    /// leaving the subscriber latched as System (#1790). Each read is wrapped INDIVIDUALLY because
+    /// the fallback read is subscribed from the first read's emission, i.e. on another thread
+    /// again, so one outer scope would not cover it.</para>
+    ///
+    /// <para>Source-set discovery is framework infrastructure, not a user-scoped read: a per-user
+    /// read of a source node UNDER this NodeType routes a permission check BACK into the grain
+    /// being read, which deadlocks a single-threaded, non-reentrant activation (#1253).</para>
+    /// </summary>
+    /// <param name="hub">The reading hub.</param>
+    /// <param name="logger">Diagnostics.</param>
+    public static Func<string, string?, IObservable<(MeshNode? Node, string Path)>> For(
+        IMessageHub hub, ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        var access = hub.ServiceProvider.GetService<AccessService>();
+
+        return (path, fallbackPath) => Read(hub, access, path, logger)
+            .SelectMany(outcome => outcome.Status switch
+            {
+                NodeReadStatus.Present => Hit(outcome.Node, path),
+
+                // Genuinely absent, and there is another legal reading of the authored path.
+                NodeReadStatus.Absent when fallbackPath is { Length: > 0 } =>
+                    Read(hub, access, fallbackPath, logger)
+                        .SelectMany(fallback => fallback.Status switch
+                        {
+                            NodeReadStatus.Present => Hit(fallback.Node, fallbackPath),
+                            NodeReadStatus.Absent => Hit(null, fallbackPath),
+                            _ => Miss(fallbackPath, fallback.Failure),
+                        }),
+
+                NodeReadStatus.Absent => Hit(null, path),
+
+                _ => Miss(path, outcome.Failure),
+            });
+    }
+
+    /// <summary>An established answer: the node, or a well-founded "there is nothing there".</summary>
+    private static IObservable<(MeshNode? Node, string Path)> Hit(MeshNode? node, string path) =>
+        Observable.Return<(MeshNode? Node, string Path)>((node, path));
+
+    /// <summary>An answer that was never established — the fingerprint is inconclusive.</summary>
+    private static IObservable<(MeshNode? Node, string Path)> Miss(string path, Exception? cause) =>
+        Observable.Throw<(MeshNode? Node, string Path)>(Inconclusive(path, cause));
+
+    /// <summary>
+    /// One System-impersonated read. <see cref="ReadTimeoutBehavior.EmitNull"/> — deliberately, and
+    /// it is NOT the "treat indeterminate as absent" contract that flag usually expresses: it maps a
+    /// timeout to <see cref="NodeReadStatus.Unavailable"/> carrying the
+    /// <see cref="TimeoutException"/>, which is exactly the third state this reader needs. Under
+    /// <see cref="ReadTimeoutBehavior.Throw"/> the exception would arrive out of band and could not
+    /// be told apart from a routing fault by the caller of <see cref="For"/>.
+    /// </summary>
+    private static IObservable<NodeReadOutcome> Read(
+        IMessageHub hub, AccessService? access, string path, ILogger? logger) =>
+        access.RunAsSystem(() =>
+            hub.GetMeshNodeOutcome(path, ReadBudget, ReadTimeoutBehavior.EmitNull))
+            .Do(outcome =>
+            {
+                if (outcome.Status is NodeReadStatus.Present)
+                    logger?.LogDebug("Fingerprint include read resolved {Path}", path);
+            });
+
+    /// <summary>
+    /// The one exception shape a caller catches to mean "I could not establish the include closure".
+    /// Named so the sources watcher can distinguish it from a genuine defect and skip the
+    /// fingerprint publication instead of tearing its subscription down.
+    /// </summary>
+    /// <param name="path">The include target that could not be established.</param>
+    /// <param name="cause">What the read reported, when it reported anything.</param>
+    public static SourceIncludeUnavailableException Inconclusive(string path, Exception? cause) =>
+        new(path, cause);
+}
+
+/// <summary>
+/// Raised when an <c>@@</c>-include target could not be READ — as distinct from being absent
+/// (#2948). It means the source fingerprint is INCONCLUSIVE for this NodeType right now, never
+/// that the include is gone.
+/// </summary>
+public sealed class SourceIncludeUnavailableException : Exception
+{
+    /// <summary>The include target whose read could not be completed.</summary>
+    public string IncludePath { get; }
+
+    /// <summary>Builds the exception.</summary>
+    /// <param name="includePath">The include target whose read could not be completed.</param>
+    /// <param name="cause">The underlying read failure, when the read reported one.</param>
+    public SourceIncludeUnavailableException(string includePath, Exception? cause = null)
+        : base(
+            $"The @@ include '{includePath}' could not be READ (it is not known to be absent), so "
+            + "the NodeType's source fingerprint is INCONCLUSIVE. Treating an unreadable include as "
+            + "absent would shorten the hashed set and turn a good prebuilt bundle into a refused "
+            + "adoption — the previous fingerprint stands instead.",
+            cause)
+        => IncludePath = includePath;
+}

--- a/src/MeshWeaver.Compiler/NodeCompileShaping.cs
+++ b/src/MeshWeaver.Compiler/NodeCompileShaping.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reactive;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
 using MeshWeaver.Mesh;
@@ -77,14 +78,34 @@ public static class NodeCompileShaping
     /// The mesh read is the caller's business: <paramref name="readInclude"/> receives the
     /// ANCHORED path plus the authored path as fallback (null when identical) and reports the
     /// node together with the path that actually produced it, so nested includes anchor there —
-    /// MeshWeaver.Graph supplies the System-impersonated, bounded read.
+    /// MeshWeaver.Compiler.Pipeline supplies the System-impersonated, bounded read.
+    ///
+    /// <para>🚨 <paramref name="closure"/> is how the STALENESS half of the mechanism sees what the
+    /// bytes see (#2948). An <c>@@</c> target is a Code node that no source query matches, so it
+    /// reaches the emitted assembly but is absent from <c>CollectCompileSources</c> — and therefore
+    /// from <see cref="NodeTypeSourceFingerprint"/> and <c>NodeTypeDefinition.CompiledSources</c>.
+    /// Passing a dictionary here records <c>resolved path → code text</c> for every include this
+    /// walk actually consumed, so the fingerprint can cover exactly the set the substitution used.
+    /// It is recorded HERE, inside the one walk, rather than by a second traversal, because a
+    /// second traversal is a second set of rules — and the whole point of the fingerprint is that
+    /// producer and consumer cannot fork on which files count.</para>
     /// </summary>
+    /// <param name="code">The source text to resolve includes in.</param>
+    /// <param name="resolved">Visited set for THIS root file — the cycle brake. A path already in
+    /// it is substituted with the empty string and neither read nor walked again.</param>
+    /// <param name="anchorPath">The path mount-relative includes rebase onto.</param>
+    /// <param name="readInclude">The caller's include read.</param>
+    /// <param name="logger">Diagnostics.</param>
+    /// <param name="closure">Optional accumulator: resolved include path → its code text. May be
+    /// shared across several root files (the entries are keyed by path, so a snippet included by
+    /// two files contributes once).</param>
     internal static IObservable<string> ResolveCodeIncludes(
         string code,
         HashSet<string> resolved,
         string? anchorPath,
         Func<string, string?, IObservable<(MeshNode? Node, string Path)>> readInclude,
-        ILogger logger)
+        ILogger logger,
+        IDictionary<string, string>? closure = null)
     {
         if (string.IsNullOrWhiteSpace(code) || !code.Contains("@@"))
             return Observable.Return(code);
@@ -118,10 +139,16 @@ public static class NodeCompileShaping
                             && !string.IsNullOrWhiteSpace(cf.Code))
                         {
                             logger.LogDebug("Resolved code include @@{Path}", hit.Path);
+                            // #2948 — record the RAW code, keyed by the path that actually produced
+                            // the node, BEFORE recursing: the fingerprint hashes each included
+                            // node's own text, not the substituted result, so a nested include
+                            // contributes exactly once no matter how many parents pull it in.
+                            if (closure is not null)
+                                closure[hit.Path] = cf.Code;
                             // Nested includes anchor from where THIS one was found, so a chain of
                             // mount-relative includes stays inside the same mount.
                             return ResolveCodeIncludes(
-                                    cf.Code, resolved, hit.Path, readInclude, logger)
+                                    cf.Code, resolved, hit.Path, readInclude, logger, closure)
                                 .Select(resolvedInner => current.Replace(matchValue, resolvedInner));
                         }
                         logger.LogWarning(
@@ -135,6 +162,89 @@ public static class NodeCompileShaping
         }
 
         return chain;
+    }
+
+    /// <summary>
+    /// The <c>@@</c>-include CLOSURE of a compile's source set — <c>resolved path → code text</c>
+    /// for every Code node the substitution would pull in, transitively (#2948).
+    ///
+    /// <para><b>Why it exists.</b> An include target is by definition a node NO source query
+    /// matches, so it is invisible to <see cref="CollectCompileSources"/> — yet it is inside the
+    /// emitted bytes. Without this, editing an included-only snippet moved neither
+    /// <c>NodeTypeDefinition.CurrentSourceFingerprint</c> nor <c>AdoptedSourceFingerprint</c>, so a
+    /// prebuilt assembly baked BEFORE that edit still adopted as
+    /// <c>BuildProvenance.AdoptedVerified</c> — a verified claim over source that was never
+    /// hashed, which is worse than no claim at all.</para>
+    ///
+    /// <para><b>It is the SAME walk.</b> This runs <see cref="ResolveCodeIncludes"/> — the exact
+    /// call the emit path makes — with a collector, and throws the substituted text away. There is
+    /// no second implementation of the include rules to drift: the anchoring, the
+    /// anchored-then-authored fallback order, the executable/blank filters upstream and the cycle
+    /// brake are all the compile's own.</para>
+    ///
+    /// <para>🚨 <b>Deterministic, and cycle-safe.</b> Three properties, because a fingerprint that
+    /// moves when nothing changed is phantom staleness — endless recompiles, or a false refusal:
+    /// <list type="number">
+    ///   <item><b>Order cannot reach the result.</b> The output is keyed by resolved path and
+    ///     handed back SORTED (ordinal), and <c>PartitionSourceFingerprint.Compute</c> sorts
+    ///     again before hashing. The roots are walked in the order
+    ///     <see cref="CollectCompileSources"/> produced them — itself ordinal by node path — and
+    ///     SERIALLY (one <c>SelectMany</c> chain, never a <c>Merge</c>), so there is no read
+    ///     interleaving to observe either.</item>
+    ///   <item><b>Suppression is result-preserving.</b> The per-root <c>resolved</c> set skips a
+    ///     path this root already walked; skipping a re-read of the SAME anchored path can only
+    ///     re-derive the entry that is already present, so which parent reached it first cannot
+    ///     change the closure.</item>
+    ///   <item><b>A cycle terminates.</b> <c>A → B → A</c> adds each path to <c>resolved</c> once;
+    ///     the second visit takes the already-added branch, reads nothing and recurses no further.
+    ///     A self-include is the same case with one hop.</item>
+    /// </list></para>
+    ///
+    /// <para>An include that does NOT resolve contributes nothing — exactly as it contributes
+    /// nothing to the bytes (it stays VERBATIM). A read that could not be COMPLETED is a different
+    /// thing entirely and must not be confused with it: the caller's <paramref name="readInclude"/>
+    /// is expected to fault, and this chain propagates that fault rather than silently returning a
+    /// short closure, because a short closure is a fingerprint mismatch and therefore a FALSE
+    /// REFUSAL — an outage strictly worse than the staleness it is guarding against.</para>
+    /// </summary>
+    /// <param name="sources">The compile's shaped source set (<see cref="CollectCompileSources"/>
+    /// output, in its order).</param>
+    /// <param name="anchorPath">The anchor the emit path uses for root files — the NodeType's own
+    /// path, matching <c>MeshNodeCompilationService.ResolveIncludesForCodeFiles</c> and
+    /// <see cref="NodeSetCompiler.ResolveInputs"/>.</param>
+    /// <param name="readInclude">The caller's include read.</param>
+    /// <param name="logger">Diagnostics.</param>
+    internal static IObservable<ImmutableSortedDictionary<string, string>> CollectIncludeClosure(
+        IReadOnlyList<CodeConfiguration> sources,
+        string? anchorPath,
+        Func<string, string?, IObservable<(MeshNode? Node, string Path)>> readInclude,
+        ILogger logger)
+    {
+        // The overwhelmingly common case: no `@@` anywhere in the set. Costs one substring scan
+        // per file and NOT ONE mesh read — which is what keeps this affordable on a path that runs
+        // at every hub activation and every source edit.
+        var roots = sources
+            .Where(s => !string.IsNullOrWhiteSpace(s.Code) && s.Code!.Contains("@@"))
+            .ToList();
+        if (roots.Count == 0)
+            return Observable.Return(ImmutableSortedDictionary<string, string>.Empty);
+
+        var closure = new Dictionary<string, string>(StringComparer.Ordinal);
+        var chain = Observable.Return(Unit.Default);
+        foreach (var root in roots)
+        {
+            var code = root.Code!;
+            chain = chain.SelectMany(_ => ResolveCodeIncludes(
+                    code,
+                    // A visited set PER ROOT FILE — the emit path's own semantics, because that is
+                    // what decides the substituted text. Sharing one across files would make the
+                    // second file's `@@S` expand to nothing.
+                    new HashSet<string>(StringComparer.Ordinal),
+                    anchorPath, readInclude, logger, closure)
+                .Select(_ => Unit.Default));
+        }
+        return chain.Select(_ =>
+            ImmutableSortedDictionary.CreateRange(StringComparer.Ordinal, closure));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Compiler/NodeSetCompiler.cs
+++ b/src/MeshWeaver.Compiler/NodeSetCompiler.cs
@@ -65,7 +65,28 @@ public static class NodeSetCompiler
         ImmutableArray<string> MatchedSourcePaths,
         ImmutableArray<string> ExpandedQueries,
         string GeneratedSource,
-        ImmutableArray<NuGetPackageReference> NuGetReferences);
+        ImmutableArray<NuGetPackageReference> NuGetReferences)
+    {
+        /// <summary>
+        /// The <c>@@</c>-include CLOSURE this resolution consumed — resolved node path → code text,
+        /// transitively, collected BY the substitution in <see cref="ResolveInputs"/> rather than by
+        /// a second walk (#2948). These are the Code nodes no source query matched, so they are in
+        /// <see cref="GeneratedSource"/> and deliberately NOT in
+        /// <see cref="MatchedSourcePaths"/>; the bake folds them into
+        /// <see cref="NodeTypeSourceFingerprint"/> so a consumer can tell that an included-only
+        /// snippet has changed under a prebuilt assembly.
+        ///
+        /// <para><c>required</c>, and an <c>init</c> member rather than a positional parameter, for
+        /// two different reasons. Positional would have changed the primary constructor's ARITY,
+        /// which is a binary break between a module and the platform it loads into — there is no
+        /// image that can serve a mixed set, so the host aborts at boot in both directions
+        /// (<c>scripts/check-record-signatures.py</c>). And <c>required</c> because the failure mode
+        /// of forgetting it is SILENT: an empty closure for a type that has includes is not "the
+        /// fingerprint minus the includes", it is a value that disagrees with every honest consumer,
+        /// i.e. a refused adoption.</para>
+        /// </summary>
+        public required ImmutableSortedDictionary<string, string> ResolvedIncludes { get; init; }
+    }
 
     /// <summary>One compiled NodeType's artifacts.</summary>
     /// <param name="NodePath">The NodeType's mesh path — the bundle's key.</param>
@@ -130,6 +151,13 @@ public static class NodeSetCompiler
         // @@ includes, resolved against the SAME node set. The runtime reads them through the mesh
         // under System impersonation with a bounded timeout; here the read is a dictionary lookup,
         // so the reactive chain completes on subscribe.
+        //
+        // 🚨 #2948 — the walk also RECORDS what it pulled in. An include target is a Code node no
+        // source query matched, so it is in the bytes and absent from `matchedPaths`; without this
+        // record the bake's source fingerprint could not cover it, and a consumer holding an edited
+        // snippet would adopt these bytes as VERIFIED. Collected here, inside the substitution
+        // itself, so there is no second traversal to disagree with the first.
+        var closure = new Dictionary<string, string>(StringComparer.Ordinal);
         var resolvedFiles = new List<CodeConfiguration>(codeFiles.Count);
         foreach (var codeFile in codeFiles)
         {
@@ -137,7 +165,7 @@ public static class NodeSetCompiler
                 .ResolveCodeIncludes(
                     codeFile.Code!, new HashSet<string>(StringComparer.Ordinal), nodePath,
                     (anchored, authored) => Observable.Return(ReadInclude(nodes, anchored, authored)),
-                    logger)
+                    logger, closure)
                 .Wait();
             resolvedFiles.Add(
                 ReferenceEquals(resolvedCode, codeFile.Code)
@@ -159,7 +187,10 @@ public static class NodeSetCompiler
             [.. matchedPaths],
             resolution.ExpandedQueries,
             source,
-            [.. nugetRefs]);
+            [.. nugetRefs])
+        {
+            ResolvedIncludes = ImmutableSortedDictionary.CreateRange(StringComparer.Ordinal, closure),
+        };
     }
 
     /// <summary>

--- a/src/MeshWeaver.Compiler/NodeTypeSourceFingerprint.cs
+++ b/src/MeshWeaver.Compiler/NodeTypeSourceFingerprint.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
 using System.Security.Cryptography;
 using System.Text;
 using MeshWeaver.Mesh;
@@ -57,30 +59,131 @@ namespace MeshWeaver.Compiler;
 /// this hash. Put it anywhere else and two meshes could disagree about the shape while agreeing
 /// about the gate, which is a false-refusal outage waiting on a refactor.</para>
 ///
-/// <para>🚨 <b>Known residue, deliberately not covered.</b> An <c>@@</c> include pulls a Code node
-/// that no source query matches, so it is absent from this fold — a change to an included-only
-/// snippet does not move the fingerprint. That is not a new hole: it is the SAME set
-/// <c>NodeTypeDefinition.CompiledSources</c> records, so <c>IsDirty</c> has always missed it too.
-/// Closing it means resolving includes on the live side (a mesh read per include) and is tracked
-/// separately rather than smuggled in here — but it is named, because a guard whose coverage is
-/// assumed rather than stated is how this mechanism went inert the first time.</para>
+/// <para>🚨 <b>And it covers the <c>@@</c> INCLUDE CLOSURE</b> (#2948). An include pulls a Code node
+/// that NO source query matches, so it is absent from the fold above while being present in the
+/// emitted bytes. Until #2948 that made this hash silently partial: editing an included-only
+/// snippet moved neither fingerprint, and a prebuilt assembly baked before that edit still adopted
+/// as <c>AdoptedVerified</c> — a VERIFIED claim over source nobody had hashed, which is strictly
+/// worse than the <c>AdoptedUnverified</c> it looks better than. Both halves now resolve includes
+/// before hashing: the bake already did (<see cref="NodeSetCompiler.ResolveInputs"/> hands back the
+/// closure its own substitution collected), and the live side resolves it through the mesh in the
+/// sources watcher. Every included node contributes a <c>@@{path}</c> entry carrying the SHA-256 of
+/// its own text — see <see cref="NodeCompileShaping.CollectIncludeClosure"/> for why that walk is
+/// order-stable and cycle-safe.</para>
+///
+/// <para>🚨 <b>Residue, named rather than assumed.</b> The include set is NOT added to
+/// <c>NodeTypeDefinition.CompiledSources</c> / <c>CurrentSourceVersions</c>, so
+/// <c>NodeTypeDefinition.IsDirty</c> still does not notice an included-only edit, and the live
+/// sources watcher — which re-runs on its source QUERY — does not re-publish until the type's own
+/// source set moves or its hub reactivates. That is the recompile-trigger half, deliberately left
+/// where it was: it is a different mechanism (a change feed, not a hash), it is the same gap
+/// <c>CompiledSources</c> has always had, and the bundle manifest's <c>sourceVersions</c> is a
+/// producer/consumer contract that both bakes and <c>BakeEquivalenceTest</c> pin to the RAW query
+/// match. What #2948 closes is the VERIFIED claim, which is decided by these two fingerprints and
+/// nothing else.</para>
 /// </summary>
 public static class NodeTypeSourceFingerprint
 {
     /// <summary>
+    /// The key prefix under which an <c>@@</c>-include contributes to the fold. It keeps the
+    /// include closure in a namespace of its own, so a node that is BOTH a matched source and the
+    /// target of an include from a sibling contributes one entry as each, and neither can be
+    /// mistaken for the other by a reader of the framed input.
+    /// </summary>
+    private const string IncludeKeyPrefix = "@@";
+
+    /// <summary>
     /// The fingerprint of <paramref name="sourceNodes"/> as a compile input for the NodeType at
-    /// <paramref name="nodeTypePath"/>.
+    /// <paramref name="nodeTypePath"/>, resolving the <c>@@</c>-include closure through
+    /// <paramref name="readInclude"/> first — the shape every LIVE caller uses, because only a mesh
+    /// read can say what an included-only snippet says today.
+    ///
+    /// <para>🚨 Faults are NOT swallowed. If an include read cannot be completed (a stall, an
+    /// unavailable owner) this observable errors, and the caller must treat that as INCONCLUSIVE —
+    /// leave the previous value standing — never as "the include is absent". Degrading a failed
+    /// read to absence shortens the closure, which reads exactly like a stale bundle and refuses a
+    /// perfectly good adoption: a self-inflicted outage worse than the bug. Same rule as the emit
+    /// canary (#890): a probe must not answer its scariest branch on its own inability to run.</para>
+    /// </summary>
+    /// <param name="sourceNodes">The RAW resolved source+test node set — the output of
+    /// <c>NodeSources.GetSources</c> at runtime, or <c>NodeSet.ResolveSources</c> in the bake. The
+    /// shaping fold is applied here so both callers cannot apply a different one.</param>
+    /// <param name="nodeTypePath">The NodeType's mesh path. Also the include ANCHOR, matching what
+    /// the emit path uses for root files.</param>
+    /// <param name="readInclude">Reads one include target (anchored path, authored fallback).</param>
+    /// <param name="logger">Diagnostics for the shaping fold (skipped executable cells).</param>
+    public static IObservable<string> Compute(
+        IEnumerable<MeshNode> sourceNodes,
+        string nodeTypePath,
+        Func<string, string?, IObservable<(MeshNode? Node, string Path)>> readInclude,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(sourceNodes);
+        ArgumentException.ThrowIfNullOrEmpty(nodeTypePath);
+        ArgumentNullException.ThrowIfNull(readInclude);
+
+        var log = logger ?? NullLogger.Instance;
+        var (sources, paths) = NodeCompileShaping.CollectCompileSources(
+            sourceNodes, nodeTypePath, log);
+
+        return NodeCompileShaping
+            .CollectIncludeClosure(sources, nodeTypePath, readInclude, log)
+            .Select(closure => Fold(sources, paths, closure));
+    }
+
+    /// <summary>
+    /// The fingerprint for a caller that has ALREADY resolved the include closure — the tree bake,
+    /// whose compile substituted the includes anyway and hands the collected set back on
+    /// <see cref="NodeSetCompiler.CompileInputs.ResolvedIncludes"/>. No second walk, no second set
+    /// of reads, and no <c>.Wait()</c> at a synchronous build-step boundary.
     ///
     /// <para>NEVER null: an empty source set folds to the empty-set hash, a real value. That is
     /// deliberate — "this type compiles from nothing" is a fact worth comparing, and returning null
     /// would make a bundle baked from three files adopt as merely <i>unverified</i> against a mesh
     /// whose sources have all been deleted, instead of being refused.</para>
+    ///
+    /// <para>🚨 Pass the closure the compile ACTUALLY resolved. Passing an empty dictionary for a
+    /// type that has includes does not produce "a fingerprint without includes" — it produces a
+    /// value that DISAGREES with every honest consumer, i.e. a refusal.</para>
     /// </summary>
-    /// <param name="sourceNodes">The RAW resolved source+test node set — the output of
-    /// <c>NodeSources.GetSources</c> at runtime, or <c>NodeSet.ResolveSources</c> in the bake. The
-    /// shaping fold is applied here so both callers cannot apply a different one.</param>
+    /// <param name="sourceNodes">The RAW resolved source+test node set.</param>
+    /// <param name="nodeTypePath">The NodeType's mesh path (diagnostics only).</param>
+    /// <param name="resolvedIncludes">The <c>@@</c>-include closure: resolved path → code text.</param>
+    /// <param name="logger">Diagnostics for the shaping fold (skipped executable cells).</param>
+    public static string Compute(
+        IEnumerable<MeshNode> sourceNodes,
+        string nodeTypePath,
+        IReadOnlyDictionary<string, string> resolvedIncludes,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(sourceNodes);
+        ArgumentException.ThrowIfNullOrEmpty(nodeTypePath);
+        ArgumentNullException.ThrowIfNull(resolvedIncludes);
+
+        var (sources, paths) = NodeCompileShaping.CollectCompileSources(
+            sourceNodes, nodeTypePath, logger ?? NullLogger.Instance);
+        return Fold(sources, paths, resolvedIncludes);
+    }
+
+    /// <summary>
+    /// The fingerprint of a source set that has NO <c>@@</c> includes at all — the shape a caller
+    /// uses when it holds the source TEXT and no way to read the mesh (a producer-side unit check,
+    /// a fixture).
+    ///
+    /// <para>🚨 <b>It REFUSES a set that does have one</b>, rather than quietly hashing without it.
+    /// That is the whole difference between this overload and a trap-door: an empty closure over a
+    /// set with includes is not "the fingerprint minus the includes", it is a value that disagrees
+    /// with every honest producer and consumer — i.e. an adoption refusal, and on a
+    /// <c>Modules:RequirePrebuilt</c> mesh a terminal one. A convenience overload that can silently
+    /// under-cover is exactly how the #2813 mechanism sat inert: the 7-argument
+    /// <c>PrebuiltAssemblySeeder.Seed</c> hard-coded <c>sourceFingerprint: null</c> and every
+    /// production caller took it. So this one cannot be taken by accident.</para>
+    /// </summary>
+    /// <param name="sourceNodes">The RAW resolved source+test node set.</param>
     /// <param name="nodeTypePath">The NodeType's mesh path (diagnostics only).</param>
     /// <param name="logger">Diagnostics for the shaping fold (skipped executable cells).</param>
+    /// <exception cref="InvalidOperationException">The shaped set contains an <c>@@</c> include
+    /// directive, so its closure cannot be known without reading it.</exception>
     public static string Compute(
         IEnumerable<MeshNode> sourceNodes,
         string nodeTypePath,
@@ -92,17 +195,45 @@ public static class NodeTypeSourceFingerprint
         var (sources, paths) = NodeCompileShaping.CollectCompileSources(
             sourceNodes, nodeTypePath, logger ?? NullLogger.Instance);
 
-        // CollectCompileSources returns the two lists in lock-step (one MatchedPath per
-        // CodeConfiguration it accepted), and PartitionSourceFingerprint sorts by path before
-        // hashing — so the enumeration order the fold happened to use cannot reach the result.
-        return PartitionSourceFingerprint.Compute(
-            paths.Select((path, index) => (path, TokenOf(sources[index]))));
+        for (var i = 0; i < sources.Count; i++)
+        {
+            if (sources[i].Code is { Length: > 0 } code
+                && NodeCompileShaping.CodeIncludePattern.IsMatch(code))
+                throw new InvalidOperationException(
+                    $"'{paths[i]}' declares an @@ include, so the source fingerprint for "
+                    + $"'{nodeTypePath}' cannot be computed from the matched sources alone (#2948). "
+                    + "An include pulls a Code node NO source query matches: it is inside the "
+                    + "emitted bytes, so it must be inside the hash, or an edit to it leaves a "
+                    + "prebuilt assembly adopting as AdoptedVerified against source that changed "
+                    + "under it. Use the overload taking an include READER (live/mesh callers) or "
+                    + "the one taking the closure the compile already resolved "
+                    + "(NodeSetCompiler.CompileInputs.ResolvedIncludes).");
+        }
+
+        return Fold(sources, paths, ImmutableDictionary<string, string>.Empty);
     }
+
+    /// <summary>
+    /// The fold itself. <c>CollectCompileSources</c> returns the two lists in lock-step (one
+    /// MatchedPath per <c>CodeConfiguration</c> it accepted), and
+    /// <c>PartitionSourceFingerprint.Compute</c> sorts by path before hashing — so neither
+    /// the enumeration order of the source set nor the traversal order of the include walk can
+    /// reach the result.
+    /// </summary>
+    private static string Fold(
+        IReadOnlyList<CodeConfiguration> sources,
+        IReadOnlyList<string> paths,
+        IReadOnlyDictionary<string, string> resolvedIncludes)
+        => PartitionSourceFingerprint.Compute(
+            paths
+                .Select((path, index) => (Path: path, Token: TokenOf(sources[index].Code)))
+                .Concat(resolvedIncludes.Select(
+                    entry => (Path: IncludeKeyPrefix + entry.Key, Token: TokenOf(entry.Value)))));
 
     /// <summary>SHA-256 over the code text — the only property of a source node the emitted bytes
     /// depend on (<see cref="NodeCompileShaping.CombineSources"/> reads <c>Code</c> and nothing
     /// else).</summary>
-    private static string TokenOf(CodeConfiguration code) =>
+    private static string TokenOf(string? code) =>
         Convert.ToHexStringLower(
-            SHA256.HashData(Encoding.UTF8.GetBytes(code.Code ?? string.Empty)));
+            SHA256.HashData(Encoding.UTF8.GetBytes(code ?? string.Empty)));
 }

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -576,9 +576,10 @@ fingerprint over ticks would never match and every adoption would be refused.
 **What exactly is hashed — `NodeTypeSourceFingerprint` (in `MeshWeaver.Compiler`).** The fingerprint
 is taken over the *compile input*: the `NodeCompileShaping.CollectCompileSources` fold — deduplicated
 ordinal-ignore-case, executable cells and blank files dropped — reduced to
-`(node path, SHA-256 of the code text)`, folded with `PartitionSourceFingerprint`, which sorts by
-path so enumeration order cannot reach the result. Both the runtime and the bake call *that* fold
-already, so they cannot fork on which files count.
+`(node path, SHA-256 of the code text)`, **plus the `@@`-include closure** as
+`(@@{resolved path}, SHA-256 of the code text)`, folded with `PartitionSourceFingerprint`, which
+sorts by path so enumeration order cannot reach the result. Both the runtime and the bake call
+*that* fold already, so they cannot fork on which files count.
 
 The obvious alternative — hashing the source MeshNodes' serialised content — is unusable across
 processes, and each of its three failure modes produces a **false refusal**, which is an outage
@@ -695,14 +696,75 @@ differently, and `assert-bake-consumption.sh` fails on it by name.
 > per-type verdict is green. Only the log says anything — and only because the refusal logs at
 > `Error`, above the gate's default level.
 
+#### 🚨 The fingerprint covers the `@@`-include closure — both sides resolve before hashing
+
+An `@@` include pulls a Code node that **no source query matches**. It reaches the emitted assembly
+(`NodeSetCompiler.ResolveInputs` substitutes it after the fold) and it used to be absent from the
+hash — so editing an included-only snippet moved neither `AdoptedSourceFingerprint` nor
+`CurrentSourceFingerprint`, and a prebuilt assembly baked *before* that edit still adopted as
+`AdoptedVerified`.
+
+That is the worst of the three rows to be wrong on. `AdoptedUnverified` says "nobody established
+where these bytes came from", and an operator reads it as the warning it is. `AdoptedVerified` is an
+**assertion** that the shipped bytes match the source this mesh holds — standing over source that
+was never hashed, it is a *false verification*, which is the #2813 incident one layer in. So both
+halves now resolve includes first (#2948):
+
+- **The producer** already substituted them, so it simply keeps what it pulled in.
+  `NodeCompileShaping.ResolveCodeIncludes` takes an optional collector and records
+  `resolved path → code text` at the point it consumes each include; `ResolveInputs` hands that back
+  on `CompileInputs.ResolvedIncludes`, and `TreeBake` / `CascadeBuild` fold it straight into the
+  fingerprint. **No second walk, no second read, and no new blocking bridge** at a synchronous build
+  step.
+- **The consumer** resolves it through the mesh, in the one place that already holds the live source
+  nodes: the sources watcher (`NodeTypeCompilationHelpers.InstallSourcesWatcher`). Resolving a closure
+  means mesh READS, which a pure `Update` lambda cannot make — so the fingerprint moved *out* of that
+  lambda into an observable step ahead of it — composed with `Switch()`, so a newer source set supersedes an in-flight
+  resolution rather than racing it.
+
+The cost is bounded by the shape of the walk, not by the size of the mesh:
+`CollectIncludeClosure` scans each source's text for `@@` and **issues no read at all** when there
+is none, which is almost every type. Only a type that actually has includes pays, and it pays the
+same reads its own compile would.
+
+**Why the walk is order-stable and cycle-safe.** A fingerprint that moves when nothing changed is
+*phantom staleness* — endless recompiles, or a false refusal — so three properties are load-bearing:
+
+1. **Order cannot reach the result.** The closure is keyed by *resolved path* and returned sorted
+   (ordinal); `PartitionSourceFingerprint` then sorts again. The roots are walked in
+   `CollectCompileSources` order — itself ordinal by node path — and **serially**, one `SelectMany`
+   chain and never a `Merge`, so there is no read interleaving to observe either.
+2. **Suppression is result-preserving.** The per-root visited set skips a path that root already
+   walked. Skipping a re-read of the *same* anchored path can only re-derive an entry that is
+   already present, so which parent reached a shared snippet first cannot change the closure.
+3. **A cycle terminates.** `A → B → A` adds each path to the visited set once; the second visit
+   takes the already-added branch, reads nothing and recurses no further. A self-include is the same
+   case with one hop.
+
+**And an unreadable include is INCONCLUSIVE, never absent.** This is the direction that would hurt.
+The producer's lookup is in-memory and never stalls; a consumer that quietly treated a stalled read
+as "the include is gone" would hash a *shorter* closure, which is indistinguishable from a stale
+bundle — so a perfectly good adoption is **refused**, and on a `Modules:RequirePrebuilt` mesh that
+is terminal and needs a human to rebake. `SourceFingerprintIncludeReader` therefore uses
+`GetMeshNodeOutcome` and keeps the three states apart: `Present` contributes, `Absent` contributes
+nothing (it contributes nothing to the bytes either — the directive stays verbatim, so both sides
+agree), and `Unavailable` / `DeleteInProgress` / a timeout raise
+`SourceIncludeUnavailableException`. The watcher catches exactly that, logs it, and **leaves the
+previously published `CurrentSourceFingerprint` standing** — the judgement then takes the "nothing
+has been compared" branch (`AdoptedUnverified`). Same rule as the emit canary (#890): a probe must
+not answer its scariest branch on its own inability to run.
+
 #### Two things this deliberately does NOT do
 
-- **`@@` includes are outside the fingerprint.** An `@@` include pulls a Code node that no source
-  query matches, so a change to an included-only snippet does not move the hash. That is not a new
-  hole: it is the same set `CompiledSources` records, so `IsDirty` has always missed it too. Closing
-  it means resolving includes on the live side (a mesh read per include) and is tracked separately —
-  but it is stated, because a guard whose coverage is assumed rather than named is exactly how this
-  mechanism went inert the first time.
+- **The include closure is NOT added to `CompiledSources` / `CurrentSourceVersions`.** So
+  `IsDirty` still does not notice an included-only edit, and the sources watcher — which re-runs on
+  its source *query* — does not re-publish until the type's own source set moves or its hub
+  reactivates. That is the recompile-*trigger* half, and it is a different mechanism: a change feed,
+  not a hash. It is also a producer/consumer contract — the bundle manifest's `sourceVersions`
+  mirrors the RAW query match on both bakes, which `BakeEquivalenceTest` pins deliberately (an
+  include target is asserted *absent* from `sourceVersions` and *present* in the emitted surface and
+  in the fingerprint's input). What #2948 closes is the **verified claim**, which is decided by the
+  two fingerprints and nothing else.
 - **Refusing to LOAD is the second line of defence.** The damage needs two ingredients — stale bytes
   *and something armed to run them*. A type that renders read-only pages from unverified bytes is a
   degraded system; a type that WRITES from them is the incident. The execute-time half is

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-shared-snippet-no-longer-hides-behind-a-verified-build.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-shared-snippet-no-longer-hides-behind-a-verified-build.md
@@ -1,0 +1,43 @@
+---
+Name: A shared snippet no longer hides behind a verified build
+Category: Fix
+Description: Code pulled in with an @@ include is part of what a type is built from, so editing it now changes the build's fingerprint — a prebuilt version made before that edit is no longer reported as verified against source it was never built from.
+Icon: ShieldCheckmark
+Order: -20260902
+---
+
+# A shared snippet no longer hides behind a verified build
+
+A type's source is not only the files under its own `Source/` folder. A file can pull another node's
+code in with an `@@` line — the way shared helpers, sample data and cross-package snippets are
+reused — and that code is compiled into the type just as much as the file that referenced it.
+
+The platform recently learned to *prove* that an installed prebuilt version of a type was built from
+the source this portal actually holds, and to mark it **verified** when it is. That proof was reading
+a smaller set of files than the compiler was. An `@@` target is, by definition, a node that none of
+the type's source queries match — so it was inside the compiled code and outside the check. Edit a
+shared snippet, and nothing moved: the portal went on reporting a build made *before* your edit as
+verified against the source it now holds.
+
+That is worse than not checking at all. "We don't know where these bytes came from" is a warning
+anyone reads correctly. "Verified" is a statement — and a statement about source nobody looked at is
+the same failure the check exists to prevent, one step further in.
+
+**Both halves now follow the `@@` lines before they hash.** The build already expands them, so it
+simply keeps the list of what it pulled in; the portal resolves them against its own content. Nested
+includes count too — a snippet that includes a snippet is followed all the way down — and a
+circular reference stops rather than spinning. Edit a shared snippet today and the fingerprints
+diverge, so a prebuilt version made before the edit is refused and rebuilt from what you actually
+have.
+
+Two things were deliberately kept as they were, because the opposite mistake is an outage:
+
+- **Nothing new is refused on a doubt.** If the portal cannot *read* an included snippet — a slow
+  moment, an owner that did not answer — that is "I could not check", not "the snippet is gone". A
+  shortened list would hash differently from every honest package and reject good ones, so instead
+  the previous answer stands and the build is reported as unverified rather than wrongly refused.
+  Packages published before any of this existed still install exactly as before.
+- **A snippet edit still does not, by itself, queue a rebuild.** Deciding *when* to recompile is a
+  separate mechanism watching the type's own files, and it works the same way it always has. What
+  changed is the honesty of the claim: the portal no longer says "verified" about a build it has
+  not actually checked.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/SourceFingerprintIncludeClosureTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/SourceFingerprintIncludeClosureTest.cs
@@ -1,0 +1,475 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Compiler;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 THE DEFECT (#2948): an <c>@@</c> include pulls a Code node that NO source query matches, so
+/// it is inside the emitted assembly and was outside <see cref="NodeTypeSourceFingerprint"/>.
+/// Editing an included-only snippet therefore moved neither
+/// <c>NodeTypeDefinition.CurrentSourceFingerprint</c> nor the producer's
+/// <c>AdoptedSourceFingerprint</c>, and a prebuilt assembly baked BEFORE that edit still adopted as
+/// <see cref="BuildProvenance.AdoptedVerified"/>.
+///
+/// <para><b>Why that is worse than no check.</b> <c>AdoptedUnverified</c> says "nobody established
+/// where these bytes came from" and an operator reads it as the warning it is.
+/// <c>AdoptedVerified</c> is an ASSERTION that the shipped bytes match the source this mesh holds.
+/// Standing over source that was never hashed, it is a false verification — the same shape as the
+/// #2813 incident it was built to prevent, one layer in.</para>
+///
+/// <para><b>What is NOT the fix.</b> Widening the refusal. <c>AdoptedUnverified</c> is a legacy
+/// state that must keep adopting (refusing it recompiles everything on every install and, on a
+/// <c>Modules:RequirePrebuilt</c> mesh, parks every legacy-bundle type). And a read that could not
+/// be COMPLETED must not shorten the closure either — that reads exactly like a stale bundle and
+/// refuses a good adoption, which is the outage direction. Both are pinned below.</para>
+///
+/// <para>The include reader is in-memory here, so every chain completes on subscribe: these are
+/// pins on the DECISION, with no hub, no mesh and no timing.
+/// <c>BakeEquivalenceTest</c> is what pins the two real producers to the same value.</para>
+/// </summary>
+public class SourceFingerprintIncludeClosureTest
+{
+    private const string TypePath = "Widget/Thing";
+
+    private static MeshNode Code(string path, string code) =>
+        new(path[(path.LastIndexOf('/') + 1)..], path[..path.LastIndexOf('/')])
+        {
+            NodeType = "Code",
+            State = MeshNodeState.Active,
+            Content = new CodeConfiguration { Code = code, Language = "csharp" },
+        };
+
+    /// <summary>
+    /// The mesh half, in memory. Mirrors <c>SourceFingerprintIncludeReader</c>'s contract exactly:
+    /// the ANCHORED path first, the authored path only as a fallback, reporting the path that
+    /// produced the node so nested includes anchor there — and a path listed in
+    /// <paramref name="unreadable"/> FAULTS rather than answering "absent", which is the one
+    /// distinction the whole inconclusive rule rests on.
+    /// </summary>
+    private static Func<string, string?, IObservable<(MeshNode? Node, string Path)>> ReaderOver(
+        IReadOnlyDictionary<string, string> nodes,
+        IReadOnlySet<string>? unreadable = null)
+        => (anchored, authored) =>
+        {
+            foreach (var candidate in authored is null ? [anchored] : new[] { anchored, authored })
+            {
+                if (unreadable?.Contains(candidate) == true)
+                    return Observable.Throw<(MeshNode? Node, string Path)>(
+                        new SourceIncludeUnavailableException(candidate));
+                if (nodes.TryGetValue(candidate, out var code))
+                    return Observable.Return<(MeshNode? Node, string Path)>(
+                        (Code(candidate, code), candidate));
+            }
+            return Observable.Return<(MeshNode? Node, string Path)>((null, anchored));
+        };
+
+    /// <summary>Subscribes the (synchronous, in-memory) chain and returns the one value it
+    /// produced. No <c>.Wait()</c>: the reader completes on subscribe, so a plain
+    /// <c>Subscribe</c> is both sufficient and non-blocking.</summary>
+    private static string FingerprintOf(
+        IReadOnlyList<MeshNode> sources,
+        IReadOnlyDictionary<string, string> mesh,
+        IReadOnlySet<string>? unreadable = null)
+    {
+        string? captured = null;
+        Exception? failure = null;
+        NodeTypeSourceFingerprint
+            .Compute(sources, TypePath, ReaderOver(mesh, unreadable))
+            .Subscribe(value => captured = value, ex => failure = ex);
+        if (failure is not null)
+            throw failure;
+        captured.Should().NotBeNull("the include walk must produce a value or fault, never neither");
+        return captured!;
+    }
+
+    private static Exception FingerprintFailureOf(
+        IReadOnlyList<MeshNode> sources,
+        IReadOnlyDictionary<string, string> mesh,
+        IReadOnlySet<string> unreadable)
+    {
+        Exception? failure = null;
+        NodeTypeSourceFingerprint
+            .Compute(sources, TypePath, ReaderOver(mesh, unreadable))
+            .Subscribe(_ => { }, ex => failure = ex);
+        failure.Should().NotBeNull("an unreadable include must FAULT, never answer");
+        return failure!;
+    }
+
+    // ── The defect ────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE ONE THAT WAS FAILING. The snippet is reachable ONLY through the <c>@@</c> directive —
+    /// no source query matches <c>Widget/Snippets/Greeting</c>, which is exactly the shape
+    /// <c>BakeEquivalenceTest</c> pins — so before #2948 both fingerprints were identical and an
+    /// edit to it was invisible.
+    /// </summary>
+    [Fact]
+    public void EditingAnIncludedOnlySnippet_MovesTheFingerprint()
+    {
+        var sources = new[]
+        {
+            Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Greeting"),
+        };
+
+        var before = FingerprintOf(sources, new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Greeting"] = "public static class Greeting { public static string Hello() => \"hi\"; }",
+        });
+        var after = FingerprintOf(sources, new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Greeting"] = "public static class Greeting { public static string Hello() => \"HELLO\"; }",
+        });
+
+        after.Should().NotBe(before,
+            "the snippet is INSIDE the emitted bytes, so a change to it must move the hash — "
+            + "otherwise an assembly compiled before the edit still claims AdoptedVerified against "
+            + "source it was never built from");
+    }
+
+    /// <summary>
+    /// 🚨 …AND THE CONTROL. A fingerprint that moved for any reason would pass the test above while
+    /// producing endless phantom staleness — a recompile on every activation, and on a
+    /// RequirePrebuilt mesh a permanent refusal. Nothing the compile does not consume may reach it.
+    /// </summary>
+    [Fact]
+    public void AnEditToANodeTheCompileNeverSees_LeavesTheFingerprintAlone()
+    {
+        var sources = new[]
+        {
+            Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Greeting"),
+        };
+        const string greeting = "public static class Greeting { }";
+
+        var before = FingerprintOf(sources, new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Greeting"] = greeting,
+            ["Widget/Snippets/Unused"] = "public static class Unused { }",
+        });
+        var after = FingerprintOf(sources, new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Greeting"] = greeting,
+            ["Widget/Snippets/Unused"] = "public static class Unused { public static int X => 1; }",
+        });
+
+        after.Should().Be(before,
+            "a node nothing includes and no query matches is not compile input — letting it move "
+            + "the hash would refuse every good bundle on the next unrelated edit");
+    }
+
+    // ── The walk: nesting, cycles, order ──────────────────────────────────────────────────────
+
+    /// <summary>An include may itself include. The closure is TRANSITIVE, so a change two hops
+    /// down still moves the hash.</summary>
+    [Fact]
+    public void ANestedIncludeIsCovered_Transitively()
+    {
+        var sources = new[] { Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Outer") };
+        var mesh = new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Outer"] = "public static class Outer { }\n\n@@Widget/Snippets/Inner",
+            ["Widget/Snippets/Inner"] = "public static class Inner { public static int V => 1; }",
+        };
+
+        var before = FingerprintOf(sources, mesh);
+
+        var edited = new Dictionary<string, string>(mesh)
+        {
+            ["Widget/Snippets/Inner"] = "public static class Inner { public static int V => 2; }",
+        };
+        FingerprintOf(sources, edited).Should().NotBe(before,
+            "the innermost snippet is in the bytes just as much as the outermost one");
+    }
+
+    /// <summary>
+    /// 🚨 A cycle must TERMINATE, and terminate at a stable value. <c>A → B → A</c> is not
+    /// hypothetical — mount-relative includes inside one subtree reference each other, and the walk
+    /// runs on the hub-activation path where a non-terminating traversal is an outage, not a slow
+    /// test.
+    /// </summary>
+    [Fact]
+    public void ACyclicIncludeTerminates_AndIsStable()
+    {
+        var sources = new[] { Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/A") };
+        var mesh = new Dictionary<string, string>
+        {
+            ["Widget/Snippets/A"] = "public static class A { }\n\n@@Widget/Snippets/B",
+            ["Widget/Snippets/B"] = "public static class B { }\n\n@@Widget/Snippets/A",
+        };
+
+        var first = FingerprintOf(sources, mesh);
+        FingerprintOf(sources, mesh).Should().Be(first,
+            "a walk that terminates must terminate at the SAME place every time");
+
+        // …and the cycle did not swallow either member: editing EITHER one still moves the hash.
+        FingerprintOf(sources, new Dictionary<string, string>(mesh)
+        {
+            ["Widget/Snippets/B"] = "public static class B { public static int V => 1; }\n\n@@Widget/Snippets/A",
+        }).Should().NotBe(first, "B is in the closure — the cycle brake stops the walk, not the coverage");
+    }
+
+    /// <summary>A self-include is the one-hop cycle, and the walk must not recurse into it.</summary>
+    [Fact]
+    public void ASelfIncludeTerminates()
+    {
+        var sources = new[] { Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Self") };
+        var mesh = new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Self"] = "public static class Self { }\n\n@@Widget/Snippets/Self",
+        };
+
+        FingerprintOf(sources, mesh).Should().NotBeNullOrEmpty();
+    }
+
+    /// <summary>
+    /// 🚨 ORDER-STABILITY, the property phantom staleness comes from. The same content delivered in
+    /// a different enumeration order — which is exactly what the mesh's <c>ImmutableDictionary</c>
+    /// fold produced before #1707's sort, over per-process-randomised string hashes — must fold to
+    /// the SAME value. That covers the include walk too: the closure is keyed by resolved path and
+    /// sorted, so which root reached a shared snippet first cannot reach the result.
+    /// </summary>
+    [Fact]
+    public void TheFingerprintIsIndependentOfDeliveryOrder()
+    {
+        var mesh = new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Shared"] = "public static class Shared { }",
+            ["Widget/Snippets/Only"] = "public static class Only { }",
+        };
+        var a = Code($"{TypePath}/Source/A", "public record A;\n\n@@Widget/Snippets/Shared");
+        var b = Code($"{TypePath}/Source/B", "public record B;\n\n@@Widget/Snippets/Shared\n@@Widget/Snippets/Only");
+
+        FingerprintOf([b, a], mesh).Should().Be(FingerprintOf([a, b], mesh),
+            "a fingerprint that depends on traversal order changes when nothing changed");
+    }
+
+    // ── Inconclusive is not absent ────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE FALSE-REFUSAL GUARD. A read that could not be COMPLETED must fault, not degrade to
+    /// "the include is absent". The producer never stalls (its lookup is in-memory), so a consumer
+    /// that quietly shortened its closure would hash differently from every good bundle and refuse
+    /// it — on a <c>Modules:RequirePrebuilt</c> mesh, terminally. Note what the assertion measures:
+    /// not merely that it faulted, but that the value it would otherwise have produced is a
+    /// DIFFERENT one, i.e. that degrading really would have refused.
+    /// </summary>
+    [Fact]
+    public void AnUnreadableInclude_IsInconclusive_NeverAbsent()
+    {
+        var sources = new[] { Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Greeting") };
+        var mesh = new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Greeting"] = "public static class Greeting { }",
+        };
+
+        var failure = FingerprintFailureOf(
+            sources, mesh, new HashSet<string>(StringComparer.Ordinal) { "Widget/Snippets/Greeting" });
+
+        failure.Should().BeOfType<SourceIncludeUnavailableException>(
+            "the caller has to be able to tell an unreadable include from a genuine defect, so it "
+            + "can leave the previous fingerprint standing instead of tearing down its watcher");
+
+        // The counterfactual: had the stall been treated as absence, THIS is the value it would
+        // have produced — and it is not the honest one, so the adoption would have been refused.
+        var asIfAbsent = FingerprintOf(sources, new Dictionary<string, string>());
+        asIfAbsent.Should().NotBe(FingerprintOf(sources, mesh),
+            "if these were equal the guard above would be measuring nothing");
+    }
+
+    /// <summary>
+    /// An include the mesh genuinely does not hold contributes NOTHING — and must, because it
+    /// contributes nothing to the bytes either (the directive stays VERBATIM and Roslyn reports on
+    /// the <c>@@</c> line). Both producer and consumer record nothing for it and therefore agree.
+    /// </summary>
+    [Fact]
+    public void AnIncludeThatResolvesToNothing_ContributesNothing()
+    {
+        var sources = new[] { Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Missing") };
+
+        FingerprintOf(sources, new Dictionary<string, string>())
+            .Should().Be(
+                NodeTypeSourceFingerprint.Compute(
+                    sources, TypePath, ImmutableDictionary<string, string>.Empty),
+                "an unresolvable include is an ordinary outcome, not a failure — the two sides must "
+                + "both fold an empty closure for it");
+    }
+
+    // ── The two producer-side entry points agree, and the third one cannot under-cover ────────
+
+    /// <summary>
+    /// The bake hands the closure its own substitution collected
+    /// (<c>NodeSetCompiler.CompileInputs.ResolvedIncludes</c>) instead of walking a second time.
+    /// That value must equal what a live reader arrives at, or the producer and the consumer
+    /// disagree and every bundle is refused.
+    /// </summary>
+    [Fact]
+    public void ThePreResolvedOverload_AgreesWithTheReaderOverload()
+    {
+        var sources = new[] { Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Greeting") };
+        const string greeting = "public static class Greeting { }";
+        var mesh = new Dictionary<string, string> { ["Widget/Snippets/Greeting"] = greeting };
+
+        NodeTypeSourceFingerprint.Compute(
+                sources, TypePath,
+                ImmutableSortedDictionary.CreateRange(
+                    StringComparer.Ordinal,
+                    new Dictionary<string, string> { ["Widget/Snippets/Greeting"] = greeting }))
+            .Should().Be(FingerprintOf(sources, mesh));
+    }
+
+    /// <summary>
+    /// 🚨 The include-less overload REFUSES a set that has an include, rather than hashing without
+    /// it. A convenience overload that can silently under-cover is precisely how #2813 sat inert
+    /// for months: the 7-argument <c>PrebuiltAssemblySeeder.Seed</c> hard-coded
+    /// <c>sourceFingerprint: null</c> and both production callers took it, so the refusal was armed
+    /// and unreachable. This one cannot be taken by accident.
+    /// </summary>
+    [Fact]
+    public void TheIncludeLessOverload_RefusesASetThatHasAnInclude()
+    {
+        var sources = new[] { Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Greeting") };
+
+        Action act = () => NodeTypeSourceFingerprint.Compute(sources, TypePath);
+
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*@@ include*");
+    }
+
+    /// <summary>A set with no include at all still folds to exactly what it always did — so no
+    /// fleet-wide fingerprint churn, and no refusal storm, for the types that have none.</summary>
+    [Fact]
+    public void ASetWithoutIncludes_FoldsIdenticallyThroughEveryOverload()
+    {
+        var sources = new[] { Code($"{TypePath}/Source/Thing", "public record Thing;") };
+
+        var plain = NodeTypeSourceFingerprint.Compute(sources, TypePath);
+        plain.Should().Be(FingerprintOf(sources, new Dictionary<string, string>()));
+        plain.Should().Be(NodeTypeSourceFingerprint.Compute(
+            sources, TypePath, ImmutableDictionary<string, string>.Empty));
+    }
+
+    // ── The consequence: the adoption verdict ─────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE ACCEPTANCE OF #2948, end to end through the decision: a bundle baked while the
+    /// snippet said one thing, adopted by a mesh whose snippet now says another, must be REFUSED —
+    /// not adopted as <see cref="BuildProvenance.AdoptedVerified"/>. Both fingerprints are REAL
+    /// values from the function under test, not opaque strings, so this fails on main and passes
+    /// here for the one reason the issue names.
+    /// </summary>
+    [Fact]
+    public void ABundleBakedBeforeAnIncludedOnlyEdit_IsRefused_NotVerified()
+    {
+        var sources = new[]
+        {
+            Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Greeting"),
+        };
+        // What the producer hashed when it baked the assembly…
+        var baked = FingerprintOf(sources, new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Greeting"] = "public static class Greeting { public static bool Delete => false; }",
+        });
+        // …and what THIS mesh holds now. Only the included-only snippet changed: the matched
+        // sources, their paths and their versions are byte-identical.
+        var live = FingerprintOf(sources, new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Greeting"] = "public static class Greeting { public static bool Delete => true; }",
+        });
+
+        var snapshot = ImmutableDictionary<string, long>.Empty
+            .SetItem($"{TypePath}/Source/Thing", 638_000_000_000_000_000);
+
+        var verdict = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            new NodeTypeDefinition
+            {
+                CompilationStatus = CompilationStatus.Ok,
+                RequestedSourceStampAt = DateTimeOffset.UtcNow,
+                AdoptedSourceFingerprint = baked,
+                CurrentSourceFingerprint = live,
+                CurrentSourceVersions = snapshot,
+                CompiledSources = snapshot,
+                LatestAssemblyCollection = "assemblies",
+                LatestAssemblyPath = "adopted/Widget.Thing.dll",
+            },
+            snapshot,
+            canCompileLocally: true);
+
+        verdict.BuildProvenance.Should().Be(BuildProvenance.AdoptionRefused,
+            "the only difference between the two builds is an included-only snippet, and that is "
+            + "the whole of #2948 — before the fix these fingerprints were EQUAL and the verdict "
+            + "was AdoptedVerified");
+        verdict.CompilationStatus.Should().Be(CompilationStatus.Pending,
+            "refusing is not enough: the live source has to actually get compiled");
+    }
+
+    /// <summary>
+    /// 🚨 …and the OPPOSITE row still holds. A bundle whose include matches must still adopt as
+    /// VERIFIED. Without this the test above is satisfiable by refusing everything, which is the
+    /// outage the whole mechanism was designed around.
+    /// </summary>
+    [Fact]
+    public void ABundleWhoseIncludeStillMatches_AdoptsAsVerified()
+    {
+        var sources = new[]
+        {
+            Code($"{TypePath}/Source/Thing", "public record Thing;\n\n@@Widget/Snippets/Greeting"),
+        };
+        var mesh = new Dictionary<string, string>
+        {
+            ["Widget/Snippets/Greeting"] = "public static class Greeting { }",
+        };
+        var fingerprint = FingerprintOf(sources, mesh);
+        var snapshot = ImmutableDictionary<string, long>.Empty
+            .SetItem($"{TypePath}/Source/Thing", 638_000_000_000_000_000);
+
+        NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+                new NodeTypeDefinition
+                {
+                    CompilationStatus = CompilationStatus.Ok,
+                    RequestedSourceStampAt = DateTimeOffset.UtcNow,
+                    AdoptedSourceFingerprint = fingerprint,
+                    CurrentSourceFingerprint = fingerprint,
+                    CurrentSourceVersions = snapshot,
+                },
+                snapshot,
+                canCompileLocally: true)
+            .BuildProvenance.Should().Be(BuildProvenance.AdoptedVerified);
+    }
+
+    /// <summary>
+    /// 🚨 AND <see cref="BuildProvenance.AdoptedUnverified"/> IS STILL NOT A REFUSAL. A legacy
+    /// bundle carries no fingerprint at all; refusing those would recompile everything on every
+    /// install and, on a <c>Modules:RequirePrebuilt</c> mesh, park every legacy type — the
+    /// documented anti-outage property this change must not erode.
+    /// </summary>
+    [Fact]
+    public void ALegacyBundleWithNoFingerprint_StillAdopts()
+    {
+        var snapshot = ImmutableDictionary<string, long>.Empty
+            .SetItem($"{TypePath}/Source/Thing", 638_000_000_000_000_000);
+
+        var verdict = NodeTypeCompilationHelpers.ApplyAdoptedSourceStamp(
+            new NodeTypeDefinition
+            {
+                CompilationStatus = CompilationStatus.Ok,
+                RequestedSourceStampAt = DateTimeOffset.UtcNow,
+                AdoptedSourceFingerprint = null,
+                CurrentSourceFingerprint = "whatever this mesh computed",
+                CurrentSourceVersions = snapshot,
+            },
+            snapshot,
+            canCompileLocally: true);
+
+        verdict.BuildProvenance.Should().Be(BuildProvenance.AdoptedUnverified);
+        verdict.CompilationStatus.Should().NotBe(CompilationStatus.Pending,
+            "an unproven bundle is not a refused one — it must not dispatch a compile");
+        verdict.CompiledSources.Should().NotBeNull("withholding the stamp parks it on a RequirePrebuilt mesh");
+    }
+}

--- a/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
@@ -319,8 +319,28 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
 
             // 7b. The @@ include pulled in a Code node NO source query matches — so it is absent
             //     from the resolved set but present in the bytes.
+            //
+            //     🚨 THE ABSENCE FROM `sourceVersions` IS DELIBERATE AND STAYS (#2948 reconciled
+            //     this assertion rather than loosening it). `sourceVersions` mirrors the mesh's
+            //     NodeTypeDefinition.CompiledSources, which is folded over the RAW QUERY MATCH —
+            //     the same set on both producers, and the set BundleReader/PrebuiltAssemblySeeder
+            //     treat as provenance. Adding include targets to it would change a
+            //     producer/consumer contract (and 7d's whole point is that the two sets are not
+            //     interchangeable). What #2948 changed is the SOURCE FINGERPRINT, a different
+            //     field answering a different question — "were these bytes built from the source
+            //     this mesh holds?" — and THAT must cover the include, because the include is in
+            //     the bytes.
             Assert.DoesNotContain("Widget/Snippets/Greeting", thing.SourceVersions.Keys);
             Assert.Contains("Greeting", thingSurface);
+            // 7b'. …and it IS in the fingerprint's input: the compile-driven bake records the
+            //      include closure it substituted, and assertion 3b above proved the MESH bake —
+            //      which resolves the same include through a real workspace, with no NodeSet
+            //      anywhere — arrives at the identical hash. Without this line 3b's agreement
+            //      would be satisfiable by BOTH producers ignoring the include, which is exactly
+            //      the state #2948 found them in.
+            Assert.Contains(
+                "Widget/Snippets/Greeting",
+                treeReport.Types.Single(t => t.NodePath == "Widget/Thing").ResolvedIncludePaths);
 
             // 7c. The `nodeType:Code` filter excluded the Scope-typed .cs from the QUERY itself…
             Assert.DoesNotContain("Widget/Thing/Source/Scoped", thing.SourceVersions.Keys);

--- a/tools/MeshWeaver.PluginTester/BakeOutput.cs
+++ b/tools/MeshWeaver.PluginTester/BakeOutput.cs
@@ -239,11 +239,16 @@ public static class BakeOutput
         // impersonated while nothing downstream inherits the identity.
         // ImpersonationScopeSiteRatchetGuard fails a NEW site carrying the old shape, and this file
         // is not on its allow list — deliberately, because it is new code.
+        // #2948 — and the `@@`-include closure is resolved through the SAME mesh read the owning
+        // hub's watcher uses, so an included-only snippet is inside the hash on both sides. The
+        // walk issues no read at all for a source set with no `@@` in it.
+        var includeReader = SourceFingerprintIncludeReader.For(workspace.Hub);
         return access
             .RunAsSystem(() => NodeSources.GetSources(workspace, def, typePath))
             .Take(1)
             .Timeout(ReadBudget)
-            .Select(sources => NodeTypeSourceFingerprint.Compute(sources, typePath));
+            .SelectMany(sources =>
+                NodeTypeSourceFingerprint.Compute(sources, typePath, includeReader));
     }
 
     /// <summary>Package ids are top-level folder names, but the bundle FILE name must be safe on

--- a/tools/MeshWeaver.PluginTester/CascadeBuild.cs
+++ b/tools/MeshWeaver.PluginTester/CascadeBuild.cs
@@ -472,9 +472,12 @@ public static class CascadeBuild
                     // the consumer can prove the bytes match the source IT holds instead of taking
                     // the bundle's word for it. Over the RAW resolved set, exactly as the runtime's
                     // sources watcher does: NodeTypeSourceFingerprint applies the shaping fold
-                    // itself so the two callers cannot apply different ones.
+                    // itself so the two callers cannot apply different ones — plus the
+                    // `@@`-include closure the compile just resolved (#2948), which is where the
+                    // Code nodes no source query matched are accounted for.
                     SourceFingerprint = NodeTypeSourceFingerprint.Compute(
-                        resolution.Sources, candidate.Node.Path, options.Logger),
+                        resolution.Sources, candidate.Node.Path,
+                        compiled.Inputs.ResolvedIncludes, options.Logger),
                 });
             }
 

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -88,6 +88,16 @@ public static class TreeBake
         string? Error,
         ImmutableArray<string> MatchedSourcePaths)
     {
+        /// <summary>
+        /// The <c>@@</c>-include targets the compile pulled in — Code nodes NO source query
+        /// matched, so they are deliberately absent from <see cref="MatchedSourcePaths"/> and from
+        /// the bundle's <c>sourceVersions</c>, while being inside both the emitted bytes and the
+        /// source fingerprint (#2948). Reported so a reader (and
+        /// <c>BakeEquivalenceTest</c>) can see that the include actually resolved rather than
+        /// assuming it from an equal hash.
+        /// </summary>
+        public ImmutableArray<string> ResolvedIncludePaths { get; init; } = [];
+
         /// <summary>True when the type produced bytes.</summary>
         public bool Success => Error is null;
     }
@@ -386,12 +396,20 @@ public static class TreeBake
                     // the same RAW resolved set for the same reason: NodeTypeSourceFingerprint
                     // applies the shaping fold, so the bake and the runtime cannot fork on which
                     // files count.
+                    //
+                    // 🚨 #2948 — plus the `@@`-include closure, handed straight back by the compile
+                    // that just substituted it (CompileInputs.ResolvedIncludes). No second walk, no
+                    // second read, and no `.Wait()` at this synchronous build-step boundary.
                     SourceFingerprint = NodeTypeSourceFingerprint.Compute(
-                        resolution.Sources, candidate.Node.Path, options.Logger),
+                        resolution.Sources, candidate.Node.Path,
+                        compiled.Inputs.ResolvedIncludes, options.Logger),
                 });
 
                 results.Add(new TypeResult(
-                    compiled.NodePath, candidate.Package, null, compiled.Inputs.MatchedSourcePaths));
+                    compiled.NodePath, candidate.Package, null, compiled.Inputs.MatchedSourcePaths)
+                {
+                    ResolvedIncludePaths = [.. compiled.Inputs.ResolvedIncludes.Keys],
+                });
                 options.Output.WriteLine(
                     $"   ok  {compiled.NodePath} "
                     + $"[{compiled.Inputs.MatchedSourcePaths.Length} source(s), "


### PR DESCRIPTION
Closes #2948

## The gap

`NodeTypeSourceFingerprint.Compute` hashed the compile input as
`NodeCompileShaping.CollectCompileSources` yields it. An `@@` include pulls a Code node that **no
source query matches**: it reaches the emitted assembly (`NodeSetCompiler.ResolveInputs` substitutes
it *after* the fold) and was absent from the hash. So editing an included-only snippet moved neither
`AdoptedSourceFingerprint` nor `CurrentSourceFingerprint`, and a prebuilt assembly baked **before**
that edit still adopted as `AdoptedVerified`.

That is the worst of the three rows to be wrong on. `AdoptedUnverified` says "nobody established
where these bytes came from" and an operator reads it as the warning it is. `AdoptedVerified` is an
**assertion** that the shipped bytes match the source this mesh holds — standing over source that
was never hashed, it is a *false verification*: the #2813 incident one layer in.

## The fix — both sides resolve includes before hashing

- **Producer.** `NodeCompileShaping.ResolveCodeIncludes` takes an optional collector and records
  `resolved path → code text` at the point it consumes each include, so the closure is a by-product
  of the **one walk that already substitutes them** — there is no second traversal to disagree with
  the first. `CompileInputs.ResolvedIncludes` carries it; `TreeBake` / `CascadeBuild` fold it
  straight in. **No second walk, no second read, and no new blocking bridge** at a synchronous build
  step (the `ProductionBlockingBridgeSites` ratchet does not move).
- **Consumer.** The sources watcher resolves it through the mesh. Reads cannot happen inside a pure
  `Update` lambda, so the fingerprint moved into an observable step ahead of it, composed with
  `Switch()` so a newer source set supersedes an in-flight resolution rather than racing it.
  `CollectIncludeClosure` scans each source's text for `@@` and **issues no read at all** when there
  is none — almost every type — so only a type that actually has includes pays, and it pays the same
  reads its own compile would.

### Deterministic and cycle-safe

An order-dependent fingerprint manufactures phantom staleness (endless recompiles, or a false
refusal), which is worse than the gap being closed. Three properties:

1. **Order cannot reach the result.** The closure is keyed by *resolved path* and returned sorted
   (ordinal); `PartitionSourceFingerprint` sorts again. Roots are walked in `CollectCompileSources`
   order — itself ordinal by node path — and **serially** (one `SelectMany` chain, never a `Merge`),
   so there is no read interleaving to observe either.
2. **Suppression is result-preserving.** The per-root visited set skips a path that root already
   walked; skipping a re-read of the *same* anchored path can only re-derive an entry that is
   already present, so which parent reached a shared snippet first cannot change the closure.
3. **A cycle terminates.** `A → B → A` adds each path once; the second visit takes the already-added
   branch, reads nothing, recurses no further. A self-include is the same case with one hop.

### An unreadable include is INCONCLUSIVE, never absent

The producer's lookup is in-memory and never stalls. A consumer that quietly treated a stalled read
as "the include is gone" would hash a *shorter* closure — indistinguishable from a stale bundle — so
a perfectly good adoption is **refused**, and on a `Modules:RequirePrebuilt` mesh that is terminal.
`SourceFingerprintIncludeReader` reads via `GetMeshNodeOutcome` and keeps the three states apart:
`Present` contributes, `Absent` contributes nothing (it contributes nothing to the bytes either —
the directive stays verbatim, so both sides agree), and `Unavailable` / `DeleteInProgress` / a
timeout raise `SourceIncludeUnavailableException`. The watcher catches exactly that and **leaves the
previously published fingerprint standing**, so the judgement takes the "nothing has been compared"
branch. Same #890 rule: a probe must not answer its scariest branch on its own inability to run.

**`AdoptedUnverified` is still never a refusal.** Pinned by a test in this PR.

## What was NOT changed, deliberately

The include closure is **not** added to `CompiledSources` / `CurrentSourceVersions`. That is the
recompile-*trigger* half — a change feed, not a hash — and `sourceVersions` is a producer/consumer
contract mirroring the RAW query match on both bakes. `#2948` closes the **verified claim**, which
is decided by the two fingerprints and nothing else. Stated in the doc rather than assumed.

## `BakeEquivalenceTest` — reconciled, not loosened

It pinned `Widget/Snippets/Greeting` **absent** from `sourceVersions`. That assertion **stays** and
is now explained: `sourceVersions` mirrors `CompiledSources` (the raw query match), which is a
different field answering a different question. A **new** assertion pins the include **present** in
the bake's resolved include set — because without it, assertion 3b's cross-producer hash equality
would be satisfiable by *both* producers ignoring the include, which is exactly the state #2948
found them in. `MeshDrivenAndCompilerDrivenBakes_ProduceTheSameArtifacts` passing is now the proof
that the mesh bake (real workspace, mesh reads) and the tree bake (`NodeSet`) resolve the same
closure.

## Binary compatibility

`CompileInputs.ResolvedIncludes` is a `required init` member, **not** a positional parameter:
positional would have changed the primary constructor's arity, which
`scripts/check-record-signatures.py` correctly rejects as a binary break between a module and the
platform it loads into. `required` because forgetting it is silent — an empty closure for a type
with includes is a refusal, not "the fingerprint minus the includes". For the same reason the
include-less `Compute` overload now **refuses** a set that has an include rather than under-covering
it: a convenience overload that can under-cover is exactly how #2813 sat inert (the 7-arg `Seed`
hard-coded `sourceFingerprint: null` and both production callers took it).

Types with no includes fold to the **identical** value as before, so there is no fleet-wide
fingerprint churn; and this file is inside `FrameworkBuildIdentity.FullMvidAssemblies`, so a producer
and a consumer that can adopt across each other necessarily run the same implementation.

## Verification

Every new test was proven falsifiable — inverted, seen red, restored (output in the PR thread).

- `MeshWeaver.Compiler.Pipeline.Test` — **583 passed** (whole project, no `--filter`)
- `MeshWeaver.PluginTester.Test` — **312 passed** (whole project; includes `BakeEquivalenceTest`)
- `MeshWeaver.Documentation.Test` — **166 passed** (whole project), plus a broken-link probe proving
  `DocumentationLinkIntegrityTest` names *both* edited pages
- `dotnet build -c Release -warnaserror` — 61 projects, `0 Warning(s) 0 Error(s)`
- `scripts/check-record-signatures.py` — clean

Docs: `Doc/Architecture/NodeTypeCompilation` gains the mechanism (determinism argument, cycle brake,
the inconclusive rule) and its "deliberately does NOT do" list is rewritten to state what is still
open. What's New entry, `Category: Fix`.
