### PR TITLE
fix(security): the API-token clamp now reaches message-routed checks (#2976)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessContextPropagation.md
@@ -255,6 +255,61 @@ Both wrap their inner work in `try/finally` so the previous value is restored wh
 
 After this phase, application code runs with `AccessService.Context = delivery.AccessContext`.
 
+#### Restoring the caller on the receiving hub
+
+There is a **third** restore site, and it exists because it runs *before* the two above.
+`AccessControlPipeline` — the `[RequiresPermission]` gate — is added with `AddDeliveryPipeline`,
+and the pipeline list composes outside-in (`Aggregate`), so the gate is the **outermost** wrapper
+and `UserServiceDeliveryPipeline` the innermost. At the moment the gate evaluates, Phase 4 has not
+happened yet: `AccessService.Context` still holds whatever the action-block thread was left with —
+typically `system-security` from the hub's own bootstrap `ImpersonateAsSystem`, or nothing at all.
+
+That matters because the permission fold snapshots the caller on the *calling* thread
+(`PermissionEvaluator.ResolveFoldServices` captures `accessService.Context ?? accessService.CircuitContext`,
+because `AsyncLocal` does not flow through the Rx schedulers `cache.GetQuery` uses), and it reads
+exactly two flags off that snapshot:
+
+| Flag | What it decides |
+|---|---|
+| `IsApiToken` | The API-token clamp — zeroes the permission set for a Bearer context this path's live policy does not admit (`api: false`). |
+| `IsHub` | The hub-credential early return — a hub reading its own vertical chain. |
+
+So the gate restores `delivery.AccessContext` itself, before subscribing the fold. Two rules:
+
+- **The cue is a REAL PRINCIPAL, never a payload shape.** The restore is keyed on the delivery
+  carrying a context with a non-empty `ObjectId` that is not
+  [hub-shaped](#debug-aid-the-hub-shape-error-log). It is deliberately *not* keyed on anything the
+  caller happens to have filled in.
+- **Hub-shaped ids keep the mesh-wide treatment.** A `sync/…`, `mesh/…`, `node/…`, `activity/…` or
+  `portal/…` id is not a user identity and is never installed as one — the same rule
+  `AccessService.SetContext`'s leak tripwire, `UserServiceDeliveryPipeline`'s `shouldStamp` and
+  `MeshNodeStreamCache`'s pass-through all encode.
+
+> 🚨 **Why this is written down: the gate's own input used to decide whether the gate ran (#2976).**
+> The condition was `delivery.AccessContext is { Roles: { Count: > 0 } }` — restore only when the
+> caller carries **role claims**. Its comment justified that in terms of claim-based role
+> resolution, a mechanism that no longer exists (the 2026-08-05 paywall fix took claim roles out of
+> node permissions; #2974 removed their last foothold). `AccessContext.Roles` is read nowhere in
+> `PermissionEvaluator` — so the condition outlived its reason, and it was never the right one.
+>
+> The consequence was silent and permissive. Most identity providers emit no role claims, so
+> `ApiToken.Roles` is normally empty; such a token reached a per-node hub with `Roles = []`, the
+> restore was skipped, `capturedContext` was null, `IsApiToken` was never seen, **and the clamp did
+> not run** — the Bearer delivery was evaluated as an interactive session. The exact-read path was
+> never exposed (`MeshNodeStreamCache.GetStreamRaw` captures the caller itself and wraps the
+> evaluation in `SwitchAccessContext`), so `api: false` held for a read that named the page and was
+> skipped for every **message-routed** check against it.
+>
+> This is the runtime cousin of the CI rule in AGENTS.md — *a gate never tests its own inputs* —
+> because "the check did not run" and "the check passed" were indistinguishable from outside: no
+> exception, no log, a served read. When a condition guards whether a security decision is made,
+> it must name the thing the decision needs (here: a principal to evaluate), never a field the
+> decision does not read.
+>
+> Pinned by `RoutedApiTokenClampTest`, whose control arm is the same person, same node, same routed
+> message *without* the Bearer flag — so the pin measures a capability decision rather than a
+> blanket deny.
+
 ### Phase 5 — Handler runs under user identity
 
 The handler body executes synchronously (or as a single observable chain — no `await`; see [AsynchronousCalls.md](/Doc/Architecture/AsynchronousCalls)). Every read of `AccessService.Context` returns the originating user. Every check (`securityService.HasPermission(...)`, `RlsNodeValidator.Validate(...)`) is evaluated under the right principal.

--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -904,21 +904,21 @@ computes for this path on every emission**. Concretely that buys freshness for f
   surfaces as `Undetermined` / `ErrorType.Unavailable` and refuses the delivery — never as a
   permissive default. See [The fold can produce NO answer](#-the-fold-can-produce-no-answer-and-that-is-a-third-outcome).
 
-`AccessContext.Roles` is now read **nowhere** in `PermissionEvaluator`. It is still carried on a
-Bearer context, for two non-authority reasons: it is a useful diagnostic, and `AccessControlPipeline`
-uses a non-empty `Roles` list as its cue to restore the sender's `AccessContext` on a receiving hub.
-Neither is a permission decision — a future "just check the claims" is a regression, not a shortcut.
+`AccessContext.Roles` is now read **nowhere** in `PermissionEvaluator`, and **nowhere else that
+decides anything**. It is still carried on a Bearer context as a diagnostic, and that is all it is —
+a future "just check the claims" is a regression, not a shortcut.
 
-> ⚠️ **Known gap, named rather than papered over — that second use is itself a defect.**
-> `AccessControlPipeline` restores the sender's context only when `delivery.AccessContext` carries a
-> **non-empty** `Roles` list. A token minted with no claims (the ordinary case) therefore reaches a
-> per-node hub with no restored context at all, so `capturedContext` is null, `IsApiToken` is
-> unknown, and the clamp **does not run** on that path. It is not a hole in the read path — the
-> exact-read gate (`MeshNodeStreamCache.GetStreamRaw` → `ProbeEffectivePermissions`) captures the
-> caller's context directly and clamps correctly — but a message-routed check on a per-node hub can
-> miss it. The cure is to make the restore unconditional rather than role-shaped; it is a
-> context-propagation defect, not a staleness one, and it is tracked separately (issue #2976) so it
-> gets its own measurement on a hot path rather than riding along here.
+> ✅ **Closed by #2976 — the clamp reaches the routed path too.** Until that fix, `Roles` had one
+> remaining non-diagnostic use: `AccessControlPipeline` restored the sender's `AccessContext` on a
+> receiving per-node hub only when `delivery.AccessContext` carried a **non-empty** `Roles` list. A
+> token minted with no claims — the ordinary case — therefore arrived with no restored context at
+> all, `capturedContext` was null, `IsApiToken` was never seen, and the clamp **did not run** on a
+> message-routed check. It was never a hole in the read path (the exact-read gate
+> `MeshNodeStreamCache.GetStreamRaw` → `ProbeEffectivePermissions` captures the caller's context
+> itself and clamps correctly), which is why it survived unmeasured for so long. The restore is now
+> keyed on the delivery carrying a **real principal**, not on role claims — see
+> [Restoring the caller on the receiving hub](/Doc/Architecture/AccessContextPropagation#restoring-the-caller-on-the-receiving-hub).
+> Pinned by `RoutedApiTokenClampTest`.
 
 > 🚨 **The general rule this is an instance of.** A credential must not carry a *copy* of an
 > authorization fact. Copies go stale silently and in both directions, and the permissive direction

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-partition-closed-to-the-api-is-now-closed-on-every-path.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-partition-closed-to-the-api-is-now-closed-on-every-path.md
@@ -1,0 +1,46 @@
+---
+Name: A partition closed to the API is now closed on every path
+Category: Fix
+Description: Marking a partition as not reachable through the API held for reads a token asked for by name, but not for requests routed to the node that owns the data — most tokens carry no role claims, and that was the condition deciding whether the check ran at all. The setting now applies on every path.
+Icon: ShieldKeyhole
+Order: -20260902
+---
+
+# A partition closed to the API is now closed on every path
+
+An administrator can declare that a partition is readable in a browser but **not reachable through
+the API** — the setting that says "people may read this page; automated clients may not". It is the
+one lever that takes API reach away from tokens that already exist, so it has to hold everywhere.
+
+It did not. It held for a read that named the page directly, and it was skipped for a request routed
+to the node that owns the data — the shape most operations actually take.
+
+## Why it was skipped
+
+Every request carries the identity of whoever made it, including the fact that it arrived through an
+API token rather than a browser. That identity was only re-established on the receiving side when it
+carried **role claims** — a list of role names attached by the sign-in provider.
+
+Most sign-in providers attach no role names at all. So for the ordinary token the list was empty, the
+identity was not re-established, the receiving node never learned the request came from a token, and
+the check that would have closed the door never ran. Nothing failed and nothing was logged: the
+request was simply evaluated as though it had come from a signed-in browser session.
+
+The condition was left over from an older design in which those role names decided what a person
+could read. That design is gone — role names have granted nothing since the access model was
+corrected — but the condition outlived the reason for it, and it was never the right condition
+anyway: the two facts actually needed are *this came from an API token* and *this came from a hub*,
+neither of which has anything to do with roles.
+
+## What changed
+
+The caller's identity is now re-established whenever the request carries one, so the receiving node
+sees the same facts the direct read path already saw. Concretely:
+
+- **`api: false` applies on every path.** A partition closed to the API is closed to a token whether
+  the token reads the page by name or drives an operation against it.
+- **No re-issuing anything.** Existing tokens are affected immediately; the decision is made from the
+  live policy on the page being read, never from the token.
+- **Nothing became less reachable for people.** A public page stays readable in a browser, and a
+  token whose owner holds a real grant on the target keeps working exactly as before — this closes a
+  door that was meant to be closed, and opens none.

--- a/src/MeshWeaver.Hosting.AspNetCore/Portal/UserContextMiddleware.cs
+++ b/src/MeshWeaver.Hosting.AspNetCore/Portal/UserContextMiddleware.cs
@@ -455,9 +455,14 @@ public class UserContextMiddleware(RequestDelegate next, ILogger<UserContextMidd
                         // PartitionAccessPolicy nodes on the target path exactly like a browser
                         // session's, and its API capability from that path's own public grant and
                         // policy cap (PermissionEvaluator.PublicSurfaceCarriesApi). They are
-                        // stamped only as a diagnostic and because AccessControlPipeline uses a
-                        // non-empty Roles list as its cue to restore the sender's AccessContext on
-                        // a receiving hub.
+                        // stamped as a DIAGNOSTIC and nothing else. 🚨 They were also
+                        // AccessControlPipeline's cue to restore the sender's AccessContext on a
+                        // receiving hub until #2976 — and because the ordinary token's list is
+                        // EMPTY (most IdPs emit no role claims), that cue skipped the restore, the
+                        // fold never saw IsApiToken, and the API-token clamp did not run on any
+                        // message-routed check. The restore is now keyed on a real principal; see
+                        // Doc/Architecture/AccessContextPropagation → "Restoring the caller on the
+                        // receiving hub".
                         //
                         // The comment this replaces claimed the stamp was load-bearing — "per-node
                         // hubs intentionally don't register the synced AccessAssignment query

--- a/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
+++ b/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
@@ -172,11 +172,43 @@ public static class AccessControlPipeline
 
                         userId = ResolveIdentity(delivery, accessService);
 
-                        // Restore the sender's AccessContext onto this scope's AccessService
-                        // so SecurityService.GetEffectivePermissions — which reads claim-based
-                        // roles from _accessService.Context.Roles — can resolve them. Trigger:
-                        // delivery carries non-empty user Roles (signed claim payload).
-                        if (delivery.AccessContext is { Roles: { Count: > 0 } } userCtx)
+                        // Restore the sender's AccessContext onto this scope's AccessService so
+                        // the permission fold snapshots the CALLER (PermissionEvaluator captures
+                        // `accessService.Context ?? accessService.CircuitContext` on this thread,
+                        // before any Rx scheduler hop). The fold reads exactly two flags off it:
+                        //   • IsApiToken — the API-token clamp, which zeroes the permission set
+                        //     for a Bearer context this path's live policy does not admit; and
+                        //   • IsHub — the hub-credential early return.
+                        // Neither has anything to do with Roles.
+                        //
+                        // 🚨 THE CONDITION USED TO BE `Roles: { Count: > 0 }` (issue #2976), and
+                        // that was the runtime form of the rule this file already states below:
+                        // the gate's own INPUT decided whether the gate ran, so "the clamp did not
+                        // run" and "the clamp passed" were indistinguishable. Its comment justified
+                        // itself in terms of claim-based role resolution — a mechanism that no
+                        // longer exists (the 2026-08-05 paywall fix took claim roles out of node
+                        // permissions; #2974 removed their last foothold, the API-token capability
+                        // hatch). AccessContext.Roles is read NOWHERE in PermissionEvaluator, so
+                        // the condition survived with its reason gone — and it was never the right
+                        // one: a token minted through an IdP that emits no role claims (the
+                        // ORDINARY case; ApiToken.Roles is usually empty) arrived here with
+                        // Roles = [], the restore was skipped, capturedContext was null, IsApiToken
+                        // was never seen and the Bearer delivery was evaluated as an interactive
+                        // session. The exact-read path was never exposed — MeshNodeStreamCache
+                        // .GetStreamRaw captures the caller itself — so the hole was precisely the
+                        // MESSAGE-ROUTED checks this pipeline gates. Pinned by
+                        // RoutedApiTokenClampTest.
+                        //
+                        // 🚨 A REAL PRINCIPAL, not "any context": a hub-shaped ObjectId (sync/,
+                        // mesh/, node/, activity/, portal/) is NOT a user identity and must never
+                        // be installed as one — the mesh-wide rule AccessService.SetContext's leak
+                        // tripwire, UserServiceDeliveryPipeline's `shouldStamp` and
+                        // MeshNodeStreamCache's pass-through all encode. Those keep falling back to
+                        // the hub/System rules exactly as before; only the empty-ObjectId anonymous
+                        // context is likewise skipped, since it names nobody to restore.
+                        if (delivery.AccessContext is { } userCtx
+                            && !string.IsNullOrEmpty(userCtx.ObjectId)
+                            && !AccessService.LooksLikeHubPrincipal(userCtx.ObjectId))
                         {
                             accessService.SetContext(userCtx);
                         }

--- a/test/MeshWeaver.Graph.Test/ApiTokenCapabilityFreshnessTest.cs
+++ b/test/MeshWeaver.Graph.Test/ApiTokenCapabilityFreshnessTest.cs
@@ -283,8 +283,11 @@ public class ApiTokenCapabilityFreshnessTest(ITestOutputHelper output) : Monolit
     /// <summary>
     /// The structural anti-regression: on the two paths where the old evaluator DID diverge on
     /// claims, the verdict is now identical with and without them. <c>AccessContext.Roles</c> is
-    /// carried for diagnostics and for <c>AccessControlPipeline</c>'s context-restore cue — a
-    /// future "just check the claims" is a regression, not a shortcut.
+    /// carried for DIAGNOSTICS ONLY — nothing reads it to decide anything. It was
+    /// <c>AccessControlPipeline</c>'s context-restore cue until #2976, which is precisely what made
+    /// a claimless token escape the clamp on every message-routed check
+    /// (<c>RoutedApiTokenClampTest</c>); a future "just check the claims" is a regression, not a
+    /// shortcut.
     /// </summary>
     [Fact(Timeout = 60_000)]
     public async Task ClaimRoles_ChangeNoVerdict()

--- a/test/MeshWeaver.Graph.Test/RoutedApiTokenClampTest.cs
+++ b/test/MeshWeaver.Graph.Test/RoutedApiTokenClampTest.cs
@@ -1,0 +1,141 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 THE API-TOKEN CLAMP MUST SURVIVE ROUTING. Issue #2976.
+///
+/// <para><b>The defect.</b> <c>AccessControlPipeline</c> restored the sender's
+/// <c>AccessContext</c> onto the receiving per-node hub only when it carried ROLE CLAIMS
+/// (<c>delivery.AccessContext is { Roles: { Count: &gt; 0 } }</c>). The comment justified that in
+/// terms of claim-based role resolution — a mechanism that no longer exists: the 2026-08-05
+/// paywall fix removed claim roles from node permissions and #2974 removed their last foothold, so
+/// <c>AccessContext.Roles</c> is read NOWHERE in <c>PermissionEvaluator</c>. What the evaluator
+/// does read off the restored context is <c>IsApiToken</c> (the API-token clamp) and <c>IsHub</c>
+/// (the hub-credential early return) — neither of which has anything to do with roles.</para>
+///
+/// <para>A token minted through an IdP that emits no role claims — <b>the ordinary case</b>;
+/// <c>ApiToken.Roles</c> is usually empty — therefore arrived at a per-node hub with
+/// <c>Roles = []</c>, the restore was skipped, <c>accessService.Context</c> stayed null on that
+/// hub, <c>capturedContext</c> was null in the fold, <b>the clamp never ran</b>, and the Bearer
+/// delivery was evaluated as if it were an interactive session. The exact-read path was never
+/// exposed (<c>MeshNodeStreamCache.GetStreamRaw</c> captures the caller's context itself), so this
+/// was reachable only through MESSAGE-ROUTED permission checks — which is what these cases drive.</para>
+///
+/// <para>Note the shape, because it is the reason the condition survived its rationale: the gate's
+/// own INPUT decided whether the gate ran. That is the runtime cousin of the CI rule in AGENTS.md —
+/// "a gate never tests its own inputs", because "did not run" and "passed" then look identical.</para>
+/// </summary>
+public class RoutedApiTokenClampTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The token's owner. Deliberately NOT the DevLogin harness admin.</summary>
+    private const string TokenUser = "routed-token-holder";
+
+    /// <summary>
+    /// Readable by anyone in a browser, explicitly NOT reachable through the API — the exact shape
+    /// an administrator writes to take API reach away (<c>api: false</c>). It is what makes the
+    /// clamp OBSERVABLE from outside: with it the two identities below differ, without it a Bearer
+    /// context and a browser context reach the same verdict and nothing can fail.
+    /// </summary>
+    private const string CappedPartition = "RoutedApiCapped";
+
+    private const string TargetPath = CappedPartition + "/Page";
+
+    /// <summary>
+    /// 🚨 <see cref="TestTimeouts.Quick"/>, never a literal — CI-scaled, and strictly below each
+    /// case's <c>[Fact(Timeout = …)]</c> so a wait that does not converge loses first and reports
+    /// WHAT it was waiting for instead of xunit killing the method anonymously.
+    /// </summary>
+    private static TimeSpan Budget => TestTimeouts.Quick;
+
+    // 🚨 ConfigureMeshBase, not base.ConfigureMesh: the latter chains PublicAdminAccess(), which
+    // grants Public the Admin role in every default partition — under it every identity carries
+    // Admin (hence Api) everywhere and every assertion here would pass vacuously.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode(CappedPartition) { Name = "Routed Api Capped", NodeType = "Markdown" },
+                new MeshNode("Page", CappedPartition) { Name = "Capped Page", NodeType = "Markdown" },
+                AssignmentNodeFactory.Policy(CappedPartition,
+                    new PartitionAccessPolicy { PublicRead = true, Api = false }));
+
+    /// <summary>
+    /// A Bearer principal as <c>UserContextMiddleware</c> builds one, with the claim list EMPTY —
+    /// what every token minted through an IdP that emits no role claims looks like.
+    /// </summary>
+    private static AccessContext Token => new()
+    {
+        ObjectId = TokenUser,
+        Name = "Routed Token Holder",
+        IsApiToken = true,
+    };
+
+    /// <summary>The same person in a browser — same node, same rights, no Bearer flag.</summary>
+    private static AccessContext Browser => new()
+    {
+        ObjectId = TokenUser,
+        Name = "Routed Token Holder",
+    };
+
+    /// <summary>
+    /// The read, ROUTED: a <c>[RequiresPermission(Read)]</c> message posted from a client hub at
+    /// the per-node hub, carrying <paramref name="identity"/> as the delivery's AccessContext
+    /// exactly as the sender's PostPipeline stamps it. Yields the gate's
+    /// <see cref="DeliveryFailure"/>, or null when the delivery was SERVED.
+    /// </summary>
+    private IObservable<DeliveryFailure?> RoutedRead(AccessContext identity)
+        => RequestHub
+            .Observe(new GetDataRequest(new UnifiedReference("data:")),
+                o => o.WithTarget(new Address(TargetPath)).WithAccessContext(identity))
+            .Take(1)
+            .Select(_ => (DeliveryFailure?)null)
+            .Catch((DeliveryFailureException ex) => Observable.Return<DeliveryFailure?>(ex.Failure));
+
+    /// <summary>
+    /// 🚨 THE PIN. A Bearer delivery with an EMPTY claim list, message-routed to the per-node hub
+    /// that owns the path, must be clamped: the administrator has said "not reachable through the
+    /// API", and that decision is made from the live policy on THIS path.
+    ///
+    /// <para>Pre-fix this was SERVED. The restore's <c>Roles.Count &gt; 0</c> condition skipped a
+    /// claimless token, so the fold snapshotted no caller context, never saw <c>IsApiToken</c>, and
+    /// returned the public <c>Read</c> the same person's browser gets.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ABearerDeliveryWithNoClaims_IsClampedOnThePerNodeHub()
+    {
+        var failure = await RoutedRead(Token).Should().Within(Budget).Emit();
+
+        failure.Should().NotBeNull(
+            "a claimless Bearer delivery reached the gate and was SERVED — the API-token clamp "
+            + "never ran, because the context that carries IsApiToken was only restored for a "
+            + "context carrying role CLAIMS, which the ordinary token does not have (#2976)");
+        failure!.ErrorType.Should().Be(ErrorType.Unauthorized,
+            "the fold reached a verdict — the token may not use this path's API surface — so the "
+            + "refusal is a denial, not an availability answer: " + failure.Message);
+        failure.Message.Should().Contain(TokenUser,
+            "the denial names the principal it refused, so an operator can act on it");
+    }
+
+    /// <summary>
+    /// The companion measurement that makes the pin a CAPABILITY decision rather than a blanket
+    /// deny: the SAME person, the SAME node, the SAME routed message — without the Bearer flag —
+    /// is served. Capping <c>Api</c> withdraws the API surface, not the public page.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task TheSamePersonInABrowser_IsNotRefused()
+    {
+        var failure = await RoutedRead(Browser).Should().Within(Budget).Emit();
+
+        failure.Should().BeNull(
+            "the page is PublicRead — an interactive session reads it, and the clamp that refuses "
+            + "the Bearer context above is about the API surface, nothing else: "
+            + (failure?.Message ?? string.Empty));
+    }
+}


### PR DESCRIPTION
Fixes #2976.

## The defect

`AccessControlPipeline` restored the sender's `AccessContext` onto the **receiving** per-node hub only when it carried role **claims**:

```csharp
// Restore the sender's AccessContext onto this scope's AccessService
// so SecurityService.GetEffectivePermissions — which reads claim-based
// roles from _accessService.Context.Roles — can resolve them. Trigger:
// delivery carries non-empty user Roles (signed claim payload).
if (delivery.AccessContext is { Roles: { Count: > 0 } } userCtx)
```

The hypothesis in the issue is **verified**: `AccessContext.Roles` is read nowhere in `PermissionEvaluator`. The 2026-08-05 paywall fix took claim roles out of node permissions and #2974 removed their last foothold (the API-token capability hatch), so the condition survived with its rationale gone — and it was never the right condition. The fold reads exactly two flags off the restored context:

| Flag | What it decides |
|---|---|
| `IsApiToken` | The API-token clamp — zeroes the permission set for a Bearer context this path's live policy does not admit (`api: false`). |
| `IsHub` | The hub-credential early return. |

Neither has anything to do with roles.

Most identity providers emit no role claims, so `ApiToken.Roles` is normally **empty**. Such a token reached a per-node hub with `Roles = []`, the restore was skipped, `capturedContext` was null in the fold, **`IsApiToken` was never seen and the clamp never ran** — the Bearer delivery was evaluated as if it were an interactive session. Silently: no exception, no log, a served read.

Not a hole in the exact-read path — `MeshNodeStreamCache.GetStreamRaw` captures the caller's context itself and wraps evaluation in `SwitchAccessContext`, so MCP `get` clamps correctly. `api: false` therefore held for a read that named the page and was skipped for every **message-routed** check against it.

**The shape is worth naming**: the gate's own INPUT decided whether the gate ran, so "the check did not run" and "the check passed" were indistinguishable from outside. That is the runtime cousin of AGENTS.md's no-skip-trapdoor rule for CI — which this very file already states for its missing-evaluator branch.

## The fix

Restore whenever the delivery carries a **real principal** — a non-empty `ObjectId` that is not hub-shaped — rather than on a payload field the decision does not read.

Hub-shaped ids (`sync/`, `mesh/`, `node/`, `activity/`, `portal/`) keep exactly the treatment the rest of the mesh already gives them (`AccessService.SetContext`'s leak tripwire, `UserServiceDeliveryPipeline`'s `shouldStamp`, `MeshNodeStreamCache`'s pass-through): a hub address is not a user identity and is never installed as one. So nothing about hub credentials changes, and the `SetContext` error tripwire is not turned into a per-delivery log flood. The empty-`ObjectId` anonymous context is likewise skipped — it names nobody to restore, and shadowing a circuit context with it would change verdicts for anonymous rendering without fixing anything.

### Cost on the per-delivery hot path

The issue flags that this sits inside the per-delivery path on every per-node hub, so what the change adds is worth naming rather than assuming. Per `[RequiresPermission]` delivery whose context previously carried no claims: one `string.IsNullOrEmpty`, one `LooksLikeHubPrincipal` (five `StartsWith` over a short id), and one `AccessService.SetContext` — an `AsyncLocal` write plus a `LogDebug` that fires only when the principal actually changes. The `new StackTrace(...)` inside `SetContext` is on the hub-shaped-principal branch, which this condition never reaches. No new allocation, no new DI resolve, no new query, and nothing added to the fold itself.

## Test evidence — measured, not assumed

New `test/MeshWeaver.Graph.Test/RoutedApiTokenClampTest.cs`: a `[RequiresPermission(Read)]` message posted from a client hub at the per-node hub that owns a `PublicRead = true, Api = false` partition, carrying an API-token `AccessContext` with **empty** `Roles`. Real monolith mesh (`MonolithMeshTestBase`), no mocks.

**Before the fix** (`src/` unchanged, test added):

```
[xUnit.net] RoutedApiTokenClampTest.ABearerDeliveryWithNoClaims_IsClampedOnThePerNodeHub [FAIL]
  Expected value not to be <null> because a claimless Bearer delivery reached the gate
  and was SERVED — the API-token clamp never ran …
Failed! - Failed: 1, Passed: 1, Skipped: 0, Total: 2
```

**After the fix:**

```
Passed! - Failed: 0, Passed: 2, Skipped: 0, Total: 2
```

The control arm — the same person, the same node, the same routed message *without* the Bearer flag — is served **both** before and after, so the pin measures a capability decision rather than a blanket deny.

Full local suites, Debug: `MeshWeaver.Graph.Test` 1086/1086, `MeshWeaver.Documentation.Test` 166/166, plus `MeshWeaver.Hosting.Test` and `MeshWeaver.Data.Test`. Release `-warnaserror`, 0 warnings / 0 errors: `MeshWeaver.Hosting`, `MeshWeaver.Hosting.AspNetCore`, `MeshWeaver.Documentation`, `MeshWeaver.Graph.Test`, `MeshWeaver.Documentation.Test`.

## Work products conserved

- `Doc/Architecture/AccessContextPropagation` gains **"Restoring the caller on the receiving hub"** — the third restore site, why it exists (the gate composes outside `UserServiceDeliveryPipeline`, so Phase 4 has not happened yet when it evaluates), the two flags the fold reads, and the #2976 finding written as the rule it is an instance of.
- `Doc/Architecture/AccessControl`'s **"Known gap"** note (which the issue cites) is closed and points at the new section.
- The stale rationale in `UserContextMiddleware` — "…and because `AccessControlPipeline` uses a non-empty `Roles` list as its cue" — is corrected; `AccessContext.Roles` is now a diagnostic and nothing else.
- What's New entry (`Category: Fix`): *A partition closed to the API is now closed on every path.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
