### PR TITLE
fix(mesh): a registration probe no longer reports itself as a transient ERROR

### DIFF
--- a/src/MeshWeaver.Data/TransientNodeProbe.cs
+++ b/src/MeshWeaver.Data/TransientNodeProbe.cs
@@ -84,6 +84,20 @@ public static class TransientProbeAddresses
     public const string SchemaLookupProbePrefix = "_schema_lookup/";
 
     /// <summary>
+    /// Prefix of the boot-time content-type registration probe's address —
+    /// <c>ContentTypeRegistration.ProbeRegister</c> (MeshWeaver.Graph).
+    ///
+    /// <para>🚨 That producer minted the literal itself, which is precisely the drift this class
+    /// exists to prevent: it is a transient probe by every other measure — same
+    /// <c>AsTransientNodeProbe</c> marker, same create-and-dispose-in-one-breath lifetime, same
+    /// impossibility of ever carrying a node — yet <see cref="IsProbeAddress"/> did not recognise
+    /// it, so the one guard keyed off the ADDRESS rather than the configuration marker
+    /// (<c>MeshNodeStreamCache.GetStreamRaw</c>, #2894) silently did not fire for it. Added with
+    /// Systemorph/MeshWeaver#2990.</para>
+    /// </summary>
+    public const string ContentTypeRegistrationProbePrefix = "content-type-registration/";
+
+    /// <summary>
     /// True when <paramref name="path"/> is a transient probe hub's own synthetic address — a
     /// path that is not, and can never become, a mesh node.
     /// </summary>
@@ -94,5 +108,6 @@ public static class TransientProbeAddresses
            && (path.StartsWith(ModelProbePrefix, StringComparison.Ordinal)
                || path.StartsWith(SchemaProbePrefix, StringComparison.Ordinal)
                || path.StartsWith(SchemaValidationProbePrefix, StringComparison.Ordinal)
-               || path.StartsWith(SchemaLookupProbePrefix, StringComparison.Ordinal));
+               || path.StartsWith(SchemaLookupProbePrefix, StringComparison.Ordinal)
+               || path.StartsWith(ContentTypeRegistrationProbePrefix, StringComparison.Ordinal));
 }

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -919,6 +919,14 @@ public class Workspace : IWorkspace
                 .Remove(new KeyValuePair<WorkspaceReference, Lazy<ISynchronizationStream>>(key, entry));
     }
 
+    /// <summary>
+    /// 🚨 The failure NAMES the reference and the owning hub. It used to throw a bare
+    /// <c>InvalidOperationException("Failed to create stream")</c> — no reference, no owner, no
+    /// inner cause — and that is exactly why three deliberate fault classifiers in
+    /// <c>SubscribeWithReEstablish</c> all missed it and reported a routine boot-time probe as a
+    /// transient prod ERROR (Systemorph/MeshWeaver#2990). A diagnostic that cannot be classified
+    /// costs more than the line it saves.
+    /// </summary>
     private ISynchronizationStream<TReduced> ReduceLocalStream<TReduced>(
         WorkspaceReference<TReduced> reference,
         Func<StreamConfiguration<TReduced>, StreamConfiguration<TReduced>>? configuration)
@@ -926,7 +934,10 @@ public class Workspace : IWorkspace
                this,
                reference,
                configuration
-           ) ?? throw new InvalidOperationException("Failed to create stream");
+           ) ?? throw new InvalidOperationException(
+               $"Failed to create stream for {reference} on {Hub.Address}: the workspace's "
+               + $"ReduceManager has no reducer producing {typeof(TReduced).Name} from this "
+               + "reference, or the data source it would reduce from has not been started.");
 
     /// <inheritdoc />
     public ISynchronizationStream<EntityStore> GetStream(params Type[] types)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ActivityControlPlane.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ActivityControlPlane.md
@@ -158,11 +158,20 @@ Faults are handled by `SubscribeWithReEstablish`, not by a bare log-and-die `OnE
 
 | Fault class | Behaviour |
 |---|---|
+| Own hub tearing down (`HubDisposingException` naming this watcher's own address) | **Terminal, and not an error.** From the first instant of `Dispose` the hub refuses hosted-hub creation, so the own-node stream cannot build its `sync/` sub-hub. The watcher is meant to die with its hub — a fresh activation installs a fresh one. Logged `Debug`; re-establishing here reported routine teardown as a prod `Error` and armed a timer rooted at the hub being collected. |
 | Own-node content cannot be deserialized (`MeshNodeStreamException` / `Deserialization`) | **Terminal.** The faulted stream would replay the same poisoned emission, so re-establishing is a 1 Hz poison loop. Logged `Critical` and surfaced through the optional `onPoisonedContent` sink; the watcher stays down until the content is repaired and the hub re-activates. |
 | Own node gone (routing `NotFound`) | **Terminal.** Re-subscribing re-issues a doomed cross-hub `SubscribeRequest` forever — the 2026-06-10 prod storm. Logged and stopped; the orphaned hub idle-disposes. |
 | Anything else | **Transient** — re-establish with a fresh subscription after ~1 s. |
 
 Faults log to the optional `ILogger` argument (or the `MeshWeaver.ActivityControlPlane` log category) so a broken control plane never disappears silently.
+
+> 🚨 **`WatchControlPlane` and `WatchSubmission` install nothing on a transient node probe.** A probe
+> hub applies a NodeType's instance configuration purely so the configuration is *built*, and is
+> disposed in the same breath — it has no mesh node, so a watcher of its own node has nothing to
+> observe and nothing to re-establish. Because the ACP is installed by the *adopter* (from its own
+> `WithInitialization`), the guard has to live at this shared seam rather than in each adopter: see
+> [Transient Node Probes](/Doc/Architecture/TransientNodeProbes) for the boot-time `Error` line this
+> removed and why the cure is not-installing rather than a quieter log level.
 
 ---
 
@@ -744,6 +753,8 @@ observation*, not a lock — fix the observer, don't bump the timeout.
 
 - [Request via Stream Update](/Doc/Architecture/RequestViaStreamUpdate) — the general rule this page
   is the activity-shaped instance of.
+- [Transient Node Probes](/Doc/Architecture/TransientNodeProbes) — the throwaway hubs this watcher is
+  deliberately not installed on, and the three own-address read seams that answer directly.
 - [Logon Actions](/Doc/Architecture/LogonActions) — per-user work at logon. Its run-once ledger is the
   same **claim-before-you-mutate** shape as the `Idle → StartingExecution` flip above, with the
   ledger key as the claim: the guard lives *inside* the update lambda so a rebased patch re-reads it

--- a/src/MeshWeaver.Documentation/Data/Architecture/TransientNodeProbes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/TransientNodeProbes.md
@@ -29,6 +29,7 @@ A probe's address is minted with a fresh GUID for a hub nobody will ever address
 | Schema probe | `$schema-probe/{guid}` | `MeshDataSourceExtensions` (SchemaReference handling) |
 | Validation probe | `_schema_validation/{guid}` | `MeshOperations.ValidateContentWithSchema` |
 | Schema-lookup probe | `_schema_lookup/{guid}` | `MeshOperations.GetContentSchema` |
+| Registration probe | `content-type-registration/{guid}` | `ContentTypeRegistration.ProbeRegister` |
 
 So *"is there a node at this path?"* has one answer, for every reader, forever: **no**. That is not a
 timing statement — nothing is in flight, nothing is about to be created. It is a fact about the
@@ -48,6 +49,13 @@ stops firing, and nothing about a probe minted under an unknown prefix looks wro
 fails in production. Adding a new probe kind means adding its constant here, which is what keeps
 `IsProbeAddress` exhaustive.
 
+The registration probe is the worked example of the drift: it was added as a literal, so it was a
+transient probe by every other measure — same marker, same lifetime, same impossibility of ever
+carrying a node — while `IsProbeAddress` did not know it existed and the cache seam below did not
+fire for it (Systemorph/MeshWeaver#2990). A read of one of its addresses died on
+`No node found at 'content-type-registration/…'`: the #2894 failure, re-created in full by one
+string literal.
+
 ## Why "read my own node" reaches a probe at all
 
 A probe applies content written for a **real per-node hub**, where the hub's address *is* its mesh
@@ -59,18 +67,25 @@ This is not a content bug to be fixed in each NodeType. It is inherent in what a
 instance configuration to a hub that is not an instance. The framework, not the content, has to
 absorb it.
 
-## The two own-address read seams — both must answer directly
+## The three own-address read seams — all must answer directly
 
-There are exactly two ways such a read leaves content, and **both are guarded**:
+There are exactly three ways such a read leaves content, and **all three are guarded**:
 
 | Seam | Answer for a probe's own address |
 |---|---|
 | `MeshNodeStreamExtensions.GetMeshNodeOutcome` (and `GetMeshNode`) | `NodeReadStatus.Absent`, immediately |
 | `IMeshNodeStreamCache.GetStream(path, options)` | an **empty stream** — no emission, immediate completion |
+| `MeshNodeStreamHandle.Subscribe` — the own-node reduce behind `workspace.GetMeshNodeStream()` | an **empty stream** |
 
 The empty stream is the stream-shaped twin of `Absent`: no emission, because there is no node;
-immediate completion, because there never will be one. Neither answer suppresses a fault — there is
-genuinely nothing there.
+immediate completion, because there never will be one. None of the three suppresses a fault — there
+is genuinely nothing there.
+
+The third seam is the one every own-node **watcher** subscribes to, and it was the last to say so.
+It threw `InvalidOperationException("Failed to create stream")` instead: a probe is built
+`startDataSources: false`, so the own-`MeshNode` reduce has no started data source to reduce from and
+`ReduceManager.ReduceStream` returns null. That diagnostic named no reference, no owner and no cause,
+which is precisely why three deliberate fault classifiers all missed it — see below.
 
 The cache seam matters more than it looks, because **it is the seam content reaches for**. Reading
 the hub's own node through the process-wide cache is the only own-node read that answers *before* the
@@ -113,11 +128,61 @@ shapes were observed on the same production pod in the same second
 moves the failure, does not remove it, and would collapse a per-user read to a privileged one. The
 address is what is wrong with the read, not the identity on it.
 
+## The own-node watchers, and the error a clean boot used to write
+
+"A probe gets the data context but not the per-node control plane" is stated above, and
+`MeshDataSource` honours it for the watchers *it* installs (`SubscribeToOwnDeletionInit` returns
+early on a probe). But the **Activity Control Plane is installed by the adopter, not by
+`MeshDataSource`** — `KernelContainer` and every Activity-shaped NodeType call
+`hub.WatchControlPlane(...)` from their own `WithInitialization`. A guard placed per-adopter is a
+guard the next adopter will not have, so the ACP watcher went on being installed on every probe.
+
+On a probe it has nothing to watch, and it said so at the wrong volume. Every mesh start wrote one
+line per swept Activity-shaped NodeType:
+
+```text
+Error MeshWeaver.Kernel.Hub.KernelContainer: ActivityControlPlane subscription faulted on
+content-type-registration/65936dcbcfa348bd921eb49885dea848 — re-establishing
+```
+
+`SubscribeWithReEstablish` classifies a watcher fault into four buckets, three of which are terminal:
+own hub disposing (`HubDisposingException` naming this address), poisoned own content (a
+deserialization `MeshNodeStreamException`), and own node gone (a routing `NotFound`). A bare
+`InvalidOperationException` matches none, so it fell through to the fourth — *genuinely transient* —
+which means `LogError` plus a one-second re-establish timer. `Information` and above ships to Loki
+and `Error` is what operators alert on, so a routine boot-time step reported itself as a production
+fault, once per type, forever. The timer was armed against a hub already being disposed: the #991
+`TimerQueue`-root shape, kept harmless only by the ordering accident that `RegisterForDisposal`
+disposes a late registrant immediately.
+
+An Activity NodeType that *also* declares a content type showed the other face of the same root: its
+own-node reduce succeeded far enough to construct a `SynchronizationStream`, whose constructor always
+calls `GetHostedHub(sync/{id}, Always)` — into the probe's own disposal, producing exactly the
+`Rejecting hosted hub creation … during disposal` warning that `startDataSources: false` was
+introduced to remove.
+
+Both are cured at the seams, not at the adopters:
+
+- `WatchControlPlane` and `WatchSubmission` **do not install** on a hub carrying the
+  `TransientNodeProbe` marker. This is the shared seam every ACP adopter goes through, so it also
+  covers the ones not yet written.
+- The own-node stream **completes empty** (the third seam above), which covers watchers that build
+  their own source rather than going through those two — `BuildNodeType`'s claim arbiter is the
+  live example.
+
+🚨 **This is not a classification change.** *Transient* keeps meaning what it meant — the node is
+alive and will come back. The cure is that the watcher is never installed on a hub for which that can
+never be true, not that its fault is reported more quietly. Downgrading the line would have left the
+re-establish timer armed and the sub-hub still being created.
+
 ## Rules
 
 - **Mint every probe address from `TransientProbeAddresses`.** Never a string literal.
 - **A new read seam that can be handed an arbitrary path must consult `IsProbeAddress`** before it
   gates, caches, routes, or opens a breaker on that path.
+- **A watcher of the hub's OWN node is not installed on a probe.** Put the guard at the shared seam
+  the adopters call, never once per adopter — and make the own-node stream itself answer empty, so a
+  watcher that composes its own source is covered too.
 - **A probe hub must never be used to WRITE.** With no own-node subscription and no persistence
   sampler it has no node identity and would not persist anything; the write guards are deliberately
   *not* short-circuited, so such an attempt fails loudly instead of being swallowed.
@@ -133,3 +198,5 @@ address is what is wrong with the read, not the identity on it.
 - [Virtual Data Sources](/Doc/DataMesh/VirtualDataSources) — the provider whose fault surfaced this.
 - [Access Context Propagation](/Doc/Architecture/AccessContextPropagation) — the identity the read
   inherits, and why moving it is not the answer.
+- [Activity Control Plane](/Doc/Architecture/ActivityControlPlane) — the watcher that is deliberately
+  not installed here, and what its four fault classes mean.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-clean-start-no-longer-reports-an-error.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-clean-start-no-longer-reports-an-error.md
@@ -1,0 +1,29 @@
+---
+Name: A clean start no longer reports an error
+Category: Fix
+Description: Starting the portal wrote one Error-level line per built-in activity type about a subscription that had "faulted" — a routine start-up step reporting itself. Start-up is now quiet.
+Icon: Sparkle
+Order: -20260902
+---
+
+# A clean start no longer reports an error
+
+Every time the portal started, its log carried one line at **Error** level for each built-in
+activity type, saying a subscription had faulted and was being re-established. Nothing was
+actually wrong: the lines described a preparation step the platform runs at start-up, watching
+itself.
+
+That step is worth explaining, because it is useful. At start-up the platform walks every content
+type it knows how to store and teaches itself to read that type — so a portal can display a kind of
+content correctly even when it does not yet hold a single item of it. To do that it builds a
+throwaway workspace per type, reads what it needs from it, and throws it away in the same breath.
+
+The throwaway workspace has no content of its own, and never will. Some types also bring along a
+watcher whose job, on a real node, is to notice when someone asks the node to stop or restart. On
+the throwaway there is nothing to watch, so the watcher immediately failed, said so at the severity
+operators alert on, and promised to try again a second later — against something that had already
+been discarded.
+
+The preparation step now leaves those watchers out, and a read of a throwaway workspace's own
+content simply answers "there is nothing here" rather than failing. A normal start writes no error
+lines, so an error in the log is once again a reason to look.

--- a/src/MeshWeaver.Graph/ContentTypeRegistrationSweep.cs
+++ b/src/MeshWeaver.Graph/ContentTypeRegistrationSweep.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading;
 using System.Threading.Tasks;
+using MeshWeaver.Data;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -36,6 +37,17 @@ namespace MeshWeaver.Graph;
 /// control plane; see <c>MeshOperations.ReadFromContentType</c>, whose probe this mirrors). Cost
 /// is a config build per type, once per process.</para>
 ///
+/// <para>🚨 "No control plane" was aspirational for one watcher until #2990: the Activity Control
+/// Plane is installed by the ADOPTER (<c>KernelContainer</c> and every Activity-shaped NodeType,
+/// from their own <c>WithInitialization</c>), not by <c>MeshDataSource</c>, so every sweep of such
+/// a type wrote an ERROR-level <c>ActivityControlPlane subscription faulted on
+/// content-type-registration/… — re-establishing</c> and armed a re-establish against a hub that
+/// was already gone. The guard now lives at the shared seam
+/// (<c>ActivityControlPlaneExtensions.WatchControlPlane</c>/<c>WatchSubmission</c>) and at the
+/// own-node read seam (<c>MeshNodeStreamHandle.Subscribe</c> answers a probe's own address with an
+/// empty stream), so an adopter cannot reinstate it. See
+/// <c>Doc/Architecture/TransientNodeProbes</c>.</para>
+///
 /// <para>Scope: the <see cref="ContentTypeRegistrationSweep"/> hosted service walks the STATIC
 /// definitions (<c>AddMeshNodes</c>) at start — which is where the measured defect lived: every
 /// commerce content type is a static definition. COMPILED (dynamic) types are deliberately NOT
@@ -67,7 +79,12 @@ public static class ContentTypeRegistration
     {
         try
         {
-            var probeAddress = new Address($"content-type-registration/{Guid.NewGuid():N}");
+            // 🚨 Minted FROM the shared constant, never as a literal: the read seams that answer a
+            // probe's own address directly (MeshNodeStreamCache.GetStreamRaw) key off
+            // TransientProbeAddresses.IsProbeAddress, and a producer whose prefix is not in that
+            // predicate is a producer those guards silently skip (#2894 → #2990).
+            var probeAddress = new Address(
+                $"{TransientProbeAddresses.ContentTypeRegistrationProbePrefix}{Guid.NewGuid():N}");
             var probeHub = meshHub.GetHostedHub(
                 probeAddress,
                 c => hubConfig(c.WithNodeTypePath(nodeTypePath))

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -1478,9 +1478,12 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     // wedged-thread / never-dispatching-watcher bug class.
     private IObservable<MeshNode> GetStreamRaw(string path)
     {
-        // ♻️ A TRANSIENT NODE PROBE HAS NO MESH NODE — and this is the SECOND seam a probe's
-        // own-address read arrives on. The first, MeshNodeStreamExtensions.GetMeshNodeOutcome,
-        // has answered such a read `Absent` since #2468; this one had no guard at all, and it is
+        // ♻️ A TRANSIENT NODE PROBE HAS NO MESH NODE — and this is the SECOND of the THREE seams a
+        // probe's own-address read arrives on. The first, MeshNodeStreamExtensions.GetMeshNodeOutcome,
+        // has answered such a read `Absent` since #2468; the third is the own-node reduce behind
+        // `workspace.GetMeshNodeStream()` (MeshNodeStreamHandle.Subscribe), which threw a causeless
+        // "Failed to create stream" until #2990 and now also completes empty. This one had no guard
+        // at all, and it is
         // the seam that in-mesh NodeType content actually reaches for, because reading the OWN
         // node through the process-wide cache is what the framework tells content to do (it is
         // also the only own-node read that works during initialization — the hub's own-node

--- a/src/MeshWeaver.Mesh.Contract/ActivityControlPlaneExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityControlPlaneExtensions.cs
@@ -68,6 +68,9 @@ public static class ActivityControlPlaneExtensions
         logger ??= hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.ActivityControlPlane");
 
+        if (SkipOnTransientProbe(hub, logger, "ActivityControlPlane subscription") is { } inert)
+            return inert;
+
         var workspace = hub.GetWorkspace();
 
         // Self-healing: a faulted control-plane subscription must NOT leave the
@@ -137,6 +140,9 @@ public static class ActivityControlPlaneExtensions
         logger ??= hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.JobOrchestration");
 
+        if (SkipOnTransientProbe(hub, logger, "Submission watcher") is { } inert)
+            return inert;
+
         // Atomic single-flight guard. The upstream `GetMeshNodeStream` can emit
         // multiple distinct fingerprints before any single dispatch's async
         // commit (CreateNodeRequest + workspace.Update) has landed; without
@@ -176,6 +182,60 @@ public static class ActivityControlPlaneExtensions
             // Release the single-flight guard a faulted in-flight dispatch may have
             // left set, so the re-established watcher can dispatch.
             onTransientFault: () => System.Threading.Interlocked.Exchange(ref dispatching, 0));
+    }
+
+    /// <summary>
+    /// 🚨 <b>A TRANSIENT NODE PROBE HAS NO MESH NODE, so it must not run the node control
+    /// plane.</b> Returns an inert disposable when <paramref name="hub"/> is such a probe, and
+    /// <c>null</c> — meaning "carry on and install the watcher" — for every real hub.
+    ///
+    /// <para>A probe hub (<c>content-type-registration/{guid}</c>, <c>$model-probe/{guid}</c>,
+    /// <c>$schema-probe/{guid}</c>, …) exists so a NodeType's HubConfiguration can be BUILT —
+    /// registering its content type / snapshotting its type registry is the build's side effect —
+    /// and is disposed in the same breath. <c>AsTransientNodeProbe</c> states the contract
+    /// outright, and <c>MeshDataSource.SubscribeToOwnDeletionInit</c> already honours it for the
+    /// per-node watchers it installs. The Activity Control Plane is the one watcher that did not:
+    /// it is installed by the ADOPTER (<c>KernelContainer</c> and every Activity-shaped NodeType)
+    /// from its own <c>WithInitialization</c>, so a guard placed per-adopter is a guard the next
+    /// adopter will not have. It belongs here, at the seam they all go through.</para>
+    ///
+    /// <para><b>What it cost.</b> Every mesh start wrote one ERROR-level line per swept
+    /// Activity-shaped NodeType — <c>ActivityControlPlane subscription faulted on
+    /// content-type-registration/… — re-establishing</c>, carrying a bare
+    /// <c>InvalidOperationException("Failed to create stream")</c> — because the probe's own-node
+    /// reduce has no started data source to reduce from. <c>Information</c> and above ships to
+    /// Loki and <c>Error</c> is what operators alert on, so this was a per-boot false alarm about
+    /// a non-event. The classifier below could not save it: the three terminal branches test for
+    /// <c>HubDisposingException</c>, a deserialization <c>MeshNodeStreamException</c> and a
+    /// routing <c>NotFound</c>, and a causeless <c>InvalidOperationException</c> matches none, so
+    /// it fell through to "genuinely transient" — <c>LogError</c> plus a 1 s re-establish timer
+    /// armed against a hub that is already being disposed (the #991 TimerQueue-root shape, whose
+    /// only current safety is the ordering accident that <c>RegisterForDisposal</c> disposes a late
+    /// registrant immediately). A NodeType that also declares a content type got one step further
+    /// and opened a <c>sync/</c> sub-hub into the probe's own disposal instead — the
+    /// <c>ProbeHubCostTest</c> warning <c>startDataSources: false</c> exists to remove. One root,
+    /// two faces. Systemorph/MeshWeaver#2990.</para>
+    ///
+    /// <para>🚨 <b>Not a classification change.</b> "Transient" keeps meaning exactly what it
+    /// meant — <i>the node is alive and will come back</i>. The cure is that the watcher is never
+    /// installed on a hub for which that can never be true, not that its fault is reported more
+    /// quietly.</para>
+    /// </summary>
+    /// <param name="hub">The hub a watcher is about to be installed on.</param>
+    /// <param name="logger">Optional logger; the skip is recorded at Debug.</param>
+    /// <param name="context">Short name of the watcher, for the Debug line.</param>
+    /// <returns>An inert <see cref="IDisposable"/> to hand back to the caller when the hub is a
+    /// transient probe; <c>null</c> when the watcher must be installed normally.</returns>
+    private static IDisposable? SkipOnTransientProbe(IMessageHub hub, ILogger? logger, string context)
+    {
+        if (hub.Configuration.Get<TransientNodeProbe>() is null)
+            return null;
+
+        logger?.LogDebug(
+            "{Context} not installed on {Address}: a transient node probe has no mesh node, so a "
+            + "watcher of its own node has nothing to observe and nothing to re-establish (#2990)",
+            context, hub.Address);
+        return System.Reactive.Disposables.Disposable.Empty;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -387,6 +387,37 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     {
         try
         {
+            // ♻️ A TRANSIENT NODE PROBE HAS NO MESH NODE — so its OWN-node stream is EMPTY, and
+            // that is the truthful answer rather than a failure. This is the THIRD own-node read
+            // seam and the last one that was not saying it: `GetMeshNodeOutcome` answers a probe's
+            // own address `Absent` (#2468) and `MeshNodeStreamCache.GetStreamRaw` answers an empty
+            // stream (#2894); this one — the reduce-backed own-node stream every own-node WATCHER
+            // subscribes to — threw instead.
+            //
+            // What it threw was `InvalidOperationException("Failed to create stream")`, from
+            // `Workspace.ReduceLocalStream`: the probe is built `startDataSources: false`, so the
+            // own-MeshNode reduce has no started data source to reduce from and `ReduceStream`
+            // returns null. Watchers installed by a NodeType's own HubConfiguration —
+            // `WatchControlPlane` on every Activity-shaped type, `BuildNodeType`'s claim arbiter —
+            // then reported that as a TRANSIENT fault (a bare InvalidOperationException matches
+            // none of `SubscribeWithReEstablish`'s three terminal classifiers) and armed a 1 s
+            // re-establish against a hub that was already disposing: an ERROR-level line per swept
+            // NodeType on every mesh start, about a non-event. Where the reduce DID succeed the
+            // cost was the other face — `SynchronizationStream`'s constructor opening a `sync/`
+            // sub-hub into the probe's own disposal, the `ProbeHubCostTest` warning
+            // `startDataSources: false` exists to remove. Systemorph/MeshWeaver#2990.
+            //
+            // Completing empty is not a swallow: there is no node at a probe's synthetic address
+            // and there never will be (see TransientProbeAddresses), so a reader learns exactly
+            // what is true, immediately, instead of a diagnosis that names no reference and no
+            // owner. Scoped to the probe's OWN address — a probe reading any REAL path is
+            // untouched, and so is every write (Update never routes through AcquireStream).
+            if (IsOwn && _workspace.Hub.Configuration.Get<TransientNodeProbe>() is not null)
+            {
+                observer.OnCompleted();
+                return Disposable.Empty;
+            }
+
             var typedObserver = new TypedContentObserver(observer, _jsonOptions, _contentTypeRegistry);
             // 🚨 Cross-hub reads route through IMeshNodeStreamCache (when one is
             // registered): one shared process-wide upstream subscription per

--- a/test/MeshWeaver.Graph.Test/ContentTypeProbeControlPlaneTest.cs
+++ b/test/MeshWeaver.Graph.Test/ContentTypeProbeControlPlaneTest.cs
@@ -1,0 +1,226 @@
+#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>The boot-time content-type sweep must not report ITSELF as a fault.</b>
+///
+/// <para><see cref="ContentTypeRegistrationSweep"/> builds one throwaway probe hub per static
+/// NodeType definition so <c>WithContentType</c> runs as a side effect of the configuration build.
+/// The probe is <c>AsTransientNodeProbe(startDataSources: false)</c> and disposed in the same
+/// breath — it has no mesh node, no started data sources, and microseconds to live.</para>
+///
+/// <para>A NodeType that adopts the Activity Control Plane installs
+/// <see cref="ActivityControlPlaneExtensions.WatchControlPlane"/> from its own
+/// <c>WithInitialization</c>, and that watcher subscribes to the hub's OWN MeshNode stream. On the
+/// probe there is no such stream, so every mesh start wrote an ERROR-level line per swept
+/// Activity-shaped NodeType — <c>ActivityControlPlane subscription faulted on
+/// content-type-registration/… — re-establishing</c> — and armed a 1 s re-establish timer against
+/// a hub that was already gone (Systemorph/MeshWeaver#2990). Information and above ships to Loki;
+/// Error is what operators alert on.</para>
+///
+/// <para>Both NodeType shapes below are real: the platform's own <c>kernel</c> type carries an ACP
+/// and NO mesh data source (the ERROR), while an Activity NodeType that also declares a content
+/// type gets far enough to build the stream and instead opens a <c>sync/</c> sub-hub into the
+/// probe's own disposal (the WARNING). One root, two faces — a probe must not run the node control
+/// plane at all, which is what <c>AsTransientNodeProbe</c> already promised and
+/// <c>MeshDataSource.SubscribeToOwnDeletionInit</c> already honours.</para>
+/// </summary>
+public class ContentTypeProbeControlPlaneTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The kernel's shape: an ACP watcher and no mesh data source.</summary>
+    private const string BareActivityNodeType = "AcpProbeGadget";
+
+    /// <summary>The other Activity shape: an ACP watcher plus a declared content type.</summary>
+    private const string TypedActivityNodeType = "AcpProbeGadgetWithContent";
+
+    public record AcpGadgetContent
+    {
+        public string? Label { get; init; }
+    }
+
+    /// <summary>
+    /// Emits once the swept probe of <see cref="BareActivityNodeType"/> has RETURNED from the ACP
+    /// install point. That ordering is the whole determinism of this test:
+    /// <c>SubscribeWithReEstablish</c> establishes synchronously and
+    /// <c>MeshNodeStreamHandle.Subscribe</c> reports a failed <c>AcquireStream</c> through
+    /// <c>OnError</c> on the calling thread — so by the time this emits, the Error line has either
+    /// been written or provably will not be. An assertion on a log's ABSENCE with no such signal
+    /// passes whenever it runs first, which is most of the time.
+    /// </summary>
+    private readonly AsyncSubject<Unit> bareWatcherInstalled = new();
+
+    /// <summary>Same signal for <see cref="TypedActivityNodeType"/>.</summary>
+    private readonly AsyncSubject<Unit> typedWatcherInstalled = new();
+
+    private readonly RecordingLoggerProvider recorder = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<ILoggerProvider>(recorder))
+            .AddMeshNodes(
+                new MeshNode(BareActivityNodeType)
+                {
+                    Name = "ACP Probe Gadget",
+                    HubConfiguration = config => InstallControlPlane(config.AddData(), bareWatcherInstalled)
+                },
+                new MeshNode(TypedActivityNodeType)
+                {
+                    Name = "ACP Probe Gadget With Content",
+                    HubConfiguration = config => InstallControlPlane(
+                        config.AddMeshDataSource(source => source.WithContentType<AcpGadgetContent>()),
+                        typedWatcherInstalled)
+                });
+
+    /// <summary>
+    /// Faithful copy of <c>KernelContainer</c>'s Activity Control Plane install: the OBSERVABLE
+    /// initialization overload, running on the <c>InitializeHubRequest</c> turn, registering the
+    /// watcher for the hub's disposal.
+    /// </summary>
+    private static MessageHubConfiguration InstallControlPlane(
+        MessageHubConfiguration config, AsyncSubject<Unit> installed)
+        => config.WithInitialization(hub => Observable.Defer(() =>
+        {
+            hub.RegisterForDisposal(hub.WatchControlPlane(_ => { }));
+            installed.OnNext(Unit.Default);
+            installed.OnCompleted();
+            return Observable.Return(Unit.Default);
+        }));
+
+    /// <summary>
+    /// 🚨 THE assertion of #2990: a clean mesh start writes no Error-level record about a faulted
+    /// control-plane subscription. Nothing is wrong with the mesh — the line reported the boot-time
+    /// content-type sweep against itself.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task BootSweep_OfActivityShapedNodeTypes_LogsNoControlPlaneFault()
+    {
+        await ProbesReachedTheInstallPoint();
+
+        var faults = recorder.Records
+            .Where(r => r.Level >= LogLevel.Error
+                        && r.Message.Contains("ActivityControlPlane subscription faulted",
+                            StringComparison.Ordinal))
+            .ToArray();
+
+        faults.Should().BeEmpty(
+            "the boot-time content-type sweep builds a throwaway probe with no mesh node and no "
+            + "started data sources — reporting its own watcher as a transient fault is an "
+            + "ERROR-level line about a non-event, and it arms a 1 s re-establish against a hub "
+            + "that is already gone (#2990)");
+    }
+
+    /// <summary>
+    /// The same root one step earlier: an Activity NodeType that also declares a content type gets
+    /// far enough for the own-node reduce to construct a <see cref="ISynchronizationStream"/>,
+    /// whose constructor always calls <c>GetHostedHub(sync/{id}, Always)</c> — into the probe's own
+    /// disposal. That is the <c>ProbeHubCostTest</c> warning <c>startDataSources: false</c> was
+    /// introduced to remove, reinstated by the one watcher that was still installed.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task BootSweep_OfActivityShapedNodeTypes_OpensNoSyncSubHubOnAProbe()
+    {
+        await ProbesReachedTheInstallPoint();
+
+        var rejected = recorder.Records
+            .Where(r => r.Message.Contains("Rejecting hosted hub creation", StringComparison.Ordinal)
+                        && r.Message.Contains("in Host content-type-registration/",
+                            StringComparison.Ordinal))
+            .ToArray();
+
+        rejected.Should().BeEmpty(
+            "a registration probe exists to have its configuration BUILT and nothing else — the "
+            + "control plane is the last machinery that still opened a sync/ sub-hub into the "
+            + "probe's own disposal (#2990)");
+    }
+
+    /// <summary>
+    /// 🚨 The registration probe is a TRANSIENT PROBE by every measure — same marker, same
+    /// create-and-dispose-in-one-breath lifetime, same impossibility of ever carrying a node — but
+    /// it minted its address as a bare literal instead of from
+    /// <see cref="TransientProbeAddresses"/>, so the one guard keyed off the ADDRESS rather than
+    /// the configuration marker did not recognise it.
+    ///
+    /// <para>That guard is <c>MeshNodeStreamCache.GetStreamRaw</c>, and it is the seam in-mesh
+    /// NodeType content actually reaches for. Unguarded, a read of such a path evaluates the
+    /// caller's permissions on a synthetic address ("lacks Read permission on …") or routes and
+    /// dies on "No node found at …" — either of which faults the virtual data source whose
+    /// provider issued it (#2894). This is the same assertion
+    /// <c>NodeTypeModelProbeTest.StreamCache_ReadOfAProbeOwnAddress_CompletesEmptyForAnUnprivilegedUser</c>
+    /// makes for <c>$model-probe</c>, for the producer that had not joined the contract.</para>
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task StreamCache_ReadOfARegistrationProbeAddress_CompletesEmpty()
+    {
+        var cache = Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+        var probePath =
+            $"{TransientProbeAddresses.ContentTypeRegistrationProbePrefix}{Guid.NewGuid():N}";
+
+        var emitted = await cache.GetStream(probePath, Mesh.JsonSerializerOptions)
+            .ToArray().Should().Within(TestTimeouts.Quick).Emit();
+
+        emitted.Should().BeEmpty(
+            "there is no node at a registration probe's synthetic address and there never will be "
+            + "— every probe producer mints its address FROM TransientProbeAddresses so that "
+            + "IsProbeAddress stays exhaustive (#2990)");
+    }
+
+    private async Task ProbesReachedTheInstallPoint()
+    {
+        await bareWatcherInstalled.Should().Within(TestTimeouts.Quick)
+            .Emit("the sweep must probe the ACP NodeType that carries no data source, or this test "
+                  + "asserts nothing");
+        await typedWatcherInstalled.Should().Within(TestTimeouts.Quick)
+            .Emit("the sweep must probe the ACP NodeType that declares a content type, or this "
+                  + "test asserts nothing");
+
+        foreach (var r in recorder.Records)
+            Output.WriteLine($"    {r.Level} {r.Category}: {r.Message}"
+                             + (r.Error is null ? "" : $"  << {r.Error.GetType().Name}: {r.Error.Message}"));
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<(LogLevel Level, string Category, string Message, Exception? Error)> records = new();
+
+        public IReadOnlyList<(LogLevel Level, string Category, string Message, Exception? Error)> Records
+            => records.ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new Recorder(categoryName, records);
+        public void Dispose() { }
+
+        private sealed class Recorder(
+            string category,
+            ConcurrentQueue<(LogLevel, string, string, Exception?)> sink) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => Disposable.Empty;
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel)) return;
+                sink.Enqueue((logLevel, category, formatter(state, exception), exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes #2990.

## The symptom

Every mesh start wrote one **Error**-level line per static NodeType whose `HubConfiguration`
installs an Activity Control Plane:

```
Error MeshWeaver.Kernel.Hub.KernelContainer: ActivityControlPlane subscription faulted on
content-type-registration/65936dcbcfa348bd921eb49885dea848 — re-establishing
   << InvalidOperationException: Failed to create stream
```

`content-type-registration/{guid}` is the boot-time content-type sweep's own throwaway probe, so
the line was that sweep reporting itself — at the severity operators alert on, once per swept type,
on every boot.

## Verified root cause — issue candidate **(a)**: the probe was running the node control plane

`AsTransientNodeProbe` states outright that a probe must not run the per-node control plane, and
`MeshDataSource` honours it (`SubscribeToOwnDeletionInit` returns early on a probe). But the ACP is
installed by the **adopter** — `KernelContainer` and every Activity-shaped NodeType, from their own
`WithInitialization` — so a guard placed per-adopter is a guard the next adopter will not have, and
the ACP went on being installed on every probe.

There it subscribes to the hub's own MeshNode stream. The probe is built `startDataSources: false`,
so that reduce has no started data source and `Workspace.ReduceLocalStream` threw a causeless
`InvalidOperationException("Failed to create stream")`. `SubscribeWithReEstablish`'s three terminal
classifiers all miss a bare `InvalidOperationException`, so it fell through to *genuinely
transient*: `LogError` + a 1 s re-establish timer armed against a hub already being disposed (the
#991 `TimerQueue`-root shape, safe today only by the ordering accident that `RegisterForDisposal`
disposes a late registrant immediately).

**Same root, second face.** An Activity NodeType that *also* declares a content type got far enough
for the reduce to construct a `SynchronizationStream`, whose constructor always calls
`GetHostedHub(sync/{id}, Always)` — into the probe's own disposal, re-creating exactly the
`Rejecting hosted hub creation … during disposal` warning that `startDataSources: false` was
introduced to remove.

## The fix — at the seams, never per adopter, and never a quieter log level

| # | Change | Why here |
|---|---|---|
| 1 | `WatchControlPlane` / `WatchSubmission` install **nothing** on a hub carrying the `TransientNodeProbe` marker | the shared seam every ACP adopter goes through |
| 2 | `MeshNodeStreamHandle.Subscribe` answers a probe's **own-node** stream with an **empty stream** | the THIRD own-node read seam, and the last one not saying "there is no node here" — `GetMeshNodeOutcome` answers `Absent` (#2468), `MeshNodeStreamCache.GetStreamRaw` answers empty (#2894). Covers watchers that compose their own source rather than going through (1) — `BuildNodeType`'s claim arbiter is the live example, and was the remaining `sync/` sub-hub after (1) alone |
| 3 | `ProbeRegister` mints its address from `TransientProbeAddresses`; `IsProbeAddress` learns the prefix | the registration probe was a transient probe by every other measure while the one guard keyed off the ADDRESS did not know it existed — a read of one of its paths died on `No node found at 'content-type-registration/…'`, i.e. #2894 re-created by one string literal |
| 4 | `ReduceLocalStream`'s exception names the reference and the owning hub | issue candidate **(b)**: a diagnostic naming no reference, no owner and no cause is *why* three deliberate classifiers missed it |

🚨 **Deliberately not the fix:** downgrading the Error. That would have left the re-establish timer
armed and the sub-hub still being created. "Transient" keeps meaning exactly what it meant — *the
node is alive and will come back*.

## Test that fails before and passes after

`test/MeshWeaver.Graph.Test/ContentTypeProbeControlPlaneTest.cs` starts a **real** monolith mesh
(`MonolithMeshTestBase`, no mocking), registers two Activity-shaped static NodeTypes — one bare like
the platform's own `kernel` type, one declaring a content type — and captures the mesh's **own
`ILoggerFactory`** through an `ILoggerProvider` registered via `MeshBuilder.ConfigureServices`: what
a deployment's log sink receives, not test output.

Ordering is a positive signal, not a hope. Each NodeType reports into an `AsyncSubject` from inside
its own `WithInitialization`, once `WatchControlPlane` has **returned** — and
`SubscribeWithReEstablish` establishes synchronously, with `MeshNodeStreamHandle.Subscribe`
reporting a failed `AcquireStream` through `OnError` on the calling thread. By the time the signal
arrives the line has been written or provably will not be. (An assertion on a log's absence with no
such signal passes whenever it runs first — which is most of the time.)

| Build | `…LogsNoControlPlaneFault` | `…OpensNoSyncSubHubOnAProbe` | `StreamCache_ReadOfARegistrationProbeAddress_CompletesEmpty` |
|---|---|---|---|
| `origin/main` | **FAIL** — 2 Error records, the reported line verbatim (one from the platform's `kernel` type, one from the test's) | **FAIL** — 3 `sync/`-into-disposal warnings | **FAIL** — `DeliveryFailureException: No node found at 'content-type-registration/…'` |
| with (1) only | PASS | **FAIL** — 1 warning left (the claim arbiter) | — |
| with (1)+(2)+(3) | PASS | PASS | PASS |

The third row's third column was falsified independently by reverting **only** (3) and re-running.

## Docs

`Doc/Architecture/TransientNodeProbes` gains the registration probe in its producer table, the
**third** own-address read seam, and a section on the own-node watchers with the boot-time Error it
removed; `Doc/Architecture/ActivityControlPlane` gains the probe rule, a cross-link, and the missing
fourth fault class its table never listed. What's New entry: `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
