### PR TITLE
fix(mesh): a content type registering LATE re-types every live reader (#2952)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentTypeRegistration.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentTypeRegistration.md
@@ -89,6 +89,111 @@ carrying its discriminator — so there is nothing for the registry's absence to
 bites built-in types, whose content is written by installers and other partitions, and those are
 precisely the static definitions the sweep covers.
 
+## 🚨 Registration is an EVENT — a degrade must never be terminal
+
+The sweep above answers *"the type is defined but nothing instantiates it"*. It does not answer the
+other way a read can find the registry empty: **the type is not registered YET**.
+
+A compiled NodeType registers its content type when its instance hub cold-activates, and that
+happens only once Roslyn has produced the assembly. Loading nodes and compiling NodeTypes are
+concurrent, so an instance's content can be read a few hundred milliseconds **before** its own type
+exists. Every read seam handles that correctly for the emission in front of it — it asks the
+registry, gets "unknown", and emits the content as an untyped `JsonElement`, which is the honest
+answer at that instant.
+
+The defect was what happened next: **nothing**. `Register` was a silent side effect — no event, no
+observable — so a subscription that opened on the losing side of the race held the untyped value for
+the life of the hub. The node itself never changes, so no further emission ever arrives to
+re-convert it. The view renders empty, `edit_content` refuses the content, and every reactive wait
+for the typed shape times out. Nothing about it is random; it is a race whose loser never recovers,
+which is exactly why re-running a failing test "fixed" it
+([#2952](https://github.com/Systemorph/MeshWeaver/issues/2952)).
+
+**`IMeshContentTypeRegistry.Registrations` makes registration observable**, and the read boundary
+waits on it:
+
+```csharp
+// MeshNodeStreamHandle.TypedContentObserver — arms only when the conversion DEGRADED
+contentTypeRegistry.Registrations
+    .StartWith(Unit.Default)          // closes the gap between the conversion and this Subscribe
+    .Select(_ => TryRetype(raw))      // re-ask; keep the answer only if it is now typed
+    .Where(n => n is not null)
+    .Take(1)
+    .Subscribe(n => observer.OnNext(n!), observer.OnError);
+```
+
+Four properties are load-bearing, and each of them is the reason a *different* wrong shape was not
+used:
+
+- **It is a subscription to the real EVENT, not a poll.** No timer, no interval, no re-subscribe
+  loop. A watchdog that re-checked "has the type shown up yet" would be the band-aid; the type
+  becoming known is an actual thing that happens, so it is published.
+- **It arms only on the already-degraded path**, and at most one wait exists per subscription. A
+  node that types on the first try pays nothing, and the wait is disarmed by the next emission, by a
+  terminal, and by disposal.
+- **It re-asks; it never force-fits.** The notification carries no content. The seam re-runs its own
+  conversion and keeps the result only when it is genuinely typed, so a registration for an
+  unrelated type is a no-op and an unresolvable discriminator stays an untyped `JsonElement`,
+  exactly as before.
+- **Notifications are delivered OFF the registering thread.** `Register` runs inside a
+  `MessageHubConfiguration` build; handing a subscriber's render to that thread would re-enter hub
+  construction from inside itself. `Registrations` therefore observes on the task pool, the same way
+  a storage change notification arrives.
+
+### Where the wait lives, and why one place is enough
+
+`MeshNodeStreamHandle.Subscribe` is the single boundary every `workspace.GetMeshNodeStream(path)`
+read passes through — own-hub and cross-hub, server-side and Blazor — and every emission already
+goes through its `TypedContentObserver`. Putting the wait there covers both the cache read
+(`MeshNodeStreamCache.GetStream`, whose conversion runs *upstream* of the handle and hands the
+handle a still-degraded `JsonElement`) and the owning hub's own read of its workspace copy.
+
+Two seams are deliberately left alone:
+
+- **`MeshNodeTypeSource.ResolveJsonElementContent`** stores the degraded node in the owning hub's
+  workspace, which is where the untyped value physically lives. It is *not* re-materialised there,
+  because putting a repaired instance back into the workspace is a WRITE: it mints a version for
+  what was only ever a read, and that is the `#1432`/`#2008` phantom-revision class. Every consumer
+  of that copy reads it through the handle above, which now re-types on the way out.
+- **`MeshNodeStreamCache.GetQuery`** is a query snapshot, not a node binding. Its consumers re-issue
+  the query; a single held emission is not the shape of the defect.
+
+### 🚨 What the late re-type does NOT fix — the same race at the ENRICHMENT seam
+
+Content typing and layout-area registration are **two side effects of one configuration build**. A
+compiled NodeType's `configuration` is a single expression:
+
+```json
+"configuration": "config => config.WithContentType<PandasExplorer>().AddLayout(layout => layout.AddPandasExplorerLayoutAreas().WithDefaultArea(\"Explorer\"))"
+```
+
+So an instance hub that did not bind the compiled configuration has **neither** the content type
+**nor** the areas — and re-typing the content afterwards does not add a renderer. The two symptoms
+travel together and have a common cause, but they need different cures, and only the first is fixed
+here.
+
+The second cure belongs at `NodeTypeEnrichmentHelpers.ApplyStreamResult`
+(`src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs`). Its "no compile lifecycle
+attached" branch —
+
+```csharp
+if ((def.CompilationStatus is null || def.CompilationStatus == CompilationStatus.Unknown)
+    && typeNode.HubConfiguration is null)
+    return Observable.Return(node);        // bare node: no overlay, no WithOverlaySelfHeal
+```
+
+— returns the instance **unwrapped by `WithOverlaySelfHeal`**, unlike every sibling branch
+(in-flight compile, missing bytes, execution refused). The instance falls to the mesh default hub
+chain, and the re-enrichment short-circuit at the top of `EnrichWithNodeType`
+(`if (node.HubConfiguration != null) return …`) pins it there for the grain's lifetime;
+`NodeTypeRebindWatcher` recycles only on a change of `MeshNode.NodeType`, never on a compile
+transition. A type whose first build has not been *kicked off* yet is therefore indistinguishable
+from one that will never compile — and the framework already has a predicate for the difference (a
+`Configuration`/`HubConfiguration` source string, or a recorded `CompilationStatus`, is what
+`NodeTypeLayoutAreas.AppendSweepSummary` counts as "participates in compilation"). Until that branch
+uses it, an instance that activates before its type's first build is stamped is answered with the
+TERMINAL `area-not-found` where the transient `compile-progress` is true.
+
 ## Diagnosing a suspected miss
 
 1. **Symptom**: a view that should render structured content renders empty, or a `ContentAs<T>`

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-page-that-opened-mid-build-no-longer-stays-empty.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-page-that-opened-mid-build-no-longer-stays-empty.md
@@ -1,0 +1,41 @@
+---
+Name: A page that opened mid-build no longer stays empty
+Category: Fix
+Description: A node opened in the moment before its type had finished building used to stay blank and uneditable until the portal restarted — it now fills in by itself the instant the build lands.
+Icon: ArrowSyncCheckmark
+Order: -20260902
+---
+
+# A page that opened mid-build no longer stays empty
+
+Types you define in the mesh are built while the portal is running. Opening a page in the short
+window before its type finished building was, until now, unlucky in a way that never wore off: the
+page came up blank, the content refused to be edited, and nothing you did on that page brought it
+back. Reloading fixed it — which is exactly why it looked like a random glitch instead of the
+mechanism it was.
+
+The mechanism: reading a node means turning what is stored into the shape the type describes. Ask
+before the type exists and the honest answer is "I don't know this shape yet", so the content is
+handed over as-is — raw. That part was right. What was missing is that **nobody was told when the
+answer changed.** The build finished a moment later and the type became known, and the page that had
+already asked was never asked again. A node does not change just because its type arrived, so no
+new reading was ever triggered. The blank page stayed blank for as long as the portal ran.
+
+**The moment a type becomes known is now an event the platform announces**, and any read still
+holding raw content is redone against it. If it now resolves, the page fills in on its own — same
+tab, no reload, nothing to click. Typically that is well under a second after the build lands, which
+is why in practice you will simply see the page appear.
+
+Three things deliberately did not change:
+
+- **Content that genuinely has no type stays raw, and still says so.** The redo re-asks the same
+  question and keeps the answer only when it is a real one — so a mis-typed or hand-edited row is
+  not force-fitted into whatever type happened to build next. That warning in the log is still the
+  right diagnosis for a broken row.
+- **Nothing polls.** The page is not re-checking on a timer; it is waiting for an announcement that
+  either comes or does not. A type that never builds costs nothing and changes nothing.
+- **Reading is still reading.** The repaired value is delivered to whoever is looking at it; it is
+  not written back over your data.
+
+The same window also explains a family of test failures that had been re-run for weeks rather than
+diagnosed. Nothing about them was random: whichever side of the race lost simply never recovered.

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -1133,12 +1133,25 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
                 // the node will render empty and refuse content edits everywhere.
                 // Silent degradation here is exactly how the prod 2026-06-12
                 // '$type: MarkdownConfiguration' rows went undiagnosed.
+                //
+                // 🚨 The message must NOT assert corruption. For an in-mesh NodeType the
+                // very same line is printed while the type's Roslyn compile is still in
+                // flight — a state that ENDS — and reading it as "this row is broken"
+                // sent the #2952 investigation after the data for weeks. The two cases
+                // are indistinguishable from HERE (a compile that has not registered yet
+                // and one that never will look identical to a registry lookup), so the
+                // line names both and says which observation separates them.
                 _logger?.LogWarning(
                     "MeshNodeTypeSource[{HubPath}]: content discriminator '$type': '{TypeName}' " +
                     "is not a registered type on the owning hub — content stays an untyped " +
-                    "JsonElement (renders empty, not editable). The row needs repair: rewrite " +
-                    "the content with the NodeType's declared content type.",
-                    _hubPath, typeName);
+                    "JsonElement for now (renders empty, not editable). Two causes look identical " +
+                    "here: (a) the NodeType's runtime compile has not registered '{TypeName}' YET, " +
+                    "which is TRANSIENT — the read boundary re-types every live reader as soon as " +
+                    "the registration lands (IMeshContentTypeRegistry.Registrations); or (b) no " +
+                    "declaration will ever claim this discriminator, in which case the row needs " +
+                    "repair: rewrite the content with the NodeType's declared content type. If the " +
+                    "NodeType reaches CompilationStatus.Ok and this content is still untyped, it is (b).",
+                    _hubPath, typeName, typeName);
                 return node;
             }
         }

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -395,9 +395,13 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             // making writes invisible to readers of the cached stream. See
             // Doc/GUI/ItemTemplateMeshNodeStreamBinding.
             if (_cache is not null && !IsOwn && _path is not null)
-                return _cache.GetStream(_path, _jsonOptions)
-                    .Where(n => n is not null)
-                    .Subscribe(typedObserver);
+                return new CompositeDisposable(
+                    _cache.GetStream(_path, _jsonOptions)
+                        .Where(n => n is not null)
+                        .Subscribe(typedObserver),
+                    // The observer holds the late-retype wait (see TypedContentObserver); it must
+                    // die with the subscription, not with the last emission.
+                    typedObserver);
 
             // 🚨 The lease lives exactly as long as this subscription. The shared mesh-node
             // cache's hydration comes through here, so its entry IS the declared holder of the
@@ -410,7 +414,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     .Where(change => change.Value != null)
                     .Select(change => change.Value!)
                     .Subscribe(typedObserver);
-                return new CompositeDisposable(subscription, lease);
+                return new CompositeDisposable(subscription, lease, typedObserver);
             }
             catch
             {
@@ -442,10 +446,39 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     /// up the producer stack where it would tear down unrelated streams.
     /// </para>
     /// </summary>
+    /// <remarks>
+    /// 🚨 <b>A degrade here is PROVISIONAL, never terminal (Systemorph/MeshWeaver#2952).</b>
+    /// <see cref="EnsureTypedContent"/> can only answer with what is registered AT THAT INSTANT,
+    /// and for an in-mesh NodeType — <c>Source/*.cs</c> compiled by Roslyn at RUNTIME — "not
+    /// registered" is a state that ENDS a few hundred milliseconds later, when the compile calls
+    /// <c>MeshDataSource.WithContentType</c>. Nothing observed that, so a subscription that opened
+    /// on the losing side of the race held an untyped <see cref="JsonElement"/> for the life of the
+    /// hub: the node itself never changes, so no further emission ever arrives to re-convert, the
+    /// view renders empty and a reactive wait for the typed shape times out. So when the
+    /// conversion degrades, this observer WAITS on
+    /// <see cref="MeshWeaver.Mesh.Services.IMeshContentTypeRegistry.Registrations"/> and re-emits
+    /// the same node typed the moment a registration makes it resolvable.
+    ///
+    /// <para>It is a subscription to the actual EVENT, not a poll: no timer, no interval, no
+    /// re-subscribe. It arms only on the already-degraded path (so the typed hot path pays
+    /// nothing), at most one wait is armed at a time, and it disarms on the next emission, on a
+    /// terminal, and on dispose.</para>
+    /// </remarks>
     private sealed class TypedContentObserver(
         IObserver<MeshNode> inner, JsonSerializerOptions jsonOptions,
-        MeshWeaver.Mesh.Services.IMeshContentTypeRegistry? contentTypeRegistry = null) : IObserver<MeshNode>
+        MeshWeaver.Mesh.Services.IMeshContentTypeRegistry? contentTypeRegistry = null)
+        : IObserver<MeshNode>, IDisposable
     {
+        // 🚨 A late re-type is delivered off the registering thread (the registry's documented
+        // contract), so it can race a stream emission. Rx's own gate serialises the two — the
+        // IObserver grammar is not optional, and hand-rolling the lock here would be one more
+        // bespoke primitive to get wrong.
+        private readonly IObserver<MeshNode> _out = System.Reactive.Observer.Synchronize(inner);
+
+        // The ONE armed wait. Assigning a new value disposes the previous, so a fresh emission
+        // supersedes the node the old wait was holding.
+        private readonly SerialDisposable _lateRetype = new();
+
         public void OnNext(MeshNode value)
         {
             MeshNode typed;
@@ -455,13 +488,72 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             }
             catch (System.Exception ex)
             {
-                inner.OnError(ex);
+                _lateRetype.Disposable = Disposable.Empty;
+                _out.OnError(ex);
                 return;
             }
-            inner.OnNext(typed);
+            // Emit FIRST, then arm: the wait re-checks immediately on subscribe (see below), and
+            // emitting first is what guarantees the subscriber can never see the typed value
+            // before the untyped one it supersedes.
+            _out.OnNext(typed);
+            ArmLateRetype(value, typed);
         }
-        public void OnError(Exception error) => inner.OnError(error);
-        public void OnCompleted() => inner.OnCompleted();
+
+        /// <summary>
+        /// Arms (or clears) the wait for a content type that is not registered YET. Clearing on a
+        /// successful conversion matters as much as arming: a node that types fine must not leave
+        /// a subscription behind on every emission.
+        /// </summary>
+        private void ArmLateRetype(MeshNode raw, MeshNode typed)
+        {
+            if (contentTypeRegistry is null || typed.Content is not JsonElement)
+            {
+                _lateRetype.Disposable = Disposable.Empty;
+                return;
+            }
+
+            _lateRetype.Disposable = contentTypeRegistry.Registrations
+                .Select(_ => System.Reactive.Unit.Default)
+                // 🚨 StartWith closes the gap between the conversion above and this Subscribe: a
+                // registration landing in that window would otherwise be missed, and the wait
+                // would hold out for a LATER one that may never come. It runs on the immediate
+                // scheduler, so the re-check is synchronous and — on the ordinary path, where
+                // nothing registered in the window — costs one failed lookup.
+                .StartWith(System.Reactive.Unit.Default)
+                .Select(_ => Retype(raw))
+                .Where(n => n is not null)
+                .Take(1)
+                .Subscribe(
+                    n => _out.OnNext(n!),
+                    // NOT swallowed. Two things can fault here and both must be visible: the
+                    // notification channel (this node will now never be re-typed) and the
+                    // conversion itself (the same MeshNodeStreamException the primary path raises,
+                    // reaching the subscriber the same way). A silent never-recovers is precisely
+                    // the defect this wait exists to end, so it must not be reintroduced here.
+                    ex => _out.OnError(ex));
+        }
+
+        /// <summary>Re-runs the conversion; null when it still degrades. Throws exactly what the
+        /// primary path throws — the Subscribe above routes it to the subscriber.</summary>
+        private MeshNode? Retype(MeshNode raw)
+        {
+            var retyped = EnsureTypedContent(raw, jsonOptions, contentTypeRegistry);
+            return retyped.Content is JsonElement ? null : retyped;
+        }
+
+        public void OnError(Exception error)
+        {
+            _lateRetype.Disposable = Disposable.Empty;
+            _out.OnError(error);
+        }
+
+        public void OnCompleted()
+        {
+            _lateRetype.Disposable = Disposable.Empty;
+            _out.OnCompleted();
+        }
+
+        public void Dispose() => _lateRetype.Dispose();
     }
 
     /// <summary>

--- a/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
@@ -1,4 +1,7 @@
 using System.Collections.Concurrent;
+using System.Reactive.Concurrency;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Microsoft.Extensions.Logging;
@@ -12,6 +15,15 @@ using Microsoft.Extensions.Logging;
 // here: NodeType source stored in the mesh is compiled at RUNTIME and is invisible to `dotnet build`,
 // so renaming a public namespace is a breaking change no build or test in this repo can catch.
 namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// One content type becoming KNOWN to the mesh — the announcement
+/// <see cref="IMeshContentTypeRegistry.Registrations"/> carries.
+/// </summary>
+/// <param name="ContentType">The CLR type that was just registered.</param>
+/// <param name="NodeTypePath">The NodeType path it was registered under, when the registrar knew
+/// one (the EXACT route — see <see cref="IMeshContentTypeRegistry.TryResolveByNodeType"/>).</param>
+public sealed record MeshContentTypeRegistration(Type ContentType, string? NodeTypePath);
 
 /// <summary>
 /// Process-wide (mesh singleton) map from a dynamically-compiled NodeType's content
@@ -69,6 +81,35 @@ public interface IMeshContentTypeRegistry
     /// <see cref="TryResolveByDiscriminator"/>.</para>
     /// </summary>
     void Register(Type contentType, string? nodeTypePath = null);
+
+    /// <summary>
+    /// 🚨 <b>Registration is an EVENT, not just a side effect</b> — one emission per
+    /// <see cref="Register"/> call.
+    ///
+    /// <para><b>The defect this closes (Systemorph/MeshWeaver#2952).</b> Every degrade seam
+    /// resolves a node's content ONCE, on the emission it is handed: it asks this registry, and
+    /// when the answer is "unknown" it emits the content as an untyped <see cref="JsonElement"/>
+    /// and moves on. For an in-mesh NodeType — <c>Source/*.cs</c> compiled by Roslyn at RUNTIME —
+    /// "unknown" is a state that ENDS: the type becomes known the moment its compile registers it
+    /// here, typically a few hundred milliseconds later. Nothing observed that, so a node whose
+    /// content loaded on the losing side of that race stayed untyped for the life of the hub: it
+    /// rendered empty, refused content edits, and every reactive wait on its typed shape timed
+    /// out. Nothing about it was random — it was a race whose loser never recovered, which is
+    /// exactly why re-running "fixed" it.</para>
+    ///
+    /// <para><b>Contract: delivered OFF the registering thread.</b> <see cref="Register"/> is
+    /// called from inside a <c>MessageHubConfiguration</c> build
+    /// (<c>MeshDataSource.WithContentType</c>, at a per-node hub's cold activation), so a
+    /// subscriber that renders a view or reads another node must never run on that thread — it
+    /// would re-enter the hub construction that is registering the type. Subscribers therefore see
+    /// notifications on the task pool, the same way a storage change notification arrives.</para>
+    ///
+    /// <para>Announcement only: it carries no content and resolves nothing. A subscriber
+    /// re-asks <see cref="TryRecoverForNodeType"/> (or its own conversion) and keeps the answer
+    /// only when it is now typed — so a registration for an unrelated type is a cheap no-op, and
+    /// the notification can never make a read WORSE than it already was.</para>
+    /// </summary>
+    IObservable<MeshContentTypeRegistration> Registrations { get; }
 
     /// <summary>
     /// Resolves a <c>$type</c> discriminator (short or full name) to its CLR type — and REFUSES
@@ -151,6 +192,27 @@ public sealed class MeshContentTypeRegistry(ILogger<MeshContentTypeRegistry>? lo
     private readonly ConcurrentDictionary<string, DiscriminatorClaim> _byDiscriminator = new(StringComparer.Ordinal);
     private readonly ConcurrentDictionary<string, Type> _byNodeType = new(StringComparer.OrdinalIgnoreCase);
 
+    // Instance subject — the registry is a mesh-scoped singleton, so its lifetime IS the mesh's
+    // and no process-wide state leaks across meshes (NoStaticState.md).
+    //
+    // 🚨 A plain Subject, deliberately NOT a Replay/BehaviorSubject. This is an EDGE ("a type just
+    // became known"), not a value: a subscriber that wants the current state asks the maps, which
+    // are always readable. A ReplaySubject would also latch a terminal — and this subject never
+    // gets one (a registry has no completion), so latching one transient fault forever (#1369) is
+    // a hazard with no upside here.
+    private readonly Subject<MeshContentTypeRegistration> _registrations = new();
+
+    /// <inheritdoc />
+    /// <remarks>
+    /// 🚨 <c>ObserveOn</c> is the CONTRACT, not tuning: <see cref="Register"/> runs inside a hub
+    /// configuration build, and a subscriber re-typing a node emits onward into whatever is bound
+    /// to that node (a layout area, a Blazor view). Handing that work to the registering thread
+    /// would re-enter hub construction from inside itself. Per-subscription by design — each
+    /// subscriber gets its own queue, so one slow consumer cannot stall another.
+    /// </remarks>
+    public IObservable<MeshContentTypeRegistration> Registrations
+        => _registrations.ObserveOn(TaskPoolScheduler.Default);
+
     /// <summary>
     /// WHO declared a content type — the NodeType path when the caller knows it, otherwise the
     /// declaring assembly's simple name. For a runtime-compiled NodeType that assembly name is
@@ -175,6 +237,11 @@ public sealed class MeshContentTypeRegistry(ILogger<MeshContentTypeRegistry>? lo
             ClaimDiscriminator(fullName, contentType, declaration);
         if (!string.IsNullOrEmpty(nodeTypePath))
             _byNodeType[nodeTypePath] = contentType;
+
+        // 🚨 ANNOUNCE LAST — after BOTH maps carry the entry. A subscriber's first act is to
+        // re-ask this registry, so publishing earlier would hand it the very "unknown" answer the
+        // notification exists to retract, and the retry would be spent on nothing.
+        _registrations.OnNext(new MeshContentTypeRegistration(contentType, nodeTypePath));
     }
 
     private void ClaimDiscriminator(string discriminator, Type contentType, string declaration)

--- a/test/MeshWeaver.Graph.Test/ContentTypeRegistrationWithoutInstancesTest.cs
+++ b/test/MeshWeaver.Graph.Test/ContentTypeRegistrationWithoutInstancesTest.cs
@@ -1,5 +1,4 @@
 using System;
-using MeshWeaver.Graph;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
@@ -8,7 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using MeshWeaver.Fixture;
 
-namespace MeshWeaver.Hosting.Monolith.Test;
+namespace MeshWeaver.Graph.Test;
 
 /// <summary>
 /// 🚨 <b>A NodeType's content type must register WITHOUT a single instance existing.</b>

--- a/test/MeshWeaver.Graph.Test/LateContentTypeRegistrationTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateContentTypeRegistrationTest.cs
@@ -1,0 +1,217 @@
+using System;
+using System.Reactive.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Text.Json;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Fixture;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>A content type that is not registered YET must not degrade a node FOREVER
+/// (Systemorph/MeshWeaver#2952).</b>
+///
+/// <para>Every read seam types a node's content from what is registered at the instant the emission
+/// passes through it. For an in-mesh NodeType — <c>Source/*.cs</c> compiled by Roslyn at RUNTIME —
+/// "not registered" is a state that ENDS: the type becomes known when the compile calls
+/// <c>MeshDataSource.WithContentType</c>, typically a few hundred milliseconds after the portal
+/// started loading nodes. Nothing observed that registration, so a reader that opened on the losing
+/// side of the race held an untyped <see cref="JsonElement"/> for the life of the hub — the node
+/// never changes, so no further emission ever arrives to re-convert it. The view renders empty, the
+/// content refuses edits, and every reactive wait for the typed shape times out. Nothing about it
+/// is random; it is a race whose loser never recovers, which is exactly why re-running "fixes" it.
+/// </para>
+///
+/// <para><b>What this test drives is the real thing</b>, not a helper: a node created with a
+/// discriminator nothing can resolve, ONE live <c>GetMeshNodeStream</c> subscription held across the
+/// registration, and the assertion that the SAME subscription is handed the content typed once the
+/// type arrives. On <c>main</c> the second wait times out — the first (untyped) emission is the only
+/// one there will ever be.</para>
+///
+/// <para>The content type is emitted into a COLLECTIBLE dynamic assembly, which is the CLR shape a
+/// runtime-compiled NodeType produces (per-compile identity, and
+/// <c>PolymorphicTypeInfoResolver</c> refuses to auto-adopt it into any hub's registry) — the same
+/// modelling <c>ReimportTypedContentRecoveryTest</c> uses, without dragging Roslyn into the test.
+/// </para>
+/// </summary>
+public class LateContentTypeRegistrationTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>Fresh mesh per test: the whole point is a registration that does NOT exist yet, so
+    /// nothing a sibling test registered may leak in.</summary>
+    protected override bool ShareMeshAcrossTests => false;
+
+    /// <summary>
+    /// 🚨 THE assertion: one subscription, opened while the type is unknown, must be handed the
+    /// content TYPED when the type registers — without the node changing, without re-subscribing,
+    /// and without anything polling for it.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task ALiveReader_IsHandedTypedContent_WhenTheTypeRegistersAfterTheRead()
+    {
+        var registry = Mesh.ServiceProvider.GetRequiredService<IMeshContentTypeRegistry>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var contentType = EmitCollectibleType("LateBoundGadget", "Label");
+        contentType.Assembly.IsCollectible.Should().BeTrue(
+            "the emitted assembly must model a NodeType compiled at runtime (loaded collectible)");
+        registry.TryResolveByDiscriminator(contentType.Name, out _).Should().BeFalse(
+            "PRECONDITION: the mesh must not know this content type yet — that is the race's losing side");
+
+        var partition = "lcr" + Guid.NewGuid().ToString("N")[..9];
+        var typePath = $"{partition}/Gadget";
+        var instancePath = $"{partition}/Live";
+
+        // The NodeType DECLARATION, with no compile lifecycle attached: the instance below needs a
+        // resolvable NodeType (the create pipeline refuses one that names nothing), and a
+        // declaration with no Configuration is the cheapest way to have one without asking Roslyn
+        // for a build inside a test about serialization.
+        await meshService.CreateNode(new MeshNode("Gadget", partition)
+        {
+            Name = "Gadget",
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition { Description = "A NodeType with no compile lifecycle" }
+        }).Should().Within(TestTimeouts.Convergence).Emit("the NodeType declaration must land before its instance");
+
+        // Content exactly as storage holds it for an instance of a runtime-compiled type: a JSON
+        // object carrying the bare short-name $type. Serialised THROUGH the mesh options so the
+        // discriminator and the property casing are what the platform actually writes.
+        var instance = Activator.CreateInstance(contentType)!;
+        contentType.GetProperty("Label")!.SetValue(instance, "live frame");
+        var storedJson = JsonSerializer.Serialize(instance, contentType, Mesh.JsonSerializerOptions);
+        Output.WriteLine($"stored content: {storedJson}");
+        var stored = JsonSerializer.Deserialize<JsonElement>(storedJson);
+        stored.TryGetProperty("$type", out var discriminator).Should().BeTrue(
+            "PRECONDITION: the stored row must carry the discriminator the reader has to resolve");
+        discriminator.GetString().Should().Be(contentType.Name);
+
+        await meshService.CreateNode(new MeshNode("Live", partition)
+        {
+            Name = "Live frame",
+            NodeType = typePath,
+            State = MeshNodeState.Active,
+            Content = stored
+        }).Should().Within(TestTimeouts.Convergence).Emit("the instance carrying the unresolvable $type must land");
+
+        // 🚨 ONE live subscription, held across the registration — the shape of a bound view, and
+        // the only shape in which the defect is visible at all. Replay(1) + Connect keeps exactly
+        // one upstream read open; a second GetMeshNodeStream call would open a fresh one and
+        // re-convert from scratch, which is precisely the self-heal the real GUI never gets.
+        var live = Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
+            .Where(n => n is not null)
+            .Replay(1);
+        using var connection = live.Connect();
+
+        var degraded = await live.FirstAsync()
+            .Should().Within(TestTimeouts.Convergence).Emit("the node must be readable even while its type is unknown");
+        degraded.Content.Should().BeOfType<JsonElement>(
+            "BUG REPRODUCED: nothing can resolve the discriminator yet, so the read boundary hands "
+            + "the subscriber an untyped JsonElement — every 'Content is T' downstream fails");
+
+        // The compile finishing is exactly this call: MeshDataSource.WithContentType records the
+        // compiled CLR type in the mesh-wide registry under the NodeType's path.
+        registry.Register(contentType, typePath);
+
+        var typed = await live.Where(n => n.Content is not JsonElement).FirstAsync()
+            .Should().Within(TestTimeouts.Convergence).Emit(
+                "the SAME subscription must be handed the content typed once the type registers — "
+                + "the node never changes, so a reader that is not told about the registration waits "
+                + "for an emission that will never come (#2952)");
+
+        typed.Content!.GetType().Should().Be(contentType,
+            "the re-type must land on the exact registered CLR type, not merely stop being a JsonElement");
+        contentType.GetProperty("Label")!.GetValue(typed.Content).Should().Be("live frame",
+            "the re-type must round-trip the payload, not just the type tag");
+        typed.Path.Should().Be(instancePath);
+    }
+
+    /// <summary>
+    /// The complement that keeps the wait honest: a registration for an UNRELATED type must not
+    /// make a genuinely unresolvable node look typed. Without this, "re-emit on any registration"
+    /// could pass the test above by simply re-emitting whatever it had.
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task AnUnrelatedRegistration_LeavesGenuinelyUnresolvableContentUntyped()
+    {
+        var registry = Mesh.ServiceProvider.GetRequiredService<IMeshContentTypeRegistry>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var partition = "lcu" + Guid.NewGuid().ToString("N")[..9];
+        var typePath = $"{partition}/Gadget";
+        var instancePath = $"{partition}/Live";
+
+        await meshService.CreateNode(new MeshNode("Gadget", partition)
+        {
+            Name = "Gadget",
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition { Description = "A NodeType with no compile lifecycle" }
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        var stored = JsonSerializer.Deserialize<JsonElement>(
+            """{"$type":"AContentTypeTheMeshNeverCompiled","label":"orphan"}""");
+        await meshService.CreateNode(new MeshNode("Live", partition)
+        {
+            Name = "Live frame",
+            NodeType = typePath,
+            State = MeshNodeState.Active,
+            Content = stored
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        var live = Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
+            .Where(n => n is not null)
+            .Replay(1);
+        using var connection = live.Connect();
+
+        (await live.FirstAsync().Should().Within(TestTimeouts.Convergence).Emit())
+            .Content.Should().BeOfType<JsonElement>();
+
+        // A registration that says nothing about this node's discriminator.
+        registry.Register(EmitCollectibleType("SomeOtherGadget", "Label"), $"{partition}/Other");
+
+        await live.Where(n => n.Content is not JsonElement).FirstAsync()
+            .Should().NotEmit(5.Seconds(),
+                "an unresolvable discriminator stays an untyped JsonElement — the wait re-asks the "
+                + "registry and keeps the answer only when it is genuinely typed, so it can never "
+                + "force-fit content onto an unrelated registration");
+    }
+
+    /// <summary>
+    /// Emits a minimal public class with one string property into a COLLECTIBLE dynamic assembly —
+    /// the CLR shape of a compiled dynamic-node content type without dragging Roslyn into the test.
+    /// (Mirrors <c>ReimportTypedContentRecoveryTest.EmitCollectibleType</c>.)
+    /// </summary>
+    private static Type EmitCollectibleType(string typeName, string propertyName)
+    {
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(
+            new AssemblyName($"DynamicNode_{typeName}"), AssemblyBuilderAccess.RunAndCollect);
+        var moduleBuilder = assemblyBuilder.DefineDynamicModule("main");
+        var typeBuilder = moduleBuilder.DefineType(
+            typeName, TypeAttributes.Public | TypeAttributes.Class);
+        var field = typeBuilder.DefineField($"_{propertyName}", typeof(string), FieldAttributes.Private);
+        var property = typeBuilder.DefineProperty(propertyName, PropertyAttributes.None, typeof(string), null);
+        const MethodAttributes accessorAttributes =
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
+        var getter = typeBuilder.DefineMethod($"get_{propertyName}", accessorAttributes, typeof(string), Type.EmptyTypes);
+        var getterIl = getter.GetILGenerator();
+        getterIl.Emit(OpCodes.Ldarg_0);
+        getterIl.Emit(OpCodes.Ldfld, field);
+        getterIl.Emit(OpCodes.Ret);
+        var setter = typeBuilder.DefineMethod($"set_{propertyName}", accessorAttributes, null, [typeof(string)]);
+        var setterIl = setter.GetILGenerator();
+        setterIl.Emit(OpCodes.Ldarg_0);
+        setterIl.Emit(OpCodes.Ldarg_1);
+        setterIl.Emit(OpCodes.Stfld, field);
+        setterIl.Emit(OpCodes.Ret);
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+        return typeBuilder.CreateType()!;
+    }
+}


### PR DESCRIPTION
Fixes #2952.

## The verified root cause

The issue's headline is exact: **a degrade is permanent because registration is unobservable.**

`MeshContentTypeRegistry.Register` (`src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs`)
writes two maps and returns. No event, no observable. Every read seam therefore answers with what
is registered *at that instant* and never revisits it: it asks, gets "unknown", emits the content as
an untyped `JsonElement`, logs, and moves on.

For an in-mesh NodeType — `Source/*.cs` compiled by Roslyn at RUNTIME — "unknown" is a state that
**ends**, when the compile calls `MeshDataSource.WithContentType`. Node loading and NodeType
compilation are concurrent, so a subscription opened on the losing side of that race holds the
untyped value **for the life of the hub**: the node itself never changes, so no further emission
ever arrives to re-convert it. Renders empty, refuses content edits, every reactive wait for the
typed shape times out. Nothing random — a race whose loser never recovers, which is exactly why
re-running "fixed" it.

`ContentTypeRegistrationSweep` (#2969) closes the *other* gap — a type defined but never
instantiated — and deliberately excludes compiled types, so it cannot cover this one.

### Where the permanence actually lives — the scope call

The brief asked me to decide whether one seam covers all four degrade sites. It does, and here is
why each is or is not one:

| site | shape | covered by |
|---|---|---|
| `MeshNodeStreamHandle.EnsureTypedContent` (`MeshNodeStreamExtensions.cs:504,524`) | applied per subscriber in `TypedContentObserver` — **the one boundary every `GetMeshNodeStream(path)` read passes through**, own-hub and cross-hub | **the fix** |
| `MeshNodeStreamCache.GetStream` (`MeshNodeStreamCache.cs:2239`) | `GetStreamRaw(path).Select(Convert)` runs **upstream** of the handle and hands it a still-degraded `JsonElement` | the same fix, one layer down |
| `MeshNodeTypeSource.ResolveJsonElementContent` (`MeshNodeTypeSource.cs:1084`) | *stores* the degraded node in the owning hub's workspace | **deliberately not re-materialised** — see below |
| `MeshNodeStreamCache.GetQuery` (`:2673`) | query snapshot, re-issued by its consumers | out of scope; not a held binding |

`MeshNodeTypeSource` is where the untyped value physically lives, and it is the one place a repair
would be a **write**: pushing a repaired instance back into the workspace mints a version for what
was only ever a read — the `#1432`/`#2008` phantom-revision class, whose whole lesson is *an
observation must never enter the write path*. `Initialize` is `Take(1)`'d by the data source, so
there is no read-only re-emission route either. Every consumer of that copy reads it through
`MeshNodeStreamHandle`, which now re-types on the way out, so fixing the read boundary covers the
stored strand without touching the store.

## The change

**1. Registration becomes an event.** `IMeshContentTypeRegistry.Registrations` —
`IObservable<MeshContentTypeRegistration>`, one emission per `Register`, published **after** both
maps carry the entry (a subscriber's first act is to re-ask), backed by an *instance* `Subject`
(mesh-scoped singleton; not a `ReplaySubject` — this is an edge, not a value, and #1369's latched
terminal is a hazard with no upside). Delivered **off the registering thread**: `Register` runs
inside a `MessageHubConfiguration` build, and handing a subscriber's render to that thread would
re-enter hub construction from inside itself.

**2. The read boundary waits on it.** `TypedContentObserver` arms a wait **only when its conversion
degraded**, and re-emits the same node typed the moment a registration resolves it.

```csharp
contentTypeRegistry.Registrations
    .StartWith(Unit.Default)     // closes the gap between the conversion and this Subscribe
    .Select(_ => Retype(raw))    // re-ask; keep the answer only if it is now typed
    .Where(n => n is not null)
    .Take(1)
    .Subscribe(n => _out.OnNext(n!), ex => _out.OnError(ex));
```

- **A subscription to the actual EVENT, not a poll.** No timer, no interval, no re-subscribe — the
  forbidden watchdog shape. The type becoming known is a real thing that happens, so it is published.
- **Arms only on the already-degraded path**; one wait at a time; disarmed by the next emission, by
  a terminal and by dispose (the observer is now `IDisposable` and joins the subscription's
  `CompositeDisposable`).
- **Re-asks; never force-fits.** The notification carries no content, so an unrelated registration
  is a no-op and genuinely unresolvable content stays an untyped `JsonElement` exactly as before —
  pinned by the second test.
- **Nothing swallowed.** Both a faulting notification channel and a faulting conversion reach the
  subscriber's own error handler. Emissions are serialised through Rx's own `Observer.Synchronize`,
  because a late re-type arrives off the stream's thread and the `IObserver` grammar is not optional.

**3. The misleading diagnostic.** `MeshNodeTypeSource`'s warning said *"The row needs repair"*. The
identical line is printed while a compile is still in flight; reading it as data corruption is what
sent this investigation after the data for weeks. It now names both causes and the observation that
separates them (`CompilationStatus.Ok` + still untyped ⇒ genuinely broken). Level unchanged.

**4. A test that had never run.** `ContentTypeRegistrationWithoutInstancesTest` (added by #2969)
lives in `test/MeshWeaver.Hosting.Monolith.Test/` — a directory with **no `.csproj`**, referenced by
no project and absent from `MeshWeaver.slnx`. It was compiled by nothing. Moved into
`MeshWeaver.Graph.Test`, where it now runs (and passes).

## Before / after evidence

`LateContentTypeRegistrationTest` (`test/MeshWeaver.Graph.Test/`, `MonolithMeshTestBase`, no mocks)
creates a node whose content carries a discriminator nothing can resolve, holds **one** live
`GetMeshNodeStream` subscription across the registration, and asserts the same subscription is
handed the content typed. The content type is emitted into a **collectible** dynamic assembly — the
CLR shape a runtime-compiled NodeType produces — so no Roslyn run is needed.

Same commit, same test, only `src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs` swapped:

**With that file at `origin/main`** — `Failed: 1, Passed: 1`:

```
ALiveReader_IsHandedTypedContent_WhenTheTypeRegistersAfterTheRead [FAIL] (30 s)
  Expected the observable to emit a value within 30s … but it did not.
  The observable emitted nothing at all.

[Warning] MeshNodeTypeSource[lcr468cb97c4/Live]: content discriminator '$type': 'LateBoundGadget'
          is not a registered type on the owning hub — content stays an untyped JsonElement
[Warning] Received '$type':'LateBoundGadget' which is NOT registered in this (receiving) hub
[Warning] MeshNodeStreamCache.GetStream: Content for lcr468cb97c4/Live stayed an untyped JsonElement
```

Those are the issue's own three log lines, reproduced deterministically.

**With the fix** — `Passed: 3, Failed: 0` in 6 s (both new tests plus the rescued #2969 test).

## 🚨 What this does NOT fix — stated deliberately

The issue's chain says *untyped content ⇒ the layout areas are never registered*. **That step does
not hold**, and the PR should not be read as closing the whole `PandasExplorer` flake:

Content typing and area registration are **two side effects of one configuration build** —
`PandasExplorer.json`'s `configuration` is a single expression,
`config => config.WithContentType<PandasExplorer>().AddLayout(… WithDefaultArea("Explorer"))`. An
instance hub that did not bind the compiled configuration has neither, and **re-typing content adds
no renderer**. The two symptoms share a cause; they need different cures.

The second cure belongs at `NodeTypeEnrichmentHelpers.ApplyStreamResult`
(`src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs`), whose "no compile lifecycle
attached" branch returns the instance **unwrapped by `WithOverlaySelfHeal`** — unlike every sibling
branch — so it falls to the mesh default chain and is pinned there for the grain's lifetime by the
re-enrichment short-circuit at the top of `EnrichWithNodeType`. A type whose first build has not
been *stamped* yet is indistinguishable there from one that will never compile, so the instance is
answered with the TERMINAL `area-not-found` where the transient `compile-progress` is true. Recorded
with file/line in the doc page and filed separately rather than bolted onto this change — it is an
enrichment-ordering change, and a half-understood fix there is worse than the flake.

## Conserved

- `Doc/Architecture/ContentTypeRegistration` gains **"Registration is an EVENT — a degrade must
  never be terminal"** (the seam, the four load-bearing properties, why one place is enough, which
  seams are deliberately left alone) and **"What the late re-type does NOT fix"** (the enrichment
  finding above, with file/line).
- What's New entry, `Category: Fix`.

## Verification

- `dotnet build -c Release -warnaserror`, one project per invocation, `0 Error(s)`:
  `MeshWeaver.Messaging.Hub`, `MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph`,
  `MeshWeaver.Documentation`, `MeshWeaver.Hosting`, `MeshWeaver.Hosting.Monolith`,
  `MeshWeaver.Hosting.Orleans`, `MeshWeaver.PluginCatalog`, and the four test projects below.
- Full test projects, Release, no `--filter`:

  | project | result |
  |---|---|
  | `MeshWeaver.Messaging.Hub.Test` (owns `MeshContentTypeRegistryTest`) | 341/341 |
  | `MeshWeaver.Documentation.Test` (`DocumentationLinkIntegrityTest`, the ratchet guards) | 166/166 |
  | `MeshWeaver.Hosting.Test` (owns `ReimportTypedContentRecoveryTest`) | 274/274 |
  | `MeshWeaver.Graph.Test` (the two new tests + the rescued #2969 test) | 1087/1087 |

  `TestTimeoutLiteralRatchetGuard` caught the new test's seven `30.Seconds()` literals on the first
  pass (386 → 393); converted to `TestTimeouts.Convergence` rather than re-seeding the baseline,
  and the guard is green at 386.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
