### PR TITLE
fix(data): the collections GetStream overload names what it could not reduce

### DIFF
--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -940,17 +940,24 @@ public class Workspace : IWorkspace
                + "reference, or the data source it would reduce from has not been started.");
 
     /// <inheritdoc />
+    /// <remarks>Same diagnostic contract as <see cref="ReduceLocalStream{TReduced}"/>: the failure
+    /// names the collections and the owning hub, never a bare "Failed to create stream".</remarks>
     public ISynchronizationStream<EntityStore> GetStream(params Type[] types)
-        => (ISynchronizationStream<EntityStore>?)
-            ReduceManager.ReduceStream<EntityStore>(
-    this,
-    new CollectionsReference(types
-        .Select(t =>
-            DataContext.TypeRegistry.TryGetCollectionName(t, out var name)
-                ? name
-                : throw new ArgumentException($"Type {t.FullName} is unknown.")
-        ).ToArray()!),
-    x => x) ?? throw new InvalidOperationException("Failed to create stream");
+    {
+        var collections = types
+            .Select(t =>
+                DataContext.TypeRegistry.TryGetCollectionName(t, out var name)
+                    ? name
+                    : throw new ArgumentException($"Type {t.FullName} is unknown.")
+            ).ToArray();
+        return (ISynchronizationStream<EntityStore>?)
+            ReduceManager.ReduceStream<EntityStore>(this, new CollectionsReference(collections!), x => x)
+            ?? throw new InvalidOperationException(
+                $"Failed to create stream for collections [{string.Join(", ", collections)}] on "
+                + $"{Hub.Address}: the workspace's ReduceManager has no reducer producing an "
+                + "EntityStore from a CollectionsReference, or the data source it would reduce "
+                + "from has not been started.");
+    }
 
     /// <inheritdoc />
     public ReduceManager<EntityStore> ReduceManager => DataContext.ReduceManager;

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -944,14 +944,20 @@ public class Workspace : IWorkspace
     /// names the collections and the owning hub, never a bare "Failed to create stream".</remarks>
     public ISynchronizationStream<EntityStore> GetStream(params Type[] types)
     {
+        // 🚨 `name is not null` is not belt-and-braces — it is what makes this a `string[]`.
+        // TryGetCollectionName's out parameter is `string?`, so without it the projection is
+        // `string?` and the array is `string?[]`, which CollectionsReference (an
+        // IReadOnlyCollection<string>) rejects with CS8620 — an error under CI's -warnaserror.
+        // Checking the invariant is the honest way to satisfy that; a `!` suppression would only
+        // assert it, and would let a `true` with a null name through as a null collection name.
         var collections = types
             .Select(t =>
-                DataContext.TypeRegistry.TryGetCollectionName(t, out var name)
+                DataContext.TypeRegistry.TryGetCollectionName(t, out var name) && name is not null
                     ? name
                     : throw new ArgumentException($"Type {t.FullName} is unknown.")
             ).ToArray();
         return (ISynchronizationStream<EntityStore>?)
-            ReduceManager.ReduceStream<EntityStore>(this, new CollectionsReference(collections!), x => x)
+            ReduceManager.ReduceStream<EntityStore>(this, new CollectionsReference(collections), x => x)
             ?? throw new InvalidOperationException(
                 $"Failed to create stream for collections [{string.Join(", ", collections)}] on "
                 + $"{Hub.Address}: the workspace's ReduceManager has no reducer producing an "


### PR DESCRIPTION
Follow-up to #3004 (which closed #2990). Lands the one review finding that arrived after
auto-merge had already taken #3004.

#3004 gave `Workspace.ReduceLocalStream` a diagnostic that names the reference and the owning hub —
because the bare `InvalidOperationException("Failed to create stream")` is precisely *why* three
deliberate fault classifiers in `SubscribeWithReEstablish` could not recognise a boot-time probe's
own-node read, and reported it as a transient production ERROR.

The adjacent `GetStream(params Type[] types)` overload kept the old bare message, so the same
`ReduceStream` failure stayed unclassifiable from one of the two call paths. It now names the
resolved collection names and the hub, matching its sibling.

Behaviour is otherwise unchanged: the collections array is hoisted to a local purely so the message
can quote it, and the unknown-type `ArgumentException` still throws from the projection, before any
reduce.

`MeshWeaver.Data.Test` 419/419 green; `dotnet build src/MeshWeaver.Data -c Release -warnaserror`
clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
