### PR TITLE
fix(mesh): serialize the registration subject, and stop re-deserializing on every unrelated registration (#2952)

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -551,6 +551,18 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     ? typeProp.GetString()
                     : null;
 
+            // 🚨 Neither route has an INPUT: no stored discriminator and no NodeType means
+            // TryRecoverForNodeType has nothing to key on, now or ever. Arming here would leave a
+            // wait per degraded subscriber that no registration can ever complete — dead weight for
+            // the life of the subscription. Content this shape is free-form JSON by design (see
+            // ContentDiscriminatorValidator: "content WITHOUT a $type stays legal"), so this is a
+            // real state, not a corner case.
+            if (discriminator is null && string.IsNullOrEmpty(raw.NodeType))
+            {
+                _lateRetype.Disposable = Disposable.Empty;
+                return;
+            }
+
             _lateRetype.Disposable = contentTypeRegistry.Registrations
                 // 🚨 String compares only, BEFORE any deserialization. A boot registers every
                 // content type in the mesh, and without this each one would re-deserialize this

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -537,19 +537,35 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
         /// </summary>
         private void ArmLateRetype(MeshNode raw, MeshNode typed)
         {
-            if (contentTypeRegistry is null || typed.Content is not JsonElement)
+            if (contentTypeRegistry is null || typed.Content is not JsonElement degraded)
             {
                 _lateRetype.Disposable = Disposable.Empty;
                 return;
             }
 
+            // Read the stored discriminator ONCE, here, so the per-registration filter below is a
+            // string compare and never touches the document again.
+            var discriminator = degraded.ValueKind == JsonValueKind.Object
+                && degraded.TryGetProperty("$type", out var typeProp)
+                && typeProp.ValueKind == JsonValueKind.String
+                    ? typeProp.GetString()
+                    : null;
+
             _lateRetype.Disposable = contentTypeRegistry.Registrations
+                // 🚨 String compares only, BEFORE any deserialization. A boot registers every
+                // content type in the mesh, and without this each one would re-deserialize this
+                // node's whole JsonElement in every degraded subscription — N×M for nothing. The
+                // predicate mirrors exactly the two routes TryRecoverForNodeType can take, so a
+                // registration it drops is one that provably could not have resolved this node.
+                .Where(r => CouldResolve(r, raw, discriminator))
                 .Select(_ => System.Reactive.Unit.Default)
                 // 🚨 StartWith closes the gap between the conversion above and this Subscribe: a
                 // registration landing in that window would otherwise be missed, and the wait
                 // would hold out for a LATER one that may never come. It runs on the immediate
                 // scheduler, so the re-check is synchronous and — on the ordinary path, where
-                // nothing registered in the window — costs one failed lookup.
+                // nothing registered in the window — costs one failed lookup. It is placed AFTER
+                // the filter deliberately: the filter answers "could THIS registration matter",
+                // and the gap re-check has no registration to judge.
                 .StartWith(System.Reactive.Unit.Default)
                 .Select(_ => Retype(raw))
                 .Where(n => n is not null)
@@ -563,6 +579,35 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                     // the defect this wait exists to end, so it must not be reintroduced here.
                     ex => _out.OnError(ex));
         }
+
+        /// <summary>
+        /// Could <paramref name="registration"/> possibly make this node resolvable? It mirrors the
+        /// TWO routes <c>TryRecoverForNodeType</c> takes, and nothing else:
+        /// <list type="number">
+        /// <item>the EXACT route — the registration was keyed on this node's own
+        /// <see cref="MeshNode.NodeType"/> (matched case-insensitively, as the registry's NodeType
+        /// map is keyed);</item>
+        /// <item>the NAME route — the registered type's short or full name IS the stored
+        /// <c>$type</c> (matched ordinally, as <c>ClaimDiscriminator</c> keys it).</item>
+        /// </list>
+        ///
+        /// <para>🚨 It must stay a superset of what could resolve, never a guess at what will: a
+        /// registration wrongly dropped here re-creates the exact defect this wait exists to end.
+        /// A node with neither a NodeType nor a <c>$type</c> matches nothing — correctly, because
+        /// neither route could ever have answered for it. The conversion still runs afterwards and
+        /// the answer is still kept only when it is genuinely typed; this only decides whether it
+        /// is worth ASKING.</para>
+        /// </summary>
+        private static bool CouldResolve(
+            MeshWeaver.Mesh.Services.MeshContentTypeRegistration registration,
+            MeshNode raw,
+            string? discriminator)
+            => (registration.NodeTypePath is { Length: > 0 } path
+                    && raw.NodeType is { Length: > 0 } nodeType
+                    && string.Equals(path, nodeType, StringComparison.OrdinalIgnoreCase))
+               || (discriminator is not null
+                    && (string.Equals(registration.ContentType.Name, discriminator, StringComparison.Ordinal)
+                        || string.Equals(registration.ContentType.FullName, discriminator, StringComparison.Ordinal)));
 
         /// <summary>Re-runs the conversion; null when it still degrades. Throws exactly what the
         /// primary path throws — the Subscribe above routes it to the subscriber.</summary>

--- a/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/IMeshContentTypeRegistry.cs
@@ -195,12 +195,18 @@ public sealed class MeshContentTypeRegistry(ILogger<MeshContentTypeRegistry>? lo
     // Instance subject — the registry is a mesh-scoped singleton, so its lifetime IS the mesh's
     // and no process-wide state leaks across meshes (NoStaticState.md).
     //
-    // 🚨 A plain Subject, deliberately NOT a Replay/BehaviorSubject. This is an EDGE ("a type just
-    // became known"), not a value: a subscriber that wants the current state asks the maps, which
-    // are always readable. A ReplaySubject would also latch a terminal — and this subject never
-    // gets one (a registry has no completion), so latching one transient fault forever (#1369) is
-    // a hazard with no upside here.
-    private readonly Subject<MeshContentTypeRegistration> _registrations = new();
+    // 🚨 NOT a Replay/BehaviorSubject. This is an EDGE ("a type just became known"), not a value: a
+    // subscriber that wants the current state asks the maps, which are always readable. A
+    // ReplaySubject would also latch a terminal — and this subject never gets one (a registry has
+    // no completion), so latching one transient fault forever (#1369) is a hazard with no upside.
+    //
+    // 🚨 Subject.Synchronize because Register IS called concurrently: every per-node hub activation
+    // that runs WithContentType publishes here, and a post-roll recompile storm activates many at
+    // once on different threads. A bare Subject's OnNext is not safe under that, and the IObserver
+    // grammar it would break is the one every downstream operator relies on. Rx's own gate, the
+    // same choice ModuleDiscoveryService / MeshNodeStreamCache made for the same reason.
+    private readonly ISubject<MeshContentTypeRegistration> _registrations =
+        Subject.Synchronize(new Subject<MeshContentTypeRegistration>());
 
     /// <inheritdoc />
     /// <remarks>

--- a/test/MeshWeaver.Graph.Test/LateContentTypeRegistrationTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateContentTypeRegistrationTest.cs
@@ -184,6 +184,71 @@ public class LateContentTypeRegistrationTest(ITestOutputHelper output) : Monolit
     }
 
     /// <summary>
+    /// 🚨 The case that could falsify the wait's cheap pre-filter. To avoid re-deserializing the
+    /// document for every unrelated registration, the seam first asks a string-only question — "could
+    /// THIS registration resolve THIS node?" — and a filter narrowed to the NodeType path alone would
+    /// look correct and silently re-open the whole defect for the NAME route.
+    ///
+    /// <para>So: the registration carries NO NodeType path (the <c>WithMeshType</c> / sweep-probe
+    /// shape), and the node's own NodeType names something else entirely. Only the bare <c>$type</c>
+    /// discriminator connects them — which is exactly what <c>TryRecover</c> resolves on, and exactly
+    /// what a path-only filter would drop.</para>
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task ARegistrationWithNoNodeTypePath_StillRetypesByDiscriminator()
+    {
+        var registry = Mesh.ServiceProvider.GetRequiredService<IMeshContentTypeRegistry>();
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        var contentType = EmitCollectibleType("NamelessRouteGadget", "Label");
+        var partition = "lcn" + Guid.NewGuid().ToString("N")[..9];
+        var typePath = $"{partition}/Gadget";
+        var instancePath = $"{partition}/Live";
+
+        await meshService.CreateNode(new MeshNode("Gadget", partition)
+        {
+            Name = "Gadget",
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition { Description = "A NodeType with no compile lifecycle" }
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        var instance = Activator.CreateInstance(contentType)!;
+        contentType.GetProperty("Label")!.SetValue(instance, "by name only");
+        var stored = JsonSerializer.Deserialize<JsonElement>(
+            JsonSerializer.Serialize(instance, contentType, Mesh.JsonSerializerOptions));
+
+        await meshService.CreateNode(new MeshNode("Live", partition)
+        {
+            Name = "Live frame",
+            NodeType = typePath,
+            State = MeshNodeState.Active,
+            Content = stored
+        }).Should().Within(TestTimeouts.Convergence).Emit();
+
+        var live = Mesh.GetWorkspace().GetMeshNodeStream(instancePath)
+            .Where(n => n is not null)
+            .Replay(1);
+        using var connection = live.Connect();
+
+        (await live.FirstAsync().Should().Within(TestTimeouts.Convergence).Emit())
+            .Content.Should().BeOfType<JsonElement>("nothing resolves the discriminator yet");
+
+        // 🚨 No nodeTypePath — and the node's NodeType ($"{partition}/Gadget") is NOT it. The bare
+        // discriminator is the only link.
+        registry.Register(contentType);
+
+        var typed = await live.Where(n => n.Content is not JsonElement).FirstAsync()
+            .Should().Within(TestTimeouts.Convergence).Emit(
+                "the name route must re-type too — a wait that only listens for its own NodeType path "
+                + "would drop every WithMeshType / sweep-probe registration and leave the node untyped "
+                + "forever, which is the defect wearing a different hat");
+
+        typed.Content!.GetType().Should().Be(contentType);
+        contentType.GetProperty("Label")!.GetValue(typed.Content).Should().Be("by name only");
+    }
+
+    /// <summary>
     /// Emits a minimal public class with one string property into a COLLECTIBLE dynamic assembly —
     /// the CLR shape of a compiled dynamic-node content type without dragging Roslyn into the test.
     /// (Mirrors <c>ReimportTypedContentRecoveryTest.EmitCollectibleType</c>.)


### PR DESCRIPTION
Follow-up to #3005 (fixes #2952). Both findings come from that PR's automatic review; it auto-merged on green before they could land there, so they land here.

**1. `Register` IS called concurrently.** The announcement subject was a bare
`Subject<T>`. Every per-node hub activation that runs `WithContentType` publishes
into it, and a post-roll recompile storm activates many at once on different
threads — so concurrent `OnNext` is a real race, not a theoretical one, and the
`IObserver` grammar it breaks is the one every downstream operator relies on. Now
`Subject.Synchronize(...)`, Rx's own gate, the same choice
`ModuleDiscoveryService` / `MeshNodeStreamCache` made for the same reason.

**2. The wait re-deserialized the whole document on every registration.** A boot
registers every content type in the mesh; each one made every degraded
subscription re-run `EnsureTypedContent` — N×M deserializations to reach the same
"still unknown". The wait now filters on STRING COMPARES first, before any
deserialization, against a discriminator read once at arm time.

🚨 The predicate is a superset of what could resolve, never a guess at what will:
it mirrors exactly the two routes `TryRecoverForNodeType` can take — the EXACT
route (the registration was keyed on this node's own `NodeType`, matched
case-insensitively as that map is keyed) and the NAME route (the registered type's
short or full name IS the stored `$type`, matched ordinally as
`ClaimDiscriminator` keys it). A registration it drops provably could not have
resolved this node. The conversion still runs afterwards and the answer is still
kept only when it is genuinely typed; the filter only decides whether it is worth
ASKING.

The narrower filter the review suggested — NodeTypePath only — would have looked
correct and silently re-opened the whole defect for the NAME route, which is how
every `WithMeshType` / sweep-probe registration lands. So the change comes with the
case that falsifies it: `ARegistrationWithNoNodeTypePath_StillRetypesByDiscriminator`
registers with NO NodeType path against a node whose own NodeType names something
else, so the bare discriminator is the only link. Narrowed to path-only, that test
FAILS at 38 s ("emitted nothing at all") while the other two still pass; with the
filter as written, Graph.Test is 1093/1093.

Verification: `dotnet build -c Release -warnaserror` clean per project;
MeshWeaver.Messaging.Hub.Test 341/341, MeshWeaver.Documentation.Test 168/168,
MeshWeaver.Hosting.Test 274/274, MeshWeaver.Graph.Test 1093/1093 — full projects,
no `--filter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
