### PR TITLE
fix(sync): the owner merges a subscriber's optimistic write instead of dropping it (#2701)

### DIFF
--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -1550,6 +1550,21 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
         var acceptRebasedFull = delivery.Message.ChangeType == ChangeType.Full
             && (Interlocked.Exchange(ref _acceptResubscribeFull, 0) == 1 || currentJson is null);
 
+        // 🚨🚨 DIRECTION, not just shape — Systemorph/MeshWeaver#2701. `Version` means TWO DIFFERENT
+        // THINGS depending on which way the message travels, and everything below turns on the
+        // difference:
+        //   • DataChangedEvent (OWNER → mirror) carries the OWNER's clock. It is comparable to
+        //     Current.Version, and it is the version this stream must adopt.
+        //   • PatchDataChangeRequest (SUBSCRIBER → owner) carries the BASE the subscriber last
+        //     APPLIED (StandardReducers.PatchJsonElement stamps `stream.Current?.Version`) — a
+        //     value that is BELOW the owner's clock by construction whenever an owner frame is in
+        //     flight. It is NOT comparable, and it must never become the owner's clock.
+        // This is the same asymmetry the frame-loss check further down already draws in so many
+        // words ("Applies to DataChangedEvent (owner→mirror) only: a PatchDataChangeRequest's chain
+        // is stamped by the SENDING mirror and is not comparable to this stream's applied
+        // version") — the version handling simply never got it.
+        var isOwnerFrame = delivery.Message is not PatchDataChangeRequest;
+
         // 🚨 Monotonicity guard — applies to PATCHES *and* FULLS. Version is ALWAYS the OWNER
         // hub's Version (BuildChangeItem/BuildFullChangeItem: the owner stamps its monotonic
         // Hub.Version — ++ per message, MessageHub.HandleMessageAsync — while a subscriber only
@@ -1564,7 +1579,20 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
         // subscriber never bumps ahead of the owner, a legitimate Full can never carry a version
         // BELOW Current — only a genuinely older snapshot can, and that is exactly what we drop —
         // EXCEPT the rebased-resubscribe Full latched above (a recycled owner's fresh snapshot).
-        if (Current is not null && delivery.Message.Version < Current.Version && !acceptRebasedFull)
+        //
+        // 🚨 …AND EXCEPT A SUBSCRIBER'S OWN WRITE (#2701). Every clause above reasons about a frame
+        // the OWNER produced. A PatchDataChangeRequest is the opposite direction: the base version
+        // it carries is older than the owner's clock precisely BECAUSE the write is optimistic —
+        // the contract this stream documents on Update() is "a subscriber carries the BASE version
+        // it last observed so the owner can fast-forward (base == current) or MERGE (base <
+        // current)". The guard was swallowing the merge case before the merge code could see it, at
+        // Debug, with no rollback Full and no failure to the writer: the user's edit was gone and
+        // the re-render it would have produced never happened, so the view sat silent forever. The
+        // measured shape is EditorTest.TestEditorWithDelayed — five UpdatePointer writes landing
+        // while the 100 ms delayed render's frame is in flight, and a control stream that then
+        // emits nothing at all. A subscriber patch that cannot be applied is not silently dropped
+        // here: the applier below throws and SyncFailed answers the writer.
+        if (isOwnerFrame && Current is not null && delivery.Message.Version < Current.Version && !acceptRebasedFull)
         {
             logger.LogDebug(
                 "[SYNC_STREAM] Dropping stale {ChangeType} for {StreamId}: incoming v{In} < current v{Cur}",
@@ -1585,10 +1613,16 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                 // 🚨 Adopt the OWNER's Version (not local Host.Version) so the
                 // monotonicity guard above compares apples-to-apples and a later
                 // client write records the owner-version it was based on.
+                // 🚨 A SUBSCRIBER's full-state proposal (a PatchDataChangeRequest a subscriber
+                // sends as a Full because its own JSON cache was empty) carries the base it read,
+                // not the owner's clock — floor it, exactly as in the Patch branch below, so
+                // applying a subscriber write can never rewind this stream's version (#2701).
                 SetCurrent(hub, new ChangeItem<TStream>(
                     currentJson.Value.Deserialize<TStream>(Host.JsonSerializerOptions)!,
                     StreamId,
-                    delivery.Message.Version));
+                    isOwnerFrame || Current is null
+                        ? delivery.Message.Version
+                        : Math.Max(delivery.Message.Version, Current.Version)));
                 Set(currentJson);
                 // A Full re-established Current — any pending resync is satisfied;
                 // allow a future Patch-before-Full gap to resubscribe again, and clear the
@@ -1690,7 +1724,18 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                 // 🚨 Adopt the OWNER's Version (the PatchFunction stamps the local
                 // stream.Hub.Version). Keeps Current.Version on the owner's clock so
                 // the monotonicity guard is consistent across Full and Patch.
-                changeItem = changeItem with { Version = delivery.Message.Version };
+                //
+                // 🚨 …but ONLY for an owner frame (#2701). A SUBSCRIBER's write carries the base it
+                // was computed on, which is BELOW this stream's clock exactly when the guard above
+                // now lets it through. Adopting it would move the OWNER's Current BACKWARDS — and
+                // the frame the owner then broadcasts would be stamped below what its other
+                // subscribers already hold, so their (correct) monotonicity guards would drop it:
+                // the same silent loss, one hop further out. The owner's clock is a FLOOR here, so
+                // applying a subscriber's write can only ever move it forward.
+                if (isOwnerFrame)
+                    changeItem = changeItem with { Version = delivery.Message.Version };
+                else if (changeItem.Version < Current!.Version)
+                    changeItem = changeItem with { Version = Current.Version };
 
                 SetCurrent(hub, changeItem);
             }

--- a/src/MeshWeaver.Data/StandardReducers.cs
+++ b/src/MeshWeaver.Data/StandardReducers.cs
@@ -97,8 +97,15 @@ public static class StandardReducers
     //     refreshing" bug on the UWDeepfield treaty tabs).
     //   • quiet client (clock < owner): the outgoing PatchDataChangeRequest carried a version below
     //     the owner mirror's Current and the USER'S EDIT was silently dropped on the owner.
-    // (UpdateStream re-stamps INCOMING patches with delivery.Message.Version before SetCurrent, so
-    // applying received frames is unaffected — this stamp matters for locally-originated updates.)
+    // 🚨 Carrying the base cures the FIRST of those and CANNOT cure the second — the base is below
+    // the owner's clock by construction whenever an owner frame is in flight, which is exactly the
+    // dropped-edit case. That half is cured on the RECEIVE side (#2701): the owner's monotonicity
+    // guard now applies to owner→mirror DataChangedEvents only, so a subscriber's optimistically
+    // based write is merged rather than discarded. See SynchronizationStream.UpdateStream and
+    // Doc/Architecture/DataSyncAndCrdt §3.
+    // (UpdateStream re-stamps INCOMING OWNER frames with delivery.Message.Version before SetCurrent
+    // — a subscriber's write keeps this stamp, floored at the owner's clock, so applying it can
+    // never rewind the owner. This stamp matters for locally-originated updates.)
     private static ChangeItem<JsonElement> PatchJsonElement(ISynchronizationStream<JsonElement> stream, JsonElement current, JsonElement updated, JsonPatch? patch, string changedBy)
     {
         var typeRegistry = stream.Hub.TypeRegistry;

--- a/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
@@ -85,14 +85,49 @@ always holds.
 
 ---
 
-## 3. The monotonicity guard — patches *and* Fulls
+## 3. The monotonicity guard — patches *and* Fulls, but OWNER frames only
 
-When a subscriber receives an owner frame (`UpdateStream`):
+When a subscriber receives an **owner frame** (`UpdateStream`):
 
 ```
-ANY FRAME (Patch or Full) : drop it if  Version < Current.Version
-                            …unless a Full is consuming the resubscribe latch (below)
+ANY OWNER FRAME (Patch or Full) : drop it if  Version < Current.Version
+                                  …unless a Full is consuming the resubscribe latch (below)
 ```
+
+### 🚨 `Version` means two different things, and the guard reads only one of them
+
+`UpdateStream` handles messages travelling in **both** directions, and the meaning of `Version`
+flips with the direction:
+
+| Message | Direction | What `Version` is | Guard? | Adopt as `Current.Version`? |
+|---|---|---|---|---|
+| `DataChangedEvent` | owner → mirror | the **owner's clock** | **yes** — comparable | **yes** |
+| `PatchDataChangeRequest` | subscriber → owner | the **base the writer last applied** | **no** — not comparable | **no** — it would rewind the owner |
+
+A subscriber's write is optimistic by definition: `StandardReducers.PatchJsonElement` stamps it
+with `stream.Current?.Version` — the frame the writer had in hand — so it is **below the owner's
+clock by construction** whenever an owner frame is in flight. §4 already names that case as the
+one the owner must *merge*. Comparing it against the owner's clock and dropping it therefore
+discards a legitimate write, silently: no rollback Full, no `DeliveryFailure`, one `Debug` line.
+
+That was Systemorph/MeshWeaver#2701. The measured shape is an editor whose re-render takes 100 ms:
+a burst of `UpdatePointer` writes lands while that render's frame is still on the wire, every one
+of them is dropped, and the control stream that should have carried the result **emits nothing at
+all** — indistinguishable from a slow machine, which is why it read as a flake for months. It is a
+data-loss bug, not a timing one: a user's edit typed while the server pushes an unrelated
+re-render was thrown away. Pinned by `StaleBaseSubscriberWriteTest`
+(`test/MeshWeaver.Layout.Test`).
+
+The same asymmetry was already drawn one block further down in the *frame-loss* check, which
+applies "to `DataChangedEvent` (owner→mirror) only: a `PatchDataChangeRequest`'s chain is stamped
+by the SENDING mirror and is not comparable to this stream's applied version". The version
+handling simply never got it.
+
+**Having applied a subscriber's write, the owner keeps its own clock.** Adopting the writer's base
+would move `Current.Version` *backwards*, and the frame the owner then broadcasts would be stamped
+below what its other subscribers already hold — so *their* (correct) guards would drop it, and the
+same loss reappears one hop out. The owner's version is a **floor**: applying a subscriber write
+can only ever move it forward.
 
 A **Patch** is a delta computed against a *specific base version*; applying a
 reordered older patch corrupts the mirror, so it is version-guarded.
@@ -380,8 +415,10 @@ mirror and the convergence rules above hold.
 |---|---|
 | Owner assigns strictly increasing versions per stream — including the init/base frame | `SynchronizationStream.OwnerVersion`; `StreamVersionMonotonicityTest` |
 | A subscriber never mints a version | `UpdateStream` adopt-only; `StreamUpdateIdentityTest` |
-| Stale **patch** AND stale **Full** dropped (`Version < Current`) | `SynchronizationStream.UpdateStream` guard |
+| Stale **patch** AND stale **Full** dropped (`Version < Current`) — **owner frames only** | `SynchronizationStream.UpdateStream` guard |
 | …except a Full consuming the version-gated resubscribe latch | `SynchronizationStream.ExpectResubscribeFull`; `TwoSiloRecycleConvergenceTest` |
+| A subscriber's write based on an EARLIER owner frame is merged, never dropped | `StaleBaseSubscriberWriteTest.ASubscriberWriteBasedOnAnEarlierOwnerFrame_IsMerged_NotDroppedAsStale` |
+| Applying a subscriber's write never rewinds the owner's clock | `StaleBaseSubscriberWriteTest.ApplyingASubscriberWrite_DoesNotRewindTheOwnersClock` |
 | A late layout-area subscriber gets its render content, not just the base frame | `DataChangeStreamUpdateTest.DataChangeRequest_ShouldUpdateLayoutAreaViews` |
 | Disjoint concurrent string edits merge | `StringDeltaTest`, `StreamConflictResolutionTest` |
 | A changed string field (incl. nested) ships only its splice | `StringDeltaPatchTest` |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-an-edit-made-while-the-page-refreshes-is-no-longer-lost.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-01-an-edit-made-while-the-page-refreshes-is-no-longer-lost.md
@@ -1,0 +1,35 @@
+---
+Name: An edit made while the page refreshes is no longer lost
+Category: Fix
+Description: A value you change in the instant the server is pushing a re-render used to be thrown away without a word — no error, no rollback, and the view then sat still. The owner now merges it, which is what it was always documented to do.
+Icon: Bug
+Order: -20260901
+---
+
+# An edit made while the page refreshes is no longer lost
+
+Type into a form, and the value travels to whoever owns the data along with a note saying which
+version of the page you were looking at when you typed it. That note is the point: it lets the
+owner reconcile your edit with anything that happened since.
+
+The owner was instead using it to **reject** you. It compared "the version the writer was looking
+at" against "the version I am on now", and if yours was older — which it is, by definition, every
+time the server has pushed anything you have not received yet — it discarded the change. Not
+rejected with an error, not rolled back visibly. Dropped, in silence.
+
+Most of the time the window is too narrow to hit. It stops being narrow the moment a view takes a
+moment to redraw: while that redraw is on its way to you, **every** change you make is inside the
+window. Change five values in a row on a slow-rendering form and all five could vanish — and
+because the change was thrown away rather than refused, the view had nothing new to show either.
+It simply stopped responding, which is very hard to tell apart from a slow connection.
+
+Nothing about the wire format or the reconciliation rules has changed — the owner already
+documented that an older base version means *merge*, and now it does. The rejection rule it was
+using still applies, in full, to the direction it was written for: state the owner pushes out to
+viewers, where an out-of-order frame really would corrupt what you are looking at.
+
+Two regression tests hold the line, and both are version arithmetic rather than timing, so they
+cannot quietly stop covering it on a fast machine: one asserts that a write based on an earlier
+frame is applied, the other that applying it never winds the owner's version backwards — which
+would have moved the same silent loss one step outwards, onto everyone else watching the same
+data.

--- a/test/MeshWeaver.Layout.Test/StaleBaseSubscriberWriteTest.cs
+++ b/test/MeshWeaver.Layout.Test/StaleBaseSubscriberWriteTest.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.ComponentModel;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// Regression cover for Systemorph/MeshWeaver#2701 — the delayed editor's control stream falling
+/// permanently silent after a burst of <c>UpdatePointer</c> writes.
+///
+/// <para>The mechanism is version arithmetic, not timing. A subscriber stamps every outgoing
+/// <see cref="PatchDataChangeRequest"/> with the version of the frame it last APPLIED
+/// (<c>StandardReducers.PatchJsonElement</c>: <c>stream.Current?.Version</c>) — an optimistic
+/// write is BY CONSTRUCTION based on an earlier owner frame. Whenever an owner frame is in
+/// flight — a re-render that the writer has not received yet, and the delayed editor's render
+/// takes 100 ms — that stamp is strictly below the owner's <c>Current.Version</c>, and the
+/// owner's monotonicity guard in <c>SynchronizationStream.UpdateStream</c> dropped the write at
+/// Debug with no rollback, no error and no signal to the writer. The edit was gone; the
+/// re-render it should have produced never happened; the view sat silent forever.</para>
+///
+/// <para>These tests pin the contract by POSTING the wire message a client posts, stamped with a
+/// base one frame behind the one the client holds — so they are deterministic and carry no
+/// wall-clock dependency at all.</para>
+/// </summary>
+[Collection("EditorTests")]
+public class StaleBaseSubscriberWriteTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddLayoutClient();
+
+    /// <summary>The edited record — two doubles, so the rendered sum names the update that produced it.</summary>
+    public record Calculator
+    {
+        /// <summary>The value the tests write.</summary>
+        [Description("This is the X value")] public double X { get; init; }
+        /// <summary>Stays zero; present so the editor renders two fields as in EditorTest.</summary>
+        [Description("This is the Y value")] public double Y { get; init; }
+    }
+
+    private const string DataId = "staleBaseCalc";
+
+    // Same shape as EditorTest.EditorWithDelayedResult: the render is slow enough that an owner
+    // frame is reliably in flight while a client writes.
+    private UiControl DelayedEditor(LayoutAreaHost host, RenderingContext ctx)
+    {
+        var editor = host.Hub.ServiceProvider.Edit(Observable.Return(new Calculator()), DataId);
+        return Controls.Stack
+            .WithView(editor)
+            .WithView((h, _) => h.Stream.GetDataStream<Calculator>(DataId)
+                .Select(c =>
+                {
+                    Thread.Sleep(100);
+                    return (UiControl)Controls.Markdown($"{c.X + c.Y}");
+                }));
+    }
+
+    /// <summary>
+    /// The #2701 shape: a subscriber's write whose base is one owner frame behind must be MERGED
+    /// by the owner, never dropped. The owner's own documentation states the contract — "a
+    /// subscriber carries the BASE version it last observed so the owner can fast-forward
+    /// (base == current) or merge (base &lt; current)" — and the monotonicity guard, which exists
+    /// to protect a MIRROR from stale OWNER frames, was applying itself to the opposite direction.
+    /// </summary>
+    [Fact]
+    public async Task ASubscriberWriteBasedOnAnEarlierOwnerFrame_IsMerged_NotDroppedAsStale()
+    {
+        var client = GetClient();
+        var area = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), new LayoutAreaReference(nameof(DelayedEditor)));
+
+        var control = await area.GetControlStream(nameof(DelayedEditor))
+            .Should().Within(TestTimeouts.Convergence).Match(x => x is not null);
+        var stack = control.Should().BeOfType<StackControl>().Subject;
+        control = await area.GetControlStream(stack.Areas.First().Area.ToString()!)
+            .Should().Within(TestTimeouts.Convergence).Match(x => x is not null);
+        var editor = control.Should().BeOfType<EditorControl>().Subject;
+        var resultArea = stack.Areas.Last().Area.ToString()!;
+
+        // Let the first render land, so the owner's clock has advanced and the client has applied
+        // that frame. Everything after this point is version arithmetic, not timing.
+        await area.GetControlStream(resultArea)
+            .Should().Within(TestTimeouts.Convergence).Match(x => x is MarkdownControl);
+
+        var appliedVersion = area.Current!.Version;
+
+        // The write a client issues while the NEXT owner frame is still in flight: computed on the
+        // previous frame, so stamped one version back. Byte-for-byte the message
+        // JsonSynchronizationStream posts on the client's behalf (ToDataChanged →
+        // PatchDataChangeRequest(ClientId, x.Version, patch, Patch, ChangedBy)).
+        PostStaleBasedWrite(client, area, editor.DataContext!, value: 5, basedOn: appliedVersion - 1);
+
+        // 🚨 The predicate must exclude the baseline render ("0"): a `Markdown: not null` match is
+        // satisfied by the render that was already there and would pass without the write ever
+        // having landed. The re-render the write produces is the ONLY positive signal here — and
+        // its absence is #2701's exact signature, "the observable emitted nothing at all".
+        var rendered = await area.GetControlStream(resultArea)
+            .Should().Within(TestTimeouts.Convergence)
+            .Match(x => x is MarkdownControl { Markdown: var m } && m!.ToString() != "0");
+
+        rendered.Should().BeOfType<MarkdownControl>()
+            .Which.Markdown!.ToString().Should().Be("5",
+                "an optimistic write is based on an earlier owner frame by construction — the owner "
+                + "must merge it, not drop it as stale");
+    }
+
+    /// <summary>
+    /// The other half of the same role confusion: having APPLIED a subscriber's write, the owner
+    /// must keep its own monotonic clock. Adopting the subscriber's base version rewound the
+    /// owner's <c>Current.Version</c>, so the frame the owner then broadcast was stamped BELOW
+    /// what every other subscriber already held — and their monotonicity guards (correctly, this
+    /// time) dropped it. Asserting on the owner's clock rather than on a second subscriber keeps
+    /// this deterministic.
+    /// </summary>
+    [Fact]
+    public async Task ApplyingASubscriberWrite_DoesNotRewindTheOwnersClock()
+    {
+        var client = GetClient();
+        var area = client.GetWorkspace().GetRemoteStream<JsonElement, LayoutAreaReference>(
+            CreateHostAddress(), new LayoutAreaReference(nameof(DelayedEditor)));
+
+        var control = await area.GetControlStream(nameof(DelayedEditor))
+            .Should().Within(TestTimeouts.Convergence).Match(x => x is not null);
+        var stack = control.Should().BeOfType<StackControl>().Subject;
+        control = await area.GetControlStream(stack.Areas.First().Area.ToString()!)
+            .Should().Within(TestTimeouts.Convergence).Match(x => x is not null);
+        var editor = control.Should().BeOfType<EditorControl>().Subject;
+        var resultArea = stack.Areas.Last().Area.ToString()!;
+
+        await area.GetControlStream(resultArea)
+            .Should().Within(TestTimeouts.Convergence).Match(x => x is MarkdownControl);
+
+        var appliedVersion = area.Current!.Version;
+        PostStaleBasedWrite(client, area, editor.DataContext!, value: 7, basedOn: appliedVersion - 1);
+
+        // The re-render the write triggers reaches this client as a frame of the owner's own
+        // making. Its version must still be ABOVE the frame the client already held: if the owner
+        // adopted the write's stale base, every subscriber sitting on `appliedVersion` discards it.
+        var frame = await area
+            .Where(ci => ci.Value.TryGetProperty("areas", out _))
+            .Should().Within(TestTimeouts.Convergence)
+            .Match(ci => ci.Value.ToString()!.Contains("\"7\""));
+
+        frame.Version.Should().BeGreaterThanOrEqualTo(appliedVersion,
+            "a subscriber's write must not rewind the owner's clock — the frame that carries it "
+            + "back out would then be dropped as stale by every other subscriber");
+    }
+
+    private static void PostStaleBasedWrite(
+        IMessageHub client,
+        ISynchronizationStream<JsonElement> area,
+        string dataContext,
+        int value,
+        long basedOn)
+    {
+        var patch = JsonSerializer.Serialize(new[]
+        {
+            new { op = "replace", path = $"{dataContext}/x", value }
+        });
+        client.Post(
+            new PatchDataChangeRequest(
+                area.StreamId,
+                basedOn,
+                new RawJson(patch),
+                ChangeType.Patch,
+                area.ClientId),
+            o => o.WithTarget(CreateHostAddress()));
+    }
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddLayout(layout => layout.WithView(nameof(DelayedEditor), DelayedEditor));
+}


### PR DESCRIPTION
Fixes #2701.

## The root cause

`SynchronizationStream.UpdateStream` handles messages travelling in **both** directions, and `Version` means a different thing in each:

| Message | Direction | What `Version` is |
|---|---|---|
| `DataChangedEvent` | owner → mirror | the **owner's clock** — comparable to `Current.Version` |
| `PatchDataChangeRequest` | subscriber → owner | the **base the writer last applied** — *not* comparable |

The monotonicity guard, written for the first, was applied to both. A subscriber's write is optimistic by construction — `StandardReducers.PatchJsonElement` stamps it with `stream.Current?.Version`, the frame the writer had in hand — so its version is **below the owner's clock whenever an owner frame is in flight**. The guard dropped it: no rollback Full, no `DeliveryFailure`, one `Debug` line. The edit was gone, the re-render it would have produced never happened, and the view sat silent.

That is the reported symptom exactly. `EditorTest.TestEditorWithDelayed` fires five `UpdatePointer` writes at an editor whose render takes 100 ms; when they land while that render's frame is on the wire, all five are discarded and the control stream **emits nothing at all** — indistinguishable from a slow machine, which is why it read as a flake for months.

**It is a data-loss bug, not a timing one:** a user's edit typed while the server pushes an unrelated re-render was silently thrown away. The flaky test is the smallest visible symptom.

Two things in the tree already said so and were not being obeyed:

- The stream's own `Update()` documentation states the contract: *"a subscriber carries the BASE version it last observed so the owner can fast-forward (base == current) or **merge (base < current)**"*. The guard swallowed the merge case before the merge code could see it.
- The **frame-loss** check twenty lines below already draws exactly this direction distinction: *"Applies to DataChangedEvent (owner→mirror) only: a PatchDataChangeRequest's chain is stamped by the SENDING mirror and is not comparable to this stream's applied version."* The version handling simply never got it.
- And `StandardReducers.PatchJsonElement`'s comment names this failure verbatim — *"quiet client (clock < owner): the outgoing PatchDataChangeRequest carried a version below the owner mirror's Current and the USER'S EDIT was silently dropped on the owner"* — while claiming the send-side stamp cured it. It cannot: carrying the base is precisely what puts the write below the owner's clock. That comment is corrected here.

## How it was found

Not by re-running the test. An instrumented replica of the delayed editor showed the five patches reaching the client, being applied to the client's JSON, forwarded to the host — and then **nothing**: `GetDataStream` on the host never emitted `x=1..5`. Comparing a losing and a winning interleaving isolated the discriminator: the writes are lost exactly when the host's render frame is applied on the host *before* the writes arrive, i.e. when the writes carry a base below the owner's `Current.Version`. From there it is version arithmetic, not timing.

Three candidates previously recorded on the issue — the `lock` around `OnNext`, the cooldown contending with the render, and value loss inside `ThrottleImmediate` — are all confirmed **not** the cause. `ThrottleImmediate` does deliver the latest value; it is untouched by this change.

## The fix

Both halves of one role confusion, in `UpdateStream`:

1. **The monotonicity guard applies to owner frames only.** A subscriber's write is merged, as documented. A patch that genuinely cannot apply is still not silent — the applier throws and `SyncFailed` answers the writer.
2. **Applying a subscriber's write never rewinds the owner's clock.** Adopting the writer's base would stamp the owner's next broadcast *below* what its other subscribers already hold, so **their** (correct) guards would drop it — the same silent loss, one hop out. The owner's version is a floor now, in both the Patch and the Full branch. This half is required by the first: before the fix such writes never landed, so they never rewound anything.

Everything the guard protects against is unchanged: an out-of-order or stale owner frame, and a resubscribe's point-in-time Full, are still dropped.

## Before / after evidence

Two regression tests in `test/MeshWeaver.Layout.Test/StaleBaseSubscriberWriteTest.cs`. They post the wire message a client posts (`PatchDataChangeRequest`, `ChangeType.Patch`, the client's `StreamId`/`ClientId`), stamped **one frame behind** the version the client holds — so they are **version arithmetic with no wall-clock dependency at all**, and cannot quietly stop covering this on a fast machine.

Same box, same commit, only `src/MeshWeaver.Data/Serialization/SynchronizationStream.cs` differing (reverted via a patch file, re-applied after):

| | Result |
|---|---|
| **without the fix** | **2 failed** — `Expected the observable to emit a value matching the predicate … it did not. Last of 1 emission(s) was: MarkdownControl { … Markdown = 0 … }`. The write never arrived; the view stayed on its baseline render. |
| **with the fix** | **2 passed in 4 s** |

Note the shape of the failure: **silence**, not a late value — which is the discriminator between this defect and mere slowness, and matches #2701's report ("the observable emitted nothing at all") rather than the CI-slowness case the test's own comment already accounts for.

🚨 **Load disclosure:** this host was heavily oversubscribed while measuring (load average 65–357 on 18 cores; several agents building concurrently). That is recorded because a *timing* claim at that load would prove nothing. No timing claim is made here: the repro is deterministic version arithmetic, the failing signal is a value that never arrives rather than one that arrives late, and the passing run takes 4 s against a 36 s budget.

## Verification

Whole projects, no `--filter`:

- `MeshWeaver.Layout.Test` — **439/439** passed (includes `EditorTest.TestEditorWithDelayed`)
- `MeshWeaver.Data.Test` — **419/419** passed
- `MeshWeaver.Documentation.Test` — **166/166** passed (incl. `DocumentationLinkIntegrityTest`)

`dotnet build -c Release -warnaserror`, one project per invocation, `0 Error(s)` each: `MeshWeaver.Data`, `MeshWeaver.Documentation`, `MeshWeaver.Layout.Test`, `MeshWeaver.Data.Test`, `MeshWeaver.Documentation.Test`.

## Work products conserved

- `Doc/Architecture/DataSyncAndCrdt` §3 now states the direction rule (with the two-row table above), and its invariant ledger carries both new tests.
- The `StandardReducers.PatchJsonElement` comment says which half of its two named failures the send-side stamp actually cures, and points at the receive-side fix.
- What's New entry (`Category: Fix`): *An edit made while the page refreshes is no longer lost*.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
