### PR TITLE
feat(icons): a page with no icon of its own wears its package's mark (#2075 item 2)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PackageMarkInheritance.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PackageMarkInheritance.md
@@ -1,0 +1,165 @@
+---
+Name: Package Mark Inheritance
+Category: Architecture
+Description: How a page with no icon of its own wears its package's mark — where the partition-root step sits in the icon chain, why the resolver stayed synchronous and total, and why inheritance is opt-in per surface rather than global.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="8" height="8" rx="2"/><path d="M15 5h5"/><path d="M15 9h3"/><path d="M7 11v6a2 2 0 0 0 2 2h3"/><rect x="13" y="15" width="8" height="6" rx="2"/></svg>
+---
+
+# Package Mark Inheritance
+
+A node with **no icon of its own** resolves its **partition root's** mark before falling through to
+the generic glyph for its type. A lesson under `AgenticEngineering`, a game under `Chess`, a doc
+under a store package — each one wore the same `document` chrome. Each one now wears its package's
+mark on its page.
+
+The package roots already carry those marks, and the store's were deliberately aligned to one visual
+language — a bold 24×24 plate with white detail — *precisely so they read at 16 px* (MeshWeaver.Plugins
+#588).
+
+🚨 **The BROWSER TAB is the surface this was reported from, and it is the surface this change does not
+finish.** The resolution is in place and `ResolveIconLink` accepts a root, but both things that
+render a tab icon live in MeshWeaver.Plugins. See *What this change does NOT cover* below.
+
+## The chain
+
+`MeshNodeImageHelper.ResolveNodeIcon` (`src/MeshWeaver.Graph/`), with the new step in bold:
+
+1. the node's **own** `Icon` — a `content:` reference resolved through the access-controlled content
+   route, a URL, inline `<svg>`, an emoji
+2. a **shipped glyph** of that name, when the icon is a Fluent icon NAME this assembly ships
+3. **the partition root's own mark** — the same two resolutions applied to the root's `Icon`
+4. the **NodeType** default (`/static/NodeTypeIcons/document.svg`, `code.svg`, `chat.svg`, …)
+5. the **neutral box**
+
+Steps 1–2 and 4–5 are untouched, and that ordering carries the whole policy:
+
+- **A page's own icon always wins.** Marking a package can never overwrite what a page chose for
+  itself.
+- **An unmarked package changes nothing.** Step 3 yields null and the chain falls through exactly as
+  it did, so adding the step cannot regress a package that never had a mark.
+- **The chain is still total.** Every node resolves to something, so no card, avatar or tab can fall
+  back to a bare initial. That guarantee predates this change and survives it.
+
+### Only the root's OWN mark is inherited
+
+Step 3 reads the root's `Icon` — it does **not** run the root's own chain. Falling through to the
+root's NodeType default would dress every document in an unmarked `Space` as an *organization*,
+which is strictly worse than the document glyph it replaced. A root with no mark contributes
+nothing; the child keeps its own type.
+
+### "Partition root" is the FIRST segment, and it never inherits
+
+`PartitionRootPath` returns the first path segment: `Doc/Architecture/LinkPreviews` inherits from
+`Doc`, not from `Doc/Architecture`. It returns **null** for a single-segment path — so a partition
+root has no ancestor to inherit from and cannot resolve itself. That is structural, not a guard bolted
+on afterwards.
+
+The supplied root is also **verified, not trusted**: it is used only when its path really is the
+node's first segment. A caller that hands over the wrong node — the parent instead of the root, a
+stale frame from another page — gets no inheritance rather than an unrelated package's mark on
+someone else's page. That is the failure mode a screenshot could not catch.
+
+## The design decision: the resolver stays pure
+
+`ResolveNodeIcon` is `static`, synchronous, and takes one `MeshNode`. The partition root is a
+*different node*, and reading one is an `IObservable` — a shape this signature cannot express and its
+callers are not built for. Two options:
+
+| | make the resolver reactive | pass the already-resolved root in |
+|---|---|---|
+| resolver | returns `IObservable<string?>`; every caller becomes reactive | unchanged: pure, total, unit-testable with no mesh |
+| call sites | all of them change, including Blazor render paths that cannot await | only the ones that opt in |
+| a caller with no root | must still open a stream to get an answer | calls the one-argument overload, exactly as today |
+
+**The second was taken.** An *overload* — `ResolveNodeIcon(node, partitionRoot)` — leaves the pure
+resolver pure and leaves every existing call site compiling and behaving identically. Pushing
+`IObservable` into a rendering helper would have made the resolution reactive in dozens of places that
+have a node in hand and nothing to await on.
+
+🚨 **An overload, not a fourth optional parameter.** `MeshNodeLayoutAreas.BuildHeader` is a
+module-facing contract, and adding a parameter — default or not — *replaces* the signature every
+already-compiled module was built against. That is the same binary-contract argument
+[`PageIcon`](../ContentFaviconRasterization) makes for using `init` properties instead of primary
+constructor parameters, and `scripts/check-record-signatures.py` is the gate that states it.
+
+## The reactive half
+
+`MeshNodeExtensions.ObservePartitionRoot(workspace, nodePath)` is the seam that fetches what the
+resolver cannot fetch for itself:
+
+```csharp
+host.Workspace.GetMeshNodeStream().CombineLatest(
+        host.Hub.GetEffectivePermissions(hubPath),
+        host.Workspace.ObservePartitionRoot(host.Hub.Address.Path),
+        (node, permissions, partitionRoot) => …)
+```
+
+Four properties are load-bearing:
+
+- **A point read that is legitimate.** Reading one node by exact path is only correct for a path
+  known to exist — a point read of an absent node answers a routing NotFound that terminates the
+  stream *and* opens the storm-breaker on that path (see
+  [CQRS and Content Access](../CqrsAndContentAccess)). A partition root exists for every node that
+  has one, by construction: it is the namespace the node lives in.
+- **A root opens no read at all.** When there is no distinct partition root the stream is a constant
+  that completes — no subscription, no path to storm.
+- **It starts null.** `CombineLatest` produces nothing until *every* source has emitted, so without a
+  seeded first value the root read would gate the page — and a slow or refused root read would leave
+  it blank. Seeding null means the page renders on the node's own stream immediately.
+
+  🚨 **That is visible, and it is the accepted trade.** The header paints its type glyph on the first
+  frame and re-renders with the package's mark when the root arrives. The alternative — waiting for
+  the root before the first paint — trades a brief icon swap for a page that can hang on a read it
+  does not need. `PartitionRootStreamTest` **waits for the mark rather than reading the first frame**
+  for exactly this reason; asserting on frame one measured the un-inherited render and reported the
+  wiring as broken, which is what it did on its first run.
+- **`DistinctUntilChanged` on `(Path, Icon)`.** The root node emits on every touch of it —
+  `LastModified`, a content edit, a new child. Without this, every one of those would re-render every
+  page in the partition for an icon that did not change.
+
+🚨 **One fault is a STATE, not an error.** Access to a node does not imply access to its partition
+root: an `AccessAssignment` can share a single node out of a partition the viewer is not a member of.
+A denial there means "this viewer inherits nothing", and it is classified by
+`AreaErrorClassifier.IsExpectedUserActionFailure` — the same predicate
+`MeshNodeThumbnailControl.ShouldSurfaceStreamError` already uses for the same reason. **Nothing else
+is caught.** A genuine infrastructure fault propagates to the page, because a decoration quietly
+swallowing infrastructure faults is how a broken mesh renders as a working one.
+
+## Inheritance is opt-in per SURFACE
+
+Every call site kept compiling; the ones that pass a root were chosen, not swept.
+
+**A page identifies ONE node**, so the package mark is pure gain there. The node-page header
+(`MeshNodeLayoutAreas.Overview`, `ContentData`) and the markdown page header
+(`MarkdownOverviewLayoutArea.Overview`) pass the root.
+
+**A LIST of siblings is not one node.** In a mixed child listing the NodeType glyph is what tells a
+doc from a code node from a thread; flattening a rail to the same package mark repeated twelve times
+would take that away and give nothing back. So the nav rail's child links, cards, pickers and search
+results keep resolving through the one-argument overload.
+
+That split is a policy, and it is the reason the mechanism is an overload rather than a global change
+to the chain: a surface that wants inheritance asks for it.
+
+## What this change does NOT cover
+
+- **The crawler-facing head.** `SeoResolver.ResolveIcon` deliberately resolves *the node's own mark or
+  nothing* — no NodeType stand-in, no synthesis — and it is a different chain from
+  `ResolveNodeIcon`. Extending it to inherit a package mark is a defensible next step and a genuinely
+  separate policy question; its consumer (`Memex.Portal.Gui/Seo/SeoHead.razor`) also lives in
+  MeshWeaver.Plugins, so it is a two-repo change. See [Link Previews](../LinkPreviews).
+- **The in-circuit tab.** `MeshNodeImageHelper.ResolveIconLink` now takes an optional root and
+  inherits when given one, but its caller — `MeshWeaver.Blazor/Pages/ApplicationPage.razor.cs` — is in
+  MeshWeaver.Plugins. Until that opts in, a signed-in tab keeps the NodeType glyph. The same
+  cross-repo seam [Content Favicon Rasterization](../ContentFaviconRasterization) describes.
+
+An inherited mark that is an **official third-party mark** still yields the portal's own mark in the
+tab: a favicon claims the tab *is* the site's, and that claim does not become truer by being
+inherited.
+
+## Verifying it
+
+The pure chain, with no mesh, is pinned by `PackageRootIconInheritanceTest`; the reactive seam is
+pinned against a real mesh by `PartitionRootStreamTest` (both in `test/MeshWeaver.Graph.Test`). In a
+running portal, open a page under a marked package and read the header tile — a doc under `Chess`
+shows the board, not the document glyph, and `Chess` itself is unchanged.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-page-wears-its-packages-mark.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-page-wears-its-packages-mark.md
@@ -1,0 +1,30 @@
+---
+Name: A page inside a package now wears that package's mark
+Category: Feature
+Description: A lesson, a game or a document that never chose an icon of its own showed the same generic glyph as every other page. It now shows the mark of the package it belongs to.
+Icon: Sparkle
+Order: -20260902
+---
+
+# A page inside a package now wears that package's mark
+
+Most pages never choose an icon. A lesson inside a course, a game's rules page, a document inside a
+store package — all of them fell back to the same generic chrome: a grey document sheet, a grey box.
+Open three of them and the page headers were indistinguishable.
+
+Those packages **do** have marks — a chess board for Chess, each course and each plugin its own — and
+the store's marks were drawn as bold, high-contrast squares precisely so they stay readable when
+they're small.
+
+A page with no icon of its own now shows **the mark of the package it lives in**. A lesson under a
+course reads as that course; a page under Chess reads as Chess. Nothing else about the page changes.
+
+Three things stay exactly as they were:
+
+- **A page that picked its own icon keeps it.** Package marks fill a gap; they never override a
+  choice.
+- **A package with no mark changes nothing.** Its pages keep the glyph for their type, as before.
+- **Lists still tell types apart.** In a side menu or a card grid, a document, a code file and a
+  conversation still show their own distinct glyphs — that is what tells them apart at a glance, and
+  repeating one package mark down a whole list would take it away. The mark appears where the page
+  identifies itself.

--- a/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
+++ b/src/MeshWeaver.Graph/MarkdownOverviewLayoutArea.cs
@@ -46,13 +46,18 @@ public static class MarkdownOverviewLayoutArea
             ? Observable.Return<NodeNavigation?>(null)
             : SuppliedNavigation(host);
 
+        // The node's PARTITION ROOT, for the header icon's package-mark inheritance (#2075 item 2).
+        // Starts null and never gates: a page that inherits nothing renders exactly as before.
+        var partitionRootStream = host.Workspace.ObservePartitionRoot(host.Hub.Address.Path);
+
         return host.Workspace.GetMeshNodeStream()
             .CombineLatest(permissionsStream, host.ObserveChildren("is:main"), suppliedStream,
-                (node, perms, children, supplied) =>
+                partitionRootStream,
+                (node, perms, children, supplied, partitionRoot) =>
             {
                 var canComment = perms.HasFlag(Permission.Comment) || perms.HasFlag(Permission.Update);
                 var canEdit = perms.HasFlag(Permission.Update);
-                var content = (UiControl)BuildOverview(host, node, canComment, canEdit, hideHeader);
+                var content = (UiControl)BuildOverview(host, node, canComment, canEdit, hideHeader, partitionRoot);
 
                 // A markdown node with sub-nodes gets a collapsible side menu of them. Skipped for
                 // @@ embeds and when there are none; internal satellites (_Access, _Thread, …) excluded.
@@ -232,7 +237,11 @@ public static class MarkdownOverviewLayoutArea
         return group;
     }
 
-    private static UiControl BuildOverview(LayoutAreaHost host, MeshNode? node, bool canComment, bool canEdit, bool hideHeader)
+    // partitionRoot: the node's partition root, when the caller holds it — the header icon inherits
+    // its package mark from there (#2075 item 2). Null keeps the NodeType glyph.
+    private static UiControl BuildOverview(
+        LayoutAreaHost host, MeshNode? node, bool canComment, bool canEdit, bool hideHeader,
+        MeshNode? partitionRoot = null)
     {
         var nodePath = node?.Path ?? host.Hub.Address.ToString();
         var rawContent = GetMarkdownContent(node);
@@ -242,7 +251,8 @@ public static class MarkdownOverviewLayoutArea
 
         // Standard header with title/icon (skipped for @@ embeds)
         if (!hideHeader)
-            container = container.WithView(MeshNodeLayoutAreas.BuildHeader(host, node, false));
+            container = container.WithView(
+                MeshNodeLayoutAreas.BuildHeader(host, node, false, partitionRoot));
 
         // Read-only markdown content — the CollaborativeMarkdownControl is added as
         // a DIRECT child of `container` so agents and tests can locate it without

--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -111,6 +111,61 @@ public static class MeshNodeExtensions
     }
 
     /// <summary>
+    /// 🚨 THE PARTITION ROOT OF A NODE, LIVE — the one read package-mark inheritance needs
+    /// (<see cref="MeshNodeImageHelper.ResolveNodeIcon(MeshNode?, MeshNode?)"/>, issue #2075 item 2).
+    ///
+    /// <para><b>Why a stream and not a lookup.</b> The icon resolver is deliberately pure, total and
+    /// synchronous over ONE node, so the root has to reach it from outside. This is the seam that
+    /// fetches it, and it is an <see cref="IObservable{T}"/> like every other read in the mesh: a
+    /// page CombineLatests it beside the node's own stream, so re-marking a package re-paints every
+    /// page under it with no invalidation to write.</para>
+    ///
+    /// <para><b>A point read that is legitimate.</b> Reading one node by exact path is only ever
+    /// correct for a path known to exist — a point read of an absent node answers a routing NotFound
+    /// that opens the storm-breaker on it. A partition root exists for every node that has one, by
+    /// construction: it is the namespace the node lives in. And when there is no distinct root
+    /// (<see cref="MeshNodeImageHelper.PartitionRootPath"/> null — the node IS a root) NOTHING is
+    /// read at all; the stream is a constant null.</para>
+    ///
+    /// <para><b>Starts null, upgrades.</b> The page renders on the node's own stream immediately and
+    /// the mark arrives when the root does — the root read can never delay, or gate, a page that
+    /// does not depend on it.</para>
+    ///
+    /// <para>🚨 <b>One fault is a STATE, not an error.</b> Access to a node does not imply access to
+    /// its partition root — an <c>AccessAssignment</c> can share a single node out of a partition
+    /// the viewer is not a member of — so a denial here means "this viewer inherits nothing", the
+    /// same normal state <c>MeshNodeThumbnailControl.ShouldSurfaceStreamError</c> already names for
+    /// the same reason. It is classified by
+    /// <see cref="MeshWeaver.Layout.AreaErrorClassifier.IsExpectedUserActionFailure"/> and nothing
+    /// else is caught: a genuine infrastructure fault propagates to the page, because a decoration
+    /// quietly swallowing infrastructure faults is how a broken mesh renders as a working one.</para>
+    /// </summary>
+    /// <param name="workspace">The workspace to read through.</param>
+    /// <param name="nodePath">🚨 A MESH NODE path — the guarantee above ("a partition root exists
+    /// for every node that has one") is a statement about node paths, and only about those. A
+    /// layout area passes <c>host.Hub.Address.Path</c>, which is the same value it already treats as
+    /// the node path for permissions and URLs.</param>
+    /// <returns>The partition root as it changes, starting with null; constant null when the node
+    /// has no distinct partition root.</returns>
+    public static IObservable<MeshNode?> ObservePartitionRoot(this IWorkspace workspace, string? nodePath)
+    {
+        if (MeshNodeImageHelper.PartitionRootPath(nodePath) is not { } rootPath)
+            return Observable.Return<MeshNode?>(null);
+
+        return workspace.GetMeshNodeStream(rootPath)
+            .Select(root => (MeshNode?)root)
+            .Catch<MeshNode?, Exception>(ex =>
+                MeshWeaver.Layout.AreaErrorClassifier.IsExpectedUserActionFailure(ex)
+                    ? Observable.Return<MeshNode?>(null)
+                    : Observable.Throw<MeshNode?>(ex))
+            .StartWith((MeshNode?)null)
+            // Only the two fields inheritance reads. The root node emits on every touch of it
+            // (LastModified, content edits, children); without this every such emission would
+            // re-render every page in the partition for an icon that did not change.
+            .DistinctUntilChanged(root => (root?.Path, root?.Icon));
+    }
+
+    /// <summary>
     /// Gets the primary node path for this node.
     /// For satellite nodes, returns the MainNode path.
     /// For regular nodes, returns the node's own path.

--- a/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
+++ b/src/MeshWeaver.Graph/MeshNodeImageHelper.cs
@@ -73,17 +73,98 @@ public static class MeshNodeImageHelper
     /// When the node carries no icon of its own, falls back to a default icon for its
     /// <see cref="MeshNode.NodeType"/> (<see cref="DefaultIconForNodeType"/>) so every node reads as
     /// its type rather than a bare letter — Markdown → document, Code → code, Agent → bot, etc.
+    ///
+    /// <para>This overload inherits NOTHING: it is the resolution for a caller that has only the one
+    /// node in hand. A caller that also holds the node's partition root — a page, a tab — passes it
+    /// to <see cref="ResolveNodeIcon(MeshNode?, MeshNode?)"/> and gets the package's mark instead of
+    /// a generic type glyph.</para>
     /// </summary>
-    public static string? ResolveNodeIcon(MeshNode? node) =>
+    public static string? ResolveNodeIcon(MeshNode? node) => ResolveNodeIcon(node, null);
+
+    /// <summary>
+    /// 🚨 THE RESOLUTION WITH PACKAGE-ROOT INHERITANCE — a node that carries no mark of its own
+    /// wears its PACKAGE's, ahead of the generic glyph for its type (issue #2075, item 2).
+    ///
+    /// <para><b>Why.</b> A lesson under <c>AgenticEngineering</c>, a game under <c>Chess</c>, a doc
+    /// under a store package: none of them authors an icon, so all of them resolved to the same
+    /// <c>document</c> / <c>box</c> chrome — in the page header and, worse, in the browser tab,
+    /// where "which package is this" is the only thing the 16 px square can usefully say. The
+    /// package roots DO carry marks, aligned to one visual language precisely so they read at that
+    /// size (MeshWeaver.Plugins #588).</para>
+    ///
+    /// <para><b>Only the root's OWN mark is inherited</b> — <see cref="MeshNode.Icon"/>, resolved
+    /// the same two ways a node's own icon is (a <c>content:</c> reference, a shipped glyph of that
+    /// name). Deliberately NOT the root's full chain: falling through to the root's NodeType default
+    /// would dress every doc under an unmarked package in the ROOT's type glyph instead of its own,
+    /// which is strictly worse than what it replaces.</para>
+    ///
+    /// <para><b>A partition root never inherits</b> — <see cref="PartitionRootPath"/> is null for a
+    /// single-segment path, so a root cannot resolve itself, and a supplied root that is not
+    /// actually this node's partition root is ignored rather than borrowed from.</para>
+    ///
+    /// <para><b>Still total</b>, exactly as the one-argument overload is: own icon → shipped glyph
+    /// of that name → the partition root's own mark → the NodeType default → the neutral box. Every
+    /// node resolves to something, so no card, tab or avatar can fall back to a bare initial.</para>
+    /// </summary>
+    /// <param name="node">The node whose icon is being resolved.</param>
+    /// <param name="partitionRoot">The node's partition root, when the caller has it — the node at
+    /// the FIRST segment of <paramref name="node"/>'s path. Null (the default, and the one-argument
+    /// overload) simply skips the inheritance step.</param>
+    public static string? ResolveNodeIcon(MeshNode? node, MeshNode? partitionRoot) =>
         node == null ? null
             // Guarantee a resolved icon for ANY non-null node so a card / avatar NEVER falls back to
             // the bare-initial (blue) placeholder: own Icon → the shipped glyph of the same name →
-            // NodeType default → a neutral box glyph (covers a typeless node, where
-            // DefaultIconForNodeType returns null).
+            // the partition root's own mark → NodeType default → a neutral box glyph (covers a
+            // typeless node, where DefaultIconForNodeType returns null).
             : ResolveContentPath(node.Icon, node.Path)
               ?? ShippedIconFor(node.Icon)
+              ?? InheritedIcon(node, partitionRoot)
               ?? DefaultIconForNodeType(node.NodeType)
               ?? NeutralIconUrl;
+
+    /// <summary>
+    /// The PARTITION ROOT path of a mesh path — its first segment — or null when there is no
+    /// distinct root to inherit from.
+    ///
+    /// <para>Null in exactly two cases, and both mean "nothing above this to inherit": an empty
+    /// path, and a path that IS a single segment. The second is the load-bearing one — a partition
+    /// root's own root is itself, and inheriting from yourself is a no-op at best and, once the
+    /// value is fed back through the chain, a way to make <c>Chess</c> resolve <c>Chess</c>
+    /// forever.</para>
+    /// </summary>
+    /// <param name="nodePath">A mesh node path, e.g. <c>AgenticEngineering/Lesson1</c>.</param>
+    public static string? PartitionRootPath(string? nodePath)
+    {
+        if (string.IsNullOrWhiteSpace(nodePath))
+            return null;
+        var segments = nodePath.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        return segments.Length <= 1 ? null : segments[0];
+    }
+
+    /// <summary>
+    /// The mark <paramref name="node"/> inherits from <paramref name="partitionRoot"/>, or null when
+    /// it inherits nothing.
+    ///
+    /// <para>🚨 The relationship is VERIFIED, not assumed: the supplied root is used only when its
+    /// path really is the first segment of the node's. A caller that hands over the wrong node —
+    /// the parent instead of the root, a stale frame from another page — gets no inheritance rather
+    /// than an unrelated package's mark on someone else's page, which is the failure that would be
+    /// invisible in a screenshot.</para>
+    /// </summary>
+    /// <param name="node">The node that would inherit.</param>
+    /// <param name="partitionRoot">The candidate partition root; null yields null.</param>
+    public static string? InheritedIcon(MeshNode? node, MeshNode? partitionRoot)
+    {
+        if (node is null || partitionRoot is null)
+            return null;
+        if (PartitionRootPath(node.Path) is not { } rootPath
+            || !string.Equals(rootPath, (partitionRoot.Path ?? "").Trim('/'),
+                StringComparison.OrdinalIgnoreCase))
+            return null;
+        // The root's OWN mark only — never its NodeType default, see ResolveNodeIcon's remarks.
+        return ResolveContentPath(partitionRoot.Icon, partitionRoot.Path)
+               ?? ShippedIconFor(partitionRoot.Icon);
+    }
 
     /// <summary>
     /// The shipped glyph matching a FLUENT ICON NAME, or null when none is shipped under that name.
@@ -302,7 +383,7 @@ public static class MeshNodeImageHelper
     /// 🚨 THE NODE'S ICON, READY FOR THE BROWSER TAB — a node page identifies itself in the tab
     /// strip rather than wearing the same portal favicon as every other page.
     ///
-    /// <para>Resolution is <see cref="ResolveNodeIcon"/>, i.e. EXACTLY what the app already renders
+    /// <para>Resolution is <see cref="ResolveNodeIcon(MeshNode?)"/>, i.e. EXACTLY what the app already renders
     /// for the node in the tree, the menus and its cards (own icon → the shipped glyph of that name
     /// → the NodeType default → a neutral box). Nothing is synthesised beyond putting a value an
     /// <c>href</c> cannot carry into a form it can: an inline <c>&lt;svg&gt;</c> identicon and a text
@@ -310,13 +391,30 @@ public static class MeshNodeImageHelper
     /// the per-instance favicon uses. So the tab and the app can never disagree about what a node
     /// looks like.</para>
     ///
-    /// <para>Total, like <see cref="ResolveNodeIcon"/>: every node resolves to something, so a tab
+    /// <para>Total, like <see cref="ResolveNodeIcon(MeshNode?)"/>: every node resolves to something, so a tab
     /// never silently keeps the previous page's icon.</para>
     /// </summary>
     /// <param name="node">The node whose page is being shown.</param>
-    public static IconLink ResolveIconLink(MeshNode node)
+    public static IconLink ResolveIconLink(MeshNode node) => ResolveIconLink(node, null);
+
+    /// <summary>
+    /// <see cref="ResolveIconLink(MeshNode)"/> with package-root inheritance — the tab of a page
+    /// under a marked package wears the PACKAGE's mark rather than a generic type glyph, which is
+    /// the surface issue #2075 was actually about: at 16 px "which package" is the only thing worth
+    /// saying, and <c>document</c> says nothing.
+    ///
+    /// <para>Resolution stays <see cref="ResolveNodeIcon(MeshNode?, MeshNode?)"/> — the identical
+    /// chain the app renders — so the tab and the page still cannot disagree, including about an
+    /// inherited mark. The official-mark substitution below applies to an inherited value too: a
+    /// package whose mark is a vendor's still yields the portal's own mark in the TAB, because a
+    /// favicon claims the tab is theirs.</para>
+    /// </summary>
+    /// <param name="node">The node whose page is being shown.</param>
+    /// <param name="partitionRoot">The node's partition root, when the caller has it; null skips
+    /// inheritance.</param>
+    public static IconLink ResolveIconLink(MeshNode node, MeshNode? partitionRoot)
     {
-        var icon = ResolveNodeIcon(node);
+        var icon = ResolveNodeIcon(node, partitionRoot);
 
         // 🚨 THE ONE PLACE THE TAB AND THE CARD DELIBERATELY DIVERGE. A card showing a vendor's mark
         // is nominative use — the package is an API client to that service, and the mark says which

--- a/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/MeshNodeLayoutAreas.cs
@@ -232,15 +232,19 @@ public static class MeshNodeLayoutAreas
     public static IObservable<UiControl?> Overview(LayoutAreaHost host, RenderingContext _)
     {
         var hubPath = host.Hub.Address.ToString();
-        // CombineLatest with permission stream — pure observable composition, no await.
+        // CombineLatest with permission stream — pure observable composition, no await. The third
+        // input is the node's PARTITION ROOT, which the header's icon inherits its package mark from
+        // (#2075 item 2); it starts null, so it can never delay the page.
         return host.Workspace.GetMeshNodeStream().CombineLatest(
                 host.Hub.GetEffectivePermissions(hubPath),
-                (node, permissions) => (Node: node, Permissions: permissions))
+                host.Workspace.ObservePartitionRoot(host.Hub.Address.Path),
+                (node, permissions, partitionRoot) =>
+                    (Node: node, Permissions: permissions, PartitionRoot: partitionRoot))
             .SelectMany(t =>
             {
                 if (t.Permissions.HasFlag(Permission.Read))
                     return Observable.Return((UiControl?)host.BuildDetailsContent(
-                        t.Node, null, t.Permissions.HasFlag(Permission.Update)));
+                        t.Node, null, t.Permissions.HasFlag(Permission.Update), t.PartitionRoot));
                 // Read denied: the partition's declared funnel page (RedirectOnDenied — e.g.
                 // a product's glossy marketing brochure) takes the viewer there instead of a
                 // dead-end Request-Access wall. Rendering the denial INSIDE the area used to
@@ -272,9 +276,12 @@ public static class MeshNodeLayoutAreas
         var hubPath = host.Hub.Address.ToString();
         return host.Workspace.GetMeshNodeStream().CombineLatest(
                 host.Hub.GetEffectivePermissions(hubPath),
-                (node, permissions) => (Node: node, Permissions: permissions))
+                host.Workspace.ObservePartitionRoot(host.Hub.Address.Path),
+                (node, permissions, partitionRoot) =>
+                    (Node: node, Permissions: permissions, PartitionRoot: partitionRoot))
             .Select(t => t.Permissions.HasFlag(Permission.Read)
-                ? (UiControl?)host.BuildDetailsContent(t.Node, null, t.Permissions.HasFlag(Permission.Update))
+                ? (UiControl?)host.BuildDetailsContent(
+                    t.Node, null, t.Permissions.HasFlag(Permission.Update), t.PartitionRoot)
                 : BuildAccessDenied(hubPath, locale: host.ViewerLocale()));
     }
 
@@ -334,7 +341,9 @@ public static class MeshNodeLayoutAreas
         return $"position: relative; max-width: {pageMaxWidth}; margin: 0 auto; padding: 0 24px;";
     }
 
-    internal static UiControl BuildDetailsContent(this LayoutAreaHost host, MeshNode? node, NodeTypeDefinition? typeDef, bool canEdit = true)
+    // partitionRoot: the node's partition root, when the caller holds it — the header icon inherits
+    // its package mark from there (#2075 item 2). Null simply keeps the NodeType glyph.
+    internal static UiControl BuildDetailsContent(this LayoutAreaHost host, MeshNode? node, NodeTypeDefinition? typeDef, bool canEdit = true, MeshNode? partitionRoot = null)
     {
         // Outer wrapper at full page width
         var outer = Controls.Stack.WithWidth("100%");
@@ -343,7 +352,7 @@ public static class MeshNodeLayoutAreas
         var content = Controls.Stack.WithWidth("100%").WithStyle(GetContainerStyle(host, typeDef));
 
         // Header with title/icon
-        content = content.WithView(BuildHeader(host, node, canEdit));
+        content = content.WithView(BuildHeader(host, node, canEdit, partitionRoot));
 
         // For built-in type nodes (Content is NodeTypeDefinition), show type info
         // instead of property editor which would expose internal NodeTypeDefinition fields.
@@ -412,6 +421,31 @@ public static class MeshNodeLayoutAreas
     /// as built-in node pages — the alternative is a hand-built copy that drifts.
     /// </summary>
     public static UiControl BuildHeader(LayoutAreaHost host, MeshNode? node, bool canEdit = true)
+        => BuildHeader(host, node, canEdit, null);
+
+    /// <summary>
+    /// <see cref="BuildHeader(LayoutAreaHost, MeshNode?, bool)"/> with the node's PARTITION ROOT in
+    /// hand, so a page under a marked package wears that package's mark instead of a generic type
+    /// glyph (#2075 item 2).
+    ///
+    /// <para>🚨 A separate overload rather than a fourth optional parameter, for the reason
+    /// <c>PageIcon.Rel</c> spells out: this method is a module-facing contract, and adding a
+    /// parameter — default or not — REPLACES the signature every already-compiled module was built
+    /// against. An overload is additive, so a module compiled against the three-argument form keeps
+    /// binding to it.</para>
+    ///
+    /// <para>Inheritance is opt-in per surface, deliberately. A page identifies ONE node, so the
+    /// package mark is pure gain there; a LIST of siblings is not — the NodeType glyph is what tells
+    /// a doc from a code node from a thread in a mixed child listing, and flattening a rail to one
+    /// repeated package mark would take that away. So the page header opts in and the nav rail's
+    /// child links do not.</para>
+    /// </summary>
+    /// <param name="host">The layout area host.</param>
+    /// <param name="node">The node whose header is being built.</param>
+    /// <param name="canEdit">Whether the viewer may edit (icon picker, inline title).</param>
+    /// <param name="partitionRoot">The node's partition root, or null to skip inheritance.</param>
+    public static UiControl BuildHeader(
+        LayoutAreaHost host, MeshNode? node, bool canEdit, MeshNode? partitionRoot)
     {
         // Chrome-less pages: a node excluded from the "header" context ships without the
         // icon/title/meta block — the content (a marketing hero, a landing page) starts
@@ -421,7 +455,7 @@ public static class MeshNodeLayoutAreas
         var hubPath = host.Hub.Address.ToString();
         var nodePath = node?.Path ?? hubPath;
         var title = node?.Name ?? node?.Id ?? hubPath;
-        var iconValue = MeshNodeImageHelper.ResolveNodeIcon(node);
+        var iconValue = MeshNodeImageHelper.ResolveNodeIcon(node, partitionRoot);
         var rawIcon = node?.Icon;
 
         // Row 1 — icon + title (+ action buttons on the right)

--- a/test/MeshWeaver.Graph.Test/PackageRootIconInheritanceTest.cs
+++ b/test/MeshWeaver.Graph.Test/PackageRootIconInheritanceTest.cs
@@ -1,0 +1,206 @@
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Package-root icon inheritance — issue #2075, item 2.
+///
+/// <para>A lesson under <c>AgenticEngineering</c>, a game under <c>Chess</c>, a doc under a store
+/// package: none authors an icon of its own, so every one of them resolved to the same generic
+/// <c>document</c> / <c>box</c> chrome, in the page header and in the browser tab. The package roots
+/// DO carry marks. These tests pin the step that reaches for one, and — just as importantly — the
+/// three places it must NOT reach.</para>
+/// </summary>
+public class PackageRootIconInheritanceTest
+{
+    private const string Package = "Chess";
+
+    /// <summary>An authored package mark: inline svg with a full-bleed plate, the shape every store
+    /// mark was aligned to so it reads at 16 px (MeshWeaver.Plugins #588).</summary>
+    private const string PackageMark =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\">"
+        + "<rect width=\"24\" height=\"24\" rx=\"5\" fill=\"#1f6feb\"/>"
+        + "<path d=\"M8 6h8v3H8z\" fill=\"#fff\"/></svg>";
+
+    private const string DocumentGlyph = "/static/NodeTypeIcons/document.svg";
+    private const string NeutralBox = "/static/NodeTypeIcons/box.svg";
+
+    private static MeshNode Root(string? icon, string? nodeType = "Space") =>
+        new(Package) { Name = "Chess", NodeType = nodeType, Icon = icon };
+
+    private static MeshNode Child(string? icon = null, string? nodeType = "Markdown") =>
+        new("Rules", Package) { Name = "Rules", NodeType = nodeType, Icon = icon };
+
+    // ── The path arithmetic ───────────────────────────────────────────────────────────────────
+
+    /// <summary>The partition root is the FIRST segment, not the parent — a doc three levels down a
+    /// package still wears the package's mark, not its folder's.</summary>
+    [Theory]
+    [InlineData("Chess/Rules", "Chess")]
+    [InlineData("Doc/Architecture/LinkPreviews", "Doc")]
+    [InlineData("AgenticEngineering/Lessons/01-TheMagicWish", "AgenticEngineering")]
+    [InlineData("/Chess/Rules", "Chess")] // leading separator tolerated
+    public void PartitionRootPath_IsTheFirstSegment(string nodePath, string expected)
+        => MeshNodeImageHelper.PartitionRootPath(nodePath).Should().Be(expected);
+
+    /// <summary>Null exactly where there is nothing above to inherit from — which is what makes a
+    /// partition root structurally unable to resolve itself.</summary>
+    [Theory]
+    [InlineData("Chess")]
+    [InlineData("/Chess/")]
+    [InlineData("")]
+    [InlineData("  ")]
+    [InlineData(null)]
+    public void PartitionRootPath_NullWhenThereIsNoDistinctRoot(string? nodePath)
+        => MeshNodeImageHelper.PartitionRootPath(nodePath).Should().BeNull();
+
+    // ── The inheritance step ──────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 THE FEATURE. A child with no icon of its own wears the package's mark instead of the
+    /// generic glyph for its type — and the one-argument overload still resolves the old way, so
+    /// nothing that has not opted in can change under it.
+    /// </summary>
+    [Fact]
+    public void AChildWithNoIconOfItsOwn_InheritsThePackageMark()
+    {
+        var child = Child();
+
+        MeshNodeImageHelper.ResolveNodeIcon(child).Should().Be(DocumentGlyph);
+        MeshNodeImageHelper.ResolveNodeIcon(child, Root(PackageMark)).Should().Be(PackageMark);
+    }
+
+    /// <summary>A node's OWN icon always wins — inheritance sits BELOW it in the chain, so marking a
+    /// package can never overwrite what a page chose for itself.</summary>
+    [Fact]
+    public void AnOwnIcon_WinsOverThePackageMark()
+        => MeshNodeImageHelper.ResolveNodeIcon(Child("🎯"), Root(PackageMark)).Should().Be("🎯");
+
+    /// <summary>A package root does not inherit: its own path has no first-segment ANCESTOR, so
+    /// handing it itself changes nothing and cannot loop.</summary>
+    [Fact]
+    public void APartitionRoot_DoesNotInheritFromItself()
+    {
+        var root = Root(icon: null, nodeType: "Markdown");
+
+        MeshNodeImageHelper.ResolveNodeIcon(root, root).Should().Be(DocumentGlyph);
+        MeshNodeImageHelper.InheritedIcon(root, root).Should().BeNull();
+    }
+
+    /// <summary>An UNMARKED package changes nothing: the chain falls through to the NodeType default
+    /// exactly as before, so adding the step cannot regress a package that never had a mark.</summary>
+    [Fact]
+    public void AnUnmarkedPackageRoot_FallsThroughToTheNodeTypeDefault()
+        => MeshNodeImageHelper.ResolveNodeIcon(Child(), Root(icon: null)).Should().Be(DocumentGlyph);
+
+    /// <summary>…and the chain stays TOTAL underneath that: a typeless child under an unmarked
+    /// package still reaches the neutral box, never null and never a bare initial.</summary>
+    [Fact]
+    public void AnUnmarkedPackageRoot_ATypelessChild_StillReachesTheNeutralBox()
+        => MeshNodeImageHelper.ResolveNodeIcon(Child(nodeType: null), Root(icon: null))
+            .Should().Be(NeutralBox);
+
+    /// <summary>
+    /// 🚨 ONLY THE ROOT'S OWN MARK IS INHERITED — never the root's own fallback chain. An unmarked
+    /// <c>Space</c> root resolves to the <c>organization</c> glyph for ITSELF; borrowing that would
+    /// dress every document in the package as an organization, which is strictly worse than the
+    /// document glyph it replaced.
+    /// </summary>
+    [Fact]
+    public void TheRootsOwnNodeTypeDefault_IsNotInherited()
+    {
+        var root = Root(icon: null);
+
+        // The root resolves to its own type glyph...
+        MeshNodeImageHelper.ResolveNodeIcon(root).Should().Be("/static/NodeTypeIcons/organization.svg");
+        // ...and the child does NOT get it.
+        MeshNodeImageHelper.ResolveNodeIcon(Child(), root).Should().Be(DocumentGlyph);
+    }
+
+    /// <summary>
+    /// 🚨 THE SUPPLIED ROOT IS VERIFIED, NOT TRUSTED. A caller that hands over the wrong node — a
+    /// stale frame, the parent instead of the root — gets no inheritance rather than an unrelated
+    /// package's mark on someone else's page, which is the failure a screenshot could not catch.
+    /// </summary>
+    [Fact]
+    public void ANodeThatIsNotThisNodesPartitionRoot_IsIgnored()
+    {
+        var otherPackage = new MeshNode("Draughts") { NodeType = "Space", Icon = PackageMark };
+        var intermediateFolder = new MeshNode("Lessons", Package) { Icon = PackageMark };
+
+        MeshNodeImageHelper.ResolveNodeIcon(Child(), otherPackage).Should().Be(DocumentGlyph);
+        MeshNodeImageHelper.ResolveNodeIcon(Child(), intermediateFolder).Should().Be(DocumentGlyph);
+    }
+
+    /// <summary>A null root is simply the un-inherited resolution — the one-argument overload's
+    /// behaviour, reached by every call site that has not opted in.</summary>
+    [Fact]
+    public void ANullRoot_ResolvesExactlyAsTheOneArgumentOverloadDoes()
+        => MeshNodeImageHelper.ResolveNodeIcon(Child(), null)
+            .Should().Be(MeshNodeImageHelper.ResolveNodeIcon(Child()));
+
+    /// <summary>A root marked with a <c>content:</c> reference is inherited through the
+    /// ACCESS-CONTROLLED content route (issue #587) and resolved against the ROOT's path — never the
+    /// child's, which holds no such file.</summary>
+    [Fact]
+    public void AContentReferenceMark_ResolvesAgainstTheRootsOwnContentCollection()
+    {
+        var icon = MeshNodeImageHelper.ResolveNodeIcon(Child(), Root("content:mark.svg"));
+
+        icon.Should().StartWith("/api/content/").And.EndWith("mark.svg");
+        icon.Should().Contain(Package).And.NotContain("Rules");
+        icon.Should().NotContain("/static/storage");
+    }
+
+    /// <summary>A root marked with a shipped glyph NAME resolves to that glyph's URL — the same
+    /// second step a node's own Fluent-named icon gets, so authoring a name on a package works the
+    /// way authoring one on a page does.</summary>
+    [Fact]
+    public void AShippedGlyphNameOnTheRoot_ResolvesToThatGlyph()
+        => MeshNodeImageHelper.ResolveNodeIcon(Child(), Root("Sparkle"))
+            .Should().Be("/static/NodeTypeIcons/sparkle.svg");
+
+    /// <summary>A root whose icon is a Fluent name this assembly ships no glyph for cannot be
+    /// rendered, so it is not inherited — the child falls through rather than carrying a value that
+    /// would render as a broken image.</summary>
+    [Fact]
+    public void AnUnrenderableFluentNameOnTheRoot_IsNotInherited()
+        => MeshNodeImageHelper.ResolveNodeIcon(Child(), Root("NoSuchIconNameAtAll"))
+            .Should().Be(DocumentGlyph);
+
+    // ── The browser tab ───────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The tab is the surface #2075 was reported on: at 16 px "which package is this" is the only
+    /// thing worth saying, and <c>document</c> says nothing. Resolution is the same chain the app
+    /// renders, so the tab and the page cannot disagree about an inherited mark either.
+    /// </summary>
+    [Fact]
+    public void ResolveIconLink_InheritsThePackageMarkIntoTheTab()
+    {
+        var withoutRoot = MeshNodeImageHelper.ResolveIconLink(Child());
+        var withRoot = MeshNodeImageHelper.ResolveIconLink(Child(), Root(PackageMark));
+
+        withoutRoot.Href.Should().Be(DocumentGlyph);
+        withRoot.Type.Should().Be(MeshNodeImageHelper.SvgMediaType);
+        Uri.UnescapeDataString(withRoot.Href["data:image/svg+xml,".Length..]).Should().Be(PackageMark);
+    }
+
+    /// <summary>An inherited mark that is an OFFICIAL third-party mark still yields the portal's own
+    /// mark in the tab — a favicon claims the tab IS the site's, and that claim does not become
+    /// truer by being inherited.</summary>
+    [Fact]
+    public void ResolveIconLink_AnInheritedOfficialMark_StillYieldsThePortalMark()
+    {
+        var official = "<svg xmlns=\"http://www.w3.org/2000/svg\" "
+                       + $"{IconBackplate.OfficialMarkAttribute}=\"{IconBackplate.OfficialMarkValue}\""
+                       + " viewBox=\"0 0 24 24\"><rect width=\"24\" height=\"24\" fill=\"#111827\"/></svg>";
+
+        // Precondition: the value really is classified as an official mark.
+        MeshNodeImageHelper.IsOfficialMark(official).Should().BeTrue();
+
+        MeshNodeImageHelper.ResolveIconLink(Child(), Root(official))
+            .Href.Should().Contain(MeshNodeImageHelper.MeshWeaverMarkUrl);
+    }
+}

--- a/test/MeshWeaver.Graph.Test/PartitionRootStreamTest.cs
+++ b/test/MeshWeaver.Graph.Test/PartitionRootStreamTest.cs
@@ -1,0 +1,196 @@
+using System.Text.Json;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Layout;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The reactive half of package-root icon inheritance (#2075 item 2):
+/// <see cref="MeshNodeExtensions.ObservePartitionRoot"/>, the seam that fetches the root the pure
+/// resolver cannot fetch for itself.
+///
+/// <para>Against a REAL mesh, because the thing worth pinning is exactly what a hand-written double
+/// would assume away: that a package root really does reach a page under it, and that a package root
+/// itself opens no read at all.</para>
+/// </summary>
+public class PartitionRootStreamTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Package = "Chess";
+    private const string ChildPath = $"{Package}/Rules";
+
+    /// <summary>An authored package mark — inline svg, the form every store mark takes.</summary>
+    private const string PackageMark =
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 24 24\">"
+        + "<rect width=\"24\" height=\"24\" rx=\"5\" fill=\"#1f6feb\"/>"
+        + "<path d=\"M8 6h8v3H8z\" fill=\"#fff\"/></svg>";
+
+    private const string UnmarkedPackage = "Draughts";
+
+    /// <summary>
+    /// 🚨 <see cref="TestTimeouts"/>, never a literal (#2819). A hand-written <c>30 s</c> is exactly
+    /// the framework's own write bound, so a test carrying one gives up ONE SECOND before the mesh
+    /// can name what went wrong — and it is a guess about a laptop, on a runner ~1.7× slower.
+    ///
+    /// <para>Two budgets because two different things are waited on, and both stay strictly below
+    /// their test's <c>[Fact(Timeout = …)]</c> so an inner wait loses first and reports what it was
+    /// waiting for.</para>
+    /// </summary>
+    private static TimeSpan ReadBudget => TestTimeouts.Quick;
+
+    /// <summary>A layout-area render round-trip, which settles later than a node read.</summary>
+    private static TimeSpan RenderBudget => TestTimeouts.Convergence;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode(Package) { Name = "Chess", NodeType = "Space", Icon = PackageMark },
+                new MeshNode("Rules", Package) { Name = "Rules", NodeType = "Markdown" },
+                // The control: same shape, no mark on the root.
+                new MeshNode(UnmarkedPackage) { Name = "Draughts", NodeType = "Space" },
+                new MeshNode("Rules", UnmarkedPackage) { Name = "Rules", NodeType = "Markdown" });
+
+    /// <summary>
+    /// 🚨 END TO END: the page under the package reads the package's node, and the pure resolver
+    /// turns it into the package's mark where it used to produce the generic document glyph.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task APageUnderThePackage_ResolvesThePackagesMark()
+    {
+        var workspace = Mesh.GetWorkspace();
+
+        var root = await workspace.ObservePartitionRoot(ChildPath)
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(ReadBudget);
+        root!.Path.Should().Be(Package);
+
+        var child = await workspace.GetMeshNodeStream(ChildPath)
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(ReadBudget);
+
+        // Before: the generic glyph for its type. After: the package's mark.
+        MeshNodeImageHelper.ResolveNodeIcon(child).Should().Be("/static/NodeTypeIcons/document.svg");
+        MeshNodeImageHelper.ResolveNodeIcon(child, root).Should().Be(PackageMark);
+    }
+
+    /// <summary>
+    /// It STARTS null, so the page it feeds renders on the node's own stream immediately — the root
+    /// read can never delay, or gate, a page that does not depend on it.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task TheStream_StartsWithNothing_SoItCannotGateThePage()
+        => (await Mesh.GetWorkspace().ObservePartitionRoot(ChildPath)
+                .FirstAsync().Timeout(ReadBudget))
+            .Should().BeNull();
+
+    /// <summary>
+    /// 🚨 A PACKAGE ROOT OPENS NO READ. Its own partition root is itself, so the stream is a
+    /// constant that completes — never a point read of a node the resolver would then have to
+    /// refuse anyway, and never a subscription per page for a value that cannot be used.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ForThePackageRootItself_NothingIsRead()
+    {
+        var emissions = await Mesh.GetWorkspace().ObservePartitionRoot(Package)
+            .ToList()
+            .FirstAsync().Timeout(ReadBudget);
+
+        emissions.Should().ContainSingle().Which.Should().BeNull();
+    }
+
+    /// <summary>
+    /// 🚨 THE WIRING, RENDERED. The page header of a node under a MARKED package really does draw
+    /// the package's mark, and the identical page under an UNMARKED one keeps its type glyph — the
+    /// control arm, without which "the mark is somewhere in the payload" would say nothing about
+    /// where it came from.
+    ///
+    /// <para>This is the transition the change makes: both of these headers used to resolve the same
+    /// generic document glyph.</para>
+    ///
+    /// <para>🚨 It waits for the mark rather than reading the first frame, and that is a REAL
+    /// property of the design, not test patience. The partition-root stream starts null so it can
+    /// never gate the page, so the header paints its type glyph on the first frame and re-renders
+    /// with the package's mark when the root arrives. Asserting on frame one measured the
+    /// un-inherited render and reported the wiring as broken — which is exactly what it did on the
+    /// first run of this test.</para>
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task TheNodePageHeader_DrawsThePackageMark()
+    {
+        var marked = await IconTile(ChildPath, MarkPathData);
+        marked.Should().Contain(MarkSignature, "the package's mark is what the header's tile draws");
+
+        // The control: same page shape, no mark on its root — it settles on the type glyph, and the
+        // other package's mark never reaches it.
+        var unmarked = await IconTile($"{UnmarkedPackage}/Rules", DocumentGlyph);
+        unmarked.Should().Contain(DocumentGlyph);
+        unmarked.Should().NotContain(MarkSignature);
+    }
+
+    private const string DocumentGlyph = "/static/NodeTypeIcons/document.svg";
+
+    /// <summary>The mark's path data — the fragment to WAIT for, because it reads identically in the
+    /// rendered HTML and in the JSON the area store travels as (it carries no character JSON
+    /// escapes).</summary>
+    private const string MarkPathData = "M8 6h8v3H8z";
+
+    /// <summary>The mark's INNER markup, which is what an assertion can pin. The whole
+    /// <see cref="PackageMark"/> string cannot be: a raw-HTML surface has no scoped CSS to size a
+    /// viewBox-only svg with, so <c>MeshNodeImageHelper.SizeInlineSvg</c> injects an explicit
+    /// <c>style</c> into the OPENING tag on the way out. Everything after it is untouched.</summary>
+    private const string MarkSignature =
+        "<rect width=\"24\" height=\"24\" rx=\"5\" fill=\"#1f6feb\"/>"
+        + "<path d=\"M8 6h8v3H8z\" fill=\"#fff\"/></svg>";
+
+    /// <summary>The 56 px square the node-page header draws its icon in — the one HTML control whose
+    /// content IS the resolved icon.</summary>
+    private const string IconTileMarker = "width: 56px; height: 56px";
+
+    /// <summary>
+    /// The node's rendered Overview header icon tile, awaited until the area carries
+    /// <paramref name="awaitedFragment"/>.
+    ///
+    /// <para>The wait is on the AREA STORE — one condition, one stream — rather than on a sub-area
+    /// resolved by name, because the header's inner area names are generated and a re-render is free
+    /// to renumber them. <paramref name="awaitedFragment"/> is therefore chosen to read identically
+    /// in the rendered HTML and in the JSON the store travels as. Once the store carries the answer
+    /// the tree is walked for the tile itself, so the assertion is still about the ICON and not about
+    /// the payload at large.</para>
+    /// </summary>
+    private async Task<string> IconTile(string nodePath, string awaitedFragment)
+    {
+        var workspace = GetClient(c => c.AddData()).GetWorkspace();
+        var reference = new LayoutAreaReference("Overview");
+        var stream = workspace.GetRemoteStream<JsonElement, LayoutAreaReference>(
+            new Address(nodePath), reference);
+
+        await stream.Should().Within(RenderBudget).Match(
+            frame => frame.Value.ToString().Contains(awaitedFragment),
+            $"the Overview of '{nodePath}' renders '{awaitedFragment}'");
+
+        var tiles = new List<string>();
+        await Collect(reference.Area!, 0);
+        return Assert.Single(tiles);
+
+        async Task Collect(string area, int depth)
+        {
+            if (depth > 6)
+                return;
+            var control = await stream.GetControlStream(area)
+                .Should().Within(ReadBudget).Match(c => c != null);
+            if (control is HtmlControl html
+                && (html.Data?.ToString() ?? "").Contains(IconTileMarker))
+                tiles.Add(html.Data!.ToString()!);
+            if (control is StackControl stack)
+                foreach (var name in stack.Areas.Select(a => a.Area?.ToString())
+                             .Where(n => !string.IsNullOrEmpty(n)))
+                    await Collect(name!, depth + 1);
+        }
+    }
+}


### PR DESCRIPTION
Closes the **one remaining item** of #2075. Items 1 (SSR `<link rel="icon">`) and 3 (raster fallback for Safari, `/api/icon/…`, #2987) already shipped; this is **item 2, package-root inheritance**.

## What was wrong

`ResolveNodeIcon`'s chain was `own icon → shipped glyph → NodeType default → neutral box`. A lesson under `AgenticEngineering`, a game under `Chess`, a doc under a store package — none of them authors an icon, so all of them resolved the same grey `document` sheet, in the page header and in the tab. Meanwhile the package roots **do** carry marks, aligned to one visual language (bold 24×24 plate, white detail) precisely so they read at 16 px (Plugins #588).

## 🚨 The design decision, and why it is not a one-liner

`ResolveNodeIcon` is `static`, **synchronous** and **total** over ONE `MeshNode`. The partition root is a *different node*, and reading one is an `IObservable` — a shape this signature cannot express and its callers are not built for.

| | make the resolver reactive | **pass the already-resolved root in** |
|---|---|---|
| resolver | returns `IObservable<string?>`; every caller becomes reactive | unchanged: pure, total, unit-testable with no mesh |
| call sites | all of them change, including Blazor render paths that cannot await | only the ones that opt in |
| a caller with no root | must open a stream to get any answer | calls the one-argument overload, exactly as today |

**The second was taken**, as an *overload*:

```csharp
ResolveNodeIcon(node)                 // unchanged — inherits nothing
ResolveNodeIcon(node, partitionRoot)  // inherits the root's own mark
```

🚨 **An overload, not a fourth optional parameter** on `MeshNodeLayoutAreas.BuildHeader` — for the reason `PageIcon.Rel` already spells out in `ContentFaviconRasterization.md`: adding a parameter to a module-facing method *replaces* the signature every already-compiled module was built against, default or not.

## Semantics — decided, and pinned by tests

- **"Partition root" is the FIRST path segment**, not the parent: `Doc/Architecture/LinkPreviews` inherits from `Doc`.
- **A partition root never inherits.** `PartitionRootPath` is null for a single-segment path, so a root *structurally* cannot resolve itself — not a guard bolted on afterwards.
- **Only the root's OWN `Icon` is inherited**, never the root's own chain. Falling through to the root's NodeType default would dress every doc under an unmarked `Space` as an *organization* — strictly worse than the document glyph it replaced.
- **The supplied root is verified, not trusted**: used only when its path really is the node's first segment, so a caller handing over the wrong node gets no inheritance rather than another package's mark on someone else's page.
- **The chain stays TOTAL**: own icon → shipped glyph → package mark → NodeType default → neutral box.

## The reactive half

`MeshNodeExtensions.ObservePartitionRoot(workspace, nodePath)`:

- **Reads nothing when there is no distinct root** — a package root's stream is a constant that completes. No point read, no path to storm.
- **A point read that is legitimate**: a partition root exists for every node that has one, by construction — it is the namespace the node lives in.
- **Starts null**, so `CombineLatest` cannot gate the page on a read it does not need.
- **`DistinctUntilChanged` on `(Path, Icon)`** — a root emits on every touch of it; without this each one would re-render every page in the partition for an icon that did not change.
- 🚨 **One fault is a STATE, not an error.** A viewer can hold access to a node without access to its partition root (an `AccessAssignment` shares one node out of a partition). That denial means "inherits nothing", classified by `AreaErrorClassifier.IsExpectedUserActionFailure` — the same predicate `MeshNodeThumbnailControl.ShouldSurfaceStreamError` uses for the same reason. **Nothing else is caught**; a genuine infrastructure fault propagates.

## Inheritance is opt-in per SURFACE

Every call site kept compiling; the ones that pass a root were chosen, not swept.

- **A page identifies ONE node** → the node-page header (`MeshNodeLayoutAreas.Overview`, `ContentData`) and the markdown page header (`MarkdownOverviewLayoutArea.Overview`) opt in.
- **A LIST of siblings is not one node** → the nav rail's child links, cards, pickers and search results keep the one-argument overload, because in a mixed child listing the NodeType glyph is what tells a doc from a code node from a thread.

## Before / after evidence

`PartitionRootStreamTest` runs against a **real mesh** (`MonolithMeshTestBase`) with `Chess` (marked) + `Chess/Rules`, and `Draughts` (unmarked) + `Draughts/Rules`. Both halves in one assertion:

```csharp
MeshNodeImageHelper.ResolveNodeIcon(child).Should().Be("/static/NodeTypeIcons/document.svg"); // before
MeshNodeImageHelper.ResolveNodeIcon(child, root).Should().Be(PackageMark);                    // after
```

And **rendered**, walking the real Overview area's control tree to the header's 56 px icon tile:

| page | tile draws |
|---|---|
| `Chess/Rules` (marked root) | the Chess mark |
| `Draughts/Rules` (unmarked root) | `/static/NodeTypeIcons/document.svg`, and never the Chess mark |

🚨 **The render test found a real property on its first run.** Asserting on the FIRST frame reported `document.svg` and read as "the wiring is broken". It is not: the partition-root stream starts null so it cannot gate the page, so the header paints its type glyph on frame one and re-renders with the package's mark when the root arrives. The test now **waits for the mark** instead of reading frame one, and both the doc page and the test's own comment say why — the alternative (waiting for the root before first paint) trades a brief icon swap for a page that can hang on a read it does not need.

18 new tests; `PackageRootIconInheritanceTest` pins the pure chain with no mesh at all.

## Deliberately NOT in this change

- **The crawler-facing head.** `SeoResolver.ResolveIcon` resolves *the node's own mark or nothing* — no NodeType stand-in, no synthesis — and is a different chain with no NodeType step for a root step to sit before. Extending it is a real policy question, and its consumer (`Memex.Portal.Gui/Seo/SeoHead.razor`) is in MeshWeaver.Plugins, so it is a two-repo change.
- **The in-circuit tab.** `ResolveIconLink(node, partitionRoot)` exists and inherits when given a root, but its caller — `MeshWeaver.Blazor/Pages/ApplicationPage.razor.cs` — is in MeshWeaver.Plugins. Until it opts in, a signed-in tab keeps the NodeType glyph. Same cross-repo seam `ContentFaviconRasterization.md` already describes.

Both are named in the doc page so the next session measures them rather than rediscovering them.

## Verification

- `dotnet build -c Release -warnaserror`, one project per invocation, clean (`0 Error(s)`, `0 Warning(s)`) for `MeshWeaver.Graph` and every dependent: `Plugin.Build`, `PluginCatalog`, `GitSync`, `Hosting`, `Mesh.Operations`, `Memex.Portal.Shared`, plus the test projects.
- Full `MeshWeaver.Graph.Test` — **1112 passed, 0 failed**. Not a filter: `TestTimeoutLiteralRatchetGuard` caught the five 30 s literals this change first wrote (386 → 391), which a filtered run would have reported as a pass. Converted to `TestTimeouts.Quick` (a node read) and `TestTimeouts.Convergence` (a render round-trip), each strictly below its test's `[Fact(Timeout = …)]` so an inner wait loses first and can say what it was waiting for.
- Full `MeshWeaver.Documentation.Test` — **166 passed, 0 failed**, including `DocumentationLinkIntegrityTest` against **rebuilt** doc assets (the pages are embedded resources, so `--no-build` after a doc edit is a false pass).

## Work products conserved

- [`Doc/Architecture/PackageMarkInheritance`](src/MeshWeaver.Documentation/Data/Architecture/PackageMarkInheritance.md) — the chain, the pure-vs-reactive decision table, the reactive seam's four load-bearing properties, the opt-in-per-surface policy, and what is deliberately out of scope.
- A What's New entry (`Category: Feature`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
