### PR TITLE
fix(#3023): the activity-tracking writes use RunAs, not Observable.Using

### DIFF
--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -235,7 +235,7 @@ public static class MeshNodeExtensions
         // Each hub has its OWN AccessService; the caller's per-delivery AccessContext
         // lives on the CALLING hub's. Capture it here (handler thread, where it is set)
         // and re-establish it on the write hubs' AccessServices across each cold write's
-        // Subscribe via Observable.Using — so the activity write is attributed to the
+        // Subscribe via RunAs (see AsCaller below) — so the activity write is attributed to the
         // acting user and owner-side RLS lets it land. Mirrors GitSync ActivityRunner's
         // per-write owner re-stamp; AsyncLocal does not survive the Rx scheduler hops.
         var callerAccess = hub.ServiceProvider.GetService<AccessService>();
@@ -244,17 +244,24 @@ public static class MeshNodeExtensions
         var trackingAccess = activityHub.ServiceProvider.GetService<AccessService>();
         var rootAccess = meshRoot.ServiceProvider.GetService<AccessService>();
 
-        IDisposable Impersonate()
-        {
-            if (callerCtx is null)
-                return System.Reactive.Disposables.Disposable.Empty;
-            var d = new System.Reactive.Disposables.CompositeDisposable();
-            if (trackingAccess is not null)
-                d.Add(trackingAccess.SwitchAccessContext(callerCtx));
-            if (rootAccess is not null && !ReferenceEquals(rootAccess, trackingAccess))
-                d.Add(rootAccess.SwitchAccessContext(callerCtx));
-            return d;
-        }
+        // 🚨 RunAs, NEVER `Observable.Using(() => access.SwitchAccessContext(ctx), …)` (#1444/#1790,
+        // and #3023 for this site). `Using` opens the AsyncLocal on the SUBSCRIBING thread and
+        // disposes it when the inner observable TERMINATES — which for a cross-hub write is
+        // whichever IoPool/response thread it finishes on, not the one that subscribed. The
+        // subscriber (an MCP session hub turn, the portal host hub behind a click) is then left
+        // latched as THIS caller for everything it does next, and AccessContext is what
+        // PermissionEvaluator reads: a wrong-principal condition that fails open in the direction
+        // of the previous user, silently. `ActivityRunner` carries the same warning verbatim.
+        //
+        // RunAs seals both ends inside one Subscribe (SubscribeScopedObservable). A null access
+        // service or a null identity runs the work unswitched and still deferred, so the old
+        // `callerCtx is null` short-circuit is preserved by construction rather than by a branch.
+        IObservable<T> AsCaller<T>(Func<IObservable<T>> work) =>
+            trackingAccess.RunAs(
+                callerCtx,
+                () => rootAccess is not null && !ReferenceEquals(rootAccess, trackingAccess)
+                    ? rootAccess.RunAs(callerCtx, work)
+                    : work());
 
         var encodedPath = req.NodePath.Replace("/", "_");
         // Activity records live under {userId}/_UserActivity/{id} — every user
@@ -298,16 +305,15 @@ public static class MeshNodeExtensions
         // WrapWithPerUserRls (SyncedQueryDataSourceExtensions) captures AccessService.Context
         // EAGERLY at the GetQuery(...) call — on the workspace's hub (the tracking hub) — so the
         // per-user RLS filter must see the caller's identity AT THAT CALL, not only at the write's
-        // subscribe. Observable.Using acquires Impersonate() BEFORE invoking the factory, so
+        // subscribe. RunAs enters the scope BEFORE invoking the work factory, so
         // GetQuery is called with the caller's context established on the tracking hub's
         // AccessService (fail-closed when callerCtx is null: no context ⇒ empty userId ⇒ the RLS
         // wrap yields no rows for the exact-path existence probe, and the subsequent write posts
-        // context-null and is rejected by PostPipeline). The inner per-write Observable.Using
-        // (Impersonate) still re-establish the identity on each write's own emission thread —
+        // context-null and is rejected by PostPipeline). The inner per-write AsCaller calls
+        // still re-establish the identity on each write's own emission thread —
         // AsyncLocal does not flow across Rx scheduler hops, so the outer scope alone is not enough.
-        var pipeline = Observable.Using(
-            Impersonate,
-            _ => workspace
+        var pipeline = AsCaller(
+            () => workspace
             .GetQuery($"UserActivity|{activityPath}", $"path:{activityPath} nodeType:UserActivity select:path,id,namespace,name,nodeType,content")
             .Take(1)
             .Select(nodes => nodes.FirstOrDefault(n =>
@@ -361,9 +367,10 @@ public static class MeshNodeExtensions
                     };
                 }
 
-                // Each write runs under the acting user via Observable.Using(Impersonate):
-                // the impersonation is acquired at the inner Subscribe (where the write
-                // primitive captures AccessContext) and held until the write terminates,
+                // Each write runs under the acting user via AsCaller/RunAs: the scope is
+                // entered at the inner Subscribe (where the write primitive captures
+                // AccessContext) and left on that same Subscribe rather than on whatever
+                // thread the write happens to terminate on,
                 // so cross-hub RLS lets it land. See ActivityRunner for the canonical shape.
                 if (existing != null)
                 {
@@ -378,10 +385,10 @@ public static class MeshNodeExtensions
                         "TrackActivity UPDATE: {Path} querySnapshotCount={SnapshotCount} "
                         + "(the written count is folded off the live node inside the Update)",
                         activityPath, record.AccessCount);
-                    return Observable.Using(Impersonate, _ => stream.Update(FoldOntoLive));
+                    return AsCaller(() => stream.Update(FoldOntoLive));
                 }
 
-                var rootProbe = Observable.Using(Impersonate, _ => storage != null
+                var rootProbe = AsCaller(() => storage != null
                         ? storage.Read(req.UserId, jsonOptions).Take(1)
                         : Observable.Return<MeshNode?>(null))
                     .Catch<MeshNode?, Exception>(probeEx =>
@@ -406,7 +413,7 @@ public static class MeshNodeExtensions
                     if (meshService != null)
                     {
                         logger?.LogDebug("TrackActivity CREATE: {Path}", activityPath);
-                        return Observable.Using(Impersonate, _ => meshService.CreateNode(saveNode))
+                        return AsCaller(() => meshService.CreateNode(saveNode))
                             // Race coalesce: a concurrent track for the same path beat us to
                             // CreateNode — fold our increment in via Update instead of throwing.
                             .Catch<MeshNode, InvalidOperationException>(ex =>
@@ -416,12 +423,12 @@ public static class MeshNodeExtensions
                                 logger?.LogDebug(
                                     "TrackActivity CREATE to UPDATE race for {Path}: another concurrent track won; folding via Update.",
                                     activityPath);
-                                return Observable.Using(Impersonate, _ => stream.Update(FoldOntoLive));
+                                return AsCaller(() => stream.Update(FoldOntoLive));
                             });
                     }
 
                     return storage != null
-                        ? Observable.Using(Impersonate, _ => storage.Write(saveNode, jsonOptions))
+                        ? AsCaller(() => storage.Write(saveNode, jsonOptions))
                         : Observable.Empty<MeshNode>();
                 });
             }));

--- a/test/ImpersonationScopeSites.allow
+++ b/test/ImpersonationScopeSites.allow
@@ -60,7 +60,6 @@ src/MeshWeaver.Graph/Configuration/SpaceNodeType.cs	1
 src/MeshWeaver.Graph/Configuration/WebhookEventNodeType.cs	1
 src/MeshWeaver.Graph/DeckSlidesCache.cs	1
 src/MeshWeaver.Compiler.Pipeline/NodeTypeBuildState.cs	1
-src/MeshWeaver.Graph/MeshNodeExtensions.cs	6
 src/MeshWeaver.Graph/NodeTypeReleaseExtensions.cs	1
 src/MeshWeaver.Graph/StaticRepoImporter.cs	1
 src/MeshWeaver.Hosting/MeshNodeStreamCache.cs	1

--- a/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ImpersonationScopeSiteRatchetGuard.cs
@@ -64,7 +64,7 @@ public class ImpersonationScopeSiteRatchetGuard(ITestOutputHelper output)
     /// the shape; this stops the list as a WHOLE from growing — including by the trick of adding a
     /// new file's line. Lower it whenever you delete or lower an entry.
     /// </summary>
-    private const int TotalBudget = 75;
+    private const int TotalBudget = 69;
 
     /// <summary>Production roots. <c>test/</c> and <c>samples/</c> are deliberately out of scope —
     /// the leak there costs test isolation, not a user's permissions, and listing 21 more entries


### PR DESCRIPTION
Closes #3023.

## What was wrong

Six sites in `HandleTrackActivity` opened an impersonation scope inside `Observable.Using`. Rx runs the resource factory on the **subscribing** thread and disposes it when the inner observable **terminates** — which for a cross-hub write is whichever `IoPool`/response thread it finishes on, not the one that subscribed. The subscriber (an MCP session hub turn, the portal host hub behind a click) is then left latched as *this* caller for everything it does next.

`AccessContext` is what `PermissionEvaluator` reads. So this is a **wrong-principal** condition, and it fails open in the direction of the *previous* user, silently.

## 🚨 Correcting my own framing on the issue: this was tracked debt, not an unseen defect

I filed #3023 suggesting a guard would have caught it. **The guard exists and did see it.** `ImpersonationScopeSiteRatchetGuard` already lists `"Impersonate"` in its `ScopeFactories`, and the allow file already carried:

```
src/MeshWeaver.Graph/MeshNodeExtensions.cs	6
```

So these six were **seeded, counted, known debt** — the ratchet was doing its job, holding the line while the inventory is paid down. That is a materially better state than the one I described, and worth correcting rather than quietly accepting credit for finding something.

This PR pays it down. Per the allow file's own rule — *"THIS LIST MAY ONLY SHRINK … TotalBudget in the guard must be lowered by the same amount"* — both move together:

```
allow file   37 files, 75 sites  ->  36 files, 69 sites
TotalBudget  75                  ->  69
```

## The fix

A local `AsCaller` helper over `RunAs`, whose `SubscribeScopedObservable` **seals both ends inside one `Subscribe`**. Nesting covers the two `AccessService`s the old helper switched at once:

```csharp
IObservable<T> AsCaller<T>(Func<IObservable<T>> work) =>
    trackingAccess.RunAs(
        callerCtx,
        () => rootAccess is not null && !ReferenceEquals(rootAccess, trackingAccess)
            ? rootAccess.RunAs(callerCtx, work)
            : work());
```

A null access service or a null identity runs the work unswitched and still deferred, so the old `callerCtx is null` short-circuit is **preserved by construction** rather than by a branch that could drift.

The eager-subscribe property the outer pipeline depends on is unchanged: `WrapWithPerUserRls` captures `AccessService.Context` at the `GetQuery(...)` call, and `RunAs` enters the scope before invoking the work factory exactly as `Using` acquired before invoking its factory.

**Stale prose went too** — three comments described `Observable.Using`'s acquire-before-factory ordering as the mechanism, and one cited GitSync `ActivityRunner` as precedent when that file carries the ban verbatim (*"the banned shape wearing a helper's name"*). A comment that cites as precedent the file that forbids it is how this survived review.

## Verification

- Full `MeshWeaver.Graph.Test`, not a filter: **1134 passed, 0 failed**.
- Full `MeshWeaver.Documentation.Test` (which runs the ratchet guard against the reduced budget): **171 passed, 0 failed**.
- `dotnet build -c Release -warnaserror` on `MeshWeaver.Graph` and `MeshWeaver.Documentation.Test`: **0 Warning(s), 0 Error(s)** each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
