### PR TITLE
Repair stale self-default MainNode rows — detection-driven, never self-arming

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/StaleMainNodeRepair.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaleMainNodeRepair.md
@@ -154,6 +154,18 @@ something a maintainer can act on.
 Every pass ends with one summary line whether or not it found anything — *"the repair never
 considered the row"* and *"the repair found nothing"* must not look the same.
 
+**Findings come back in path order, and that is a contract rather than an accident.**
+`IStorageAdapter.ReadMany` states outright that its order is not guaranteed — the default
+implementation merges N reads, and Postgres answers one batched `IN (…)` in whatever order the
+planner likes — so the candidates are sorted at the stage that loses the order, which makes
+classification, the per-node log lines and the report all follow the same sequence.
+
+It matters because this repair's deliverable *is* its evidence. A run against live data is read by a
+person deciding whether it did the right thing, so the report has to be diffable between the `Detect`
+dry run and the real run, and lineable-up against an expected set. A stable order is also what lets a
+second run's report be compared against the first — which is how the idempotence claim gets *checked*
+rather than merely asserted.
+
 ## Using it
 
 ```csharp

--- a/src/MeshWeaver.Documentation/Data/Architecture/StaleMainNodeRepair.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaleMainNodeRepair.md
@@ -1,0 +1,227 @@
+---
+Name: Repairing a Stale MainNode — When the Broken Field Guards Itself
+Category: Architecture
+Description: Why a node whose MainNode points into another partition is invisible to every listing and refuses to be corrected, and how the detection-driven repair fixes both shapes without deleting anything.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg>
+---
+
+# Repairing a Stale MainNode
+
+`MainNode` is the field that says **which node a row belongs to**. When it equals the row's own
+`Path`, the row *is* a main node — that is the framework's literal definition, and `is:main` is SQL
+`n.main_node = n.path`. When it differs, the row is a satellite of whatever it names.
+
+A third state exists that is neither, and it is a defect: `MainNode` naming **this node's own id in a
+partition the node no longer occupies**. The row is Active, fully formed, returned by `get` — and
+absent from every listing, because it is not a main node by the only test anything applies.
+
+This page is about repairing rows already in that state. The mint sites that produced it are fixed
+(see [How the shape is minted](#how-the-shape-is-minted) below); this is the other half.
+
+## What it looks like
+
+```
+Hosting/Skill/deployment    mainNode → Skill/deployment
+Skill/deployment            mainNode → Hosting/Skill/deployment
+```
+
+Both Active, byte-identical instructions, created a week apart. `get @Hosting/Skill/deployment`
+returns the node in full. `search nodeType:Skill limit:200` does not list it. Neither does
+`path:Hosting/Skill scope:descendants`, which returns only the one healthy sibling.
+
+Nothing errors. Nothing logs. No status flips. The only symptom is absence.
+
+## Two properties make this defect unusual
+
+### 1. The broken field is the field that decides who may fix it
+
+Authorization resolves against `MainNode`, not `Path`. A node pointing into another partition has
+its permission check answered by **that partition's** scope, so the obvious correction is refused:
+
+```
+patch @Hosting/Skill/deployment {"mainNode":"Hosting/Skill/deployment"}
+→ Access denied: user 'rbuergi' lacks Update permission on 'Hosting/Skill/deployment'
+```
+
+The corruption protects itself. Here it fails closed, which is the safe direction — but nothing in
+the mechanism guarantees it always will, and *"a node whose `MainNode` is wrong delegates its own
+authorization to a partition it does not belong to"* is worth reading on its own terms next to
+[Access Control](/Doc/Architecture/AccessControl).
+
+The repair therefore runs under `RunAsSystem` — the sanctioned *legitimate infrastructure* case from
+[Access Context Propagation](/Doc/Architecture/AccessContextPropagation). 🚨 `RunAsSystem`, never
+`Observable.Using(access.ImpersonateAsSystem, …)`: Rx runs a `Using` factory on the subscribing
+thread and disposes it on the terminating one, latching System onto whatever the subscriber does
+next.
+
+### 2. Detection cannot use a query
+
+The condition's own definition is *"invisible to the index"*. `is:main` keeps exactly
+`main_node = path`, and Postgres' `search_across_schemas` hard-filters **every union branch** on that
+predicate — unconditionally, not only when the caller asks for `is:main`.
+
+So a query-driven detector would pass its tests against a permissive in-memory provider and find
+**zero rows on the deployment that actually has the corruption**. That is the
+green-signal-measuring-the-wrong-thing trap in its purest form.
+
+Enumeration runs on `IStorageAdapter.ListChildPaths` / `ListDescendantPaths` instead — the
+authoritative path-routed tree walk the recursive-delete planner is built on. It routes by **path**,
+which is intact, so a wrong `MainNode` cannot hide from it.
+
+## Both shapes, and why the detector does not care which
+
+The original report described a mutual **cycle**: A names B, B names A. That is real, but it is not
+the whole population — a measurement on 2026-09-01 found that two of the seven were **dangling**
+(the named node does not point back), and an eighth node shared the signature and was missing from
+the report's list entirely.
+
+A repair driven by the reported list would have left that eighth node corrupt; one written for
+cycles would have skipped the dangling pair or faulted looking for a partner that was not there.
+
+**So the repair detects a condition rather than consuming a list.** The predicate —
+`MeshExtensions.IsStaleSelfDefaultMainNode` — is a **per-node shape test**:
+
+- `MainNode`'s **last segment is this node's own id** (which is what makes it a frozen self-default
+  rather than a deliberate pointer at some other node), **and**
+- it names a **different partition** (first segment).
+
+Both halves are required. Either alone over-reaches: a node may legitimately point `MainNode` at a
+parent inside its own partition, and it may legitimately point at another partition under a
+different id. Both are left untouched.
+
+Because the test is per-node, every affected row is found by construction, a partner is never
+required to exist, and repairing one end of a cycle never depends on the other — the other is found
+and repaired on its own merits in the same pass. What the pointer points at is read **only to
+classify the finding for the report**, never to decide whether to repair:
+
+| Shape | Meaning |
+|---|---|
+| `Cycle` | The named node exists and points back at this one. |
+| `DanglingMissingTarget` | Nothing exists at the named path. |
+| `DanglingUnrelatedTarget` | The named node exists but names something else. |
+| `Unclassified` | The named node could not be read. **Repaired anyway.** |
+
+🚨 That classification read goes through `IStorageAdapter.Read` (null-on-absent), **never**
+`GetMeshNodeStream(target)`. A point stream read of a node that does not exist terminates the stream
+with a routing NotFound *and* opens the storm breaker on that path — and the breaker fast-fails
+writes too. On a dangling finding, where the target is absent by definition, classifying through the
+stream would suppress the very repair the pass is there to perform.
+
+## One predicate, shared with the forward fix
+
+`IsStaleSelfDefaultMainNode` is the **same method** the create and upsert paths apply to every node
+they write. Two predicates would drift, and the drift would be invisible in exactly the way this
+defect already is: a repair that skipped a shape the guard refuses would leave rows corrupt with
+nothing reporting it. Widening the shape widens both halves at once.
+
+## The write
+
+```csharp
+access.RunAsSystem(() => hub.GetMeshNodeStream(path)
+    .Update(current => current with { MainNode = current.Path }))
+```
+
+`GetMeshNodeStream(path).Update(…)` is not merely the preferred route, it is the **only** one that
+can express this correction. A full-instance upsert can move a `MainNode` anywhere *except* back onto
+the node's own path, because that intent is indistinguishable from the untouched default —
+`MainNode` is non-nullable and self-defaults, so "the writer never touched it" and "the writer set it
+to this node" are the same value on the wire. See `MeshNode.HasExplicitMainNode`, and
+[the mutation API](/Doc/Architecture/DataAccessPatterns).
+
+## The idempotence contract
+
+The repair writes the one value the predicate **cannot match**: after `MainNode = Path`,
+`HasExplicitMainNode` reads `false` and `IsStaleSelfDefaultMainNode` returns `false` at the first
+test.
+
+That is the whole mechanism, and it matters that it is a *property of the written value* rather than
+a ledger:
+
+- A second run enumerates the same paths, reads the same rows, and finds nothing. It does not
+  remember having run — there is nothing left to find.
+- A mesh with zero affected nodes performs zero writes.
+- A run that fails partway is safe to repeat: an unrepaired node still matches, a repaired one does
+  not.
+- Concurrent runs converge — both compute the same value.
+
+## Reporting: evidence, not a count
+
+Every finding carries the path, the pointer as found, the classified shape, and the outcome
+(including the error message when a write failed). A failed node does not stop the rest, and it comes
+back **named** rather than as a swallowed exception, so a run against a live portal produces
+something a maintainer can act on.
+
+Every pass ends with one summary line whether or not it found anything — *"the repair never
+considered the row"* and *"the repair found nothing"* must not look the same.
+
+## Using it
+
+```csharp
+// Measurement. Writes nothing. Safe on production.
+StaleMainNodeRepair.Detect(hub).Subscribe(r => …);
+
+// The repair. Scope it to partitions, or omit for the whole mesh.
+StaleMainNodeRepair.Repair(hub, ["Hosting", "Store"]).Subscribe(r => …);
+```
+
+Both return **cold** observables — the sweep runs on `Subscribe`, not on the call.
+
+🚨 **Nothing self-arms.** This is a static one-shot pipeline, not an `IHostedService`, and nothing in
+the composition root calls it: deploying an image containing it runs no repair. Running it against a
+live portal is a separate, deliberate decision, and `Detect` exists so that decision can be taken on
+measured evidence first.
+
+This is the same shape `AssemblyCacheRetentionHostedService` uses for its own destructive sweep —
+report by default, act only when explicitly armed — and it is the reason the raw `psql UPDATE`
+alternative is not on the table: a direct SQL write bypasses the workspace cache, so live
+subscriptions keep serving the old value until the portal restarts. See
+[Postgres Schema Architecture](/Doc/Architecture/PostgresSchemaArchitecture).
+
+## The unresolved duplicate-copy question
+
+**The repair deliberately does not answer it, and deletes nothing.**
+
+A cycle is two Active copies of one node — `Skill/deployment` beside `Hosting/Skill/deployment` —
+with identical content, created a week apart. Re-stamping both makes both visible, which is correct
+as far as pointers go and leaves the real question open:
+
+> Why does a package skill have a second Active copy in the platform `Skill/` partition at all?
+
+That is likely the mechanism that produced the cycle in the first place — two writers each rebasing
+the other's half — so repairing pointers without answering it invites a recurrence. But deciding
+which copy is canonical, and whether the other should be deleted, is a judgement about **content**,
+not a mechanical one. The repair re-stamps `MainNode = Path` on both ends and leaves both copies in
+place.
+
+A `Detect` pass is the input to that decision: its `Cycle` findings are exactly the duplicate pairs.
+
+## How the shape is minted
+
+`MainNode` is a **stored** property; `Path` and `Segments` are **computed**. So a plain
+`with { Namespace = … }` moves the path and leaves `MainNode` naming the partition the node was born
+in — and because the field is non-nullable, that stale value is indistinguishable on the wire from a
+deliberate satellite pointer, so every upsert faithfully persists it.
+
+The fix at the mint sites is `MeshNode.WithPath(id, ns)`, which rebases the pointer when it was the
+self-default and carries a deliberate one across untouched. The create and upsert paths additionally
+re-stamp anything that arrives with the shape, so no new row can acquire it.
+
+Neither of those touches a row already stored: the defect moved out of the code and into the data,
+and only a pass over the data closes it. `SelfTypedDeclarationDurableRepair` exists for the same
+reason and draws the same distinction — a write guard can only ever refuse the *next* bad row.
+
+🚨 **Restoring `MainNode == Path` is necessary but not sufficient** for a decentral node to be
+searchable again. A second, independent defect produces the identical symptom: a query union whose
+legacy single `Query` field carries only `list[0]`, so a static node matched by the *second* query is
+silently absent. Both halves are required; neither alone restores visibility.
+
+## Related
+
+- [CQRS and Content Access](/Doc/Architecture/CqrsAndContentAccess) — why a query is the wrong tool
+  for reading, deciding on, or gating a specific node.
+- [The MeshNode Stream Cache](/Doc/Architecture/MeshNodeStreamCache) — the handle the write goes
+  through, and the storm breaker that makes an absent-node point read a defect.
+- [Access Context Propagation](/Doc/Architecture/AccessContextPropagation) — when running as System
+  is legitimate, and how the scope is sealed.
+- [Postgres Schema Architecture](/Doc/Architecture/PostgresSchemaArchitecture) — one schema per
+  partition, and why raw SQL is not the repair route.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-node-that-vanished-from-every-list-can-be-brought-back.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-node-that-vanished-from-every-list-can-be-brought-back.md
@@ -1,0 +1,47 @@
+---
+Name: A node that vanished from every list can be brought back
+Category: Fix
+Description: A handful of skills were still there and still worked if you knew their address, but had dropped out of every list and search — and could not be corrected, because the thing that was wrong about them was the thing deciding who was allowed to correct it. There is now a repair that finds them and puts them back.
+Icon: Bug
+Order: -20260902
+---
+
+# A node that vanished from every list can be brought back
+
+Every node carries a note saying which node it belongs to. Usually it points at itself — that is what
+makes it a thing in its own right rather than an attachment to something else. Lists and search are
+built on exactly that: *show me the things that point at themselves.*
+
+A small number of nodes ended up pointing somewhere else by accident. Nothing about them looked
+broken. They were live, complete, and worked perfectly if you went straight to their address. They
+had simply stopped answering "yes" to the question every list asks, so they were missing from all of
+them — search, the contents of the page they lived on, everything. No error, no warning, nothing to
+notice except an absence, which is the hardest thing to spot.
+
+**And they could not be corrected by hand.** Permission to change a node is decided by that same
+note. A node pointing into somewhere it does not belong had its permission question answered by
+somewhere it does not belong — so trying to fix the note was refused for not having rights over the
+place the broken note pointed at. The thing that was wrong was the thing guarding it.
+
+**There is now a repair that works around that properly.** It runs with the platform's own authority
+rather than a person's, so the guard does not apply, and it goes through the normal way of changing a
+node so live pages see the correction immediately rather than after a restart.
+
+Two things about it are worth knowing:
+
+- **It finds the affected nodes rather than being handed a list.** The original report named seven.
+  It turned out there was an eighth nobody had spotted, and two of the seven were broken in a
+  slightly different way than the report described. A repair working from the list would have missed
+  all three. This one recognises the *condition*, so it finds whatever is actually there — including,
+  in future, anything the list-writers never saw.
+- **It never deletes anything.** Some of these come in pairs — two copies of the same thing, each
+  pointing at the other. Both get put back to pointing at themselves, and both are kept. Whether one
+  of the pair is a duplicate that should go is a judgement about your content, not something a repair
+  should decide on its own; it is reported so a person can look.
+
+Running it twice is harmless — the second pass finds nothing, because the repair is simply not a
+thing that can be done twice. And on a system with nothing wrong it looks at everything, changes
+nothing, and says so.
+
+There is also a report-only mode that finds and lists the affected nodes without touching anything,
+so the state of a system can be checked before deciding to change it.

--- a/src/MeshWeaver.Hosting/Persistence/StaleMainNodeRepair.cs
+++ b/src/MeshWeaver.Hosting/Persistence/StaleMainNodeRepair.cs
@@ -1,0 +1,405 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Hosting.Persistence;
+
+/// <summary>
+/// The BACKWARD half of Systemorph/MeshWeaver#2939 — a detection-driven repair for mesh nodes whose
+/// <see cref="MeshNode.MainNode"/> is a self-default frozen in a partition the node no longer
+/// occupies, which drops them out of <c>is:main</c> (SQL <c>n.main_node = n.path</c>) and therefore
+/// out of every listing, while <c>get</c> keeps returning them Active and fully formed.
+///
+/// <para><b>Why a repair is needed at all when the mint sites are fixed.</b> #2939 and
+/// MeshWeaver.Plugins#1053 corrected the writers (<c>MeshNode.WithPath</c> and the create/upsert
+/// paths now run <c>RepairStaleSelfDefaultMainNode</c> on everything they store), so no NEW row can
+/// acquire the shape. Neither fix touches a row already persisted: the defect moved out of the code
+/// and into the DATA, and only a pass over the data closes it. The same distinction
+/// <c>SelfTypedDeclarationDurableRepair</c> draws for #2425/#2506.</para>
+///
+/// <para><b>🚨 The corruption is SELF-PROTECTING, which dictates both halves of the design
+/// (#2970).</b> Authorization resolves against <see cref="MeshNode.MainNode"/>, not
+/// <see cref="MeshNode.Path"/>, so a node pointing into another partition has its permission check
+/// answered by THAT partition's scope: the field that is wrong is the field that decides who may
+/// correct it, and the obvious re-stamp is refused —
+/// <c>patch @Hosting/Skill/deployment {"mainNode":"Hosting/Skill/deployment"}</c> →
+/// <i>Access denied: user 'rbuergi' lacks Update permission on 'Hosting/Skill/deployment'</i>.
+/// Hence the write runs under <see cref="ImpersonationScopeExtensions.RunAsSystem{T}"/> — the
+/// sanctioned "legitimate infrastructure" case, and the ONE shape allowed here: never
+/// <c>Observable.Using(access.ImpersonateAsSystem, …)</c>, whose store/restore land on different
+/// threads and latch System onto the subscriber (#1790, and a ratchet guard that may only shrink).
+/// </para>
+///
+/// <para><b>🚨 And it dictates that detection CANNOT use a query.</b> The condition's own definition
+/// is "invisible to the index": <c>is:main</c> keeps exactly <c>main_node = path</c>, and Postgres'
+/// <c>search_across_schemas</c> hard-filters every union branch on that predicate
+/// <i>unconditionally</i> — not only when the caller asks for <c>is:main</c>. A query-driven
+/// detector would therefore pass its tests against a permissive in-memory provider and find ZERO
+/// rows on the deployment that has the corruption. Enumeration runs on
+/// <see cref="IStorageAdapter.ListChildPaths"/> / <see cref="IStorageAdapter.ListDescendantPaths"/>
+/// instead — the authoritative path-routed tree walk the recursive-delete planner is built on
+/// (#839), which routes by PATH and so cannot be hidden from by a wrong <c>MainNode</c>.</para>
+///
+/// <para><b>One predicate, shared with the forward fix.</b> A candidate is anything
+/// <see cref="MeshExtensions.IsStaleSelfDefaultMainNode"/> accepts — the very method the create and
+/// upsert paths apply to every node they write. Two predicates would drift, and the drift would be
+/// invisible in exactly the way this defect is.</para>
+///
+/// <para><b>Both shapes, and neither assumes the other end exists.</b> The issue described a mutual
+/// cycle (<c>Hosting/Skill/deployment</c> ↔ <c>Skill/deployment</c>), and a repair written only for
+/// cycles would silently skip the rest — two of the seven measured on memex on 2026-09-01 are
+/// DANGLING, and an eighth node (<c>Skill/email</c>) shares the signature and is absent from the
+/// issue's list. Because the predicate is a per-node SHAPE test rather than a pair test, all of them
+/// are found by construction, a partner is never required to exist, and repairing one end never
+/// depends on the other. The pointed-at node is read only to CLASSIFY the finding for the report
+/// (<see cref="StaleMainNodeShape"/>) — never to decide whether to repair. This is also why the
+/// hardcoded list from the issue is deliberately not used anywhere in this file.</para>
+///
+/// <para><b>Idempotent, and safe on a healthy mesh.</b> The repair writes
+/// <c>MainNode = Path</c>, after which <see cref="MeshNode.HasExplicitMainNode"/> reads
+/// <c>false</c> and the predicate can no longer match — so a second run reads the same rows and
+/// writes nothing, and a mesh with zero affected nodes performs zero writes and reports an empty
+/// finding list. Repairing one end of a cycle does not disturb the other end, which is found and
+/// repaired on its own merits in the same pass.</para>
+///
+/// <para><b>Reports per node, not a count.</b> Every finding carries the path, the stale pointer,
+/// the classified shape and the outcome, so a run against a live portal produces evidence a
+/// maintainer can act on — including for the question this repair deliberately does NOT answer.
+/// Classification of the WHOLE candidate set completes before any write, so every finding describes
+/// the state as FOUND rather than as the sweep's own writes left it (see <c>Process</c>).</para>
+///
+/// <para><b>🚨 What this deliberately does NOT do: delete anything.</b> A cycle is two Active
+/// copies of one node with identical content, and whether the platform-partition copy should be
+/// deleted as a duplicate is a maintainer's decision about CONTENT, not a mechanical one. Both ends
+/// are re-stamped to point at themselves and both copies are left in place. See
+/// <c>Doc/Architecture/StaleMainNodeRepair</c> → "The unresolved duplicate-copy question".</para>
+///
+/// <para><b>🚨 Nothing here self-arms.</b> This is a static one-shot pipeline, not an
+/// <c>IHostedService</c>, and nothing in the composition root calls it — deploying an image
+/// containing this file runs no repair. That is deliberate: running it against a live portal is a
+/// separate decision, and <see cref="Detect"/> exists so the decision can be taken on measured
+/// evidence (it writes nothing and is safe on production).</para>
+/// </summary>
+public static class StaleMainNodeRepair
+{
+    /// <summary>
+    /// How many paths one <see cref="IStorageAdapter.ReadMany"/> asks for. Batching keeps a
+    /// whole-mesh sweep's working set and its per-round-trip cost bounded — Postgres turns one batch
+    /// into a single <c>WHERE (namespace, id) IN (…)</c>, and an unbatched sweep of a large mesh
+    /// would build one query per node or one query of every node, both of which are worse.
+    /// </summary>
+    private const int ReadBatchSize = 250;
+
+    /// <summary>
+    /// Finds every node carrying the stale-self-default shape and reports them WITHOUT writing
+    /// anything — the measurement pass. Safe to run against a live portal: it reads the storage tree
+    /// and nothing else.
+    /// </summary>
+    /// <param name="hub">Hub supplying the storage adapter, serializer options and logger.</param>
+    /// <param name="roots">
+    /// Partitions / subtrees to sweep. Null or empty sweeps the whole mesh, starting from the
+    /// storage adapter's root listing.
+    /// </param>
+    /// <returns>A cold observable emitting one report and completing. <b>Subscribe to run it.</b></returns>
+    public static IObservable<StaleMainNodeRepairReport> Detect(
+        IMessageHub hub, IReadOnlyCollection<string>? roots = null)
+        => Sweep(hub, roots, write: false);
+
+    /// <summary>
+    /// Finds every node carrying the stale-self-default shape and re-stamps
+    /// <see cref="MeshNode.MainNode"/> to the node's own <see cref="MeshNode.Path"/>, restoring it to
+    /// <c>is:main</c>.
+    ///
+    /// <para>The write goes through <c>GetMeshNodeStream(path).Update(…)</c> — the one mutation API,
+    /// and the only route that can express this correction at all: a full-instance upsert cannot
+    /// move a MainNode back ONTO the node's own path, because that intent is indistinguishable from
+    /// the untouched default (see <see cref="MeshNode.HasExplicitMainNode"/>). It runs under
+    /// <c>RunAsSystem</c> because the field being repaired is the field the permission check reads.
+    /// </para>
+    /// </summary>
+    /// <param name="hub">Hub supplying the storage adapter, access service, serializer options and logger.</param>
+    /// <param name="roots">
+    /// Partitions / subtrees to sweep. Null or empty sweeps the whole mesh, starting from the
+    /// storage adapter's root listing.
+    /// </param>
+    /// <returns>A cold observable emitting one report and completing. <b>Subscribe to run it.</b></returns>
+    public static IObservable<StaleMainNodeRepairReport> Repair(
+        IMessageHub hub, IReadOnlyCollection<string>? roots = null)
+        => Sweep(hub, roots, write: true);
+
+    private static IObservable<StaleMainNodeRepairReport> Sweep(
+        IMessageHub hub, IReadOnlyCollection<string>? roots, bool write)
+        => Observable.Defer(() =>
+        {
+            var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(StaleMainNodeRepair));
+            var storage = hub.ServiceProvider.GetService<IStorageAdapter>();
+            if (storage is null)
+            {
+                // A mesh with no storage adapter has no durable rows to sweep. Reported as an
+                // explicit zero rather than an absent line: "the sweep never considered a row" and
+                // "the sweep found nothing" must not look the same.
+                logger?.LogInformation(
+                    "[StaleMainNodeRepair] no storage adapter on this hub — nothing to sweep");
+                return Observable.Return(StaleMainNodeRepairReport.Empty(write));
+            }
+
+            var options = hub.JsonSerializerOptions;
+            return EnumeratePaths(storage, roots, logger)
+                .SelectMany(paths => ReadCandidates(storage, paths, options)
+                    .SelectMany(read => Process(hub, storage, read.Candidates, options, write, logger)
+                        .Select(findings => new StaleMainNodeRepairReport(
+                            findings, paths.Count, read.NodesRead, write))))
+                .Do(report => logger?.LogInformation(
+                    "[StaleMainNodeRepair] sweep completed ({Mode}): {Scanned} path(s) enumerated, "
+                    + "{Read} node(s) read, {Found} stale MainNode(s) found, {Repaired} repaired, "
+                    + "{Failed} failed [{Paths}]",
+                    write ? "repair" : "detect-only",
+                    report.PathsScanned, report.NodesRead, report.Findings.Count,
+                    report.RepairedCount, report.FailedCount,
+                    string.Join(", ", report.Findings.Select(f => $"{f.Path}→{f.StaleMainNode}"))));
+        });
+
+    /// <summary>
+    /// Every node path in scope, enumerated by PATH through the storage tree — never through the
+    /// query index, which by the definition of this defect cannot see the rows being looked for.
+    /// A null/empty <paramref name="roots"/> starts from the adapter's root listing, whose DIRECTORY
+    /// paths are recursed into as well as its node paths (a node-less intermediate level still
+    /// anchors real descendants).
+    /// </summary>
+    private static IObservable<ImmutableList<string>> EnumeratePaths(
+        IStorageAdapter storage, IReadOnlyCollection<string>? roots, ILogger? logger)
+        => (roots is { Count: > 0 }
+            ? Observable.Return((
+                Roots: (IEnumerable<string>)roots,
+                Seed: ImmutableHashSet<string>.Empty.WithComparer(StringComparer.OrdinalIgnoreCase)
+                    .Union(roots)))
+            : storage.ListChildPaths(null).Take(1).Select(level =>
+            {
+                var nodes = (level.NodePaths ?? []).Where(p => !string.IsNullOrEmpty(p)).ToArray();
+                var directories = (level.DirectoryPaths ?? []).Where(p => !string.IsNullOrEmpty(p));
+                return (
+                    Roots: nodes.Concat(directories).Distinct(StringComparer.OrdinalIgnoreCase),
+                    Seed: ImmutableHashSet.Create(StringComparer.OrdinalIgnoreCase, nodes));
+            }))
+        .SelectMany(start => start.Roots
+            // Sequential, not merged: a whole-mesh walk must not open one storage round-trip per
+            // partition at once. Ordering also keeps the log line reproducible.
+            .Select(root => storage.ListDescendantPaths(root)
+                // Per-root tolerance: a partition that cannot be listed (an absent schema, a
+                // backend hiccup) ends THIS root, not the sweep. Logged, never swallowed silently —
+                // a root that answered nothing must be distinguishable from a root that is clean.
+                .Catch<IReadOnlyCollection<string>, Exception>(ex =>
+                {
+                    logger?.LogWarning(ex,
+                        "[StaleMainNodeRepair] enumerating descendants of '{Root}' failed; any stale "
+                        + "MainNode under it is NOT covered by this sweep", root);
+                    return Observable.Return<IReadOnlyCollection<string>>([]);
+                }))
+            .Concat()
+            .Aggregate(start.Seed, (acc, descendants) => acc.Union(descendants)))
+        .Select(set => set.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToImmutableList());
+
+    /// <summary>
+    /// Reads the enumerated paths in batches and keeps the ones the SHARED predicate accepts. Paths
+    /// that no longer resolve to a node are simply absent from <see cref="IStorageAdapter.ReadMany"/>'s
+    /// output, so a tree that moved under the sweep costs nothing.
+    ///
+    /// <para>The row count is carried out alongside the candidates because it is the sweep's proof
+    /// of work: candidates alone cannot distinguish "read 900 rows, none of them wrong" from "read
+    /// nothing at all", and those are the two outcomes a clean report must never conflate.</para>
+    /// </summary>
+    private static IObservable<(ImmutableList<MeshNode> Candidates, int NodesRead)> ReadCandidates(
+        IStorageAdapter storage, ImmutableList<string> paths, JsonSerializerOptions options)
+        => paths.Count == 0
+            ? Observable.Return((ImmutableList<MeshNode>.Empty, 0))
+            : paths.Chunk(ReadBatchSize)
+                .Select(batch => storage.ReadMany(batch, options).ToList())
+                // Concat, not Merge: one batch in flight at a time.
+                .Concat()
+                .Aggregate(
+                    (Candidates: ImmutableList<MeshNode>.Empty, NodesRead: 0),
+                    (acc, batch) => (
+                        acc.Candidates.AddRange(batch.Where(n => n.IsStaleSelfDefaultMainNode())),
+                        acc.NodesRead + batch.Count));
+
+    /// <summary>
+    /// Classifies every candidate, and only THEN repairs them.
+    ///
+    /// <para>🚨 <b>The two phases must not interleave, and a test caught it doing so.</b> Both ends
+    /// of a cycle are candidates, and repairing is what makes an end stop pointing back — so a pass
+    /// that classified each node just before writing it saw the FIRST end already repaired by the
+    /// time it classified the SECOND, and reported the pair as one <see cref="StaleMainNodeShape.Cycle"/>
+    /// plus one <see cref="StaleMainNodeShape.DanglingUnrelatedTarget"/>. The repair was correct
+    /// either way; the EVIDENCE was not, and the evidence is what the maintainer reads to answer the
+    /// duplicate-copy question — a half-reported cycle understates exactly the pairs that question is
+    /// about. Classifying the whole set first makes every finding describe the state as FOUND, which
+    /// is the only thing a report should ever describe.</para>
+    /// </summary>
+    private static IObservable<ImmutableList<StaleMainNodeFinding>> Process(
+        IMessageHub hub,
+        IStorageAdapter storage,
+        ImmutableList<MeshNode> candidates,
+        JsonSerializerOptions options,
+        bool write,
+        ILogger? logger)
+        => candidates.Count == 0
+            ? Observable.Return(ImmutableList<StaleMainNodeFinding>.Empty)
+            // Phase 1 — reads only. Sequential, and complete before any write is composed.
+            : candidates
+                .Select(node => Classify(storage, node, options)
+                    .Select(shape => (Node: node, Shape: shape)))
+                .Concat()
+                .ToList()
+                .SelectMany(classified => write
+                    // Phase 2 — the writes, also sequential: a whole-mesh sweep must not fan
+                    // per-node-hub writes out all at once.
+                    ? classified
+                        .Select(c => RepairOne(hub, c.Node, c.Shape, logger))
+                        .Concat()
+                        .Aggregate(
+                            ImmutableList<StaleMainNodeFinding>.Empty,
+                            (acc, finding) => acc.Add(finding))
+                    : Observable.Return(classified
+                        .Select(c => new StaleMainNodeFinding(
+                            c.Node.Path, c.Node.MainNode, c.Shape, Repaired: false, Error: null))
+                        .ToImmutableList()));
+
+    /// <summary>
+    /// What the stale pointer points AT — reported, never used to decide whether to repair.
+    ///
+    /// <para>🚨 Read through <see cref="IStorageAdapter.Read"/>, which answers <c>null</c> for an
+    /// absent path, and NOT through <c>GetMeshNodeStream(target)</c>: a point stream read of a node
+    /// that does not exist is a framework defect, not merely a miss — the owner answers a routing
+    /// NotFound that terminates the stream AND opens the storm-breaker on that path, and the breaker
+    /// fast-fails WRITES too. On a DANGLING finding — where the target is absent by definition —
+    /// classifying through the stream would suppress the very repair this pass is here to perform.
+    /// </para>
+    /// </summary>
+    private static IObservable<StaleMainNodeShape> Classify(
+        IStorageAdapter storage, MeshNode node, JsonSerializerOptions options)
+        => storage.Read(node.MainNode, options)
+            .Take(1)
+            .Select(target => target is null
+                ? StaleMainNodeShape.DanglingMissingTarget
+                : string.Equals(target.MainNode, node.Path, StringComparison.OrdinalIgnoreCase)
+                    ? StaleMainNodeShape.Cycle
+                    : StaleMainNodeShape.DanglingUnrelatedTarget)
+            // Classification is REPORTING. A target that cannot be read must never cost the repair,
+            // so an unreadable target is reported as unclassified and the node is repaired anyway.
+            .Catch<StaleMainNodeShape, Exception>(_ =>
+                Observable.Return(StaleMainNodeShape.Unclassified));
+
+    /// <summary>
+    /// The one write. <c>MainNode = Path</c> through the mesh-node stream, under a System scope
+    /// sealed at Subscribe.
+    /// </summary>
+    private static IObservable<StaleMainNodeFinding> RepairOne(
+        IMessageHub hub, MeshNode node, StaleMainNodeShape shape, ILogger? logger)
+    {
+        var path = node.Path;
+        var stale = node.MainNode;
+        var access = hub.ServiceProvider.GetService<AccessService>();
+        // 🚨 RunAsSystem, never Observable.Using(access.ImpersonateAsSystem, …) (#1790): Rx runs a
+        // Using factory on the subscribing thread and disposes it on the terminating one, latching
+        // System onto whatever the subscriber does next. RunAsSystem opens the scope across this
+        // cold Update's Subscribe — which is where the write primitive eager-captures the
+        // AccessContext — and leaves it on the way out of that same Subscribe.
+        return access.RunAsSystem(() => hub.GetMeshNodeStream(path)
+                .Update(current => current with { MainNode = current.Path }))
+            .Take(1)
+            .Select(_ =>
+            {
+                logger?.LogInformation(
+                    "[StaleMainNodeRepair] repaired '{Path}': mainNode '{Stale}' → '{Restored}' "
+                    + "({Shape}) — it was Active and absent from is:main (#2939/#2970)",
+                    path, stale, path, shape);
+                return new StaleMainNodeFinding(path, stale, shape, Repaired: true, Error: null);
+            })
+            // Per-node tolerance, and the reason the report carries an Error per finding rather than
+            // a bare count: one path that cannot be written must not stop the remaining nodes from
+            // being repaired, and the failure must come back as EVIDENCE naming the node, not as a
+            // swallowed exception. Re-running is safe — an unrepaired node still matches the
+            // predicate, a repaired one no longer does.
+            .Catch<StaleMainNodeFinding, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[StaleMainNodeRepair] repairing '{Path}' failed; it keeps mainNode '{Stale}' "
+                    + "and stays absent from is:main until the next run", path, stale);
+                return Observable.Return(
+                    new StaleMainNodeFinding(path, stale, shape, Repaired: false, Error: ex.Message));
+            });
+    }
+}
+
+/// <summary>
+/// What a stale <see cref="MeshNode.MainNode"/> points at. Reported for evidence; never used to
+/// decide whether a node is repaired.
+/// </summary>
+public enum StaleMainNodeShape
+{
+    /// <summary>The pointed-at node exists and points back at this one — a mutual cycle.</summary>
+    Cycle,
+
+    /// <summary>The pointed-at node does not exist. The pointer dangles.</summary>
+    DanglingMissingTarget,
+
+    /// <summary>
+    /// The pointed-at node exists but does not point back — it names some third node, or itself.
+    /// </summary>
+    DanglingUnrelatedTarget,
+
+    /// <summary>The pointed-at node could not be read, so the shape is unknown. Repaired anyway.</summary>
+    Unclassified,
+}
+
+/// <summary>
+/// One node found carrying a stale self-default <see cref="MeshNode.MainNode"/>, and what the sweep
+/// did about it.
+/// </summary>
+/// <param name="Path">The node's own path — what <see cref="MeshNode.MainNode"/> should equal.</param>
+/// <param name="StaleMainNode">The pointer as found.</param>
+/// <param name="Shape">What that pointer pointed at.</param>
+/// <param name="Repaired">Whether this run re-stamped the node.</param>
+/// <param name="Error">Why the repair failed, when it did; null otherwise.</param>
+public sealed record StaleMainNodeFinding(
+    string Path,
+    string StaleMainNode,
+    StaleMainNodeShape Shape,
+    bool Repaired,
+    string? Error);
+
+/// <summary>
+/// The outcome of one sweep — per node, so a run against a live portal produces evidence rather than
+/// a count.
+/// </summary>
+/// <param name="Findings">Every node found with the stale shape, in path order.</param>
+/// <param name="PathsScanned">How many paths the storage-tree enumeration produced.</param>
+/// <param name="NodesRead">
+/// How many rows storage actually returned for those paths. Carried separately from
+/// <paramref name="Findings"/> because it is the sweep's proof of work: without it, "read 900 rows,
+/// none of them wrong" and "read nothing at all" are the same empty report.
+/// </param>
+/// <param name="Wrote">Whether this was a repair pass (<c>true</c>) or detect-only (<c>false</c>).</param>
+public sealed record StaleMainNodeRepairReport(
+    ImmutableList<StaleMainNodeFinding> Findings,
+    int PathsScanned,
+    int NodesRead,
+    bool Wrote)
+{
+    /// <summary>A sweep that had nothing to look at.</summary>
+    /// <param name="wrote">Whether the caller asked for a repair pass.</param>
+    public static StaleMainNodeRepairReport Empty(bool wrote) =>
+        new(ImmutableList<StaleMainNodeFinding>.Empty, PathsScanned: 0, NodesRead: 0, wrote);
+
+    /// <summary>How many findings this run successfully re-stamped.</summary>
+    public int RepairedCount => Findings.Count(f => f.Repaired);
+
+    /// <summary>How many findings this run tried and failed to re-stamp.</summary>
+    public int FailedCount => Findings.Count(f => f.Error is not null);
+}

--- a/src/MeshWeaver.Hosting/Persistence/StaleMainNodeRepair.cs
+++ b/src/MeshWeaver.Hosting/Persistence/StaleMainNodeRepair.cs
@@ -213,6 +213,24 @@ public static class StaleMainNodeRepair
     /// <para>The row count is carried out alongside the candidates because it is the sweep's proof
     /// of work: candidates alone cannot distinguish "read 900 rows, none of them wrong" from "read
     /// nothing at all", and those are the two outcomes a clean report must never conflate.</para>
+    ///
+    /// <para>🚨 <b>The candidates are SORTED here, because this is where order is lost.</b>
+    /// <see cref="IStorageAdapter.ReadMany"/>'s contract says plainly that "order is not guaranteed"
+    /// — its default implementation is an <c>Observable.Merge</c> over N reads, and Postgres answers
+    /// one batched <c>IN (…)</c> whose row order is the planner's business. Sorting at the stage the
+    /// nondeterminism ENTERS (rather than sorting the finished report) makes the whole pass
+    /// deterministic: classification order, the per-node repair log lines, and the report's
+    /// <c>Findings</c> all follow one path order.</para>
+    ///
+    /// <para>That matters more here than it would elsewhere. This repair's deliverable IS its
+    /// evidence: it is meant to be run once against live data by a person reading the per-node
+    /// report to judge whether it did the right thing. A nondeterministically-ordered report cannot
+    /// be diffed between the <see cref="Detect"/> dry run and the real run, and cannot be lined up
+    /// against an expected set — which would make the one artifact that renders the run auditable
+    /// unreliable. A stable order is also what lets a second run's report be compared to the first,
+    /// which is how the idempotence claim gets checked in practice rather than merely asserted.
+    /// Ordinal-ignore-case, the same comparer <see cref="EnumeratePaths"/> orders paths with, so the
+    /// two stages cannot disagree.</para>
     /// </summary>
     private static IObservable<(ImmutableList<MeshNode> Candidates, int NodesRead)> ReadCandidates(
         IStorageAdapter storage, ImmutableList<string> paths, JsonSerializerOptions options)
@@ -226,7 +244,12 @@ public static class StaleMainNodeRepair
                     (Candidates: ImmutableList<MeshNode>.Empty, NodesRead: 0),
                     (acc, batch) => (
                         acc.Candidates.AddRange(batch.Where(n => n.IsStaleSelfDefaultMainNode())),
-                        acc.NodesRead + batch.Count));
+                        acc.NodesRead + batch.Count))
+                .Select(acc => (
+                    Candidates: acc.Candidates.Sort(
+                        (left, right) => string.Compare(
+                            left.Path, right.Path, StringComparison.OrdinalIgnoreCase)),
+                    acc.NodesRead));
 
     /// <summary>
     /// Classifies every candidate, and only THEN repairs them.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -4492,8 +4492,23 @@ public static class MeshExtensions
     /// question is asked through <see cref="MeshNode.HasExplicitMainNode"/> (which compares it
     /// segment-wise against <c>Namespace</c>/<c>Id</c>), and the partition comparison runs on
     /// <c>Namespace</c> directly, whose first segment IS the node's partition.</para>
+    ///
+    /// <para>🚨 <b>Public because the FORWARD fix and the BACKWARD repair must share one
+    /// predicate</b> (#2970). This method is what the write paths above apply to every node they
+    /// create or upsert, so new corruption cannot be minted; <c>StaleMainNodeRepair</c> applies the
+    /// SAME method to rows already persisted. Two predicates would drift, and the drift would be
+    /// invisible in exactly the way this defect already is — a repair that skipped a shape the
+    /// guard refuses would leave rows corrupt with nothing reporting it. Widening a shape here
+    /// therefore widens both halves at once, which is the point.</para>
     /// </summary>
-    private static bool IsStaleSelfDefaultMainNode(MeshNode node)
+    /// <param name="node">The node whose <see cref="MeshNode.MainNode"/> is under test.</param>
+    /// <returns>
+    /// <c>true</c> when <see cref="MeshNode.MainNode"/> is this node's own self-default frozen at a
+    /// path the node no longer occupies — the shape that drops it out of <c>is:main</c>
+    /// (SQL <c>n.main_node = n.path</c>). <c>false</c> for a healthy node AND for a deliberate
+    /// cross-node pointer, both of which must be left untouched.
+    /// </returns>
+    public static bool IsStaleSelfDefaultMainNode(this MeshNode node)
     {
         var mainNode = node.MainNode;
         var id = node.Id;

--- a/test/MeshWeaver.Graph.Test/StaleMainNodeRepairTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaleMainNodeRepairTest.cs
@@ -1,0 +1,288 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshWeaver.Fixture;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// <see cref="StaleMainNodeRepair"/> — the backward half of #2939, filed as #2970.
+///
+/// <para><b>Why every fixture is seeded through the STORAGE adapter and not through
+/// <c>CreateNode</c>.</b> The forward fix runs <c>RepairStaleSelfDefaultMainNode</c> on every create
+/// and every upsert, so a corrupt node handed to the ordinary write path is healed on the way in and
+/// the test would be asserting on a node that was never corrupt. The rows this repair exists for
+/// were written BEFORE that fix, which is a durable row the serve path never re-stamped —
+/// so the fixture writes one, and <see cref="SeedCorruptAsync"/> reads it back and FAILS if the
+/// stale pointer did not survive. Without that read-back the whole suite could pass against nodes
+/// that were healthy all along.</para>
+///
+/// <para><b>The assertions are on observable state</b> — the node's persisted
+/// <see cref="MeshNode.MainNode"/> and what a real query shape returns — never on a log line or a
+/// count the test itself kept. Nothing is mocked: the repair runs against the same monolith mesh,
+/// storage adapter and query providers the portal uses.</para>
+/// </summary>
+public class StaleMainNodeRepairTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// The one place a wait is decided (<see cref="TestTimeouts"/>) — never a hand-written literal,
+    /// which is a guess about machine speed that CI's ~1.7× ratio invalidates. It stays strictly
+    /// below each <c>[Fact(Timeout = …)]</c> above, so a wedge is reported as the assertion that did
+    /// not converge rather than as an anonymous xunit kill.
+    /// </summary>
+    private static readonly TimeSpan Budget = TestTimeouts.Convergence;
+
+    /// <summary>
+    /// Writes a node straight to storage carrying <paramref name="mainNode"/>, then reads it back and
+    /// asserts the stale pointer PERSISTED — so a fixture that the storage layer silently normalised
+    /// fails here rather than turning a later assertion green for the wrong reason.
+    /// </summary>
+    private async Task<MeshNode> SeedCorruptAsync(string id, string ns, string mainNode)
+    {
+        var seeded = await SeedRawAsync(id, ns, mainNode);
+        seeded.MainNode.Should().Be(mainNode,
+            "the fixture must actually be corrupt — otherwise this suite proves nothing");
+        seeded.IsStaleSelfDefaultMainNode().Should().BeTrue(
+            "the shared predicate must recognise the fixture as the shape under repair");
+        return seeded;
+    }
+
+    /// <summary>Writes a node straight to storage and returns it as persisted.</summary>
+    private async Task<MeshNode> SeedRawAsync(string id, string ns, string mainNode)
+    {
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var node = new MeshNode(id, ns)
+        {
+            MainNode = mainNode,
+            Name = id,
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+        var written = await storage.Write(node, Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(Budget).Await();
+        written.Should().NotBeNull("the storage adapter must own and accept the seeded path");
+        return await ReadRawAsync(node.Path);
+    }
+
+    /// <summary>Reads the DURABLE row — the thing the repair has to move.</summary>
+    private async Task<MeshNode> ReadRawAsync(string path)
+    {
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var node = await storage.Read(path, Mesh.JsonSerializerOptions)
+            .Take(1).Timeout(Budget).Await();
+        node.Should().NotBeNull($"'{path}' must exist in storage");
+        return node!;
+    }
+
+    private Task<StaleMainNodeRepairReport> RepairAsync(params string[] roots)
+        => StaleMainNodeRepair.Repair(Mesh, roots).Timeout(Budget).Await();
+
+    private Task<StaleMainNodeRepairReport> DetectAsync(params string[] roots)
+        => StaleMainNodeRepair.Detect(Mesh, roots).Timeout(Budget).Await();
+
+    /// <summary>
+    /// The mutual cycle from the issue: two Active copies of one node in different partitions, each
+    /// naming the other. BOTH ends must end up self-pointing — repairing one and leaving the other
+    /// is the failure mode the issue calls out.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task A_cycle_pair_is_repaired_at_both_ends()
+    {
+        // Alpha/Skill/deployment ⇄ CycleSkill/deployment — the Hosting/Skill ⇄ Skill shape.
+        var left = await SeedCorruptAsync("deployment", "Alpha/Skill", "CycleSkill/deployment");
+        var right = await SeedCorruptAsync("deployment", "CycleSkill", "Alpha/Skill/deployment");
+
+        var report = await RepairAsync("Alpha", "CycleSkill");
+
+        report.Findings.Should().HaveCount(2, "both ends carry the shape independently");
+        report.Findings.Should().OnlyContain(f => f.Shape == StaleMainNodeShape.Cycle,
+            "each end's pointer resolves to a node that points back at it");
+        report.Findings.Should().OnlyContain(f => f.Repaired && f.Error == null);
+        report.RepairedCount.Should().Be(2);
+
+        (await ReadRawAsync(left.Path)).MainNode.Should().Be(left.Path,
+            "the left end is self-pointing again");
+        (await ReadRawAsync(right.Path)).MainNode.Should().Be(right.Path,
+            "the right end is repaired on its own merits, not as a side effect of the left");
+    }
+
+    /// <summary>
+    /// The shape the issue does NOT describe and which a cycle-only repair would skip: the pointer
+    /// names a node that does not exist. Two of the seven measured on memex are this.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task A_dangling_pointer_is_repaired_when_its_target_does_not_exist()
+    {
+        var node = await SeedCorruptAsync("email", "Beta/Skill", "NoSuchPartition/email");
+
+        var report = await RepairAsync("Beta");
+
+        report.Findings.Should().ContainSingle();
+        report.Findings[0].Shape.Should().Be(StaleMainNodeShape.DanglingMissingTarget,
+            "nothing lives at the pointed-at path");
+        report.Findings[0].Repaired.Should().BeTrue(
+            "a missing partner must not make the node unrepairable");
+        report.Findings[0].StaleMainNode.Should().Be("NoSuchPartition/email",
+            "the report carries the pointer as found, as evidence");
+
+        (await ReadRawAsync(node.Path)).MainNode.Should().Be(node.Path);
+    }
+
+    /// <summary>
+    /// The second dangling flavour: the target EXISTS but names something else, so there is no cycle
+    /// to close. A repair that assumed a partner pointing back would mis-handle this.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task A_pointer_to_a_node_that_does_not_point_back_is_repaired()
+    {
+        // The target is a perfectly healthy node in another partition — it does NOT point back.
+        var target = await SeedRawAsync("instance", "Gamma", "Gamma/instance");
+        target.MainNode.Should().Be(target.Path, "the target is healthy and must stay that way");
+
+        var node = await SeedCorruptAsync("instance", "Delta/Skill", "Gamma/instance");
+
+        var report = await RepairAsync("Delta", "Gamma");
+
+        report.Findings.Should().ContainSingle("only the corrupt node carries the shape");
+        report.Findings[0].Path.Should().Be(node.Path);
+        report.Findings[0].Shape.Should().Be(StaleMainNodeShape.DanglingUnrelatedTarget);
+        report.Findings[0].Repaired.Should().BeTrue();
+
+        (await ReadRawAsync(node.Path)).MainNode.Should().Be(node.Path);
+        (await ReadRawAsync(target.Path)).MainNode.Should().Be(target.Path,
+            "a healthy node that merely happens to be pointed AT is never rewritten");
+    }
+
+    /// <summary>
+    /// The false-positive arm. A healthy main node and a DELIBERATE cross-node pointer (a satellite,
+    /// whose MainNode names its owner under a different id) must both be left alone — the predicate
+    /// that separates them is the one the write paths already apply.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task Healthy_nodes_and_deliberate_pointers_are_left_untouched()
+    {
+        var healthy = await SeedRawAsync("readme", "Epsilon", "Epsilon/readme");
+        // A deliberate pointer: MainNode's last segment is NOT this node's id, so it is a real
+        // reference to another node rather than a frozen self-default.
+        var deliberate = await SeedRawAsync("_Policy", "Epsilon", "Epsilon/readme");
+
+        var report = await RepairAsync("Epsilon");
+
+        report.Findings.Should().BeEmpty(
+            "neither shape is a stale self-default, so neither is a candidate");
+        // 🚨 The clean result must be measured on a NON-EMPTY set, or it is the "verification that
+        // cannot fail" trap: a sweep that enumerated nothing and read nothing also reports zero
+        // findings, and the two are indistinguishable without these two counts.
+        report.PathsScanned.Should().BeGreaterThan(0,
+            "the sweep must actually have enumerated this partition");
+        report.NodesRead.Should().BeGreaterThan(0,
+            "and must actually have READ the nodes it then judged clean");
+
+        (await ReadRawAsync(healthy.Path)).MainNode.Should().Be(healthy.Path);
+        (await ReadRawAsync(deliberate.Path)).MainNode.Should().Be("Epsilon/readme",
+            "a deliberate pointer must survive the sweep verbatim");
+    }
+
+    /// <summary>Detect is the measurement pass: it finds the node and writes nothing.</summary>
+    [Fact(Timeout = 120000)]
+    public async Task Detect_reports_the_finding_without_writing()
+    {
+        var node = await SeedCorruptAsync("policy", "Zeta/Skill", "OtherZeta/policy");
+
+        var report = await DetectAsync("Zeta");
+
+        report.Wrote.Should().BeFalse();
+        report.Findings.Should().ContainSingle();
+        report.Findings[0].Repaired.Should().BeFalse();
+        report.RepairedCount.Should().Be(0);
+
+        (await ReadRawAsync(node.Path)).MainNode.Should().Be("OtherZeta/policy",
+            "a detect-only pass must leave the row exactly as it found it");
+    }
+
+    /// <summary>
+    /// Idempotence, and the reason it holds: the repair writes the one value the predicate cannot
+    /// match. The second pass is a no-op because there is nothing left to find — not because the
+    /// repair remembers having run.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task A_second_run_is_a_no_op_and_an_unaffected_mesh_is_safe()
+    {
+        var node = await SeedCorruptAsync("remote", "Eta/Skill", "OtherEta/remote");
+
+        var first = await RepairAsync("Eta");
+        first.Findings.Should().ContainSingle();
+        first.RepairedCount.Should().Be(1);
+
+        var second = await RepairAsync("Eta");
+        second.Findings.Should().BeEmpty("the repaired node no longer matches the predicate");
+        second.RepairedCount.Should().Be(0);
+        second.PathsScanned.Should().BeGreaterThan(0,
+            "the second pass still enumerated the partition — it found nothing, it did not skip");
+
+        (await ReadRawAsync(node.Path)).MainNode.Should().Be(node.Path,
+            "the second pass did not disturb the repaired value");
+
+        // A partition with nothing wrong in it: zero findings, zero writes, no fault.
+        await SeedRawAsync("clean", "Theta", "Theta/clean");
+        var healthyMesh = await RepairAsync("Theta");
+        healthyMesh.Findings.Should().BeEmpty();
+        healthyMesh.RepairedCount.Should().Be(0);
+    }
+
+    /// <summary>
+    /// 🚨 <b>The one that matters.</b> The user-visible defect is not the field, it is that the node
+    /// is missing from listings — so the repair is only proven by a query shape that could not see
+    /// the node before and can see it after.
+    ///
+    /// <para>The shape is <c>is:main</c> (SQL <c>n.main_node = n.path</c>), named explicitly because
+    /// the issue asks for it to be: it is the framework's literal definition of a main node, it is
+    /// what the home catalog's own listings carry (<c>namespace:{path} is:main</c>), and Postgres'
+    /// <c>search_across_schemas</c> hard-filters every union branch on that same predicate
+    /// unconditionally — which is why on memex the node is absent from every listing and not merely
+    /// from this one.</para>
+    ///
+    /// <para>The first assertion is the CONTROL ARM: without <c>is:main</c> the very same query
+    /// returns the node. Without it a green result here could just as well mean the node was never
+    /// indexed at all, and the test would prove nothing about MainNode.</para>
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task A_repaired_node_becomes_visible_to_the_listing_that_could_not_see_it()
+    {
+        var node = await SeedCorruptAsync("ci-policy", "Iota/Skill", "OtherIota/ci-policy");
+        var service = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        async Task<string[]> PathsAsync(string query)
+        {
+            var results = await service.QueryAsync<MeshNode>(query).ToArrayAsync();
+            return results.Select(n => n.Path).ToArray();
+        }
+
+        // CONTROL: the node IS in the index, Active and fully formed.
+        (await PathsAsync($"namespace:{node.Namespace}"))
+            .Should().Contain(node.Path,
+                "the corrupt node is present and indexed — its absence below is caused by MainNode, "
+                + "not by the node being missing");
+
+        // THE DEFECT: the same listing with is:main cannot see it.
+        (await PathsAsync($"namespace:{node.Namespace} is:main"))
+            .Should().NotContain(node.Path,
+                "main_node != path drops the node out of is:main — this is the user-visible symptom");
+
+        var report = await RepairAsync("Iota");
+        report.RepairedCount.Should().Be(1);
+
+        // THE OUTCOME: it is back in the listing.
+        (await PathsAsync($"namespace:{node.Namespace} is:main"))
+            .Should().Contain(node.Path,
+                "restoring MainNode == Path puts the node back into is:main — the whole point");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/StaleMainNodeRepairTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaleMainNodeRepairTest.cs
@@ -239,6 +239,36 @@ public class StaleMainNodeRepairTest(ITestOutputHelper output) : MonolithMeshTes
     }
 
     /// <summary>
+    /// The report's ordering is a CONTRACT, not an accident of how storage answered.
+    /// <c>IStorageAdapter.ReadMany</c> states that its order is not guaranteed, so without an
+    /// explicit sort the findings — and the per-node log lines — would come back in whatever order
+    /// the backend produced.
+    ///
+    /// <para>It matters because this repair's deliverable is its EVIDENCE: a run against live data
+    /// is read by a person deciding whether it did the right thing, and a nondeterministically
+    /// ordered report cannot be diffed between the dry run and the real run, nor lined up against an
+    /// expected set. The seeds below are written in deliberately non-alphabetical order so a
+    /// missing sort cannot pass by coincidence.</para>
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task Findings_come_back_in_path_order()
+    {
+        // Seeded high-to-low, so "insertion order" and "path order" disagree.
+        await SeedCorruptAsync("zeta-item", "Mu/Skill", "OtherMu/zeta-item");
+        await SeedCorruptAsync("mid-item", "Mu/Skill", "OtherMu/mid-item");
+        await SeedCorruptAsync("alpha-item", "Mu/Skill", "OtherMu/alpha-item");
+
+        var report = await DetectAsync("Mu");
+
+        var paths = report.Findings.Select(f => f.Path).ToArray();
+        paths.Should().HaveCount(3);
+        paths.Should().Equal(
+            paths.OrderBy(p => p, StringComparer.OrdinalIgnoreCase).ToArray(),
+            "the report must be ordered by path so a second run's evidence can be diffed "
+            + "against the first — ReadMany itself guarantees no order");
+    }
+
+    /// <summary>
     /// The DEFAULT call shape — no roots, so the sweep starts from the storage adapter's own root
     /// listing and walks the whole tree. Scoping every other test would leave
     /// <c>ListChildPaths(null)</c> — the branch a real run against a portal takes — never executed.

--- a/test/MeshWeaver.Graph.Test/StaleMainNodeRepairTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaleMainNodeRepairTest.cs
@@ -239,6 +239,37 @@ public class StaleMainNodeRepairTest(ITestOutputHelper output) : MonolithMeshTes
     }
 
     /// <summary>
+    /// The DEFAULT call shape — no roots, so the sweep starts from the storage adapter's own root
+    /// listing and walks the whole tree. Scoping every other test would leave
+    /// <c>ListChildPaths(null)</c> — the branch a real run against a portal takes — never executed.
+    ///
+    /// <para>The node is seeded in a partition the test never names to the repair, so finding it is
+    /// the enumeration's own work rather than something the caller pointed at. A second node is
+    /// seeded in a DIFFERENT top-level partition, and the path count must cover both: that is what
+    /// distinguishes a root listing that fans out across partitions from one that reached only the
+    /// first thing it found. (The count is exactly the durable rows this test wrote — the harness's
+    /// other nodes are statically seeded, not storage rows, so they are legitimately not walked.)
+    /// </para>
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task An_unscoped_sweep_walks_the_whole_tree_and_finds_it()
+    {
+        var node = await SeedCorruptAsync("platform-update", "Kappa/Skill", "OtherKappa/platform-update");
+        var elsewhere = await SeedRawAsync("bystander", "Lambda", "Lambda/bystander");
+
+        var report = await StaleMainNodeRepair.Repair(Mesh).Timeout(Budget).Await();
+
+        report.Findings.Select(f => f.Path).Should().Contain(node.Path,
+            "an unscoped sweep must reach a partition nobody named");
+        report.NodesRead.Should().BeGreaterThanOrEqualTo(2,
+            "the root listing must fan out across BOTH seeded partitions, not stop at the first");
+
+        (await ReadRawAsync(node.Path)).MainNode.Should().Be(node.Path);
+        (await ReadRawAsync(elsewhere.Path)).MainNode.Should().Be(elsewhere.Path,
+            "the healthy bystander in the other partition is read and left alone");
+    }
+
+    /// <summary>
     /// 🚨 <b>The one that matters.</b> The user-visible defect is not the field, it is that the node
     /// is missing from listings — so the repair is only proven by a query shape that could not see
     /// the node before and can see it after.


### PR DESCRIPTION
Fixes #2970

A node whose `MainNode` names a partition it does not occupy is **Active, complete, and returned by
`get`** — and missing from every listing, because `is:main` is SQL `n.main_node = n.path` and
Postgres' `search_across_schemas` hard-filters every union branch on that same predicate
unconditionally. Nothing errors, nothing logs, no status flips. #2939 and Plugins#1053 fixed the mint
sites, so no *new* row can acquire the shape; neither touches a row already stored. This is that
other half.

## 🚨 The migration has NOT been run anywhere

Nothing in the composition root calls it. It is a static one-shot pipeline, **not** an
`IHostedService`, so deploying an image containing it runs no repair. Running it against `memex` — or
any portal — is a separate decision, deliberately left to the maintainer. `Detect` exists so that
decision can be taken on measured evidence: it writes nothing and is safe on production.

## Two properties of this defect dictate the whole design

**1. The broken field is the field that decides who may fix it.** Authorization resolves against
`MainNode`, not `Path`, so the permission check is answered by the *other* partition's scope and the
obvious re-stamp is refused:

```
patch @Hosting/Skill/deployment {"mainNode":"Hosting/Skill/deployment"}
→ Access denied: user 'rbuergi' lacks Update permission on 'Hosting/Skill/deployment'
```

The write therefore runs under `RunAsSystem` — the sanctioned *legitimate infrastructure* case.
🚨 `RunAsSystem`, never `Observable.Using(access.ImpersonateAsSystem, …)`, whose halves land on
different threads and latch System onto the subscriber (#1790; the ratchet may only shrink, and this
adds no line to it).

**2. Detection cannot use a query.** The condition's own definition is *"invisible to the index"*, so
a query-driven detector would pass its tests against a permissive in-memory provider and find **zero
rows on the deployment that actually has the corruption**. Enumeration runs on
`IStorageAdapter.ListChildPaths` / `ListDescendantPaths` — the authoritative path-routed tree walk,
which routes by `Path` and so cannot be hidden from.

## Detection, not a list — which is what catches the three corrections

The predicate is `MeshExtensions.IsStaleSelfDefaultMainNode`, made public: **the same method the
create and upsert paths already apply to every node they write.** Two predicates would drift, and the
drift would be invisible in exactly the way this defect is.

Because it is a per-node *shape* test rather than a pair test, the three measured corrections to the
issue body fall out for free:

- **Two of the seven are dangling, not cyclic.** No partner is ever required to exist; a dangling
  pointer is repaired on its own merits.
- **There is an eighth node (`Skill/email`).** Nothing here consumes the issue's list, so it is
  found like any other.
- **The healthy baseline moves.** No assertion anywhere depends on a total. (Measured again today:
  `nodeType:Skill` now returns **68**, and both `Hosting/Skill/deployment` and `Skill/deployment` are
  no longer `get`-able — the census has drifted again since 2026-09-01, which is precisely why this
  is detection-driven.)

What the pointer points *at* is read only to **classify** the finding for the report (`Cycle` /
`DanglingMissingTarget` / `DanglingUnrelatedTarget` / `Unclassified`), never to decide whether to
repair — and through `IStorageAdapter.Read` (null-on-absent), **never** `GetMeshNodeStream(target)`,
whose absent-node point read would open the storm breaker and fast-fail the very write the pass is
there to perform.

## Idempotence

The repair writes the one value the predicate **cannot match**: after `MainNode = Path`,
`HasExplicitMainNode` is `false` and the predicate returns `false` at the first test. A second run
enumerates the same paths, reads the same rows, and finds nothing — it does not *remember* having
run, there is nothing left to find. Zero affected nodes ⇒ zero writes. Concurrent runs converge.

## Tests — `test/MeshWeaver.Graph.Test/StaleMainNodeRepairTest.cs` (7, real monolith mesh, no mocks)

Fixtures are seeded through the **storage adapter**, because the forward fix heals anything handed to
the ordinary write path — and each fixture is **read back and asserted corrupt**, so the suite cannot
pass against nodes that were healthy all along.

Cycle repaired at both ends · dangling-missing-target repaired · target-that-does-not-point-back
repaired · healthy nodes and deliberate pointers untouched · `Detect` writes nothing · second run is
a no-op and a clean partition is safe · **and the one that matters:**

```
namespace:{ns}            → contains the node      (CONTROL: it is indexed, Active, present)
namespace:{ns} is:main    → does NOT contain it     (the user-visible symptom)
   … repair …
namespace:{ns} is:main    → contains it             (the outcome)
```

The control arm is load-bearing: without it a green result could equally mean the node was never
indexed, and the test would prove nothing about `MainNode`.

**One test found a real defect during development.** Classification was interleaved with repair, so
the second end of a cycle was classified *after* the first had already been repaired — reporting the
pair as one `Cycle` + one `DanglingUnrelatedTarget`. The repair was correct either way; the
**evidence** was not, and a half-reported cycle understates exactly the duplicate pairs the report
exists to surface. Classification of the whole set now completes before any write.

## Deliberately not answered: the duplicate-copy question

A cycle is two Active copies of one node with identical content. Whether the platform-partition copy
should be **deleted** as a duplicate is a judgement about content, not a mechanical one. Both ends are
re-stamped to point at themselves, **both copies are kept, nothing is deleted**, and the open question
is recorded in the doc page. A `Detect` pass is the input to that decision — its `Cycle` findings are
exactly the duplicate pairs.

## Verification

- `dotnet build -c Release -warnaserror` — `0 Error(s)`, `0 Warning(s)` — for
  `test/MeshWeaver.Graph.Test` (covering `Mesh.Contract`, `Hosting`, `Graph`) and
  `test/MeshWeaver.Documentation.Test` (covering `Documentation`); Release outputs confirmed freshly
  written, not up-to-date no-ops.
- Full `MeshWeaver.Documentation.Test` and `MeshWeaver.Graph.Test` runs (not `--filter`), so the
  ratchet guards were actually exercised. `TestTimeoutLiteralRatchetGuard` caught a hand-written
  `TimeSpan.FromSeconds(30)` in the new test; converted to `TestTimeouts.Convergence` rather than
  re-seeded. `DocumentationLinkIntegrityTest` green.

## Files

- `src/MeshWeaver.Hosting/Persistence/StaleMainNodeRepair.cs` — the repair.
- `src/MeshWeaver.Mesh.Contract/MeshExtensions.cs` — the detection predicate made public so the
  forward fix and the backward repair share one method.
- `src/MeshWeaver.Documentation/Data/Architecture/StaleMainNodeRepair.md` — the design, both shapes,
  the idempotence contract, and the unresolved duplicate-copy question.
- `src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-node-that-vanished-from-every-list-can-be-brought-back.md`
- `test/MeshWeaver.Graph.Test/StaleMainNodeRepairTest.cs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
