### PR TITLE
fix: a package install rebuilds the packages that share its sources

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CompileProgramStateOfRecord.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CompileProgramStateOfRecord.md
@@ -99,31 +99,88 @@ with single-activation semantics, so on the clustered portal the status compare-
 cluster-wide. That does not hold for the monolith, and nothing in the compile pipeline asserts or
 tests it.
 
-## 🚨 A Store update does not rebuild its dependents
+## 🚨 A Store update does not rebuild its dependents — FIXED 2026-09-02
 
-This is the one live defect the programs contained, and it is the mechanism behind the 2026-08-25
-Store outage, in which every Store NodeType recompiled green and the page still went down.
+This was the one live defect the programs contained, and it is the mechanism behind the 2026-08-25
+Store outage, in which every Store NodeType recompiled green and the page still went down. **The
+history below is the point of this section — read it before touching the installer's release
+sequencing.**
 
 The correct closure exists. `ReleaseAffectedNodeTypes` enumerates NodeTypes **mesh-wide** and
 matches a changed path against every type's expanded source and test queries — so it *does* catch a
 cross-package `shared=@{package}/…` consumer, ordered topologically.
 
-**It has exactly one production caller, and it is not the installer.** The sync transaction uses it.
-The package installer instead releases the paths of the nodes it just wrote that happen to be
+**It had exactly one production caller, and it was not the installer.** The sync transaction used
+it. The package installer instead released the paths of the nodes it just wrote that happened to be
 NodeType definitions — which can only ever name types **inside the installed package**. So a Store
-package update rebuilds Store's own types and leaves every package that compiles Store's sources
-into its own assembly on the assembly it already had. The result is two hubs on different compiles
-of the same sources disagreeing about the type registry, which reads as `$type` is not registered
-and renders as an empty view.
+package update rebuilt Store's own types and left every package that compiles Store's sources into
+its own assembly on the assembly it already had. The result is two hubs on different compiles of the
+same sources disagreeing about the type registry, which reads as `$type` is not registered and
+renders as an empty view.
 
-The pieces for the fix are all present: the installer already tracks the paths it wrote and pruned,
-and the closure already accepts exactly that input.
+### What the fix is
 
-> While fixing it, note that the installer selects its release targets with an `is`
-> **pattern-match on an `object` payload**. Per the platform's own rule that is a trap-door: content
-> that arrived as JSON reads as absent, so the filter would silently select *nothing* and no release
-> would be issued at all — a second, quieter way to reach the same outage. Use the content
-> accessor.
+The derivation was split out of `ReleaseAffectedNodeTypes` as `hub.AffectedNodeTypes(changedPaths)`
+— the mesh-wide enumeration plus `RecompileClosure`, ordered dependencies-first, with no seeding and
+no release — so a caller that owns its own release sequencing can run exactly the same closure.
+`ReleaseAffectedNodeTypes` is now that derivation plus the seed and the trigger, unchanged for the
+sync transaction.
+
+`PackageInstaller` calls it on **every** install path, over what actually moved (the paths written ∪
+the paths actually deleted), after its own package-local releases:
+
+| Path | Package-local release, as before | …then the closure |
+|---|---|---|
+| Full node-repo install | two waves around the retyped root's recycle | every affected type outside the package |
+| Incremental delta | one wave over `releaseTargets` | same |
+| Single `Code` package | the one synthesized NodeType | same |
+| `Content` package | *(none — it declares no type)* | the whole affected set |
+
+Four paths, not three: the content-package path issued **no** release at all, and a content package
+can perfectly well ship the `Source/` a NodeType compiles — the same hole, reached differently.
+
+Three properties are load-bearing and easy to lose:
+
+- **The closure ADDS to the package-local set, it does not replace it.** Each half covers what the
+  other structurally cannot. The closure enumerates from the query index, which *trails* the store,
+  so a type the install just CREATED may not be listed — and the installer must release those anyway
+  (`SettleRetypedRoot` waits on the in-package type's rebuild). The package-local set, in turn, can
+  never see a cross-package consumer. The closure call subtracts what was already released, so
+  nothing is requested twice; when the install released nothing locally (a prune-only run), it
+  subtracts nothing and the closure covers the package's own types too.
+- **Dependents come last.** Every changed path is inside the installed package, so an affected type
+  either IS a package type (a dependency — released first) or reaches those files through `shared=`
+  (a dependent). Seed before release everywhere: adopt-before-compile is deliberate.
+- **Write outcomes travel as `(path, wrote)` pairs, not counts.** The writes fan out through
+  `Merge`, which does not preserve order, so a count — or a positional zip — cannot be turned back
+  into paths. `InstallResult.WrittenPaths` is now populated by every flavour, and the prune returns
+  the paths it *actually* deleted (a claimed or absent candidate is not a change).
+
+### The second defect, on the same line
+
+The package-local selector was `n.Content is NodeTypeDefinition` — a **pattern-match on an `object`
+payload**, the trap-door the platform's own rule forbids. Content that arrived as JSON does not
+match, so the filter selected *nothing* and no release was issued at all: the same outage, reached
+more quietly, with no exception and nothing to grep. Every such site in the installer now reads
+`ImportWriteOrder.IsNodeTypeDefinition` — the framework's shape-tolerant predicate (the CLR test OR
+the cast-free `NodeType` meta-marker).
+
+🚨 **A bare `ContentAs<NodeTypeDefinition>` is the wrong accessor *here*, and would be a second bug
+in the opposite direction:** every member of that record is optional, so *any* JSON object
+deserializes into one — and every plain content node would then read as a NodeType, land in the
+types' write bucket, and be handed a release request. The `NodeType` field is the discriminator that
+is both cast-free and cannot over-match. `ContentAs<T>` remains correct where the *definition* is
+what you want (`AffectedNodeTypes` reads each type's declared `Sources` that way).
+
+### What pins it
+
+`PackageInstallRebuildsDependentsTest` (Memex.Portal.Shared.Test): a dependent package's NodeType is
+seeded whose only source is `shared=@{provider}/…/Source`; the provider package is then installed,
+and the dependent must end up with a `RequestedReleaseAt` stamp. The cross-package assertion is the
+whole test — asserting that the provider's *own* types are released passes on the broken code and
+proves nothing. The provider's NodeType ships with an untyped content payload on purpose, so one
+install drives both fixes; a second, hub-free test compares the trap-door and its replacement on the
+same parsed node so the selector cannot be answered for by a query index that happened to catch up.
 
 ## What shipped elsewhere in the program, and is fine
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-updating-a-package-now-rebuilds-what-builds-on-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-updating-a-package-now-rebuilds-what-builds-on-it.md
@@ -1,0 +1,43 @@
+---
+Name: Updating a package now rebuilds what builds on it
+Category: Fix
+Description: Updating a package that other packages build on used to leave those packages running the old code — pages went blank with no error anywhere. The update now rebuilds them too.
+Icon: ArrowSync
+Order: -20260902
+---
+
+# Updating a package now rebuilds what builds on it
+
+Packages can share code. One package publishes source files; another says "build those into me too",
+and from then on the second package carries its own copy of that code. That is a real dependency,
+and it means the second package is out of date the moment the first one changes.
+
+Until now, updating the first package rebuilt only *itself*. Everything built on top of it kept
+running the code it had been built with — and nothing said so. The two halves of the platform then
+disagreed about what the shared shapes were, which came out as a page that renders **empty**: no
+error banner, no failed install, nothing in the log to search for. The install even reported
+success, because as far as it could tell it had rebuilt everything it knew about. It had; the
+problem is that a package can only ever know about itself.
+
+This is what took the Store down on 25 August. Every one of the Store's own pieces rebuilt cleanly
+and the page still went blank.
+
+**An update now rebuilds the whole set that depends on it**, worked out across the entire mesh
+rather than inside the updated package: whichever packages build the changed files into themselves
+are rebuilt as well, dependencies first so nothing is rebuilt against something that is still
+moving. It applies to every kind of install — a full package, an incremental update, a single code
+package, and a plain content package, which previously triggered no rebuild at all even when the
+files it shipped were somebody's source code.
+
+Two details worth knowing:
+
+- **Deleting a shared file counts as a change.** A file the package no longer ships makes its
+  consumers just as stale as an edited one, and they are rebuilt for it too.
+- **Nothing is rebuilt twice.** The update still rebuilds its own pieces first, exactly as before,
+  and the wider set skips whatever has already been handled — so an update does not get slower for
+  packages that nothing depends on.
+
+There was a second, quieter route to the same blank page, and it is closed in the same change: when
+a package's type definition arrived in a slightly different shape than expected, the installer
+concluded there was nothing to rebuild *at all* — and issued no rebuild, silently. That check no
+longer depends on the shape the content happened to arrive in.

--- a/src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs
+++ b/src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs
@@ -23,6 +23,16 @@ namespace MeshWeaver.Graph;
 /// as part of the sync transaction; the release requests are ISSUED within the transaction (the
 /// compiles themselves run on the per-type hubs' compile watchers, serialized on the Compile
 /// IoPool — an update must not block on Roslyn).</para>
+///
+/// <para>🚨 <b>Two entry points, one closure.</b> <see cref="AffectedNodeTypes"/> is the DERIVATION
+/// alone — enumerate mesh-wide, run <see cref="RecompileClosure"/>, order topologically — for a
+/// caller that owns its own seed/release sequencing (the package installer, whose retyped-root
+/// recycle sits BETWEEN two release waves). <see cref="ReleaseAffectedNodeTypes"/> is that
+/// derivation plus adopt-before-compile plus the release trigger. A caller that derives its targets
+/// from "the nodes I just wrote" instead of from this closure can only ever name types inside its
+/// own package, and that is precisely how a Store package update left every <c>shared=</c> consumer
+/// on the assembly it already had (2026-08-25; see
+/// <c>Doc/Architecture/CompileProgramStateOfRecord</c>).</para>
 /// </summary>
 public static class NodeTypeRecompileExtensions
 {
@@ -33,28 +43,42 @@ public static class NodeTypeRecompileExtensions
     private static readonly TimeSpan PrebuiltSeedBudget = TimeSpan.FromSeconds(60);
 
     /// <summary>
-    /// Requests a release for every NodeType affected by <paramref name="changedNodePaths"/>
-    /// (written or pruned node paths). Emits the release-requested type paths, in dependency
-    /// order, exactly once; an empty change set emits an empty list without querying anything.
+    /// The mesh-wide recompile closure for <paramref name="changedNodePaths"/> — every NodeType
+    /// whose own node changed OR whose expanded <c>Sources</c>/<c>Tests</c> queries reach a changed
+    /// path, in dependency order (dependencies before dependents). Derivation ONLY: nothing is
+    /// seeded and no release is requested, so a caller that owns its own seed/release sequencing
+    /// (the package installer, whose root recycle sits BETWEEN two release waves) can use exactly
+    /// the same closure as <see cref="ReleaseAffectedNodeTypes"/>. An empty change set emits an
+    /// empty list without querying anything.
     ///
-    /// <para>Runs as SYSTEM end-to-end — the type enumeration spans every partition
-    /// (infrastructure, not a user-attributable read; mirrors <c>DynamicTypePreWarmer</c>), and the
-    /// release trigger is a node write on types the syncing user may not own, consistent with how
-    /// the update's own writes land. A derivation failure is surfaced LOUDLY on
-    /// <paramref name="progress"/> (an <see cref="LogLevel.Error"/> line — on an activity sink this
-    /// flips the terminal status) and emits empty rather than failing the caller: the content is
-    /// applied either way, and the operator must learn the assemblies were left stale.</para>
+    /// <para>🚨 <b>Mesh-wide is the point.</b> The set a change touches is NOT confined to the
+    /// package/space the change landed in: a type in ANOTHER package that pulls those files in
+    /// through <c>shared=@{package}/…</c> compiles their TEXT into its OWN assembly, so it is stale
+    /// the moment they move. Deriving release targets from "the nodes I just wrote" instead can
+    /// only ever name types inside the changed package — which is exactly how a Store update left
+    /// every consumer running the assembly it already had (2026-08-25; see
+    /// <c>Doc/Architecture/CompileProgramStateOfRecord</c>).</para>
+    ///
+    /// <para>The enumeration runs as SYSTEM — it spans every partition (infrastructure, not a
+    /// user-attributable read; mirrors <c>DynamicTypePreWarmer</c>). A derivation failure is
+    /// surfaced LOUDLY on <paramref name="progress"/> (an <see cref="LogLevel.Error"/> line — on an
+    /// activity sink this flips the terminal status) and emits empty rather than failing the
+    /// caller: the content is applied either way, and the operator must learn the assemblies were
+    /// left stale.</para>
     ///
     /// <para>Types are enumerated from the query index (<c>nodeType:NodeType</c>) — eventually
     /// consistent, which is correct for an UPDATE channel: the affected types existed before the
     /// update by definition. A type CREATED by the very same update needs no release — its first
-    /// activation compiles it fresh.</para>
+    /// activation compiles it fresh. A caller that must release just-created types anyway (the
+    /// installer does: its root recycle waits on the in-package type's rebuild) unions them in
+    /// itself rather than relying on the index having caught up.</para>
     /// </summary>
     /// <param name="hub">The hub the update runs on.</param>
     /// <param name="changedNodePaths">The node paths the update wrote or pruned.</param>
-    /// <param name="progress">Optional progress sink (an activity's <c>ctx.Log</c>): receives the
-    /// recompile set, per-type release failures, and derivation failures.</param>
-    public static IObservable<IReadOnlyList<string>> ReleaseAffectedNodeTypes(
+    /// <param name="progress">Optional progress sink (an activity's <c>ctx.Log</c>): receives
+    /// dependency-cycle and derivation failures.</param>
+    /// <returns>A cold observable of the affected type paths in dependency order; Subscribe to run.</returns>
+    public static IObservable<IReadOnlyList<string>> AffectedNodeTypes(
         this IMessageHub hub,
         IReadOnlyCollection<string> changedNodePaths,
         Action<string, LogLevel>? progress = null)
@@ -72,10 +96,11 @@ public static class NodeTypeRecompileExtensions
         // `AsSystem(x)` IS `x.ImpersonateAsSystem()`, so the helper only hides the shape: `Using`
         // opens the AsyncLocal on the SUBSCRIBING thread and disposes it on whichever thread the
         // query terminates, latching the subscriber — here a content-update pipeline that continues
-        // as the USER who pushed. Only the enumeration needs System; the release trigger below
-        // already opens its own synchronous `using (accessService?.ImpersonateAsSystem())` around
-        // the loop, and the prebuilt-adoption leg (ShippedPrebuiltBundles.SeedBundles) opens its
-        // own, so nothing downstream depends on this scope leaking past the query.
+        // as the USER who pushed. Only the enumeration needs System; the release trigger in
+        // ReleaseAffectedNodeTypes opens its own synchronous
+        // `using (accessService?.ImpersonateAsSystem())` around the loop, and the prebuilt-adoption
+        // leg (ShippedPrebuiltBundles.SeedBundles) opens its own, so nothing downstream depends on
+        // this scope leaking past the query.
         return accessService.RunAsSystem(
                 () => meshService
                     .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
@@ -106,8 +131,51 @@ public static class NodeTypeRecompileExtensions
                         $"⚠ Dependency cycle among NodeTypes: {cycleList} — recompiled in flush order, not dependency order.",
                         LogLevel.Warning);
                 }
-                return ordered;
+                return (IReadOnlyList<string>)ordered;
             })
+            .Catch<IReadOnlyList<string>, Exception>(ex =>
+            {
+                // LOUD, not fatal: the content landed; what failed is DERIVING the recompile set.
+                // The Error line flips an owning activity's terminal status, so the stale-assembly
+                // state is impossible to miss — while the update itself stands.
+                logger?.LogError(ex, "[Recompile] Deriving the recompile set failed.");
+                progress?.Invoke(
+                    $"Recompile derivation failed: {ex.Message} — affected NodeType assemblies are STALE until compiled manually.",
+                    LogLevel.Error);
+                return Observable.Return<IReadOnlyList<string>>([]);
+            });
+    }
+
+    /// <summary>
+    /// Requests a release for every NodeType affected by <paramref name="changedNodePaths"/>
+    /// (written or pruned node paths) — <see cref="AffectedNodeTypes"/> plus adopt-before-compile
+    /// and the release trigger. Emits the release-requested type paths, in dependency order,
+    /// exactly once; an empty change set emits an empty list without querying anything.
+    ///
+    /// <para>Runs as SYSTEM end-to-end — the enumeration for the reasons on
+    /// <see cref="AffectedNodeTypes"/>, and the release trigger because it is a node write on types
+    /// the syncing user may not own, consistent with how the update's own writes land. Never faults
+    /// the caller: a derivation or release failure is logged and reported on
+    /// <paramref name="progress"/> instead.</para>
+    /// </summary>
+    /// <param name="hub">The hub the update runs on.</param>
+    /// <param name="changedNodePaths">The node paths the update wrote or pruned.</param>
+    /// <param name="progress">Optional progress sink (an activity's <c>ctx.Log</c>): receives the
+    /// recompile set, per-type release failures, and derivation failures.</param>
+    public static IObservable<IReadOnlyList<string>> ReleaseAffectedNodeTypes(
+        this IMessageHub hub,
+        IReadOnlyCollection<string> changedNodePaths,
+        Action<string, LogLevel>? progress = null)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        if (changedNodePaths.Count == 0)
+            return Observable.Return<IReadOnlyList<string>>([]);
+
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Graph.NodeTypeRecompileExtensions");
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
+
+        return hub.AffectedNodeTypes(changedNodePaths, progress)
             .SelectMany(ordered =>
             {
                 if (ordered.Count == 0)
@@ -168,15 +236,15 @@ public static class NodeTypeRecompileExtensions
                     return ordered;
                 });
             })
-            .Select(ordered => (IReadOnlyList<string>)ordered)
             .Catch<IReadOnlyList<string>, Exception>(ex =>
             {
-                // LOUD, not fatal: the content landed; what failed is deriving/issuing the
-                // recompiles. The Error line flips an owning activity's terminal status, so the
-                // stale-assembly state is impossible to miss — while the update itself stands.
-                logger?.LogError(ex, "[Recompile] Deriving the recompile set failed.");
+                // LOUD, not fatal: the content landed; what failed is ISSUING the recompiles
+                // (deriving them has its own Catch inside AffectedNodeTypes). The Error line flips
+                // an owning activity's terminal status, so the stale-assembly state is impossible
+                // to miss — while the update itself stands.
+                logger?.LogError(ex, "[Recompile] Issuing the recompile requests failed.");
                 progress?.Invoke(
-                    $"Recompile derivation failed: {ex.Message} — affected NodeType assemblies are STALE until compiled manually.",
+                    $"Recompile requests failed: {ex.Message} — affected NodeType assemblies are STALE until compiled manually.",
                     LogLevel.Error);
                 return Observable.Return<IReadOnlyList<string>>([]);
             });

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -143,20 +143,29 @@ public static class PackageInstaller
         // the permission fold correctly denies because the grants are simply not there yet.
         var ownAccess = nodes.Where(n => IsPartitionAccessSatellite(n.Path, partition)).ToArray();
         var content = nodes.Where(n => !IsPartitionAccessSatellite(n.Path, partition)).ToArray();
+        // Carried as (path, wrote) PAIRS, not counts: the recompile closure below needs WHICH nodes
+        // moved, and `Merge` does not preserve order, so a positional zip could not recover them.
         return EnsureInstallPartitions(hub, partition, logger)
             .SelectMany(_ => ownAccess
-                .Select(n => UpsertIfChanged(hub, persistence, n, options))
+                .Select(n => UpsertIfChanged(hub, persistence, n, options)
+                    .Select(wrote => (n.Path, Wrote: wrote)))
                 .ToObservable().Concat().ToList())
             .SelectMany(accessWrites => EnsureDeclaredAccess(
                     hub, manifest, partition, logger, nodes.Select(n => n.Path))
                 .Select(_ => accessWrites))
             .SelectMany(accessWrites => content
-                .Select(n => UpsertIfChanged(hub, persistence, n, options))
+                .Select(n => UpsertIfChanged(hub, persistence, n, options)
+                    .Select(wrote => (n.Path, Wrote: wrote)))
                 .ToObservable().Merge(batchSize).ToList()
-                .Select(contentWrites => (IList<bool>)accessWrites.Concat(contentWrites).ToList()))
+                .Select(contentWrites => (IReadOnlyList<(string Path, bool Wrote)>)
+                    accessWrites.Concat(contentWrites).ToArray()))
             .SelectMany(writes =>
             {
-                var result = new InstallResult(nodes.Length, writes.Count(w => w));
+                var written = writes.Where(w => w.Wrote).Select(w => w.Path).ToImmutableList();
+                var result = new InstallResult(nodes.Length, written.Count)
+                {
+                    WrittenPaths = written,
+                };
                 logger?.LogInformation(
                     "Installed package {Id} v{Version}: {Written} written, {Unchanged} unchanged into {Partition} @ {Ref}",
                     manifest.Id, manifest.Version, result.Written, result.Unchanged, partition, installedFromRef);
@@ -165,6 +174,13 @@ public static class PackageInstaller
                 // reported LOUDLY — an install that reports success while its partition is
                 // unreadable is exactly the failure this ordering exists to make impossible.
                 return VerifyDeclaredAccess(hub, manifest, partition, logger)
+                    // 🚨 A content package declares no NodeType of its own, so this path issued NO
+                    // release at all — yet the nodes it writes can be a type's COMPILE INPUTS (a
+                    // package that ships shared `Source/` for others to compile is exactly the
+                    // Store shape). The mesh-wide closure is the only thing that can see those
+                    // consumers; with nothing released locally, `alreadyReleased` is empty.
+                    .SelectMany(_ => ReleaseDependentsOutsidePackage(
+                        hub, written, Array.Empty<string>(), manifest.Id, logger))
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, nodes.Length, authorizingUserId: authorizingUserId))
                     .SelectMany(_ => WarmInstalledRoots(hub, manifest, nodes, logger))
@@ -1223,7 +1239,7 @@ public static class PackageInstaller
             .FirstOrDefault(n => string.Equals(n.Path, root, StringComparison.Ordinal))?.NodeType;
         if (string.IsNullOrEmpty(declaredType))
             return null;
-        return nodes.Any(n => n.Content is NodeTypeDefinition
+        return nodes.Any(n => ImportWriteOrder.IsNodeTypeDefinition(n)
                 && string.Equals(n.Path, declaredType, StringComparison.OrdinalIgnoreCase))
             ? declaredType
             : null;
@@ -1968,17 +1984,25 @@ public static class PackageInstaller
 
         // NodeType first (so its Source nodes attach under a present type), then the Source nodes;
         // each is skipped when unchanged.
+        // 🚨 The write outcomes are carried as (path, wrote) PAIRS, not as a count: the recompile
+        // closure below needs to know WHICH nodes moved, and `Merge` does not preserve order, so a
+        // count (or a positional zip against sourceNodes) cannot be turned back into paths.
         return EnsureInstallPartitions(hub, partition, logger)
-            .SelectMany(_ => UpsertIfChanged(hub, persistence, nodeTypeNode, options))
-            .SelectMany(typeWritten => sourceNodes
-                .Select(n => UpsertIfChanged(hub, persistence, n, options))
+            .SelectMany(_ => UpsertIfChanged(hub, persistence, nodeTypeNode, options)
+                .Select(wrote => (nodeTypeNode.Path, Wrote: wrote)))
+            .SelectMany(typeWrite => sourceNodes
+                .Select(n => UpsertIfChanged(hub, persistence, n, options)
+                    .Select(wrote => (n.Path, Wrote: wrote)))
                 .ToObservable().Merge(batchSize).ToList()
-                .Select(srcWrites => typeWritten
-                    ? srcWrites.Count(w => w) + 1
-                    : srcWrites.Count(w => w)))
-            .SelectMany(written =>
+                .Select(srcWrites => (IReadOnlyList<(string Path, bool Wrote)>)
+                    new[] { typeWrite }.Concat(srcWrites).ToArray()))
+            .SelectMany(writes =>
             {
-                var result = new InstallResult(all.Length, written);
+                var written = writes.Where(w => w.Wrote).Select(w => w.Path).ToImmutableList();
+                var result = new InstallResult(all.Length, written.Count)
+                {
+                    WrittenPaths = written,
+                };
                 logger?.LogInformation(
                     "Installed code package {Id} v{Version}: {Written} written, {Unchanged} unchanged ({Path}) @ {Ref}",
                     manifest.Id, manifest.Version, result.Written, result.Unchanged, nodeTypePath, installedFromRef);
@@ -1986,10 +2010,18 @@ public static class PackageInstaller
                 // kick a redundant Roslyn build. SEQUENCED, never fire-and-forget: the observable is
                 // cold, so a bare call would request no release at all, and an install that cannot
                 // order against the compiles it starts is the defect #1732 is about.
-                var releases = written > 0
+                var releases = result.Written > 0
                     ? SeedThenRequestReleases(hub, [nodeTypePath], logger)
                     : Observable.Return(System.Reactive.Unit.Default);
                 return releases
+                    // 🚨 …and every NodeType OUTSIDE this package that compiles these sources into
+                    // its own assembly through `shared=@…`. `[nodeTypePath]` is this package's ONE
+                    // type — package-local by construction, and the reason a Store update used to
+                    // leave every consumer stale (2026-08-25).
+                    .SelectMany(_ => ReleaseDependentsOutsidePackage(
+                        hub, written,
+                        result.Written > 0 ? [nodeTypePath] : Array.Empty<string>(),
+                        manifest.Id, logger))
                     .SelectMany(_ => WriteInstalledRecord(
                         hub, manifest, installedFromRef, all.Length, authorizingUserId: authorizingUserId))
                     .SelectMany(_ => WarmInstalledRoots(hub, manifest, all, logger))
@@ -2271,7 +2303,17 @@ public static class PackageInstaller
         var options = hub.JsonSerializerOptions;
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
         var meshService = hub.ServiceProvider.GetService<IMeshService>();
-        var nodeTypePaths = nodes.Where(n => n.Content is NodeTypeDefinition).Select(n => n.Path).ToArray();
+        // 🚨 NEVER `n.Content is NodeTypeDefinition` — a pattern-match on an `object` payload is the
+        // trap-door: content that arrived as an untyped JsonElement (the polymorphic converter
+        // degrades an unresolvable `$type`; a hub without NodeTypeDefinition in its TypeRegistry
+        // hands back JSON) does not match, so this filter would select NOTHING and the install would
+        // issue no release at all — the 2026-08-25 Store outage reached silently, with no exception
+        // and nothing to grep. ImportWriteOrder.IsNodeTypeDefinition is the framework's own
+        // shape-tolerant predicate: the CLR test OR the cast-free `NodeType` meta-marker, which is
+        // exactly what survives the degradation. (A bare ContentAs<NodeTypeDefinition> would be
+        // WRONG here in the other direction — every member of that record is optional, so any JSON
+        // object deserializes into one and every plain content node would read as a type.)
+        var nodeTypePaths = nodes.Where(ImportWriteOrder.IsNodeTypeDefinition).Select(n => n.Path).ToArray();
 
         // Ordering solves two chicken-and-eggs at once:
         // (1) a NodeType's Source must land BEFORE the NodeType itself — creating the NodeType
@@ -2299,7 +2341,7 @@ public static class PackageInstaller
                 return 4;                                        // satellites after their owners
             if (!n.Path.Contains('/', StringComparison.Ordinal))
                 return 2;                                        // the root (written in stage 0/2)
-            if (n.Content is NodeTypeDefinition)
+            if (ImportWriteOrder.IsNodeTypeDefinition(n))
                 return 1;                                        // the types (after their Source)
             if (nodeTypePaths.Any(t =>
                     n.Path.StartsWith(t + "/Source/", StringComparison.Ordinal)
@@ -2511,7 +2553,9 @@ public static class PackageInstaller
         IObservable<System.Reactive.Unit> ValidateBulkTypes(IReadOnlyList<MeshNode> bulk)
         {
             var inPackage = nodeTypePaths
-                .Concat(root?.Content is NodeTypeDefinition ? new[] { root.Path } : Array.Empty<string>())
+                .Concat(root is not null && ImportWriteOrder.IsNodeTypeDefinition(root)
+                    ? new[] { root.Path }
+                    : Array.Empty<string>())
                 .ToImmutableHashSet(StringComparer.Ordinal);
             var unknown = bulk
                 .Select(n => n.NodeType)
@@ -2645,7 +2689,7 @@ public static class PackageInstaller
                 // barrier; a bulk-written type is committed when its batch responds. (These paths
                 // already exist, so the barrier passes on its first probe — no 100 ms tail.)
                 var requestTypePaths = requestStage1
-                    .Where(n => n.Content is NodeTypeDefinition).Select(n => n.Path).ToArray();
+                    .Where(ImportWriteOrder.IsNodeTypeDefinition).Select(n => n.Path).ToArray();
                 var allBulk = bulkSources.Concat(bulkTypes).Concat(bulkInstances).ToArray();
 
                 return ValidateBulkTypes(allBulk)
@@ -2786,6 +2830,12 @@ public static class PackageInstaller
                 var releases = result.Written > 0
                     ? SeedPrebuiltAssemblies(hub, nodeTypePaths, logger)
                     : Observable.Return(0);
+                // What the two waves below actually released — the input
+                // ReleaseDependentsOutsidePackage subtracts, so nothing is requested twice. When
+                // the install wrote nothing, the waves are skipped and this is EMPTY: a prune-only
+                // install must still have its (package-local as well as foreign) consumers derived
+                // from the closure rather than silently left out.
+                var locallyReleased = result.Written > 0 ? nodeTypePaths : Array.Empty<string>();
 
                 // The declared access was published as a PHASE before the first content node
                 // landed (see the note at that call site, #1758) — there is deliberately no second
@@ -2804,29 +2854,45 @@ public static class PackageInstaller
                     // moved, then recompiled against zero sources and parked the portal's readiness.
                     .SelectMany(_ => PruneRetiredNodes(
                         hub, manifest, moduleManifest, nodes, persistence, meshService, options, logger))
-                    .SelectMany(_ => WriteInstalledRecord(
-                        hub, manifest, installedFromRef, nodes.Length, moduleManifest, authorizingUserId))
+                    // The pruned paths are carried THROUGH the rest of the chain: together with
+                    // `written` they are the change set the mesh-wide recompile closure runs over
+                    // at the end (a retired Source/*.cs is exactly as stale-making for a foreign
+                    // `shared=` consumer as a rewritten one).
+                    .SelectMany(pruned => WriteInstalledRecord(
+                            hub, manifest, installedFromRef, nodes.Length, moduleManifest, authorizingUserId)
+                        .Select(_ => pruned))
                     // Adoption first (it can settle a release without compiling at all), then the
                     // FIRST wave: the root's own in-package NodeType, whose rebuild is precisely
                     // what SettleRetypedRoot waits for.
-                    .SelectMany(_ => releases)
-                    .SelectMany(_ => result.Written > 0
-                        ? RequestReleases(hub, firstWave, logger)
-                        : Observable.Return(System.Reactive.Unit.Default))
+                    .SelectMany(pruned => releases.Select(_ => pruned))
+                    .SelectMany(pruned => (result.Written > 0
+                            ? RequestReleases(hub, firstWave, logger)
+                            : Observable.Return(System.Reactive.Unit.Default))
+                        .Select(_ => pruned))
                     // The retyped root's recycle, moved here from the write stage and made ORDERED
                     // (see the note there). Only now can it do its job: the in-package type has had
                     // its rebuild, so the hub that comes back binds the package's own configuration
                     // instead of the fallback — and the install no longer returns while a teardown
                     // it started is still running.
-                    .SelectMany(_ => SettleRetypedRoot(hub, retypedRoot, nodes, logger))
+                    .SelectMany(pruned => SettleRetypedRoot(hub, retypedRoot, nodes, logger)
+                        .Select(_ => pruned))
                     // …and ONLY NOW the rest of the package's types. Their compiles read the root
                     // (ValidateCellSurfaceSingleHome → GetMeshNode('<packageRoot>') for every
                     // `shared=` consumer), so launching them before the recycle above pointed a
                     // whole package's compiles at a hub this very method was about to dispose
                     // (#1732).
-                    .SelectMany(_ => result.Written > 0
-                        ? RequestReleases(hub, deferredWave, logger)
-                        : Observable.Return(System.Reactive.Unit.Default))
+                    .SelectMany(pruned => (result.Written > 0
+                            ? RequestReleases(hub, deferredWave, logger)
+                            : Observable.Return(System.Reactive.Unit.Default))
+                        .Select(_ => pruned))
+                    // 🚨 …and FINALLY every NodeType OUTSIDE this package that compiles the files
+                    // this install just moved into its OWN assembly. The waves above can only ever
+                    // name types inside the package; a `shared=@{package}/…` consumer lives
+                    // elsewhere, and leaving it on the assembly it already had is the 2026-08-25
+                    // Store outage. LAST because those consumers are the DEPENDENTS — dependencies
+                    // (this package's own types) release first.
+                    .SelectMany(pruned => ReleaseDependentsOutsidePackage(
+                        hub, written.AddRange(pruned), locallyReleased, manifest.Id, logger))
                     .SelectMany(_ => WarmInstalledRoots(hub, manifest, nodes, logger))
                     // …then the package's committed binaries (course videos/posters) into the
                     // warmed root's content collection — the half of "publish" that merging used
@@ -2859,16 +2925,17 @@ public static class PackageInstaller
     /// node path is still produced by a currently-shipped file (the <c>X.json</c> → <c>X/index.json</c>
     /// layout-move case) is never a prune candidate. Bounded by construction to paths THIS package's
     /// own record previously listed — never a scan of the shared partition — so it can never touch
-    /// another package's content. No-ops (returns 0) when the package ships no <c>manifest.lock</c>
+    /// another package's content. Returns the paths it actually deleted — half of the change set the
+    /// recompile closure runs over. No-ops (returns empty) when the package ships no <c>manifest.lock</c>
     /// (no file-level baseline exists at all) or has no prior record with a file map.</para>
     /// </summary>
-    private static IObservable<int> PruneRetiredNodes(
+    private static IObservable<ImmutableList<string>> PruneRetiredNodes(
         IMessageHub hub, PackageManifest manifest, ModuleManifest? moduleManifest,
         IReadOnlyList<MeshNode> nodes, IStorageAdapter? persistence, IMeshService? meshService,
         JsonSerializerOptions options, ILogger? logger)
     {
         if (moduleManifest is null || persistence is null)
-            return Observable.Return(0);
+            return Observable.Return(ImmutableList<string>.Empty);
 
         var recordPath = $"{InstalledPartition}/{manifest.Id}";
         return persistence.Read(recordPath, options).Take(1)
@@ -2878,7 +2945,7 @@ public static class PackageInstaller
             .SelectMany(previousFiles =>
             {
                 if (previousFiles is not { Count: > 0 })
-                    return Observable.Return(0);
+                    return Observable.Return(ImmutableList<string>.Empty);
 
                 var currentNodePaths = nodes.Select(n => n.Path)
                     .ToImmutableHashSet(StringComparer.Ordinal);
@@ -2891,10 +2958,10 @@ public static class PackageInstaller
                 return PruneRemovedNodes(hub, meshService, persistence, removedNodePaths, options, logger)
                     .Do(pruned =>
                     {
-                        if (pruned > 0)
+                        if (pruned.Count > 0)
                             logger?.LogInformation(
                                 "[PackageInstaller] {Id}: pruned {Pruned} node(s) the repo no longer "
-                                + "ships (full install).", manifest.Id, pruned);
+                                + "ships (full install).", manifest.Id, pruned.Count);
                     });
             });
     }
@@ -2911,13 +2978,18 @@ public static class PackageInstaller
     /// <see cref="SyncBehavior.Include"/>) is the user's, not the repo's — the repo dropping its
     /// file revokes the PACKAGE's copy, never the user's claim. The same fence
     /// <see cref="UpsertIfChanged"/> applies on the write side.</para>
+    ///
+    /// <para>Returns the paths it ACTUALLY deleted — a claimed, absent or failed one is omitted.
+    /// The recompile closure runs over "what actually changed" (written ∪ pruned), so a candidate
+    /// that was never removed must not enter it: nothing about that node moved, and naming it would
+    /// recompile a package for a change that did not happen.</para>
     /// </summary>
-    private static IObservable<int> PruneRemovedNodes(
+    private static IObservable<ImmutableList<string>> PruneRemovedNodes(
         IMessageHub hub, IMeshService? meshService, IStorageAdapter? persistence,
         IReadOnlyCollection<string> removedNodePaths, JsonSerializerOptions options, ILogger? logger)
     {
         if (meshService is null || removedNodePaths.Count == 0)
-            return Observable.Return(0);
+            return Observable.Return(ImmutableList<string>.Empty);
         var accessService = hub.ServiceProvider.GetService<AccessService>();
         return removedNodePaths
             .Select(path => (persistence is not null
@@ -2925,7 +2997,7 @@ public static class PackageInstaller
                     : Observable.Return<MeshNode?>(null))
                 .SelectMany(current =>
                     current is not null && current.SyncBehavior != SyncBehavior.Include
-                        ? Observable.Return(0)
+                        ? Observable.Return<string?>(null)
                         // Sealed at Subscribe (RunAsSystem), never Observable.Using(ImpersonateAsSystem):
                         // impersonation is an AsyncLocal store/restore pair, and Using disposes on the
                         // TERMINATING thread — for a cross-hub delete, the owning hub's response thread,
@@ -2933,13 +3005,14 @@ public static class PackageInstaller
                         // runs next on the subscribing thread (#1790).
                         : accessService.RunAsSystem(() => meshService.DeleteNode(path))
                             .Take(1)
-                            .Select(deleted => deleted ? 1 : 0))
-                .Catch<int, Exception>(ex =>
+                            .Select(deleted => deleted ? path : null))
+                .Catch<string?, Exception>(ex =>
                 {
                     logger?.LogWarning(ex, "Pruning removed node {Path} failed.", path);
-                    return Observable.Return(0);
+                    return Observable.Return<string?>(null);
                 }))
-            .ToObservable().Concat().Sum();
+            .ToObservable().Concat().ToList()
+            .Select(outcomes => outcomes.Where(p => p is not null).Select(p => p!).ToImmutableList());
     }
 
     /// <summary>
@@ -3007,7 +3080,9 @@ public static class PackageInstaller
         var options = hub.JsonSerializerOptions;
         var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
         var meshService = hub.ServiceProvider.GetService<IMeshService>();
-        var nodeTypePaths = nodes.Where(n => n.Content is NodeTypeDefinition).Select(n => n.Path).ToArray();
+        // Shape-tolerant, never `Content is NodeTypeDefinition` — see the note at the full install's
+        // own nodeTypePaths (InstallNodeRepo).
+        var nodeTypePaths = nodes.Where(ImportWriteOrder.IsNodeTypeDefinition).Select(n => n.Path).ToArray();
 
         // Same landing order as the full install: a changed type's compile inputs before the type,
         // types before instances, satellites last.
@@ -3015,7 +3090,7 @@ public static class PackageInstaller
         {
             if (n.Path.Split('/').Any(seg => seg.StartsWith('_')))
                 return 4;
-            if (n.Content is NodeTypeDefinition)
+            if (ImportWriteOrder.IsNodeTypeDefinition(n))
                 return 1;
             if (OwningTypePath(n.Path) is not null)
                 return 0;
@@ -3051,7 +3126,7 @@ public static class PackageInstaller
         // unattended (opted-in) auto-update safe. Only ever narrows the existing prune set:
         // removedNodePaths is already restricted to previously-installed paths, so a user-ADDED
         // node was never a prune candidate to begin with.
-        IObservable<int> Prune() =>
+        IObservable<ImmutableList<string>> Prune() =>
             PruneRemovedNodes(hub, meshService, persistence, removedNodePaths, options, logger);
 
         // 🚨 The declared access is re-asserted BEFORE the delta's writes, not after them (#1758).
@@ -3076,13 +3151,16 @@ public static class PackageInstaller
                     .Where(x => x.wrote)
                     .Select(x => x.node)
                     .ToArray();
-                var result = new InstallResult(nodes.Length, written.Length);
+                var result = new InstallResult(nodes.Length, written.Length)
+                {
+                    WrittenPaths = written.Select(n => n.Path).ToImmutableList(),
+                };
 
                 // Recompile exactly what the delta touched: a written NodeType node, and the OWNER
                 // of any written Source/Test node whose type node itself did not change. A pruned
                 // source's owner recompiles too (stale code must leave the assembly).
                 var releaseTargets = written
-                    .Select(n => n.Content is NodeTypeDefinition ? n.Path : OwningTypePath(n.Path))
+                    .Select(n => ImportWriteOrder.IsNodeTypeDefinition(n) ? n.Path : OwningTypePath(n.Path))
                     .Concat(removedNodePaths.Select(OwningTypePath))
                     .Where(p => p is not null).Select(p => p!)
                     .Distinct(StringComparer.Ordinal)
@@ -3091,7 +3169,7 @@ public static class PackageInstaller
                 logger?.LogInformation(
                     "Updated node-repo plugin {Id} incrementally: {Written} written, {Unchanged} unchanged, " +
                     "{Pruned} pruned, {Releases} recompile(s) @ {Ref} (module {ModuleVersion})",
-                    manifest.Id, result.Written, result.Unchanged, t.Pruned,
+                    manifest.Id, result.Written, result.Unchanged, t.Pruned.Count,
                     releaseTargets.Length, installedFromRef, newManifest.ModuleVersion);
 
                 // SEQUENCED, never fire-and-forget (the observable is cold — a bare call requests
@@ -3100,10 +3178,19 @@ public static class PackageInstaller
                 var releases = releaseTargets.Length > 0
                     ? SeedThenRequestReleases(hub, releaseTargets, logger)
                     : Observable.Return(System.Reactive.Unit.Default);
+                // 🚨 …then every NodeType OUTSIDE this package that compiles the changed files into
+                // its OWN assembly. `releaseTargets` above resolves a compile input to the prefix
+                // before /Source|/Test, so it is package-LOCAL by construction — a cross-package
+                // `shared=@{package}/…` consumer can never appear in it, and leaving it on the
+                // assembly it already had is the 2026-08-25 Store outage. The change set is what
+                // actually moved: the paths written, plus the paths actually deleted.
+                var changed = written.Select(n => n.Path).Concat(t.Pruned).ToArray();
                 // The declared access was re-asserted BEFORE the writes (see the note at that call
                 // site, #1758). What stays here is its POST-CONDITION — a read, never a second
                 // write pass, so nothing can re-derive a shape from nodes it just wrote.
                 return releases
+                    .SelectMany(_ => ReleaseDependentsOutsidePackage(
+                        hub, changed, releaseTargets, manifest.Id, logger))
                     .SelectMany(_ => VerifyDeclaredAccess(
                         hub, manifest, manifest.TargetPartition ?? manifest.Id, logger))
                     .SelectMany(_ => WriteInstalledRecord(hub, manifest, installedFromRef,
@@ -3252,8 +3339,12 @@ public static class PackageInstaller
     /// <para>The authored element is written instead, and the OWNING hub — the one place the node's
     /// own NodeType is known — types it on read. Statically-registered content
     /// (<see cref="NodeTypeDefinition"/>, markdown, access assignments) is a real, process-unique
-    /// registration rather than a name guess, so it stays typed: the installer's own ordering and
-    /// compile-trigger logic reads <c>Content is NodeTypeDefinition</c>.</para>
+    /// registration rather than a name guess, so it stays typed. 🚨 The installer's ordering and
+    /// compile-trigger logic must nevertheless NOT depend on that: a NodeType file authored without
+    /// a <c>$type</c> on its content — and any content read where the discriminator does not
+    /// resolve — arrives as a raw <see cref="JsonElement"/>, and a <c>Content is
+    /// NodeTypeDefinition</c> test then silently answers "not a type". It reads
+    /// <c>ImportWriteOrder.IsNodeTypeDefinition</c> instead.</para>
     ///
     /// <para>🚨 #2266: the re-read here MUST tolerate exactly what the PRIMARY parse tolerated —
     /// <see cref="FileFormatParserRegistry.TryParse"/> already produced <paramref name="parsed"/>
@@ -3619,6 +3710,70 @@ public static class PackageInstaller
         => SeedPrebuiltAssemblies(hub, nodeTypePaths, logger)
             .SelectMany(_ => RequestReleases(hub, nodeTypePaths, logger));
 
+    /// <summary>
+    /// 🚨 <b>IF STORE UPDATES, ALL DEPENDENT PACKAGES UPDATE AS WELL.</b> Seeds and releases every
+    /// NodeType OUTSIDE this package that the install's own changed nodes made stale — the
+    /// mesh-wide recompile closure (<see cref="NodeTypeRecompileExtensions.AffectedNodeTypes"/>)
+    /// over <paramref name="changedNodePaths"/>, minus the <paramref name="alreadyReleased"/> types
+    /// the install released itself.
+    ///
+    /// <para><b>The defect this closes.</b> The installer used to derive its release targets from
+    /// the nodes it had just written — which can only ever name types INSIDE the installed package.
+    /// A type in ANOTHER package that pulls those files in through <c>shared=@{package}/…</c>
+    /// compiles their TEXT into its OWN assembly, so it is stale the instant they move, and nothing
+    /// told it. A Store update therefore rebuilt Store's own types and left every consumer running
+    /// the assembly it already had: two hubs on different compiles of the same sources, disagreeing
+    /// about the type registry, which reads as <c>$type … is not registered</c> and renders as an
+    /// empty view. That is the mechanism behind the 2026-08-25 Store outage — see
+    /// <c>Doc/Architecture/CompileProgramStateOfRecord</c>. The correct closure already existed and
+    /// the sync transaction already used it; the installer did not.</para>
+    ///
+    /// <para><b>Why this ADDS to the package-local set rather than replacing it.</b> Each half
+    /// covers what the other structurally cannot. The closure enumerates types from the query index,
+    /// which TRAILS the store — so a type this very install CREATED may not be listed yet, and the
+    /// installer must release those anyway (<c>SettleRetypedRoot</c> waits on the in-package type's
+    /// rebuild). The package-local set, in turn, can never see a cross-package consumer. Releasing a
+    /// type twice is not a cost worth taking a hole for: this call excludes what the caller already
+    /// released, so nothing is requested twice within one install.</para>
+    ///
+    /// <para><b>Ordering.</b> Dependencies before dependents — which is why this runs AFTER the
+    /// package's own releases: every changed path is inside the installed package, so a type
+    /// affected by one either IS a package type (a dependency, released already) or reaches those
+    /// files through <c>shared=</c> (a dependent). Within the extra set the closure's own
+    /// topological order is preserved. Seed before release, exactly as every other release site
+    /// here — adopt-before-compile is deliberate.</para>
+    ///
+    /// <para>Never faults: <c>AffectedNodeTypes</c> reports a derivation failure loudly and emits
+    /// empty, and <see cref="RequestReleases"/> absorbs a per-type refusal — an install must not be
+    /// failed by the recompile of a package it does not own.</para>
+    /// </summary>
+    /// <returns>A cold observable; Subscribe to derive, seed and release.</returns>
+    private static IObservable<System.Reactive.Unit> ReleaseDependentsOutsidePackage(
+        IMessageHub hub,
+        IReadOnlyCollection<string> changedNodePaths,
+        IReadOnlyCollection<string> alreadyReleased,
+        string packageId,
+        ILogger? logger)
+    {
+        if (changedNodePaths.Count == 0)
+            return Observable.Return(System.Reactive.Unit.Default);
+        var own = alreadyReleased.ToImmutableHashSet(StringComparer.OrdinalIgnoreCase);
+        return hub.AffectedNodeTypes(changedNodePaths)
+            .Take(1)
+            .SelectMany(affected =>
+            {
+                var extra = affected.Where(p => !own.Contains(p)).ToArray();
+                if (extra.Length == 0)
+                    return Observable.Return(System.Reactive.Unit.Default);
+                logger?.LogInformation(
+                    "[PackageInstaller] {Id}: {Count} NodeType(s) OUTSIDE this package compile its "
+                    + "changed sources into their own assemblies (shared=@…) and are now stale — "
+                    + "recompiling them too: {Types}",
+                    packageId, extra.Length, string.Join(", ", extra));
+                return SeedThenRequestReleases(hub, extra, logger);
+            });
+    }
+
 }
 
 /// <summary>
@@ -3633,11 +3788,15 @@ public readonly record struct InstallResult(int Total, int Written)
     public int Unchanged => Total - Written;
 
     /// <summary>
-    /// The PATHS that were actually written, when the install path tracked them (the node-repo
-    /// flavor does; older flavors leave this empty). A re-install of an unchanged snapshot must
+    /// The PATHS that were actually written. A re-install of an unchanged snapshot must
     /// write nothing — when it does, a bare count is undiagnosable, and an unnamed regression is
     /// how the placeholder-root churn shipped: every gate run said "wrote 1 node" and nothing said
     /// WHICH. Named paths turn the idempotence pin's failure into the fix's first line.
+    ///
+    /// <para>Every install flavour tracks this now (node-repo, its incremental delta, and the
+    /// single Code package): together with the pruned paths it is the change set the mesh-wide
+    /// recompile closure runs over, which is what makes a dependent package rebuild when the
+    /// package it shares sources from updates. A count cannot answer that question.</para>
     /// </summary>
     public System.Collections.Immutable.ImmutableList<string> WrittenPaths { get; init; } =
         System.Collections.Immutable.ImmutableList<string>.Empty;

--- a/test/Memex.Portal.Shared.Test/PackageInstallRebuildsDependentsTest.cs
+++ b/test/Memex.Portal.Shared.Test/PackageInstallRebuildsDependentsTest.cs
@@ -1,0 +1,207 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Hosting.Persistence.Parsers;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>IF STORE UPDATES, ALL DEPENDENT PACKAGES UPDATE AS WELL</b> — the mandate, and the defect
+/// that made it false. This is the mechanism behind the 2026-08-25 Store outage, in which every
+/// Store NodeType recompiled green and the page still went down. See
+/// <c>Doc/Architecture/CompileProgramStateOfRecord</c> → "A Store update does not rebuild its
+/// dependents".
+///
+/// <para><b>What was wrong.</b> A type in package B that names
+/// <c>shared=@{A}/…/Source</c> compiles A's source TEXT into B's OWN assembly, so B is stale the
+/// instant A's sources move. The correct closure existed — <c>ReleaseAffectedNodeTypes</c>
+/// enumerates NodeTypes MESH-WIDE and matches a changed path against every type's expanded
+/// source/test queries — and the GitSync transaction used it. The package installer did not: it
+/// derived its release targets from the nodes it had just written that happened to be NodeType
+/// definitions, which can only ever name types INSIDE the installed package. So an update to A
+/// rebuilt A and left B running the assembly it already had — two hubs on different compiles of
+/// the same sources, disagreeing about the type registry, which reads as
+/// <c>$type … is not registered</c> and renders as an empty view.</para>
+///
+/// <para><b>Why the cross-package assertion is the whole test.</b> Asserting that A's OWN types are
+/// released passes on the broken code and proves nothing. B — a type this install never writes,
+/// never parses, and cannot name — is the only observation that separates the package-local
+/// derivation from the mesh-wide closure.</para>
+///
+/// <para><b>The second defect, on the same line.</b> The package-local selector was
+/// <c>n.Content is NodeTypeDefinition</c> — a pattern-match on an <c>object</c> payload. Content
+/// that arrived as JSON does not match, so the filter selected NOTHING and no release was issued at
+/// all: the same outage reached more quietly, with no exception and nothing to grep. The provider
+/// package installed here ships its NodeType with an untyped content payload on purpose, so this
+/// test drives both fixes in one install;
+/// <see cref="ANodeTypeWhoseContentArrivedAsJson_IsStillSelectedAsAType"/> pins the selector
+/// itself, deterministically and without the closure being able to answer for it.</para>
+/// </summary>
+public class PackageInstallRebuildsDependentsTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The install record is a <c>Package</c> node, so the catalog's own types have to be
+    /// registered for an install to record itself — the same registration every portal makes.</summary>
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder).AddPluginCatalog();
+
+    /// <summary>The package being installed — the "Store" of the incident.</summary>
+    private const string Package = "SharedSourcePkg";
+
+    /// <summary>Its own NodeType, whose <c>Source/</c> subtree other packages compile.</summary>
+    private const string ProviderType = $"{Package}/Catalog";
+
+    /// <summary>The shared compile input the install writes.</summary>
+    private const string SharedSource = $"{ProviderType}/Source/Shared";
+
+    /// <summary>The DEPENDENT package — already installed, outside <see cref="Package"/>, and named
+    /// nowhere in the install's inputs.</summary>
+    private const string ConsumerNamespace = "DependentPkg";
+    private const string ConsumerType = $"{ConsumerNamespace}/Model";
+
+    /// <summary>
+    /// The provider's NodeType node exactly as a repo may author it: <c>nodeType: NodeType</c> and a
+    /// <c>content</c> object carrying NO <c>$type</c> discriminator — so the polymorphic converter
+    /// hands the installer a raw <see cref="JsonElement"/>, which is also what ANY hub whose
+    /// TypeRegistry cannot resolve the discriminator hands back.
+    /// </summary>
+    private const string UntypedNodeTypeJson = """
+        {
+          "id": "Catalog",
+          "namespace": "SharedSourcePkg",
+          "path": "SharedSourcePkg/Catalog",
+          "nodeType": "NodeType",
+          "name": "Provider catalog",
+          "state": "Active",
+          "content": { "configuration": "config => config" }
+        }
+        """;
+
+    /// <summary>
+    /// Installing the provider package must release the DEPENDENT package's type — the type that
+    /// compiles the provider's sources into its own assembly and that the install can neither see
+    /// nor name.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task InstallingAPackage_ReleasesTheDependentPackageThatSharesItsSources()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+        // ── The dependent package, already installed. Its ONLY source is the provider's, which is
+        //    the shape a cross-package `shared=` consumer has: its assembly is built from text it
+        //    does not own, so it is stale the moment that text moves.
+        await meshService.CreateNode(new MeshNode("Model", ConsumerNamespace)
+            {
+                NodeType = MeshNode.NodeTypePath,
+                Name = "Dependent model",
+                State = MeshNodeState.Active,
+                Content = new NodeTypeDefinition
+                {
+                    Configuration = "config => config",
+                    Sources = [$"shared=@{ProviderType}/Source"],
+                },
+            })
+            .Should().Within(60.Seconds())
+            .Emit("the dependent type must exist BEFORE the provider updates — that is the whole "
+                  + "premise: it is already running an assembly built from the provider's sources");
+
+        // The closure enumerates types from the query INDEX, which trails the store. Waiting for
+        // the dependent to be listed is this test's precondition, not a settle: without it the
+        // assertion could measure index lag instead of the installer's behaviour.
+        await Mesh.GetQuery("dependents-probe", $"nodeType:{MeshNode.NodeTypePath}")
+            .Where(nodes => nodes.Any(n =>
+                string.Equals(n.Path, ConsumerType, StringComparison.OrdinalIgnoreCase)))
+            .FirstAsync()
+            .Timeout(60.Seconds())
+            .Await();
+
+        // ── The provider package's install. A node repo: the files ARE nodes at their canonical
+        //    paths. Its NodeType arrives with UNTYPED content on purpose (see UntypedNodeTypeJson).
+        var result = await PackageInstaller.Install(
+                Mesh,
+                new PackageManifest
+                {
+                    Id = Package,
+                    Name = Package,
+                    Kind = PackageKind.NodeRepo,
+                    TargetPartition = Package,
+                    SourceFolder = Package,
+                    Version = "1.0.0",
+                },
+                [
+                    new PackageFile($"{Package}.md", $"# {Package}"),
+                    new PackageFile($"{ProviderType}.json", UntypedNodeTypeJson),
+                    new PackageFile($"{SharedSource}.cs", "public class SharedThing { }"),
+                ],
+                "HEAD")
+            .Should().Within(180.Seconds())
+            .Emit("the install itself must complete before anything about releases can be read");
+
+        result.WrittenPaths.Should().Contain(SharedSource,
+            "the shared compile input is what makes every dependent stale — if it was not written "
+            + "there is no change for the closure to run over and this test proves nothing");
+
+        // ── THE assertion. A release stamps RequestedReleaseAt, and nothing else writes it.
+        await Mesh.GetWorkspace().GetMeshNodeStream(ConsumerType)
+            .Should().Within(120.Seconds())
+            .Match(
+                n => n.ContentAs<NodeTypeDefinition>(Mesh.JsonSerializerOptions)
+                    ?.RequestedReleaseAt is not null,
+                "a package OUTSIDE the installed one, whose assembly is built from the installed "
+                + "package's sources, must be rebuilt by that install. Releasing only the types "
+                + "the installer just wrote leaves it on the assembly it already had — the "
+                + "2026-08-25 Store outage, where every Store type recompiled green and the page "
+                + "still rendered empty");
+    }
+
+    /// <summary>
+    /// The quieter half: a NodeType whose content arrived as JSON must still be SELECTED as a type.
+    ///
+    /// <para>Deterministic on purpose. Driving this through an install would let the mesh-wide
+    /// closure answer for the selector whenever the query index happens to have caught up — an
+    /// assertion that can pass for the wrong reason. Here the real parser produces the real node
+    /// and both predicates are read directly, so the trap-door and its replacement are compared on
+    /// the same value.</para>
+    /// </summary>
+    [Fact]
+    public void ANodeTypeWhoseContentArrivedAsJson_IsStillSelectedAsAType()
+    {
+        var parsers = new FileFormatParserRegistry(
+            Mesh.JsonSerializerOptions,
+            Mesh.ServiceProvider.GetServices<IFileFormatParser>());
+
+        var parsed = parsers.TryParse(
+            ".json", $"{ProviderType}.json", UntypedNodeTypeJson, $"{ProviderType}.json");
+
+        parsed.Should().NotBeNull("the file is a well-formed node file");
+        parsed!.Content.Should().BeOfType<JsonElement>(
+            "content with no $type discriminator degrades to raw JSON — and so does ANY content "
+            + "read on a hub whose TypeRegistry cannot resolve the discriminator, which is the "
+            + "case that actually happens in a running mesh");
+
+        (parsed.Content is NodeTypeDefinition).Should().BeFalse(
+            "THIS is the trap-door: the installer picked its release targets with exactly this "
+            + "pattern-match on an object payload, so an untyped NodeType selected NOTHING and the "
+            + "install issued no release at all — the outage reached with no exception, no log, "
+            + "and nothing to grep");
+
+        ImportWriteOrder.IsNodeTypeDefinition(parsed).Should().BeTrue(
+            "the framework's shape-tolerant predicate — the CLR test OR the cast-free NodeType "
+            + "meta-marker — is what the installer selects with now. A bare "
+            + "ContentAs<NodeTypeDefinition> would be wrong in the OTHER direction: every member "
+            + "of that record is optional, so any JSON object deserializes into one and every "
+            + "plain content node would read as a type");
+    }
+}


### PR DESCRIPTION
## The defect

The mandate was *"if Store updates, all dependent packages update as well."* It was false, and that
is the mechanism behind the **2026-08-25 Store outage**, in which every Store NodeType recompiled
green and the page still went down. Written up in
[`Doc/Architecture/CompileProgramStateOfRecord`](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Documentation/Data/Architecture/CompileProgramStateOfRecord.md)
during an audit of the (closed) #2193; it had no issue of its own.

A type in package **B** that names `shared=@{A}/…/Source` compiles A's source **text** into B's own
assembly, so B is stale the instant those files move. The correct closure already existed —
`ReleaseAffectedNodeTypes` enumerates NodeTypes **mesh-wide** and matches a changed path against
every type's *expanded* source/test queries, ordered topologically — and the GitSync transaction used
it. `PackageInstaller` did not:

```
$ git grep -n "ReleaseAffectedNodeTypes" -- 'src/*.cs'
src/MeshWeaver.GitSync/GitHubSyncService.cs:403   ← the sync transaction. Uses it.
src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs:57   ← the declaration
src/MeshWeaver.Graph/StaticRepoImporter.cs:1222   ← a comment reference only
```

It released the paths of the nodes it had just written that happened to be NodeType definitions —
which can only ever name types **inside the installed package**. Two hubs then run different compiles
of the same sources and disagree about the type registry: `$type … is not registered`, rendered as an
empty view.

## The fix

The derivation is split out as **`hub.AffectedNodeTypes(changedPaths)`** — mesh-wide enumeration +
`RecompileClosure`, dependency-ordered, no seed, no release — so a caller that owns its own release
sequencing can run exactly the same closure. `ReleaseAffectedNodeTypes` is now that derivation plus
adopt-before-compile plus the trigger, byte-for-byte unchanged in behaviour for GitSync.

`PackageInstaller` runs it over what actually moved (`WrittenPaths ∪ actually-pruned`) on **every**
install path, *after* its own package-local releases:

| Path | Package-local release, as before | …then the closure |
|---|---|---|
| Full node-repo install (`:2274`) | two waves around the retyped root's recycle | every affected type outside the package |
| Incremental delta (`:3081-3090`) | one wave over `releaseTargets` | same |
| Single `Code` package (`:1990`) | the one synthesized NodeType | same |
| `Content` package | *(none — it declares no type)* | the whole affected set |

**Four paths, not three.** The content-package path issued *no* release at all, and a content package
can perfectly well ship the `Source/` a NodeType compiles — the same hole, reached differently.

Three properties are load-bearing:

- **The closure ADDS to the package-local set; it does not replace it.** The query index *trails* the
  store, so a type this install just CREATED may not be listed — and the installer must release those
  anyway (`SettleRetypedRoot` waits on the in-package type's rebuild). The package-local set, in turn,
  can never see a cross-package consumer. The call subtracts what was already released, so nothing is
  requested twice; on a prune-only install nothing was released locally, so the closure covers the
  package's own types too.
- **Dependents last, seed before release.** Every changed path is inside the installed package, so an
  affected type either IS a package type (a dependency, released first) or reaches those files through
  `shared=` (a dependent). `SeedThenRequestReleases` — adopt-before-compile is deliberate and is
  preserved everywhere, including the existing two-wave ordering around the root recycle (#1732).
- **Write outcomes travel as `(path, wrote)` pairs, not counts.** The writes fan out through `Merge`,
  which does not preserve order, so a count (or a positional zip) cannot be turned back into paths.
  `InstallResult.WrittenPaths` is now populated by every flavour, and the prune returns the paths it
  *actually* deleted (a claimed/absent/failed candidate is not a change).

## The second, quieter defect on the same line

The package-local selector was `n.Content is NodeTypeDefinition` — a **pattern-match on an `object`
payload**, the trap-door AGENTS.md forbids. Content that arrived as JSON does not match, so the filter
selected **nothing** and no release was issued at all: the same outage with no exception and nothing
to grep. Every such site in the installer now reads `ImportWriteOrder.IsNodeTypeDefinition` — the
framework's own shape-tolerant predicate (the CLR test **OR** the cast-free `NodeType` meta-marker).

🚨 A bare `ContentAs<NodeTypeDefinition>` would be wrong *here*, in the opposite direction: every
member of that record is optional, so any JSON object deserializes into one — every plain content node
would then read as a type, land in the types' write bucket and be handed a release request.
`ContentAs<T>` stays correct where the *definition* is what you want (`AffectedNodeTypes` reads each
type's declared `Sources` that way).

## Verification

`PackageInstallRebuildsDependentsTest` (new): seeds a dependent package's NodeType whose only source
is `shared=@{provider}/…/Source`, installs the provider package, and asserts the **dependent** ends up
with a `RequestedReleaseAt` stamp. The cross-package assertion is the whole test — asserting the
provider's *own* types passes on the broken code and proves nothing.

**Control run** (closure call disabled, everything else identical) — the test fails after its full
120 s budget with the dependent at:

```
Path = DependentPkg/Model, CompilationStatus = Ok,
LatestReleasePath = DependentPkg/Model/Release/20260902002753-pW5m_e-o,
RequestedReleaseAt =            ← never re-released by the install
```

With the fix it passes in ~3 s. A second, hub-free test compares the trap-door and its replacement on
the same parsed node, so the selector cannot be answered for by a query index that happened to catch
up.

Local, Release + `-warnaserror`, one project per invocation, all `0 Error(s) / 0 Warning(s)`:
`MeshWeaver.Graph`, `MeshWeaver.PluginCatalog`, `MeshWeaver.GitSync`, `MeshWeaver.Documentation`,
`Memex.Portal.Shared`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test`,
`MeshWeaver.Graph.Test`.

Full test projects (no `--filter`): **Memex.Portal.Shared.Test 590/590**, **MeshWeaver.Graph.Test
1134/1134**, **MeshWeaver.Documentation.Test 172/172** (incl.
`DocumentationLinkIntegrityTest.AllInternalDocLinks_ResolveToExistingNodes`).

## Docs

The *"A Store update does not rebuild its dependents"* section of `CompileProgramStateOfRecord` is
updated in place — kept, not deleted, because the history is the point — recording that it is fixed,
how, and the three properties above. Plus a What's New entry (`Category: Fix`).

No closing keyword: this defect had no issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
