### PR TITLE
The storage serve seam honours IsDefinitionOnly — an acknowledged write is readable again (#2899)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DurableButUnreadable.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DurableButUnreadable.md
@@ -110,13 +110,83 @@ will 503 forever with a message telling them to retry.
 The same applies to a per-file import manifest: record success on a read-back-visible write, or do
 not record it at all.
 
+## The core-side mechanism, found and fixed (2026-09-02)
+
+One producer of this signature lived in core, is now fixed, and is pinned by
+`AcknowledgedWriteIsReadableTest` (`test/MeshWeaver.Hosting.Test`). It is worth reading even if your
+instance turns out to have a different cause, because it shows the shape in full.
+
+`MeshNode.IsDefinitionOnly` is the marker `serveFromPartition` stamps on a static entry to say *the
+durable row owns this path; I am only the type definition*. **Six seams answer "which node is served
+here", and five honoured it** — `FindServedStaticNode`, `MeshDataSource.WithMeshNodes`,
+`MessageHubGrain.TryResolveStaticNode`, the `CreateNode` existing-node probe,
+`PartitionWriteGuardValidator` and `StaticNodeQueryProvider`. `FindServedStaticNode`'s own contract
+states the invariant outright: keeping them on one resolution is what guarantees *"served static" ⇔
+"not persistence-backed"* can never drift apart.
+
+**`StaticNodeStorageAdapter` — the sixth, and the one `PersistenceService` reads — did not.** It
+served definition-only entries from `Read`, `Exists`, `ListChildPaths` and `FindBestPrefixMatch`.
+That single gap produces the whole signature, because of how the provider chain is ordered:
+
+- `StaticNodePartitionStorageProvider` carries a fixed namespace, so it sorts into
+  `PersistenceService`'s **first** provider band — ahead of every wildcard durable backend.
+- It is `IsReadOnly`, so it is **absent from the write chain** (`Write` walks writable providers
+  only; `Read` walks *all* of them and takes the first non-null).
+
+So on a DB-synced static partition the write was claimed by the durable backend and acknowledged
+with the non-null try-then-claim ACCEPT sentinel; `VersionWritingStorageAdapter` chained the
+version-history row off that same acknowledgement; and every read from then on returned the
+in-memory definition instead of the row. **Read and Write disagreed about which provider owns the
+path, and only the write side was ever asked.**
+
+The fix is one predicate — the adapter is a *serve* surface, so it holds only nodes that are
+actually served. Definitions stay reachable as definitions through
+`StaticNodeProviderExtensions.FindStaticNode`, which enumerates the providers directly and never
+goes through the adapter.
+
+> **Residual, deliberately not widened:** the adapter sees one provider's node list, not the
+> cross-provider precedence `ResolveStaticNodes` applies. If a *higher*-precedence provider marks a
+> path definition-only while a *lower*-precedence one still offers a served node there, the storage
+> seam serves the lower one while `FindServedStaticNode` answers "nothing serves this" — the
+> MeshWeaver#2908 divergence, one layer down. That collision is reported by name today
+> (`DescribeStaticServeCollision`); closing it at this seam needs the adapter to consult the
+> resolution rather than a flat list.
+
+## What the 2026-09-02 re-measurement settled, and what it falsified
+
+Re-measured read-only on memex.systemorph.com. Two hypotheses died on evidence that could have gone
+the other way — record them so nobody spends the day again:
+
+| Probe | Answer | What it kills |
+|---|---|---|
+| `autocomplete @/AgenticEngineering/Introduction` | the node **and six of its children**, correct names and node types | **The write is not lost.** A row no reader can see cannot be returned by autocomplete. The failure is a read seam, not the write lane — which is what the issue title says and what three days were spent on. |
+| `get_version AgenticEngineering/WriteLaneProbe 1` | `mainNode == path` — and the node is **invisible** | The `is:main` / `n.main_node = n.path` filter (#2939) is **not** the discriminator here. |
+| `get_version AgenticEngineering/_Policy 1` | `mainNode != path` — and the node is **visible** | …and the correlation is exactly *inverted* from that filter, so it cannot be the cause. |
+| `search namespace:AgenticPrimer scope:descendants` | full content, same portal, same `_Access` shape (`Public — Viewer` + `Anonymous — Viewer`, nothing else) | It is not the grant shape, not the install date, and not a portal-wide query regression. |
+
+What survives, 5 cases out of 5 including one that could have falsified it: **a row in that
+partition passes the read filter iff its `main_node` is the partition root `AgenticEngineering`** —
+which is precisely the prefix its two grants project at (`COALESCE(main_node, namespace)` in
+`rebuild_user_effective_permissions`) and precisely the column the per-schema access clause folds
+the caller's effective permissions against (`n.main_node`, not `n.path`). So the surviving candidate
+for *that* instance is the access projection, and its SQL lives in
+`MeshWeaver.Plugins/src/MeshWeaver.Hosting.PostgreSql`, not here.
+
+The three hypotheses the issue posed, resolved: **transport (the oversized Orleans frame) — ruled
+out** (see the Related link below: a transport refusal is loud, terminal, and leaves no version row,
+and the frames post-date the import by three days); **the untyped-content degrade (#2952/#3006) —
+ruled out** (a degrade leaves the node *in* the listing with unusable content, and `get_version`
+returns fully-typed content here, so the discriminator resolves); **the listing/index path — ruled
+in.**
+
 ## Open
 
-The underlying question — *why* the node row is unreachable while its version row is not — is not
-settled here, and cannot be settled from the MCP surface alone: it needs the partition schemas
-inspected on the portal in question. Both instances above are still live and reproduce on demand, so
-the evidence has not decayed. Do not repair either by restoring versions until the write lane is
-fixed; a restore would take the same path and can land the same way.
+*Why the AgenticEngineering rows specifically are unreachable* is not settled from the MCP surface
+alone — it needs the partition schema inspected on that portal (`main_node`, `partition_access` and
+`user_effective_permissions` for `agenticengineering`, against the same three columns for
+`agenticprimer`, which works). Both instances above are still live and reproduce on demand, so the
+evidence has not decayed. Do not repair either by restoring versions until the read seam is
+understood; a restore takes the same path and can land the same way.
 
 ### Candidates from the code (not yet confirmed against a live schema)
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-content-saved-into-a-synced-space-can-be-read-back-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-content-saved-into-a-synced-space-can-be-read-back-again.md
@@ -1,0 +1,34 @@
+---
+Name: Content saved into a synced space can be read back again
+Category: Fix
+Description: In a space whose built-in definitions are kept in the database, saving a page reported success while every later read returned the built-in placeholder instead. The saved content was never lost — it was unreachable. Reads now answer with what was saved.
+Icon: Sparkle
+Order: -20260902
+---
+
+# Content saved into a synced space can be read back again
+
+Some spaces carry built-in definitions that ship with the platform and are then kept in the
+database, so that what you edit is a real, saved record rather than something baked into the
+product. In those spaces a save could complete successfully — the confirmation appeared, the
+change was recorded in the page's version history, everything reported done — and yet every
+later read of that page returned the built-in placeholder instead of what had just been saved.
+
+Reopen the page and your edit was gone. Search did not find it. Nothing reported an error,
+because as far as the saving side was concerned nothing had gone wrong: the content really was
+written, and it really was still there. It simply could not be reached, because the read went to
+the built-in placeholder first and stopped there.
+
+**This is the worst shape a bug can take**, and it is worth saying why. Everything that happens
+after a save trusts the confirmation. An import that copies a folder of pages marks each one as
+done and never retries it. A tool that hands out a key after saving it hands out a key nobody can
+look up afterwards. A person edits, sees "saved", and moves on. A save that confirms without
+being readable turns one silent failure into a long tail of them.
+
+The rule is now enforced where it belongs: a built-in definition that has been handed over to the
+database is no longer treated as the page at that address by any part of the system. Reads,
+existence checks, listings and navigation all agree on the same answer — the saved record.
+
+Nothing you can see today changes: pages whose built-in version is genuinely the one being shown
+keep behaving exactly as before. And there is now a standing check that fails the build if a save
+is ever again confirmed for content that cannot be read back.

--- a/src/MeshWeaver.Mesh.Contract/Services/StaticNodeStorageAdapter.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/StaticNodeStorageAdapter.cs
@@ -22,6 +22,11 @@ namespace MeshWeaver.Mesh.Services;
 /// are immutable. To allow runtime writes under the same partition prefix,
 /// layer a writable provider higher in the registration order so it wins
 /// first-match.</para>
+///
+/// <para>🚨 <b>This adapter is a SERVE surface, so it holds only nodes that are actually
+/// served</b> — see the constructor. Definition-only entries stay reachable as
+/// <i>definitions</i> through <see cref="StaticNodeProviderExtensions.FindStaticNode"/>, which
+/// enumerates the <see cref="IStaticNodeProvider"/>s directly and never goes through here.</para>
 /// </summary>
 public sealed class StaticNodeStorageAdapter : IStorageAdapter
 {
@@ -30,11 +35,33 @@ public sealed class StaticNodeStorageAdapter : IStorageAdapter
     /// <summary>
     /// Wraps <paramref name="nodes"/> in an immutable, path-keyed lookup. Duplicate
     /// paths are deduped to the last entry (caller wins).
+    ///
+    /// <para>🚨 <b><see cref="MeshNode.IsDefinitionOnly"/> entries are excluded — MeshWeaver#2899.</b>
+    /// That marker is what <c>serveFromPartition</c> stamps to say *the durable row owns this path;
+    /// I am only the type definition* (Doc/Architecture/NodeTypeCatalogs). Every other seam that
+    /// answers "which node is served here" already honours it —
+    /// <see cref="StaticNodeProviderExtensions.FindServedStaticNode"/>,
+    /// <c>MeshDataSource.WithMeshNodes</c>, <c>MessageHubGrain.TryResolveStaticNode</c>, the
+    /// <c>CreateNode</c> existing-node probe, <c>PartitionWriteGuardValidator</c> and
+    /// <c>StaticNodeQueryProvider</c> — and <c>FindServedStaticNode</c>'s own contract states the
+    /// invariant outright: keeping them on one resolution is what guarantees
+    /// "served static" ⇔ "not persistence-backed" can never drift apart.</para>
+    ///
+    /// <para>This adapter was the one seam that drifted, and it is the seam
+    /// <c>PersistenceService</c> reads. <c>StaticNodePartitionStorageProvider</c> carries a fixed
+    /// namespace, so it sorts into <c>PersistenceService</c>'s FIRST provider band — ahead of every
+    /// wildcard durable backend — while being <c>IsReadOnly</c> and therefore absent from the write
+    /// chain. Serving a definition from <see cref="Read"/> therefore made a DB-synced static
+    /// partition answer every read with the in-memory definition while writes landed durably: the
+    /// write was acknowledged (the non-null try-then-claim ACCEPT sentinel), the version-history row
+    /// was chained off that acknowledgement, and no reader could ever see the row again. Durable,
+    /// versioned, unreadable — Doc/Architecture/DurableButUnreadable. Pinned by
+    /// <c>AcknowledgedWriteIsReadableTest</c>.</para>
     /// </summary>
     public StaticNodeStorageAdapter(IEnumerable<MeshNode> nodes)
     {
         _nodes = nodes
-            .Where(n => !string.IsNullOrEmpty(n.Path))
+            .Where(n => !string.IsNullOrEmpty(n.Path) && !n.IsDefinitionOnly)
             .GroupBy(n => Norm(n.Path), StringComparer.OrdinalIgnoreCase)
             .ToImmutableDictionary(g => g.Key, g => g.Last(), StringComparer.OrdinalIgnoreCase);
     }

--- a/test/MeshWeaver.Hosting.Test/AcknowledgedWriteIsReadableTest.cs
+++ b/test/MeshWeaver.Hosting.Test/AcknowledgedWriteIsReadableTest.cs
@@ -137,7 +137,7 @@ public class AcknowledgedWriteIsReadableTest
         // DEFINITION and the durable row owns the path.
         var (adapter, versions) = BuildStack(Static("in-memory type definition", definitionOnly: true));
 
-        var acknowledged = await adapter.Write(Durable("the durable row"), Options).Timeout(Budget);
+        var acknowledged = await adapter.Write(Durable("the durable row"), Options).Timeout(Budget).Await();
 
         acknowledged.Should().NotBeNull(
             "a non-null emission is the try-then-claim ACCEPT sentinel — the write was acknowledged");
@@ -145,7 +145,7 @@ public class AcknowledgedWriteIsReadableTest
             "the version-history row is chained off that same acknowledgement, so a caller that "
             + "checks history sees the write as landed");
 
-        var readBack = await adapter.Read(NodePath, Options).Timeout(Budget);
+        var readBack = await adapter.Read(NodePath, Options).Timeout(Budget).Await();
 
         readBack.Should().NotBeNull("a write that was acknowledged must be readable back");
         readBack!.Name.Should().Be("the durable row",
@@ -167,14 +167,14 @@ public class AcknowledgedWriteIsReadableTest
     {
         var adapter = new StaticNodeStorageAdapter([Static("in-memory type definition", definitionOnly: true)]);
 
-        (await adapter.Read(NodePath, Options).Timeout(Budget))
+        (await adapter.Read(NodePath, Options).Timeout(Budget).Await())
             .Should().BeNull("the durable row owns this path; the definition does not serve it");
-        (await adapter.Exists(NodePath).Timeout(Budget))
+        (await adapter.Exists(NodePath).Timeout(Budget).Await())
             .Should().BeFalse("Exists must agree with Read — a true here makes the create path "
                               + "refuse a path that has no durable row");
-        var (nodePaths, _) = await adapter.ListChildPaths(Partition).Timeout(Budget);
+        var (nodePaths, _) = await adapter.ListChildPaths(Partition).Timeout(Budget).Await();
         nodePaths.Should().BeEmpty("a definition is not a child node of its partition");
-        var (prefixNode, matched) = await adapter.FindBestPrefixMatch(NodePath, Options).Timeout(Budget);
+        var (prefixNode, matched) = await adapter.FindBestPrefixMatch(NodePath, Options).Timeout(Budget).Await();
         prefixNode.Should().BeNull("prefix routing must not resolve onto a definition-only entry");
         matched.Should().Be(0);
     }
@@ -192,10 +192,10 @@ public class AcknowledgedWriteIsReadableTest
     {
         var adapter = new StaticNodeStorageAdapter([Static("served static node", definitionOnly: false)]);
 
-        var served = await adapter.Read(NodePath, Options).Timeout(Budget);
+        var served = await adapter.Read(NodePath, Options).Timeout(Budget).Await();
 
         served.Should().NotBeNull("a served static node is the node at its path");
         served!.Name.Should().Be("served static node");
-        (await adapter.Exists(NodePath).Timeout(Budget)).Should().BeTrue();
+        (await adapter.Exists(NodePath).Timeout(Budget).Await()).Should().BeTrue();
     }
 }

--- a/test/MeshWeaver.Hosting.Test/AcknowledgedWriteIsReadableTest.cs
+++ b/test/MeshWeaver.Hosting.Test/AcknowledgedWriteIsReadableTest.cs
@@ -1,0 +1,201 @@
+using System.Collections.Concurrent;
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// MeshWeaver#2899 — <b>a write that is acknowledged, versioned, and permanently unreadable</b>.
+///
+/// <para>The invariant these tests pin is one sentence, and the platform had no test for it:
+/// <b>a write the storage layer acknowledged must be readable back through the seam readers
+/// use.</b> Everything downstream of a write treats the acknowledgement as proof the node
+/// landed — an import manifest records the file as done, a credential mint hands out a key, a
+/// reactive wait completes — so an acknowledgement that asserts nothing about readability is the
+/// most expensive defect shape the platform has. See
+/// <c>Doc/Architecture/DurableButUnreadable</c>.</para>
+///
+/// <para><b>The concrete leak these tests were written against.</b> Six seams answer "which node
+/// is served at this path", and every one of them honours <see cref="MeshNode.IsDefinitionOnly"/>
+/// — the marker <c>serveFromPartition</c> stamps on a static entry to say *Postgres owns the row
+/// at this path, I am only the type definition*:
+/// <c>FindServedStaticNode</c>, <c>MeshDataSource.WithMeshNodes</c>,
+/// <c>MessageHubGrain.TryResolveStaticNode</c>, the <c>CreateNode</c> existing-node probe,
+/// <c>PartitionWriteGuardValidator</c>, and <c>StaticNodeQueryProvider</c>.
+/// <see cref="StaticNodeStorageAdapter"/> — the STORAGE read seam — did not, and it is the one
+/// <see cref="PersistenceService"/> consults. Because
+/// <see cref="StaticNodePartitionStorageProvider"/> carries a fixed namespace it sorts into
+/// <see cref="PersistenceService"/>'s FIRST band, ahead of every wildcard durable backend, while
+/// being read-only and therefore absent from the write chain. So on a DB-synced static partition
+/// the write landed in the durable store, was acknowledged, got its version-history row — and
+/// every subsequent read returned the in-memory definition node instead. Durable, versioned,
+/// unreadable.</para>
+/// </summary>
+public class AcknowledgedWriteIsReadableTest
+{
+    private const string Partition = "Doc";
+    private const string NodePath = "Doc/Architecture";
+    private static readonly JsonSerializerOptions Options = new();
+    private static readonly TimeSpan Budget = TimeSpan.FromSeconds(10);
+
+    /// <summary>A static repo contributor — the shape <c>AddMeshNodes</c> / a platform module registers.</summary>
+    private sealed class ListProvider(params MeshNode[] nodes) : IStaticNodeProvider
+    {
+        public IEnumerable<MeshNode> GetStaticNodes() => nodes;
+    }
+
+    /// <summary>
+    /// The version store, recording exactly what <c>VersionWritingStorageAdapter</c> hands it.
+    /// Instance state only — a static dictionary would bleed across tests (see
+    /// <c>Doc/Architecture/NoStaticState</c>).
+    /// </summary>
+    private sealed class RecordingVersionStore : IVersionQuery
+    {
+        private readonly ConcurrentDictionary<string, MeshNode> _written = new(StringComparer.OrdinalIgnoreCase);
+
+        public bool HasVersionFor(string path) => _written.ContainsKey(path);
+
+        public IObservable<MeshNodeVersion> GetVersions(string path) =>
+            _written.TryGetValue(path, out var n)
+                ? Observable.Return(new MeshNodeVersion(n.Path, n.Version, n.LastModified, n.LastModifiedBy, n.Name, n.NodeType))
+                : Observable.Empty<MeshNodeVersion>();
+
+        public IObservable<MeshNode?> GetVersion(string path, long version, JsonSerializerOptions options) =>
+            Observable.Return(_written.GetValueOrDefault(path));
+
+        public IObservable<MeshNode?> GetVersionBefore(string path, long beforeVersion, JsonSerializerOptions options) =>
+            Observable.Return<MeshNode?>(null);
+
+        public IObservable<MeshNode> WriteVersion(MeshNode node, JsonSerializerOptions options)
+        {
+            _written[node.Path] = node;
+            return Observable.Return(node);
+        }
+    }
+
+    private static MeshNode Static(string name, bool definitionOnly) =>
+        MeshNode.FromPath(NodePath) with
+        {
+            NodeType = "Markdown",
+            Name = name,
+            IsDefinitionOnly = definitionOnly,
+        };
+
+    private static MeshNode Durable(string name) =>
+        MeshNode.FromPath(NodePath) with
+        {
+            NodeType = "Markdown",
+            Name = name,
+            State = MeshNodeState.Active,
+            Version = 1,
+        };
+
+    /// <summary>
+    /// The PRODUCTION decorator chain, in the production order — the one
+    /// <c>PersistenceExtensions.DecorateWithVersionWriting</c> builds:
+    /// <c>SubtreeDeletionGuard → MonotonicWriteGuard → VersionWriting → PersistenceService</c>,
+    /// over a static (read-only, fixed-namespace) provider and a writable wildcard one. The
+    /// provider ordering is production's too: a fixed-namespace provider sorts ahead of every
+    /// wildcard, so the static adapter answers reads first.
+    /// </summary>
+    private static (IStorageAdapter Adapter, RecordingVersionStore Versions) BuildStack(MeshNode staticNode)
+    {
+        var versions = new RecordingVersionStore();
+        var providers = new IPartitionStorageProvider[]
+        {
+            new StaticNodePartitionStorageProvider(Partition, new ListProvider(staticNode)),
+            new InMemoryPartitionStorageProvider(new InMemoryStorageAdapter()),
+        };
+
+        IStorageAdapter adapter = new SubtreeDeletionGuardStorageAdapter(
+            new MonotonicWriteGuardStorageAdapter(
+                new VersionWritingStorageAdapter(new PersistenceService(providers), versions)),
+            registry: null);
+
+        return (adapter, versions);
+    }
+
+    /// <summary>
+    /// 🚨 THE GUARD. A write the storage layer acknowledged — a non-null emission from
+    /// <see cref="IStorageAdapter.Write"/>, which is precisely what makes
+    /// <c>VersionWritingStorageAdapter</c> record a version row and what
+    /// <c>RequireClaimedWrite</c> lets through as <c>CreateNodeResponse.Ok</c> — MUST be
+    /// readable back.
+    ///
+    /// <para>This is the #2899 signature expressed as an invariant: on the failing code the
+    /// acknowledgement arrived, the version row was written, and <c>Read</c> answered with a
+    /// different node forever. Nothing threw, nothing logged, nothing timed out.</para>
+    /// </summary>
+    [Fact]
+    public async Task An_acknowledged_write_is_readable_back_through_the_same_adapter()
+    {
+        // serveFromPartition: the host declared this path DB-backed, so the static entry is a
+        // DEFINITION and the durable row owns the path.
+        var (adapter, versions) = BuildStack(Static("in-memory type definition", definitionOnly: true));
+
+        var acknowledged = await adapter.Write(Durable("the durable row"), Options).Timeout(Budget);
+
+        acknowledged.Should().NotBeNull(
+            "a non-null emission is the try-then-claim ACCEPT sentinel — the write was acknowledged");
+        versions.HasVersionFor(NodePath).Should().BeTrue(
+            "the version-history row is chained off that same acknowledgement, so a caller that "
+            + "checks history sees the write as landed");
+
+        var readBack = await adapter.Read(NodePath, Options).Timeout(Budget);
+
+        readBack.Should().NotBeNull("a write that was acknowledged must be readable back");
+        readBack!.Name.Should().Be("the durable row",
+            "the acknowledgement came from the durable store, so the durable row is what every "
+            + "reader must see — a definition-only static entry is NOT the node at this path, and "
+            + "shadowing the row here is exactly MeshWeaver#2899: acknowledged, versioned, invisible");
+    }
+
+    /// <summary>
+    /// The same rule for the OTHER serve surfaces on the storage seam. A half-fix that excluded
+    /// definition-only entries from <see cref="IStorageAdapter.Read"/> alone would leave
+    /// <see cref="IStorageAdapter.Exists"/> answering <c>true</c> for a path with no durable row
+    /// (the create handler's NodeType-existence probe reads it) and
+    /// <c>ListChildPaths</c> / <c>FindBestPrefixMatch</c> still serving the definition — three
+    /// readers disagreeing about one path, which is the defect class this repo keeps paying for.
+    /// </summary>
+    [Fact]
+    public async Task A_definition_only_entry_is_served_by_NO_storage_surface()
+    {
+        var adapter = new StaticNodeStorageAdapter([Static("in-memory type definition", definitionOnly: true)]);
+
+        (await adapter.Read(NodePath, Options).Timeout(Budget))
+            .Should().BeNull("the durable row owns this path; the definition does not serve it");
+        (await adapter.Exists(NodePath).Timeout(Budget))
+            .Should().BeFalse("Exists must agree with Read — a true here makes the create path "
+                              + "refuse a path that has no durable row");
+        var (nodePaths, _) = await adapter.ListChildPaths(Partition).Timeout(Budget);
+        nodePaths.Should().BeEmpty("a definition is not a child node of its partition");
+        var (prefixNode, matched) = await adapter.FindBestPrefixMatch(NodePath, Options).Timeout(Budget);
+        prefixNode.Should().BeNull("prefix routing must not resolve onto a definition-only entry");
+        matched.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The negative half — the fix must not disarm the case it is NOT about. A static entry the
+    /// host genuinely SERVES (no <c>serveFromPartition</c>, so not definition-only) still owns its
+    /// path on every seam. That collision with a durable write is a *configuration* error the
+    /// create path already refuses loudly by name
+    /// (<c>StaticNodeProviderExtensions.DescribeStaticServeCollision</c>, #1209); it must keep
+    /// behaving exactly as before.
+    /// </summary>
+    [Fact]
+    public async Task A_genuinely_SERVED_static_node_still_owns_its_path()
+    {
+        var adapter = new StaticNodeStorageAdapter([Static("served static node", definitionOnly: false)]);
+
+        var served = await adapter.Read(NodePath, Options).Timeout(Budget);
+
+        served.Should().NotBeNull("a served static node is the node at its path");
+        served!.Name.Should().Be("served static node");
+        (await adapter.Exists(NodePath).Timeout(Budget)).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
## The measurement first — the write lane is NOT the defect

#2899 is titled "a write into a Store-plugin partition false-passes". Re-measured read-only on
memex.systemorph.com on 2026-09-02, **that framing is falsified**:

| Probe | Answer | What it kills |
|---|---|---|
| `autocomplete @/AgenticEngineering/Introduction` | the node **and six of its children**, correct names and node types | **The write is not lost.** A row no reader can see cannot be returned by autocomplete. The failure is a read seam. |
| `get_version AgenticEngineering/WriteLaneProbe 1` | `mainNode == path` — and the node is **invisible** | The `is:main` / `n.main_node = n.path` filter (#2939) is not the discriminator. |
| `get_version AgenticEngineering/_Policy 1` | `mainNode != path` — and the node is **visible** | …and the correlation is *inverted* from that filter, so it cannot be the cause. |
| `search namespace:AgenticPrimer scope:descendants` | full content, same portal, byte-identical `_Access` shape (`Public — Viewer` + `Anonymous — Viewer`, nothing else) | Not the grant shape, not the install date, not a portal-wide query regression. |

Nothing was mutated on any portal.

**The three hypotheses in the brief, resolved:**

- **(a) Transport (the oversized Orleans frame, #2897)** — **RULED OUT.** A transport refusal is
  loud and terminal and leaves no version row, and the frames post-date the import by three days.
  #3018's producer-side refusal is merged and the symptom is unchanged, which is the confirmation:
  the mechanism it fixed was never this one.
- **(b) The untyped-content degrade (#2952/#3006)** — **RULED OUT.** A degrade leaves the node *in*
  the listing with unusable content; it cannot remove one or make a point read answer Not found.
  `get_version` returns fully-typed content here (`$type: MarkdownContent`), so the discriminator
  resolves.
- **(c) The listing/index path** — **RULED IN.**

## The core-side producer of that class, found and fixed

`MeshNode.IsDefinitionOnly` is the marker `serveFromPartition` stamps on a static entry to say
*the durable row owns this path; I am only the type definition*. **Six seams answer "which node is
served here", and five honoured it** — `FindServedStaticNode`, `MeshDataSource.WithMeshNodes`,
`MessageHubGrain.TryResolveStaticNode`, the `CreateNode` existing-node probe,
`PartitionWriteGuardValidator`, `StaticNodeQueryProvider`. `FindServedStaticNode`'s own contract
states the invariant outright: keeping them on one resolution is what guarantees *"served static" ⇔
"not persistence-backed"* can never drift apart.

**`StaticNodeStorageAdapter` — the sixth, and the one `PersistenceService` reads — did not.**

That one gap produces the full signature, because of how the provider chain is ordered:

- `StaticNodePartitionStorageProvider` carries a fixed namespace, so it sorts into
  `PersistenceService`'s **first** provider band, ahead of every wildcard durable backend;
- it is `IsReadOnly`, so it is **absent from the write chain** — `Write` walks the writable
  providers, `Read` walks *all* of them and takes the first non-null.

So on a DB-synced static partition the write was claimed by the durable backend and acknowledged
with the non-null try-then-claim ACCEPT sentinel; `VersionWritingStorageAdapter` chained the
version-history row off that same acknowledgement; and every read from then on returned the
in-memory definition instead of the row. **Read and Write disagreed about which provider owns the
path, and only the write side was ever asked.** Nothing threw, nothing logged, nothing timed out.

The fix is one predicate — the adapter is a *serve* surface, so it holds only nodes that are
actually served. Definitions stay reachable as definitions through
`StaticNodeProviderExtensions.FindStaticNode`, which enumerates the providers directly and never
goes through the adapter.

## The repro — worth more than the fix, so it is the first thing here

`test/MeshWeaver.Hosting.Test/AcknowledgedWriteIsReadableTest.cs` pins the invariant the platform
had no test for:

> **A write the storage layer acknowledged must be readable back through the seam readers use.**

It drives the **real production decorator chain** in the real production order —
`SubtreeDeletionGuard → MonotonicWriteGuard → VersionWriting → PersistenceService` — over a
read-only fixed-namespace static provider and a writable wildcard one, i.e. production's own
provider ordering. No mocks.

**Negative control (a pin is only a pin if it fails against the defect).** Against the pre-fix
code, with the fix reverted:

```
Failed  An_acknowledged_write_is_readable_back_through_the_same_adapter [32 ms]
  Expected value to be "the durable row" … but found "in-memory type definition".
Failed  A_definition_only_entry_is_served_by_NO_storage_surface [1 ms]
Failed!  - Failed: 2, Passed: 1, Total: 3
```

The first failure is the production signature exactly: the write **was** acknowledged (the
assertion before it passed), the **version row was written** (the assertion before it passed), and
the read-back returned the shadow. The one test that passed pre-fix is the deliberate negative
half — a genuinely *served* static node still owns its path, so the fix cannot disarm the #1209
collision case the create path already refuses by name.

With the fix: **277 passed, 0 failed** in that project.

## 🚨 Why this does NOT close #2899, and must not

The production instance on systemorph is a **different producer of the same class** and is still
live. Per the table above, the surviving candidate there — 5 cases out of 5, including one that
could have falsified it — is that a row passes the read filter **iff its `main_node` is the
partition root `AgenticEngineering`**, which is precisely the prefix its two grants project at
(`COALESCE(main_node, namespace)` in `rebuild_user_effective_permissions`) and precisely the column
the per-schema access clause folds effective permissions against (`n.main_node`, not `n.path`).
That SQL lives in `MeshWeaver.Plugins/src/MeshWeaver.Hosting.PostgreSql`, not here, and settling it
needs the partition schema inspected on that portal.

**Closing #2899 on this PR would bury 371 still-unreadable nodes** — the precise false-pass shape
the issue is about. So this is `Refs #2899`, not `Fixes`. The issue's remaining asks (repair the
partition, the GitSync wrapper activity's `Succeeded`-over-`Warning`) are untouched and named
below.

## Deliberately NOT done

- **The GitSync wrapper activity reporting `Succeeded` over a child that ended `Warning`** is real
  and is a gate-cannot-fail defect. Its sibling half is already fixed
  (`GitHubSyncService.MayAdvanceBaseline`, #2229 item C). I did not fix the status fold: memory
  `activity-finish-override-is-a-floor-dual-writer-splitbrain` records that `Finish(v, override)`
  is `MAX(floor, fold)` with dual writers that split-brain, and shipping an unstudied change to
  terminal-status semantics *in a gate* is worse than leaving it named. It stays on #2899.
- **Widening the fix to cross-provider precedence.** The adapter sees one provider's node list,
  not the resolution `ResolveStaticNodes` applies. A higher-precedence definition-only claim over a
  lower-precedence served node still diverges at this seam — the #2908 shape one layer down. That
  is reported by name today (`DescribeStaticServeCollision`); the residual is written into the doc
  rather than papered over.

## Verification that can fail

- `dotnet build -c Release -warnaserror` (solution) — **0 Error(s), 0 Warning(s)**, 61 project
  outputs; `MeshWeaver.Mesh.Contract.dll` and `MeshWeaver.Documentation.dll` rebuilt *after* the
  source edit (timestamps checked — a warm no-op would not have).
- `MeshWeaver.Hosting.Test` — **277 passed, 0 failed**, `.trx` written.
- `MeshWeaver.Documentation.Test` — **172 passed, 0 failed**, covering
  `DocumentationLinkIntegrityTest` for the edited doc page and the new What's New entry.
- `MeshWeaver.Graph.Test` — the project that exercises static-node serving through
  `MeshDataSource.WithMeshNodes`.

## Work conserved

- `Doc/Architecture/DurableButUnreadable` — extended with the core-side mechanism and its fix, the
  two falsified hypotheses (with the measurements that could have gone the other way), the
  three-hypothesis resolution, the named residual, and an `Open` section rewritten to say what is
  now settled and what still needs the live schema.
- A What's New entry (`Category: Fix`) — users lost content to this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
