### PR TITLE
fix: a settled build that no release names is repaired, never left silent

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -3297,8 +3297,24 @@ internal static class NodeTypeCompilationHelpers
                         // contract; DefaultIfEmpty makes the write unconditional even if that
                         // contract is ever violated.
                         .DefaultIfEmpty()
-                        .Subscribe(newReleasePath =>
+                        // 🚨 THE POST-CONDITION (#781), checked where the compile SETTLES — the one
+                        // moment at which "does a release name the build this node is about to
+                        // advertise?" is answerable from facts all in hand. A consumed request whose
+                        // release did not land leaves LatestReleasePath on the PREVIOUS build and
+                        // nothing ever revisits it: status Ok, sources current, an assembly built, a
+                        // release path present — and every instance binding yesterday's bytes. The
+                        // remedy re-cuts from the bytes this compile just produced (no recompile,
+                        // under System) and is loud either way. Also totality-safe: exactly one
+                        // emission, never a fault.
+                        .SelectMany(newReleasePath => ok
+                            ? ReleasePostCondition.Restore(
+                                hub, hubPath, outcome.Result!, outcome.PendingNode,
+                                resolvedActivityPath, newReleasePath, logger)
+                            : Observable.Return<(string? ReleasePath, string? Diagnosis)>(
+                                (newReleasePath, null)))
+                        .Subscribe(settle =>
                     {
+                    var newReleasePath = settle.ReleasePath;
                     // Terminal writes run under System — same rule as every other
                     // deferred pipeline in RunCompile (the ambient scope from the
                     // compile subscription does not flow into this create-response
@@ -3352,6 +3368,11 @@ internal static class NodeTypeCompilationHelpers
                     if (newReleasePath is not null)
                         activityMessages.Add(new LogMessage(
                             $"Release created: {newReleasePath}", LogLevel.Information));
+                    // The post-condition's verdict belongs on the OFFICIAL diagnosis surface, not
+                    // only in a log sink — a stale release is invisible everywhere else (#781).
+                    if (settle.Diagnosis is { } diagnosis)
+                        activityMessages.Add(new LogMessage(diagnosis,
+                            newReleasePath is null ? LogLevel.Error : LogLevel.Warning));
                     NodeTypeCompilationActivity.Complete(hub, resolvedActivityPath,
                         ok ? ActivityStatus.Succeeded : ActivityStatus.Failed,
                         activityMessages.ToImmutable(), logger!);

--- a/src/MeshWeaver.Compiler.Pipeline/ReleasePostCondition.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/ReleasePostCondition.cs
@@ -1,0 +1,194 @@
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Graph;
+
+/// <summary>
+/// 🚨 The POST-CONDITION of a successful compile (issue #781): once a release request has been
+/// CONSUMED, <see cref="NodeTypeDefinition.LatestReleasePath"/> must never name a build older than
+/// <see cref="NodeTypeDefinition.LastCompiledVersion"/>.
+///
+/// <para><b>Why it is checked HERE, where the compile SETTLES.</b> The release watcher already
+/// refuses to fire mid-compile (it gates on a SETTLED status), and that gate is not the gap. A
+/// request and a compile can still be ordered so the release is cut, correctly by its own contract,
+/// against a build the compile is about to supersede — or the release create can simply not land:
+/// <c>TryCreateReleaseNode</c> is best-effort by design (compile correctness must not depend on a
+/// MeshNode create), so a bound that expires, a fault, or a refusal — it runs under the REQUESTER's
+/// identity for attribution, and a partition the requester may not create in refuses it — all emit
+/// <c>null</c>, logged at Warning and swallowed. <c>ApplyCompileSuccess</c> then stamps
+/// <c>releasePath ?? def.LatestReleasePath</c>, i.e. the PREVIOUS build's release, and the trigger
+/// is already spent (<c>LastReleaseRequestHandledAt == RequestedReleaseAt</c>, stamped on the
+/// dispatch commit). Nothing revisits it.</para>
+///
+/// <para>The resulting node looks healthy from every angle — <c>compilationStatus: Ok</c>, sources
+/// current, an assembly built, a release path present — while every instance keeps binding the
+/// previous build. Only comparing the release against <c>lastCompiledVersion</c> reveals it, and
+/// the settle is the one moment at which that comparison can be made from facts all in hand. It
+/// catches the state regardless of which ordering produced it (<c>Publish/Deck</c>, 2026-08-27:
+/// <c>lastCompiledVersion 575</c> beside a release cut the previous day).</para>
+///
+/// <para><b>The response is to RE-CUT, and to say so loudly.</b> The bytes are in hand — the
+/// compile just produced them — so the missing release is minted from those exact store coordinates
+/// with NO recompile, under SYSTEM (the credential that produced the bytes; the attributed create
+/// is what failed, and the requester already passed the <see cref="Permission.Compile"/> gate at
+/// the entry point, so nothing is widened by cutting the artefact the compile owed them). Reporting
+/// alone would leave the mesh in exactly the state the incident describes: unrepairable from the
+/// outside, because the trigger is spent and a fresh request is absorbed by the build already in
+/// hand. Un-consuming the trigger instead is worse — a release create that keeps failing would
+/// re-dispatch a compile forever, a reconcile fed by its own writes.</para>
+///
+/// <para>🚨 And it stays LOUD either way: the violation is logged as an ERROR naming the type, the
+/// stale path and the build, and the remedy's outcome is recorded on the compile <c>_Activity</c>
+/// (the official diagnosis surface). Silence is what made the incident invisible for a day.</para>
+/// </summary>
+internal static class ReleasePostCondition
+{
+    /// <summary>
+    /// The pure verdict — <c>null</c> when the post-condition HOLDS, otherwise a human-readable
+    /// description of the violation. No hub, no stream, no IO: unit-testable on its own.
+    /// </summary>
+    /// <param name="before">The NodeType definition as observed when the compile was dispatched
+    /// (<c>outcome.PendingNode</c>) — it carries the request stamps and the coordinates of the
+    /// build the standing release was cut for.</param>
+    /// <param name="result">The SUCCESSFUL compile's result — the build about to be stamped.</param>
+    /// <param name="newReleasePath">The release cut on THIS settle, or <c>null</c> when none landed.</param>
+    internal static string? Violation(
+        NodeTypeDefinition? before, NodeCompilationResult result, string? newReleasePath)
+    {
+        if (before is null) return null;
+        // A release for these exact bytes was just cut — the invariant holds by construction.
+        if (!string.IsNullOrEmpty(newReleasePath)) return null;
+
+        // SCOPE: only a CONSUMED request (#781's wording). A request still standing re-fires by
+        // itself on the next settled emission — that is the release watcher's own contract and
+        // must not be pre-empted here. And a build nobody asked to release (a first-build kickoff,
+        // an adopted bundle) has never had a release to be stale: absence there is inconclusive,
+        // not evidence of a lost request.
+        if (before.RequestedReleaseAt is not { } requested) return null;
+        if (before.LastReleaseRequestHandledAt is not { } handled || handled < requested) return null;
+
+        if (string.IsNullOrEmpty(before.LatestReleasePath))
+            return $"a release request (requestedReleaseAt={requested:O}) was consumed and this "
+                 + "compile succeeded, yet the node names NO release at all";
+
+        return NamesAnEarlierBuild(before, result) is { } drift
+            ? $"a release request (requestedReleaseAt={requested:O}) was consumed and this compile "
+              + $"succeeded, yet latestReleasePath still names '{before.LatestReleasePath}' — cut "
+              + $"for an EARLIER build ({drift})"
+            : null;
+    }
+
+    /// <summary>
+    /// Which recorded build identity MOVED with this compile — i.e. the evidence that the standing
+    /// release cannot be naming the bytes the settle is about to stamp. Any single fact is enough;
+    /// a fact the result does not carry (a producer without an assembly store) is INCONCLUSIVE and
+    /// never counted, so this never invents a violation from an absence.
+    /// </summary>
+    private static string? NamesAnEarlierBuild(NodeTypeDefinition before, NodeCompilationResult result)
+    {
+        if (result.Version is { } version && before.LastCompiledVersion != version)
+            return $"lastCompiledVersion {before.LastCompiledVersion?.ToString() ?? "(none)"} → {version}";
+        if (Moved(before.LatestAssemblyPath, result.ContentPath))
+            return $"assembly path '{before.LatestAssemblyPath}' → '{result.ContentPath}'";
+        if (Moved(before.LatestAssemblyCollection, result.Collection))
+            return $"assembly collection '{before.LatestAssemblyCollection}' → '{result.Collection}'";
+        // The source snapshot is the identity available on EVERY producer, store or not: a release
+        // cut from other sources is by definition a release of another build.
+        if (result.CompiledSources is { Count: > 0 } compiled
+            && before.CompiledSources is { } previous
+            && !SameSnapshot(previous, compiled))
+            return "the compiled-source snapshot changed";
+        return null;
+    }
+
+    private static bool Moved(string? recorded, string? produced)
+        => !string.IsNullOrEmpty(produced) && !string.Equals(recorded, produced, StringComparison.Ordinal);
+
+    private static bool SameSnapshot(
+        IReadOnlyDictionary<string, long> previous,
+        IReadOnlyDictionary<string, long> current)
+    {
+        if (previous.Count != current.Count) return false;
+        foreach (var (path, version) in current)
+            if (!previous.TryGetValue(path, out var was) || was != version) return false;
+        return true;
+    }
+
+    /// <summary>
+    /// The settle-path remedy. Emits the release path the terminal stamp should use: the one this
+    /// settle already cut, or — when the post-condition is violated — the one re-cut from the bytes
+    /// the compile just produced, or <c>null</c> when even that could not land. The second element
+    /// is the diagnosis line for the compile <c>_Activity</c> (<c>null</c> when there is nothing to
+    /// report), so the official surface carries the story rather than only a log sink.
+    ///
+    /// <para>🚨 Never faults and always emits exactly once — the terminal Status write runs in this
+    /// observable's OnNext, so a sequence that completed empty or errored would wedge the NodeType
+    /// at <c>Compiling</c>.</para>
+    /// </summary>
+    internal static IObservable<(string? ReleasePath, string? Diagnosis)> Restore(
+        IMessageHub hub,
+        string nodeTypePath,
+        NodeCompilationResult result,
+        MeshNode pendingNode,
+        string? activityPath,
+        string? newReleasePath,
+        ILogger? logger)
+    {
+        var before = pendingNode.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
+        if (Violation(before, result, newReleasePath) is not { } violation)
+            return Observable.Return<(string?, string?)>((newReleasePath, null));
+
+        logger?.LogError(
+            "[ReleasePostCondition] {HubPath}: {Violation}. Re-cutting the release from the bytes "
+            + "this compile produced (no recompile) — see issue #781.",
+            nodeTypePath, violation);
+
+        // Under SYSTEM, and with the requester cleared so TryCreateReleaseNode does not re-attempt
+        // the very attribution that was refused. RunAsSystem (not Observable.Using over
+        // ImpersonateAsSystem) — the sealed impersonation boundary is what keeps the scope off the
+        // subscriber and off the terminating thread.
+        var access = hub.ServiceProvider.GetService<AccessService>();
+        var systemPending = pendingNode with { Content = before! with { RequestedReleaseBy = null } };
+
+        return access
+            .RunAsSystem(() => NodeTypeBuildState.TryCreateReleaseNode(
+                hub, nodeTypePath, result, systemPending, activityPath, logger))
+            .Take(1)
+            .Catch((Exception ex) =>
+            {
+                logger?.LogError(ex,
+                    "[ReleasePostCondition] {HubPath}: the re-cut faulted", nodeTypePath);
+                return Observable.Return<string?>(null);
+            })
+            .DefaultIfEmpty()
+            .Select<string?, (string? ReleasePath, string? Diagnosis)>(restored =>
+            {
+                if (restored is not null)
+                {
+                    logger?.LogInformation(
+                        "[ReleasePostCondition] {HubPath}: release restored at {ReleasePath} — the "
+                        + "node no longer advertises a build no release names",
+                        nodeTypePath, restored);
+                    return ((string?)restored,
+                        (string?)$"Release post-condition (#781): {violation}. Restored at {restored} "
+                               + "from the bytes this compile produced — no recompile.");
+                }
+
+                logger?.LogError(
+                    "[ReleasePostCondition] {HubPath}: {Violation} — AND the release could not be "
+                    + "re-cut. The node advertises a build no release names; instances will keep "
+                    + "binding '{Stale}' until a release is created for it.",
+                    nodeTypePath, violation, before!.LatestReleasePath);
+                return ((string?)null,
+                    (string?)$"Release post-condition (#781) VIOLATED: {violation}. The re-cut did "
+                           + "not land either — this build has no release.");
+            });
+    }
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/Postmortems/NodeTypeReleaseRedesign.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Postmortems/NodeTypeReleaseRedesign.md
@@ -346,3 +346,103 @@ un-skipped and running today.
    NodeType simultaneously will get different auto-stamped versions (timestamp
    differs). Both compile independently; the latest Succeeded wins active
    status. This is probably fine.
+
+---
+
+## 2026-09-02 — the post-condition at the settle (#781)
+
+**Symptom.** `Publish/Deck` had compiled the current source and instances kept binding the previous
+day's assembly. The node's own state said it, and said it quietly:
+
+```
+lastCompileSucceededAt        2026-08-27T21:53:01.850Z
+lastCompiledVersion           575
+latestAssemblyPath            Publish_Deck/v575-s8929555-aadb349047af.dll
+
+requestedReleaseAt            2026-08-27T21:52:59.898Z
+lastReleaseRequestHandledAt   2026-08-27T21:52:59.898Z   ← consumed
+latestReleasePath             Publish/Deck/Release/20260826065548-neI3XM25   ← the PREVIOUS DAY
+```
+
+`compilationStatus: Ok`, `compiledSources` identical to `currentSourceVersions`, an assembly built,
+a release path present. Healthy from every angle. **Only comparing `lastCompiledVersion` against the
+release reveals it**, and nothing was comparing them.
+
+### What was NOT the cause
+
+The obvious reading — "a release request fired while a compile was in flight" — is wrong, and
+chasing it would have produced a second gate that already exists. `InstallReleaseRequestWatcher`
+has gated on a SETTLED status (`not Pending and not Compiling`) since long before the incident:
+
+```csharp
+&& def.CompilationStatus is not CompilationStatus.Pending
+                          and not CompilationStatus.Compiling
+```
+
+Checked out at 2026-08-01, 2026-08-20 and 2026-08-27T21:00 — present in all three, all before the
+21:52:59 request. So at the moment the request was handled, nothing was in flight.
+
+### What it actually is: an ordering the request side cannot see
+
+Two ways to reach the same state, and the fix must not care which one happened:
+
+1. The request cut the build that was current at 21:52:59 — correctly, by its own contract — and the
+   compile that finished at 21:53:01 started *after* it. Nothing revisits the result.
+2. The release create simply did not land. `TryCreateReleaseNode` is **best-effort by design**
+   (compile correctness must not depend on a MeshNode create), so an expired bound, a fault, or a
+   refusal all emit `null`, logged at Warning and swallowed. The create runs under the REQUESTER's
+   identity for attribution, so a partition the requester may not create in refuses it — and
+   `Access denied: user 'rbuergi' lacks Update permission on 'Publish/Deck'` makes that the leading
+   candidate for that night.
+
+In both, `ApplyCompileSuccess` stamps `releasePath ?? def.LatestReleasePath` — the previous build's
+release — while `LastReleaseRequestHandledAt` was stamped on the DISPATCH commit and the trigger is
+therefore already spent. **Nothing retries, and asking again cannot repair it**: a second request is
+absorbed by the build already in hand (#1707 slice 3).
+
+### The fix: a post-condition, checked where the compile SETTLES
+
+> **`latestReleasePath` must never be older than `lastCompiledVersion` while `requestedReleaseAt`
+> has been consumed.**
+
+`ReleasePostCondition` (`MeshWeaver.Compiler.Pipeline`) evaluates it in the terminal chain of
+`RunCompile`, after the release create has answered and before the terminal stamp — the one moment
+at which every fact is in hand. The verdict is a pure function of (the definition at dispatch, the
+compile result, the release cut on this settle), so it is unit-testable with no mesh.
+
+It fires only on EVIDENCE, and stays silent wherever the answer is inconclusive:
+
+| Condition | Verdict |
+|---|---|
+| A release was cut on this settle | holds |
+| The request was never made, or is still standing (`handled < requested`) | not this check's business — the watcher re-fires a standing trigger itself |
+| Consumed request, no release at all | **violated** |
+| Consumed request, and the store version / assembly coordinates / compiled-source snapshot MOVED past the standing release | **violated** |
+| Nothing in the result can distinguish the builds (a producer with no store and unchanged sources) | inconclusive — never a violation |
+
+### Why RE-CUT rather than only report
+
+The remedy mints the missing release **from the bytes this compile just produced — no recompile** —
+under SYSTEM, with the requester cleared so it does not re-attempt the attribution that was refused.
+
+- **Reporting alone leaves the mesh in the incident's state**: unrepairable from the outside,
+  because the trigger is spent and a fresh request is absorbed by the build in hand. Only `force`
+  escaped, and the person who needed it could not write the node.
+- **Un-consuming the trigger is worse.** A release create that keeps failing would re-dispatch a
+  compile on every settle — a reconcile fed by its own writes, unbounded.
+- **System is the credential that produced the bytes.** The compile already runs as System precisely
+  so it succeeds on a partition the caller cannot write; the requester passed the `Compile` gate at
+  the entry point. Cutting the artefact that compile owed them widens nothing.
+
+### …and it stays LOUD
+
+Silence is what made this invisible for a day, so the violation is an **ERROR** naming the type, the
+stale path and the build that moved — whether or not the re-cut succeeds — and the outcome is
+written to the compile `_Activity`, the official diagnosis surface. A re-cut that also fails says so
+explicitly: *"the node advertises a build no release names"*.
+
+**Pinned by:** `ReleasePostConditionTest` (10 cases, `MeshWeaver.Compiler.Pipeline.Test`) for the
+verdict, and — on a real mesh, in MeshWeaver.Plugins — `ReleasePostConditionAtSettleTest`, which
+reproduces the incident end to end: an Editor who holds `Compile` asks for a release on a type whose
+`Release` subtree denies `Create`, the compile succeeds as System, the attributed create is refused
+and swallowed, and the settle must still leave a release naming `lastCompiledVersion`.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-published-type-can-no-longer-be-left-on-yesterdays-build.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-published-type-can-no-longer-be-left-on-yesterdays-build.md
@@ -1,0 +1,37 @@
+---
+Name: A published type can no longer be left on yesterday's build
+Category: Fix
+Description: A type could finish compiling your latest code and still hand every page the previous build, because the release that publishes it quietly failed to be written and nothing ever checked. The platform now checks at the end of every compile, and cuts the missing release itself.
+Icon: CheckmarkCircle
+Order: -20260902
+---
+
+# A published type can no longer be left on yesterday's build
+
+Some changes are hard to notice because everything says they worked. This was one of them.
+
+When you press Compile on a type, two things happen: your code is built, and a **release** is written
+— a small record that says "this is the build to serve". Pages load the build the release names. The
+build and the release are produced together, and until now nothing checked that they agreed.
+
+They could disagree. The build is compiled by the platform itself, so it succeeds even where you
+personally cannot write; the release is written **as you**, so that it carries your name. On a
+curated or read-only area, that second write can be refused — and it was refused quietly, because a
+missing release was never allowed to fail a compile. The type then finished in a state that looks
+completely healthy: compiled successfully, sources current, an assembly built, a release present.
+The release was simply the previous one, and every page kept loading the previous build.
+
+Worse, there was no way out from the outside. The request had already been marked as handled, so
+asking again did nothing: the second request was answered by the build that already existed. On one
+type this went unnoticed for a day, while a merged fix sat compiled and unreachable.
+
+**The platform now checks the obvious thing at the end of every compile**: does a release actually
+name the build this type is about to advertise? If not — and the check only fires when it can prove
+the build moved on — it writes the missing release itself, from the bytes just compiled. Nothing is
+recompiled, nothing waits, and the release is written under the platform's own identity, so an area
+you cannot write to no longer costs you your release.
+
+And it is no longer quiet. A type that reaches this state is reported as an error naming the type
+and the stale release, and the compile's own activity log records what was found and what was done —
+including the case where even the repair could not be written, which now says so instead of leaving
+you to compare two fields nobody thinks to compare.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/ReleasePostConditionTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/ReleasePostConditionTest.cs
@@ -1,0 +1,158 @@
+using System;
+using System.Collections.Immutable;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 Issue #781 — the release POST-CONDITION as a pure verdict: once a release request has been
+/// CONSUMED, <see cref="NodeTypeDefinition.LatestReleasePath"/> must never name a build older than
+/// <see cref="NodeTypeDefinition.LastCompiledVersion"/>.
+///
+/// <para>The production state it exists to catch (<c>Publish/Deck</c>, 2026-08-27):
+/// <c>lastCompiledVersion 575</c>, <c>compilationStatus Ok</c>, sources current, an assembly built
+/// — and <c>latestReleasePath</c> pointing at a release cut the previous day, with
+/// <c>lastReleaseRequestHandledAt == requestedReleaseAt</c> marking the trigger spent. Healthy from
+/// every angle; every instance binding yesterday's bytes.</para>
+///
+/// <para>These cases pin the two halves that keep the check honest: it FIRES on every way the build
+/// can have moved past the standing release, and it stays SILENT wherever the answer is
+/// inconclusive or the request was never consumed — a check that cried wolf on a first build or an
+/// adopted bundle would be turned off, and the settle path re-cuts a release on its verdict. The
+/// end-to-end behaviour (a refused attributed create, and the release restored from the bytes in
+/// hand) is pinned on a real mesh by <c>ReleasePostConditionAtSettleTest</c> in
+/// MeshWeaver.Plugins.</para>
+/// </summary>
+public class ReleasePostConditionTest
+{
+    private static readonly DateTimeOffset Requested = new(2026, 8, 27, 21, 52, 59, TimeSpan.Zero);
+
+    private static ImmutableDictionary<string, long> Sources(long version) =>
+        ImmutableDictionary<string, long>.Empty.Add("Publish/Deck/Source/Deck", version);
+
+    /// <summary>The node as the compile watcher observed it at dispatch: a consumed request, and a
+    /// release cut for the PREVIOUS build (store version 569).</summary>
+    private static NodeTypeDefinition Consumed() => new()
+    {
+        Configuration = "config => config",
+        CompilationStatus = CompilationStatus.Compiling,
+        RequestedReleaseAt = Requested,
+        LastReleaseRequestHandledAt = Requested,
+        LastCompiledVersion = 569,
+        LatestAssemblyCollection = "assemblies",
+        LatestAssemblyPath = "Publish_Deck/v569-s8929555-aadb349047af.dll",
+        LatestReleasePath = "Publish/Deck/Release/20260826065548-neI3XM25",
+        CompiledSources = Sources(569),
+    };
+
+    /// <summary>The compile that just succeeded — store version 575, new bytes.</summary>
+    private static NodeCompilationResult Built(
+        long? version = 575, string? contentPath = "Publish_Deck/v575-s8929555-aadb349047af.dll",
+        string? collection = "assemblies", long sourceVersion = 569)
+        => new(
+            AssemblyLocation: "/cache/Publish_Deck/Deck.dll",
+            NodeTypeConfigurations: [],
+            CompiledSources: Sources(sourceVersion),
+            Collection: collection,
+            ContentPath: contentPath,
+            Version: version);
+
+    [Fact]
+    public void AConsumedRequest_WhoseReleaseNamesAnEarlierBuild_IsAViolation()
+    {
+        var violation = ReleasePostCondition.Violation(Consumed(), Built(), newReleasePath: null);
+
+        violation.Should().NotBeNull(
+            "this is the incident: the request is spent, the compile produced build 575, and the "
+            + "only release on the node was cut for 569 — nothing will ever revisit it");
+        violation.Should().Contain("20260826065548-neI3XM25", "the verdict must NAME the stale release");
+        violation.Should().Contain("575", "…and the build it is stale against");
+    }
+
+    [Fact]
+    public void AReleaseCutOnThisSettle_HoldsTheInvariant()
+        => ReleasePostCondition.Violation(
+                Consumed(), Built(), newReleasePath: "Publish/Deck/Release/20260827215301-abcd1234")
+            .Should().BeNull("a release for these exact bytes just landed");
+
+    [Fact]
+    public void ARequestStillStanding_IsNotThisChecksBusiness()
+    {
+        // handled < requested: the trigger has NOT been consumed. The release watcher's own
+        // contract is that it re-fires on the next settled emission — pre-empting that here would
+        // cut a release for a build the pending request is about to supersede.
+        var standing = Consumed() with { LastReleaseRequestHandledAt = Requested.AddSeconds(-30) };
+
+        ReleasePostCondition.Violation(standing, Built(), newReleasePath: null).Should().BeNull();
+    }
+
+    [Fact]
+    public void ABuildNobodyAskedToRelease_IsNotAViolation()
+    {
+        // A first-build kickoff / an adopted bundle: no request was ever made, so the absence of a
+        // matching release is inconclusive — never evidence of a lost one (#3010's rule, kept).
+        var never = Consumed() with { RequestedReleaseAt = null, LastReleaseRequestHandledAt = null };
+
+        ReleasePostCondition.Violation(never, Built(), newReleasePath: null).Should().BeNull();
+    }
+
+    [Fact]
+    public void AConsumedRequest_WithNoReleaseAtAll_IsAViolation()
+    {
+        var noRelease = Consumed() with { LatestReleasePath = null };
+
+        ReleasePostCondition.Violation(noRelease, Built(), newReleasePath: null)
+            .Should().Contain("NO release",
+                "the request asked for a release and the compile succeeded — an empty "
+                + "latestReleasePath is the same defect with nothing to compare against");
+    }
+
+    [Fact]
+    public void TheSameBuild_SettlingAgain_IsNotAViolation()
+    {
+        // An idempotent settle (same store version, same coordinates, same sources): the standing
+        // release genuinely names these bytes, so there is nothing to restore and nothing to shout
+        // about. This is the case that keeps the check from re-cutting a release on every compile.
+        var same = Built(version: 569, contentPath: "Publish_Deck/v569-s8929555-aadb349047af.dll");
+
+        ReleasePostCondition.Violation(Consumed(), same, newReleasePath: null).Should().BeNull();
+    }
+
+    [Fact]
+    public void AMovedAssemblyPath_IsEnoughEvidence_EvenWithoutAStoreVersion()
+    {
+        // A producer that reports coordinates but no integer store version still moved the bytes.
+        var moved = Built(version: null);
+
+        ReleasePostCondition.Violation(Consumed(), moved, newReleasePath: null)
+            .Should().Contain("assembly path");
+    }
+
+    [Fact]
+    public void AChangedSourceSnapshot_IsEnoughEvidence_OnAProducerWithNoStore()
+    {
+        // No store at all (Null-store hosts): the compiled-source snapshot is the identity that is
+        // always present, and a release cut from other sources is a release of another build.
+        var storeless = Built(version: null, contentPath: null, collection: null, sourceVersion: 999);
+
+        ReleasePostCondition.Violation(Consumed(), storeless, newReleasePath: null)
+            .Should().Contain("compiled-source snapshot");
+    }
+
+    [Fact]
+    public void NoIdentityFactAtAll_IsInconclusive_NeverAViolation()
+    {
+        // Nothing the result carries can distinguish the builds — never invent a violation from an
+        // absence: the remedy is a WRITE (a re-cut release node), so a false positive is a write.
+        var blind = Built(version: null, contentPath: null, collection: null, sourceVersion: 569);
+
+        ReleasePostCondition.Violation(Consumed(), blind, newReleasePath: null).Should().BeNull();
+    }
+
+    [Fact]
+    public void AnUnreadableDefinition_IsNotJudged()
+        => ReleasePostCondition.Violation(before: null, Built(), newReleasePath: null)
+            .Should().BeNull("a definition the settle could not read says nothing about releases");
+}


### PR DESCRIPTION
Reported as **Systemorph/MeshWeaver.Plugins#781** (core owns the machinery; the end-to-end test lands in the Plugins PR below).

## The state

`Publish/Deck` had compiled the current source, and every instance kept binding the previous day's assembly:

```
lastCompiledVersion           575
requestedReleaseAt            2026-08-27T21:52:59.898Z
lastReleaseRequestHandledAt   2026-08-27T21:52:59.898Z   ← consumed
latestReleasePath             Publish/Deck/Release/20260826065548-neI3XM25   ← the PREVIOUS DAY
```

`compilationStatus: Ok`, sources current, an assembly built, a release path present. Healthy from every angle — and unrepairable from the outside, because the trigger is spent and a fresh request is absorbed by the build already in hand (#1707 slice 3).

## The mechanism is NOT the one the title guesses

`InstallReleaseRequestWatcher` has gated on a **settled** status (`not Pending and not Compiling`) since well before the incident — verified at 2026-08-01, 2026-08-20 and 2026-08-27T21:00. Nothing was in flight. Two orderings reach the same state, and the fix must not care which:

1. the request cut the build that was current at that instant, correctly, and the compile that superseded it started afterwards; nothing revisits the result;
2. the release create simply did not land — `TryCreateReleaseNode` is best-effort by design, and it runs under the **requester's** identity for attribution, so a partition they may not create in refuses it (logged at Warning, swallowed).

Either way `ApplyCompileSuccess` stamps `releasePath ?? def.LatestReleasePath`.

## The fix: the post-condition, checked where the compile SETTLES

> `latestReleasePath` must never be older than `lastCompiledVersion` while `requestedReleaseAt` has been consumed.

`ReleasePostCondition.Violation` is a **pure verdict** over (definition at dispatch, compile result, release cut this settle). It fires only on evidence that the build MOVED — store version, assembly coordinates, or the compiled-source snapshot — and is silent wherever the question is inconclusive: no request at all, a request still standing (the watcher re-fires that itself), or a producer carrying no identity fact. A false positive here would be a write, so absence is never evidence.

**The response is to re-cut, deliberately** — from the bytes this compile just produced, **no recompile**, under System with the requester cleared so it does not re-attempt the attribution that was refused:

- reporting alone leaves the mesh in the incident's dead end;
- un-consuming the trigger would re-dispatch a compile on every settle — a reconcile fed by its own writes;
- System is the credential that compiled those bytes (the compile already runs as System so it succeeds where the caller cannot write), and the requester passed the `Compile` gate at the entry point, so nothing is widened.

**And it stays loud either way**: an ERROR naming the type, the stale release and the build that moved, plus a line on the compile `_Activity` — the surface an operator reads. Silence is what made this invisible for a day.

## Evidence

- `ReleasePostConditionTest` — 10 cases pinning both halves (fires on each identity that moved; silent on every inconclusive shape).
- End-to-end, on a real mesh, in the Plugins PR: an Editor who holds `Compile` requests a release on a type whose `Release` subtree denies `Create` → the compile succeeds as System, the attributed create is refused and swallowed → **red on `main`** (`latestReleasePath` still the kickoff release, `lastCompiledVersion` moved 4→9), **green on this branch**.
- Suites: `MeshWeaver.Compiler.Pipeline.Test` 599/599 · `MeshWeaver.Graph.Test` 1143/1143 · `MeshWeaver.Documentation.Test` 172/172 · the Plugins release-adjacent suites (`NodeTypeReleaseGateTest`, `ReleaseRequestSatisfiedByCurrentBuildTest`, `ReleaseRequestWatcherHighWaterTest`, `ReleaseArtifactLinkTest`, `BuildCoordinationTest`, `CodeEditRecompileTest`, `CompileSourceSnapshotWedgeTest`) 48/48 against this branch.
- Written up durably in `Doc/Architecture/Postmortems/NodeTypeReleaseRedesign.md` (new dated section) plus a What's New entry.

## Overlap with #3010

#3010 (open) attacks the same issue from the REQUEST side — "a request is satisfied only if the release names the build". This PR is the maintainer's later, narrower ask: the post-condition at the settle. They compose (both end at "a release names the build in hand"); if #3010 lands first, the merge is textual, in `NodeTypeCompilationHelpers`' terminal chain and the postmortem doc.