### PR TITLE
fix(sync): a resync that never converges faults the mirror instead of asking forever (#1384)

### DIFF
--- a/src/MeshWeaver.Data/Serialization/StreamNotConvergingException.cs
+++ b/src/MeshWeaver.Data/Serialization/StreamNotConvergingException.cs
@@ -1,0 +1,40 @@
+﻿namespace MeshWeaver.Data.Serialization;
+
+/// <summary>
+/// A mirror asked its owner for a fresh authoritative snapshot, was ACKNOWLEDGED, and never
+/// received one — repeatedly. Terminal: the stream that carries this can never emit again.
+///
+/// <para>🚨 <b>This exception exists so that a lost frame cannot become a SILENT permanent wedge
+/// (Systemorph/MeshWeaver#1384).</b> The recovery path it ends is event-driven by design and has no
+/// timer anywhere in it: a frame whose <c>BasedOnVersion</c> does not chain onto the last one this
+/// mirror applied PROVES a frame was lost in transport, and the only sound reaction is a fresh
+/// snapshot from the owner. #2654 made that recovery survive a single lost answer — the resync gate
+/// is released by the re-ask's round trip, so the next proven gap earns one new re-ask. What it
+/// could not do is TERMINATE: when the owner→subscriber leg keeps eating this stream's snapshots,
+/// every re-ask is acknowledged, every acknowledgement releases the gate, every answer dies on the
+/// way back, and the mirror re-asks for the rest of the process's life. Its subscribers see none of
+/// it — a layout area holds "awaiting first data", a data-bound view holds its last value, and no
+/// error and no completion ever reaches them.</para>
+///
+/// <para>Measured on memex-cloud, 2026-09-01, on <c>Event/SavGeneralversammlung2026/Talk</c>:
+/// <c>[SYNC_STREAM] Frame loss detected … incoming Patch v13 chains onto v12 but the last applied
+/// frame is v11</c>, followed by <c>Layout area 'Present' … was torn down having never rendered</c>
+/// — while plain node reads on the same path answered instantly. Recycling the pod that held the
+/// activation did not clear it: the owner was healthy, and the wedge lived entirely in a subscriber
+/// that had not been told anything was wrong.</para>
+///
+/// <para>Fault, therefore, rather than wait. A faulted stream is the one state every consumer
+/// already knows how to act on: the store's terminal error reaches every reader,
+/// <c>StreamLiveness.IsUsable</c> stops serving the stream from the workspace's caches, and the
+/// next natural caller opens a fresh stream that subscribes from scratch. Nothing here retries —
+/// re-establishing is the subscriber's decision, taken because it was finally told.</para>
+/// </summary>
+public sealed class StreamNotConvergingException : SynchronizationException
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="StreamNotConvergingException"/> class.
+    /// </summary>
+    /// <param name="message">A message naming the stream, its owner and how many acknowledged
+    /// fresh-snapshot requests went unanswered.</param>
+    public StreamNotConvergingException(string message) : base(message) { }
+}

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -1629,6 +1629,10 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                 // did-not-converge counter: THIS is the event that says the resync worked.
                 ReleaseResyncGate();
                 resyncAttempts = 0;
+                // …and the evidence of non-convergence with it: a base snapshot ARRIVED, so every
+                // ack that preceded it turned out to be answered after all (#1384). Interlocked
+                // because the counter's other writer is the ack arm, on the response thread.
+                Interlocked.Exchange(ref unansweredResyncs, 0);
             }
             catch (Exception ex)
             {
@@ -1817,6 +1821,67 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
     private int resyncAttempts;
 
     /// <summary>
+    /// Re-asks the owner ACKNOWLEDGED and then never followed with a base snapshot, reset by the
+    /// <see cref="ChangeType.Full"/> that finally arrives. This — not <see cref="resyncAttempts"/> —
+    /// is the evidence <see cref="MaxUnansweredResyncs"/> bounds, and the difference is the whole
+    /// of the #2745 policy: a re-ask REFUSED transiently (a silo whose pod-hub claim has not landed
+    /// during a rolling deploy answers <see cref="ErrorType.ShuttingDown"/>) is deliberately ridden
+    /// out, so it must not accumulate towards a fault. Only an owner that said "I have processed
+    /// your re-subscribe" and then produced nothing is evidence that the leg is eating this
+    /// stream's snapshots.
+    ///
+    /// <para>Written from the response thread (the ack arm) and from the hub turn (the reset), so
+    /// every access is interlocked.</para>
+    /// </summary>
+    private int unansweredResyncs;
+
+    /// <summary>
+    /// How many acknowledged-but-unanswered fresh-snapshot requests this mirror accumulates before
+    /// it stops asking and FAULTS itself instead — the bound that turns #2654's residual silent
+    /// forever-wedge into a surfaced error (Systemorph/MeshWeaver#1384).
+    ///
+    /// <para><b>What #2654 left behind.</b> The resync gate is released by the re-ask's ROUND TRIP
+    /// (the Full, the owner's ack, or a verdict), so a lost fresh snapshot no longer latches the
+    /// mirror shut: the next frame that proves the gap earns one new re-ask. That converges when
+    /// the leg loses ONE frame. It does not terminate when the leg keeps losing this stream's
+    /// Fulls — every re-ask is acked, every acked re-ask releases the gate, every answering Full
+    /// dies on the same leg, and the mirror re-asks forever at Warning while its subscriber sits on
+    /// "awaiting first data" with no error, no completion and nothing to re-establish from. That is
+    /// the state measured on memex-cloud 2026-09-01 on <c>Event/SavGeneralversammlung2026/Talk</c>:
+    /// <c>Frame loss detected … incoming Patch v13 chains onto v12 but the last applied frame is
+    /// v11</c>, then a layout area <c>torn down having never rendered</c>. Recycling the pod holding
+    /// the activation did not clear it, because nothing on the subscriber side had learned that
+    /// anything had gone wrong.</para>
+    ///
+    /// <para><b>Why a COUNT is not a retry budget.</b> Nothing here retries and nothing polls: this
+    /// counts EVIDENCE, not attempts at success. An increment costs a full round trip to the owner
+    /// (the gate suppresses every re-ask while one is outstanding, and only the ANSWER releases it)
+    /// PLUS a subsequent owner frame that proves the mirror still has no base. So
+    /// <c>unansweredResyncs == n</c> means n separate authoritative snapshots were asked for,
+    /// acknowledged, and never arrived. Raising this bound buys a longer silence, not a better
+    /// chance — which is the opposite of a widened timeout, and why the number is small.</para>
+    ///
+    /// <para><b>Why 3.</b> The one healthy way to spend an attempt without converging is a Patch
+    /// overtaking the answering Full — and the owner queues its re-assert on the SAME stream hub
+    /// that produces the patches, so a patch can only overtake a re-assert that was already in
+    /// flight when the re-ask landed. That is one redundant round trip, twice over at the very
+    /// worst. Three consecutive acknowledged, unanswered asks is not that shape. The two failure
+    /// directions are also not symmetric: faulting a stream that would eventually have converged
+    /// costs one re-establish (<c>StreamLiveness.IsUsable</c> refuses to serve a faulted stream, so
+    /// the workspace cache evicts it and the next natural caller opens a fresh one that subscribes
+    /// from scratch), while NOT faulting costs a view that never loads and never says so.</para>
+    /// </summary>
+    private const int MaxUnansweredResyncs = 3;
+
+    /// <summary>
+    /// Set once this mirror has given up (see <see cref="MaxUnansweredResyncs"/>) so a later frame
+    /// arriving on the already-faulted stream re-reports nothing. The store is terminal by then and
+    /// would swallow a second <see cref="OnError"/> per the Rx grammar, but the Warning beside it
+    /// would repeat per frame — log volume that says nothing new.
+    /// </summary>
+    private int resyncGaveUp;
+
+    /// <summary>
     /// The re-ask currently outstanding. At most ONE at a time (<see cref="resyncInFlight"/>), so a
     /// <see cref="SerialDisposable"/> both bounds the registration — a CompositeDisposable entry per
     /// resync would grow for the life of the stream — and cancels a superseded pending callback,
@@ -1857,8 +1922,55 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                 StreamId, Reference);
             return;
         }
+        // Terminal already declared below — this mirror has stopped asking for good. A later frame
+        // must not re-enter: the stream is faulted, and re-reporting it every frame is log volume
+        // that says nothing new.
+        if (Volatile.Read(ref resyncGaveUp) == 1)
+            return;
         if (Interlocked.Exchange(ref resyncInFlight, 1) == 1)
             return;
+
+        // 🚨 …AND THE ONE THAT ENDS IT (#1384). VISIBLE is not the same as OVER: #2654 made the
+        // non-convergence audible in a portal log and left the SUBSCRIBER exactly where it was —
+        // holding a placeholder for a snapshot that is not coming, with no error and no completion,
+        // so nothing downstream could re-establish. A log line is not an API. Past
+        // MaxUnansweredResyncs acknowledged-and-unanswered asks this mirror stops asking and FAULTS
+        // instead, which is the one signal a subscriber can act on: the store's terminal error
+        // reaches every reader, StreamLiveness.IsUsable stops serving this stream from the
+        // workspace caches, and the next natural caller opens a fresh one.
+        //
+        // Read AFTER the gate is taken, so "no ask is outstanding" is part of the verdict — an
+        // answer still in flight is not evidence of anything. The gate is then released BEFORE the
+        // fault, in the order this method's opening comment teaches: never leave a latch behind a
+        // decision that posted no request. Releasing it asks for nothing by itself, and resyncGaveUp
+        // keeps a later frame from re-reporting a stream that is already terminal.
+        //
+        // 🚨 A MIRROR ONLY, and the qualifier is load-bearing. PatchDataChangeRequest reaches
+        // UpdateStream on the OWNER's server-side stream too, where a subscriber's write arriving
+        // before that stream has emitted its first frame (its outbound JSON cursor still null)
+        // takes the same "Patch before base Full" branch. On such a stream the count measures
+        // nothing: the re-ask is addressed to this very hub, and the Full that would reset it is
+        // one this stream SENDS rather than receives — so it could only ever climb, and faulting on
+        // it would kill an owner's stream for a subscriber-side race. Convergence is a claim about
+        // a REMOTE owner; only a stream that has one can fail to converge. Same predicate as
+        // OwnerVersion() uses to tell the two apart.
+        if (Volatile.Read(ref unansweredResyncs) >= MaxUnansweredResyncs
+            && !Owner.Equals(Host.Address))
+        {
+            Volatile.Write(ref resyncGaveUp, 1);
+            ReleaseResyncGate();
+            logger.LogWarning(
+                "[SYNC_STREAM] Resync gave up for {StreamId}: {Attempts} consecutive fresh-snapshot requests to {Owner} were acknowledged and none produced a base snapshot — faulting the mirror so its subscribers can re-establish",
+                StreamId, Volatile.Read(ref unansweredResyncs), StreamIdentity.Owner);
+            OnError(new StreamNotConvergingException(
+                $"Synchronization stream '{StreamId}' could not recover from a lost frame: "
+                + $"{Volatile.Read(ref unansweredResyncs)} consecutive fresh-snapshot requests to owner "
+                + $"'{StreamIdentity.Owner}' were acknowledged and none produced a base snapshot. The "
+                + "mirror holds no state it can patch onto, so it is faulted rather than left waiting "
+                + "for a snapshot that is not arriving."));
+            return;
+        }
+
         // 🚨 THE ONE LINE THAT MAKES NON-CONVERGENCE VISIBLE. A second consecutive ask means the
         // first one produced no base snapshot — the answer was lost, refused or thrown away — which
         // is exactly the state #2654 spent its whole life in at Debug level, with a stuck layout
@@ -1920,9 +2032,18 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                         // the mirror still has no base, so the worst case is one redundant round
                         // trip when a Patch overtakes the answering Full — and that redundant
                         // re-ask is itself answered with a Full, which ends the cycle.
+                        //
+                        // 🚨 …AND THE ACK IS ALSO THE EVIDENCE (#1384). An acknowledgement says the
+                        // owner processed this re-subscribe; if a base snapshot never follows, the
+                        // answer died on the leg rather than never being sent, which is exactly the
+                        // non-convergence MaxUnansweredResyncs bounds. Counted HERE and nowhere
+                        // else, deliberately: a re-ask REFUSED transiently is ridden out (#2745)
+                        // and must not accumulate towards a fault, and an increment that races an
+                        // answering Full is undone by that Full's reset a moment later.
                         logger.LogDebug(
                             "[SYNC_STREAM] Fresh-snapshot request for {StreamId} acknowledged by owner {Owner}",
                             StreamId, StreamIdentity.Owner);
+                        Interlocked.Increment(ref unansweredResyncs);
                         ReleaseResyncGate();
                     },
                     ResyncRefused);

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -1954,20 +1954,27 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
         // it would kill an owner's stream for a subscriber-side race. Convergence is a claim about
         // a REMOTE owner; only a stream that has one can fail to converge. Same predicate as
         // OwnerVersion() uses to tell the two apart.
-        if (Volatile.Read(ref unansweredResyncs) >= MaxUnansweredResyncs
-            && !Owner.Equals(Host.Address))
+        //
+        // Read ONCE into a local, and report from that local everywhere. The verdict, the Warning and
+        // the exception must be the same number: a diagnostic that says "gave up after 3" beside an
+        // exception that says "after 4" costs the next reader more than it tells them, and a second
+        // read is one more thing they would have to prove is stable. (It is — the gate is HELD from
+        // here, so the ack arm cannot increment, and the reset runs on this same hub turn — but the
+        // local means nobody has to reconstruct that argument to trust the number.)
+        var unanswered = Volatile.Read(ref unansweredResyncs);
+        if (unanswered >= MaxUnansweredResyncs && !Owner.Equals(Host.Address))
         {
             Volatile.Write(ref resyncGaveUp, 1);
             ReleaseResyncGate();
             logger.LogWarning(
                 "[SYNC_STREAM] Resync gave up for {StreamId}: {Attempts} consecutive fresh-snapshot requests to {Owner} were acknowledged and none produced a base snapshot — faulting the mirror so its subscribers can re-establish",
-                StreamId, Volatile.Read(ref unansweredResyncs), StreamIdentity.Owner);
+                StreamId, unanswered, Owner);
             OnError(new StreamNotConvergingException(
                 $"Synchronization stream '{StreamId}' could not recover from a lost frame: "
-                + $"{Volatile.Read(ref unansweredResyncs)} consecutive fresh-snapshot requests to owner "
-                + $"'{StreamIdentity.Owner}' were acknowledged and none produced a base snapshot. The "
-                + "mirror holds no state it can patch onto, so it is faulted rather than left waiting "
-                + "for a snapshot that is not arriving."));
+                + $"{unanswered} consecutive fresh-snapshot requests to owner '{Owner}' were "
+                + "acknowledged and none produced a base snapshot. The mirror holds no state it can "
+                + "patch onto, so it is faulted rather than left waiting for a snapshot that is not "
+                + "arriving."));
             return;
         }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
@@ -355,6 +355,98 @@ on a rebased clock, the re-ask refused **terminally** (must fault), and the re-a
 **transiently** with the identical `TargetUnserved` stamp (must be ridden out and still
 converge). Each fails on the pre-#2654 tree.
 
+### The termination contract — when the mirror stops asking and faults (#1384)
+
+The contract above recovers a mirror when the leg loses **one** thing. It does not
+terminate when the leg keeps losing **this stream's** snapshots, and that residual is a
+silent forever-wedge: every re-ask is acknowledged, every acknowledgement re-opens the
+gate, every answering Full dies on the way back, and the mirror asks again for the rest of
+the process's life. The `Resync has not converged` Warning above is the only trace, and a
+**log line is not an API** — nothing downstream of the stream is told anything, so nothing
+can re-establish.
+
+Measured on memex-cloud, 2026-09-01, on `Event/SavGeneralversammlung2026/Talk`:
+
+```
+[SYNC_STREAM] Frame loss detected for G4LJWZjBXkWdULLsT-5N5g: incoming Patch v13 chains onto v12
+  but the last applied frame is v11 — a frame was lost in transport; requesting fresh snapshot
+Layout area 'Present' on Event/SavGeneralversammlung2026/Talk was torn down having never rendered
+  — the subscriber only ever saw the "awaiting first data" placeholder.
+```
+
+Plain node reads on that path answered instantly, so the owner was healthy; **recycling the
+pod that held the activation did not clear it**, because the wedge lived entirely in a
+subscriber that had not been told anything was wrong.
+
+So the count of consecutive **acknowledged-and-unanswered** re-asks is bounded, and at
+`SynchronizationStream.MaxUnansweredResyncs` (3) the mirror stops asking and calls
+`OnError` with a `StreamNotConvergingException`.
+
+🚨 **The count is of ACKS, not of asks, and that is the #2745 policy in one line.** The
+increment lives in the ack arm of `RequestFreshSnapshot` and nowhere else. An
+acknowledgement means the owner *processed* the re-subscribe, so a base snapshot that never
+follows died on the leg — evidence. A re-ask **refused transiently** (`ShuttingDown`, the
+rolling-deploy overlap window) is deliberately ridden out by the table above, and counting
+it would fault every mirror in that window, which is worse than the bug this fixes. An
+increment that races an answering Full is undone by that Full's own reset a moment later.
+A re-ask that gets **no verdict at all** (undeliverable, so the hub's own request/response
+terminal fires) is likewise not counted — "we could not find out" is not an answer about
+the owner, and the table above already keeps that case recoverable and loud, one Warning
+carrying the exception per attempt. Widening the count to cover it would be a separate
+decision with a separate justification, not a free extension of this one.
+
+🚨 **Mirrors only.** The give-up applies where `StreamIdentity.Owner` is another hub — the
+same predicate `OwnerVersion()` uses. `PatchDataChangeRequest` reaches `UpdateStream` on the
+*owner's* server-side stream as well, where a subscriber write that races that stream's
+first outbound frame takes the same "Patch before base Full" branch; there the counter never
+resets (the Full that would reset it is one that stream **sends**), so it measures nothing
+and faulting on it would kill an owner's stream for a subscriber-side race.
+
+🚨 **This is a bound on EVIDENCE, not a retry budget.** Nothing here retries and nothing
+polls. An increment costs a full round trip to the owner — the gate suppresses every re-ask
+while one is outstanding, and only the answer releases it — **plus** a subsequent owner
+frame that proves the mirror still has no base. Raising the bound buys a longer silence, not
+a better chance; that is the opposite of a widened timeout, and it is why the number is
+small.
+
+**Why 3.** The one healthy way to spend an attempt without converging is a Patch overtaking
+the answering Full. The owner queues its re-assert on the **same** stream hub that produces
+the patches, so a patch can only overtake a re-assert that was already in flight when the
+re-ask landed — one redundant round trip, twice over at the very worst. The two failure
+directions are also not symmetric:
+
+| bound too low | bound too high |
+|---|---|
+| a stream that would have converged is faulted ⇒ **one re-establish**: `StreamLiveness.IsUsable` refuses to serve a faulted stream (#2387), the cache evicts it, and the next natural caller opens a fresh one that subscribes from scratch | a view that never loads and never says so ⇒ the incident above |
+
+**The fault is the recovery signal**, not the end of the road. A faulted stream is the one
+state every consumer already knows how to act on: the store's terminal error reaches every
+reader, `Workspace` drops it from `_remoteStreamCache` and closes it, and `OnError` also
+calls `Hub.FailStartup` + `Hub.OpenGate(SynchronizationGate)` — which releases whatever was
+deferred behind that gate. Re-establishing stays the *subscriber's* decision, taken because
+it was finally told.
+
+**The operator signal** is `[SYNC_STREAM] Resync gave up for {StreamId}: N consecutive
+fresh-snapshot requests to {Owner} were acknowledged and none produced a base snapshot` at
+**Warning**, followed by the stream's own `OnError` line. Seeing it means the
+owner→subscriber leg is losing frames systematically — read it together with the query
+pressure work in
+[Cross-Schema Fan-Out Elimination](/Doc/Architecture/CrossSchemaFanOutElimination): a leg
+drops frames when the process behind it is saturated, and that saturation is the thing to
+fix. This bound exists so the saturation cannot cash out as a view that is blank forever.
+
+**A note on the ordering inside `RequestFreshSnapshot`.** The method establishes that it
+*can* ask — `Reference is WorkspaceReference` — **before** it nulls the cached JSON or takes
+the gate. That order matters (the reverse closes the gate on a re-ask that was never made,
+permanently by construction) and it is already how the code reads since #2654. It is **not**
+what produced the incident above: `LayoutAreaReference` *is* a `WorkspaceReference`, so the
+Present-area stream took the ordinary path, asked, was acknowledged, and was never answered.
+
+Pinned by `StreamResyncGivesUpTest`: one mid-burst Patch eaten to start the resync, then
+**every** fresh snapshot eaten, one write per proven gap — the mirror must fault with a
+`StreamNotConvergingException`, and a fresh subscriber must then get a new stream that
+converges on the owner's complete state. It hangs on the pre-#1384 tree.
+
 ---
 
 ## 7. Minimal bytes on the wire

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-view-that-never-loads-now-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-view-that-never-loads-now-says-so.md
@@ -1,0 +1,37 @@
+---
+Name: A view that never loads now says so instead of waiting forever
+Category: Fix
+Description: When the same connection kept losing the fresh copy a stuck page asked for, the page waited in silence for good; it now reports the failure so it can reconnect.
+Icon: ArrowSyncCheckmark
+Order: -20260902
+---
+
+# A view that never loads now says so instead of waiting forever
+
+Live areas on a page are kept current by a stream of small updates. If one goes missing on the way,
+the page notices and asks the server for a complete, fresh copy. A previous fix made that recovery
+survive the fresh copy *also* going missing: the page asks again the next time something changes,
+which costs one more round trip instead of the rest of the session.
+
+What was still missing is what happens when the same connection keeps losing **every** fresh copy.
+The page asked, the server answered, the answer never arrived — over and over, forever, without a
+word to the part of the app that draws the area. On screen that was an area stuck on "loading" on a
+page whose menus, banner and breadcrumb were fine, with nothing to click and no error to report.
+It happened during a live presentation on 1 September: a slide deck whose presentation view never
+appeared, while the same page's plain content loaded instantly. Reloading the page could clear it;
+restarting the server could not, because nothing was wrong on the server.
+
+Now the page stops asking after a few unanswered attempts and **reports the failure** instead. That
+one change is what makes recovery possible at all: the failed view is dropped rather than kept, so
+the next thing that needs it opens a fresh connection and loads normally — the same thing a reload
+used to do, without the reload.
+
+Two things this deliberately is not. It is not a timer: the page only ever asks again when a real
+update arrives proving it still has nothing to show, so a quiet page stays quiet. And it is not a
+retry budget — only attempts the server *confirmed it had handled* count, each one costing a full
+round trip plus a fresh piece of evidence, so a handful of them is proof the connection is dropping
+this view's data rather than impatience. An attempt the server turns down because it is briefly
+busy — during a rolling update, say — is waited out as before and never counts against the view.
+
+For anyone reading server logs, the give-up is recorded at warning level naming the view and the
+server it was asking, right after the `Resync has not converged` warnings that precede it.

--- a/test/MeshWeaver.Data.Test/StreamResyncGivesUpTest.cs
+++ b/test/MeshWeaver.Data.Test/StreamResyncGivesUpTest.cs
@@ -1,0 +1,244 @@
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using MeshWeaver.Data.Serialization;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// A RESYNC THAT NEVER CONVERGES MUST STOP BEING SILENT — Systemorph/MeshWeaver#1384.
+///
+/// <para>This is the third member of the frame-loss family, and it starts where the other two stop.
+/// <see cref="StreamFrameLossResyncTest"/> proves the mirror DETECTS a lost frame and asks for a
+/// fresh snapshot. <see cref="StreamResyncConvergenceTest"/> proves it still converges when that ONE
+/// answer fails — the resync gate is released by the re-ask's round trip (#2654), so the next frame
+/// that proves the gap earns one new re-ask. Neither of them TERMINATES when the owner→subscriber
+/// leg keeps eating this stream's snapshots, and that is the state a live portal was measured
+/// in.</para>
+///
+/// <para><b>The live incident.</b> memex-cloud, 2026-09-01, node
+/// <c>Event/SavGeneralversammlung2026/Talk</c>: <c>[SYNC_STREAM] Frame loss detected … incoming
+/// Patch v13 chains onto v12 but the last applied frame is v11</c>, then <c>Layout area 'Present' …
+/// was torn down having never rendered — the subscriber only ever saw the "awaiting first data"
+/// placeholder</c>. Plain node reads on the same path answered instantly and recycling the pod that
+/// held the activation did not clear it: the owner was healthy, and the wedge lived entirely in a
+/// subscriber nobody had told anything was wrong. Every re-ask was acknowledged, every
+/// acknowledgement released the gate, every answering Full died on the same leg, and the mirror
+/// asked again for the rest of the process's life — at Warning in a log, and at NOTHING AT ALL in
+/// the API a consumer can act on.</para>
+///
+/// <para><b>What this test injects, and why it is deterministic.</b> Two losses on the owner's post
+/// pipeline, both scoped to the one mirror stream under test: one mid-burst Patch (the wire loss
+/// that starts the resync — the same injection the other two tests use), and then EVERY
+/// <see cref="ChangeType.Full"/> the owner sends on that stream, which is what a leg that keeps
+/// losing frames looks like from the mirror. The test posts the next write only after the loss it
+/// depends on has actually happened — an event, never a delay — so the sequence of proven gaps is
+/// fixed rather than raced.</para>
+///
+/// <para><b>The contract.</b> Past <c>MaxUnansweredResyncs</c> ACKNOWLEDGED, unanswered re-asks the
+/// mirror stops asking and FAULTS. That is not a retry budget: an increment costs a full round trip
+/// to the owner plus a subsequent frame proving the mirror still has no base, so the count is
+/// evidence, not effort. And the fault is not the end of the story — it is the only signal a
+/// subscriber can act on. <c>StreamLiveness.IsUsable</c> refuses to serve a faulted stream (#2387),
+/// so the workspace cache evicts it and the next natural caller opens a fresh one that subscribes
+/// from scratch; the second half of this test proves exactly that.</para>
+/// </summary>
+public class StreamResyncGivesUpTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// How many acknowledged-but-unanswered fresh-snapshot requests the mirror tolerates before it
+    /// faults. Mirrors <c>SynchronizationStream.MaxUnansweredResyncs</c>, which is private — the
+    /// coupling is deliberate and asserted by construction: the drive loop below spends exactly this
+    /// many attempts and then expects the next proven gap to fault. If the production bound moves
+    /// and this does not, the loop under-drives and the fault wait goes red, which is the right way
+    /// round for a guard.
+    /// </summary>
+    private const int MaxUnansweredResyncs = 3;
+
+    /// <summary>1 after the pipeline ate its one mid-burst Patch. Instance field — per-test lifetime.</summary>
+    private int droppedPatches;
+
+    /// <summary>
+    /// Patch frames the owner has emitted on the mirror's stream. The loss is injected on the SECOND
+    /// one so the mirror has applied a real patch first — a gap can only be PROVEN against a frame
+    /// that landed.
+    /// </summary>
+    private int patchFramesSeen;
+
+    /// <summary>
+    /// How many fresh snapshots the pipeline has eaten. Every one of them is a re-ask the owner
+    /// answered and the leg destroyed.
+    /// </summary>
+    private int droppedFreshSnapshots;
+
+    /// <summary>
+    /// Fires once per eaten fresh snapshot, carrying the running count. A
+    /// <see cref="ReplaySubject{T}"/> because the injection runs on the owner's post pipeline and
+    /// can complete before the test subscribes.
+    /// </summary>
+    private readonly ReplaySubject<int> freshSnapshotDropped = new(MaxUnansweredResyncs + 2);
+
+    /// <summary>
+    /// The stream carrying the mirror this test is about, learned from its INITIAL Full. Both hubs
+    /// run a data source, so more than one sync stream is alive; every injection is scoped to this
+    /// id so the test can never eat a frame belonging to somebody else's stream — including the
+    /// FRESH stream the recovery half opens, whose id is different by construction.
+    /// </summary>
+    private volatile string? mirrorStreamId;
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(ds => ds
+                .WithType<MyData>(t => t.WithKey(d => d.Id))))
+            .AddPostPipeline(p => p.AddPipeline((d, next) =>
+            {
+                if (d.Message is not DataChangedEvent evt)
+                    return next.Invoke(d);
+
+                // Learn the mirror's stream from its initial Full — the first frame it ever gets.
+                if (evt.ChangeType == ChangeType.Full && mirrorStreamId is null)
+                {
+                    mirrorStreamId = evt.StreamId;
+                    return next.Invoke(d);
+                }
+                if (evt.StreamId != mirrorStreamId)
+                    return next.Invoke(d);
+
+                // THE WIRE LOSS that starts the resync: eat exactly one mid-burst Patch. An Ignored
+                // post is dropped by ScheduleNotify, exactly the shape of the at-most-once transport
+                // losing a published frame between owner and mirror.
+                if (evt.ChangeType == ChangeType.Patch
+                    && Interlocked.Increment(ref patchFramesSeen) == 2
+                    && Interlocked.Exchange(ref droppedPatches, 1) == 0)
+                    return d.Ignored();
+
+                // …AND THE LEG KEEPS LOSING. Every fresh snapshot the owner sends in answer to a
+                // re-ask dies exactly like the frame that started the resync. This is the ONE thing
+                // this test adds to StreamResyncConvergenceTest, which eats a single answer and then
+                // lets the mirror converge.
+                if (evt.ChangeType == ChangeType.Full)
+                {
+                    // Signalling HERE is ORDERED, not hopeful: the owner posts its SubscribeAck from
+                    // HandleSubscribeRequest the moment SubscribeToClient returns, while the
+                    // re-assert runs later on the stream's own turn — so by the time this frame
+                    // exists the ack is already on its way to the mirror's host hub, ahead of
+                    // anything the test posts next. The write below therefore lands on an OPEN gate
+                    // with still no base: the frame that earns the next re-ask.
+                    freshSnapshotDropped.OnNext(Interlocked.Increment(ref droppedFreshSnapshots));
+                    return d.Ignored();
+                }
+                return next.Invoke(d);
+            }));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .AddData(data => data.AddSource(ds => ds
+                .WithType<MyData>(t => t.WithKey(d => d.Id))));
+
+    /// <summary>
+    /// THE WEDGE BECOMES AN ERROR, AND THE ERROR BECOMES A RECOVERY.
+    ///
+    /// <para>Pre-fix this test hangs on its fault wait: the mirror re-asks forever, the log fills
+    /// with "Resync has not converged", and the subscriber is handed neither a value nor a terminal
+    /// — which is precisely why the production incident survived a pod recycle.</para>
+    /// </summary>
+    [HubFact]
+    public async Task AResyncThatNeverConverges_FaultsTheMirror_AndAFreshSubscriberRecovers()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        var accessService = host.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetContext(new AccessContext { ObjectId = "alice", Name = "Alice" });
+
+        var collectionName = host.GetWorkspace().DataContext.GetTypeSource(typeof(MyData))!.CollectionName;
+        var clientWorkspace = client.GetWorkspace();
+        var clientStream = clientWorkspace
+            .GetRemoteStream<EntityStore>(CreateHostAddress(), new CollectionsReference(collectionName));
+
+        // The mirror is live and mirrorStreamId is known — every injection below is scoped to it.
+        await clientStream.Should().Within(10.Seconds()).Emit();
+
+        // Arm the terminal wait BEFORE driving. A store is a ReplaySubject, so subscribing after the
+        // fault would still replay it; arming first means the assertion cannot be satisfied by
+        // anything that happened before the drive, and it makes the pre-fix failure a TIMEOUT on the
+        // thing that never happens rather than a race with the drive loop.
+        var faulted = clientStream
+            .Materialize()
+            .Where(n => n.Kind == NotificationKind.OnError)
+            .Select(n => n.Exception!)
+            .Take(1)
+            .Replay(1);
+        using var faultedConnection = faulted.Connect();
+
+        // A burst whose SECOND patch the wire eats — the third patch chains onto a version the
+        // mirror never applied, which is proven gap #1 and earns re-ask #1.
+        for (var i = 1; i <= 3; i++)
+            host.Post(
+                new DataChangeRequest().WithUpdates(new MyData($"doc-{i}", $"value-{i}")),
+                o => o.WithAccessContext(accessService.Context!));
+
+        // Then one write per further proven gap. Each iteration waits for the answer to the PREVIOUS
+        // re-ask to have been destroyed — the event, never a delay — so the next write is guaranteed
+        // to be a frame the mirror sees while it still holds no base.
+        for (var attempt = 1; attempt <= MaxUnansweredResyncs; attempt++)
+        {
+            var expected = attempt;
+            await freshSnapshotDropped
+                .Where(count => count >= expected)
+                .Take(1)
+                .Should().Within(15.Seconds())
+                .Emit($"the owner must have ANSWERED re-ask {expected} with a fresh snapshot for the "
+                    + "leg to destroy — an unanswered re-ask would mean this test is measuring a "
+                    + "refusal, which StreamResyncConvergenceTest already covers");
+
+            host.Post(
+                new DataChangeRequest().WithUpdates(new MyData($"doc-{3 + attempt}", $"value-{3 + attempt}")),
+                o => o.WithAccessContext(accessService.Context!));
+        }
+
+        // THE ASSERTION. The gap proven by that last write must fault the mirror instead of asking a
+        // fourth time into a leg that has now destroyed three acknowledged snapshots.
+        var error = await faulted
+            .Should().Within(20.Seconds())
+            .Emit("a mirror whose fresh snapshots keep being lost must SURFACE that, not re-ask "
+                + "forever: a subscriber that is never told cannot re-establish, which is how one "
+                + "lost frame became a layout area that never rendered");
+
+        error.Should().BeOfType<StreamNotConvergingException>(
+            "the fault must name the non-convergence rather than arrive as some incidental "
+            + "exception — a consumer classifies on the type");
+
+        Volatile.Read(ref droppedPatches).Should().Be(1,
+            "the wire loss is what starts the resync — without it there is no re-ask to leave "
+            + "unanswered and this test asserts nothing");
+        Volatile.Read(ref droppedFreshSnapshots).Should().BeGreaterThanOrEqualTo(MaxUnansweredResyncs,
+            "every re-ask must have been ANSWERED and the answer destroyed — that is the shape this "
+            + "test exists for, as opposed to an owner that simply went quiet or refused");
+
+        // AND THE RECOVERY. The faulted stream is unusable, so the workspace cache must not hand it
+        // back: a fresh subscriber gets a NEW stream (a new StreamId, therefore untouched by the
+        // injections above) which subscribes from scratch and converges on the owner's state. This
+        // is the whole point of faulting rather than waiting.
+        var recovered = clientWorkspace
+            .GetRemoteStream<EntityStore>(CreateHostAddress(), new CollectionsReference(collectionName));
+
+        ReferenceEquals(recovered, clientStream).Should().BeFalse(
+            "a faulted mirror must be evicted from the stream cache, not replayed to the next caller");
+
+        await recovered
+            .Where(ci => ci.Value?.Collections.GetValueOrDefault(collectionName) is { } coll
+                && coll.Instances.Values.OfType<MyData>()
+                    .Count(dd => dd.Text?.StartsWith("value-") == true) == 3 + MaxUnansweredResyncs)
+            .Take(1)
+            .Should().Within(20.Seconds())
+            .Emit("the subscriber that learned of the failure must be able to re-establish and see "
+                + "the owner's complete state — surfacing the wedge is only useful if recovery "
+                + "follows from it");
+    }
+}


### PR DESCRIPTION
Closes the residual of #1384 (RCA in [this comment](https://github.com/Systemorph/MeshWeaver/issues/1384#issuecomment-3186142614)) — defence in depth for a frame that IS lost, so the recovery cannot become a silent permanent wedge.

## The residual #2654 left behind

A Patch whose `BasedOnVersion` does not chain onto the last applied frame proves a frame was lost in transport, so the mirror asks the owner for a fresh snapshot. **#2654 made that recovery survive ONE lost answer**: the resync gate is released by the re-ask's *round trip*, so the next proven gap earns one new re-ask.

What it could not do is **terminate**. When the owner→subscriber leg keeps eating *this stream's* snapshots:

- every re-ask is **acknowledged** (the owner is healthy — it processes the re-subscribe fine),
- every acknowledgement releases the gate,
- every answering Full dies on the same leg that lost the original frame,
- and the mirror re-asks for the rest of the process's life.

`Resync has not converged` at Warning is the only trace, and **a log line is not an API**: the subscriber is handed neither a value nor a terminal, so nothing downstream can re-establish.

## The live incident — memex-cloud, 2026-09-01, `Event/SavGeneralversammlung2026/Talk`

```
[SYNC_STREAM] Frame loss detected for G4LJWZjBXkWdULLsT-5N5g: incoming Patch v13 chains onto v12
  but the last applied frame is v11 — a frame was lost in transport; requesting fresh snapshot
Layout area 'Present' on Event/SavGeneralversammlung2026/Talk was torn down having never rendered
  — the subscriber only ever saw the "awaiting first data" placeholder.
```

Plain node reads on that path answered instantly, and **recycling the pod holding the activation did not clear it** — the owner was healthy, and the wedge lived entirely in a subscriber nobody had told anything was wrong. Repro from the user: present the deck, page to the last slide, press Esc.

The *root* cause of the frame loss is being handled elsewhere (#2976 blocked from prod by #1043 ⇒ null `AccessContext` ⇒ cross-schema fan-out ⇒ 6–9 s queries ⇒ dropped frames). **This PR is not about that.** It is about what happens when a frame is lost anyway, and it holds while the portal is slow.

## The fix

Bound the count of consecutive **acknowledged-and-unanswered** re-asks. At `MaxUnansweredResyncs` (3) the mirror stops asking and `OnError`s with a new `StreamNotConvergingException`.

That fault **is** the recovery signal. `StreamLiveness.IsUsable` already refuses to serve a faulted stream (#2387), so `Workspace` evicts and closes it and the next natural caller opens a fresh one that subscribes from scratch; `OnError` also opens `SynchronizationGate`, releasing whatever was deferred behind it.

### Three things this deliberately is NOT

| not | why |
|---|---|
| a **timer / poller / watchdog** | nothing retries, nothing polls. An increment costs a full round trip to the owner (the gate suppresses every re-ask while one is outstanding, and only the answer releases it) **plus** a subsequent owner frame proving the mirror still has no base. It counts EVIDENCE, not effort — raising the bound buys a longer silence, not a better chance |
| a count of **asks** | the increment lives in the **ack arm** and nowhere else. A re-ask refused *transiently* (`ShuttingDown` — the rolling-deploy overlap window, #2745) is deliberately ridden out, and counting it would fault every mirror in that window, which `ResyncRefused` already calls "a worse outcome than the bug this ticket fixes". A re-ask with no verdict at all stays recoverable and loud, unchanged |
| applied to a **self-owned** stream | `PatchDataChangeRequest` reaches `UpdateStream` on the owner's server-side stream too, where the counter never resets (the Full that would reset it is one that stream *sends*), so it measures nothing. Guarded with the same `Owner.Equals(Host.Address)` predicate `OwnerVersion()` uses |

### The latch ordering the RCA also flagged

`RequestFreshSnapshot` nulling the cache and latching **before** its `Reference is WorkspaceReference` check was fixed by be39fc607 (#2654) and is already correct on main. **It would not have prevented this incident**: `LayoutAreaReference : WorkspaceReference<EntityStore>`, so the Present-area stream took the ordinary path — it asked, was acknowledged, and was never answered.

## Verification — deterministic repro, and it can fail

`StreamResyncGivesUpTest` injects two losses on the owner's post pipeline, both scoped to the one mirror stream: one mid-burst Patch (starts the resync), then **every** `Full` on that stream. One write per proven gap, each gated on the *event* that the previous answer was destroyed — never a delay.

**Inverted probe** (`MaxUnansweredResyncs = int.MaxValue`, i.e. pre-fix "never give up") — the whole project, `DOTNET_PROCESSOR_COUNT=4`, Release:

```
[Warning] [SYNC_STREAM] Frame loss detected for HlKMxLgrO0uYjT709DO6jQ: incoming Patch v4
  chains onto v3 but the last applied frame is v2 — a frame was lost in transport
[Warning] [SYNC_STREAM] Resync has not converged … asking host/1 for a fresh snapshot again (attempt 2)
[Warning] [SYNC_STREAM] Resync has not converged … asking host/1 for a fresh snapshot again (attempt 3)
[Warning] [SYNC_STREAM] Resync has not converged … asking host/1 for a fresh snapshot again (attempt 4)
=== TEST FAILED: Expected the observable to emit a value within 20s … but it did not.
    The observable emitted nothing at all.

Failed!  - Failed: 1, Passed: 420, Skipped: 0, Total: 421 - MeshWeaver.Data.Test.dll
```

That is the production signature reproduced in a test, and then the silence.

**Restored** — same project, same flags:

```
Passed!  - Failed: 0, Passed: 421, Skipped: 0, Total: 421, Duration: 1 m 39 s - MeshWeaver.Data.Test.dll
Passed StreamResyncGivesUpTest.AResyncThatNeverConverges_FaultsTheMirror_AndAFreshSubscriberRecovers
```

Also green: `MeshWeaver.Documentation.Test` 172/172, and a deliberately-broken-link probe confirmed `DocumentationLinkIntegrityTest` names the edited page (`Doc/Architecture/DataSyncAndCrdt: … does not exist`) rather than passing vacuously. `dotnet build -c Release -warnaserror`, one project per invocation: `0 Warning(s) / 0 Error(s)` on `MeshWeaver.Data`, `MeshWeaver.Documentation`, `MeshWeaver.Data.Test`, `MeshWeaver.Documentation.Test`. `check-record-signatures.py` and `check-type-forwards.py` both clean against current main.

## Work products conserved

- `Doc/Architecture/DataSyncAndCrdt` → new section **"The termination contract — when the mirror stops asking and faults (#1384)"**: the incident, why the count is of acks, the mirrors-only qualifier, the bound-too-low/too-high asymmetry, the operator signal, and the deliberate boundary at "no verdict at all".
- What's New entry (`Category: Fix`) — a user notices a view that never loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
