### PR TITLE
perf(import): the static-repo import writes creates in BULK — ⌈n÷25⌉ requests, not n

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
@@ -128,6 +128,51 @@ the instruction, so it is stated rather than escalated.
 
 The importer must be **idempotent over existing rows** (re-imports, eventually-consistent snapshots, and especially the migration backfill's content-NULL shadow rows). Plain `CreateNode` faults on an existing node; a hand-rolled stream-`Overwrite` re-asserts the *same* Version, which the owner drops as not-newer — so content silently never lands. The canonical `CreateOrUpdateNodeRequest` does the right thing for both cases and **increments the Version on update**, so the write is accepted and persists. This is non-negotiable: do not re-implement create/update in the importer.
 
+### Creates travel in BULK; updates do not — and why that is not a compromise
+
+An import used to cost **one write request and one single-row upsert per node**. Storage has had the
+bulk contract all along — `IStorageAdapter.WriteMany`, which the PostgreSQL adapter implements as one
+`NpgsqlBatch` **per (schema, table) window**: N upserts, one round-trip, one implicit transaction, the
+same upsert SQL the singular `Write` uses. Nothing on the import path reached it, because **a node
+write has to route through the mesh's canonical verbs**, and `WriteMany` is an `IStorageAdapter` call
+one level below them. Calling the adapter from the importer would have bought the batching by dropping
+the typing, access check and per-node-hub observability the write depends on.
+
+The answer is a **bulk verb, not a bypass**. `CreateNodesRequest` is the bulk sibling of
+`CreateNodeRequest` and runs the identical pipeline — partition bootstrap once per partition, every
+validator including RLS for every node, the type-existence probe per distinct type, then **one**
+`WriteMany`, the `Created` change-feed publishes in caller order post-commit, and the post-creation
+handlers. So the importer splits each **write stage** (see [Import Write Ordering](ImportWriteOrdering)
+— everything inside a stage may be written concurrently, a stage begins only after the previous one
+completed):
+
+| Write | Verb | Why |
+|---|---|---|
+| **Plain create** (this pass read no node at the path) | `CreateNodesRequest`, chunked at 25 | Nobody owns the node yet — the create is executed by the mesh hub against storage either way, so batching changes only how many times it crosses the wire. |
+| **Update** (a node is already there) | `CreateOrUpdateNodeRequest` per node | An update is applied by the node's **own hub** through `GetMeshNodeStream(path).Update(...)`. The mesh hub does not write over a live node, so there is nothing to batch. |
+| **Satellite** (`_Access`, `_Policy`, …) **or `AccessAssignment`** | `CreateOrUpdateNodeRequest` per node | Per-node lifecycle guards and MainNode normalization. `CreateNodesRequest.BulkRefusal` is the single statement of that rule — the handler and the importer both ask it, so the two cannot drift. |
+
+Two properties are load-bearing and neither is free:
+
+1. **Per-file isolation survives.** `CreateNodesRequest` is validate-all-then-write: one offender
+   refuses the whole request and can name at most one path, while the import's contract is the
+   opposite — every other node still has to land, and the one that did not has to be **named**,
+   because `Failed > 0` is what holds the git baseline. So a **refused or faulted batch is re-run one
+   node at a time**, which attributes the failure to the file that caused it and lands everything
+   else. The extra pass is paid only on the failing chunk. Likewise a path the batch reports in
+   `CreateNodesResponse.Existing` — the snapshot said "absent", the authoritative read disagreed — is
+   an update, and falls through to the per-node verb rather than being dropped.
+2. **The chunks are MERGED, not concatenated.** `BatchSize` bounds *concurrent heavy operations*, and
+   one bulk request is internally sequential. Running the chunks back to back would cut the import's
+   concurrency from ~5 to 1 and could make a large first import **slower** than the per-node path it
+   replaces. Merged at `BatchSize`, the bound is unchanged and each of those in-flight operations now
+   carries 25 nodes instead of one.
+
+`StaticRepoImportResult.WriteRequests` reports the round-trip count — `⌈bulk creates ÷ 25⌉` plus one
+per node written individually — and the import's summary log line carries it, so "did this import
+batch?" is answerable from an operator's log rather than by reading code. A first import of 40 fresh
+nodes costs **2** requests; it used to cost 40.
+
 ## Scope: mesh nodes AND content-collection files
 
 The import materializes both **mesh nodes** (a node's `Content` + prerendered HTML, via the node upsert above) and, for sources that need it, the node's **content-collection files** — the assets a node references through the `content` collection, e.g. an `@@content/logo.svg` image embed on a Space page.
@@ -241,3 +286,4 @@ Shipped and enabled for `Doc` / `Agent` / `Model` on the distributed portal. The
 - Re-run with an unchanged source is a **no-op** (fingerprint short-circuit).
 - The import runs on the **dedicated `import/{meshHubId}` hub**, not the root mesh hub — the bulk create/upsert traffic never touches the router (verified end-to-end by `OrleansStaticRepoImportTest` / `OrleansContentImportSyncTest`, which complete only because the import hub is reachable).
 - A **single node failing does not abort the import**; it logs a `⚠` line and the activity ends **`Warning`**, not a green `Succeeded`.
+- A first import of a whole partition costs **⌈n ÷ 25⌉ write requests, not n** — and a node the batch cannot carry (a satellite) or that a validator refuses is routed around it / re-run individually, so it is still named and everything else still lands (`StaticRepoImportBulkWriteTest`).

--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
@@ -142,7 +142,7 @@ The answer is a **bulk verb, not a bypass**. `CreateNodesRequest` is the bulk si
 `CreateNodeRequest` and runs the identical pipeline — partition bootstrap once per partition, every
 validator including RLS for every node, the type-existence probe per distinct type, then **one**
 `WriteMany`, the `Created` change-feed publishes in caller order post-commit, and the post-creation
-handlers. So the importer splits each **write stage** (see [Import Write Ordering](ImportWriteOrdering)
+handlers. So the importer splits each **write stage** (see [Import Write Ordering](/Doc/Architecture/ImportWriteOrdering)
 — everything inside a stage may be written concurrently, a stage begins only after the previous one
 completed):
 

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -75,6 +75,20 @@ public sealed record StaticRepoImportResult(string Partition, string Fingerprint
     /// none" on its root), where declining everything IS the instruction.
     /// </summary>
     public ImmutableList<string> BlockedCreatePaths { get; init; } = ImmutableList<string>.Empty;
+
+    /// <summary>
+    /// How many WRITE REQUESTS this import posted to the mesh hub — the round-trip count, not the node
+    /// count.
+    ///
+    /// <para>Plain creates travel in bulk (one <c>CreateNodesRequest</c> per chunk, which reaches
+    /// storage as ONE <c>WriteMany</c> — on Postgres one batch per (schema, table) window), while
+    /// updates, satellites and grants keep the per-node verb because their write has to route through
+    /// the owning per-node hub. So this is <c>⌈bulk creates ÷ chunk⌉ + one per node written
+    /// individually</c>, and on a first import of a whole partition it is a small fraction of
+    /// <see cref="StaticRepoImportResult.Count"/>. It used to equal it exactly
+    /// (Systemorph/MeshWeaver.Plugins#1013).</para>
+    /// </summary>
+    public int WriteRequests { get; init; }
 }
 
 /// <summary>
@@ -144,6 +158,22 @@ public static class StaticRepoImporter
     /// than floods; sources still run sequentially (<c>.Concat()</c>), so this is the only concurrency.
     /// </summary>
     private const int BatchSize = 5;
+
+    /// <summary>
+    /// How many plain CREATES travel in ONE <see cref="CreateNodesRequest"/>
+    /// (Systemorph/MeshWeaver.Plugins#1013). A stage's creates are chunked at this size, so the
+    /// import costs ⌈creates/25⌉ cross-hub round-trips instead of one per node, and each request
+    /// reaches storage as ONE <c>IStorageAdapter.WriteMany</c> — on Postgres one <c>NpgsqlBatch</c>
+    /// per (schema, table) window rather than N separate statements.
+    ///
+    /// <para>Deliberately a few dozen rather than "the whole stage". The bulk handler validates,
+    /// type-probes and runs post-creation handlers SEQUENTIALLY over its batch, so the request's
+    /// duration grows with the chunk and has to stay well inside the hub's request timeout; and a
+    /// refused batch is re-run one node at a time to attribute the failure, so the chunk also bounds
+    /// what a single bad node costs. 25 removes 96% of the round-trips; 200 would remove 99.5% and
+    /// buy that with an eight-times longer request and an eight-times more expensive fallback.</para>
+    /// </summary>
+    private const int BulkCreateBatchSize = 25;
 
     /// <summary>
     /// How many blocked-create paths the import NAMES in its summary + log line before summarising the
@@ -1031,192 +1061,238 @@ public static class StaticRepoImporter
                     && unsatisfiableTypes.Contains(sourceNode.NodeType!)
                     && !ImportWriteOrder.TypeIsOrderedAhead(plan, sourceNode);
 
+                // 🚨 ONE WRITE PER STAGE, NOT ONE PER NODE (Systemorph/MeshWeaver.Plugins#1013).
+                // The decision for a source node is PURE — claimed? blocked? outside the git diff?
+                // unchanged? server-newer? — so it is taken here, in memory, for the whole stage
+                // before anything is posted. Only the nodes that actually have to be written reach
+                // a hub, and the ones that are plain CREATES (this pass read no node at that path)
+                // travel together in ONE CreateNodesRequest per chunk: one cross-hub round-trip
+                // instead of N, and ONE IStorageAdapter.WriteMany instead of N single Writes —
+                // which on Postgres is one NpgsqlBatch per (schema, table) window rather than N
+                // statements. The bulk verb is the SAME pipeline the singular create runs (partition
+                // bootstrap, every validator including RLS, the type-existence probe, the
+                // post-creation handlers), so nothing is bypassed: this is the canonical mesh verb,
+                // just addressed to a list. Writes that are NOT plain creates keep the per-node
+                // canonical upsert, because that is where the write has to route through the OWNING
+                // per-node hub's stream — an update is applied by the node's own hub, never by the
+                // mesh hub, and satellites and grants carry per-node lifecycle guards.
+                bool IsBulkCreate(MeshNode node, MeshNode? target) =>
+                    // Absent as far as this pass could tell. The snapshot is eventually consistent,
+                    // so this can be stale — the bulk verb re-reads authoritatively and reports any
+                    // path that turned out to exist in CreateNodesResponse.Existing, which falls
+                    // back to the per-node upsert below rather than being dropped.
+                    target is null
+                    // The refusal rules of CreateNodesRequest itself, asked of the contract rather
+                    // than re-derived here — one implementation, so the two cannot drift.
+                    && CreateNodesRequest.BulkRefusal(node) is null;
+
+                // The round-trip count this import reports back (StaticRepoImportResult.WriteRequests)
+                // — the evidence that the writes really are batched, in the operator's own log line.
+                var tally = new WriteTally();
+
                 var upserted = Observable.Concat(plan.Stages
-                    .Select(stage => stage
-                    .Select(sourceNode =>
+                    .Select(stage =>
                     {
-                        var path = sourceNode.Path;
-                        existing.TryGetValue(path, out var target);
-                        if (IsClaimed(path, target))
-                        {
-                            // 🚨 A CLAIMED SKIP OF A NODE THAT DOES NOT EXIST IS NOT A SKIP — it is a
-                            // node the source declares that can NEVER appear, and it is counted and
-                            // NAMED (see the terminal-status decision below). A claim means "this is
-                            // the admin's now, don't overwrite it"; there is nothing to protect on a
-                            // path the mesh has no node at, so a claim that blocks its CREATION is a
-                            // claim that is wider than the thing it protects. That is issue #2211:
-                            // Provider/{name} was claimed ExcludeThisAndChildren, so the 12 configured
-                            // LanguageModel children were declined on every boot, the import wrote
-                            // "Imported: 0 node(s)" and stamped the marker Succeeded — and Succeeded at
-                            // that fingerprint is the durable short-circuit, so every later boot
-                            // skipped before it could look at anything. Permanent AND invisible.
-                            logger?.LogDebug(
-                                "[StaticRepoImport] {Partition}: skip claimed {Path}", source.Partition, path);
-                            return Observable.Return((
-                                Imported: 0, Failed: 0, Preserved: 0, Claimed: 1,
-                                Written: (string?)null,
-                                Blocked: target is null ? (string?)path : null,
-                                Log: (LogMessage?)null));
-                        }
+                        // ——— Decide, in stage order, without touching the mesh. ———
+                        var settled = new List<ImportItem>();
+                        var bulk = new List<MeshNode>();
+                        var singles = new List<MeshNode>();
+                        // A stage may carry the SAME path twice (ImportWritePlan keeps duplicates
+                        // together in input order). The bulk verb refuses a batch with a duplicate
+                        // path, and last-writer-wins is the semantics a duplicate has always had —
+                        // so only the first copy is bulk-creatable and every later one takes the
+                        // per-node upsert, which runs AFTER the batch (Concat below).
+                        var seenInStage = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
 
-                        // 🚨 A TYPE THIS PASS CANNOT PUT IN PLACE IS DRIFT, NOT A FAILURE TO RETRY
-                        // (#2556). Ordering fixes the case where the type is carried by this very
-                        // import; it cannot fix a type that arrives from ANOTHER partition/repo, nor a
-                        // cycle where two nodes type each other. Attempting the write anyway is what
-                        // produced the 6,902 refusals: the create is refused, the ⚠ counts as a per-file
-                        // FAILURE, and Failed>0 holds the git baseline — so one node whose type lives
-                        // elsewhere froze every LATER commit of the same repo as well, while the same
-                        // refusal was re-logged on every pass. Named as a BLOCKED CREATE instead: the
-                        // marker is stamped Warning (so the next boot re-attempts and it self-heals the
-                        // moment the defining source is installed), the path and the missing type are
-                        // reported, and the baseline is free to move on. No write is attempted, so the
-                        // refusal — and its log line — is not produced at all.
-                        if (TypeCannotLand(sourceNode, target))
+                        foreach (var sourceNode in stage)
                         {
-                            logger?.LogWarning(
-                                "[StaticRepoImport] {Partition}: {Path} declares NodeType '{NodeType}', which "
-                                + "this source does not carry ahead of it and the mesh does not have — the "
-                                + "create would be refused. Recorded as a blocked create; import the source "
-                                + "that defines '{NodeType}', or drop the node.",
-                                source.Partition, path, sourceNode.NodeType, sourceNode.NodeType);
-                            return Observable.Return((
-                                Imported: 0, Failed: 0, Preserved: 0, Claimed: 0,
-                                Written: (string?)null,
-                                Blocked: (string?)path,
-                                Log: (LogMessage?)new LogMessage(
-                                    $"🚫 {path}: NodeType '{sourceNode.NodeType}' is not carried by this "
-                                    + "source and is absent from the mesh — no write order can create it.",
-                                    Microsoft.Extensions.Logging.LogLevel.Warning)));
-                        }
-
-                        // 🅶 Git-diff scope: when the caller supplied the changed-path set (a webhook /
-                        // reimport that diffed the last-synced commit against the new head), an EXISTING
-                        // node NOT in that set was not touched by any commit since the last sync — skip it
-                        // WITHOUT computing its token or re-upserting. This survives a missing/stale
-                        // manifest (the failure that made every webhook re-materialise the whole partition
-                        // → mass recompile storm, memex-cloud 2026-07-23): git, not a mesh write that can
-                        // fail under load, is the authority on "what changed". A node ABSENT from the DB is
-                        // NOT skipped even if outside the diff (first materialisation / self-heal safety),
-                        // and prune still runs over the full source set, so deletes are unaffected.
-                        if (changedNodePaths is not null && target is not null
-                            && !changedNodePaths.Contains(path))
-                        {
-                            // 🚨 A server-newer node OUTSIDE the diff scope is still a pending LOCAL
-                            // change: the repo copy didn't change, so there is nothing to apply — but
-                            // the mesh is AHEAD of the repo for this node (the edit isn't committed
-                            // back yet). Count it PRESERVED so the caller does not advance the
-                            // conflict horizon (LastSyncedAt) past it — otherwise a LATER repo edit
-                            // to this file would no longer see it as "newer on the server" and
-                            // silently overwrite the edit (the diff-scope shape of issue #677).
-                            if (policy?.PreservesServerCopyOf(target) == true)
+                            var path = sourceNode.Path;
+                            existing.TryGetValue(path, out var target);
+                            if (IsClaimed(path, target))
                             {
+                                // 🚨 A CLAIMED SKIP OF A NODE THAT DOES NOT EXIST IS NOT A SKIP — it is a
+                                // node the source declares that can NEVER appear, and it is counted and
+                                // NAMED (see the terminal-status decision below). A claim means "this is
+                                // the admin's now, don't overwrite it"; there is nothing to protect on a
+                                // path the mesh has no node at, so a claim that blocks its CREATION is a
+                                // claim that is wider than the thing it protects. That is issue #2211:
+                                // Provider/{name} was claimed ExcludeThisAndChildren, so the 12 configured
+                                // LanguageModel children were declined on every boot, the import wrote
+                                // "Imported: 0 node(s)" and stamped the marker Succeeded — and Succeeded at
+                                // that fingerprint is the durable short-circuit, so every later boot
+                                // skipped before it could look at anything. Permanent AND invisible.
                                 logger?.LogDebug(
-                                    "[StaticRepoImport] {Partition}: outside git-diff scope, {Path} is server-newer — counted preserved.",
-                                    source.Partition, path);
-                                return Observable.Return(
-                                    (Imported: 0, Failed: 0, Preserved: 1, Claimed: 0, Written: (string?)null, Blocked: (string?)null, Log: (LogMessage?)null));
+                                    "[StaticRepoImport] {Partition}: skip claimed {Path}", source.Partition, path);
+                                settled.Add(new ImportItem(
+                                    Claimed: 1, Blocked: target is null ? path : null));
+                                continue;
                             }
-                            logger?.LogDebug(
-                                "[StaticRepoImport] {Partition}: outside git-diff scope, skipping {Path}",
-                                source.Partition, path);
-                            return Observable.Return(
-                                (Imported: 0, Failed: 0, Preserved: 0, Claimed: 0, Written: (string?)null, Blocked: (string?)null, Log: (LogMessage?)null));
-                        }
 
-                        // Incremental skip: unchanged since the last import (same source token) AND the
-                        // node is actually present (so a drifted/deleted node still re-imports). Skips the
-                        // expensive cross-hub upsert + owner re-render. Token is over the RAW source node,
-                        // matching what the manifest stored.
-                        var token = PartitionSourceFingerprint.ComputeNodeToken(sourceNode, hub.JsonSerializerOptions);
-                        if (target is not null
-                            && manifest.TryGetValue(path, out var prevToken)
-                            && string.Equals(prevToken, token, StringComparison.Ordinal))
-                        {
-                            // 🚨 Same shape as the diff-scope skip above: an unchanged repo copy of a
-                            // SERVER-NEWER node means the mesh is ahead (a pending local edit, not
-                            // yet committed back). Count it preserved so the conflict horizon stays
-                            // put; skipping with 0 let the horizon advance past the edit and disarm
-                            // the two-way protection for the next repo push (issue #677).
-                            if (policy?.PreservesServerCopyOf(target) == true)
+                            // 🚨 A TYPE THIS PASS CANNOT PUT IN PLACE IS DRIFT, NOT A FAILURE TO RETRY
+                            // (#2556). Ordering fixes the case where the type is carried by this very
+                            // import; it cannot fix a type that arrives from ANOTHER partition/repo, nor a
+                            // cycle where two nodes type each other. Attempting the write anyway is what
+                            // produced the 6,902 refusals: the create is refused, the ⚠ counts as a per-file
+                            // FAILURE, and Failed>0 holds the git baseline — so one node whose type lives
+                            // elsewhere froze every LATER commit of the same repo as well, while the same
+                            // refusal was re-logged on every pass. Named as a BLOCKED CREATE instead: the
+                            // marker is stamped Warning (so the next boot re-attempts and it self-heals the
+                            // moment the defining source is installed), the path and the missing type are
+                            // reported, and the baseline is free to move on. No write is attempted, so the
+                            // refusal — and its log line — is not produced at all.
+                            if (TypeCannotLand(sourceNode, target))
                             {
-                                logger?.LogDebug(
-                                    "[StaticRepoImport] {Partition}: unchanged in repo, {Path} is server-newer — counted preserved.",
-                                    source.Partition, path);
-                                return Observable.Return(
-                                    (Imported: 0, Failed: 0, Preserved: 1, Claimed: 0, Written: (string?)null, Blocked: (string?)null, Log: (LogMessage?)null));
-                            }
-                            logger?.LogDebug(
-                                "[StaticRepoImport] {Partition}: unchanged, skipping {Path}", source.Partition, path);
-                            return Observable.Return(
-                                (Imported: 0, Failed: 0, Preserved: 0, Claimed: 0, Written: (string?)null, Blocked: (string?)null, Log: (LogMessage?)null));
-                        }
-
-                        // Two-way conflict resolution: a node changed on the SERVER since the last sync
-                        // is NOT overwritten by the repo — it is preserved here and carried back to
-                        // GitHub on the next commit ("newer on the server wins → GitHub"). Only reached
-                        // once the repo's copy actually differs (past the incremental-skip above), i.e. a
-                        // real conflict. A forced import ignores this and overwrites (deliberate discard).
-                        if (policy?.PreservesServerCopyOf(target) == true)
-                        {
-                            logger?.LogInformation(
-                                "[StaticRepoImport] {Partition}: two-way — preserving server-newer {Path} (not overwritten).",
-                                source.Partition, path);
-                            // 🚨 The activity line RIDES ALONG with the result instead of being written
-                            // here. A per-item stream.Update re-serialises the whole activity node, so
-                            // one write per kept/failed file is O(n²) — see the phase-level AppendLogs
-                            // below and NodeTypeCompilationActivity.AppendLogs.
-                            return Observable.Return((Imported: 0, Failed: 0, Preserved: 1, Claimed: 0, Written: (string?)null, Blocked: (string?)null,
-                                Log: (LogMessage?)new LogMessage(
-                                    $"↩ Kept local change to {path} (newer on the server — commit to sync it back).",
-                                    Microsoft.Extensions.Logging.LogLevel.Information)));
-                        }
-
-                        var materialized = Materialize(sourceNode);
-                        if (target is not null)
-                            materialized = materialized with
-                            {
-                                CreatedDate = target.CreatedDate,
-                                CreatedBy = target.CreatedBy
-                            };
-                        // 🚨 Mesh-owned compile state is NOT carried over here any more (#748). It
-                        // used to be — against `target`, which comes from the eventually-consistent
-                        // `path:{p} scope:descendants` snapshot above. That snapshot is fine for the
-                        // decisions it was read for (SyncBehavior, identity, prune candidates: all
-                        // authored, all under the import's own lock) but NOT for the operational
-                        // members, which the compile pipeline writes OUTSIDE that lock. Preserving
-                        // from a lagged index is the CQRS rule's forbidden shape ("never read a
-                        // single node's content from the query"), and it actively regressed live
-                        // state: after a framework roll, an import would stamp the pre-roll verdict
-                        // back and a healthy type reverted to `Pending` with a dangling
-                        // `latestReleasePath` (memex 2026-08-02). The rule now lives at the OWNER —
-                        // MeshExtensions.PreserveMeshOwnedOperational, inside the upsert's merge —
-                        // where the answer is authoritative and every upsert writer gets it.
-                        // 🚨 Per-FILE isolation. A single node's upsert faulting (bad content, a
-                        // validator reject, a transient owner timeout) must NOT abort the whole
-                        // partition import — the first failure used to propagate through Merge and
-                        // kill every remaining node. Guard each create: log the exact path to the
-                        // logger AND append a per-file ⚠ line to the import activity (so the failure
-                        // is diagnosable from the activity log after the fact), then count it as a
-                        // Failed and continue. The Failed tally drives the terminal Warning status
-                        // below — the activity never reports a green Succeeded while hiding failures.
-                        return Upsert(hub, materialized)
-                            .Select(_ => (Imported: 1, Failed: 0, Preserved: 0, Claimed: 0, Written: (string?)path, Blocked: (string?)null,
-                                Log: (LogMessage?)null))
-                            .Catch<(int Imported, int Failed, int Preserved, int Claimed, string? Written, string? Blocked, LogMessage? Log), Exception>(ex =>
-                            {
-                                logger?.LogWarning(ex,
-                                    "[StaticRepoImport] {Partition}: upsert of {Path} failed (continuing).",
-                                    source.Partition, path);
-                                return Observable.Return((Imported: 0, Failed: 1, Preserved: 0, Claimed: 0, Written: (string?)null, Blocked: (string?)null,
-                                    Log: (LogMessage?)new LogMessage(
-                                        $"⚠ Failed to import {path}: {ex.Message}",
+                                logger?.LogWarning(
+                                    "[StaticRepoImport] {Partition}: {Path} declares NodeType '{NodeType}', which "
+                                    + "this source does not carry ahead of it and the mesh does not have — the "
+                                    + "create would be refused. Recorded as a blocked create; import the source "
+                                    + "that defines '{NodeType}', or drop the node.",
+                                    source.Partition, path, sourceNode.NodeType, sourceNode.NodeType);
+                                settled.Add(new ImportItem(
+                                    Blocked: path,
+                                    Log: new LogMessage(
+                                        $"🚫 {path}: NodeType '{sourceNode.NodeType}' is not carried by this "
+                                        + "source and is absent from the mesh — no write order can create it.",
                                         Microsoft.Extensions.Logging.LogLevel.Warning)));
-                            });
-                    })
-                    .ToObservable()
-                    // The barrier is BETWEEN stages (Observable.Concat above); inside one it is the
-                    // same BatchSize fan-out the import always used.
-                    .Merge(BatchSize)))
+                                continue;
+                            }
+
+                            // 🅶 Git-diff scope: when the caller supplied the changed-path set (a webhook /
+                            // reimport that diffed the last-synced commit against the new head), an EXISTING
+                            // node NOT in that set was not touched by any commit since the last sync — skip it
+                            // WITHOUT computing its token or re-upserting. This survives a missing/stale
+                            // manifest (the failure that made every webhook re-materialise the whole partition
+                            // → mass recompile storm, memex-cloud 2026-07-23): git, not a mesh write that can
+                            // fail under load, is the authority on "what changed". A node ABSENT from the DB is
+                            // NOT skipped even if outside the diff (first materialisation / self-heal safety),
+                            // and prune still runs over the full source set, so deletes are unaffected.
+                            if (changedNodePaths is not null && target is not null
+                                && !changedNodePaths.Contains(path))
+                            {
+                                // 🚨 A server-newer node OUTSIDE the diff scope is still a pending LOCAL
+                                // change: the repo copy didn't change, so there is nothing to apply — but
+                                // the mesh is AHEAD of the repo for this node (the edit isn't committed
+                                // back yet). Count it PRESERVED so the caller does not advance the
+                                // conflict horizon (LastSyncedAt) past it — otherwise a LATER repo edit
+                                // to this file would no longer see it as "newer on the server" and
+                                // silently overwrite the edit (the diff-scope shape of issue #677).
+                                if (policy?.PreservesServerCopyOf(target) == true)
+                                {
+                                    logger?.LogDebug(
+                                        "[StaticRepoImport] {Partition}: outside git-diff scope, {Path} is server-newer — counted preserved.",
+                                        source.Partition, path);
+                                    settled.Add(new ImportItem(Preserved: 1));
+                                    continue;
+                                }
+                                logger?.LogDebug(
+                                    "[StaticRepoImport] {Partition}: outside git-diff scope, skipping {Path}",
+                                    source.Partition, path);
+                                settled.Add(new ImportItem());
+                                continue;
+                            }
+
+                            // Incremental skip: unchanged since the last import (same source token) AND the
+                            // node is actually present (so a drifted/deleted node still re-imports). Skips the
+                            // expensive cross-hub upsert + owner re-render. Token is over the RAW source node,
+                            // matching what the manifest stored.
+                            var token = PartitionSourceFingerprint.ComputeNodeToken(sourceNode, hub.JsonSerializerOptions);
+                            if (target is not null
+                                && manifest.TryGetValue(path, out var prevToken)
+                                && string.Equals(prevToken, token, StringComparison.Ordinal))
+                            {
+                                // 🚨 Same shape as the diff-scope skip above: an unchanged repo copy of a
+                                // SERVER-NEWER node means the mesh is ahead (a pending local edit, not
+                                // yet committed back). Count it preserved so the conflict horizon stays
+                                // put; skipping with 0 let the horizon advance past the edit and disarm
+                                // the two-way protection for the next repo push (issue #677).
+                                if (policy?.PreservesServerCopyOf(target) == true)
+                                {
+                                    logger?.LogDebug(
+                                        "[StaticRepoImport] {Partition}: unchanged in repo, {Path} is server-newer — counted preserved.",
+                                        source.Partition, path);
+                                    settled.Add(new ImportItem(Preserved: 1));
+                                    continue;
+                                }
+                                logger?.LogDebug(
+                                    "[StaticRepoImport] {Partition}: unchanged, skipping {Path}", source.Partition, path);
+                                settled.Add(new ImportItem());
+                                continue;
+                            }
+
+                            // Two-way conflict resolution: a node changed on the SERVER since the last sync
+                            // is NOT overwritten by the repo — it is preserved here and carried back to
+                            // GitHub on the next commit ("newer on the server wins → GitHub"). Only reached
+                            // once the repo's copy actually differs (past the incremental-skip above), i.e. a
+                            // real conflict. A forced import ignores this and overwrites (deliberate discard).
+                            if (policy?.PreservesServerCopyOf(target) == true)
+                            {
+                                logger?.LogInformation(
+                                    "[StaticRepoImport] {Partition}: two-way — preserving server-newer {Path} (not overwritten).",
+                                    source.Partition, path);
+                                // 🚨 The activity line RIDES ALONG with the result instead of being written
+                                // here. A per-item stream.Update re-serialises the whole activity node, so
+                                // one write per kept/failed file is O(n²) — see the phase-level AppendLogs
+                                // below and NodeTypeCompilationActivity.AppendLogs.
+                                settled.Add(new ImportItem(
+                                    Preserved: 1,
+                                    Log: new LogMessage(
+                                        $"↩ Kept local change to {path} (newer on the server — commit to sync it back).",
+                                        Microsoft.Extensions.Logging.LogLevel.Information)));
+                                continue;
+                            }
+
+                            var materialized = Materialize(sourceNode);
+                            if (target is not null)
+                                materialized = materialized with
+                                {
+                                    CreatedDate = target.CreatedDate,
+                                    CreatedBy = target.CreatedBy
+                                };
+                            // 🚨 Mesh-owned compile state is NOT carried over here any more (#748). It
+                            // used to be — against `target`, which comes from the eventually-consistent
+                            // `path:{p} scope:descendants` snapshot above. That snapshot is fine for the
+                            // decisions it was read for (SyncBehavior, identity, prune candidates: all
+                            // authored, all under the import's own lock) but NOT for the operational
+                            // members, which the compile pipeline writes OUTSIDE that lock. Preserving
+                            // from a lagged index is the CQRS rule's forbidden shape ("never read a
+                            // single node's content from the query") and it actively regressed live
+                            // state: after a framework roll, an import would stamp the pre-roll verdict
+                            // back and a healthy type reverted to `Pending` with a dangling
+                            // `latestReleasePath` (memex 2026-08-02). The rule now lives at the OWNER —
+                            // MeshExtensions.PreserveMeshOwnedOperational, inside the upsert's merge —
+                            // where the answer is authoritative and every upsert writer gets it.
+                            if (seenInStage.Add(path) && IsBulkCreate(materialized, target))
+                                bulk.Add(materialized);
+                            else
+                                singles.Add(materialized);
+                        }
+
+                        // ——— Write. Settled outcomes first (they cost nothing), then the bulk
+                        // creates, then the per-node writes — an update of a path this stage also
+                        // creates therefore runs after that create, which is the last-writer-wins
+                        // order a duplicate has always had.
+                        //
+                        // 🚨 The chunks are MERGED at BatchSize, not concatenated, and that is what
+                        // keeps this a pure win. BatchSize bounds CONCURRENT HEAVY OPERATIONS, and one
+                        // bulk request is internally sequential (validators .Concat(), then one
+                        // WriteMany that builds each row — prerender, embedding — in order). Running
+                        // the chunks one after another would therefore cut the import's concurrency
+                        // from 5 to 1 and could make a large first import SLOWER than the per-node
+                        // path it replaces, batching or not. Merged, the bound is unchanged — ~5 heavy
+                        // operations in flight, the boot import still trickling rather than flooding —
+                        // and each of those now carries 25 nodes instead of one. ———
+                        return Observable.Concat(
+                            settled.ToObservable(),
+                            bulk.Chunk(BulkCreateBatchSize)
+                                .Select(chunk => WriteBulk(hub, source.Partition, chunk, logger, tally))
+                                .ToObservable()
+                                .Merge(BatchSize),
+                            singles.Select(node => WriteOne(hub, source.Partition, node, logger, tally))
+                                .ToObservable()
+                                // The barrier is BETWEEN stages (Observable.Concat above); inside one it is
+                                // the same BatchSize fan-out the import always used.
+                                .Merge(BatchSize));
+                    }))
                     // WrittenPaths ride along with the counts: only a node that really landed can
                     // leave a NodeType's assembly stale, so the recompile derivation downstream
                     // (GitHubSyncService → ReleaseAffectedNodeTypes) keys off exactly this list.
@@ -1437,8 +1513,10 @@ public static class StaticRepoImporter
                                     "[StaticRepoImport] {Partition}: {Claimed} node(s) skipped as claimed (all present).",
                                     source.Partition, count.Claimed);
                             logger?.LogInformation(
-                                "[StaticRepoImport] {Partition}: imported {Count}, failed {Failed}, claimed {Claimed}, pruned {Pruned}, content {Content} at {Fingerprint}.",
-                                source.Partition, count.Imported, failed, count.Claimed, prunedPaths.Count, contentCount, fingerprint);
+                                "[StaticRepoImport] {Partition}: imported {Count} in {WriteRequests} write request(s), "
+                                + "failed {Failed}, claimed {Claimed}, pruned {Pruned}, content {Content} at {Fingerprint}.",
+                                source.Partition, count.Imported, tally.Requests, failed, count.Claimed,
+                                prunedPaths.Count, contentCount, fingerprint);
                             return new StaticRepoImportResult(source.Partition, fingerprint,
                                 failed > 0 ? "ImportedWithErrors"
                                     : blockedCreates.Count > 0 ? "ImportedWithBlockedCreates" : "Imported",
@@ -1451,6 +1529,7 @@ public static class StaticRepoImporter
                                 // the baseline past it and the miss is permanent (#2229 item C).
                                 Failed = failed,
                                 BlockedCreatePaths = blockedCreates,
+                                WriteRequests = tally.Requests,
                             };
                         });
                         }));
@@ -2094,6 +2173,155 @@ public static class StaticRepoImporter
                 logger?.LogWarning(ex,
                     "[StaticRepoImport] {Partition}: manifest write failed (next import non-incremental).", partition);
                 return Observable.Return(0);
+            });
+    }
+
+    /// <summary>
+    /// Counts the WRITE REQUESTS one import posts — the round-trip count reported as
+    /// <see cref="StaticRepoImportResult.WriteRequests"/>. A mutable box rather than a returned value
+    /// because the writes fan out across stages, chunks and the per-node fallbacks, and the number has
+    /// to survive every one of those paths (including a batch that was refused and re-run node by
+    /// node). Incremented at SUBSCRIBE, so it counts requests actually issued, never merely planned.
+    /// </summary>
+    private sealed class WriteTally
+    {
+        /// <summary>Write requests issued so far. Written via <see cref="Interlocked"/>.</summary>
+        public int Requests;
+    }
+
+    /// <summary>
+    /// ONE source node's contribution to the upsert phase's tally: the counters, the path it wrote or
+    /// could not create, and the per-file activity line that rides along to the phase's single
+    /// <c>AppendLogs</c> (written per item it is O(n²) — see the phase-log note at the call site).
+    /// </summary>
+    /// <param name="Imported">1 when the node was written, else 0.</param>
+    /// <param name="Failed">1 when the write was attempted and faulted, else 0.</param>
+    /// <param name="Preserved">1 when a server-newer copy was kept, else 0.</param>
+    /// <param name="Claimed">1 when a claim declined the node, else 0.</param>
+    /// <param name="Written">The path that landed, or <c>null</c>.</param>
+    /// <param name="Blocked">The path that can never be created, or <c>null</c>.</param>
+    /// <param name="Log">The activity line this item contributes, or <c>null</c>.</param>
+    private readonly record struct ImportItem(
+        int Imported = 0,
+        int Failed = 0,
+        int Preserved = 0,
+        int Claimed = 0,
+        string? Written = null,
+        string? Blocked = null,
+        LogMessage? Log = null);
+
+    /// <summary>
+    /// Writes ONE node through the canonical per-node upsert verb, isolated.
+    ///
+    /// <para>🚨 Per-FILE isolation. A single node's upsert faulting (bad content, a validator reject, a
+    /// transient owner timeout) must NOT abort the whole partition import — the first failure used to
+    /// propagate through <c>Merge</c> and kill every remaining node. So the fault is caught here: the
+    /// exact path is logged AND a per-file ⚠ line is appended to the import activity (so the failure is
+    /// diagnosable from the activity log after the fact), and it counts as a <c>Failed</c>. The Failed
+    /// tally drives the terminal Warning status — the activity never reports a green Succeeded while
+    /// hiding failures.</para>
+    /// </summary>
+    private static IObservable<ImportItem> WriteOne(
+        IMessageHub hub, string partition, MeshNode node, ILogger? logger, WriteTally tally) =>
+        Observable.Defer(() =>
+        {
+            Interlocked.Increment(ref tally.Requests);
+            return Upsert(hub, node);
+        })
+            .Select(_ => new ImportItem(Imported: 1, Written: node.Path))
+            .Catch<ImportItem, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[StaticRepoImport] {Partition}: upsert of {Path} failed (continuing).",
+                    partition, node.Path);
+                return Observable.Return(new ImportItem(
+                    Failed: 1,
+                    Log: new LogMessage(
+                        $"⚠ Failed to import {node.Path}: {ex.Message}",
+                        Microsoft.Extensions.Logging.LogLevel.Warning)));
+            });
+
+    /// <summary>
+    /// Writes a chunk of plain CREATES as ONE <see cref="CreateNodesRequest"/> — the bulk sibling of the
+    /// singular create, running the identical pipeline (partition bootstrap once per partition, every
+    /// validator including RLS for every node, the type-existence probe, then ONE
+    /// <c>IStorageAdapter.WriteMany</c> and the post-creation handlers). This is the canonical mesh verb
+    /// addressed to a list, NOT a direct storage write: the importer never reaches past the hub.
+    ///
+    /// <para>🚨 Two fallbacks, and both exist so that BATCHING CANNOT COST THE IMPORT ITS PER-FILE
+    /// REPORTING:</para>
+    /// <list type="number">
+    ///   <item><b>A refused (or faulted) batch is re-run one node at a time.</b> The bulk verb is
+    ///     validate-all-then-write — one offender refuses the whole request and can name at most one
+    ///     path — while the import's contract is the opposite: every other node still has to land, and
+    ///     the one that did not has to be NAMED in the activity log. Re-running attributes the failure
+    ///     to the file that caused it and lands everything else, exactly as before batching. The cost is
+    ///     paid only on the failing path.</item>
+    ///   <item><b>A path the batch did NOT create falls through to the per-node upsert.</b> The importer
+    ///     chose this chunk from an eventually-consistent snapshot, so "absent" can be stale; the bulk
+    ///     verb re-reads authoritatively and reports such paths in <see cref="CreateNodesResponse.Existing"/>
+    ///     rather than overwriting them. Those are UPDATES, and an update routes through the owning
+    ///     per-node hub's stream — which is precisely what <see cref="Upsert"/> does. Dropping them here
+    ///     would silently fail to apply a changed node.</item>
+    /// </list>
+    /// </summary>
+    private static IObservable<ImportItem> WriteBulk(
+        IMessageHub hub, string partition, IReadOnlyList<MeshNode> chunk, ILogger? logger, WriteTally tally)
+    {
+        if (chunk.Count == 0)
+            return Observable.Empty<ImportItem>();
+        // One node is not a batch: the singular verb reports its own failure without a second pass.
+        if (chunk.Count == 1)
+            return WriteOne(hub, partition, chunk[0], logger, tally);
+
+        IObservable<ImportItem> PerNode(IEnumerable<MeshNode> nodes) =>
+            nodes.Select(n => WriteOne(hub, partition, n, logger, tally)).ToObservable().Merge(BatchSize);
+
+        return Observable.Defer(() =>
+            {
+                Interlocked.Increment(ref tally.Requests);
+                return AsSystem(hub, () => hub.Observe<CreateNodesResponse>(
+                    new CreateNodesRequest(chunk.ToImmutableList())));
+            })
+            .FirstAsync()
+            .Select(d => d.Message)
+            // A transport fault says nothing about WHICH node is at fault, so it takes the same
+            // per-node re-run a refusal does rather than failing the whole chunk unattributed.
+            .Catch<CreateNodesResponse, Exception>(ex =>
+            {
+                logger?.LogWarning(ex,
+                    "[StaticRepoImport] {Partition}: bulk create of {Count} node(s) FAULTED.",
+                    partition, chunk.Count);
+                return Observable.Return(CreateNodesResponse.Fail(ex.Message));
+            })
+            .SelectMany(response =>
+            {
+                if (!response.Success)
+                {
+                    logger?.LogInformation(
+                        "[StaticRepoImport] {Partition}: bulk create of {Count} node(s) was refused "
+                        + "({Error}{FailedPath}) — re-running the batch one node at a time so the "
+                        + "failure is attributed to the node that caused it.",
+                        partition, chunk.Count, response.Error,
+                        response.FailedPath is null ? "" : $" at {response.FailedPath}");
+                    return PerNode(chunk);
+                }
+
+                var created = response.Created
+                    .Select(n => n.Path)
+                    .ToHashSet(StringComparer.OrdinalIgnoreCase);
+                var landed = chunk
+                    .Where(n => created.Contains(n.Path))
+                    .Select(n => new ImportItem(Imported: 1, Written: n.Path))
+                    .ToObservable();
+                var leftOver = chunk.Where(n => !created.Contains(n.Path)).ToList();
+                if (leftOver.Count == 0)
+                    return landed;
+                logger?.LogDebug(
+                    "[StaticRepoImport] {Partition}: {Count} of {Total} node(s) in a bulk create already "
+                    + "existed — applying them as updates through the per-node verb.",
+                    partition, leftOver.Count, chunk.Count);
+                return landed.Concat(PerNode(leftOver));
             });
     }
 

--- a/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
+++ b/src/MeshWeaver.Mesh.Contract/CreateNodeRequest.cs
@@ -157,6 +157,45 @@ public record CreateNodesRequest(ImmutableList<MeshNode> Nodes) : IRequest<Creat
     /// <see cref="CreateNodeRequest.CreatedBy"/>.
     /// </summary>
     public string? CreatedBy { get; init; }
+
+    /// <summary>
+    /// The <c>AccessAssignment</c> node type name. Named by literal here rather than by type so
+    /// Mesh.Contract needs no dependency on the assembly that defines the type.
+    /// </summary>
+    public const string AccessAssignmentNodeType = "AccessAssignment";
+
+    /// <summary>
+    /// Why this node may NOT travel in a bulk create — or <c>null</c> when it may.
+    ///
+    /// <para>These ARE the handler's structural (phase 0) guards: it calls this, so there is exactly
+    /// one statement of the rule. A caller that has to SPLIT a set into "what can go in one request"
+    /// and "what must keep the per-node verb" — the static-repo importer does exactly that per write
+    /// stage — asks this instead of re-deriving the rule, because a second copy drifts and the
+    /// symptom would be a whole batch refused for a reason the caller thought it had excluded.</para>
+    ///
+    /// <para>Not covered here, because they are properties of a BATCH rather than of a node: a null
+    /// entry and a duplicate path. The handler checks both itself.</para>
+    /// </summary>
+    /// <param name="node">The candidate node.</param>
+    /// <returns>The refusal message and its reason, or <c>null</c> when the node is bulk-creatable.</returns>
+    public static (string Error, NodeCreationRejectionReason Reason)? BulkRefusal(MeshNode node)
+    {
+        if (string.IsNullOrWhiteSpace(node.Id) || string.IsNullOrWhiteSpace(node.Path))
+            return ("Node path and Id must not be empty", NodeCreationRejectionReason.ValidationFailed);
+        if (string.IsNullOrWhiteSpace(node.NodeType) && node.Content == null)
+            return ($"Node '{node.Path}' must have a NodeType or Content set; bare nodes are not allowed.",
+                NodeCreationRejectionReason.ValidationFailed);
+        // Satellites (_Access, _Activity, _Thread, …) carry per-node guards (ownerless-activity,
+        // assignment scope/system-owned) and satellite-MainNode normalization that are deliberately
+        // per-node lifecycle — refused here rather than half-supported.
+        if (node.Segments.Any(segment => segment.StartsWith('_')))
+            return ($"'{node.Path}' is a satellite path — satellites are per-node lifecycle; use CreateNodeRequest/CreateOrUpdateNodeRequest.",
+                NodeCreationRejectionReason.InvalidPath);
+        if (string.Equals(node.NodeType, AccessAssignmentNodeType, StringComparison.OrdinalIgnoreCase))
+            return ($"'{node.Path}' is an AccessAssignment — grants are per-node lifecycle; use CreateNodeRequest.",
+                NodeCreationRejectionReason.ValidationFailed);
+        return null;
+    }
 }
 
 /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -1245,33 +1245,14 @@ public static class MeshExtensions
                     NodeCreationRejectionReason.ValidationFailed);
                 return request.Processed();
             }
-            if (string.IsNullOrWhiteSpace(candidate.Id) || string.IsNullOrWhiteSpace(candidate.Path))
+            // The per-NODE structural rules live on the request itself (CreateNodesRequest.BulkRefusal)
+            // — ONE statement of what may travel in a bulk create, so a caller that has to split a set
+            // into "batchable" and "not" (StaticRepoImporter, per write stage) asks the same function
+            // instead of re-deriving it. Only the BATCH-level rules stay here: a null entry and a
+            // duplicate path are properties of the list, not of any node in it.
+            if (CreateNodesRequest.BulkRefusal(candidate) is { } refusal)
             {
-                PostFail("Node path and Id must not be empty",
-                    NodeCreationRejectionReason.ValidationFailed, candidate.Path);
-                return request.Processed();
-            }
-            if (string.IsNullOrWhiteSpace(candidate.NodeType) && candidate.Content == null)
-            {
-                PostFail($"Node '{candidate.Path}' must have a NodeType or Content set; bare nodes are not allowed.",
-                    NodeCreationRejectionReason.ValidationFailed, candidate.Path);
-                return request.Processed();
-            }
-            // Satellites (_Access, _Activity, _Thread, …) carry per-node guards (ownerless-activity,
-            // assignment scope/system-owned) and satellite-MainNode normalization that are
-            // deliberately per-node lifecycle — refuse them here rather than half-support them.
-            if (candidate.Segments.Any(segment => segment.StartsWith('_')))
-            {
-                PostFail(
-                    $"'{candidate.Path}' is a satellite path — satellites are per-node lifecycle; use CreateNodeRequest/CreateOrUpdateNodeRequest.",
-                    NodeCreationRejectionReason.InvalidPath, candidate.Path);
-                return request.Processed();
-            }
-            if (string.Equals(candidate.NodeType, AccessAssignmentNodeTypeName, StringComparison.OrdinalIgnoreCase))
-            {
-                PostFail(
-                    $"'{candidate.Path}' is an AccessAssignment — grants are per-node lifecycle; use CreateNodeRequest.",
-                    NodeCreationRejectionReason.ValidationFailed, candidate.Path);
+                PostFail(refusal.Error, refusal.Reason, candidate.Path);
                 return request.Processed();
             }
             if (!seenPaths.Add(candidate.Path))
@@ -1509,7 +1490,7 @@ public static class MeshExtensions
     private const string PartitionRootNodeTypeName = "Space";
 
     /// <summary>The <c>AccessAssignment</c> node type name — same rationale as <see cref="PartitionRootNodeTypeName"/>.</summary>
-    private const string AccessAssignmentNodeTypeName = "AccessAssignment";
+    private const string AccessAssignmentNodeTypeName = CreateNodesRequest.AccessAssignmentNodeType;
 
     /// <summary>
     /// SELF-HEALING PARTITION BOOTSTRAP — the centralized invariant that every mesh partition

--- a/test/MeshWeaver.Graph.Test/StaticRepoImportBulkWriteTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaticRepoImportBulkWriteTest.cs
@@ -1,0 +1,262 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Markdown;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 AN IMPORT MUST NOT COST ONE WRITE PER NODE (Systemorph/MeshWeaver.Plugins#1013).
+///
+/// <para>The static-repo importer used to post one <c>CreateOrUpdateNodeRequest</c> per source node:
+/// one cross-hub round-trip AND one single-row upsert each, so materialising a partition of n nodes
+/// cost n of both. The storage layer has had the bulk contract all along —
+/// <c>IStorageAdapter.WriteMany</c>, which PostgreSQL implements as ONE <c>NpgsqlBatch</c> per
+/// (schema, table) window — but nothing on the import path reached it, because a node write has to
+/// route through the mesh's canonical verbs rather than straight at the adapter.</para>
+///
+/// <para>It now does, through <c>CreateNodesRequest</c> — the bulk sibling of the singular create,
+/// which runs the identical pipeline (partition bootstrap, every validator including RLS, the
+/// type-existence probe, post-creation handlers) and then ONE <c>WriteMany</c>. Plain creates travel
+/// in chunks; everything else keeps the per-node verb, because an UPDATE is applied by the node's own
+/// hub and satellites and grants carry per-node lifecycle guards.</para>
+///
+/// <para>What is measured here is <see cref="StaticRepoImportResult.WriteRequests"/> — the number of
+/// write requests actually issued, counted at subscribe — because that is the quantity the change is
+/// about. Asserting only "every node landed" would stay green through a revert to per-node writes.</para>
+/// </summary>
+public class StaticRepoImportBulkWriteTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>
+    /// The importer's chunk size. Mirrored here rather than exposed: the test states the arithmetic it
+    /// expects (⌈n ÷ chunk⌉ requests) instead of recomputing it from the implementation, so a silent
+    /// change to the chunk is a red test to think about, not a quietly-passing one.
+    /// </summary>
+    private const int Chunk = 25;
+
+    /// <summary>Node count that spans more than one chunk without being slow to import.</summary>
+    private const int Pages = 40;
+
+    // 🚨 A DERIVED FIELD INITIALIZER RUNS BEFORE THE BASE CONSTRUCTOR, and the base constructor is
+    // what calls ConfigureMesh. So the partition name (and the rejection hook below) are already set
+    // by the time the mesh is built and can be closed over by services registered there.
+    private readonly string _partition = "Bw" + Guid.NewGuid().ToString("N")[..8];
+
+    /// <summary>
+    /// The one path the test validator rejects, or null. Set by the test that needs a create to be
+    /// refused from INSIDE a batch — the only realistic way to reach the bulk verb's
+    /// validate-all-then-write refusal without inventing a malformed node.
+    /// </summary>
+    private string? _rejectPath;
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<INodeValidator>(
+                new RejectOnePathValidator(() => _rejectPath)));
+
+    /// <summary>
+    /// 🚨 THE REGRESSION GUARD. A first import of a whole partition — every node a plain create —
+    /// must cost ⌈n ÷ chunk⌉ write requests, not n. Before batching this was exactly n (40), which is
+    /// also 40 single-row upserts at the adapter.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task FirstImportOfAWholePartition_CostsOneRequestPerChunk_NotOnePerNode()
+    {
+        var source = new FakeRepoSource(_partition)
+        {
+            Root = Space(_partition),
+            Nodes = [.. Enumerable.Range(0, Pages).Select(i => Page(_partition, $"P{i:D2}"))],
+        };
+
+        var result = await Import(source);
+
+        result.Count.Should().Be(Pages, "every node in the source must land");
+        result.Failed.Should().Be(0);
+        result.WriteRequests.Should().Be((Pages + Chunk - 1) / Chunk,
+            $"{Pages} plain creates must travel as ⌈{Pages}÷{Chunk}⌉ bulk requests — one request per "
+            + "chunk, each reaching storage as ONE WriteMany (on Postgres one NpgsqlBatch per "
+            + $"(schema, table) window). {result.WriteRequests} requests for {Pages} nodes means the "
+            + "per-node write is back and the import is paying a round-trip and a single-row upsert "
+            + "for every file again");
+
+        // …and the batching is not bought by losing content: read two of them back through their own
+        // per-node hubs, which is what the change feed had to wake.
+        (await Body($"{_partition}/P00")).Should().Contain("page");
+        (await Body($"{_partition}/P39")).Should().Contain("page");
+    }
+
+    /// <summary>
+    /// 🚨 PER-FILE ISOLATION SURVIVES BATCHING. <c>CreateNodesRequest</c> is validate-all-then-write:
+    /// ONE offender refuses the whole request and can name at most one path. The import's contract is
+    /// the opposite — every other node still has to land, and the one that did not has to be NAMED in
+    /// the activity log, because <c>Failed &gt; 0</c> is what holds the git baseline (#2229 item C).
+    /// So a refused batch is re-run one node at a time, and what the operator sees is unchanged.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task ARejectedNodeInABatch_IsAttributedToItself_AndEveryOtherNodeStillLands()
+    {
+        _rejectPath = $"{_partition}/Bad";
+        var source = new FakeRepoSource(_partition)
+        {
+            Root = Space(_partition),
+            Nodes =
+            [
+                Page(_partition, "Before"),
+                Page(_partition, "Bad"),
+                Page(_partition, "After"),
+            ],
+        };
+
+        var result = await Import(source);
+
+        result.Failed.Should().Be(1,
+            "exactly ONE node was rejected — a batched write must not turn one validator refusal into "
+            + "three failures, nor swallow it into a green import");
+        result.Outcome.Should().Be("ImportedWithErrors");
+        result.Count.Should().Be(2, "the other two nodes of the refused batch must still land");
+        result.WrittenPaths.Should().HaveCount(2);
+        result.WrittenPaths.Should().Contain($"{_partition}/Before");
+        result.WrittenPaths.Should().Contain($"{_partition}/After");
+
+        // The re-run is what makes the failure attributable: one bulk attempt plus one request per
+        // node in the chunk. A batch that simply failed would have cost one request and named nothing.
+        result.WriteRequests.Should().Be(1 + source.Nodes.Count,
+            "a refused batch is re-run node by node so the failure lands on the file that caused it");
+
+        (await Body($"{_partition}/Before")).Should().Contain("page");
+        (await Body($"{_partition}/After")).Should().Contain("page");
+    }
+
+    /// <summary>
+    /// A satellite path (any segment starting with <c>_</c>) is refused by the bulk verb on purpose —
+    /// satellites carry per-node lifecycle guards and MainNode normalization. The importer must
+    /// therefore route it to the per-node verb rather than let it refuse the whole batch, and it must
+    /// still land.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task ASatellitePath_KeepsThePerNodeVerb_AndStillLands()
+    {
+        var source = new FakeRepoSource(_partition)
+        {
+            Root = Space(_partition),
+            Nodes =
+            [
+                Page(_partition, "Plain"),
+                Page(_partition, "_Notes"),
+                Page(_partition, "Other"),
+            ],
+        };
+
+        var result = await Import(source);
+
+        result.Failed.Should().Be(0,
+            "a satellite the bulk verb cannot carry must be routed AROUND the batch, never left in it "
+            + "to refuse the whole request");
+        result.Count.Should().Be(3);
+        result.WriteRequests.Should().Be(2,
+            "the two plain creates travel in ONE bulk request; the satellite takes the per-node verb");
+        (await Body($"{_partition}/_Notes")).Should().Contain("page");
+    }
+
+    /// <summary>
+    /// An UPDATE is applied by the node's OWN hub — <c>GetMeshNodeStream(path).Update(...)</c> — never
+    /// by the mesh hub writing over it, so it keeps the per-node verb. This pins that: the second
+    /// import of a changed source costs one request per changed node and applies the new content.
+    /// </summary>
+    [Fact(Timeout = 240000)]
+    public async Task AReimportOfChangedNodes_UpdatesThroughThePerNodeVerb()
+    {
+        var source = new FakeRepoSource(_partition)
+        {
+            Root = Space(_partition),
+            Nodes = [Page(_partition, "A"), Page(_partition, "B")],
+        };
+        var first = await Import(source);
+        first.Count.Should().Be(2);
+        first.WriteRequests.Should().Be(1, "two fresh creates are one batch");
+
+        source.Nodes = [.. source.Nodes.Select(n => n with
+        {
+            Content = new MarkdownContent { Content = $"# {n.Id}\n\nrevised" }
+        })];
+        var second = await Import(source);
+
+        second.Failed.Should().Be(0);
+        second.Count.Should().Be(2);
+        second.WriteRequests.Should().Be(2,
+            "an existing node is UPDATED by its own per-node hub, so an update costs its own request — "
+            + "batching creates must not have quietly moved updates onto the mesh hub's write path");
+        (await Body($"{_partition}/A")).Should().Contain("revised");
+        (await Body($"{_partition}/B")).Should().Contain("revised");
+    }
+
+    private async Task<StaticRepoImportResult> Import(FakeRepoSource source)
+    {
+        // 🚨 .Await(), never a bare `await source`: Rx's own awaiter resumes the continuation INLINE
+        // on the signalling thread, still inside the trampoline, and every later await in the method
+        // inherits that scheduler — the .ToTask() defect wearing different clothes.
+        var result = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(180.Seconds()).Await();
+        Output.WriteLine(
+            $"outcome={result.Outcome} count={result.Count} failed={result.Failed} "
+            + $"writeRequests={result.WriteRequests} written=[{string.Join(", ", result.WrittenPaths)}]");
+        return result;
+    }
+
+    private async Task<string> Body(string path)
+    {
+        var node = await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(60.Seconds()).Await();
+        return node.ContentAs<MarkdownContent>(Mesh.JsonSerializerOptions)?.Content ?? "";
+    }
+
+    private static MeshNode Space(string partition) => new(partition)
+    {
+        Name = "Bulk Write", NodeType = "Space", State = MeshNodeState.Active,
+        Content = new MarkdownContent { Content = "# Bulk Write\n\nfixture." }
+    };
+
+    private static MeshNode Page(string partition, string id) => new(id, partition)
+    {
+        NodeType = "Markdown", Name = id, State = MeshNodeState.Active,
+        Content = new MarkdownContent { Content = $"# {id}\n\npage" }
+    };
+
+    /// <summary>
+    /// Rejects the creation of ONE path, chosen per test. The realistic way to make a node inside a
+    /// bulk batch refuse: the bulk verb runs the very same <c>INodeValidator</c> pass the singular
+    /// create runs, for every node, before anything is written.
+    /// </summary>
+    private sealed class RejectOnePathValidator(Func<string?> path) : INodeValidator
+    {
+        public IReadOnlyCollection<NodeOperation> SupportedOperations { get; } = [NodeOperation.Create];
+
+        public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+            => Observable.Return(
+                string.Equals(context.Node.Path, path(), StringComparison.Ordinal)
+                    ? NodeValidationResult.Invalid($"'{context.Node.Path}' is rejected by the test validator")
+                    : NodeValidationResult.Valid());
+    }
+
+    private sealed class FakeRepoSource(string partition) : IStaticRepoSource
+    {
+        public string Partition => partition;
+        public bool Versioned => false;
+        public List<MeshNode> Nodes { get; set; } = [];
+        public MeshNode? Root { get; set; }
+        public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
+        public MeshNode? PartitionRoot => Root;
+    }
+}


### PR DESCRIPTION
Closes Systemorph/MeshWeaver.Plugins#1013

## The gap that was actually left

`PostgreSqlStorageAdapter.WriteMany` (MeshWeaver.Plugins) already does everything the issue title
asks for: it windows on `ResolveTable`, whose `QualifyTable` returns `"{schema}"."{table}"`, and
sends **one `NpgsqlBatch` per (schema, table) window** — N upserts, one round-trip, one implicit
transaction, the same `BuildUpsertAsync` SQL the singular `Write` uses; per-node outcomes survive
via `BatchCommands[i].Rows`; the committed set is announced even when a later window throws. Nothing
there needed re-implementing.

What did **not** reach it was the import path. `StaticRepoImporter` posted one
`CreateOrUpdateNodeRequest` per source node — one cross-hub round-trip **and** one single-row upsert
each — so materialising a partition of n nodes cost n of both. And it could not simply call
`WriteMany`: a node write has to route through the mesh's canonical verbs, which is what makes it
typed, access-checked and observable to the node's hub, and `WriteMany` is an `IStorageAdapter` call
one level below them.

## So: a bulk VERB, not a bypass

`CreateNodesRequest` already exists as the bulk sibling of `CreateNodeRequest` and runs the
**identical** pipeline — partition bootstrap once per partition, every validator (RLS included) for
every node, the type-existence probe per distinct type, then **one** `WriteMany`, the `Created`
change-feed publishes in caller order post-commit, and the post-creation handlers. Nothing on the
import path had ever used it. Each write stage (see `ImportWriteOrder` — everything inside a stage
may be written concurrently) is now split:

| Write | Verb | Why |
|---|---|---|
| **plain create** | `CreateNodesRequest`, chunked at 25 | Nobody owns the node yet; the create is executed by the mesh hub against storage either way, so batching changes only how many times it crosses the wire. |
| **update** | `CreateOrUpdateNodeRequest` per node | An update is applied by the node's **own** hub via `GetMeshNodeStream(path).Update(...)`. The mesh hub never writes over a live node — there is nothing to batch. |
| **satellite / `AccessAssignment`** | `CreateOrUpdateNodeRequest` per node | Per-node lifecycle guards and MainNode normalization. |

`CreateNodesRequest.BulkRefusal` is now the **one** statement of what may travel in a bulk create —
the handler's phase-0 guards call it, and the importer asks it rather than re-deriving the rule, so
the two cannot drift into "a batch refused for a reason the caller thought it had excluded".

## Two properties that are load-bearing, and neither is free

1. **Per-file isolation survives batching.** `CreateNodesRequest` is validate-all-then-write: one
   offender refuses the whole request and can name at most one path, while the import's contract is
   the opposite — every other node still has to land, and the one that did not has to be **named**,
   because `Failed > 0` is what holds the git baseline (#2229 item C). A refused **or faulted** batch
   is therefore re-run one node at a time, which attributes the failure to the file that caused it;
   the extra pass is paid only on the failing chunk. Likewise a path the batch reports in
   `CreateNodesResponse.Existing` — the lagged snapshot said "absent", the authoritative read
   disagreed — falls through to the per-node upsert **as an update**, never dropped.
2. **The chunks are MERGED at `BatchSize`, not concatenated.** `BatchSize` bounds *concurrent heavy
   operations*, and one bulk request is internally sequential (validators `.Concat()`, then a
   `WriteMany` that builds each row — prerender, embedding — in order). Concatenating the chunks
   would cut the import's concurrency from ~5 to 1 and could have made a large first import **slower**
   than the per-node path it replaces. Merged, the bound is unchanged — the boot import still trickles
   rather than floods — and each in-flight operation now carries 25 nodes instead of one.

## Evidence

`StaticRepoImportResult.WriteRequests` reports the round-trip count and the import's summary log line
carries it, so *"did this import batch?"* is answerable from an operator's log rather than by reading
code. `StaticRepoImportBulkWriteTest` measures that number, because asserting only "every node landed"
would stay green through a revert to per-node writes:

| Case | `WriteRequests` | was |
|---|---|---|
| first import, 40 fresh nodes | **2** | 40 |
| batch with one validator-refused node (3 nodes) | 1 + 3 (re-run) — offender named, other two land | 3 |
| 2 plain + 1 satellite | 2 | 3 |
| re-import of 2 changed nodes | 2 (updates keep the per-node verb) | 2 |

## Tests run (not just compiled)

| Suite | Result |
|---|---|
| `MeshWeaver.Graph.Test` | **1147 passed**, 0 failed |
| `MeshWeaver.Hosting.Test` | **290 passed**, 0 failed |
| Plugins `MeshWeaver.NodeOperations.Test` (`-p:MeshWeaverRoot=` this branch) | **76 passed**, 0 failed |
| Plugins `MeshWeaver.GitSync.Test` | **194 passed**, 0 failed |
| Plugins `MeshWeaver.PluginCatalog.Test` | **726 passed**, 0 failed |
| Plugins `MeshWeaver.Hosting.PostgreSql.Test` (real PG, testcontainers) | **878 passed**, 0 failed — incl. all 12 `StaticRepoImporterTests`, i.e. the batched import verified end to end through the (schema, table)-windowed `WriteMany` |
| `MeshWeaver.Documentation.Test` | **172 passed**, 0 failed |
| Plugins `MeshWeaver.Hosting.Monolith.Test` | 786 passed, **1 unrelated flake** — see below |

The first push was RED on `DocumentationLinkIntegrityTest` — my own doing: the new doc used a bare `(ImportWriteOrdering)` link, which resolves against the doc's OWN path. Fixed to the absolute `/Doc/Architecture/…` form the same file already uses, and the suite is green locally.

The remaining red is `OwnerDisposalNackTest.DisposingOwner_BeforeMergeTurnRuns_NacksOwnerDisposing`, an
8 s force-teardown timeout in `RegisterOwnerDisposingNack` during hub disposal — a path this diff
never enters (no importer, no node create, no storage write). It **passes in isolation against this
same build**; it went red only inside the 11-minute full-suite run.

## Measured and deliberately NOT changed

Inside one `WriteMany` the PostgreSQL adapter builds each row sequentially, and `BuildUpsertAsync`
awaits `IEmbeddingProvider.GenerateEmbeddingAsync` — a real network call on a portal with
`Embedding:Endpoint` set. A 25-node batch therefore serialises 25 embedding round-trips. That is a
**wash**, not a regression: `n·E/5` before (5 concurrent single writes), `(n/25)·(25E)/5 = n·E/5` now
(5 concurrent batches) — which is exactly why the chunks are merged rather than concatenated. Making
those calls concurrent inside the batch would be a further win, but it multiplies the fan-out at a
rate-limited cloud embedding endpoint during a boot import, so it belongs in its own change with its
own measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

