### PR TITLE
fix: the resync give-up must not count an ack that overtook its own answer (#3058)

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -2118,12 +2118,17 @@ public static class DataExtensions
                 }
 
                 // Identity flows through message-level AccessContext (stamped by PostPipeline).
+                //
+                // 🚨 THE ACK IS POSTED BY THE SUBSCRIBE ITSELF, NOT FROM HERE (#3058). It still
+                // exists for the same reason it always did — to close the
+                // hub.Observe(subscribeRequest) pending callback on the subscriber side, which
+                // DataChangedEvents cannot close because RouteStreamMessage intercepts them before
+                // HandleCallbacks sees them — but WHEN it is sent is now part of its meaning.
+                // Posting it from here acknowledged a re-subscribe BEFORE the snapshot answering it
+                // had been produced, and a subscriber that reads "acknowledged" as "the owner
+                // answered" then counts a promise as a result. See the ack sites in
+                // JsonSynchronizationStream.CreateSynchronizationStream for the full argument.
                 hub.GetWorkspace().SubscribeToClient(request);
-                // Send SubscribeAck immediately to close the hub.Observe(subscribeRequest)
-                // pending callback on the subscriber side. Without this, the callback stays
-                // in responseSubjects until the 30-s RequestTimeout fires (DataChangedEvents
-                // are intercepted by RouteStreamMessage before HandleCallbacks can close it).
-                hub.Post(new SubscribeAck(), o => o.ResponseFor(request));
                 logger?.LogDebug("HandleSubscribeRequest: Subscription created for {Sender} at {Hub}",
                     request.Sender, hub.Address);
             });

--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -1198,6 +1198,69 @@ public static class JsonSynchronizationStream
         var logger = GetLogger(hub.ServiceProvider);
         var request = delivery.Message with { Subscriber = delivery.Sender };
 
+        // 🚨🚨 THE ACKNOWLEDGEMENT MUST NOT OVERTAKE THE ANSWER — Systemorph/MeshWeaver#3058.
+        //
+        // SubscribeAck closes the subscriber's hub.Observe(subscribeRequest) pending callback (a
+        // DataChangedEvent cannot: RouteStreamMessage intercepts it before HandleCallbacks). It
+        // used to be posted from HandleSubscribeRequest the instant SubscribeToClient returned —
+        // i.e. BEFORE the snapshot answering this subscribe had been produced, because the
+        // re-assert below only QUEUES an UpdateStreamRequest on the stream's own action block.
+        //
+        // For an initial subscribe that ordering costs nothing. For a RE-subscribe it inverts the
+        // meaning of the word: SynchronizationStream.RequestFreshSnapshot reads an ack as "the
+        // owner has processed my re-subscribe and done whatever it is going to do", counts the ask
+        // as answered-or-not on that basis, and faults the mirror past MaxUnansweredResyncs
+        // acknowledged-and-unanswered asks. When the ack precedes the answer, "acknowledged and
+        // unanswered" is true of every ask the moment it is made, so the
+        // count measures the owner's QUEUE DEPTH rather than non-convergence: during a bulk install
+        // the re-assert waits behind the burst's own frames, every one of those frames re-proves
+        // the mirror has no base, each re-ask is acked in ~1 ms, and three of them land inside 9 ms
+        // — measured, run 33593426491 — while the first Full is still queued and perfectly healthy.
+        // That faulted a mirror mid-install and reddened the samples content gate on roughly a
+        // third of all runs, on unmodified main.
+        //
+        // So the ack now follows the frame it acknowledges: on the re-assert path it is posted from
+        // the update turn's <c>applied</c> callback, which runs in the SAME turn immediately after
+        // SetCurrent — by which point the outbound forwarding subscription has already handed the
+        // Full to <c>hub.Post</c>, so the two arrive at the subscriber in that order. Nothing waits
+        // and nothing polls: the ack rides the work it describes.
+        //
+        // 🚨 Every path must post exactly ONE ack — a path that posts none leaves the subscriber's
+        // pending callback open until the hub's RequestTimeout, which is the wedge this ack exists
+        // to prevent. The failure arms below are part of that contract, not tidiness.
+        var acked = 0;
+        void Ack()
+        {
+            // Idempotent by construction: the deferred arm and its failure arm can both be reached
+            // (a disposed stream signals the exception callback), and a second SubscribeAck would
+            // be answered into a callback that .Take(1) has already closed.
+            if (Interlocked.Exchange(ref acked, 1) == 1)
+                return;
+            try
+            {
+                // The AccessContext comes off the SUBSCRIBE delivery, exactly as the outbound
+                // DataChangedEvent's does below: the deferred arm runs on the STREAM's turn, where
+                // the ambient identity is the stream's, not the subscriber's, and PostPipeline
+                // fails closed on an absent one.
+                hub.Post(new SubscribeAck(), o =>
+                {
+                    var opt = o.ResponseFor(delivery);
+                    return delivery.AccessContext is not null
+                        ? opt.WithAccessContext(delivery.AccessContext)
+                        : opt;
+                });
+            }
+            catch (Exception ex)
+            {
+                // The owner can begin winding down between the decision and the post. Debug, not
+                // swallowed silence: the subscriber's own request/response terminal fires and
+                // ResyncRefused releases its gate — the recoverable verdict, not a latch.
+                logger.LogDebug(ex,
+                    "Owner {Owner} could not acknowledge the subscribe of stream {StreamId} for {Subscriber}",
+                    hub.Address, request.StreamId, request.Subscriber);
+            }
+        }
+
         // 🚨 RE-SUBSCRIBE IS A REFRESH, NOT A SECOND SUBSCRIPTION (issue #606).
         //
         // Resubscribe() re-posts a SubscribeRequest carrying the SAME StreamId — it means
@@ -1247,13 +1310,30 @@ public static class JsonSynchronizationStream
             // that resubscribed is by definition not ahead) — but it can neither erase newer
             // state nor poison the mirror's version.
             if (alreadyServing.Current is { Value: not null })
+                // 🚨 THE DEFERRED ACK (#3058). `applied` runs in the update's OWN turn right after
+                // SetCurrent — and SetCurrent drives the outbound forwarding subscription
+                // synchronously (Store.OnNext → ToDataChanged → hub.Post), so the answering Full is
+                // already in the owner's outbound queue when this runs. Acking here therefore means
+                // what the subscriber's give-up reads it as: "your snapshot has been SENT". Ack from
+                // the failure arm too — a re-assert that could not be applied still owes the
+                // subscriber a verdict, and its gate is released by the ack it gets rather than by a
+                // 30-second request timeout.
                 alreadyServing.Update(
                     _ => BuildReassertFrame(alreadyServing),
-                    ex => logger.LogWarning(ex,
-                        "Stream {StreamId}: could not re-assert snapshot for resubscribing subscriber {Subscriber}",
-                        alreadyServing.StreamId, request.Subscriber));
-            // Nothing yet to re-assert (the initial subscribe is still hydrating) — its own
-            // first Full is already on its way to this subscriber; do NOT build a second stream.
+                    ex =>
+                    {
+                        logger.LogWarning(ex,
+                            "Stream {StreamId}: could not re-assert snapshot for resubscribing subscriber {Subscriber}",
+                            alreadyServing.StreamId, request.Subscriber);
+                        Ack();
+                    },
+                    Ack);
+            else
+                // Nothing yet to re-assert (the initial subscribe is still hydrating) — its own
+                // first Full is already on its way to this subscriber, so the ack is not overtaking
+                // anything and is owed immediately.
+                Ack();
+            // Do NOT build a second stream — see the #606 note above.
             return alreadyServing;
         }
 
@@ -1435,6 +1515,17 @@ public static class JsonSynchronizationStream
         // stream that has no way to reach the subscriber. Unregisters itself on disposal.
         (workspace as Workspace)?.RegisterClientSubscription(
             request.Subscriber, request.StreamId, request.Reference, reduced);
+
+        // 🚨 A FRESH stream acks IMMEDIATELY, and the asymmetry with the re-assert path above is
+        // deliberate (#3058). This subscribe has no answer to overtake — the stream was just built
+        // and its first Full comes out of the reduce's own hydration, which is IO-bound and
+        // unbounded (a cold data source, a per-node hub activating). Waiting for it before
+        // acknowledging would hold the subscriber's pending callback open across that hydration and
+        // risk the very RequestTimeout the ack exists to prevent, for a subscribe that cannot
+        // produce the miscount: the mirror's give-up counts CONSECUTIVE unanswered re-asks, and a
+        // re-ask reaches this path at most once per gap (the registration above makes the next one
+        // a re-assert), so the hydrating Full always lands and resets the count.
+        Ack();
 
         return reduced;
     }

--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -1188,6 +1188,27 @@ public static class JsonSynchronizationStream
             ? new ChangeItem<TReduced>(live.Value, stream.StreamId, live.Version)
             : null;
 
+    /// <summary>
+    /// Whether <paramref name="error"/> is a stream/hub TEARDOWN rather than a genuine failure to
+    /// produce a snapshot — the classification a refused re-subscribe carries (#3058).
+    /// <para><c>SynchronizationStream.SignalDisposedToProducer</c> raises an
+    /// <see cref="ObjectDisposedException"/> when the stream's hub is gone, and
+    /// <c>HubDisposingException</c> derives from it, so one walk covers both. A teardown is
+    /// TRANSIENT — the owner's server-side stream is going away, the mirror must be kept alive and
+    /// re-ask on its next proven gap (the #2745 policy), never faulted and never counted toward the
+    /// give-up. Everything else is terminal: this owner cannot answer, so the subscriber is better
+    /// off failing and re-establishing than waiting.</para>
+    /// </summary>
+    /// <param name="error">The failure reported by the re-assert.</param>
+    /// <returns><c>true</c> when the stream or its hub is tearing down.</returns>
+    private static bool IsTearingDown(Exception? error)
+    {
+        for (var e = error; e is not null; e = e.InnerException)
+            if (e is ObjectDisposedException)
+                return true;
+        return false;
+    }
+
     internal static ISynchronizationStream CreateSynchronizationStream<TReduced, TReference>(
         this IWorkspace workspace,
         IMessageDelivery<SubscribeRequest> delivery
@@ -1225,30 +1246,62 @@ public static class JsonSynchronizationStream
         // Full to <c>hub.Post</c>, so the two arrive at the subscriber in that order. Nothing waits
         // and nothing polls: the ack rides the work it describes.
         //
-        // 🚨 Every path must post exactly ONE ack — a path that posts none leaves the subscriber's
-        // pending callback open until the hub's RequestTimeout, which is the wedge this ack exists
-        // to prevent. The failure arms below are part of that contract, not tidiness.
-        var acked = 0;
+        // 🚨 EVERY PATH ANSWERS EXACTLY ONCE, AND ONLY A PATH THAT SENT A SNAPSHOT MAY ACK.
+        //
+        // Two obligations, and they pull in opposite directions unless both are met by the same
+        // one-shot:
+        //
+        //   • A path that answers NOTHING leaves the subscriber's pending callback open until the
+        //     hub's RequestTimeout — with its resync gate shut for that whole window, which is the
+        //     wedge the ack exists to prevent (#2654).
+        //   • A path that ACKS without having sent a Full re-commits #3058 one branch over. If an
+        //     ack means "your snapshot is on the wire", then acking a re-assert that could not be
+        //     applied — the stream was disposed, the update turn threw — feeds an OWNER-side
+        //     failure into the mirror's acknowledged-and-unanswered count, which is reserved for
+        //     evidence that the LEG is eating snapshots. The give-up would then fire on a
+        //     recycling owner instead of on a lossy leg: the same miscount, narrower door.
+        //
+        // So a failure arm REFUSES instead. `DeliveryFailure` is the verdict
+        // SynchronizationStream.ResyncRefused already classifies, one policy per ErrorType, and it
+        // is deliberately NOT counted toward the give-up:
+        //
+        //   • the stream or its hub is tearing down (ObjectDisposedException, from
+        //     SynchronizationStream.SignalDisposedToProducer) ⇒ ShuttingDown, which is TRANSIENT:
+        //     the mirror is kept alive, its gate re-opens, and the next proven gap re-asks — the
+        //     #2745 rolling-deploy policy, and the right answer for an owner whose server-side
+        //     stream is simply going away;
+        //   • the re-assert genuinely threw ⇒ Exception, which ResyncRefused treats as TERMINAL:
+        //     this owner cannot produce a snapshot for this stream, so waiting is pointless and the
+        //     mirror faults, gets evicted by StreamLiveness.IsUsable, and the next natural caller
+        //     opens a fresh one. Strictly more actionable than the silent ack this replaces.
+        //
+        // CreateExternalClient's own Resubscribe arm reads the same verdict the same way (transient
+        // ⇒ push back through the recycle re-arm; otherwise Warning and clear the flag), so both
+        // callers of the re-assert path are served by one classification.
+        var answered = 0;
+        bool ClaimTheAnswer() => Interlocked.Exchange(ref answered, 1) == 0;
+
+        // The AccessContext comes off the SUBSCRIBE delivery, exactly as the outbound
+        // DataChangedEvent's does below: the deferred arm runs on the STREAM's turn, where the
+        // ambient identity is the stream's, not the subscriber's, and PostPipeline fails closed on
+        // an absent one.
+        PostOptions RespondTo(PostOptions o)
+        {
+            var opt = o.ResponseFor(delivery);
+            return delivery.AccessContext is not null
+                ? opt.WithAccessContext(delivery.AccessContext)
+                : opt;
+        }
+
         void Ack()
         {
-            // Idempotent by construction: the deferred arm and its failure arm can both be reached
-            // (a disposed stream signals the exception callback), and a second SubscribeAck would
-            // be answered into a callback that .Take(1) has already closed.
-            if (Interlocked.Exchange(ref acked, 1) == 1)
+            // Idempotent by construction: `applied` and the exception callback are both reachable
+            // for one Update, and a second answer would land in a callback .Take(1) has closed.
+            if (!ClaimTheAnswer())
                 return;
             try
             {
-                // The AccessContext comes off the SUBSCRIBE delivery, exactly as the outbound
-                // DataChangedEvent's does below: the deferred arm runs on the STREAM's turn, where
-                // the ambient identity is the stream's, not the subscriber's, and PostPipeline
-                // fails closed on an absent one.
-                hub.Post(new SubscribeAck(), o =>
-                {
-                    var opt = o.ResponseFor(delivery);
-                    return delivery.AccessContext is not null
-                        ? opt.WithAccessContext(delivery.AccessContext)
-                        : opt;
-                });
+                hub.Post(new SubscribeAck(), RespondTo);
             }
             catch (Exception ex)
             {
@@ -1257,6 +1310,52 @@ public static class JsonSynchronizationStream
                 // ResyncRefused releases its gate — the recoverable verdict, not a latch.
                 logger.LogDebug(ex,
                     "Owner {Owner} could not acknowledge the subscribe of stream {StreamId} for {Subscriber}",
+                    hub.Address, request.StreamId, request.Subscriber);
+            }
+        }
+
+        // The answer for a path that HAS a stream but nothing to put on the wire yet: hold the
+        // answer until that stream first produces state, which is the moment a Full really does go
+        // out. The forwarding subscription was registered when the stream was created — ahead of
+        // this one — so by the time this runs it has already handed the frame to hub.Post, exactly
+        // as `applied` does on the re-assert path.
+        //
+        // Not a poll and not a retry: one Rx one-shot on the very state the subscriber is waiting
+        // for, disposed by Take(1) when it fires and by the stream when it does not. If the state
+        // never arrives, the subscriber's own request/response terminal fires and ResyncRefused
+        // re-opens its gate WITHOUT counting the ask — the correct reading, since an owner with
+        // nothing to send has not failed to answer.
+        void AnswerWhenTheStreamFirstEmits(ISynchronizationStream<TReduced> stream)
+        {
+            logger.LogDebug(
+                "Owner {Owner} has nothing to re-assert on stream {StreamId} for {Subscriber} yet — "
+                + "holding the acknowledgement until its first frame",
+                hub.Address, request.StreamId, request.Subscriber);
+            var pending = stream.Take(1).Subscribe(_ => Ack(), Refuse);
+            stream.RegisterForDisposal(pending);
+        }
+
+        // The answer for a path that produced NO snapshot — never an ack. See the note above.
+        void Refuse(Exception error)
+        {
+            if (!ClaimTheAnswer())
+                return;
+            var tearingDown = IsTearingDown(error);
+            try
+            {
+                hub.Post(
+                    new DeliveryFailure(delivery)
+                    {
+                        ErrorType = tearingDown ? ErrorType.ShuttingDown : ErrorType.Exception,
+                        Message = $"Stream {request.StreamId} could not re-assert its snapshot for "
+                                  + $"{request.Subscriber}: {error.Message}",
+                    },
+                    RespondTo);
+            }
+            catch (Exception ex)
+            {
+                logger.LogDebug(ex,
+                    "Owner {Owner} could not refuse the subscribe of stream {StreamId} for {Subscriber}",
                     hub.Address, request.StreamId, request.Subscriber);
             }
         }
@@ -1309,30 +1408,57 @@ public static class JsonSynchronizationStream
             // snapshot — the orphaned mirror re-converges (a Full always lands, and the mirror
             // that resubscribed is by definition not ahead) — but it can neither erase newer
             // state nor poison the mirror's version.
-            if (alreadyServing.Current is { Value: not null })
-                // 🚨 THE DEFERRED ACK (#3058). `applied` runs in the update's OWN turn right after
-                // SetCurrent — and SetCurrent drives the outbound forwarding subscription
-                // synchronously (Store.OnNext → ToDataChanged → hub.Post), so the answering Full is
-                // already in the owner's outbound queue when this runs. Acking here therefore means
-                // what the subscriber's give-up reads it as: "your snapshot has been SENT". Ack from
-                // the failure arm too — a re-assert that could not be applied still owes the
-                // subscriber a verdict, and its gate is released by the ack it gets rather than by a
-                // 30-second request timeout.
-                alreadyServing.Update(
-                    _ => BuildReassertFrame(alreadyServing),
-                    ex =>
-                    {
-                        logger.LogWarning(ex,
-                            "Stream {StreamId}: could not re-assert snapshot for resubscribing subscriber {Subscriber}",
-                            alreadyServing.StreamId, request.Subscriber);
+            // 🚨 THE DEFERRED ACK (#3058). `applied` runs in the update's OWN turn right after
+            // SetCurrent — and SetCurrent drives the outbound forwarding subscription synchronously
+            // (Store.OnNext → ToDataChanged → hub.Post), so the answering Full is already in the
+            // owner's outbound queue when this runs. Acking there therefore means what the
+            // subscriber's give-up reads it as: "your snapshot has been SENT".
+            //
+            // 🚨 …AND ONLY WHEN A FRAME WAS ACTUALLY BUILT. `BuildReassertFrame` returns null when
+            // the stream has no state to assert — the ordinary condition for a server-side stream
+            // whose reduce has not produced yet, which during an INSTALL is not a moment but a
+            // PHASE: the owner is a NodeType hub that cannot emit until its source compiles, and it
+            // sits Current-less for as long as that takes. Acking there was the same defect this
+            // change exists to remove, one branch over, and worse because it REPEATS: every re-ask
+            // for the whole compile window was answered "acknowledged" with nothing behind it, so
+            // three of them tripped MaxUnansweredResyncs on a stream whose owner was merely busy.
+            // (Measured: the fault survived the ordering fix and still named 'Course/Card', a
+            // NodeType, in MeshWeaver.PluginTester.Test.)
+            //
+            // So a re-assert that produced no frame defers its answer to the stream's FIRST
+            // emission, which is the moment a Full really does go out. Nothing polls and nothing
+            // retries — it is one Rx one-shot on the state the subscriber is waiting for. If that
+            // state never arrives, the subscriber's own request/response terminal fires and
+            // ResyncRefused re-opens its gate WITHOUT counting the ask, which is the correct
+            // reading: an owner with nothing to send has not failed to answer, it has nothing to
+            // answer with.
+            //
+            // The failure arm REFUSES rather than acks, for the same reason: nothing was sent, so
+            // an ack there would feed an OWNER-side failure into the mirror's
+            // acknowledged-and-unanswered count. The subscriber still gets a verdict either way.
+            var reasserted = 0;
+            alreadyServing.Update(
+                _ =>
+                {
+                    var frame = BuildReassertFrame(alreadyServing);
+                    if (frame is not null)
+                        Interlocked.Exchange(ref reasserted, 1);
+                    return frame;
+                },
+                ex =>
+                {
+                    logger.LogWarning(ex,
+                        "Stream {StreamId}: could not re-assert snapshot for resubscribing subscriber {Subscriber}",
+                        alreadyServing.StreamId, request.Subscriber);
+                    Refuse(ex);
+                },
+                () =>
+                {
+                    if (Volatile.Read(ref reasserted) == 1)
                         Ack();
-                    },
-                    Ack);
-            else
-                // Nothing yet to re-assert (the initial subscribe is still hydrating) — its own
-                // first Full is already on its way to this subscriber, so the ack is not overtaking
-                // anything and is owed immediately.
-                Ack();
+                    else
+                        AnswerWhenTheStreamFirstEmits(alreadyServing);
+                });
             // Do NOT build a second stream — see the #606 note above.
             return alreadyServing;
         }

--- a/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/SynchronizationStream.cs
@@ -1830,6 +1830,17 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
     /// your re-subscribe" and then produced nothing is evidence that the leg is eating this
     /// stream's snapshots.
     ///
+    /// <para>🚨 WHAT MAKES AN ACK EVIDENCE AT ALL is the owner's ordering, not this counter's
+    /// arithmetic (#3058). A <c>SubscribeAck</c> is posted only AFTER the frame answering that
+    /// subscribe has been handed to the owner's outbound queue
+    /// (<c>JsonSynchronizationStream.CreateSynchronizationStream</c>), so "acknowledged and no base
+    /// snapshot followed" says the snapshot was SENT and died on the leg. While the ack was posted
+    /// the instant the re-subscribe was received — i.e. before the re-assert had even left the
+    /// stream's action block — that sentence was true of every ask the moment it was made, and this
+    /// counter measured the owner's queue depth instead: a bulk install re-asked three times inside
+    /// 9 ms while the first, entirely healthy Full was still queued, and faulted a mirror
+    /// mid-install. A give-up must count outstanding FAILURES, never attempts.</para>
+    ///
     /// <para>Written from the response thread (the ack arm) and from the hub turn (the reset), so
     /// every access is interlocked.</para>
     /// </summary>
@@ -2041,8 +2052,10 @@ public record SynchronizationStream<TStream> : ISynchronizationStream<TStream>, 
                         // re-ask is itself answered with a Full, which ends the cycle.
                         //
                         // 🚨 …AND THE ACK IS ALSO THE EVIDENCE (#1384). An acknowledgement says the
-                        // owner processed this re-subscribe; if a base snapshot never follows, the
-                        // answer died on the leg rather than never being sent, which is exactly the
+                        // owner SENT the snapshot answering this re-subscribe — the owner posts it
+                        // from the re-assert's own update turn, after the frame is already in its
+                        // outbound queue (#3058) — so if a base snapshot never follows, the answer
+                        // died on the leg rather than never being sent, which is exactly the
                         // non-convergence MaxUnansweredResyncs bounds. Counted HERE and nowhere
                         // else, deliberately: a re-ask REFUSED transiently is ridden out (#2745)
                         // and must not accumulate towards a fault, and an increment that races an

--- a/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DataSyncAndCrdt.md
@@ -288,16 +288,59 @@ while the breadcrumb, banner and menus around it rendered fine.
 | release | meaning |
 |---|---|
 | the fresh **Full** lands | the mirror has its base — the success case; also resets the did-not-converge counter |
-| the owner's **`SubscribeAck`** | the owner has processed the re-subscribe and done whatever it is going to do |
+| the owner's **`SubscribeAck`** | the owner has **sent** the snapshot answering the re-subscribe (see the ordering rule below) |
 | a **verdict** on the request (`DeliveryFailure`, or the hub's own no-response terminal) | the request cannot be answered — `ResyncRefused` |
 
 🚨 **Releasing the gate asks for nothing.** Nothing polls, retries or runs on a timer:
 only the *next frame that proves the mirror still has no base* drives a new re-ask, so
 the rate is bounded by the round trip **and** by the owner actually emitting — the same
 bound `JsonSynchronizationStream.Resubscribe`'s in-flight flag has always lived with.
-Because the owner ACKs before its re-assert reaches the wire, the common case costs at
-most **one redundant round trip** per gap, and that redundant re-ask is itself answered
-with a Full, which ends the cycle.
+The common case therefore costs at most **one redundant round trip** per gap, and that
+redundant re-ask is itself answered with a Full, which ends the cycle.
+
+#### 🚨 The ack must not overtake its own answer (#3058)
+
+That last sentence is only true because of an ordering rule the ack did not originally
+have. `SubscribeAck` was posted from `DataExtensions.HandleSubscribeRequest` the instant
+the re-subscribe was received — but the `alreadyServing` branch only *queues* an
+`UpdateStreamRequest` on the stream's action block, so the ack raced ahead of the frame it
+was supposed to acknowledge, down a different path (a direct hub response) from the one the
+Full takes (the stream's outbound forwarding subscription).
+
+**The gate then bounded one round trip to the owner, not one outstanding answer** — and the
+give-up below, which reads an ack as evidence, counted a promise as a result:
+
+```
+05:14:07.039  Fresh-snapshot request acknowledged by owner   ← re-assert still queued
+05:14:07.043  Fresh-snapshot request acknowledged by owner   ← behind the burst's own frames
+05:14:07.048  Fresh-snapshot request acknowledged by owner
+              Resync gave up: 3 consecutive fresh-snapshot requests to owner
+              'FutuRe/AmountType' were acknowledged and none produced a base snapshot
+```
+
+Three acks in **9 ms**, one healthy Full still in the queue. During a bulk install the
+re-assert waits behind the install's own frames, every one of those frames re-proves the
+mirror has no base and earns a fresh re-ask, and each re-ask is acknowledged in about a
+millisecond — so the count measured the owner's **queue depth** and called it
+non-convergence. It faulted mirrors mid-install and reddened the samples content gate on
+roughly a third of all runs, on unmodified `main`.
+
+So `CreateSynchronizationStream` owns the ack now, and posts it **from the re-assert's own
+update turn** via `Update(…, applied:)` — the callback that runs in the same turn right
+after `SetCurrent`, by which point `Store.OnNext` has already driven the forwarding
+subscription and handed the Full to `hub.Post`. Ack and frame leave through the same
+outbound queue, in that order.
+
+A **fresh** stream still acks immediately, and the asymmetry is deliberate: that subscribe
+has no answer to overtake, its first Full comes out of the reduce's own hydration (IO-bound
+and unbounded), and waiting would hold the subscriber's pending callback across it — risking
+the very `RequestTimeout` the ack exists to prevent. It also cannot produce the miscount: a
+re-ask reaches that path at most once per gap, because `RegisterClientSubscription` makes the
+next one a re-assert.
+
+Every path posts exactly **one** ack, failure arms included — a path that posts none leaves
+the subscriber's pending callback open until `RequestTimeout`, which is the wedge the ack
+exists to prevent.
 
 Three properties this contract needs, each of which was missing:
 
@@ -344,11 +387,12 @@ answered" (the healthy shape above) from "a stream that keeps asking and never c
 **What a re-subscribe is owed by the owner.** `CreateSynchronizationStream`'s
 `alreadyServing` branch re-asserts the current snapshot as a Full. When there is nothing to
 assert yet — the initial subscribe is still hydrating, `Current` is null — it returns
-without sending, and that is correct rather than a hole: `Current` and the outbound JSON
-cursor are set by the *same* emission, so a stream with no `Current` has an empty cursor,
-and `ToDataChanged`'s `currentJson is null` branch makes its **first** frame a `Full` by
-construction. The subscriber is therefore always answered with a Full; if that Full is lost
-in transport, the gate above — not the chain — is what recovers it.
+without sending (acknowledging immediately, since there is no answer to overtake), and that
+is correct rather than a hole: `Current` and the outbound JSON cursor are set by the *same*
+emission, so a stream with no `Current` has an empty cursor, and `ToDataChanged`'s
+`currentJson is null` branch makes its **first** frame a `Full` by construction. The
+subscriber is therefore always answered with a Full; if that Full is lost in transport, the
+gate above — not the chain — is what recovers it.
 
 Pinned by `StreamResyncConvergenceTest`: the answer lost in transport, the answer arriving
 on a rebased clock, the re-ask refused **terminally** (must fault), and the re-ask refused
@@ -384,8 +428,13 @@ So the count of consecutive **acknowledged-and-unanswered** re-asks is bounded, 
 
 🚨 **The count is of ACKS, not of asks, and that is the #2745 policy in one line.** The
 increment lives in the ack arm of `RequestFreshSnapshot` and nowhere else. An
-acknowledgement means the owner *processed* the re-subscribe, so a base snapshot that never
-follows died on the leg — evidence. A re-ask **refused transiently** (`ShuttingDown`, the
+acknowledgement means the owner **sent** the snapshot answering the re-subscribe — it is
+posted from the re-assert's own update turn, after the frame is already in the owner's
+outbound queue (see *The ack must not overtake its own answer*, #3058) — so a base snapshot
+that never follows died on the leg. That ordering is what makes an ack evidence at all: an
+ack that precedes its own answer makes "acknowledged and unanswered" true of every ask the
+moment it is made, and the bound then fires on a burst rather than on a wedge. A re-ask
+**refused transiently** (`ShuttingDown`, the
 rolling-deploy overlap window) is deliberately ridden out by the table above, and counting
 it would fault every mirror in that window, which is worse than the bug this fixes. An
 increment that races an answering Full is undone by that Full's own reset a moment later.
@@ -409,11 +458,22 @@ frame that proves the mirror still has no base. Raising the bound buys a longer 
 a better chance; that is the opposite of a widened timeout, and it is why the number is
 small.
 
+🚨 **A give-up counter must count outstanding FAILURES, never attempts — #3058, and it is
+the general lesson.** The two are the same number only when each attempt has been given its
+answer's round trip. The moment the counter can be incremented by something that has not yet
+had a chance to succeed, it stops measuring the condition it names and starts measuring
+*load*: a bound written against "the owner is not answering" fires hardest exactly when the
+owner is busiest — during an install, a burst, a cold start — which is when a healthy system
+looks most like a broken one. The cure is never a bigger bound (that just moves the burst
+size that trips it, and re-hides the underlying frame loss); it is to make each increment
+cost a completed failure. Here that meant fixing the *ordering of the evidence*, not the
+arithmetic: the ack had to start following its own answer.
+
 **Why 3.** The one healthy way to spend an attempt without converging is a Patch overtaking
-the answering Full. The owner queues its re-assert on the **same** stream hub that produces
-the patches, so a patch can only overtake a re-assert that was already in flight when the
-re-ask landed — one redundant round trip, twice over at the very worst. The two failure
-directions are also not symmetric:
+the answering Full — the re-assert was already in flight when the re-ask landed. With the
+ordering rule above, that is bounded by one redundant round trip, twice over at the very
+worst; without it, it was bounded by nothing at all. The two failure directions are also not
+symmetric:
 
 | bound too low | bound too high |
 |---|---|
@@ -442,10 +502,19 @@ permanently by construction) and it is already how the code reads since #2654. I
 what produced the incident above: `LayoutAreaReference` *is* a `WorkspaceReference`, so the
 Present-area stream took the ordinary path, asked, was acknowledged, and was never answered.
 
-Pinned by `StreamResyncGivesUpTest`: one mid-burst Patch eaten to start the resync, then
-**every** fresh snapshot eaten, one write per proven gap — the mirror must fault with a
-`StreamNotConvergingException`, and a fresh subscriber must then get a new stream that
-converges on the owner's complete state. It hangs on the pre-#1384 tree.
+Pinned by **two** tests, one per direction, and neither passes without the other's code:
+
+- `StreamResyncGivesUpTest` — one mid-burst Patch eaten to start the resync, then **every**
+  fresh snapshot eaten, one write per proven gap. The mirror must fault with a
+  `StreamNotConvergingException`, and a fresh subscriber must then get a new stream that
+  converges on the owner's complete state. It hangs on the pre-#1384 tree, and it passes
+  **unchanged** across #3058 — which is the evidence that correcting the ack's ordering did
+  not weaken the termination it enables.
+- `StreamResyncAnswerInFlightTest` — the answer is **held**, not destroyed: the re-assert
+  Full and the ack the owner posts once that frame is on its way, together, because on a real
+  leg they leave through the same queue. The burst's own patches keep flowing. The mirror
+  must ask **once**, never fault, and converge the moment the answer is released. On the
+  pre-#3058 tree the ack escapes the hold and the mirror asks again per frame.
 
 ---
 
@@ -517,6 +586,8 @@ mirror and the convergence rules above hold.
 | Cross-hub: subscriber sends a delta, owner reconstructs the exact entity | `EntityDeltaTest`, `StringDeltaTransportTest` |
 | A value-equal **Full** still applies (no dedup) — rollback / resync lands | `SynchronizationStream.SetCurrent` Fulls-bypass |
 | Out-of-sync subscriber can request a Full | `RequestFreshSnapshot` |
+| A re-subscribe is acknowledged only AFTER its answering Full is on the wire | `JsonSynchronizationStream.CreateSynchronizationStream` (`Update(…, applied:)`); `StreamResyncAnswerInFlightTest` |
+| A resync that never converges faults the mirror; one merely SLOW does not | `StreamResyncGivesUpTest`; `StreamResyncAnswerInFlightTest` |
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-busy-install-no-longer-breaks-live-views.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-busy-install-no-longer-breaks-live-views.md
@@ -1,0 +1,26 @@
+---
+Name: A busy install no longer breaks live views
+Category: Fix
+Description: Fixed a recovery check that mistook a slow answer for a missing one and cut off live views in the middle of a large install.
+Icon: Sparkle
+Order: -20260902
+---
+
+# A busy install no longer breaks live views
+
+When a page is showing live data and one update goes missing on the way to it, the page asks
+the server to send the whole picture again. If those requests are asked for repeatedly and
+nothing ever comes back, the page gives up and says so, which is what lets it reconnect
+instead of sitting on a spinner forever.
+
+The check for "nothing ever comes back" was reading the wrong signal. The server
+acknowledged each request the instant it arrived — before it had actually produced the fresh
+copy — so a page that asked while the server was busy was told "acknowledged" three times in
+a few milliseconds and concluded that its answers were being lost. They were not: they were
+queued behind the very work that made the server busy.
+
+During a large import or package install that is exactly what happens, so a perfectly
+healthy view was being cut off mid-install and had to be re-established. The server now
+acknowledges a request only once it has sent the answer, so "acknowledged with nothing
+behind it" means what it says. A view whose answer is merely slow now waits and catches up;
+a view whose answers really are being lost still gives up and reconnects, exactly as before.

--- a/test/MeshWeaver.Data.Test/StreamResyncAnswerInFlightTest.cs
+++ b/test/MeshWeaver.Data.Test/StreamResyncAnswerInFlightTest.cs
@@ -260,6 +260,9 @@ public class StreamResyncAnswerInFlightTest(ITestOutputHelper output) : HubTestB
             + "at all: it asked once, the owner is answering, and every frame since has merely "
             + "re-stated that the answer has not arrived yet");
 
+        // Snapshot BEFORE the release re-opens the pipeline: from here on, acks travel normally.
+        var acksThatOvertookTheirAnswer = Volatile.Read(ref acksLetThrough);
+
         // ── RELEASE, IN THE ORDER THE OWNER POSTED IT ──────────────────────────────────────────
         holdAnswers = false;
         var released = 0;
@@ -296,6 +299,17 @@ public class StreamResyncAnswerInFlightTest(ITestOutputHelper output) : HubTestB
             "the owner must acknowledge a re-subscribe only AFTER posting the snapshot that answers "
             + "it — an ack that overtakes its own answer makes 'acknowledged and unanswered' true of "
             + "every ask the moment it is made, which is exactly what the give-up then counts");
+
+        // The same invariant stated as an ABSENCE, which is the half that keeps it honest: it is not
+        // enough that SOME ack rode behind its answer, no ack may have gone out ahead of one. An ack
+        // with no snapshot behind it is exactly the evidence the give-up consumes, so a single
+        // escapee is a re-ask miscounted as a failure — which is why the owner's failure arms
+        // REFUSE with a DeliveryFailure rather than ack (ResyncRefused classifies that verdict and
+        // never counts it) instead of acknowledging a snapshot they did not send.
+        acksThatOvertookTheirAnswer.Should().Be(0,
+            "an ack means 'your snapshot is on the wire' — so no path may post one without having "
+            + "posted the snapshot first, and no path may leave the subscriber unanswered either: "
+            + "the two obligations are met by one answer per subscribe, an ack or a refusal");
 
         Volatile.Read(ref patchesLetThroughAfterTheLoss).Should().BeGreaterThanOrEqualTo(
             MaxUnansweredResyncs + 1,

--- a/test/MeshWeaver.Data.Test/StreamResyncAnswerInFlightTest.cs
+++ b/test/MeshWeaver.Data.Test/StreamResyncAnswerInFlightTest.cs
@@ -1,0 +1,324 @@
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// A GIVE-UP COUNTER MUST COUNT OUTSTANDING FAILURES, NEVER ATTEMPTS — Systemorph/MeshWeaver#3058.
+///
+/// <para><see cref="StreamResyncGivesUpTest"/> proves the mirror FAULTS when the owner→subscriber
+/// leg keeps eating this stream's fresh snapshots (#1384). This class proves the other half, which
+/// that bound got wrong the moment it shipped: a mirror whose answer is merely SLOW must not be
+/// faulted, and it was — on roughly a third of all CI runs, on unmodified main.</para>
+///
+/// <para><b>The live shape.</b> During an ordinary bulk install the owner's re-assert is queued on
+/// the stream's action block BEHIND the burst's own frames, so it takes milliseconds to come out.
+/// Every one of those frames re-proves the mirror has no base and earns a new re-ask, each re-ask
+/// is acknowledged in about a millisecond, and three acks landed inside 9 ms — measured,
+/// <c>05:14:07.039 → .043 → .048</c> in run 33593426491 — while the first, entirely healthy Full
+/// was still queued. The mirror then faulted itself mid-install with
+/// <c>StreamNotConvergingException: 3 consecutive fresh-snapshot requests to owner 'FutuRe/AmountType'
+/// were acknowledged and none produced a base snapshot</c>. Three asks, one outstanding request:
+/// the counter measured the owner's QUEUE DEPTH and called it non-convergence.</para>
+///
+/// <para><b>The defect was the word "acknowledged".</b> <c>SubscribeAck</c> was posted from
+/// <c>HandleSubscribeRequest</c> the instant the re-subscribe was received — before the re-assert
+/// had even left the stream's action block — while the subscriber's give-up reads an ack as "the
+/// owner answered and nothing followed". A promise was being counted as a result, so "acknowledged
+/// and unanswered" was true of every ask the moment it was made. The owner now posts the ack from
+/// the re-assert's own update turn, AFTER the answering Full is in its outbound queue, so an ack
+/// with no snapshot behind it means what the exception says it means.</para>
+///
+/// <para><b>What this test injects.</b> The answer to a re-ask is HELD — the re-assert Full and the
+/// <see cref="SubscribeAck"/> the owner posts once that frame is on its way, together, because in a
+/// running mesh they leave the owner through the same queue. The burst's own patches keep flowing,
+/// exactly as they do during an install. Held, not destroyed: a delayed answer is not a lost one,
+/// and telling the two apart is the whole point — <see cref="StreamResyncGivesUpTest"/> owns the
+/// destroyed case and still faults.</para>
+///
+/// <para>Pre-fix, the ack overtakes its own answer, escapes the hold, and the mirror re-asks once
+/// per further frame until it faults. Post-fix the ack rides behind the frame, the resync gate
+/// stays shut for exactly one outstanding re-ask, and the mirror waits — then converges the moment
+/// the answer is released.</para>
+/// </summary>
+public class StreamResyncAnswerInFlightTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// Mirrors <c>SynchronizationStream.MaxUnansweredResyncs</c>, which is private. The drive loop
+    /// below spends MORE gap-proving frames than this while one answer is outstanding — that is
+    /// precisely the burst the bound used to mistake for non-convergence.
+    /// </summary>
+    private const int MaxUnansweredResyncs = 3;
+
+    /// <summary>1 after the pipeline ate its one mid-burst Patch — the wire loss that starts the resync.</summary>
+    private int droppedPatches;
+
+    /// <summary>
+    /// Patch frames the owner has emitted on the mirror's stream. The loss is injected on the
+    /// SECOND one so the mirror has applied a real patch first — a gap can only be PROVEN against a
+    /// frame that landed.
+    /// </summary>
+    private int patchFramesSeen;
+
+    /// <summary>Patch frames let THROUGH to the mirror after the loss — the burst that keeps re-proving the gap.</summary>
+    private int patchesLetThroughAfterTheLoss;
+
+    /// <summary>Fires per patch let through after the loss, carrying the running count.</summary>
+    private readonly ReplaySubject<int> patchLetThrough = new(2 * MaxUnansweredResyncs + 4);
+
+    /// <summary>
+    /// Re-assert <see cref="ChangeType.Full"/> frames the owner has produced for the mirror — one
+    /// per re-ask it decided to answer. THE discriminator: while a single answer is in flight this
+    /// must stay at ONE, because a mirror with an outstanding re-ask has nothing to re-ask for.
+    /// </summary>
+    private int reassertFullsPosted;
+
+    /// <summary>Fires per held answer, carrying <see cref="reassertFullsPosted"/>.</summary>
+    private readonly ReplaySubject<int> answerHeld = new(2 * MaxUnansweredResyncs + 4);
+
+    /// <summary>
+    /// Acks the owner posted with no answering frame ahead of them. Pre-fix this is every re-ask's
+    /// ack; post-fix it is only the initial subscribe's, which answers nothing and overtakes
+    /// nothing.
+    /// </summary>
+    private int acksLetThrough;
+
+    /// <summary>
+    /// Acks held BECAUSE the owner had already posted the frame answering the same re-subscribe —
+    /// the positive, deterministic signal that the acknowledgement no longer overtakes its answer.
+    /// Zero on the pre-fix code, by construction.
+    /// </summary>
+    private int acksHeldBehindTheirAnswer;
+
+    /// <summary>The held answer, in the order the owner posted it. Released FIFO, so the mirror sees the wire it would really have seen.</summary>
+    private readonly ConcurrentQueue<IMessageDelivery> heldAnswer = new();
+
+    /// <summary>Turned off before the release, so a re-delivered frame is not held a second time.</summary>
+    private volatile bool holdAnswers = true;
+
+    /// <summary>
+    /// The stream carrying the mirror this test is about, learned from its INITIAL Full. Both hubs
+    /// run a data source, so more than one sync stream is alive; every injection is scoped to this
+    /// id so the test can never touch somebody else's stream.
+    /// </summary>
+    private volatile string? mirrorStreamId;
+
+    /// <summary>The subscriber every injection is scoped to — set from the client hub before it subscribes.</summary>
+    private volatile Address? subscriber;
+
+    /// <summary>The mirror's terminal error, if it ever produced one. Must stay null.</summary>
+    private volatile Exception? mirrorFault;
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(ds => ds
+                .WithType<MyData>(t => t.WithKey(d => d.Id))))
+            .AddPostPipeline(p => p.AddPipeline((d, next) =>
+            {
+                if (subscriber is null || !Equals(d.Target, subscriber))
+                    return next.Invoke(d);
+
+                // ── THE ACK ARM ────────────────────────────────────────────────────────────────
+                // An ack the owner posts AFTER the frame answering the same re-subscribe is part of
+                // that answer and is held with it: on a real leg both leave through the same queue,
+                // so a delay that hides the snapshot hides the acknowledgement too. An ack posted
+                // with NO answer ahead of it is not part of one and travels — which is every
+                // re-ask's ack on the pre-fix code, and is what let the mirror mistake a queued
+                // answer for a lost one.
+                //
+                // Counting only starts once the resync does (droppedPatches == 1): the INITIAL
+                // subscribe's ack answers no re-ask and must not consume a pairing slot.
+                if (d.Message is SubscribeAck)
+                {
+                    if (Volatile.Read(ref droppedPatches) == 0)
+                        return next.Invoke(d);
+                    if (holdAnswers
+                        && Volatile.Read(ref acksLetThrough) < Volatile.Read(ref reassertFullsPosted))
+                    {
+                        Interlocked.Increment(ref acksHeldBehindTheirAnswer);
+                        heldAnswer.Enqueue(d);
+                        return d.Ignored();
+                    }
+                    Interlocked.Increment(ref acksLetThrough);
+                    return next.Invoke(d);
+                }
+
+                if (d.Message is not DataChangedEvent evt)
+                    return next.Invoke(d);
+
+                // Learn the mirror's stream from its initial Full — the first frame it ever gets.
+                if (evt.ChangeType == ChangeType.Full && mirrorStreamId is null)
+                {
+                    mirrorStreamId = evt.StreamId;
+                    return next.Invoke(d);
+                }
+                if (evt.StreamId != mirrorStreamId)
+                    return next.Invoke(d);
+
+                // THE WIRE LOSS that starts the resync: eat exactly one mid-burst Patch. An Ignored
+                // post is dropped by ScheduleNotify, exactly the shape of the at-most-once transport
+                // losing a published frame between owner and mirror.
+                if (evt.ChangeType == ChangeType.Patch
+                    && Interlocked.Increment(ref patchFramesSeen) == 2
+                    && Interlocked.Exchange(ref droppedPatches, 1) == 0)
+                    return d.Ignored();
+
+                // ── THE ANSWER, HELD ───────────────────────────────────────────────────────────
+                // Every re-assert Full is captured rather than delivered. This is the owner's
+                // answer sitting in a queue — the install's own frames overtake it, which is the
+                // condition the whole test exists for.
+                if (evt.ChangeType == ChangeType.Full && holdAnswers)
+                {
+                    var held = Interlocked.Increment(ref reassertFullsPosted);
+                    heldAnswer.Enqueue(d);
+                    answerHeld.OnNext(held);
+                    return d.Ignored();
+                }
+
+                // Patches keep flowing — that is what a bulk install looks like, and each one
+                // re-proves to the mirror that it still has no base.
+                if (evt.ChangeType == ChangeType.Patch && Volatile.Read(ref droppedPatches) == 1)
+                    patchLetThrough.OnNext(Interlocked.Increment(ref patchesLetThroughAfterTheLoss));
+                return next.Invoke(d);
+            }));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration)
+            .AddData(data => data.AddSource(ds => ds
+                .WithType<MyData>(t => t.WithKey(d => d.Id))));
+
+    /// <summary>
+    /// A BURST OF ASKS AGAINST ONE OUTSTANDING ANSWER IS NOT A BURST OF FAILURES.
+    ///
+    /// <para>Pre-fix this test fails twice over, and both failures are the same defect: no ack is
+    /// ever held (the acknowledgement overtakes its own answer), and the mirror spends a re-ask per
+    /// gap-proving frame until <c>MaxUnansweredResyncs</c> faults it — the exception that reddened
+    /// the samples content gate on a third of all runs.</para>
+    /// </summary>
+    [HubFact]
+    public async Task AnAnswerStillInFlight_DoesNotCountAsUnanswered_AndTheMirrorConverges()
+    {
+        var host = GetHost();
+        var client = GetClient();
+        subscriber = client.Address;
+        var accessService = host.ServiceProvider.GetRequiredService<AccessService>();
+        accessService.SetContext(new AccessContext { ObjectId = "alice", Name = "Alice" });
+
+        var collectionName = host.GetWorkspace().DataContext.GetTypeSource(typeof(MyData))!.CollectionName;
+        var clientWorkspace = client.GetWorkspace();
+        var clientStream = clientWorkspace
+            .GetRemoteStream<EntityStore>(CreateHostAddress(), new CollectionsReference(collectionName));
+
+        // The mirror is live and mirrorStreamId is known — every injection below is scoped to it.
+        await clientStream.Should().Within(10.Seconds()).Emit();
+
+        // A fault is the pre-fix outcome, so observe it explicitly rather than letting it surface
+        // as an incidental timeout: every wait below then reports what actually went wrong.
+        using var faultWatch = clientStream.Subscribe(_ => { }, ex => mirrorFault = ex);
+
+        // A burst whose SECOND patch the wire eats — the third patch chains onto a version the
+        // mirror never applied, which is the proven gap that earns the one and only re-ask.
+        for (var i = 1; i <= 3; i++)
+            host.Post(
+                new DataChangeRequest().WithUpdates(new MyData($"doc-{i}", $"value-{i}")),
+                o => o.WithAccessContext(accessService.Context!));
+
+        await answerHeld
+            .Where(count => count >= 1)
+            .Take(1)
+            .Should().Within(15.Seconds())
+            .Emit("the owner must have ANSWERED the re-ask with a re-assert snapshot — this test is "
+                + "about an answer that is slow, so there has to be one");
+
+        // THE BURST. More gap-proving frames than the give-up bound tolerates, every one of them
+        // arriving while that single answer is still in flight. Each is posted only after the
+        // previous one has actually reached the wire, so the sequence is fixed rather than raced.
+        var writes = 3;
+        for (var i = 1; i <= MaxUnansweredResyncs + 1; i++)
+        {
+            host.Post(
+                new DataChangeRequest().WithUpdates(new MyData($"doc-{++writes}", $"value-{writes}")),
+                o => o.WithAccessContext(accessService.Context!));
+            var expected = i;
+            await patchLetThrough
+                .Where(count => count >= expected)
+                .Take(1)
+                .Should().Within(15.Seconds())
+                .Emit($"gap-proving frame {expected} must reach the mirror — a burst the mirror "
+                    + "never sees proves nothing about how it counts");
+        }
+
+        mirrorFault.Should().BeNull(
+            "a mirror whose one outstanding re-ask is still being answered has observed no failure "
+            + "at all: it asked once, the owner is answering, and every frame since has merely "
+            + "re-stated that the answer has not arrived yet");
+
+        // ── RELEASE, IN THE ORDER THE OWNER POSTED IT ──────────────────────────────────────────
+        holdAnswers = false;
+        var released = 0;
+        while (heldAnswer.TryDequeue(out var delivery))
+        {
+            ((MessageHub)client).DeliverMessage(delivery);
+            released++;
+        }
+        released.Should().BeGreaterThan(0, "the answer this test held has to be given back");
+
+        // The released snapshot carries the two documents the mirror could never have obtained
+        // otherwise: the one whose patch the wire ate, and the one whose patch proved the gap.
+        await clientStream
+            .Where(ci => ci.Value?.Collections.GetValueOrDefault(collectionName) is { } coll
+                && coll.Instances.Values.OfType<MyData>().Any(x => x.Id == "doc-2")
+                && coll.Instances.Values.OfType<MyData>().Any(x => x.Id == "doc-3"))
+            .Take(1)
+            .Should().Within(20.Seconds())
+            .Emit("the held answer must land and re-base the mirror once the leg delivers it — a "
+                + "resync that is merely slow still converges");
+
+        // ── THE DISCRIMINATOR ──────────────────────────────────────────────────────────────────
+        // Measured only now: the mirror has applied the released Full, and its sync hub is FIFO, so
+        // every gap-proving frame above was processed before it. Whatever re-asks the burst was
+        // going to provoke have provoked their re-asserts by now.
+        Volatile.Read(ref reassertFullsPosted).Should().Be(1,
+            $"the mirror had ONE outstanding re-ask, so it must have asked ONCE — {MaxUnansweredResyncs + 1} "
+            + "further frames proving it still has no base are not "
+            + $"{MaxUnansweredResyncs + 1} failures, they are the same request re-proved. Asking per "
+            + "frame is what drove the give-up counter to its bound inside 9 ms during a bulk "
+            + "install and faulted a perfectly healthy mirror");
+
+        Volatile.Read(ref acksHeldBehindTheirAnswer).Should().BeGreaterThan(0,
+            "the owner must acknowledge a re-subscribe only AFTER posting the snapshot that answers "
+            + "it — an ack that overtakes its own answer makes 'acknowledged and unanswered' true of "
+            + "every ask the moment it is made, which is exactly what the give-up then counts");
+
+        Volatile.Read(ref patchesLetThroughAfterTheLoss).Should().BeGreaterThanOrEqualTo(
+            MaxUnansweredResyncs + 1,
+            "the burst has to have been big enough to trip the bound had every frame earned its own "
+            + "re-ask — otherwise this test would pass on the code it exists to fail");
+
+        mirrorFault.Should().BeNull(
+            "a delayed answer must never fault the mirror: StreamLiveness.IsUsable then refuses to "
+            + "serve it and every subscriber is torn down and re-established mid-install");
+
+        // AND IT IS STILL A LIVE MIRROR, not merely an unfaulted one: the next write converges.
+        host.Post(
+            new DataChangeRequest().WithUpdates(new MyData($"doc-{++writes}", $"value-{writes}")),
+            o => o.WithAccessContext(accessService.Context!));
+
+        var total = writes;
+        await clientStream
+            .Where(ci => ci.Value?.Collections.GetValueOrDefault(collectionName) is { } coll
+                && coll.Instances.Values.OfType<MyData>()
+                    .Count(dd => dd.Text?.StartsWith("value-") == true) == total)
+            .Take(1)
+            .Should().Within(TestTimeouts.CrossSilo)
+            .Emit("the mirror must end up holding the owner's COMPLETE state — surviving the burst "
+                + "is only worth anything if the stream still tracks its owner afterwards");
+    }
+}

--- a/test/MeshWeaver.Data.Test/StreamResyncConvergenceTest.cs
+++ b/test/MeshWeaver.Data.Test/StreamResyncConvergenceTest.cs
@@ -106,12 +106,15 @@ public class StreamResyncConvergenceTest(ITestOutputHelper output) : HubTestBase
                     if (eatTheFreshSnapshot
                         && Interlocked.Exchange(ref droppedFreshSnapshots, 1) == 0)
                     {
-                        // Signalling HERE is ORDERED, not hopeful: the owner posts its SubscribeAck
-                        // from HandleSubscribeRequest the moment SubscribeToClient returns, while
-                        // the re-assert runs later on the stream's own turn — so by the time this
-                        // frame exists the ack is already on its way and the subscriber's gate is
-                        // opening. The write the test makes next therefore lands on an OPEN gate
-                        // with still no base: the frame that has to earn a second re-ask.
+                        // Signalling HERE is ORDERED, not hopeful — and since #3058 the ordering
+                        // runs the other way round. The owner posts its SubscribeAck from the
+                        // re-assert's own update turn, immediately AFTER this frame was handed to
+                        // hub.Post (CreateSynchronizationStream's Update(…, applied:)), so the ack
+                        // is one enqueue behind the frame this pipeline is eating and is already on
+                        // its way — far ahead of the write the test makes next, which cannot be
+                        // posted until this signal has travelled back out to the test thread. That
+                        // write therefore lands on an OPEN gate with still no base: the frame that
+                        // has to earn a second re-ask.
                         failureInjected.OnNext(Unit.Default);
                         return d.Ignored();
                     }

--- a/test/MeshWeaver.Data.Test/StreamResyncGivesUpTest.cs
+++ b/test/MeshWeaver.Data.Test/StreamResyncGivesUpTest.cs
@@ -124,12 +124,18 @@ public class StreamResyncGivesUpTest(ITestOutputHelper output) : HubTestBase(out
                 // lets the mirror converge.
                 if (evt.ChangeType == ChangeType.Full)
                 {
-                    // Signalling HERE is ORDERED, not hopeful: the owner posts its SubscribeAck from
-                    // HandleSubscribeRequest the moment SubscribeToClient returns, while the
-                    // re-assert runs later on the stream's own turn — so by the time this frame
-                    // exists the ack is already on its way to the mirror's host hub, ahead of
-                    // anything the test posts next. The write below therefore lands on an OPEN gate
-                    // with still no base: the frame that earns the next re-ask.
+                    // Signalling HERE is ORDERED, not hopeful — and since #3058 the ordering runs
+                    // the other way round, which is what makes this test's "acknowledged" honest.
+                    // The owner posts its SubscribeAck from the re-assert's own update turn,
+                    // immediately AFTER this frame was handed to hub.Post (CreateSynchronizationStream's
+                    // Update(…, applied:)), so the ack is one enqueue behind the frame the pipeline
+                    // is eating right now — already on its way to the mirror's host hub, and far
+                    // ahead of the write below, which cannot be posted until this signal has
+                    // travelled back out to the test thread. The write therefore lands on an OPEN
+                    // gate with still no base: the frame that earns the next re-ask.
+                    //
+                    // That ordering is also why the ack is EVIDENCE here rather than noise: it now
+                    // means "the owner SENT your snapshot", and this pipeline is what destroys it.
                     freshSnapshotDropped.OnNext(Interlocked.Increment(ref droppedFreshSnapshots));
                     return d.Ignored();
                 }


### PR DESCRIPTION
## The hypothesis held — and there were **two** doors, not one

`SubscribeAck` was posted from `DataExtensions.HandleSubscribeRequest` the instant a re-subscribe arrived. But the `alreadyServing` branch that answers it only **queues** an `UpdateStreamRequest` on the stream's action block — so the acknowledgement raced ahead of its own answer, down a **different path** (a direct hub response) from the one the Full takes (the stream's outbound forwarding subscription). The two are unordered, and the ack always wins.

`SynchronizationStream.RequestFreshSnapshot` reads an ack as *"the owner answered and nothing followed"* and faults the mirror past `MaxUnansweredResyncs` of them. With the ack arriving first, that sentence was true of **every ask the moment it was made**, so the counter measured the owner's **queue depth**:

```
05:14:07.039  Fresh-snapshot request acknowledged by owner   <- re-assert still queued
05:14:07.043  Fresh-snapshot request acknowledged by owner   <- behind the burst's own frames
05:14:07.048  Fresh-snapshot request acknowledged by owner
              Resync gave up: 3 consecutive fresh-snapshot requests to owner
              'FutuRe/AmountType' were acknowledged and none produced a base snapshot
```

Three asks, **one** outstanding request, one perfectly healthy Full still in the queue.

**But fixing the ordering alone did not close the gate flake** — its own control arm re-measured at 2/14, no better than main. Because once an ack means "I sent it", *any* path that acks without sending is the same defect, and there were two more:

| door | why it acked with nothing sent | can it repeat? |
|---|---|---|
| the failure arm of the re-assert | a disposed stream / an apply error — nothing was enqueued | no (once per subscribe) |
| **`BuildReassertFrame` returned `null`** | the stream has no state to assert yet | **yes — for as long as that lasts** |

The second one is what was actually reddening the gate. During an install the owner is a **NodeType hub that cannot emit until its source compiles**, so it sits `Current`-less for the whole compile window and every re-ask inside it was answered "acknowledged" with no Full behind it. Three of those trip the bound on a stream whose owner is merely busy. The measurement names it: after the ordering fix the fault still fired, still named `Course/Card` — a NodeType — and still fired in the **`[checks]` phase**, i.e. at NodeType activation.

## The fix

**An ack means the snapshot is on the wire, on every path — and every path still answers exactly once.**

1. **The ack follows the frame.** `CreateSynchronizationStream` owns the ack and, on the re-assert path, posts it from `Update(…, applied:)` — the callback that runs in the **same turn** right after `SetCurrent`, by which point `Store.OnNext` has already driven the forwarding subscription and handed the Full to `hub.Post`.
2. **A failed re-assert refuses instead of acking.** It posts a `DeliveryFailure`, which `ResyncRefused` already classifies one-policy-per-`ErrorType`: `ObjectDisposedException` (incl. `HubDisposingException`) ⇒ `ShuttingDown` ⇒ transient, ridden out per #2745 and **not counted**; anything else ⇒ terminal, so the mirror faults and re-establishes. `ResyncRefused` releases the gate as its **first, unconditional statement**, so the verdict is as prompt as the ack it replaces.
3. **An empty re-assert defers its answer to the stream's first emission** — the moment a Full really does go out. One Rx one-shot; nothing polls, nothing retries. If that state never arrives, the subscriber's own request/response terminal fires and `ResyncRefused` re-opens the gate **without counting the ask** — an owner with nothing to send has not failed to answer, it has nothing to answer with.

`Ack` and `Refuse` share one compare-and-set, so exactly one verdict leaves per subscribe however the arms interleave.

A **fresh** stream still acks immediately, deliberately: it has no answer to overtake, its first Full comes out of the reduce's own hydration (IO-bound, unbounded), waiting would hold the subscriber's callback across it — and it cannot repeat, because `RegisterClientSubscription` makes the next re-ask a re-assert.

Nothing waits on a timer. `MaxUnansweredResyncs` is **unchanged at 3**.

## #1384's termination is intact — the strongest available evidence

`StreamResyncGivesUpTest` passes **unchanged**: same drive loop, same bound, same `StreamNotConvergingException`. An owner that genuinely never answers still faults after three acknowledged-and-lost snapshots, because an ack now means *"I sent it"*.

## Control arms — matched 20 runs each

`MeshWeaver.PluginTester.Test`, full project per run, same machine, alternating only `src/`:

| arm | runs | `StreamNotConverging` | any failure |
|---|---|---|---|
| `origin/main` | 20 | **5** (25%) | 6 |
| ordering fix only (first commit) | 14 | **2** | 3 |
| **both doors closed (this PR)** | 20 | **0** | **0** |

The control's 25% matches the ~1-in-3 the issue measured. The middle row is the load-bearing one: **the first commit alone did not move it** — which is why the second exists.

## Tests

| | |
|---|---|
| **`StreamResyncAnswerInFlightTest`** (new) | The answer is **held**, not destroyed — the re-assert Full **and** the ack the owner posts once that frame is on its way, together, because on a real leg they leave through the same queue. The burst's own patches keep flowing. The mirror must ask **once**, never fault, and converge when the answer is released. It also asserts the invariant as an **absence**: zero acks may go out ahead of their answer during a resync. |
| **`StreamResyncGivesUpTest`** | Unchanged. The genuine wedge still faults. |

The new test fails **deterministically** on unmodified `src` (full project: 421 pass, 1 fail) in 245 ms:

```
Expected value to be 1 because the mirror had ONE outstanding re-ask, so it must have
asked ONCE — 4 further frames proving it still has no base are not 4 failures, they are
the same request re-proved […], but found 2.

[Warning] [SYNC_STREAM] Resync has not converged for 1y0zionfsEWuSKXn04tcIQ: asking host/1
  for a fresh snapshot again (attempt 2) — the previous request produced no base snapshot
```

`StreamResyncConvergenceTest` and `StreamResyncGivesUpTest` both carried comments asserting the **old** ack ordering, and each test's determinism argument rests on it — those rationales are corrected in the same change.

Also green locally, Release: `MeshWeaver.Data.Test` 422/422, `MeshWeaver.Layout.Test` 443/443, `MeshWeaver.Documentation.Test` 176/176 (link integrity + the timeout-literal ratchet), and the full 61-project solution at `-c Release -warnaserror` with `0 Warning(s), 0 Error(s)`.

## Docs

`DataSyncAndCrdt` §6 and §9 carried the ordering claim that was wrong — *"Because the owner ACKs before its re-assert reaches the wire, the common case costs at most one redundant round trip"* — and the "Why 3" reasoning built on it. Corrected, plus the general lesson recorded:

> A give-up counter must count outstanding **failures**, never attempts. The two are the same number only when each attempt has been given its answer's round trip. The moment the counter can be incremented by something that has not yet had a chance to succeed, it stops measuring the condition it names and starts measuring **load** — so a bound written against "the owner is not answering" fires hardest exactly when the owner is busiest. The cure is never a bigger bound.

Plus a What's New entry (`Category: Fix`).

## Scope

This is question **2** of the issue ("why does an acknowledged re-ask produce no base snapshot"). Question **1** — *why a Patch frame is lost at all*, 8–15 per samples-gate run on `main` — is untouched and still open: the give-up was the messenger. That frame loss no longer reds the gate, but it is still there.

Fixes #3058

🤖 Generated with [Claude Code](https://claude.com/claude-code)
