### PR TITLE
Resolver's derived-type scan tolerates unloadable types — a diagnostic never loses a delivery

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/Serialization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Serialization.md
@@ -181,6 +181,42 @@ The `$type` discriminator defaults to the **short** type name (`StackControl`, `
 
 > Backward compatibility: the registry keeps an alias from each type's full name to its definition, so JSON persisted with a legacy `"$type":"MeshWeaver.Layout.StackControl"` still deserializes. New writes always emit the short name.
 
+### The resolver's diagnostics must never fail the serialization they run in
+
+`PolymorphicTypeInfoResolver` runs two kinds of work inside `GetTypeInfo`: the work the serializer
+needs (the `$type` discriminators for a base type's registered subtypes) and **diagnostics** — the
+"unregistered type serialised here" warning, and a scan of the base type's assembly for polymorphic
+subtypes nobody registered (which would drop to the nearest ancestor and render empty on the
+receiver). Because `GetTypeInfo` is on the path of *every* serialization on the hub, a diagnostic
+that throws does not merely lose its own warning: it fails whatever message was being written.
+
+That was measured on the one message that must never be lost. `MessageService.ReportFailure` posts
+a `DeliveryFailure` back to the sender of a request that could not be delivered; serializing that
+envelope resolved type info for a base type whose assembly came from a module with an incomplete
+dependency closure (a closure without `Microsoft.Agents.AI` — see
+[Module Closure Accounting](../ModuleClosureAccounting)). `Assembly.GetTypes()` on such an
+assembly throws `ReflectionTypeLoadException` for the *one* type it cannot load, the exception
+escaped the scan, and the hub logged
+`Failed to post DeliveryFailure message for CreateNodeRequest … - breaking error cascade` — the
+sender waited for a verdict that never came.
+
+The rule, and how the resolver now honours it:
+
+- **Enumerate types loader-safely.** `GetTypes()` is wrapped in the canonical
+  `catch (ReflectionTypeLoadException e) → e.Types.Where(t => t is not null)`: the loadable types
+  are scanned, the rest are skipped.
+- **Report the skipped remainder once per assembly, per hub.** The de-duplicated
+  `LoaderExceptions` messages name the missing dependency, so the warning is the actionable
+  diagnostic for the closure defect — one line, not one per serialized type.
+- **Compute the per-assembly type list once.** The loadable types are cached per assembly in an
+  instance `ConditionalWeakTable<Assembly, Type[]>` on the resolver (it dies with the hub's options
+  and, being weak-keyed, does not root a collectible module assembly), so a busy hub does not
+  re-enumerate — and, in the failing case, re-attempt the failed load — for every base type it
+  serializes.
+
+The closure defect itself stays a defect and is fixed where closures are built; the resolver's job
+is to make sure it can no longer silence the report of some *other* request's failure.
+
 ### Use typed query helpers
 
 `IMeshService.Query<T>` filters by `$type` and projects directly to `T`, avoiding manual

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-failed-request-is-reported-even-when-a-module-is-incomplete.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-failed-request-is-reported-even-when-a-module-is-incomplete.md
@@ -1,0 +1,24 @@
+---
+Name: A failed request is reported even when a module is incomplete
+Category: Fix
+Description: A message whose failure could not be reported is now reported — an incomplete package no longer turns "your request failed" into silence, and the hub names the package and the file it is missing.
+Icon: Warning
+Order: -20260902
+---
+
+# A failed request is reported even when a module is incomplete
+
+When a request could not be delivered, the hub tells the sender so — that failure notice is how a
+save, a create, or a page knows to show an error instead of waiting forever.
+
+Writing that notice runs the same serializer as every other message, and the serializer runs a
+small diagnostic: it looks through the assembly of the type it is serializing for related types
+nobody registered, so it can warn about them. When a package shipped without one of its
+dependencies, that look-through failed — and its failure escaped and took the failure notice with
+it. The sender never heard back. On the affected portals this looked like requests that neither
+succeeded nor failed, with a single "breaking error cascade" line in the log as the only trace.
+
+The diagnostic now stays a diagnostic. It reports what it could not load — once per assembly, with
+the assembly's name and the dependency it is missing — and the message it was serializing goes out
+regardless. The incomplete package is still a defect (and is fixed separately), but it can no
+longer silence the report of some other request's failure.

--- a/src/MeshWeaver.Messaging.Hub/Serialization/PolymorphicTypeInfoResolver.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/PolymorphicTypeInfoResolver.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Concurrent;
+using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
@@ -176,15 +178,23 @@ public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry, string? own
     // (A) Polymorphic subtypes of baseType that EXIST in its assembly but are NOT registered in THIS hub
     // serialise fine here yet DROP to FallBackToNearestAncestor when this hub RECEIVES them, with no other
     // signal (the silent-skin-drop class). Warn once per type (instance dict — no static state) so the
-    // missing registration surfaces. Scoped to baseType.Assembly to avoid a full AppDomain scan; STJ caches
-    // JsonTypeInfo so this runs at most once per base type.
+    // missing registration surfaces. Scoped to baseType.Assembly to avoid a full AppDomain scan, and the
+    // assembly's type list comes from the per-assembly cache below, so STJ's once-per-type resolution
+    // costs one enumeration per ASSEMBLY, not one per base type.
+    //
+    // 🚨 This is a DIAGNOSTIC running inside GetTypeInfo — i.e. inside every serialization on the hub,
+    // including MessageService.ReportFailure's DeliveryFailure post. It must never throw: when it did
+    // (Assembly.GetTypes() on a module whose closure lacked Microsoft.Agents.AI threw
+    // ReflectionTypeLoadException), the sender of the failed request never learned it had failed —
+    // "Failed to post DeliveryFailure message … breaking error cascade". A diagnostic degrades to a
+    // diagnostic (GetLoadableTypes + WarnUnloadableTypes), never to a lost delivery.
     private readonly ConcurrentDictionary<Type, byte> warnedMissingDerived = new();
     private void WarnMissingDerivedRegistrations(Type baseType, List<JsonDerivedType> derivedTypes)
     {
         if (logger is null || baseType == typeof(object) || baseType.IsSealed)
             return;
         var present = derivedTypes.Select(d => d.DerivedType).ToHashSet();
-        foreach (var t in baseType.Assembly.GetTypes())
+        foreach (var t in GetLoadableTypes(baseType.Assembly))
         {
             if (t.IsAbstract || t.IsInterface || t.IsGenericTypeDefinition || t == baseType
                 || !baseType.IsAssignableFrom(t) || present.Contains(t)
@@ -197,6 +207,60 @@ public class PolymorphicTypeInfoResolver(ITypeRegistry typeRegistry, string? own
                 + "and receiving hub.",
                 t.FullName, baseType.Name, owner ?? "(unknown)", t.Name, t.Name);
         }
+    }
+
+    // (B) Loadable types per assembly, computed ONCE per assembly per resolver. Weak-keyed on purpose: the
+    // resolver belongs to a long-lived hub, and a strong Assembly → Type[] entry would root every
+    // collectible module/dynamic-node assembly whose type was ever serialised here (the recompile-ALC leak
+    // TypeRegistry's weak shadow exists to prevent). ConditionalWeakTable keeps the array alive only while
+    // the assembly is otherwise reachable. Instance field — dies with the hub's options; never static.
+    private readonly ConditionalWeakTable<Assembly, Type[]> loadableTypesByAssembly = new();
+    // Warn ONCE per offending assembly (keyed by name — a string never pins the assembly).
+    private readonly ConcurrentDictionary<string, byte> warnedUnloadableAssemblies = new();
+
+    private Type[] GetLoadableTypes(Assembly assembly)
+    {
+        if (loadableTypesByAssembly.TryGetValue(assembly, out var cached))
+            return cached;
+        Type[] types;
+        try
+        {
+            types = assembly.GetTypes();
+        }
+        catch (ReflectionTypeLoadException ex)
+        {
+            // The canonical loader-safe enumeration: keep every type that DID load, report the rest once.
+            types = ex.Types.OfType<Type>().ToArray();
+            WarnUnloadableTypes(assembly, ex);
+        }
+        // A concurrent caller may have computed the same array first; either copy is equally valid.
+        loadableTypesByAssembly.TryAdd(assembly, types);
+        return types;
+    }
+
+    /// <summary>
+    /// One or more types in <paramref name="assembly"/> could not be loaded — in practice a module whose
+    /// dependency closure is missing an assembly (measured: a closure without <c>Microsoft.Agents.AI</c>
+    /// on Plugins CI and Reinsurance main). The derived-type scan has already continued with the types
+    /// that did load, so the serialization this runs inside is unaffected; what is lost is only the
+    /// scan's own coverage of the unloadable types, and THAT is what this warning reports — once per
+    /// assembly per hub, naming the assembly and the de-duplicated loader messages, which name the
+    /// missing dependency. It is the actionable diagnostic for the closure defect; the closure itself is
+    /// fixed where closures are built, never here.
+    /// </summary>
+    private void WarnUnloadableTypes(Assembly assembly, ReflectionTypeLoadException ex)
+    {
+        var assemblyName = assembly.FullName ?? assembly.GetName().Name ?? "(unnamed)";
+        if (logger is null || !warnedUnloadableAssemblies.TryAdd(assemblyName, 0))
+            return;
+        var loaderMessages = string.Join("; ",
+            ex.LoaderExceptions.Where(e => e is not null).Select(e => e!.Message).Distinct());
+        logger.LogWarning(
+            "{UnloadableCount} of {TotalCount} types in assembly {Assembly} cannot be loaded on hub {Hub}: "
+            + "{LoaderMessages}. Serialization continued with the types that did load, but a polymorphic "
+            + "subtype among the unloadable ones cannot round-trip here. Fix the module's dependency closure "
+            + "so the assembly named in the loader message ships with it.",
+            ex.Types.Count(t => t is null), ex.Types.Length, assemblyName, owner ?? "(unknown)", loaderMessages);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Messaging.Hub.Test/PolymorphicResolverUnloadableAssemblyTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/PolymorphicResolverUnloadableAssemblyTest.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Collections.Concurrent;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Runtime.Loader;
+using System.Text.Json;
+using MeshWeaver.Domain;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging.Serialization;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// A diagnostic must degrade to a diagnostic, never to a lost delivery.
+///
+/// <para><c>PolymorphicTypeInfoResolver.WarnMissingDerivedRegistrations</c> exists only to WARN about
+/// polymorphic subtypes that are not registered on the hub, and to find them it enumerates the base
+/// type's assembly with <c>Assembly.GetTypes()</c>. When ONE type in that assembly cannot be loaded —
+/// a module whose dependency closure lacks an assembly (Plugins CI run 33595986160 and Reinsurance
+/// main: a closure without <c>Microsoft.Agents.AI</c>) — <c>GetTypes()</c> throws
+/// <see cref="ReflectionTypeLoadException"/>, the exception escapes <c>GetTypeInfo</c>, and the
+/// serialization it was resolving for fails. The measured victim was
+/// <c>MessageService.ReportFailure</c>: it could not serialize the <c>DeliveryFailure</c> envelope, so
+/// the sender of the failed <c>CreateNodeRequest</c> never learned its request had failed.</para>
+///
+/// <para>The fixture reproduces the exact CLR condition without Roslyn: a probe module emitted with
+/// <see cref="PersistedAssemblyBuilder"/> carries two loadable classes and one whose base type lives
+/// in an assembly the module's load context cannot resolve. Serializing a loadable type from that
+/// module must succeed, and the unloadable remainder must surface as ONE warning per assembly
+/// naming the assembly and the missing dependency.</para>
+/// </summary>
+public class PolymorphicResolverUnloadableAssemblyTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    [Fact]
+    public void SerializationSurvivesAnAssemblyWhoseTypesDoNotAllLoad_AndWarnsOncePerAssembly()
+    {
+        var probe = LoadProbeModuleWithMissingDependency();
+
+        // The fixture must reproduce the production condition, or a green below proves nothing.
+        Action scan = () => probe.Loadable.Assembly.GetTypes();
+        scan.Should().Throw<ReflectionTypeLoadException>(
+            "the probe module must carry a type whose base lives in an assembly its load context cannot resolve");
+
+        var typeRegistry = GetHost().ServiceProvider.GetRequiredService<ITypeRegistry>();
+        var log = new ConcurrentQueue<(LogLevel Level, string Message)>();
+        var options = new JsonSerializerOptions
+        {
+            TypeInfoResolver = new PolymorphicTypeInfoResolver(typeRegistry, "probe-hub", new CapturingLogger(log))
+        };
+
+        var instance = Activator.CreateInstance(probe.Loadable)!;
+        probe.Loadable.GetProperty("Value")!.SetValue(instance, "hello");
+
+        // Before the fix this threw ReflectionTypeLoadException out of GetTypeInfo: the envelope was
+        // never written, and ReportFailure's DeliveryFailure post died in the same way.
+        var json = JsonSerializer.Serialize(instance, probe.Loadable, options);
+        json.Should().Contain("\"Value\":\"hello\"");
+
+        var unloadable = log.Where(e => e.Message.Contains(probe.MissingDependency)).ToList();
+        unloadable.Should().ContainSingle(
+            "the unloadable remainder is reported once per assembly, naming the missing dependency");
+        unloadable[0].Level.Should().Be(LogLevel.Warning);
+        unloadable[0].Message.Should().Contain(probe.ModuleName,
+            "the warning must name the assembly that could not be fully loaded");
+
+        // A second type from the SAME assembly: the loadable-type scan is computed once per assembly
+        // per resolver, so the diagnostic does not repeat per serialized type.
+        var sibling = Activator.CreateInstance(probe.Sibling)!;
+        JsonSerializer.Serialize(sibling, probe.Sibling, options).Should().StartWith("{");
+        log.Count(e => e.Message.Contains(probe.MissingDependency)).Should().Be(1,
+            "a per-type repeat of the per-assembly diagnostic would be a log storm on a busy hub");
+    }
+
+    private sealed record ProbeModule(Type Loadable, Type Sibling, string ModuleName, string MissingDependency);
+
+    /// <summary>
+    /// Emits a dependency assembly (one public class), then a probe module with two self-contained
+    /// classes and one class deriving from the dependency's class, and loads the probe module into a
+    /// context that cannot resolve the dependency — so <c>GetTypes()</c> on it throws
+    /// <see cref="ReflectionTypeLoadException"/> with exactly one <c>null</c> slot.
+    /// </summary>
+    private static ProbeModule LoadProbeModuleWithMissingDependency()
+    {
+        var suffix = Guid.NewGuid().ToString("N");
+        var dependencyName = $"MissingDependency_{suffix}";
+        var moduleName = $"ProbeModule_{suffix}";
+
+        var dependencyBuilder = new PersistedAssemblyBuilder(new AssemblyName(dependencyName), typeof(object).Assembly);
+        dependencyBuilder.DefineDynamicModule(dependencyName)
+            .DefineType("Dependency.DependencyBase", TypeAttributes.Public | TypeAttributes.Class)
+            .CreateType();
+        using var dependencyStream = new MemoryStream();
+        dependencyBuilder.Save(dependencyStream);
+        dependencyStream.Position = 0;
+
+        // The dependency is loaded into a THROWAWAY context only so the probe module can be emitted
+        // against a runtime Type. The context the probe module is loaded into below never consults
+        // this one (custom contexts resolve through their own Load, then the Default context), so
+        // from the probe module's point of view the dependency does not exist.
+        var emitContext = new AssemblyLoadContext($"emit-{suffix}", isCollectible: true);
+        var dependencyBase = emitContext.LoadFromStream(dependencyStream).GetType("Dependency.DependencyBase")!;
+
+        var moduleBuilder = new PersistedAssemblyBuilder(new AssemblyName(moduleName), typeof(object).Assembly);
+        var module = moduleBuilder.DefineDynamicModule(moduleName);
+        DefineClassWithStringProperty(module, "Probe.Loadable", "Value");
+        DefineClassWithStringProperty(module, "Probe.Sibling", "Value");
+        module.DefineType("Probe.Unloadable", TypeAttributes.Public | TypeAttributes.Class, dependencyBase).CreateType();
+        using var moduleStream = new MemoryStream();
+        moduleBuilder.Save(moduleStream);
+        moduleStream.Position = 0;
+
+        var runContext = new AssemblyLoadContext($"run-{suffix}", isCollectible: true);
+        var probeAssembly = runContext.LoadFromStream(moduleStream);
+        return new ProbeModule(
+            probeAssembly.GetType("Probe.Loadable")!,
+            probeAssembly.GetType("Probe.Sibling")!,
+            moduleName,
+            dependencyName);
+    }
+
+    private static void DefineClassWithStringProperty(ModuleBuilder module, string typeName, string propertyName)
+    {
+        var typeBuilder = module.DefineType(typeName, TypeAttributes.Public | TypeAttributes.Class);
+        var field = typeBuilder.DefineField($"_{propertyName}", typeof(string), FieldAttributes.Private);
+        var property = typeBuilder.DefineProperty(propertyName, PropertyAttributes.None, typeof(string), null);
+        const MethodAttributes accessorAttributes =
+            MethodAttributes.Public | MethodAttributes.SpecialName | MethodAttributes.HideBySig;
+        var getter = typeBuilder.DefineMethod($"get_{propertyName}", accessorAttributes, typeof(string), Type.EmptyTypes);
+        var getterIl = getter.GetILGenerator();
+        getterIl.Emit(OpCodes.Ldarg_0);
+        getterIl.Emit(OpCodes.Ldfld, field);
+        getterIl.Emit(OpCodes.Ret);
+        var setter = typeBuilder.DefineMethod($"set_{propertyName}", accessorAttributes, null, [typeof(string)]);
+        var setterIl = setter.GetILGenerator();
+        setterIl.Emit(OpCodes.Ldarg_0);
+        setterIl.Emit(OpCodes.Ldarg_1);
+        setterIl.Emit(OpCodes.Stfld, field);
+        setterIl.Emit(OpCodes.Ret);
+        property.SetGetMethod(getter);
+        property.SetSetMethod(setter);
+        typeBuilder.CreateType();
+    }
+
+    private sealed class CapturingLogger(ConcurrentQueue<(LogLevel Level, string Message)> sink) : ILogger
+    {
+        public IDisposable BeginScope<TState>(TState state) where TState : notnull => NullScope.Instance;
+        public bool IsEnabled(LogLevel logLevel) => true;
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) => sink.Enqueue((logLevel, formatter(state, exception)));
+
+        private sealed class NullScope : IDisposable
+        {
+            public static readonly NullScope Instance = new();
+            public void Dispose() { }
+        }
+    }
+}


### PR DESCRIPTION
## A diagnostic scan must not take down the error-reporting path

### What was failing

Measured in Plugins CI (run 33595986160, job 100141052832) and on Reinsurance `main`: with a module whose dependency closure lacks `Microsoft.Agents.AI[.Abstractions]`, the hub logs

```
fail: MeshWeaver.Messaging.MessageService — Failed to post DeliveryFailure message for CreateNodeRequest … - breaking error cascade
System.Reflection.ReflectionTypeLoadException: Unable to load one or more of the requested types. Could not load file or assembly 'Microsoft.Agents.AI, Version=1.17.0.0…'
   at System.Reflection.RuntimeModule.GetTypes / Assembly.GetTypes()
   at PolymorphicTypeInfoResolver.WarnMissingDerivedRegistrations(...)   :184
   at PolymorphicTypeInfoResolver.ComputeDerivedTypes :172 → GetTypeInfo :38 → … → MessageService.Post → MessageService.ReportFailure
```

`WarnMissingDerivedRegistrations` exists only to **warn** about polymorphic subtypes nobody registered. To find them it called `Assembly.GetTypes()` on the base type's assembly. One assembly with a single unloadable type (an unresolvable base-type dependency) makes `GetTypes()` throw, the exception escaped `GetTypeInfo`, and the serialization it was resolving for died with it — here the `DeliveryFailure` envelope in `MessageService.ReportFailure`. **The sender never learned its request had failed** (silent loss, the #3044 family). The closure defect itself is fixed elsewhere (core #2977); this is the independent core defect: a diagnostic must degrade to a diagnostic, never to a lost delivery.

### What changed

`src/MeshWeaver.Messaging.Hub/Serialization/PolymorphicTypeInfoResolver.cs`
- **Loader-safe enumeration at the root.** `GetTypes()` is wrapped in the canonical `catch (ReflectionTypeLoadException e) → e.Types.OfType<Type>()`: the scan continues over the types that did load.
- **One warning per offending assembly, per hub**, naming the assembly and the de-duplicated `LoaderExceptions` messages (which name the missing dependency: `Could not load file or assembly 'Microsoft.Agents.AI, …'`). That is the actionable diagnostic for the closure defect — one line, not one per serialized type.
- **Computed once per assembly, cached on the instance.** The loadable-type list is held in an instance `ConditionalWeakTable<Assembly, Type[]>` on the resolver (dies with the hub's options; weak-keyed so it cannot root a collectible module/dynamic-node assembly — the recompile-ALC leak `TypeRegistry`'s weak shadow exists to prevent). Before, every base type re-enumerated its whole assembly inside `GetTypeInfo`, and in the failing case re-attempted the failed load each time.
- `ComputeDerivedTypes` was checked for the same scan: it enumerates `typeRegistry.Types` (already-loaded types), not `GetTypes()` — no change needed there.

`test/MeshWeaver.Messaging.Hub.Test/PolymorphicResolverUnloadableAssemblyTest.cs` — a test that **failed before the fix** with the production exception. It emits (via `PersistedAssemblyBuilder`, no Roslyn) a dependency assembly and a probe module with two loadable classes and one whose base type lives in that dependency, loads the probe module into a context that cannot resolve the dependency (`GetTypes()` provably throws), then serializes a loadable type through the resolver: serialization succeeds, exactly one `Warning` names the module assembly and the missing dependency, and serializing a second type from the same assembly does not repeat it.

Pre-fix run (same test, unfixed resolver):
```
Failed … PolymorphicResolverUnloadableAssemblyTest.SerializationSurvivesAnAssemblyWhoseTypesDoNotAllLoad_AndWarnsOncePerAssembly
   System.Reflection.ReflectionTypeLoadException : Unable to load one or more of the requested types.
   at PolymorphicTypeInfoResolver.WarnMissingDerivedRegistrations(...) :187 → ComputeDerivedTypes :172 → GetTypeInfo :38
```

`src/MeshWeaver.Documentation/Data/Architecture/Serialization.md` — new subsection "The resolver's diagnostics must never fail the serialization they run in" (conserve-work-products).
`src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-failed-request-is-reported-even-when-a-module-is-incomplete.md` — Category: Fix.

### Verification

- `dotnet build test/MeshWeaver.Messaging.Hub.Test/… -c Release -warnaserror` → `0 Warning(s) 0 Error(s)` (emits `MeshWeaver.Messaging.Hub` and the test project).
- `dotnet test test/MeshWeaver.Messaging.Hub.Test -c Release --no-build` (whole project, `DOTNET_PROCESSOR_COUNT=4`) → **342 passed, 0 failed**, 1 m 21 s, `.trx` carries the new test `outcome="Passed"`.
- `dotnet build test/MeshWeaver.Documentation.Test/… -c Release -warnaserror` → `0 Error(s)`; whole project run (doc-link integrity, What's New integrity, the `src/` ratchet guards) → see the final commit's CI.

Not in scope (deliberately): the closure accounting that produced the incomplete module (core #2977); `GetCustomAttributes` on a base type whose attribute type is unloadable is a different, unmeasured failure and was left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
