### PR TITLE
fix: a missing org grant reds the repository, not every pull request

### DIFF
--- a/.github/workflows/arm-credential.yml
+++ b/.github/workflows/arm-credential.yml
@@ -41,6 +41,11 @@ jobs:
   can-arm:
     name: The App can arm and merge
     runs-on: ubuntu-latest
+    # Four API calls and a mint. Ten minutes is already an order of magnitude of
+    # headroom; the fleet cap is 45 (check-workflow-timeouts.py) and nothing here
+    # has any business approaching it. A lane that asserts a credential must not be
+    # able to sit on a billed runner because a mint hung on a socket.
+    timeout-minutes: 10
     steps:
       # No `if:` anywhere in this job. It asserts, it does not choose whether to assert —
       # that is the entire difference between this lane and a skip-trapdoor.

--- a/.github/workflows/arm-credential.yml
+++ b/.github/workflows/arm-credential.yml
@@ -1,0 +1,116 @@
+# The repo-scoped assertion that auto-merge CAN be armed at all.
+#
+# 🚨 This lane exists so that `auto-arm.yml` does not have to lie. Whether the meshweaver-cloud App
+# holds `Contents: write` + `Pull requests: write` is a property of the ORGANISATION INSTALLATION —
+# one fact, shared by every pull request in the repo at the same instant. Asserting it inside the
+# per-PR arm lane therefore produced a red that was identical on every open PR, said nothing about
+# any of them, and could not be fixed by anyone looking at one. A check whose value never varies
+# carries no information; a wall of permanent red is how a genuine red stops being read.
+#
+# So the assertion lives here instead. It is exactly as loud and exactly as red — the AGENTS.md
+# preflight shape, "assert every external input and fail RED naming what to provision" — but it
+# fails ONCE, against the repository, in the one place where the fix is the obvious next action.
+#
+# 🚨 It is deliberately NOT a no-op mint. The failure this ultimately guards is #2916: an arm
+# performed with `secrets.GITHUB_TOKEN` merges as `github-actions[bot]`, whose push triggers NO
+# workflows, so main's HEAD gets no `Consolidate test results`, `main-cd`'s readiness gate reads
+# `absent/none` forever, and nothing is ever promoted. The credential is the whole mechanism —
+# see `ArmedMergeMustTriggerMainsPushLanesGuard`, which forbids the dangerous form at BUILD time,
+# unconditionally, inside the required check. This lane covers the other half: the safe form being
+# configured but not actually usable.
+name: Arm credential
+
+on:
+  schedule:
+    # Four times a day. The consequence of a lapsed grant is delivery quietly degrading to
+    # hand-merges, which is survivable for hours but must not be survivable for weeks.
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      # A change to the arm lane or to this file re-asserts immediately rather than waiting
+      # for the next tick.
+      - '.github/workflows/auto-arm.yml'
+      - '.github/workflows/arm-credential.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  can-arm:
+    name: The App can arm and merge
+    runs-on: ubuntu-latest
+    steps:
+      # No `if:` anywhere in this job. It asserts, it does not choose whether to assert —
+      # that is the entire difference between this lane and a skip-trapdoor.
+      - name: The App credential is provisioned
+        env:
+          MESHWEAVER_APP_ID: ${{ secrets.MESHWEAVER_APP_ID }}
+          MESHWEAVER_APP_PRIVATE_KEY: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+        run: |
+          missing=()
+          [ -n "$MESHWEAVER_APP_ID" ]          || missing+=("secrets.MESHWEAVER_APP_ID           app id of the org's meshweaver-cloud GitHub App, installed on every repo in the fleet")
+          [ -n "$MESHWEAVER_APP_PRIVATE_KEY" ] || missing+=("secrets.MESHWEAVER_APP_PRIVATE_KEY  that App's private key (PEM); source of truth is Key Vault Systemorph/github-app-privatekey")
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::the arm credential is not provisioned — provision the following, then re-run:"
+            for m in "${missing[@]}"; do echo "  • $m"; done
+            exit 1
+          fi
+          echo "App credential present."
+
+      # 🚨 Requesting both permissions EXPLICITLY is what makes a missing grant fail here, at the
+      # mint, rather than degrading to a token that arms fine and then merges in a way that starts
+      # no CI. A token minted without naming them inherits whatever the installation happens to
+      # hold, and "whatever it happens to hold" is the state that produced the outage.
+      - name: Mint a token with Contents:write + PullRequests:write
+        id: mint
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.MESHWEAVER_APP_ID }}
+          private-key: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: ${{ github.event.repository.name }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Name the grant, if the mint could not get it
+        if: failure() && steps.mint.outcome == 'failure'
+        run: |
+          echo "::error::the meshweaver-cloud App cannot mint Contents:write + PullRequests:write on ${{ github.repository }}."
+          echo ""
+          echo "CONSEQUENCE — auto-merge is unarmed on every PR in this repo. Nothing is broken and"
+          echo "nothing is unsafe: every required check still runs and still decides. PRs simply do"
+          echo "not land on their own, so each one needs a human merge until this is fixed."
+          echo ""
+          echo "TO FIX — both halves are required, and the second is the one that gets forgotten:"
+          echo "  1. In the App's settings, set 'Pull requests' to 'Read and write'."
+          echo "  2. ACCEPT the new permission on the org installation. A requested-but-unaccepted"
+          echo "     permission reads as requested in the UI and is NOT granted to the token."
+          echo ""
+          echo "TO INSPECT what the installation actually holds right now:"
+          echo "  gh api orgs/${{ github.repository_owner }}/installations \\"
+          echo "    --jq '.installations[] | \"\(.app_slug) \(.permissions|tojson)\"'"
+          echo ""
+          echo "🚨 Do NOT 'fix' this by pointing the arm lane at secrets.GITHUB_TOKEN. That token"
+          echo "arms and merges successfully and its push triggers NOTHING — main's HEAD gets no"
+          echo "check runs at all, main-cd waits on evidence that can never arrive, and delivery"
+          echo "stops silently (#2916). ArmedMergeMustTriggerMainsPushLanesGuard fails the build if"
+          echo "anyone tries."
+
+      # The mint proves the App CAN hold the permissions. This proves the token actually works
+      # against this repository — a mint can succeed against an installation that no longer has
+      # access to the repo it was scoped to.
+      - name: The minted token can reach this repository
+        env:
+          GH_TOKEN: ${{ steps.mint.outputs.token }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          perms=$(gh api "repos/$REPO" --jq '.permissions | tojson')
+          echo "token sees: $perms"
+          echo "$perms" | grep -q '"push":true' || {
+            echo "::error::the minted token cannot push to $REPO ($perms) — it can be minted but not used."
+            exit 1
+          }
+          echo "The App can arm auto-merge and perform the merge on $REPO."

--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -94,8 +94,25 @@ jobs:
       # step whose name says what it wanted — rather than degrading to a token that arms fine and
       # then merges in a way that starts no CI. There is deliberately no fallback: falling back to
       # `secrets.GITHUB_TOKEN` is precisely the outage this file's header documents.
+      # 🚨 `continue-on-error` — the ONE in this file, and the reason is that arming is an
+      # ACTION, not a GATE. AGENTS.md forbids this on a step that fetches a gate's input, because
+      # a verification that silently does not run is indistinguishable from one that passed. That
+      # hazard does not exist here: this job asserts NOTHING about the pull request. Every required
+      # context still runs, `Consolidate test results` still decides, and a PR that cannot be armed
+      # is merged by a human — the outcome is a lost convenience, not a lost check.
+      #
+      # What it buys is signal. A missing grant is a property of the REPOSITORY, identical on every
+      # PR at once, so failing here painted a red that was the same on all of them — a check whose
+      # value never varies carries no information about any PR, and a wall of permanent red is how
+      # a real red stops being read. The assertion still exists and is still RED; it moved to
+      # `arm-credential.yml`, which asks the repo-scoped question in the one place it is actionable.
+      #
+      # 🚨 That split is load-bearing: the tolerance below is only safe while that lane exists.
+      # `ArmedMergeMustTriggerMainsPushLanesGuard.ToleratingAFailedMintRequiresARepoScopedAssertion`
+      # fails the build if this `continue-on-error` outlives it.
       - name: Mint an installation token whose merges actually trigger workflows
         id: arm-token
+        continue-on-error: true
         uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.MESHWEAVER_APP_ID }}
@@ -105,25 +122,41 @@ jobs:
           permission-contents: write
           permission-pull-requests: write
 
-      # PRESENT is not GRANTED. The mint above fails with a bare "not permitted" when the App is
+      # PRESENT is not GRANTED. The mint fails with a bare "not permitted" when the App is
       # installed but lacks one of the two permissions, and that message names neither the App nor
-      # the grant — so say it here, where a reader lands. Diagnostics on a failed step, not a gate:
-      # this cannot make a red run green.
-      # 🚨 Scoped to the MINT's own outcome, not to `failure()` alone. A bare `if: failure()` also
-      # fires when the secret-presence assert above failed — the mint never ran — and would then
-      # print "could not mint an installation token" over a run whose actual problem was a missing
-      # secret it had just named correctly. Diagnostics that describe a step that did not execute
-      # are worse than none: they send the reader to the wrong half of the lane.
-      - name: Name the grant, if the mint could not get it
-        if: failure() && steps.arm-token.outcome == 'failure'
+      # the grant — so say it here, where a reader lands.
+      #
+      # 🚨 This is a WARNING, not an error, and the distinction is the point. The honest per-PR
+      # outcome of a missing grant is "this PR was not armed" — degraded automation, not a fault in
+      # the branch. Reporting it as a failure of the pull request is a false statement about the
+      # pull request, and it was being made on every one of them simultaneously.
+      - name: Say why nothing was armed, if the mint could not get the grant
+        if: steps.arm-token.outcome == 'failure'
         run: |
-          echo "::error::could not mint an installation token with Contents:write + PullRequests:write."
-          echo "The meshweaver-cloud App must carry BOTH. Check:"
-          echo "  gh api orgs/${{ github.repository_owner }}/installations --jq '.installations[] | \"\(.app_slug) \(.permissions|tojson)\"'"
-          echo "Grant 'Pull requests: Read and write' in the App's settings, then ACCEPT the new"
-          echo "permission on the org installation — a requested-but-unaccepted permission is not granted."
+          echo "::warning::auto-merge was NOT armed on this PR — the meshweaver-cloud App could not"
+          echo "::warning::mint a token with Contents:write + PullRequests:write. Merge this PR by hand."
+          {
+            echo "### Auto-merge not armed"
+            echo
+            echo "The \`meshweaver-cloud\` App must carry **both** \`Contents: write\` and"
+            echo "\`Pull requests: write\`. It currently cannot mint one with both, so this PR was"
+            echo "left unarmed and needs a human merge once it is green."
+            echo
+            echo '```'
+            echo "gh api orgs/${{ github.repository_owner }}/installations \\"
+            echo "  --jq '.installations[] | \"\(.app_slug) \(.permissions|tojson)\"'"
+            echo '```'
+            echo
+            echo "Grant *Pull requests: Read and write* in the App's settings, then **accept** the"
+            echo "new permission on the org installation — a requested-but-unaccepted permission is"
+            echo "not granted. \`arm-credential.yml\` is the lane that stays red until that is done."
+          } >> "$GITHUB_STEP_SUMMARY"
 
+      # Conditioned on the MINT's outcome, never on whether a secret "looks set" — the shape
+      # AGENTS.md forbids. Without a token there is nothing to arm with; running gh anyway would
+      # fall back to the runner's default credential, which is the #2916 outage exactly.
       - name: Arm it
+        if: steps.arm-token.outcome == 'success'
         env:
           GH_TOKEN: ${{ steps.arm-token.outputs.token }}
           PR: ${{ github.event.pull_request.number }}

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -433,6 +433,69 @@ and it failed immediately on a real defect. **"Red for a known reason" is the ch
 which to miss a second regression**, and it is an argument for fixing the first red rather than
 routing around it. Expect the count of problems to go *up* when you fix one.
 
+## 🚨 A check that is red on EVERY pull request is not telling you about any of them
+
+A signal carries information only to the extent that it *varies*. A check that fails on every open
+PR at the same instant has variance zero: it partitions nothing, exonerates nothing, and the
+correct reading of it on any individual PR is "ignore this". That is a strictly worse state than
+having no check at all, because the red is still spent — it dilutes every other red on the wall,
+and it trains readers to skip the one place they are supposed to look.
+
+**Measured here, 2026-09-01/02.** `auto-arm.yml` asserted that the `meshweaver-cloud` App could
+mint a token carrying `Contents: write` + `Pull requests: write`. The grant was missing, so
+`Arm auto-merge on this PR` failed — on **every PR in the repository, simultaneously and
+permanently**. The wall read as four red PRs. Two of them were entirely green on the required
+check; the other two had genuine, unrelated shard failures that the noise was actively hiding.
+
+### The discriminator: is the fact a property of the PR, or of the repository?
+
+That is the whole test, and it is mechanical:
+
+| the assertion is about… | where it belongs | what its red means |
+|---|---|---|
+| this branch's code, tests, build, contracts | a per-PR check | *this* PR is not ready |
+| the org installation, a secret, a registry grant, a quota | **one repo-scoped lane** | the *repository* is degraded; every PR is equally affected |
+
+A repository-scoped fact asserted per-PR is duplicated N times and actionable in none of them —
+nobody fixes an org installation from a pull request's Checks tab. Hoisting it does not weaken it:
+`arm-credential.yml` fails exactly as red, on a schedule, naming the grant and the acceptance step,
+in the one place where the fix is the obvious next action.
+
+### This is NOT the skip-trapdoor exemption, and the difference is worth stating precisely
+
+AGENTS.md forbids `continue-on-error` on a gate's input step, because a verification that silently
+does not run is indistinguishable from one that passed. `auto-arm.yml` now carries exactly that
+`continue-on-error` — and it is not the forbidden shape, because **arming is an action, not a
+gate**. It asserts nothing about the pull request. Every required context still runs, `Consolidate
+test results` still decides, and the honest per-PR consequence of a missing grant is "this PR was
+not armed, merge it by hand" — a lost convenience, not a lost check. Reporting that as a *failure
+of the pull request* was a false statement about the pull request.
+
+The load-bearing part is that the assertion was **moved, not deleted**. A tolerance whose companion
+assertion is gone *is* the trapdoor, so the two files are coupled by a test:
+`ArmedMergeMustTriggerMainsPushLanesGuard.ToleratingAFailedMintRequiresARepoScopedAssertion` fails
+the build if `auto-arm.yml` tolerates a failed mint while `arm-credential.yml` is missing, tolerates
+its own failure, or loses its schedule. **When you hoist an assertion out of a hot lane, guard the
+hoist** — otherwise the next person sees only the tolerance and reasonably concludes the check was
+abandoned.
+
+### Before you conclude "all the PRs are red"
+
+Read *which* context is red, not the rollup colour. The required check is the only one that gates,
+and a non-required red that is identical everywhere is the signature of a repo-scoped fact in the
+wrong place:
+
+```bash
+gh api graphql -f query='query{repository(owner:"Systemorph",name:"MeshWeaver"){
+  pullRequests(states:OPEN,first:20){nodes{number mergeStateStatus
+    commits(last:1){nodes{commit{statusCheckRollup{contexts(first:80){
+      nodes{... on CheckRun{name conclusion}}}}}}}}}}}'
+```
+
+If the same check name appears in every PR's failure list, stop triaging PRs and go fix the
+repository. `UNSTABLE` means the required set passed and something non-required did not — it is
+mergeable, and it is the state a hoistable assertion leaves behind.
+
 ## Related
 
 [Module Versioning](/Doc/Architecture/ModuleVersioning) · [Modules](/Doc/Architecture/Modules) ·

--- a/test/MeshWeaver.Documentation.Test/ArmedMergeMustTriggerMainsPushLanesGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ArmedMergeMustTriggerMainsPushLanesGuard.cs
@@ -126,6 +126,67 @@ public class ArmedMergeMustTriggerMainsPushLanesGuard
         }
     }
 
+    /// <summary>
+    /// 🚨 <c>auto-arm.yml</c> tolerates a failed mint, and that tolerance is only defensible
+    /// because the assertion it drops was MOVED rather than deleted.
+    ///
+    /// <para>The move was made because a missing grant is a property of the org installation, not
+    /// of any pull request: asserting it per-PR produced an identical red on every open PR at
+    /// once, told a reader nothing about the branch they were looking at, and could not be acted
+    /// on from there. A check whose value never varies carries no information, and a permanent
+    /// wall of red is how a real red stops being read. So the arm lane now degrades to a warning
+    /// — the honest per-PR statement is "this PR was not armed", which costs a convenience and no
+    /// check — while <c>arm-credential.yml</c> keeps failing red, once, against the repository.</para>
+    ///
+    /// <para><b>Delete that lane and the tolerance becomes exactly the trapdoor AGENTS.md
+    /// forbids:</b> a credential that silently stopped working, an arm that silently stops
+    /// happening, and green everywhere. This test is the coupling — the two files may not drift
+    /// apart, and the day someone removes the preflight, the build says why it mattered.</para>
+    /// </summary>
+    [Fact]
+    public void ToleratingAFailedMintRequiresARepoScopedAssertion()
+    {
+        var armLines = ExecutableLines(File.ReadAllText(Path.Combine(WorkflowsDir(), "auto-arm.yml")));
+        if (!armLines.Any(l => l.Contains("continue-on-error", StringComparison.Ordinal)))
+            return; // The arm lane asserts for itself; no companion lane is owed.
+
+        var preflight = Path.Combine(WorkflowsDir(), "arm-credential.yml");
+        Assert.True(
+            File.Exists(preflight),
+            "auto-arm.yml tolerates a failed token mint, but arm-credential.yml — the lane that "
+            + "carries the assertion it dropped — is gone. Nothing now fails when the App loses "
+            + "Pull requests: write: the mint fails, the arm is skipped, the job is green, and PRs "
+            + "quietly stop landing with no red anywhere. Restore the lane, or delete the "
+            + "continue-on-error and let auto-arm assert for itself again.");
+
+        var lines = ExecutableLines(File.ReadAllText(preflight));
+
+        Assert.True(
+            lines.All(l => !l.Contains("continue-on-error", StringComparison.Ordinal)),
+            "arm-credential.yml carries continue-on-error. It is the ONLY thing left that fails "
+            + "when the arm credential is unusable; a tolerated failure there means no lane in the "
+            + "repository asserts the credential at all.");
+
+        // The whole point is that it runs without a pull request. A dispatch-only lane asserts
+        // only when a human already suspects the answer.
+        Assert.True(
+            lines.Any(l => l.StartsWith("schedule:", StringComparison.Ordinal))
+            || lines.Any(l => l.StartsWith("- cron:", StringComparison.Ordinal)),
+            "arm-credential.yml has no schedule. Manual dispatch only asserts the credential when "
+            + "someone already suspects it is broken, which is precisely when the assertion is no "
+            + "longer needed.");
+
+        foreach (var permission in new[] { "permission-contents: write", "permission-pull-requests: write" })
+        {
+            Assert.True(
+                lines.Any(l => l.Contains(permission, StringComparison.Ordinal)),
+                $"arm-credential.yml does not request '{permission}'. A token minted without naming "
+                + "both permissions inherits whatever the installation happens to hold — and "
+                + "'whatever it happens to hold' is the state that produced #2916. Requesting them "
+                + "explicitly is the entire mechanism by which a missing grant fails here.");
+        }
+    }
+
     private static string FindRepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
## The red that was on every PR at once

`Arm auto-merge on this PR` asserted that the `meshweaver-cloud` App can mint a token carrying
`Contents: write` + `Pull requests: write`. That grant is missing, so the check failed **on every
open pull request in the repository, simultaneously and permanently.**

A signal carries information only to the extent that it varies. This one had variance zero — it
partitioned nothing, exonerated nothing, and the correct reading of it on any individual PR was
"ignore this". Worse, the red was still *spent*: the wall showed four red PRs, two of which were
entirely green on the required check, while the two with genuine shard failures looked exactly the
same as the two without.

## The discriminator

| the assertion is about… | where it belongs | what its red means |
|---|---|---|
| this branch's code, tests, build, contracts | a per-PR check | *this* PR is not ready |
| an org installation, a secret, a registry grant, a quota | **one repo-scoped lane** | the *repository* is degraded; every PR equally |

An org installation's permissions are a property of the repository. Asserted per-PR they are
duplicated N times and actionable in none of them — nobody fixes an org installation from a pull
request's Checks tab.

## What this does

**The assertion moved; it was not dropped.** `arm-credential.yml` mints the same token with the same
two permissions — four times a day, on dispatch, and on any change to the arm lane — and fails
exactly as red, naming the grant *and* the acceptance step that gets forgotten (a
requested-but-unaccepted permission reads as requested in the UI and is not granted to the token).
It then proves the minted token can actually push to this repo, which the mint alone does not: an
installation can lose access to a repository it was scoped to.

**`auto-arm.yml` degrades honestly.** A failed mint leaves the PR unarmed with a `::warning::` and a
job summary saying to merge it by hand. The arm step is *skipped*, not run without a token — falling
through to the runner's default credential is the #2916 outage exactly.

## Why this is not the skip-trapdoor AGENTS.md forbids

The rule exists because a verification that silently does not run is indistinguishable from one that
passed. **Arming is an action, not a gate.** It asserts nothing about the pull request: every
required context still runs, `Consolidate test results` still decides, and the honest per-PR
consequence of a missing grant is "this PR was not armed, merge it by hand" — a lost convenience,
not a lost check. Reporting that as a *failure of the pull request* was a false statement about the
pull request, made on all of them at once.

The dangerous form is untouched and still enforced unconditionally at build time:
`ArmedMergeMustTriggerMainsPushLanesGuard` still fails if any workflow arms or merges with
`secrets.GITHUB_TOKEN`, still requires the mint, and still requires both permissions be named.

## The coupling, because a hoist that loses its destination IS a trapdoor

The tolerance in `auto-arm.yml` is only defensible while the companion lane exists. Delete
`arm-credential.yml` and the mint fails, the arm is skipped, the job is green, and PRs quietly stop
landing with no red anywhere. So the two files are coupled by a test rather than by a comment:

`ToleratingAFailedMintRequiresARepoScopedAssertion` fails the build if `auto-arm.yml` tolerates a
failed mint while `arm-credential.yml` is missing, carries `continue-on-error` itself, loses its
schedule, or stops naming both permissions.

**Mutation-proven — the guard is not vacuous:**

| mutation | result |
|---|---|
| baseline | ✅ 3 passed |
| delete `arm-credential.yml` | ❌ caught |
| preflight tolerates its own failure | ❌ caught |
| preflight drops its schedule | ❌ caught |

`MeshWeaver.Documentation.Test`: **177 passed, 0 failed** (whole project, not a filtered run).

## What still needs a human

This PR removes the *false* red. It does not create the grant — that is org-admin action and remains
yours: set **Pull requests: Read and write** on the App, then **accept** it on the org installation.
`arm-credential.yml` stays red until both halves are done, which is the point.

Closes #3063

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
