### PR TITLE
#3022 is fixed — prove it, and guard the property CLASS, not one switch

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/BakeIdentityMismatch.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BakeIdentityMismatch.md
@@ -176,6 +176,79 @@ and can no longer move an address. A caller who genuinely wants a different asse
 for it by name — `-p:AssemblyVersion=` / `-p:FileVersion=` / `-p:InformationalVersion=` still win —
 so the escape hatch survives, it just cannot be taken by accident.
 
+## Confirmed on the shipped images
+
+The fix landed on `main` as `71869075`. CD run
+[33587509969](https://github.com/Systemorph/MeshWeaver/actions/runs/33587509969) built both images
+from that commit, and the step that had been failing since 2026-09-01 passed:
+
+```text
+the bake published under: s8fe4902c0b2f5974f824be2867221dbd
+portal /app: 46 MeshWeaver assemblies, 46 manifest lines
+framework-identity: MATCH — '/portal' resolves s8fe4902c0b2f5974f824be2867221dbd,
+the identity the bake published under. Its bundles are addressed to this host.
+```
+
+Re-measured afterwards off the promoted `7186907` tags, by exactly the method that found the defect
+(`docker create` + `docker cp`, no execution) — so the confirmation is the same measurement, not a
+different one:
+
+| | before the fix | after the fix (`7186907`) |
+|---|---|---|
+| canonical names present in both manifests | 25 | 25 |
+| of those, hashes **equal** | **0** | **25** |
+
+```text
+memex-portal-ai   MeshWeaver.Utils.dll   3.0.0-rc9+71869075f5ace055629c7b1812b08d7334f871af
+mw-plugin-test    MeshWeaver.Utils.dll   3.0.0-rc9+71869075f5ace055629c7b1812b08d7334f871af
+```
+
+> **A green bake leg is not a sealed publication.** With the identity matching, `main-cd`'s platform
+> bake leg is green and the *next* leg — `Plugins: bake + seal the publication for this identity` —
+> reds on `CS0234: The type or namespace name 'Maps' does not exist in the namespace 'MeshWeaver'`
+> for `GoogleMaps/Gallery` and `OpenStreetMap/Gallery`. That is a different defect with a different
+> owner: `MeshWeaver.Maps` left the content surface in
+> [#2941](https://github.com/Systemorph/MeshWeaver/pull/2941) and its module has not started riding
+> yet, which is
+> [MeshWeaver.Plugins#1061](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1061) step 3 —
+> the cross-repo half of a carve-out, not an identity fork. Two red bake legs in one pipeline are not
+> one cause; read *which job* failed before attributing it.
+
+### The "second cause" that wasn't
+
+While the fix was in review, a second divergence was read off the same two images — the commit
+suffix apparently truncated to different lengths on the two legs:
+
+```text
+memex-portal-ai   3.0.0-rc9.ci.7471+30dda849febd
+mw-plugin-test    3.0.0-rc9+30dda849febd95c82d6f
+```
+
+Twelve hex characters against twenty. It is an artifact of the *reading*, not of the build: **both
+strings are exactly 30 characters long.** Whatever printed them truncated at 30, and `.ci.7471` —
+eight characters of prefix — is what pushed the suffix out of the window. `$(SourceRevisionId)` is
+the full 40-character SHA on both legs, as the post-fix dump above shows. One cause, not two.
+
+A version string is length-sensitive evidence. When two of them differ in a suffix *and* agree in
+total length, suspect the pipe before the compiler.
+
+### The run that looked like it still failed
+
+Run [33585729083](https://github.com/Systemorph/MeshWeaver/actions/runs/33585729083) started six
+minutes after the fix merged, carried `71869075` — the fix's merge commit — as its **head SHA**, and
+failed the identity check. It did not build that commit. `main-cd`'s `gate` job resolves its *own*
+target (the newest commit whose required check is green) and logs it:
+
+```text
+IMAGE: meshweaver.azurecr.io/mw-plugin-test:staging-3ac34af-33585729083
+SHA:   3ac34af522a933ac8a84a11825b593460a754a91      ← the fix's PARENT
+```
+
+The next run resolved `71869075` and passed. **A CD run's `headSha` is the ref the workflow was
+triggered on, never a claim about what it built.** Read `gate`'s own `SHA:` line — or the staging tag
+embedded in every image reference in the job — before attributing a red to a commit. That reading
+cost this issue a reopen.
+
 ## What was ruled out, and how
 
 A mismatch has three plausible causes and the error message names two of them. Both were falsified
@@ -210,12 +283,42 @@ Three details make it a guard rather than a green tick:
   guard is still measuring a real evaluation, but no longer one that can fork a bake address, so it
   fails and asks to be re-pointed.
 
+### And the general form of it
+
+`CdImageLegPropertiesDoNotForkTheIdentityGuard` (same project) guards the **class**, not the
+switch. The property that broke this was called `Version`, but nothing about the defect depends on
+that name: `main-cd.yml` publishes the two images from one commit with two *different sets* of
+global `-p:` properties, and a global property reaches every project in the graph. Any property one
+leg passes and the other does not — or passes with a different value — that reaches a compiled
+attribute forks the address.
+
+So it reads the two `dotnet publish` commands out of `main-cd.yml`, takes the union of every `-p:`
+name they carry, evaluates the probe project bare and with all of them applied at once, and requires
+the three compiled attributes to be identical. On a failure it re-probes one property at a time, so
+the message names the culprit rather than the set.
+
+- **`CIRun` is the one exclusion, and it is principled.** Both legs pass `-p:CIRun=true`, so it is
+  symmetric by construction and cannot fork them; and it is the one property that is *supposed* to
+  move `InformationalVersion` — it selects the commit-deterministic branch over the local-dev one.
+- **Reading the workflow is what keeps it from going stale.** A list of property names written in
+  the test would have been correct on the day it was written and wrong the day `-p:Version=` was
+  added to one leg — which is exactly how this defect got in. The next `-p:` added to either leg is
+  covered the moment it lands, with no second place to remember.
+- **The control arm asserts the parse found something.** Both publish commands must be located, each
+  must carry a plausible number of properties, both must carry `CIRun` (which is what proves these
+  are the platform's own publish commands and not two arbitrary lines), and the union must contain
+  `Version`. A parser that silently matched nothing would probe the empty set and pass having
+  measured nothing — a gate testing its own inputs.
+
 The CD step that caught this (`mw-plugin-test framework-identity /portal --expect <baked>`) stays
-exactly as it is. It is the artifact-level proof and it must remain able to fail; the guard just
-moves the *ordinary* case of this failure from minute 25 of a CD run to second 5 of a PR.
+exactly as it is. It is the artifact-level proof and it must remain able to fail; the guards just
+move the *ordinary* case of this failure from minute 25 of a CD run to second 5 of a PR.
 
 ## If you are staring at one of these right now
 
+0. **Confirm which job failed, and which commit it built.** `main-cd` has two bake legs — the
+   platform's own and `Plugins: bake + seal` — and they fail for unrelated reasons. Then read
+   `gate`'s `SHA:` line (or the staging tag): a run's head SHA is the trigger ref, not what it built.
 1. **Read both manifests, do not reason about them.** Pull the two images by their *staging* tags —
    immutable, unlike `main`/`latest` — and `docker cp` `/app/meshweaver-surface.manifest` out of
    each. Publish nothing; this is a read.

--- a/test/MeshWeaver.Documentation.Test/CdImageLegPropertiesDoNotForkTheIdentityGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CdImageLegPropertiesDoNotForkTheIdentityGuard.cs
@@ -89,10 +89,10 @@ public class CdImageLegPropertiesDoNotForkTheIdentityGuard
         var tester = PropertiesOf(TesterPublishCommand);
 
         Assert.True(portal.Count >= 4,
-            $"only {portal.Count} `-p:` propert(ies) parsed off the portal publish command in {Workflow}. "
+            $"only {portal.Count} `-p:` switch(es) parsed off the portal publish command in {Workflow}. "
             + "The guard below would then probe almost nothing and pass vacuously.");
         Assert.True(tester.Count >= 4,
-            $"only {tester.Count} `-p:` propert(ies) parsed off the tester publish command in {Workflow}. "
+            $"only {tester.Count} `-p:` switch(es) parsed off the tester publish command in {Workflow}. "
             + "The guard below would then probe almost nothing and pass vacuously.");
 
         Assert.Contains("CIRun", portal);

--- a/test/MeshWeaver.Documentation.Test/CdImageLegPropertiesDoNotForkTheIdentityGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CdImageLegPropertiesDoNotForkTheIdentityGuard.cs
@@ -1,0 +1,236 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using MeshWeaver.Compiler;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>No MSBuild property CD's two image legs pass may move a COMPILED version attribute</b>
+/// (#3022, second pass) — the general form of the invariant
+/// <see cref="CompiledVersionAttributesIgnoreVersionOverrideGuard"/> guards for one property.
+///
+/// <para><b>Why the narrow guard is not enough.</b> That one asserts a single remembered switch,
+/// <c>-p:Version=</c>, because that is the switch that broke. But the defect class is wider and
+/// has nothing to do with the NAME <c>Version</c>: <c>main-cd.yml</c> publishes
+/// <c>memex-portal-ai</c> and <c>mw-plugin-test</c> from the SAME commit in two different jobs,
+/// with two different sets of global <c>-p:</c> properties. A global property reaches every
+/// project in the graph, core's included. So ANY property one leg passes and the other does not —
+/// or passes with a different value — that reaches <c>InformationalVersion</c>,
+/// <c>AssemblyVersion</c> or <c>FileVersion</c> forks the two images' reference assemblies, hence
+/// all 25 shared <c>meshweaver-surface.manifest</c> hashes, hence the framework build identity the
+/// bake is published under. The bundles then sit at an address no portal resolves: INERT, #1814's
+/// shape, every pod recompiling the mesh at boot with the whole pipeline green.</para>
+///
+/// <para><b>Why it reads the workflow instead of a hard-coded list.</b> <c>-p:Version=</c> was
+/// added to the portal leg on 2026-09-01 for #2555 (so the image reports its own build) and
+/// nothing existed that could notice. A list written here would go stale the same way — the next
+/// property added to one leg would be outside it, and the guard would pass having checked the
+/// wrong set. Reading the two publish commands out of <c>main-cd.yml</c> makes the guard FOLLOW
+/// CD: a new <c>-p:</c> on either leg is covered the moment it lands, with no second place to
+/// remember.</para>
+///
+/// <para>See <c>Doc/Architecture/BakeIdentityMismatch</c>.</para>
+/// </summary>
+public class CdImageLegPropertiesDoNotForkTheIdentityGuard
+{
+    private const string Workflow = ".github/workflows/main-cd.yml";
+
+    /// <summary>The portal image leg: the deployment image, and the one that passes <c>-p:Version=</c>.</summary>
+    private const string PortalPublishCommand =
+        "dotnet publish plugins-repo/src/Memex.Portal.Distributed/Memex.Portal.Distributed.csproj";
+
+    /// <summary>The tester/bake image leg: the host the bake runs in, and the one that must resolve the SAME identity.</summary>
+    private const string TesterPublishCommand =
+        "dotnet publish tools/MeshWeaver.PluginTester/MeshWeaver.PluginTester.csproj";
+
+    /// <summary>
+    /// <c>CIRun</c> is excluded, and only <c>CIRun</c>. BOTH legs pass <c>-p:CIRun=true</c>, so it
+    /// is symmetric by construction and cannot fork them; and it is the one property that is
+    /// SUPPOSED to change <c>InformationalVersion</c> — it selects the commit-deterministic CI
+    /// branch over the local-dev one (see the note in Directory.Build.props). Probing it would red
+    /// this guard for the behaviour the design requires. Every other property is fair game.
+    /// </summary>
+    private static readonly string[] NotProbed = ["CIRun"];
+
+    private const string ProbeProject = "src/MeshWeaver.ShortGuid/MeshWeaver.ShortGuid.csproj";
+
+    private const string ProbeAssembly = "MeshWeaver.ShortGuid";
+
+    /// <summary>
+    /// The value every probed property is set to. A version-shaped string that
+    /// <c>Directory.Build.props</c> could never produce itself, so its appearance in a compiled
+    /// attribute is unambiguous — and one no path-valued property will make MSBuild choke on,
+    /// because evaluation resolves no imports from these.
+    /// </summary>
+    private const string ProbeValue = "9.9.9-guard.ci.424242";
+
+    /// <summary>The three properties that become attributes inside the emitted (and reference) assembly.</summary>
+    private static readonly string[] CompiledAttributes =
+        ["InformationalVersion", "AssemblyVersion", "FileVersion"];
+
+    /// <summary>
+    /// 🚨 The control arm, and it runs FIRST. Everything below rests on having actually found the
+    /// two publish commands and read their switches; a parser that silently matched nothing would
+    /// probe the empty set and pass having measured NOTHING — the shape AGENTS.md calls a gate
+    /// that tests its own inputs. So: both commands must be found, each must carry a plausible
+    /// number of properties, both must carry the one property they are known to share
+    /// (<c>CIRun</c> — that is what proves these are the platform's own publish commands and not
+    /// two arbitrary lines), and the union must contain <c>Version</c>, the property whose
+    /// asymmetry caused #3022.
+    /// </summary>
+    [Fact]
+    public void TheTwoImageLegsPublishCommandsAreFoundAndCarryProperties()
+    {
+        var portal = PropertiesOf(PortalPublishCommand);
+        var tester = PropertiesOf(TesterPublishCommand);
+
+        Assert.True(portal.Count >= 4,
+            $"only {portal.Count} `-p:` propert(ies) parsed off the portal publish command in {Workflow}. "
+            + "The guard below would then probe almost nothing and pass vacuously.");
+        Assert.True(tester.Count >= 4,
+            $"only {tester.Count} `-p:` propert(ies) parsed off the tester publish command in {Workflow}. "
+            + "The guard below would then probe almost nothing and pass vacuously.");
+
+        Assert.Contains("CIRun", portal);
+        Assert.Contains("CIRun", tester);
+
+        Assert.True(portal.Contains("Version") || tester.Contains("Version"),
+            "neither image leg passes -p:Version= any more. If that switch was deliberately removed "
+            + "the #3022 exposure is gone and this assertion should go with it — but silently losing "
+            + "it from the parse is how a guard stops covering its subject, so it fails here first.");
+    }
+
+    /// <summary>
+    /// The measurement. Evaluate the probe project bare, then again with EVERY property either
+    /// image leg passes (bar <see cref="NotProbed"/>) set at once, and require the three compiled
+    /// attributes to be byte-identical. Applying them together keeps the green path to two
+    /// evaluations; on a failure the properties are re-probed one at a time so the message names
+    /// the culprit rather than the set.
+    /// </summary>
+    [Fact]
+    public void NoPropertyEitherImageLegPassesMovesACompiledVersionAttribute()
+    {
+        var probed = ProbedProperties();
+        Assert.NotEmpty(probed);
+
+        var bare = Evaluate();
+        var all = Evaluate([.. probed.Select(name => $"-p:{name}={ProbeValue}")]);
+
+        // 🚨 Non-empty in BOTH, asserted before equality. The #3022 regression evaluated the three
+        // properties to the EMPTY STRING (the SDK fills them in a later target, from $(Version)),
+        // so a bare equality check would have compared "" with "" and passed while shipping the
+        // defect.
+        foreach (var name in CompiledAttributes)
+        {
+            Assert.False(string.IsNullOrWhiteSpace(bare[name]),
+                $"{name} evaluated empty for {ProbeProject} with no CD properties applied — the root "
+                + "Directory.Build.props no longer sets it, so the SDK derives it from $(Version), "
+                + "the run-numbered string (#3022).");
+            Assert.False(string.IsNullOrWhiteSpace(all[name]),
+                $"{name} evaluated empty for {ProbeProject} once CD's image-leg properties were "
+                + "applied. That is the #3022 regression: the PropertyGroup deriving the compiled "
+                + "version attributes is conditional on one of them again.");
+        }
+
+        var drifted = CompiledAttributes
+            .Where(name => !string.Equals(bare[name], all[name], StringComparison.Ordinal))
+            .ToList();
+        if (drifted.Count == 0)
+            return;
+
+        // Name the property, not just the set: "one of ten switches did it" is a starting point,
+        // and the point of a guard is to hand over the finish line.
+        var culprits = new List<string>();
+        foreach (var name in probed)
+        {
+            var one = Evaluate($"-p:{name}={ProbeValue}");
+            culprits.AddRange(CompiledAttributes
+                .Where(attribute => !string.Equals(bare[attribute], one[attribute], StringComparison.Ordinal))
+                .Select(attribute => $"-p:{name}= moves {attribute}: '{bare[attribute]}' -> '{one[attribute]}'"));
+        }
+
+        Assert.Fail(
+            "A property `main-cd.yml` passes to an image publish reaches a COMPILED version "
+            + $"attribute of {ProbeProject}:\n  "
+            + string.Join("\n  ", culprits.Count > 0 ? culprits : drifted)
+            + "\n\nThese attributes are emitted into the assembly and therefore into its REFERENCE "
+            + "assembly, which meshweaver-surface.manifest hashes into the framework build identity. "
+            + "CD publishes memex-portal-ai and mw-plugin-test from ONE commit with DIFFERENT "
+            + "property sets, so any dependence here makes the two images resolve different "
+            + "identities and every published bake INERT (#3022, #1814). The compiled attributes "
+            + "must be a function of $(PlatformVersion) and the commit, and of nothing else; a "
+            + "caller who genuinely needs a different assembly version asks for it by name "
+            + "(-p:AssemblyVersion= / -p:FileVersion= / -p:InformationalVersion=).");
+    }
+
+    /// <summary>
+    /// The probed project's assembly must be part of the canonical content surface — the set whose
+    /// per-assembly surface hashes ARE the framework build identity. If it ever leaves that set the
+    /// guard would still measure a real MSBuild evaluation, but no longer one that can fork a bake
+    /// address, so it must be re-pointed rather than quietly kept.
+    /// </summary>
+    [Fact]
+    public void ProbedAssemblyIsPartOfTheContentSurface()
+        => Assert.Contains(ProbeAssembly, FrameworkBuildIdentity.ContentSurfaceAssemblies);
+
+    /// <summary>The union of both legs' properties, minus <see cref="NotProbed"/>.</summary>
+    private static IReadOnlyList<string> ProbedProperties()
+        => PropertiesOf(PortalPublishCommand)
+            .Concat(PropertiesOf(TesterPublishCommand))
+            .Where(name => !NotProbed.Contains(name, StringComparer.Ordinal))
+            .Distinct(StringComparer.Ordinal)
+            .ToList();
+
+    private static IReadOnlyDictionary<string, string> Evaluate(params string[] extraArguments)
+        => MsBuildPropertyProbe.Evaluate(ProbeProject, CompiledAttributes, extraArguments);
+
+    private static readonly Regex PropertySwitch = new(@"-p:([A-Za-z_][A-Za-z0-9_]*)=", RegexOptions.Compiled);
+
+    /// <summary>
+    /// Reads the <c>-p:</c> property NAMES off one publish command in <see cref="Workflow"/>.
+    ///
+    /// <para>Deliberately a text scan and not a YAML parse: the two commands are written in two
+    /// different YAML scalar styles (the portal leg is a backslash-continued shell <c>if</c> inside
+    /// a literal block, the tester leg a folded scalar), and what matters is the switches the shell
+    /// finally sees, which is the text either way. The continuation rule is exact rather than
+    /// heuristic — a trimmed line whose first character is <c>-</c> and whose second is NOT a space
+    /// is a command-line option; <c>- name:</c> and <c>- uses:</c> (YAML sequence entries) always
+    /// have the space, and the portal leg's terminating <c>2&gt;&amp;1 | tee …</c> starts with
+    /// neither. A miscount cannot pass silently: the control-arm test above asserts what this must
+    /// find.</para>
+    /// </summary>
+    private static IReadOnlyList<string> PropertiesOf(string publishCommand)
+    {
+        var path = Path.Combine(MsBuildPropertyProbe.FindRepoRoot(),
+            Workflow.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(path), $"{Workflow} does not exist — this guard reads CD's publish commands out of it.");
+
+        var lines = File.ReadAllLines(path);
+        var start = Array.FindIndex(lines, line => line.Contains(publishCommand, StringComparison.Ordinal));
+        Assert.True(start >= 0,
+            $"could not find `{publishCommand}` in {Workflow}. Either the project moved or the leg was "
+            + "renamed; re-point this guard at the command that publishes that image. It must not be "
+            + "left matching nothing — a guard whose subject moved and whose anchor did not passes "
+            + "having checked nothing.");
+
+        var names = new List<string>();
+        for (var i = start; i < lines.Length; i++)
+        {
+            var trimmed = lines[i].Trim();
+            if (i > start && !(trimmed.Length >= 2 && trimmed[0] == '-' && trimmed[1] != ' '))
+                break;
+            foreach (Match match in PropertySwitch.Matches(trimmed))
+            {
+                var name = match.Groups[1].Value;
+                if (!names.Contains(name, StringComparer.Ordinal))
+                    names.Add(name);
+            }
+        }
+
+        return names;
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/CompiledVersionAttributesIgnoreVersionOverrideGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/CompiledVersionAttributesIgnoreVersionOverrideGuard.cs
@@ -1,10 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Text.Json;
 using MeshWeaver.Compiler;
 using Xunit;
 
@@ -154,90 +150,12 @@ public class CompiledVersionAttributesIgnoreVersionOverrideGuard
     public void ProbedAssemblyIsPartOfTheContentSurface()
         => Assert.Contains(ProbeAssembly, FrameworkBuildIdentity.ContentSurfaceAssemblies);
 
+
     /// <summary>
-    /// Evaluates <see cref="ProbeProject"/> and returns the requested properties. Fails RED —
-    /// never skips — when the project is missing, <c>dotnet</c> cannot be launched, MSBuild exits
-    /// non-zero, or the answer is not the JSON shape <c>-getProperty</c> promises: "could not
-    /// measure" must never be reported as "measured and fine".
+    /// Evaluates <see cref="ProbeProject"/> and returns the compiled attributes plus
+    /// <c>$(Version)</c>. The launcher itself lives in <see cref="MsBuildPropertyProbe"/>, shared
+    /// with <see cref="CdImageLegPropertiesDoNotForkTheIdentityGuard"/>.
     /// </summary>
     private static IReadOnlyDictionary<string, string> Evaluate(params string[] extraArguments)
-    {
-        var root = FindRepoRoot();
-        var project = Path.Combine(root, ProbeProject.Replace('/', Path.DirectorySeparatorChar));
-        Assert.True(File.Exists(project),
-            $"{ProbeProject} does not exist — this guard evaluates it to prove that -p:Version= "
-            + "cannot reach a compiled attribute. Re-point it at another project that inherits the "
-            + "root Directory.Build.props and is part of FrameworkBuildIdentity.ContentSurfaceAssemblies.");
-
-        var psi = new ProcessStartInfo("dotnet")
-        {
-            WorkingDirectory = root,
-            RedirectStandardOutput = true,
-            RedirectStandardError = true,
-            UseShellExecute = false,
-        };
-        psi.ArgumentList.Add("msbuild");
-        psi.ArgumentList.Add(project);
-        psi.ArgumentList.Add("-nologo");
-        // CIRun is how the platform is built everywhere the identity matters; evaluating without it
-        // would exercise the local-dev branch and prove nothing about CD.
-        psi.ArgumentList.Add("-p:CIRun=true");
-        foreach (var name in CompiledAttributes.Append("Version"))
-            psi.ArgumentList.Add($"-getProperty:{name}");
-        foreach (var argument in extraArguments)
-            psi.ArgumentList.Add(argument);
-
-        using var process = Process.Start(psi);
-        Assert.NotNull(process);
-
-        // 🚨 Drain BOTH pipes concurrently via the event-based reader, never
-        // `StandardOutput.ReadToEnd()` then `StandardError.ReadToEnd()`. Sequential draining
-        // deadlocks whenever the child writes enough to the *undrained* pipe to fill its buffer:
-        // MSBuild blocks writing stderr, the test blocks reading stdout, and neither moves. That
-        // this guard exists to catch a wedge makes hanging in the same way particularly poor.
-        // Event-based reading needs no TaskCompletionSource and no async bridge, so it stays
-        // inside the house rules for `test/`.
-        var outBuffer = new StringBuilder();
-        var errBuffer = new StringBuilder();
-        process!.OutputDataReceived += (_, e) => { if (e.Data is not null) outBuffer.AppendLine(e.Data); };
-        process.ErrorDataReceived += (_, e) => { if (e.Data is not null) errBuffer.AppendLine(e.Data); };
-        process.BeginOutputReadLine();
-        process.BeginErrorReadLine();
-        // `-getProperty` only EVALUATES (no restore, no compile) — sub-second warm, a few seconds
-        // cold. A minute is far past any legitimate evaluation, so hitting it means MSBuild is
-        // wedged, and the guard says so instead of hanging out xUnit's method timeout.
-        if (!process.WaitForExit(60_000))
-        {
-            // Kill the TREE, not just `dotnet` — MSBuild spawns node processes that outlive the
-            // launcher, and a guard that leaks build nodes on every timeout degrades the machine
-            // it is measuring on.
-            try { process.Kill(entireProcessTree: true); } catch (InvalidOperationException) { /* already gone */ }
-            Assert.Fail(
-                $"`dotnet msbuild {ProbeProject} -getProperty:…` did not finish within 60s. Evaluation "
-                + "does not restore or build, so this is a wedged MSBuild, not a slow one.");
-        }
-
-        // Only valid after WaitForExit() returned true: it is what flushes the final buffered lines.
-        var stdout = outBuffer.ToString();
-        var stderr = errBuffer.ToString();
-
-        Assert.True(process.ExitCode == 0,
-            $"`dotnet msbuild {ProbeProject} -getProperty:…` exited {process.ExitCode}.\n"
-            + $"stdout:\n{stdout}\nstderr:\n{stderr}");
-
-        using var document = JsonDocument.Parse(stdout);
-        var properties = document.RootElement.GetProperty("Properties");
-        return CompiledAttributes.Append("Version")
-            .ToDictionary(name => name, name => properties.GetProperty(name).GetString() ?? string.Empty,
-                StringComparer.Ordinal);
-    }
-
-    private static string FindRepoRoot()
-    {
-        var dir = new DirectoryInfo(AppContext.BaseDirectory);
-        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
-            dir = dir.Parent;
-        return dir?.FullName
-               ?? throw new InvalidOperationException("Could not locate the repository root (no MeshWeaver.slnx above the test binary).");
-    }
+        => MsBuildPropertyProbe.Evaluate(ProbeProject, [.. CompiledAttributes, "Version"], extraArguments);
 }

--- a/test/MeshWeaver.Documentation.Test/MsBuildPropertyProbe.cs
+++ b/test/MeshWeaver.Documentation.Test/MsBuildPropertyProbe.cs
@@ -1,0 +1,118 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Evaluates MSBuild properties of a project in this repository, out of process, the way CD does.
+/// Shared by the two #3022 guards — <see cref="CompiledVersionAttributesIgnoreVersionOverrideGuard"/>
+/// (does <c>-p:Version=</c> reach a compiled attribute?) and
+/// <see cref="CdImageLegPropertiesDoNotForkTheIdentityGuard"/> (does ANY property CD's two image
+/// legs pass reach one?) — because both ask the same question of the same evaluator and a second
+/// copy of a process launcher is a second place for the draining and timeout rules below to rot.
+/// </summary>
+internal static class MsBuildPropertyProbe
+{
+    /// <summary>
+    /// Evaluates <paramref name="project"/> (a repo-relative path) and returns the requested
+    /// properties. Fails RED — never skips — when the project is missing, <c>dotnet</c> cannot be
+    /// launched, MSBuild exits non-zero, or the answer is not the JSON shape <c>-getProperty</c>
+    /// promises: "could not measure" must never be reported as "measured and fine".
+    /// </summary>
+    /// <param name="project">Repo-relative path of the project to evaluate, forward-slashed.</param>
+    /// <param name="propertyNames">The properties to read back.</param>
+    /// <param name="extraArguments">Extra MSBuild switches, e.g. <c>-p:Version=…</c>.</param>
+    public static IReadOnlyDictionary<string, string> Evaluate(
+        string project,
+        IReadOnlyList<string> propertyNames,
+        params string[] extraArguments)
+    {
+        var root = FindRepoRoot();
+        var projectPath = Path.Combine(root, project.Replace('/', Path.DirectorySeparatorChar));
+        Assert.True(File.Exists(projectPath),
+            $"{project} does not exist — a #3022 guard evaluates it to prove that a property CD "
+            + "passes cannot reach a compiled version attribute. Re-point the guard at another "
+            + "project that inherits the root Directory.Build.props and is part of "
+            + "FrameworkBuildIdentity.ContentSurfaceAssemblies.");
+
+        var psi = new ProcessStartInfo("dotnet")
+        {
+            WorkingDirectory = root,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+        };
+        psi.ArgumentList.Add("msbuild");
+        psi.ArgumentList.Add(projectPath);
+        psi.ArgumentList.Add("-nologo");
+        // CIRun is how the platform is built everywhere the identity matters; evaluating without it
+        // would exercise the local-dev branch and prove nothing about CD.
+        psi.ArgumentList.Add("-p:CIRun=true");
+        foreach (var name in propertyNames)
+            psi.ArgumentList.Add($"-getProperty:{name}");
+        foreach (var argument in extraArguments)
+            psi.ArgumentList.Add(argument);
+
+        using var process = Process.Start(psi);
+        Assert.NotNull(process);
+
+        // 🚨 Drain BOTH pipes concurrently via the event-based reader, never
+        // `StandardOutput.ReadToEnd()` then `StandardError.ReadToEnd()`. Sequential draining
+        // deadlocks whenever the child writes enough to the *undrained* pipe to fill its buffer:
+        // MSBuild blocks writing stderr, the test blocks reading stdout, and neither moves. That
+        // these guards exist to catch a wedge makes hanging in the same way particularly poor.
+        // Event-based reading needs no TaskCompletionSource and no async bridge, so it stays
+        // inside the house rules for `test/`.
+        var outBuffer = new StringBuilder();
+        var errBuffer = new StringBuilder();
+        process!.OutputDataReceived += (_, e) => { if (e.Data is not null) outBuffer.AppendLine(e.Data); };
+        process.ErrorDataReceived += (_, e) => { if (e.Data is not null) errBuffer.AppendLine(e.Data); };
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+        // `-getProperty` only EVALUATES (no restore, no compile) — sub-second warm, a few seconds
+        // cold. A minute is far past any legitimate evaluation, so hitting it means MSBuild is
+        // wedged, and the guard says so instead of hanging out xUnit's method timeout.
+        if (!process.WaitForExit(60_000))
+        {
+            // Kill the TREE, not just `dotnet` — MSBuild spawns node processes that outlive the
+            // launcher, and a guard that leaks build nodes on every timeout degrades the machine
+            // it is measuring on.
+            try { process.Kill(entireProcessTree: true); } catch (InvalidOperationException) { /* already gone */ }
+            Assert.Fail(
+                $"`dotnet msbuild {project} -getProperty:…` did not finish within 60s. Evaluation "
+                + "does not restore or build, so this is a wedged MSBuild, not a slow one.");
+        }
+
+        // Only valid after WaitForExit() returned true: it is what flushes the final buffered lines.
+        var stdout = outBuffer.ToString();
+        var stderr = errBuffer.ToString();
+
+        Assert.True(process.ExitCode == 0,
+            $"`dotnet msbuild {project} -getProperty:…` exited {process.ExitCode}.\n"
+            + $"arguments: {string.Join(' ', extraArguments)}\n"
+            + $"stdout:\n{stdout}\nstderr:\n{stderr}");
+
+        using var document = JsonDocument.Parse(stdout);
+        var properties = document.RootElement.GetProperty("Properties");
+        return propertyNames.ToDictionary(
+            name => name,
+            name => properties.GetProperty(name).GetString() ?? string.Empty,
+            StringComparer.Ordinal);
+    }
+
+    /// <summary>The repository root — the directory holding <c>MeshWeaver.slnx</c>.</summary>
+    public static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName
+               ?? throw new InvalidOperationException("Could not locate the repository root (no MeshWeaver.slnx above the test binary).");
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/MsBuildPropertyProbe.cs
+++ b/test/MeshWeaver.Documentation.Test/MsBuildPropertyProbe.cs
@@ -89,7 +89,14 @@ internal static class MsBuildPropertyProbe
                 + "does not restore or build, so this is a wedged MSBuild, not a slow one.");
         }
 
-        // Only valid after WaitForExit() returned true: it is what flushes the final buffered lines.
+        // 🚨 The TIMED overload waits only for the PROCESS; the parameterless one is what waits for
+        // the async readers started above to finish flushing. Reading the buffers straight after
+        // WaitForExit(ms) can therefore catch a TRUNCATED stdout — and a truncated JSON document
+        // makes this guard fail on a parse error instead of on its subject, which is exactly the
+        // "measured the wrong thing" failure the guard exists to prevent. The process has already
+        // exited here, so this returns as soon as the readers drain.
+        process.WaitForExit();
+
         var stdout = outBuffer.ToString();
         var stderr = errBuffer.ToString();
 


### PR DESCRIPTION
Fixes #3022

## The identity fork is gone, measured the way it was found

Both promoted images of `71869075` pulled `--platform linux/amd64`, `/app/meshweaver-surface.manifest`
read out with `docker create` + `docker cp` (no execution, nothing published):

| | before the fix | after (`7186907`) |
|---|---|---|
| canonical names present in both manifests | 25 | 25 |
| of those, hashes EQUAL | 0 | 25 |

and the stamped attribute the fork lived in:

    memex-portal-ai   MeshWeaver.Utils.dll   3.0.0-rc9+71869075f5ace055629c7b1812b08d7334f871af
    mw-plugin-test    MeshWeaver.Utils.dll   3.0.0-rc9+71869075f5ace055629c7b1812b08d7334f871af

CD run 33587509969 — which built both images from `71869075` — says the same thing in its own words:
`framework-identity: MATCH`. So does 33591379356 against the promoted tags.

## Why it looked like it still failed

Run 33585729083 ran six minutes after the fix merged and carried `71869075` as its HEAD SHA. It did
not build that commit: `gate` resolves its own target and logged
`staging-3ac34af-33585729083` / `SHA: 3ac34af52…` — the fix's PARENT. A CD run's head SHA is the
trigger ref, never a claim about what it built.

And the reported "second cause" — a 12-vs-20 hex commit suffix between the two legs — was a
30-character display truncation: both strings are exactly 30 characters long, and `.ci.7471` is what
pushed the suffix out of the window. `$(SourceRevisionId)` is the full 40-char SHA on both legs. One
cause, not two.

## What is actually left, and it is not this

`Plugins: bake + seal the publication for this identity` reds on
`CS0234: The type or namespace name 'Maps' does not exist in the namespace 'MeshWeaver'` for
`GoogleMaps/Gallery` and `OpenStreetMap/Gallery`. `MeshWeaver.Maps` left the content surface in
#2941 and has not started riding as a module yet — MeshWeaver.Plugins#1061 step 3, the cross-repo
half of a carve-out. Core's follow-up (adding Maps to `plugins-modules`/`plugins-bake`'s compose set)
is inert until that lands, because `src/platform-shipped.txt` still suppresses the assembly from the
bundle.

## The guard

`CdImageLegPropertiesDoNotForkTheIdentityGuard` generalises #3041's guard from one remembered switch
to the defect class. `main-cd.yml` publishes the two images from ONE commit with two different sets
of global `-p:` properties, and a global property reaches every project in the graph — so ANY of
them reaching a compiled attribute forks the address. The guard reads both `dotnet publish` commands
out of the workflow, probes the union of every `-p:` they carry (bar `CIRun`, which both pass and
which is supposed to select the commit-deterministic branch), and requires InformationalVersion /
AssemblyVersion / FileVersion to be identical; on a failure it re-probes one at a time so the
message names the culprit. Reading the workflow is what stops it going stale: a list written in the
test would have been right until the day `-p:Version=` was added to one leg, which is how this got
in.

Mutation-proved both ways, locally:
  * restoring `Condition="'$(Version)' == ''"` on the compiled-attributes group reds BOTH guards;
  * leaking `$(ContainerRepository)` into InformationalVersion reds the NEW guard alone —
    `-p:ContainerRepository= moves InformationalVersion: '3.0.0-rc9' -> '3.0.0-rc9-9.9.9-guard.ci.424242'` —
    while all three of #3041's tests stay green. Strictly greater cover, demonstrated.

`MsBuildPropertyProbe` holds the out-of-process evaluator both guards share, so the concurrent
pipe-draining and the 60s wedge bound live in one place.

## What's New

Skipped deliberately: this is a pure-internal change — one guard test, a shared test helper, and an
engineering doc page. The user-facing effect of the fix it verifies already shipped its entry with
#3041 (`2026-09-02-a-new-build-no-longer-rebuilds-itself-before-serving-you`).

## Verification

* `dotnet build -c Release -warnaserror` — `src/MeshWeaver.Documentation` and
  `test/MeshWeaver.Documentation.Test`, one project per invocation: **0 Warning(s), 0 Error(s)**.
* `dotnet test test/MeshWeaver.Documentation.Test -c Release --no-build` — the **FULL** project, no
  `--filter`: **179 passed, 0 failed**, `.trx` written, 12 s. Includes `DocumentationLinkIntegrityTest`
  (run after the doc edits) and `WhatsNewEntryIntegrityTest`.
* Nothing was published, retagged or deleted; the registry work was `az acr repository show-tags`,
  `docker pull`, `docker create`/`docker cp` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SD7aiLSo59xng2TzU32xEa
