### PR TITLE
ci: a skipped or cancelled doc/licence/binary-compat gate is NOT a pass of the required check

### DIFF
--- a/.claude/skills/worktree/SKILL.md
+++ b/.claude/skills/worktree/SKILL.md
@@ -87,7 +87,7 @@ and getting it wrong wastes a cycle in one direction or blocks you in the other.
 | MeshWeaver.Education (was education) | no branch protection | yes |
 | MeshWeaver.Reinsurance | false | yes |
 | MeshWeaver.SocialMedia | false | yes |
-| **MeshWeaver.Plugins** | **true** | **NO — `mergeStateStatus: BEHIND`, must update the branch** |
+| MeshWeaver.Plugins | false (measured 2026-09-02; was true until 2026-08-29) | yes |
 
 One command answers it for any repo, and beats trusting this table:
 

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2252,8 +2252,13 @@ jobs:
         echo "Pruning ${#refspecs[@]} stale marker(s)."
         git push origin "${refspecs[@]}"
 
+    # `!= 'success'` rather than `== 'failure'` (2026-09-02 fleet audit, finding A5): a gate that
+    # was SKIPPED or CANCELLED produced no verdict, and no verdict must never read as passed — this
+    # is the repo's ONLY required check. The one legitimate skip is the reuse path (the tree was
+    # already tested green, so `build` — and with it `doc-gate` — did not run); it is exempted on
+    # precheck's own output, never on the gate's result.
     - name: Fail if the doc gate failed
-      if: needs.doc-gate.result == 'failure'
+      if: needs.precheck.outputs.skip != 'true' && needs.doc-gate.result != 'success'
       env:
         # Empty when the gate produced no verdict (it died before judging). Degrades to
         # "see the job", which is true either way.
@@ -2273,7 +2278,8 @@ jobs:
     # dependency licence that is incompatible with shipping under Apache-2.0 / MIT must be able
     # to turn the repo's ONLY required status check RED, or the gate is decorative.
     - name: Fail if the licence gate failed
-      if: needs.licence-gate.result == 'failure'
+      # Same shape as the doc gate: skipped/cancelled is not a pass; the reuse path is the one exemption.
+      if: needs.precheck.outputs.skip != 'true' && needs.licence-gate.result != 'success'
       run: |
         echo "::error::A dependency licence is incompatible with shipping MeshWeaver under Apache-2.0 / MIT — see the 'Dependency licences' job for the offending package(s) and their licence."
         echo "::error::Fix it by removing the package or replacing it with a permissively-licensed one. Do NOT add it to EXCEPTIONS unless the upstream licence genuinely IS permissive and only the package metadata is missing."
@@ -2286,7 +2292,9 @@ jobs:
     # moves assembly, or a public record whose primary constructor changes shape, breaks every
     # module built before the change while every compile in the repo stays green.
     - name: Fail if the binary-compatibility gate failed
-      if: needs.record-signatures.result == 'failure'
+      # The gate itself runs only on pull_request / merge_group (it diffs against a base), so the
+      # exemption is written on the EVENT — the same predicate the gate carries — never on its result.
+      if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && needs.record-signatures.result != 'success'
       run: |
         echo "::error::A public surface changed in a way that breaks ALREADY-PUBLISHED modules — see the 'Public surface (binary compatibility)' job for the exact types."
         echo "::error::A moved public type needs [assembly: TypeForwardedTo] left behind in its ORIGINAL assembly (a forwarder keeps one type identity; a shim mints a second and reintroduces the is/as trap-door). A forwarder cannot rename, so the type keeps its original name."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ it, not before.
 
 ### 🚨 Before you push: make CI green LOCALLY first
 
-CI builds **Release with warnings-as-errors**; a plain local Debug build passes while CI fails. **Build every touched project and its dependents with `dotnet build -c Release -warnaserror`, one project per invocation, and only push when that is clean.** The bar is MERGEABLE, not merged: a branch merely *behind* main merges fine here (`strict: false`, one required check — `Consolidate test results`), so do NOT re-sync just to catch up; merge main only when the PR is `DIRTY` or CI fails on something your diff cannot reach. 🚨 `strict` is **PER-REPO** — `MeshWeaver.Plugins` is `strict: true`.
+CI builds **Release with warnings-as-errors**; a plain local Debug build passes while CI fails. **Build every touched project and its dependents with `dotnet build -c Release -warnaserror`, one project per invocation, and only push when that is clean.** The bar is MERGEABLE, not merged: a branch merely *behind* main merges fine here (`strict: false`, one required check — `Consolidate test results`), so do NOT re-sync just to catch up; merge main only when the PR is `DIRTY` or CI fails on something your diff cannot reach. 🚨 `strict` is **PER-REPO** and it FLIPS — `MeshWeaver.Plugins` was `strict: true` until 2026-08-29 and measured `false` on 2026-09-02; never trust a written value, run `gh api repos/Systemorph/<repo>/branches/main/protection --jq '.required_status_checks.strict'`.
 
 ### 🚨 A verification step that cannot fail is not a verification step
 


### PR DESCRIPTION
Finding **A5** of today's fleet CI audit (ranked "fleet-blocking or silent false-green").

## The hole

`Consolidate test results` is this repo's ONLY required check. Three of the gates it folds in were judged with `result == 'failure'`:

| step | was | a SKIPPED or CANCELLED gate… |
|---|---|---|
| Fail if the doc gate failed | `needs.doc-gate.result == 'failure'` | passed the required check |
| Fail if the licence gate failed | `needs.licence-gate.result == 'failure'` | passed the required check |
| Fail if the binary-compatibility gate failed | `needs.record-signatures.result == 'failure'` | passed the required check |

The shell, shared-rules and clients gates in the same job already say `!= 'success'`, with the comment *"a gate that was skipped or cancelled has produced no verdict, and 'no verdict' must never read as 'passed'"*. These three now follow it.

## The exemptions, written on their cause

- **doc-gate / licence-gate**: the reuse path (`needs.precheck.outputs.skip == 'true'`) — the tree was already tested green, `build` did not run, and `doc-gate` (`needs: [build]`, `if: build == success`) and `licence-gate` (`if: precheck.skip != 'true'`) are legitimately absent. Exempted on precheck's own output, never on the gate's result.
- **record-signatures**: it diffs against a base, so it runs only on `pull_request` / `merge_group`; the fail step carries the same event predicate, so the two can never disagree about when the gate is expected.

## Also in this PR

AGENTS.md and `.claude/skills/worktree` said MeshWeaver.Plugins is `strict: true`. It was, until 2026-08-29; `gh api repos/Systemorph/MeshWeaver.Plugins/branches/main/protection` measures `false` today. Both now tell the reader to measure rather than trust the sentence.

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/dotnet-test.yml'))"` → ok
- `check-workflow-shell.py` on the tree → `0 live` findings; `check-shared-rules.py` → clean (the edited sentence is outside every shared-rule block)
- The effect is only visible when a gate skips or is cancelled; a normal green run is unchanged.

Internal CI change → no What's New.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
