### PR TITLE
Owner-side patch ack reaches a terminal on every path — guarded completion arm, tested (#3033)

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1541,10 +1541,46 @@ public static class DataExtensions
                                     .Timeout(TimeSpan.FromSeconds(10))
                                     .Subscribe(
                                         _ => AckOnce(true),
-                                        ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
+                                        ex => AckOnce(false, ClassifyPatchException(ex, hubPath)),
+                                        // Same completion gap as the outer subscription below:
+                                        // `.Take(1)` over a flush that ENDS without emitting runs
+                                        // neither arm, and the durable-flush ack is never posted.
+                                        () => AckOnce(false, new MeshNodeError(
+                                            MeshNodeErrorCode.OwnerDisposing,
+                                            hubPath,
+                                            "the post-commit flush stream ended before it reported "
+                                            + "durability — the merge committed in memory but the "
+                                            + "durable flush is UNCONFIRMED; safe to retry")));
                                 hub.RegisterForDisposal(flushSub);
                             },
-                            ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
+                            ex => AckOnce(false, ClassifyPatchException(ex, hubPath)),
+                            // 🚨 THE COMPLETION ARM. Without it this subscription had two ways out
+                            // for three outcomes: `.Skip(1).Take(1)` needs TWO emissions, so a
+                            // stream that ENDS before the commit is observed completes EMPTY —
+                            // neither onNext nor onError runs, and no acknowledgement is ever
+                            // posted. The writer then burns its full confirmation window and
+                            // reports OwnerUnreachable for a patch the owner may already have
+                            // committed (#3033; the user-visible half was #2896, whose own
+                            // re-measurement showed the owner DID produce a terminal — the ack was
+                            // simply never sent).
+                            //
+                            // OwnerDisposing rather than a new code: a stream ending under a live
+                            // patch IS the owner's stream going away, which is what that code
+                            // means, and it is documented TRANSIENT and retry-worthy — the
+                            // resubscribe latch rides it out (#2986) instead of tearing down.
+                            // Reporting "unknown, retry-worthy" is the honest verdict: the merge
+                            // may or may not have committed, and the caller must be free to retry
+                            // rather than left waiting on silence.
+                            //
+                            // AckOnce is an Interlocked gate, so this cannot double-post — a real
+                            // ack that already won makes it a no-op, which is what makes adding a
+                            // third arm safe rather than a race.
+                            () => AckOnce(false, new MeshNodeError(
+                                MeshNodeErrorCode.OwnerDisposing,
+                                hubPath,
+                                "the owner's stream ended before the patch's commit was observed — "
+                                + "the write's fate is UNKNOWN and it is safe to retry against the "
+                                + "fresh activation; the owner did not report a verdict")));
                     hub.RegisterForDisposal(postSub);
 
                     // Route via the hub's DataChangeRequest pipeline — the workspace

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -983,6 +983,99 @@ public static class DataExtensions
     }
 
     /// <summary>
+    /// 🚨 Totality for a one-shot watcher: runs <paramref name="onEmptyCompletion"/> when
+    /// <paramref name="source"/> COMPLETES WITHOUT EVER EMITTING — Rx's third termination, the one a
+    /// <c>Subscribe(onNext, onError)</c> settles as silence (issue #3033; the owner-side twin of the
+    /// writer-side <c>RequireBaseState</c>, #3001/#3020). Emissions, errors, and a completion that FOLLOWS
+    /// an emission pass through untouched — so a <c>.Take(1)</c> completing right after its single value,
+    /// while work started in <c>onNext</c> is still in flight, never triggers it. That guard is the whole
+    /// point: a bare completion arm on the ack watcher would NACK every SUCCESSFUL write, because
+    /// <c>Take(1)</c> completes while the durable flush is still in flight and <c>AckOnce</c> latches.
+    /// Internal for the deterministic pins in <c>MeshWeaver.Data.Test</c>.
+    /// </summary>
+    internal static IObservable<T> WhenCompletesEmpty<T>(this IObservable<T> source, Action onEmptyCompletion)
+        => Observable.Create<T>(observer =>
+        {
+            // Rx serialises an observer's notifications, so a flag written in OnNext and read in
+            // OnCompleted is ordered without further synchronisation.
+            var emitted = false;
+            return source.Subscribe(
+                value =>
+                {
+                    emitted = true;
+                    observer.OnNext(value);
+                },
+                observer.OnError,
+                () =>
+                {
+                    if (!emitted)
+                        onEmptyCompletion();
+                    observer.OnCompleted();
+                });
+        });
+
+    /// <summary>
+    /// The owner-side ack watcher for a cross-hub <see cref="PatchDataRequest"/>, armed as a PURE
+    /// composition so that its totality — every path posts exactly ONE terminal — is testable without a
+    /// mesh (issue #3033). The caller supplies the already-shaped commit echo (identity-filtered,
+    /// <c>Take(1)</c>, bounded), the durable-flush factory (<c>null</c> when no
+    /// <see cref="IPostCommitFlush"/> is registered), and its latching <c>AckOnce</c>.
+    /// <list type="bullet">
+    ///   <item><b>Echo arrives</b> → flush durably → ack <c>true</c> on the flush's emission. Nothing is
+    ///     posted between the echo and the flush landing: the echo's own <c>Take(1)</c> completion is NOT
+    ///     a verdict (see <see cref="WhenCompletesEmpty{T}"/>).</item>
+    ///   <item><b>Echo stream ENDS without the echo</b> — a <c>SynchronizationStream</c> disposed by mirror
+    ///     eviction while the hub lives completes its store — → NACK
+    ///     <see cref="MeshNodeErrorCode.OwnerDisposing"/>, naming the condition. That code, not
+    ///     <see cref="MeshNodeErrorCode.OwnerUnreachable"/> and not a new one: a stream ending under a live
+    ///     patch IS the owner's stream going away, which is what the code means, and it is the writer's
+    ///     auto-retried code — a re-enqueue re-runs the update lambda against the FRESH state and re-diffs,
+    ///     so a merge that DID commit before the stream ended becomes a no-op. "Fate unknown, safe to retry"
+    ///     is the honest verdict; the timeout verdict stays <c>Unknown</c> + <c>TimeoutException</c>, so the
+    ///     two are separable by <c>Code</c> (Doc/Architecture/ReadingAWriteVerdict).</item>
+    ///   <item><b>Flush ENDS without emitting</b> → ack <c>true</c>. <see cref="IPostCommitFlush.Flush"/> is
+    ///     contracted to "complete immediately for entity types this hook does not persist": nothing to
+    ///     make durable means the in-memory commit IS the durable state — the same verdict as when no hook
+    ///     is registered. (<c>StoragePostCommitFlush</c> itself ends in <c>DefaultIfEmpty(true)</c>, so this
+    ///     arm is the contract made explicit, not a behaviour change for it.) A NACK here would fail every
+    ///     successful write on a hook honouring the contract.</item>
+    ///   <item><b>Either stream faults</b> → NACK with the classified code.</item>
+    /// </list>
+    /// </summary>
+    internal static IDisposable ArmPatchAckWatcher<TEcho>(
+        IObservable<TEcho> commitEcho,
+        Func<TEcho, IObservable<bool>?> flush,
+        TimeSpan flushTimeout,
+        Action<bool, MeshNodeError?> ackOnce,
+        Action<IDisposable> registerForDisposal,
+        string hubPath)
+        => commitEcho
+            .WhenCompletesEmpty(() => ackOnce(false, new MeshNodeError(
+                MeshNodeErrorCode.OwnerDisposing, hubPath,
+                "the owner's stream ended before this patch's commit echo arrived — the owner reported no "
+                + "verdict, so the write's fate is UNKNOWN; safe to retry: a re-enqueue re-diffs against the "
+                + "fresh state, so a merge that did commit is a no-op")))
+            .Subscribe(
+                committed =>
+                {
+                    var durable = flush(committed);
+                    if (durable is null)
+                    {
+                        ackOnce(true, null);
+                        return;
+                    }
+                    var flushSub = durable
+                        .Take(1)
+                        .Timeout(flushTimeout)
+                        .WhenCompletesEmpty(() => ackOnce(true, null))
+                        .Subscribe(
+                            _ => ackOnce(true, null),
+                            ex => ackOnce(false, ClassifyPatchException(ex, hubPath)));
+                    registerForDisposal(flushSub);
+                },
+                ex => ackOnce(false, ClassifyPatchException(ex, hubPath)));
+
+    /// <summary>
     /// Typed helper for <see cref="HandlePatchDataRequest"/>. Reads the stream's
     /// current value synchronously via <c>.Take(1)</c>, applies the JSON merge
     /// patch, then posts the merged instance through the hub's regular
@@ -1383,6 +1476,15 @@ public static class DataExtensions
 
         stream
             .Take(1)
+            // 🚨 Totality (#3033): this initial read had NEITHER an error nor a completion arm. A
+            // stream that faults or ENDS before delivering the state to merge against left the
+            // request accepted and silently unanswered — the writer then burned its full
+            // confirmation window and reported OwnerUnreachable. Here the merge provably never
+            // ran, so OwnerDisposing ("the patch was NOT applied; safe to retry") is exact.
+            .WhenCompletesEmpty(() => AckOnce(false, new MeshNodeError(
+                MeshNodeErrorCode.OwnerDisposing, hubPath,
+                "the owner's stream ended before it delivered the current state to merge against — "
+                + "the patch was NOT applied; safe to retry against the fresh activation")))
             .Subscribe(change =>
             {
                 try
@@ -1513,74 +1615,24 @@ public static class DataExtensions
                     // deadlock under load. The post-commit response timing
                     // is preserved (caller's Observe subscription fires after the
                     // commit lands, before any subsequent Get).
-                    var postSub = stream
-                        .Skip(1)
-                        .Take(1)
-                        .Timeout(TimeSpan.FromSeconds(5))
-                        .Subscribe(
-                            committed =>
-                            {
-                                // Chain the ack off DURABLE persistence (not just the
-                                // in-memory commit) so the owner's PatchDataResponse —
-                                // and therefore a cross-hub stream.Update completion —
-                                // guarantees read-after-write: a subsequent Query's
-                                // initial snapshot (which reads storage) reflects this
-                                // write instead of racing the per-node hub's ~200ms
-                                // persistence debounce. Mirrors the commit → persist →
-                                // Ok shape of the deleted UpdateNodeRequest handler.
-                                // No hook registered (non-MeshNode data hub) → ack on
-                                // the in-memory commit, unchanged.
-                                var flush = hub.ServiceProvider.GetService<IPostCommitFlush>();
-                                if (flush is null)
-                                {
-                                    AckOnce(true);
-                                    return;
-                                }
-                                var flushSub = flush.Flush(committed.Value!)
-                                    .Take(1)
-                                    .Timeout(TimeSpan.FromSeconds(10))
-                                    .Subscribe(
-                                        _ => AckOnce(true),
-                                        ex => AckOnce(false, ClassifyPatchException(ex, hubPath)),
-                                        // Same completion gap as the outer subscription below:
-                                        // `.Take(1)` over a flush that ENDS without emitting runs
-                                        // neither arm, and the durable-flush ack is never posted.
-                                        () => AckOnce(false, new MeshNodeError(
-                                            MeshNodeErrorCode.OwnerDisposing,
-                                            hubPath,
-                                            "the post-commit flush stream ended before it reported "
-                                            + "durability — the merge committed in memory but the "
-                                            + "durable flush is UNCONFIRMED; safe to retry")));
-                                hub.RegisterForDisposal(flushSub);
-                            },
-                            ex => AckOnce(false, ClassifyPatchException(ex, hubPath)),
-                            // 🚨 THE COMPLETION ARM. Without it this subscription had two ways out
-                            // for three outcomes: `.Skip(1).Take(1)` needs TWO emissions, so a
-                            // stream that ENDS before the commit is observed completes EMPTY —
-                            // neither onNext nor onError runs, and no acknowledgement is ever
-                            // posted. The writer then burns its full confirmation window and
-                            // reports OwnerUnreachable for a patch the owner may already have
-                            // committed (#3033; the user-visible half was #2896, whose own
-                            // re-measurement showed the owner DID produce a terminal — the ack was
-                            // simply never sent).
-                            //
-                            // OwnerDisposing rather than a new code: a stream ending under a live
-                            // patch IS the owner's stream going away, which is what that code
-                            // means, and it is documented TRANSIENT and retry-worthy — the
-                            // resubscribe latch rides it out (#2986) instead of tearing down.
-                            // Reporting "unknown, retry-worthy" is the honest verdict: the merge
-                            // may or may not have committed, and the caller must be free to retry
-                            // rather than left waiting on silence.
-                            //
-                            // AckOnce is an Interlocked gate, so this cannot double-post — a real
-                            // ack that already won makes it a no-op, which is what makes adding a
-                            // third arm safe rather than a race.
-                            () => AckOnce(false, new MeshNodeError(
-                                MeshNodeErrorCode.OwnerDisposing,
-                                hubPath,
-                                "the owner's stream ended before the patch's commit was observed — "
-                                + "the write's fate is UNKNOWN and it is safe to retry against the "
-                                + "fresh activation; the owner did not report a verdict")));
+                    // Chain the ack off DURABLE persistence (not just the in-memory commit) so
+                    // the owner's PatchDataResponse — and therefore a cross-hub stream.Update
+                    // completion — guarantees read-after-write; no hook registered (non-MeshNode
+                    // data hub) → ack on the in-memory commit. Emission-COUNTING (Skip(1).Take(1))
+                    // is tolerated ONLY on this generic path — the MeshNode path is identity-gated
+                    // (see ApplyMeshNodePatchInTurn). Armed through the totality seam so a stream
+                    // that ENDS before the commit is observed, or a flush that ends without
+                    // emitting, still posts exactly one terminal (#3033).
+                    var postSub = ArmPatchAckWatcher(
+                        stream
+                            .Skip(1)
+                            .Take(1)
+                            .Timeout(TimeSpan.FromSeconds(5)),
+                        committed => hub.ServiceProvider.GetService<IPostCommitFlush>()?.Flush(committed.Value!),
+                        TimeSpan.FromSeconds(10),
+                        AckOnce,
+                        d => hub.RegisterForDisposal(d),
+                        hubPath);
                     hub.RegisterForDisposal(postSub);
 
                     // Route via the hub's DataChangeRequest pipeline — the workspace
@@ -1592,7 +1644,8 @@ public static class DataExtensions
                 {
                     AckOnce(false, ClassifyPatchException(ex, hubPath));
                 }
-            });
+            },
+            ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
     }
 
     /// <summary>
@@ -1662,32 +1715,29 @@ public static class DataExtensions
         // 30068597014 / 30079395006 (post-recycle store frozen at the pre-recycle
         // version despite a fast Success ack). Write-echo detection is identity-based,
         // never emission-count-based (PR #584 rule).
-        var postSub = stream
-            .Where(c => ChangeContainsStampedWrite(
-                c.Value,
-                System.Threading.Volatile.Read(ref stampedId),
-                System.Threading.Interlocked.Read(ref stampedVersion),
-                idKey, versionKey, jsonOpts))
-            .Take(1)
-            // Bounded: covers the one-shot cold-store defer below (10s) + flush. On
-            // expiry the AckOnce guard means this NACK only fires if no terminal was
-            // posted yet (e.g. commit emission lost in a teardown) — the caller's
-            // retry machinery takes over; never a silent hang.
-            .Timeout(TimeSpan.FromSeconds(20))
-            .Subscribe(
-                committed =>
-                {
-                    var flush = hub.ServiceProvider.GetService<IPostCommitFlush>();
-                    if (flush is null) { AckOnce(true); return; }
-                    var flushSub = flush.Flush(committed.Value!)
-                        .Take(1)
-                        .Timeout(TimeSpan.FromSeconds(10))
-                        .Subscribe(
-                            _ => AckOnce(true),
-                            ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
-                    hub.RegisterForDisposal(flushSub);
-                },
-                ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
+        var postSub = ArmPatchAckWatcher(
+            stream
+                .Where(c => ChangeContainsStampedWrite(
+                    c.Value,
+                    System.Threading.Volatile.Read(ref stampedId),
+                    System.Threading.Interlocked.Read(ref stampedVersion),
+                    idKey, versionKey, jsonOpts))
+                .Take(1)
+                // Bounded: covers the one-shot cold-store defer below (10s) + flush. On
+                // expiry the AckOnce guard means this NACK only fires if no terminal was
+                // posted yet (e.g. commit emission lost in a teardown) — the caller's
+                // retry machinery takes over; never a silent hang.
+                .Timeout(TimeSpan.FromSeconds(20)),
+            // Durable flush (persist + publish the cache-eviction feed event), then ack; no hook
+            // registered → ack on the in-memory commit. Armed through the totality seam so a
+            // stream that ENDS before the echo arrives, or a flush that ends without emitting,
+            // still posts exactly one terminal (#3033) — ArmPatchAckWatcher names each path's
+            // verdict and why a bare completion arm would NACK successful writes.
+            committed => hub.ServiceProvider.GetService<IPostCommitFlush>()?.Flush(committed.Value!),
+            TimeSpan.FromSeconds(10),
+            AckOnce,
+            d => hub.RegisterForDisposal(d),
+            hubPath);
         hub.RegisterForDisposal(postSub);
         // Registered AFTER postSub so the composite disposes the watcher FIRST, then this NACK
         // claims the gate — an unacked in-flight patch always gets a terminal, never silence.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingAWriteVerdict.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingAWriteVerdict.md
@@ -28,15 +28,16 @@ public MeshNodeStreamException(MeshNodeError error)
 So a log line has the shape `MeshNode {Code} at '{Path}': {Message}`, and **`Code` alone separates
 the two investigations.**
 
-## The three shapes, and what each one means
+## The four shapes, and what each one means
 
 | `Code` | Message shape | What actually happened | Where to look |
 |---|---|---|---|
 | `OwnerUnreachable` | `The owner of '…' returned no verdict for this update within Ns. The patch was posted and may still apply… Request trail: …` | The owner produced **no terminal at all**. The writer's late-response window expired. | The **owner's** activation: is it alive, mid-recycle, pinned dead? |
 | `Unknown` | `{ExceptionTypeName}: {message}` — e.g. `TimeoutException: The operation has timed out.` | The owner **answered**, with a NACK carrying its own internal exception. | The owner's **ack chain**: which of its two internal bounds expired. |
 | `AccessDenied` / `Deserialization` / `Validation` | `Access denied: …` / `Patch deserialization failed: …` / `Validation failed: …` | The owner answered with a classified application-level refusal. | The patch itself. |
+| `OwnerDisposing` | `the owner's stream ended before this patch's commit echo arrived — … the write's fate is UNKNOWN; safe to retry …` | The owner **answered**: the stream its ack watcher was on completed before the echo — mirror eviction while the hub lives. The writer auto-retries it (a re-enqueue re-diffs, so a merge that did commit is a no-op). | The owner's **stream lifetime** (`ReclaimIfUnheld`, `SynchronizationStream.Dispose`), not its bounds. |
 
-The last three rows all come from one classifier on the **owner**:
+Rows two and three come from one classifier on the **owner**:
 
 ```csharp
 // src/MeshWeaver.Data/DataExtensions.cs — ClassifyPatchException
@@ -61,24 +62,18 @@ watches for its own commit echo and then flushes durably — two bounded steps, 
 
 ```csharp
 // src/MeshWeaver.Data/DataExtensions.cs
-var postSub = stream
-    .Where(c => ChangeContainsStampedWrite(...))   // identity-based echo detection
-    .Take(1)
-    .Timeout(TimeSpan.FromSeconds(20))             // ① commit echo
-    .Subscribe(
-        committed =>
-        {
-            var flush = hub.ServiceProvider.GetService<IPostCommitFlush>();
-            if (flush is null) { AckOnce(true); return; }
-            var flushSub = flush.Flush(committed.Value!)
-                .Take(1)
-                .Timeout(TimeSpan.FromSeconds(10))  // ② durable flush
-                .Subscribe(_ => AckOnce(true),
-                           ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
-            hub.RegisterForDisposal(flushSub);
-        },
-        ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
+var postSub = ArmPatchAckWatcher(
+    stream
+        .Where(c => ChangeContainsStampedWrite(...))   // identity-based echo detection
+        .Take(1)
+        .Timeout(TimeSpan.FromSeconds(20)),            // ① commit echo
+    committed => hub.ServiceProvider.GetService<IPostCommitFlush>()?.Flush(committed.Value!),
+    TimeSpan.FromSeconds(10),                          // ② durable flush
+    AckOnce, d => hub.RegisterForDisposal(d), hubPath);
 ```
+
+`ArmPatchAckWatcher` subscribes the echo with all three arms (see "The ack watcher's completion arm"
+below); the two bounds are unchanged.
 
 **Which one fired is readable from the elapsed time** between the user's action and the log line:
 
@@ -95,22 +90,47 @@ write-side twin of the read-side hazard in
 [Durable But Unreadable](/Doc/Architecture/DurableButUnreadable): the durable state and the
 reported outcome disagree, in opposite directions.
 
-## A known gap: the ack watcher has no completion arm
+## The ack watcher's completion arm (the gap closed by #3033)
 
-`postSub` above subscribes with **`onNext` and `onError` only**. If the filtered stream *completes
+`postSub` used to subscribe with **`onNext` and `onError` only**. If the filtered stream *completed
 without emitting* — which `SynchronizationStream.Dispose` does by calling `Store.OnCompleted()`, and
-which mirror eviction can do while the hub still lives — then `Take(1)` ends empty, the `Timeout` is
-cancelled, **neither arm runs, and no ack is ever posted**. The writer then waits out its full
-window and reports `OwnerUnreachable`.
+which mirror eviction can do while the hub still lives — then `Take(1)` ended empty, the `Timeout` was
+cancelled, **neither arm ran, and no ack was ever posted**. The writer then waited out its full
+window and reported `OwnerUnreachable` for a write the owner may already have committed. This was the
+exact defect fixed on the *writer* side by `RequireBaseState`
+([Write Verdict Totality](../WriteVerdictTotality)), one hub over; `RegisterOwnerDisposingNack` covered
+a *disposing hub*, not a stream that completes while the hub lives.
 
-This is the exact defect that was fixed on the *writer* side by giving a write with no base a
-verdict (`RequireBaseState`), and it is still open on the owner side. `RegisterOwnerDisposingNack`
-covers the case where the hub is disposing, but not a stream that completes while the hub lives.
+The watcher is now armed through one pure composition, `DataExtensions.ArmPatchAckWatcher`, built on
+the `WhenCompletesEmpty` operator — "run this callback if the source completes without ever having
+emitted" — so every path posts exactly one terminal:
 
-The fix shape is a completion arm guarded on "the commit echo was never observed" — it must **not**
-be a bare `AckOnce(false)` on completion, because `Take(1)` completes immediately after `onNext` on
-the *successful* path, while the inner flush is still in flight; latching a failure there would NACK
-writes that are about to succeed.
+| Path | Verdict |
+|---|---|
+| commit echo arrives, flush emits | `Success` — posted once, on the flush's emission |
+| **echo stream ends without the echo** | NACK `OwnerDisposing`, message `the owner's stream ended before this patch's commit echo arrived — … the write's fate is UNKNOWN; safe to retry …` |
+| flush ends without emitting | `Success` — `IPostCommitFlush.Flush` is contracted to complete empty for entity types it does not persist, so the in-memory commit is the durable state (the same verdict as when no hook is registered) |
+| either stream faults | NACK with `ClassifyPatchException`'s code (a timeout stays `Unknown` + `TimeoutException`) |
+
+Two things about that shape are load-bearing:
+
+- 🚨 **The completion arm is guarded on "no emission was ever observed".** A bare
+  `onCompleted => AckOnce(false)` would NACK every *successful* write: on the happy path `Take(1)`
+  emits the echo and completes immediately, while the inner flush is still in flight, and `AckOnce`
+  latches — the completion arm would win the race against the flush's later `AckOnce(true)`.
+  `WhenCompletesEmpty` fires only for a completion that no emission preceded.
+- **`OwnerDisposing`, not `OwnerUnreachable` and not a new code.** A stream ending under a live patch
+  *is* the owner's stream going away, which is what the code means; it is the code the writer
+  auto-retries (bounded — `MaxOwnerDisposingReenqueues`), and a re-enqueue re-runs the update lambda
+  against the **fresh** state and re-diffs, so a merge that did commit before the stream ended becomes a
+  no-op. "Fate unknown, safe to retry" is the honest verdict — and because the timeout verdict stays
+  `Unknown`, the two are separable by `Code`.
+
+The generic deferred path (`ApplyJsonMergePatchAndUpdate`, non-MeshNode data hubs) had the same gap
+twice over — its initial `stream.Take(1)` read had *neither* an error nor a completion arm, and its
+`Skip(1).Take(1)` echo watcher had no completion arm — and is closed by the same two seams. An empty
+initial read NACKs `OwnerDisposing` with `the patch was NOT applied` (there the write provably never
+ran).
 
 ## Procedure
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
@@ -115,6 +115,21 @@ refused this at version N and the mirror never moved past it" send an operator t
 The same two-callback subscribe existed on the sync-stream write path
 (`WriteViaSyncStream`, the Overwrite/bypass route) and carries the same guard for the same reason.
 
+### The owner side has the same seam
+
+The owner's ack watcher (`ApplyMeshNodePatchInTurn`, `DataExtensions.cs`) is a `.Take(1)` over the
+owner's reduced stream waiting for the emission that carries the write, and it was subscribed with the
+same two arms. A reduced stream that completes without emitting — mirror eviction disposing a
+`SynchronizationStream` while the hub lives — ended the watcher with no ack posted, and the writer
+reported `OwnerUnreachable` for a write the owner may have committed (issue #3033). It is now armed
+through `ArmPatchAckWatcher` over the `WhenCompletesEmpty` operator — "run this callback if the
+source completes without ever having emitted" — which is `RequireBaseState`'s idea in operator form,
+with one twist the owner side needs and the writer side does not: the callback must fire ONLY for a
+completion that no emission preceded, because on the happy path `Take(1)` completes while the durable
+flush started in `onNext` is still in flight, and a bare completion arm would NACK the write that is
+about to succeed. Which verdict each path posts, and why the code is `OwnerDisposing`, is in
+[Reading a Write Verdict](../ReadingAWriteVerdict).
+
 ## What this is NOT
 
 **It is not a timeout, a retry, or a watchdog.** No bound moves; nothing is re-attempted; no poller is

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-save-the-owner-stopped-watching-fails-fast.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-save-the-owner-stopped-watching-fails-fast.md
@@ -1,0 +1,28 @@
+---
+Name: A save that the owner stopped watching now fails fast instead of hanging
+Category: Fix
+Description: When the stream a save was waiting on ended without answering, the save sat for 31 seconds and then reported the owner unreachable. It now gets a prompt, retryable verdict that says what happened.
+Icon: Warning
+Order: -20260902
+---
+
+# A save that the owner stopped watching now fails fast instead of hanging
+
+When you save content that lives on another hub, the owner of that content confirms the write: it
+watches for its own commit to come back on its stream, makes it durable, and only then tells your
+side "saved". Your side waits for that answer.
+
+There was one way for that answer never to come. If the stream the owner was watching *ended* —
+which happens when the owner's cached view of the node is evicted while the owner itself keeps
+running — the watcher simply stopped, without reporting anything. Nothing had failed as far as it
+could tell; it had just run out of things to watch. Your side then waited out its whole confirmation
+window (31 seconds) and reported the owner as unreachable, even though the owner had been alive the
+entire time and may well have committed the write. On the portal this looked like a text-area save
+that neither succeeded nor failed for half a minute.
+
+The watcher now reports that case the moment it happens: a verdict that says the owner's stream
+ended before the write's confirmation arrived, marked as safe to retry — and the retry is automatic,
+because re-applying a write that already landed changes nothing. The same gap existed one level in,
+where the durable flush is awaited, and in the generic path used by non-content data hubs; all three
+are closed together. A verdict of this kind is now distinguishable from a genuine timeout, so a slow
+owner and a stopped watcher no longer read the same in the log.

--- a/test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs
+++ b/test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs
@@ -1,0 +1,258 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// 🚨 The owner-side patch ack must ALWAYS reach exactly one terminal — issue #3033, the owner-side
+/// twin of #3001 / #3020 (<c>WriteBaseStateTotalityTest</c>).
+///
+/// <para><b>The defect.</b> <c>ApplyMeshNodePatchInTurn</c> (and the generic deferred path in
+/// <c>ApplyJsonMergePatchAndUpdate</c>) armed the ack watcher with <c>Subscribe(onNext, onError)</c> —
+/// two of Rx's three terminations. The watcher is a <c>.Take(1)</c> over the owner's reduced stream,
+/// waiting for the emission that carries this write. A stream that COMPLETES WITHOUT EMITTING — a
+/// <c>SynchronizationStream</c> disposed by mirror eviction while the hub lives, which completes its
+/// store — ends the <c>Take(1)</c> empty, cancels the <c>Timeout</c>, and runs neither arm. No
+/// acknowledgement is ever posted; the writer burns its full 31 s confirmation window and reports
+/// <c>OwnerUnreachable</c> for a patch the owner may already have committed.</para>
+///
+/// <para><b>🚨 The naive fix is itself a defect.</b> A bare <c>onCompleted =&gt; AckOnce(false)</c>
+/// NACKs every SUCCESSFUL write: on the happy path <c>Take(1)</c> emits the commit echo and completes
+/// immediately, while the durable flush started in <c>onNext</c> is still in flight — and
+/// <c>AckOnce</c> latches, so the completion arm's NACK would win against the flush's later
+/// <c>AckOnce(true)</c>. The completion arm must be guarded on "no emission was ever observed".</para>
+///
+/// <para><b>What is pinned.</b> The arming is a pure composition
+/// (<c>DataExtensions.ArmPatchAckWatcher</c>, over the <c>WhenCompletesEmpty</c> operator), so each
+/// path is driven without a mesh: an empty echo NACKs promptly with its own code and a message naming
+/// the condition (separable from a timeout by <c>Code</c>); a commit echo with the flush in flight
+/// posts NOTHING until the flush lands, then exactly one <c>true</c>; an empty FLUSH completion acks
+/// success, because <c>IPostCommitFlush.Flush</c> is contracted to "complete immediately for entity
+/// types this hook does not persist" (the in-memory commit is then the durable state — the same
+/// verdict as when no hook is registered); errors still fault with their classified code; and every
+/// path posts exactly ONE terminal.</para>
+///
+/// <para>Deterministic by construction: <see cref="Observable.Empty{TResult}()"/> IS a disposed
+/// stream's replay and terminates synchronously on Subscribe. No mesh, no cluster, no wall clock.</para>
+/// </summary>
+public class PatchAckTotalityTest
+{
+    private const string HubPath = "charlie/_Thread/thread_1";
+    private static readonly TimeSpan FlushTimeout = TimeSpan.FromSeconds(10);
+
+    private sealed record Ack(bool Success, MeshNodeError? Error);
+
+    private sealed class Harness : IDisposable
+    {
+        public List<Ack> Acks { get; } = [];
+        public List<IDisposable> Registered { get; } = [];
+        public void AckOnce(bool success, MeshNodeError? error) => Acks.Add(new Ack(success, error));
+        public void Register(IDisposable d) => Registered.Add(d);
+        public void Dispose()
+        {
+            foreach (var d in Registered) d.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. The watched stream ends without ever carrying the commit echo. RED before
+    /// the fix: neither arm ran and nothing was posted — the writer's silence for 31 s. GREEN: one
+    /// prompt NACK whose code and message name the condition, not a timeout.
+    /// </summary>
+    [Fact]
+    public void EchoStreamThatEndsBeforeTheCommit_NacksPromptly_NamingTheCondition()
+    {
+        using var h = new Harness();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Empty<int>(), _ => Observable.Return(true), FlushTimeout, h.AckOnce, h.Register, HubPath);
+
+        h.Acks.Should().ContainSingle(
+            "a stream that completes without emitting is Rx's third termination; a two-arm subscribe "
+            + "settles it as SILENCE and the writer waits out its whole confirmation window");
+        var ack = h.Acks[0];
+        ack.Success.Should().BeFalse("the owner reported no verdict for this write");
+        ack.Error.Should().NotBeNull();
+        ack.Error!.Code.Should().Be(MeshNodeErrorCode.OwnerDisposing,
+            "a stream ending under a live patch IS the owner's stream going away — the code the writer "
+            + "auto-retries (a re-enqueue re-diffs against fresh state, so a merge that DID commit becomes "
+            + "a no-op), and one a timeout never carries, so the two are separable by Code");
+        ack.Error.Path.Should().Be(HubPath);
+        ack.Error.Message.Should().Contain("ended before", "the message names the condition …");
+        ack.Error.Message.Should().Contain("commit echo", "… and what never arrived");
+        ack.Error.Message.Should().NotContain("Timeout", "this is not the timeout verdict");
+    }
+
+    /// <summary>
+    /// 🚨 THE NAIVE-FIX TRAP. The commit echo arrives and <c>Take(1)</c> completes at once, while the
+    /// flush started in onNext is still in flight. An unguarded completion arm NACKs here — and,
+    /// because the real <c>AckOnce</c> latches, that NACK would win against the flush's later
+    /// <c>true</c>. The guarded arm posts nothing until the flush lands, then exactly one success.
+    /// </summary>
+    [Fact]
+    public void CommitEchoWithFlushInFlight_PostsNothingOnTake1Completion_ThenAcksTrueOnce()
+    {
+        using var h = new Harness();
+        var flush = new Subject<bool>();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Return(42), _ => flush, FlushTimeout, h.AckOnce, h.Register, HubPath);
+
+        h.Acks.Should().BeEmpty(
+            "Take(1) has completed right after the echo while the flush is in flight — a completion "
+            + "arm that fires here NACKs a write that is about to succeed (the trap #3033 warns about)");
+        h.Registered.Should().ContainSingle("the flush subscription is handed to the hub for disposal");
+
+        flush.OnNext(true);
+
+        h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null),
+            "the durable flush is the ack's basis, and it is posted exactly once");
+    }
+
+    /// <summary>No flush hook registered (a non-MeshNode data hub): the in-memory commit is the ack.</summary>
+    [Fact]
+    public void CommitEchoWithoutAFlushHook_AcksTrueOnce()
+    {
+        using var h = new Harness();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Return(42), _ => null, FlushTimeout, h.AckOnce, h.Register, HubPath);
+
+        h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null));
+    }
+
+    /// <summary>
+    /// <c>IPostCommitFlush.Flush</c> is contracted to "complete immediately for entity types this hook
+    /// does not persist". An empty flush completion therefore means there was nothing to make
+    /// durable — the in-memory commit IS the durable state, the same verdict as when no hook is
+    /// registered. NACKing it (the parked branch's shape) would fail every successful write on a
+    /// hook that honours that contract.
+    /// </summary>
+    [Fact]
+    public void FlushThatCompletesWithoutEmitting_AcksTrueOnce_PerTheHookContract()
+    {
+        using var h = new Harness();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Return(42), _ => Observable.Empty<bool>(), FlushTimeout, h.AckOnce, h.Register, HubPath);
+
+        h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null),
+            "nothing to persist is not a failure; a NACK here would fail a write that committed");
+    }
+
+    /// <summary>The echo stream faulting still NACKs exactly once, with the classified error — and that
+    /// error's code differs from the completion arm's, which is what makes the two separable.</summary>
+    [Fact]
+    public void EchoStreamThatFaults_NacksOnceWithTheClassifiedError()
+    {
+        using var h = new Harness();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Throw<int>(new TimeoutException("owner echo timed out")),
+            _ => Observable.Return(true), FlushTimeout, h.AckOnce, h.Register, HubPath);
+
+        h.Acks.Should().ContainSingle();
+        h.Acks[0].Success.Should().BeFalse();
+        h.Acks[0].Error!.Message.Should().Contain("TimeoutException");
+        h.Acks[0].Error!.Code.Should().NotBe(MeshNodeErrorCode.OwnerDisposing,
+            "the timeout verdict and the stream-ended verdict must stay distinguishable by Code");
+    }
+
+    /// <summary>The flush faulting still NACKs exactly once with its classified code.</summary>
+    [Fact]
+    public void FlushThatFaults_NacksOnceWithTheClassifiedError()
+    {
+        using var h = new Harness();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Return(42), _ => Observable.Throw<bool>(new UnauthorizedAccessException("row-level security")),
+            FlushTimeout, h.AckOnce, h.Register, HubPath);
+
+        h.Acks.Should().ContainSingle();
+        h.Acks[0].Success.Should().BeFalse();
+        h.Acks[0].Error!.Code.Should().Be(MeshNodeErrorCode.AccessDenied);
+    }
+
+    /// <summary>
+    /// The operator the watcher is built on. An empty completion runs the callback exactly once and
+    /// still completes; a value passes through and the completion that FOLLOWS it does NOT run the
+    /// callback; an error passes through untouched. This is also what guards the generic deferred
+    /// path's initial read (<c>stream.Take(1)</c>), which had neither an error nor a completion arm.
+    /// </summary>
+    [Fact]
+    public void WhenCompletesEmpty_FiresOnlyForACompletionWithoutAnyEmission()
+    {
+        var emptyFired = 0;
+        var emptySeen = new List<int>();
+        var emptyCompleted = false;
+        using (Observable.Empty<int>().WhenCompletesEmpty(() => emptyFired++)
+            .Subscribe(emptySeen.Add, _ => { }, () => emptyCompleted = true))
+        {
+            emptyFired.Should().Be(1, "an empty completion is the case the operator exists for");
+            emptySeen.Should().BeEmpty();
+            emptyCompleted.Should().BeTrue("the completion itself still reaches the subscriber");
+        }
+
+        var valueFired = 0;
+        var valueSeen = new List<int>();
+        var valueCompleted = false;
+        using (Observable.Return(7).WhenCompletesEmpty(() => valueFired++)
+            .Subscribe(valueSeen.Add, _ => { }, () => valueCompleted = true))
+        {
+            valueSeen.Should().Equal(new[] { 7 }, "the value passes through unchanged");
+            valueCompleted.Should().BeTrue();
+            valueFired.Should().Be(0, "a completion that follows an emission is the ordinary Take(1) shape");
+        }
+
+        var errorFired = 0;
+        Exception? error = null;
+        using (Observable.Throw<int>(new InvalidOperationException("boom")).WhenCompletesEmpty(() => errorFired++)
+            .Subscribe(_ => { }, ex => error = ex, () => { }))
+        {
+            error.Should().BeOfType<InvalidOperationException>("errors pass through untouched");
+            errorFired.Should().Be(0);
+        }
+    }
+
+    /// <summary>
+    /// The counterfactuals, kept beside the fix the way <c>PatchAckWriteIdentityTest</c> keeps the old
+    /// counting shape: (1) the two-arm subscribe the watcher HAD is silent on an empty completion —
+    /// the defect, RED-by-absence: no terminal, so the writer waits out 31 s; (2) the NAIVE third arm
+    /// (a bare <c>onCompleted =&gt; NACK</c>) posts a false NACK on the happy path while the flush is
+    /// still in flight — the trap the issue warns about. Together they are why the guard exists.
+    /// </summary>
+    [Fact]
+    public void Counterfactuals_TwoArmsAreSilentOnEmpty_AndABareThirdArmNacksAWriteAboutToSucceed()
+    {
+        // (1) The shape before the fix: onNext + onError only, over a stream that ends empty.
+        var twoArmAcks = new List<Ack>();
+        using (Observable.Empty<int>().Take(1).Subscribe(
+            _ => twoArmAcks.Add(new Ack(true, null)),
+            _ => twoArmAcks.Add(new Ack(false, null))))
+        {
+            twoArmAcks.Should().BeEmpty(
+                "this silence IS the defect: Rx's third termination reaches neither arm, no terminal is "
+                + "posted, and the writer burns its whole confirmation window before reporting OwnerUnreachable");
+        }
+
+        // (2) The naive fix: a bare completion arm, over the HAPPY path with the flush in flight.
+        var naiveAcks = new List<Ack>();
+        var flush = new Subject<bool>();
+        var inner = new List<IDisposable>();
+        using (Observable.Return(42).Take(1).Subscribe(
+            _ => inner.Add(flush.Take(1).Subscribe(__ => naiveAcks.Add(new Ack(true, null)))),
+            _ => naiveAcks.Add(new Ack(false, null)),
+            () => naiveAcks.Add(new Ack(false, null))))
+        {
+            naiveAcks.Should().ContainSingle().Which.Success.Should().BeFalse(
+                "Take(1) completed right after the echo while the flush is still in flight, so the bare "
+                + "completion arm NACKs a write that is about to succeed — and because the real AckOnce "
+                + "latches, that NACK would win over the flush's later true");
+        }
+        foreach (var d in inner) d.Dispose();
+    }
+}


### PR DESCRIPTION
## The owner-side patch ack watcher has no completion arm — Fixes #3033

**Likely root cause of #2896** (GUI text-area save timing out with no verdict, memex-cloud 2026-08-31) — left open for its own re-measurement.

### What was failing

`ApplyMeshNodePatchInTurn`'s ack watcher is a `.Take(1)` over the owner's reduced stream, waiting for the emission that carries the write, subscribed with `onNext` and `onError` only — two of Rx's three terminations. A stream that **completes without emitting** — `SynchronizationStream.Dispose` completes its store, and mirror eviction (`ReclaimIfUnheld`) can do that while the hub lives — ends the `Take(1)` empty, cancels the `Timeout`, runs neither arm, and posts no ack. The writer waits out its full 31 s confirmation window and reports `OwnerUnreachable` for a patch the owner may already have committed. `RegisterOwnerDisposingNack` covers a disposing *hub*, not a stream completing under a live hub. This is the owner-side twin of #3001 / #3020 (`RequireBaseState`).

### What changed

Builds on the parked branch `fix/3033-ack-completion-arm` (`72e31a2a8`, cherry-picked with its authorship — this PR supersedes it) and corrects two things in it:

1. 🚨 **Its completion arms were unguarded.** On the *successful* path `Take(1)` emits the echo and completes immediately while the flush started in `onNext` is still in flight — and `AckOnce` latches — so a bare `onCompleted => AckOnce(false)` wins against the flush's later `AckOnce(true)`: every successful write would have been NACKed. Exactly the trap the issue warns about. The arm is now guarded on "no emission was ever observed" (flag set in `onNext`, read in `onCompleted`).
2. **Its flush-side arm NACKed an empty flush completion.** `IPostCommitFlush.Flush` is contracted to "complete immediately for entity types this hook does not persist" — an empty completion means *nothing to make durable*, so the in-memory commit is the durable state and the verdict is **Success**, the same as when no hook is registered. (`StoragePostCommitFlush` itself ends in `.DefaultIfEmpty(true)`, so for it this is the contract made explicit, not a behaviour change.)

`src/MeshWeaver.Data/DataExtensions.cs`
- `WhenCompletesEmpty<T>(source, onEmptyCompletion)` — one operator: run the callback iff the source completes having never emitted; values, errors and a completion that *follows* an emission pass through untouched.
- `ArmPatchAckWatcher(commitEcho, flush, flushTimeout, ackOnce, registerForDisposal, hubPath)` — the echo → flush → ack composition as a pure function (the `RebaseSource` remedy from #3020, one hub over), used by **both** the in-turn MeshNode path and the generic deferred path. The generic path's initial `stream.Take(1)` read — which had *neither* an error nor a completion arm — gets both.
- **Verdict code for "stream ended before the echo": `OwnerDisposing`**, with a message naming the condition (`the owner's stream ended before this patch's commit echo arrived — … the write's fate is UNKNOWN; safe to retry …`). Not `OwnerUnreachable` (that is the writer's *no terminal at all*) and not a new enum member: a stream ending under a live patch *is* the owner's stream going away, it is the writer's auto-retried code (bounded by `MaxOwnerDisposingReenqueues`), and a re-enqueue re-runs the update lambda against the **fresh** state and re-diffs, so a merge that did commit before the stream ended becomes a no-op. A timeout stays `Unknown` + `TimeoutException`, so the two are separable by `Code`.

`test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs` — deterministic, no mesh (`Observable.Empty` *is* a disposed stream's replay), 8 facts:
- empty echo → exactly one prompt NACK, `OwnerDisposing`, message contains "ended before" / "commit echo", not a timeout;
- **commit echo with the flush in flight → posts NOTHING** (the naive fix NACKs here), then exactly one `true` when the flush lands;
- no hook / empty flush → one `true`; echo or flush faults → one NACK with the classified code (`AccessDenied` for `UnauthorizedAccessException`; a `TimeoutException` stays `Unknown`, pinned as `!= OwnerDisposing`);
- the operator fires only for a completion no emission preceded;
- **counterfactuals**, kept beside the fix as `PatchAckWriteIdentityTest` keeps the old counting shape: the two-arm subscribe is silent on an empty completion (the defect), and a bare third arm NACKs the happy path while the flush is in flight (the trap).

Docs (conserve-work-products): `ReadingAWriteVerdict.md` — the "known gap" section becomes "The ack watcher's completion arm (the gap closed by #3033)", the code block shows the seam, the shapes table gains the `OwnerDisposing` row; `WriteVerdictTotality.md` — "The owner side has the same seam". What's New: `2026-09-02-a-save-the-owner-stopped-watching-fails-fast.md` (Fix).

### Interaction with #3059
Core #3059 moves *when* `SubscribeAck` is posted. Nothing here encodes that ordering — the tests drive `ArmPatchAckWatcher` with plain observables, and the production call sites keep their existing echo shapes (`Where(ChangeContainsStampedWrite).Take(1).Timeout(20s)` / `Skip(1).Take(1).Timeout(5s)`).

### Verification (local, CI flags)
- `dotnet build test/MeshWeaver.Data.Test/… -c Release -warnaserror` → `MeshWeaver.Data` + `MeshWeaver.Data.Test` emitted, `0 Warning(s) 0 Error(s)`.
- `dotnet test test/MeshWeaver.Data.Test -c Release --no-build` (whole project, `DOTNET_PROCESSOR_COUNT=4`) → **429 passed, 0 failed** (2 m 1 s), `.trx` carries all 8 `PatchAckTotalityTest` facts `Passed`.
- `dotnet build test/MeshWeaver.Documentation.Test/… -c Release -warnaserror` (recompiles the dependent graph against the changed `MeshWeaver.Data`) → `0 Warning(s) 0 Error(s)`; whole project run (doc-link + What's New integrity, the `src/` guards) → **176 passed, 0 failed**.

https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj

🤖 Generated with [Claude Code](https://claude.com/claude-code)
