### PR TITLE
A hub-owned watcher stops at the first instant of teardown, not in ShutDown (#3026)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -210,7 +210,8 @@ internal static class NodeTypeCompilationHelpers
         // again) while the hub kept running. Transient stream faults re-establish; poisoned
         // own content (undeserializable NodeTypeDefinition) parks the type — the visible,
         // bounded sink — and stops instead of looping on the replayed emission.
-        var watcherSub = ActivityControlPlaneExtensions.SubscribeWithReEstablish(
+        var watcherSub = ActivityControlPlaneExtensions.SubscribeHubWatcher(
+            hub,
             () => ownStream
             .Where(node => node?.Content is NodeTypeDefinition)
             .DistinctUntilChanged(node => ((NodeTypeDefinition)node!.Content!).CompilationStatus)
@@ -519,7 +520,6 @@ internal static class NodeTypeCompilationHelpers
                         }
                     }
                 },
-            hub.Address,
             logger,
             "Compile watcher",
             onPoisonedContent: ex => parkRegistry?.OnCompileFailed(
@@ -1196,7 +1196,8 @@ internal static class NodeTypeCompilationHelpers
         // instead of being mistaken for non-convergence.
         var stampHighWater = new MonotonicHighWaterMark();
 
-        return ActivityControlPlaneExtensions.SubscribeWithReEstablish(
+        return ActivityControlPlaneExtensions.SubscribeHubWatcher(
+            hub,
             () => ownStream
                 .Where(node => node?.Content is NodeTypeDefinition def
                     && def.RequestedSourceStampAt is not null
@@ -1257,7 +1258,6 @@ internal static class NodeTypeCompilationHelpers
                         "[AdoptedSourceStamp] {HubPath}: failed to stamp the adopted build's source "
                         + "snapshot — the next release request will recompile it", hubPath));
             },
-            hub.Address,
             logger,
             "Adopted source-stamp watcher");
     }
@@ -1342,7 +1342,8 @@ internal static class NodeTypeCompilationHelpers
         // never fired again. Transient faults re-establish (the DistinctUntilChanged resets
         // and the current source set re-resolves — idempotent); poisoned own content stops
         // loudly (the compile watcher's park is the visible sink for the same emission).
-        return ActivityControlPlaneExtensions.SubscribeWithReEstablish(
+        return ActivityControlPlaneExtensions.SubscribeHubWatcher(
+            hub,
             () => ownStream
             .Where(node => node?.Content is NodeTypeDefinition def
                 && !IsStaticOnlyNodeType(node, def))
@@ -1557,7 +1558,6 @@ internal static class NodeTypeCompilationHelpers
                             "SourcesWatcher: failed to write CurrentSourceVersions for {HubPath}",
                             hubPath));
                 },
-            hub.Address,
             logger,
             "Sources watcher");
     }
@@ -1696,7 +1696,8 @@ internal static class NodeTypeCompilationHelpers
         // trigger replayed by the fresh subscription fails the IsPast gate — no double compile.
         // Poisoned own content stops loudly (the compile watcher parks the type on the same
         // emission — the visible sink).
-        return ActivityControlPlaneExtensions.SubscribeWithReEstablish(
+        return ActivityControlPlaneExtensions.SubscribeHubWatcher(
+            hub,
             () => ownStream
             .Where(node => node?.Content is NodeTypeDefinition def
                 && def.RequestedReleaseAt is { } req
@@ -1876,7 +1877,6 @@ internal static class NodeTypeCompilationHelpers
                         ex => logger?.LogWarning(ex,
                             "[ReleaseRequestWatcher] {HubPath}: failed to dispatch release", hubPath));
                 },
-            hub.Address,
             logger,
             "ReleaseRequestWatcher");
     }

--- a/src/MeshWeaver.Documentation/Data/Architecture/ActivityControlPlane.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ActivityControlPlane.md
@@ -154,7 +154,7 @@ public static class JobNodeType
 
 `hub.WatchControlPlane(...)` lives in `MeshWeaver.Mesh.Contract` (`ActivityControlPlaneExtensions.cs`). It projects the hub's own `MeshNodeReference` stream down to `ActivityLog.RequestedStatus`, applies `DistinctUntilChanged`, and forwards each transition to your handler. **The handler parameter is `ActivityStatus?`** — `null` means no request is pending (never set, or cleared after a transition), so always compare against the specific status you handle.
 
-Faults are handled by `SubscribeWithReEstablish`, not by a bare log-and-die `OnError`, because a dead control plane leaves the hub half-alive (process running, control plane gone):
+Faults are handled by `SubscribeHubWatcher` (the hub-owned form of `SubscribeWithReEstablish`), not by a bare log-and-die `OnError`, because a dead control plane leaves the hub half-alive (process running, control plane gone). Being hub-owned also fixes the watcher's *lifetime*: it stops at the hub's `ShuttingDown` signal — the first instant the hub is part of a shutdown, its own or an ancestor's — rather than in the ShutDown phase where `RegisterForDisposal` would finally reach it, and it delivers nothing to a hub that is shutting down (see [Hub Disposal Model](/Doc/Architecture/HubDisposalModel) → "The first instant of teardown", #3026):
 
 | Fault class | Behaviour |
 |---|---|
@@ -193,7 +193,7 @@ hub.WatchSubmission(
 `WatchSubmission` lives next to `WatchControlPlane` in `MeshWeaver.Mesh.Contract`. Internally it is:
 
 ```csharp
-SubscribeWithReEstablish(() => hub.GetWorkspace().GetMeshNodeStream()
+SubscribeHubWatcher(hub, () => hub.GetWorkspace().GetMeshNodeStream()
     .DistinctUntilChanged(fingerprint)
     .Where(needsDispatch)
     // Single-flight: only one dispatch in flight per watcher, released in Finally.

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -175,6 +175,17 @@ If the budget elapses with callbacks still pending, the hub sets the sticky
 subscription that never got its reply is a real bug, not a teardown oddity. Either
 path then posts `DisposeHostedHubs` from `OnQuiesceComplete`'s `finally`.
 
+> 🚨 **Known blind spot: the verdict does not see children that have already LEFT.**
+> A hosted hub removes itself from its parent's registry in its own ShutDown phase —
+> before the parent's teardown completes — so `AnyHubQuiescingTimedOut()`, which walks
+> the parent's *live* children, finds none of them by the time a test base asks. That
+> is how a per-NodeType hub could time out its 2 s budget on 22 consecutive fixture
+> teardowns (#3026) while the fixture's leak gate read the mesh as clean on all 22.
+> Making the verdict keep each departing child's summary is straightforward, but it
+> immediately surfaces pre-existing hosted-hub timeouts in unrelated test classes
+> (measured: two in `MeshWeaver.Graph.Test` alone), so it is tracked as its own change
+> rather than folded into the watcher fix.
+
 > **There is no separate "dispose-action drain" phase.** Registered cleanups —
 > including the reactive `Func<IMessageHub, IObservable<Unit>>` ones — are run in the
 > **ShutDown** phase by `DisposeImpl`, and the reactive ones are **fired and not
@@ -421,8 +432,90 @@ teardown; silent on a direct `Dispose()`).
 
 ---
 
+## The first instant of teardown: `ShuttingDown`
+
+`Dispose()` is not the first moment a hub is part of a shutdown. An **ancestor's**
+`Dispose()` freezes hosted-hub creation across the whole subtree, synchronously,
+before it returns (see "The creation window" above);
+a descendant's own `Dispose()` — its `DisposeRequest` — arrives only in the ancestor's
+DisposeHostedHubs phase, after the ancestor has spent up to its whole `QuiesceTimeout`
+draining its own callbacks. `IsShuttingDown` reports that window as a property;
+`RunLevelChanged` reports only this hub's own phases; `DisposalCompleted` reports the
+end. Nothing reported the *beginning* as an event, so a watcher could only sample it.
+
+**`IMessageHub.ShuttingDown`** is that event: it fires once, at the first instant the
+hub becomes part of a shutdown — its own `Dispose()` or the ancestor cascade
+(`CloseHostedHubCreation`), whichever comes first — then completes, and it replays to
+a late subscriber (an `AsyncSubject`, the same contract as `DisposalCompleted` at the
+other end).
+
+### Why it exists: a watcher that outlived the start of teardown (#3026)
+
+Every per-NodeType hub installs watchers over its own node — compile, release-request,
+sources / `IsDirty`, adopted-stamp — and hands each one's `IDisposable` to
+`hub.RegisterForDisposal`. That disposes them in the **ShutDown** phase: the last one.
+Through the entire window before it — the ancestor's quiesce, the ancestor's hosted
+join, this hub's own Quiescing — the watchers kept working. The sources watcher in
+particular recomputes the source fingerprint on every emission, and resolving the
+`@@`-include closure issues cross-hub `GetDataRequest`s **from the hub that is
+tearing down**. Those requests are exactly the pending callbacks Quiescing then waits
+for; when the budget elapsed, `CancelCallbacks` errored them:
+
+```
+DISPOSE_INVOKED
+  … 2 052 ms …
+[FAULT] [Warning] SourcesWatcher: the @@-include closure for FutuRe/LocalAnalysis could not be established
+  SourceIncludeUnavailableException ---> ObjectDisposedException:
+  Hub FutuRe/LocalAnalysis was disposed before the response arrived
+  (GetDataRequest, target FutuRe/GroupAnalysis/Source/ExternalDependencies)
+DISPOSE_DONE elapsed=2088ms teardown clean — all pooled I/O joined
+```
+
+Twenty-two times in one `MeshWeaver.FutuRe.Test` shard — one per fixture teardown,
+each exactly one quiesce budget after `DISPOSE_INVOKED` — and once a sibling of that
+callback ran on a raw scheduler thread against a hub whose scope was gone and killed
+the host (exit 139). The teardown verdict read *clean* every time because the
+timed-out hub had already left its parent's registry (the blind spot noted under the
+Quiescing phase above).
+
+### The rule for hub-owned watchers
+
+Install every watcher a hub owns through
+`ActivityControlPlaneExtensions.SubscribeHubWatcher(hub, source, onNext, …)` — the
+hub-aware form of `SubscribeWithReEstablish`. It differs in three ways, all of them
+this signal:
+
+1. **It stops at `ShuttingDown`.** The live subscription *and* any pending
+   re-establish are disposed at the first instant of teardown. Because that disposal
+   propagates into the watched pipeline, an in-flight cross-hub read is *unsubscribed*
+   — its pending callback leaves the hub's response registry — rather than waited on,
+   so Quiescing drains at once instead of timing out on the watcher's own traffic.
+2. **Every delivery is gated on `IsShuttingDown`.** An emission already dispatched on
+   another thread when the signal fires is dropped, never run against a disposing hub.
+   Dropping is correct: the fresh activation installs a fresh watcher and reads the
+   current state anew.
+3. **The source factory runs under `Observable.Defer`.** A re-establish evaluates the
+   factory on the 1 s `Observable.Timer` tick — a scheduler thread with nothing above
+   it — so a factory that throws synchronously there (a `GetMeshNodeStream()` on a
+   hub whose scope is gone) used to be an unhandled exception on a timer thread. Under
+   `Defer` it is a stream fault the classifier owns.
+
+The address-only `SubscribeWithReEstablish(source, onNext, address, …)` remains for
+watchers with no owning hub. It knows nothing of teardown, so for a hub-owned watcher
+it *is* the #3026 defect.
+
+Pinned by `HubWatcherStopsAtTeardownStartTest` (the primitive, with the action block
+deliberately parked so no disposal phase can run during the assertions),
+`ShuttingDownSignalTest` (the signal on a whole subtree, synchronously inside the
+ancestor's `Dispose()`) and `SourcesWatcherStopsAtTeardownTest` (the sources watcher
+with a deterministically in-flight `@@`-include read, disposed mid-read: no quiesce
+timeout, no `[FAULT]`).
+
 ## Adding disposal work — the rule
 
+- **Installing a WATCHER the hub owns?** `SubscribeHubWatcher(hub, …)`, then hand the
+  result to `RegisterForDisposal` as before. The registration is the backstop; the
+  `ShuttingDown` signal is what actually ends the watcher — see the section above.
 - **Need to run sync cleanup on dispose?** `hub.RegisterForDisposal(IDisposable)`
   (the common case) or `RegisterForDisposal(Action<IMessageHub>)`. These run in the
   ShutDown phase on the action block.
@@ -435,7 +528,9 @@ teardown; silent on a direct `Dispose()`).
 - **Need to wait for the hub to finish disposing?** Subscribe to
   `hub.DisposalCompleted`. Only at the test / grain edge may you bridge it once, and
   only with `.FirstOrDefaultAsync().ObserveCompletion(reportLateFault, ct)` — never
-  `.ToTask()`. To ask "is it shutting down?", read `IsDisposing`.
+  `.ToTask()`. To ask "is it shutting down?", read `IsShuttingDown` (which also sees
+  an ancestor's teardown; `IsDisposing` sees only this hub's own). To *react* to it
+  beginning, subscribe to `hub.ShuttingDown`.
 - **Tempted to `await` something during disposal?** Don't — it deadlocks the action
   block. Express the wait as an `Observable` (`Interval` poll, `Timer`/`Amb` deadline,
   subscribe to a child's `DisposalCompleted`) and post the next phase from its

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-background-compile-watcher-stops-when-its-host-stops.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-background-compile-watcher-stops-when-its-host-stops.md
@@ -1,0 +1,28 @@
+---
+Name: A background compile watcher stops when its host stops
+Category: Fix
+Description: The watcher that tracks a node type's source files no longer keeps working against a host that has already begun shutting down, which used to cost every teardown two seconds and could take the whole process down with it.
+Icon: Bug
+Order: -20260902
+---
+
+# A background compile watcher stops when its host stops
+
+Every node type has a small background watcher that keeps an eye on its source files, so the
+platform knows when the type needs recompiling. Part of that work is reading the other files a
+source pulls in with an `@@` include — a request to wherever those files live.
+
+When a node type's host shut down, that watcher kept going. It was only stopped in the very last
+step of the shutdown, and until then it still reacted to changes and still sent requests — from a
+host that was on its way out, to hosts that were on their way out too. The shutdown then waited its
+full two-second budget for answers that could never come, gave up, and logged a warning about an
+include that "could not be established". In one test run that happened twenty-two times in a row,
+and once the same late work ran on a thread with nothing to catch it and ended the process.
+
+**The watcher now stops the moment its host begins shutting down** — whether the host itself is
+being stopped or one of its parents is — and hands back any request it had in flight instead of
+leaving the shutdown to wait for it. Shutdowns that used to pause for two seconds finish at once,
+the warning is gone, and nothing runs after the host has started to leave.
+
+One smaller thing came with it: anything else that wants to react to a host *beginning* to shut down
+now has a signal to subscribe to, rather than a flag to keep checking.

--- a/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
@@ -208,7 +208,8 @@ public static class BuildNodeType
                     ex => logger?.LogWarning(
                         ex, "Build claim arbitration failed on {Address}", hub.Address));
 
-        var onEmission = ActivityControlPlaneExtensions.SubscribeWithReEstablish(
+        var onEmission = ActivityControlPlaneExtensions.SubscribeHubWatcher(
+            hub,
             () => workspace.GetMeshNodeStream()
                 .Select(node => node?.ContentAs<BuildState>(hub.JsonSerializerOptions))
                 .Where(state => state?.RequestedClaims is { Count: > 0 })
@@ -228,7 +229,6 @@ public static class BuildNodeType
                     .Select(_ => key)
                     .StartWith(key)),
             _ => TryArbitrate(),
-            hub.Address,
             logger,
             "build claim arbiter");
 

--- a/src/MeshWeaver.Mesh.Contract/ActivityControlPlaneExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityControlPlaneExtensions.cs
@@ -80,12 +80,12 @@ public static class ActivityControlPlaneExtensions
         // ThreadExecution.InitializeThreadLifecycle. A disposed guard + SerialDisposable
         // make the re-establish stop cleanly when the hub tears down. See
         // Doc/Architecture/ActivityControlPlane.md → "Recovery on activation".
-        return SubscribeWithReEstablish(
+        return SubscribeHubWatcher(
+            hub,
             () => workspace.GetMeshNodeStream()
                 .Select(node => node.ContentAs<ActivityLog>(hub.JsonSerializerOptions)?.RequestedStatus)
                 .DistinctUntilChanged(),
             onRequestedStatus,
-            hub.Address,
             logger,
             "ActivityControlPlane subscription");
     }
@@ -161,7 +161,8 @@ public static class ActivityControlPlaneExtensions
         // sibling of the init-recovery deadlock). On fault we reset the single-flight
         // guard and re-establish after a short delay. Mirrors WatchControlPlane and
         // ThreadExecution.InitializeThreadLifecycle.
-        return SubscribeWithReEstablish<System.Reactive.Unit>(
+        return SubscribeHubWatcher<System.Reactive.Unit>(
+            hub,
             () => hub.GetWorkspace().GetMeshNodeStream()
                 .DistinctUntilChanged(fingerprint)
                 .Where(needsDispatch)
@@ -176,7 +177,6 @@ public static class ActivityControlPlaneExtensions
                     })
                     .Finally(() => System.Threading.Interlocked.Exchange(ref dispatching, 0))),
             _ => { },
-            hub.Address,
             logger,
             "Submission watcher",
             // Release the single-flight guard a faulted in-flight dispatch may have
@@ -298,6 +298,14 @@ public static class ActivityControlPlaneExtensions
     /// <param name="onPoisonedContent">Optional visible sink invoked (once, with the fault) when
     /// the watcher stops on poisoned own content — route it somewhere a user/operator can see
     /// (park registry, health surface), not just a log.</param>
+    /// <remarks>
+    /// 🚨 For a watcher that a HUB owns — one whose <see cref="IDisposable"/> goes to
+    /// <c>hub.RegisterForDisposal</c> — use <see cref="SubscribeHubWatcher{T}"/> instead: this
+    /// shape knows only the hub's ADDRESS and therefore nothing of its teardown, so the watcher
+    /// keeps running through the hub's whole disposal window until the ShutDown phase finally
+    /// disposes it (Systemorph/MeshWeaver#3026). This address-only form remains for watchers
+    /// with no owning hub.
+    /// </remarks>
     public static IDisposable SubscribeWithReEstablish<T>(
         Func<IObservable<T>> source,
         Action<T> onNext,
@@ -307,6 +315,77 @@ public static class ActivityControlPlaneExtensions
         Action? onTransientFault = null,
         Func<Action, IDisposable>? scheduleReEstablish = null,
         Action<Exception>? onPoisonedContent = null)
+        => SubscribeWithReEstablishCore(
+            source, onNext, address, logger, faultLogContext,
+            onTransientFault, scheduleReEstablish, onPoisonedContent, hub: null);
+
+    /// <summary>
+    /// <see cref="SubscribeWithReEstablish{T}"/> for a watcher OWNED BY <paramref name="hub"/> —
+    /// the shape every hub-installed watcher must use, because it ties the watcher's lifetime to
+    /// the hub's TEARDOWN STATE rather than to the hub's last disposal phase
+    /// (Systemorph/MeshWeaver#3026). A distinct name rather than an overload, deliberately: a
+    /// <c>cref</c> to the generic method without a parameter list — which other repositories carry
+    /// — would become ambiguous the moment a second overload existed, and every satellite builds
+    /// with warnings as errors.
+    ///
+    /// <para><b>The defect this closes.</b> A watcher's <see cref="IDisposable"/> is handed to
+    /// <c>hub.RegisterForDisposal</c>, which disposes it in the hub's ShutDown phase — the LAST
+    /// phase, after Quiescing has waited up to its whole budget for pending callbacks and after
+    /// the hosted subtree has been joined. And <see cref="IMessageHub.IsShuttingDown"/> flips even
+    /// earlier than the hub's own <c>Dispose()</c>: an ANCESTOR's disposal freezes the subtree
+    /// first and reaches this hub only in its DisposeHostedHubs phase. Through that whole window
+    /// the watcher kept working: every emission still ran its callback, still issued cross-hub
+    /// requests — which are exactly the callbacks Quiescing then waited 2 s for and errored with
+    /// <c>ObjectDisposedException</c> (the 22 <c>SourceIncludeUnavailableException</c> faults per
+    /// FutuRe.Test shard) — and still ran on whatever scheduler thread delivered the emission,
+    /// against a hub whose lifetime scope may already be gone. One such callback escaping on a
+    /// raw thread is the exit-139 host kill.</para>
+    ///
+    /// <para><b>What this does differently.</b> (1) It subscribes
+    /// <see cref="IMessageHub.ShuttingDown"/> and tears the watcher down — live subscription AND any
+    /// pending re-establish — at the FIRST instant of teardown, own or ancestral. Because that
+    /// disposal propagates into the watched pipeline, an in-flight cross-hub read is unsubscribed
+    /// (its pending callback is removed from the hub's response registry) rather than waited on,
+    /// so Quiescing drains at once. (2) Every delivery is GATED on
+    /// <see cref="IMessageHub.IsShuttingDown"/>, so an emission already dispatched when the signal
+    /// fires is dropped instead of running the callback against a disposing hub. (3) Installing on
+    /// a hub that is already shutting down is inert. The fault classification is unchanged.</para>
+    /// </summary>
+    /// <typeparam name="T">Element type produced by the observed source.</typeparam>
+    /// <param name="hub">The hub that OWNS this watcher — whose teardown ends it.</param>
+    /// <param name="source">Factory that (re-)creates the observable to watch.</param>
+    /// <param name="onNext">Invoked for every element the source emits while the hub is live.</param>
+    /// <param name="logger">Optional logger for transient-fault and terminal-stop diagnostics.</param>
+    /// <param name="faultLogContext">Short human-readable name of the watcher, for fault logs.</param>
+    /// <param name="onTransientFault">Optional callback run before a transient re-establish.</param>
+    /// <param name="scheduleReEstablish">Test seam for how a transient re-establish is scheduled.</param>
+    /// <param name="onPoisonedContent">Optional visible sink for a poisoned-own-content stop.</param>
+    public static IDisposable SubscribeHubWatcher<T>(
+        IMessageHub hub,
+        Func<IObservable<T>> source,
+        Action<T> onNext,
+        ILogger? logger,
+        string faultLogContext,
+        Action? onTransientFault = null,
+        Func<Action, IDisposable>? scheduleReEstablish = null,
+        Action<Exception>? onPoisonedContent = null)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        return SubscribeWithReEstablishCore(
+            source, onNext, hub.Address, logger, faultLogContext,
+            onTransientFault, scheduleReEstablish, onPoisonedContent, hub);
+    }
+
+    private static IDisposable SubscribeWithReEstablishCore<T>(
+        Func<IObservable<T>> source,
+        Action<T> onNext,
+        Address address,
+        ILogger? logger,
+        string faultLogContext,
+        Action? onTransientFault,
+        Func<Action, IDisposable>? scheduleReEstablish,
+        Action<Exception>? onPoisonedContent,
+        IMessageHub? hub)
     {
         var serial = new System.Reactive.Disposables.SerialDisposable();
         // 🚨 #991 — the PENDING re-establish must be cancellable, and cancelled by teardown.
@@ -328,11 +407,46 @@ public static class ActivityControlPlaneExtensions
         var schedule = scheduleReEstablish
             ?? (reEstablish => Observable.Timer(TimeSpan.FromSeconds(1)).Subscribe(_ => reEstablish()));
 
+        // 🚨 #3026 — the callback is GATED on the hub's teardown state. `Stop()` below disposes the
+        // subscription at the first instant of teardown, but an emission that was already
+        // dispatched on another thread can still arrive; a hub that is shutting down must not run
+        // watcher work (a cross-hub read, an own-node write) for it. Dropping it is correct: the
+        // fresh activation installs a fresh watcher and observes the current state anew.
+        Action<T> deliver = hub is null
+            ? onNext
+            : x =>
+            {
+                if (hub.IsShuttingDown)
+                {
+                    logger?.LogDebug(
+                        "{Context}: dropping an emission on {Address} — the hub is shutting down",
+                        faultLogContext, address);
+                    return;
+                }
+                onNext(x);
+            };
+
+        void Stop()
+        {
+            disposed = true;
+            // Drop the pending re-establish FIRST — that is the TimerQueue entry rooting
+            // this whole closure graph (#991); `serial` only holds the live subscription.
+            pendingReEstablish.Dispose();
+            serial.Dispose();
+        }
+
         void Establish()
         {
             if (disposed) return;
-            serial.Disposable = source().Subscribe(
-                onNext,
+            // 🚨 Observable.Defer, never a bare `source()`. A factory that throws SYNCHRONOUSLY —
+            // `GetMeshNodeStream()` on a hub whose scope is gone, evaluated inside the factory —
+            // would otherwise throw out of Establish(): on the first call that is the installer's
+            // problem, but on a RE-establish the caller is the 1 s Observable.Timer tick, i.e. a
+            // raw scheduler thread with nothing above it, and an unhandled throw there kills the
+            // host (#2468's shape, #3026's crash). Defer forwards a factory throw to OnError, where
+            // the classifier below owns it like any other fault.
+            serial.Disposable = Observable.Defer(source).Subscribe(
+                deliver,
                 ex =>
                 {
                     if (IsOwnHubDisposing(ex, address))
@@ -385,14 +499,30 @@ public static class ActivityControlPlaneExtensions
                         pendingReEstablish.Disposable = schedule(Establish);
                 });
         }
+
+        // 🚨 #3026 — the watcher's lifetime is the hub's TEARDOWN STATE, not its ShutDown phase.
+        // ShuttingDown replays, so a hub that is already shutting down stops the watcher right
+        // here, before Establish() ever subscribes: installing on a disposing hub is inert.
+        var teardown = hub is null
+            ? System.Reactive.Disposables.Disposable.Empty
+            : hub.ShuttingDown.Take(1).Subscribe(
+                _ =>
+                {
+                    if (disposed) return;
+                    logger?.LogDebug(
+                        "{Context}: hub {Address} is shutting down — the watcher stops with it "
+                        + "(a fresh activation installs a new one)",
+                        faultLogContext, address);
+                    Stop();
+                },
+                ex => logger?.LogDebug(ex,
+                    "{Context}: the ShuttingDown signal of {Address} faulted", faultLogContext, address));
+
         Establish();
         return System.Reactive.Disposables.Disposable.Create(() =>
         {
-            disposed = true;
-            // Drop the pending re-establish FIRST — that is the TimerQueue entry rooting
-            // this whole closure graph (#991); `serial` only holds the live subscription.
-            pendingReEstablish.Dispose();
-            serial.Dispose();
+            teardown.Dispose();
+            Stop();
         });
     }
 

--- a/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
@@ -277,6 +277,32 @@ public interface IMessageHub : IMessageHandlerRegistry, IDisposable
     bool IsShuttingDown { get; }
 
     /// <summary>
+    /// <see cref="IsShuttingDown"/> as a SOURCE: fires <see cref="Unit"/> exactly once — at the
+    /// FIRST instant this hub becomes part of a shutdown — then completes. A late subscriber is
+    /// told at once (the source replays), so subscribing can never race the moment.
+    ///
+    /// <para>That first instant is either this hub's own <see cref="IDisposable.Dispose"/> or an
+    /// ANCESTOR's: the ancestor's creation freeze cascades through the whole subtree synchronously
+    /// inside its <c>Dispose()</c> (<c>HostedHubsCollection.CloseCreation</c>), strictly BEFORE
+    /// this hub's own disposal phase reaches it — potentially seconds before, because the ancestor
+    /// first drains its own callbacks for the whole <c>QuiesceTimeout</c>. Neither
+    /// <see cref="RunLevelChanged"/> (this hub's own phases only) nor <see cref="DisposalCompleted"/>
+    /// (the END of teardown) can see that window.</para>
+    ///
+    /// <para>🚨 <b>This is the signal a hub-owned WATCHER stops on</b> (Systemorph/MeshWeaver#3026).
+    /// <see cref="RegisterForDisposal(IDisposable)"/> disposes its registrants in the ShutDown
+    /// phase — the LAST one, after Quiescing has waited up to its budget for pending callbacks.
+    /// A watcher registered there therefore keeps running through the whole teardown window: it
+    /// still reacts to emissions, still issues cross-hub requests (which are the very callbacks
+    /// Quiescing then waits for and finally errors with <c>ObjectDisposedException</c>), and its
+    /// callbacks still run on scheduler threads against a hub whose scope may already be gone.
+    /// <c>ActivityControlPlaneExtensions.SubscribeWithReEstablish</c> observes this signal so a
+    /// watcher dies at the first instant of teardown instead — releasing its in-flight requests
+    /// (so Quiescing drains immediately) and delivering nothing further.</para>
+    /// </summary>
+    IObservable<Unit> ShuttingDown { get; }
+
+    /// <summary>
     /// Observable completion of disposal — fires <see cref="Unit"/> once, then completes, when
     /// the hub has finished disposing (or OnError on a disposal fault). Hubs dispose
     /// SYNCHRONOUSLY (only the mesh-level IO pools drain async), so disposal completion is

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1583,6 +1583,43 @@ public sealed class MessageHub : IMessageHub
     /// </summary>
     public bool IsShuttingDown => disposalStarted || hostedHubs.IsCreationFrozen;
 
+    /// <summary>
+    /// Backing source for <see cref="ShuttingDown"/>. An AsyncSubject so a subscriber attaching
+    /// after the moment still receives it — the same replay contract as
+    /// <see cref="disposalCompleted"/>, at the OTHER end of teardown. Completed exactly once
+    /// (CAS-guarded) by <see cref="SignalShuttingDown"/>, from whichever of the two entry points
+    /// — this hub's own <see cref="Dispose"/> or an ancestor's <see cref="CloseHostedHubCreation"/>
+    /// cascade — fires first.
+    /// </summary>
+    private readonly AsyncSubject<Unit> shuttingDown = new();
+    private int shuttingDownSignalled;
+
+    /// <inheritdoc />
+    public IObservable<Unit> ShuttingDown => shuttingDown.AsObservable();
+
+    /// <summary>
+    /// Completes <see cref="shuttingDown"/> exactly once. Idempotent — both entry points can run
+    /// for one hub (an ancestor freezes the subtree, then this hub's own Dispose arrives seconds
+    /// later) and only the first is the "first instant". Subscribers run INLINE on the caller's
+    /// thread (the disposing ancestor's <c>Dispose()</c>), so the notification is guarded: a
+    /// teardown signal must never fault the teardown it announces.
+    /// </summary>
+    private void SignalShuttingDown()
+    {
+        if (Interlocked.CompareExchange(ref shuttingDownSignalled, 1, 0) != 0)
+            return;
+        try
+        {
+            shuttingDown.OnNext(Unit.Default);
+            shuttingDown.OnCompleted();
+        }
+        catch (Exception ex)
+        {
+            TryLog(LogLevel.Warning, ex,
+                "[SHUTTING-DOWN] {Address}: a ShuttingDown subscriber threw — teardown proceeds", Address);
+        }
+    }
+
     /// <inheritdoc />
     // Native reactive view of the completion subject — NOT bridged from a Task. Fires Unit +
     // completes when disposal finishes (or OnError on a disposal fault); a subscriber attaching
@@ -1675,8 +1712,17 @@ public sealed class MessageHub : IMessageHub
     /// the moment an ANCESTOR begins disposing, so no straggler emission anywhere in
     /// the tree can enter hub construction during teardown (issue #613). Does NOT
     /// dispose anything — existing hubs keep draining until their own dispose phase.
+    ///
+    /// <para>It IS, however, the first instant this hub is part of a shutdown
+    /// (<see cref="IsShuttingDown"/> flips here), so it also raises <see cref="ShuttingDown"/> —
+    /// the watchers this hub owns stop NOW, not when its own ShutDown phase disposes their
+    /// registrations seconds later (#3026).</para>
     /// </summary>
-    internal void CloseHostedHubCreation() => hostedHubs.CloseCreation();
+    internal void CloseHostedHubCreation()
+    {
+        hostedHubs.CloseCreation();
+        SignalShuttingDown();
+    }
 
     public void Dispose()
     {
@@ -1704,6 +1750,10 @@ public sealed class MessageHub : IMessageHub
         // (see HostedHubsCollection.CloseCreation — the FutuRe.Test teardown SIGSEGV,
         // issue #613). Existing hubs still resolve for the drain.
         hostedHubs.CloseCreation();
+        // The first instant of THIS hub's teardown — every watcher it owns stops here, before the
+        // Quiescing phase starts waiting for the callbacks those watchers would otherwise keep
+        // issuing (#3026). Descendants were signalled by the cascade above.
+        SignalShuttingDown();
 
         // Log all hosted hubs that will be disposed
         var hostedHubAddresses = hostedHubs.Hubs.Select(h => h.Address.ToString()).ToArray();

--- a/test/MeshWeaver.Graph.Test/SourcesWatcherStopsAtTeardownTest.cs
+++ b/test/MeshWeaver.Graph.Test/SourcesWatcherStopsAtTeardownTest.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 Systemorph/MeshWeaver#3026 — <b>the sources watcher kept requesting against a hub that was
+/// already 2 s into its teardown.</b>
+///
+/// <para>The measurement, from a <c>MeshWeaver.FutuRe.Test</c> shard: <c>DISPOSE_INVOKED</c>, then
+/// 2 052 ms later a <c>[FAULT]</c> — <c>SourceIncludeUnavailableException ---&gt;
+/// ObjectDisposedException: Hub FutuRe/LocalAnalysis was disposed before the response arrived
+/// (GetDataRequest, target FutuRe/GroupAnalysis/Source/ExternalDependencies)</c> — then
+/// <c>DISPOSE_DONE … teardown clean</c>. Twenty-two times in one shard, one per fixture teardown,
+/// and once a sibling of that callback escaped on a raw thread and killed the host (exit 139).</para>
+///
+/// <para><b>The mechanism.</b> The watcher's <c>@@</c>-include read was IN FLIGHT when the hub
+/// began tearing down. Its subscription was registered with <c>hub.RegisterForDisposal</c>, which
+/// disposes registrants in the ShutDown phase — the LAST one — so through the Quiescing phase the
+/// read stayed pending, Quiescing waited its whole 2 s budget for it, then <c>CancelCallbacks</c>
+/// errored it with the <c>ObjectDisposedException</c> above. The fixture's own leak gate could not
+/// see it either: the hub had left its parent's registry before the verdict was read.</para>
+///
+/// <para><b>This test reproduces the in-flight read deterministically.</b> The include target is
+/// an instance of a NodeType whose hub never finishes initializing (a <c>WithInitialization</c>
+/// that never completes), so a <c>GetDataRequest</c> to it is parked behind its init gate and the
+/// reader's callback stays pending for the whole 15 s read budget. The NodeType hub is then
+/// disposed while that read is outstanding. Post-fix the watcher lets go of the read at the first
+/// instant of teardown, so Quiescing drains at once and no fault is logged; pre-fix the hub timed
+/// out its quiesce budget and logged the very <c>[FAULT]</c> the issue quotes.</para>
+/// </summary>
+public class SourcesWatcherStopsAtTeardownTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>A NodeType whose instance hubs never open their initialization gate.</summary>
+    private const string GateNodeType = "IncludeGate";
+
+    /// <summary>The include target — an instance of <see cref="GateNodeType"/>, so a read of it parks.</summary>
+    private const string IncludePath = "Gate/Target";
+
+    private const string TypePath = "Watched/Type";
+
+    /// <summary>Emits once the gated hub has been ACTIVATED — i.e. the watcher's include read has
+    /// reached it and is now parked behind its init gate. The positive signal that the in-flight
+    /// read this test is about actually exists.</summary>
+    private readonly AsyncSubject<Unit> gateActivated = new();
+
+    /// <summary>The gated hub's initialization: completed by nobody, so its gate never opens while
+    /// the test runs. Completed in the test's <c>finally</c> so the fixture's teardown finds an
+    /// ordinary hub.</summary>
+    private readonly AsyncSubject<Unit> gateOpen = new();
+
+    private readonly RecordingLoggerProvider recorder = new();
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<ILoggerProvider>(recorder))
+            .AddGraph()
+            .AddMeshNodes(new MeshNode(GateNodeType)
+            {
+                Name = "Include Gate",
+                HubConfiguration = config => config.WithInitialization(_ => Observable.Defer(() =>
+                {
+                    gateActivated.OnNext(Unit.Default);
+                    gateActivated.OnCompleted();
+                    return gateOpen;
+                }))
+            });
+
+    [Fact(Timeout = 120_000)]
+    public async Task DisposingTheNodeTypeHub_ReleasesTheWatchersInFlightIncludeRead_AndLogsNoFault()
+    {
+        try
+        {
+            // ── The include target: an instance of the gated type ────────────────────────────
+            await MeshService.CreateNode(new MeshNode("Target", "Gate")
+            {
+                NodeType = GateNodeType,
+                Name = "Target",
+                State = MeshNodeState.Active
+            }).Should().Within(TestTimeouts.Convergence).Emit();
+
+            // ── The NodeType and its one source, whose @@ include points at the gated target ──
+            var typeNode = MeshNode.FromPath(TypePath) with
+            {
+                Name = "Watched",
+                NodeType = MeshNode.NodeTypePath,
+                Content = new NodeTypeDefinition
+                {
+                    Configuration = "config => config.WithContentType<WatchedThing>()"
+                },
+                State = MeshNodeState.Active
+            };
+            await MeshService.CreateNode(typeNode).Should().Within(TestTimeouts.Convergence).Emit();
+            await MeshService.CreateNode(new MeshNode("model", $"{TypePath}/Source")
+            {
+                NodeType = "Code",
+                Name = "model",
+                Content = new CodeConfiguration
+                {
+                    Code = $"@@{IncludePath}\n\npublic record WatchedThing;",
+                    Language = "csharp"
+                },
+                State = MeshNodeState.Active
+            }).Should().Within(TestTimeouts.Convergence).Emit();
+
+            // ── Activate the NodeType hub through the mesh (a routed read), which installs its
+            //    watchers; the sources watcher's first pass resolves the @@ closure ───────────
+            await Mesh.GetMeshNode(TypePath, TestTimeouts.Convergence)
+                .Should().Within(TestTimeouts.Convergence).Emit("the NodeType node must be readable");
+            await gateActivated.Should().Within(TestTimeouts.Convergence).Emit(
+                "the sources watcher's @@-include read must reach the gated target — that read, "
+                + "parked behind the target's never-opening init gate, is the in-flight request the "
+                + "rest of this test is about");
+
+            var typeHub = Mesh.GetHostedHub(new Address(TypePath), HostedHubCreation.Never);
+            typeHub.Should().NotBeNull("the routed read activated the NodeType's own hub");
+            typeHub!.IsShuttingDown.Should().BeFalse("nothing has disposed it yet");
+
+            // ── Dispose the NodeType hub with the include read outstanding ────────────────────
+            typeHub.Dispose();
+            await typeHub.DisposalCompleted.Take(1).Should().Within(TestTimeouts.Convergence)
+                .Emit("the NodeType hub's teardown must complete");
+
+            ((MessageHub)typeHub).QuiescingTimedOut.Should().BeFalse(
+                "the sources watcher must release its in-flight @@-include read at the FIRST instant "
+                + "of the hub's teardown. A pending callback here means the watcher outlived "
+                + "Dispose(): Quiescing waited its whole 2 s budget for a read the watcher should "
+                + "have let go of, then errored it — the [FAULT] 2 s after DISPOSE_INVOKED in #3026. "
+                + $"Detail: {((MessageHub)typeHub).QuiescingTimeoutDetail}");
+
+            var faults = recorder.Records
+                .Where(r => r.Level >= LogLevel.Warning
+                            && r.Category == "MeshWeaver.Graph.CompileWatcher"
+                            && r.Message.Contains("could not be established", StringComparison.Ordinal))
+                .ToArray();
+            foreach (var r in recorder.Records)
+                Output.WriteLine($"    {r.Level} {r.Category}: {r.Message}"
+                                 + (r.Error is null ? "" : $"  << {r.Error.GetType().Name}: {r.Error.Message}"));
+            faults.Should().BeEmpty(
+                "a read the watcher released is never errored by CancelCallbacks, so the "
+                + "'@@-include closure could not be established' warning — the issue's [FAULT] — "
+                + "must not appear for a hub that was simply disposed");
+        }
+        finally
+        {
+            // Let the gated hub finish initializing so the fixture's teardown meets an ordinary hub.
+            gateOpen.OnNext(Unit.Default);
+            gateOpen.OnCompleted();
+        }
+    }
+
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<(LogLevel Level, string Category, string Message, Exception? Error)> records = new();
+
+        public IReadOnlyList<(LogLevel Level, string Category, string Message, Exception? Error)> Records
+            => records.ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new Recorder(categoryName, records);
+        public void Dispose() { }
+
+        private sealed class Recorder(
+            string category,
+            ConcurrentQueue<(LogLevel, string, string, Exception?)> sink) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull => Disposable.Empty;
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel)) return;
+                sink.Enqueue((logLevel, category, formatter(state, exception), exception));
+            }
+        }
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/HubWatcherStopsAtTeardownStartTest.cs
+++ b/test/MeshWeaver.Hosting.Test/HubWatcherStopsAtTeardownStartTest.cs
@@ -52,7 +52,7 @@ public class HubWatcherStopsAtTeardownStartTest(ITestOutputHelper output) : HubT
         {
             Entered.OnNext(Unit.Default);
             Entered.OnCompleted();
-            SpinWait.SpinUntil(() => Volatile.Read(ref Release) == 1, TimeSpan.FromSeconds(30));
+            SpinWait.SpinUntil(() => Volatile.Read(ref Release) == 1, TestTimeouts.Convergence);
             return request.Processed();
         }
     }

--- a/test/MeshWeaver.Hosting.Test/HubWatcherStopsAtTeardownStartTest.cs
+++ b/test/MeshWeaver.Hosting.Test/HubWatcherStopsAtTeardownStartTest.cs
@@ -1,0 +1,221 @@
+using System;
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins the lifetime contract of <see cref="ActivityControlPlaneExtensions.SubscribeHubWatcher{T}"/>
+/// — the primitive every hub-owned watcher (compile, sources, release-request, adopted-stamp,
+/// control-plane, submission, build-claim) is installed through (Systemorph/MeshWeaver#3026).
+///
+/// <para><b>The defect.</b> A watcher's <see cref="IDisposable"/> is handed to
+/// <c>hub.RegisterForDisposal</c>, which disposes it in the hub's ShutDown phase — the LAST phase,
+/// after Quiescing has waited up to its whole budget for pending callbacks and after the hosted
+/// subtree was joined. And a hub is part of a shutdown even earlier than its own <c>Dispose()</c>:
+/// an ancestor's disposal freezes the subtree first and reaches the hub only in its
+/// DisposeHostedHubs phase. Through that whole window the watcher kept reacting to emissions and
+/// kept issuing cross-hub requests — which are precisely the callbacks Quiescing then waited 2 s
+/// for and errored with <c>ObjectDisposedException</c>: the 22
+/// <c>SourceIncludeUnavailableException</c> faults per <c>MeshWeaver.FutuRe.Test</c> shard, each
+/// exactly one quiesce budget after <c>DISPOSE_INVOKED</c>.</para>
+///
+/// <para>Deterministic by construction: the hub's single-threaded action block is stalled by a
+/// gated handler, so no disposal PHASE can run during the assertions — if the watcher has let go
+/// of its source after <c>Dispose()</c> returned, the only thing that can have stopped it is the
+/// hub's synchronous teardown signal.</para>
+/// </summary>
+public class HubWatcherStopsAtTeardownStartTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record Blocker;
+
+    /// <summary>
+    /// A deliberately parked action block. Handler → test is the <see cref="Entered"/> subject the
+    /// handler completes; test → parked handler is the volatile <see cref="Release"/> flag polled
+    /// under a bounded <see cref="SpinWait.SpinUntil(Func{bool},TimeSpan)"/>, written in the test's
+    /// <c>finally</c> so a failing assertion cannot strand the action block.
+    /// </summary>
+    private sealed class Stall
+    {
+        public readonly AsyncSubject<Unit> Entered = new();
+        public int Release;
+
+        public IMessageDelivery Handle(IMessageDelivery request)
+        {
+            Entered.OnNext(Unit.Default);
+            Entered.OnCompleted();
+            SpinWait.SpinUntil(() => Volatile.Read(ref Release) == 1, TimeSpan.FromSeconds(30));
+            return request.Processed();
+        }
+    }
+
+    private IMessageHub CreateStallableRoot(Stall stall, string id) =>
+        GetClient().ServiceProvider.CreateMessageHub(
+            new Address("watcher-root", id),
+            c => c
+                .WithPostingIdentity(PostingIdentity.System)
+                .WithTypes(typeof(Blocker))
+                .WithHandler<Blocker>((_, request) => stall.Handle(request)));
+
+    private static async Task ParkTheActionBlock(IMessageHub root, Stall stall)
+    {
+        root.Post(new Blocker(), o => o.WithTarget(root.Address));
+        await stall.Entered.Should().Within(10.Seconds()).Emit("the blocker handler must be running");
+    }
+
+    [Fact]
+    public async Task OwnDispose_StopsTheWatcher_BeforeAnyDisposalPhaseRuns()
+    {
+        var stall = new Stall();
+        var hub = CreateStallableRoot(stall, "own");
+        var source = new Subject<int>();
+        var delivered = 0;
+        using var watcher = ActivityControlPlaneExtensions.SubscribeHubWatcher<int>(
+            hub, () => source, _ => delivered++, logger: null, "test watcher");
+        try
+        {
+            await ParkTheActionBlock(hub, stall);
+
+            source.HasObservers.Should().BeTrue("the watcher is live while its hub is");
+            source.OnNext(1);
+            delivered.Should().Be(1, "a live hub's watcher delivers");
+
+            hub.Dispose();
+
+            source.HasObservers.Should().BeFalse(
+                "the watcher must let go of its source at the FIRST instant of teardown — Dispose() "
+                + "has returned, no disposal phase has run (the action block is parked), and "
+                + "RegisterForDisposal would only have reached it in the ShutDown phase, after the "
+                + "Quiescing budget it would have kept feeding (#3026)");
+            source.OnNext(2);
+            delivered.Should().Be(1,
+                "nothing may be delivered to a watcher whose hub has begun shutting down");
+        }
+        finally
+        {
+            Volatile.Write(ref stall.Release, 1);
+        }
+    }
+
+    /// <summary>
+    /// The FutuRe.Test shape exactly: the MESH is disposed, the per-NodeType hub is still live
+    /// (its own DisposeRequest arrives only in the mesh's DisposeHostedHubs phase), and its sources
+    /// watcher is still running — issuing the include reads the hub's own Quiescing will later wait
+    /// 2 s for. The freeze that reaches the hub synchronously inside the ancestor's Dispose() is its
+    /// first instant of teardown, and the watcher must stop there.
+    /// </summary>
+    [Fact]
+    public async Task AncestorDispose_StopsAHostedHubsWatcher_WhileThatHubIsStillLive()
+    {
+        var stall = new Stall();
+        var root = CreateStallableRoot(stall, "ancestor");
+        var child = root.GetHostedHub(new Address("watcher-child", "1"));
+        var source = new Subject<int>();
+        var delivered = 0;
+        using var watcher = ActivityControlPlaneExtensions.SubscribeHubWatcher<int>(
+            child, () => source, _ => delivered++, logger: null, "test watcher");
+        try
+        {
+            await ParkTheActionBlock(root, stall);
+            source.HasObservers.Should().BeTrue("the watcher is live while its hub is");
+
+            root.Dispose();
+
+            child.IsDisposing.Should().BeFalse(
+                "the child's own disposal has not begun — the root's DisposeHostedHubs phase cannot "
+                + "run while its action block is parked");
+            child.RunLevel.Should().Be(MessageHubRunLevel.Started, "the child is fully live");
+            child.IsShuttingDown.Should().BeTrue("…but the ancestor's freeze has reached it");
+
+            source.HasObservers.Should().BeFalse(
+                "an ancestor's Dispose() is the hosted hub's first instant of teardown; a watcher that "
+                + "waits for the hosted hub's OWN Dispose keeps issuing requests for the whole ancestor "
+                + "quiesce window — the 2 s between DISPOSE_INVOKED and the [FAULT] in #3026");
+            source.OnNext(1);
+            delivered.Should().Be(0, "nothing may be delivered once the subtree is shutting down");
+        }
+        finally
+        {
+            Volatile.Write(ref stall.Release, 1);
+        }
+    }
+
+    [Fact]
+    public async Task InstallingOnAHubThatIsAlreadyShuttingDown_IsInert()
+    {
+        var stall = new Stall();
+        var hub = CreateStallableRoot(stall, "late");
+        var source = new Subject<int>();
+        var factoryCalls = 0;
+        try
+        {
+            await ParkTheActionBlock(hub, stall);
+            hub.Dispose();
+
+            using var watcher = ActivityControlPlaneExtensions.SubscribeHubWatcher<int>(
+                hub, () => { factoryCalls++; return source; }, _ => { }, logger: null, "test watcher");
+
+            factoryCalls.Should().Be(0,
+                "a watcher installed on a hub that is already shutting down must not open a "
+                + "subscription at all — there is nothing for it to observe and nobody to act for");
+            source.HasObservers.Should().BeFalse("nothing was subscribed");
+        }
+        finally
+        {
+            Volatile.Write(ref stall.Release, 1);
+        }
+    }
+
+    /// <summary>
+    /// The raw-thread escape. A transient fault schedules a re-establish on a 1 s
+    /// <c>Observable.Timer</c>; the re-establish evaluates the source FACTORY again — on the timer's
+    /// thread, with nothing above it. A factory that throws synchronously there (a
+    /// <c>GetMeshNodeStream()</c> on a hub whose scope is gone) used to throw straight out of the
+    /// tick: an unhandled exception on a scheduler thread, i.e. the host kill. The factory must be
+    /// evaluated under <c>Observable.Defer</c>, so its throw is a stream fault the classifier owns.
+    /// Bounded, synchronous seam: the re-establish runs inline, so an escape would surface HERE, as
+    /// a throw out of the install call.
+    /// </summary>
+    [Fact]
+    public void AReEstablishWhoseFactoryThrows_IsClassifiedAsAFault_NotThrownOnTheScheduler()
+    {
+        var factoryCalls = 0;
+        var scheduled = 0;
+        IDisposable? watcher = null;
+
+        Action install = () => watcher = ActivityControlPlaneExtensions.SubscribeWithReEstablish<int>(
+            () =>
+            {
+                factoryCalls++;
+                if (factoryCalls == 1)
+                    return Observable.Throw<int>(new InvalidOperationException("transient hub hiccup"));
+                throw new InvalidOperationException("the source factory itself threw");
+            },
+            _ => { },
+            new Address("mesh", "1"),
+            logger: null,
+            faultLogContext: "test",
+            scheduleReEstablish: reEstablish =>
+            {
+                if (scheduled++ < 2) reEstablish();
+                return Disposable.Empty;
+            });
+
+        install.Should().NotThrow(
+            "a synchronous factory throw on a re-establish runs on the schedule's thread — in "
+            + "production a bare Observable.Timer tick — so it must reach the fault classifier as a "
+            + "stream fault, never be thrown out of the re-establish");
+        factoryCalls.Should().Be(3,
+            "the first subscribe faulted transiently, and each of the two bounded re-establishes ran "
+            + "the factory again and classified its throw as one more transient fault");
+        watcher?.Dispose();
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/ShuttingDownSignalTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/ShuttingDownSignalTest.cs
@@ -50,7 +50,7 @@ public class ShuttingDownSignalTest(ITestOutputHelper output) : HubTestBase(outp
                     handlerEntered.OnCompleted();
                     // Deliberately ignores cancellation: keeps the root's action block busy so
                     // the ShutdownRequest posted by Dispose() cannot be processed until released.
-                    SpinWait.SpinUntil(() => Volatile.Read(ref releaseHandler) == 1, TimeSpan.FromSeconds(30));
+                    SpinWait.SpinUntil(() => Volatile.Read(ref releaseHandler) == 1, TestTimeouts.Convergence);
                     return request.Processed();
                 }));
         var child = root.GetHostedHub(new Address("shutting-down-child", "1"));

--- a/test/MeshWeaver.Messaging.Hub.Test/ShuttingDownSignalTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/ShuttingDownSignalTest.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins <see cref="IMessageHub.ShuttingDown"/> — the hub's teardown state as a SOURCE
+/// (Systemorph/MeshWeaver#3026).
+///
+/// <para><b>Why the source exists.</b> A hub-owned watcher must stop at the FIRST instant its hub
+/// becomes part of a shutdown. That instant is not the hub's own <c>Dispose()</c> alone: an
+/// ancestor's <c>Dispose()</c> freezes hosted-hub creation across the whole subtree synchronously
+/// (issue #613), and a descendant's own disposal begins only in the ancestor's DisposeHostedHubs
+/// phase — potentially seconds later, after the ancestor has drained its own callbacks for the
+/// entire quiesce budget. <see cref="IMessageHub.IsShuttingDown"/> already reports that window as
+/// a property; nothing reported it as an event, so a watcher could only sample it.</para>
+///
+/// <para>Deterministic by construction, the same way <c>TeardownHubCreationFreezeTest</c> is: the
+/// root's single-threaded action block is stalled by a gated handler, so the posted
+/// <c>ShutdownRequest</c> provably cannot be processed during the assertions — the only thing that
+/// can have raised the signal on a descendant is the synchronous cascade inside <c>Dispose()</c>.</para>
+/// </summary>
+public class ShuttingDownSignalTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record Blocker;
+
+    [Fact]
+    public async Task Dispose_RaisesShuttingDownOnTheWholeSubtree_BeforeAnyDisposalPhaseRuns()
+    {
+        // 🚨 No hand-woven gate: handler → test is an AsyncSubject the handler completes; test →
+        // parked handler is a volatile flag polled under a bounded SpinUntil, released in `finally`.
+        var handlerEntered = new AsyncSubject<Unit>();
+        var releaseHandler = 0;
+
+        var client = GetClient();
+        var root = client.ServiceProvider.CreateMessageHub(
+            new Address("shutting-down-root", "1"),
+            c => c
+                .WithPostingIdentity(PostingIdentity.System)
+                .WithTypes(typeof(Blocker))
+                .WithHandler<Blocker>((_, request) =>
+                {
+                    handlerEntered.OnNext(Unit.Default);
+                    handlerEntered.OnCompleted();
+                    // Deliberately ignores cancellation: keeps the root's action block busy so
+                    // the ShutdownRequest posted by Dispose() cannot be processed until released.
+                    SpinWait.SpinUntil(() => Volatile.Read(ref releaseHandler) == 1, TimeSpan.FromSeconds(30));
+                    return request.Processed();
+                }));
+        var child = root.GetHostedHub(new Address("shutting-down-child", "1"));
+        var grandchild = child.GetHostedHub(new Address("shutting-down-grandchild", "1"));
+
+        var rootSignalled = 0;
+        var childSignalled = 0;
+        var grandchildSignalled = 0;
+        using var rootSub = root.ShuttingDown.Subscribe(
+            _ => Interlocked.Exchange(ref rootSignalled, 1),
+            ex => Output.WriteLine($"root ShuttingDown faulted: {ex}"));
+        using var childSub = child.ShuttingDown.Subscribe(
+            _ => Interlocked.Exchange(ref childSignalled, 1),
+            ex => Output.WriteLine($"child ShuttingDown faulted: {ex}"));
+        using var grandchildSub = grandchild.ShuttingDown.Subscribe(
+            _ => Interlocked.Exchange(ref grandchildSignalled, 1),
+            ex => Output.WriteLine($"grandchild ShuttingDown faulted: {ex}"));
+
+        try
+        {
+            root.Post(new Blocker(), o => o.WithTarget(root.Address));
+            await handlerEntered.Should().Within(10.Seconds()).Emit("the blocker handler must be running");
+
+            Volatile.Read(ref rootSignalled).Should().Be(0, "a live hub has not begun shutting down");
+            Volatile.Read(ref childSignalled).Should().Be(0, "a live hub has not begun shutting down");
+            Volatile.Read(ref grandchildSignalled).Should().Be(0, "a live hub has not begun shutting down");
+
+            root.Dispose();
+
+            // Synchronous: Dispose() has returned and the async shutdown pipeline is provably
+            // NOT running (the action block is parked), so every signal below came from the
+            // cascade inside Dispose() itself.
+            Volatile.Read(ref rootSignalled).Should().Be(1,
+                "the disposing hub's own ShuttingDown fires inside Dispose(), before any phase runs");
+            Volatile.Read(ref childSignalled).Should().Be(1,
+                "an ancestor's Dispose() freezes the subtree synchronously — that IS the child's first "
+                + "instant of teardown, and it must be observable as an event, not only as IsShuttingDown");
+            Volatile.Read(ref grandchildSignalled).Should().Be(1,
+                "the cascade reaches arbitrarily deep, and so must the signal");
+
+            child.IsShuttingDown.Should().BeTrue("the freeze has reached the child");
+            child.IsDisposing.Should().BeFalse(
+                "the child's OWN disposal has not started — its DisposeRequest arrives only in the "
+                + "root's DisposeHostedHubs phase, which cannot run while the root's action block is "
+                + "parked. This is the window nothing but ShuttingDown can see");
+            child.RunLevel.Should().Be(MessageHubRunLevel.Started,
+                "no disposal phase has run on the child, so RunLevelChanged cannot have reported anything");
+
+            var late = 0;
+            using var lateSub = grandchild.ShuttingDown.Subscribe(
+                _ => Interlocked.Exchange(ref late, 1),
+                ex => Output.WriteLine($"late ShuttingDown faulted: {ex}"));
+            Volatile.Read(ref late).Should().Be(1,
+                "the source replays: a subscriber attaching after the moment is told at once, so "
+                + "subscribing can never race the moment it exists to observe");
+        }
+        finally
+        {
+            Volatile.Write(ref releaseHandler, 1);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #3026.

## What was wrong

A per-NodeType hub's watchers — sources / `IsDirty`, compile, release-request, adopted-stamp — are installed through `SubscribeWithReEstablish` and handed to `hub.RegisterForDisposal`. That disposes them in the hub's **ShutDown** phase, the LAST one: after Quiescing has waited up to its whole 2 s budget for pending callbacks and after the hosted subtree has been joined. And a hub is part of a shutdown even earlier than its own `Dispose()`: an ancestor's `Dispose()` freezes the subtree synchronously (`CloseCreation`, #613) and reaches the hub only in the ancestor's DisposeHostedHubs phase.

Through that whole window the sources watcher kept working. Resolving the `@@`-include closure issues cross-hub `GetDataRequest`s **from the hub that is tearing down** — those are exactly the pending callbacks its Quiescing then waited 2 s for, and `CancelCallbacks` finally errored them with `ObjectDisposedException: Hub FutuRe/LocalAnalysis was disposed before the response arrived (GetDataRequest, target FutuRe/GroupAnalysis/Source/ExternalDependencies)`. That is the `[FAULT]` the issue quotes, 2 052 ms after `DISPOSE_INVOKED`, 22 times in one shard — one per fixture teardown, each exactly one quiesce budget late. A re-establish of the same watcher evaluates its source factory on a bare `Observable.Timer` tick; a factory that throws synchronously there (a hub whose scope is gone) is an unhandled exception on a scheduler thread — the exit-139 host kill.

## What changed

- **`IMessageHub.ShuttingDown`** — `IsShuttingDown` as a source: fires once at the FIRST instant the hub is part of a shutdown (own `Dispose()` or the ancestor cascade in `CloseHostedHubCreation`), then completes; replays to a late subscriber.
- **`ActivityControlPlaneExtensions.SubscribeHubWatcher(hub, …)`** — the hub-owned form of `SubscribeWithReEstablish` (a distinct name, not an overload: MeshWeaver.Plugins carries a parameterless `cref` to the generic method, which a second overload would make ambiguous under its warnings-as-errors). It (1) stops at `ShuttingDown` — live subscription and pending re-establish — so an in-flight cross-hub read is *unsubscribed* (its pending callback leaves the response registry) and Quiescing drains at once; (2) gates every delivery on `hub.IsShuttingDown`; (3) is inert on a hub already shutting down; (4) evaluates the source factory under `Observable.Defer`, so a synchronous factory throw on a re-establish is a stream fault the classifier owns, not a throw on the timer thread. All seven hub-owned watchers now use it (compile, release-request, sources, adopted-stamp, control-plane, submission, build-claim arbiter).
- Docs: `HubDisposalModel.md` (new section "The first instant of teardown: `ShuttingDown`", the rule for hub-owned watchers), `ActivityControlPlane.md`. What's New entry (`Category: Fix`).

No `catch` anywhere on the path, no re-run: the fix is the lifetime and the gate, as the issue directs.

## Deliberately left out — the fixture verdict's blind spot

The issue also asks that the fixture's `teardown clean` verdict not read clean while a hosted hub timed out. The cause is real: a hosted hub removes itself from its parent's registry in its own ShutDown phase, so `AnyHubQuiescingTimedOut()` walks an empty registry by the time the test base asks. I implemented the fix (the collection keeps each departing child's verdict) and ran `MeshWeaver.Graph.Test` with it: it immediately reddened **two unrelated classes** on pre-existing hosted-hub timeouts — `DanglingNodeTypeUpdateTest` (a `cache/…` hub with a `SubscribeRequest@TestData/dnt…` pending 2002 ms: routed, "no handler was ever entered" — a genuine leaked subscribe to an error-overlay node) and `EventContinuationHandlerTest` (a `cache/…` hub whose callback drained exactly at the 2 s hand-off — the detector racing its own budget). Every other suite in the fleet would need the same sweep before that verdict can land, so it is split out rather than holding this crash fix hostage; the blind spot is documented in `HubDisposalModel.md` under the Quiescing phase.

## Tests (each fails before the fix)

- `ShuttingDownSignalTest` (Messaging.Hub.Test): the signal fires synchronously inside `Dispose()` on the whole subtree while the root's action block is deliberately parked (so no disposal phase can have run); a child's `IsDisposing` is still false and its `RunLevel` still `Started`; a late subscriber is told at once.
- `HubWatcherStopsAtTeardownStartTest` (Hosting.Test): own dispose and ancestor dispose stop the watcher before any phase runs (`source.HasObservers` false, nothing delivered); installing on a shutting-down hub is inert; a factory throw on a re-establish is classified, not thrown.
- `SourcesWatcherStopsAtTeardownTest` (Graph.Test): a real mesh, a NodeType whose one source has an `@@` include pointing at an instance of a NodeType whose hub never opens its init gate — so the watcher's include read is deterministically in flight — then the NodeType hub is disposed: `QuiescingTimedOut` is false and no "closure could not be established" warning is logged.

## Verification

- `dotnet build … -c Release -warnaserror`: `MeshWeaver.Messaging.Hub.Test`, `MeshWeaver.Hosting.Test`, `MeshWeaver.Graph.Test` (closure covers Messaging.Hub, Mesh.Contract, Compiler.Pipeline, Graph, Hosting) — 0 warnings, 0 errors.
- Whole-project runs (Release, `DOTNET_PROCESSOR_COUNT=4`, `.trx`): Messaging.Hub.Test 343/343, Hosting.Test 294/294, Graph.Test 1157/1159 — the 2 reds were the departed-verdict exposure described above and disappeared with its removal; the new integration test passed.
- `MeshWeaver.FutuRe.Test` (the observation site, in MeshWeaver.Plugins) was NOT run locally — stopped on the maintainer's quota directive before the Plugins build; CI on that repo is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
