### PR TITLE
fix(ci): the arm-credential reach probe could never pass

### DIFF
--- a/.github/workflows/arm-credential.yml
+++ b/.github/workflows/arm-credential.yml
@@ -103,19 +103,45 @@ jobs:
           echo "stops silently (#2916). ArmedMergeMustTriggerMainsPushLanesGuard fails the build if"
           echo "anyone tries."
 
-      # The mint proves the App CAN hold the permissions. This proves the token actually works
-      # against this repository — a mint can succeed against an installation that no longer has
-      # access to the repo it was scoped to.
+      # The mint above already proves the PERMISSIONS: `actions/create-github-app-token` asks for
+      # `contents: write` + `pull-requests: write` explicitly and fails when the installation does
+      # not hold them. What it does NOT prove is REACH — an installation scoped to selected
+      # repositories can hold both permissions and still not include this repo, and a token minted
+      # that way arms nothing while looking perfectly healthy.
+      #
+      # 🚨 DO NOT ask `repos/{owner}/{repo}` for `.permissions` here. That object reports the
+      # AUTHENTICATED USER's permissions on the repo, and an App installation token has no user, so
+      # GitHub answers `{"admin":false,"maintain":false,"pull":false,"push":false,"triage":false}`
+      # — every field false, for a token that works perfectly. The first version of this step did
+      # exactly that and grepped for `"push":true`, which made it a check that COULD NOT PASS: it
+      # was red on runs 33605406624 and 33605578037 *after* the grant had landed and after auto-arm
+      # had demonstrably armed a PR on its own. An assertion that cannot pass is the same defect as
+      # one that cannot fail — it stops carrying information, and here it slandered a working grant.
+      #
+      # `/installation/repositories` is the endpoint an installation token actually answers about
+      # itself: it enumerates exactly the repositories the installation can reach.
       - name: The minted token can reach this repository
         env:
           GH_TOKEN: ${{ steps.mint.outputs.token }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          perms=$(gh api "repos/$REPO" --jq '.permissions | tojson')
-          echo "token sees: $perms"
-          echo "$perms" | grep -q '"push":true' || {
-            echo "::error::the minted token cannot push to $REPO ($perms) — it can be minted but not used."
+          # --paginate: an installation on "all repositories" returns a paged list, and a repo
+          # sitting on page 2 must not read as absent.
+          if ! reachable=$(gh api --paginate /installation/repositories --jq '.repositories[].full_name'); then
+            echo "::error::the minted token could not enumerate its own installation. It was minted but is not usable."
             exit 1
-          }
-          echo "The App can arm auto-merge and perform the merge on $REPO."
+          fi
+          # Control arm: an EMPTY list would make the grep below fail for the wrong reason, and
+          # "the token reaches nothing" deserves its own message rather than looking like "this repo
+          # is missing from an otherwise healthy installation".
+          count=$(printf '%s\n' "$reachable" | grep -c . || true)
+          if [ "$count" -eq 0 ]; then
+            echo "::error::the installation reaches ZERO repositories. The App is installed but scoped to nothing."
+            exit 1
+          fi
+          if ! printf '%s\n' "$reachable" | grep -qx "$REPO"; then
+            echo "::error::the installation does not include $REPO. It reaches $count repository(ies), but not this one — so a token minted here arms nothing. Add $REPO to the meshweaver-cloud installation's repository access."
+            exit 1
+          fi
+          echo "The App can arm auto-merge and perform the merge on $REPO (installation reaches $count repo(s))."

--- a/test/MeshWeaver.Documentation.Test/ArmedMergeMustTriggerMainsPushLanesGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ArmedMergeMustTriggerMainsPushLanesGuard.cs
@@ -187,6 +187,58 @@ public class ArmedMergeMustTriggerMainsPushLanesGuard
         }
     }
 
+    /// <summary>
+    /// 🚨 A step that authenticates with an App INSTALLATION token must not assert on
+    /// <c>repos/{owner}/{repo}</c>'s <c>.permissions</c> object.
+    ///
+    /// <para>That object reports the <b>authenticated user's</b> permissions on the repository. An
+    /// installation token has no user, so GitHub answers every field <c>false</c> —
+    /// <c>{"admin":false,"maintain":false,"pull":false,"push":false,"triage":false}</c> — for a
+    /// token that works perfectly. Grepping it for <c>"push":true</c> therefore yields a check that
+    /// <b>can never pass</b>.</para>
+    ///
+    /// <para><b>Measured.</b> <c>arm-credential.yml</c> shipped with exactly that probe and was red
+    /// on runs 33605406624 and 33605578037 — <i>after</i> the org grant had landed, and after
+    /// <c>auto-arm.yml</c> had demonstrably armed a pull request on its own using a token from the
+    /// same mint. The lane was reporting a broken credential while the credential worked.</para>
+    ///
+    /// <para>An assertion that cannot pass is the same defect as one that cannot fail: it stops
+    /// carrying information. It is arguably worse, because a permanent red slanders something that
+    /// is healthy and trains readers to disbelieve the lane. The endpoint an installation token can
+    /// actually answer about itself is <c>/installation/repositories</c>.</para>
+    /// </summary>
+    [Fact]
+    public void NoInstallationTokenStepAssertsOnTheRepositoryPermissionsObject()
+    {
+        var offenders = Directory
+            .EnumerateFiles(WorkflowsDir(), "*.yml")
+            .Select(path => (path, text: File.ReadAllText(path)))
+            .Where(w =>
+            {
+                var lines = ExecutableLines(w.text);
+                // Only lanes that actually mint an installation token can hit this.
+                if (!lines.Any(l => l.Contains("create-github-app-token", StringComparison.Ordinal)))
+                    return false;
+                return lines.Any(l =>
+                    l.Contains("repos/", StringComparison.Ordinal) &&
+                    l.Contains(".permissions", StringComparison.Ordinal));
+            })
+            .Select(w => Path.GetFileName(w.path))
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToArray();
+
+        Assert.True(
+            offenders.Length == 0,
+            "These workflows mint a GitHub App installation token and then assert on "
+            + $"repos/{{owner}}/{{repo}}'s .permissions object: {string.Join(", ", offenders)}.\n"
+            + "That object reports the AUTHENTICATED USER's permissions. An installation token has no "
+            + "user, so every field comes back false for a token that works — the assertion can never "
+            + "pass, and it reports a broken credential while arming succeeds elsewhere in the same "
+            + "run (measured on arm-credential.yml, runs 33605406624 and 33605578037).\n"
+            + "Use /installation/repositories, which an installation token answers about itself, and "
+            + "let the mint's explicit permission-* requests assert the permissions.");
+    }
+
     private static string FindRepoRoot()
     {
         var dir = new DirectoryInfo(AppContext.BaseDirectory);


### PR DESCRIPTION
A defect in my own #3064, and the same failure class that PR was written to remove.

## What was wrong

The final step asserted on `repos/{owner}/{repo}`'s `.permissions` object and grepped for `"push":true`. That object reports the **authenticated user's** permissions. An App installation token has no user, so GitHub answers every field `false` for a token that works perfectly:

```
{"admin":false,"maintain":false,"pull":false,"push":false,"triage":false}
```

The check could never pass.

## The evidence that it was slandering a working grant

Red on runs `33605406624` and `33605578037` — both **after** the org grant landed, and after `auto-arm.yml` had armed a pull request entirely on its own using a token from the same mint. So in one repository, at the same time: arming worked, and the lane whose job is to assert arming can work was red.

**An assertion that cannot pass is the same defect as one that cannot fail** — it stops carrying information. It is arguably worse here, because a permanent red discredits something healthy, which is precisely what #3064 existed to stop doing. One step further down, I reintroduced it.

## The fix

The mint already proves the **permissions**: `create-github-app-token` requests `contents: write` + `pull-requests: write` explicitly and fails when the installation lacks either. What it does not prove is **reach** — an installation scoped to selected repositories can hold both permissions and still not include this repo, minting a token that arms nothing while looking healthy.

So the probe now asks `/installation/repositories`, which is what an installation token can answer about itself:

- `--paginate`, because an "all repositories" installation pages and a repo on page 2 must not read as absent;
- a control arm separating **"the installation reaches zero repositories"** from **"it reaches things, but not this one"** — two different provisioning mistakes with two different fixes, and the bare grep would have reported both as the second.

## Guarded

`NoInstallationTokenStepAssertsOnTheRepositoryPermissionsObject` fails the build if any workflow mints an installation token and then asserts on a `repos/*.permissions` object.

**Mutation-proven:** restoring the old probe reds it. Whole project, unfiltered: **181 passed, 0 failed**.

Found by another session reading the post-grant runs rather than assuming the red meant the grant had not landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)