### PR TITLE
fix(cd): a PR build must not evict main's delivery run

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -74,9 +74,34 @@ name: Continuous Delivery (main)
 # commit server-side as the tip of THIS repo's main and re-check the required test check on it,
 # which a fork's code can never be.
 on:
+  # 🚨 `branches:` IS LOAD-BEARING — without it, EVERY pull request's build starts a CD run.
+  #
+  # A `workflow_run` trigger fires on every completion of the named workflow on ANY branch, and the
+  # resulting run's own `head_branch` is always the default branch (it is the workflow FILE's ref),
+  # so a PR-triggered CD run is indistinguishable from a real one in the run list. They all key into
+  # the same concurrency group below, and `cancel-in-progress: false` keeps exactly ONE pending run
+  # per group — so each arrival CANCELS the pending one. A genuine main push-path delivery run
+  # waiting its turn is therefore evicted by the next PR build that happens to finish.
+  #
+  # Measured 2026-09-02, 07:35–07:43, six CD runs on two main shas, every one cancelled:
+  #   07:35 PR fix/arm-red-is-repo-scoped          → CD run, cancelled
+  #   07:37 PR ci/hard-cap-every-job-at-45-minutes → CD run, cancelled
+  #   07:39 main push                              → CD run, cancelled   ← real delivery
+  #   07:40 PR fix/oversized-pod-hub-delivery      → CD run, cancelled
+  #   07:41 PR fix/3022-identity-fork-remainder    → CD run, cancelled
+  #   07:43 main push                              → CD run, cancelled   ← real delivery
+  # Nothing was promoted between 03:33:50 and that window, while every dashboard was green: the
+  # runs existed, they were just never allowed to finish. The failure SCALES WITH PR THROUGHPUT,
+  # which is the worst possible shape — delivery stops hardest exactly when the repo is busiest,
+  # and it looks like "CD is slow today" rather than a defect.
+  #
+  # `branches:` filters on the TRIGGERING run's branch, which is the only place that information
+  # survives. This is not a batching or a cadence knob: a PR build is not a delivery event and must
+  # never enter this lane at all.
   workflow_run:
     workflows: ["MeshWeaver Build and Test"]
     types: [completed]
+    branches: [main]
   # Reconcile cadence. Off the hour on purpose (the top of the hour is GitHub's most contended
   # scheduling slot).
   #

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -496,6 +496,61 @@ If the same check name appears in every PR's failure list, stop triaging PRs and
 repository. `UNSTABLE` means the required set passed and something non-required did not — it is
 mergeable, and it is the state a hoistable assertion leaves behind.
 
+## 🚨 Delivery can stop for hours with every dashboard green — look for CANCELLED, not failed
+
+A cancelled run is not a failed run, and nothing alerts on it. `alert-on-failure` keys on failure;
+the delivery verdict never runs; the required check on main is green because the *tests* passed. The
+only symptom is a registry that stops receiving digests, which nobody watches minute to minute.
+
+**Measured 2026-09-02.** `main-cd` promoted nothing between 03:33:50 and 07:50 — over four hours —
+while the repository looked entirely healthy. In one ten-minute window, six CD runs were created and
+**every one was cancelled**:
+
+```
+07:35  PR fix/arm-red-is-repo-scoped           -> CD run, cancelled
+07:37  PR ci/hard-cap-every-job-at-45-minutes  -> CD run, cancelled
+07:39  main push                               -> CD run, cancelled   <- real delivery
+07:40  PR fix/oversized-pod-hub-delivery       -> CD run, cancelled
+07:41  PR fix/3022-identity-fork-remainder     -> CD run, cancelled
+07:43  main push                               -> CD run, cancelled   <- real delivery
+```
+
+### The mechanism: an unfiltered `workflow_run` plus a shared concurrency group
+
+`main-cd` triggers on `workflow_run` of *MeshWeaver Build and Test*. That fires on completions from
+**every branch**, pull-request builds included. All of those runs key into the same `concurrency`
+group, and GitHub keeps exactly **one pending run per group** — each arrival cancels the pending one.
+So a genuine push-path delivery run, sitting pending behind whatever is in flight, is evicted by the
+next PR build that happens to finish.
+
+**The failure scales with pull-request throughput.** Delivery stops hardest exactly when the repo is
+busiest, and it presents as "CD is slow today". Draining a PR queue makes it strictly worse, which
+inverts the usual intuition that merging more is progress.
+
+### Why this survives review, and why the run list actively misleads
+
+For a `workflow_run` event, the resulting run's `head_branch` is the **workflow file's** ref — always
+the default branch. A CD run started by a PR build therefore reports `head_branch=main`, exactly like
+a real one. Querying the CD runs *confirms* the wrong hypothesis. The triggering branch survives in
+only one place: the trigger's own `branches:` filter.
+
+To see what actually started them, list the *triggering* workflow's runs in the window instead:
+
+```bash
+gh run list --repo <owner>/<repo> --workflow "MeshWeaver Build and Test" --limit 20   --json headBranch,event,conclusion,updatedAt   --jq '.[] | select(.updatedAt >= "<from>" and .updatedAt <= "<to>") |
+        "\(.updatedAt[11:19]) \(.headBranch) \(.event)"'
+```
+
+### The rule
+
+**A `workflow_run` trigger on a workflow that declares a `concurrency` group MUST carry
+`branches:`.** Without the concurrency group an unfiltered trigger is usually harmless and sometimes
+intended — `retry-known-transients.yml` deliberately retries transients on PR builds and evicts
+nothing. The two together are what makes off-branch triggers destructive.
+
+Guarded by `WorkflowRunTriggerBranchFilterGuard`, which carries a control arm: if its block matcher
+ever stops recognising `workflow_run:`, it fails rather than passing having examined nothing.
+
 ## Related
 
 [Module Versioning](/Doc/Architecture/ModuleVersioning) · [Modules](/Doc/Architecture/Modules) ·

--- a/test/MeshWeaver.Documentation.Test/WorkflowRunTriggerBranchFilterGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/WorkflowRunTriggerBranchFilterGuard.cs
@@ -1,0 +1,129 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 A <c>workflow_run</c>-triggered workflow that also declares a <c>concurrency</c> group must
+/// filter the trigger with <c>branches:</c>.
+///
+/// <para><b>Why the two conditions together.</b> A <c>workflow_run</c> trigger fires on every
+/// completion of the named workflow on ANY branch — a pull request's build included. On its own
+/// that is often harmless and sometimes wanted (<c>retry-known-transients.yml</c> deliberately
+/// retries transients on PR builds too, and declares no concurrency group, so it evicts nothing).
+/// It stops being harmless the moment the workflow shares a concurrency group: GitHub keeps exactly
+/// ONE pending run per group, so each arrival CANCELS the pending one. An off-branch trigger then
+/// evicts an on-branch run that was waiting its turn.</para>
+///
+/// <para><b>The measured outage (2026-09-02).</b> <c>main-cd.yml</c> had no <c>branches:</c> filter.
+/// Between 07:35 and 07:43, six CD runs were created and every one was cancelled — four from pull
+/// request builds, two from real pushes to main:</para>
+/// <code>
+/// 07:35 PR fix/arm-red-is-repo-scoped          -> CD run, cancelled
+/// 07:37 PR ci/hard-cap-every-job-at-45-minutes -> CD run, cancelled
+/// 07:39 main push                              -> CD run, cancelled   &lt;- real delivery
+/// 07:40 PR fix/oversized-pod-hub-delivery      -> CD run, cancelled
+/// 07:41 PR fix/3022-identity-fork-remainder    -> CD run, cancelled
+/// 07:43 main push                              -> CD run, cancelled   &lt;- real delivery
+/// </code>
+/// <para>Nothing was promoted for over four hours while every dashboard stayed green: the delivery
+/// runs existed, they were simply never allowed to finish. <b>The failure scales with pull-request
+/// throughput</b>, which is the worst possible shape — delivery stops hardest exactly when the repo
+/// is busiest, and it presents as "CD is slow today" rather than as a defect.</para>
+///
+/// <para><b>Why review cannot catch it.</b> A CD run started by a PR build is indistinguishable
+/// from a real one in the run list: for a <c>workflow_run</c> event the run's own
+/// <c>head_branch</c> is the workflow FILE's ref, i.e. always the default branch. The triggering
+/// branch survives only in the trigger filter itself.</para>
+/// </summary>
+public class WorkflowRunTriggerBranchFilterGuard
+{
+    private static string WorkflowsDir() => Path.Combine(FindRepoRoot(), ".github", "workflows");
+
+    private static string[] ExecutableLines(string text) =>
+        text.Split('\n')
+            .Where(l => !l.TrimStart().StartsWith("#", StringComparison.Ordinal))
+            .ToArray();
+
+    /// <summary>
+    /// The <c>workflow_run:</c> block — from that key to the next key at the same indentation.
+    /// Returns null when the workflow has no such trigger.
+    /// </summary>
+    private static string[]? WorkflowRunBlock(string[] lines)
+    {
+        var start = Array.FindIndex(lines, l => l.TrimEnd() == "  workflow_run:");
+        if (start < 0) return null;
+
+        var block = new List<string>();
+        for (var i = start + 1; i < lines.Length; i++)
+        {
+            var line = lines[i];
+            if (line.Trim().Length == 0) continue;
+            // A key at the same indent (two spaces, not more) ends the block.
+            var indent = line.Length - line.TrimStart().Length;
+            if (indent <= 2) break;
+            block.Add(line);
+        }
+        return block.ToArray();
+    }
+
+    private static bool DeclaresConcurrency(string[] lines) =>
+        lines.Any(l => l.TrimEnd() == "concurrency:");
+
+    [Fact]
+    public void AWorkflowRunTriggerSharingAConcurrencyGroupFiltersItsBranches()
+    {
+        var offenders = new List<string>();
+        var examined = 0;
+
+        foreach (var path in Directory.EnumerateFiles(WorkflowsDir(), "*.yml").OrderBy(p => p, StringComparer.Ordinal))
+        {
+            var lines = ExecutableLines(File.ReadAllText(path));
+            var block = WorkflowRunBlock(lines);
+            if (block is null) continue;
+
+            examined++;
+            if (!DeclaresConcurrency(lines)) continue;   // evicts nothing; an unfiltered trigger is safe here
+            if (block.Any(l => l.TrimStart().StartsWith("branches:", StringComparison.Ordinal))) continue;
+
+            offenders.Add(Path.GetFileName(path));
+        }
+
+        // 🚨 Control arm. If the block matcher stops recognising `workflow_run:` — a reformat, a
+        // move to a different quoting style — this test would pass having examined nothing, which
+        // is the failure mode it exists to prevent one level up.
+        Assert.True(examined > 0,
+            "No workflow_run trigger was found in .github/workflows. Either every one was removed, "
+            + "or the block matcher no longer recognises them — in the second case this guard checks "
+            + "nothing while reporting green.");
+
+        Assert.True(
+            offenders.Count == 0,
+            $"These workflows declare a concurrency group AND a workflow_run trigger with no "
+            + $"`branches:` filter: {string.Join(", ", offenders)}.\n"
+            + "workflow_run fires on completions from EVERY branch, including pull-request builds. "
+            + "GitHub keeps exactly one pending run per concurrency group, so each arrival cancels "
+            + "the pending one — an off-branch trigger evicts an on-branch run that was waiting.\n"
+            + "Measured on main-cd.yml (2026-09-02): six consecutive CD runs cancelled, four of them "
+            + "started by PR builds, and nothing promoted for over four hours while every dashboard "
+            + "was green. The failure scales with PR throughput, and a PR-started run is "
+            + "indistinguishable from a real one in the run list (head_branch is the workflow file's "
+            + "ref, always the default branch).\n"
+            + "Add `branches: [main]` to the workflow_run trigger.");
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !Directory.Exists(Path.Combine(dir.FullName, ".github", "workflows")))
+            dir = dir.Parent;
+
+        Assert.NotNull(dir);
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
CD promoted nothing between **03:33:50 and 07:50** — over four hours — while every dashboard stayed green. The delivery runs existed. They were never allowed to finish.

Six CD runs in one ten-minute window, all cancelled:

```
07:35  PR fix/arm-red-is-repo-scoped           -> cancelled
07:37  PR ci/hard-cap-every-job-at-45-minutes  -> cancelled
07:39  main push                               -> cancelled   <- real delivery
07:40  PR fix/oversized-pod-hub-delivery       -> cancelled
07:41  PR fix/3022-identity-fork-remainder     -> cancelled
07:43  main push                               -> cancelled   <- real delivery
```

## Cause

The `workflow_run` trigger had no `branches:` filter, so it fires on completions of *MeshWeaver Build and Test* from **every branch** — pull requests included. Every one of those runs keys into this workflow's single concurrency group, and GitHub keeps exactly **one pending run per group**: each arrival cancels the pending one. A real push-path delivery run, waiting behind whatever is in flight, is evicted by the next PR build that finishes.

**It scales with PR throughput.** Delivery stops hardest exactly when the repo is busiest, and draining a PR queue makes it strictly worse — the opposite of the intuition that merging more is progress. I made this worse all morning while trying to clear the backlog.

**Nothing alerts on it.** A cancelled run is not a failed run: `alert-on-failure` keys on failure, the delivery verdict never runs, and main's required check is green because the tests really did pass. The only symptom is a registry that quietly stops receiving digests.

## 🚨 The run list actively misleads

For a `workflow_run` event, the resulting run's `head_branch` is the **workflow file's** ref — always the default branch. So a CD run started by a PR build reports `head_branch=main`, indistinguishable from a real one. I checked exactly that field first and it *confirmed the wrong hypothesis*. The triggering branch survives in one place only: the trigger's own filter. The evidence lives in the **triggering** workflow's run list.

## Guard

`WorkflowRunTriggerBranchFilterGuard` requires `branches:` on a `workflow_run` trigger **when the workflow also declares a concurrency group**.

Deliberately not a blanket rule: without a concurrency group an unfiltered trigger evicts nothing and is sometimes intended — `retry-known-transients.yml` retries transients on PR builds on purpose. It is the *combination* that is destructive, so that is what the guard asserts.

**Mutation-proven in both directions:**

| mutation | result |
|---|---|
| remove `branches: [main]` | ❌ caught |
| rename the trigger so the matcher cannot see it | ❌ control arm fires — refuses to pass on an empty scan |

The first control-arm attempt (trailing whitespace) did **not** trip it, because the matcher uses `TrimEnd()` — an ineffective mutation, not a weak guard. Re-tested with a real rename.

Whole project, unfiltered: **181 passed, 0 failed**. Finding documented in `Doc/Architecture/ReadingCiSignals`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)