### PR TITLE
fix(cd): report a heal whichever path delivered it

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2326,8 +2326,26 @@ jobs:
         run: .github/scripts/check-image-set.sh "${{ needs.gate.outputs.short_sha }}" "${{ needs.gate.outputs.plugins_short }}"
       # A heal that WORKED has to say so on the same issue that recorded the attempt, or the
       # ledger only ever grows and nobody can tell a fixed hole from an open one.
+      # 🚨 HEALING IS AN OUTCOME, NOT A PATH. This used to require
+      # `needs.gate.outputs.reason == 'reconcile'`, on the reasoning that the reconciler is what
+      # repairs a failed delivery. But the PUSH path publishes far more often, and when it is the
+      # one that carries main past a failure the heal went unreported — the `ci-failure` issue
+      # stayed open, with zero comments, describing a state that no longer existed.
+      #
+      # Measured 2026-09-02: #3074 was filed at 08:01 for `cb1dd360`. Delivery recovered at
+      # 08:19:44 on `1b044e5` — six commits later, full set in ACR, pair tag present — via the PUSH
+      # path. This step was skipped, so nothing said so, and the issue was still open reporting a
+      # broken delivery long after it worked.
+      #
+      # That matters more than one stale issue: a `ci-failure` issue that outlives its cause is the
+      # same defect as a check that is red on every pull request. It costs nothing to file and
+      # everything to trust — the next real one arrives into a backlog of alerts that were already
+      # known to be wrong, and gets read as more of the same.
+      #
+      # The condition is now the fact the comment actually asserts: main's HEAD has a complete image
+      # set, whoever put it there.
       - name: Report a successful heal
-        if: needs.gate.outputs.reason == 'reconcile' && needs.promote.result == 'success'
+        if: needs.promote.result == 'success'
         env:
           GH_TOKEN: ${{ github.token }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
The heal reporter fired only on the reconcile path. The **push** path publishes far more often — and when it is the one that carries main past a failure, the recovery went unreported.

## Measured

| | |
|---|---|
| #3074 filed | 08:01, for `cb1dd360` |
| delivery recovered | **08:19:44**, on `1b044e5` — six commits later |
| by which path | **push** |
| heal step | **skipped** (`reason == 'reconcile'` was false) |
| #3074 today | still open, **zero comments** |

The full set was in ACR with the pair tag present. Nothing said so.

## Why this is worth fixing rather than closing by hand

A `ci-failure` issue that outlives its cause is the same defect as a check that is red on every pull request — the one #3064 and #3075 were about. It costs nothing to file and everything to trust. The next genuine alert arrives into a backlog of alerts already known to be wrong, and gets read as more of the same. That is precisely the state this alerting exists to prevent, so the alerting undermining itself is worse than an ordinary bug.

## The change

The condition becomes the fact the comment actually asserts — *main's HEAD has a complete image set* — rather than the path that achieved it:

```diff
-        if: needs.gate.outputs.reason == 'reconcile' && needs.promote.result == 'success'
+        if: needs.promote.result == 'success'
```

A side benefit: `promote.result == 'success'` implies `portal-image` ran, so the version the comment quotes is always populated. Under the old condition a bake-only reconcile could not reach this step at all, so the narrower form was not even covering the case it was written for.

Workflow-only; no test surface. `MeshWeaver.Documentation.Test` (which parses these workflows): **180 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)