### PR TITLE
fix: a request timeout describes the hub that gave up, not the one that stayed silent

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingMessageFlow.md
@@ -395,6 +395,75 @@ node CRUD serializes node `Content` on behalf of the whole mesh.
 
 ---
 
+## 🚨 Reading a request timeout: it describes the hub that GAVE UP, not the one that stayed silent
+
+`TimeoutException: No response received in hub X within 00:01:00 for request Y → target Z` is the
+most common banner in this system, and the most commonly misread. **It is written by the waiter.**
+The waiter cannot see the target at all — it can only report that nothing arrived, which is
+consistent with several different worlds.
+
+The message used to end *"The request may have been undeliverable or the target hub was not
+found"*. Two buckets, asserted as though they were the whole set. They are not, and the missing
+third is the one to rule out first:
+
+| world | what actually happened |
+|---|---|
+| routing | the target never received the request |
+| **the target is wedged** | it received it and stopped answering (a per-node hub that stops responding — #2896) |
+| the reply was lost | it answered and the response did not land |
+| **the CALLER is wedged** | the response arrived and this hub never processed it |
+
+**The last one is invisible from the sentence and indistinguishable from the others.** A
+single-threaded actor whose action block is busy, gated, or backed up looks — from inside — exactly
+like a peer that never replied. So the message now carries the waiter's own `RunLevel` and queue
+snapshot, and states the classification explicitly:
+
+- **queue non-empty, gates open, or a message executing** → *this hub was not idle, so it cannot
+  attribute the silence upstream.* Investigate **here** first; the answer may be sitting behind the
+  work in that snapshot.
+- **idle** → the silence really is upstream, and the message says so — then names the three
+  remaining worlds and states that it **cannot distinguish them**. An explicit unknown, because a
+  diagnostic offering two options when there are four teaches the reader to pick the nearer one.
+
+### The production case that motivated it
+
+2026-09-02: a document read failed with the old wording, naming `cache/…` as the waiter and a node
+path as the target. **Both offered buckets were wrong.** The node existed — version 53, edited the
+previous evening — and its hub resolved fine; exactly one per-node hub was wedged while every
+sibling answered instantly. The sentence sent the reader to *"does this node exist?"*, the one
+question never in doubt.
+
+The control arm is what settled it, and it is cheap enough to run every time:
+
+```
+point-read the failing path      -> times out (twice, different ids => deterministic, not transient)
+point-read a SIBLING path        -> instant  => partition, store and routing are fine
+list the namespace via the index -> healthy  => the node exists and is indexed
+```
+
+Two probes separate "the mesh is broken" from "one hub is wedged", and the second is the answer far
+more often.
+
+### 🚨 `recycle` fixes it and destroys the evidence
+
+`recycle` posts a `DisposeRequest` and forces re-initialisation. It cleared the wedge above with no
+data loss (all 53 versions intact) — and it also destroyed the only state that could have explained
+it. **Capture before recycling** when the situation allows: the owner's `RunLevel`, queue depth, and
+whether it sits in `Starting` with an open gate. Recycling first is the right call when someone is
+blocked on live data; just say so plainly rather than reporting a diagnosis you no longer have the
+evidence for.
+
+### The string coupling nobody can see
+
+🚨 **`MeshNodeStreamCache.IsTransientOwnerFailure` and `AreaErrorClassifier.IsTransientHubFailure`
+decide retryability by substring match on this message.** `"No response received in hub"` is what
+keeps a hub timeout classified RETRYABLE. Change the wording without that phrase and every such
+read becomes terminal — silently: no compiler error, no exception, just reads that stop being
+retried and wait out their budgets. `MessageService` documents the same hazard from the other
+direction (a *deleted-address* NACK must NOT contain any of those markers, or a provable absence
+degrades back into "retry shortly"). Pinned by
+`TimeoutMessageNamesTheCallersOwnStateTest.TheTimeoutMessage_KeepsTheMarkerThatClassifiesItAsTransient`.
+
 ## The Golden Rule
 
 > **Run once. Grep the trace. Fix the root cause.**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-timeout-says-what-the-waiting-hub-was-doing.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-timeout-says-what-the-waiting-hub-was-doing.md
@@ -1,0 +1,49 @@
+---
+Name: A timeout says what the waiting hub was doing
+Category: Fix
+Description: When a request times out, the error now reports the state of the hub that gave up — and says plainly when it cannot tell whose fault the silence was, instead of naming two causes as though they were the only ones.
+Icon: Timer
+Order: -20260902
+---
+
+# A timeout says what the waiting hub was doing
+
+`No response received in hub X within 00:01:00 for request Y → target Z` is the most common error
+banner in the system. It used to end like this:
+
+> The request may have been undeliverable or the target hub was not found.
+
+Two causes, offered as though they were the whole set. They are not, and on 2026-09-02 both of them
+were wrong at once.
+
+Someone opened a document and got that message. It named the waiting hub and it named the document
+as the target. So the obvious question was *does this document still exist?* — and that question was
+never in doubt. The document existed, at version 53, edited the evening before. Its hub resolved
+fine. Every other document in the same space opened instantly. Exactly one thing was wrong: the
+component that owns that single document had stopped answering.
+
+The sentence had sent the reader to the one place there was nothing to find.
+
+## What it says now
+
+The message now reports **the state of the hub that gave up** — what it was running, how much work
+was queued behind it — and draws the distinction that actually matters:
+
+- **If that hub was busy**, it says so, and says to look there first. A component that is itself
+  stuck cannot tell the difference between "nobody answered me" and "an answer arrived and I never
+  got round to reading it". From the inside, those look identical.
+- **If it was genuinely idle**, it says that too — and then names the possibilities it *cannot*
+  distinguish between: the request never arrived, it arrived at something stuck, or the reply was
+  lost on the way back.
+
+That last part is the real change. An explicit "I don't know, and here is exactly what I could and
+could not observe" is more useful than a confident guess, because a message that offers two options
+when there are four teaches people to pick whichever is nearer — and then to go looking in the wrong
+place, which is what happened.
+
+## Why this is worth a release note
+
+Nothing about the underlying behaviour changed: the same requests time out after the same interval,
+and a timed-out read is still retried exactly as before. What changed is that the error now carries
+the evidence needed to act on it. On the deployment where this happened, the logs do not reach the
+log service — so that one sentence was, quite literally, all there was to read.

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1152,16 +1152,66 @@ public sealed class MessageHub : IMessageHub
                     new TimeoutException(BuildTimeoutMessage(requestType, target, messageId)))));
 
     /// <summary>
-    /// Names the request that timed out. The previous form said only "No response
-    /// received in hub X within 30s" — diagnostics had to walk the call stack to
-    /// guess which Observe call timed out. Now the message includes the request
-    /// type, target address (the hub we expected to respond), and message id (so
-    /// you can grep MESSAGE_FLOW logs for the exact delivery).
+    /// Names the request that timed out, AND this hub's own state at the moment it gave up.
+    ///
+    /// <para>🚨 <b>The previous message blamed the target without ever looking at the caller.</b> It
+    /// ended "The request may have been undeliverable or the target hub was not found" — two
+    /// buckets, asserted as though they were exhaustive. They are not, and the third possibility is
+    /// the one a reader most needs to rule out first: <b>this hub never PROCESSED a response that
+    /// did arrive</b>, because its own action block was busy, gated, or backed up. A single-threaded
+    /// actor that is wedged looks, from inside, exactly like a peer that never answered.</para>
+    ///
+    /// <para>Measured on prod 2026-09-02: a document read failed with that message naming
+    /// <c>cache/…</c> as the waiting hub and a node path as the target. Both buckets it offered were
+    /// wrong — the node existed (version 53, edited the previous evening) and its hub resolved fine;
+    /// one per-node hub was wedged and a <c>recycle</c> cleared it with no data loss. The message
+    /// sent the reader to "does this node exist?", which is the one question that was not in doubt,
+    /// and the deployment ships no logs to Log Analytics so there was nothing else to read
+    /// (MeshWeaver#2896, open for weeks as "write verdict unconfirmed" for exactly this reason).</para>
+    ///
+    /// <para>So the message now carries the caller's <c>RunLevel</c> and queue snapshot — the same
+    /// fields the disposal diagnostic prints — and states the classification EXPLICITLY, including
+    /// an explicit unknown. A diagnostic that offers two buckets when there are three teaches the
+    /// reader to pick the nearer one; naming what this hub could and could not observe is what makes
+    /// it a measurement rather than a guess.</para>
     /// </summary>
-    private string BuildTimeoutMessage(string requestType, Address? target, string messageId) =>
-        $"No response received in hub {Address} within {Configuration.RequestTimeout} " +
-        $"for request {requestType} (id={messageId}) → target {target?.ToString() ?? "<unset>"}. " +
-        $"The request may have been undeliverable or the target hub was not found.";
+    private string BuildTimeoutMessage(string requestType, Address? target, string messageId)
+    {
+        var snapshot = (messageService is MessageService ms)
+            ? ms.GetQueueSnapshot()
+            : (Buffer: -1, Deferred: -1, Execution: -1, OpenGates: -1, DeliveryCompleted: false,
+               CurrentMessage: (string?)null, CurrentMessageElapsedMs: 0L);
+
+        // The discriminator. A hub that was IDLE while waiting genuinely heard nothing: the silence
+        // is upstream. A hub that was busy, gated, or holding queued work cannot make that claim —
+        // the response may have arrived and be sitting behind the very work that delayed it.
+        var callerBusy = snapshot.Buffer > 0
+                         || snapshot.Deferred > 0
+                         || snapshot.OpenGates > 0
+                         || snapshot.CurrentMessage is not null;
+
+        var state =
+            $"This hub: RunLevel={RunLevel} Queue(buffer={snapshot.Buffer},deferred={snapshot.Deferred}," +
+            $"openGates={snapshot.OpenGates},deliveryActionCompleted={snapshot.DeliveryCompleted})" +
+            (snapshot.CurrentMessage is not null
+                ? $" Executing({snapshot.CurrentMessage}, {snapshot.CurrentMessageElapsedMs}ms)"
+                : string.Empty);
+
+        var verdict = callerBusy
+            ? "🚨 THIS HUB WAS NOT IDLE while waiting, so it cannot attribute the silence upstream: " +
+              "a response may have arrived and be queued behind the work above. Investigate THIS hub " +
+              "before the target."
+            : "This hub was idle while waiting, so it processed everything delivered to it and the " +
+              "silence is upstream of here. Cause is UNKNOWN between: the target never received the " +
+              "request (routing), the target received it and is wedged (a per-node hub that stops " +
+              "answering — MeshWeaver#2896), or the target answered and the reply was lost. This " +
+              "message cannot distinguish them; the target's own RunLevel and queue can.";
+
+        return
+            $"No response received in hub {Address} within {Configuration.RequestTimeout} " +
+            $"for request {requestType} (id={messageId}) → target {target?.ToString() ?? "<unset>"}. " +
+            $"{state}. {verdict}";
+    }
 
     private System.Reactive.Subjects.AsyncSubject<IMessageDelivery> GetOrAddResponseSubject(
         string messageId,

--- a/test/MeshWeaver.Messaging.Hub.Test/TimeoutMessageNamesTheCallersOwnStateTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/TimeoutMessageNamesTheCallersOwnStateTest.cs
@@ -1,0 +1,115 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>A request timeout must describe the hub that gave up, not guess about the one that did
+/// not answer.</b>
+///
+/// <para>The message used to end <i>"The request may have been undeliverable or the target hub was
+/// not found"</i> — two buckets, asserted as though they were exhaustive. They are not. The third
+/// possibility is the one a reader most needs ruled out first: <b>this hub never PROCESSED a
+/// response that did arrive</b>, because its own action block was busy, gated, or backed up. A
+/// single-threaded actor that is wedged looks, from inside, exactly like a peer that never
+/// replied.</para>
+///
+/// <para><b>Measured on production, 2026-09-02.</b> Opening a document failed with that message
+/// naming <c>cache/…</c> as the waiting hub and a node path as the target. <i>Both</i> buckets it
+/// offered were wrong: the node existed (version 53, edited the previous evening) and its hub
+/// resolved fine — one per-node hub was wedged, and a recycle cleared it with no data loss. The
+/// message sent the reader to "does this node exist?", the one question that was never in doubt,
+/// and that deployment ships no logs to Log Analytics, so there was nothing else to read
+/// (MeshWeaver#2896, open for weeks as "write verdict unconfirmed" for exactly this reason).</para>
+/// </summary>
+public class TimeoutMessageNamesTheCallersOwnStateTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record NeverAnswered : IRequest<NeverAnswer>;
+    private record NeverAnswer;
+
+    /// <summary>
+    /// A handler that receives the request and deliberately answers nothing, so the requester can
+    /// only end by the HUB's own <c>RequestTimeout</c> — which is the message under test. Answering
+    /// nothing is the point: an Rx-level <c>.Timeout(...)</c> would raise Rx's own exception and
+    /// never reach <c>BuildTimeoutMessage</c> at all.
+    ///
+    /// <para>The bound is <c>TestTimeouts.Quick</c>, not a literal: it scales with the host under
+    /// the same factor as every other wait here, and a hand-written one would spend budget from
+    /// <c>TestTimeoutLiteralRatchetGuard</c>, whose inventory may only shrink. These tests also
+    /// carry no <c>[Fact(Timeout = …)]</c> — the hub's own <c>RequestTimeout</c> IS the thing under
+    /// test and already bounds them, and xunit's <c>methodTimeout</c> is the outer net. A second,
+    /// hand-written bound would be a guess about machine speed with nothing left to catch.</para>
+    /// </summary>
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .WithRequestTimeout(TestTimeouts.Quick)
+            .WithHandler<NeverAnswered>((_, delivery) => delivery.Processed());
+
+    [Fact]
+    public async Task TheTimeoutMessage_NamesThisHubsRunLevelAndQueue_AndDoesNotClaimTwoCausesAreExhaustive()
+    {
+        var host = GetHost();
+
+        var act = async () => await host
+            .Observe<NeverAnswer>(new NeverAnswered(), o => o.WithTarget(CreateHostAddress()))
+            .FirstAsync()
+            .Await(TestContext.Current.CancellationToken);
+
+        var message = (await act.Should().ThrowAsync<TimeoutException>()).Which.Message;
+
+        // The request is still named — the property the previous form already had, and which a
+        // rewrite must not lose.
+        message.Should().Contain("NeverAnswered", "the timed-out request type must still be named");
+
+        // 🚨 The addition: this hub's OWN state, so a reader can tell "I heard nothing" from
+        // "I never got round to processing what I heard".
+        message.Should().Contain("This hub:", "the message must describe the hub that gave up");
+        message.Should().Contain("RunLevel=", "the caller's run level is half the discriminator");
+        message.Should().Contain("Queue(buffer=", "the caller's queue depth is the other half");
+
+        // 🚨 The removal: the old sentence presented two causes as the whole set. Whatever the
+        // message says now, it must not resurrect that claim.
+        message.Should().NotContain("may have been undeliverable",
+            "asserting two buckets as exhaustive is what sent the production reader to the wrong "
+            + "question; the message must state its uncertainty instead of guessing");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The silent regression this rewrite could have caused.</b>
+    ///
+    /// <para><c>MeshNodeStreamCache.IsTransientOwnerFailure</c> and
+    /// <c>AreaErrorClassifier.IsTransientHubFailure</c> both decide RETRYABILITY by substring, and
+    /// the old message matched three of their markers: <c>"No response received in hub"</c>,
+    /// <c>"target hub was not found"</c> and <c>"undeliverable"</c>. The rewrite deliberately drops
+    /// the last two. That is safe only because the first survives — and nothing would have said so
+    /// if it had not: <c>MessageService</c> notes in its own comment that a violation of this
+    /// coupling is <i>silent</i> — no compiler error, no exception, just a read that stops being
+    /// retried and waits out its budget instead.</para>
+    ///
+    /// <para>So this asserts the marker directly. It is a string assertion because the coupling
+    /// IS a string coupling; making it look like anything else would misrepresent how fragile it
+    /// is.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheTimeoutMessage_KeepsTheMarkerThatClassifiesItAsTransient()
+    {
+        var host = GetHost();
+
+        var act = async () => await host
+            .Observe<NeverAnswer>(new NeverAnswered(), o => o.WithTarget(CreateHostAddress()))
+            .FirstAsync()
+            .Await(TestContext.Current.CancellationToken);
+
+        var message = (await act.Should().ThrowAsync<TimeoutException>()).Which.Message;
+
+        message.Should().Contain("No response received in hub",
+            "both IsTransientOwnerFailure and IsTransientHubFailure classify a hub timeout as "
+            + "RETRYABLE on this substring. The rewrite dropped the other two markers it used to "
+            + "carry ('target hub was not found', 'undeliverable'), so this one is now the only "
+            + "thing keeping a timed-out read retryable. Losing it would make every such read "
+            + "terminal — silently, with no compiler error and no exception.");
+    }
+}


### PR DESCRIPTION
Found while diagnosing a live production symptom this morning.

## The message was confidently wrong

`No response received in hub X within 00:01:00 for request Y → target Z` used to end:

> The request may have been undeliverable or the target hub was not found.

Two causes, offered as the whole set. There are four, and the missing one is the first a reader should rule out:

| world | what happened |
|---|---|
| routing | the target never received the request |
| **target wedged** | it received it and stopped answering (#2896) |
| reply lost | it answered; the response never landed |
| **CALLER wedged** | the response arrived and this hub never processed it |

The last is invisible from that sentence. A single-threaded actor whose action block is busy, gated, or backed up looks — from inside — exactly like a peer that never replied.

## The production case

A document read failed with that wording. **Both offered buckets were wrong.** The node existed (version 53, edited the previous evening), its hub resolved fine, and every sibling in the partition opened instantly. Exactly one per-node hub was wedged; a `recycle` cleared it with no data loss. The sentence sent the reader to *"does this node exist?"* — the one question never in doubt — and that deployment ships no logs to Log Analytics, so it was literally all there was to read.

That is why #2896 has been open for weeks as "write verdict unconfirmed".

## What it says now

It carries the caller's `RunLevel` and queue snapshot — the same fields the disposal diagnostic prints, from the same `GetQueueSnapshot()` — and states the classification:

- **not idle** → says so, and says to investigate *here* first; the answer may be queued behind the work it just named.
- **idle** → says the silence is genuinely upstream, names the three remaining worlds, and states that it **cannot distinguish them**.

An explicit unknown beats a confident guess, because a diagnostic offering two options when there are four teaches people to pick whichever is nearer — which is what happened.

## 🚨 The silent regression this could have caused

The rewrite drops two substrings: `"target hub was not found"` and `"undeliverable"`. Both are matched by `MeshNodeStreamCache.IsTransientOwnerFailure` **and** `AreaErrorClassifier.IsTransientHubFailure` to decide **retryability**.

It is safe only because `"No response received in hub"` survives — and nothing would have told me otherwise. `MessageService` documents the same coupling from the other direction and says plainly that a violation is *silent*: no compiler error, no exception, just reads that stop being retried and wait out their budgets. There is now a test asserting that marker directly, with the reasoning attached, because the coupling **is** a string coupling and dressing it up as anything else would misrepresent how fragile it is.

## Verification

| | |
|---|---|
| `MeshWeaver.Messaging.Hub.Test` (full, unfiltered) | **349 passed, 0 failed** |
| `MeshWeaver.Documentation.Test` (full) | **180 passed, 0 failed** |
| mutation: revert the message | state test ❌ caught |

Honest note on the mutation: the *marker* test passes against both old and new messages by design — it guards a future regression, not this change. Only the state test discriminates.

No hand-written `[Fact(Timeout = …)]`: the hub's own `RequestTimeout` is the thing under test and already bounds these, with xunit's `methodTimeout` as the outer net. A second hand-written bound would spend `TestTimeoutLiteralRatchetGuard` budget for a guess about machine speed.

Findings committed to `Doc/Architecture/DebuggingMessageFlow` (how to read a timeout, the two-probe control arm, and the string coupling) plus a What's New entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)