### PR TITLE
fix: the audit stamp is one function, so the two copies cannot disagree

### DIFF
--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -1464,16 +1464,14 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                         // ChangeItem (per-entity Updates + ChangeType + owner-only
                         // Version) consistently. We supply only the value transform;
                         // we never hand-roll a ChangeItem (a hand-rolled EntityUpdate
-                        // silently failed the owner's write-back). Audit identity
-                        // (LastModifiedBy) is content, so we still stamp it here.
+                        // silently failed the owner's write-back). The audit fields are
+                        // CONTENT, so they are stamped here — through the same
+                        // ApplyAuditStamp the own-stream path uses, never a second copy.
                         // Explicit Func type disambiguates from the ChangeItem overload.
                         Func<MeshNode?, MeshNode?> valueUpdate = current =>
                         {
                             if (current is null) return null;
-                            var updated = update(current);
-                            if (updated.LastModifiedBy == current.LastModifiedBy
-                                && !string.IsNullOrEmpty(capturedContext?.ObjectId))
-                                updated = updated with { LastModifiedBy = capturedContext.ObjectId };
+                            var updated = ApplyAuditStamp(current, update(current), capturedContext, out var _unusedStamped);
                             EmitOnce(updated);
                             return updated;
                         };
@@ -1694,18 +1692,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             // the outgoing patch, so a client can't forge a different author.
                             // This preserves the audit trail UpdateNodeRequest used to stamp
                             // from UpdatedBy now that writes go through stream.Update.
-                            var stamped = false;
-                            if (updated.LastModified == current.LastModified)
-                            {
-                                updated = updated with { LastModified = DateTimeOffset.UtcNow };
-                                stamped = true;
-                            }
-                            if (updated.LastModifiedBy == current.LastModifiedBy
-                                && !string.IsNullOrEmpty(capturedContextAtEntry?.ObjectId))
-                            {
-                                updated = updated with { LastModifiedBy = capturedContextAtEntry.ObjectId };
-                                stamped = true;
-                            }
+                            updated = ApplyAuditStamp(current, updated, capturedContextAtEntry, out var stamped);
                             if (stamped)
                                 // 🚨 O(1) in the node — issue #1284. The stamp touches exactly two
                                 // TOP-LEVEL SCALARS, and the answer to "what did that change in the
@@ -2357,6 +2344,54 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             composite.Add(initialSub);
             return composite;
         });
+    /// <summary>
+    /// 🚨 <b>THE AUDIT STAMP, IN ONE PLACE.</b> <c>LastModified</c> and <c>LastModifiedBy</c> are
+    /// stamped here for EVERY <c>stream.Update</c> write, whoever owns the node.
+    ///
+    /// <para><b>Why it is a function and not two copies.</b> It used to be inlined twice, and the
+    /// two copies disagreed: the own-stream path stamped both fields, while the sync-stream
+    /// write-through path stamped only <c>LastModifiedBy</c>. A write through the second therefore
+    /// minted a NEW version while carrying the snapshot's OWN <c>LastModified</c> — so the node's
+    /// version order and its timestamp order disagreed, which is precisely what MeshWeaver#3021
+    /// reports: a Markdown node whose newest version carried a timestamp identical, to the second,
+    /// to a much earlier version's, with a 45-minute editing session's content gone. Nothing
+    /// errored; the loss surfaced only because someone remembered the content had been there
+    /// before lunch.</para>
+    ///
+    /// <para>A wrong timestamp is not cosmetic here. <c>NodeUpdatePipeline</c> re-stamps for the
+    /// same reason, and NodeType <c>IsDirty</c> / <c>CurrentSourceVersions</c> key on
+    /// <c>LastModified.UtcTicks</c> — so a stale stamp leaves an edited source looking clean and
+    /// the recompile never fires. And once on disk, a stale write is indistinguishable from a
+    /// legitimate one.</para>
+    ///
+    /// <para><b>Only when the lambda left them untouched.</b> A caller that deliberately sets
+    /// either field — an importer preserving source timestamps, a migration — keeps its value.
+    /// Equality against <paramref name="current"/> expresses "the lambda did not care", and it is
+    /// the same test both call sites already used.</para>
+    /// </summary>
+    /// <param name="current">The live node the lambda diffed against.</param>
+    /// <param name="updated">The lambda's result.</param>
+    /// <param name="ctx">The caller's AUTHENTICATED context — never a client-supplied author.</param>
+    /// <param name="stamped">True when either field was written; the own-stream path splices
+    /// exactly these two scalars into its outgoing patch and needs to know.</param>
+    private static MeshNode ApplyAuditStamp(
+        MeshNode current, MeshNode updated, AccessContext? ctx, out bool stamped)
+    {
+        stamped = false;
+        if (updated.LastModified == current.LastModified)
+        {
+            updated = updated with { LastModified = DateTimeOffset.UtcNow };
+            stamped = true;
+        }
+        if (updated.LastModifiedBy == current.LastModifiedBy
+            && !string.IsNullOrEmpty(ctx?.ObjectId))
+        {
+            updated = updated with { LastModifiedBy = ctx.ObjectId };
+            stamped = true;
+        }
+        return updated;
+    }
+
 
     /// <summary>
     /// Writes the audit stamp (<see cref="MeshNode.LastModified"/> /

--- a/test/MeshWeaver.Documentation.Test/AuditStampHasExactlyOneImplementationGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/AuditStampHasExactlyOneImplementationGuard.cs
@@ -1,0 +1,93 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>The audit stamp — <c>LastModified</c> and <c>LastModifiedBy</c> on a
+/// <c>stream.Update</c> write — must exist in exactly ONE place.</b>
+///
+/// <para><b>The measured cost of two copies (MeshWeaver#3021).</b> It was inlined twice. The
+/// own-stream path stamped both fields; the sync-stream write-through path stamped only
+/// <c>LastModifiedBy</c>. A write through the second therefore minted a NEW version while carrying
+/// the snapshot's OWN <c>LastModified</c> — so a node's version order and its timestamp order
+/// disagreed.</para>
+///
+/// <para>On a live install that presented as silent data loss: a Markdown node's newest version
+/// carried a timestamp identical, to the second, to a much earlier version's, with a 45-minute
+/// editing session's content gone. Nothing errored. It was noticed only because someone remembered
+/// the content had been there before lunch.</para>
+///
+/// <para><b>Why a source guard rather than a behavioural test.</b> The divergent path is the
+/// CROSS-HUB one, which needs a multi-hub fixture to exercise; the two paths were identical in
+/// every observable respect except this stamp, so a single-process test passes against both the
+/// bug and the fix. What actually failed here was not a behaviour nobody checked — it was two
+/// copies of one rule drifting apart. This guard pins the property that makes the drift
+/// impossible, which is the defect's real shape. A cross-hub behavioural test is still worth
+/// adding and would catch a different failure: the helper being correct but not called.</para>
+/// </summary>
+public class AuditStampHasExactlyOneImplementationGuard
+{
+    private const string Subject = "src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs";
+
+    /// <summary>
+    /// The decision "the lambda did not set LastModified, so stamp it". Written as a regex over
+    /// whitespace because the formatting, not the rule, is what varies.
+    /// </summary>
+    private static readonly Regex StampDecision =
+        new(@"updated\s*\.\s*LastModified\s*==\s*current\s*\.\s*LastModified", RegexOptions.Compiled);
+
+    private static string ReadSubject()
+    {
+        var path = Path.Combine(SourceScan.FindRepoRoot(), Subject);
+        Assert.True(File.Exists(path), $"{Subject} is missing — this guard's subject moved; follow it.");
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>Executable lines only: the rule is quoted in prose here, deliberately.</summary>
+    private static string ExecutableText(string text) =>
+        string.Join('\n', text.Split('\n').Where(l => !l.TrimStart().StartsWith("///", StringComparison.Ordinal)
+                                                      && !l.TrimStart().StartsWith("//", StringComparison.Ordinal)));
+
+    [Fact]
+    public void TheStampDecisionAppearsExactlyOnce()
+    {
+        var code = ExecutableText(ReadSubject());
+        var hits = StampDecision.Matches(code).Count;
+
+        // Control arm: zero means the matcher stopped recognising its subject, which would let
+        // this guard pass having checked nothing — the failure mode it exists to prevent.
+        Assert.True(hits > 0,
+            "The audit-stamp decision (`updated.LastModified == current.LastModified`) was not found "
+            + $"in {Subject}. Either the stamp moved — follow it — or this guard is now checking "
+            + "nothing while reporting green.");
+
+        Assert.True(hits == 1,
+            $"The audit-stamp decision appears {hits} times in {Subject}; it must appear exactly ONCE, "
+            + "inside ApplyAuditStamp.\n"
+            + "Two copies is not a style problem: they drifted, and the copy that stamped only "
+            + "LastModifiedBy let a cross-hub write mint a new version while carrying the snapshot's "
+            + "own LastModified. A node's version order and timestamp order then disagree, which on a "
+            + "live install destroyed a 45-minute editing session silently (#3021).\n"
+            + "Call ApplyAuditStamp instead of inlining the rule again.");
+    }
+
+    [Fact]
+    public void BothUpdatePathsCallTheSharedStamp()
+    {
+        var code = ExecutableText(ReadSubject());
+        var calls = Regex.Matches(code, @"ApplyAuditStamp\s*\(").Count;
+
+        Assert.True(calls >= 3,
+            $"Expected the ApplyAuditStamp declaration plus at least two call sites in {Subject}; "
+            + $"found {calls} occurrence(s). Both stream.Update paths — the own-stream write and the "
+            + "cross-hub sync-stream write-through — must stamp through it. A path that stops calling "
+            + "it silently reverts to writing whatever LastModified the caller's snapshot happened to "
+            + "carry (#3021).");
+    }
+}


### PR DESCRIPTION
Closes #3021 — silent data loss on a live install.

## Root cause

`LastModified` and `LastModifiedBy` were stamped by **two inlined copies** in `MeshNodeStreamExtensions`, and the copies had drifted:

| path | `LastModified` | `LastModifiedBy` |
|---|---|---|
| own-stream (`UpdateRemote`) | ✅ stamped | ✅ |
| cross-hub sync-stream write-through | ❌ **not stamped** | ✅ |

A write through the second minted a **new version** while carrying the snapshot's **own** `LastModified`. The node's version order and its timestamp order then disagree — which is precisely what the issue reports:

> the overwrite was recorded as the **newest** version, but its `lastModified` timestamp exactly matched a much **earlier** version's timestamp

with a 45-minute editing session's content gone, no error anywhere, discovered only because the user remembered it had been there before lunch.

## Why the existing guard could not catch it

`MonotonicWriteGuardStorageAdapter` refuses writes whose **Version** moves backward. Here the version moved correctly *forward* while the content and timestamp went back — outside what it inspects. I checked the enforcement before concluding it was absent.

## Why a stale timestamp is not cosmetic

`NodeUpdatePipeline` re-stamps for the same reason, and NodeType `IsDirty` / `CurrentSourceVersions` key on `LastModified.UtcTicks` — a stale stamp leaves an edited source looking **clean** and the recompile never fires. And once on disk, a stale write is indistinguishable from a legitimate one, which is why only human memory caught it.

## The change

Both paths call `ApplyAuditStamp`. The own-stream path's behaviour is unchanged (it already did both fields and still gets the `stamped` flag its patch splice needs); the cross-hub path gains the stamp it was missing. Callers that deliberately set either field keep their value — the equality test against `current` is what expresses *"the lambda did not care"*, and it is the same test both sites already used.

Making it a function is the actual fix. Two copies of one rule is what drifted; a second correct copy would drift again.

## Guard

`AuditStampHasExactlyOneImplementationGuard` fails if the stamp decision appears more than once, or if a path stops calling the helper. It carries a control arm: zero matches fails too, so it cannot pass having checked nothing.

**Mutation-proven** — re-inlining the rule in the cross-hub path reds both arms.

## 🚨 What this does NOT include

A cross-hub **behavioural** test, which would catch a different failure: the helper being correct but not called. It needs a multi-hub fixture, because the two paths are identical in every observable respect *except* this stamp — so a single-process test passes against both the bug and the fix. Worth adding; I did not, and the commit says so.

**Verified:** `MeshWeaver.Documentation.Test` **189 passed**, `MeshWeaver.Graph.Test` **1164 passed** — both full projects, unfiltered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)