### PR TITLE
Supersede the delete tombstone at the recreate's commit, before Created is published (#3008)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
@@ -363,6 +363,19 @@ The protocol is the idle sweep's: **detach → claim pair-exact → tear down** 
 
 🚨 The guard lives in `GetStreamRaw`, **never in `GetEntry`** — `GetEntry` is a pin-or-recreate loop, and evicting there spins forever on an entry that faults during creation. Running once per read *call* also bounds the re-probe: only a terminal entry qualifies, so an in-flight probe is shared, giving one new upstream per **fault**, not per read.
 
+## A delete tombstone is superseded at the recreate's commit — before `Created` is published
+
+The one read failure a reader is *designed not to retry* is the delete tombstone's verdict: `No node found at '…' — the node was deleted, so this address will not reactivate`. A hub that is going down because its node was **deleted** NACKs an abandoned delivery with that authoritative `NotFound` (instead of the transient `ShuttingDown` a recycling hub answers), and the classifier here turns it into a definitive absence — the stream terminates, the negative entry is recorded, and by contract the caller stops. The verdict is read off `RecentlyDeletedRegistry` (`IAddressTombstones`), which the **delete marks synchronously** before its response returns.
+
+**The recreate must supersede that tombstone with the same discipline — synchronously, at the durable write, before `Created` is published (#3008).** Until it did, the only clear ran inside a *live per-node hub's* change handler: asynchronous, incidental (it needed a hub to be alive for the path at that instant — the delete had just disposed it), and conditional (a same-version recreate was skipped as a self-write echo). So after `Deleted` **and** `Created` had both been observed on the change feed, a fresh subscriber whose `SubscribeRequest` was routed to the still-disposing old hub — the hub stays resolvable until its `ShutDown` phase, potentially seconds after `DisposeHostedHubs` under load — was told, authoritatively, that a node which provably existed again would never come back.
+
+The seam is the outermost storage decorator (`SubtreeDeletionGuardStorageAdapter`), because **every durable write crosses it**: on the write's post-commit emission it calls `RecentlyDeletedRegistry.Supersede(path, version)`, and `StorageAdapterChangeFeedExtensions` composes the `IMeshChangeFeed` publish *downstream* of that emission — so by construction `Created` never reaches a subscriber while the tombstone still reads live. Two rules keep it correct:
+
+- **Supersede, never erase.** A superseded tombstone answers `IsDeleted` / `IsRecentlyDeleted` with `false` (the address is not gone for good; a save there is not a resurrection), but the delete stays on record for the TTL *with the version the recreate landed at*. `MeshNodeTypeSource`'s version floor recognises the recreate's rewind to `Version = 1` through `IsRecreatedAt(path, version)` — a hub whose routing-supplied own-node stream delivers the recreate *after* the commit would otherwise drop it as a stale replay.
+- **Only a commit supersedes.** The `null` write sentinel (no adapter owns the path), a `WriteIfVersion` that answers `false`, and a refused write under an active subtree deletion write nothing and leave the tombstone live.
+
+Pinned by `TombstoneSupersededBeforeCreatedTest` (the ordering, hub-free and deterministic) and `RecreateSupersedesTombstoneTest` (the end-to-end shape on a Monolith mesh).
+
 ## 🚨 Never go around the cache
 
 An ad-hoc `workspace.GetRemoteStream<MeshNode, …>(addr, …)` would open a **separate** stream instance. Writes through it are invisible to every reader on the cached handle (and vice versa) — this exact bug once made compile results never land on a NodeType's node. So the public overloads now **throw `InvalidOperationException`** for `MeshNode` (`Workspace.ThrowIfMeshNode`); framework plumbing that legitimately needs the raw reduce uses the internal `GetRemoteStreamUnchecked` overload.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-re-created-page-is-never-reported-as-gone.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-re-created-page-is-never-reported-as-gone.md
@@ -1,0 +1,23 @@
+---
+Name: A re-created page is never reported as gone
+Category: Fix
+Description: Fixed a fault where a page opened right after a node had been deleted and re-created at the same address could be told, definitively, that it no longer existed — and would stop trying.
+Icon: Sparkle
+Order: -20260902
+---
+
+# A re-created page is never reported as gone
+
+Deleting a node and re-creating it at the same address is an everyday shape: a re-import, a repair
+migration, a node moved away and back. When a node is deleted, the platform remembers that for a
+short while so that anyone still asking for it gets a clear, final answer — *this address is gone
+and will not come back* — instead of waiting on a node that will never reappear.
+
+That final answer used to outlive the re-creation. The record of the delete was only cleared as a
+side effect of the node's own machinery noticing the re-creation, which under load could happen
+late — or not at all, because the delete had just shut that machinery down. A page opened in that
+window, even after the re-creation was already visible everywhere else, could be told the node was
+gone for good, and because that answer is meant to be final, it stopped asking.
+
+The re-creation now retires the delete record in the same breath as it is stored, before anyone is
+told about the new node. A page opened after a re-creation always sees the re-created node.

--- a/src/MeshWeaver.Graph/MeshDataSource.cs
+++ b/src/MeshWeaver.Graph/MeshDataSource.cs
@@ -1395,9 +1395,13 @@ public static class MeshDataSourceExtensions
             if (newNode.Version == lastSelfWrite.Value)
                 return;
             cache.IsDeleted = false;
-            // A genuine (re)create/update clears the tombstone so a same-id recreate
-            // persists normally (a self-write echo was already suppressed above).
-            recentlyDeleted?.Clear(ownPath);
+            // A genuine (re)create/update SUPERSEDES the tombstone so a same-id recreate persists
+            // normally (a self-write echo was already suppressed above). The storage write seam has
+            // usually done this already, synchronously at the commit (#3008); this covers the
+            // cross-process feed, where the write committed in another process. Supersede — not
+            // Clear — so the delete stays on record and AcceptOwnNodeEmission can still recognise
+            // the recreate's version rewind when the routing-supplied own-node stream delivers it.
+            recentlyDeleted?.Supersede(ownPath, newNode.Version);
             try
             {
                 // 🚨 ADOPTION, NOT A WRITE — `newNode` is the node as PERSISTED, at the version

--- a/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
+++ b/src/MeshWeaver.Graph/MeshNodeTypeSource.cs
@@ -989,7 +989,10 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
     /// <para><b>Named escape hatch: delete-then-recreate.</b> A same-path recreate legitimately
     /// restarts at <c>Version = 1</c>. The mesh-scoped tombstone (<see cref="RecentlyDeletedRegistry"/>)
     /// is the framework's existing record of exactly that, so a tombstoned path resets the floor
-    /// instead of dropping the emission. This mirrors the forward-only own-node refresh the
+    /// instead of dropping the emission — and so does a path whose tombstone the recreate has already
+    /// SUPERSEDED at or below this emission's version (<see cref="RecentlyDeletedRegistry.IsRecreatedAt"/>):
+    /// the write seam supersedes synchronously at the commit (#3008), typically before the
+    /// routing-supplied own-node stream delivers the recreate here. This mirrors the forward-only own-node refresh the
     /// change-notification handler in <c>MeshDataSourceExtensions.SubscribeToOwnDeletion</c>
     /// already applies ("a persisted snapshot may only REPLACE the in-RAM commit when it is
     /// STRICTLY NEWER").</para>
@@ -1016,12 +1019,14 @@ public record MeshNodeTypeSource : TypeSourceWithType<MeshNode, MeshNodeTypeSour
             return false;
         if (node.Version < floor)
         {
-            if (_recentlyDeletedRegistry?.IsRecentlyDeleted(node.Path) ?? false)
+            if (_recentlyDeletedRegistry is { } tombstones
+                && (tombstones.IsRecentlyDeleted(node.Path)
+                    || tombstones.IsRecreatedAt(node.Path, node.Version)))
             {
                 _logger?.LogDebug(
                     "MeshNodeTypeSource[{HubPath}]: own-node emission version {Version} is below the floor "
-                    + "{Floor}, but the path carries a delete tombstone — treating it as a recreate and "
-                    + "resetting the floor.",
+                    + "{Floor}, but the path carries a delete tombstone (live or superseded by a recreate at "
+                    + "or below this version) — treating it as a recreate and resetting the floor.",
                     _hubPath, node.Version, floor);
                 _ownNodeAdopted = 1;
                 Interlocked.Exchange(ref _ownNodeVersionFloor, node.Version);

--- a/src/MeshWeaver.Hosting/Persistence/SubtreeDeletionGuardStorageAdapter.cs
+++ b/src/MeshWeaver.Hosting/Persistence/SubtreeDeletionGuardStorageAdapter.cs
@@ -32,6 +32,16 @@ namespace MeshWeaver.Hosting.Persistence;
 /// <c>.Subscribe(_ => …, ex => log)</c> shape surfaces the refusal; a create request fails
 /// with a clear message instead of silently minting a doomed node.</para>
 ///
+/// <para><b>It is also the seam that SUPERSEDES a delete tombstone (#3008).</b> Every durable write
+/// crosses this decorator, so its post-commit emission is the one place that knows, synchronously,
+/// that the path exists again: <see cref="RecentlyDeletedRegistry.Supersede"/> runs in a <c>Do</c> on
+/// the write's emission — strictly BEFORE the caller's <c>IMeshChangeFeed</c> publish, which
+/// <c>StorageAdapterChangeFeedExtensions</c> composes downstream of it. That mirrors the delete, which
+/// marks the tombstone synchronously before its response returns. Before this, the only clear ran in
+/// a LIVE per-node hub's change handler — asynchronous, and absent when no hub was alive for the path
+/// — so a reader whose delivery reached the still-disposing old hub after <c>Created</c> had already
+/// been published was NACKed with the authoritative, non-retryable "will not reactivate".</para>
+///
 /// <para>Pass-through when no <see cref="RecentlyDeletedRegistry"/> is registered (meshes
 /// without Graph) and O(active deletions) — i.e. effectively free — on the write hot path.</para>
 /// </summary>
@@ -62,7 +72,14 @@ internal sealed class SubtreeDeletionGuardStorageAdapter(
                     return Observable.Throw<MeshNode?>(new InvalidOperationException(
                         $"Cannot write '{node.Path}': the subtree '{root}' is currently being deleted."));
                 }
-                return inner.Write(node, options);
+                // Post-commit, pre-publish: the null sentinel means "no adapter owns this path" —
+                // nothing was written, so nothing is superseded.
+                return inner.Write(node, options)
+                    .Do(saved =>
+                    {
+                        if (saved is not null)
+                            registry.Supersede(saved.Path, saved.Version);
+                    });
             });
 
     /// <inheritdoc />
@@ -84,7 +101,14 @@ internal sealed class SubtreeDeletionGuardStorageAdapter(
                             $"Cannot write '{node.Path}': the subtree '{root}' is currently being deleted."));
                     }
                 }
-                return inner.WriteMany(nodes, options);
+                // Only the nodes the adapter reports as written were claimed — same rule as the
+                // singular null sentinel.
+                return inner.WriteMany(nodes, options)
+                    .Do(written =>
+                    {
+                        foreach (var saved in written)
+                            registry.Supersede(saved.Path, saved.Version);
+                    });
             });
 
     /// <inheritdoc />
@@ -109,7 +133,14 @@ internal sealed class SubtreeDeletionGuardStorageAdapter(
                     return Observable.Throw<bool?>(new InvalidOperationException(
                         $"Cannot write '{node.Path}': the subtree '{root}' is currently being deleted."));
                 }
-                return inner.WriteIfVersion(node, expectedVersion, options);
+                // `true` is the one outcome that committed; a version mismatch (false) or an
+                // unowned path (null) wrote nothing.
+                return inner.WriteIfVersion(node, expectedVersion, options)
+                    .Do(written =>
+                    {
+                        if (written == true)
+                            registry.Supersede(node.Path, node.Version);
+                    });
             });
 
     /// <inheritdoc />

--- a/src/MeshWeaver.Mesh.Contract/Services/RecentlyDeletedRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/RecentlyDeletedRegistry.cs
@@ -121,8 +121,16 @@ public sealed class RecentlyDeletedRegistry : IAddressTombstones
     {
         if (string.IsNullOrEmpty(path) || _deleted.IsEmpty)
             return;
+        var now = DateTimeOffset.UtcNow;
         while (_deleted.TryGetValue(path, out var current))
         {
+            // An expired tombstone is already dead for every reader (TryGetLive prunes it on
+            // access) — prune it here too rather than stamp a recreate version onto a corpse.
+            if (now - current.DeletedAt > Ttl)
+            {
+                _deleted.TryRemove(new KeyValuePair<string, Tombstone>(path, current));
+                return;
+            }
             if (current.SupersededAtVersion is { } already && already <= version)
                 return;
             if (_deleted.TryUpdate(path, current with { SupersededAtVersion = version }, current))

--- a/src/MeshWeaver.Mesh.Contract/Services/RecentlyDeletedRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/RecentlyDeletedRegistry.cs
@@ -21,11 +21,28 @@ namespace MeshWeaver.Mesh.Services;
 /// This is what makes the guard deterministic: an earlier attempt that populated only from the async
 /// per-hub <c>storage.Changes</c> subscriber still raced at cold start (no per-node hub was active yet
 /// to observe the delete). Per-node hubs (via the Graph MeshDataSource guards) then READ this registry
-/// and drop a resurrecting save; a legitimate re-create <see cref="Clear"/>s the tombstone.</para>
+/// and drop a resurrecting save; a legitimate re-create <see cref="Supersede"/>s the tombstone.</para>
+///
+/// <para><b>Superseding is SYNCHRONOUS at the durable write, exactly as marking is synchronous at the
+/// delete (#3008).</b> The storage write seam (the outermost <c>IStorageAdapter</c> decorator) calls
+/// <see cref="Supersede"/> on the write's post-commit emission — strictly BEFORE the caller's
+/// <c>IMeshChangeFeed</c> <c>Created</c> publish, which is composed downstream of that emission. Until
+/// this existed the only clear ran inside a LIVE per-node hub's change handler, i.e. asynchronously,
+/// incidentally (it needed a hub to be alive for the path at that moment) and conditionally (a
+/// same-version recreate was skipped as a self-write echo) — so a reader whose delivery landed on the
+/// still-disposing old hub was NACKed with the authoritative "the node was deleted, so this address
+/// will not reactivate" for a node that provably existed again, and the reader stopped, by contract.</para>
+///
+/// <para>A superseded tombstone answers <see cref="IsRecentlyDeleted"/> / <see cref="IsDeleted"/> with
+/// <c>false</c> — the address is not gone for good and a save to it is not a resurrection — but the
+/// delete stays ON RECORD for the TTL, together with the version the recreate landed at: that is what
+/// lets <c>MeshNodeTypeSource</c> tell a legitimate version rewind (a recreate restarting at
+/// <c>Version = 1</c>) from a stale replay (<see cref="IsRecreatedAt"/>). Erasing the entry at the write
+/// would have thrown that recognition away for a hub whose own-node stream delivers the recreate later.</para>
 ///
 /// <para>Instance-only state (a <see cref="ConcurrentDictionary{TKey,TValue}"/> — the lifetime is the
 /// mesh singleton's, never <c>static</c>; see NoStaticState.md). TTL-bounded so the map can't grow
-/// unbounded, and cleared on a legitimate re-create so a same-id recreate persists normally.</para>
+/// unbounded; superseded entries expire on the same TTL.</para>
 ///
 /// <para>It is also the mesh's <see cref="IAddressTombstones"/>: the message pipeline reads it to
 /// tell "this hub is going down because its node was DELETED" (the address is gone for good) from
@@ -42,7 +59,14 @@ public sealed class RecentlyDeletedRegistry : IAddressTombstones
     // itself be a no-op. A re-create clears the entry explicitly, so the TTL is only a backstop.
     private static readonly TimeSpan Ttl = TimeSpan.FromSeconds(30);
 
-    private readonly ConcurrentDictionary<string, DateTimeOffset> _deleted =
+    /// <summary>
+    /// One delete on record. <see cref="SupersededAtVersion"/> is <c>null</c> while the tombstone is
+    /// LIVE (the address is gone for good); once a durable write lands on the path it carries the
+    /// version that write committed at — the LOWEST such version, i.e. the recreate itself.
+    /// </summary>
+    private readonly record struct Tombstone(DateTimeOffset DeletedAt, long? SupersededAtVersion);
+
+    private readonly ConcurrentDictionary<string, Tombstone> _deleted =
         new(StringComparer.OrdinalIgnoreCase);
 
     // UtcTicks of the last opportunistic prune sweep — gates the O(n) sweep in MarkDeleted to at
@@ -58,7 +82,7 @@ public sealed class RecentlyDeletedRegistry : IAddressTombstones
         if (string.IsNullOrEmpty(path))
             return;
         var now = DateTimeOffset.UtcNow;
-        _deleted[path] = now;
+        _deleted[path] = new Tombstone(now, SupersededAtVersion: null);
 
         // Time-gated sweep: only one thread prunes per TTL window (CAS on _lastPruneTicks), so the
         // map can't accumulate tombstones for one-off deletes that are never checked/cleared again.
@@ -67,27 +91,69 @@ public sealed class RecentlyDeletedRegistry : IAddressTombstones
             && Interlocked.CompareExchange(ref _lastPruneTicks, now.UtcTicks, last) == last)
         {
             foreach (var kv in _deleted)
-                if (now - kv.Value > Ttl)
+                if (now - kv.Value.DeletedAt > Ttl)
                     _deleted.TryRemove(kv.Key, out _);
         }
     }
 
-    /// <summary>Clears the tombstone for <paramref name="path"/> — a legitimate (re)create so a
-    /// same-id node persists normally. Called from the Created change handler.</summary>
+    /// <summary>Removes the tombstone for <paramref name="path"/> outright. Prefer
+    /// <see cref="Supersede"/> for a (re)create — it keeps the delete on record so a version rewind
+    /// is still recognised as the recreate; <c>Clear</c> forgets that too.</summary>
     public void Clear(string? path)
     {
         if (!string.IsNullOrEmpty(path))
             _deleted.TryRemove(path, out _);
     }
 
+    /// <summary>
+    /// Records that a durable write landed on <paramref name="path"/> at <paramref name="version"/>
+    /// AFTER its delete — the tombstone is superseded: the address is no longer "gone for good"
+    /// (<see cref="IsDeleted"/> / <see cref="IsRecentlyDeleted"/> turn <c>false</c>) while the delete
+    /// stays on record for the TTL so <see cref="IsRecreatedAt"/> can recognise the recreate.
+    ///
+    /// <para>Called synchronously by the storage write seam on the write's post-commit emission, and
+    /// by a live per-node hub's change handler when it adopts a persisted (re)create. Untracked paths
+    /// (the overwhelming majority of writes) cost one dictionary probe and nothing else; a tombstone
+    /// already superseded keeps the LOWER version — the first write after the delete IS the recreate,
+    /// every later one is an ordinary update above it.</para>
+    /// </summary>
+    public void Supersede(string? path, long version)
+    {
+        if (string.IsNullOrEmpty(path) || _deleted.IsEmpty)
+            return;
+        while (_deleted.TryGetValue(path, out var current))
+        {
+            if (current.SupersededAtVersion is { } already && already <= version)
+                return;
+            if (_deleted.TryUpdate(path, current with { SupersededAtVersion = version }, current))
+                return;
+        }
+    }
+
     /// <summary>True when <paramref name="path"/> was deleted within the TTL window and has not
     /// been re-created since — the caller (a per-node hub's save path) must then DROP the write.
-    /// Expired entries are pruned on access.</summary>
+    /// Expired entries are pruned on access; a superseded entry answers <c>false</c>.</summary>
     public bool IsRecentlyDeleted(string? path)
+        => TryGetLive(path, out var tombstone) && tombstone.SupersededAtVersion is null;
+
+    /// <summary>
+    /// True when <paramref name="path"/> was deleted within the TTL window and a durable write has
+    /// since landed on it at or below <paramref name="version"/> — i.e. an own-node emission carrying
+    /// <paramref name="version"/> IS the recreate (or a later update of it), not a stale replay of the
+    /// pre-delete node. The version floor in <c>MeshNodeTypeSource</c> resets on this instead of
+    /// dropping the emission as a regression.
+    /// </summary>
+    public bool IsRecreatedAt(string? path, long version)
+        => TryGetLive(path, out var tombstone)
+           && tombstone.SupersededAtVersion is { } recreatedAt
+           && version >= recreatedAt;
+
+    private bool TryGetLive(string? path, out Tombstone tombstone)
     {
-        if (string.IsNullOrEmpty(path) || !_deleted.TryGetValue(path, out var at))
+        tombstone = default;
+        if (string.IsNullOrEmpty(path) || !_deleted.TryGetValue(path, out tombstone))
             return false;
-        if (DateTimeOffset.UtcNow - at > Ttl)
+        if (DateTimeOffset.UtcNow - tombstone.DeletedAt > Ttl)
         {
             _deleted.TryRemove(path, out _);
             return false;
@@ -98,7 +164,7 @@ public sealed class RecentlyDeletedRegistry : IAddressTombstones
     /// <inheritdoc />
     /// <remarks>
     /// The pipeline-facing name for <see cref="IsRecentlyDeleted"/>: same tombstone, same TTL,
-    /// same "a re-create clears it" semantics. Kept as a separate member so the message pipeline
+    /// same "a re-create supersedes it" semantics. Kept as a separate member so the message pipeline
     /// depends on the intent (<see cref="IAddressTombstones"/> — "is this address gone for good?")
     /// rather than on this class, which lives above it in the reference graph.
     /// </remarks>

--- a/src/MeshWeaver.Messaging.Contract/IAddressTombstones.cs
+++ b/src/MeshWeaver.Messaging.Contract/IAddressTombstones.cs
@@ -18,8 +18,9 @@ namespace MeshWeaver.Messaging;
 /// <para>Implemented over the mesh's delete tombstone (<c>RecentlyDeletedRegistry</c>), which the
 /// delete handler populates SYNCHRONOUSLY — every planned path is marked before the delete's
 /// response returns — so a lookup here is authoritative at exactly the moment a racing delivery
-/// arrives at the dying hub. A legitimate re-create clears the tombstone, so a recycled or
-/// re-created address is never reported as deleted.</para>
+/// arrives at the dying hub. A legitimate re-create SUPERSEDES the tombstone just as synchronously —
+/// at the durable write's commit, before its <c>Created</c> is published (#3008) — so a recycled or
+/// re-created address is never reported as deleted once the store holds it again.</para>
 ///
 /// <para>Optional: meshes without a delete tombstone (bare messaging fixtures) register no
 /// implementation and the pipeline keeps its historical <see cref="ErrorType.ShuttingDown"/>

--- a/test/MeshWeaver.Graph.Test/RecreateSupersedesTombstoneTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecreateSupersedesTombstoneTest.cs
@@ -26,7 +26,7 @@ namespace MeshWeaver.Graph.Test;
 /// </summary>
 public class RecreateSupersedesTombstoneTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
-    [Fact(Timeout = 30000)]
+    [Fact]
     public async Task Recreate_SupersedesTheTombstone_BeforeCreatedIsPublished_AndAFreshSubscriberSeesTheNewNode()
     {
         const string id = "tombstone-recreate";

--- a/test/MeshWeaver.Graph.Test/RecreateSupersedesTombstoneTest.cs
+++ b/test/MeshWeaver.Graph.Test/RecreateSupersedesTombstoneTest.cs
@@ -1,0 +1,72 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// End-to-end shape of #3008 on a real Monolith mesh: delete a node, recreate it at the same path,
+/// and assert — at the moment <c>Created</c> is published on the <see cref="IMeshChangeFeed"/> — that
+/// the mesh's delete tombstone (<see cref="IAddressTombstones"/>) no longer reports the address as
+/// gone for good, so a fresh subscriber sees the recreated node instead of the tombstone's terminal
+/// "will not reactivate".
+///
+/// <para>Before the fix the tombstone was cleared only inside a LIVE per-node hub's change handler:
+/// after the delete had disposed that hub nothing cleared it on the recreate, and the assertion at
+/// <c>Created</c> depended on whether the dying hub's handler happened to still be subscribed (the
+/// 2-in-4 failure of the Plugins-side <c>WorkspaceCacheEvictionTest.NewSubscriber_AfterRecreate…</c>).
+/// The deterministic, hub-free half of this pin is
+/// <c>MeshWeaver.Hosting.Test.TombstoneSupersededBeforeCreatedTest</c>.</para>
+/// </summary>
+public class RecreateSupersedesTombstoneTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 30000)]
+    public async Task Recreate_SupersedesTheTombstone_BeforeCreatedIsPublished_AndAFreshSubscriberSeesTheNewNode()
+    {
+        const string id = "tombstone-recreate";
+        var path = $"{TestPartition}/{id}";
+        await NodeFactory.CreateNode(
+            new MeshNode(id, TestPartition) { Name = "First", NodeType = "Markdown" }).Should().Emit();
+
+        // Warm a per-node hub for the path — the delete then has a hub to dispose, which is the
+        // still-disposing owner the issue's reader was routed to.
+        var stream1 = GetClient(c => c.AddData()).GetWorkspace().GetMeshNodeStream(path);
+        await stream1.Select(n => n?.Name).Should().Match(n => n == "First");
+
+        var tombstones = Mesh.ServiceProvider.GetRequiredService<IAddressTombstones>();
+        var feed = Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>();
+        var tombstonedAtDeleted = new ReplaySubject<bool>();
+        var tombstonedAtCreated = new ReplaySubject<bool>();
+        using var feedSub = feed.Subscribe(ev =>
+        {
+            if (ev.Path != path) return;
+            if (ev.Kind == MeshChangeKind.Deleted) tombstonedAtDeleted.OnNext(tombstones.IsDeleted(path));
+            if (ev.Kind == MeshChangeKind.Created) tombstonedAtCreated.OnNext(tombstones.IsDeleted(path));
+        });
+
+        await NodeFactory.DeleteNode(path).Should().Emit();
+        var atDeleted = await tombstonedAtDeleted.Should().Within(5.Seconds()).Emit();
+        atDeleted.Should().BeTrue("the delete marks the tombstone synchronously, before Deleted is published");
+
+        await NodeFactory.CreateNode(
+            new MeshNode(id, TestPartition) { Name = "Second", NodeType = "Markdown" }).Should().Emit();
+        var atCreated = await tombstonedAtCreated.Should().Within(5.Seconds()).Emit();
+        atCreated.Should().BeFalse(
+            "the recreate's durable commit supersedes the tombstone BEFORE its Created is published — "
+            + "a reader acting on Created must never be told the address will not reactivate");
+        tombstones.IsDeleted(path).Should().BeFalse();
+
+        // The issue's reader: a brand-new subscriber after Created was observed.
+        var fresh = await GetClient(c => c.AddData()).GetWorkspace().GetMeshNodeStream(path)
+            .Select(n => n?.Name)
+            .Where(n => n != null)
+            .Should().Within(10.Seconds()).Emit();
+        fresh.Should().Be("Second", "a fresh subscriber after delete+recreate sees the recreated node");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/TombstoneSupersededBeforeCreatedTest.cs
+++ b/test/MeshWeaver.Hosting.Test/TombstoneSupersededBeforeCreatedTest.cs
@@ -1,0 +1,153 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Deterministic pin for #3008: a delete tombstone must be SUPERSEDED at the recreate's durable
+/// commit — strictly before the recreate's <c>Created</c> reaches the <see cref="IMeshChangeFeed"/>.
+///
+/// <para>The forced interleaving is the seam itself. <c>StorageAdapterChangeFeedExtensions</c>
+/// composes the feed publish downstream of the outermost adapter's write emission, so a feed
+/// subscriber that reads the tombstone AT PUBLISH TIME observes exactly the ordering a reader in
+/// production would: before the fix the tombstone was still live here (the only clear ran later,
+/// inside a live per-node hub's change handler — or never, when no hub was alive for the path), and
+/// a delivery abandoned by the still-disposing old hub was NACKed with the authoritative, non-retryable
+/// <c>"the node was deleted, so this address will not reactivate"</c> for a node that provably
+/// existed again. After the fix the write seam supersedes the tombstone on the post-commit emission,
+/// upstream of the publish. No hub, no timing — the same assertion fails before and passes after.</para>
+///
+/// <para>The end-to-end shape (delete → recreate → a fresh subscriber must see the new node) is
+/// <c>MeshWeaver.Graph.Test.RecreateSupersedesTombstoneTest</c>; the routing-level NACK
+/// classification itself is pinned by <c>DeletedAddressNackClassificationTest</c>.</para>
+/// </summary>
+public class TombstoneSupersededBeforeCreatedTest
+{
+    private static readonly JsonSerializerOptions JsonOptions = new();
+    private const string Partition = "TestData";
+    private const string Id = "cache-recreate";
+    private const string Path = Partition + "/" + Id;
+
+    // MeshNode(id, @namespace) — Path is DERIVED as "{namespace}/{id}". Version is set explicitly so
+    // the recreate-version bookkeeping below asserts on a value the test controls.
+    private static MeshNode Node(string name, long version = 1) =>
+        new(Id, Partition) { Name = name, NodeType = "Markdown", State = MeshNodeState.Active, Version = version };
+
+    private static (RecentlyDeletedRegistry Registry, IStorageAdapter Adapter, InProcessMeshChangeFeed Feed) Rig()
+    {
+        var registry = new RecentlyDeletedRegistry();
+        // The real outermost decorator over the real in-memory adapter — the exact object graph
+        // PersistenceExtensions builds, minus the version-history layers this seam does not touch.
+        IStorageAdapter adapter = new SubtreeDeletionGuardStorageAdapter(new InMemoryStorageAdapter(), registry);
+        return (registry, adapter, new InProcessMeshChangeFeed());
+    }
+
+    [Fact(Timeout = 5000)]
+    public void Supersede_LiftsGoneForGood_ButKeepsTheDeleteOnRecord()
+    {
+        var registry = new RecentlyDeletedRegistry();
+        var tombstones = (IAddressTombstones)registry;
+
+        registry.MarkDeleted(Path);
+        tombstones.IsDeleted(Path).Should().BeTrue("a just-deleted address is gone for good until something is written there again");
+        registry.IsRecreatedAt(Path, 1).Should().BeFalse("nothing has been written after the delete yet");
+
+        registry.Supersede(Path, version: 1);
+
+        tombstones.IsDeleted(Path).Should().BeFalse("a durable write landed after the delete — the address is not gone for good");
+        registry.IsRecentlyDeleted(Path).Should().BeFalse("a save to a recreated path is not a resurrection");
+        registry.IsRecreatedAt(Path, 1).Should().BeTrue("an emission at the recreate's own version IS the recreate");
+        registry.IsRecreatedAt(Path, 2).Should().BeTrue("an emission above the recreate's version is a later update of it");
+        registry.IsRecreatedAt(Path, 0).Should().BeFalse("an emission below the recreate's version predates it — a stale replay");
+
+        // A later, higher write does not move the recreate marker: the FIRST write after the delete is the recreate.
+        registry.Supersede(Path, version: 2);
+        registry.IsRecreatedAt(Path, 1).Should().BeTrue("the recreate is still the version-1 write");
+
+        // A fresh delete re-arms the tombstone from scratch.
+        registry.MarkDeleted(Path);
+        tombstones.IsDeleted(Path).Should().BeTrue("a new delete is again gone for good");
+        registry.IsRecreatedAt(Path, 1).Should().BeFalse("the new delete has no recreate yet");
+
+        // Untracked paths are a no-op — the overwhelming majority of writes.
+        registry.Supersede("TestData/never-deleted", 1);
+        registry.IsRecreatedAt("TestData/never-deleted", 1).Should().BeFalse();
+        tombstones.IsDeleted("TestData/never-deleted").Should().BeFalse();
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task Write_SupersedesTheTombstone_BeforeCreatedIsPublished()
+    {
+        var (registry, adapter, feed) = Rig();
+        var tombstones = (IAddressTombstones)registry;
+        var tombstonedAtPublish = new ReplaySubject<bool>();
+        using var feedSub = feed.Subscribe(ev =>
+        {
+            if (ev.Path == Path && ev.Kind == MeshChangeKind.Created)
+                tombstonedAtPublish.OnNext(tombstones.IsDeleted(Path));
+        });
+
+        // The delete marks synchronously (HandleDeleteNodeRequest) — modelled here as the mark itself.
+        registry.MarkDeleted(Path);
+        tombstones.IsDeleted(Path).Should().BeTrue();
+
+        var saved = await adapter.WriteAndPublishCreated(Node("Second"), JsonOptions, feed).FirstAsync();
+        saved.Should().NotBeNull();
+
+        var observed = await tombstonedAtPublish.Should().Emit();
+        observed.Should().BeFalse(
+            "by the time Created reaches the change feed the tombstone must already be superseded — "
+            + "a subscriber acting on Created would otherwise still be told the address will not reactivate");
+        tombstones.IsDeleted(Path).Should().BeFalse();
+        registry.IsRecreatedAt(Path, saved!.Version).Should().BeTrue(
+            "the delete stays on record with the recreate's version so a version rewind is recognised as the recreate");
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task WriteMany_SupersedesEveryWrittenPath_BeforeCreatedIsPublished()
+    {
+        var (registry, adapter, feed) = Rig();
+        var tombstones = (IAddressTombstones)registry;
+        var tombstonedAtPublish = new ReplaySubject<bool>();
+        using var feedSub = feed.Subscribe(ev =>
+        {
+            if (ev.Path == Path && ev.Kind == MeshChangeKind.Created)
+                tombstonedAtPublish.OnNext(tombstones.IsDeleted(Path));
+        });
+        registry.MarkDeleted(Path);
+
+        var written = await adapter.WriteManyAndPublishCreated(new[] { Node("Second") }, JsonOptions, feed).FirstAsync();
+        written.Count.Should().Be(1);
+
+        var observed = await tombstonedAtPublish.Should().Emit();
+        observed.Should().BeFalse("the bulk write is a recreate like any other — superseded before its Created is published");
+        tombstones.IsDeleted(Path).Should().BeFalse();
+    }
+
+    [Fact(Timeout = 5000)]
+    public async Task WriteIfVersion_SupersedesOnlyWhenTheCompareAndSetCommitted()
+    {
+        var (registry, adapter, _) = Rig();
+        var tombstones = (IAddressTombstones)registry;
+
+        var first = await adapter.Write(Node("First", version: 1), JsonOptions).FirstAsync();
+        first.Should().NotBeNull();
+        registry.MarkDeleted(Path);
+
+        // A mismatching expected version writes nothing — the tombstone must stay live.
+        var refused = await adapter.WriteIfVersion(Node("Second", version: 2), expectedVersion: 99, JsonOptions).FirstAsync();
+        refused.Should().Be(false);
+        tombstones.IsDeleted(Path).Should().BeTrue("a compare-and-set that did not commit supersedes nothing");
+
+        var committed = await adapter.WriteIfVersion(Node("Second", version: 2), expectedVersion: 1, JsonOptions).FirstAsync();
+        committed.Should().Be(true);
+        tombstones.IsDeleted(Path).Should().BeFalse("the compare-and-set committed — the path exists again");
+        registry.IsRecreatedAt(Path, 2).Should().BeTrue();
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/TombstoneSupersededBeforeCreatedTest.cs
+++ b/test/MeshWeaver.Hosting.Test/TombstoneSupersededBeforeCreatedTest.cs
@@ -97,7 +97,7 @@ public class TombstoneSupersededBeforeCreatedTest
         registry.MarkDeleted(Path);
         tombstones.IsDeleted(Path).Should().BeTrue();
 
-        var saved = await adapter.WriteAndPublishCreated(Node("Second"), JsonOptions, feed).FirstAsync();
+        var saved = await adapter.WriteAndPublishCreated(Node("Second"), JsonOptions, feed).Await();
         saved.Should().NotBeNull();
 
         var observed = await tombstonedAtPublish.Should().Emit();
@@ -122,7 +122,7 @@ public class TombstoneSupersededBeforeCreatedTest
         });
         registry.MarkDeleted(Path);
 
-        var written = await adapter.WriteManyAndPublishCreated(new[] { Node("Second") }, JsonOptions, feed).FirstAsync();
+        var written = await adapter.WriteManyAndPublishCreated(new[] { Node("Second") }, JsonOptions, feed).Await();
         written.Count.Should().Be(1);
 
         var observed = await tombstonedAtPublish.Should().Emit();
@@ -136,16 +136,16 @@ public class TombstoneSupersededBeforeCreatedTest
         var (registry, adapter, _) = Rig();
         var tombstones = (IAddressTombstones)registry;
 
-        var first = await adapter.Write(Node("First", version: 1), JsonOptions).FirstAsync();
+        var first = await adapter.Write(Node("First", version: 1), JsonOptions).Await();
         first.Should().NotBeNull();
         registry.MarkDeleted(Path);
 
         // A mismatching expected version writes nothing — the tombstone must stay live.
-        var refused = await adapter.WriteIfVersion(Node("Second", version: 2), expectedVersion: 99, JsonOptions).FirstAsync();
+        var refused = await adapter.WriteIfVersion(Node("Second", version: 2), expectedVersion: 99, JsonOptions).Await();
         refused.Should().Be(false);
         tombstones.IsDeleted(Path).Should().BeTrue("a compare-and-set that did not commit supersedes nothing");
 
-        var committed = await adapter.WriteIfVersion(Node("Second", version: 2), expectedVersion: 1, JsonOptions).FirstAsync();
+        var committed = await adapter.WriteIfVersion(Node("Second", version: 2), expectedVersion: 1, JsonOptions).Await();
         committed.Should().Be(true);
         tombstones.IsDeleted(Path).Should().BeFalse("the compare-and-set committed — the path exists again");
         registry.IsRecreatedAt(Path, 2).Should().BeTrue();


### PR DESCRIPTION
Fixes #3008.

## Root cause

The delete tombstone (`RecentlyDeletedRegistry`, the mesh's `IAddressTombstones`) is marked **synchronously at the delete**, but until now it was cleared only **asynchronously, incidentally and conditionally** — inside a *live* per-node hub's `storage.Changes` handler (`MeshDataSource.SubscribeToOwnDeletion` → `AdoptDurable` → `Clear`). The delete had just disposed that hub; nothing else cleared the tombstone on the recreate, and a same-version recreate was skipped there as a self-write echo anyway. Meanwhile the disposing hub stays resolvable in `HostedHubsCollection` until its `ShutDown` phase (seconds after `DisposeHostedHubs` under load), and any delivery it abandons is NACKed through `MessageService.NackThroughParent`, which reads the tombstone: live ⇒ the authoritative, non-retryable `No node found … the node was deleted, so this address will not reactivate`. So after `Deleted` **and** `Created` had both been published, a fresh `SubscribeRequest` routed to the old hub got a terminal verdict for a node that provably existed again.

## Fix — supersede the tombstone at the durable write, before `Created` is published

- `RecentlyDeletedRegistry.Supersede(path, version)`: a durable write landed after the delete. `IsDeleted`/`IsRecentlyDeleted` turn `false`; the delete stays on record for the TTL with the recreate's version, read by the new `IsRecreatedAt(path, version)`.
- `SubtreeDeletionGuardStorageAdapter` (the outermost decorator every durable write crosses) calls `Supersede` on the post-commit emission of `Write`/`WriteMany`/`WriteIfVersion` — strictly upstream of the `IMeshChangeFeed` publish `StorageAdapterChangeFeedExtensions` composes after it. Null sentinel / `false` CAS / refused write supersede nothing.
- `MeshDataSource.AdoptDurable` supersedes instead of erasing (covers the cross-process feed).
- `MeshNodeTypeSource.AcceptOwnNodeEmission` resets the version floor on a live tombstone **or** `IsRecreatedAt` — erasing the record at the write would have made a hub whose routing own-node stream delivers the recreate later drop it as a stale replay.

## Tests

- `MeshWeaver.Hosting.Test/TombstoneSupersededBeforeCreatedTest` — hub-free, deterministic: a feed subscriber reads the tombstone *at publish time* through the real decorated adapter; fails before (still live), passes after. Covers `Write`, `WriteMany`, `WriteIfVersion` and the registry contract.
- `MeshWeaver.Graph.Test/RecreateSupersedesTombstoneTest` — the issue's end-to-end shape on a Monolith mesh.
- Full `MeshWeaver.Hosting.Test` and the Plugins-side `MeshWeaver.Hosting.Monolith.Test` (bound to this branch via `MeshWeaverRoot`) run locally — results in the PR comment below.

## Docs

`Doc/Architecture/MeshNodeStreamCache` → "A delete tombstone is superseded at the recreate's commit — before `Created` is published". What's New: Fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
