### PR TITLE
Defer an exhausted boot reconcile instead of dropping it (#2888)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
@@ -79,6 +79,46 @@ boot** — plus immediately, on demand, whenever somebody opens the catalog page
 feed and offers the same **Update**. An installation that never restarts also never picks up
 framework fixes, which is a louder problem with its own alarm.
 
+### 🚨 A boot read that fails past its budget is deferred, not dropped (#2888)
+
+The boot read re-asks a *transient* answer — 503, 429, a gateway error, a connection that never
+landed — within a small budget (four attempts, ~26 s). That budget exists to survive a hiccup, not
+to wait out an outage, and it is **not** widened when an outage outlasts it: a registry that stays
+down for a minute leaves the boot with nothing to reconcile against. What happens then used to be
+one Error line on one pod, and the line's own promise — "the next chance is a human opening the
+catalog page" — was false: the catalog page only *renders* the feed; it never ran the reconcile.
+So the installation silently stopped noticing package and grant changes until its next restart.
+
+Two things now happen instead, and neither is a clock:
+
+1. **The skipped reconcile becomes a durable fact.** The reconciler owns one bookkeeping node,
+   `Plugins/_RegistryReconcileLedger` (a `RegistryReconcileLedger`, one entry per configured
+   registry), and the registry is recorded there as `Pending`, with the attempts spent and the
+   registry's own last answer. Platform admins get **one** bell notification anchored under `Admin`
+   — the same surface `StartupErrorNotifier` uses for a degraded boot — naming the registry and
+   pointing at that ledger.
+2. **The next successful feed read drains it.** Every contact this installation makes with a
+   registry goes through one class, `RegistryPackageSource.ListPackages` — the catalog page, an
+   install, the Store's package count, the boot reconcile itself. That method reports each
+   successful read back to the reconciler, which checks whether that registry is pending at the
+   ref that was read and, if so, **claims** the marker (one compare-and-swap, so two catalog opens
+   in the same second drain it once) and runs the reconcile the boot skipped — from the packages
+   that read already returned, so there is no second round-trip, and off the reader's thread, so
+   the catalog render is never delayed. The ledger entry then records when and how (`feed-read`)
+   the reconcile ran; a drain that faults re-marks the registry pending and says so.
+
+The ledger is the reconciler's in-memory state projected onto a node: the running process is the
+authority, the node is what an admin (or a test) reads. Its writes are serialised through one Rx
+channel (`Subject` + `Concat`), so a drain completing while the boot pass is still recording another
+registry can never land an older snapshot over a newer one — the same shape as every other
+"one at a time" in the codebase, never a lock
+([Removing Hand-Woven Gates](/Doc/Architecture/RemovingHandWovenGates)).
+
+What this deliberately does **not** do: retry on a timer, widen the budget, or add a new caller
+that has to remember to reconcile. The design decision above — no poll, the restart and the
+catalog open are the events — stands; the change is that a catalog open now *is* a reconcile when
+one is owed, which the log line had always claimed and the code had never done.
+
 ## Why a node and not a call
 
 The producer is `MeshWeaver.GitSync` (it owns webhook signature verification, payload parsing and
@@ -195,6 +235,7 @@ install-time seed.
 | A module never updates, and the log says it "has no module content identity" | The module's `manifest.lock` is missing or unparseable, so there is no `ModuleVersion` to compare and "has it changed" is unanswerable. A missing hash is the **absence of evidence**, not evidence of a change: treating it as changed would re-install the module on every green build of the repo *and* on every pod start, which is acting on the event rather than the content. It is refused, loudly, and the catalog card's manual **Update** stays available. Fix the module's CI to emit the sidecar. |
 | Nothing happens on a green build, **and the log says the delivery "matched NONE of the N sync config(s)"** | No `_GitSync` targets that repository — usually because the repository was **renamed** and the configs still store its old name. The matcher falls back to GitHub's canonical `full_name` (which follows the rename redirect) and repoints the config when it finds one, so this line surviving means the lookup could not be made either: the repository is unreachable with the config creator's credential, or the hook really is installed on a repository this mesh does not sync. The Warning names both sides — the incoming repository and everything it was compared against. |
 | Build node updates but no installation reacts | The package is not installed on that instance. A catalog lists far more packages than any instance installs; only packages with an install record are considered. |
+| The boot log says the feed of a registry could not be read after N attempts and was **recorded as PENDING**, and admins got a bell notification pointing at `Plugins/_RegistryReconcileLedger` | The registry stayed unavailable for longer than the boot's retry budget (#2888). Nothing is lost: the ledger entry for that registry reads `Pending: true`, and the reconcile runs on the next successful feed read — open the catalog page (or install anything from that registry) once the registry is back, then check the entry reads `LastReconciledVia: feed-read`. If the registry answers a *definite* refusal (401/403) instead, the entry is pending too, but no catalog open will drain it until the key or grant is fixed — the `LastFault` names which. |
 
 The webhook **never throws** on a write failure: GitHub retries a non-2xx delivery, so an unhandled
 fault would turn one bad write into a delivery storm. Failures are logged and reported as "nothing

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-registry-outage-at-startup-no-longer-freezes-your-updates.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-registry-outage-at-startup-no-longer-freezes-your-updates.md
@@ -1,0 +1,28 @@
+---
+Name: A registry outage at startup no longer freezes your installed packages
+Category: Fix
+Description: When the plugin registry stayed unavailable for longer than an installation's startup retry budget, the installation silently stopped checking its packages for updates until its next restart. The skipped check is now recorded, platform admins are told, and it runs automatically the next time anyone opens the catalog or installs a package.
+Icon: Sparkle
+Order: -20260902
+---
+
+# A registry outage at startup no longer freezes your installed packages
+
+An installation checks its installed packages against the plugin registry when it starts. Since
+the end of August a registry that answers *temporarily unavailable* is asked again a few times
+within that startup window — but a registry that stays down for longer than the window left the
+check undone, and nothing said so: the only trace was one error line in one server log, and the
+installation did not notice package or grant changes again until somebody restarted it.
+
+Two things are different now.
+
+**You are told.** When the startup check gives up on a registry, platform administrators get a
+notification in the bell naming the registry, how many attempts were made and what the registry
+last answered. The check is also recorded as *pending* on a small bookkeeping node in the Plugins
+partition, so the state can be read rather than inferred from a log.
+
+**It catches up by itself — without a timer.** The next time the installation reaches that
+registry for any reason at all — someone opens the plugin catalog, installs a package, or the
+Store counts what is available — the check that was skipped at startup runs from that very
+answer. There is still no background poll behind this, deliberately: the events the installation
+already has are enough, and now they do what the startup log always said they would.

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -271,6 +271,8 @@
   "plugins.discovery.orphaned.body": "{0} wird hier weiterhin synchronisiert, das Plugin-Repository enthält es aber nicht mehr. {1}",
   "plugins.discovery.failed.title": "Modul konnte nicht hinzugefügt werden: {0}",
   "plugins.discovery.failed.body": "Das Einrichten von {0} aus dem Plugin-Repository ist fehlgeschlagen. {1}",
+  "plugins.reconcile.deferred.title": "Plugin-Updates wurden nicht geprüft: {0}",
+  "plugins.reconcile.deferred.body": "Die Plugin-Registry {0} ({1}) war während des gesamten Startfensters dieser Installation nicht erreichbar ({2} Versuche), daher wurden installierte Pakete daraus nicht auf Updates geprüft. Die Prüfung läuft automatisch, sobald diese Installation die Registry das nächste Mal erreicht — etwa wenn jemand den Katalog öffnet oder ein Paket installiert. Letzte Antwort: {3}",
   "settings.whatsNew": "Neuerungen",
   "settings.invitations": "Einladungen",
   "settings.updates": "Updates",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -271,6 +271,8 @@
   "plugins.discovery.orphaned.body": "{0} is still synced here, but the plugin repository no longer ships it. {1}",
   "plugins.discovery.failed.title": "Module could not be added: {0}",
   "plugins.discovery.failed.body": "Setting up {0} from the plugin repository failed. {1}",
+  "plugins.reconcile.deferred.title": "Plugin updates were not checked: {0}",
+  "plugins.reconcile.deferred.body": "The plugin registry {0} ({1}) stayed unavailable for this installation's whole startup window ({2} attempts), so installed packages from it were not checked for updates. The check runs automatically the next time this installation reaches the registry — for example when someone opens the catalog or installs a package. Last answer: {3}",
   "settings.whatsNew": "What's new",
   "settings.invitations": "Invitations",
   "settings.updates": "Updates",

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -262,7 +262,8 @@ public static class PackageInstaller
     /// exist). Idempotent, promise-cached in the providers; providers that need no per-partition
     /// provisioning no-op. Emits exactly once.
     /// </summary>
-    private static IObservable<System.Reactive.Unit> EnsurePartitionsProvisioned(
+    // Internal: RegistryUpdateReconciler writes its ledger into the install-records partition too.
+    internal static IObservable<System.Reactive.Unit> EnsurePartitionsProvisioned(
         IMessageHub hub, params string?[] partitions)
     {
         var providers = hub.ServiceProvider.GetServices<IPartitionStorageProvider>().ToArray();

--- a/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginCatalogConfigurationExtensions.cs
@@ -38,12 +38,15 @@ public static class PluginCatalogConfigurationExtensions
             .AddMeshNodes(CreateSigningKeyNodeType())
             .AddMeshNodes(CreateModuleDiscoveryNodeType())
             .AddMeshNodes(CreateDefaultInstallLedgerNodeType())
+            .AddMeshNodes(CreateRegistryReconcileLedgerNodeType())
             // Infrastructure credential, never pickable content.
             .AddAutocompleteExcludedTypes(PluginRegistryCredentials.NodeType)
             // The registry's token signing key — infrastructure, never pickable content.
             .AddAutocompleteExcludedTypes(SyncTokenSigningKeys.NodeType)
             // Bookkeeping, never pickable content — same reason as the credential above.
             .AddAutocompleteExcludedTypes(InstanceAutoRegistrationService.LedgerNodeType)
+            // The per-registry reconcile state (#2888) — bookkeeping, never pickable content.
+            .AddAutocompleteExcludedTypes(RegistryUpdateReconciler.LedgerNodeType)
             // The build-completion subscriber. A mesh-scoped SINGLETON, so its subscriptions live
             // and die with the mesh rather than surviving disposal into the next test
             // (Doc/Architecture/NoStaticState). The IHostedService registration is what STARTS it —
@@ -206,7 +209,8 @@ public static class PluginCatalogConfigurationExtensions
             .WithType(typeof(PluginRegistryCredential), nameof(PluginRegistryCredential))
             .WithType(typeof(SyncTokenSigningKey), nameof(SyncTokenSigningKey))
             .WithType(typeof(ModuleDiscovery), nameof(ModuleDiscovery))
-            .WithType(typeof(DefaultInstallLedger), nameof(DefaultInstallLedger));
+            .WithType(typeof(DefaultInstallLedger), nameof(DefaultInstallLedger))
+            .WithType(typeof(RegistryReconcileLedger), nameof(RegistryReconcileLedger));
 
     private static MeshNode CreatePackageNodeType() => new(PackageInstaller.PackageNodeType)
     {
@@ -286,6 +290,23 @@ public static class PluginCatalogConfigurationExtensions
             ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
             HubConfiguration = config => config
                 .AddMeshDataSource(s => s.WithContentType<DefaultInstallLedger>()),
+        };
+
+    // The reconcile ledger (#2888): same shape and same two-half registration as the default-install
+    // ledger above — WithType registers the CONTENT type, this registers the NODE type CreateNode
+    // validates against; without it the write dies with "NodeType is not registered" and the
+    // deferred-reconcile record this exists to keep would be silently lost.
+    private static MeshNode CreateRegistryReconcileLedgerNodeType() =>
+        new(RegistryUpdateReconciler.LedgerNodeType)
+        {
+            Name = "Registry Reconcile Ledger",
+            Icon = "/static/NodeTypeIcons/box.svg",
+            // Bookkeeping, not a satellite of anything: a single node in the Plugins partition,
+            // addressed by a fixed path, exactly like the default-install ledger.
+            IsSatelliteType = false,
+            ExcludeFromContext = new HashSet<string> { "search", "create", "content" },
+            HubConfiguration = config => config
+                .AddMeshDataSource(s => s.WithContentType<RegistryReconcileLedger>()),
         };
 
     // Read-only, world-readable policy for the install-records partition — the same shape every

--- a/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
@@ -32,6 +32,7 @@ public sealed class RegistryPackageSource : IPackageSource
     // Immutable shared resource, not a cache, so it does not fall under the no-static-state rule.
     private static readonly HttpClient SharedHttp = new();
 
+    private readonly IMessageHub _hub;
     private readonly string _registryUrl;
     private readonly IIoPool _httpPool;
     private readonly HttpClient _http;
@@ -44,6 +45,7 @@ public sealed class RegistryPackageSource : IPackageSource
     /// empty → unauthenticated (only an open dev/e2e registry answers).</summary>
     public RegistryPackageSource(IMessageHub hub, string registryUrl, string? token = null)
     {
+        _hub = hub;
         _registryUrl = (registryUrl ?? "").TrimEnd('/');
         _token = (token ?? "").Trim();
         _httpPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Http) ?? IoPool.Unbounded;
@@ -90,7 +92,15 @@ public sealed class RegistryPackageSource : IPackageSource
                     $"Registry catalog list failed ({(int)resp.StatusCode}): {json}");
             var parsed = JsonSerializer.Deserialize<ListResponse>(json, Json);
             return (IReadOnlyList<PackageManifest>)(parsed?.Packages ?? []);
-        });
+        })
+        // 🚨 A successful read is the EVENT a deferred boot reconcile waits for (#2888). Every
+        // registry contact this installation makes — a catalog open, an install, the Store's
+        // count, the boot reconcile itself — comes through here, so reporting the read from this
+        // one place is what lets the reconciler drain a registry that was down at boot without a
+        // timer and without every caller having to remember to. A no-op unless that registry is
+        // pending; the reconciler runs off this thread and never delays the read's subscriber.
+        .Do(packages => _hub.ServiceProvider.GetService<RegistryUpdateReconciler>()
+            ?.OnFeedRead(_registryUrl, gitRef, packages));
 
     /// <inheritdoc />
     public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef) =>

--- a/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryPackageSource.cs
@@ -99,8 +99,17 @@ public sealed class RegistryPackageSource : IPackageSource
         // one place is what lets the reconciler drain a registry that was down at boot without a
         // timer and without every caller having to remember to. A no-op unless that registry is
         // pending; the reconciler runs off this thread and never delays the read's subscriber.
-        .Do(packages => _hub.ServiceProvider.GetService<RegistryUpdateReconciler>()
-            ?.OnFeedRead(_registryUrl, gitRef, packages));
+        // Gated on the hub's run level, never wrapped in a catch: once the hub has begun quiescing its
+        // service scope is being torn down and a resolve would throw ObjectDisposedException INTO the
+        // caller's successful read. A read during teardown has no boot reconcile left to drain, so it
+        // simply does not report.
+        .Do(packages =>
+        {
+            if (_hub.RunLevel > MessageHubRunLevel.Started)
+                return;
+            _hub.ServiceProvider.GetService<RegistryUpdateReconciler>()
+                ?.OnFeedRead(_registryUrl, gitRef, packages);
+        });
 
     /// <inheritdoc />
     public IObservable<IReadOnlyList<PackageFile>> FetchPackageFiles(PackageManifest package, string gitRef) =>

--- a/src/MeshWeaver.PluginCatalog/RegistryReconcileLedger.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryReconcileLedger.cs
@@ -1,0 +1,64 @@
+using System.Collections.Immutable;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// What <see cref="RegistryUpdateReconciler"/> knows about each configured registry's reconcile —
+/// stored at <see cref="RegistryUpdateReconciler.LedgerPath"/> so that "the boot reconcile did not
+/// run" is a durable, admin-readable fact instead of one Error line on one pod (Systemorph/MeshWeaver#2888).
+///
+/// <para>A SNAPSHOT per process, rewritten from the reconciler's in-memory state on every change:
+/// each boot re-attempts every configured registry, so an entry always describes the current
+/// process, and a registry removed from configuration drops off on the next boot.</para>
+/// </summary>
+public record RegistryReconcileLedger
+{
+    /// <summary>One entry per configured registry, ordered by URL.</summary>
+    public ImmutableList<RegistryReconcileEntry> Registries { get; init; } =
+        ImmutableList<RegistryReconcileEntry>.Empty;
+
+    /// <summary>When the ledger last changed.</summary>
+    public DateTimeOffset UpdatedAt { get; init; }
+}
+
+/// <summary>The reconcile state of ONE registry as this process sees it.</summary>
+public record RegistryReconcileEntry
+{
+    /// <summary>The reconcile ran as part of this process starting.</summary>
+    public const string ViaBoot = "boot";
+
+    /// <summary>The reconcile the boot skipped ran later, on the first successful feed read this
+    /// installation made for another reason (a catalog open, an install).</summary>
+    public const string ViaFeedRead = "feed-read";
+
+    /// <summary>The registry's base URL (the configured value, trailing slash trimmed).</summary>
+    public string Url { get; init; } = "";
+
+    /// <summary>The registry's display name, or its URL when it has none.</summary>
+    public string Name { get; init; } = "";
+
+    /// <summary>The ref the reconcile reads the feed at.</summary>
+    public string Ref { get; init; } = "HEAD";
+
+    /// <summary>
+    /// 🚨 The boot reconcile against this registry did NOT run and has not run since: the feed read
+    /// exhausted its startup budget. The reconciler drains this on the next successful feed read
+    /// any caller makes against the same registry — there is deliberately no timer behind it.
+    /// </summary>
+    public bool Pending { get; init; }
+
+    /// <summary>When <see cref="Pending"/> was last set.</summary>
+    public DateTimeOffset? PendingSince { get; init; }
+
+    /// <summary>How many feed-read attempts the last failed boot spent.</summary>
+    public int Attempts { get; init; }
+
+    /// <summary>The last fault's message — the registry's own answer when it gave one.</summary>
+    public string? LastFault { get; init; }
+
+    /// <summary>When a reconcile against this registry last completed in this process.</summary>
+    public DateTimeOffset? LastReconciledAt { get; init; }
+
+    /// <summary><see cref="ViaBoot"/> or <see cref="ViaFeedRead"/>.</summary>
+    public string? LastReconciledVia { get; init; }
+}

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -133,7 +133,10 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
     /// snapshot over a newer one. Serialization through Rx, never a lock
     /// (Doc/Architecture/RemovingHandWovenGates).
     /// </summary>
-    private readonly Subject<Unit> ledgerDirty = new();
+    // Synchronized: Mark(...) is reached from the boot pass AND from a feed read on another thread;
+    // a bare Subject<T> does not serialise concurrent OnNext calls (Rx contract), so the producers are
+    // serialised here and the Concat below sees one well-formed sequence.
+    private readonly ISubject<Unit> ledgerDirty = Subject.Synchronize(new Subject<Unit>());
 
     private sealed record TrackedRegistry(PluginRegistryReference Registry, RegistryReconcileEntry Entry);
 
@@ -336,6 +339,12 @@ public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
     /// </summary>
     internal void OnFeedRead(string registryUrl, string gitRef, IReadOnlyList<PackageManifest> packages)
     {
+        // A feed read that lands while this service is tearing down has nothing to drain into: the
+        // subscriptions it would register are being disposed (CompositeDisposable.Add throws once
+        // disposed), and the read itself must still succeed for ITS caller. Gate on the teardown
+        // state — the same shape as every hub watcher — never catch the throw.
+        if (subscriptions.IsDisposed)
+            return;
         var key = Key(registryUrl);
         if (!tracked.TryGetValue(key, out var candidate) || !candidate.Entry.Pending)
             return;

--- a/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
+++ b/src/MeshWeaver.PluginCatalog/RegistryUpdateReconciler.cs
@@ -1,7 +1,12 @@
-﻿using System.Reactive;
+using System.Collections.Immutable;
+using System.Reactive;
 using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Graph;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
@@ -48,6 +53,27 @@ namespace MeshWeaver.PluginCatalog;
 /// Update. An installation that never restarts also never picks up framework fixes, which is a
 /// louder problem with its own alarm.</para>
 ///
+/// <para>🚨 <b>A boot read that fails past its budget is DEFERRED, not dropped
+/// (Systemorph/MeshWeaver#2888).</b> The 2026-08-31 fix taught the boot read to re-ask a transient
+/// answer (503/429/gateway) within a ~26 s budget. That narrowed the failure, and the residual bit
+/// the same day: a registry down for longer than the budget left a pod unreconciled for the rest
+/// of its life, with one Error line on one pod as the only witness — and the line's own "next
+/// chance is a human opening the catalog page" was false, because the catalog page only RENDERS
+/// the feed; it never ran the reconcile. Two things change, and neither is a clock:
+/// <list type="bullet">
+///   <item><b>The skipped reconcile is recorded as PENDING</b> on the node this service owns
+///   (<see cref="LedgerPath"/>, a <see cref="RegistryReconcileLedger"/>), and platform admins get
+///   ONE <c>Admin</c>-anchored bell notification naming the registry, the attempts and the
+///   registry's own last answer — the same surface <see cref="StartupErrorNotifier"/> uses for a
+///   degraded boot.</item>
+///   <item><b>The next successful feed read drains it.</b> Every registry contact this
+///   installation makes goes through <see cref="RegistryPackageSource.ListPackages"/> — a catalog
+///   open, an install, the Store's count — and that method hands each successful read back here
+///   (<see cref="OnFeedRead"/>). A pending registry then gets the reconcile the boot skipped, from
+///   the packages that read already returned: no second read, no timer, no new caller to remember
+///   anything.</item>
+/// </list></para>
+///
 /// <para><b>An installation with no registry keeps working.</b> With no registry configured this
 /// service resolves no registry source and does nothing at all — the git path stays correct for the
 /// registry instance itself, which legitimately reads GitHub and is served by
@@ -62,22 +88,73 @@ namespace MeshWeaver.PluginCatalog;
 /// this one authenticates with. Instance-scoped, so its subscriptions live and die with the mesh.
 /// Reactive throughout.</para>
 /// </summary>
-public sealed class RegistryUpdateReconciler(
-    IMessageHub hub, ILogger<RegistryUpdateReconciler> logger)
-    : IHostedService, IDisposable
+public sealed class RegistryUpdateReconciler : IHostedService, IDisposable
 {
+    private readonly IMessageHub hub;
+    private readonly ILogger<RegistryUpdateReconciler> logger;
     private readonly CompositeDisposable subscriptions = new();
+
+    /// <summary>Id of the ledger node — an underscore-prefixed sibling in the install-records
+    /// partition, exactly like <c>_DefaultInstallLedger</c>.</summary>
+    public const string LedgerId = "_RegistryReconcileLedger";
+
+    /// <summary>The node this service owns: the per-registry reconcile state, see
+    /// <see cref="RegistryReconcileLedger"/>.</summary>
+    public const string LedgerPath = PackageInstaller.InstalledPartition + "/" + LedgerId;
+
+    /// <summary>The ledger's own node type — deliberately distinct from <c>Package</c> so it never
+    /// appears in installed-package enumerations (the <c>_DefaultInstallLedger</c> lesson).</summary>
+    public const string LedgerNodeType = "RegistryReconcileLedger";
 
     /// <summary>
     /// How many times a transport-level failure of the feed read is re-attempted within the boot
-    /// reconcile (see the RetryWhen in <see cref="ReconcileOne"/>). Small on purpose: this bounds a
-    /// cold pod's startup work, and the retries exist to survive a hiccup, not to wait out an outage.
+    /// reconcile (see the RetryWhen in <see cref="ReconcileRegistry"/>). Small on purpose: this
+    /// bounds a cold pod's startup work, and the retries exist to survive a hiccup, not to wait out
+    /// an outage. An outage longer than the budget is DEFERRED (see the type remarks), never waited out.
     /// </summary>
-    private const int FeedReadRetries = 3;
+    internal const int FeedReadRetries = 3;
 
     /// <summary>Exponential-ish backoff between feed-read attempts: 2 s, 6 s, 18 s.</summary>
     private static TimeSpan FeedReadBackoff(int attempt) =>
         TimeSpan.FromSeconds(2 * Math.Pow(3, attempt));
+
+    /// <summary>
+    /// What this process knows about each configured registry, keyed by URL — THE state for the
+    /// running process; the ledger node is its durable projection. Instance-scoped (never static)
+    /// and immutable-swapped, so a claim (<see cref="OnFeedRead"/>) is one compare-and-swap.
+    /// </summary>
+    private ImmutableDictionary<string, TrackedRegistry> tracked =
+        ImmutableDictionary<string, TrackedRegistry>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// The ledger write channel: every state change signals it, and the writes run ONE AT A TIME
+    /// (<c>Concat</c>), each projecting the state as it stands when the write starts — so a drain
+    /// completing while a boot pass is still recording another registry can never land an older
+    /// snapshot over a newer one. Serialization through Rx, never a lock
+    /// (Doc/Architecture/RemovingHandWovenGates).
+    /// </summary>
+    private readonly Subject<Unit> ledgerDirty = new();
+
+    private sealed record TrackedRegistry(PluginRegistryReference Registry, RegistryReconcileEntry Entry);
+
+    /// <summary>Creates the service; the ledger write channel is live from construction so a state
+    /// change is recorded whether it arrives from the boot pass or from a later feed read.</summary>
+    public RegistryUpdateReconciler(IMessageHub hub, ILogger<RegistryUpdateReconciler> logger)
+    {
+        this.hub = hub;
+        this.logger = logger;
+        subscriptions.Add(ledgerDirty
+            .Select(_ => Observable.Defer(WriteLedger)
+                .Catch((Exception ex) =>
+                {
+                    // A ledger write failure must not stop the channel — the NEXT change re-projects
+                    // the whole state, so nothing is lost but this one snapshot.
+                    logger.LogWarning(ex, "[RegistryUpdate] could not write the reconcile ledger at {Path}", LedgerPath);
+                    return Observable.Return(Unit.Default);
+                }))
+            .Concat()
+            .Subscribe(_ => { }, ex => logger.LogWarning(ex, "[RegistryUpdate] the reconcile ledger channel faulted")));
+    }
 
     /// <summary>
     /// Whether a failed feed read is worth re-asking within the boot window.
@@ -166,23 +243,38 @@ public sealed class RegistryUpdateReconciler(
     /// </summary>
     private IObservable<Unit> Reconcile(PluginCatalogOptions options)
     {
-        var tokenResolver = hub.ServiceProvider.GetService<RegistryTokenResolver>();
-        if (tokenResolver is null)
+        if (hub.ServiceProvider.GetService<RegistryTokenResolver>() is null)
             return Observable.Return(Unit.Default);
 
         return RegistryTokenResolver.WithLegacyTokens(options, options.EffectiveRegistries)
-            .Select(registry => ReconcileOne(registry, tokenResolver))
+            .Select(registry => ReconcileRegistry(registry, FeedReadBackoff))
             .ToObservable()
             .Concat()
             .DefaultIfEmpty(Unit.Default)
             .LastAsync();
     }
 
-    private IObservable<Unit> ReconcileOne(
-        PluginRegistryReference registry, RegistryTokenResolver tokenResolver)
+    /// <summary>
+    /// The boot reconcile against ONE registry: read its feed within the retry budget, then
+    /// reconcile the install records against what it serves. Exhausting the budget records the
+    /// registry as pending and notifies admins (see the type remarks) — it never throws, so one
+    /// unreachable registry cannot withhold the others. Emits exactly once.
+    /// </summary>
+    /// <param name="registry">The registry to reconcile against.</param>
+    /// <param name="backoff">The pause before re-asking attempt <c>n</c> (0-based) — production
+    /// passes <see cref="FeedReadBackoff"/>; a test hands in zero so the exhausted budget is
+    /// reached in milliseconds instead of ~26 s.</param>
+    internal IObservable<Unit> ReconcileRegistry(PluginRegistryReference registry, Func<int, TimeSpan> backoff)
     {
-        var name = string.IsNullOrWhiteSpace(registry.Name) ? registry.Url : registry.Name;
-        var gitRef = string.IsNullOrWhiteSpace(registry.Ref) ? "HEAD" : registry.Ref;
+        var tokenResolver = hub.ServiceProvider.GetService<RegistryTokenResolver>();
+        if (tokenResolver is null)
+            return Observable.Return(Unit.Default);
+
+        var name = DisplayName(registry);
+        var gitRef = EffectiveRef(registry.Ref);
+        // Every configured registry appears on the ledger from the moment it is attempted, so an
+        // admin can tell "not configured" from "configured, never answered".
+        Mark(registry, entry => entry);
 
         return tokenResolver.ResolveToken(registry)
             .Take(1)
@@ -211,50 +303,240 @@ public sealed class RegistryUpdateReconciler(
                     //
                     // So this is a bounded retry INSIDE the boot attempt, not a clock. It does not
                     // widen any bound and it adds no background load. What it retries is decided by
-                    // ShouldRetryFeedRead below — a DEFINITE refusal is not re-asked, because a
-                    // registry that refuses this instance's key will refuse it again in two seconds,
-                    // and burning the boot window on that would only delay the log line naming it.
+                    // ShouldRetryFeedRead — a DEFINITE refusal is not re-asked, because a registry
+                    // that refuses this instance's key will refuse it again in two seconds, and
+                    // burning the boot window on that would only delay the log line naming it.
+                    // Past the budget the read is NOT abandoned either: the exhaustion is typed so
+                    // the Catch below can record how many attempts were spent and DEFER (#2888).
                     .RetryWhen(faults => faults
                         .Select((fault, attempt) => (fault, attempt))
                         .SelectMany(f => ShouldRetryFeedRead(f.fault) && f.attempt < FeedReadRetries
-                            ? Observable.Timer(FeedReadBackoff(f.attempt)).Select(_ => Unit.Default)
+                            ? Observable.Timer(backoff(f.attempt)).Select(_ => Unit.Default)
                                 .Do(_ => logger.LogWarning(f.fault,
-                                    "[RegistryUpdate] reading {Url} failed (attempt {Attempt}/{Total}) — retrying; "
-                                    + "this boot is the only chance this installation gets to reconcile.",
+                                    "[RegistryUpdate] reading {Url} failed (attempt {Attempt}/{Total}) — retrying "
+                                    + "within the boot budget.",
                                     registry.Url, f.attempt + 1, FeedReadRetries + 1))
-                            : Observable.Throw<Unit>(f.fault)))
+                            : Observable.Throw<Unit>(new FeedReadExhaustedException(f.fault, f.attempt + 1))))
                     .Take(1)
-                    .SelectMany(packages =>
-                    {
-                        logger.LogInformation(
-                            "[RegistryUpdate] {Name} serves {Count} package(s) at {Ref} — "
-                            + "reconciling this installation's records against them.",
-                            name, packages.Count, gitRef);
-                        return PackageUpdateReconciler.ReconcileInstalled(
-                                hub, source, gitRef, packages,
-                                $"Served by registry '{name}'", logger)
-                            // The MODULE lane of the same reconcile (#1664): for installed
-                            // packages that declare a compiled module, consult the registry's
-                            // bundle index and land what is newer FOR THE RUNNING framework.
-                            // AFTER the content reconcile, so a content update and its module
-                            // land in one pass; keyed on the bundle index, NOT the content
-                            // hash — a bundle rebuilt for a new framework MVID has unchanged
-                            // content, and this lane is what heals it after an image roll.
-                            .SelectMany(_ => ReconcileModules(bundles, name, packages));
-                    });
+                    .SelectMany(packages => ReconcileFromFeed(
+                        registry, name, gitRef, source, bundles, packages, RegistryReconcileEntry.ViaBoot));
             })
+            .Catch((Exception ex) => Defer(registry, name, ex));
+    }
+
+    /// <summary>
+    /// A successful feed read happened somewhere in this process — the event a deferred reconcile
+    /// waits for. Called by <see cref="RegistryPackageSource.ListPackages"/> for EVERY successful
+    /// read, whoever subscribed it; a no-op unless <paramref name="registryUrl"/> is a configured
+    /// registry whose boot reconcile is pending at the ref the caller read. The pending marker is
+    /// CLAIMED with one compare-and-swap, so two catalog opens in the same second drain it once.
+    /// The reconcile then runs from <paramref name="packages"/> — the read that just happened —
+    /// with no second round-trip, off the caller's thread, and re-marks the registry pending if it
+    /// faults, so nothing is ever silently dropped.
+    /// </summary>
+    internal void OnFeedRead(string registryUrl, string gitRef, IReadOnlyList<PackageManifest> packages)
+    {
+        var key = Key(registryUrl);
+        if (!tracked.TryGetValue(key, out var candidate) || !candidate.Entry.Pending)
+            return;
+        var readRef = EffectiveRef(gitRef);
+        if (!string.Equals(readRef, EffectiveRef(candidate.Registry.Ref), StringComparison.Ordinal))
+        {
+            logger.LogDebug(
+                "[RegistryUpdate] {Name} answered a feed read at {ReadRef}, but its reconcile is pending at "
+                + "{Ref} — leaving it pending.", candidate.Entry.Name, readRef, candidate.Registry.Ref);
+            return;
+        }
+        var tokenResolver = hub.ServiceProvider.GetService<RegistryTokenResolver>();
+        if (tokenResolver is null)
+            return;
+
+        // The claim: only the writer that swaps the marker out runs the drain.
+        var claimed = candidate with { Entry = candidate.Entry with { Pending = false } };
+        if (!ImmutableInterlocked.TryUpdate(ref tracked, key, claimed, candidate))
+            return;
+
+        var registry = candidate.Registry;
+        var name = candidate.Entry.Name;
+        logger.LogInformation(
+            "[RegistryUpdate] {Name} ({Url}) answered a feed read — running the reconcile this boot "
+            + "could not ({Count} package(s) served at {Ref}).",
+            name, registry.Url, packages.Count, readRef);
+
+        subscriptions.Add(tokenResolver.ResolveToken(registry)
+            .Take(1)
+            .SelectMany(token =>
+            {
+                var bundles = new PluginBundleClient(hub, registry.Url, token);
+                var source = new RegistryPackageSource(hub, registry.Url, token) { Bundles = bundles };
+                return ReconcileFromFeed(
+                    registry, name, readRef, source, bundles, packages, RegistryReconcileEntry.ViaFeedRead);
+            })
+            // Off the reading caller's thread: that is an IO-pool continuation (a catalog render, an
+            // install) and the reconcile is a partition's worth of writes.
+            .SubscribeOn(TaskPoolScheduler.Default)
+            .Subscribe(
+                _ => { },
+                ex =>
+                {
+                    logger.LogError(ex,
+                        "[RegistryUpdate] the deferred reconcile against {Name} ({Url}) failed — it stays "
+                        + "pending and the next successful feed read re-runs it.", name, registry.Url);
+                    Mark(registry, entry => entry with
+                    {
+                        Pending = true,
+                        PendingSince = DateTimeOffset.UtcNow,
+                        LastFault = ex.Message,
+                    });
+                }));
+    }
+
+    /// <summary>The reconcile proper — the content lane, then the module lane — followed by the
+    /// ledger entry recording that it completed and how it was reached.</summary>
+    private IObservable<Unit> ReconcileFromFeed(
+        PluginRegistryReference registry,
+        string name,
+        string gitRef,
+        RegistryPackageSource source,
+        PluginBundleClient bundles,
+        IReadOnlyList<PackageManifest> packages,
+        string via)
+    {
+        logger.LogInformation(
+            "[RegistryUpdate] {Name} serves {Count} package(s) at {Ref} — reconciling this installation's "
+            + "records against them ({Via}).",
+            name, packages.Count, gitRef, via);
+        return PackageUpdateReconciler.ReconcileInstalled(
+                hub, source, gitRef, packages, $"Served by registry '{name}'", logger)
+            // The MODULE lane of the same reconcile (#1664): for installed packages that declare a
+            // compiled module, consult the registry's bundle index and land what is newer FOR THE
+            // RUNNING framework. AFTER the content reconcile, so a content update and its module
+            // land in one pass; keyed on the bundle index, NOT the content hash — a bundle rebuilt
+            // for a new framework MVID has unchanged content, and this lane is what heals it after
+            // an image roll.
+            .SelectMany(_ => ReconcileModules(bundles, name, packages))
+            .Do(_ => Mark(registry, entry => entry with
+            {
+                Pending = false,
+                PendingSince = null,
+                LastFault = null,
+                LastReconciledAt = DateTimeOffset.UtcNow,
+                LastReconciledVia = via,
+            }));
+    }
+
+    /// <summary>
+    /// The boot read is over and the reconcile did not run: record it as pending on the ledger and
+    /// tell platform admins — ONE bell notification anchored under <c>Admin</c> (RLS scopes it to
+    /// them), the same surface a degraded boot uses. Emits once; never throws.
+    /// </summary>
+    private IObservable<Unit> Defer(PluginRegistryReference registry, string name, Exception fault)
+    {
+        var attempts = fault is FeedReadExhaustedException exhausted ? exhausted.Attempts : 1;
+        var cause = fault is FeedReadExhaustedException { InnerException: { } inner } ? inner : fault;
+        logger.LogError(cause,
+            "[RegistryUpdate] could not read the package feed of {Name} ({Url}) after {Attempts} attempt(s) "
+            + "— installed packages from it are NOT reconciled this boot. Recorded as PENDING on {Ledger}; "
+            + "the next successful feed read against this registry (a catalog open, an install) runs "
+            + "the reconcile. Platform admins have been notified.",
+            name, registry.Url, attempts, LedgerPath);
+
+        Mark(registry, entry => entry with
+        {
+            Pending = true,
+            PendingSince = DateTimeOffset.UtcNow,
+            Attempts = attempts,
+            LastFault = cause.Message,
+        });
+
+        var access = hub.ServiceProvider.GetService<AccessService>();
+        return NotificationService.Dispatch(
+                hub,
+                recipient: null,
+                mainNodePath: StartupErrorNotifier.AdminPartition,
+                title: access.Localize("plugins.reconcile.deferred.title", name),
+                message: access.Localize("plugins.reconcile.deferred.body", name, registry.Url, attempts, cause.Message),
+                type: NotificationType.System,
+                targetNodePath: LedgerPath,
+                createdBy: "system")
             .Catch((Exception ex) =>
             {
-                // One unreachable registry must not withhold the others, and must never be silent:
-                // "the store is empty and nobody said why" is the exact failure this issue began as.
-                logger.LogError(ex,
-                    "[RegistryUpdate] could not read the package feed of {Name} ({Url}) after up to "
-                    + "{Attempts} attempt(s) — installed packages from it are NOT reconciled this "
-                    + "boot, and there is no poll behind this: the next chance is the next restart "
-                    + "or a human opening the catalog page.",
-                    name, registry.Url, FeedReadRetries + 1);
+                logger.LogWarning(ex,
+                    "[RegistryUpdate] raising the admin notification for the deferred reconcile of {Name} failed.",
+                    name);
                 return Observable.Return(Unit.Default);
-            });
+            })
+            .DefaultIfEmpty(Unit.Default)
+            .LastAsync();
+    }
+
+    /// <summary>Applies <paramref name="mutate"/> to the registry's entry (creating it on first sight)
+    /// and signals the ledger channel.</summary>
+    private void Mark(PluginRegistryReference registry, Func<RegistryReconcileEntry, RegistryReconcileEntry> mutate)
+    {
+        var key = Key(registry.Url);
+        ImmutableInterlocked.AddOrUpdate(
+            ref tracked,
+            key,
+            _ => new TrackedRegistry(registry, mutate(new RegistryReconcileEntry
+            {
+                Url = key,
+                Name = DisplayName(registry),
+                Ref = EffectiveRef(registry.Ref),
+            })),
+            (_, current) => current with { Entry = mutate(current.Entry) });
+        if (!subscriptions.IsDisposed)
+            ledgerDirty.OnNext(Unit.Default);
+    }
+
+    /// <summary>Projects the in-memory state onto the ledger node — a full snapshot, written as
+    /// System (the install-records partition is System-owned), after making sure that partition is
+    /// provisioned, because a consumer can be configured with a registry before anything from it
+    /// is installed.</summary>
+    private IObservable<Unit> WriteLedger()
+    {
+        var snapshot = tracked;
+        var meshService = hub.ServiceProvider.GetService<IMeshService>();
+        if (meshService is null)
+            return Observable.Return(Unit.Default);
+        var access = hub.ServiceProvider.GetService<AccessService>();
+
+        // Satellite(): MainNode = the Plugins partition root, not the ledger's own path (#2383) —
+        // bookkeeping that points at itself IS a main node by the catalog's definition and would be
+        // listed as partition CONTENT and put in mesh-wide search.
+        var node = MeshNode.Satellite(LedgerId, PackageInstaller.InstalledPartition) with
+        {
+            Name = "Registry reconcile ledger",
+            NodeType = LedgerNodeType,
+            State = MeshNodeState.Active,
+            Content = new RegistryReconcileLedger
+            {
+                Registries = snapshot.Values
+                    .Select(t => t.Entry)
+                    .OrderBy(e => e.Url, StringComparer.OrdinalIgnoreCase)
+                    .ToImmutableList(),
+                UpdatedAt = DateTimeOffset.UtcNow,
+            },
+        };
+        return access.RunAsSystem(() => PackageInstaller
+            .EnsurePartitionsProvisioned(hub, PackageInstaller.InstalledPartition)
+            .SelectMany(_ => meshService.CreateOrUpdateNode(node))
+            .Select(_ => Unit.Default));
+    }
+
+    private static string Key(string? url) => (url ?? "").Trim().TrimEnd('/');
+
+    private static string EffectiveRef(string? gitRef) => string.IsNullOrWhiteSpace(gitRef) ? "HEAD" : gitRef;
+
+    private static string DisplayName(PluginRegistryReference registry) =>
+        string.IsNullOrWhiteSpace(registry.Name) ? Key(registry.Url) : registry.Name;
+
+    /// <summary>The feed read spent its whole budget (or met a definite refusal) — carries the last
+    /// fault and how many attempts were made, so the deferral can record both.</summary>
+    private sealed class FeedReadExhaustedException(Exception cause, int attempts)
+        : Exception(cause.Message, cause)
+    {
+        public int Attempts { get; } = attempts;
     }
 
     /// <summary>The most one package's module adopt may take before the reconcile moves on —

--- a/test/Memex.Portal.Shared.Test/RegistryReconcileDeferralTest.cs
+++ b/test/Memex.Portal.Shared.Test/RegistryReconcileDeferralTest.cs
@@ -1,0 +1,229 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Reactive.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using MeshWeaver.PluginCatalog;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>A registry down for longer than the boot budget must DEFER the reconcile, not drop it
+/// (Systemorph/MeshWeaver#2888).</b>
+///
+/// <para>The 2026-08-31 fix taught <see cref="RegistryUpdateReconciler"/> to re-ask a 503 within
+/// its startup budget. The same day a registry stayed down past that budget and the pod gave up
+/// with one Error line — no durable record, no notification, and no path that would ever run the
+/// skipped reconcile short of a restart (the log line's "a human opening the catalog page" only
+/// RENDERS the feed). This fixture pins the two halves that close that gap, against the REAL
+/// reconciler, the REAL <see cref="RegistryPackageSource"/> HTTP path and a registry that answers
+/// exactly as the incident's did:</para>
+/// <list type="number">
+///   <item>Exhausting the budget records the registry as <see cref="RegistryReconcileEntry.Pending"/>
+///   on the ledger node the reconciler owns and raises ONE <c>Admin</c>-anchored notification
+///   naming the registry and its last answer.</item>
+///   <item>The next successful feed read — made through the same class every catalog surface
+///   uses, with no involvement from the reconciler's caller — drains the marker: the reconcile
+///   runs from THAT read's packages (no second round-trip), the ledger clears, and the
+///   installation's outdated package gets its "Update available" reminder.</item>
+/// </list>
+/// </summary>
+public class RegistryReconcileDeferralTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string RegistryUrl = "http://registry.reconcile.test";
+    private const string RegistryName = "Reconcile Test Registry";
+    private const string PackageId = "ReconcileDeferralPkg";
+    private const string InstalledModuleVersion = "mv-installed-7c1";
+    private const string ServedModuleVersion = "mv-served-9e4";
+    private const string Token = "mwi_reconcile_deferral_test";
+
+    private readonly FakeRegistry registry = new();
+
+    private System.Text.Json.JsonSerializerOptions Json => Mesh.JsonSerializerOptions;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddPluginCatalog()
+            // The registry, as RegistryPackageSource reaches it: through the named HttpClient the
+            // catalog wires. Nothing between the reconciler and the wire is replaced.
+            .ConfigureServices(s => s.AddSingleton<IHttpClientFactory>(new FakeRegistryClientFactory(registry)));
+
+    [Fact]
+    public async Task RegistryDownPastTheBudget_DefersTheReconcile_AndTheNextFeedReadDrainsIt()
+    {
+        await SeedInstallRecord();
+        registry.Serve(HttpStatusCode.ServiceUnavailable, []);
+
+        var reconciler = Mesh.ServiceProvider.GetRequiredService<RegistryUpdateReconciler>();
+        var reference = new PluginRegistryReference { Name = RegistryName, Url = RegistryUrl, Token = Token };
+
+        // ── 1. The boot reconcile, against a registry that 503s for the whole budget ────────────
+        // Zero backoff: the budget is exhausted in milliseconds instead of ~26 s; the ATTEMPT count
+        // below proves every retry in it was spent before the reconciler deferred.
+        await reconciler.ReconcileRegistry(reference, _ => TimeSpan.Zero).Timeout(TestTimeouts.Convergence);
+        // The whole boot budget is spent before the reconcile is deferred.
+        Assert.Equal(RegistryUpdateReconciler.FeedReadRetries + 1, registry.Attempts);
+
+        // ── 2a. The skipped reconcile is a durable fact on the node the reconciler owns ─────────
+        var pending = await LedgerEntries()
+            .Where(entries => entries.Any(e => e.Url == RegistryUrl && e.Pending))
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        var deferred = pending.Single(e => e.Url == RegistryUrl);
+        Assert.Equal(RegistryName, deferred.Name);
+        Assert.Equal(RegistryUpdateReconciler.FeedReadRetries + 1, deferred.Attempts);
+        Assert.Contains("503", deferred.LastFault);
+        Assert.NotNull(deferred.PendingSince);
+        Assert.Null(deferred.LastReconciledAt);
+
+        // ── 2b. Platform admins were told — ONE Admin-anchored bell pointing at the ledger ──────
+        var notifications = await AdminNotifications()
+            .Where(ns => ns.Any(n => n.TargetNodePath == RegistryUpdateReconciler.LedgerPath))
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        var notification = notifications.Single(n => n.TargetNodePath == RegistryUpdateReconciler.LedgerPath);
+        Assert.Equal(NotificationType.System, notification.NotificationType);
+        Assert.Contains(RegistryName, notification.Title);
+        Assert.Contains(RegistryUrl, notification.Message);
+        Assert.Contains("503", notification.Message);
+        Assert.False(notification.IsRead);
+
+        // ── 3. The registry recovers and somebody opens the catalog ─────────────────────────────
+        // A plain feed read through the class every catalog surface uses — the reconciler is not
+        // told anything by this caller. The served package carries a NEWER module version than the
+        // install record, so a reconcile that actually runs has something observable to do.
+        registry.Serve(HttpStatusCode.OK, [ServedManifest()]);
+        var served = await new RegistryPackageSource(Mesh, RegistryUrl, Token)
+            .ListPackages("HEAD").FirstAsync().Timeout(TestTimeouts.Convergence);
+        Assert.Single(served, p => p.Id == PackageId);
+
+        // ── 4. Drained: the ledger clears, and the reconcile ran ────────────────────────────────
+        var drained = await LedgerEntries()
+            .Where(entries => entries.Any(e => e.Url == RegistryUrl && !e.Pending && e.LastReconciledAt is not null))
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        Assert.Equal(RegistryReconcileEntry.ViaFeedRead, drained.Single(e => e.Url == RegistryUrl).LastReconciledVia);
+
+        // The reconcile's own witness: the install record opted OUT of unattended updates, so a
+        // changed module raises the "Update available" reminder on it — carrying the provenance
+        // that names THIS registry.
+        var reminder = await Mesh.GetWorkspace()
+            .GetQuery("notif|pkg|reconcile",
+                $"path:{PackageInstaller.InstalledPartition}/{PackageId}/_Notification scope:children nodeType:Notification")
+            .Select(ns => (ns ?? [])
+                .Select(n => n.ContentAs<Notification>(Json))
+                .FirstOrDefault(n => n?.Title.StartsWith("Update available", StringComparison.Ordinal) == true))
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(TestTimeouts.Convergence);
+        Assert.Contains($"Served by registry '{RegistryName}'", reminder!.Message);
+
+        // The drain reconciled from the packages the catalog read returned: the boot's attempts
+        // plus that ONE read, and not a single extra round-trip to the registry.
+        // The deferred reconcile must run from the read that drained it, never re-read the feed.
+        Assert.Equal(RegistryUpdateReconciler.FeedReadRetries + 2, registry.Attempts);
+    }
+
+    private async Task SeedInstallRecord()
+    {
+        var manifest = new PackageManifest
+        {
+            Id = PackageId,
+            Name = "Reconcile Deferral Package",
+            Version = "1.0.0",
+            ModuleVersion = InstalledModuleVersion,
+            TargetPartition = PackageId,
+            AutoUpdate = false,
+        };
+        var record = MeshNode.FromPath($"{PackageInstaller.InstalledPartition}/{PackageId}") with
+        {
+            NodeType = PackageInstaller.PackageNodeType,
+            Name = manifest.Name,
+            State = MeshNodeState.Active,
+            Content = manifest,
+        };
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        await access.RunAsSystem(() => NodeFactory.CreateOrUpdateNode(record))
+            .Timeout(TestTimeouts.Convergence);
+    }
+
+    private static PackageManifest ServedManifest() => new()
+    {
+        Id = PackageId,
+        Name = "Reconcile Deferral Package",
+        Version = "1.0.1",
+        ModuleVersion = ServedModuleVersion,
+        TargetPartition = PackageId,
+    };
+
+    // The ledger, read LIVE through a children query (a query never storms on a node that does not
+    // exist yet, and it re-emits on every write), flattened to its registry entries.
+    private IObservable<IReadOnlyList<RegistryReconcileEntry>> LedgerEntries() =>
+        Mesh.GetWorkspace()
+            .GetQuery("ledger|reconcile",
+                $"path:{PackageInstaller.InstalledPartition} scope:children nodeType:{RegistryUpdateReconciler.LedgerNodeType}")
+            .Select(ns => (IReadOnlyList<RegistryReconcileEntry>)(ns ?? [])
+                .Select(n => n.ContentAs<RegistryReconcileLedger>(Json))
+                .Where(l => l is not null)
+                .SelectMany(l => l!.Registries)
+                .ToList());
+
+    private IObservable<IReadOnlyList<Notification>> AdminNotifications() =>
+        Mesh.GetWorkspace()
+            .GetQuery("notif|Admin|reconcile",
+                $"path:{StartupErrorNotifier.AdminPartition}/_Notification scope:children nodeType:Notification")
+            .Select(ns => (IReadOnlyList<Notification>)(ns ?? [])
+                .Select(n => n.ContentAs<Notification>(Json))
+                .Where(n => n is not null)
+                .Select(n => n!)
+                .ToList());
+
+    /// <summary>
+    /// The registry as the incident saw it: every request answered with the status the test set —
+    /// a 503 whose body names instance-key resolution as temporarily unavailable, exactly the
+    /// answer memex got on 2026-08-31 — or, once recovered, the real list payload. Counts attempts.
+    /// </summary>
+    private sealed class FakeRegistry : HttpMessageHandler
+    {
+        private volatile HttpStatusCode status = HttpStatusCode.ServiceUnavailable;
+        private volatile string body = "";
+        private int attempts;
+
+        public int Attempts => Volatile.Read(ref attempts);
+
+        public void Serve(HttpStatusCode code, IReadOnlyList<PackageManifest> packages)
+        {
+            // Body before status: a reader that sees the new status sees the body it belongs to.
+            body = PluginRegistryPayloads.List(packages);
+            status = code;
+        }
+
+        // HttpMessageHandler's contract is Task-shaped; nothing here bridges an observable.
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            Interlocked.Increment(ref attempts);
+            var current = status;
+            var content = current == HttpStatusCode.OK
+                ? body
+                : "{\"error\":\"Instance-key resolution is temporarily unavailable — retry shortly. This is NOT a statement about your key or your grant.\"}";
+            return Task.FromResult(new HttpResponseMessage(current)
+            {
+                Content = new StringContent(content, Encoding.UTF8, "application/json"),
+            });
+        }
+    }
+
+    private sealed class FakeRegistryClientFactory(HttpMessageHandler handler) : IHttpClientFactory
+    {
+        public HttpClient CreateClient(string name) => new(handler, disposeHandler: false);
+    }
+}


### PR DESCRIPTION
Fixes #2888.

## Root cause

`RegistryUpdateReconciler.ReconcileOne`'s terminal `Catch` absorbed an exhausted feed-read budget into one `LogError` and returned `Unit` — no durable record, no notification, and no path that would ever run the skipped reconcile short of a restart. The log line's own claim ("the next chance is … a human opening the catalog page") was false: `CatalogLayoutAreas.ObserveAvailable` only *renders* `ListPackages`; nothing on that page runs `PackageUpdateReconciler`. So an outage longer than the ~26 s budget (memex, 2026-08-31 06:26Z, four 503s) silently froze package/grant reconciliation for the pod's lifetime.

## Change (no timer, no widened budget)

- **Pending marker on the node the reconciler owns**: `Plugins/_RegistryReconcileLedger` (`RegistryReconcileLedger`, one `RegistryReconcileEntry` per configured registry — `Pending`, `PendingSince`, `Attempts`, `LastFault`, `LastReconciledAt/Via`). In-memory state is the authority for the running process; the node is its projection, written as System through one `Subject`+`Concat` channel (serialised, never a lock).
- **Admin signal**: on exhaustion, ONE `Admin`-anchored bell via `NotificationService.Dispatch` (the `StartupErrorNotifier` surface), targeting the ledger; localized (`plugins.reconcile.deferred.*`, en+de).
- **Drain on the next existing contact**: `RegistryPackageSource.ListPackages` — the one class every registry contact goes through (catalog, install, Store count, boot) — reports each successful read to `RegistryUpdateReconciler.OnFeedRead`. A pending registry at the read's ref is claimed with one `ImmutableInterlocked.TryUpdate` and reconciled from *that read's packages* (no second round-trip), off the reader's thread; a faulting drain re-marks pending.
- `PackageInstaller.EnsurePartitionsProvisioned` → `internal` (ledger write provisions `Plugins` first).
- Doc: `PluginUpdateOnGreenBuild.md` (new subsection + failure-modes row). What's New: Fix.

## Verification

| Check | Result |
|---|---|
| `dotnet build test/Memex.Portal.Shared.Test -c Release -warnaserror` | `0 Error(s)` |
| `RegistryReconcileDeferralTest` (real reconciler, real `RegistryPackageSource` over a 503-then-200 fake registry; zero backoff): 4 attempts → ledger `Pending` + Admin notification → one `ListPackages("HEAD")` → ledger `feed-read` + "Update available" reminder; attempts = 5 (drain did not re-read) | Passed (1/1, fresh trx) |
| `MeshWeaver.Documentation.Test` full run (link integrity, What's New integrity, ratchet guards) | 187/187 passed |
| `LocalizationTest` (Messaging.Hub.Test) | 58/58 passed |

## Follow-up (other repo)

- `MeshWeaver.Plugins/clients/react/src/i18n/strings.{en,de}.json` mirror needs the two new keys when its core pin advances (mirror guard compares against the pinned core; core merges first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
