### PR TITLE
fix: an update validator sees the existing node typed like the proposed one (#3056 fallout)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/UpdateValidatorsSeeTypedContent.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UpdateValidatorsSeeTypedContent.md
@@ -1,0 +1,66 @@
+---
+Name: Update Validators See Typed Content
+Category: Architecture
+Description: An update validator compares the existing node with the proposed one, so the pipeline owes it both sides typed alike. How a hub used to learn content types by accident, how #3056 removed that accident, and why the update pipeline now types the existing snapshot off the proposal's own CLR type.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"/><path d="m9 12 2 2 4-4"/></svg>
+---
+
+# Update Validators See Typed Content
+
+**An `INodeValidator` for `Update` compares `context.ExistingNode` with `context.Node`. The
+pipeline that calls it — `NodeUpdatePipeline` behind `IMeshService.UpdateNode` — owes it BOTH
+sides with content of the same CLR type.** A validator that finds a `JsonElement` on one side and a
+typed record on the other skips its own comparison and answers Valid, and a write that should have
+been refused lands with nothing logged as an error. This page records how that happened once, and
+where the guarantee now lives.
+
+## How a hub learned content types by accident
+
+Every hub carries a `TypeRegistry` behind its `JsonSerializerOptions`; `$type` discriminators are
+resolved against it. The documented way to teach a hub a content type is `WithType(typeof(T), …)`.
+There was, until 2026-09-02, a second, undocumented way: `MessageService.Post` rendered every
+delivery through the logging options — eagerly, as a method argument, whether or not Debug logging
+was on — and `ObjectPolymorphicConverter.Write` calls `typeRegistry.GetOrAddType(valueType)` for
+every value it serialises. So a hub that merely handed a typed instance to `CreateNode` had, by the
+time the request left, registered that instance's type in its own registry. Reading the node back
+on the same hub then re-typed it. Nothing declared that dependency; everything that did not call
+`WithType` relied on it.
+
+Core #3056 removed the eager render (it was the allocation that threw `OutOfMemoryException` on a
+production pod), and with it the accidental registration. The very next Plugins run against core
+`main` failed `NodeOperationsWithUpdateValidatorTest.UpdateNode_VersionDowngrade_ShouldFail`: the
+test hub never registered `UpdatableContent`, `MeshNodeStreamCache.GetStream` logged
+`Content for … stayed an untyped JsonElement after deserialization`, the validator's
+`ExistingNode.Content is UpdatableContent` was false, and the downgrade went through. The bisect is
+exact — `804b9beca` (#3059) passes, `3d6faa284` (#3056) fails — and the warning line is the
+mechanism, not a guess.
+
+## Where the guarantee lives now
+
+`NodeUpdatePipeline` reads the existing node through the stream cache (typed with the running hub's
+options) and, before building the `NodeValidationContext`, types its content **like the proposal**:
+the proposed node carries a live CLR instance of exactly the type the existing content must have
+(same node, same NodeType), and the hub running the validators demonstrably holds that type. The
+degraded snapshot is deserialised as `node.Content.GetType()` through the runtime-`Type` overload
+of `As` (`ObjectAsExtensions.As(object, Type, options, …)`) — a concrete-type deserialisation, which
+needs no registry entry for the discriminator. It is the same recovery `ContentAs<T>` performs at a
+consumer, done once for every validator instead of being each one's problem.
+
+A snapshot that will not deserialise as the proposal's type is left as it was and logged at Error by
+`As`: hiding a shape mismatch from the validators would be a second silent pass.
+
+`UpdateValidatorSeesTypedExistingContentTest` (MeshWeaver.Graph.Test) pins the contract with a
+content type registered on no hub, records the CLR type the validator actually saw, and asserts the
+refusal. It exists in core because the test that found the hole runs only in MeshWeaver.Plugins —
+the cross-repo blind spot that let #3056 merge green.
+
+## What this does not change
+
+- A validator should still read payloads through `.As<T>()` / `.ContentAs<T>()` rather than a cast
+  (see [CQRS and content access](../CqrsAndContentAccess)); the pipeline guarantee makes the fleet's
+  existing validators safe, it does not make the cast idiom right.
+- A test fixture that posts a custom content type should still register it with `WithType` on the
+  hub that reads it back. The Plugins fixture above does not, and should.
+- No registry is mutated on the read path. `As` deliberately deserialises to the concrete type
+  without adopting it, so a same-named type from another collectible assembly cannot poison the
+  running hub's `$type` resolution.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-rejected-update-is-refused-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-rejected-update-is-refused-again.md
@@ -1,0 +1,21 @@
+---
+Name: A rejected update is refused again
+Category: Fix
+Description: An update that a validation rule should have refused — a version going backwards, for instance — could briefly go through with no error anywhere, because the rule was shown the current content in an unreadable form and stepped aside. Rules now see the current content the same way they see the proposed one.
+Icon: ShieldCheckmark
+Order: -20260902
+---
+
+# A rejected update is refused again
+
+Some node types carry rules about how they may change: a version may not go backwards, a name may
+not be emptied, a reference may not point at nothing. Those rules compare what a node currently
+holds with what an update proposes, and refuse when the two do not fit together.
+
+For a short window on 2 September 2026 a rule could be shown the node's current content in a raw,
+unreadable form while the proposed content arrived readable. A rule that compares the two found
+nothing to compare, stepped aside, and the update landed — no error, no warning where a person
+would see it. The rule was fine; what it was handed was not.
+
+Updates now always present the current content to the rules in the same readable form as the
+proposed content, so a refusal is a refusal again. Nothing changes for updates the rules accept.

--- a/src/MeshWeaver.Hosting/NodeUpdatePipeline.cs
+++ b/src/MeshWeaver.Hosting/NodeUpdatePipeline.cs
@@ -2,11 +2,14 @@ using System;
 using System.Linq;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Hosting;
 
@@ -119,6 +122,41 @@ internal static class NodeUpdatePipeline
                     return candidate with { LastModified = DateTimeOffset.UtcNow };
                 }));
 
+    // 🚨 A VALIDATOR COMPARES THE EXISTING NODE WITH THE PROPOSED ONE, SO BOTH MUST BE TYPED
+    // ALIKE — and the pipeline, not the validator, owes it that (#3056 fallout, found by the
+    // Plugins UpdateNode_VersionDowngrade_ShouldFail test on 2026-09-02).
+    //
+    // `existing` arrives through MeshNodeStreamCache.GetStream, which re-types the cache's raw
+    // JSON with THIS hub's registry — and a content type this hub never registered stays a
+    // JsonElement there. Until #3056, every hub registered every type it ever posted as a SIDE
+    // EFFECT: MessageService.Post rendered each delivery through the logging options eagerly
+    // (the argument was built before the LogDebug call), and ObjectPolymorphicConverter.Write
+    // calls typeRegistry.GetOrAddType for each value it meets. A hub that had merely handed a
+    // typed instance to CreateNode therefore "knew" the type when it read the node back. #3056
+    // removed that render (it was the OOM), and with it the accidental registration — so a
+    // validator written as `context.ExistingNode.Content is Versioned e && context.Node.Content
+    // is Versioned p && p.Version < e.Version` now sees a JsonElement on the left, skips its
+    // own `if`, and answers Valid. A refused write went through with nothing logged as an error.
+    //
+    // The proposed node carries a LIVE CLR instance of exactly the type the existing content
+    // must have (same node, same NodeType), and this hub demonstrably holds that type: it is
+    // the type authority for this update. Deserialise the degraded snapshot AS that type, here,
+    // on the hub that runs the validators — the same recovery ContentAs<T> performs at a
+    // consumer, done once for every validator instead of being each one's problem. A snapshot
+    // that will not deserialise as the proposal's type is left as it was (logged loud by As):
+    // hiding a shape mismatch from the validators would be a second silent pass.
+    private static MeshNode WithContentTypedLikeTheProposal(IMessageHub hub, MeshNode node, MeshNode existing)
+    {
+        var proposed = node.Content;
+        if (proposed is null or JsonElement or JsonNode || existing.Content is null)
+            return existing;
+        var logger = hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger(typeof(NodeUpdatePipeline));
+        var typed = existing.Content.As(proposed.GetType(), hub.JsonSerializerOptions, logger, existing.Path);
+        return typed is null || ReferenceEquals(typed, existing.Content)
+            ? existing
+            : existing with { Content = typed };
+    }
+
     // 2. Run client-side Update validators sequentially (Concat preserves short-circuit:
     //    the chain stops at the first failure). Returns the mapped exception or null.
     private static IObservable<Exception?> RunUpdateValidators(
@@ -136,7 +174,7 @@ internal static class NodeUpdatePipeline
         {
             Operation = NodeOperation.Update,
             Node = node,
-            ExistingNode = existing,
+            ExistingNode = WithContentTypedLikeTheProposal(hub, node, existing),
             AccessContext = ctx,
         };
 

--- a/src/MeshWeaver.Mesh.Contract/ObjectAsExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/ObjectAsExtensions.cs
@@ -164,6 +164,77 @@ public static class ObjectAsExtensions
     }
 
     /// <summary>
+    /// The runtime-<see cref="Type"/> form of <see cref="As{T}"/>, for the seams that learn the
+    /// target type from a LIVE instance rather than from a type parameter — the update pipeline
+    /// handing validators an existing node typed like the proposed one is the canonical case.
+    /// Same contract: already an instance of <paramref name="type"/> → as-is; a degraded
+    /// <see cref="JsonElement"/> / <see cref="JsonNode"/> → deserialized as <paramref name="type"/>
+    /// (a concrete-type deserialization needs no registry entry for the <c>$type</c> discriminator);
+    /// a same-named foreign CLR type → recovered by a JSON round-trip; anything else → <c>null</c>,
+    /// logged loud. Callers keep their original value when this answers <c>null</c>.
+    /// </summary>
+    public static object? As(
+        this object? value,
+        Type type,
+        JsonSerializerOptions options,
+        ILogger? logger = null,
+        string? what = null)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        switch (value)
+        {
+            case null:
+                return null;
+            case var typed when type.IsInstanceOfType(typed):
+                return typed;
+            case JsonElement je:
+                try
+                {
+                    return je.Deserialize(type, options);
+                }
+                catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+                {
+                    logger?.LogError(ex, "As<{TargetType}> could not recover {What}: {RawJson}",
+                        type.Name, what ?? "value", Excerpt(je.GetRawText()));
+                    return null;
+                }
+            case JsonNode jn:
+                try
+                {
+                    return jn.Deserialize(type, options);
+                }
+                catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+                {
+                    logger?.LogError(ex, "As<{TargetType}> could not recover {What}: {RawJson}",
+                        type.Name, what ?? "value", Excerpt(jn.ToJsonString()));
+                    return null;
+                }
+            default:
+                if (value.GetType().Name == type.Name)
+                {
+                    try
+                    {
+                        // Same reasoning as the generic overload: serialize AS the concrete runtime
+                        // type so the read does not adopt a foreign type into the caller's registry.
+                        var element = JsonSerializer.SerializeToElement(value, value.GetType(), options);
+                        var recovered = element.Deserialize(type, options);
+                        if (recovered is not null)
+                            return recovered;
+                    }
+                    catch (Exception ex) when (ex is JsonException or NotSupportedException or InvalidOperationException)
+                    {
+                        // fall through to the loud log below
+                    }
+                }
+                logger?.LogError(
+                    "As<{TargetType}> for {What}: value is {ActualType} ({ActualAssembly}), not convertible",
+                    type.Name, what ?? "value", value.GetType().FullName,
+                    value.GetType().Assembly.GetName().Name);
+                return null;
+        }
+    }
+
+    /// <summary>
     /// The head of a payload, for a diagnostic log line. Bounded because the value being logged is
     /// by definition the one we could NOT parse — a degraded content blob or a whole snapshot can be
     /// megabytes, and these lines ship to the log store. The first 2 KB is what a human reads to

--- a/test/MeshWeaver.Graph.Test/UpdateValidatorSeesTypedExistingContentTest.cs
+++ b/test/MeshWeaver.Graph.Test/UpdateValidatorSeesTypedExistingContentTest.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>AN UPDATE VALIDATOR SEES THE EXISTING NODE TYPED LIKE THE PROPOSED ONE</b> — the
+/// <c>NodeUpdatePipeline</c> contract that core #3056 broke and MeshWeaver.Plugins'
+/// <c>UpdateNode_VersionDowngrade_ShouldFail</c> caught on 2026-09-02.
+///
+/// <para>The content type here is deliberately registered on NO hub (no <c>WithType</c>). Before
+/// #3056 that did not matter: every hub registered every type it posted as a side effect of
+/// <c>MessageService.Post</c> rendering each delivery through the logging options, so the hub that
+/// created the node could re-type it when the update pipeline read it back. #3056 removed that
+/// render — correctly, it was an OOM — and with it the accidental registration, so
+/// <c>NodeValidationContext.ExistingNode.Content</c> reached validators as a <c>JsonElement</c>
+/// while <c>Node.Content</c> was the caller's CLR instance. A validator comparing the two skipped
+/// its own check and answered Valid: a refused write went through, with nothing logged as an
+/// error.</para>
+///
+/// <para>The validator below is written the way validators across the fleet are written — a typed
+/// comparison of both sides. That shape is the SUBJECT here, not a lapse: the pipeline owes a
+/// validator content typed alike on both sides, and this test pins that it delivers it. The
+/// observed CLR type is recorded separately so a regression names the shape it saw.</para>
+/// </summary>
+public class UpdateValidatorSeesTypedExistingContentTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        // 🚨 No WithType(typeof(VersionedContent), …) anywhere: the pipeline must not depend on it.
+        builder.ConfigureServices(services => services
+            .AddSingleton<IStaticNodeProvider, VersionedTypeProvider>()
+            .AddSingleton<INodeValidator, NoVersionDowngradeValidator>());
+        return base.ConfigureMesh(builder);
+    }
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    private NoVersionDowngradeValidator Validator =>
+        Mesh.ServiceProvider.GetServices<INodeValidator>().OfType<NoVersionDowngradeValidator>().Single();
+
+    private static string NewId() => "vc" + Guid.NewGuid().ToString("N")[..8];
+
+    private static MeshNode Versioned(string id, string title, int version) => new(id, TestPartition)
+    {
+        Name = title,
+        NodeType = VersionedTypeProvider.TypeName,
+        State = MeshNodeState.Active,
+        Content = new VersionedContent(title, version),
+    };
+
+    [Fact(Timeout = 180000)]
+    public async Task UpdateNode_Downgrade_IsRefused_BecauseTheValidatorSawTypedExistingContent()
+    {
+        var id = NewId();
+        var path = $"{TestPartition}/{id}";
+        await MeshService.CreateNode(Versioned(id, "High", 5)).Take(1)
+            .Should().Within(60.Seconds()).Emit("the node to downgrade must exist first");
+
+        var failure = await Record.ExceptionAsync(() =>
+            MeshService.UpdateNode(Versioned(id, "Downgraded", 3))
+                .Take(1).Timeout(60.Seconds()).Await());
+
+        var seen = await Validator.ObservedExistingContentType.FirstAsync().Timeout(60.Seconds()).Await();
+        seen.Should().Be(typeof(VersionedContent),
+            "the pipeline must hand validators the existing node with content typed like the "
+            + "proposed one — a JsonElement here is the silent pass #3056 opened");
+
+        failure.Should().BeOfType<UnauthorizedAccessException>(
+            "a validator's ValidationFailed maps to UnauthorizedAccessException on the IMeshService surface");
+        failure!.Message.Should().Contain("downgrade");
+
+        var after = await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null).FirstAsync().Timeout(60.Seconds()).Await();
+        after.ContentAs<VersionedContent>(Mesh.JsonSerializerOptions)!.Version.Should().Be(5,
+            "a refused update must leave the node as it was");
+    }
+
+    [Fact(Timeout = 180000)]
+    public async Task UpdateNode_Upgrade_StillLands()
+    {
+        var id = NewId();
+        var path = $"{TestPartition}/{id}";
+        await MeshService.CreateNode(Versioned(id, "Low", 1)).Take(1)
+            .Should().Within(60.Seconds()).Emit("the node to upgrade must exist first");
+
+        await MeshService.UpdateNode(Versioned(id, "Upgraded", 2)).Take(1)
+            .Should().Within(60.Seconds()).Emit("an upgrade passes the validator and lands");
+
+        var seen = await Validator.ObservedExistingContentType.FirstAsync().Timeout(60.Seconds()).Await();
+        seen.Should().Be(typeof(VersionedContent));
+
+        var after = await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(n => n is not null && n.ContentAs<VersionedContent>(Mesh.JsonSerializerOptions)?.Version == 2)
+            .FirstAsync().Timeout(60.Seconds()).Await();
+        after.Name.Should().Be("Upgraded");
+    }
+}
+
+/// <summary>Content type for the typed-existing-node contract. Registered on NO hub on purpose.</summary>
+public record VersionedContent(string Title, int Version);
+
+/// <summary>
+/// Refuses a version downgrade. Written as validators are written across the fleet — a typed
+/// comparison of the existing and the proposed content — because that shape is what the pipeline
+/// owes it; see the test class remarks.
+/// </summary>
+public sealed class NoVersionDowngradeValidator : INodeValidator
+{
+    private readonly ReplaySubject<Type?> observed = new();
+
+    /// <summary>The CLR type of <c>ExistingNode.Content</c> as this validator saw it, per call.</summary>
+    public IObservable<Type?> ObservedExistingContentType => observed;
+
+    public IReadOnlyCollection<NodeOperation> SupportedOperations => [NodeOperation.Update];
+
+    public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+    {
+        if (context.ExistingNode is null || context.ExistingNode.NodeType != VersionedTypeProvider.TypeName)
+            return Observable.Return(NodeValidationResult.Valid());
+
+        observed.OnNext(context.ExistingNode.Content?.GetType());
+
+        if (context.ExistingNode.Content is VersionedContent existing
+            && context.Node.Content is VersionedContent proposed
+            && proposed.Version < existing.Version)
+            return Observable.Return(new NodeValidationResult(
+                false,
+                $"Cannot downgrade version from {existing.Version} to {proposed.Version}",
+                NodeRejectionReason.ValidationFailed));
+
+        return Observable.Return(NodeValidationResult.Valid());
+    }
+}
+
+/// <summary>The static NodeType the versioned nodes are instances of, plus its static partition.</summary>
+internal sealed class VersionedTypeProvider : IStaticNodeProvider
+{
+    public const string TypeName = "VersionedProbe";
+
+    public IEnumerable<MeshNode> GetStaticNodes()
+    {
+        yield return new MeshNode(TypeName)
+        {
+            Name = "Versioned probe",
+            NodeType = "NodeType",
+            HubConfiguration = c => c.AddMeshDataSource(),
+            Content = new NodeTypeDefinition { Description = "Test NodeType for the typed-existing-node contract." },
+        };
+        yield return new MeshNode(TypeName, "Admin/Partition")
+        {
+            NodeType = "Partition",
+            Name = $"{TypeName} (static)",
+            State = MeshNodeState.Active,
+            Content = new PartitionDefinition
+            {
+                Namespace = TypeName,
+                DataSource = "static",
+                Description = $"Test NodeType definition partition for '{TypeName}'",
+            },
+        };
+    }
+}


### PR DESCRIPTION
## An update validator sees the existing node typed like the proposed one

**Symptom.** MeshWeaver.Plugins PR #1171 (run 33606589197, `Portal hosts (shard 0)`) failed
`NodeOperationsWithUpdateValidatorTest.UpdateNode_VersionDowngrade_ShouldFail`: *Expected a
UnauthorizedAccessException, but no exception was thrown.* A validator-refused write went through.
The same shard passed on #1165 at 05:45Z; #1171 touches nothing that test reaches.

**Bisect (core `main`, first-parent, the Plugins test run against each checkout):**
`470cdd58e` pass · `02e9007c1` pass · `3ac34af52` pass · `cb1dd3600` pass · `554f07e94` pass ·
`804b9beca` (#3059) pass · **`3d6faa284` (#3056) FAIL** · `9b3b00201` fail · `19035c1ea` fail.

**Mechanism.** The failing run's log carries
`MeshNodeStreamCache.GetStream: Content for update/validation/HighVersionNode stayed an untyped JsonElement after deserialization (TypeRegistry lacks the $type discriminator) … Raw: {"$type":"UpdatableContent",…}`
— absent in every passing run. `NodeUpdatePipeline` reads the existing node through the stream cache,
which re-types the raw JSON with the running hub's registry. `UpdatableContent` is registered on no
hub in that fixture. Until #3056 that did not matter: `MessageService.Post` rendered every delivery
through the logging options EAGERLY (built as the `LogDebug` argument), and
`ObjectPolymorphicConverter.Write` calls `typeRegistry.GetOrAddType` for every value it serialises —
so a hub that had merely handed a typed instance to `CreateNode` had registered the type as a side
effect and could re-type the node when the pipeline read it back. #3056 removed the render (it was
the production OOM) and, with it, the accidental registration. `ExistingNode.Content` reached the
validator as a `JsonElement` while `Node.Content` was the caller's CLR instance; its
`ExistingNode.Content is UpdatableContent && Node.Content is UpdatableContent` was false, the `if`
was skipped, it answered Valid.

**Fix (root, in the pipeline).** Before building the `NodeValidationContext`,
`NodeUpdatePipeline` types the existing content **like the proposal**: the proposed node carries a
live CLR instance of exactly the type the existing content must have (same node, same NodeType), so
the degraded snapshot is deserialised as `node.Content.GetType()` on the hub that runs the
validators — a concrete-type deserialisation, which needs no registry entry. This is `ContentAs<T>`
done once for every validator; a new runtime-`Type` overload `ObjectAsExtensions.As(object, Type, …)`
carries it. A snapshot that will not deserialise as the proposal's type is left as it was and logged
at Error — hiding a shape mismatch would be a second silent pass. No registry is mutated on the read
path.

**Test.** `UpdateValidatorSeesTypedExistingContentTest` (MeshWeaver.Graph.Test): content type
registered on no hub, a fleet-shaped downgrade validator, the CLR type it saw recorded. Fails before
(`seen == JsonElement`, no exception), passes after. It lives in core because the test that found the
hole runs only in Plugins — the cross-repo blind spot that let #3056 merge green.

**Docs.** `Doc/Architecture/UpdateValidatorsSeeTypedContent` records the finding; What's New:
*A rejected update is refused again* (Fix).

**Plugins follow-up (not in this PR).** The fixture in `NodeOperationsTest.cs` should register
`UpdatableContent` on the hub (`WithType`) and `NoVersionDowngradeValidator` should read both sides
through `.ContentAs<UpdatableContent>(hub.JsonSerializerOptions)` instead of `is` — the pipeline
guarantee makes the existing validators safe; it does not make the cast idiom right.

**Verification.** `MeshWeaver.Mesh.Contract`, `MeshWeaver.Hosting`, `MeshWeaver.Graph.Test` build
`-c Release -warnaserror` clean; `MeshWeaver.Graph.Test` run whole; the Plugins
`NodeOperationsWithUpdateValidatorTest` filter re-run against this branch passes 4/4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
