### PR TITLE
ci: gate on a content type degrading to an untyped JsonElement

### DIFF
--- a/.github/scripts/check-untyped-content.sh
+++ b/.github/scripts/check-untyped-content.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# Fail a test shard whose logs show a node's content degrading to an untyped JsonElement.
+#
+# 🚨 WHY THIS IS A GATE AND NOT A LOG LINE.
+#
+# A content type that is not registered on the hub reading it does NOT fail. The polymorphic
+# converter cannot resolve the `$type`, degrades the value to a raw JsonElement, and everything
+# downstream reads it as absent: `node.Content is MyType` misses, a view renders empty, a reactive
+# wait never completes. No exception, no NACK, nothing to grep for after the fact.
+#
+# Contrast the message-payload case, which is LOUD: an unregistered inbound payload type raises
+# "type 'X' is not registered in this hub's TypeRegistry" with a NACK policy attached. That
+# asymmetry — loud for payloads, silent for content — is the whole reason this file exists.
+#
+# 🚨 WHAT CHANGED, AND WHY THE WARNING IS NOW LOAD-BEARING (MeshWeaver#3056).
+#
+# `MessageService.Post` used to log at Debug via `JsonSerializer.Serialize(ret, …)`. That serialize
+# walked every posted payload through ObjectPolymorphicConverter.Write → typeRegistry.GetOrAddType,
+# so EVERY posted type got registered as a side effect of LOGGING. #3056 removed that line (an OOM
+# fix — the allocation was the failure), which was correct: logging must not register types.
+#
+# But it was also a net. It masked every place that relied on "this type is registered because it
+# was once posted". With the net gone those places surface as this warning — which nothing was
+# checking. Measured the same day: MeshWeaver.Plugins' NodeOperations validator test began passing
+# a node whose Content "stayed an untyped JsonElement", the validator's `is` missed, it returned
+# Valid, and a version-downgrade guard silently stopped guarding. It read as a validator BYPASS.
+#
+# Prod content types are covered by ContentTypeRegistrationSweep (static definitions, swept at boot)
+# and by WithContentType running on instance-hub activation (dynamic types). This gate covers what
+# neither does: catching a NEW gap the moment a test run first exhibits it.
+set -euo pipefail
+
+PHRASE='stayed an untyped JsonElement'
+DIR="${1:?usage: check-untyped-content.sh <collected-logs-dir>}"
+
+if [ ! -d "$DIR" ]; then
+  echo "::error::$DIR does not exist — this gate had nothing to scan. That is a FAILED sweep, not a clean one: it must never be possible to pass by scanning nothing."
+  exit 1
+fi
+
+# 🚨 Deliberately NOT failing on an empty directory. A shard whose tests wrote no logs is a real,
+# healthy state here (log files are collected from bin/*/test-logs, which not every project emits),
+# so "no files" cannot be treated as evidence either way. The control arm for THIS gate is not the
+# file count — it is UntypedContentDegradationGate, which fails the build if the phrase stops
+# existing in the source that emits it, or if this script stops grepping the identical phrase.
+# Without that test, a reworded log message would silently retire this gate.
+matches=$(grep -rl "$PHRASE" "$DIR" 2>/dev/null || true)
+
+if [ -z "$matches" ]; then
+  echo "No content-type degradation in $DIR."
+  exit 0
+fi
+
+echo "::error::A node's content degraded to an untyped JsonElement — a content type was not registered on the hub that read it."
+echo ""
+echo "This does NOT throw. The value reads as absent: an 'is MyType' check misses, a view renders"
+echo "empty, a reactive wait never completes. It is caught here or not at all."
+echo ""
+echo "Occurrences:"
+# Trim to the node path — the whole line carries a serialised payload and drowns the signal.
+grep -rh "$PHRASE" "$DIR" 2>/dev/null \
+  | sed -E 's/.*Content for ([^ ]+) stayed.*/  \1/' \
+  | sort | uniq -c | sort -rn | head -20
+echo ""
+echo "Files: $(printf '%s' "$matches" | tr '\n' ' ')"
+echo ""
+echo "FIX: register the content type where it is READ — WithContentType<T>() on the hub's data"
+echo "source, or WithType(typeof(T), nameof(T)). Do NOT paper over it with .ContentAs<T>() at the"
+echo "call site: AGENTS.md is explicit that deserialising close to where the type IS registered"
+echo "comes first, and .As<T>() on a payload read where the type was never registered hides a"
+echo "routing mistake rather than fixing it."
+exit 1

--- a/.github/scripts/check-untyped-content.sh
+++ b/.github/scripts/check-untyped-content.sh
@@ -32,6 +32,8 @@ set -euo pipefail
 
 PHRASE='stayed an untyped JsonElement'
 DIR="${1:?usage: check-untyped-content.sh <collected-logs-dir>}"
+scan_err="$(mktemp)"
+trap 'rm -f "$scan_err"' EXIT
 
 if [ ! -d "$DIR" ]; then
   echo "::error::$DIR does not exist — this gate had nothing to scan. That is a FAILED sweep, not a clean one: it must never be possible to pass by scanning nothing."
@@ -44,10 +46,26 @@ fi
 # file count — it is UntypedContentDegradationGate, which fails the build if the phrase stops
 # existing in the source that emits it, or if this script stops grepping the identical phrase.
 # Without that test, a reworded log message would silently retire this gate.
-matches=$(grep -rl "$PHRASE" "$DIR" 2>/dev/null || true)
+# 🚨 SEPARATE "found nothing" FROM "the scan failed". grep exits 0 on a match, 1 on no match, and
+# 2+ on a real error (unreadable file, bad path, I/O). The first version of this line was
+# `$(grep … 2>/dev/null || true)`, which collapses all three into an empty string — so a scan that
+# ERRORED reported "no degradation" and passed the gate. That is precisely the silent pass this file
+# exists to prevent, committed inside the file that prevents it. Caught by the repo's own
+# `CI's own shell` gate, which flags a captured command substitution that swallows stderr and status.
+set +e
+matches=$(grep -rl "$PHRASE" "$DIR" 2>"$scan_err")
+scan_rc=$?
+set -e
+
+if [ "$scan_rc" -gt 1 ]; then
+  echo "::error::the scan itself FAILED (grep exit $scan_rc) — this gate reached no verdict about $DIR."
+  echo "Treat this as a failed sweep, not a clean one: an unreadable log is not an absent degradation."
+  sed 's/^/  /' "$scan_err" 2>/dev/null | head -20
+  exit 1
+fi
 
 if [ -z "$matches" ]; then
-  echo "No content-type degradation in $DIR."
+  echo "No content-type degradation in $DIR (scan exit $scan_rc)."
   exit 0
 fi
 

--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1339,6 +1339,25 @@ jobs:
           collected-logs/
         compression-level: 9
         retention-days: 15
+    # 🚨 AFTER the upload on purpose: this step can RED the shard, and the logs it reds on are the
+    #    evidence. Uploading first means the artifact exists whichever way the gate goes.
+    #
+    #    What it catches is silent by construction. A content type not registered on the hub that
+    #    READS it does not throw — the `$type` will not resolve, the value degrades to a raw
+    #    JsonElement, and everything downstream reads it as absent: an `is MyType` check misses, a
+    #    view renders empty, a reactive wait never completes. The message-payload equivalent is
+    #    loud ("type 'X' is not registered in this hub's TypeRegistry", with a NACK); the content
+    #    equivalent is a warning nothing was reading.
+    #
+    #    🚨 The warning became load-bearing on 2026-09-02. `MessageService.Post` used to log via
+    #    `JsonSerializer.Serialize(ret, …)`, and that serialize registered every posted payload
+    #    type as a side effect (ObjectPolymorphicConverter.Write → GetOrAddType). #3056 removed it
+    #    — correctly; logging must not register types — and with the net gone, everything that had
+    #    relied on "registered because it was once posted" surfaces here. It surfaced the same day
+    #    as a validator that silently stopped validating.
+    - name: "Gate: no content degraded to an untyped JsonElement"
+      if: always()
+      run: bash .github/scripts/check-untyped-content.sh collected-logs
     # ── Per-shard surfacing: publish THIS shard's results as soon as it
     #    finishes, so you don't wait for the slowest sibling + the collector to
     #    see shard 0's outcome. The collect-results job re-consolidates all

--- a/test/MeshWeaver.Documentation.Test/UntypedContentDegradationGate.cs
+++ b/test/MeshWeaver.Documentation.Test/UntypedContentDegradationGate.cs
@@ -1,0 +1,108 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>The control arm for <c>check-untyped-content.sh</c>.</b> That script greps a shard's logs
+/// for one phrase. A phrase-matching gate has exactly one silent failure mode — the phrase changes
+/// and the gate keeps passing, having matched nothing forever — and nothing else can catch it.
+///
+/// <para>This test pins the coupling from both ends: the source must still EMIT the phrase, and the
+/// script must still GREP the identical phrase. Reword either and the build fails, naming the
+/// other.</para>
+///
+/// <para><b>What is being protected.</b> A content type that is not registered on the hub reading
+/// it does not throw. The polymorphic converter cannot resolve the <c>$type</c>, degrades the value
+/// to a raw <c>JsonElement</c>, and everything downstream reads it as absent — an
+/// <c>is MyType</c> check misses, a view renders empty, a reactive wait never completes. The
+/// message-PAYLOAD equivalent is loud (<c>type 'X' is not registered in this hub's
+/// TypeRegistry</c>, with a NACK); the CONTENT equivalent is this warning. That asymmetry is why
+/// the warning needs a gate at all.</para>
+///
+/// <para><b>Why now (MeshWeaver#3056).</b> <c>MessageService.Post</c> used to log through
+/// <c>JsonSerializer.Serialize(ret, …)</c>, and that serialize registered every posted payload type
+/// as a side effect (<c>ObjectPolymorphicConverter.Write</c> → <c>GetOrAddType</c>). #3056 removed
+/// it — correctly, logging must not register types — and with that net gone, every place relying on
+/// "registered because it was once posted" now surfaces as this warning. On the day it merged it
+/// surfaced as a validator that silently stopped validating.</para>
+///
+/// <para><b>What this test deliberately does NOT do.</b> It does not plant an unregistered type and
+/// assert the warning is emitted at runtime. That would be a stronger control arm — it would prove
+/// the emission path is live, not merely that the string exists — but the planted case would write
+/// the very phrase the shard gate greps for, so the gate validating itself would red every run.
+/// Isolating the planted log from <c>collected-logs/</c> is possible and is the right follow-up;
+/// it is called out here rather than silently omitted.</para>
+/// </summary>
+public class UntypedContentDegradationGate
+{
+    /// <summary>The exact phrase. Both ends are asserted against THIS constant, so the two can
+    /// never agree with each other while disagreeing with reality.</summary>
+    private const string Phrase = "stayed an untyped JsonElement";
+
+    private const string Script = ".github/scripts/check-untyped-content.sh";
+    private const string EmittingSource = "src/MeshWeaver.Hosting/MeshNodeStreamCache.cs";
+
+    private static string Read(string relative)
+    {
+        var path = Path.Combine(SourceScan.FindRepoRoot(), relative);
+        Assert.True(File.Exists(path), $"{relative} is missing — this gate's subject moved; follow it.");
+        return File.ReadAllText(path);
+    }
+
+    [Fact]
+    public void TheSourceStillEmitsThePhraseTheGateGrepsFor()
+    {
+        var emitted = Read(EmittingSource).Split('\n').Count(l => l.Contains(Phrase, StringComparison.Ordinal));
+
+        Assert.True(
+            emitted > 0,
+            $"'{EmittingSource}' no longer contains \"{Phrase}\".\n"
+            + $"{Script} greps for exactly that phrase, so it now matches NOTHING and passes every "
+            + "run having checked nothing — the silent retirement this test exists to prevent.\n"
+            + "If the message was reworded, update the phrase in BOTH this test and the script. If "
+            + "the degradation warning was removed entirely, remove the gate deliberately and say "
+            + "why in the commit — do not leave a gate grepping for a string nobody writes.");
+
+        // Both read seams — GetStream and GetQuery — must keep reporting. A degradation reachable
+        // through only one of them is still a view that renders empty.
+        Assert.True(
+            emitted >= 2,
+            $"Only {emitted} occurrence(s) of \"{Phrase}\" in {EmittingSource}; expected at least 2 "
+            + "(GetStream and GetQuery). One read seam falling silent means content can degrade "
+            + "down that path with nothing said, which is exactly the state before this gate.");
+    }
+
+    [Fact]
+    public void TheGateScriptStillGrepsTheIdenticalPhrase()
+    {
+        var script = Read(Script);
+
+        // 🚨 The ASSIGNMENT, not the file. My first version asserted the phrase appeared anywhere
+        // in the script — and the script EXPLAINS itself at length, so its own comments contain the
+        // phrase. Mutating `PHRASE=` to something else left the comments intact and the test passed
+        // while the gate matched nothing: a grep hit is not a binder, in a guard whose entire job is
+        // to stop a silent no-op. Caught by mutating this test rather than by reading it.
+        var assignment = $"PHRASE='{Phrase}'";
+        Assert.True(
+            script.Contains(assignment, StringComparison.Ordinal),
+            $"{Script} no longer assigns {assignment}. The source still emits that phrase, so the "
+            + "gate is now looking for something that is never written and will pass forever. Keep "
+            + "the two in step, or retire both together.\n"
+            + "(Asserted on the assignment specifically — the script's comments quote the phrase "
+            + "too, so a whole-file match would not notice.)");
+
+        // A gate handed a directory that does not exist must FAIL, never pass. "Nothing to scan" is
+        // a failed sweep, not a clean one — the same reading that makes an absent required check
+        // read as green.
+        Assert.True(
+            script.Contains("does not exist", StringComparison.Ordinal)
+            && script.Contains("FAILED sweep", StringComparison.Ordinal),
+            $"{Script} lost its missing-directory guard. Without it, a rename of the log-collection "
+            + "directory turns this gate into a no-op that reports success on every shard.");
+    }
+}

--- a/test/MeshWeaver.Documentation.Test/UntypedContentDegradationGate.cs
+++ b/test/MeshWeaver.Documentation.Test/UntypedContentDegradationGate.cs
@@ -104,5 +104,17 @@ public class UntypedContentDegradationGate
             && script.Contains("FAILED sweep", StringComparison.Ordinal),
             $"{Script} lost its missing-directory guard. Without it, a rename of the log-collection "
             + "directory turns this gate into a no-op that reports success on every shard.");
+
+        // 🚨 grep exits 0 on a match, 1 on NO match, and 2+ on a real error. Collapsing those — the
+        // `$(grep … 2>/dev/null || true)` idiom — makes an ERRORED scan indistinguishable from a
+        // clean one, so an unreadable log file reports "no degradation" and the gate passes. The
+        // first version of the script did exactly that; the repo's own `CI's own shell` gate caught
+        // it. Pinned here so it cannot come back under a reformat.
+        Assert.True(
+            script.Contains("scan_rc", StringComparison.Ordinal)
+            && script.Contains("-gt 1", StringComparison.Ordinal),
+            $"{Script} no longer distinguishes a FAILED scan from an EMPTY one. grep's exit code is "
+            + "the only thing that separates 'nothing degraded' from 'I could not look', and this "
+            + "gate's whole purpose is to make the second one impossible to mistake for the first.");
     }
 }

--- a/test/MeshWeaver.Documentation.Test/UntypedContentDegradationGate.cs
+++ b/test/MeshWeaver.Documentation.Test/UntypedContentDegradationGate.cs
@@ -3,6 +3,7 @@
 using System;
 using System.IO;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Xunit;
 
 namespace MeshWeaver.Documentation.Test;
@@ -87,14 +88,26 @@ public class UntypedContentDegradationGate
         // phrase. Mutating `PHRASE=` to something else left the comments intact and the test passed
         // while the gate matched nothing: a grep hit is not a binder, in a guard whose entire job is
         // to stop a silent no-op. Caught by mutating this test rather than by reading it.
-        var assignment = $"PHRASE='{Phrase}'";
+        // Match the ASSIGNMENT, tolerant of formatting. The invariant is "PHRASE is bound to this
+        // string", not "this file contains these exact characters" — so whitespace around `=` and
+        // either quote style pass, while the phrase itself must be exact.
+        //
+        // 🚨 Two failure modes had to be excluded together, and it took two attempts:
+        //   * too loose — an earlier version searched the WHOLE FILE, and the script's own comments
+        //     quote the phrase, so changing `PHRASE=` to something else still passed;
+        //   * too strict — the fix for that pinned the literal `PHRASE='…'`, which would red on a
+        //     harmless reformat (double quotes, a space around `=`) while the gate stayed correct.
+        // A guard that cries wolf on formatting gets deleted, which costs the same as one that
+        // never fires.
+        var assignment = new Regex(
+            @"PHRASE\s*=\s*[""']" + Regex.Escape(Phrase) + @"[""']", RegexOptions.Compiled);
         Assert.True(
-            script.Contains(assignment, StringComparison.Ordinal),
-            $"{Script} no longer assigns {assignment}. The source still emits that phrase, so the "
-            + "gate is now looking for something that is never written and will pass forever. Keep "
-            + "the two in step, or retire both together.\n"
-            + "(Asserted on the assignment specifically — the script's comments quote the phrase "
-            + "too, so a whole-file match would not notice.)");
+            assignment.IsMatch(script),
+            $"{Script} no longer binds PHRASE to \"{Phrase}\". The source still emits that phrase, "
+            + "so the gate is now looking for something that is never written and will pass "
+            + "forever. Keep the two in step, or retire both together.\n"
+            + "(Matched on the ASSIGNMENT, not the file — the script's comments quote the phrase "
+            + "too, so a whole-file match would not notice a rebinding.)");
 
         // A gate handed a directory that does not exist must FAIL, never pass. "Nothing to scan" is
         // a failed sweep, not a clean one — the same reading that makes an absent required check


### PR DESCRIPTION
Closes the enforcement gap that #3056 (mine, merged today) turned from theoretical into load-bearing.

## The asymmetry that makes this necessary

A content type not registered on the hub **reading** it does not throw. The `$type` will not resolve, the value degrades to a raw `JsonElement`, and everything downstream reads it as absent — an `is MyType` check misses, a view renders empty, a reactive wait never completes.

| | |
|---|---|
| unregistered **payload** type | **loud** — `type 'X' is not registered in this hub's TypeRegistry`, with a NACK |
| unregistered **content** type | **silent** — a warning nothing was reading |

## Why now

`MessageService.Post` used to log through `JsonSerializer.Serialize(ret, …)`, and that serialize walked every posted payload through `ObjectPolymorphicConverter.Write → GetOrAddType` — **registering every posted type as a side effect of logging.** #3056 removed it as part of an OOM fix. That was correct: logging must not register types.

But it was also a net. It masked everything relying on *"this type is registered because it was once posted"*. The same day, its removal surfaced as a MeshWeaver.Plugins validator whose existing node arrived untyped: `is UpdatableContent` missed, it returned `Valid`, and a version-downgrade guard silently stopped guarding. It presented as a validator **bypass**.

Prod content types are already covered — `ContentTypeRegistrationSweep` walks static definitions at boot (built after a real incident where every Store cover computed no action buttons), and dynamic types register via `WithContentType` on instance-hub activation. **This gate covers what neither does: catching a new gap the moment a test run first exhibits it.**

## Placement

In the shard job, **after** the artifact upload — the step can red the shard, and the logs it reds on are the evidence.

## The control arm is the point

A phrase-matching gate has exactly one silent failure mode: the phrase changes and it passes forever, having matched nothing. `UntypedContentDegradationGate` pins the coupling from both ends — the source must still emit the phrase at **both** read seams (`GetStream` and `GetQuery`), and the script must still **assign** it.

**Mutation-proven:**

| mutation | result |
|---|---|
| reword the phrase in source | ❌ caught |
| script stops grepping it | ❌ caught |
| script loses its missing-directory guard | ❌ caught |
| script vs missing dir / empty / clean / dirty | fail / pass / pass / fail |

🚨 **The second mutation initially PASSED.** The test asserted the phrase appeared *anywhere* in the script — and the script explains itself at length, so its own comments carried the phrase while `PHRASE=` had been changed to something else. A grep hit is not a binder, inside a guard whose entire job is preventing a silent no-op. It now asserts the assignment specifically. I found that by mutating the test, not by reading it.

## Deliberately not included

A runtime control arm that plants an unregistered type and asserts the warning fires. That is stronger — it would prove the emission path is live rather than that a string exists — but the planted case writes the very phrase the shard gate greps, so the gate validating itself would red every run. Isolating that log from `collected-logs/` is the right follow-up; it is named in the test rather than silently omitted.

`MeshWeaver.Documentation.Test`: **191 passed, 0 failed** (full project, unfiltered). Script is `bash -n` clean and `shellcheck -S warning` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)