### PR TITLE
ci: the timeout guard names itself in its first 400 bytes — the validate lane's fetch check can pass

### DIFF
--- a/.github/scripts/check-workflow-timeouts.py
+++ b/.github/scripts/check-workflow-timeouts.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-"""Every CI job carries a hard wall-clock cap, and the cap is at most 45 minutes.
+"""check-workflow-timeouts.py — every CI job carries a hard wall-clock cap, and the cap is at most 45 minutes.
+
+(The name on this first line is load-bearing: node-repo-validate.yml fetches this file at platform-ref and
+refuses a body whose first 400 bytes do not name it — the same shape as compile-check.py's check.)
 
 WHY THIS EXISTS (maintainer, 2026-09-02: "hard cut ci runs after 45min — we pay all this")
 ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Found by the Reinsurance CI pilot (Reinsurance #144, run 33616233487): `node-repo-validate.yml` fetches `check-workflow-timeouts.py` at `platform-ref` and refuses a body whose first 400 bytes do not contain `check-workflow-timeouts` — the same check `compile-check.py` passes because it names itself on line 2. The guard named itself only at byte 2032, so **every satellite adopting the validate lane at a pin ≥ #3067 went red at the fetch step**, before checking anything. The docstring now opens with the name and says why the position is load-bearing.

Verification: `--self-test` 12/12 + no-workflows case; `--root .` → 0 violations; the name is at byte 3.

Internal CI fix → no What's New.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
