### PR TITLE
The per-node settings surface gets its own UiContribution lane (#3055)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
@@ -220,6 +220,17 @@ long-lived chain — the #1962 defect, where an early `Permission.None` seed sta
 later re-renders the menu with every entitled tab silently missing. The Read floor is what still
 makes an anonymous viewer see nothing.
 
+🚨 **One compiled tab shape does not survive migration unchanged: `RequiredPermission =
+Permission.None`.** `FilterByPermission` treats a `None` tab as chrome *every* viewer sees, but a
+contribution can never demand less than `Read` (that floor is what makes the lane fail closed), so
+a `None` tab becomes `Read`-gated the moment it moves onto the lane. In practice that is the same
+set of viewers — you cannot open a node's settings page without reading the node — with one real
+difference: a viewer holding `Permission.None` on the node loses the tab. Per-node tabs registered
+as `None` today (Notifications is one) are therefore a deliberate decision at migration time, not a
+copy-paste: either accept the narrowing, or leave that tab compiled. This is the closed vocabulary
+working as designed — a contribution narrows, never widens — but it is a behaviour change, so it
+belongs in the migration PR's description rather than being discovered afterwards.
+
 **Whole top-bar menus** (`Context: TopBar`): the contribution declares a NEW dropdown — its `Area`
 names the menu's own context key, `Label`/`Icon`/`Order`/`Tooltip` style the button, and its
 entries are ordinary contributions targeting that key. The gates apply to the declaration itself

--- a/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UiExtensibility.md
@@ -146,7 +146,8 @@ in its `TypeRegistry` or it degrades to an untyped `JsonElement` and the area re
 | A named area on a node type | `LayoutDefinition.WithView(name, generator)` | the NodeType's configuration — in-mesh or compiled |
 | Default areas on every node | `AddDefaultLayoutAreas()` composition | core only — extending it puts your area on *every node in the mesh*; prefer a NodeType-scoped area |
 | A left-rail navigation for a node family | `INodeNavigationProvider` | DI singleton (pack) — claimed by node shape at render time |
-| A settings tab | a `UiContribution` node (`Context: Settings`) pointing at a layout area — or compiled `AddGlobalSettingsMenuItems(...)` for content that needs code | mesh data / hub configuration |
+| A GLOBAL settings tab (`/_Setting/GlobalSettings/{id}`) | a `UiContribution` node (`Context: Settings`) pointing at a layout area — or compiled `AddGlobalSettingsMenuItems(...)` for content that needs code | mesh data / hub configuration |
+| A PER-NODE settings tab (`/{nodePath}/Settings/{id}`) | a `UiContribution` node (`Context: NodeSettings`) — or compiled `AddSettingsMenuItems(...)` | mesh data / hub configuration |
 | Node-menu entries / presentation | a `UiContribution` node (`Context: Node`/`Mesh`/`AI`/`SidePanel`/…) — or compiled `AddNodeMenuItems(...)`; presentation stays editable data (`MenuPresentationOverlay`) | mesh data / hub configuration |
 | A whole NEW top-bar menu | a `UiContribution` node (`Context: TopBar`) declaring the dropdown; entries target its key | mesh data — no code at all |
 | A home-screen tab | a `HomeTab` node | mesh data — no code at all |
@@ -171,7 +172,7 @@ The full field surface:
 
 | Field | Meaning |
 |---|---|
-| `Context` | Which menu: `Node` (default), `Mesh`, `Settings`, `AI`, `SidePanel`, `GitHub`, any registered context — or `TopBar` (below) |
+| `Context` | Which menu: `Node` (default), `Mesh`, `Settings` (GLOBAL settings page), `NodeSettings` (PER-NODE settings page), `AI`, `GitHub`, any registered context — or `TopBar` (below) |
 | `Area` | The layout area the entry opens (settings: embedded into the pane; menus: the link target) |
 | `Href` | Optional explicit link overriding the derived area URL — **portal-internal only** (a single-slash-rooted path like `/search?…`; schemes and `//host` forms are discarded by the compiled gate and the entry falls back to its area link) |
 | `Label` / `LabelKey` | Display text; the key resolves against the shared localization catalog |
@@ -179,17 +180,45 @@ The full field surface:
 | `Tooltip` / `TooltipKey` | Hover text (menus and top-bar buttons) |
 | `Order` | Sort position (default 100 — after the built-ins) |
 | `Group` / `GroupKey` / `GroupIcon` | Settings-tab grouping (entries sharing a group nest under its header) |
+| `Keywords` | Extra SEARCH terms for the per-node settings search box — what is *inside* the tab, not its name. Consumed by `NodeSettings` only (the global page has no search); omitting them on a migrating tab removes it from search silently |
 | `RequiredPermission` | Checked against the viewer's LIVE effective permission on the anchoring node, floored at `Read`; anonymous sees nothing |
 | `Gates.NodeTypes` | Suffix-aware node-type filter (`"Slide"` matches `Publish/Slide`) |
-| `Gates.ExcludePartitionRoot` | Never on a protected partition root — the built-in suppression's own predicate |
+| `Gates.ExcludePartitionRoot` | Never on ANY user's home — the built-in suppression's own predicate |
+| `Gates.ExcludeViewerHome` | Never on the VIEWER'S OWN home (the anchoring path is the viewer's partition key). Strictly narrower than `ExcludePartitionRoot`, not a replacement: declare both when both apply |
+| `Gates.SyncedOnly` | Only while the node still participates in sync (`SyncBehavior.Include`) — the shape the "Stop synchronization" action needs. The inverse is deliberately absent; the vocabulary stays closed |
 | `Gates.AdminOnly` | Platform admins only (`hub.IsGlobalAdmin()`, reactive) |
 
-**Settings tabs** (`Context: Settings`): the contributed area is embedded into the pane's styled
-stack; the tab id is the NODE id, so `/GlobalSettings/{id}` deep links stay stable when a compiled
-tab migrates to a same-named seed. The platform's own global tabs ship this way — What's New /
-About / Privacy plus the admin tabs Invitations / Inbox / Updates / Published to the web / Token
-Usage (`Admin/UiContribution/*` seeds); every admin tab's AREA re-asserts the admin gate, because
-an area is directly URL-addressable and `Gates.AdminOnly` only hides the menu entry.
+Every gate SUBTRACTS, and they are evaluated in ONE compiled place (`UiContributionProjection.PassesNodeGates`)
+so the node menu and the per-node settings page can never drift on what a gate word means.
+
+**Settings tabs — TWO surfaces, TWO keys.** The portal has two settings pages, and each answers
+its own context key:
+
+| Surface | Route | Context | Projects into |
+|---|---|---|---|
+| Global settings | `/_Setting/GlobalSettings/{id}` | `Settings` | `GlobalSettingsMenuItemDefinition` |
+| Per-node settings | `/{nodePath}/Settings/{id}` | `NodeSettings` | `SettingsMenuItemDefinition` |
+
+They are **not one key**, deliberately. A single key would list every tab on both pages — the seven
+platform tabs seeded for the global page would appear on every node's settings page, which is a
+visible regression rather than a migration — and it would make the two surfaces impossible to gate
+independently, which is the property the contribution lane exists for. A tab that genuinely belongs
+on both is two contributions, and says so.
+
+On both surfaces the contributed area is embedded into the pane's styled stack, and the tab id is
+the NODE id, so a `/…/Settings/{id}` deep link stays stable when a compiled tab migrates to a
+same-named seed. The platform's own global tabs ship this way — What's New / About / Privacy plus
+the admin tabs Invitations / Inbox / Updates / Published to the web / Token Usage
+(`Admin/UiContribution/*` seeds); every admin tab's AREA re-asserts the admin gate, because an area
+is directly URL-addressable and `Gates.AdminOnly` only hides the menu entry.
+
+🚨 **The per-node lane never filters on permission and takes none.** It stamps
+`RequiredPermission` (floored at `Read`) onto the definition and lets
+`SettingsMenuItemsExtensions.FilterByPermission` apply it at the render fold, against the LATEST
+permission value. Filtering inside the provider stream would bake a permission SNAPSHOT into a
+long-lived chain — the #1962 defect, where an early `Permission.None` seed stays subscribed and
+later re-renders the menu with every entitled tab silently missing. The Read floor is what still
+makes an anonymous viewer see nothing.
 
 **Whole top-bar menus** (`Context: TopBar`): the contribution declares a NEW dropdown — its `Area`
 names the menu's own context key, `Label`/`Icon`/`Order`/`Tooltip` style the button, and its
@@ -203,6 +232,23 @@ deliberately cannot express.
 **Seeding**: platform-static seeds ride `MeshBuilder.AddMeshNodes(...)`
 (`AddPlatformSettingsTabContributions`, `AddAiMenuContributions`); a plugin just ships
 `UiContribution` nodes as pack content under its own namespace.
+
+### 🚨 A contribution nobody consumes is DARK — check it statically
+
+A contributed entry naming a `Context` nobody declares renders **nowhere**, and nothing anywhere
+says so: no error, no warning, not even an area-not-found placeholder. Six shipped entries were
+dark for nine days that way. The same silence covers an empty `Area` (dropped before any gate
+runs), a non-portal-internal `Href` (discarded, so the entry quietly opens the derived area URL
+instead), a node whose `NodeType` is not `UiContribution` (the catalog query never returns it), a
+label with no `LabelKey` (English for every German viewer), and two seeds at the same path (the
+catalog is keyed on path — one silently replaces the other).
+
+`UiContributionSeedValidation.Validate(seeds, options, additionalContexts, registeredAreas)` is the
+pure check for all six; it folds in the context keys a `TopBar` declaration in the same set
+introduces. Core pins its own seed list with it (`PlatformSettingsTabSeedTest`); the Plugins repo's
+`scripts/check-menu-contexts.py` is the script form of the same check for content-authored packs.
+Any repo seeding contributions from compiled code should call it from a test — with a control arm,
+because a check that cannot fail reproduces exactly the silence it exists to break.
 
 ## What cannot be extended today
 

--- a/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeMenuItemsExtensions.cs
@@ -520,8 +520,9 @@ public static class NodeMenuItemsExtensions
     /// gate vocabulary — the viewer's live effective permission (floored at Read; anonymous is
     /// already forced to <see cref="Permission.None"/> by <see cref="GetMenuContext"/>, so the
     /// whole slice fails closed), <c>AdminOnly</c> against the reactive
-    /// <c>IsGlobalAdmin</c> stream, <c>ExcludePartitionRoot</c> against the same predicate the
-    /// built-in suppression uses, and suffix-aware <c>NodeTypes</c> matching. Enforcement lives
+    /// <c>IsGlobalAdmin</c> stream, <c>ExcludePartitionRoot</c> and <c>ExcludeViewerHome</c>
+    /// against the same predicates the built-in suppressions use, <c>SyncedOnly</c> against the
+    /// node's <c>SyncBehavior</c>, and suffix-aware <c>NodeTypes</c> matching. Enforcement lives
     /// HERE, in compiled code — a contribution can only ever narrow its own visibility (#1645).
     /// </summary>
     private static IObservable<IReadOnlyCollection<NodeMenuItemDefinition>> ContributionStream(
@@ -532,10 +533,15 @@ public static class NodeMenuItemsExtensions
             return Observable.Return(EmptyItems);
 
         var adminStream = host.Hub.IsGlobalAdmin().StartWith(false);
+        // The viewer's own partition key, for the ExcludeViewerHome gate. Captured on the render
+        // turn — the same rule ViewerId() itself states, and the same value PinLayoutArea and
+        // PresentationLayoutArea already read here.
+        var viewerId = host.Hub.ServiceProvider.GetService<AccessService>().ViewerId();
         return catalog.Contributions
             .CombineLatest(GetMenuContext(host), adminStream,
                 (contributions, menuCtx, isAdmin) => UiContributionProjection.ProjectMenu(
-                    contributions, context, menuCtx.menuPath, menuCtx.menuNode, menuCtx.perms, isAdmin));
+                    contributions, context, menuCtx.menuPath, menuCtx.menuNode, menuCtx.perms,
+                    isAdmin, viewerId));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/SettingsMenuItemsExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/SettingsMenuItemsExtensions.cs
@@ -1,9 +1,11 @@
 using System.Reactive.Linq;
 using MeshWeaver.Application.Styles;
+using MeshWeaver.Data;
 using MeshWeaver.Layout.Composition;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.Graph.Configuration;
 
@@ -69,12 +71,20 @@ public static class SettingsMenuItemsExtensions
             RenderingContext ctx)
     {
         var collection = config.Get<SettingsMenuProviderCollection>();
-        if (collection == null || collection.Providers.Count == 0)
-            return Observable.Return<IReadOnlyList<SettingsMenuItemDefinition>>([]);
+        var providerDelegates = collection?.Providers ?? (IReadOnlyList<SettingsMenuItemProvider>)[];
 
-        var streams = collection.Providers.Select(provider =>
+        var streams = providerDelegates.Select(provider =>
             // Skip failing providers so one broken tab can't crash all settings.
             provider(host, ctx).Catch<IReadOnlyList<SettingsMenuItemDefinition>, Exception>(
+                _ => Observable.Return<IReadOnlyList<SettingsMenuItemDefinition>>([])))
+            .ToList();
+
+        // Data-contributed tabs (UiContribution nodes with Context = NodeSettings, design #1645):
+        // the per-node twin of GlobalSettingsMenuItemsExtensions.ContributedSettingsTabs. This lane
+        // is added UNCONDITIONALLY — a mesh with zero compiled providers still renders its
+        // contributed tabs, which is the point of the fallback the compiled defaults shrink to.
+        streams.Add(ContributedSettingsTabs(host)
+            .Catch<IReadOnlyList<SettingsMenuItemDefinition>, Exception>(
                 _ => Observable.Return<IReadOnlyList<SettingsMenuItemDefinition>>([])));
 
         return Observable.CombineLatest(streams)
@@ -87,6 +97,57 @@ public static class SettingsMenuItemsExtensions
                 items.Sort((a, b) => a.Order.CompareTo(b.Order));
                 return (IReadOnlyList<SettingsMenuItemDefinition>)items;
             });
+    }
+
+    /// <summary>
+    /// The DATA-contributed PER-NODE settings tabs: every <see cref="UiContribution"/> in the
+    /// shared mesh-scoped catalog declaring <see cref="UiContribution.NodeSettingsContext"/>,
+    /// projected through the closed gate vocabulary in compiled code (#3055). The twin of
+    /// <c>GlobalSettingsMenuItemsExtensions.ContributedSettingsTabs</c>; the differences are the
+    /// ones the surface forces:
+    ///
+    /// <para>🚨 <b>Permission is NOT applied here.</b> The projection stamps
+    /// <see cref="SettingsMenuItemDefinition.RequiredPermission"/> (floored at
+    /// <see cref="Permission.Read"/>) and <see cref="FilterByPermission"/> applies it at the render
+    /// fold against the LATEST permission value — see <see cref="ObserveSettingsMenuItems"/> for
+    /// why a permission snapshot must never be baked into this stream (#1962).</para>
+    ///
+    /// <para>Fails CLOSED for an anonymous or virtual viewer, the same way the node menu forces
+    /// <see cref="Permission.None"/> for one: a settings page is an authoring surface, and a
+    /// public-read node must not hand a logged-out visitor its contributed tabs.</para>
+    ///
+    /// <para>The node-shape gates need the anchoring node, so the projection is combined with the
+    /// live own-node stream — which also makes a contributed tab appear/disappear the moment the
+    /// node's shape changes (a claim flipping <c>SyncBehavior</c>, say), with no reload.</para>
+    /// </summary>
+    private static IObservable<IReadOnlyList<SettingsMenuItemDefinition>>
+        ContributedSettingsTabs(LayoutAreaHost host)
+    {
+        var catalog = host.Hub.ServiceProvider.GetService<UiContributionCatalog>();
+        if (catalog is null)
+            return Observable.Return<IReadOnlyList<SettingsMenuItemDefinition>>([]);
+
+        var accessService = host.Hub.ServiceProvider.GetService<AccessService>();
+        var viewer = accessService?.Context ?? accessService?.CircuitContext;
+        var isAuthenticated = !string.IsNullOrEmpty(viewer?.ObjectId) && viewer?.IsVirtual != true;
+        if (!isAuthenticated)
+            return Observable.Return<IReadOnlyList<SettingsMenuItemDefinition>>([]);
+
+        var viewerId = accessService.ViewerId();
+        var menuPath = host.Hub.Address.ToString();
+
+        // Deferred so a hub without a MeshDataSource — where GetMeshNodeStream() throws
+        // SYNCHRONOUSLY — surfaces as OnError into the caller's Catch rather than as a throw out
+        // of the aggregator, taking every other settings tab with it.
+        return Observable.Defer(() =>
+        {
+            var ownNode = host.Workspace.GetMeshNodeStream()
+                .Catch<MeshNode, Exception>(_ => Observable.Return<MeshNode>(null!));
+            return catalog.Contributions
+                .CombineLatest(ownNode, host.Hub.IsGlobalAdmin().StartWith(false),
+                    (contributions, node, isAdmin) => UiContributionProjection
+                        .ProjectNodeSettingsTabs(contributions, menuPath, node, isAdmin, viewerId));
+        });
     }
 
     /// <summary>

--- a/src/MeshWeaver.Graph/Configuration/UiContributionNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionNodeType.cs
@@ -8,7 +8,8 @@ namespace MeshWeaver.Graph.Configuration;
 /// <summary>
 /// The <c>UiContribution</c> node type — a MENU ENTRY contributed as mesh DATA (design #1645, the
 /// WS7 composition-first lane). A contribution adds an entry to one of the shell's menu contexts
-/// (<c>Node</c>, <c>Mesh</c>, <c>Settings</c>, <c>AiMenu</c>, <c>SidePanel</c>) pointing at a
+/// (<c>Node</c>, <c>Mesh</c>, <c>Settings</c> — the GLOBAL settings page, <c>NodeSettings</c> —
+/// the PER-NODE settings page, <c>TopBar</c>, <c>AI</c>) pointing at a
 /// layout AREA the contributing plugin already ships — rendering stays the existing layout
 /// pipeline; contributions never introduce a render surface.
 ///
@@ -60,8 +61,33 @@ public record UiContribution
     public const string NodeContext = "Node";
     /// <summary>The <c>Mesh</c> menu context — mesh-level operations (Create/Import/Export).</summary>
     public const string MeshContext = "Mesh";
-    /// <summary>The global settings tabs context.</summary>
+    /// <summary>
+    /// The GLOBAL settings tabs context (<c>/_Setting/GlobalSettings/{Id}</c>) — node-independent,
+    /// platform-wide tabs. Projects into <c>GlobalSettingsMenuItemDefinition</c>.
+    /// </summary>
     public const string SettingsContext = "Settings";
+
+    /// <summary>
+    /// The PER-NODE settings tabs context (<c>/{nodePath}/Settings/{Id}</c>) — tabs anchored on
+    /// the node whose settings page is open. Projects into <c>SettingsMenuItemDefinition</c>.
+    ///
+    /// <para><b>Why a SECOND key rather than reusing <see cref="SettingsContext"/>.</b> The two
+    /// surfaces are different pages with different definition types, different routes and
+    /// different content-builder signatures (the per-node builder receives the anchoring
+    /// <see cref="MeshNode"/>; the global one has no node at all). One shared key would make every
+    /// contribution appear on BOTH — the seven platform tabs already seeded for the global surface
+    /// (What's New, About, Privacy, Invitations, Inbox, Updates, Published) would suddenly list on
+    /// every node's settings page, which is a visible regression rather than a migration. Two keys
+    /// also make the surfaces independently gateable, which is the property the whole
+    /// contribution lane exists for: a plugin decides which page its tab belongs on. A tab that
+    /// genuinely belongs on both is two contributions, and says so.</para>
+    ///
+    /// <para>The per-node lane is additionally the only one that carries
+    /// <see cref="UiContribution.Keywords"/> and <see cref="UiContribution.RequiredPermission"/>
+    /// through to the rendered tab — the per-node settings page has a search box and a node to
+    /// bind permissions to; the global page has neither.</para>
+    /// </summary>
+    public const string NodeSettingsContext = "NodeSettings";
 
     /// <summary>
     /// The top-bar MENU-DECLARATION context: a contribution here declares a whole NEW top-bar
@@ -74,8 +100,13 @@ public record UiContribution
     public const string TopBarContext = "TopBar";
 
     /// <summary>
-    /// Which menu the entry contributes to: <c>Node</c>, <c>Mesh</c>, <c>Settings</c>,
-    /// <c>AiMenu</c> or <c>SidePanel</c>. Unset ⇒ <c>Node</c>.
+    /// Which menu the entry contributes to: <c>Node</c>, <c>Mesh</c>, <c>Settings</c> (the GLOBAL
+    /// settings page), <c>NodeSettings</c> (the PER-NODE settings page), <c>TopBar</c>, <c>AI</c>
+    /// or any key a <c>TopBar</c> declaration introduces. Unset ⇒ <c>Node</c>.
+    ///
+    /// <para>🚨 A context nobody consumes renders NOWHERE — no error, no warning, not even an
+    /// area-not-found placeholder. <see cref="UiContributionSeedValidation"/> is the static check
+    /// that catches a mistyped or retired context before it ships dark.</para>
     /// </summary>
     public string? Context { get; init; }
 
@@ -125,6 +156,24 @@ public record UiContribution
     public string? GroupIcon { get; init; }
 
     /// <summary>
+    /// Extra SEARCH terms describing the fields/content INSIDE the contributed tab — the data
+    /// equivalent of <c>SettingsMenuItemDefinition.Keywords</c>, and the reason a migrating tab
+    /// does not silently vanish from settings search. The per-node settings page matches a query
+    /// against Label, Group AND these terms, so a viewer finds a setting by what is in it, not
+    /// only by the section's name (<c>PartitionSyncAdminLayoutArea</c> ships fifteen: "partitions",
+    /// "sync source", "decouple", "delete space", …).
+    ///
+    /// <para>Consumed by <see cref="NodeSettingsContext"/> only — the global settings page has no
+    /// search box and <c>GlobalSettingsMenuItemDefinition</c> has no keyword slot; declaring them
+    /// on a <see cref="SettingsContext"/> contribution is harmless but inert.</para>
+    ///
+    /// <para>These are user-VISIBLE search terms: a contribution serving a localized portal
+    /// should list the terms of the languages it serves, since there is no per-key translation
+    /// lane for a free-text search vocabulary (the same shape the compiled tabs use).</para>
+    /// </summary>
+    public ImmutableList<string>? Keywords { get; init; }
+
+    /// <summary>
     /// The permission the VIEWER must hold on the node for the entry to appear — enforced by the
     /// compiled aggregator against the live effective-permission stream (never trusted from
     /// data alone). Unset ⇒ <see cref="Permission.Read"/>; contributions can never demand less
@@ -155,4 +204,30 @@ public record UiContributionGates
 
     /// <summary>Only for platform admins (<c>hub.IsGlobalAdmin()</c> — the ONE admin predicate).</summary>
     public bool AdminOnly { get; init; }
+
+    /// <summary>
+    /// Only on nodes still PARTICIPATING in static-repo synchronization — <see
+    /// cref="MeshNode.SyncBehavior"/> is <see cref="SyncBehavior.Include"/>. The gate the
+    /// "Stop synchronization" entry needs (design #1645): once a viewer has claimed a node
+    /// (<see cref="SyncBehavior.ExcludeThisOnly"/> / <see cref="SyncBehavior.ExcludeThisAndChildren"/>)
+    /// there is nothing left to stop.
+    ///
+    /// <para>Narrowing only, like every gate here. The INVERSE ("only on claimed nodes", which the
+    /// compiled "Resume synchronization" branch renders) is deliberately NOT in the vocabulary —
+    /// a second gate word is a separate decision, and the vocabulary stays closed.</para>
+    /// </summary>
+    public bool SyncedOnly { get; init; }
+
+    /// <summary>
+    /// Never on the VIEWER'S OWN home — the node whose path is the viewer's own partition key.
+    /// The same predicate <c>PinLayoutArea</c> and <c>PresentationLayoutArea</c> already apply
+    /// ("you do not pin yourself to yourself"; "hiding your own home empties the page you are
+    /// reading"), and the gate the Edit/Move/Copy/Delete defaults need when they migrate.
+    ///
+    /// <para>Strictly narrower than <see cref="ExcludePartitionRoot"/>, and NOT a replacement for
+    /// it: <c>ExcludePartitionRoot</c> suppresses on ANY user's home (so an admin browsing someone
+    /// else's home still cannot Delete it from the menu), while this one suppresses only on the
+    /// viewer's own. Declare both when both apply.</para>
+    /// </summary>
+    public bool ExcludeViewerHome { get; init; }
 }

--- a/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
@@ -180,6 +180,13 @@ internal static class UiContributionProjection
     /// A contribution can never demand LESS than <see cref="Permission.Read"/> — an entry that
     /// declares nothing still requires Read, which is what makes an anonymous viewer (who arrives
     /// as <see cref="Permission.None"/>) see nothing at all.
+    ///
+    /// <para>🚨 Consequence for the per-node settings migration: a COMPILED tab registered with
+    /// <see cref="Permission.None"/> is chrome every viewer sees
+    /// (<c>SettingsMenuItemsExtensions.FilterByPermission</c> passes those unconditionally), and it
+    /// cannot be reproduced on this lane — it becomes Read-gated. Same viewers in practice, except
+    /// one holding <see cref="Permission.None"/> on the node; a decision to make when migrating
+    /// such a tab, not a detail to discover afterwards.</para>
     /// </summary>
     private static Permission RequiredPermissionFloor(UiContribution contribution)
         => contribution.RequiredPermission == Permission.None

--- a/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionProjection.cs
@@ -20,8 +20,9 @@ internal static class UiContributionProjection
     /// Projects the catalog into one node/mesh-menu context's entries. Gates, all enforced here:
     /// context match, a non-empty Area, the viewer's effective permission (floored at
     /// <see cref="Permission.Read"/> — an anonymous viewer arrives with
-    /// <see cref="Permission.None"/> and gets nothing), <c>AdminOnly</c>, and the node-shape
-    /// vocabulary (<c>ExcludePartitionRoot</c>, suffix-aware <c>NodeTypes</c>).
+    /// <see cref="Permission.None"/> and gets nothing), and the whole node-shape vocabulary via
+    /// <see cref="PassesNodeGates"/> (<c>AdminOnly</c>, <c>ExcludePartitionRoot</c>,
+    /// <c>ExcludeViewerHome</c>, <c>SyncedOnly</c>, suffix-aware <c>NodeTypes</c>).
     /// </summary>
     public static IReadOnlyCollection<NodeMenuItemDefinition> ProjectMenu(
         IReadOnlyList<(MeshNode Node, UiContribution Content)> contributions,
@@ -29,7 +30,8 @@ internal static class UiContributionProjection
         string menuPath,
         MeshNode? menuNode,
         Permission perms,
-        bool isAdmin)
+        bool isAdmin,
+        string? viewerId = null)
     {
         List<NodeMenuItemDefinition>? items = null;
         foreach (var (_, contribution) in contributions)
@@ -38,19 +40,10 @@ internal static class UiContributionProjection
                 continue;
             if (contribution.Area is not { Length: > 0 } area)
                 continue;
-            var required = contribution.RequiredPermission == Permission.None
-                ? Permission.Read
-                : contribution.RequiredPermission;
+            var required = RequiredPermissionFloor(contribution);
             if (!perms.HasFlag(required))
                 continue;
-            var gates = contribution.Gates;
-            if (gates?.AdminOnly == true && !isAdmin)
-                continue;
-            if (gates?.ExcludePartitionRoot == true
-                && PartitionRootDeletionGuard.IsUserPartitionRoot(menuNode))
-                continue;
-            if (gates?.NodeTypes is { Count: > 0 } nodeTypes
-                && !nodeTypes.Any(t => NodeTypeGateMatches(menuNode?.NodeType, t)))
+            if (!PassesNodeGates(contribution.Gates, menuPath, menuNode, isAdmin, viewerId))
                 continue;
 
             (items ??= []).Add(new NodeMenuItemDefinition(
@@ -110,6 +103,131 @@ internal static class UiContributionProjection
         }
         return items;
     }
+
+    /// <summary>
+    /// Projects the catalog into the PER-NODE settings tabs
+    /// (<c>/{nodePath}/Settings/{Id}</c>) — the lane the global settings surface has had since WS7
+    /// slice 2 and this one did not, which is why every remaining compiled tab was stuck
+    /// (#3055). Same closed vocabulary, same "narrow only" property; the differences are the ones
+    /// the surface itself forces:
+    ///
+    /// <list type="bullet">
+    /// <item><description>It answers a DIFFERENT context key
+    /// (<see cref="UiContribution.NodeSettingsContext"/>) — see that constant for why the two
+    /// surfaces are not one key.</description></item>
+    /// <item><description>🚨 It does NOT filter on the viewer's permission and takes none. It
+    /// carries <see cref="UiContribution.RequiredPermission"/> onto the definition and lets
+    /// <c>SettingsMenuItemsExtensions.FilterByPermission</c> apply it at the render fold, against
+    /// the LATEST permission value. Filtering here would bake a permission SNAPSHOT into a
+    /// long-lived provider stream — the #1962 defect, where a chain built on an early
+    /// <see cref="Permission.None"/> seed stays subscribed and later re-renders the menu with
+    /// every entitled tab silently missing. The floor is still applied (an entry that demands
+    /// nothing demands <see cref="Permission.Read"/>), so an anonymous viewer, who reaches the
+    /// fold as <see cref="Permission.None"/>, gets nothing.</description></item>
+    /// <item><description>It carries <see cref="UiContribution.Keywords"/> through to
+    /// <see cref="SettingsMenuItemDefinition.Keywords"/>, so a migrated tab keeps answering the
+    /// settings SEARCH box. Without it, migrating a tab removes it from search silently.</description></item>
+    /// <item><description>The node-shape gates apply, because unlike the global surface this one
+    /// HAS an anchoring node.</description></item>
+    /// </list>
+    /// </summary>
+    /// <param name="contributions">The live catalog slice.</param>
+    /// <param name="menuPath">The path of the node whose settings page is being rendered.</param>
+    /// <param name="menuNode">That node, or null when it could not be resolved.</param>
+    /// <param name="isAdmin">The viewer's live platform-admin answer.</param>
+    /// <param name="viewerId">The viewer's own partition key, for <c>ExcludeViewerHome</c>.</param>
+    public static IReadOnlyList<SettingsMenuItemDefinition> ProjectNodeSettingsTabs(
+        IReadOnlyList<(MeshNode Node, UiContribution Content)> contributions,
+        string menuPath,
+        MeshNode? menuNode,
+        bool isAdmin,
+        string? viewerId)
+    {
+        var items = new List<SettingsMenuItemDefinition>();
+        foreach (var (node, contribution) in contributions)
+        {
+            if (contribution.Context != UiContribution.NodeSettingsContext)
+                continue;
+            if (contribution.Area is not { Length: > 0 } area)
+                continue;
+            if (!PassesNodeGates(contribution.Gates, menuPath, menuNode, isAdmin, viewerId))
+                continue;
+
+            items.Add(new SettingsMenuItemDefinition(
+                // The node id (= the trailing path segment) keeps the tab's /Settings/{Id} deep
+                // link stable when a compiled tab migrates to a same-named seeded contribution.
+                Id: node.Id is { Length: > 0 } id ? id : area,
+                Label: contribution.Label ?? area,
+                // Embed INTO the pane's stack so a contributed tab inherits the same
+                // padding/scroll container every compiled tab renders in. The node argument is
+                // deliberately unused: the area renders on the anchoring node's OWN hub, so it
+                // resolves that node the same way every other layout area does.
+                ContentBuilder: (h, stack, _) => stack.WithView(Controls.LayoutArea(h.Hub.Address, area)),
+                Group: contribution.Group,
+                // Icon.Parse is the platform's TOTAL string→Icon conversion (Fluent name, SVG,
+                // URL, emoji→text) — the NavMenu renderer expects Icon objects here.
+                Icon: Icon.Parse(contribution.Icon),
+                GroupIcon: Icon.Parse(contribution.GroupIcon),
+                Order: contribution.Order,
+                RequiredPermission: RequiredPermissionFloor(contribution),
+                Keywords: contribution.Keywords)
+                { LabelKey = contribution.LabelKey, GroupKey = contribution.GroupKey });
+        }
+        return items;
+    }
+
+    /// <summary>
+    /// A contribution can never demand LESS than <see cref="Permission.Read"/> — an entry that
+    /// declares nothing still requires Read, which is what makes an anonymous viewer (who arrives
+    /// as <see cref="Permission.None"/>) see nothing at all.
+    /// </summary>
+    private static Permission RequiredPermissionFloor(UiContribution contribution)
+        => contribution.RequiredPermission == Permission.None
+            ? Permission.Read
+            : contribution.RequiredPermission;
+
+    /// <summary>
+    /// The CLOSED node-shape gate vocabulary, evaluated in ONE place so the node menu and the
+    /// per-node settings page can never drift on what a gate word means. Every clause
+    /// SUBTRACTS: an absent gate set passes.
+    /// </summary>
+    /// <param name="gates">The declared gates, or null.</param>
+    /// <param name="menuPath">The anchoring node's path.</param>
+    /// <param name="menuNode">The anchoring node, or null when unresolved.</param>
+    /// <param name="isAdmin">The viewer's live platform-admin answer.</param>
+    /// <param name="viewerId">The viewer's own partition key, or null when anonymous/unknown.</param>
+    private static bool PassesNodeGates(
+        UiContributionGates? gates, string menuPath, MeshNode? menuNode, bool isAdmin, string? viewerId)
+    {
+        if (gates is null)
+            return true;
+        if (gates.AdminOnly && !isAdmin)
+            return false;
+        if (gates.ExcludePartitionRoot && PartitionRootDeletionGuard.IsUserPartitionRoot(menuNode))
+            return false;
+        if (gates.ExcludeViewerHome && IsViewerHome(menuPath, viewerId))
+            return false;
+        // "Still synced" is the shape the Stop-synchronization action needs; a node the viewer has
+        // already claimed (any non-Include SyncBehavior) has nothing left to stop. A node that
+        // could not be resolved fails the gate — narrowing, never widening, on missing evidence.
+        if (gates.SyncedOnly && menuNode is not { SyncBehavior: SyncBehavior.Include })
+            return false;
+        if (gates.NodeTypes is { Count: > 0 } nodeTypes
+            && !nodeTypes.Any(t => NodeTypeGateMatches(menuNode?.NodeType, t)))
+            return false;
+        return true;
+    }
+
+    /// <summary>
+    /// The viewer's OWN home: the anchoring path IS the viewer's partition key. The identical
+    /// comparison <c>PinLayoutArea.GetMenuItem</c> and <c>PresentationLayoutArea.GetMenuItem</c>
+    /// already make, so the gate word and the compiled defaults it will replace agree by
+    /// construction. Never true for an anonymous viewer — there is no home to be on.
+    /// </summary>
+    internal static bool IsViewerHome(string? menuPath, string? viewerId)
+        => !string.IsNullOrEmpty(menuPath)
+           && !string.IsNullOrEmpty(viewerId)
+           && menuPath.Equals(viewerId, StringComparison.OrdinalIgnoreCase);
 
     /// <summary>
     /// The one token a contributed <c>Href</c> may carry: the path of the node whose menu is being

--- a/src/MeshWeaver.Graph/Configuration/UiContributionSeedValidation.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionSeedValidation.cs
@@ -1,0 +1,150 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+using MeshWeaver.Mesh;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// The STATIC integrity check for a set of seeded <see cref="UiContribution"/> nodes — core's
+/// equivalent of <c>MeshWeaver.Plugins/scripts/check-menu-contexts.py</c>, expressed as a pure
+/// function so a pinning test rather than a script enforces it (#3055).
+///
+/// <para><b>Why this exists.</b> Every defect it catches is SILENT — the contribution simply never
+/// appears, with no error, no warning and not even an area-not-found placeholder to notice:</para>
+/// <list type="bullet">
+/// <item><description>a <see cref="UiContribution.Context"/> nobody consumes: the entry is
+/// projected into a menu that is never rendered. Six shipped entries were dark for nine days that
+/// way (Systemorph/MeshWeaver.Plugins#1162) before anyone looked.</description></item>
+/// <item><description>an empty <see cref="UiContribution.Area"/>: both projections drop the entry
+/// BEFORE any gate runs, so it cannot even be found by turning gates off.</description></item>
+/// <item><description>a non-portal-internal <see cref="UiContribution.Href"/>:
+/// <c>UiContributionProjection.ResolveHref</c> rejects it and the entry quietly opens the DERIVED
+/// area URL instead — it renders, it is clickable, and it goes somewhere else.</description></item>
+/// <item><description>a <see cref="MeshNode.NodeType"/> that is not <c>UiContribution</c>: the
+/// catalog's <c>nodeType:UiContribution</c> query never returns the node at all.</description></item>
+/// <item><description>a missing <see cref="UiContribution.LabelKey"/> beside a
+/// <see cref="UiContribution.Label"/>: the entry ships its English label to every German
+/// viewer.</description></item>
+/// <item><description>two seeds at the SAME path: the catalog is keyed on path, so one silently
+/// replaces the other and which one wins depends on query order.</description></item>
+/// </list>
+///
+/// <para>Reusable by any repo that seeds contributions from compiled code — the check belongs with
+/// the vocabulary, not with one seed list.</para>
+/// </summary>
+public static class UiContributionSeedValidation
+{
+    /// <summary>
+    /// The menu contexts the PLATFORM itself consumes. A contribution naming anything else renders
+    /// nowhere unless something declares that key — which, for a top-bar menu, is a
+    /// <see cref="UiContribution.TopBarContext"/> contribution whose <c>Area</c> IS the new key
+    /// (<see cref="Validate(IReadOnlyCollection{MeshNode}, JsonSerializerOptions?, IEnumerable{string}?, IReadOnlyCollection{string}?)"/>
+    /// folds those in automatically), and for anything else a caller-supplied extra context.
+    ///
+    /// <para>Derived from the constants, never re-typed: a renamed context moves this set with it.
+    /// The shell's own renderer lives in another repo, so this is deliberately the set core can
+    /// PROVE it projects — a satellite passes its own keys as <c>additionalContexts</c> rather
+    /// than widening this one.</para>
+    /// </summary>
+    public static ImmutableHashSet<string> PlatformContexts { get; } =
+    [
+        UiContribution.NodeContext,
+        UiContribution.MeshContext,
+        UiContribution.SettingsContext,
+        UiContribution.NodeSettingsContext,
+        UiContribution.TopBarContext,
+        NodeMenuItemsExtensions.AiMenuContext,
+        NodeMenuItemsExtensions.GitHubMenuContext,
+    ];
+
+    /// <summary>
+    /// Validates a seed set, returning one message per problem — empty means clean. Never throws:
+    /// the caller (a test, a startup assertion) decides what a problem costs.
+    /// </summary>
+    /// <param name="seeds">The seeded contribution nodes.</param>
+    /// <param name="options">The owning hub's serializer options, when the content may have been
+    /// round-tripped through JSON. Null for a COMPILED seed list, whose <c>Content</c> is the CLR
+    /// record itself — anything else in that position is reported rather than silently skipped.</param>
+    /// <param name="additionalContexts">Context keys this deployment declares beyond
+    /// <see cref="PlatformContexts"/>.</param>
+    /// <param name="registeredAreas">When supplied, every seed's <c>Area</c> must name one of
+    /// these — the "this area is actually registered" half a dangling seed fails.</param>
+    public static ImmutableList<string> Validate(
+        IReadOnlyCollection<MeshNode> seeds,
+        JsonSerializerOptions? options = null,
+        IEnumerable<string>? additionalContexts = null,
+        IReadOnlyCollection<string>? registeredAreas = null)
+    {
+        var problems = ImmutableList.CreateBuilder<string>();
+
+        var contents = new List<(MeshNode Node, UiContribution? Content)>(seeds.Count);
+        foreach (var seed in seeds)
+            contents.Add((seed, ReadContent(seed, options)));
+
+        // A TopBar declaration INTRODUCES a context key (its Area), which entries in the same set
+        // may then target. Fold those in before judging any entry's context.
+        var known = PlatformContexts;
+        if (additionalContexts is not null)
+            known = known.Union(additionalContexts.Where(c => !string.IsNullOrEmpty(c)));
+        foreach (var (_, content) in contents)
+            if (content is { Context: UiContribution.TopBarContext, Area: { Length: > 0 } key })
+                known = known.Add(key);
+
+        var seenPaths = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var (node, content) in contents)
+        {
+            var path = node.Path;
+            if (!seenPaths.Add(path))
+                problems.Add($"{path}: two seeds share this path — the catalog is keyed on path, so one silently replaces the other");
+
+            if (!UiContributionNodeType.Matches(node.NodeType))
+                problems.Add($"{path}: NodeType is '{node.NodeType ?? "(null)"}', not '{UiContributionNodeType.NodeType}' — the catalog query never returns it");
+
+            if (content is null)
+            {
+                problems.Add($"{path}: Content is not a readable UiContribution (it is {node.Content?.GetType().Name ?? "null"})");
+                continue;
+            }
+
+            var context = content.Context ?? UiContribution.NodeContext;
+            if (!known.Contains(context))
+                problems.Add($"{path}: Context '{context}' is declared by nobody — the entry renders NOWHERE, silently. Known: {string.Join(", ", known.OrderBy(c => c, StringComparer.Ordinal))}");
+
+            if (content.Area is not { Length: > 0 } area)
+            {
+                problems.Add($"{path}: Area is empty — both projections drop the entry before any gate runs");
+            }
+            else if (registeredAreas is not null && !registeredAreas.Contains(area))
+            {
+                problems.Add($"{path}: Area '{area}' is not a registered layout area — the tab renders the not-found placeholder");
+            }
+
+            // The gate applies to the RESOLVED href, so judge it the way the projection will: with
+            // the {node} token substituted for a representative path.
+            if (content.Href is { Length: > 0 } href
+                && UiContributionProjection.ResolveHref(href, path) is null)
+            {
+                problems.Add($"{path}: Href '{href}' is not portal-internal — the projection discards it and the entry quietly opens the derived area URL instead");
+            }
+
+            if (content.Label is { Length: > 0 } && content.LabelKey is not { Length: > 0 })
+                problems.Add($"{path}: Label '{content.Label}' has no LabelKey — it ships English to every non-English viewer");
+
+            if (content.Group is { Length: > 0 } && content.GroupKey is not { Length: > 0 })
+                problems.Add($"{path}: Group '{content.Group}' has no GroupKey — the group header ships English to every non-English viewer");
+        }
+
+        return problems.ToImmutable();
+    }
+
+    /// <summary>
+    /// Reads a seed's content. With serializer options this is the ordinary bad-data-tolerant
+    /// <c>As&lt;T&gt;</c> read; without them the content must ALREADY be the CLR record, which is
+    /// the only shape a compiled seed list can hold — and when it is not, the caller gets a
+    /// PROBLEM naming the runtime type rather than a silent null.
+    /// </summary>
+    private static UiContribution? ReadContent(MeshNode node, JsonSerializerOptions? options)
+        => options is not null
+            ? node.Content.As<UiContribution>(options, what: node.Path)
+            : node.Content as UiContribution;
+}

--- a/test/Memex.Portal.Shared.Test/PlatformSettingsTabSeedTest.cs
+++ b/test/Memex.Portal.Shared.Test/PlatformSettingsTabSeedTest.cs
@@ -96,4 +96,49 @@ public class PlatformSettingsTabSeedTest
             Assert.Equal("Admin/UiContribution", seed.Namespace);
         });
     }
+
+    [Fact]
+    public void Every_Seed_Passes_The_Contribution_Integrity_Check()
+    {
+        // 🚨 The check core did not have. A contributed entry naming a context nobody declares
+        // renders NOWHERE — no error, no warning, not even an area-not-found placeholder; six
+        // shipped entries were dark for nine days that way (Systemorph/MeshWeaver.Plugins#1162,
+        // which is why that repo grew scripts/check-menu-contexts.py). Core seeds its
+        // contributions from COMPILED code, so the cheap equivalent is a pinning test over the
+        // seed list — this one.
+        var problems = UiContributionSeedValidation.Validate(
+            PlatformSettingsTabAreas.Seeds,
+            registeredAreas: PlatformSettingsTabAreas.Areas);
+        Assert.Empty(problems);
+
+        // CONTROL ARM 1 — the subject is still there. A Seeds list that emptied (a moved module, a
+        // renamed property, a refactor that stopped populating it) would make the assertion above
+        // pass having checked nothing at all.
+        Assert.Equal(ExpectedIds.Length, PlatformSettingsTabAreas.Seeds.Count);
+
+        // CONTROL ARM 2 — the checker can still fail. Break one real seed in each of the ways that
+        // ship dark and require the validator to say so; a validator degenerated into "no
+        // problems" (or one whose vocabulary drifted away from the projection's) reds HERE.
+        var sample = PlatformSettingsTabAreas.Seeds[0];
+        var content = Assert.IsType<UiContribution>(sample.Content);
+
+        Assert.NotEmpty(UiContributionSeedValidation.Validate(
+            [sample with { Content = content with { Context = "SettingsTypo" } }],
+            registeredAreas: PlatformSettingsTabAreas.Areas));
+        Assert.NotEmpty(UiContributionSeedValidation.Validate(
+            [sample with { Content = content with { Area = null } }],
+            registeredAreas: PlatformSettingsTabAreas.Areas));
+        Assert.NotEmpty(UiContributionSeedValidation.Validate(
+            [sample with { Content = content with { Area = "NotRegisteredAnywhere" } }],
+            registeredAreas: PlatformSettingsTabAreas.Areas));
+        Assert.NotEmpty(UiContributionSeedValidation.Validate(
+            [sample with { Content = content with { Href = "https://evil.example/phish" } }],
+            registeredAreas: PlatformSettingsTabAreas.Areas));
+        Assert.NotEmpty(UiContributionSeedValidation.Validate(
+            [sample with { Content = content with { LabelKey = null } }],
+            registeredAreas: PlatformSettingsTabAreas.Areas));
+        Assert.NotEmpty(UiContributionSeedValidation.Validate(
+            [sample with { NodeType = "Markdown" }],
+            registeredAreas: PlatformSettingsTabAreas.Areas));
+    }
 }

--- a/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
+++ b/test/MeshWeaver.Graph.Test/UiContributionProjectionTest.cs
@@ -29,9 +29,20 @@ public class UiContributionProjectionTest
         string context = UiContribution.NodeContext,
         MeshNode? node = null,
         Permission perms = Permission.Read,
-        bool isAdmin = false)
+        bool isAdmin = false,
+        string menuPath = "Org/Doc",
+        string? viewerId = null)
         => UiContributionProjection.ProjectMenu(
-            [Contribution(content)], context, "Org/Doc", node ?? SomeNode, perms, isAdmin);
+            [Contribution(content)], context, menuPath, node ?? SomeNode, perms, isAdmin, viewerId);
+
+    private static IReadOnlyList<SettingsMenuItemDefinition> ProjectNodeSettings(
+        UiContribution content,
+        MeshNode? node = null,
+        bool isAdmin = false,
+        string menuPath = "Org/Doc",
+        string? viewerId = null)
+        => UiContributionProjection.ProjectNodeSettingsTabs(
+            [Contribution(content)], menuPath, node ?? SomeNode, isAdmin, viewerId);
 
     [Fact]
     public void AnonymousViewer_PermissionNone_GetsNothing_EvenWhenTheContributionDemandsNothing()
@@ -267,6 +278,212 @@ public class UiContributionProjectionTest
         var icon = Assert.IsType<Domain.Icon>(tab.Icon);
         Assert.Equal(Domain.Icon.FluentProvider, icon.Provider);
         Assert.Equal("Shield", icon.Id);
+        Assert.IsType<Domain.Icon>(tab.GroupIcon);
+    }
+
+    [Fact]
+    public void SyncedOnly_Subtracts_OnceTheNodeHasBeenClaimed()
+    {
+        // The gate the "Stop synchronization" entry needs: a node the viewer already claimed has
+        // nothing left to stop, so the entry must not offer it.
+        var gated = new UiContribution
+        {
+            Area = "StopSync",
+            Gates = new UiContributionGates { SyncedOnly = true },
+        };
+        var synced = new MeshNode("Doc", "Org") { NodeType = "Markdown", SyncBehavior = SyncBehavior.Include };
+        var claimed = new MeshNode("Doc", "Org") { NodeType = "Markdown", SyncBehavior = SyncBehavior.ExcludeThisOnly };
+        var subtreeClaimed = new MeshNode("Doc", "Org")
+            { NodeType = "Markdown", SyncBehavior = SyncBehavior.ExcludeThisAndChildren };
+
+        Assert.Single(Project(gated, node: synced));
+        Assert.Empty(Project(gated, node: claimed));
+        Assert.Empty(Project(gated, node: subtreeClaimed));
+
+        // Missing evidence NARROWS: an unresolved node cannot prove it is still synced.
+        Assert.Empty(UiContributionProjection.ProjectMenu(
+            [Contribution(gated)], UiContribution.NodeContext, "Org/Doc", null, Permission.Read, false));
+
+        // And the gate is opt-in — an ungated entry is unaffected by the node's sync state.
+        Assert.Single(Project(new UiContribution { Area = "StopSync" }, node: claimed));
+    }
+
+    [Fact]
+    public void ExcludeViewerHome_SubtractsOnTheViewersOwnHomeOnly()
+    {
+        // The gate the Edit/Move/Copy/Delete defaults need — the same comparison PinLayoutArea and
+        // PresentationLayoutArea already make ("you do not pin yourself to yourself").
+        var alice = new MeshNode("alice", "") { NodeType = "User" };
+        var gated = new UiContribution
+        {
+            Area = "Edit",
+            Gates = new UiContributionGates { ExcludeViewerHome = true },
+        };
+
+        Assert.Empty(Project(gated, node: alice, menuPath: "alice", viewerId: "alice"));
+        // Case-insensitive, like every other partition-key comparison on this path.
+        Assert.Empty(Project(gated, node: alice, menuPath: "Alice", viewerId: "alice"));
+        // Someone ELSE's home is not the viewer's home — this gate alone does not suppress there.
+        Assert.Single(Project(gated, node: alice, menuPath: "bob", viewerId: "alice"));
+        // No viewer id (anonymous, or a host with no AccessService): there is no home to be on.
+        Assert.Single(Project(gated, node: alice, menuPath: "alice", viewerId: null));
+    }
+
+    [Fact]
+    public void ExcludeViewerHome_IsStrictlyNarrowerThan_ExcludePartitionRoot()
+    {
+        // The two gate words are NOT interchangeable, and a contribution that means "never on any
+        // home" must keep declaring ExcludePartitionRoot: an admin browsing someone else's home
+        // still must not get a Delete entry there.
+        var alice = new MeshNode("alice", "") { NodeType = "User" };
+        var viewerHomeOnly = new UiContribution
+            { Area = "Delete", Gates = new UiContributionGates { ExcludeViewerHome = true } };
+        var anyRoot = new UiContribution
+            { Area = "Delete", Gates = new UiContributionGates { ExcludePartitionRoot = true } };
+
+        Assert.Single(Project(viewerHomeOnly, node: alice, menuPath: "alice", viewerId: "bob"));
+        Assert.Empty(Project(anyRoot, node: alice, menuPath: "alice", viewerId: "bob"));
+    }
+
+    [Fact]
+    public void NodeSettingsTabs_AreASeparateSurface_FromTheGlobalSettingsTabs()
+    {
+        // 🚨 The context-key decision of #3055, pinned. ONE shared key would list every one of the
+        // seven platform tabs already seeded for the GLOBAL settings page (What's New, About,
+        // Privacy, Invitations, Inbox, Updates, Published) on EVERY node's settings page — a
+        // visible regression shipped in the name of a refactor. Each surface answers its own key.
+        var globalTab = new UiContribution
+            { Context = UiContribution.SettingsContext, Area = "SettingsAbout", Label = "About" };
+        var nodeTab = new UiContribution
+            { Context = UiContribution.NodeSettingsContext, Area = "NotificationsTab", Label = "Notifications" };
+
+        Assert.Empty(ProjectNodeSettings(globalTab));
+        Assert.Empty(UiContributionProjection.ProjectSettingsTabs([Contribution(nodeTab)], isAdmin: true));
+
+        Assert.Equal("Notifications", Assert.Single(ProjectNodeSettings(nodeTab)).Label);
+        Assert.Equal("About", Assert.Single(
+            UiContributionProjection.ProjectSettingsTabs([Contribution(globalTab)], isAdmin: false)).Label);
+
+        // A NodeSettings entry is not a node-MENU entry either — the contexts do not bleed.
+        Assert.Empty(Project(nodeTab));
+    }
+
+    [Fact]
+    public void NodeSettingsTabs_CarryKeywords_SoAMigratedTabStaysSearchable()
+    {
+        // SettingsMenuItemDefinition.Keywords backs the settings SEARCH box. Without a keywords
+        // field on the contribution, migrating a tab onto this lane would silently remove it from
+        // search — PartitionSyncAdminLayoutArea alone ships fifteen terms.
+        var tab = ProjectNodeSettings(new UiContribution
+        {
+            Context = UiContribution.NodeSettingsContext,
+            Area = "PartitionSyncAdmin",
+            Label = "Partition Sync",
+            LabelKey = "settings.partitionSync",
+            Keywords = ["partitions", "sync source", "decouple", "delete space"],
+        });
+
+        Assert.Equal(
+            new[] { "partitions", "sync source", "decouple", "delete space" },
+            Assert.Single(tab).Keywords);
+    }
+
+    [Fact]
+    public void NodeSettingsTabs_StampRequiredPermission_RatherThanFilteringOnIt()
+    {
+        // 🚨 The #1962 property. This projection takes NO permission argument on purpose: baking a
+        // permission snapshot into a long-lived provider stream is what silently emptied the
+        // settings menu. The floor is stamped onto the definition and applied at the render fold.
+        var declaresNothing = Assert.Single(ProjectNodeSettings(new UiContribution
+            { Context = UiContribution.NodeSettingsContext, Area = "A" }));
+        Assert.Equal(Permission.Read, declaresNothing.RequiredPermission);
+        // Label falls back to the area when the contribution declares none.
+        Assert.Equal("A", declaresNothing.Label);
+
+        var demandsUpdate = Assert.Single(ProjectNodeSettings(new UiContribution
+        {
+            Context = UiContribution.NodeSettingsContext,
+            Area = "B",
+            RequiredPermission = Permission.Update,
+        }));
+        Assert.Equal(Permission.Update, demandsUpdate.RequiredPermission);
+
+        // …and the fold is what subtracts: a Read viewer keeps the first and loses the second, and
+        // an anonymous viewer (Permission.None at the fold) loses BOTH — the Read floor is what
+        // makes "declares nothing" still mean "not for the logged-out".
+        IReadOnlyList<SettingsMenuItemDefinition> both = [declaresNothing, demandsUpdate];
+        Assert.Equal(["A"], SettingsMenuItemsExtensions
+            .FilterByPermission(both, Permission.Read).Select(i => i.Label));
+        Assert.Empty(SettingsMenuItemsExtensions.FilterByPermission(both, Permission.None));
+    }
+
+    [Fact]
+    public void NodeSettingsTabs_EnforceTheSameClosedGateVocabulary_AsTheNodeMenu()
+    {
+        var adminTab = new UiContribution
+        {
+            Context = UiContribution.NodeSettingsContext,
+            Area = "AdminTab",
+            Gates = new UiContributionGates { AdminOnly = true },
+        };
+        Assert.Empty(ProjectNodeSettings(adminTab));
+        Assert.Single(ProjectNodeSettings(adminTab, isAdmin: true));
+
+        var typeGated = new UiContribution
+        {
+            Context = UiContribution.NodeSettingsContext,
+            Area = "SpaceTab",
+            Gates = new UiContributionGates { NodeTypes = ["Space"] },
+        };
+        Assert.Empty(ProjectNodeSettings(typeGated));
+        // Suffix-aware, exactly like the node menu: a plugin-installed "Publish/Space" matches.
+        Assert.Single(ProjectNodeSettings(typeGated,
+            node: new MeshNode("S", "Org") { NodeType = "Publish/Space" }));
+
+        var homeGated = new UiContribution
+        {
+            Context = UiContribution.NodeSettingsContext,
+            Area = "HomeTab",
+            Gates = new UiContributionGates { ExcludeViewerHome = true },
+        };
+        Assert.Empty(ProjectNodeSettings(homeGated, menuPath: "alice", viewerId: "alice"));
+        Assert.Single(ProjectNodeSettings(homeGated, menuPath: "alice", viewerId: "bob"));
+
+        // An empty Area is dropped before any gate runs, on this lane as on every other.
+        Assert.Empty(ProjectNodeSettings(new UiContribution
+            { Context = UiContribution.NodeSettingsContext, Label = "No target" }));
+    }
+
+    [Fact]
+    public void NodeSettingsTabs_KeepTheNodeIdAsTheTabId_AndResolveIcons()
+    {
+        // The node id becomes the /{nodePath}/Settings/{Id} route segment, so a compiled tab that
+        // migrates to a same-named seed keeps every bookmarked deep link it had.
+        var tab = Assert.Single(UiContributionProjection.ProjectNodeSettingsTabs(
+            [(new MeshNode("Notifications", "Admin/UiContribution")
+                  { NodeType = UiContributionNodeType.NodeType },
+              new UiContribution
+              {
+                  Context = UiContribution.NodeSettingsContext,
+                  Area = "SettingsNotifications",
+                  Label = "Notifications",
+                  LabelKey = "settings.notifications",
+                  Icon = "Alert",
+                  Group = "Management",
+                  GroupKey = "settings.groupManagement",
+                  GroupIcon = "Document",
+                  Order = 120,
+              })],
+            "Org/Doc", SomeNode, isAdmin: false, viewerId: "alice"));
+
+        Assert.Equal("Notifications", tab.Id);
+        Assert.Equal(120, tab.Order);
+        Assert.Equal("Management", tab.Group);
+        Assert.Equal("settings.notifications", tab.LabelKey);
+        Assert.Equal("settings.groupManagement", tab.GroupKey);
+        var icon = Assert.IsType<Domain.Icon>(tab.Icon);
+        Assert.Equal(Domain.Icon.FluentProvider, icon.Provider);
+        Assert.Equal("Alert", icon.Id);
         Assert.IsType<Domain.Icon>(tab.GroupIcon);
     }
 }

--- a/test/MeshWeaver.Graph.Test/UiContributionSeedValidationTest.cs
+++ b/test/MeshWeaver.Graph.Test/UiContributionSeedValidationTest.cs
@@ -1,0 +1,190 @@
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// The CONTROL ARM of <see cref="UiContributionSeedValidation"/>: every defect the validator claims
+/// to catch is exercised here against a deliberately broken seed, so a validator that degenerated
+/// into "return no problems" fails HERE rather than passing quietly wherever it is applied.
+///
+/// <para>That matters more than usual for this subject. Every defect below is invisible at runtime
+/// — the contribution simply never appears, with no error, no warning and no placeholder. Six
+/// shipped entries were dark for nine days that way (Systemorph/MeshWeaver.Plugins#1162) before
+/// anyone noticed. A check that cannot fail would reproduce exactly that silence.</para>
+/// </summary>
+public class UiContributionSeedValidationTest
+{
+    private static MeshNode Seed(string id, UiContribution content, string? nodeType = null) =>
+        new(id, "Admin/UiContribution")
+        {
+            Name = id,
+            NodeType = nodeType ?? UiContributionNodeType.NodeType,
+            Content = content,
+        };
+
+    private static UiContribution WellFormed => new()
+    {
+        Context = UiContribution.NodeSettingsContext,
+        Area = "SettingsNotifications",
+        Label = "Notifications",
+        LabelKey = "settings.notifications",
+    };
+
+    [Fact]
+    public void AWellFormedSeedSet_HasNoProblems()
+    {
+        Assert.Empty(UiContributionSeedValidation.Validate([Seed("Notifications", WellFormed)]));
+    }
+
+    [Fact]
+    public void AContextNobodyDeclares_IsReported()
+    {
+        // THE defect this check exists for: a mistyped or retired context key renders NOWHERE.
+        var problems = UiContributionSeedValidation.Validate(
+            [Seed("Ghost", WellFormed with { Context = "NodeSettingz" })]);
+        Assert.Contains(problems, p => p.Contains("NodeSettingz") && p.Contains("declared by nobody"));
+    }
+
+    [Fact]
+    public void EveryPlatformContext_IsAccepted()
+    {
+        // The inventory must actually contain the keys the platform projects — a set that had
+        // drifted empty would make the previous test pass for the wrong reason.
+        Assert.All(UiContributionSeedValidation.PlatformContexts, context =>
+            Assert.Empty(UiContributionSeedValidation.Validate(
+                [Seed("C", WellFormed with { Context = context })])));
+        Assert.Contains(UiContribution.SettingsContext, UiContributionSeedValidation.PlatformContexts);
+        Assert.Contains(UiContribution.NodeSettingsContext, UiContributionSeedValidation.PlatformContexts);
+    }
+
+    [Fact]
+    public void AContextIntroducedByATopBarDeclaration_IsAccepted_InTheSameSet()
+    {
+        // A TopBar declaration's Area IS a new context key; entries targeting it are legitimate.
+        var declaration = Seed("ReinsuranceMenu", new UiContribution
+        {
+            Context = UiContribution.TopBarContext,
+            Area = "Reinsurance",
+            Label = "Reinsurance",
+            LabelKey = "menu.reinsurance",
+        });
+        var entry = Seed("Treaties", new UiContribution
+        {
+            Context = "Reinsurance",
+            Area = "TreatyList",
+            Label = "Treaties",
+            LabelKey = "menu.treaties",
+        });
+
+        Assert.Empty(UiContributionSeedValidation.Validate([declaration, entry]));
+        // …and WITHOUT the declaration the very same entry is dark, which is the whole point.
+        Assert.Contains(
+            UiContributionSeedValidation.Validate([entry]),
+            p => p.Contains("Reinsurance") && p.Contains("declared by nobody"));
+    }
+
+    [Fact]
+    public void AnExtraContextTheCallerDeclares_IsAccepted()
+    {
+        var entry = Seed("Panel", WellFormed with { Context = "SidePanel" });
+        Assert.Contains(UiContributionSeedValidation.Validate([entry]), p => p.Contains("declared by nobody"));
+        Assert.Empty(UiContributionSeedValidation.Validate([entry], additionalContexts: ["SidePanel"]));
+    }
+
+    [Fact]
+    public void AnEmptyArea_IsReported()
+    {
+        // Both projections drop an area-less entry BEFORE any gate runs, so it cannot even be
+        // found by relaxing gates.
+        Assert.Contains(
+            UiContributionSeedValidation.Validate([Seed("NoArea", WellFormed with { Area = null })]),
+            p => p.Contains("Area is empty"));
+    }
+
+    [Fact]
+    public void AnAreaTheDeploymentDoesNotRegister_IsReported_WhenTheAreaListIsSupplied()
+    {
+        Assert.Empty(UiContributionSeedValidation.Validate(
+            [Seed("Ok", WellFormed)], registeredAreas: ["SettingsNotifications"]));
+        Assert.Contains(
+            UiContributionSeedValidation.Validate(
+                [Seed("Dangling", WellFormed with { Area = "SettingsTypo" })],
+                registeredAreas: ["SettingsNotifications"]),
+            p => p.Contains("SettingsTypo") && p.Contains("not a registered layout area"));
+    }
+
+    [Theory]
+    [InlineData("https://evil.example/phish")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("//evil.example/phish")]
+    public void ANonPortalInternalHref_IsReported(string href)
+    {
+        // ResolveHref discards it and the entry quietly opens the DERIVED area URL — it renders,
+        // it is clickable, and it goes somewhere else entirely.
+        Assert.Contains(
+            UiContributionSeedValidation.Validate([Seed("Link", WellFormed with { Href = href })]),
+            p => p.Contains("not portal-internal"));
+    }
+
+    [Fact]
+    public void APortalInternalHref_IncludingOneCarryingTheNodeToken_IsAccepted()
+    {
+        Assert.Empty(UiContributionSeedValidation.Validate(
+            [Seed("Search", WellFormed with { Href = "/search?q=nodeType%3AThread" })]));
+        Assert.Empty(UiContributionSeedValidation.Validate(
+            [Seed("Approval", WellFormed with { Href = "/Approvals/Workspace/Request?doc={node}" })]));
+    }
+
+    [Fact]
+    public void ANodeThatIsNotAUiContributionNode_IsReported()
+    {
+        // The catalog query is `nodeType:UiContribution` — a seed carrying any other node type is
+        // never returned at all, however well-formed its content is.
+        Assert.Contains(
+            UiContributionSeedValidation.Validate([Seed("Wrong", WellFormed, nodeType: "Markdown")]),
+            p => p.Contains("NodeType is 'Markdown'"));
+    }
+
+    [Fact]
+    public void ContentThatIsNotAUiContribution_IsReported_RatherThanSkipped()
+    {
+        // The silent-null shape: content that is not the record reads as absent everywhere. Naming
+        // the runtime type is the difference between a diagnosis and a mystery.
+        var node = new MeshNode("Bad", "Admin/UiContribution")
+        {
+            NodeType = UiContributionNodeType.NodeType,
+            Content = "not a contribution",
+        };
+        Assert.Contains(
+            UiContributionSeedValidation.Validate([node]),
+            p => p.Contains("not a readable UiContribution") && p.Contains("String"));
+    }
+
+    [Fact]
+    public void TwoSeedsAtTheSamePath_AreReported()
+    {
+        // The catalog is a dictionary keyed on path: one silently replaces the other, and which
+        // one survives depends on query order.
+        Assert.Contains(
+            UiContributionSeedValidation.Validate([Seed("Dup", WellFormed), Seed("Dup", WellFormed)]),
+            p => p.Contains("two seeds share this path"));
+    }
+
+    [Fact]
+    public void AnUntranslatedLabelOrGroup_IsReported()
+    {
+        // The portal ships English + German; a label with no key renders English for every viewer.
+        Assert.Contains(
+            UiContributionSeedValidation.Validate([Seed("Raw", WellFormed with { LabelKey = null })]),
+            p => p.Contains("has no LabelKey"));
+        Assert.Contains(
+            UiContributionSeedValidation.Validate(
+                [Seed("RawGroup", WellFormed with { Group = "Management" })]),
+            p => p.Contains("has no GroupKey"));
+        Assert.Empty(UiContributionSeedValidation.Validate(
+            [Seed("Translated", WellFormed with
+                { Group = "Management", GroupKey = "settings.groupManagement" })]));
+    }
+}


### PR DESCRIPTION
Closes #3055.

WS7 step 4, the core half. The global settings surface has had a `ContributedSettingsTabs` lane
since slice 2; the per-node one had **none** — `SettingsMenuItemsExtensions` did not mention
`UiContribution` at all, and `UiContributionProjection.ProjectSettingsTabs` projected into
`GlobalSettingsMenuItemDefinition` only. All ten remaining tabs register on the per-node surface,
so gating was never what blocked them: there was nowhere for them to go.

## Ask 1 — the lane, with its OWN context key

`UiContribution.NodeSettingsContext` (`"NodeSettings"`) → `UiContributionProjection.ProjectNodeSettingsTabs`
→ `SettingsMenuItemsExtensions.ContributedSettingsTabs`, mirroring the global lane's shape rather
than inventing a parallel one.

**The decision, and why.** The issue leaves open whether the per-node surface reuses `Settings` or
gets its own key. It gets its **own key**:

* A single key means every seeded tab appears on **both** surfaces. Seven platform tabs are already
  seeded as `Admin/UiContribution/*` for the global page (What's New, About, Privacy, Invitations,
  Inbox, Updates, Published to the web) — reusing `Settings` would list all seven on *every node's*
  settings page. That is a visible regression shipped in the name of a refactor.
* The two surfaces are different pages with different definition types, routes and content-builder
  signatures (the per-node builder receives the anchoring `MeshNode`; the global one has no node).
* Two keys make the surfaces **independently gateable**, which is the property the contribution lane
  exists for. A tab that genuinely belongs on both is two contributions, and says so.

The cost is one `const string`. `UiContributionProjectionTest.NodeSettingsTabs_AreASeparateSurface_FromTheGlobalSettingsTabs`
pins the decision in both directions.

🚨 **The per-node lane takes no permission and does not filter on one.** It stamps
`RequiredPermission` (floored at `Read`) onto the definition and lets `FilterByPermission` apply it
at the render fold, against the *latest* value. Filtering inside the provider stream is precisely
the #1962 defect — a long-lived chain frozen on an early `Permission.None` seed that later
re-renders the menu with every entitled tab silently missing. The Read floor is what still makes an
anonymous viewer see nothing.

## Ask 2 — `Keywords`

Added to `UiContribution` and projected into `SettingsMenuItemDefinition.Keywords`, which backs the
settings search box (`SettingsLayoutArea.FilterMenuItems` matches Label ∪ Group ∪ Keywords).
Migrating a tab without it removes the tab from search with no other symptom —
`PartitionSyncAdminLayoutArea` alone ships fifteen terms. Consumed by `NodeSettings` only: the
global settings page has no search box and `GlobalSettingsMenuItemDefinition` has no keyword slot.

## Ask 3 — the two missing gate words

* **`SyncedOnly`** — the node still participates in sync (`SyncBehavior.Include`), the shape the
  "Stop synchronization" entry needs. A node that could not be resolved fails the gate: narrowing,
  never widening, on missing evidence. The inverse ("only on claimed nodes", the *Resume* branch) is
  deliberately **not** added — a second gate word is its own decision and the vocabulary stays closed.
* **`ExcludeViewerHome`** — the anchoring path IS the viewer's partition key, the same comparison
  `PinLayoutArea` and `PresentationLayoutArea` already make. **Strictly narrower** than
  `ExcludePartitionRoot` and not a replacement for it: `ExcludePartitionRoot` suppresses on *any*
  user's home (so an admin browsing someone else's home still gets no Delete entry), this one only
  on the viewer's own. Declare both when both apply — there is a test for exactly that distinction.

All gate words now evaluate in **one** place (`UiContributionProjection.PassesNodeGates`), so the
node menu and the per-node settings page cannot drift on what a gate word means.

## The seed-integrity check (the issue's last section)

`UiContributionSeedValidation` — core's equivalent of `MeshWeaver.Plugins/scripts/check-menu-contexts.py`,
as a pure function so a *test* enforces it rather than a script. It catches the whole silent class:

| defect | symptom without the check |
|---|---|
| a `Context` nobody declares | renders **nowhere** — no error, no warning, no placeholder. Six shipped entries were dark for nine days that way |
| an empty `Area` | dropped before any gate runs, so relaxing gates does not find it |
| a non-portal-internal `Href` | discarded; the entry quietly opens the *derived* area URL instead |
| a `NodeType` that is not `UiContribution` | the catalog query never returns the node |
| a `Label`/`Group` with no key | English for every German viewer |
| two seeds at one path | the catalog is keyed on path — one silently replaces the other |

It folds in the context keys a `TopBar` declaration introduces (an entry targeting a menu declared
in the same set is legitimate) and takes optional `additionalContexts` / `registeredAreas`, so the
Plugins repo can call the same function over `AiMenuContributions.Seeds`.

**Control arms**, because a check that cannot fail reproduces the silence it exists to break:

* `UiContributionSeedValidationTest` — 13 tests, one per defect, each asserting the validator
  *reports* a deliberately broken seed, plus the positive cases and an assertion that
  `PlatformContexts` actually contains the keys the platform projects (a set that drifted empty
  would make the negative tests pass for the wrong reason).
* `PlatformSettingsTabSeedTest.Every_Seed_Passes_The_Contribution_Integrity_Check` runs it over the
  **real** seed list, then (arm 1) asserts the seed count so an emptied `Seeds` cannot pass having
  checked nothing, and (arm 2) breaks one real seed six ways and requires the validator to reject
  each — a validator degenerated into "no problems" reds there.

## 🚫 Ask 4 is NOT included

The minimal compiled fallback (Data + Versions + Delete) is not in this PR, and it is not a matter
of time. Three things block it, and two of them are outside this repo:

1. **The PlatformUI pack must carry the retired defaults first.** It lives in `MeshWeaver.Plugins`
   and today declares the shell's top-bar menus, not the node-menu default item set. Shrinking
   `DefaultNodeMenuProvider` here before that lands removes Edit/Pin/Presentation/Move/Copy/Files/
   StopSync/Recycle from every mesh that does not have the pack — a shipped regression, not a
   migration.
2. **Two defaults cannot be expressed by the closed vocabulary at all.** The Presentation entry's
   *label* flips (Hide/Show) on the viewer's live screen, and StopSync's flips (Stop/Resume) on the
   node's `SyncBehavior`. `SyncedOnly` (this PR) migrates StopSync's *Stop* half; the *Resume* half
   needs the inverse gate that #1645 deliberately excludes. A label that depends on viewer or node
   state is behaviour, which the vocabulary is designed not to carry — so these stay compiled, and
   saying "the defaults retire" without saying that would be inaccurate.
3. **The separators are computed, not declared.** The `_separator` entries at Order 20/40 exist only
   where both adjacent sections are non-empty — pure compiled logic over the *result*.

The issue calls item 4 "a consolidation before it is a retirement", and notes the design's
`DefaultNodeMenuProvider`/`DefaultMeshMenuProvider` do not exist. They do, as private methods in
`NodeMenuItemsExtensions` — so the consolidation the design imagined is already done; what remains
is the retirement, which is cross-repo. What this PR contributes to item 4 is the vocabulary half:
`SyncedOnly` and `ExcludeViewerHome` were the two gate words the node-menu defaults were missing.

## No What's New entry

Deliberate, per the step-0.5 rule: this is a mechanism plus a test with **no user-visible effect** —
no tab has been migrated onto the lane, no gate word is declared by any shipped contribution yet.
The first PR that moves a tab onto the per-node lane is the user-facing one and gets the entry.

## One finding recorded for the migration: `RequiredPermission = Permission.None`

Found while checking the lane against the ten blocked tabs. `FilterByPermission` passes a
`Permission.None` tab **unconditionally** — it is chrome every viewer sees — but a contribution can
never demand less than `Read`, and that floor is exactly what makes the lane fail closed. So a
compiled per-node tab registered as `None` (Notifications is one of the ten) becomes `Read`-gated
the moment it moves onto the lane.

Same viewers in practice — you cannot open a node's settings page without reading the node — with
one real difference: a viewer holding `Permission.None` on the node loses the tab. That is the
closed vocabulary working as designed (a contribution narrows, never widens), but it IS a behaviour
change, so it is now recorded on the doc page for whoever plans the migration and on
`RequiredPermissionFloor` for whoever reads the code, rather than being discovered afterwards.

## Verification

* `dotnet build … -c Release -warnaserror` → `0 Error(s)`: `MeshWeaver.Graph`,
  `Memex.Portal.Shared`, `MeshWeaver.Graph.Test`, `Memex.Portal.Shared.Test`,
  `MeshWeaver.Documentation.Test`.
* Full, **unfiltered** test projects: `MeshWeaver.Graph.Test` (1202), `Memex.Portal.Shared.Test`
  (592), `MeshWeaver.Documentation.Test` (189 — the ratchet-guard home, so the new files are
  scanned) — all green.
* `scripts/check-record-signatures.py` → `✓ 8 changed C# file(s): no binary-breaking
  primary-constructor changes`. `UiContribution` / `UiContributionGates` carry init-only
  properties, not primary constructors, so the new fields are additive;
  `SettingsMenuItemDefinition`'s primary constructor is untouched.

The design decision is committed as a doc page, not left in this description:
`Doc/Architecture/UiExtensibility` gains the two-surfaces table with the reasoning, the two gate
words, `Keywords`, and a "a contribution nobody consumes is DARK" section pointing at the validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPe8CH4mFU9E74HafWppqL
