### PR TITLE
docs(#2901): the /api/content 503 is the pod-hub claim loss, measured end to end

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PodHubClaimReassertion.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PodHubClaimReassertion.md
@@ -59,6 +59,69 @@ Put those together and a mapping that is lost once is lost for the life of the p
 The startup population and the lost-after-landing population are two different triggers of one
 cause. Neither recovers, for the same reason: **there is no second assertion.**
 
+## The user-visible face of it: `/api/content` answers 503 (#2901)
+
+The measurement above is stated in routing terms. This is what the same fault looks like from a
+browser, and it is worth writing down because the shape was mis-attributed twice before the routing
+cause was found — once to a post-upload *settle window*, once to the memory `PubSubStore` and the
+streams-retirement program (#1729/#1742).
+
+`/api/content/{node}/{collection}/{file}` resolves the owning node's collection config with **one
+`GetDataRequest` per request** — deliberately uncacheable, because that round trip IS the permission
+check (`ContentFileResolver.Resolve`). It is issued from `portal/nodeops-{meshId}` and bounded by
+`ReadBudget.Default` (10 s). When the reply cannot get back, the budget is the only terminal, and the
+route answers **503 after ~10.3 s, per request, for as long as the process lives**.
+
+### The chain, measured end to end on `memex-cloud`, 2026-09-02
+
+| # | Observation | Reading |
+|---|---|---|
+| 1 | `Content read timed out for DoublePendulum/content/og-card.png` — **33 occurrences in 24 h, every one on a single pod**, zero on the other six replicas and zero in namespace `memex` | Per-pod and persistent. Neither a settle window nor a cluster-wide transport fault can produce that distribution |
+| 2 | Same millisecond: `HubUnreachableException: Reading content collection config from 'DoublePendulum' gave up after 10s … Reader: Hub portal/nodeops-Gpdh… RunLevel=Started Queue(buffer=0,deferred=0,exec=0) … Target: NO LOCAL HUB` | The reader is healthy and idle. Nothing arrived — this is the reply leg, not the request leg |
+| 3 | `[ROUTE] Directed delivery to pod hub 'portal/nodeops-Gpdh…' was refused: no silo in this cluster is currently serving that hub. Message RawJson (…) **from `AgenticEngineering`** was NOT posted` — logged by **four** different peer pods | The owning per-node hub DID produce the `GetDataResponse`. It had nowhere to go. Exactly the "reply produced, no route home" pair, now on the directed transport |
+| 4 | Onset: the refusals and the content timeouts start in the **same hour**, ~8 h after that pod had started clean and served fine | Lost-after-landing, not never-landed |
+| 5 | `03:12:52Z` — a peer silo logs `I have been told I am dead, so this silo will stop` and restarts | The membership change that re-partitioned the directory, immediately before the onset |
+
+Rows 3 and 5 together are the whole issue: a membership change moved the grain directory, one
+process's entry did not survive it, and every answer addressed to that process was refused from then
+on.
+
+### The two corrections this measurement makes
+
+**It is not a settle window.** Nothing about a freshly written file is involved. The discriminator is
+*which replica served the request*, which is why the same file alternated 200/503 across round-robin
+attempts and why a single-replica probe cannot see the fault at all.
+
+**It is not the memory `PubSubStore`.** The refusal line says in its own words that the message
+**was NOT posted to the Orleans stream** — the directed pod-hub call replaced that publish
+(`PodHubDeliveryRollPlan`). A discarded stream publish is a different failure with a different fix,
+and attributing this to the streams-retirement program would have parked a closed bug behind an open
+programme.
+
+### How to re-run it
+
+Two Loki queries, no mutation, and the first one alone settles the family:
+
+```
+sum by (namespace,pod) (count_over_time({namespace=~"memex|memex-cloud"} |= "Content read timed out" [24h]))
+sum by (pod)           (count_over_time({namespace="memex-cloud"} |= "portal/nodeops-<meshId>" |= "was refused" [1h]))
+```
+
+🚨 **`sum by (pod)` is the whole method.** An aggregate count reads as a low-grade cluster-wide
+flake; per pod it is one replica at 33 and six at zero, which names the cause. See
+[Measuring a Live Portal Read-Only](../MeasuringALivePortalReadOnly).
+
+### What closes it
+
+Re-assertion repairs the mapping at the next membership change, so the same measurement after the
+roll must show the failures **spread across replicas or absent**, never concentrated on one pod
+again. A fresh single-pod concentration would mean the re-assertion did not land for that address,
+and the next thing to look at is its ORDERING against the directory re-partition — the claim fires on
+the membership *notification*, which is not the same instant as the re-partition completing.
+
+> 🚨 A green probe through a load balancer in front of **one** replica has no power to detect a
+> per-replica fault. The replica count is part of the verification criterion, not context for it.
+
 ## Why the fix is an event and not a retry
 
 The claim already retried indefinitely on failure. That was never the gap. The gap is that **landing


### PR DESCRIPTION
Conserves a root-cause investigation that would otherwise have lived only in an issue thread.

## The finding

#2901 has carried **two** root-cause attributions and neither survives measurement — a post-upload "settle window" (already retracted in the thread) and the memory PubSubStore / streams-retirement programme (#1729/#1742, still recorded as the cause).

Measured on `memex-cloud` today, it is the **pod-hub claim loss** — #2938/#2915 — already fixed in core by `f37f3fc87` ("fix(orleans): re-assert the pod-hub claim on every membership change", merged 2026-09-02 02:46). **Production does not have it.**

## Why the evidence is worth keeping

The issue's own probe was re-run first and came back **18/18 `206`, all sub-2.5s** — which proves nothing about a per-replica defect, and the investigation says so rather than declaring victory. The log distribution is what discriminates:

```
sum by (namespace,pod) (count_over_time({namespace=~"memex|memex-cloud"} |= "Content read timed out" [24h]))
  memex-cloud / …-rfjgc   33
  every other pod, both namespaces   0
```

**33 occurrences in 24h, all on ONE pod**, zero across six sibling replicas and zero in the other namespace. That alone excludes a settle window and excludes a cluster-wide transport fault.

The terminal then names the link:

```
Reader: Hub portal/nodeops-… RunLevel=Started Queue(buffer=0,deferred=0,exec=0)
        PendingCallbacks=1[…=GetDataRequest@DoublePendulum(10003ms)]
Target: NO LOCAL HUB at 'DoublePendulum' — it never activated in this process
        (or it is owned by another silo and the reply was lost in transit).
```

Reader `Started`, queue empty, one callback outstanding — **not** a wedged caller, **not** a busy caller, **not** the request leg. The reply never came, because the reader's `portal/nodeops-{meshId}` address is not claimed in the cluster's grain directory.

## Disposition

This makes #2901 **fixed-and-undeployed**, not open-and-unexplained — which is a different action for whoever picks it up. It is the same root as this morning's observation that both portals are behind and were not self-updating; the CD stalls fixed today (#3075, #3078, #3080) are what let a fix reach them at all.

Doc-only. `MeshWeaver.Documentation.Test`: **189 passed, 0 failed** (full project, unfiltered, including `DocumentationLinkIntegrityTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)