### PR TITLE
compile-check: a Roslyn generator or analyzer is never a reference assembly (CS0433 on every satellite)

### DIFF
--- a/.github/scripts/compile-check.py
+++ b/.github/scripts/compile-check.py
@@ -333,6 +333,27 @@ def _report_framework_provenance(refs: dict, ref_roots) -> None:
         line += f"  image={digest}"
     print(line)
 
+# Assemblies that are COMPILER-TIME TOOLING, never a reference: Roslyn source generators and analyzers
+# ship beside the real assemblies (the tester image lays the SDK's generators out under
+# `sdk-generators/`, MeshWeaver#2905) and they carry INTERNAL copies of the public types they
+# generate code for — `System.Text.Json.SourceGeneration.dll` declares its own
+# `JsonSerializerDefaults`/`JsonIgnoreCondition`. Handed to the compiler as a reference beside
+# `System.Text.Json.dll`, every NodeType naming those types fails CS0433 "exists in both"
+# (Reinsurance #145: Ifrs17/Engine, UWDeepfield/TreatyRenewalTracking; Manufacturing run 212:
+# 12 of 15 types). A generator is consumed through the analyzer channel, never as a reference.
+_TOOLING_DIR_PARTS = {"sdk-generators", "analyzers"}
+_TOOLING_NAME_SUFFIXES = (".SourceGeneration.dll", ".Generators.dll", ".Generator.dll",
+                          ".Analyzers.dll", ".Analyzer.dll", ".CodeFixes.dll")
+
+
+def is_reference_assembly(path: str) -> bool:
+    """False for a Roslyn generator/analyzer assembly — by its directory or by its name."""
+    parts = set(Path(path).parts)
+    if parts & _TOOLING_DIR_PARTS:
+        return False
+    return not os.path.basename(path).endswith(_TOOLING_NAME_SUFFIXES)
+
+
 def discover_refs(refs_arg):
     """Return ({name.dll: path}, search_roots). If --refs is a dir, glob its *.dll. Else
        auto-discover the sibling core build (Debug preferred, else Release), deduped preferring the
@@ -378,6 +399,11 @@ def discover_refs(refs_arg):
         if core_used is not None:
             _refuse_if_sibling_stale(core_used)
         search_roots = [core_used] if core_used else list(candidates)
+    excluded = [d for d in dlls if not is_reference_assembly(d)]
+    if excluded:
+        print(f"refs: excluded {len(excluded)} compiler-tooling assembl(ies) (generators/analyzers are not references): "
+              + ", ".join(sorted({os.path.basename(d) for d in excluded})))
+    dlls = [d for d in dlls if is_reference_assembly(d)]
     seen = {}
     for dll in dlls:
         n = os.path.basename(dll)
@@ -710,6 +736,24 @@ def _self_test() -> int:
     emitted = [f"global using {u};" for u in union]
     if any(u.startswith("global using static ") for u in emitted):
         failures.append("  IMPLICIT_USINGS unexpectedly contains a static import")
+
+    # The reference set must never carry a Roslyn generator/analyzer beside the assembly it generates
+    # for (CS0433 "exists in both" on every NodeType naming a System.Text.Json type — Reinsurance #145).
+    import tempfile
+    with tempfile.TemporaryDirectory() as tmp:
+        flat = os.path.join(tmp, "app")
+        os.makedirs(os.path.join(flat, "sdk-generators"))
+        for name in ("System.Text.Json.dll", "System.Text.Json.SourceGeneration.dll", "MeshWeaver.Data.dll",
+                     "Some.Analyzers.dll"):
+            open(os.path.join(flat, name), "wb").close()
+        open(os.path.join(flat, "sdk-generators", "Microsoft.Extensions.Logging.Generators.dll"), "wb").close()
+        open(os.path.join(flat, "sdk-generators", "Innocent.Name.dll"), "wb").close()  # by DIRECTORY, not name
+        refs, _ = discover_refs(flat)
+        kept = set(refs)
+        if kept != {"System.Text.Json.dll", "MeshWeaver.Data.dll"}:
+            failures.append(f"  reference-set filter kept {sorted(kept)!r}; expected only System.Text.Json.dll + MeshWeaver.Data.dll")
+        if not is_reference_assembly(os.path.join(flat, "System.Text.Json.dll")):
+            failures.append("  is_reference_assembly refused the real System.Text.Json.dll")
 
     if failures:
         print("✗ using-directive parser self-test FAILED:")


### PR DESCRIPTION
Found by the Reinsurance CI pilot (Reinsurance #144 run 33618081238, filed as Reinsurance #145) and matching Manufacturing run 212.

**The red:** `CS0433: JsonSerializerDefaults exists in both System.Text.Json.SourceGeneration 10.0.14.37416 and System.Text.Json 10.0.0.0` on `Ifrs17/Engine`, `UWDeepfield/TreatyRenewalTracking` (Reinsurance) and 12 of 15 Manufacturing NodeTypes — every type naming a `System.Text.Json` attribute/enum, at any pin whose image lays the SDK generators out beside the real assemblies (#2905).

**Cause:** `compile-check.py discover_refs` takes every `*.dll` in the extracted image as a reference. `System.Text.Json.SourceGeneration.dll` is a Roslyn generator and carries internal copies of the public types it generates code for; as a *reference* beside `System.Text.Json.dll` the compiler sees two declarations. A generator is consumed through the analyzer channel, never as a reference.

**Fix:** compiler-tooling assemblies are excluded by directory (`sdk-generators/`, `analyzers/`) and by name (`*.SourceGeneration/Generators/Generator/Analyzers/Analyzer/CodeFixes.dll`); the run says what it dropped. `--self-test` plants both shapes beside the real assembly and asserts only the real one survives — including a generator with an innocent NAME under `sdk-generators/`, excluded by its directory.

Verification: `python3 .github/scripts/compile-check.py --self-test` → excluded 4, parser 9/9 OK. Every satellite fetches this script at `platform-ref`, so their lane pins move to this merge to pick it up (Reinsurance #144 is waiting on it).

Internal CI fix → no What's New.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
