### PR TITLE
fix: the patch-ack completion arm stands aside for a shutting-down owner (teardown NACK reaches the waiter again)

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1024,15 +1024,31 @@ public static class DataExtensions
     ///   <item><b>Echo arrives</b> → flush durably → ack <c>true</c> on the flush's emission. Nothing is
     ///     posted between the echo and the flush landing: the echo's own <c>Take(1)</c> completion is NOT
     ///     a verdict (see <see cref="WhenCompletesEmpty{T}"/>).</item>
-    ///   <item><b>Echo stream ENDS without the echo</b> — a <c>SynchronizationStream</c> disposed by mirror
-    ///     eviction while the hub lives completes its store — → NACK
-    ///     <see cref="MeshNodeErrorCode.OwnerDisposing"/>, naming the condition. That code, not
+    ///   <item><b>Echo stream ENDS without the echo while the owner LIVES</b> — a
+    ///     <c>SynchronizationStream</c> disposed by mirror eviction while the hub lives completes its store
+    ///     — → NACK <see cref="MeshNodeErrorCode.OwnerDisposing"/>, naming the condition. That code, not
     ///     <see cref="MeshNodeErrorCode.OwnerUnreachable"/> and not a new one: a stream ending under a live
     ///     patch IS the owner's stream going away, which is what the code means, and it is the writer's
     ///     auto-retried code — a re-enqueue re-runs the update lambda against the FRESH state and re-diffs,
     ///     so a merge that DID commit before the stream ended becomes a no-op. "Fate unknown, safe to retry"
     ///     is the honest verdict; the timeout verdict stays <c>Unknown</c> + <c>TimeoutException</c>, so the
     ///     two are separable by <c>Code</c> (Doc/Architecture/ReadingAWriteVerdict).</item>
+    ///   <item>🚨 <b>Echo stream ENDS without the echo while the owner is SHUTTING DOWN</b>
+    ///     (<paramref name="ownerIsShuttingDown"/>) → post NOTHING here. The stream completes in the owner's
+    ///     <c>DisposeHostedHubs</c> phase (its sync hub disposes and <c>Store.OnCompleted()</c>s), and the
+    ///     verdict for a patch in flight at owner teardown belongs to the ShutDown-phase disposal NACK
+    ///     (<c>RegisterOwnerDisposingNack</c>, on the same once-only gate). Claiming the gate here was the
+    ///     regression that turned <c>LateNackReenqueueTest</c> and <c>NackReachesTheWaiterDuringTeardownTest</c>
+    ///     red on 2026-09-02, for two reasons: (1) <b>one phase too early</b> — the dying activation still holds
+    ///     the address until its ShutDown phase removes it from the parent's registry, so an
+    ///     <c>OwnerDisposing</c> ("safe to retry against the fresh activation") minted at DisposeHostedHubs sends
+    ///     the writer's immediate re-enqueue into the SAME activation, which rejects it <c>ShuttingDown</c>, and
+    ///     the write fails <c>Unknown</c>; (2) <b>the wrong transport</b> — <c>hub.Post</c> from a hub past
+    ///     Quiescing is dropped under a whole-mesh teardown, and with the gate already claimed the registrant's
+    ///     direct <c>ILatePatchVerdictSink.Dispatch</c> — the one route that still reaches the armed waiter —
+    ///     is skipped, so the caller burns its whole verdict budget in silence (#2778 again). The registrant
+    ///     is total for a disposing hub (a registration racing disposal is disposed at once), so deferring
+    ///     to it loses no verdict.</item>
     ///   <item><b>Flush ENDS without emitting</b> → ack <c>true</c>. <see cref="IPostCommitFlush.Flush"/> is
     ///     contracted to "complete immediately for entity types this hook does not persist": nothing to
     ///     make durable means the in-memory commit IS the durable state — the same verdict as when no hook
@@ -1048,13 +1064,22 @@ public static class DataExtensions
         TimeSpan flushTimeout,
         Action<bool, MeshNodeError?> ackOnce,
         Action<IDisposable> registerForDisposal,
-        string hubPath)
+        string hubPath,
+        Func<bool> ownerIsShuttingDown)
         => commitEcho
-            .WhenCompletesEmpty(() => ackOnce(false, new MeshNodeError(
-                MeshNodeErrorCode.OwnerDisposing, hubPath,
-                "the owner's stream ended before this patch's commit echo arrived — the owner reported no "
-                + "verdict, so the write's fate is UNKNOWN; safe to retry: a re-enqueue re-diffs against the "
-                + "fresh state, so a merge that did commit is a no-op")))
+            .WhenCompletesEmpty(() =>
+            {
+                // The stream ended because the OWNER is going down: the ShutDown-phase disposal NACK
+                // owns this verdict (see remarks) — claiming the gate here mints it one phase too early
+                // and on a transport that does not reach the waiter under a whole-mesh teardown.
+                if (ownerIsShuttingDown())
+                    return;
+                ackOnce(false, new MeshNodeError(
+                    MeshNodeErrorCode.OwnerDisposing, hubPath,
+                    "the owner's stream ended before this patch's commit echo arrived — the owner reported no "
+                    + "verdict, so the write's fate is UNKNOWN; safe to retry: a re-enqueue re-diffs against the "
+                    + "fresh state, so a merge that did commit is a no-op"));
+            })
             .Subscribe(
                 committed =>
                 {
@@ -1480,11 +1505,19 @@ public static class DataExtensions
             // stream that faults or ENDS before delivering the state to merge against left the
             // request accepted and silently unanswered — the writer then burned its full
             // confirmation window and reported OwnerUnreachable. Here the merge provably never
-            // ran, so OwnerDisposing ("the patch was NOT applied; safe to retry") is exact.
-            .WhenCompletesEmpty(() => AckOnce(false, new MeshNodeError(
-                MeshNodeErrorCode.OwnerDisposing, hubPath,
-                "the owner's stream ended before it delivered the current state to merge against — "
-                + "the patch was NOT applied; safe to retry against the fresh activation")))
+            // ran, so OwnerDisposing ("the patch was NOT applied; safe to retry") is exact — unless
+            // the stream ended because the OWNER is shutting down, in which case the ShutDown-phase
+            // disposal NACK (RegisterOwnerDisposingNack, above) owns the verdict: minted here it
+            // would be one phase too early and on the wrong transport (see ArmPatchAckWatcher).
+            .WhenCompletesEmpty(() =>
+            {
+                if (hub.IsShuttingDown)
+                    return;
+                AckOnce(false, new MeshNodeError(
+                    MeshNodeErrorCode.OwnerDisposing, hubPath,
+                    "the owner's stream ended before it delivered the current state to merge against — "
+                    + "the patch was NOT applied; safe to retry against the fresh activation"));
+            })
             .Subscribe(change =>
             {
                 try
@@ -1632,7 +1665,8 @@ public static class DataExtensions
                         TimeSpan.FromSeconds(10),
                         AckOnce,
                         d => hub.RegisterForDisposal(d),
-                        hubPath);
+                        hubPath,
+                        () => hub.IsShuttingDown);
                     hub.RegisterForDisposal(postSub);
 
                     // Route via the hub's DataChangeRequest pipeline — the workspace
@@ -1737,10 +1771,14 @@ public static class DataExtensions
             TimeSpan.FromSeconds(10),
             AckOnce,
             d => hub.RegisterForDisposal(d),
-            hubPath);
+            hubPath,
+            () => hub.IsShuttingDown);
         hub.RegisterForDisposal(postSub);
         // Registered AFTER postSub so the composite disposes the watcher FIRST, then this NACK
         // claims the gate — an unacked in-flight patch always gets a terminal, never silence.
+        // The watcher's own completion arm stands aside for a shutting-down owner precisely so
+        // that this registrant — the ShutDown-phase seam, whose Dispatch reaches the waiter and
+        // whose timing lets the re-enqueue land on a FRESH activation — is the one that claims it.
         RegisterOwnerDisposingNack(hub, request, hubPath,
             () => System.Threading.Interlocked.Exchange(ref ackPosted, 1) == 0);
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingAWriteVerdict.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingAWriteVerdict.md
@@ -35,7 +35,8 @@ the two investigations.**
 | `OwnerUnreachable` | `The owner of '…' returned no verdict for this update within Ns. The patch was posted and may still apply… Request trail: …` | The owner produced **no terminal at all**. The writer's late-response window expired. | The **owner's** activation: is it alive, mid-recycle, pinned dead? |
 | `Unknown` | `{ExceptionTypeName}: {message}` — e.g. `TimeoutException: The operation has timed out.` | The owner **answered**, with a NACK carrying its own internal exception. | The owner's **ack chain**: which of its two internal bounds expired. |
 | `AccessDenied` / `Deserialization` / `Validation` | `Access denied: …` / `Patch deserialization failed: …` / `Validation failed: …` | The owner answered with a classified application-level refusal. | The patch itself. |
-| `OwnerDisposing` | `the owner's stream ended before this patch's commit echo arrived — … the write's fate is UNKNOWN; safe to retry …` | The owner **answered**: the stream its ack watcher was on completed before the echo — mirror eviction while the hub lives. The writer auto-retries it (a re-enqueue re-diffs, so a merge that did commit is a no-op). | The owner's **stream lifetime** (`ReclaimIfUnheld`, `SynchronizationStream.Dispose`), not its bounds. |
+| `OwnerDisposing` | `the owner's stream ended before this patch's commit echo arrived — … the write's fate is UNKNOWN; safe to retry …` | The owner **answered**: the stream its ack watcher was on completed before the echo — mirror eviction **while the hub lives**. The writer auto-retries it (a re-enqueue re-diffs, so a merge that did commit is a no-op). | The owner's **stream lifetime** (`ReclaimIfUnheld`, `SynchronizationStream.Dispose`), not its bounds. |
+| `OwnerDisposing` | `owner activation disposing before the merge turn ran — the patch was NOT applied; safe to retry against the fresh activation` | The owner **answered from its ShutDown phase**: the patch was in flight when the owner hub tore down. This is the disposal NACK (`RegisterOwnerDisposingNack`), handed to the armed late watch directly; the writer's re-enqueue lands on the fresh activation. | The owner's **teardown** (`HubDisposalModel`): why did the activation go down under a live patch? |
 
 Rows two and three come from one classifier on the **owner**:
 
@@ -108,11 +109,12 @@ emitted" — so every path posts exactly one terminal:
 | Path | Verdict |
 |---|---|
 | commit echo arrives, flush emits | `Success` — posted once, on the flush's emission |
-| **echo stream ends without the echo** | NACK `OwnerDisposing`, message `the owner's stream ended before this patch's commit echo arrived — … the write's fate is UNKNOWN; safe to retry …` |
+| **echo stream ends without the echo, owner alive** | NACK `OwnerDisposing`, message `the owner's stream ended before this patch's commit echo arrived — … the write's fate is UNKNOWN; safe to retry …` |
+| **echo stream ends without the echo, owner shutting down** (`hub.IsShuttingDown`) | **nothing from the watcher** — the ShutDown-phase disposal NACK (`RegisterOwnerDisposingNack`) is the verdict; see the third point below |
 | flush ends without emitting | `Success` — `IPostCommitFlush.Flush` is contracted to complete empty for entity types it does not persist, so the in-memory commit is the durable state (the same verdict as when no hook is registered) |
 | either stream faults | NACK with `ClassifyPatchException`'s code (a timeout stays `Unknown` + `TimeoutException`) |
 
-Two things about that shape are load-bearing:
+Three things about that shape are load-bearing:
 
 - 🚨 **The completion arm is guarded on "no emission was ever observed".** A bare
   `onCompleted => AckOnce(false)` would NACK every *successful* write: on the happy path `Take(1)`
@@ -125,6 +127,21 @@ Two things about that shape are load-bearing:
   against the **fresh** state and re-diffs, so a merge that did commit before the stream ended becomes a
   no-op. "Fate unknown, safe to retry" is the honest verdict — and because the timeout verdict stays
   `Unknown`, the two are separable by `Code`.
+- 🚨 **The completion arm stands aside when the OWNER is shutting down** (`hub.IsShuttingDown`, passed
+  to `ArmPatchAckWatcher` as `ownerIsShuttingDown`). An owner hub's teardown completes the very same
+  stream — its sync hub disposes in the `DisposeHostedHubs` phase and `Store.OnCompleted()`s — but that
+  completion is not the eviction case, and answering it from the watcher broke both teardown-NACK tests
+  on 2026-09-02 (`LateNackReenqueueTest`, `NackReachesTheWaiterDuringTeardownTest`). Two defects in one
+  claim of the once-only ack gate: **one phase too early** — a hosted hub leaves its parent's registry
+  only in its ShutDown phase ([Hub Disposal Model](../HubDisposalModel)), so a "safe to retry against
+  the fresh activation" minted at DisposeHostedHubs sent the writer's immediate re-enqueue into the
+  *dying* activation, which rejected it `ShuttingDown`, and the write failed `Unknown`; and **the wrong
+  transport** — `hub.Post` from a hub past Quiescing is dropped under a whole-mesh teardown, and with
+  the gate already claimed the disposal registrant's direct `ILatePatchVerdictSink.Dispatch` (the one
+  route that still reaches the armed waiter) was skipped, so the caller burned its whole verdict budget
+  in silence (#2778's shape again). The ShutDown-phase `RegisterOwnerDisposingNack` — registered on the
+  same hub, total for a disposing hub — therefore owns the verdict for a patch in flight at owner
+  teardown, and the watcher's arm fires only while the owner lives.
 
 The generic deferred path (`ApplyJsonMergePatchAndUpdate`, non-MeshNode data hubs) had the same gap
 twice over — its initial `stream.Take(1)` read had *neither* an error nor a completion arm, and its

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-save-caught-by-a-restart-lands-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-save-caught-by-a-restart-lands-again.md
@@ -1,0 +1,28 @@
+---
+Name: A save caught by the owner restarting lands again instead of failing
+Category: Fix
+Description: A write in flight while the hub owning the content shut down was answered too early, so its automatic retry hit the dying hub and the save failed — or, during a full shutdown, the answer never reached the waiting save at all. The retry now waits for the hub to actually let go of the address.
+Icon: Warning
+Order: -20260902
+---
+
+# A save caught by the owner restarting lands again instead of failing
+
+When you save content that lives on another hub and that hub happens to be shutting down at the same
+moment — a recycle, a restart, a whole-portal stop — the owner tells your side "I did not apply this;
+retry against my successor", and your side retries automatically. That has worked for a while.
+
+Yesterday's fix for saves that hung when the owner *stopped watching* introduced a second place that
+could give that same "retry" answer — and it gave it one step too early. The owner's stream ends
+partway through its shutdown, while the old hub still holds the address. Answering at that instant
+sent the automatic retry straight into the hub that was still going down, which refused it, and the
+save failed with an unexplained error instead of landing. During a full shutdown the early answer was
+worse: it was sent over a route that no longer delivers, and because a save is answered only once, the
+proper answer — the one that does reach the waiting save — was never given. The save then waited out
+its whole confirmation window in silence.
+
+The early answer now stands aside whenever the owner is shutting down. The verdict comes, as before,
+from the owner's final shutdown step — the point at which it has released the address — so the
+retry lands on the fresh hub and the save completes, and it is handed to the waiting save directly,
+so a portal-wide shutdown no longer leaves a save hanging. The "owner stopped watching" case keeps
+its prompt answer; the two are told apart by whether the owner is going down.

--- a/test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs
+++ b/test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs
@@ -69,7 +69,7 @@ public class PatchAckTotalityTest
         using var h = new Harness();
 
         using var sub = DataExtensions.ArmPatchAckWatcher(
-            Observable.Empty<int>(), _ => Observable.Return(true), FlushTimeout, h.AckOnce, h.Register, HubPath);
+            Observable.Empty<int>(), _ => Observable.Return(true), FlushTimeout, h.AckOnce, h.Register, HubPath, () => false);
 
         h.Acks.Should().ContainSingle(
             "a stream that completes without emitting is Rx's third termination; a two-arm subscribe "
@@ -100,7 +100,7 @@ public class PatchAckTotalityTest
         var flush = new Subject<bool>();
 
         using var sub = DataExtensions.ArmPatchAckWatcher(
-            Observable.Return(42), _ => flush, FlushTimeout, h.AckOnce, h.Register, HubPath);
+            Observable.Return(42), _ => flush, FlushTimeout, h.AckOnce, h.Register, HubPath, () => false);
 
         h.Acks.Should().BeEmpty(
             "Take(1) has completed right after the echo while the flush is in flight — a completion "
@@ -120,7 +120,7 @@ public class PatchAckTotalityTest
         using var h = new Harness();
 
         using var sub = DataExtensions.ArmPatchAckWatcher(
-            Observable.Return(42), _ => null, FlushTimeout, h.AckOnce, h.Register, HubPath);
+            Observable.Return(42), _ => null, FlushTimeout, h.AckOnce, h.Register, HubPath, () => false);
 
         h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null));
     }
@@ -138,7 +138,7 @@ public class PatchAckTotalityTest
         using var h = new Harness();
 
         using var sub = DataExtensions.ArmPatchAckWatcher(
-            Observable.Return(42), _ => Observable.Empty<bool>(), FlushTimeout, h.AckOnce, h.Register, HubPath);
+            Observable.Return(42), _ => Observable.Empty<bool>(), FlushTimeout, h.AckOnce, h.Register, HubPath, () => false);
 
         h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null),
             "nothing to persist is not a failure; a NACK here would fail a write that committed");
@@ -153,7 +153,7 @@ public class PatchAckTotalityTest
 
         using var sub = DataExtensions.ArmPatchAckWatcher(
             Observable.Throw<int>(new TimeoutException("owner echo timed out")),
-            _ => Observable.Return(true), FlushTimeout, h.AckOnce, h.Register, HubPath);
+            _ => Observable.Return(true), FlushTimeout, h.AckOnce, h.Register, HubPath, () => false);
 
         h.Acks.Should().ContainSingle();
         h.Acks[0].Success.Should().BeFalse();
@@ -170,7 +170,7 @@ public class PatchAckTotalityTest
 
         using var sub = DataExtensions.ArmPatchAckWatcher(
             Observable.Return(42), _ => Observable.Throw<bool>(new UnauthorizedAccessException("row-level security")),
-            FlushTimeout, h.AckOnce, h.Register, HubPath);
+            FlushTimeout, h.AckOnce, h.Register, HubPath, () => false);
 
         h.Acks.Should().ContainSingle();
         h.Acks[0].Success.Should().BeFalse();
@@ -254,5 +254,45 @@ public class PatchAckTotalityTest
                 + "latches, that NACK would win over the flush's later true");
         }
         foreach (var d in inner) d.Dispose();
+    }
+
+    /// <summary>
+    /// 🚨 THE TEARDOWN TRAP (Plugins <c>LateNackReenqueueTest</c> / <c>NackReachesTheWaiterDuringTeardownTest</c>,
+    /// red on core main 2026-09-02). The echo stream ends empty because the OWNER is shutting down —
+    /// its sync hub disposes in the DisposeHostedHubs phase and completes the store. The watcher must
+    /// post NOTHING: the ShutDown-phase disposal NACK owns that verdict. Minted here it is one phase
+    /// too early (the dying activation still holds the address, so the writer's immediate re-enqueue is
+    /// rejected ShuttingDown and the write fails Unknown) and, under a whole-mesh teardown, on a
+    /// transport that is dropped — having claimed the once-only gate, the registrant's direct
+    /// <c>Dispatch</c> to the armed waiter is then skipped and the caller hears nothing.
+    /// </summary>
+    [Fact]
+    public void EchoStreamThatEndsWhileTheOwnerIsShuttingDown_LeavesTheVerdictToTheDisposalNack()
+    {
+        using var h = new Harness();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Empty<int>(), _ => Observable.Return(true), FlushTimeout, h.AckOnce, h.Register, HubPath,
+            ownerIsShuttingDown: () => true);
+
+        h.Acks.Should().BeEmpty(
+            "the stream ended as part of the owner's own teardown; the ShutDown-phase disposal NACK "
+            + "(RegisterOwnerDisposingNack) is the verdict for a patch in flight at owner teardown — it fires "
+            + "when the address is released, so the writer's re-enqueue lands on a fresh activation, and it "
+            + "hands the verdict to the armed late watch directly, which a post from a disposing hub cannot");
+    }
+
+    /// <summary>The live-owner counterpart: the same empty completion, owner alive, still NACKs promptly.</summary>
+    [Fact]
+    public void EchoStreamThatEndsWhileTheOwnerLives_StillNacksPromptly()
+    {
+        using var h = new Harness();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Empty<int>(), _ => Observable.Return(true), FlushTimeout, h.AckOnce, h.Register, HubPath,
+            ownerIsShuttingDown: () => false);
+
+        h.Acks.Should().ContainSingle().Which.Error!.Code.Should().Be(MeshNodeErrorCode.OwnerDisposing,
+            "mirror eviction while the hub lives is #3033's case, and it has no other seam to answer on");
     }
 }

--- a/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
@@ -1,0 +1,153 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshWeaver.Fixture;
+
+// Core twin of MeshWeaver.Plugins/src/MeshWeaver.Hosting.Monolith.Test/LateNackReenqueueTest.cs (ported 2026-09-02):
+// core's own CI cannot run the Plugins-hosted suite, so the 2026-09-02 regression of the owner-disposing
+// NACK (PR #3070) reached main unseen. Keep the two in step.
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Pins hole 2 of the residual acked-write-loss behind <c>TwoSiloRecycleConvergenceTest</c>
+/// (main run 30159928718 / PR-645 run 30160988085): the mirror's <c>UpdateRemote</c> bounds
+/// its owner-response wait at ~2s and emits the optimistic snapshot on timeout — but the OLD
+/// shape also KILLED the response subscription there, so an owner verdict arriving later
+/// (above all the <see cref="MeshNodeErrorCode.OwnerDisposing"/> disposal NACK, which only
+/// lands after the owner's phased teardown) was observed by NOBODY. The caller saw success;
+/// the write was gone.
+///
+/// <para>The fix: the write stays armed in <c>LatePatchResponseRegistry</c> for
+/// <c>LateResponseWatchBound</c> (30s); the cache hub's <c>PatchDataResponse</c> handler
+/// dispatches the late verdict, and an OwnerDisposing NACK — the owner's explicit
+/// "the patch NEVER applied" — re-enqueues the ORIGINAL update lambda against the fresh
+/// activation (bounded re-enqueue budget, re-diffed against the freshest state).</para>
+///
+/// <para>The scripted interleaving: park the owner's merge turn behind a gated no-op turn
+/// (so no response can arrive inside the 2s window), THEN dispose the owner — the disposal
+/// NACK is necessarily LATE. The write must still reach durable storage via the re-enqueue.
+/// Without Part 2 the late NACK is dropped and the storage poll times out at the pre-write
+/// state.</para>
+///
+/// <para>🚨 Since #2661 the caller is NOT completed at the 2 s bound — a bound expiring is not
+/// a commit, so the write's terminal is the owner's verdict wherever it arrives. Here that
+/// verdict is the re-enqueued attempt's ack, chained back to the original caller, so this test
+/// now also pins that a late NACK's remedy is reported to the writer instead of being swallowed
+/// into a log line.</para>
+/// </summary>
+public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    [Fact(Timeout = 90_000)]
+    public async Task LateOwnerDisposingNack_AfterOptimisticEmit_ReenqueuesAndLands()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var path = $"{TestPartition}/late-nack-node";
+        await NodeFactory.CreateNode(
+                new MeshNode("late-nack-node", TestPartition) { Name = "initial", NodeType = "Markdown" })
+            .Should().Emit();
+
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            .Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(10.Seconds()).Await(ct);
+
+        var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull();
+
+        // Park the owner's merge executor (same gating pattern as OwnerDisposalNackTest):
+        // the cross-hub write below is accepted by the owner's handler but its merge turn
+        // provably cannot run — no ack can arrive inside the caller's 2s window.
+        var primary = nodeHub!.GetWorkspace().DataContext
+            .GetDataSourceForType(typeof(MeshNode))!
+            .GetStreamForPartition(null)!;
+        // 🚨 No hand-woven gate. The turn → test signal is an AsyncSubject the parked turn
+        // completes; the release travels back INTO that deliberately parked executor turn, so it
+        // is a volatile flag polled under a bounded SpinUntil and written in the `finally` below.
+        var gateEntered = new AsyncSubject<Unit>();
+        var releaseGate = 0;
+        primary.Update((Func<EntityStore?, ChangeItem<EntityStore>?>)(_ =>
+        {
+            gateEntered.OnNext(Unit.Default);
+            gateEntered.OnCompleted();
+            SpinWait.SpinUntil(() => Volatile.Read(ref releaseGate) == 1, TimeSpan.FromSeconds(60));
+            return null;
+        }), _ => { });
+        try
+        {
+            await gateEntered.Should().Within(10.Seconds()).Emit(
+                "the gated turn must be running on the primary stream's executor before the write");
+
+            // Cross-hub cache write — the production mirror path (UpdateRemote via the
+            // per-path queue). With the owner's merge parked, no verdict can arrive inside the
+            // caller's response bound, so the caller is NOT settled here (#2661): it stays open
+            // on the late watch, and the terminal it eventually gets is the re-enqueued
+            // attempt's. Subscribe rather than await — awaiting a verdict the parked owner
+            // cannot give is what would hang.
+            var marker = $"post-nack-{Guid.NewGuid():N}"[..24];
+            var workspace = Mesh.GetWorkspace();
+            MeshNode? callerTerminal = null;
+            Exception? callerError = null;
+            using var writeSub = workspace.GetMeshNodeStream(path)
+                .Update(n => n with { Name = marker })
+                .Subscribe(n => callerTerminal = n, ex => callerError = ex);
+            Output.WriteLine($"[write] patch posted with marker {marker}; owner merge is parked");
+
+            // Fence on the patch actually being in flight before the dispose below — the armed
+            // late watch is that fact, and it is the same fact the disposal NACK will land on.
+            var registry = Mesh.ServiceProvider.GetRequiredService<LatePatchResponseRegistry>();
+            await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+                .Where(_ => registry.ArmedCount > 0)
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
+
+            // Fence: the patch handler has provably run on the owner (registered the
+            // disposal NACK) before the dispose below.
+            await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+                .Should().Within(10.Seconds()).Emit();
+
+            // Dispose the owner AFTER the caller's response bound has expired — its
+            // OwnerDisposing NACK (posted from the ShutDown-phase disposal action) is
+            // necessarily LATE. The armed late watch must consume it and re-enqueue the
+            // ORIGINAL update against the fresh activation the re-posted patch brings up.
+            nodeHub!.Dispose();
+            Output.WriteLine($"[dispose] owner per-node hub disposal invoked for {path}");
+
+            // Ground truth: the write eventually lands in durable storage. Without the
+            // late-NACK re-enqueue the store stays frozen at 'initial' (the parked merge
+            // turn died with the sync hub; nobody re-applies) and this poll times out —
+            // the WaitForPersistedBeyond signature of the TwoSilo failure.
+            var persisted = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+                .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+                .Where(n => n is not null && n.Name == marker)
+                .FirstAsync().Timeout(45.Seconds()).Await(ct);
+            persisted!.Name.Should().Be(marker,
+                "a write whose owner NACKed OwnerDisposing must be re-enqueued and applied on "
+                + "the fresh activation — never silently lost");
+
+            // #2661: the re-attempt's verdict is the CALLER's verdict. Chaining it back is what
+            // makes "saved" mean the owner committed, on the late path as much as the early one.
+            await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+                .Where(_ => callerTerminal is not null || callerError is not null)
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
+            callerError.Should().BeNull("the re-enqueued attempt landed, so the caller must see a success");
+            callerTerminal!.Name.Should().Be(marker,
+                "the caller's terminal is the verdict of the attempt that actually committed");
+        }
+        finally
+        {
+            Volatile.Write(ref releaseGate, 1);
+        }
+    }
+}

--- a/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
+++ b/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+using MeshWeaver.Fixture;
+
+// Core twin of MeshWeaver.Plugins/src/MeshWeaver.Hosting.Monolith.Test/NackReachesTheWaiterDuringTeardownTest.cs (ported 2026-09-02):
+// core's own CI cannot run the Plugins-hosted suite, so the 2026-09-02 regression of the owner-disposing
+// NACK (PR #3070) reached main unseen. Keep the two in step.
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>#2778 — the OwnerDisposing NACK was dropped exactly when the parent is disposing hosted
+/// hubs, and the caller then burned its full verdict budget in silence.</b>
+///
+/// <para><c>RegisterOwnerDisposingNack</c> delivered the NACK as
+/// <c>parent.Post(...)</c> guarded by <c>parent.RunLevel &lt; DisposeHostedHubs</c>. With the run
+/// levels ordered <c>Starting, Started, Quiescing, DisposeHostedHubs, …</c> that guard is open
+/// for the first three and shut for the rest — so the one moment a whole BATCH of owner hubs goes
+/// down with patches in flight is the one moment none of their NACKs is delivered.</para>
+///
+/// <para><b>The guard's rationale was an assumption the code could not verify.</b> It read:
+/// <i>"during a whole-mesh teardown the parent is past that mark too, the post is skipped, and
+/// nobody is waiting."</i> A caller whose wait outlives the START of teardown is still waiting,
+/// and it is exactly that caller which is guaranteed to get silence instead of its answer.</para>
+///
+/// <para><b>Why this test disposes the MESH and not just the owner.</b> Disposing only the
+/// per-node hub — what <c>LateNackReenqueueTest</c> and <c>OwnerDisposalNackTest</c> do — leaves
+/// the parent at <c>Started</c>, where the old guard was OPEN and the NACK was delivered. Those
+/// tests therefore pass with the defect fully present. Reaching the hole at all requires the
+/// parent to be past <c>DisposeHostedHubs</c> when the owner's disposal action runs, and disposing
+/// the mesh is what puts it there — which is also precisely the production shape the issue
+/// reported (~13 distinct stream ids retiring in one burst).</para>
+///
+/// <para><b>What is asserted is that the NACK REACHES THE ARMED WATCH, not that the caller's
+/// callback runs.</b> This distinction was learned from the first draft of this test, which
+/// asserted the caller's terminal and failed even with the fix in place. The reason is sound and
+/// worth recording: disposing the mesh takes the CALLER's own subscription down along with the
+/// owner, so by the time the verdict is raised there is no live observer left to receive it —
+/// `observer.OnError` on a disposed subscription is a silent no-op. Asserting on the caller's
+/// callback would therefore be asserting on something this scenario cannot produce, whatever the
+/// framework does.</para>
+///
+/// <para>The armed watch is the right subject because it IS the thing #2778 is about. The registry
+/// entry is armed while a caller waits and is REMOVED by <c>Dispatch</c> — so the entry returning
+/// to zero is precisely "the owner's verdict reached the waiter", the step that used to be skipped.
+/// With the defect present the post is never made, nothing dispatches, and the entry simply sits
+/// armed until it expires 30 s later.</para>
+/// </summary>
+public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    [Fact]
+    public async Task OwnerDisposingUnderMeshTeardown_StillAnswersTheWaitingCaller()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var path = $"{TestPartition}/teardown-nack-node";
+        await NodeFactory.CreateNode(
+                new MeshNode("teardown-nack-node", TestPartition) { Name = "initial", NodeType = "Markdown" })
+            .Should().Emit();
+
+        await RequestHub.Observe(new GetDataRequest(new MeshNodeReference()), o => o.WithTarget(new Address(path)))
+            .Should().Emit();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(n => n is not null)
+            .FirstAsync().Timeout(10.Seconds()).Await(ct);
+
+        var nodeHub = Mesh.GetHostedHub(new Address(path), HostedHubCreation.Never);
+        nodeHub.Should().NotBeNull();
+
+        // Park the owner's merge executor, so the write below is ACCEPTED by the owner's handler
+        // (which is what registers the disposal NACK) but provably cannot be answered inside the
+        // caller's ~2 s response bound. The caller therefore hands its wait to the late watch —
+        // and being armed there is the precondition the whole issue turns on.
+        //
+        // 🚨 No hand-woven gate: the turn → test signal is an AsyncSubject the parked turn
+        // completes; the release travels back INTO the deliberately parked turn, so it is a
+        // volatile flag polled under a bounded SpinUntil and written in the `finally`.
+        var primary = nodeHub!.GetWorkspace().DataContext
+            .GetDataSourceForType(typeof(MeshNode))!
+            .GetStreamForPartition(null)!;
+        var gateEntered = new AsyncSubject<Unit>();
+        var releaseGate = 0;
+        primary.Update((Func<EntityStore?, ChangeItem<EntityStore>?>)(_ =>
+        {
+            gateEntered.OnNext(Unit.Default);
+            gateEntered.OnCompleted();
+            SpinWait.SpinUntil(() => Volatile.Read(ref releaseGate) == 1, TimeSpan.FromSeconds(60));
+            return null;
+        }), _ => { });
+        try
+        {
+            await gateEntered.Should().Within(10.Seconds()).Emit(
+                "the gated turn must be running on the primary stream's executor before the write");
+
+            var marker = $"teardown-nack-{Guid.NewGuid():N}"[..24];
+            var workspace = Mesh.GetWorkspace();
+            MeshNode? callerTerminal = null;
+            Exception? callerError = null;
+            using var writeSub = workspace.GetMeshNodeStream(path)
+                .Update(n => n with { Name = marker })
+                .Subscribe(n => callerTerminal = n, ex => callerError = ex);
+            Output.WriteLine($"[write] patch posted with marker {marker}; owner merge is parked");
+
+            // Fence on the caller actually WAITING — an armed late watch is that fact, and it is
+            // the same fact the disposal NACK has to land on. Without it this test could pass by
+            // asserting about a caller that was never waiting in the first place.
+            var registry = Mesh.ServiceProvider.GetRequiredService<LatePatchResponseRegistry>();
+            await Observable.Interval(TimeSpan.FromMilliseconds(50)).StartWith(0L)
+                .Where(_ => registry.ArmedCount > 0)
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await(ct);
+            Output.WriteLine($"[fence] caller is armed on the late watch (ArmedCount={registry.ArmedCount})");
+
+            // 🚨 The scenario. Dispose the MESH, not the node hub: the owner's disposal action then
+            // runs with its parent already past DisposeHostedHubs — the exact window in which the
+            // old guard skipped the post and the caller heard nothing.
+            Mesh.Dispose();
+            Output.WriteLine("[dispose] mesh disposal invoked — parent is past DisposeHostedHubs");
+
+            // 🚨 The assertion: the armed watch is CONSUMED. Dispatch removes the entry, so
+            // ArmedCount returning to zero is the observable fact "the owner's verdict reached the
+            // waiter". The bound is deliberately far below LateResponseWatchBound (30 s), because
+            // an entry that merely EXPIRES would also end at zero — waiting that long is
+            // indistinguishable from the defect, so a generous bound would pass on it.
+            await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+                .Where(_ => registry.ArmedCount == 0)
+                .FirstAsync().Timeout(10.Seconds()).Await(ct);
+
+            registry.ArmedCount.Should().Be(0,
+                "the owner minted an OwnerDisposing NACK for this patch, and a caller was armed and "
+                + "waiting for it; the verdict must reach that watch even though the parent is past "
+                + "DisposeHostedHubs. Leaving the watch armed is the #2778 defect — the caller then "
+                + "hears nothing and burns the whole 31 s verdict budget for an answer that had "
+                + "already been minted");
+
+            // Diagnostics only — under a full mesh teardown the caller's own subscription is going
+            // down too, so whether its callback still runs is not this test's subject (see the
+            // class remarks).
+            Output.WriteLine(
+                $"[caller] terminal={(callerTerminal is null ? "<null>" : callerTerminal.Name)} "
+                + $"error={(callerError is null ? "<null>" : callerError.GetType().Name)}");
+        }
+        finally
+        {
+            // In a `finally` so a failing assertion above cannot strand the parked executor turn.
+            Volatile.Write(ref releaseGate, 1);
+        }
+    }
+}


### PR DESCRIPTION
## The regression

Two teardown-NACK tests in the Plugins-hosted core suite (`MeshWeaver.Hosting.Monolith.Test`) went red against core main today and block every MeshWeaver.Plugins PR:

- `NackReachesTheWaiterDuringTeardownTest.OwnerDisposingUnderMeshTeardown_StillAnswersTheWaitingCaller`
- `LateNackReenqueueTest.LateOwnerDisposingNack_AfterOptimisticEmit_ReenqueuesAndLands`

Bisected locally (Plugins test project built with `-p:MeshWeaverRoot=<core>` at each commit): **pass 2/2 at `67b0f1947` (the commit before #3070), fail 2/2 at `9b3b00201` (the #3070 merge), fail 2/2 on current main.** First bad commit is #3070 (`fix/3033-patch-ack-completion-arm`). #3072's `ShuttingDown` signal is not on this path.

## Mechanism

#3070 gave the owner-side patch-ack watcher a completion arm: when the echo stream completes without ever emitting, NACK `OwnerDisposing` through `AckOnce` (`hub.Post`). The arm was written for *mirror eviction while the hub lives* (its own docs say so) but did not check that condition — and an owner hub's teardown completes the very same stream: its sync hub disposes in the `DisposeHostedHubs` phase and `Store.OnCompleted()`s. Claiming the once-only ack gate there is wrong twice:

1. **One phase too early.** A hosted hub leaves its parent's registry only in its ShutDown phase, so an `OwnerDisposing` ("safe to retry against the fresh activation") minted at `DisposeHostedHubs` sends the writer's immediate re-enqueue into the *dying* activation. Measured in the failing run: `OWNER_NACK_REENQUEUE … attempt=1` at +0 ms, then 44 ms later `DeliveryFailureException: Hub TestData/late-nack-node is shutting down (RunLevel=DisposeHostedHubs) … Rejecting now` → `[UpdateQueue] FAILED … MeshNode Unknown`. The write is lost.
2. **The wrong transport.** `hub.Post` from a hub past Quiescing is dropped under a whole-mesh teardown, and with the gate already claimed the ShutDown-phase registrant `RegisterOwnerDisposingNack` — whose direct `ILatePatchVerdictSink.Dispatch` is the one route that still reaches the armed waiter — finds `tryClaimAck()` false and does nothing. The waiter's registry entry stays armed until it expires (#2778's shape again).

The tests encode the documented contract (`ReadingAWriteVerdict.md`: the eviction verdict is for a stream that ends *while the hub lives*; `HubDisposalModel.md`: a hosted hub releases its address in ShutDown). The code was wrong, not the contract.

## The fix

`ArmPatchAckWatcher` takes `Func<bool> ownerIsShuttingDown` (call sites pass `() => hub.IsShuttingDown`); the empty-completion arm posts nothing when the owner is shutting down and leaves the verdict to the ShutDown-phase disposal NACK, which is total for a disposing hub (a registration racing disposal is disposed at once). The generic path's initial-read arm gets the same guard. Mirror eviction while the hub lives — #3033's case — still NACKs promptly.

- `src/MeshWeaver.Data/DataExtensions.cs` — the guard, with the mechanism recorded at the seam.
- `test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs` — two new pure pins (owner shutting down ⇒ no ack; owner alive ⇒ prompt `OwnerDisposing`), existing pins pass `() => false`.
- `test/MeshWeaver.Graph.Test/{LateNackReenqueueTest,NackReachesTheWaiterDuringTeardownTest}.cs` — the two Plugins tests ported verbatim so core CI covers the seam from now on (red before this fix, green after).
- `Doc/Architecture/ReadingAWriteVerdict.md` — the second `OwnerDisposing` row and the third load-bearing property of the watcher.
- What's New: Fix.

## Verification

- `dotnet build -c Release -warnaserror`: MeshWeaver.Data, MeshWeaver.Data.Test, MeshWeaver.Graph.Test — `0 Error(s)`.
- `MeshWeaver.Data.Test` whole and `MeshWeaver.Graph.Test` whole: see the run log in the PR conversation.
- Plugins `MeshWeaver.Hosting.Monolith.Test` built with `-p:MeshWeaverRoot=<this branch>`: both tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
