### PR TITLE
fix: the delivery gate consults the node type's own access rule (#3061)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AccessControl.md
@@ -1499,15 +1499,67 @@ code, and its exception text can carry an internal path, a connection string or 
 identifier — while the type is all a caller can act on ("retry, or ask an operator"). The full
 exception, message and stack, goes to the log where only an operator sees it.
 
-**What is still NOT routed through the rule, on purpose.** `DeleteNodeRequest` and
-`ValidateDeleteRequest` carry `[RequiresPermission(Permission.Delete)]`, so on a route that passes
-through a hub with the `AccessControlPipeline` (a per-node hub) the delivery gate still demands
-`Permission.Delete` on the *receiving hub's own path* before the handler runs. The off-router
-node-operation execution hub — where `IMeshService.DeleteNode` lands — carries no such pipeline, and
-that is the route the pre-flight governs. Widening the message-level gate is a separate decision with
-a much larger blast radius; it has not been made.
+### 🚨 …and the DELIVERY GATE is the third seam — it was left out, and that is #3061
 
-Pinned by `DeleteHonoursNodeTypeAccessRuleTest` (`test/MeshWeaver.Security.Test`), whose four cases
+The paragraph that used to stand here said the message-level gate was deliberately *not* routed
+through the rule: `DeleteNodeRequest` and `ValidateDeleteRequest` carry
+`[RequiresPermission(Permission.Delete)]`, so on a route that passes through a per-node hub the
+`AccessControlPipeline` demanded `Permission.Delete` on the receiving hub's own path before the
+handler ran, and widening that was "a separate decision with a much larger blast radius". **That
+decision has now been made, because the un-widened gate is a live defect** — and it is the SAME
+defect #2913 fixed one seam earlier, which is precisely the shape a rule stated as "every path that
+decides this node type's access consults it" exists to prevent.
+
+**Measured, memex 2026-09-02 (#3061).** A recursive delete of the orphan NodeType `Edu/Course` was
+refused with
+
+```
+Access denied: user 'rbuergi' lacks Delete permission on 'Edu/Course/_Activity/compile-…'
+```
+
+for all 72 of its `_Activity` satellites. Their registered `SatelliteAccessRule` says a satellite's
+Delete is `Permission.Update` on its `MainNode` — the very reasoning #2913 wrote down — but
+`RequiresPermissionAttribute.GetPermissionChecks` yields a RAW `(hubPath, Permission)` pair, the gate
+folded it with no rule in sight, and the gate runs **first**. So the one repair for a dangling
+NodeType was unavailable through any API.
+
+The gate now consults the same authority, resolved through the same index
+(`NodeTypeAccessRuleGate`, `src/MeshWeaver.Mesh.Contract/Services/NodeTypeAccessRuleGate.cs`), which
+also owns the evaluation both seams share — its three terminals and the "detail names the exception
+TYPE, never its message" rule. Reading it is what tells you the two cannot drift again.
+
+**Where the reconsideration sits, and why there.** It is reached ONLY from a definitive denial:
+
+| Fold outcome for `(hubPath, Permission)` | What happens |
+|---|---|
+| Granted | delivered — the rule is never consulted, so a hot `SubscribeRequest` reads no node |
+| **Denied** | **re-decided through the node type's rule** — the rule's answer is the gate's answer |
+| Undetermined | refused as `Unavailable` — "we could not check" is not a rule question |
+
+and four conditions each leave the denial exactly as it was: the check is not on this hub's own path;
+the permission names no operation a rule can decide about that node; nothing is served at that path;
+or no rule governs `(node type, operation)`.
+
+**`Permission.Create` deliberately maps to no operation.** A create names a node that does not exist
+yet and the gate evaluates on the PARENT's hub path, so the node type a lookup here would find is the
+parent's — and the parent's rule has no standing to decide a child's creation. `RlsNodeValidator`
+keys the Create rule off the node BEING CREATED, which only the handler can supply. Everything
+outside the CRUD four (Comment, Thread, Execute, Export, Compile, Api…) maps to nothing for the
+matching reason: `INodeTypeAccessRule.SupportedOperations` is expressed in `NodeOperation`s, so a
+rule cannot have an opinion about them.
+
+**A node read that FAULTS answers `Undetermined`, never the original denial.** Falling back to the
+denial would make a transient storage fault silently restore the pre-fix behaviour — the gate's own
+input deciding whether the gate ran, the shape AGENTS.md bans and `MissingEvaluatorFailsClosedTests`
+pins one level up. `Undetermined` is still fail-closed; it just stops claiming a verdict nobody
+reached.
+
+Pinned by `SatelliteDeliveryGateTest` (`test/MeshWeaver.Graph.Test`), whose three cases are the three
+verdicts on one mesh: an Editor's satellite pre-flight is served, a Viewer's is refused
+`Unauthorized` (the rule DENIES — consulting a rule never means granting), and the same Editor at a
+plain `Markdown` child of the same node is still refused (no rule, nothing widened).
+
+Pinned by `DeleteHonoursNodeTypeAccessRuleTest` (`MeshWeaver.Plugins`, `src/MeshWeaver.Security.Test`), whose four cases
 are the four rows of the table above — including the one that matters most, that an Editor still
 cannot delete a node whose type has no rule.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-deleting-a-node-takes-its-bookkeeping-with-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-deleting-a-node-takes-its-bookkeeping-with-it.md
@@ -1,0 +1,29 @@
+---
+Name: Deleting a node takes its bookkeeping with it
+Category: Fix
+Description: A delete could be refused because of the run records, comments and other bookkeeping filed beside the node — even for someone allowed to edit that node, which is the same permission those records are created under. The refusal is gone; a delete you may not do is still refused, and says so.
+Icon: Delete
+Order: -20260902
+---
+
+# Deleting a node takes its bookkeeping with it
+
+Most nodes carry small records filed beside them: what happened on the last run, the comments
+people left, the log of a build. You never create those by hand — they appear because you edited
+the node, and permission to edit the node is what creates them.
+
+Deleting the node should therefore take them with it, and the platform has always been written that
+way. One check on the way in disagreed: it asked for delete rights on each individual record rather
+than edit rights on the node they belong to. Anyone with edit access but not delete access hit a
+wall — able to create the records, unable to remove them — and because that check runs before
+everything else, its answer was the one that counted.
+
+Concretely, on 2 September a course type on the production portal could not be removed at all: the
+delete was refused once for each of its seventy-two run records, naming a permission that the
+records' own rule says is not the one required. The type was already broken and deleting it was the
+repair, so the repair was unavailable.
+
+The check now asks each record's own type what it requires, exactly as the deletion itself already
+did. Nothing widened beyond that: a record whose type states no rule is governed by the ordinary
+delete permission as before, and where a type's rule says no, the delete is still refused — with the
+reason, not with silence.

--- a/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
+++ b/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using MeshWeaver.Data;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using MeshWeaver.Messaging.Security;
 using Microsoft.Extensions.DependencyInjection;
@@ -106,6 +107,104 @@ public static class AccessControlPipeline
     /// delivery — the whole point of running the checks in order.
     /// </summary>
     private sealed record EvaluatedCheck(string Path, Permission Permission, PermissionCheckOutcome Outcome);
+
+    /// <summary>
+    /// Re-decides a DENIED check through the node type's own <see cref="INodeTypeAccessRule"/> —
+    /// the authority <c>MeshExtensions.CheckDeletePermissionForNode</c> already consults, resolved
+    /// through the same <see cref="NodeTypeAccessRuleGate"/> so the two cannot drift (issue #3061).
+    ///
+    /// <para><b>What it may change, and what it may not.</b> It is only ever reached from a
+    /// definitive DENIAL — never from a grant (nothing to reconsider) and never from an undetermined
+    /// fold (there is no verdict to reconsider, and "we could not check" must not be laundered into
+    /// a rule question). Its answer replaces the denial ONLY when the rule grants; a rule that
+    /// refuses leaves the delivery refused, and a rule that cannot reach a verdict answers
+    /// <see cref="PermissionCheckOutcome.Undetermined(string)"/>, which is still
+    /// <c>IsGranted = false</c>. Fail-closed on every leg.</para>
+    ///
+    /// <para><b>Four conditions, each of which returns the original denial unchanged:</b>
+    /// <list type="bullet">
+    ///   <item><description>the check is not on THIS hub's own path — a rule at this hub speaks for
+    ///     the node at this hub, nothing else;</description></item>
+    ///   <item><description>the permission does not name an operation a rule can decide about that
+    ///     node (<see cref="NodeTypeAccessRuleGate.SubjectOperationFor"/> — notably Create, whose
+    ///     subject is a node that does not exist yet);</description></item>
+    ///   <item><description>nothing is served at that path, so there is no node type to look
+    ///     up;</description></item>
+    ///   <item><description>no rule governs (node type, operation) — <c>Find</c> returning null is
+    ///     "no rule has an opinion", and the standard check's denial stands.</description></item>
+    /// </list></para>
+    ///
+    /// <para>🚨 A node READ that FAULTS answers Undetermined, not the original denial. Falling back
+    /// to the denial would make a transient storage fault silently restore the pre-fix behaviour —
+    /// the gate's own input deciding whether the gate ran, which is the shape AGENTS.md bans and
+    /// <c>MissingEvaluatorFailsClosedTests</c> pins one level up. Undetermined is still fail-closed;
+    /// it just stops claiming a verdict nobody reached.</para>
+    /// </summary>
+    private static IObservable<PermissionCheckOutcome> ReconsiderThroughNodeTypeRule(
+        IMessageHub hub,
+        IMessageDelivery delivery,
+        string hubPath,
+        (string Path, Permission Permission) check,
+        string userId,
+        ILogger? logger)
+    {
+        if (!string.Equals(check.Path, hubPath, StringComparison.OrdinalIgnoreCase))
+            return Observable.Return(PermissionCheckOutcome.Denied);
+
+        if (NodeTypeAccessRuleGate.SubjectOperationFor(check.Permission) is not { } operation)
+            return Observable.Return(PermissionCheckOutcome.Denied);
+
+        return NodeTypeAccessRuleGate.ReadSubjectNode(hub, hubPath)
+            .SelectMany(node =>
+            {
+                if (node is null
+                    || NodeTypeAccessRuleGate.Find(hub, node.NodeType, operation) is not { } rule)
+                    return Observable.Return(PermissionCheckOutcome.Denied);
+
+                var accessService = hub.ServiceProvider.GetService<AccessService>();
+                var context = new NodeValidationContext
+                {
+                    Operation = operation,
+                    Node = node,
+                    // The DELIVERY's context, exactly as CheckDeletePermissionByRule builds it —
+                    // it is the only copy that survives the scheduler hops to here.
+                    AccessContext = delivery.AccessContext
+                                    ?? accessService?.Context
+                                    ?? accessService?.CircuitContext,
+                    // A ValidateDeleteRequest / DeleteNodeRequest issued as part of a cascade names
+                    // its root; invariant validators use it to tell "the whole subtree is going
+                    // away" from "this one node is". Absent for every other message shape.
+                    DeleteCascadeRootPath = CascadeRootOf(delivery.Message)
+                };
+                logger?.LogDebug(
+                    "AccessControlPipeline: {Permission} on {Path} was denied by the standard check — "
+                    + "re-deciding through the {NodeType} access rule, which governs this node type",
+                    check.Permission, check.Path, node.NodeType);
+                return NodeTypeAccessRuleGate.Evaluate(rule, context, userId, logger);
+            })
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "AccessControlPipeline: could not read the node at {Path} to apply its node-type "
+                    + "access rule — reporting UNAVAILABLE rather than a denial nobody established",
+                    hubPath);
+                return Observable.Return(PermissionCheckOutcome.Undetermined(
+                    $"the node at '{hubPath}' could not be read to apply its node-type access rule "
+                    + $"({ex.GetType().Name})"));
+            });
+    }
+
+    /// <summary>
+    /// The cascade root a delete-shaped message belongs to, or <c>null</c> for every other message.
+    /// Mirrors what <c>MeshExtensions.CheckDeletePermissionByRule</c> puts on the context, so a rule
+    /// sees the same input whichever seam asked it.
+    /// </summary>
+    private static string? CascadeRootOf(object message) => message switch
+    {
+        ValidateDeleteRequest v => v.RootPath ?? v.Path,
+        DeleteNodeRequest d => d.CascadeRootPath ?? d.Path,
+        _ => null
+    };
 
     /// <summary>
     /// Adds the access control pipeline step to a per-node hub. Checks
@@ -411,6 +510,26 @@ public static class AccessControlPipeline
                         // the handler body runs, and the pool hop flows ExecutionContext
                         // anyway. See HubPermissionExtensions.TakeDecisionOutsideGate.
                         .TakeDecisionOutsideGate()
+                        // 🚨 THE NODE TYPE'S OWN RULE IS THE AUTHORITY, and the raw fold above does
+                        // not know it exists — issue #3061. `attr.GetPermissionChecks` yields a RAW
+                        // (hubPath, Permission) pair, so this gate demanded Delete on a satellite's
+                        // own path while the satellite's registered INodeTypeAccessRule says a
+                        // satellite's Delete is Update on its MainNode. #2913 taught
+                        // MeshExtensions.CheckDeletePermissionForNode to resolve that rule; it did
+                        // not teach the gate, and the gate runs FIRST — so on production a recursive
+                        // delete of Edu/Course was refused for all 72 of its `_Activity` satellites
+                        // ("lacks Delete permission on 'Edu/Course/_Activity/compile-…'") by a check
+                        // the node's own type says should pass, and the orphan could not be removed
+                        // through any API. Both seams now go through NodeTypeAccessRuleGate.
+                        //
+                        // Reached ONLY on a definitive denial, and that ordering is load-bearing in
+                        // two directions. It costs nothing on the hot path (a granted SubscribeRequest
+                        // never reads a node), and it never turns an UNDETERMINED fold into a rule
+                        // question — "we could not check" must stay "we could not check".
+                        .SelectMany(outcome => outcome.IsGranted || outcome.IsUndetermined
+                            ? Observable.Return(outcome)
+                            : ReconsiderThroughNodeTypeRule(
+                                hub, delivery, hubPath, check, effectiveUserId, logger))
                         .Select(outcome => new EvaluatedCheck(check.Path, check.Permission, outcome)))
                     // Concat, not Merge: the checks run ONE AT A TIME, in order — which is what
                     // makes the termination below actually save the remaining evaluations, and

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -3425,8 +3425,10 @@ public static class MeshExtensions
         if (userId == WellKnownUsers.System)
             return Observable.Return((DeletePreflight.Allowed, (string?)null));
 
-        var accessRule = hub.ServiceProvider.GetService<NodeTypeAccessRuleSet>()
-            ?.Find(node.NodeType, NodeOperation.Delete);
+        // 🚨 NodeTypeAccessRuleGate.Find, not a direct NodeTypeAccessRuleSet lookup — the delivery
+        // gate resolves through the same call (#3061), so "which rule governs this?" has exactly
+        // one implementation on both seams.
+        var accessRule = NodeTypeAccessRuleGate.Find(hub, node.NodeType, NodeOperation.Delete);
 
         return accessRule is null
             ? CheckDeletePermissionByPath(hub, userId, node, logger)
@@ -3438,6 +3440,11 @@ public static class MeshExtensions
     /// exactly as <see cref="RunDeletionValidatorsWithWarningsObs"/> builds it, so the rule sees the
     /// same inputs on both paths — including the DELIVERY's AccessContext, which is the only copy
     /// that survives the scheduler hops between handler entry and here.
+    ///
+    /// <para>🚨 The evaluation itself lives in <see cref="NodeTypeAccessRuleGate.Evaluate"/>, shared
+    /// with the <c>[RequiresPermission]</c> DELIVERY gate (issue #3061). When it was written out
+    /// here, the gate — which runs FIRST — never consulted a rule at all, and refused every
+    /// satellite delete the rule permits.</para>
     /// </summary>
     private static IObservable<(DeletePreflight Verdict, string? Detail)> CheckDeletePermissionByRule(
         IMessageHub hub,
@@ -3458,48 +3465,28 @@ public static class MeshExtensions
             DeleteCascadeRootPath = request.CascadeRootPath ?? request.Path
         };
 
-        return accessRule.HasAccess(context, userId)
-            // TakeDecisionOutsideGate for the reason spelled out in CheckDeletePermissionByPath:
-            // the rules reach the very same permission fold (SatelliteAccessRule calls
-            // hub.CheckPermission), and the caller chains the entire delete pipeline onto this.
-            .TakeDecisionOutsideGate()
-            .Select(allowed =>
+        // 🚨 THROUGH NodeTypeAccessRuleGate, never a local copy of the evaluation — issue #3061.
+        // The three terminals (verdict / fault / completed-without-emitting), the
+        // TakeDecisionOutsideGate hop and the "detail names the exception TYPE, never its message"
+        // rule used to be written out HERE, which is exactly how this seam and the DELIVERY gate
+        // came to answer the same question two ways. Both now call the same evaluation; the only
+        // thing that stays local is the projection onto this method's own vocabulary.
+        return NodeTypeAccessRuleGate.Evaluate(accessRule, context, userId, logger)
+            .Do(outcome =>
             {
-                if (!allowed)
+                if (!outcome.IsGranted && !outcome.IsUndetermined)
                     logger.LogDebug(
                         "[DeleteNode] rule-denied for {User} on {Path} (the {NodeType} access rule refused)",
                         userId, node.Path, node.NodeType);
-                return ((DeletePreflight Verdict, string? Detail)?)
-                    (allowed ? DeletePreflight.Allowed : DeletePreflight.Denied, null);
             })
-            // 🚨 FAIL CLOSED, and say WHICH failure it was. A rule reaches the same starve-able
-            // permission fold every other check does, so it can fault — and a fault is not a
-            // refusal. Answering Unestablished refuses the delete (the caller posts a failure) while
-            // reporting an availability problem rather than a decision about the caller's rights.
-            .Catch((Exception ex) =>
-            {
-                logger.LogWarning(ex,
-                    "[DeleteNode] the {NodeType} access rule for {Path} could not reach a verdict for "
-                    + "{User} — refusing the delete and reporting an availability failure, not a denial",
-                    node.NodeType, node.Path, userId);
-                // 🚨 The TYPE, never the exception's MESSAGE. This detail is echoed to the CALLER
-                // in the DeleteNodeResponse, and an arbitrary rule's exception text can carry
-                // internal paths, connection strings or another tenant's identifiers. The type
-                // names the condition, which is all a caller can act on ("retry, or ask an
-                // operator"); the full exception — message and stack — is on the LogWarning above,
-                // where only an operator sees it. (Copilot review, #2945.)
-                return Observable.Return<(DeletePreflight Verdict, string? Detail)?>(
-                    (DeletePreflight.Unestablished,
-                        $"the '{node.NodeType}' access rule failed ({ex.GetType().Name})"));
-            })
-            // 🚨 THE THIRD TERMINAL — a chain can also COMPLETE WITHOUT EMITTING (the shape that
-            // made RlsNodeValidator's own fold read as "nothing objected", #2742). Built LAZILY via
-            // nullable + DefaultIfEmpty() + Select so the message is only ever composed when it is
-            // actually used.
-            .DefaultIfEmpty()
-            .Select(outcome => outcome
-                ?? (DeletePreflight.Unestablished,
-                    $"the '{node.NodeType}' access rule completed without producing a verdict"));
+            // FAIL CLOSED on both non-granted legs, and say WHICH one it was: a rule reaches the
+            // same starve-able permission fold every other check does, so "it refused" and "it could
+            // not reach a verdict" are different facts and only the first is about the caller.
+            .Select(outcome => outcome.IsGranted
+                ? (DeletePreflight.Allowed, (string?)null)
+                : outcome.IsUndetermined
+                    ? (DeletePreflight.Unestablished, outcome.UndeterminedReason)
+                    : (DeletePreflight.Denied, (string?)null));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/Services/NodeTypeAccessRuleGate.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/NodeTypeAccessRuleGate.cs
@@ -1,0 +1,183 @@
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.Mesh.Services;
+
+/// <summary>
+/// The ONE way a caller asks "does this node type's own <see cref="INodeTypeAccessRule"/> decide
+/// this operation, and what does it say?" — resolution, evaluation and the three terminals, in one
+/// place so the seams that ask it cannot answer it differently.
+///
+/// <para>🚨 <b>Why it exists (issue #3061).</b> #2913 made
+/// <c>MeshExtensions.CheckDeletePermissionForNode</c> resolve the rule through
+/// <see cref="NodeTypeAccessRuleSet"/> instead of demanding <see cref="Permission.Delete"/>
+/// outright — but it fixed only that ONE seam. The <c>[RequiresPermission]</c> DELIVERY gate
+/// (<c>AccessControlPipeline</c>) runs FIRST, and it still yielded a raw
+/// <c>(hubPath, Permission)</c> pair from
+/// <c>RequiresPermissionAttribute.GetPermissionChecks</c> and folded it with no rule in sight. So
+/// the two seams disagreed again, and the gate won because it is earlier: on
+/// <c>memex.systemorph.com</c> a recursive delete of <c>Edu/Course</c> was refused with
+/// <c>Access denied: user 'rbuergi' lacks Delete permission on
+/// 'Edu/Course/_Activity/compile-…'</c> for all 72 of its <c>_Activity</c> satellites — whose
+/// registered <c>SatelliteAccessRule</c> says a satellite's Delete is
+/// <see cref="Permission.Update"/> on its <see cref="MeshNode.MainNode"/>, which the caller held.
+/// Both seams now come through here.</para>
+///
+/// <para><b>The rule set is still the index</b> — this type adds no second registry. It supplies
+/// the two things the two seams were each re-deriving: the (permission ⇒ operation) mapping a
+/// delivery gate needs to ask the index a question at all, and the EVALUATION with all three
+/// terminals represented.</para>
+/// </summary>
+public static class NodeTypeAccessRuleGate
+{
+    /// <summary>
+    /// The <see cref="NodeOperation"/> a <c>[RequiresPermission(<paramref name="permission"/>)]</c>
+    /// delivery gate is deciding ABOUT THE HUB'S OWN NODE, or <c>null</c> when no rule at that hub
+    /// can speak for the check.
+    ///
+    /// <para>🚨 <b><see cref="Permission.Create"/> deliberately maps to nothing.</b> A create names
+    /// a node that does not exist yet, and the gate evaluates on the PARENT's hub path — so the
+    /// node whose type would be looked up here is the parent, and the parent's rule has no standing
+    /// to decide a child's creation. <c>RlsNodeValidator</c> keys the Create rule off the node BEING
+    /// CREATED (<c>context.Node.NodeType</c>, path-checked against the parent), which only the
+    /// handler can supply. Returning null keeps the gate's coarse Create check exactly as it was and
+    /// leaves the decision where it has always been.</para>
+    ///
+    /// <para>Everything outside the CRUD four (Comment, Thread, Execute, Export, Compile, Api, …)
+    /// maps to nothing for the same reason in a different shape:
+    /// <see cref="INodeTypeAccessRule.SupportedOperations"/> is expressed in
+    /// <see cref="NodeOperation"/>s, so a rule cannot have an opinion about them.</para>
+    /// </summary>
+    /// <param name="permission">The permission the delivery gate demands.</param>
+    /// <returns>The operation a rule could decide, or null.</returns>
+    public static NodeOperation? SubjectOperationFor(Permission permission) => permission switch
+    {
+        Permission.Read => NodeOperation.Read,
+        Permission.Update => NodeOperation.Update,
+        Permission.Delete => NodeOperation.Delete,
+        _ => null
+    };
+
+    /// <summary>
+    /// The rule governing (<paramref name="nodeType"/>, <paramref name="operation"/>) on
+    /// <paramref name="hub"/>'s mesh, or <c>null</c> when none does.
+    ///
+    /// <para>🚨 <c>null</c> is "no rule has an opinion", never "allowed" — see
+    /// <see cref="NodeTypeAccessRuleSet.Find"/>. Every caller keeps its own standard check as the
+    /// fallback; that fallback IS the closed-by-default behaviour.</para>
+    /// </summary>
+    /// <param name="hub">The hub whose service provider carries the mesh's rule index.</param>
+    /// <param name="nodeType">The subject node's <see cref="MeshNode.NodeType"/>.</param>
+    /// <param name="operation">The operation being decided.</param>
+    /// <returns>The governing rule, or null.</returns>
+    public static INodeTypeAccessRule? Find(IMessageHub hub, string? nodeType, NodeOperation operation)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        return hub.ServiceProvider.GetService<NodeTypeAccessRuleSet>()?.Find(nodeType, operation);
+    }
+
+    /// <summary>
+    /// Runs <paramref name="rule"/> and reports its answer as a
+    /// <see cref="PermissionCheckOutcome"/> — the tri-state, because a rule has THREE terminals and
+    /// only one of them is a verdict.
+    ///
+    /// <list type="bullet">
+    ///   <item><description>emits <c>true</c>/<c>false</c> ⇒
+    ///     <see cref="PermissionCheckOutcome.Granted"/> / <see cref="PermissionCheckOutcome.Denied"/>;</description></item>
+    ///   <item><description>FAULTS ⇒ <see cref="PermissionCheckOutcome.Undetermined(string)"/> — a rule
+    ///     reaches the same starve-able permission fold every other check does
+    ///     (<c>SatelliteAccessRule</c> calls <c>hub.CheckPermission</c>), and a fault is not a
+    ///     refusal;</description></item>
+    ///   <item><description>COMPLETES WITHOUT EMITTING ⇒ <see cref="PermissionCheckOutcome.Undetermined(string)"/>
+    ///     — the shape #2742 established: <c>CombineLatest</c> completes the instant any source
+    ///     completes having produced nothing, and an empty check reads as "nothing objected"
+    ///     everywhere downstream.</description></item>
+    /// </list>
+    ///
+    /// <para>Undetermined carries <c>IsGranted = false</c>, so every consumer fails CLOSED whether
+    /// or not it branches on the tri-state. There is deliberately no <c>.Catch(_ =&gt; true)</c>
+    /// shape here: the identical instinct on the security-fold twin is what made a group deny fail
+    /// OPEN (#2011).</para>
+    ///
+    /// <para>🚨 The DETAIL names the exception TYPE, never its message. This string is echoed to the
+    /// caller (a <c>DeleteNodeResponse</c>, a <c>DeliveryFailure</c>), and an arbitrary rule's
+    /// exception text can carry internal paths, connection strings or another tenant's identifiers.
+    /// The full exception goes to <paramref name="logger"/>, where only an operator sees it.</para>
+    /// </summary>
+    /// <param name="rule">The governing rule.</param>
+    /// <param name="context">The validation context — built identically by every caller.</param>
+    /// <param name="userId">The identity being decided for.</param>
+    /// <param name="logger">Operator log for a faulting rule; optional.</param>
+    /// <returns>Exactly one outcome, always.</returns>
+    public static IObservable<PermissionCheckOutcome> Evaluate(
+        INodeTypeAccessRule rule,
+        NodeValidationContext context,
+        string userId,
+        ILogger? logger = null)
+    {
+        ArgumentNullException.ThrowIfNull(rule);
+        ArgumentNullException.ThrowIfNull(context);
+
+        var nodeType = context.Node.NodeType ?? rule.NodeType;
+        return Observable.Defer(() => rule.HasAccess(context, userId))
+            // TakeDecisionOutsideGate, not a bare Take(1) — the rules reach the very same permission
+            // fold every other check does, and the caller chains real work (a delete pipeline, the
+            // downstream delivery handler) onto this verdict. See HubPermissionExtensions.
+            .TakeDecisionOutsideGate()
+            .Select(PermissionCheckOutcome.FromVerdict)
+            .Catch((Exception ex) =>
+            {
+                logger?.LogWarning(ex,
+                    "The {NodeType} access rule for {Path} could not reach a verdict for {User} — "
+                    + "reporting an availability failure, not a denial",
+                    nodeType, context.Node.Path, userId);
+                return Observable.Return(PermissionCheckOutcome.Undetermined(
+                    $"the '{nodeType}' access rule failed ({ex.GetType().Name})"));
+            })
+            // 🚨 Built LAZILY (nullable + DefaultIfEmpty() + Select), never
+            // `DefaultIfEmpty(Undetermined($"…"))` — that argument is an ordinary C# expression and
+            // would format the message on EVERY evaluation to hand it to a branch that virtually
+            // never fires.
+            .Select(outcome => (PermissionCheckOutcome?)outcome)
+            .DefaultIfEmpty()
+            .Select(outcome => outcome ?? PermissionCheckOutcome.Undetermined(
+                $"the '{nodeType}' access rule completed without producing a verdict"));
+    }
+
+    /// <summary>
+    /// The node SERVED at <paramref name="path"/>, as this hub can see it: the storage adapter
+    /// first, the static/config node provider second — the same order
+    /// <c>MeshExtensions.ReadNodeAuthoritative</c> uses, and for the same reason (a partition whose
+    /// root is a static node is present even though no row exists).
+    ///
+    /// <para>🚨 A read FAULT is propagated, never swallowed into <c>null</c>. The caller has to be
+    /// able to tell "there is no node here, so no rule governs it" (a verdict) from "this hub could
+    /// not find out" (an availability answer) — collapsing them would make a transient storage blip
+    /// silently restore the pre-fix behaviour, which is the gate deciding its own input all over
+    /// again.</para>
+    /// </summary>
+    /// <param name="hub">The hub whose persistence and static providers answer.</param>
+    /// <param name="path">The node path to read.</param>
+    /// <returns>The node, or null when nothing is served at that path.</returns>
+    public static IObservable<MeshNode?> ReadSubjectNode(IMessageHub hub, string path)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        return Observable.Defer(() =>
+        {
+            var persistence = hub.ServiceProvider.GetService<IStorageAdapter>();
+            return persistence is null
+                ? Observable.Return(hub.ServiceProvider.FindServedStaticNode(path))
+                : persistence.Read(path, hub.JsonSerializerOptions)
+                    .Take(1)
+                    .DefaultIfEmpty(null)
+                    // 🚨 The static fallback is resolved LAZILY — `FindServedStaticNode` enumerates
+                    // every registered provider's node list, and this method is on the denial path
+                    // of a hot delivery gate. Storage answers for all but the config-node case, so
+                    // the enumeration must not be paid before the read that usually obviates it.
+                    .Select(node => node ?? hub.ServiceProvider.FindServedStaticNode(path));
+        });
+    }
+}

--- a/test/MeshWeaver.Graph.Test/SatelliteDeliveryGateTest.cs
+++ b/test/MeshWeaver.Graph.Test/SatelliteDeliveryGateTest.cs
@@ -1,0 +1,170 @@
+using System.Reactive.Linq;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 THE DELIVERY GATE MUST CONSULT THE NODE TYPE'S OWN ACCESS RULE. Issue #3061.
+///
+/// <para><b>The defect.</b> <c>ValidateDeleteRequest</c> carries
+/// <c>[RequiresPermission(Permission.Delete)]</c>, and <c>AccessControlPipeline</c> evaluated it
+/// through <c>RequiresPermissionAttribute.GetPermissionChecks</c>, whose default implementation is
+/// literally <c>yield return (hubPath, Permission)</c> — a RAW <c>Delete</c> on the satellite's own
+/// path. It never consulted <c>INodeTypeAccessRule</c>. Meanwhile
+/// <c>SatelliteAccessRule</c> — registered by <c>ActivityNodeType</c> and every other satellite
+/// type — maps a satellite's Delete to <c>Permission.Update</c> on its <c>MainNode</c>, because
+/// creating a satellite is a modification of its main node and so is removing it.</para>
+///
+/// <para>#2913 reconciled exactly that mismatch in the delete PRE-FLIGHT
+/// (<c>MeshExtensions.CheckDeletePermissionForNode</c>). It did not reconcile the DELIVERY gate,
+/// which runs FIRST — so the gate won, and an <c>Editor</c> (Update, no Delete) could publish a
+/// satellite and then be refused when erasing it. Measured on production: a recursive delete of
+/// <c>Edu/Course</c> refused with <c>Access denied: user 'rbuergi' lacks Delete permission on
+/// 'Edu/Course/_Activity/compile-…'</c> for all 72 of its <c>_Activity</c> satellites, leaving an
+/// orphan NodeType that could not be removed through any API.</para>
+///
+/// <para><b>What is pinned here.</b> The three verdicts the gate must reach, on the same mesh with
+/// the same three nodes, so that a fix which simply widened Delete would fail two of them:
+/// <list type="number">
+///   <item><description>an Editor's <c>ValidateDeleteRequest</c> at a SATELLITE is not refused —
+///     the rule grants what the raw path check denies;</description></item>
+///   <item><description>a Viewer's is still refused — the rule DENIES (no Update on the MainNode),
+///     and a rule that refuses leaves the delivery refused;</description></item>
+///   <item><description>the same Editor at a PLAIN child, whose node type has no rule, is still
+///     refused — nothing widened outside the types that declare a rule.</description></item>
+/// </list></para>
+/// </summary>
+public class SatelliteDeliveryGateTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Partition = "SatelliteDeleteGate";
+
+    /// <summary>The satellite's MainNode — the node its Delete delegates to.</summary>
+    private const string MainNodePath = Partition + "/Doc";
+
+    /// <summary>
+    /// An <c>Activity</c> satellite, in the shape <c>ActivityNodeType</c> mints: it lives under the
+    /// <c>_Activity</c> segment of its main node and its <c>MainNode</c> points AT that main node,
+    /// never at itself.
+    /// </summary>
+    private const string SatellitePath = MainNodePath + "/_Activity/run1";
+
+    /// <summary>An ordinary child of the same main node — a node type with NO access rule.</summary>
+    private const string PlainChildPath = MainNodePath + "/Plain";
+
+    private const string EditorUser = "satellite-editor";
+    private const string ViewerUser = "satellite-viewer";
+
+    /// <summary>
+    /// 🚨 <see cref="TestTimeouts.Quick"/>, never a literal — CI-scaled, and the only bound in the
+    /// suite, so a wait that does not converge reports WHAT it was waiting for rather than being
+    /// killed anonymously.
+    /// </summary>
+    private static TimeSpan Budget => TestTimeouts.Quick;
+
+    // 🚨 ConfigureMeshBase, not base.ConfigureMesh: the latter chains PublicAdminAccess(), which
+    // grants Public the Admin role in every default partition — under it both identities below
+    // would hold Delete outright and every assertion here would pass vacuously.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode(Partition) { Name = "Satellite Delete Gate", NodeType = "Markdown" },
+                new MeshNode("Doc", Partition) { Name = "Doc", NodeType = "Markdown" },
+                new MeshNode("Plain", MainNodePath) { Name = "Plain Child", NodeType = "Markdown" },
+                new MeshNode("run1", MainNodePath + "/_Activity")
+                {
+                    Name = "Compile run",
+                    NodeType = "Activity",
+                    // The satellite pointer. Without it SatelliteAccessRule takes its degenerate
+                    // branch and falls back to the standard path check — i.e. the pre-fix answer —
+                    // so this line is what makes the case a satellite at all.
+                    MainNode = MainNodePath,
+                },
+                // Update but NOT Delete — the exact entitlement #2913's own rationale names: "an
+                // Editor holds Update and not Delete, so an Editor could PUBLISH a satellite and
+                // then be refused when erasing it".
+                AssignmentNodeFactory.UserRole(EditorUser, "Editor", Partition),
+                // Read only — neither Delete on the satellite nor Update on its MainNode.
+                AssignmentNodeFactory.UserRole(ViewerUser, "Viewer", Partition));
+
+    private static AccessContext Identity(string userId) => new()
+    {
+        ObjectId = userId,
+        Name = userId,
+    };
+
+    /// <summary>
+    /// The pre-flight fan-out's message, posted exactly as <c>PreValidateDescendantsObs</c> posts
+    /// it: one <c>ValidateDeleteRequest</c> at the descendant's OWN address, carrying the caller's
+    /// AccessContext explicitly (the only copy that survives the scheduler hops). Yields the gate's
+    /// <see cref="DeliveryFailure"/>, or null when the delivery was SERVED.
+    /// </summary>
+    private IObservable<DeliveryFailure?> PreflightRefusal(string path, string userId)
+        => RequestHub
+            .Observe(new ValidateDeleteRequest(path, MainNodePath),
+                o => o.WithTarget(new Address(path)).WithAccessContext(Identity(userId)))
+            .Take(1)
+            .Select(_ => (DeliveryFailure?)null)
+            .Catch((DeliveryFailureException ex) => Observable.Return<DeliveryFailure?>(ex.Failure));
+
+    /// <summary>
+    /// 🚨 THE PIN. The satellite's registered rule says its Delete is Update on the MainNode, and
+    /// the Editor holds Update there — so the gate must not refuse the pre-flight.
+    ///
+    /// <para>Pre-fix this failed with <c>Unauthorized</c> / "lacks Delete permission on
+    /// 'SatelliteDeleteGate/Doc/_Activity/run1'": the gate folded a raw Delete on the satellite's
+    /// own path and never asked the node type.</para>
+    /// </summary>
+    [Fact]
+    public async Task AnEditorsSatellitePreflight_IsNotRefusedByTheGate()
+    {
+        var failure = await PreflightRefusal(SatellitePath, EditorUser).Should().Within(Budget).Emit();
+
+        failure.Should().BeNull(
+            "the Activity type registers SatelliteAccessRule, which maps a satellite's Delete to "
+            + "Update on its MainNode — an entitlement this Editor holds. The delivery gate refused "
+            + "anyway because it folded a RAW Delete on the satellite's own path and never consulted "
+            + "the rule the delete pre-flight already consults (#3061): "
+            + (failure?.Message ?? string.Empty));
+    }
+
+    /// <summary>
+    /// The companion measurement that makes the pin a RULE decision rather than a widening: the same
+    /// satellite, the same message, a Viewer instead of an Editor. The rule is consulted and it says
+    /// NO — no Update on the MainNode — so the refusal stands.
+    /// </summary>
+    [Fact]
+    public async Task AViewersSatellitePreflight_IsStillRefused()
+    {
+        var failure = await PreflightRefusal(SatellitePath, ViewerUser).Should().Within(Budget).Emit();
+
+        failure.Should().NotBeNull(
+            "a Viewer holds neither Delete on the satellite nor Update on its MainNode, so the "
+            + "node type's own rule refuses — consulting the rule must never mean granting");
+        failure!.ErrorType.Should().Be(ErrorType.Unauthorized,
+            "the rule reached a VERDICT and it is no, so this is a denial and not an availability "
+            + "answer: " + failure.Message);
+    }
+
+    /// <summary>
+    /// The scope boundary: a node type with NO registered rule is unchanged.
+    /// <c>NodeTypeAccessRuleSet.Find</c> returning null means "no rule has an opinion", and the
+    /// standard closed-by-default check stands — the same Editor, one level away from the
+    /// satellite, is still refused.
+    /// </summary>
+    [Fact]
+    public async Task AnEditorsPlainChildPreflight_IsStillRefused()
+    {
+        var failure = await PreflightRefusal(PlainChildPath, EditorUser).Should().Within(Budget).Emit();
+
+        failure.Should().NotBeNull(
+            "Markdown registers no INodeTypeAccessRule, so nothing overrides the standard "
+            + "Permission.Delete check and an Editor (Update, no Delete) stays refused — the fix "
+            + "may only reach node types that declare a rule");
+        failure!.ErrorType.Should().Be(ErrorType.Unauthorized,
+            "the standard fold reached a verdict: " + failure.Message);
+    }
+}


### PR DESCRIPTION
Fixes #3061.

## The defect

`ValidateDeleteRequest` carries `[RequiresPermission(Permission.Delete)]`. The delivery gate
(`AccessControlPipeline`) evaluates it through `RequiresPermissionAttribute.GetPermissionChecks`,
whose default implementation is literally `yield return (hubPath, Permission)` — a **raw** `Delete`
on the satellite's own path. It never consulted `INodeTypeAccessRule`.

`ActivityNodeType` (and every other satellite type) registers `SatelliteAccessRule`, which maps a
satellite's Delete to **`Permission.Update` on its `MainNode`** — creating a satellite is a
modification of its main node, and so is removing it. **#2913 reconciled exactly that mismatch in
the delete pre-flight (`MeshExtensions.CheckDeletePermissionForNode`) but not in the delivery gate,
which runs first** — so the gate won.

Measured on production (memex.systemorph.com, 2026-09-02): a recursive delete of the orphan NodeType
`Edu/Course` refused with

```
Access denied: user 'rbuergi' lacks Delete permission on 'Edu/Course/_Activity/compile-…'
```

for all 72 of its `_Activity` satellites — a check the node's own registered rule says should pass.
The one repair for a dangling NodeType was therefore unavailable through any API.

## The fix

**One shared seam so the two cannot drift again.** New
`NodeTypeAccessRuleGate` (`src/MeshWeaver.Mesh.Contract/Services/NodeTypeAccessRuleGate.cs`) owns
resolution *and* evaluation — the three terminals (verdict / fault / completed-without-emitting), the
`TakeDecisionOutsideGate` hop, and the "the caller-visible detail names the exception TYPE, never its
message" rule. `CheckDeletePermissionForNode` and `CheckDeletePermissionByRule` were rewritten to
call it (they used to write the evaluation out inline — which is how the seams diverged), and
`AccessControlPipeline` now calls it too.

**Where the reconsideration sits in the gate**, reached ONLY from a definitive denial:

| Fold outcome for `(hubPath, Permission)` | What happens |
|---|---|
| Granted | delivered — the rule is never consulted, so a hot `SubscribeRequest` reads no node |
| **Denied** | **re-decided through the node type's rule** — the rule's answer is the gate's answer |
| Undetermined | refused as `Unavailable` — "we could not check" is not a rule question |

Four conditions leave the denial exactly as it was: the check is not on this hub's own path; the
permission names no operation a rule can decide about that node; nothing is served at that path; or
no rule governs `(node type, operation)`.

`Permission.Create` deliberately maps to **no** operation: a create names a node that does not exist
yet and the gate evaluates on the PARENT's hub path, so the type a lookup here would find is the
parent's, and the parent's rule has no standing over a child's creation. Everything outside the CRUD
four maps to nothing for the matching reason — `INodeTypeAccessRule.SupportedOperations` is expressed
in `NodeOperation`s.

**No skip-trapdoor:** a node read that FAULTS answers `Undetermined`, never the original denial.
Falling back to the denial would let a transient storage fault silently restore the pre-fix
behaviour — the gate's own input deciding whether the gate ran.

## Verification

- `dotnet build … -c Release -warnaserror`, one project per invocation, `0 Error(s)` / `0 Warning(s)`
  on all nine touched-or-dependent projects.
- **The test fails without the fix and passes with it.** With `AccessControlPipeline.cs` reverted to
  `origin/main` and everything else in place, `AnEditorsSatellitePreflight_IsNotRefusedByTheGate`
  fails with the production message verbatim:
  `Access denied: user 'satellite-editor' lacks Delete permission on 'SatelliteDeleteGate/Doc/_Activity/run1'`.
- Full unfiltered runs (never `--filter`, so the ratchet guards actually run) of
  `MeshWeaver.Graph.Test`, `MeshWeaver.Documentation.Test`, `MeshWeaver.Hosting.Test`,
  `MeshWeaver.Security.MeshTest`, `MeshWeaver.Data.Test`, `MeshWeaver.Messaging.Hub.Test`.

`SatelliteDeliveryGateTest` pins three verdicts on one mesh, so a fix that merely widened Delete
would fail two of them: the Editor's satellite pre-flight is served; a **Viewer's is still refused**
`Unauthorized` (the rule DENIES — consulting a rule never means granting); and the same Editor at a
plain `Markdown` child of the same node is **still refused** (no rule, nothing widened).

## No band-aids

No timeout was raised, no retry added, no non-answer treated as consent, no permission widened. The
only behaviour change is that a denial on a rule-governed node type is now decided by that rule —
the same authority the delete pre-flight has consulted since #2913.

## Docs

`Doc/Architecture/AccessControl.md` — the paragraph that used to say the message-level gate was
deliberately *not* routed through the rule ("a separate decision with a much larger blast radius; it
has not been made") is replaced with the decision, the measurement, the ordering table and the two
deliberate exclusions. Plus a `Category: Fix` What's New entry.

---

## 🚩 One thing that does NOT fully reconstruct, and the maintainer asked to hear it

The mechanism is confirmed and now pinned by a test that reproduces the production message verbatim.
The production **grant topology**, however, does not by itself explain the reported denial, and I
could not close that gap read-only:

- `Edu/_Access` holds exactly three assignments — `system-security`, `Public — Viewer`,
  `Anonymous — Viewer`. **There is no `rbuergi` grant anywhere under `Edu`**, no root `_Access`
  grant for `rbuergi` (his 34 assignments are all per-partition; the platform-admin one is
  `Admin/_Access`, which by design confers no data access), and **zero** `GroupMembership` nodes.
  `Edu/_Policy` is `{ publicRead: true }` — no cap, no `breaksInheritance`.
- The delete nevertheless **reached** the `pre-validate-descendants` stage, which only happens after
  the ROOT check (`Delete` on `Edu/Course.MainNode ?? Path` = `Edu/Course`) has passed.
- `GetScopeHierarchy` is a plain path walk, so **any** inheritable Delete grant that let the root
  through would also have covered `Edu/Course/_Activity/compile-…` — and the gate would have granted
  there too.

So the grant that let the root through is not visible in the mesh's `AccessAssignment` rows —
most likely a **static** assignment seeded into the deployment (`CollectStaticAccessAssignments`,
invisible to `search`) — and if it is inheritable the two facts do not sit together. This does not
change what the fix does or that it is correct, but the exact production trigger is not fully
reconstructed and someone with a shell on that portal could settle it in one
`GetEffectivePermissions` call.

## Secondary defects — NOT fixed here, please file

1. **`AccessControlPipeline`'s fold has no `Timeout`.** Correct as stated for a *stall*: a fold that
   never emits parks `Concat` and the delivery is dropped with no `DeliveryFailure` and no log line.
   Left out on purpose — the file carries an explicit, argued "No Timeout here" decision, the
   cold-start silence measured on #3061 was per-node-hub ACTIVATION (upstream of this fold, so a gate
   timeout would not have produced that message), and bounding it needs its own rung on the
   `MeshOperationOptions` ladder plus a measurement of what actually stalls.
   **Correction to the brief:** the *empty-completion* half is already covered —
   `CheckPermissionOutcome` materialises the silent terminal as `Undetermined` (#2742), so
   `DefaultIfEmpty()` here can only mean "every check was granted".
2. **`PreValidateDescendantsObs` bounds an O(N) cold fan-out with ONE stage budget.** Real, and the
   fix is a per-descendant rung, not a bigger number — a design change with the #1198 ladder
   invariant at stake.
3. **`HandleValidateDeleteRequest` puts `NestedTimeout` on the storage read only;
   `RunDeletionValidatorsObs` runs unbounded.** Also real, and also a ladder decision: rung 2 is
   already spent on the read and rung 3 is `RlsNodeValidator`'s own budget, so bounding the validator
   chain needs a **new** rung — equal budgets are exactly the "inner bound can never fire" defect
   #1198 exists to remove.
4. **Stale doc claim (now corrected in this PR):** `AccessControl.md` cited
   `DeleteHonoursNodeTypeAccessRuleTest` at `test/MeshWeaver.Security.Test`, a path that does not
   exist in this repo. The test is real but lives in **MeshWeaver.Plugins**
   (`src/MeshWeaver.Security.Test`); the reference now says so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PPe8CH4mFU9E74HafWppqL
