### PR TITLE
fix(Plugins#1135): Skip/Limit paged over an order that did not exist

### DIFF
--- a/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/MeshQuery.cs
@@ -760,6 +760,17 @@ public class MeshQuery : IMeshQueryCore
     }
 
     /// <summary>
+    /// The FINAL sort dimension of the merged result set: <see cref="MeshNode.Path"/>, ascending
+    /// and ordinal. It is what turns the score ordering into a TOTAL order, so that the
+    /// <see cref="MeshQueryRequest.Skip"/>/<see cref="MeshQueryRequest.Limit"/> clip below is a
+    /// partition of the result set rather than three independent samples of an arbitrary one.
+    /// A non-<see cref="MeshNode"/> hit sorts under the empty key and so keeps its arrival order
+    /// among its peers — LINQ's sorts are stable.
+    /// </summary>
+    private static string PathTiebreak<T>((T Item, double Score) hit)
+        => hit.Item is MeshNode node ? node.Path ?? "" : "";
+
+    /// <summary>
     /// Sort + skip + clip the merged initial set. The authoritative ordering
     /// pass for every multi-provider Initial emission. Mirrors the post-collect
     /// pipeline that <c>StorageAdapterMeshQueryProvider.RunQueryNodes</c> runs per-provider.
@@ -782,9 +793,12 @@ public class MeshQuery : IMeshQueryCore
     ///     scores and hands them here. Higher score = stronger match.
     ///     See <see cref="QueryResultChange{T}.Scores"/> for the per-provider
     ///     scoring conventions.</item>
-    ///   <item>Insertion order as the final tiebreaker — preserves the
-    ///     provider's own deterministic ordering for two items at the same
-    ///     score (e.g. two PG rows tied on the prefix bonus).</item>
+    ///   <item><b>Path ascending</b> as the FINAL tiebreaker
+    ///     (<see cref="PathTiebreak{T}"/>) — the dimension that makes this a TOTAL order, which
+    ///     is what <see cref="MeshQueryRequest.Skip"/> needs to be paging rather than sampling.
+    ///     It replaced "insertion order", which reads as a tiebreaker and is not one: nothing
+    ///     orders two providers' Initial emissions against each other, and even a single
+    ///     provider's scope walk emits in read-COMPLETION order.</item>
     /// </list>
     ///
     /// <para><b>Why score sort lives here, not in each provider.</b> A single
@@ -818,8 +832,14 @@ public class MeshQuery : IMeshQueryCore
                     if (item is MeshNode node && node.Path is not null)
                         scoreByItem[node] = score;
                 }
+                // Path-ordered BEFORE the OrderBy: OrderResults sorts stably, so the explicit
+                // sort dimension wins and ties fall back to path rather than to the arbitrary
+                // order the providers happened to merge in. See PathTiebreak below.
                 var ordered = evaluator
-                    .OrderResults(hits.Select(h => h.Item).OfType<MeshNode>(), orderBy)
+                    .OrderResults(
+                        hits.Select(h => h.Item).OfType<MeshNode>()
+                            .OrderBy(n => n.Path ?? "", StringComparer.Ordinal),
+                        orderBy)
                     .ToList();
                 merged = ordered.Select(node => ((T)(object)node,
                     scoreByItem.TryGetValue(node, out var s) ? s : 0.0));
@@ -828,11 +848,20 @@ public class MeshQuery : IMeshQueryCore
         else
         {
             // No explicit OrderBy → score IS the sort dimension. Sort
-            // descending so the highest-relevance match lands first;
-            // insertion order is the implicit tiebreaker because
-            // OrderByDescending is stable in LINQ-to-objects.
-            merged = hits.OrderByDescending(h => h.Score);
+            // descending so the highest-relevance match lands first.
+            merged = hits.OrderByDescending(h => h.Score)
+                .ThenBy(PathTiebreak, StringComparer.Ordinal);
         }
+        // 🚨 The Skip below is only paging if the sequence it skips over has a TOTAL order.
+        // Insertion order — the tiebreaker this used to rely on — is the order the providers'
+        // Initial emissions merged in, which is not an order at all: two providers race, and even
+        // ONE provider's scope walk emits in read-COMPLETION order. Three page queries then agree
+        // idle and disagree under load, re-serving one row while dropping another
+        // (MeshWeaver.Plugins#1135, measured 11/120 under 36 CPU burners vs 0/120 idle).
+        // PathTiebreak is what makes Skip/Take a partition; every provider ordering above ends in
+        // it, and StorageAdapterMeshQueryProvider applies the same key before its own load cap —
+        // it clips to Skip+Limit BEFORE this merge sees the rows, so a total order here alone
+        // would still be paging over three different subsets.
         if (request.Skip is int skip && skip > 0)
             merged = merged.Skip(skip);
         var effectiveLimit = request.Limit ?? parsed.Limit;

--- a/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
+++ b/src/MeshWeaver.Hosting/Persistence/Query/StorageAdapterMeshQueryProvider.cs
@@ -215,12 +215,28 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                 IEnumerable<object> matchedNodes =
                     matched.Where(n => !IsExcludedFromResults(n, parsedQuery));
 
-                IEnumerable<object> sorted = matchedNodes;
+                // 🚨 EVERY branch below ends in PathTiebreak, and the `else` exists at all for
+                // that reason: the sequence this produces is CLIPPED a few lines down
+                // (`projected.Take(loadCap)`, loadCap = Skip + Limit) and then SKIPPED in
+                // MeshQuery.ClipMergedInitial, and a Skip/Take over a sequence with no defined
+                // order is not paging — it is three independent samples of an arbitrary order.
+                //
+                // The arbitrary order was real and it was NOT the store's: the scope walk reads
+                // each path with `SelectMany(path => persistence.Read(path))`, which MERGES, so
+                // the emission order is the order the pooled reads COMPLETE. Idle, that is the
+                // walk order and three successive page queries agree; under load the reads
+                // interleave differently each time and the pages re-serve one row while dropping
+                // another. Measured 2026-09-02 on MeshWeaver.Plugins#1135: the
+                // "Skip and Limit paginate without overlap" case fails 11/120 with 36 CPU
+                // burners and 0/120 idle, with every page COUNT correct (3+3+1=7) and one path
+                // duplicated — the signature of a re-ordering, not of a growing set.
+                IEnumerable<object> sorted;
                 if (parsedQuery.OrderBy != null)
                 {
-                    sorted = parsedQuery.OrderBy.Descending
+                    sorted = (parsedQuery.OrderBy.Descending
                         ? matchedNodes.OrderByDescending(n => GetSortableValue(n, parsedQuery.OrderBy.Property))
-                        : matchedNodes.OrderBy(n => GetSortableValue(n, parsedQuery.OrderBy.Property));
+                        : matchedNodes.OrderBy(n => GetSortableValue(n, parsedQuery.OrderBy.Property)))
+                        .ThenBy(PathTiebreak, StringComparer.Ordinal);
                 }
                 else if (!string.IsNullOrEmpty(parsedQuery.TextSearch))
                 {
@@ -233,10 +249,16 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
                     // file-system directory enumeration order. That is the CI-only
                     // SearchQueryTests.TextSearch_CaseInsensitive flake (10 content matches
                     // returned, the Alice-named nodes clipped away on ext4 ordering).
-                    // OrderByDescending is stable, so equal-score ties keep the walk order.
+                    // OrderByDescending is stable — but "keeps the walk order" is exactly the
+                    // non-order above, so equal-score ties now break on path instead.
                     // An explicit sort: (OrderBy above) still wins over relevance.
-                    sorted = matchedNodes.OrderByDescending(n =>
-                        _evaluator.GetFuzzyScore(n, parsedQuery.TextSearch));
+                    sorted = matchedNodes
+                        .OrderByDescending(n => _evaluator.GetFuzzyScore(n, parsedQuery.TextSearch))
+                        .ThenBy(PathTiebreak, StringComparer.Ordinal);
+                }
+                else
+                {
+                    sorted = matchedNodes.OrderBy(PathTiebreak, StringComparer.Ordinal);
                 }
 
                 // 🚨 NEVER hand a projection to a caller typed on MeshNode. ProjectToSelect returns a
@@ -875,6 +897,21 @@ internal class StorageAdapterMeshQueryProvider : IMeshQueryProvider, IMeshQueryC
 
         return null;
     }
+
+    /// <summary>
+    /// The FINAL sort dimension of every result set this provider emits — the one that turns an
+    /// ordering into a TOTAL order, so that <c>Skip</c>/<c>Limit</c> over it is paging rather than
+    /// sampling. <see cref="MeshNode.Path"/> is the only field guaranteed present, unique and
+    /// stable across the three independent queries a caller issues for three pages.
+    ///
+    /// <para>A non-<see cref="MeshNode"/> row (a <c>select:</c> projection reaching here, a
+    /// partition object) sorts under the empty key: LINQ's sorts are stable, so those rows keep
+    /// their relative arrival order rather than being shuffled among themselves. Paging over a
+    /// result set made only of those is still undefined — no field of theirs can define it — and
+    /// that is a smaller surface than the one this closes, not a claim that it is safe.</para>
+    /// </summary>
+    private static string PathTiebreak(object item)
+        => item is MeshNode node ? node.Path ?? "" : "";
 
     /// <summary>
     /// Gets a sortable value from a node for the given property name.

--- a/test/MeshWeaver.Hosting.Test/PagedQueryTotalOrderTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PagedQueryTotalOrderTest.cs
@@ -1,0 +1,228 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Hosting.Persistence.Query;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>Skip/Limit is paging only over a TOTAL order.</b> Three page queries are three
+/// independent evaluations, so unless each one sorts the matched set the same way, page 2 can
+/// re-serve a row page 1 already returned while dropping one nobody ever sees — with every page
+/// COUNT correct, which is why it reads as a data bug rather than an ordering one.
+///
+/// <para><b>The order that was missing.</b> Neither clip site defined one.
+/// <c>StorageAdapterMeshQueryProvider</c> left <c>sorted = matchedNodes</c> whenever the query
+/// carried no <c>sort:</c> and no free text, then clipped to <c>Skip + Limit</c>;
+/// <c>MeshQuery.ClipMergedInitial</c> sorted by score and documented "insertion order as the final
+/// tiebreaker". Insertion order is not an order: the scope walk reads each path with
+/// <c>SelectMany(path =&gt; persistence.Read(path))</c>, which MERGES, so rows arrive in the order
+/// the pooled reads COMPLETE. Idle that is the walk order and three queries agree; under load they
+/// interleave differently every time.</para>
+///
+/// <para><b>What these tests do about the load.</b> Nothing — they remove it. Both drive a source
+/// that reorders DETERMINISTICALLY, once per query, which is the same input the runner produces by
+/// accident. There is no timing, no repetition and no CPU pressure here, so neither test can flake
+/// and neither can go green by getting lucky. Measured against the real flake
+/// (MeshWeaver.Plugins#1135, <c>HierarchicalBrowsingSuite</c> "Skip and Limit paginate without
+/// overlap"): 11/120 failures under 36 CPU burners, 0/120 idle, 0/120 under the same 36 burners
+/// once the total order landed.</para>
+/// </summary>
+public class PagedQueryTotalOrderTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+
+    /// <summary>The seven story paths of the suite this reduces, in creation order.</summary>
+    private static readonly string[] Stories =
+    [
+        "Marketing/ClaimsProcessing",
+        "Marketing/DataIngestionStrategy",
+        "Marketing/ClaimsProcessing/EmailTriage",
+        "Marketing/ClaimsProcessing/DocumentExtraction",
+        "Marketing/ClaimsProcessing/ClientCorrespondence",
+        "Marketing/DataIngestionStrategy/AnnotatedDataModel",
+        "Marketing/DataIngestionStrategy/HistoricIngestion",
+    ];
+
+    private static MeshNode Node(string path, string nodeType = "Markdown") => new(
+        path.Split('/').Last(),
+        path.Contains('/') ? path[..path.LastIndexOf('/')] : null)
+    {
+        Name = path.Split('/').Last(),
+        NodeType = nodeType,
+        State = MeshNodeState.Active,
+    };
+
+    private const string All = "path:Marketing nodeType:Markdown scope:descendants";
+
+    /// <summary>Page N of <see cref="All"/>, three rows at a time — the suite's own request shape.</summary>
+    private static MeshQueryRequest Page(int skip) =>
+        new() { Query = All, Skip = skip, Limit = 3 };
+
+    private static async Task<IReadOnlyList<string>> Paths(IMeshQueryCore query, MeshQueryRequest request)
+    {
+        var change = await query.Query<MeshNode>(request, Options)
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(30))
+            .Await();
+        return change.Items.Select(n => n.Path!).ToList();
+    }
+
+    /// <summary>
+    /// The end-to-end claim, through the REAL provider: the three pages partition the result set
+    /// even though the storage walk hands them the seven paths in a different rotation each time.
+    ///
+    /// <para>The rotation is what makes this test deterministic AND what makes it a fair stand-in:
+    /// the provider clips to <c>Skip + Limit</c> BEFORE the merge sees a row, so page 1 is
+    /// "whatever three the walk yielded first". A merge-layer sort cannot repair that — only an
+    /// order applied before the load cap can, which is the half of the fix this test covers.</para>
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task ThreePages_OverAWalkThatReordersEachTime_PartitionTheResultSet()
+    {
+        var store = new InMemoryStorageAdapter();
+        foreach (var path in Stories.Prepend("Marketing"))
+            await store.Write(Node(path, path == "Marketing" ? "Group" : "Markdown"), Options).Await();
+
+        var rotating = new RotatingWalkStorageAdapter(store);
+        var query = (IMeshQueryCore)new MeshQuery(
+            [new StorageAdapterMeshQueryProvider(persistence: rotating)], hub: null!);
+
+        var page1 = await Paths(query, Page(0));
+        var page2 = await Paths(query, Page(3));
+        var page3 = await Paths(query, Page(6));
+
+        rotating.Rotations.Should().BeGreaterThan(1,
+            "the point of this test is that the walk order CHANGED between the page queries — if "
+            + "it did not, the test proves nothing");
+
+        var served = page1.Concat(page2).Concat(page3).ToList();
+        served.Should().HaveCount(7, "3 + 3 + 1 rows must be served in total");
+        served.Distinct(StringComparer.Ordinal).Should().HaveCount(7,
+            "the pages must not overlap — a repeated path means paging re-served a row while "
+            + "another row was never served at all");
+        foreach (var story in Stories)
+            served.Should().Contain(story,
+                "the union of the pages IS the result set — a row served by no page is the other "
+                + "half of an overlap");
+    }
+
+    /// <summary>
+    /// The merge layer's half, isolated: given providers whose Initial arrives in an arbitrary
+    /// order, the clip must still be taken over a total order. Two providers, so the emissions
+    /// race the way two real backends do; the second one's rows are handed back reversed.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public async Task TheMerge_ClipsOverATotalOrder_NotOverProviderArrivalOrder()
+    {
+        var forward = new CannedProvider("forward", Stories.Take(4).Select(p => Node(p)).ToArray());
+        var reversed = new CannedProvider("reversed",
+            Stories.Skip(4).Reverse().Select(p => Node(p)).ToArray());
+
+        var query = (IMeshQueryCore)new MeshQuery([forward, reversed], hub: null!);
+
+        var page1 = await Paths(query, Page(0));
+        var page2 = await Paths(query, Page(3));
+        var page3 = await Paths(query, Page(6));
+
+        var served = page1.Concat(page2).Concat(page3).ToList();
+        served.Should().HaveCount(7);
+        served.Distinct(StringComparer.Ordinal).Should().HaveCount(7,
+            "two providers contributing to one result set must still be paged as one ordered set");
+        served.Should().ContainInOrder(Stories.OrderBy(p => p, StringComparer.Ordinal).ToList(),
+            "read back page by page, the rows come out in the order the paging is defined over");
+    }
+
+    /// <summary>A provider that answers every query with the same canned rows, in the given order.</summary>
+    private sealed class CannedProvider(string name, MeshNode[] nodes) : IMeshQueryProvider
+    {
+        public string Name => name;
+
+        public bool Matches(IReadOnlyList<string> queryNamespaces) => true;
+
+        public IObservable<QueryResultChange<T>> Query<T>(MeshQueryRequest request, JsonSerializerOptions options)
+            => (IObservable<QueryResultChange<T>>)(object)Observable.Return(new QueryResultChange<MeshNode>
+            {
+                ChangeType = QueryChangeType.Initial,
+                Items = nodes,
+                Timestamp = DateTimeOffset.UtcNow,
+            });
+
+        public IObservable<IReadOnlyCollection<QueryResult>> Query(MeshQueryRequest request, JsonSerializerOptions options)
+            => Observable.Return((IReadOnlyCollection<QueryResult>)Array.Empty<QueryResult>());
+
+        public IObservable<IReadOnlyCollection<QueryResult>> Autocomplete(
+            string basePath, string prefix, JsonSerializerOptions options,
+            AutocompleteMode mode = AutocompleteMode.RelevanceFirst, int limit = 10,
+            string? contextPath = null, string? context = null)
+            => Observable.Return((IReadOnlyCollection<QueryResult>)Array.Empty<QueryResult>());
+
+        public IObservable<T?> Select<T>(string path, string property, JsonSerializerOptions options)
+            => Observable.Return<T?>(default);
+    }
+
+    /// <summary>
+    /// The store, with its walk order ROTATED one position per call — the deterministic stand-in
+    /// for the merged, load-sensitive read completion order the real walk emits. Everything else
+    /// forwards to the real <see cref="InMemoryStorageAdapter"/>, so the rows, the matching and
+    /// the clipping are the production code paths.
+    /// </summary>
+    private sealed class RotatingWalkStorageAdapter(IStorageAdapter inner) : IStorageAdapter
+    {
+        private int _rotations;
+
+        /// <summary>How many times the walk order has been rotated — asserted, so a refactor that
+        /// stops calling <see cref="ListChildPaths"/> cannot leave this test silently vacuous.</summary>
+        public int Rotations => _rotations;
+
+        public IObservable<(IEnumerable<string> NodePaths, IEnumerable<string> DirectoryPaths)>
+            ListChildPaths(string? parentPath)
+            => inner.ListChildPaths(parentPath).Select(result =>
+            {
+                var nodePaths = result.NodePaths.ToList();
+                var rotation = System.Threading.Interlocked.Increment(ref _rotations);
+                if (nodePaths.Count < 2)
+                    return (result.NodePaths, result.DirectoryPaths);
+                var offset = rotation % nodePaths.Count;
+                return ((IEnumerable<string>)nodePaths.Skip(offset).Concat(nodePaths.Take(offset)).ToList(),
+                    result.DirectoryPaths);
+            });
+
+        public IObservable<DataChangeNotification> Changes => inner.Changes;
+
+        public IObservable<MeshNode?> Read(string path, JsonSerializerOptions options)
+            => inner.Read(path, options);
+
+        public IObservable<MeshNode> ReadMany(IReadOnlyCollection<string> paths, JsonSerializerOptions options)
+            => inner.ReadMany(paths, options);
+
+        public IObservable<MeshNode?> Write(MeshNode node, JsonSerializerOptions options)
+            => inner.Write(node, options);
+
+        public IObservable<string> Delete(string path) => inner.Delete(path);
+
+        public IObservable<bool> Exists(string path) => inner.Exists(path);
+
+        public IObservable<object> GetPartitionObjects(string nodePath, string? subPath, JsonSerializerOptions options)
+            => inner.GetPartitionObjects(nodePath, subPath, options);
+
+        public IObservable<Unit> SavePartitionObjects(
+            string nodePath, string? subPath, IReadOnlyCollection<object> objects, JsonSerializerOptions options)
+            => inner.SavePartitionObjects(nodePath, subPath, objects, options);
+
+        public IObservable<Unit> DeletePartitionObjects(string nodePath, string? subPath = null)
+            => inner.DeletePartitionObjects(nodePath, subPath);
+
+        public IObservable<DateTimeOffset?> GetPartitionMaxTimestamp(string nodePath, string? subPath = null)
+            => inner.GetPartitionMaxTimestamp(nodePath, subPath);
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/PagedQueryTotalOrderTest.cs
+++ b/test/MeshWeaver.Hosting.Test/PagedQueryTotalOrderTest.cs
@@ -72,7 +72,11 @@ public class PagedQueryTotalOrderTest
     {
         var change = await query.Query<MeshNode>(request, Options)
             .FirstAsync()
-            .Timeout(TimeSpan.FromSeconds(30))
+            // TestTimeouts, not a hand-written literal: nothing here is expected to WAIT — the
+            // fake provider answers synchronously and the in-memory adapter's reads are Defer'd —
+            // so this bound exists only so a regression that wedges the merge fails with a
+            // timeout instead of hanging the shard.
+            .Timeout(TestTimeouts.Convergence)
             .Await();
         return change.Items.Select(n => n.Path!).ToList();
     }


### PR DESCRIPTION
## Outcome: **reproduced under load, cause identified, fixed** — red-then-green under identical conditions.

`MeshWeaver.Plugins#1135` item 7 — `HierarchicalBrowsingSuite` *"Skip and Limit paginate without
overlap"* — was filed rather than patched because a race nobody can reproduce cannot be falsified.
It reproduces on demand under CPU load, and what it exposes is not a test problem.

## The recorded mechanism does not survive the failure's own shape

The issue proposed that the underlying set GREW between the page queries (core's new
`ContentTypeRegistrationSweep` writing activity nodes). It cannot have: the case checks the page
counts BEFORE the overlap, `MeshTestContext.Expect` throws on the first false check, and
`page1=3 / page2=3 / page3=1` all passed. Seven rows at every page, one of them served twice —
that is a **re-ordering**, not a growth. (The sweep is also outside the query: it is scoped to the
case's own subtree and filtered to `nodeType:Markdown`.)

## Skip/Limit was paging over an order that did not exist

Neither of the two clip sites defined one.

* **`StorageAdapterMeshQueryProvider.RunQueryNodes`** left `sorted = matchedNodes` for any query
  with no `sort:` and no free text — then clipped to the load cap, `Skip + Limit`.
* **`MeshQuery.ClipMergedInitial`** sorted by score and named *"insertion order as the final
  tiebreaker"* before applying `Skip`/`Take`.

Insertion order is not an order, and the store is not what makes it vary. The scope walk reads
every path with `SelectMany(path => persistence.Read(path))` — a **merge** — so rows arrive in the
order the pooled reads COMPLETE. Idle, that is the walk order and three successive page queries
agree. Under CPU pressure the reads interleave differently each time, so page 2 skips past a row
page 1 never served and re-serves one it did.

Both sites needed it: the provider clips to `Skip + Limit` **before the merge sees a row**, so a
total order in the merge alone would still be paging over three different subsets.

## The fix

Every ordering branch now ends in `Path` ascending, ordinal — the one field that is present,
unique, and stable across the three independent queries a caller issues for three pages. An
explicit `sort:` still wins; relevance still wins for a free-text query; only the ties, which were
arbitrary, are now decided. `RunQueryNodes` gains the `else` branch that was missing entirely.

## Measurements (this worktree, Release, 18-core M-series)

| tree | conditions | failures |
|---|---|---|
| unfixed | idle (machine quiet, load avg ~2) | **0 / 60** |
| unfixed | no burners of mine, machine busy at load avg 60–100 | **2 / 60** |
| unfixed | 36 CPU burners | **11 / 120** |
| **fixed** | 36 CPU burners (load avg ~140) | **0 / 120** |

Monotone in load, and zero at both ends for the two reasons that matter: idle it does not happen,
and with the total order it does not happen under the load that made it happen 11 times in 120.

## The committed test asserts the CAUSE, not the race

`PagedQueryTotalOrderTest` has **no timing, no repetition and no load** in it. Both cases drive a
source that reorders DETERMINISTICALLY — a storage walk rotated one position per call, and two
providers whose canned rows arrive forward and reversed — which is the same input the runner
produces by accident. Neither can flake, and neither can go green by getting lucky.

* unfixed → **RED**: `Expected collection to have 7 item(s) … but found 6` (the overlap), and the
  merge case's rows come back out of order;
* fixed → **GREEN**.

Nothing was relaxed: no timeout widened, no retry, no assertion softened, no allow-file touched.

## Suites run locally on the fixed tree

Core (`-c Release -warnaserror`):

* `MeshWeaver.Hosting.Test` — **300/300** (including the two new cases)
* `MeshWeaver.Graph.Test` — **1205/1205**

MeshWeaver.Plugins' moved suites, built against this branch with `-p:MeshWeaverRoot`:

| suite | result |
|---|---|
| `PathResolution.Test` | 168/168 |
| `Persistence.Test` | 1213/1213 |
| `Query.Test` | 354/354 † |
| `NodeOperations.Test` | 76/76 |
| `Search.Test` | 5/5 |
| `Acme.Test` | 65/65 (includes Plugins#1135 item 8, the ColdCycle case) |
| `Content.Test` | 142/142 |
| `Hosting.Monolith.Test` | 786/790, 2 skipped, **2 failed** ‡ |
| `Autocomplete.Test` | 145/146, **1 failed** ‡ |

† **with MeshWeaver.Plugins#1183**, which lands first. That case
(`GlobalSearchPartitionTest.GlobalSearch_WithAccessAssignment_ReturnsGrantedNodes`) asserted through
`scope:descendants limit:50` with **no `sort:`** — a fifty-row window over the very order this
change defines. It was passing on luck (the mesh it shares holds more than fifty rows by the time it
runs), and it now asks for `sort:LastModified-desc` like its sibling in the same class. Verified
green **both** with and without this change, so the two land in either order without a red minute on
either trunk. That is the one behavioural consequence of this change and it is deliberate: a clip
over an undefined order is a sample, not a window.

‡ **Pre-existing, measured on the control tree** (this branch with the two source files reverted to
`main`, everything else identical):

* `LateNackReenqueueTest.LateOwnerDisposingNack_AfterOptimisticEmit_ReenqueuesAndLands` and
  `NackReachesTheWaiterDuringTeardownTest.OwnerDisposingUnderMeshTeardown_StillAnswersTheWaitingCaller`
  — **2/2 fail on the control** as well. Teardown-NACK races, the family already tracked as #3008 /
  #3017; nothing in them reaches a query.
* `AutocompleteIntegrationTest.ChatAutocomplete_GlobalFanOut_ReachesOtherPartitions` — Plugins#1135
  item 6, filed as **#3094**: a 150 ms settle window in `HandleAutocompleteRequest` answering a
  partially-filled merge. It failed here in 412 ms with the recorded signature, i.e. the settle
  window, not a clip.

## Relationship to MeshWeaver.Plugins#1179

That PR (open, in the Plugins repo) reaches the same diagnosis from the other side and fixes it in
the TEST, by adding `sort:path` to the paging query. The two are complementary and do not conflict
— with an explicit `sort:` the provider takes its `OrderBy` branch and this change is a no-op for
that query. This one closes the same hole for every OTHER caller: `MeshQueryRequest.Skip` is a
public paging surface, and the provider's load cap already clipped a plain `limit:N` to an
arbitrary N rows, which is the shape the code's own comment records as the earlier
`SearchQueryTests.TextSearch_CaseInsensitive` CI flake.

Refs Systemorph/MeshWeaver.Plugins#1135

🤖 Generated with [Claude Code](https://claude.com/claude-code)
