### PR TITLE
A NACK about an oversized TYPED payload is still one — measure it, at the packaging seam (#3104)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/OversizedDeliveryRefusal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/OversizedDeliveryRefusal.md
@@ -135,6 +135,67 @@ their surrounding comments carry the incident history.
 > incident history and its public surface. This is the same move #2885 made one assembly earlier, for
 > the same reason, and the alternative is the same one it rejected: a copy-paste of the check.
 
+### The invariant was blind to half the traffic (#3104)
+
+Making the strip a construction invariant fixed *which sites* it reaches. It did not fix *which
+payloads* it can see, and the two are easy to conflate. `IsOversized` opens:
+
+```csharp
+if (delivery?.Message is not RawJson { Content: { } content })
+    return false;
+```
+
+A payload that is not `RawJson` is never measured and never stripped. That test is **right on the
+router hot path**, and its own doc says why: by the time a delivery reaches a transport `MeshBuilder`
+has packaged it, so `RawJson` is the routed shape, and guessing at anything else's size would mean
+serialising twice to answer a question that is almost always "no".
+
+🚨 **That reasoning does not transfer to the strip.** The strip runs only while a failure report is
+being made ready to travel — a rare path, where an exact measurement is the correct thing to pay for.
+Inheriting the hot path's excuse there left the entire **pre-packaging** half of the mesh unmeasured,
+and the construction invariant inherited the blind spot with it: it covers all ~25 sites, but only for
+a payload that is already `RawJson`.
+
+`AccessControlPipeline` is the case that bites, and it is not a corner. `[RequiresPermission]` is an
+attribute on the message **type**, so the gate cannot evaluate a `RawJson` at all — its deliveries are
+typed by construction. A permission denial therefore echoed a multi-megabyte body back verbatim, and
+serialising it at the packaging seam is the same
+`Utf8JsonWriter.TranscodeAndWriteRawValue` → `SharedArrayPool.Rent` → `GC.AllocateNewArray`
+allocation that threw in #3049. Every in-process NACK is in the same position:
+`MessageService.ReportFailure`, `MessageHub`'s unhandled and failed-state answers,
+`HierarchicalRouting`'s NotFound.
+
+**The measurement now takes options, and the strip is applied at the packaging seam.**
+`DeliveryPayloadBounds.IsOversized(delivery, options, limit, out bytes)` keeps the `RawJson` branch
+byte-for-byte as it was and serialises a typed payload only when options are supplied — into a
+counting `IBufferWriter` that keeps nothing, because rendering the document to read its `Length` is
+the very allocation this exists to prevent. A null `options` reproduces the old behaviour exactly, so
+no caller is worse off. `MessageDelivery.Package` applies it to a `DeliveryFailure`'s echo before it
+serialises.
+
+Three things about that placement are deliberate:
+
+- **The seam, not the call sites.** `Package` is the one place a delivery becomes its wire form and
+  the one place a hub's `JsonSerializerOptions` are in hand. Applying the rule there covers the sites
+  nobody has enumerated yet — which is the whole lesson of the section above, applied once more
+  rather than re-learned.
+- **Packaging, not construction.** A report that never crosses a boundary keeps its full echo. It
+  costs nothing to carry in-process and is the better diagnostic; the strip exists to keep a report
+  *deliverable*, never to redact it.
+- **Unmeasurable is not "too big".** A payload the serializer refuses has an *unknown* size, and the
+  honest answer to unknown is to echo it. Treating a failed measurement as oversized would be a
+  fail-closed default that silently destroys the content of every NACK whose payload happens to be
+  awkward to serialise — and it would buy nothing, since a payload that cannot be serialised cannot
+  be packaged either and so never reaches this bound's wall.
+
+Both seams are pinned by `DeliveryFailureEchoStripGuard`, which asserts the *seams* rather than the
+call sites — a per-site scan would enforce exactly the convention this page records the failure of,
+and could not see a site that reaches a report through a helper. It checks that the construction
+invariant still runs the strip, that `Package` strips **before** it serialises (the order is the
+assertion: stripping afterwards compiles, passes every functional test, and does nothing), that
+`MeshBuilder` still routes through `Package`, and that the seam has exactly one implementation. Each
+arm fails when its subject is missing rather than merely non-compliant.
+
 ## The fourth leg: the router's OWN grain call (#2885)
 
 The three sites above all live **inside** `RoutingGrain`. But a delivery has to *reach* that grain,
@@ -374,6 +435,14 @@ are in flight, never how big one of them is.
 - **A rule enforced by remembering is not enforced.** If a payload rule can be violated by
   constructing a type, it belongs in that type's construction, not in the call sites. Two hand-applied
   call sites and a third that had never been told is how #1890 became #3044 two weeks later.
+- **Ask what a guard can SEE, not only where it runs.** Moving the strip to every site fixed *which
+  sites*; it said nothing about *which payloads*, and the `is not RawJson` test at the bottom of it
+  left every pre-packaging NACK unmeasured for as long again (#3104). A hot-path optimisation
+  inherited by a rare path is an optimisation nobody chose.
+- **A measurement on the error path must cost less than the thing it is deciding.** Count into a
+  discarding buffer; never render the document to read its `Length`. The error path is where the
+  process can least afford the allocation, which is precisely why the check was skipped there in the
+  first place.
 - **Never build a log argument eagerly.** `logger.LogDebug("…", Serialize(x), …)` renders `x`
   whether or not anyone is listening. Guard with `IsEnabled`, and on any per-message path render a
   summary rather than a payload.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-refused-big-message-now-tells-you-why.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-refused-big-message-now-tells-you-why.md
@@ -1,0 +1,29 @@
+---
+Name: A refused large message now tells you why instead of vanishing
+Category: Fix
+Description: Fixed error reports about very large messages being lost in transit, which left the sender waiting with no message and no explanation.
+Icon: Sparkle
+Order: -20260902
+---
+
+# A refused large message now tells you why instead of vanishing
+
+When something goes wrong with a message — you lack permission for it, or nothing is
+listening at the address you sent it to — the mesh sends you back an error report that
+quotes the message it is about, so you can see which one failed.
+
+For a very large message that quote was the problem. The report carried a full copy of
+the message inside it, which made the report at least as large as the message — so a
+report explaining that a 37 MB import could not be delivered was itself a 37 MB message,
+and it failed to be delivered for exactly the same reason. Nothing was logged on your
+side and nothing came back: the request simply sat there until it timed out, with no
+message and no explanation of what had happened to it.
+
+Reports about messages that are too big to carry now quote the message's size and its
+type instead of its contents, so the report gets through. You see which message failed
+and how far over the limit it was, which is what you need in order to act — usually by
+importing or writing in smaller batches.
+
+Nothing changes for ordinary errors. A report about a normal-sized message still quotes
+it in full, exactly as before; the summary only replaces content that would have cost you
+the report itself.

--- a/src/MeshWeaver.Messaging.Contract/DeliveryPayloadBounds.cs
+++ b/src/MeshWeaver.Messaging.Contract/DeliveryPayloadBounds.cs
@@ -65,8 +65,18 @@ public static class DeliveryPayloadBounds
             return false;
         if ((long)content.Length * 3 < limitBytes)
             return false;
-        payloadBytes = Encoding.UTF8.GetByteCount(content);
-        return payloadBytes >= limitBytes;
+        // 🚨 Assigned only on the TRUE return, so the documented contract ("0 otherwise") holds even
+        // on the branch that DID compute a count. A payload big enough to defeat the O(1) pre-filter
+        // but still under the bound used to come back `false` with a real byte count in hand, which
+        // reads as evidence and is the one shape a caller could mistake for a small measurement of
+        // an oversized payload. No production caller looks at the value on a false return — every
+        // one of them reads it inside the branch — so this makes the promise true rather than
+        // changing what anyone observes.
+        var bytes = Encoding.UTF8.GetByteCount(content);
+        if (bytes < limitBytes)
+            return false;
+        payloadBytes = bytes;
+        return true;
     }
 
     /// <summary>
@@ -110,13 +120,13 @@ public static class DeliveryPayloadBounds
             return IsOversized(delivery, limitBytes, out payloadBytes);
         if (options is null)
             return false;
-        if (!Measure(delivery.Message, options, out payloadBytes))
-        {
-            payloadBytes = 0;
+        // Same contract as the overload above, for the same reason: the count is published only when
+        // the answer is "oversized". A typed payload that was measured and FITS is a false return
+        // with nothing in the out parameter, not a false return carrying a number.
+        if (!Measure(delivery.Message, options, out var bytes) || bytes < limitBytes)
             return false;
-        }
-
-        return payloadBytes >= limitBytes;
+        payloadBytes = bytes;
+        return true;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Messaging.Contract/DeliveryPayloadBounds.cs
+++ b/src/MeshWeaver.Messaging.Contract/DeliveryPayloadBounds.cs
@@ -1,4 +1,6 @@
+using System.Buffers;
 using System.Text;
+using System.Text.Json;
 
 namespace MeshWeaver.Messaging;
 
@@ -68,6 +70,137 @@ public static class DeliveryPayloadBounds
     }
 
     /// <summary>
+    /// 🚨 <b>The same question, asked of a payload that has NOT been packaged yet — issue #3104.</b>
+    ///
+    /// <para>The overload above measures <see cref="RawJson"/> and nothing else, and its doc explains
+    /// why that is right ON THE ROUTER HOT PATH: by the time a delivery reaches a transport
+    /// <c>MeshBuilder</c> has packaged it, so <see cref="RawJson"/> is the routed shape, and guessing
+    /// at anything else's size would mean serialising twice to answer a question that is almost
+    /// always "no".</para>
+    ///
+    /// <para>🚨 <b>That reasoning does not transfer to the STRIP.</b>
+    /// <see cref="WithoutOversizedPayload(IMessageDelivery, JsonSerializerOptions?, int)"/> runs only
+    /// while a failure report is being made ready for a transport — a rare path, where an exact
+    /// measurement is the correct thing to pay for. Inheriting the hot path's excuse there is what
+    /// left the whole PRE-PACKAGING half of the mesh unmeasured: <c>AccessControlPipeline</c> NACKs a
+    /// message that is still a CLR object (<c>[RequiresPermission]</c> is an attribute on the message
+    /// TYPE — the gate cannot read a <see cref="RawJson"/>), so a denial echoed a multi-megabyte body
+    /// back verbatim and the report died at the wall it was describing.</para>
+    ///
+    /// <para><b>The fast path is untouched.</b> A <see cref="RawJson"/> payload takes exactly the
+    /// branch it always did, at exactly the same cost. Only a typed payload — and only when
+    /// <paramref name="options"/> are supplied — is serialised, and then into a byte COUNTER rather
+    /// than a string: see <see cref="Measure"/>. A null <paramref name="options"/> reproduces the old
+    /// behaviour exactly, so a caller with nothing to serialise with is never worse off.</para>
+    /// </summary>
+    /// <param name="delivery">The delivery to measure; null is never oversized.</param>
+    /// <param name="options">The serializer options the payload would be packaged with. Null means
+    /// "cannot measure a typed payload", which degrades to the <see cref="RawJson"/>-only rule.</param>
+    /// <param name="limitBytes">The transport bound to measure against.</param>
+    /// <param name="payloadBytes">The exact UTF-8 byte count when oversized; 0 otherwise.</param>
+    /// <returns><c>true</c> when the payload is at or over <paramref name="limitBytes"/>.</returns>
+    public static bool IsOversized(
+        IMessageDelivery? delivery, JsonSerializerOptions? options, int limitBytes, out int payloadBytes)
+    {
+        payloadBytes = 0;
+        if (delivery is null)
+            return false;
+        // The shape the O(1) pre-filter already handles — identical cost, identical verdict.
+        if (delivery.Message is RawJson)
+            return IsOversized(delivery, limitBytes, out payloadBytes);
+        if (options is null)
+            return false;
+        if (!Measure(delivery.Message, options, out payloadBytes))
+        {
+            payloadBytes = 0;
+            return false;
+        }
+
+        return payloadBytes >= limitBytes;
+    }
+
+    /// <summary>
+    /// The exact UTF-8 size <paramref name="message"/> would occupy once packaged, computed in
+    /// <b>O(1) memory</b>.
+    ///
+    /// <para>🚨 <b>Counting, not rendering, is the whole point.</b> The failure this measurement
+    /// serves is an ALLOCATION failure: #3049's <c>OutOfMemoryException</c> came out of
+    /// <c>Utf8JsonWriter.TranscodeAndWriteRawValue</c> → <c>SharedArrayPool.Rent</c> →
+    /// <c>GC.AllocateNewArray</c>, on a pod that was already in trouble. A measurement that
+    /// materialised the JSON to read its <c>Length</c> would therefore reproduce the exact defect it
+    /// exists to prevent, at the exact moment the process can least afford it. Writing through
+    /// <see cref="ByteCountingBufferWriter"/> hands the serializer the same scratch span over and
+    /// over and keeps only a running total, so a 142 MB payload is measured without a 142 MB
+    /// allocation.</para>
+    ///
+    /// <para><b>Serialised as <see cref="object"/>, deliberately</b> — that is what
+    /// <c>MessageDelivery.Package</c> does, so the polymorphic converter contributes its
+    /// <c>$type</c> discriminator here exactly as it would on the wire. Measuring the runtime type
+    /// instead would quietly under-count every payload by the size of its discriminator.</para>
+    ///
+    /// <para>🚨 <b>An unmeasurable payload is reported as NOT oversized, and that is not a swallow.</b>
+    /// The serializer's declared failures — an unregistered type, a cycle, a converter that refuses —
+    /// mean the size is unknown, and the honest response to "unknown" is the behaviour that was in
+    /// place before this measurement existed: echo the payload. The alternative, treating
+    /// "could not measure" as "too big", would silently destroy the diagnostic content of every NACK
+    /// whose payload happens to be awkward to serialise — a fail-closed default that forges
+    /// correct-looking bugs. Note also that a payload that cannot be serialised here cannot be
+    /// packaged either, so it never reaches the transport wall this bound is about.</para>
+    /// </summary>
+    /// <param name="message">The unpackaged payload.</param>
+    /// <param name="options">The options it would be packaged with.</param>
+    /// <param name="bytes">The exact UTF-8 byte count, when it could be determined.</param>
+    /// <returns><c>true</c> when <paramref name="bytes"/> holds a real measurement.</returns>
+    private static bool Measure(object message, JsonSerializerOptions options, out int bytes)
+    {
+        bytes = 0;
+        try
+        {
+            var counter = new ByteCountingBufferWriter();
+            using (var writer = new Utf8JsonWriter(counter))
+            {
+                JsonSerializer.Serialize(writer, message, typeof(object), options);
+            }
+
+            bytes = counter.Count >= int.MaxValue ? int.MaxValue : (int)counter.Count;
+            return true;
+        }
+        catch (Exception e) when (e is JsonException or NotSupportedException or InvalidOperationException)
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="IBufferWriter{T}"/> that counts what is written to it and keeps none of it. The
+    /// same span is handed out for every request and overwritten each time, so the peak footprint is
+    /// the largest single write the serializer asks for rather than the size of the document — which
+    /// is what makes <see cref="Measure"/> safe to run on the error path of a process that is already
+    /// short of memory.
+    /// </summary>
+    private sealed class ByteCountingBufferWriter : IBufferWriter<byte>
+    {
+        private byte[] scratch = new byte[4096];
+
+        /// <summary>Total bytes written, as a <see cref="long"/> so a payload larger than
+        /// <see cref="int.MaxValue"/> saturates rather than wrapping to a small (and passing) count.</summary>
+        public long Count { get; private set; }
+
+        public void Advance(int count) => Count += count;
+
+        public Memory<byte> GetMemory(int sizeHint = 0) => Grow(sizeHint);
+
+        public Span<byte> GetSpan(int sizeHint = 0) => Grow(sizeHint).Span;
+
+        private Memory<byte> Grow(int sizeHint)
+        {
+            if (sizeHint > scratch.Length)
+                scratch = new byte[sizeHint];
+            return scratch;
+        }
+    }
+
+    /// <summary>
     /// 🚨 <b>A NACK about an oversized message must not BE one.</b>
     /// <see cref="DeliveryFailure"/> embeds the ORIGINAL delivery — payload and all — and travels
     /// the SAME transport back to the sender, so a failure report about a 142 MB message is itself a
@@ -98,11 +231,59 @@ public static class DeliveryPayloadBounds
         ArgumentNullException.ThrowIfNull(delivery);
         if (!IsOversized(delivery, limitBytes, out var payloadBytes))
             return delivery;
-        return delivery.WithMessage(new RawJson(
-            $"{{\"payloadOmitted\":\"{payloadBytes} bytes exceeded the {limitBytes}-byte "
-            + "memory-stream limit; the failure report would not have been deliverable with it "
-            + $"attached\",\"bytes\":{payloadBytes},\"head\":{Quote(Head(delivery))}}}"));
+        return delivery.WithMessage(Omission(delivery, payloadBytes, limitBytes));
     }
+
+    /// <summary>
+    /// 🚨 <b>The same strip, for a payload that is still a CLR object — issue #3104.</b>
+    ///
+    /// <para>The overload above is <see cref="DeliveryFailure"/>'s construction invariant and covers
+    /// every site structurally, but only for a payload that has already been packaged. A NACK raised
+    /// BEFORE packaging — every in-process one, and <c>AccessControlPipeline</c>'s permission denials
+    /// above all, since a permission check must see the message's CLR type — was measured by nothing
+    /// and stripped by nothing, so the report carried the whole body into
+    /// <c>MessageDelivery.Package</c> and out onto the transport that could not take it.</para>
+    ///
+    /// <para><b>Where this is applied.</b> At the packaging seam itself
+    /// (<c>MessageDelivery.Package</c>), which is the one place in the mesh that turns a delivery
+    /// into its wire form and the one place the hub's <see cref="JsonSerializerOptions"/> are in
+    /// hand. That is deliberate and it is the lesson of #3056: the rule was hand-applied at two of
+    /// ~25 construction sites for two years, and the site that took a production pod down was a third
+    /// one that had never been told. A rule enforced at ONE structural seam covers the sites nobody
+    /// has enumerated yet — including the ones a future PR adds.</para>
+    ///
+    /// <para><b>And only there.</b> A report that never crosses a boundary keeps its full echo: it
+    /// costs nothing to carry in-process and is the better diagnostic. The strip exists to keep a
+    /// report DELIVERABLE, not to redact it.</para>
+    /// </summary>
+    /// <param name="delivery">The delivery a failure report is about to echo across a transport.</param>
+    /// <param name="options">The serializer options the payload would be packaged with. Null keeps
+    /// the <see cref="RawJson"/>-only behaviour of the overload above.</param>
+    /// <param name="limitBytes">The bound the report itself must survive.</param>
+    /// <returns>The delivery, with an undeliverable payload replaced by a description of it.</returns>
+    public static IMessageDelivery WithoutOversizedPayload(
+        IMessageDelivery delivery, JsonSerializerOptions? options, int limitBytes = MemoryStreamBlockBytes)
+    {
+        ArgumentNullException.ThrowIfNull(delivery);
+        if (!IsOversized(delivery, options, limitBytes, out var payloadBytes))
+            return delivery;
+        return delivery.WithMessage(Omission(delivery, payloadBytes, limitBytes));
+    }
+
+    /// <summary>
+    /// What replaces an undeliverable payload: how far over the bound it was, and enough of it to
+    /// identify the producer. Shared by both strips so the two can never describe the same omission
+    /// differently.
+    ///
+    /// <para>The head is the front of the JSON for an already-packaged payload — where the
+    /// <c>$type</c> discriminator and first fields sit — and the CLR type name for one that is still
+    /// an object, which is the same fact by another route. A refusal nobody can attribute is not a
+    /// refusal.</para>
+    /// </summary>
+    private static RawJson Omission(IMessageDelivery delivery, int payloadBytes, int limitBytes) =>
+        new($"{{\"payloadOmitted\":\"{payloadBytes} bytes exceeded the {limitBytes}-byte "
+            + "memory-stream limit; the failure report would not have been deliverable with it "
+            + $"attached\",\"bytes\":{payloadBytes},\"head\":{Quote(Head(delivery))}}}");
 
     /// <summary>
     /// 🚨 <b>AN ACKNOWLEDGEMENT IS NOT AN ECHO — issue #3045.</b>
@@ -168,8 +349,17 @@ public static class DeliveryPayloadBounds
             ? Head(content) is var head && head.Length < content.Length ? head + "…" : head
             : delivery.Message?.GetType().Name ?? "<null>";
 
+    /// <summary>
+    /// The identifying head of a payload: the front of the JSON when it is already packaged (where
+    /// the <c>$type</c> discriminator lives), and the CLR type name when it is still an object.
+    /// Before #3104 the second case returned <see cref="string.Empty"/> — correct while only
+    /// packaged payloads could ever be stripped, and an unattributable omission the moment a typed
+    /// one could be.
+    /// </summary>
     private static string Head(IMessageDelivery delivery) =>
-        delivery.Message is RawJson { Content: { } content } ? Head(content) : string.Empty;
+        delivery.Message is RawJson { Content: { } content }
+            ? Head(content)
+            : delivery.Message?.GetType().Name ?? "<null>";
 
     private static string Head(string content) =>
         content.Length <= PayloadPreviewChars ? content : content[..PayloadPreviewChars];

--- a/src/MeshWeaver.Messaging.Contract/DeliveryPayloadBounds.cs
+++ b/src/MeshWeaver.Messaging.Contract/DeliveryPayloadBounds.cs
@@ -120,18 +120,28 @@ public static class DeliveryPayloadBounds
     }
 
     /// <summary>
-    /// The exact UTF-8 size <paramref name="message"/> would occupy once packaged, computed in
-    /// <b>O(1) memory</b>.
+    /// The exact UTF-8 size <paramref name="message"/> would occupy once packaged, counted rather
+    /// than rendered.
     ///
     /// <para>🚨 <b>Counting, not rendering, is the whole point.</b> The failure this measurement
     /// serves is an ALLOCATION failure: #3049's <c>OutOfMemoryException</c> came out of
     /// <c>Utf8JsonWriter.TranscodeAndWriteRawValue</c> → <c>SharedArrayPool.Rent</c> →
     /// <c>GC.AllocateNewArray</c>, on a pod that was already in trouble. A measurement that
     /// materialised the JSON to read its <c>Length</c> would therefore reproduce the exact defect it
-    /// exists to prevent, at the exact moment the process can least afford it. Writing through
-    /// <see cref="ByteCountingBufferWriter"/> hands the serializer the same scratch span over and
-    /// over and keeps only a running total, so a 142 MB payload is measured without a 142 MB
-    /// allocation.</para>
+    /// exists to prevent, at the exact moment the process can least afford it.
+    /// <see cref="ByteCountingBufferWriter"/> keeps a running total and throws every byte away.</para>
+    ///
+    /// <para>🚨 <b>What that does and does not bound — measured, not assumed.</b>
+    /// <c>Utf8JsonWriter</c> asks its <see cref="IBufferWriter{T}"/> for a span large enough for the
+    /// token it is about to write, so a document of many small tokens is counted inside the 4 KB
+    /// scratch buffer, while ONE giant string value still asks for a span the size of its escaped
+    /// self. So this is not O(1) in the payload — it is one buffer, reused, whose peak is the
+    /// largest single token. That is still strictly cheaper than the path it replaces, which
+    /// materialised the whole document as a UTF-16 <see cref="string"/> (two bytes per char) AND
+    /// paid the three-bytes-per-char transcode rent on top; and it is the LAST allocation of that
+    /// size in the operation, because a payload found oversized here is then replaced by a marker of
+    /// a few hundred bytes and never serialised at all. Do not read this as "measuring cannot
+    /// OOM" — read it as "measuring costs less than the packaging it is deciding".</para>
     ///
     /// <para><b>Serialised as <see cref="object"/>, deliberately</b> — that is what
     /// <c>MessageDelivery.Package</c> does, so the polymorphic converter contributes its
@@ -174,9 +184,13 @@ public static class DeliveryPayloadBounds
     /// <summary>
     /// An <see cref="IBufferWriter{T}"/> that counts what is written to it and keeps none of it. The
     /// same span is handed out for every request and overwritten each time, so the peak footprint is
-    /// the largest single write the serializer asks for rather than the size of the document — which
-    /// is what makes <see cref="Measure"/> safe to run on the error path of a process that is already
-    /// short of memory.
+    /// the largest single write the serializer asks for rather than the size of the whole document.
+    ///
+    /// <para>Deliberately NOT an <c>ArrayPool</c> rental. The pool is exactly what
+    /// <c>SharedArrayPool.Rent</c> → <c>GC.AllocateNewArray</c> threw out of in #3049, and a
+    /// measurement that competes for the same pool on the error path would be contending for the
+    /// resource whose exhaustion it is there to prevent. A 4 KB array that the GC reclaims is the
+    /// cheaper and more predictable trade.</para>
     /// </summary>
     private sealed class ByteCountingBufferWriter : IBufferWriter<byte>
     {

--- a/src/MeshWeaver.Messaging.Contract/Events.cs
+++ b/src/MeshWeaver.Messaging.Contract/Events.cs
@@ -52,7 +52,7 @@ public record DeliveryFailure(IMessageDelivery Delivery, string? Message = null)
     /// about a 142 MB message is itself a 142 MB message and dies at exactly the wall it is
     /// describing — leaving the producer with neither the message nor the report. An undeliverable
     /// payload is therefore replaced, on construction, by a description of itself: see
-    /// <see cref="DeliveryPayloadBounds.WithoutOversizedPayload"/> for the full argument and for why
+    /// <see cref="DeliveryPayloadBounds.WithoutOversizedPayload(IMessageDelivery, int)"/> for the full argument and for why
     /// the strip belongs HERE rather than at the ~20 sites that build one. A payload that fits is
     /// echoed unchanged, so this is invisible to every ordinary failure; senders correlate a
     /// <see cref="DeliveryFailure"/> on <c>RequestId</c>, never on the echoed payload.</para>

--- a/src/MeshWeaver.Messaging.Hub/MessageDelivery.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageDelivery.cs
@@ -186,7 +186,37 @@ public abstract record MessageDelivery : IMessageDelivery
             var message = GetMessage();
             if (message is RawJson)
                 return this;
-            var serialized = JsonSerializer.Serialize(message, options ?? fallbackOptions);
+            var effectiveOptions = options ?? fallbackOptions;
+            // 🚨 A NACK ABOUT AN OVERSIZED MESSAGE MUST NOT BE ONE — issue #3104, and this is the
+            // seam where that stops being a statement about RawJson only.
+            //
+            // DeliveryFailure has applied the strip in its own constructor since #3056, which
+            // covers every one of the ~25 construction sites — but only for a payload that was
+            // ALREADY packaged, because DeliveryPayloadBounds could not measure a CLR object
+            // without serializer options and the record has none. Every NACK raised before
+            // packaging therefore slipped through, AccessControlPipeline's permission denials
+            // above all: [RequiresPermission] is an attribute on the message TYPE, so the gate
+            // cannot run against RawJson and its deliveries are typed by construction. Such a
+            // report kept the whole body and reached the line below, where serializing it is the
+            // Utf8JsonWriter.TranscodeAndWriteRawValue → SharedArrayPool.Rent → GC.AllocateNewArray
+            // allocation that threw OutOfMemoryException on a production pod (#3049) — losing the
+            // notification at exactly the wall it was describing.
+            //
+            // Here, and not at the call sites, for the reason #3056 established: "remember to
+            // strip" was never a control. This is the ONE place a delivery becomes its wire form
+            // and the one place a hub's options are in hand, so it also covers the sites nobody has
+            // enumerated yet. And it is bound to PACKAGING rather than to construction on purpose —
+            // an in-process report never meets a transport, so it keeps its full echo, which is the
+            // better diagnostic and costs nothing.
+            if (message is DeliveryFailure failure && failure.Delivery is not null)
+            {
+                var echoed = DeliveryPayloadBounds.WithoutOversizedPayload(
+                    failure.Delivery, effectiveOptions);
+                if (!ReferenceEquals(echoed, failure.Delivery))
+                    message = failure with { Delivery = echoed };
+            }
+
+            var serialized = JsonSerializer.Serialize(message, effectiveOptions);
             var rawJson = new RawJson(serialized);
             var packaged = WithMessage(rawJson);
             // 🚨 Carry the payload's ANSWERABILITY across the type erasure — issue #1485, and the

--- a/src/MeshWeaver.Messaging.Hub/Serialization/MessageSizeGuard.cs
+++ b/src/MeshWeaver.Messaging.Hub/Serialization/MessageSizeGuard.cs
@@ -228,7 +228,7 @@ public static class MessageSizeGuard
     /// <c>MessageService.ReportFailure</c> (#3044/#3049). With ~20 <c>new DeliveryFailure(delivery)</c>
     /// sites in this repository, "remember to strip" was never a control. It is now
     /// <see cref="DeliveryFailure"/>'s own construction invariant — see
-    /// <see cref="DeliveryPayloadBounds.WithoutOversizedPayload"/>, which this delegates to — so the
+    /// <see cref="DeliveryPayloadBounds.WithoutOversizedPayload(IMessageDelivery, int)"/>, which this delegates to — so the
     /// two explicit calls are idempotent and kept only because their surrounding comments carry the
     /// incident history.</para>
     /// </summary>

--- a/test/MeshWeaver.Documentation.Test/DeliveryFailureEchoStripGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/DeliveryFailureEchoStripGuard.cs
@@ -354,9 +354,16 @@ public class DeliveryFailureEchoStripGuard(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// The masked code of a repo-relative source file. A missing file FAILS: this guard's subjects
-    /// are three named seams, and one of them having moved is exactly the condition that would
-    /// otherwise turn every assertion here into a silent no-op.
+    /// The masked code of a repo-relative NAMED seam. Both ways of not getting the text FAIL, and
+    /// deliberately do not share <see cref="Read"/>'s behaviour.
+    ///
+    /// <para>🚨 <see cref="Read"/> returns empty on an <see cref="IOException"/> because in a
+    /// whole-tree SCAN a file a concurrent build is writing is not evidence of an offence — the
+    /// worst case there is one file not counted. Here the file IS the subject: an unreadable seam
+    /// would be masked to the empty string, every pattern below would fail to match, and the guard
+    /// would report the seam as non-compliant for a reason that has nothing to do with the code. So
+    /// each case gets its own message and neither is silently absorbed: a missing file means the
+    /// subject MOVED (follow it), an unreadable one means the scan itself failed (re-run it).</para>
     /// </summary>
     private static string Masked(string relative)
     {
@@ -364,6 +371,19 @@ public class DeliveryFailureEchoStripGuard(ITestOutputHelper output)
         Assert.True(File.Exists(path),
             $"{relative} is missing — this guard's subject moved; follow it in the same change. An "
             + "assertion about a file that is not there passes having checked nothing.");
-        return SourceScan.MaskCommentsAndStrings(File.ReadAllText(path));
+        try
+        {
+            return SourceScan.MaskCommentsAndStrings(File.ReadAllText(path));
+        }
+        catch (IOException e)
+        {
+            Assert.Fail(
+                $"{relative} could not be read ({e.GetType().Name}: {e.Message}). This is a FAILED "
+                + "SCAN, not a non-compliant seam — most likely a concurrent build holding the file. "
+                + "Re-run. Do not 'fix' it by treating an unreadable subject as absent: that turns "
+                + "the one file this assertion is about into a guaranteed pass or a guaranteed "
+                + "failure, and neither says anything about the code.");
+            throw; // unreachable — Assert.Fail throws; present so the compiler sees a value on every path
+        }
     }
 }

--- a/test/MeshWeaver.Documentation.Test/DeliveryFailureEchoStripGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/DeliveryFailureEchoStripGuard.cs
@@ -1,0 +1,369 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 <b>A NACK about an oversized message must not BE one — and the two seams that make that true
+/// for EVERY construction site must both stay armed.</b> Issues #1890, #2885, #3044/#3049, #3056,
+/// #3104.
+///
+/// <para><b>What is being protected.</b> <see cref="MeshWeaver.Messaging.DeliveryFailure"/> embeds
+/// the ORIGINAL delivery, payload and all, and travels the SAME transport back to the sender. A
+/// failure report about a 37 MB message is therefore itself a 37 MB message and dies at exactly the
+/// wall it is reporting on — silently, leaving the producer with neither the message nor the
+/// report.</para>
+///
+/// <para><b>Why this is a GUARD and not a code review.</b> The rule shipped twice as a hand-applied
+/// call at ONE site each (<c>RoutingGrain.PostFailure</c> #1890,
+/// <c>OrleansRoutingService.SendDeliveryFailure</c> #2885), and the site that then took a production
+/// pod down was a THIRD one that had never been told: <c>MessageService.ReportFailure</c>
+/// (#3044/#3049). With ~25 <c>new DeliveryFailure(delivery)</c> sites in this repository, "remember
+/// to strip" was never a control. Twice it drifted; twice it was found in production.</para>
+///
+/// <para>🚨 <b>So the rule is not enforced per call site, and a guard that demanded a call at every
+/// site would be enforcing the wrong thing.</b> It is enforced at TWO structural seams, and every
+/// construction site — including the ones no one has written yet — is covered by them:</para>
+/// <list type="number">
+///   <item><b>The construction invariant</b> (#3056). <c>DeliveryFailure.Delivery</c>'s init accessor
+///     runs the strip, so any site whose payload is already <c>RawJson</c> is safe by the time the
+///     record exists. That is every post-packaging NACK, which by #1485 is every one the routers
+///     raise.</item>
+///   <item><b>The packaging seam</b> (#3104). <c>MessageDelivery.Package</c> strips a
+///     <c>DeliveryFailure</c>'s echo before serialising it. The construction invariant cannot cover a
+///     TYPED payload — measuring one needs <c>JsonSerializerOptions</c> and the record has none — and
+///     typed is exactly what every PRE-packaging NACK carries. <c>AccessControlPipeline</c> is the
+///     sharpest case: <c>[RequiresPermission]</c> is an attribute on the message TYPE, so a
+///     permission check cannot run against <c>RawJson</c> at all, and a denial echoed the whole body
+///     back.</item>
+/// </list>
+///
+/// <para>Between them: whatever the payload's shape, and whichever of the ~25 sites built the report,
+/// it is stripped exactly when carrying it is what would lose it — and never otherwise, because an
+/// echo that fits is diagnostic and an unconditional strip would destroy it.</para>
+///
+/// <para>🚨 <b>Each assertion here carries a CONTROL ARM, because the silent failure of a
+/// source-scanning guard is that its matcher stops matching.</b> A guard whose subject was renamed
+/// or moved reports green having checked nothing, which is indistinguishable from a clean tree — the
+/// same reading that makes an absent required check look like a passing one.
+/// <see cref="TheGuardStillHasSubjectsToProtect"/> fails when
+/// <c>new DeliveryFailure(</c> can no longer be found in <c>src/</c> at all, and every seam assertion
+/// fails when the code it is reading about is missing rather than merely non-compliant.</para>
+/// </summary>
+public class DeliveryFailureEchoStripGuard(ITestOutputHelper output)
+{
+    /// <summary>Production roots. A NACK raised in a test never meets a transport.</summary>
+    private static readonly string[] ScannedRoots = ["src"];
+
+    private const string ConstructionInvariantSource = "src/MeshWeaver.Messaging.Contract/Events.cs";
+    private const string PackagingSeamSource = "src/MeshWeaver.Messaging.Hub/MessageDelivery.cs";
+    private const string RoutingSource = "src/MeshWeaver.Mesh.Contract/MeshBuilder.cs";
+
+    /// <summary>The strip, in either of its overloads — the name is the whole coupling.</summary>
+    private const string Strip = "WithoutOversizedPayload";
+
+    /// <summary>
+    /// <c>JsonSerializer.Serialize</c>, whitespace-tolerant. 🚨 A literal would be blind to the call
+    /// spelled across lines, which is how <see cref="ImpersonationScopeSiteRatchetGuard"/>'s matcher
+    /// hid 19 real sites (#2441) — a reformat must never silently disarm a guard.
+    /// </summary>
+    private static readonly Regex SerializeCall =
+        new(@"JsonSerializer\s*\.\s*Serialize", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary><c>new DeliveryFailure(</c>, whitespace-tolerant.</summary>
+    private static readonly Regex ConstructionSite =
+        new(@"new\s+DeliveryFailure\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The <c>Delivery</c> init accessor running the strip. Matched as "the initializer of THIS
+    /// property contains the call", not "the file mentions the call" — <c>Events.cs</c>'s own remarks
+    /// name <c>WithoutOversizedPayload</c>, and a whole-file match would keep passing after the
+    /// invariant itself was deleted. A grep hit is not a binder.
+    /// </summary>
+    private static readonly Regex ConstructionInvariant =
+        new(@"IMessageDelivery\s+Delivery\s*\{\s*get\s*;\s*init\s*;\s*\}\s*=[^;]*" + Strip,
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>A declaration of the packaging seam itself.</summary>
+    private static readonly Regex PackagingSeamDeclaration =
+        new(@"IMessageDelivery\s+Package\s*\(", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// The routing handler handing the router a PACKAGED delivery. Pinned as the pair, not as a bare
+    /// <c>.Package(</c>: the seam only protects the mesh while routing actually goes through it, and
+    /// <c>DeliverMessage(delivery)</c> would bypass it while still compiling and still passing every
+    /// functional test.
+    /// </summary>
+    private static readonly Regex RoutesThroughSeam =
+        new(@"DeliverMessage\s*\(\s*delivery\s*\.\s*Package\s*\(",
+            RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    /// <summary>
+    /// 🚨 SEAM 1 — the construction invariant (#3056). Every site whose payload is already
+    /// <c>RawJson</c> is covered by the record itself, so no call site has to remember.
+    /// </summary>
+    [Fact]
+    public void TheConstructionInvariantStrapsEveryConstructionSite()
+    {
+        var code = Masked(ConstructionInvariantSource);
+
+        Assert.True(
+            ConstructionInvariant.IsMatch(code),
+            $"{ConstructionInvariantSource} no longer applies {Strip} in DeliveryFailure.Delivery's "
+            + "init accessor.\n"
+            + "That accessor is what makes the rule structural instead of a thing ~25 construction "
+            + "sites have to remember — and it exists because 'remember to strip' already failed "
+            + "twice in production (#1890 and #2885 applied it at one site each; #3044/#3049 died at "
+            + "a third that had never been told).\n"
+            + "If the invariant moved, move this assertion with it in the SAME change. Do not delete "
+            + "it: a NACK that carries the payload it is reporting on is lost in silence, and the "
+            + "sender is left waiting out its timeout with nothing to show for it.");
+    }
+
+    /// <summary>
+    /// 🚨 SEAM 2 — the packaging seam (#3104), and the ORDER is the whole assertion. Stripping after
+    /// the serialize would compile, pass every functional test, and do nothing: the allocation that
+    /// threw <c>OutOfMemoryException</c> in production is the serialize itself.
+    /// </summary>
+    [Fact]
+    public void ThePackagingSeamStripsBeforeItSerializes()
+    {
+        var code = Masked(PackagingSeamSource);
+        var serialize = SerializeCall.Match(code);
+
+        // 🚨 The control arm. No serialize in this file means the seam moved, and every ordering
+        // claim below would be vacuously true — "nothing to check" reported as "checked and clean".
+        Assert.True(
+            serialize.Success,
+            $"{PackagingSeamSource} contains no JsonSerializer.Serialize call. This guard reads that "
+            + "call as the moment a delivery becomes its wire form, so its absence means the "
+            + "packaging seam has moved and this guard is now measuring nothing. Follow the seam — "
+            + "do not soften the assertion that surfaced it (#2844).");
+
+        var strip = code.IndexOf(Strip, StringComparison.Ordinal);
+        Assert.True(
+            strip >= 0 && strip < serialize.Index,
+            $"{PackagingSeamSource} does not apply {Strip} to a DeliveryFailure's echoed delivery "
+            + "BEFORE serializing it"
+            + (strip < 0 ? " (the call is absent entirely)." : " (the call is there, but AFTER).")
+            + "\nOrder is the whole point: the serialize IS the allocation that threw "
+            + "OutOfMemoryException on a production pod (Utf8JsonWriter.TranscodeAndWriteRawValue → "
+            + "SharedArrayPool.Rent → GC.AllocateNewArray, #3049). Stripping afterwards is stripping "
+            + "a report that has already been lost.\n"
+            + "This is the ONLY place a TYPED payload can be measured — DeliveryFailure's own "
+            + "constructor has no JsonSerializerOptions and therefore cannot see one (#3104) — so "
+            + "without it every pre-packaging NACK echoes its body back verbatim, "
+            + "AccessControlPipeline's permission denials above all.");
+    }
+
+    /// <summary>
+    /// The seam only protects the mesh while traffic actually goes through it. A routing handler that
+    /// stopped packaging would leave the strip armed and unreachable — a merged guard can be
+    /// unreachable in production (#2813).
+    /// </summary>
+    [Fact]
+    public void TheRoutingHandlerStillGoesThroughThePackagingSeam()
+    {
+        var code = Masked(RoutingSource);
+
+        Assert.True(
+            code.Contains("DeliverMessage", StringComparison.Ordinal),
+            $"{RoutingSource} no longer hands anything to IRoutingService.DeliverMessage — the "
+            + "routing handler this guard reads has moved, so the assertion below would pass having "
+            + "checked nothing. Follow it.");
+        Assert.True(
+            RoutesThroughSeam.IsMatch(code),
+            $"{RoutingSource} no longer routes through delivery.Package(...). Every cross-boundary "
+            + "delivery reaches a transport through that one call, which is why the oversized-echo "
+            + "strip can live there and cover all ~25 DeliveryFailure construction sites at once. "
+            + "Route around it and the strip is still armed and never reached — the payload goes back "
+            + "onto the wire whole and the failure report is lost exactly as it was before #3104.");
+    }
+
+    /// <summary>
+    /// 🚨 ONE seam, not two. A second implementation of <c>Package</c> would be a second way for a
+    /// delivery to become its wire form, and the strip would cover only the first — which is
+    /// precisely the "a fix landed on one site and missed the other" shape this codebase has already
+    /// paid for three times.
+    /// </summary>
+    [Fact]
+    public void ThePackagingSeamHasExactlyOneImplementation()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var declaring = SourceScan.SourceFiles(root, ScannedRoots)
+            .Where(f => PackagingSeamDeclaration.IsMatch(SourceScan.MaskCommentsAndStrings(Read(f))))
+            .Select(f => SourceScan.Relative(root, f))
+            .OrderBy(f => f, StringComparer.Ordinal)
+            .ToArray();
+
+        // Control arm: the interface AND the implementation must both be seen. Zero would mean the
+        // matcher has stopped matching, which reads identically to "there is only one seam".
+        Assert.True(
+            declaring.Length >= 2,
+            "Fewer than two files declare IMessageDelivery Package(...) — expected the interface and "
+            + "its one implementation. This guard's matcher has stopped matching, so its uniqueness "
+            + "claim is vacuous. Found: [" + string.Join(", ", declaring) + "]");
+        Assert.True(
+            declaring.Length == 2,
+            "More than one implementation of the packaging seam now exists:\n  "
+            + string.Join("\n  ", declaring)
+            + "\nThe oversized-echo strip is applied in MessageDelivery.Package and covers every "
+            + "DeliveryFailure construction site precisely BECAUSE that is the only way a delivery "
+            + "becomes its wire form. A second implementation is a second wire path, and a report "
+            + "taking it carries the payload it is reporting on. Either route the new one through "
+            + "the existing seam, or apply DeliveryPayloadBounds.WithoutOversizedPayload(delivery, "
+            + "options) in it and teach this guard about it — in the same change.");
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL ARM FOR THE WHOLE FILE. Every assertion above is about seams that protect
+    /// <c>new DeliveryFailure(...)</c> sites. If there are no such sites, the type was renamed or
+    /// retired and this guard is reading about something that no longer exists — a wall of green over
+    /// an unenforced rule, which is worse than no guard because it reads as evidence.
+    /// </summary>
+    [Fact]
+    public void TheGuardStillHasSubjectsToProtect()
+    {
+        var root = SourceScan.FindRepoRoot();
+        var sites = SourceScan.SourceFiles(root, ScannedRoots)
+            .Select(f => (File: SourceScan.Relative(root, f), Count: CountConstructionSitesIn(Read(f))))
+            .Where(x => x.Count > 0)
+            .OrderBy(x => x.File, StringComparer.Ordinal)
+            .ToArray();
+
+        var total = sites.Sum(x => x.Count);
+        output.WriteLine($"{total} DeliveryFailure construction site(s) across {sites.Length} file(s) "
+                         + "— all covered by the two seams asserted in this class:");
+        foreach (var (file, count) in sites)
+            output.WriteLine($"  {count,3}  {file}");
+
+        Assert.True(
+            total > 0,
+            "No `new DeliveryFailure(` site was found anywhere under "
+            + string.Join(", ", ScannedRoots) + ".\n"
+            + "Either the type is gone — in which case delete this guard deliberately and say why in "
+            + "the commit — or the scanner is broken, in which case every assertion in this class is "
+            + "passing on no evidence. 'Nothing to scan' is a FAILED sweep, never a clean one.");
+    }
+
+    /// <summary>
+    /// 🚨 NON-VACUITY OF THE MATCHERS, mutation-proved in BOTH directions on planted text.
+    ///
+    /// <para>Both directions matter equally and are easy to get wrong in opposite ways. A matcher
+    /// that fires on nothing scores identically to a clean tree; a matcher that fires on everything
+    /// scores identically to a guard that works, right up until someone deletes it for crying wolf.
+    /// Planted text is used rather than the live tree so that a spelling stays pinned even after the
+    /// tree stops containing an example of it.</para>
+    /// </summary>
+    [Fact]
+    public void TheMatchersSeeWhatTheyClaimToAndNothingElse()
+    {
+        // ── The packaging seam: strip BEFORE serialize ──────────────────────────────────────────
+        Assert.True(StripsBeforeSerializingIn(
+            "if (message is DeliveryFailure f)\n"
+            + "    message = f with { Delivery = DeliveryPayloadBounds.WithoutOversizedPayload(f.Delivery, o) };\n"
+            + "var serialized = JsonSerializer.Serialize(message, o);"));
+        // …and the same across lines, which a literal matcher would miss.
+        Assert.True(StripsBeforeSerializingIn(
+            "message = DeliveryPayloadBounds.WithoutOversizedPayload(d, o);\n"
+            + "var s = JsonSerializer\n    .Serialize(message, o);"));
+
+        // The three ways it can be wrong, each of which compiles and passes every functional test.
+        Assert.False(StripsBeforeSerializingIn(
+            "var serialized = JsonSerializer.Serialize(message, o);"),
+            "no strip at all is the pre-#3104 state");
+        Assert.False(StripsBeforeSerializingIn(
+            "var s = JsonSerializer.Serialize(message, o);\n"
+            + "var stripped = DeliveryPayloadBounds.WithoutOversizedPayload(d, o);"),
+            "stripping AFTER the serialize strips a report that has already cost the allocation");
+        Assert.False(StripsBeforeSerializingIn(
+            "// DeliveryPayloadBounds.WithoutOversizedPayload(d, o) used to be called here.\n"
+            + "var s = JsonSerializer.Serialize(message, o);"),
+            "a commented-out call is not a call — comment masking must hold, or every count here is "
+            + "unreliable");
+        Assert.False(StripsBeforeSerializingIn(
+            "var doc = \"WithoutOversizedPayload before JsonSerializer.Serialize\";"),
+            "and neither is a string literal that happens to describe the rule");
+        Assert.False(StripsBeforeSerializingIn(
+            "message = DeliveryPayloadBounds.WithoutOversizedPayload(d, o);"),
+            "no serialize found is a BROKEN SCAN, reported as non-compliant rather than as clean");
+
+        // ── The construction invariant ──────────────────────────────────────────────────────────
+        Assert.True(AppliesTheConstructionInvariantIn(
+            "public IMessageDelivery Delivery { get; init; } =\n"
+            + "    Delivery is null ? null! : DeliveryPayloadBounds.WithoutOversizedPayload(Delivery);"));
+        Assert.False(AppliesTheConstructionInvariantIn(
+            "public IMessageDelivery Delivery { get; init; } = Delivery;"),
+            "the property without the strip is exactly the pre-#3056 state");
+        Assert.False(AppliesTheConstructionInvariantIn(
+            "/// See DeliveryPayloadBounds.WithoutOversizedPayload for why.\n"
+            + "public IMessageDelivery Delivery { get; init; } = Delivery;"),
+            "🚨 Events.cs's own remarks name the strip, so a whole-file match would keep passing "
+            + "after the invariant was deleted — the exact false pass UntypedContentDegradationGate "
+            + "was caught by");
+
+        // ── Routing goes through the seam ───────────────────────────────────────────────────────
+        Assert.True(RoutesThroughSeamIn(
+            ".DeliverMessage(delivery.Package(routes.Hub.JsonSerializerOptions));"));
+        Assert.True(RoutesThroughSeamIn(
+            ".DeliverMessage(\n    delivery\n        .Package(options));"));
+        Assert.False(RoutesThroughSeamIn(".DeliverMessage(delivery);"),
+            "bypassing the seam leaves the strip armed and unreachable — which is what a merged but "
+            + "unreachable guard looks like (#2813)");
+
+        // ── Construction sites (the control arm's matcher) ──────────────────────────────────────
+        Assert.Equal(1, CountConstructionSitesIn("Post(new DeliveryFailure(delivery) { });"));
+        Assert.Equal(1, CountConstructionSitesIn("Post(new\n    DeliveryFailure(delivery));"));
+        Assert.Equal(2, CountConstructionSitesIn(
+            "var a = new DeliveryFailure(d); var b = new DeliveryFailure(e, \"x\");"));
+        Assert.Equal(0, CountConstructionSitesIn("// new DeliveryFailure(delivery) is the shape."));
+        Assert.Equal(0, CountConstructionSitesIn("var s = \"new DeliveryFailure(delivery)\";"));
+        Assert.Equal(0, CountConstructionSitesIn("failure with { Delivery = echoed };"));
+    }
+
+    internal static bool StripsBeforeSerializingIn(string text)
+    {
+        var code = SourceScan.MaskCommentsAndStrings(text);
+        var serialize = SerializeCall.Match(code);
+        if (!serialize.Success)
+            return false;
+        var strip = code.IndexOf(Strip, StringComparison.Ordinal);
+        return strip >= 0 && strip < serialize.Index;
+    }
+
+    internal static bool AppliesTheConstructionInvariantIn(string text) =>
+        ConstructionInvariant.IsMatch(SourceScan.MaskCommentsAndStrings(text));
+
+    internal static bool RoutesThroughSeamIn(string text) =>
+        RoutesThroughSeam.IsMatch(SourceScan.MaskCommentsAndStrings(text));
+
+    internal static int CountConstructionSitesIn(string text) =>
+        text.Contains("DeliveryFailure", StringComparison.Ordinal)
+            ? ConstructionSite.Matches(SourceScan.MaskCommentsAndStrings(text)).Count
+            : 0;
+
+    private static string Read(string absolutePath)
+    {
+        try { return File.ReadAllText(absolutePath); }
+        catch (IOException) { return string.Empty; } // a file a concurrent build is writing is not evidence
+    }
+
+    /// <summary>
+    /// The masked code of a repo-relative source file. A missing file FAILS: this guard's subjects
+    /// are three named seams, and one of them having moved is exactly the condition that would
+    /// otherwise turn every assertion here into a silent no-op.
+    /// </summary>
+    private static string Masked(string relative)
+    {
+        var path = Path.Combine(SourceScan.FindRepoRoot(), relative);
+        Assert.True(File.Exists(path),
+            $"{relative} is missing — this guard's subject moved; follow it in the same change. An "
+            + "assertion about a file that is not there passes having checked nothing.");
+        return SourceScan.MaskCommentsAndStrings(File.ReadAllText(path));
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/OversizedFailureReportSurvivesTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/OversizedFailureReportSurvivesTest.cs
@@ -66,7 +66,10 @@ public class OversizedFailureReportSurvivesTest : TestBase
     {
         Services.AddSingleton<AccessService>();
         Services.AddSingleton<IMessageHub>(sp => sp.CreateMessageHub(SenderAddress, conf => conf
-            .WithPostingIdentity(PostingIdentity.System)));
+            .WithPostingIdentity(PostingIdentity.System)
+            // Registered so the polymorphic converter writes a real $type discriminator for it —
+            // the same shape a production payload has, and the fact the stripped report quotes back.
+            .WithTypes(typeof(ImportPayload))));
     }
 
     private IMessageHub Hub => ServiceProvider.GetRequiredService<IMessageHub>();
@@ -226,5 +229,253 @@ public class OversizedFailureReportSurvivesTest : TestBase
             + "for the DeliveryFailure that MessageService.ReportFailure posts about an oversized "
             + "RawJson, that discarded render is what threw OutOfMemoryException on a production "
             + "pod and lost the failure notification (#3044/#3049)");
+    }
+
+    // ────────────────────────────────────────────────────────────────────────────────────────────
+    // 🚨 #3104 — THE SAME INVARIANT, FOR A PAYLOAD THAT IS STILL A CLR OBJECT.
+    //
+    // Everything above measures RawJson. DeliveryPayloadBounds.IsOversized opens
+    // `if (delivery?.Message is not RawJson …) return false;`, so until #3104 a typed payload was
+    // never measured and never stripped — and the constructor invariant introduced above inherited
+    // that blind spot wholesale. The gap is not a corner case: AccessControlPipeline NACKs a message
+    // that is still an object, because [RequiresPermission] is an attribute on the message TYPE and
+    // a permission check cannot run against a RawJson. Every in-process NACK is in that position.
+    // ────────────────────────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// The payload shape a pre-packaging NACK actually sees: a CLR object, not
+    /// <see cref="RawJson"/>. Public so the polymorphic converter can name it in the <c>$type</c>
+    /// discriminator, which is what a stripped report quotes back.
+    /// </summary>
+    /// <param name="Nodes">The bulk field — what makes an import payload big.</param>
+    public record ImportPayload(string Nodes);
+
+    /// <summary>
+    /// A payload that CANNOT be serialised: the self-reference makes <see cref="JsonSerializer"/>
+    /// throw <see cref="JsonException"/> ("a possible object cycle was detected"). The subject of
+    /// <see cref="An_unmeasurable_payload_is_not_treated_as_oversized"/>.
+    /// </summary>
+    public class CyclicPayload
+    {
+        /// <summary>Points at itself, which is the whole point.</summary>
+        public CyclicPayload? Self { get; set; }
+    }
+
+    /// <summary>
+    /// A delivery carrying an UNPACKAGED payload of roughly <paramref name="payloadBytes"/> — the
+    /// shape every NACK raised before the packaging seam is handed.
+    /// </summary>
+    private IMessageDelivery TypedDeliveryOf(int payloadBytes, string id = "d-typed") =>
+        new MessageDelivery<ImportPayload>(
+            SenderAddress, TargetAddress,
+            new ImportPayload(new string('x', payloadBytes)),
+            Hub.JsonSerializerOptions) with
+        { Id = id };
+
+    /// <summary>The wire form of <paramref name="delivery"/> — what the transport would carry.</summary>
+    private string Packaged(IMessageDelivery delivery) =>
+        PayloadOf(delivery.Package(Hub.JsonSerializerOptions));
+
+    /// <summary>
+    /// A report about a failed delivery, as an outbound delivery ready to be packaged — exactly what
+    /// <c>hub.Post(new DeliveryFailure(delivery), o =&gt; o.ResponseFor(delivery))</c> produces on
+    /// its way back to the sender.
+    /// </summary>
+    private IMessageDelivery ReportAbout(IMessageDelivery failed, string reason) =>
+        new MessageDelivery<DeliveryFailure>(
+            TargetAddress, SenderAddress, new DeliveryFailure(failed, reason), Hub.JsonSerializerOptions);
+
+    /// <summary>
+    /// 🚨 THE HEADLINE. A permission denial about a multi-megabyte typed message must not itself be a
+    /// multi-megabyte message.
+    ///
+    /// <para>Against <c>origin/main</c> this fails outright: the report reaches the packaging seam
+    /// carrying the whole body, <c>Package</c> serialises it, and the frame going back to the sender
+    /// is larger than the frame that could not be delivered in the first place. The constructor
+    /// invariant does not help — it measures <see cref="RawJson"/>, and this payload is an
+    /// <see cref="ImportPayload"/>.</para>
+    /// </summary>
+    [Fact]
+    public void A_typed_failure_report_does_not_carry_the_payload_across_the_wire()
+    {
+        var denied = TypedDeliveryOf(OversizedPayloadBytes);
+
+        var wire = Packaged(ReportAbout(denied, "access denied"));
+
+        wire.Length.Should().BeLessThan(OversizedPayloadBytes / 100,
+            "a NACK about an oversized message must not BE one, and 'oversized' is a property of the "
+            + "payload rather than of the CLR shape it currently happens to have. A permission "
+            + "denial NACKs a message that is still an object — [RequiresPermission] is an attribute "
+            + "on the message TYPE, so AccessControlPipeline cannot even run against RawJson — so "
+            + "before #3104 the entire pre-packaging half of the mesh echoed the body back verbatim "
+            + "and the report died at the wall it was describing (#3049)");
+    }
+
+    /// <summary>
+    /// A stripped TYPED report is still attributable. There is no <c>$type</c> discriminator to quote
+    /// from — the payload was never JSON — so the CLR type name is what identifies the producer, and
+    /// the byte count says how far over the bound it was.
+    /// </summary>
+    [Fact]
+    public void A_stripped_typed_report_names_the_type_it_dropped()
+    {
+        var wire = Packaged(ReportAbout(TypedDeliveryOf(OversizedPayloadBytes), "access denied"));
+
+        wire.Should().Contain(nameof(ImportPayload),
+            "the CLR type name is the only handle on WHICH producer sent the undeliverable message "
+            + "once the body is gone; before #3104 the omission marker rendered an empty head for a "
+            + "typed payload, and a refusal nobody can act on is not a refusal");
+        wire.Should().Contain("payloadOmitted",
+            "the report must SAY that it dropped the body — a silently small report reads as a small "
+            + "message and sends the next reader looking in the wrong place");
+        wire.Should().Contain("access denied",
+            "the strip must not cost the FAILURE's own message; only the echoed payload goes");
+    }
+
+    /// <summary>
+    /// 🚨 THE CONTROL, and it carries as much weight as the headline. An ordinary typed NACK is
+    /// untouched: its echoed payload arrives whole. A strip that fired unconditionally would pass the
+    /// test above identically while destroying the diagnostic content of every ordinary failure in
+    /// the mesh — this exists to keep a report DELIVERABLE, never to redact it.
+    /// </summary>
+    [Fact]
+    public void An_ordinary_typed_failure_report_still_echoes_its_delivery()
+    {
+        var small = TypedDeliveryOf(SmallPayloadBytes, "d-small-typed");
+
+        var wire = Packaged(ReportAbout(small, "handler threw"));
+
+        wire.Should().Contain(new string('x', SmallPayloadBytes),
+            "a payload that fits is echoed whole — the strip must be invisible to every ordinary "
+            + "NACK, or it is a behaviour change dressed as a fix");
+        wire.Should().NotContain("payloadOmitted",
+            "and it must not even claim to have dropped something");
+    }
+
+    /// <summary>
+    /// 🚨 THE FAST PATH IS NOT SLOWED, and — more importantly — not CHANGED. The options-aware
+    /// overload must give a <see cref="RawJson"/> payload the same verdict AND the same byte count as
+    /// the overload that has always handled it, via the same O(1) pre-filter. A widening that quietly
+    /// re-decided the packaged case would be a change to the routers' refusal behaviour, which is not
+    /// what #3104 is about.
+    /// </summary>
+    [Fact]
+    public void The_raw_json_verdict_is_identical_with_and_without_options()
+    {
+        foreach (var delivery in new[]
+                 { DeliveryOf(OversizedPayloadBytes), DeliveryOf(SmallPayloadBytes, "d-fits") })
+        {
+            var withoutOptions = DeliveryPayloadBounds.IsOversized(
+                delivery, DeliveryPayloadBounds.MemoryStreamBlockBytes, out var bytesWithout);
+            var withOptions = DeliveryPayloadBounds.IsOversized(
+                delivery, Hub.JsonSerializerOptions, DeliveryPayloadBounds.MemoryStreamBlockBytes,
+                out var bytesWith);
+
+            withOptions.Should().Be(withoutOptions,
+                "the RawJson branch must be the branch it always was — same verdict, same cost");
+            bytesWith.Should().Be(bytesWithout, "and the same exact byte count");
+        }
+    }
+
+    /// <summary>
+    /// The degradation is EXACT. With no options in hand there is nothing to serialise with, so a
+    /// typed payload is treated exactly as it was before #3104 — not measured, not stripped. A caller
+    /// that cannot supply options is never made worse off, and the old overload's contract is
+    /// unchanged.
+    /// </summary>
+    [Fact]
+    public void Without_options_a_typed_payload_is_left_exactly_as_before()
+    {
+        var typed = TypedDeliveryOf(OversizedPayloadBytes);
+
+        DeliveryPayloadBounds
+            .IsOversized(typed, null, DeliveryPayloadBounds.MemoryStreamBlockBytes, out _)
+            .Should().BeFalse("with no options there is no measurement, and inventing one would be a guess");
+        DeliveryPayloadBounds.WithoutOversizedPayload(typed, null).Should().BeSameAs(typed,
+            "and an unmeasured payload is echoed, exactly as it was before this overload existed");
+    }
+
+    /// <summary>
+    /// 🚨 UNMEASURABLE IS NOT "TOO BIG". A payload the serializer refuses has an UNKNOWN size, and the
+    /// honest answer to unknown is the behaviour that predates the measurement: echo it.
+    ///
+    /// <para>Treating a failed measurement as "oversized" would be a fail-closed default that
+    /// silently destroys the diagnostic content of every NACK whose payload happens to be awkward to
+    /// serialise — a correct-looking bug of exactly the shape this repository has been bitten by
+    /// before. Failing open is also safe here: a payload that cannot be serialised cannot be packaged
+    /// either, so it never reaches the transport wall this bound is about.</para>
+    /// </summary>
+    [Fact]
+    public void An_unmeasurable_payload_is_not_treated_as_oversized()
+    {
+        var cyclic = new CyclicPayload();
+        cyclic.Self = cyclic;
+        var delivery = new MessageDelivery<CyclicPayload>(
+            SenderAddress, TargetAddress, cyclic, Hub.JsonSerializerOptions);
+
+        DeliveryPayloadBounds.WithoutOversizedPayload(delivery, Hub.JsonSerializerOptions)
+            .Should().BeSameAs(delivery,
+                "a measurement that could not be taken is not evidence of anything — least of all "
+                + "evidence to throw the payload away on");
+    }
+
+    /// <summary>
+    /// 🚨 THE MEASUREMENT COUNTS RATHER THAN RENDERS — asserted as an A/B against the obvious
+    /// implementation, because allocation is what actually failed in production and because a bare
+    /// budget would be a number nobody could defend.
+    ///
+    /// <para>The reason a typed payload was never measured is that measuring it means serialising it,
+    /// and serialising on the error path is what threw <c>OutOfMemoryException</c> in #3049
+    /// (<c>Utf8JsonWriter.TranscodeAndWriteRawValue</c> → <c>SharedArrayPool.Rent</c> →
+    /// <c>GC.AllocateNewArray</c>). So the two candidates are compared directly, in one run, on one
+    /// thread: the counting writer, against <c>JsonSerializer.Serialize(payload, options).Length</c>
+    /// — which is what anyone would reach for first, and which materialises the whole document as a
+    /// UTF-16 string on top of the writer's transcode buffers.</para>
+    ///
+    /// <para>🚨 <b>What this deliberately does NOT claim.</b> The counting writer is not O(1) in the
+    /// payload: <c>Utf8JsonWriter</c> asks for a span big enough for the token it is about to write,
+    /// so ONE giant string value still requests one large buffer (measured here at ~2× the payload,
+    /// against ~5× for the render). "Cheaper than the thing it replaces, and the last allocation of
+    /// that size in the operation" is the honest claim, and it is the one pinned — a payload found
+    /// oversized here is replaced by a marker and never serialised again.</para>
+    ///
+    /// <para><c>GC.GetAllocatedBytesForCurrentThread</c> is an exact per-thread counter, not a sample,
+    /// and both candidates are synchronous on the calling thread — so this is a deterministic fact
+    /// and not a timing one.</para>
+    /// </summary>
+    [Fact]
+    public void Measuring_a_typed_payload_costs_less_than_rendering_it()
+    {
+        var options = Hub.JsonSerializerOptions;
+        var typed = TypedDeliveryOf(OversizedPayloadBytes);
+        var payload = typed.Message;
+        // Warm every lazy path on BOTH candidates (options, the type's JsonTypeInfo, the converter
+        // cache) so what is compared below is the write and not one-time initialisation.
+        DeliveryPayloadBounds.IsOversized(
+            typed, options, DeliveryPayloadBounds.MemoryStreamBlockBytes, out _);
+        _ = JsonSerializer.Serialize(payload, typeof(object), options).Length;
+
+        var before = GC.GetAllocatedBytesForCurrentThread();
+        var oversized = DeliveryPayloadBounds.IsOversized(
+            typed, options, DeliveryPayloadBounds.MemoryStreamBlockBytes, out var counted);
+        var countingCost = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        before = GC.GetAllocatedBytesForCurrentThread();
+        var renderedBytes = Encoding.UTF8.GetByteCount(
+            JsonSerializer.Serialize(payload, typeof(object), options));
+        var renderingCost = GC.GetAllocatedBytesForCurrentThread() - before;
+
+        oversized.Should().BeTrue("the fixture is comfortably over the 1 MiB block");
+        counted.Should().Be(renderedBytes,
+            "the count must be EXACT and must be the PACKAGED size — the same number of bytes the "
+            + "real serialization produces, envelope and $type discriminator included. A measurement "
+            + "that merely approximated would decide a refusal on a number nobody could reproduce");
+        countingCost.Should().BeLessThan(renderingCost,
+            $"counting allocated {countingCost:N0} bytes where rendering allocated "
+            + $"{renderingCost:N0} for the same {OversizedPayloadBytes:N0}-byte payload. Rendering "
+            + "to read a Length materialises the document as a UTF-16 string on top of the "
+            + "shared-pool transcode rent — the allocation that threw OutOfMemoryException on a "
+            + "production pod (#3049) — which would have this check reproduce the very failure it "
+            + "exists to prevent, on the error path, where the process can least afford it");
     }
 }

--- a/test/MeshWeaver.Messaging.Hub.Test/OversizedFailureReportSurvivesTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/OversizedFailureReportSurvivesTest.cs
@@ -396,6 +396,42 @@ public class OversizedFailureReportSurvivesTest : TestBase
     }
 
     /// <summary>
+    /// 🚨 THE <c>out</c> COUNT IS PUBLISHED ONLY WITH A "YES" — both overloads, every branch.
+    ///
+    /// <para>Both document <c>payloadBytes</c> as "the exact UTF-8 byte count when oversized; 0
+    /// otherwise", and both had a branch that broke the promise: a payload big enough to defeat the
+    /// O(1) pre-filter (or, for a typed one, big enough to be worth measuring) but still UNDER the
+    /// bound returned <c>false</c> with a real count sitting in the out parameter.</para>
+    ///
+    /// <para>Nothing in production reads the value on a false return — every caller reads it inside
+    /// the branch — so this costs nothing to make true. It is worth making true because a
+    /// non-zero count next to a "no" is the one shape a reader can mistake for evidence, and the
+    /// next caller to reach for it would have no way to tell a measured-and-fits from an
+    /// oversized-and-measured. Caught by review on this PR, not by a test — hence a test.</para>
+    /// </summary>
+    [Fact]
+    public void A_payload_that_fits_reports_no_byte_count()
+    {
+        // RawJson, big enough that the 3 × Length pre-filter cannot prove it fits, so the exact
+        // count IS computed — the branch that used to leak it.
+        var justUnder = DeliveryOf(DeliveryPayloadBounds.MemoryStreamBlockBytes - 1, "d-just-under");
+        DeliveryPayloadBounds
+            .IsOversized(justUnder, DeliveryPayloadBounds.MemoryStreamBlockBytes, out var rawBytes)
+            .Should().BeFalse("one byte under the block still fits");
+        rawBytes.Should().Be(0,
+            "the count is the answer to 'how far over', and there is no over — a measured-and-fits "
+            + "must be indistinguishable from a proved-and-fits at the out parameter");
+
+        // The same, through the typed path, which measures by serialising.
+        var typed = TypedDeliveryOf(SmallPayloadBytes, "d-fits-typed");
+        DeliveryPayloadBounds
+            .IsOversized(typed, Hub.JsonSerializerOptions,
+                DeliveryPayloadBounds.MemoryStreamBlockBytes, out var typedBytes)
+            .Should().BeFalse("a small typed payload fits");
+        typedBytes.Should().Be(0, "and it reports no count either");
+    }
+
+    /// <summary>
     /// 🚨 UNMEASURABLE IS NOT "TOO BIG". A payload the serializer refuses has an UNKNOWN size, and the
     /// honest answer to unknown is the behaviour that predates the measurement: echo it.
     ///


### PR DESCRIPTION
Closes #3104

## A NACK about an oversized **typed** message is still one

`DeliveryFailure` embeds the ORIGINAL delivery, payload and all, and travels the SAME transport back
to the sender. #3056 made the strip that keeps it deliverable the record's own construction
invariant, which fixed **which sites** it reaches — all ~25 of them.

It said nothing about **which payloads** it can see. `IsOversized` opens:

```csharp
if (delivery?.Message is not RawJson { Content: { } content })
    return false;
```

That test is right **on the router hot path**, and its own doc says why: `MeshBuilder` has packaged a
delivery long before it reaches a transport, so `RawJson` is the routed shape, and guessing at
anything else's size would mean serialising twice to answer a question that is almost always "no".

🚨 **That reasoning does not transfer to the strip.** It runs only while a failure report is being
made ready to travel — a rare path, where an exact measurement is the right thing to pay for.
Inheriting the hot path's excuse there left the whole **pre-packaging** half of the mesh unmeasured,
and the construction invariant inherited the blind spot with it.

`AccessControlPipeline` is the case that bites, and it is not a corner: `[RequiresPermission]` is an
attribute on the message **type**, so the gate cannot evaluate a `RawJson` at all and its deliveries
are typed by construction. A permission denial echoed a multi-megabyte body back verbatim, and
serialising it at the packaging seam is the same `Utf8JsonWriter.TranscodeAndWriteRawValue` →
`SharedArrayPool.Rent` → `GC.AllocateNewArray` allocation that threw `OutOfMemoryException` on a
production pod in #3049. The sender got neither its message nor the report.

## The fix

**1. An options-aware measurement.** `DeliveryPayloadBounds.IsOversized(delivery, options, limit, out
bytes)` and the matching `WithoutOversizedPayload` overload. The `RawJson` branch is byte-for-byte
the one it always took — same verdict, same O(1) pre-filter, same cost. A typed payload is serialised
only when options are supplied, and then into a **counting `IBufferWriter` that keeps nothing**:
rendering the document to read its `Length` is the very allocation this exists to prevent, on the one
path where the process can least afford it. A null `options` reproduces the old behaviour exactly.

**2. Applied at the packaging seam.** `MessageDelivery.Package` strips a `DeliveryFailure`'s echo
before it serialises. Three deliberate choices:

* **The seam, not the call sites.** `Package` is the ONE place a delivery becomes its wire form and
  the one place a hub's `JsonSerializerOptions` are in hand, so it covers the sites nobody has
  enumerated yet. Applying this at call sites would re-adopt exactly the convention that failed twice
  in production and that #3056 deliberately retired.
* **Packaging, not construction.** An in-process report never meets a transport, so it keeps its full
  echo — the better diagnostic, at no cost. The strip keeps a report *deliverable*; it does not redact.
* **Unmeasurable is not "too big".** A payload the serializer refuses has an *unknown* size; the
  honest answer is to echo it. Fail-closed here would silently destroy the content of every NACK whose
  payload is awkward to serialise, and buy nothing — a payload that cannot be serialised cannot be
  packaged either, so it never reaches this wall.

**3. `DeliveryFailureEchoStripGuard`** — a source-scan guard over `src/`, asserting the **seams**
rather than the call sites, because a per-site scan would enforce the retired convention and could not
see a site that reaches a report through a helper. Four couplings, each with a control arm that FAILS
rather than passing on no evidence:

| Coupling | Control arm |
|---|---|
| the construction invariant still runs the strip | matched on the `Delivery` **initializer**, not the file — `Events.cs`'s own remarks name the call, so a whole-file match would keep passing after the invariant was deleted |
| `Package` strips **before** it serialises | a missing `JsonSerializer.Serialize` is reported as a BROKEN SCAN, not as compliance |
| `MeshBuilder` still routes through `delivery.Package(...)` | a missing `DeliverMessage` fails first — a seam nothing reaches is a merged guard that is unreachable in production (#2813) |
| exactly one implementation of the seam | fewer than two declarations fails: the matcher going blind reads identically to "there is only one" |

## Mutation proof

Every mutation compiles and passes the rest of the suite. Both directions are covered: an
unstripped/misordered tree is caught, **and** a correctly-stripped tree passes — the second arm
matters as much, since a guard that always fails scores identically on the first.

| # | Mutation | Caught by | Result |
|---|---|---|---|
| — | **none (the tree as shipped)** | — | **`Messaging.Hub.Test` 357/357, `Data.Test` 430/430, `Hosting.Test` 298/298, `Documentation.Test` 199/199 — 1,284 tests, all unfiltered** |
| M1 | remove the seam strip (= `origin/main`) | guard `ThePackagingSeamStripsBeforeItSerializes`; `A_typed_failure_report_does_not_carry_the_payload_across_the_wire`; `A_stripped_typed_report_names_the_type_it_dropped` | 1/6 + 2/12 red; every control green |
| M2 | keep the strip, move it **after** the serialize | guard `ThePackagingSeamStripsBeforeItSerializes` | 1/6 red |
| M3 | **strip unconditionally** (the rejected band-aid) | `An_ordinary_typed_failure_report_still_echoes_its_delivery`; `Without_options_a_typed_payload_is_left_exactly_as_before`; `An_unmeasurable_payload_is_not_treated_as_oversized` | 3/12 red — the headline test PASSES, so only the controls catch it |
| M4 | delete the #3056 construction invariant | guard `TheConstructionInvariantStrapsEveryConstructionSite`; `A_failure_report_does_not_carry_the_payload_it_reports_on`; `A_stripped_report_still_names_what_it_dropped` | 1/6 + 2/12 red |
| M5 | `DeliverMessage(delivery)` — bypass the seam | guard `TheRoutingHandlerStillGoesThroughThePackagingSeam` | 1/6 red |
| M6 | blind both scan matchers (rename their subjects away) | `TheGuardStillHasSubjectsToProtect`; `ThePackagingSeamHasExactlyOneImplementation`; `TheMatchersSeeWhatTheyClaimToAndNothingElse` | 3/6 red — a matcher that stops matching FAILS, it does not pass having scanned nothing |

`TheMatchersSeeWhatTheyClaimToAndNothingElse` additionally mutation-proves every matcher on planted
text in both directions, including the across-lines spellings a literal matcher would miss (#2441) and
the shapes that must NOT match: a commented-out call, a string literal describing the rule, and
strip-after-serialize.

## Behavioural tests

In `OversizedFailureReportSurvivesTest`, beside the invariant they belong to:

* a typed report packaged for the wire is < 1% of the payload and still names its type;
* **the control** — an ordinary typed report is echoed WHOLE, `payloadOmitted` absent;
* the `RawJson` verdict AND byte count are identical with and without options;
* no options degrades exactly to the pre-#3104 behaviour;
* an unserializable (cyclic) payload is not treated as oversized;
* counting the payload allocates less than rendering it — measured as an **A/B in one run** rather
  than against a budget nobody could defend, with `counted == renderedBytes` pinning exactness.

## Two corrections to the obvious reading of this bug

* **The three routing NACK sites are NOT holes.** `MonolithRoutingService` and both
  `RoutingServiceBase` sites document (and #1485 established) that `MeshBuilder` is the only caller of
  `IRoutingService.DeliverMessage` and it packages — their payload is `RawJson` by construction and
  the #3056 invariant already covers them. The hole is specifically the pre-packaging sites.
* **Per-call-site stripping was already retired, on purpose.** Adding calls at the ~25 sites would
  restore the convention that failed twice in production. That is why the fix and the guard both target
  seams.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation, all **0 Error(s) / 0 Warning(s)**:
`MeshWeaver.Messaging.Contract`, `MeshWeaver.Messaging.Hub`, `MeshWeaver.Mesh.Contract`,
`MeshWeaver.Hosting`, `MeshWeaver.Documentation`, `MeshWeaver.Messaging.Hub.Test`,
`MeshWeaver.Documentation.Test`, `MeshWeaver.Hosting.Test`, `MeshWeaver.Data.Test`. Full projects run
unfiltered — a `--filter`ed run is a false pass for a ratchet guard.

No public type is removed, so the cross-repo pair gate does not apply. `Pairs-with: none — this adds
overloads and a guard; nothing leaves core's public surface.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
