### PR TITLE
fix(hub): a BuildupAction never starts after its hub has begun shutting down

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -548,6 +548,23 @@ creates a child hub, the `_Exec` shape — must not have run by the time
 `DisposalCompleted` fires; a control arm on a live hub proves the same chain runs to the
 end and the child exists.
 
+**What the skip does NOT touch — and how to observe a probe.** Only the OBSERVABLE
+`WithInitialization` actions run on the init turn. The synchronous overload
+(`SyncBuildupActions`) runs inside `Build`, before message processing starts and therefore
+before any caller can `Dispose()` the hub — which is where content-type registration lives:
+`AddMeshDataSource` composes its `WithContentType` into `AddData`, whose
+`RegisterWorkspaceTypes` runs `DataContext.Initialize` synchronously and records the type in
+the mesh-wide `IMeshContentTypeRegistry`. So `ContentTypeRegistration.ProbeRegister`'s
+build-and-dispose shape registers every swept type whether or not its init turn ever runs;
+the skip removes only the born-dead control plane. Two consequences for tests: a test that
+needs to know a probe was swept must NOT take its signal from an observable init action
+(that action is legitimately skipped whenever `Dispose()` beats the init turn — the
+determinism `ContentTypeProbeControlPlaneTest` lost when this rule landed), it captures the
+probe's `DisposalCompleted` from a synchronous `WithInitialization` and waits on that; and an
+assertion that a probe wrote no fault line is complete once `DisposalCompleted` fires,
+because the `ShutdownRequest` is queued behind the init turn and the teardown has written
+whatever it writes by then.
+
 ## Adding disposal work — the rule
 
 - **Installing a WATCHER the hub owns?** `SubscribeHubWatcher(hub, …)`, then hand the

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -511,6 +511,43 @@ ancestor's `Dispose()`) and `SourcesWatcherStopsAtTeardownTest` (the sources wat
 with a deterministically in-flight `@@`-include read, disposed mid-read: no quiesce
 timeout, no `[FAULT]`).
 
+### The rule for initialization: a BuildupAction never starts after `ShuttingDown`
+
+The init turn (`InitializeHubRequest`, which runs the `WithInitialization` observables as
+a `Concat`) is queued at `Build` and runs whenever the action block reaches it. That can
+be **after this hub's own `Dispose()`** — a transient probe is created and disposed in
+one breath (`ContentTypeRegistration.ProbeRegister` at boot, the schema probes in
+`MeshOperations`) — or after an ancestor's cascade froze the subtree before any
+descendant had initialised. Every BuildupAction is a piece of the per-node control
+plane: a watcher over the own node, an eagerly created child hub, a ticker. Installed on
+a hub that is already leaving, each one is born dead and faults on the way out:
+`HostedHubsCollection` refuses the child with a Warning (`Rejecting hosted hub creation
+… during disposal - collection is disposing`), the teardown errors the watcher's stream.
+
+Measured on the Thread NodeType's boot-time registration probe: its `AddThreadExecution`
+chain reached the `_Exec` child creation after the probe's own `Dispose()` in **159 of
+643** test logs of one CI run (MeshWeaver CD 33619142646) — a Warning each time, at a
+random offset from boot — and the one test that asserts a fault-free probe teardown
+(`ProbeHubCostTest.ValidateContentWithSchema_OnInvalidContent_BuildsOneProbeNotTwo`,
+MeshWeaver.Plugins) red whenever the late creation landed inside its recording window.
+The same interleaving does not reproduce on an idle developer machine, which is why it
+cannot be bisected locally and must be reasoned from the CI evidence.
+
+`HandleInitialize` therefore checks `IsShuttingDown` **at every action boundary**: once
+teardown has begun, the remaining actions are skipped (one Debug line), the Initialize
+gate still opens so the disposal state machine flows, and nothing is installed. This is
+the init-turn form of the watcher rule above, and the same policy the existing `.Catch`
+already applies one step later ("teardown ENDED an action" is a recognised shutdown, not
+a failure). A single action that is already running when the signal fires is not
+interrupted — the boundary is the granularity, exactly as a watcher's in-flight delivery
+is the granularity of `SubscribeHubWatcher`.
+
+Pinned by `InitializationStopsAtTeardownStartTest`: the first action is parked on the
+action block, `Dispose()` is called, the park is released, and the second action — which
+creates a child hub, the `_Exec` shape — must not have run by the time
+`DisposalCompleted` fires; a control arm on a live hub proves the same chain runs to the
+end and the child exists.
+
 ## Adding disposal work — the rule
 
 - **Installing a WATCHER the hub owns?** `SubscribeHubWatcher(hub, …)`, then hand the

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-host-that-is-leaving-installs-nothing.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-host-that-is-leaving-installs-nothing.md
@@ -1,0 +1,25 @@
+---
+Name: A host that is already leaving installs nothing
+Category: Fix
+Description: A node's host that was stopped before it finished starting no longer installs its background machinery on the way out, which used to log a warning about a refused child on most portal starts.
+Icon: Bug
+Order: -20260902
+---
+
+# A host that is already leaving installs nothing
+
+Some hosts live for a moment on purpose. When the portal starts, it briefly builds a host for each
+node type it ships, only to learn what kind of content that type carries, and lets it go at once.
+The same happens when an assistant checks a piece of content against a type's schema.
+
+Starting a host is a short list of steps that runs shortly after it is created — subscribe to its
+own node, install a helper or two, start a ticker. When such a moment-long host was let go
+*before* that list had run, the list ran anyway, on a host that was already on its way out. Every
+step then installed something that was dead on arrival, and one of them — creating a helper — was
+refused with a warning: `Rejecting hosted hub creation … during disposal`. On a typical start the
+warning appeared for most of those brief hosts; it meant nothing was wrong, and it was the one line
+that could turn a clean-teardown check red.
+
+**A host that has begun to leave now skips the rest of its start-up list.** Nothing is installed on
+it, nothing is refused, and the teardown finishes exactly as before. Hosts that are staying start
+exactly as they always did.

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -490,8 +490,37 @@ public sealed class MessageHub : IMessageHub
         var actions = Configuration.BuildupActions;
         logger.LogDebug("Message hub {address} has {count} BuildupActions to run", Address, actions.Count);
 
+        // 🚨 A BuildupAction never STARTS after teardown has begun. The init turn is queued at Build and
+        // runs whenever the action block reaches it — which can be after this hub's own Dispose() (a
+        // transient probe is created and disposed in one breath: ContentTypeRegistration.ProbeRegister,
+        // the schema probes) or after an ancestor's cascade froze the subtree. Every action is a piece
+        // of the per-node control plane — a watcher over the own node, an eagerly created child hub, a
+        // ticker — and installed on a hub that is already leaving each one is born dead and faults on
+        // the way out: HostedHubsCollection refuses the child with a Warning ("Rejecting hosted hub
+        // creation … during disposal"), the teardown errors the watcher's stream. The .Catch below
+        // already classifies "teardown ENDED an action" as a recognised shutdown; this is the same
+        // policy one step earlier, at the action boundary: once IsShuttingDown, the remaining actions
+        // are skipped, the gate still opens (so the disposal state machine flows) and nothing is
+        // installed. Measured: the boot-time content-type registration probe of the Thread NodeType
+        // reached its _Exec child creation after its own Dispose() in 159 of 643 test logs of one CI
+        // run (MeshWeaver CD 33619142646) — a Warning each time, and the one test that asserts a
+        // fault-free probe teardown (ProbeHubCostTest) red whenever the late creation landed in its
+        // window. Pinned by InitializationStopsAtTeardownStartTest.
+        var skipLogged = false;
         return Observable
-            .Concat(actions.Select(a => a(this).DefaultIfEmpty(Unit.Default).Take(1)))
+            .Concat(actions.Select(a => Observable.Defer(() =>
+            {
+                if (!IsShuttingDown)
+                    return a(this).DefaultIfEmpty(Unit.Default).Take(1);
+                if (!skipLogged)
+                {
+                    skipLogged = true;
+                    logger.LogDebug(
+                        "Message hub {address} began shutting down before its BuildupActions completed — the remaining actions are skipped; nothing is installed on a hub that is leaving",
+                        Address);
+                }
+                return Observable.Empty<Unit>();
+            })))
             .ToList()
             // 🚫 Liveness bound. A BuildupAction that HANGS — never emits and never completes (a
             // dependency that never initialises, a stuck NodeType compile, a subscribe that never

--- a/test/MeshWeaver.Graph.Test/ContentTypeProbeControlPlaneTest.cs
+++ b/test/MeshWeaver.Graph.Test/ContentTypeProbeControlPlaneTest.cs
@@ -8,6 +8,7 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
+using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Hosting.Monolith.TestBase;
@@ -44,6 +45,22 @@ namespace MeshWeaver.Graph.Test;
 /// probe's own disposal (the WARNING). One root, two faces — a probe must not run the node control
 /// plane at all, which is what <c>AsTransientNodeProbe</c> already promised and
 /// <c>MeshDataSource.SubscribeToOwnDeletionInit</c> already honours.</para>
+///
+/// <para>🚨 <b>The probe's init turn RACES its own <c>Dispose()</c>, and both outcomes must be
+/// fault-free.</b> <c>ProbeRegister</c> builds the hub (which posts <c>InitializeHubRequest</c>)
+/// and disposes it on the next line. When the action block reaches the init turn first, the
+/// <c>WithInitialization</c> observables run and the ACP install above is exercised against the
+/// #2990 guards. When <c>Dispose()</c> lands first, <c>MessageHub.HandleInitialize</c> skips the
+/// remaining BuildupActions altogether — a hub that is leaving installs nothing (#3109,
+/// <c>Doc/Architecture/HubDisposalModel</c> → "The rule for initialization") — and the install
+/// never runs. The tests therefore take their determinism signal from the probe's
+/// <c>DisposalCompleted</c>, captured in the SYNCHRONOUS <c>WithInitialization</c> overload that
+/// runs inside <c>Build</c> (before the sweep can dispose the hub), not from the install point: the
+/// <c>ShutdownRequest</c> that <c>Dispose()</c> posts is queued BEHIND the init turn, so by the
+/// time disposal completes the init turn has ended (run or skipped) and the teardown has written
+/// whatever it writes. Content-type REGISTRATION is unaffected by the skip either way — it happens
+/// in <c>DataContext.Initialize</c>, a synchronous buildup action inside <c>Build</c>, which is what
+/// makes the sweep's build-and-dispose shape sufficient.</para>
 /// </summary>
 public class ContentTypeProbeControlPlaneTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
@@ -59,18 +76,28 @@ public class ContentTypeProbeControlPlaneTest(ITestOutputHelper output) : Monoli
     }
 
     /// <summary>
-    /// Emits once the swept probe of <see cref="BareActivityNodeType"/> has RETURNED from the ACP
-    /// install point. That ordering is the whole determinism of this test:
-    /// <c>SubscribeWithReEstablish</c> establishes synchronously and
-    /// <c>MeshNodeStreamHandle.Subscribe</c> reports a failed <c>AcquireStream</c> through
-    /// <c>OnError</c> on the calling thread — so by the time this emits, the Error line has either
+    /// Emits once the swept probe of <see cref="BareActivityNodeType"/> has COMPLETED its disposal.
+    /// That ordering is the whole determinism of this test: the init turn is queued at
+    /// <c>Build</c>, the <c>ShutdownRequest</c> behind it, so disposal completing proves the init
+    /// turn has ended — either it ran (and <c>SubscribeWithReEstablish</c> established
+    /// synchronously, <c>MeshNodeStreamHandle.Subscribe</c> reporting a failed
+    /// <c>AcquireStream</c> through <c>OnError</c> on the calling thread) or it was skipped because
+    /// teardown had begun (#3109). Either way, by the time this emits the Error line has either
     /// been written or provably will not be. An assertion on a log's ABSENCE with no such signal
     /// passes whenever it runs first, which is most of the time.
     /// </summary>
-    private readonly AsyncSubject<Unit> bareWatcherInstalled = new();
+    private readonly AsyncSubject<Unit> bareProbeDisposed = new();
 
     /// <summary>Same signal for <see cref="TypedActivityNodeType"/>.</summary>
-    private readonly AsyncSubject<Unit> typedWatcherInstalled = new();
+    private readonly AsyncSubject<Unit> typedProbeDisposed = new();
+
+    /// <summary>
+    /// Which way the init-turn-vs-dispose race went on each probe: 1 when the ACP install point
+    /// was reached (the init turn won), 0 when the BuildupActions were skipped (dispose won).
+    /// Diagnostic only — both outcomes are legitimate and both must be fault-free.
+    /// </summary>
+    private int bareInstallRan;
+    private int typedInstallRan;
 
     private readonly RecordingLoggerProvider recorder = new();
 
@@ -81,30 +108,37 @@ public class ContentTypeProbeControlPlaneTest(ITestOutputHelper output) : Monoli
                 new MeshNode(BareActivityNodeType)
                 {
                     Name = "ACP Probe Gadget",
-                    HubConfiguration = config => InstallControlPlane(config.AddData(), bareWatcherInstalled)
+                    HubConfiguration = config => InstallControlPlane(
+                        config.AddData(), bareProbeDisposed, () => Interlocked.Exchange(ref bareInstallRan, 1))
                 },
                 new MeshNode(TypedActivityNodeType)
                 {
                     Name = "ACP Probe Gadget With Content",
                     HubConfiguration = config => InstallControlPlane(
                         config.AddMeshDataSource(source => source.WithContentType<AcpGadgetContent>()),
-                        typedWatcherInstalled)
+                        typedProbeDisposed, () => Interlocked.Exchange(ref typedInstallRan, 1))
                 });
 
     /// <summary>
     /// Faithful copy of <c>KernelContainer</c>'s Activity Control Plane install: the OBSERVABLE
     /// initialization overload, running on the <c>InitializeHubRequest</c> turn, registering the
-    /// watcher for the hub's disposal.
+    /// watcher for the hub's disposal. The SYNCHRONOUS overload beside it is test instrumentation
+    /// only: it runs inside <c>Build</c>, the one point that is guaranteed to precede the sweep's
+    /// <c>Dispose()</c>, and forwards the probe's <c>DisposalCompleted</c> to the test.
     /// </summary>
     private static MessageHubConfiguration InstallControlPlane(
-        MessageHubConfiguration config, AsyncSubject<Unit> installed)
-        => config.WithInitialization(hub => Observable.Defer(() =>
-        {
-            hub.RegisterForDisposal(hub.WatchControlPlane(_ => { }));
-            installed.OnNext(Unit.Default);
-            installed.OnCompleted();
-            return Observable.Return(Unit.Default);
-        }));
+        MessageHubConfiguration config, AsyncSubject<Unit> probeDisposed, Action installRan)
+        => config
+            .WithInitialization((IMessageHub hub) =>
+            {
+                hub.DisposalCompleted.Take(1).Subscribe(probeDisposed);
+            })
+            .WithInitialization(hub => Observable.Defer(() =>
+            {
+                hub.RegisterForDisposal(hub.WatchControlPlane(_ => { }));
+                installRan();
+                return Observable.Return(Unit.Default);
+            }));
 
     /// <summary>
     /// 🚨 THE assertion of #2990: a clean mesh start writes no Error-level record about a faulted
@@ -114,7 +148,7 @@ public class ContentTypeProbeControlPlaneTest(ITestOutputHelper output) : Monoli
     [Fact(Timeout = 120_000)]
     public async Task BootSweep_OfActivityShapedNodeTypes_LogsNoControlPlaneFault()
     {
-        await ProbesReachedTheInstallPoint();
+        await ProbesWereBuiltAndTornDown();
 
         var faults = recorder.Records
             .Where(r => r.Level >= LogLevel.Error
@@ -139,7 +173,7 @@ public class ContentTypeProbeControlPlaneTest(ITestOutputHelper output) : Monoli
     [Fact(Timeout = 120_000)]
     public async Task BootSweep_OfActivityShapedNodeTypes_OpensNoSyncSubHubOnAProbe()
     {
-        await ProbesReachedTheInstallPoint();
+        await ProbesWereBuiltAndTornDown();
 
         var rejected = recorder.Records
             .Where(r => r.Message.Contains("Rejecting hosted hub creation", StringComparison.Ordinal)
@@ -184,15 +218,23 @@ public class ContentTypeProbeControlPlaneTest(ITestOutputHelper output) : Monoli
             + "IsProbeAddress stays exhaustive (#2990)");
     }
 
-    private async Task ProbesReachedTheInstallPoint()
+    /// <summary>
+    /// Waits for both swept probes to finish disposing — the positive signal that each was built
+    /// (so the NodeType WAS swept) and that its init turn has ended, run or skipped. A faulted
+    /// probe teardown surfaces here as the subject's error.
+    /// </summary>
+    private async Task ProbesWereBuiltAndTornDown()
     {
-        await bareWatcherInstalled.Should().Within(TestTimeouts.Quick)
-            .Emit("the sweep must probe the ACP NodeType that carries no data source, or this test "
-                  + "asserts nothing");
-        await typedWatcherInstalled.Should().Within(TestTimeouts.Quick)
-            .Emit("the sweep must probe the ACP NodeType that declares a content type, or this "
-                  + "test asserts nothing");
+        await bareProbeDisposed.Should().Within(TestTimeouts.Quick)
+            .Emit("the sweep must probe the ACP NodeType that carries no data source and dispose "
+                  + "that probe, or this test asserts nothing");
+        await typedProbeDisposed.Should().Within(TestTimeouts.Quick)
+            .Emit("the sweep must probe the ACP NodeType that declares a content type and dispose "
+                  + "that probe, or this test asserts nothing");
 
+        Output.WriteLine(
+            $"    init turn reached the ACP install point: bare={Volatile.Read(ref bareInstallRan) == 1}, "
+            + $"typed={Volatile.Read(ref typedInstallRan) == 1} (false = skipped, teardown had begun)");
         foreach (var r in recorder.Records)
             Output.WriteLine($"    {r.Level} {r.Category}: {r.Message}"
                              + (r.Error is null ? "" : $"  << {r.Error.GetType().Name}: {r.Error.Message}"));

--- a/test/MeshWeaver.Messaging.Hub.Test/InitializationStopsAtTeardownStartTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/InitializationStopsAtTeardownStartTest.cs
@@ -43,6 +43,7 @@ public class InitializationStopsAtTeardownStartTest(ITestOutputHelper output) : 
     {
         var parkEntered = new AsyncSubject<Unit>();
         var release = 0;
+        var parkTimedOut = 0;
         var laterActionRan = 0;
         var client = GetClient();
         var hub = client.ServiceProvider.CreateMessageHub(
@@ -54,7 +55,11 @@ public class InitializationStopsAtTeardownStartTest(ITestOutputHelper output) : 
                     parkEntered.OnNext(Unit.Default);
                     parkEntered.OnCompleted();
                     // Parks the init turn on the action block until the test has called Dispose().
-                    SpinWait.SpinUntil(() => Volatile.Read(ref release) == 1, TestTimeouts.Convergence);
+                    // A park that ends on its BUDGET rather than on the release is recorded, so the
+                    // later action running for that reason is reported as such — not as the rule
+                    // under test failing.
+                    if (!SpinWait.SpinUntil(() => Volatile.Read(ref release) == 1, TestTimeouts.Convergence))
+                        Interlocked.Exchange(ref parkTimedOut, 1);
                     return Observable.Return(Unit.Default);
                 }))
                 .WithInitialization(h => Observable.Defer(() =>
@@ -86,6 +91,9 @@ public class InitializationStopsAtTeardownStartTest(ITestOutputHelper output) : 
         // fire before the action it tests would have run.
         await hub.DisposalCompleted.Should().Within(TestTimeouts.Convergence)
             .Emit("a hub disposed mid-initialization must still finish disposing");
+        Volatile.Read(ref parkTimedOut).Should().Be(0,
+            "the park must end on the release the test writes in its finally, never on its budget — "
+            + "a timed-out park would let the later action run for a reason unrelated to the rule under test");
         Volatile.Read(ref laterActionRan).Should().Be(0,
             "a BuildupAction must never start after the hub began shutting down: the control plane it "
             + "would install is born dead and faults on the way out (a child creation refused with a "

--- a/test/MeshWeaver.Messaging.Hub.Test/InitializationStopsAtTeardownStartTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/InitializationStopsAtTeardownStartTest.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>A BuildupAction never STARTS after its hub has begun shutting down.</b>
+///
+/// <para>The init turn (<c>InitializeHubRequest</c>) is queued at <c>Build</c> and runs whenever the
+/// action block reaches it. That can be after the hub's own <c>Dispose()</c>: a transient probe is
+/// created and disposed in one breath (<c>ContentTypeRegistration.ProbeRegister</c> at boot, the
+/// schema probes), and an ancestor's <c>Dispose()</c> freezes a whole subtree before any descendant
+/// has initialised. Every <c>WithInitialization</c> action is a piece of the per-node control plane
+/// — a watcher over the own node, an eagerly created child hub, a ticker — and on a hub that is
+/// already leaving each one is born dead and faults on the way out. The one this pins is the child
+/// creation: <c>HostedHubsCollection</c> refuses it with a Warning (<c>Rejecting hosted hub creation
+/// … during disposal</c>). Measured on the Thread NodeType's boot-time registration probe: 159 of
+/// 643 test logs of one CI run carried that Warning (MeshWeaver CD 33619142646), and the one test
+/// asserting a fault-free probe teardown red whenever the late creation landed inside its window
+/// (<c>ProbeHubCostTest.ValidateContentWithSchema_OnInvalidContent_BuildsOneProbeNotTwo</c>).</para>
+///
+/// <para>The rule is the init-turn form of #3026/#3072 ("a watcher stops at the first instant of
+/// teardown"): at each action boundary, <c>HandleInitialize</c> checks <c>IsShuttingDown</c> and
+/// skips the remaining actions — the gate still opens so the disposal state machine flows, and
+/// nothing is installed. See <c>Doc/Architecture/HubDisposalModel</c> → "The first instant of
+/// teardown".</para>
+///
+/// <para>No hand-woven gate: the action → test signal is an <c>AsyncSubject</c> the action
+/// completes; the test → parked action release is a volatile flag polled under a bounded
+/// <c>SpinUntil</c>, written in <c>finally</c>. The park IS the subject — it makes "teardown began
+/// mid-initialization" a certainty instead of a race.</para>
+/// </summary>
+public class InitializationStopsAtTeardownStartTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    [Fact]
+    public async Task DisposeDuringInitialization_SkipsTheRemainingBuildupActions()
+    {
+        var parkEntered = new AsyncSubject<Unit>();
+        var release = 0;
+        var laterActionRan = 0;
+        var client = GetClient();
+        var hub = client.ServiceProvider.CreateMessageHub(
+            new Address("init-at-teardown", "1"),
+            c => c
+                .WithPostingIdentity(PostingIdentity.System)
+                .WithInitialization(_ => Observable.Defer(() =>
+                {
+                    parkEntered.OnNext(Unit.Default);
+                    parkEntered.OnCompleted();
+                    // Parks the init turn on the action block until the test has called Dispose().
+                    SpinWait.SpinUntil(() => Volatile.Read(ref release) == 1, TestTimeouts.Convergence);
+                    return Observable.Return(Unit.Default);
+                }))
+                .WithInitialization(h => Observable.Defer(() =>
+                {
+                    Interlocked.Exchange(ref laterActionRan, 1);
+                    // The shape of every per-node control plane: an eagerly created child hub
+                    // (ThreadExecution.InstallExecutionHub's _Exec). On a hub that is leaving,
+                    // HostedHubsCollection refuses it with a Warning — the fault this pins away.
+                    h.GetHostedHub(new Address("init-at-teardown-child", "1"), cfg => cfg, HostedHubCreation.Always);
+                    return Observable.Return(Unit.Default);
+                })));
+
+        try
+        {
+            await parkEntered.Should().Within(TestTimeouts.Convergence)
+                .Emit("the first BuildupAction must be running, or the park proves nothing");
+            Volatile.Read(ref laterActionRan).Should().Be(0,
+                "BuildupActions run in registration order; the second cannot start while the first is parked");
+            hub.Dispose();
+            hub.IsShuttingDown.Should().BeTrue("Dispose() begins this hub's teardown synchronously");
+        }
+        finally
+        {
+            Volatile.Write(ref release, 1);
+        }
+
+        // The ShutdownRequest that Dispose() posted is queued BEHIND the init turn, so the disposal
+        // completing is the positive signal that the init turn has ended — the assertion below cannot
+        // fire before the action it tests would have run.
+        await hub.DisposalCompleted.Should().Within(TestTimeouts.Convergence)
+            .Emit("a hub disposed mid-initialization must still finish disposing");
+        Volatile.Read(ref laterActionRan).Should().Be(0,
+            "a BuildupAction must never start after the hub began shutting down: the control plane it "
+            + "would install is born dead and faults on the way out (a child creation refused with a "
+            + "Warning, a watcher errored by the teardown)");
+    }
+
+    /// <summary>
+    /// The control arm: on a hub that is NOT shutting down, every action runs and the child exists —
+    /// so the test above cannot pass by an initialization that installs nothing at all.
+    /// </summary>
+    [Fact]
+    public async Task LiveHub_RunsEveryBuildupAction_AndCreatesItsChild()
+    {
+        var laterActionDone = new AsyncSubject<Unit>();
+        var childAddress = new Address("init-live-child", "1");
+        var client = GetClient();
+        var hub = client.ServiceProvider.CreateMessageHub(
+            new Address("init-live", "1"),
+            c => c
+                .WithPostingIdentity(PostingIdentity.System)
+                .WithInitialization(_ => Observable.Return(Unit.Default))
+                .WithInitialization(h => Observable.Defer(() =>
+                {
+                    h.GetHostedHub(childAddress, cfg => cfg, HostedHubCreation.Always);
+                    laterActionDone.OnNext(Unit.Default);
+                    laterActionDone.OnCompleted();
+                    return Observable.Return(Unit.Default);
+                })));
+
+        await laterActionDone.Should().Within(TestTimeouts.Convergence)
+            .Emit("on a live hub the second BuildupAction runs");
+        hub.GetHostedHub(childAddress, HostedHubCreation.Never).Should().NotBeNull(
+            "the child created by the init turn exists on a live hub");
+
+        hub.Dispose();
+        await hub.DisposalCompleted.Should().Within(TestTimeouts.Convergence).Emit("the live hub disposes");
+    }
+}


### PR DESCRIPTION
## A BuildupAction never starts after its hub has begun shutting down

**Red:** core CD run 33619142646 (head `eb172af0`) — `Module bundle (MeshWeaver.AI)` →
`ProbeHubCostTest.ValidateContentWithSchema_OnInvalidContent_BuildsOneProbeNotTwo` failed on its
last assertion, `recorder.Records.Where(IsTeardownFault).Should().BeEmpty()` → 1 item:

```
[Warning] [HostedHubsCollection] Rejecting hosted hub creation for address
content-type-registration/ff3a6622…/_Exec in Host content-type-registration/ff3a6622…
during disposal - collection is disposing
```

### Root cause

`ContentTypeRegistration.ProbeRegister` (the boot-time sweep, since #2973/2026-09-01) builds a
transient probe hub for every static NodeType with a HubConfiguration and disposes it in the same
breath. `Dispose()` closes hosted-hub creation synchronously; the probe's **init turn**
(`InitializeHubRequest`, queued at Build) then runs whenever the action block reaches it — for the
Thread NodeType that is `AddThreadExecution`'s six `WithInitialization` actions, the fourth of which
eagerly creates the `_Exec` child hub (`HostedHubCreation.Always`). On a hub that is already
leaving, that creation is refused with the Warning above. It is not a regression of one commit in
`470cdd58e..eb172af0`: none of the involved code moved in the range (sweep, `HostedHubsCollection`,
the immediate `CloseCreation` in `Dispose()`), and the run's own evidence artifact shows the Warning
in **159 of 643** per-test logs, at a random offset from each boot — `ProbeHubCostTest` is simply the
one test asserting a fault-free probe teardown, and it reds whenever the late creation lands inside
its recording window. The interleaving does not occur on an idle developer machine (both `eb172af0`
and #3098's tree pass locally with no Warning anywhere in the class lifetime), so it cannot be
bisected locally.

### Fix (core seam, the init-turn form of #3026/#3072)

`MessageHub.HandleInitialize` checks `IsShuttingDown` at every BuildupAction boundary: once teardown
has begun the remaining actions are skipped (one Debug line), the Initialize gate still opens so the
disposal state machine flows, and nothing is installed on a hub that is leaving. This is the same
policy the existing `.Catch` applies one step later ("teardown ENDED an action" is a recognised
shutdown, not a failure).

- `src/MeshWeaver.Messaging.Hub/MessageHub.cs` — the boundary check.
- `test/MeshWeaver.Messaging.Hub.Test/InitializationStopsAtTeardownStartTest.cs` — parks the first
  action on the action block, calls `Dispose()`, releases the park: the second action (which creates a
  child hub, the `_Exec` shape) must not have run by `DisposalCompleted`. Fails before / passes after.
  A control arm on a live hub proves the chain runs to the end and the child exists.
- `Doc/Architecture/HubDisposalModel.md` — "The rule for initialization" under "The first instant of
  teardown". What's New entry (Fix): the Warning appeared on most portal starts.

### Verified

- `dotnet build test/MeshWeaver.Messaging.Hub.Test -c Release -warnaserror` clean; the whole test
  project green; the new test red with the `MessageHub.cs` change reverted.
- MeshWeaver.Plugins `MeshWeaver.AI.Test --filter ProbeHubCostTest` green against this tree.

### Left out, deliberately

The Thread NodeType's `AddThreadExecution` still installs its full control plane on any transient
probe that lives long enough to answer a request (a `_schema_validation/` probe validating Thread
content). That is wasted work, not a fault, and it lives in MeshWeaver.Plugins — a follow-up there
(skip the chain when the configuration carries `TransientNodeProbe`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
