### PR TITLE
fix(hub): a disposal warning names the message instead of serialising it

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -1505,8 +1505,31 @@ public class MessageService : IMessageService
         }
         else
         {
-            var jsonMessage = JsonSerializer.Serialize(delivery, hub.JsonSerializerOptions);
-            logger.LogWarning("Hub {Address} is disposing. Not processing message {Message}", hub.Address, jsonMessage);
+            // 🚨 NAME the message; never SERIALISE it. This line read
+            // `JsonSerializer.Serialize(delivery, hub.JsonSerializerOptions)` passed as a log
+            // argument — the #3044 shape that #3056 removed from `Post`, but at WARNING rather than
+            // Debug, which makes it strictly worse in two ways.
+            //
+            // A method argument is evaluated BEFORE the call, so the whole delivery was serialised
+            // on EVERY message that arrived at a disposing hub, whatever the log level. And because
+            // Warning ships, the rendered payload actually LEFT the process for Loki — a message
+            // body of arbitrary size, including whatever a caller happened to be writing.
+            //
+            // It is on the disposal path, which is exactly where this is least affordable: a hub
+            // tearing down under load can take a whole queue of these, each one an eager transcode
+            // (~5x the payload to render, per #2885's measurement) at the moment the process is
+            // trying to release memory rather than allocate it.
+            //
+            // The type name, the delivery id and the sender are what a reader actually needs here —
+            // "which message was dropped, from whom" — and they identify it without carrying it.
+            // The full body was never the useful part of this line: it is a DROP notice, and the
+            // fate trail below already records the routing story.
+            logger.LogWarning(
+                "Hub {Address} is disposing. Not processing {MessageType} (id={DeliveryId}, sender {Sender})",
+                hub.Address,
+                delivery.Message?.GetType().Name ?? "<null>",
+                delivery.Id,
+                delivery.Sender);
             fate?.Add($"NOT_PROCESSED_DISPOSING runLevel={hub.RunLevel}", Address);
             // 🚨 ANSWER it — never just drop it. This is the FOURTH door into the silent-
             // abandonment park, and the one neither #672 fix covers: the delivery was ACCEPTED
@@ -1533,7 +1556,7 @@ public class MessageService : IMessageService
             // distinct owners must key off the activation tag, never the whole message text.
             NackThroughParent(delivery,
                 $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}, {ActivationTag()}) — "
-                + $"{delivery.Message.GetType().Name} (id={delivery.Id}) was accepted before "
+                + $"{delivery.Message?.GetType().Name ?? "<null>"} (id={delivery.Id}) was accepted before "
                 + "disposal began and its turn came too late to process. The address may "
                 + "reactivate (recycle / restart); retry to get the authoritative answer.");
             exec = Observable.Return(delivery);


### PR DESCRIPTION
The adjacent finding from #3104, which #3108 recorded rather than folded in — correctly, because it changes a production log's contents.

## What it did

```csharp
var jsonMessage = JsonSerializer.Serialize(delivery, hub.JsonSerializerOptions);
logger.LogWarning("Hub {Address} is disposing. Not processing message {Message}", hub.Address, jsonMessage);
```

This is the #3044 shape that #3056 removed from `Post` — but at **Warning**, not Debug, and that makes it worse in two independent ways:

- **A method argument is evaluated before the call.** The whole delivery was serialised on every message arriving at a disposing hub, whatever the log level.
- **Warning ships.** The rendered payload actually left the process for Loki — a message body of arbitrary size, including whatever a caller happened to be writing.

And it is on the **disposal path**, which is where it is least affordable: a hub tearing down under load takes a queue of these, each an eager transcode (~5× the payload to render, per #2885's measurement) at the moment the process is trying to release memory rather than allocate it.

## What it does now

Names the message type, the delivery id and the sender. That is what a drop notice is *for* — "which message was dropped, from whom" — and it identifies the message without carrying it. The fate trail two lines below already records the routing story, so nothing diagnostic is lost.

🚨 This changes a production log's contents, which AGENTS.md treats as committed contract rather than a free edit, so the trade is stated rather than assumed: the body was never the useful half of a drop notice, and shipping arbitrary payloads to a log sink at Warning level is a cost — and an exposure — the line was never meant to carry.

## A latent bug it exposed

Guarding `delivery.Message` with `?.` told the compiler it may be null, which surfaced an **unguarded `delivery.Message.GetType()` ~50 lines below**, in the shutdown NACK text. Pre-existing, and it would have thrown while building the message that explains a shutdown. Fixed in the same commit.

## Verification

`-c Release -warnaserror` → **0 Error(s)**. `MeshWeaver.Messaging.Hub.Test`: **350 passed, 0 failed** — full project, unfiltered.

One process note worth recording: my first run used `--no-build` on the test project after changing only the referenced library. That would have executed a **stale assembly and passed without testing the change** — the false-pass AGENTS.md warns about. I rebuilt the test project and re-ran; the 350 above is from that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)