### PR TITLE
Pin the control-instance Warning for an empty framework-broadcast subscriber set (Memex#140)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -529,6 +529,27 @@ that does not exist is what stops the next reader from looking at the one that d
 `ReleaseDeliveryChainGuard` (`test/MeshWeaver.Documentation.Test`) now fails RED for any joint of
 this chain whose configuration key no chart renders.
 
+**Rendered is not provisioned** (Memex#140, measured 2026-09-01 and again 2026-09-02): after the
+chart rendered the four slots, memex-cloud's ConfigMap carried `FrameworkBroadcast__Subscribers__0..3`
+**all blank** — the environment overlay never named a subscriber, so the wave still dispatched to
+nobody. Two controls now tell that state from a legitimately inert mesh, and neither is inferred
+from the ConfigMap:
+
+- **At runtime, on the control instance only.** `FrameworkReleaseBroadcaster` reads its own
+  `WebhookInbox:Targets`; a mesh whose allowlist carries `Hosting/PlatformBuilds` IS the control
+  instance (it receives the release events), and there an empty subscriber set logs a **Warning**
+  naming `FrameworkBroadcast__Subscribers__0..N` — everywhere else the same state is Information.
+  `FrameworkBroadcastEmptySubscribersGuard` pins both levels and the target normalisation.
+- **At deploy time, in the deployment repo.** The subscriber set is a field on the
+  `Hosting/Deployment` record (`extraPortalConfig`), rendered into the committed overlay, and
+  `helm-release.yml` reads `helm get values --all` back after every upgrade and fails RED naming any
+  overlay leaf the release does not carry — the same assertion that caught `values.gate.yaml`
+  never having rendered (Memex#137).
+
+The subscriber set for the Systemorph fleet is the four repos that call `node-repo-publish-bake`
+and listen for `meshweaver-framework-released`: MeshWeaver.Plugins, .Education, .Reinsurance,
+.SocialMedia. Crm and Manufacturing do not bake and are not subscribed.
+
 🚨 **The notify job is a GATE, not a reporter (#2235).** It was written reporter-class — "losing one
 notification costs one delayed rebake wave" — with an input-shaped `if [ -z "$SECRET" ] … exit 0`
 and a `::warning::` on every non-2xx. Result: **zero releases broadcast between 2026-08-22 and

--- a/test/MeshWeaver.Documentation.Test/FrameworkBroadcastEmptySubscribersGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/FrameworkBroadcastEmptySubscribersGuard.cs
@@ -1,0 +1,125 @@
+using System.Reactive.Linq;
+using MeshWeaver.GitSync;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 Pins the ONE line that tells "notified nobody" from "nobody needed notifying" (#2235,
+/// Memex#140). A framework-release broadcast with zero subscribers has two causes with identical
+/// outcomes — <c>0 dispatched, 0 failed</c>: on a mesh that does not receive platform-build
+/// deliveries it is the correct, permanent state; on the CONTROL instance it means the release wave
+/// silently never runs and every satellite falls back to its schedule poll. memex-cloud sat in the
+/// second state for four days with the slots rendered and blank, and nothing was red.
+///
+/// <para>The control instance is identified by configuration alone — its
+/// <c>WebhookInbox:Targets</c> allowlist carries <see cref="FrameworkBroadcastOptions.PlatformBuildsTarget"/>,
+/// which is what makes it the mesh that receives release events. The broadcaster reads that
+/// section itself (<c>IConfiguration</c> is injected for exactly this), so the level of the line
+/// depends on nothing but the deployment's own config: WARNING naming the env key to set on the
+/// control instance, INFORMATION everywhere else. These tests fail if either side regresses — a
+/// warning that fires on every non-control mesh is noise nobody reads, and an Information line on
+/// the control instance is the four silent days again.</para>
+/// </summary>
+public class FrameworkBroadcastEmptySubscribersGuard
+{
+    [Fact]
+    public void OnTheControlInstance_ZeroSubscribers_IsAWarningNamingTheKeyToSet()
+    {
+        var logger = new CapturingLogger();
+        using var pools = new IoPoolRegistry();
+        var broadcaster = Create(pools, logger, controlInstance: true);
+
+        BroadcastOutcome? outcome = null;
+        broadcaster.Broadcast(subscribers: null).Subscribe(o => outcome = o);
+
+        Assert.NotNull(outcome);
+        Assert.Empty(outcome!.Results);   // nothing is dispatched either way — the point is the LEVEL
+        var warning = Assert.Single(logger.Lines, l => l.Level == LogLevel.Warning).Message;
+        Assert.Contains(FrameworkBroadcastOptions.PlatformBuildsTarget, warning);
+        // The warning must name the exact env key a deployment sets, or the reader is sent searching again.
+        Assert.Contains(FrameworkBroadcastOptions.SubscribersEnvKeyPrefix, warning);
+        Assert.DoesNotContain(logger.Lines, l => l.Level == LogLevel.Information);   // never "the normal state" here
+    }
+
+    [Fact]
+    public void OnANonControlMesh_ZeroSubscribers_IsTheNormalState()
+    {
+        var logger = new CapturingLogger();
+        using var pools = new IoPoolRegistry();
+        var broadcaster = Create(pools, logger, controlInstance: false);
+
+        BroadcastOutcome? outcome = null;
+        broadcaster.Broadcast(subscribers: null).Subscribe(o => outcome = o);
+
+        Assert.NotNull(outcome);
+        Assert.Empty(outcome!.Results);
+        // A mesh that does not receive platform-build deliveries is CORRECTLY inert — a warning there is noise.
+        Assert.DoesNotContain(logger.Lines, l => l.Level == LogLevel.Warning);
+        Assert.Single(logger.Lines, l => l.Level == LogLevel.Information);
+    }
+
+    /// <summary>
+    /// The predicate is the NORMALIZED target, not a string match: a deployment's allowlist may
+    /// carry the path with a leading slash or different casing and is still the control instance.
+    /// </summary>
+    [Fact]
+    public void TheControlInstancePredicate_NormalizesTheTarget()
+    {
+        var logger = new CapturingLogger();
+        using var pools = new IoPoolRegistry();
+        var broadcaster = Create(pools, logger, controlInstance: true, target: "/hosting/platformbuilds/");
+
+        broadcaster.Broadcast(subscribers: null).Subscribe(_ => { });
+
+        Assert.Single(logger.Lines, l => l.Level == LogLevel.Warning);
+    }
+
+    /// <summary>
+    /// Builds the broadcaster as the portal wires it, with the App CONFIGURED (so the zero-subscriber
+    /// branch is reached rather than the "App not configured" one) and the empty subscriber list the
+    /// default options carry — the exact shape of a deployment whose slots rendered blank.
+    /// </summary>
+    private static FrameworkReleaseBroadcaster Create(
+        IoPoolRegistry pools, CapturingLogger logger, bool controlInstance,
+        string target = FrameworkBroadcastOptions.PlatformBuildsTarget)
+    {
+        var appOptions = Options.Create(new GitHubAppOptions { ClientId = "Iv1.test", PrivateKey = "not-a-real-key" });
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(controlInstance
+                ? new Dictionary<string, string?>
+                {
+                    [$"{WebhookInbox.TargetsConfigSection}:0"] = "Store/Payments",
+                    [$"{WebhookInbox.TargetsConfigSection}:1"] = target,
+                }
+                : new Dictionary<string, string?> { [$"{WebhookInbox.TargetsConfigSection}:0"] = "Store/Payments" })
+            .Build();
+        return new FrameworkReleaseBroadcaster(
+            new GitHubAppTokenService(pools, appOptions),
+            pools,
+            appOptions,
+            Options.Create(new FrameworkBroadcastOptions()),
+            configuration,
+            logger);
+    }
+
+    /// <summary>Captures every line with its level so the LEVEL — the whole point — can be asserted.</summary>
+    private sealed class CapturingLogger : ILogger<FrameworkReleaseBroadcaster>
+    {
+        public List<(LogLevel Level, string Message)> Lines { get; } = [];
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(
+            LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter) =>
+            Lines.Add((logLevel, formatter(state, exception)));
+    }
+}


### PR DESCRIPTION
Companion to Systemorph/Memex#140 (subscribers rendered blank on memex-cloud for 6 days) and Memex#137.

**What this pins.** `FrameworkReleaseBroadcaster` already tells the two zero-subscriber cases apart since #2235: a mesh whose `WebhookInbox:Targets` carries `Hosting/PlatformBuilds` IS the control instance, and there an empty set logs a **Warning** naming `FrameworkBroadcast__Subscribers__0..N`; everywhere else it is Information. Nothing tested it — `FrameworkBroadcastEmptySubscribersGuard` now fails RED if the control instance regresses to "the normal state", if a non-control mesh starts warning, or if the predicate stops normalizing the target. Built as the portal wires it (App configured, default options, in-memory config), no mocks of core interfaces.

**Doc.** `ContinuousDeliveryContract.md` records the finding: rendered is not provisioned, the two controls (runtime Warning on the control instance; the deployment repo's post-deploy `helm get values --all` assertion), and the fleet's subscriber set.

Pure internal (test + doc) — no What's New.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
