### PR TITLE
The flush bound acks the commit instead of NACKing a landed write (#3112)

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1055,7 +1055,14 @@ public static class DataExtensions
     ///     is registered. (<c>StoragePostCommitFlush</c> itself ends in <c>DefaultIfEmpty(true)</c>, so this
     ///     arm is the contract made explicit, not a behaviour change for it.) A NACK here would fail every
     ///     successful write on a hook honouring the contract.</item>
-    ///   <item><b>Either stream faults</b> → NACK with the classified code.</item>
+    ///   <item>🚨 <b>Flush OUTLIVES <paramref name="flushTimeout"/></b> → ack <c>true</c> on the bound and
+    ///     let the flush run on (#3112). The echo already proved the merge COMMITTED; the bound is a wait
+    ///     bound on the ack, never a fate. Expiry used to NACK <c>Unknown</c> + <c>TimeoutException</c> —
+    ///     "the write did NOT apply" for a write that had — and dispose the flush, re-queueing the row
+    ///     through the sampler under the very congestion that made it slow. Logged as
+    ///     <c>FLUSH_OUTLIVED_BOUND</c>; a fault the flush raises after that ack is logged as
+    ///     <c>FLUSH_FAULTED_AFTER_ACK</c> (the sampler is then the writer of record).</item>
+    ///   <item><b>Either stream faults</b> (the flush inside its bound) → NACK with the classified code.</item>
     /// </list>
     /// </summary>
     internal static IDisposable ArmPatchAckWatcher<TEcho>(
@@ -1065,7 +1072,9 @@ public static class DataExtensions
         Action<bool, MeshNodeError?> ackOnce,
         Action<IDisposable> registerForDisposal,
         string hubPath,
-        Func<bool> ownerIsShuttingDown)
+        Func<bool> ownerIsShuttingDown,
+        ILogger? logger = null,
+        System.Reactive.Concurrency.IScheduler? flushBoundScheduler = null)
         => commitEcho
             .WhenCompletesEmpty(() =>
             {
@@ -1089,14 +1098,80 @@ public static class DataExtensions
                         ackOnce(true, null);
                         return;
                     }
+                    // 🚨 The COMMIT is the verdict; the flush is durability (#3112). Reaching this arm
+                    // means the owner's reduced stream emitted the echo that CONTAINS this write: the
+                    // merge landed, the Version advanced, every mirror is already receiving the new
+                    // state. What follows only decides WHEN the ack is posted, never WHETHER the write
+                    // applied — so the flush bound below is a wait bound on the ack, not a fate.
+                    //
+                    // This used to be `durable.Take(1).Timeout(flushTimeout)` feeding the fault arm,
+                    // which on expiry NACKed `Unknown` + "TimeoutException" — read by the writer as
+                    // "the write did NOT apply and is not auto-retryable" (LATE_NACK_TERMINAL) and
+                    // by its caller as a failed write. Measured on the node-repo gate (Manufacturing
+                    // run 33623113056): the bake seed's adoption stamp for Radzen/Gallery committed at
+                    // the owner (echo at +ε), the storage flush sat behind the mass install's queue
+                    // past 10 s, the owner answered NACK, the seed concluded "not adopted", the sweep
+                    // compiled the type OVER the adoption that had landed, and the gate DECLINED a
+                    // bundle a sibling repo adopted fine on the same seal. A slow flush was reported
+                    // as a lost write — a false verdict, the write-side twin of DurableButUnreadable.
+                    //
+                    // Now: the flush keeps running — `.Timeout` also DISPOSED it, cancelling a
+                    // storage write that had been queued for the whole bound and handing the row to
+                    // the persistence sampler, which re-queued it: under exactly the congestion that
+                    // made it slow, every slow flush became two writes. On the bound the owner acks
+                    // SUCCESS — truthful, the commit is what "saved" means (#2661) — and logs that
+                    // durability is still in flight. The flush's own terminal then finds the gate
+                    // latched: an emission is a no-op, a fault is logged (the sampler is the writer
+                    // of record — StoragePostCommitFlush releases its claim in Finally). A flush that
+                    // FAULTS inside the bound still NACKs with its classified code: a storage refusal
+                    // is a fact the caller should hear; slowness is not a verdict.
+                    //
+                    // The watcher itself posts at most ONE verdict for the flush leg — the bound and
+                    // the flush's terminal race only inside the millisecond the bound expires, and the
+                    // claim below decides it, so the caller's latch is never what keeps the count at one.
+                    var verdictClaimed = 0;
+                    bool ClaimVerdict() => System.Threading.Interlocked.Exchange(ref verdictClaimed, 1) == 0;
+                    var bound = new SingleAssignmentDisposable();
                     var flushSub = durable
                         .Take(1)
-                        .Timeout(flushTimeout)
-                        .WhenCompletesEmpty(() => ackOnce(true, null))
+                        .Finally(bound.Dispose)
+                        .WhenCompletesEmpty(() =>
+                        {
+                            if (ClaimVerdict()) ackOnce(true, null);
+                        })
                         .Subscribe(
-                            _ => ackOnce(true, null),
-                            ex => ackOnce(false, ClassifyPatchException(ex, hubPath)));
-                    registerForDisposal(flushSub);
+                            _ =>
+                            {
+                                if (ClaimVerdict()) ackOnce(true, null);
+                            },
+                            ex =>
+                            {
+                                if (!ClaimVerdict())
+                                {
+                                    logger?.LogWarning(ex,
+                                        "[PatchAck] FLUSH_FAULTED_AFTER_ACK path={Path} — the commit was "
+                                        + "acked on the flush bound and the durable flush has now faulted; "
+                                        + "the persistence sampler is the writer of record for this version",
+                                        hubPath);
+                                    return;
+                                }
+                                ackOnce(false, ClassifyPatchException(ex, hubPath));
+                            });
+                    bound.Disposable = Observable
+                        .Timer(flushTimeout, flushBoundScheduler ?? System.Reactive.Concurrency.Scheduler.Default)
+                        .Subscribe(_ =>
+                        {
+                            if (!ClaimVerdict()) return;
+                            logger?.LogWarning(
+                                "[PatchAck] FLUSH_OUTLIVED_BOUND path={Path} bound={BoundMs}ms — the merge "
+                                + "committed and is acked as such; the durable flush is still in flight "
+                                + "(storage behind), and keeps running",
+                                hubPath, flushTimeout.TotalMilliseconds);
+                            ackOnce(true, null);
+                        });
+                    // ONE registration for the leg, as before: the flush subscription and the bound
+                    // timer live and die together with the owner hub.
+                    registerForDisposal(new CompositeDisposable(flushSub, bound));
                 },
                 ex => ackOnce(false, ClassifyPatchException(ex, hubPath)));
 
@@ -1666,7 +1741,8 @@ public static class DataExtensions
                         AckOnce,
                         d => hub.RegisterForDisposal(d),
                         hubPath,
-                        () => hub.IsShuttingDown);
+                        () => hub.IsShuttingDown,
+                        hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"));
                     hub.RegisterForDisposal(postSub);
 
                     // Route via the hub's DataChangeRequest pipeline — the workspace
@@ -1772,7 +1848,8 @@ public static class DataExtensions
             AckOnce,
             d => hub.RegisterForDisposal(d),
             hubPath,
-            () => hub.IsShuttingDown);
+            () => hub.IsShuttingDown,
+            hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"));
         hub.RegisterForDisposal(postSub);
         // Registered AFTER postSub so the composite disposes the watcher FIRST, then this NACK
         // claims the gate — an unacked in-flight patch always gets a terminal, never silence.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingAWriteVerdict.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingAWriteVerdict.md
@@ -69,27 +69,63 @@ var postSub = ArmPatchAckWatcher(
         .Take(1)
         .Timeout(TimeSpan.FromSeconds(20)),            // ① commit echo
     committed => hub.ServiceProvider.GetService<IPostCommitFlush>()?.Flush(committed.Value!),
-    TimeSpan.FromSeconds(10),                          // ② durable flush
-    AckOnce, d => hub.RegisterForDisposal(d), hubPath);
+    TimeSpan.FromSeconds(10),                          // ② flush bound — a WAIT bound on the ack, not a fate
+    AckOnce, d => hub.RegisterForDisposal(d), hubPath, () => hub.IsShuttingDown, patchAckLogger);
 ```
 
 `ArmPatchAckWatcher` subscribes the echo with all three arms (see "The ack watcher's completion arm"
-below); the two bounds are unchanged.
+below). **Only bound ① can mint the timeout NACK.** Bound ② no longer produces a verdict at all —
+see "The flush bound is not a verdict" below.
 
 **Which one fired is readable from the elapsed time** between the user's action and the log line:
 
-- **~20 s** → ① the commit echo never arrived. The merge turn did not reach the stream, or the
-  reduced stream's fan-out is starved.
-- **~25–30 s** → ② the commit landed and `IPostCommitFlush` (i.e. `StoragePostCommitFlush` →
-  `storage.WriteAndPublishUpdated`, a Postgres write) did not finish in 10 s.
+- **~20 s** and a NACK `Unknown` + `TimeoutException` → ① the commit echo never arrived. The merge turn
+  did not reach the stream, or the reduced stream's fan-out is starved. The write's fate is genuinely
+  unknown: read the node's `Version` before retrying anything that accumulates.
+- **~10 s after the merge**, a SUCCESS, and an owner-side `FLUSH_OUTLIVED_BOUND` warning → ② the commit
+  landed and `IPostCommitFlush` (i.e. `StoragePostCommitFlush` → `storage.WriteAndPublishUpdated`) had
+  not finished in 10 s. The write applied; the storage behind that owner is slow. This is the signal
+  to read when a bulk operation drags — never a reason to retry the write.
 - **~31 s** → neither: this is the writer's `OwnerUnreachable` window, and the `Code` will say so.
 
-🚨 **In case ② the write is already committed in memory when the NACK is sent.** The caller is told
-the write failed, and the node's `Version` has nonetheless advanced. Check the version before
-retrying anything that accumulates — an append, a counter, a `with { X = X + 1 }`. This is the
-write-side twin of the read-side hazard in
-[Durable But Unreadable](/Doc/Architecture/DurableButUnreadable): the durable state and the
-reported outcome disagree, in opposite directions.
+## The flush bound is not a verdict (#3112)
+
+Reaching the flush at all means the owner's reduced stream emitted the echo **containing this write**:
+the merge landed, the `Version` advanced, every mirror is already receiving the new state. Whatever
+happens to the durable flush afterwards decides *when* the ack is posted, never *whether* the write
+applied. Until #3112 the code disagreed with that: `durable.Take(1).Timeout(10 s)` fed the fault arm, so
+a flush still queued at the bound became a NACK `Unknown` + `TimeoutException` — read by the writer as
+`LATE_NACK_TERMINAL … the write did NOT apply and is not auto-retryable` and by its caller as a failed
+write — and the `Timeout` also **disposed** the flush, cancelling a storage write that had been queued
+for the whole bound and handing the row to the persistence sampler, which queued it again. Under the
+congestion that made the flush slow, every slow flush became two writes and one false failure.
+
+**The measurement.** MeshWeaver.Manufacturing PR #48, run 33623113056, `test-repos / Compile + render
+node repos`: the gate's disposable mesh installs 37 upstream packages and, per installed NodeType,
+re-seeds the sealed bake's prebuilt assembly through one cross-hub `Update` on the type's node. For
+`Radzen/Gallery` the trace reads `ADVANCE_WITHOUT_HANDOFF … bound=5000ms` at +5 s, then at
++10.02 s `LATE_NACK_TERMINAL … code=Unknown … msg=TimeoutException` — the owner **answered**, ten
+seconds after the post, which is the flush bound measured from an echo that arrived within
+milliseconds. The seed logged `seeding Radzen/Gallery … did not complete — the sweep compiles it
+instead`, the sweep compiled the type over the adoption stamp that had in fact committed, and the
+consumption postcondition reported `adopted 101 of 102 … DECLINED: Radzen/Gallery`. The control arm —
+Reinsurance run 33623801785, same seal, same bytes, minutes later — adopted `Radzen.zip 1/1`. Same
+store, same code; only the queue depth differed. In the same failing log, `portal/nodeops` held a
+`CreateOrUpdateNodeRequest` for 60 s (`[STALE-CALLBACK] … AWAITING`), which is the depth of the queue
+the flush was sitting in.
+
+**The shape now.** On the bound the owner acks **Success** — the commit is what "saved" means (#2661),
+so this is the truthful verdict — logs `[PatchAck] FLUSH_OUTLIVED_BOUND path=… bound=10000ms` on the
+`MeshWeaver.Data.PatchAck` channel, and **leaves the flush running**. The flush's own terminal then
+finds the once-only gate claimed: an emission is a no-op; a fault is logged as
+`FLUSH_FAULTED_AFTER_ACK` and the sampler — whose claim `StoragePostCommitFlush` releases in `Finally`
+— stays the writer of record for that version. A flush that faults **inside** the bound still NACKs
+with its classified code: a storage refusal is a fact the caller should hear; slowness is not a
+verdict. `PatchAckTotalityTest` pins all three paths on a virtual clock.
+
+Under a genuinely slow store the writer therefore sees the ack arrive late — `LATE_ACK`, the caller
+completes with success — and `ADVANCE_WITHOUT_HANDOFF` at 5 s still says the successor diffed against
+the mirror. That warning is now the one to read for storage pressure; it is not a failed write.
 
 ## The ack watcher's completion arm (the gap closed by #3033)
 
@@ -112,7 +148,8 @@ emitted" — so every path posts exactly one terminal:
 | **echo stream ends without the echo, owner alive** | NACK `OwnerDisposing`, message `the owner's stream ended before this patch's commit echo arrived — … the write's fate is UNKNOWN; safe to retry …` |
 | **echo stream ends without the echo, owner shutting down** (`hub.IsShuttingDown`) | **nothing from the watcher** — the ShutDown-phase disposal NACK (`RegisterOwnerDisposingNack`) is the verdict; see the third point below |
 | flush ends without emitting | `Success` — `IPostCommitFlush.Flush` is contracted to complete empty for entity types it does not persist, so the in-memory commit is the durable state (the same verdict as when no hook is registered) |
-| either stream faults | NACK with `ClassifyPatchException`'s code (a timeout stays `Unknown` + `TimeoutException`) |
+| **flush outlives its 10 s bound** | `Success` on the bound, `FLUSH_OUTLIVED_BOUND` logged, the flush keeps running (#3112 — see "The flush bound is not a verdict") |
+| the echo stream faults, or the flush faults inside its bound | NACK with `ClassifyPatchException`'s code (the echo bound's timeout stays `Unknown` + `TimeoutException`) |
 
 Three things about that shape are load-bearing:
 
@@ -156,7 +193,9 @@ ran).
 3. **Read the node's `Version`.** If it advanced, the write landed and only the ack failed — do not
    retry a non-idempotent write.
 4. **Only then look at the owner.** For `OwnerUnreachable`, ask whether the activation was alive at
-   all; for `Unknown` + `TimeoutException`, ask what made the commit echo or the storage flush slow.
+   all; for `Unknown` + `TimeoutException`, ask what kept the commit echo from the owner's reduced
+   stream for 20 s (the flush bound cannot produce this code any more — a slow flush is a
+   `FLUSH_OUTLIVED_BOUND` warning beside a successful write).
 
 ## See also
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-slow-save-is-no-longer-reported-as-a-lost-write.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-slow-save-is-no-longer-reported-as-a-lost-write.md
@@ -1,0 +1,26 @@
+---
+Name: A slow save is no longer reported as a lost write
+Category: Fix
+Description: When storage was busy, a change that had already been applied could come back as "did not apply" — and whatever asked for it redid the work over the top of it. The owner now confirms the change it applied and finishes writing it out in the background.
+Icon: ArrowSyncCheckmark
+Order: -20260902
+---
+
+# A slow save is no longer reported as a lost write
+
+Every change to a node is applied by the node's owner and then written out to storage. The owner
+waits for that write before it confirms the change, so that "saved" has always meant "durable" as well
+as "applied". Under heavy load — a bulk install writing hundreds of nodes at once — the write to
+storage could queue for longer than the owner was prepared to wait, and at that point the owner gave
+up on the write and answered with a *failure*: the change did not apply.
+
+It had applied. The node already carried it, every reader already saw it. What the owner reported was
+the fate of the storage write, phrased as the fate of the change — and whatever had asked for the
+change believed the report. On the repository check that installs a sibling repository's packages,
+the thing asking was the step that adopts a prebuilt build instead of compiling; told it had failed,
+the check compiled the type over the build it had just adopted, and reported the adoption as declined
+while an identical check minutes later adopted the same build without incident.
+
+Now the owner tells the two apart. Once a change is applied, it is confirmed as applied — a slow
+storage write is finished in the background and noted in the owner's log as slow, not converted into
+a failure. A storage write that genuinely fails still surfaces as one.

--- a/test/MeshWeaver.Data.Test/MeshWeaver.Data.Test.csproj
+++ b/test/MeshWeaver.Data.Test/MeshWeaver.Data.Test.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="..\..\src\MeshWeaver.Mesh.Contract\MeshWeaver.Mesh.Contract.csproj" />
     <ProjectReference Include="..\MeshWeaver.Data.TestDomain\MeshWeaver.Data.TestDomain.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- TestScheduler: PatchAckTotalityTest drives the owner-side flush bound on a virtual clock. -->
+    <PackageReference Include="Microsoft.Reactive.Testing" />
+  </ItemGroup>
 </Project>

--- a/test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs
+++ b/test/MeshWeaver.Data.Test/PatchAckTotalityTest.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using MeshWeaver.Mesh;
+using Microsoft.Reactive.Testing;
 using Xunit;
 
 namespace MeshWeaver.Data.Test;
@@ -175,6 +176,85 @@ public class PatchAckTotalityTest
         h.Acks.Should().ContainSingle();
         h.Acks[0].Success.Should().BeFalse();
         h.Acks[0].Error!.Code.Should().Be(MeshNodeErrorCode.AccessDenied);
+    }
+
+    /// <summary>
+    /// 🚨 THE #3112 REGRESSION — a slow flush reported as a lost write. The commit echo has arrived
+    /// (the merge landed, the Version advanced), the durable flush is still queued behind a congested
+    /// store when the flush bound expires. Before: <c>Take(1).Timeout(bound)</c> faulted into the NACK
+    /// arm — <c>Unknown</c> + <c>TimeoutException</c>, "the write did NOT apply" — AND disposed the
+    /// flush, so the queued storage write was cancelled and re-queued through the sampler. On the
+    /// node-repo gate (Manufacturing run 33623113056) that NACK made the bake seed abandon an adoption
+    /// stamp that had committed; the sweep compiled over it and the gate DECLINED the bundle. After: the
+    /// bound acks <c>true</c> once — the commit IS the verdict — and the flush keeps its subscriber.
+    /// Driven on a virtual clock: no wall time, no race.
+    /// </summary>
+    [Fact]
+    public void FlushThatOutlivesTheBound_AcksTrueOnceOnTheCommit_AndKeepsTheFlushRunning()
+    {
+        using var h = new Harness();
+        var flush = new Subject<bool>();
+        var clock = new TestScheduler();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Return(42), _ => flush, FlushTimeout, h.AckOnce, h.Register, HubPath, () => false,
+            logger: null, flushBoundScheduler: clock);
+
+        clock.AdvanceBy(FlushTimeout.Ticks - 1);
+        h.Acks.Should().BeEmpty("inside the bound the ack waits for the durable flush");
+        flush.HasObservers.Should().BeTrue("the flush is in flight");
+
+        clock.AdvanceBy(1);
+        h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null),
+            "the echo already proved the merge committed — on the bound the owner acks the commit; a NACK "
+            + "here told the writer a landed write had NOT applied (#3112)");
+        flush.HasObservers.Should().BeTrue(
+            "the bound is a wait bound on the ack, not a cancellation of the storage write — disposing it "
+            + "re-queued every slow flush through the sampler under the congestion that made it slow");
+
+        flush.OnNext(true);
+        h.Acks.Should().ContainSingle("the flush landing after the bound finds the once-only gate claimed");
+        flush.HasObservers.Should().BeFalse("Take(1) completes on the flush's own emission");
+    }
+
+    /// <summary>A flush that faults AFTER the bound acked the commit must not re-verdict it: the gate
+    /// is latched on the owner, so the fault is logged and the sampler stays the writer of record.</summary>
+    [Fact]
+    public void FlushThatFaultsAfterTheBound_LeavesTheAckedCommitStanding()
+    {
+        using var h = new Harness();
+        var flush = new Subject<bool>();
+        var clock = new TestScheduler();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Return(42), _ => flush, FlushTimeout, h.AckOnce, h.Register, HubPath, () => false,
+            logger: null, flushBoundScheduler: clock);
+
+        clock.AdvanceBy(FlushTimeout.Ticks);
+        flush.OnError(new System.IO.IOException("disk full"));
+
+        h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null),
+            "the fault arrives after the commit was acked on the bound; it is a durability event, not a verdict");
+    }
+
+    /// <summary>The happy path is unchanged: a flush landing inside the bound acks once on its emission
+    /// and the bound timer is released with it — advancing the clock past the bound posts nothing more.</summary>
+    [Fact]
+    public void FlushThatLandsInsideTheBound_AcksOnce_AndTheBoundTimerIsReleased()
+    {
+        using var h = new Harness();
+        var flush = new Subject<bool>();
+        var clock = new TestScheduler();
+
+        using var sub = DataExtensions.ArmPatchAckWatcher(
+            Observable.Return(42), _ => flush, FlushTimeout, h.AckOnce, h.Register, HubPath, () => false,
+            logger: null, flushBoundScheduler: clock);
+
+        flush.OnNext(true);
+        h.Acks.Should().ContainSingle().Which.Should().Be(new Ack(true, null));
+
+        clock.AdvanceBy(FlushTimeout.Ticks * 2);
+        h.Acks.Should().ContainSingle("the bound timer was disposed with the flush's terminal — no second ack");
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3112

## What the trace says

MeshWeaver.Manufacturing PR #48, run 33623113056, job `test-repos / Compile + render node repos`, the bake seed's adoption write for `Radzen/Gallery`:

```
11:14:52.305 [UpdateQueue] ADVANCE_WITHOUT_HANDOFF path=Radzen/Gallery seq=681 bound=5000ms
11:14:57.329 [UpdateRemote] LATE_NACK_TERMINAL hub=cache/… target=Radzen/Gallery code=Unknown attempt=0 msg=TimeoutException: The operation has timed out. — the write did NOT apply and is not auto-retryable
11:14:57.330 [UpdateQueue] FAILED path=Radzen/Gallery seq=681 elapsedMs=10024.9
11:14:57.332 bake-seed ShippedPrebuiltBundles: seeding Radzen/Gallery from Radzen.zip did not complete — the sweep compiles it instead
```

- The owner **answered** (a `MeshNode Unknown …: TimeoutException` is minted only by the owner's `ClassifyPatchException`; the writer's no-verdict path stamps `OwnerUnreachable`). So this is not #2543's lost reply.
- It answered **10.02 s after the post**. The owner has two internal bounds: 20 s for its commit echo, 10 s for the durable flush. 10 s from the post = the flush bound, measured from an echo that arrived within milliseconds — i.e. **the merge had committed**, the `Version` had advanced, every mirror already carried the stamp, and only the storage write was still queued (the same log holds a `CreateOrUpdateNodeRequest → portal/nodeops` at `AWAITING` for 60 s — the depth of that queue during the 37-package install).
- `ArmPatchAckWatcher` fed `durable.Take(1).Timeout(10 s)` into its fault arm: expiry became NACK `Unknown` + `TimeoutException`, which the writer reads as "did NOT apply" and the seed as "not adopted". The sweep then compiled the type OVER the adoption that had landed, and the consumption postcondition correctly reported `DECLINED: Radzen/Gallery`. The `.Timeout` also **disposed** the flush — cancelling a storage write queued for the whole bound and handing the row to the persistence sampler, which queued it again: under the congestion that made it slow, every slow flush became two writes and one false failure.
- Control arm: Reinsurance run 33623801785, same seal, adopted `Radzen.zip 1/1` — same bytes, same code, shallower queue.

## The fix (owner side, `DataExtensions.ArmPatchAckWatcher`)

The commit echo is the verdict; the flush is durability. On the flush bound the owner now acks **Success** (the commit is what "saved" means — #2661), logs `[PatchAck] FLUSH_OUTLIVED_BOUND path=… bound=10000ms` on `MeshWeaver.Data.PatchAck`, and **leaves the flush running**. The flush's own terminal then finds the once-only gate latched: an emission is a no-op, a fault is logged as `FLUSH_FAULTED_AFTER_ACK` (the sampler stays the writer of record — `StoragePostCommitFlush` releases its claim in `Finally`). A flush that faults **inside** the bound still NACKs with its classified code. No bound was widened; the 20 s echo bound and its `Unknown` + `TimeoutException` verdict are unchanged.

Deterministic pins in `PatchAckTotalityTest` on a `TestScheduler` (the bound timer takes an optional scheduler): flush outlives the bound → exactly one `true`, flush keeps its subscriber; flush faults after the bound → the acked commit stands; flush lands inside the bound → one ack, the bound timer is released.

## Docs

- `Doc/Architecture/ReadingAWriteVerdict` — new section "The flush bound is not a verdict (#3112)" with the measurement; the verdict table and the elapsed-time reading updated (bound ② can no longer mint the timeout code).
- What's New (Fix): *A slow save is no longer reported as a lost write*.

## Not in this PR

- Why `portal/nodeops` held a `CreateOrUpdateNodeRequest` for 60 s during the install (the queue the flush sat in) — #2543's family; this PR makes that slowness visible as a warning beside a successful write instead of a false failure.
- The 20 s echo-bound NACK (`Manufacturing/CarbonIntensity/_Activity/compile-state`, `elapsedMs=20006` in the same log) is a genuinely-unknown fate and keeps its verdict.

Pairs-with: none — no public type removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
