### PR TITLE
fix(cache): the change-feed reset releases the upstream too — a finished activity stops heart-beating itself awake

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshNodeStreamCache.md
@@ -352,7 +352,7 @@ A failure that is *not* a genuine missing node — a transient reactivation miss
 
 Both breakers *suppress* while their window is open. When no window is open, the opposite must hold: the read has to actually re-probe. `GetStreamRaw`'s third guard enforces that — an entry whose hydration terminated with an error is evicted before the read resolves, so `SharedView` opens a fresh upstream.
 
-The eviction (`EvictFaultedEntry`) is the one teardown shared by all three re-probe triggers, and it must reach **two** layers:
+The eviction (`EvictFaultedEntry`) is the one teardown shared by all **four** triggers that can drop a faulted entry — the storm breaker's window expiry, the transient breaker's, `GetStreamRaw`'s faulted-entry guard, and the change-feed invalidation reset (`ResetFailureState`) — and it must reach **two** layers:
 
 1. the cache's own `Entry`, whose `Replay(1)` holds the terminal error, and
 2. the cacheHub **workspace's** remote-stream cache, keyed `(owner, reference, identity)`, which holds the errored `ISynchronizationStream`.
@@ -362,6 +362,14 @@ Dropping only (1) re-creates a fresh entry over the same dead stream: no `Subscr
 The protocol is the idle sweep's: **detach → claim pair-exact → tear down** (a loser re-parks what it detached). Detaching first is what makes disposal safe — a concurrent read builds a new stream with a new `StreamId`, so the `UnsubscribeRequest` for the old one cannot race it. Only a **faulted** entry qualifies; a healthy live entry is never torn down, because a breaker record can outlive the fault that wrote it and severing live subscribers over a stale counter would be a regression.
 
 🚨 The guard lives in `GetStreamRaw`, **never in `GetEntry`** — `GetEntry` is a pin-or-recreate loop, and evicting there spins forever on an entry that faults during creation. Running once per read *call* also bounds the re-probe: only a terminal entry qualifies, so an in-flight probe is shared, giving one new upstream per **fault**, not per read.
+
+### Dropping the entry without the upstream orphans a heartbeat nothing can reach (#3110)
+
+The fourth trigger — the change-feed reset — used to hand-roll its own teardown and dispose only layer (1). That is a second, worse failure than #1202's replay, because **both reclaimers of a warm mirror are keyed on the cache entry**: the idle sweep *iterates* `_streams`, and the event-driven `ReleaseIfUnwatched` (which a terminal activity write fires — see *A warm mirror is a KEEP-ALIVE, so "final" must be an event, not a wait*, above) *looks the path up* in it. Remove the entry and leave the stream attached, and neither can ever reach it again unless that exact path happens to be read once more.
+
+The fault class that matters here is the **transient** one. A `NotFound` disposes the stream's `keepAlive`, so its 45 s `HeartBeatEvent` is already dead — that is what made the old prose ("a terminally errored upstream has already torn down its own keep-alive") look true. An idle-collected grain or a 60 s request timeout is different: the node *exists*, the stream stays live, and the heartbeat keeps firing. Orphan one of those and it heartbeats its owner awake for the process lifetime.
+
+That is exactly what a finished compile activity showed in production: a `HeartBeatEvent` from `cache/…` still routing to `…/_Activity/compile-…` **49 minutes** after it succeeded in about a second — a path nothing reads again, so the accidental self-heal never came, and every compile storm multiplied the set of stale-but-routable activity hubs. The reset now calls `EvictFaultedEntry` like the other three, and `ChangeFeedResetReleasesUpstreamTest` pins it: a control arm releases the same faulted-with-live-upstream state through `ReleaseIfUnwatched` and asserts an upstream really was disposed, so the change-feed arm cannot pass vacuously.
 
 ## A delete tombstone is superseded at the recreate's commit — before `Created` is published
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-finished-work-stops-keeping-itself-awake.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-finished-work-stops-keeping-itself-awake.md
@@ -1,0 +1,32 @@
+---
+Name: Finished work stops keeping itself awake
+Category: Fix
+Description: Fixed a leak where a finished compile — or any other completed activity — could go on pinging its own node every 45 seconds for as long as the portal ran, so memory climbed with every burst of compiles.
+Icon: Sparkle
+Order: -20260902
+---
+
+# Finished work stops keeping itself awake
+
+When something in the portal reads or writes a node, it keeps a warm connection to that node for a
+short while, because whatever just touched it will usually touch it again. That connection sends a
+small keep-alive ping every 45 seconds so the node stays responsive while it is in use. When nothing
+has used it for a while, the connection is closed and the pings stop — and when the work it belonged
+to has visibly finished, it is closed straight away rather than waiting.
+
+A finished compile was not being closed by either route. A compile that succeeded in about a second
+was found still being pinged **49 minutes later**, and it would have gone on doing so for as long as
+the portal was running. Each such leftover keeps a node and its helper connections alive, so a burst
+of compiles — a hundred in a quarter of an hour is normal when a space is being reimported — left a
+hundred of them behind. Memory climbed, and on a portal already under pressure the next allocation
+was the one that failed.
+
+The cause was a bookkeeping gap. If a node was briefly unreachable while being read — a momentary
+blip, not a real error — the portal remembered the failure so the next read could start fresh. When
+it later cleared that memory, it dropped its own record of the warm connection but not the
+connection itself. Both of the routines that close idle connections work from that record, so from
+that moment neither could see it, and the ping had nothing left to switch it off.
+
+Clearing the record now closes the connection with it, using the same shared routine the other three
+paths already used. Nothing else changes: a node someone is actively watching is still left alone,
+and work that is genuinely in progress still gets its keep-alive.

--- a/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
+++ b/src/MeshWeaver.Hosting/MeshNodeStreamCache.cs
@@ -682,10 +682,33 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
     ///     shared handle down on every post-commit broadcast would sever live
     ///     GUI subscribers.</item>
     /// </list>
-    /// Same discipline as the storm-breaker's own re-probe eviction (guard #2 in
-    /// <see cref="GetStreamRaw"/>): dispose ONLY the Rx hydration — a terminally
-    /// errored upstream has already torn down its own keep-alive, and posting
-    /// UnsubscribeRequest at a mid-recycle owner would race its re-activation.
+    /// Same teardown as the storm-breaker's and the transient breaker's own re-probe
+    /// evictions — literally the same method, <see cref="EvictFaultedEntry"/>, which
+    /// DETACHES the path's upstream sync streams before it claims the entry and disposes
+    /// them once the claim is won.
+    ///
+    /// <para>🚨 <b>This is the FOURTH faulted-entry eviction and it used to hand-roll its own
+    /// teardown, disposing only the Rx hydration (#3110).</b> The prose here claimed that was
+    /// safe because "a terminally errored upstream has already torn down its own keep-alive" —
+    /// true only of a NotFound, which is the one fault class that disposes the stream's
+    /// <c>keepAlive</c>. The class that actually matters is the TRANSIENT one — an
+    /// idle-collected grain, a 60 s request timeout — where the node EXISTS and its stream
+    /// stays live with the 45 s <c>HeartBeatEvent</c> running. Dropping the entry then orphans
+    /// that stream in the cache hub's workspace, and BOTH reclaimers are keyed on the entry:
+    /// the idle sweep ITERATES <c>_streams</c>, and <see cref="ReleaseIfUnwatched"/> — the
+    /// event-driven release a terminal activity write fires (#1435/#1324) — LOOKS THE PATH UP
+    /// in it. So nothing could ever reach the stream again unless that exact path was read
+    /// once more. A finished <c>_Activity/compile-…</c> never is: a <c>HeartBeatEvent</c> was
+    /// still routing to one 49 minutes after it succeeded, pinning its node hub and both
+    /// <c>sync/</c> sub-hubs for the process lifetime, and every compile storm multiplied the
+    /// set. Never re-open this by hand — the whole point of
+    /// <see cref="EvictFaultedEntry"/> is that these four sites cannot drift.</para>
+    ///
+    /// <para>Disposing here is safe for the same reason it is safe in the other three: the
+    /// detach happens FIRST, so a concurrent read builds a fresh stream and can never adopt
+    /// the doomed one, and the <c>UnsubscribeRequest</c> a disposal posts carries the OLD
+    /// StreamId — a mid-recycle owner cannot mistake it for its new activation's. A lost
+    /// claim re-parks what it detached.</para>
     /// </summary>
     internal void ResetFailureState(string path)
     {
@@ -717,23 +740,21 @@ internal sealed class MeshNodeStreamCache : IMeshNodeStreamCache, IDisposable
                     path, clearedStreak.FailCount);
         }
 
-        if (_streams.TryGetValue(path, out var lazy) && lazy.IsValueCreated && lazy.Value.IsFaulted
-            && _streams.TryRemove(new KeyValuePair<string, Lazy<Entry>>(path, lazy)))
+        try
         {
-            try
-            {
-                var stale = lazy.Value;
-                stale.MarkEvicted();
-                stale.HydrationSub.Dispose();
-                readStreamEvictions.OnNext(new ReadStreamEviction(path, false, "invalidate"));
-                logger.LogDebug(
-                    "MeshNodeStreamCache: evicted faulted read entry for {Path} on change-feed invalidation", path);
-            }
-            catch (Exception ex)
-            {
-                logger.LogDebug(ex,
-                    "MeshNodeStreamCache: error disposing faulted entry for {Path}", path);
-            }
+            // The SHARED teardown, never a copy of it — see the remarks. EvictFaultedEntry
+            // applies the same IsFaulted gate this site used to apply inline, and adds the two
+            // things the copy was missing: the upstream detach + disposal (#3110) and the
+            // pair-exact claim that re-parks on a lost race.
+            EvictFaultedEntry(path, "invalidate");
+        }
+        catch (Exception ex)
+        {
+            // Eviction is state hygiene on the CHANGE FEED's publisher thread — a post-commit
+            // storage write. It must never break the writer, and OnMeshChange's own catch logs
+            // at Error, which would make a benign teardown hiccup look like a broken feed.
+            logger.LogDebug(ex,
+                "MeshNodeStreamCache: error evicting faulted entry for {Path} on change-feed invalidation", path);
         }
     }
 

--- a/test/MeshWeaver.Hosting.Test/ChangeFeedResetReleasesUpstreamTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ChangeFeedResetReleasesUpstreamTest.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Immutable;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using MeshWeaver.Reflection;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>Evicting a faulted read entry must ALSO release the path's upstream sync streams —
+/// on EVERY eviction path, including the change-feed one.</b> Issue #3110.
+///
+/// <para><b>The live defect.</b> A <c>HeartBeatEvent</c> from <c>cache/…</c> was still being
+/// routed to <c>Crm/Stage/_Activity/compile-…</c> <b>49 minutes</b> after that compile had
+/// finished <c>Succeeded</c> in about a second. Two reclaimers exist for such a mirror and both
+/// are keyed on the cache's <c>_streams</c> entry: the ten-minute idle sweep ITERATES it, and the
+/// event-driven <c>ReleaseIfUnwatched</c> (which <c>ActivityLogAppender</c> fires on the terminal
+/// activity write, #1435/#1324) LOOKS THE PATH UP in it. Remove the entry without detaching its
+/// upstream and the stream survives in the cache hub's workspace with its 45 s heartbeat running —
+/// invisible to both, and reachable again only if that exact path is ever read again. A finished
+/// compile activity is never read again, so "never" is the process lifetime.</para>
+///
+/// <para><b>The mechanism.</b> #1202 established the rule — an eviction must DETACH the upstream,
+/// not just drop the entry — and centralised it in <c>MeshNodeStreamCache.EvictFaultedEntry</c>,
+/// whose own remarks call it "the single teardown behind all three re-probe triggers … so they
+/// cannot drift". There was a FOURTH faulted-entry eviction, and it drifted: the change-feed
+/// invalidation reset (<c>ResetFailureState</c>) kept a hand-rolled copy that disposed only the Rx
+/// hydration and reported its eviction with <c>UpstreamReleased: false</c> hard-coded. That path
+/// runs on EVERY mesh change event for the path — including the activity's own terminal write —
+/// so a compile activity whose owner had one transient miss (an idle-collected grain, a 60 s
+/// request timeout: the node EXISTS, it was momentarily unreachable, and the stream therefore
+/// stays live) had its entry dropped and its heartbeat orphaned in the same breath.</para>
+///
+/// <para><b>The contract under test.</b> A faulted entry evicted by the change feed releases its
+/// upstream, exactly as the idle sweep's and the breakers' evictions do. The control arm proves
+/// the assertion is not vacuous: the SAME fault shape, released through the already-correct
+/// <c>ReleaseIfUnwatched</c> seam, reports an upstream too — so "no upstream was released" can
+/// only mean the change-feed path failed to release one.</para>
+/// </summary>
+public class ChangeFeedResetReleasesUpstreamTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshNodeStreamCache Cache =>
+        (MeshNodeStreamCache)Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+
+    /// <summary>
+    /// Stands in as the OWNER of one throwaway node path through the framework's own
+    /// <see cref="IRoutingService.RegisterStream(Address, SyncDelivery)"/> seam — the same call
+    /// every hub makes for itself, so the node's real per-node hub is never activated and every
+    /// <c>SubscribeRequest</c> the cache opens for the path lands here.
+    ///
+    /// <para>Each attempt is answered with the verbatim production timeout banner
+    /// (<c>MessageHub.BuildTimeoutMessage</c>). That is the TRANSIENT owner-unreachable class:
+    /// the node exists, so no negative window opens and nothing suppresses the path — the entry
+    /// is left faulted with its upstream still live, which is precisely the state #3110 leaks.
+    /// Borrowed verbatim from <c>MeshNodeStreamCacheFaultedEntryReprobeTest</c> (#1202).</para>
+    /// </summary>
+    private sealed class UnreachableOwner : IDisposable
+    {
+        private readonly IDisposable registration;
+        private ImmutableList<string> requestIds = ImmutableList<string>.Empty;
+
+        public UnreachableOwner(IMessageHub mesh, IRoutingService routing, string path)
+        {
+            var access = mesh.ServiceProvider.GetService<AccessService>();
+            SyncDelivery answer = delivery =>
+            {
+                // Mirror PostNotFound's guard: never NACK a NACK, and never answer a
+                // [CanBeIgnored] lifecycle message (that is the disposal ping-pong storm).
+                if (delivery.Message is DeliveryFailure
+                    || delivery.Message.GetType().HasAttribute<CanBeIgnoredAttribute>())
+                    return delivery.Processed();
+                var requestId = Guid.NewGuid().ToString("N")[..12];
+                ImmutableInterlocked.Update(ref requestIds, ids => ids.Add(requestId));
+                var banner = Banner(path, requestId);
+                using (delivery.AccessContext is null ? access?.ImpersonateAsSystem() : null)
+                    mesh.Post(
+                        new DeliveryFailure(delivery) { ErrorType = ErrorType.Exception, Message = banner },
+                        o => o.ResponseFor(delivery));
+                return delivery.FailedAndNacked(banner);
+            };
+            registration = routing.RegisterStream(new Address(path), answer);
+        }
+
+        public ImmutableList<string> RequestIds => Volatile.Read(ref requestIds);
+
+        public void Dispose() => registration.Dispose();
+
+        private static string Banner(string path, string requestId) =>
+            $"No response received in hub cache/mesh-node-cache within 00:01:00 for request " +
+            $"SubscribeRequest (id={requestId}) → target {path}. The request may have been " +
+            "undeliverable or the target hub was not found.";
+    }
+
+    private async Task<string> CreateNodeAsync(string prefix)
+    {
+        var path = $"{TestPartition}/{prefix}-{Guid.NewGuid():N}";
+        var node = MeshNode.FromPath(path) with
+        {
+            Name = "Original",
+            NodeType = "Markdown",
+            State = MeshNodeState.Active,
+        };
+        await NodeFactory.CreateNode(node).Should().Within(TestTimeouts.Convergence).Emit();
+        return path;
+    }
+
+    private UnreachableOwner Hijack(string path) =>
+        new(Mesh, Mesh.ServiceProvider.GetRequiredService<IRoutingService>(), path);
+
+    /// <summary>Reads through the cache and waits for the terminal fault the hijacked owner
+    /// produces, leaving the entry cached and FAULTED with its upstream still attached.</summary>
+    private async Task<Notification<MeshNode>> FaultTheEntry(string path)
+    {
+        var failure = await Cache.GetStream(path, Mesh.JsonSerializerOptions)
+            .Materialize()
+            .Should().Within(TestTimeouts.Convergence).Match(
+                n => n.Kind == NotificationKind.OnError,
+                "an owner that cannot answer the SubscribeRequest must surface as OnError");
+        MeshNodeStreamCache.IsTransientOwnerFailure(failure.Exception!).Should().BeTrue(
+            "precondition: the 'no response received' banner is the TRANSIENT class — the node "
+            + "exists and its stream stays live, which is what makes the orphan heartbeat possible");
+        MeshNodeStreamCache.IsMissingNodeFailure(failure.Exception!).Should().BeFalse(
+            "precondition: the node EXISTS — its owner is unreachable, which is not an absence, so "
+            + "no NotFound tears the stream's keep-alive down for us");
+        Cache.IsReadStreamLive(path).Should().BeTrue(
+            "precondition: the faulted read left its entry cached — that entry is the ONLY handle "
+            + "either reclaimer has on the upstream");
+        return failure;
+    }
+
+    /// <summary>The exact broadcast every post-commit write publishes for a path (and the one
+    /// <c>MeshOperations.RecycleCore</c> publishes for a recycle).</summary>
+    private void PublishChangeBroadcast(string path)
+    {
+        var segments = path.Split('/');
+        Mesh.ServiceProvider.GetRequiredService<IMeshChangeFeed>().Publish(new MeshChangeEvent(
+            Namespace: segments.Length > 1 ? string.Join("/", segments[..^1]) : "",
+            Id: segments.Length > 0 ? segments[^1] : path,
+            Path: path,
+            Kind: MeshChangeKind.Updated,
+            NodeType: MeshNode.NodeTypePath,
+            Version: 0,
+            Timestamp: DateTimeOffset.UtcNow));
+    }
+
+    /// <summary>
+    /// THE control arm, and it runs FIRST because it is what makes the subject arm mean anything:
+    /// the same faulted-with-live-upstream state, released through the seam that already applies
+    /// the #1202 rule, MUST report that it disposed an upstream. If this ever goes red the fault
+    /// shape stopped leaving a stream behind and the subject arm below is measuring nothing.
+    /// </summary>
+    // 240_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a constant,
+    // so the property cannot be written here. The value must still DOMINATE it — 216 s at the
+    // CI factor (Convergence 108 s x OuterMargin 2) — or the xunit kill pre-empts the inner
+    // wait and the failure cannot say what it was waiting for.
+    [Fact(Timeout = 240_000)]
+    public async Task ControlArm_ReleaseIfUnwatched_OfTheSameFaultedEntry_DisposesAnUpstream()
+    {
+        var path = await CreateNodeAsync("control");
+        using var owner = Hijack(path);
+        await FaultTheEntry(path);
+
+        // Attach BEFORE the release — an eviction is a point event on a hot subject, so observing
+        // it must not be able to race the action that produces it.
+        var evictions = Cache.ReadStreamEvictions.Where(e => e.Path == path).Replay();
+        using var connection = evictions.Connect();
+
+        Cache.ReleaseIfUnwatched(path).Should().BeTrue(
+            "nothing is subscribed to the faulted entry, so the release must claim and tear it down");
+
+        var eviction = await evictions.FirstAsync().Should().Within(TestTimeouts.Convergence).Emit();
+        eviction.UpstreamReleased.Should().BeTrue(
+            "a transiently-faulted read leaves a LIVE upstream sync stream — with its 45 s "
+            + "HeartBeatEvent — in the cache hub's workspace. If this is false the scenario no "
+            + "longer holds an upstream and the change-feed arm below would pass vacuously");
+    }
+
+    /// <summary>
+    /// THE pin for #3110. A change-feed event evicts the faulted entry — and must release its
+    /// upstream in the same breath. Before the fix this eviction disposed only the Rx hydration
+    /// and reported <c>UpstreamReleased: false</c>, orphaning a live sync stream that neither the
+    /// idle sweep (which iterates <c>_streams</c>) nor <c>ReleaseIfUnwatched</c> (which looks the
+    /// path up in it) could ever reach again — a 45 s heartbeat to a finished activity for the
+    /// process lifetime.
+    /// </summary>
+    // 240_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a constant,
+    // so the property cannot be written here. The value must still DOMINATE it — 216 s at the
+    // CI factor (Convergence 108 s x OuterMargin 2) — or the xunit kill pre-empts the inner
+    // wait and the failure cannot say what it was waiting for.
+    [Fact(Timeout = 240_000)]
+    public async Task ChangeFeedReset_OfAFaultedEntry_ReleasesItsUpstreamToo()
+    {
+        var path = await CreateNodeAsync("changefeed");
+        using var owner = Hijack(path);
+        await FaultTheEntry(path);
+
+        var evictions = Cache.ReadStreamEvictions.Where(e => e.Path == path).Replay();
+        using var connection = evictions.Connect();
+
+        PublishChangeBroadcast(path);
+
+        var eviction = await evictions.FirstAsync().Should().Within(TestTimeouts.Convergence).Emit(
+            "a change-feed event must evict the faulted entry so the next read re-probes");
+        Cache.IsReadStreamLive(path).Should().BeFalse(
+            "the faulted entry is gone — from here on NOTHING in the cache references the path, so "
+            + "this eviction was the last chance to release its upstream");
+        eviction.UpstreamReleased.Should().BeTrue(
+            "the eviction must DETACH and dispose the path's upstream sync streams, not merely "
+            + "dispose the Rx hydration. Leaving them attached orphans a live stream in the cache "
+            + "hub's workspace whose 45 s HeartBeatEvent keeps the finished node's hub — and its "
+            + "sync/ sub-hubs — alive for the process lifetime, unreachable by BOTH reclaimers "
+            + "(#3110). This is the same rule #1202 established and EvictFaultedEntry centralises");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/MeshWeaver.Hosting.Test.csproj
+++ b/test/MeshWeaver.Hosting.Test/MeshWeaver.Hosting.Test.csproj
@@ -5,6 +5,11 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\MeshWeaver.Hosting\MeshWeaver.Hosting.csproj" />
     <ProjectReference Include="..\MeshWeaver.Fixture\MeshWeaver.Fixture.csproj" />
+    <!-- ChangeFeedResetReleasesUpstreamTest (#3110) drives a REAL monolith mesh: the defect is in
+         MeshNodeStreamCache's eviction teardown, and this assembly is the one MeshWeaver.Hosting
+         already grants InternalsVisibleTo for the cache's eviction seam (ReadStreamEvictions /
+         IsReadStreamLive). -->
+    <ProjectReference Include="..\MeshWeaver.Hosting.Monolith.TestBase\MeshWeaver.Hosting.Monolith.TestBase.csproj" />
   </ItemGroup>
   <ItemGroup>
     <!-- Concrete HostBuilder for MeshHostBuilderTeardownOrderingTest (the legacy


### PR DESCRIPTION
Fixes #3110.

## What #3110 actually is

A system `HeartBeatEvent` from `cache/…` was still routing to
`Crm/Stage/_Activity/compile-202609021024566204c48055472004402b49f4d77fe64bb89`
**49 minutes** after that compile finished `Succeeded` in about a second — and would have
gone on doing so for the pod's lifetime. The `OutOfMemoryException` in the recorded stack is
where the exhausted heap surfaced, not the defect.

The issue's own hypothesis — *"whatever activates hubs for `_Activity` nodes does not release
them at terminal status"* — is **not** what is broken. That release exists and works
(#1435/#1324): `ActivityLogAppender.Append` fires `IMeshNodeStreamCache.ReleaseIfUnwatched` on
the terminal write, and `NodeTypeCompilationActivity` (which owns every `compile-<ts>` node) is
on that path. What is broken is one layer down, and it is why the release found nothing to
release.

## Root cause — the FOURTH faulted-entry eviction drifted from the other three

#1202 established that evicting a faulted cache entry must reach **two** layers — the cache's
own `Entry`, and the cacheHub **workspace's** remote-stream cache holding the
`ISynchronizationStream` — and centralised that in `MeshNodeStreamCache.EvictFaultedEntry`,
whose remarks call it *"the single teardown behind all three re-probe triggers … so they cannot
drift"*.

There is a fourth trigger. `ResetFailureState` — the change-feed invalidation, which runs on
**every** mesh change event for a path, including the activity's own terminal write — kept a
hand-rolled copy that disposed only the Rx hydration and emitted
`ReadStreamEviction(path, UpstreamReleased: false, "invalidate")` with the flag hard-coded.

Its prose justified that: *"a terminally errored upstream has already torn down its own
keep-alive"*. That is true of a **NotFound** — the one fault class that disposes the stream's
`keepAlive`, which is what made the claim look right. The class that actually matters is the
**transient** one the cache documents two screens earlier: an Orleans-idle-collected grain or a
60 s request timeout, where *the node exists and is momentarily unreachable*. There the stream
stays live and its 45 s heartbeat keeps firing.

Orphan one of those and nothing can ever reap it, because **both reclaimers of a warm mirror are
keyed on the cache entry**:

| reclaimer | how it finds the mirror |
|---|---|
| the 10-minute idle sweep | **iterates** `_streams` |
| `ReleaseIfUnwatched` (the terminal-activity event, #1435) | **looks the path up** in `_streams` |

Remove the entry and leave the stream attached and both are blind to it. The only escape left is
someone reading that exact path again, so a fresh `Entry` re-adopts the stream and a later
release disposes it. A finished `_Activity/compile-…` is never read again — so "never" is the
process lifetime, and every compile storm (100+ in a quarter of an hour on a reimport)
multiplied the set of stale-but-routable activity hubs, each with a periodic heartbeat pointed
at it.

## The fix

`ResetFailureState` calls `EvictFaultedEntry(path, "invalidate")` — the same gate it applied
inline, plus the two things the copy was missing: the upstream detach + disposal, and the
pair-exact claim that re-parks what it detached on a lost race. Disposal is safe here for the
same reason it is safe at the other three sites, which `EvictFaultedEntry` already argues: the
detach happens FIRST, so a concurrent read builds a fresh stream, and the `UnsubscribeRequest`
a disposal posts carries the OLD `StreamId`.

No timer, no watchdog, no shortened window, no new bound.

## Verified

- New `test/MeshWeaver.Hosting.Test/ChangeFeedResetReleasesUpstreamTest.cs`. A hijacked owner
  (`IRoutingService.RegisterStream`, the harness `MeshNodeStreamCacheFaultedEntryReprobeTest`
  already uses for #1202) answers the `SubscribeRequest` with the verbatim production timeout
  banner, producing the real transient fault — asserted as such via
  `IsTransientOwnerFailure` / `!IsMissingNodeFailure`. A change event must then release the
  upstream.
- **The control arm is what makes it non-vacuous:** the same faulted-with-live-upstream state,
  released through the already-correct `ReleaseIfUnwatched`, must report
  `UpstreamReleased: true`. If the scenario ever stops leaving a stream behind, the control goes
  red rather than the subject going quietly green.
- Measured both ways: with the one-line change reverted the subject arm fails on exactly that
  assertion while the control arm passes; with it, both pass.
- `dotnet build -c Release -warnaserror`, `0 Error(s)` each: `MeshWeaver.Hosting`,
  `MeshWeaver.Hosting.Orleans`, `MeshWeaver.Connection.Orleans`, `MeshWeaver.Documentation`,
  `MeshWeaver.Hosting.Test`, `MeshWeaver.Documentation.Test`.
- Full unfiltered runs: `MeshWeaver.Hosting.Test` **302/302**, `MeshWeaver.Documentation.Test`
  **202/202**. (`TestTimeoutLiteralRatchetGuard` caught three `30.Seconds()` literals in the
  first draft — converted to `TestTimeouts.Convergence`; the baseline is untouched.)

## Notes for review

- `test/MeshWeaver.Hosting.Test` gains a `ProjectReference` to
  `MeshWeaver.Hosting.Monolith.TestBase`: the defect needs a real mesh, and this is the assembly
  `MeshWeaver.Hosting` already grants `InternalsVisibleTo` for the cache's eviction seam
  (`ReadStreamEvictions` / `IsReadStreamLive`). The cache's own suite moved to
  `MeshWeaver.Plugins` with the 17 mesh suites (#2276), so core had no other home for it.
- That Plugins suite (`MeshNodeStreamCacheRecycleResetTest`,
  `MeshNodeStreamCacheFaultedEntryReprobeTest`, `MeshNodeStreamCacheIdleReleaseTest`,
  `CompileActivityHubRetentionTest`) covers this path from the other side. Reviewed statically
  against the change: the recycle-reset test's organic arm now disposes an already-dead NotFound
  stream instead of leaving it re-adoptable — the same disposal the storm-breaker branch it
  passes today already performs — and the retention tests exercise seams this diff does not
  touch.
- A separate finding, deliberately **not** in this PR: several terminal `_Activity` writers do
  not go through `ActivityLogAppender.Append` at all, so they never fire `ReleaseIfUnwatched` —
  `ActivityLogLogger.PublishSnapshotLocked` (every kernel/script/markdown/test run — the
  highest-volume one), `CodeNodeType.FailActivity`, and `BuildProtocolDriver.FinishActivity`.
  Those leave a warm mirror to the 10-minute idle sweep rather than orphaning it, so they are a
  retention rather than the unbounded leak fixed here. Worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
