### PR TITLE
One seam composes every owner-side shutdown refusal, and recognises one (#3017)

### DIFF
--- a/src/MeshWeaver.Data/DataContext.cs
+++ b/src/MeshWeaver.Data/DataContext.cs
@@ -531,11 +531,11 @@ public sealed record DataContext : IDisposable
             // reactivate; retry") immediately. It records no InitializationError, no
             // fail-level log and no errored data streams — the post-mortem FAILED residue
             // #1122 removed stays removed.
-            Hub.FailGate(InitializationGateName,
-                $"Hub '{Hub.Address}' is shutting down; its DataContext initialization ended "
-                + $"without opening '{InitializationGateName}', which can therefore never open. "
-                + "The address may reactivate (recycle / restart); retry to get the "
-                + "authoritative answer.");
+            Hub.FailGate(InitializationGateName, ShutdownNack.RetryForTheAuthoritativeAnswer(
+                Hub.Address,
+                null,
+                $"its DataContext initialization ended without opening "
+                + $"'{InitializationGateName}', which can therefore never open"));
             return;
         }
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ErrorPropagationAndWedges.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ErrorPropagationAndWedges.md
@@ -100,6 +100,46 @@ answered flag first, then read the CARRIED verdict, and fall back to the shared 
 `MeshNodeStreamCache.IsTransientOwnerFailure` use) rather than to a terminal default.** A verdict
 that cannot be read is not evidence of a permanent failure.
 
+#### Who refused? The BANNER, not the classification (#3017)
+
+A caller that gets `ErrorType.ShuttingDown` still has a second question to answer: **did the OWNER
+refuse me, or did the routing layer fail to reach it?** They call for opposite responses — re-probe
+the address that announced its own return, versus stop asking about one nothing can route to — and
+the classification cannot tell them apart, because the routing layer mints `ShuttingDown` too, off
+the owner's own text (`ClassifyRoutedFailure`).
+
+The evidence that does separate them is the **banner**: `Hub {address} is shutting down`. Only the
+owner makes THIS address the subject of it. The routing layer says `No node found at 'x'`,
+`No route to 'x'`, `Mesh is shutting down, cannot route to x`, `Host is shutting down, cannot route
+to x` — the mesh or the host is the subject there, never the address you asked about.
+
+**One seam composes every owner-side refusal, and the same seam recognises one.**
+`ShutdownNack.RejectingNow` (a delivery turned away at the door) and
+`ShutdownNack.RetryForTheAuthoritativeAnswer` (work the hub accepted and can no longer finish) build
+the sentence; `ShutdownNack.IsAnsweredByOwner` reads the banner back out. The producers are the
+intake gate and the late turn (`MessageService`), the access gate (`AccessControlPipeline`, which
+runs INSIDE the owner and is its own intake — not the routing layer), the typed
+`HubDisposingException` a handler throws, and the `DataContext` gate that can never open.
+
+**Why it is a seam and not a convention.** Recognition used to be a LIST of the refusal sentences
+somebody had thought of, and the list lost a race with the source three times. #1599 removed the
+first version (pinning one arm's free text — 21 failures in 60 on unmodified `main`). A fourth
+terminal was added after it reddened a suite in 2026-08. A fifth did the same in #3017 — the access
+gate's refusal, rejected as "not from the owner" although it is the owner's own gate — and a sixth
+was live and unlisted the whole time, the intake gate's `Rejecting now.` form. Each round the
+enumeration's own guard passed, because **a guard over an enumeration can only assert the members
+already written down**: it cannot discover the terminal nobody listed. A derived predicate follows
+the producers instead of trailing them, and a seventh terminal is recognised the day it is written.
+
+The wording of these sentences is contract in the other direction too — the transient classifiers
+(`MeshNodeStreamCache.IsTransientOwnerFailure`, `AreaErrorClassifier.IsTransientHubFailure`,
+`OrleansRoutingService.ClassifyRoutedFailure`) match on `is shutting down` / `Rejecting now`, and a
+casual reword silently restores #2727: nothing fails to compile, the delivery is still refused, and
+the caller simply stops retrying. Composing through the seam is what makes both contracts hold by
+construction rather than by memory. `OwnerAnswerRecognitionGuard` calls every reachable producer and
+runs the real predicate and the real classifier over what they actually say; `DisposalRaceNackTest`
+pins the same recognition on a NACK that travelled the real path.
+
 ### Long-running operations (activity → activity log)
 
 An import / compile / mirror runs as an activity. A fault must not strand the activity "Running" forever — it writes `Status = Error` with the message onto the activity node, which the activity log and any progress reader render. Persistence at the bottom of the stack never re-gates and never fail-closes a write that was already approved; it forwards. See [Activity Control Plane](/Doc/Architecture/ActivityControlPlane) and [Activity Operations](/Doc/Architecture/ActivityOperations).

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-refusal-now-says-which-hub-refused.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-refusal-now-says-which-hub-refused.md
@@ -1,0 +1,34 @@
+---
+Name: A refusal now says which hub refused
+Category: Fix
+Description: When a part of the mesh is restarting, the refusal it sends back is now written in one place instead of six, so everything reading it can tell "this address is coming back, ask again" from "there is nothing there" — whichever part of the hub happened to answer.
+Icon: ArrowSync
+Order: -20260902
+---
+
+# A refusal now says which hub refused
+
+A node's own little service can go away for a moment — a restart, a recycle, a piece of content
+being republished. Anything that asked it something at that instant gets a refusal rather than an
+answer, and the refusal has a job to do: it has to say **"this address is coming back — ask
+again"**, so the page, the reader or the installer waiting on it re-asks a second later and gets the
+real answer instead of reporting that the thing does not exist.
+
+That message is written at the moment of refusal, and there are several moments where it can happen:
+the request arrived after the service left duty, or it was already queued and its turn came too
+late, or the permission check could not run because the service was already gone, or the work it
+needed could no longer be created. **Each of those wrote its own sentence.** They said the same
+thing, but not in the same words — and the words are what the rest of the system reads.
+
+So the answer to "who refused, and is it coming back?" depended on which of those moments you
+happened to hit. Most of the time it did not matter. When it did, the reader saw a refusal it did
+not recognise, and treated a service that was two seconds from being back as one that was not there
+at all.
+
+**All of them now compose the sentence in one place**, and everything that reads a refusal reads it
+from that same place. A new kind of refusal added later is understood the day it is written, rather
+than the day someone notices a page went blank and traces it back.
+
+Nothing you do changes. What changes is that a restart stays a pause instead of occasionally looking
+like an absence — and that the next moment of refusal added to the platform cannot quietly reopen
+the gap, because there is no second place left to write it.

--- a/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
+++ b/src/MeshWeaver.Hosting/Security/AccessControlPipeline.cs
@@ -65,14 +65,16 @@ public static class AccessControlPipeline
     /// </summary>
     /// <summary><see cref="RecyclingRefusal(Address, string, Exception)"/> for a reason string.</summary>
     internal static string RecyclingRefusal(Address address, string messageTypeName, string? reason) =>
-        $"Hub {address} is shutting down (its access gate could not reach a verdict: {reason}) "
-        + $"— cannot evaluate access for {messageTypeName}; the address may reactivate "
-        + "(recycle / restart). Rejecting now.";
+        ShutdownNack.RejectingNow(
+            address,
+            $"its access gate could not reach a verdict: {reason}",
+            $"cannot evaluate access for {messageTypeName}");
 
     internal static string RecyclingRefusal(Address address, string messageTypeName, Exception error) =>
-        $"Hub {address} is shutting down (its lifetime scope is gone, {error.GetType().Name}) "
-        + $"— cannot evaluate access for {messageTypeName}; the address may reactivate "
-        + "(recycle / restart). Rejecting now.";
+        ShutdownNack.RejectingNow(
+            address,
+            $"its lifetime scope is gone, {error.GetType().Name}",
+            $"cannot evaluate access for {messageTypeName}");
 
     /// <summary>
     /// <see cref="IsHubGone(IMessageHub, Exception)"/> for a path that has a REASON STRING rather

--- a/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
+++ b/src/MeshWeaver.Messaging.Contract/HubDisposingException.cs
@@ -44,8 +44,8 @@ public sealed class HubDisposingException : ObjectDisposedException
             // WorkspaceReference renders as its own POINTER, which already carries single quotes
             // around its segments — EntityReference's is `/{collection}/'{id}'` — so single-quoting
             // it produced the unreadable `cannot create '/data/'postAdvanceStatus''` (#2255).
-            $"Hub {hubAddress} is shutting down — cannot create {Describe(what)}. "
-            + "The address may reactivate (recycle / restart); retry to get the authoritative answer.")
+            ShutdownNack.RetryForTheAuthoritativeAnswer(
+                hubAddress, null, $"cannot create {Describe(what)}"))
     {
         HubAddress = hubAddress;
     }
@@ -65,8 +65,8 @@ public sealed class HubDisposingException : ObjectDisposedException
     /// <param name="innerException">The fault that revealed the teardown.</param>
     public HubDisposingException(Address hubAddress, object what, Exception innerException)
         : base(
-            $"Hub {hubAddress} is shutting down — cannot create {Describe(what)}. "
-            + "The address may reactivate (recycle / restart); retry to get the authoritative answer.",
+            ShutdownNack.RetryForTheAuthoritativeAnswer(
+                hubAddress, null, $"cannot create {Describe(what)}"),
             innerException)
     {
         HubAddress = hubAddress;

--- a/src/MeshWeaver.Messaging.Contract/ShutdownNack.cs
+++ b/src/MeshWeaver.Messaging.Contract/ShutdownNack.cs
@@ -65,4 +65,97 @@ public static class ShutdownNack
             end++;
         return end > start ? message[start..end] : null;
     }
+
+    /// <summary>
+    /// The promise that makes an owner-side refusal RETRYABLE — "this address is coming back".
+    ///
+    /// <para>It is what separates a hub that is recycling from the routing layer reporting that
+    /// there is nowhere to go: <c>"No node found at 'x'"</c>, <c>"No route to 'x'"</c> and
+    /// <c>"Mesh/Host is shutting down, cannot route to x"</c> all promise nothing, because none of
+    /// them speaks for an address that reactivates.</para>
+    /// </summary>
+    public const string ReactivationPromise = "t" + ReactivationTail;
+
+    /// <summary>Both casings of <see cref="ReactivationPromise"/> off one string.</summary>
+    private const string ReactivationTail = "he address may reactivate (recycle / restart)";
+
+    /// <summary>
+    /// 🚨 The BANNER every owner-side shutdown refusal opens with — <c>"Hub {address} is shutting
+    /// down"</c> — and the reason it is a function rather than a literal at six call sites.
+    ///
+    /// <para>The banner is the only thing in a refusal that names WHO refused. Consumers use it to
+    /// tell an answer from the OWNER (its intake gate, its access gate, its handler, its
+    /// DataContext) from one manufactured by the ROUTING layer, which never makes this address the
+    /// subject of "is shutting down" — see <see cref="IsAnsweredByOwner"/>.</para>
+    /// </summary>
+    /// <param name="address">The owner — an <see cref="Address"/>, or its path.</param>
+    public static string Banner(object address) => $"Hub {address} is shutting down";
+
+    /// <summary>
+    /// The refusal for a delivery this hub declines HERE AND NOW — it arrived (or was evaluated)
+    /// after the hub left service, and was never accepted for processing.
+    ///
+    /// <para>🚨 THE WORDING IS CONTRACT, not prose. The mesh classifies delivery failures by their
+    /// MESSAGE TEXT as well as by <see cref="ErrorType"/>, and this sentence must be matched as
+    /// TRANSIENT by <c>MeshNodeStreamCache.IsTransientOwnerFailure</c>,
+    /// <c>OrleansRoutingService.ClassifyRoutedFailure</c> and
+    /// <c>AreaErrorClassifier.IsTransientHubFailure</c> — so the caller RE-PROBES and lands on the
+    /// fresh activation instead of taking a corpse's answer as final. It therefore carries their
+    /// markers ("is shutting down", "Rejecting now") by construction. Reword it casually at a call
+    /// site and #2727 comes back SILENTLY: nothing fails to compile, the delivery is still refused,
+    /// and the caller simply stops retrying.</para>
+    /// </summary>
+    /// <param name="address">The owner refusing the delivery.</param>
+    /// <param name="detail">Parenthesised evidence — run level, activation tag, what faulted. May be null.</param>
+    /// <param name="what">What could not be done, e.g. <c>"cannot process GetDataRequest"</c>.</param>
+    public static string RejectingNow(object address, string? detail, string what) =>
+        $"{Open(address, detail)} — {what}; {ReactivationPromise}. Rejecting now.";
+
+    /// <summary>
+    /// The refusal for work this hub ACCEPTED and can no longer finish — a queued turn that came
+    /// too late, machinery that can no longer be created, a gate that can never open. Same contract
+    /// as <see cref="RejectingNow"/>; the tail differs only because the caller is being told to ask
+    /// again rather than that its delivery was turned away at the door.
+    /// </summary>
+    /// <param name="address">The owner that cannot finish the work.</param>
+    /// <param name="detail">Parenthesised evidence. May be null.</param>
+    /// <param name="what">What could not be finished.</param>
+    public static string RetryForTheAuthoritativeAnswer(object address, string? detail, string what) =>
+        $"{Open(address, detail)} — {what}. T{ReactivationTail}; retry to get the authoritative answer.";
+
+    /// <summary>
+    /// 🚨 <b>Did the OWNER at <paramref name="ownerAddress"/> answer, or did the routing layer?</b>
+    /// The one predicate for that question — DERIVED from <see cref="Banner"/>, never a list of the
+    /// sentences somebody happened to think of.
+    ///
+    /// <para>Issue #3017. Enumerating owner terminals is what failed: a caller's four-shape list
+    /// rejected a FIFTH owner-side terminal (the access gate's refusal) as "not from the owner",
+    /// reddening a suite on a perfectly correct outcome — and its own guard passed, because a guard
+    /// over an enumeration can only assert the members somebody already wrote down. A sixth existed
+    /// at the time and had not been noticed either (the intake gate's <see cref="RejectingNow"/>).
+    /// Every owner-side refusal opens with <see cref="Banner"/> because every one is composed here,
+    /// so recognition follows the producers instead of trailing them.</para>
+    ///
+    /// <para>What it still REFUSES, which is what keeps it a real check: the routing layer's own
+    /// failures. <c>"No node found at 'x'"</c> and <c>"No route to 'x'"</c> carry no banner;
+    /// <c>"Mesh is shutting down, cannot route to x"</c> / <c>"Host is shutting down, cannot route
+    /// to x"</c> make the MESH or the HOST the subject, never this address; and a DIFFERENT hub's
+    /// refusal (<c>"Hub x/child is shutting down"</c>) names that hub, not this one.</para>
+    ///
+    /// <para>🚨 Deliberately NOT "the failure is classified <see cref="ErrorType.ShuttingDown"/>":
+    /// the routing layer mints that classification too, off the very same text
+    /// (<c>OrleansRoutingService.ClassifyRoutedFailure</c>), so an ErrorType test would answer this
+    /// question with the routing layer's echo of it. The banner is the only evidence that
+    /// identifies the speaker.</para>
+    /// </summary>
+    /// <param name="message">A NACK message, typically <c>DeliveryFailure.Message</c>.</param>
+    /// <param name="ownerAddress">The owner the caller addressed — an <see cref="Address"/>, or its path.</param>
+    /// <returns><c>true</c> when the refusal came from that owner.</returns>
+    public static bool IsAnsweredByOwner(string? message, object ownerAddress) =>
+        !string.IsNullOrEmpty(message)
+        && message.Contains(Banner(ownerAddress), System.StringComparison.Ordinal);
+
+    /// <summary>The banner plus its parenthesised evidence, when there is any.</summary>
+    private static string Open(object address, string? detail) =>
+        string.IsNullOrEmpty(detail) ? Banner(address) : $"{Banner(address)} ({detail})";
 }

--- a/src/MeshWeaver.Messaging.Contract/ShutdownNack.cs
+++ b/src/MeshWeaver.Messaging.Contract/ShutdownNack.cs
@@ -89,7 +89,7 @@ public static class ShutdownNack
     /// subject of "is shutting down" — see <see cref="IsAnsweredByOwner"/>.</para>
     /// </summary>
     /// <param name="address">The owner — an <see cref="Address"/>, or its path.</param>
-    public static string Banner(object address) => $"Hub {address} is shutting down";
+    public static string Banner(object address) => $"{BannerOpen}{address}{BannerClose}";
 
     /// <summary>
     /// The refusal for a delivery this hub declines HERE AND NOW — it arrived (or was evaluated)
@@ -147,13 +147,57 @@ public static class ShutdownNack
     /// (<c>OrleansRoutingService.ClassifyRoutedFailure</c>), so an ErrorType test would answer this
     /// question with the routing layer's echo of it. The banner is the only evidence that
     /// identifies the speaker.</para>
+    ///
+    /// <para>🚨 It compares the banner's SUBJECT by PATH, not the whole rendered address. A HOSTED
+    /// address renders as <c>path~host</c> (<see cref="Address.ToString"/>), so a producer holding
+    /// the <see cref="Address"/> and a caller holding the path would otherwise disagree about the
+    /// same hub — a false negative that reads as "the routing layer answered", which is the exact
+    /// misclassification this predicate exists to prevent. The path IS the address's identity
+    /// (<see cref="Address.Path"/>); the host chain says where it is activated, not who it is.</para>
     /// </summary>
     /// <param name="message">A NACK message, typically <c>DeliveryFailure.Message</c>.</param>
     /// <param name="ownerAddress">The owner the caller addressed — an <see cref="Address"/>, or its path.</param>
     /// <returns><c>true</c> when the refusal came from that owner.</returns>
-    public static bool IsAnsweredByOwner(string? message, object ownerAddress) =>
-        !string.IsNullOrEmpty(message)
-        && message.Contains(Banner(ownerAddress), System.StringComparison.Ordinal);
+    public static bool IsAnsweredByOwner(string? message, object ownerAddress)
+    {
+        if (string.IsNullOrEmpty(message))
+            return false;
+        var owner = PathOf(ownerAddress);
+        if (owner.Length == 0)
+            return false;
+        // Every banner reads "Hub {subject} is shutting down". Walk them and compare SUBJECTS —
+        // a substring test on the whole banner cannot tell "Hub a/b" from "Hub a/b/child".
+        for (var i = message.IndexOf(BannerOpen, System.StringComparison.Ordinal);
+             i >= 0;
+             i = message.IndexOf(BannerOpen, i + BannerOpen.Length, System.StringComparison.Ordinal))
+        {
+            var start = i + BannerOpen.Length;
+            var end = message.IndexOf(BannerClose, start, System.StringComparison.Ordinal);
+            // No banner closes after this point, so none closes after any later "Hub " either.
+            if (end < 0)
+                return false;
+            if (string.Equals(PathOf(message[start..end]), owner, System.StringComparison.Ordinal))
+                return true;
+        }
+        return false;
+    }
+
+    private const string BannerOpen = "Hub ";
+    private const string BannerClose = " is shutting down";
+
+    /// <summary>
+    /// The identity half of an address: its <see cref="Address.Path"/>, or — for text lifted out of
+    /// a rendered banner, or a path a caller passed as a string — everything before the <c>~</c>
+    /// that introduces the host chain.
+    /// </summary>
+    private static string PathOf(object address)
+    {
+        if (address is Address typed)
+            return typed.Path;
+        var text = address.ToString() ?? string.Empty;
+        var host = text.IndexOf('~');
+        return host < 0 ? text : text[..host];
+    }
 
     /// <summary>The banner plus its parenthesised evidence, when there is any.</summary>
     private static string Open(object address, string? detail) =>

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -855,10 +855,10 @@ public class MessageService : IMessageService
             // about whether it was 110 probes at one corpse or at 110 of them. The object hash is
             // stable for an activation's lifetime and differs across activations, which is the
             // whole question.
-            var reason =
-                $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}, {ActivationTag()}) "
-                + $"— cannot process {typeName}; the address may reactivate (recycle / restart). "
-                + "Rejecting now.";
+            var reason = ShutdownNack.RejectingNow(
+                Address,
+                $"RunLevel={hub.RunLevel}, {ActivationTag()}",
+                $"cannot process {typeName}");
 
             return NackThroughParent(delivery, reason)
                 ? delivery.FailedAndNacked("Hub is shutting down")
@@ -1554,11 +1554,11 @@ public class MessageService : IMessageService
             // per-DELIVERY `(id=...)` right after it: the delivery id is unique to THIS message and
             // varies on every retry even against the SAME activation, so a re-probe loop counting
             // distinct owners must key off the activation tag, never the whole message text.
-            NackThroughParent(delivery,
-                $"Hub {Address} is shutting down (RunLevel={hub.RunLevel}, {ActivationTag()}) — "
-                + $"{delivery.Message?.GetType().Name ?? "<null>"} (id={delivery.Id}) was accepted before "
-                + "disposal began and its turn came too late to process. The address may "
-                + "reactivate (recycle / restart); retry to get the authoritative answer.");
+            NackThroughParent(delivery, ShutdownNack.RetryForTheAuthoritativeAnswer(
+                Address,
+                $"RunLevel={hub.RunLevel}, {ActivationTag()}",
+                $"{delivery.Message?.GetType().Name ?? "<null>"} (id={delivery.Id}) was accepted "
+                + "before disposal began and its turn came too late to process"));
             exec = Observable.Return(delivery);
         }
 

--- a/test/MeshWeaver.Hosting.Test/OwnerAnswerRecognitionGuard.cs
+++ b/test/MeshWeaver.Hosting.Test/OwnerAnswerRecognitionGuard.cs
@@ -81,6 +81,31 @@ public class OwnerAnswerRecognitionGuard(ITestOutputHelper output)
             + new HubDisposingException(Owner, "/data/'x'").Message);
     }
 
+    /// <summary>
+    /// A HOSTED address renders as <c>path~host</c>, so the producer's banner and a caller holding
+    /// only the path disagree on the TEXT while meaning the same hub. Pinned separately because the
+    /// asymmetry is invisible from either side alone — the producer looks right, the caller looks
+    /// right, and the answer comes back "the routing layer refused you".
+    /// </summary>
+    [Fact]
+    public void AHostedOwner_IsRecognised_WhicheverHalfTheCallerHolds()
+    {
+        var hosted = new Address("TestData", "silent-read") { Host = new Address("portal") };
+        var refusal = ShutdownNack.RejectingNow(hosted, "RunLevel=Dead", "cannot process GetDataRequest");
+        output.WriteLine(refusal);
+        refusal.Should().Contain("~",
+            "the premise: a hosted address renders its host chain, so this case is only "
+            + "meaningful while Address.ToString() still does that");
+
+        ShutdownNack.IsAnsweredByOwner(refusal, hosted).Should().BeTrue(
+            "the producer's own address must recognise its own refusal");
+        ShutdownNack.IsAnsweredByOwner(refusal, hosted.Path).Should().BeTrue(
+            "and so must the PATH — a reader that resolved the node by path holds nothing else, "
+            + "and a false negative here reads as 'the routing layer answered'");
+        ShutdownNack.IsAnsweredByOwner(refusal, "TestData/other").Should().BeFalse(
+            "matching on the path must not degrade into matching any hosted address");
+    }
+
     public static TheoryData<string, string> ProducedOwnerAnswers()
     {
         var data = new TheoryData<string, string>();
@@ -136,15 +161,22 @@ public class OwnerAnswerRecognitionGuard(ITestOutputHelper output)
     }
 
     /// <summary>
-    /// The producers are enumerated by hand, so the enumeration itself can silently empty out —
-    /// a Theory with no cases PASSES. Assert there are cases, and that each says something.
+    /// The producers are enumerated by hand, so the enumeration itself can silently shrink — and a
+    /// Theory with no cases PASSES, having tested nothing.
+    ///
+    /// <para>The floor is deliberately the CURRENT number rather than "not empty": a set that
+    /// quietly falls from seven producers to one still satisfies "non-empty" while covering almost
+    /// nothing, which is the same rubber stamp one level up. Consolidating a producer is a
+    /// legitimate change — it just has to move this number in the same commit, which is the point:
+    /// the shrink becomes a decision instead of an accident.</para>
     /// </summary>
     [Fact]
-    public void TheProducerSetIsNotEmpty()
+    public void TheProducerSetCoversEverySeam()
     {
         OwnerAnswers().Should().HaveCountGreaterThanOrEqualTo(7,
-            "a Theory with no data passes having tested nothing — the one failure mode a "
-            + "recognition guard must not have");
+            "one case per owner-side seam, plus the relayed shape — if a producer was genuinely "
+            + "consolidated away, lower this number deliberately rather than letting the coverage "
+            + "drop unnoticed");
         OwnerAnswers().Should().OnlyContain(p => !string.IsNullOrWhiteSpace(p.Message));
     }
 

--- a/test/MeshWeaver.Hosting.Test/OwnerAnswerRecognitionGuard.cs
+++ b/test/MeshWeaver.Hosting.Test/OwnerAnswerRecognitionGuard.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using MeshWeaver.Hosting.Security;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// 🚨 <b>#3017 — "did the OWNER answer, or did the routing layer?" must be DERIVED from the
+/// producers, never from a list of the sentences somebody thought of.</b>
+///
+/// <para><b>What went wrong.</b>
+/// <c>MeshWeaver.Hosting.Monolith.Test.SilentReadNackTest</c> asks that question of every NACK a
+/// torn-down owner sends, and answered it by matching four hand-written shapes. A FIFTH owner-side
+/// terminal — <see cref="AccessControlPipeline"/>'s refusal for a delivery whose access gate could
+/// not run because the hub is gone — was rejected as "not from the owner" and reddened the suite on
+/// a perfectly correct outcome. A SIXTH was already live and equally unlisted: the intake gate's
+/// <see cref="ShutdownNack.RejectingNow"/>. The class's own guard passed throughout, because a
+/// guard over an enumeration can only assert the members that were already written down.</para>
+///
+/// <para><b>What replaced it.</b> Every owner-side refusal is now COMPOSED by
+/// <see cref="ShutdownNack"/>, so it opens with <see cref="ShutdownNack.Banner"/> by construction,
+/// and <see cref="ShutdownNack.IsAnsweredByOwner"/> reads that same banner back. Recognition
+/// follows the producers instead of trailing them: a seventh terminal is recognised the day it is
+/// written, without anybody remembering to widen a list.</para>
+///
+/// <para><b>What this guard is, and is not.</b> It asserts no spelling — asserting the literal
+/// would be the same defect one level up, a guard checking its own copy of the string. It CALLS
+/// the real producers and runs the real predicate over what they actually say, exactly as
+/// <c>TransientMarkerPairingGuard</c> does for the transient-marker contract. A producer whose
+/// wording drifts off the seam fails here, whatever the new wording is.</para>
+/// </summary>
+public class OwnerAnswerRecognitionGuard(ITestOutputHelper output)
+{
+    private static readonly Address Owner = new("TestData", "silent-read");
+
+    private static ObjectDisposedException DisposedScope() =>
+        new("LifetimeScope",
+            "Instances cannot be resolved and nested lifetimes cannot be created from this "
+            + "LifetimeScope as it (or one of its parent scopes) has already been disposed.");
+
+    /// <summary>
+    /// Every owner-side refusal a real producer emits, built by CALLING that producer.
+    /// </summary>
+    private static IEnumerable<(string Producer, string Message)> OwnerAnswers()
+    {
+        // The access gate — the FIFTH terminal, and the one #3017 was filed for.
+        yield return ("AccessControlPipeline.RecyclingRefusal(scope disposed)",
+            AccessControlPipeline.RecyclingRefusal(Owner, "GetDataRequest", DisposedScope()));
+        yield return ("AccessControlPipeline.RecyclingRefusal(undetermined fold)",
+            AccessControlPipeline.RecyclingRefusal(Owner, "GetDataRequest",
+                "the permission query could not run"));
+
+        // The intake gate — the SIXTH, unlisted and unnoticed until the seam made it moot.
+        yield return ("MessageService intake gate (ShutdownNack.RejectingNow)",
+            ShutdownNack.RejectingNow(
+                Owner,
+                $"RunLevel=Dead, {ShutdownNack.ActivationMarker}DEADBEEF",
+                "cannot process GetDataRequest"));
+
+        // The queued turn that came too late.
+        yield return ("MessageService late turn (ShutdownNack.RetryForTheAuthoritativeAnswer)",
+            ShutdownNack.RetryForTheAuthoritativeAnswer(
+                Owner,
+                "RunLevel=Dead",
+                "GetDataRequest (id=abc) was accepted before disposal began and its turn came "
+                + "too late to process"));
+
+        // The typed refusal a handler throws, both constructors — they build the sentence
+        // independently of each other.
+        yield return ("HubDisposingException(address, what)",
+            new HubDisposingException(Owner, "the synchronization stream").Message);
+        yield return ("HubDisposingException(address, what, inner)",
+            new HubDisposingException(Owner, "the permission fold", DisposedScope()).Message);
+
+        // The shape that actually reaches a consumer: the owner's answer flattened into a
+        // DeliveryFailure message and relayed by the routing layer. Relayed is still the OWNER's
+        // answer — the routing layer only carried it.
+        yield return ("owner answer relayed by routing",
+            $"Delivery to '{Owner}' failed: "
+            + new HubDisposingException(Owner, "/data/'x'").Message);
+    }
+
+    public static TheoryData<string, string> ProducedOwnerAnswers()
+    {
+        var data = new TheoryData<string, string>();
+        foreach (var (producer, message) in OwnerAnswers())
+            data.Add(producer, message);
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(ProducedOwnerAnswers))]
+    public void EveryOwnerSideRefusal_IsRecognisedAsTheOwnersAnswer(string producer, string message)
+    {
+        output.WriteLine($"{producer}: {message}");
+
+        ShutdownNack.IsAnsweredByOwner(message, Owner).Should().BeTrue(
+            $"{producer} speaks FOR the owner at {Owner}. If this fails the producer stopped "
+            + "composing through ShutdownNack — restore that rather than widening the predicate "
+            + "to whatever the new sentence says, which is the enumeration #3017 removed");
+        ShutdownNack.IsAnsweredByOwner(message, Owner.Path).Should().BeTrue(
+            "callers hold the owner as a PATH as often as an Address, and the two must answer "
+            + "identically or the predicate is a coin toss on which one is at hand");
+
+        MeshNodeStreamCache.IsTransientOwnerFailure(new InvalidOperationException(message))
+            .Should().BeTrue(
+                "the same sentence must also read TRANSIENT — a recognised owner answer that the "
+                + "read path treats as terminal is #2727 in a new costume");
+    }
+
+    /// <summary>
+    /// 🚨 The half that keeps the predicate a real check. The routing layer manufactures failures
+    /// for the SAME address, and two of them even contain "is shutting down" — but none of them
+    /// makes THIS address the subject of it, which is the whole discrimination.
+    /// </summary>
+    [Theory]
+    [InlineData("No node found at 'TestData/silent-read' — the node was deleted, so this address "
+                + "will not reactivate.", "a routing NotFound is a provable ABSENCE, not a recycling owner")]
+    [InlineData("No route to 'TestData/silent-read'",
+        "a bare routing failure promises no retry and names no owner")]
+    [InlineData("Mesh is shutting down, cannot route to TestData/silent-read",
+        "the MESH going down is not this owner answering — the subject of 'is shutting down' is "
+        + "the mesh, and it says nothing about whether this address reactivates")]
+    [InlineData("Host is shutting down, cannot route to TestData/silent-read",
+        "same for the Orleans host — an ErrorType-only predicate would have accepted this, which "
+        + "is why the banner and not the classification is the evidence")]
+    [InlineData("Hub TestData/silent-read/child is shutting down; retry to get the authoritative answer.",
+        "a DIFFERENT hub's recycle is not this owner answering")]
+    [InlineData("Hub TestData/silent-rea is shutting down — cannot process GetDataRequest.",
+        "a PREFIX of the owner's path is a different address")]
+    public void ARoutingLayerFailure_IsNotTheOwnersAnswer(string message, string because)
+    {
+        ShutdownNack.IsAnsweredByOwner(message, Owner).Should().BeFalse(because);
+        ShutdownNack.IsAnsweredByOwner(message, Owner.Path).Should().BeFalse(because);
+    }
+
+    /// <summary>
+    /// The producers are enumerated by hand, so the enumeration itself can silently empty out —
+    /// a Theory with no cases PASSES. Assert there are cases, and that each says something.
+    /// </summary>
+    [Fact]
+    public void TheProducerSetIsNotEmpty()
+    {
+        OwnerAnswers().Should().HaveCountGreaterThanOrEqualTo(7,
+            "a Theory with no data passes having tested nothing — the one failure mode a "
+            + "recognition guard must not have");
+        OwnerAnswers().Should().OnlyContain(p => !string.IsNullOrWhiteSpace(p.Message));
+    }
+
+    /// <summary>
+    /// 🚨 And the predicate must be able to say NO at all — a rubber stamp would make every
+    /// assertion above vacuous.
+    /// </summary>
+    [Fact]
+    public void WithTheBannerRemoved_ThePredicateRefuses()
+    {
+        ShutdownNack.IsAnsweredByOwner(
+            $"Hub {Owner} has stopped — cannot process GetDataRequest.", Owner)
+            .Should().BeFalse(
+                "if this passes the predicate accepts anything that names the address, and every "
+                + "assertion above is vacuous");
+        ShutdownNack.IsAnsweredByOwner(null, Owner).Should().BeFalse("no message is no answer");
+        ShutdownNack.IsAnsweredByOwner(string.Empty, Owner).Should().BeFalse("nor is an empty one");
+    }
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalRaceNackTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalRaceNackTest.cs
@@ -148,6 +148,17 @@ public class DisposalRaceNackTest(ITestOutputHelper output) : HubTestBase(output
                 "the transient classifiers (MeshNodeStreamCache.IsTransientOwnerFailure, "
                 + "AreaErrorClassifier.IsTransientHubFailure) match this phrase when the typed "
                 + "failure has been flattened into a DeliveryFailureException message");
+
+            // 🚨 #3017 — and it must be recognisable as THIS OWNER's answer, not merely as some
+            // transient failure. A caller discriminating "the owner refused me" from "the routing
+            // layer could not reach it" reads ShutdownNack.IsAnsweredByOwner; the two live seams
+            // that mint this NACK (the late turn, and the handler that threw
+            // HubDisposingException) are pinned here against the REAL message rather than against
+            // a copy of its wording, because enumerating the sentences is exactly what failed.
+            ShutdownNack.IsAnsweredByOwner(failure.Failure.Message, victimAddress).Should().BeTrue(
+                "the owner at " + victimAddress + " refused this delivery, so its own banner must "
+                + "be in the message — a caller that cannot tell this from a routing failure "
+                + "cannot tell 'ask again at the fresh activation' from 'there is nothing there'");
         }
         finally
         {


### PR DESCRIPTION
Fixes the platform half of #3017: **owner-side shutdown refusals are composed by ONE seam, and
recognition is DERIVED from it** instead of enumerated by every consumer that needs to ask "did the
owner refuse me, or did the routing layer fail to reach it?".

## The defect, measured

`SilentReadNackTest.AnsweredByTheOwner` (in MeshWeaver.Plugins) answered that question with a list of
four hand-written sentences. Deterministic repro, run with the list restored and the new
producer-driven guard in place:

```
Failed  AnsweredByTheOwner_AcceptsEveryOwnerTerminal(terminal: "AccessControlPipeline — the access gate could not run")
Failed  AnsweredByTheOwner_AcceptsEveryOwnerTerminal(terminal: "MessageService — the intake gate")
Failed!  - Failed: 2, Passed: 9
```

The issue names the FIFTH terminal (the access gate). The run above found that a **SIXTH** was live
and unlisted the whole time as well — `MessageService`'s intake gate, whose refusal ends
`Rejecting now.` rather than `retry to get the authoritative answer.` and so failed the same list.
That is the shape the issue predicted: *"enumerating owner terminals is what failed here, and a sixth
will arrive"* — it had already arrived.

## Why an enumeration could not hold

Six sites each wrote their own refusal sentence, and they had drifted: two tails
(`Rejecting now.` / `retry to get the authoritative answer.`), and `DataContext`'s put the address in
quotes so it did not carry the banner at all. Nothing named WHO refused in a single, readable form,
so every consumer re-derived the answer from whichever sentences it had seen. That is the same defect
#3100 fixed one layer up — the pre-flight and the delivery gate had each written their terminal
handling inline and diverged — and the same cure applies: one seam owning both production and
recognition.

## The change

`ShutdownNack` (which already owns the activation tag: *"one marker, one parser, one formatter, in
the contract assembly both sides already reference"*) gains the sentence:

- `Banner(address)` → `Hub {address} is shutting down` — the only part of a refusal that names who
  refused;
- `RejectingNow(address, detail, what)` — a delivery turned away at the door;
- `RetryForTheAuthoritativeAnswer(address, detail, what)` — work the hub accepted and can no longer
  finish;
- `IsAnsweredByOwner(message, address)` — walks each banner and compares its SUBJECT to the owner.

All six producers now compose through it: `MessageService`'s intake gate and late turn,
`AccessControlPipeline.RecyclingRefusal` (both overloads), both `HubDisposingException`
constructors, and `DataContext`'s init-gate failure. **Five of the six emit byte-identical text**;
the sixth (`DataContext`) drops the quotes around the address, which is what made it unidentifiable.

### What it deliberately does NOT key on

Not `ErrorType.ShuttingDown`. The routing layer mints that classification too, off the owner's own
text (`OrleansRoutingService.ClassifyRoutedFailure`) — so a predicate over the classification would
answer "did the owner speak?" with the routing layer's echo of it. `Mesh is shutting down, cannot
route to x` and `Host is shutting down, cannot route to x` are both classified `ShuttingDown` and are
both refused by the new predicate, because they make the mesh or the host the subject, never the
address you asked about.

And not a substring test on the whole banner, which the review caught: a HOSTED address renders as
`path~host`, so a producer holding the `Address` and a caller holding the path disagreed about the
same hub and the predicate answered "the routing layer refused you". It compares the banner's
SUBJECT by PATH, which also tightens the unhosted case — a substring test could not tell
`Hub a/b` from `Hub a/b/child` except by luck of the following character.

### Nothing about a verdict changes

The access gate's refusal is a NON-verdict — *"cannot evaluate access"* — and it stays one:
`ErrorType.ShuttingDown`, transient, retry. This change alters no permission semantics, widens no
accepted permission outcome, and swallows nothing. It only makes the refusal's SPEAKER readable.

## Verification

Two negative controls, because a recognition guard that cannot fail is not a guard:

- drift one producer off the seam (restore an inline literal in `AccessControlPipeline`) →
  `Failed: 1, Passed: 14`;
- restore the substring predicate → the hosted-address case is the single failure,
  `Failed: 1, Passed: 15`.

`OwnerAnswerRecognitionGuard` calls every reachable producer and runs the real predicate AND the real
transient classifier over what they actually say (the `TransientMarkerPairingGuard` pattern), plus a
routing-layer negative arm and a floor on the producer set. `DisposalRaceNackTest` pins the same
recognition on a NACK that travelled the real path, rather than on a copy of its wording.

`dotnet build -c Release -warnaserror` clean (0 Error(s), 0 Warning(s)) on Messaging.Contract,
Messaging.Hub, Data, Documentation, Connection.Orleans, Hosting.Orleans, Hosting.Monolith,
PluginCatalog, Mesh.Operations, Memex.Portal.Shared and every test project below. Full, unfiltered
local runs on the final tree: Messaging.Hub.Test 358, Hosting.Test 316, Documentation.Test 202,
Layout.Test 443, Data.Test 432, Graph.Test 1210, Hosting.Orleans.Test 234 — all 0 failed.

## Pairs with

Systemorph/MeshWeaver.Plugins#1188 — the consumer half (`SilentReadNackTest`), which is where the
red actually is. Core merges FIRST; that PR stays red until this one lands.

Doc: [Error Propagation & Wedges → "Who refused? The BANNER, not the classification"](src/MeshWeaver.Documentation/Data/Architecture/ErrorPropagationAndWedges.md).

Closes #3017

🤖 Generated with [Claude Code](https://claude.com/claude-code)
