### PR TITLE
Autocomplete answers on convergence, not on a 150 ms quiet window

### DIFF
--- a/src/MeshWeaver.Data.Contract/Completion/AutocompleteBounds.cs
+++ b/src/MeshWeaver.Data.Contract/Completion/AutocompleteBounds.cs
@@ -1,0 +1,56 @@
+#nullable enable
+
+namespace MeshWeaver.Data.Completion;
+
+/// <summary>
+/// The one place the <see cref="AutocompleteRequest"/> round-trip's time bounds are decided.
+///
+/// <para>🚨 <b>There is no "settle window" here, and there must never be one again.</b> The handler
+/// used to answer when the merged provider snapshot had been QUIET for 150 ms. Quiet is not
+/// settled: a provider whose rows arrive more than a beat after the fast in-memory ones — a
+/// cross-partition query under load — missed the window, and the response went out truncated and
+/// still labelled <see cref="AutocompleteResponse.IsComplete"/> = <c>true</c>, so no caller could
+/// tell (#3094). The answer now comes from the providers' own lifecycle: the merged stream
+/// COMPLETES when every <see cref="IAutocompleteProvider"/> has settled, which is authoritative and
+/// carries no clock at all.</para>
+///
+/// <para>What is left is a HANG bound, which every one-shot request needs: a provider that never
+/// completes must not hold the answer forever. That is <see cref="AnswerDeadline"/>, and an answer
+/// forced by it is labelled <c>IsComplete = false</c> and logged with the offending provider's
+/// name — never passed off as settled.</para>
+/// </summary>
+public static class AutocompleteBounds
+{
+    /// <summary>
+    /// The answer deadline: how long the handler waits for every provider to settle before it
+    /// answers with the best snapshot so far and marks the response
+    /// <see cref="AutocompleteResponse.IsComplete"/> = <c>false</c>.
+    ///
+    /// <para>🚨 This is not a latency budget to tune. A contract-honouring provider set completes
+    /// long before it and the answer goes out on completion; reaching this bound means some
+    /// provider's <see cref="IAutocompleteProvider.GetItems"/> stream never completed, which is a
+    /// defect in that provider, not a reason to move this number.</para>
+    /// </summary>
+    public static readonly TimeSpan AnswerDeadline = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// The slack a CALLER adds on top of <see cref="AnswerDeadline"/> before giving up on an
+    /// <see cref="AutocompleteRequest"/>.
+    ///
+    /// <para>🚨 <b>A caller's bound must strictly DOMINATE the producer's, never equal it.</b>
+    /// Every caller in the tree used to wait exactly 2 s — the same value the handler answers at —
+    /// so a legitimately late-but-in-contract answer raced its own caller's timeout and was
+    /// dropped as often as it was kept. That was invisible while the handler answered at 150 ms;
+    /// it becomes a coin toss the moment the handler is allowed to use its full deadline. Same
+    /// rule, same reason as <c>LateResponseWatchBound</c> + <c>VerdictBoundGrace</c> on the write
+    /// path: the outer bound exists to catch a WEDGE, so it must sit clear of the inner one.</para>
+    /// </summary>
+    public static readonly TimeSpan CallerGrace = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// How long to wait for an <see cref="AutocompleteResponse"/> from another hub. Derived from
+    /// <see cref="AnswerDeadline"/> + <see cref="CallerGrace"/> so the ordering holds by
+    /// construction rather than by whoever writes the next caller remembering it.
+    /// </summary>
+    public static TimeSpan CallerBound => AnswerDeadline + CallerGrace;
+}

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -3684,94 +3684,139 @@ public static class DataExtensions
     private const int AutocompleteAggregateTopN = 200;
 
     /// <summary>
-    /// How long the merged snapshot must stay unchanged before it counts as settled. Short enough
-    /// to feel instant in a composer, long enough for a second provider's first real snapshot to
-    /// land after the seeded empty one.
-    /// </summary>
-    private static readonly TimeSpan AutocompleteSettleWindow = TimeSpan.FromMilliseconds(150);
-
-    /// <summary>
-    /// The answer deadline. A provider that keeps emitting (a live catalog under load) never goes
-    /// quiet, so at this point the best snapshot so far is the answer.
-    /// </summary>
-    private static readonly TimeSpan AutocompleteAnswerDeadline = TimeSpan.FromSeconds(2);
-
-    /// <summary>
-    /// The floor: if the combined stream never produced ANYTHING — a provider that emits neither a
-    /// snapshot nor an error, against the contract in <see cref="AutocompleteSnapshots.Empty"/> —
-    /// an empty response still goes out. Deliberately later than
-    /// <see cref="AutocompleteAnswerDeadline"/> so a real snapshot always wins the race.
-    /// </summary>
-    private static readonly TimeSpan AutocompleteSilenceFloor = TimeSpan.FromMilliseconds(2500);
-
-    /// <summary>
     /// Handles the one-shot <see cref="AutocompleteRequest"/> by aggregating the SNAPSHOT streams of
     /// every registered <see cref="IAutocompleteProvider"/>. CombineLatest + merge (see
     /// <see cref="AutocompleteSnapshots.Combine"/>), then ONE <see cref="AutocompleteResponse"/> is
-    /// posted. Progressive consumers use the <see cref="AutocompleteReference"/> workspace stream
-    /// instead. Each provider's <c>OnError</c> is swallowed to an empty snapshot so one bad provider
+    /// posted. Each provider's <c>OnError</c> is swallowed to an empty snapshot so one bad provider
     /// doesn't stall the CombineLatest.
     ///
-    /// <para>🚨 <b>"Settled" is a QUIET PERIOD, never completion.</b> This used to take
-    /// <c>LastAsync()</c>, which emits only when the combined stream COMPLETES — and a provider
-    /// backed by mesh data never completes: it is a live subscription, which is the whole point of
-    /// the snapshot model (<c>SkillAutocompleteProvider</c> composes ObserveSkillQueries →
-    /// ObserveSnapshot → Switch; every one of those is endless by design). So on any hub with such a
-    /// provider registered the handler ran, returned <c>Processed</c> in ~27 ms, and posted NOTHING
-    /// — the caller waited out its timeout with no error anywhere. Verified from the message trace:
-    /// <c>HUB_HANDLE_END … Result: Processed</c> followed by silence, and no response post from that
-    /// hub (issue #2276).</para>
+    /// <para>🚨 <b>The answer settles on CONVERGENCE, never on silence (#3094).</b> This used to
+    /// answer when the merged snapshot had been quiet for 150 ms. A quiet period is not a settled
+    /// answer: <see cref="AutocompleteSnapshots.Combine"/> seeds every provider with an empty
+    /// snapshot so it can emit progressively, so the merge is ALWAYS emitting a partial first — and
+    /// whenever the fast in-memory providers landed and a cross-partition provider's rows arrived
+    /// more than a beat later, the timer fired and the response went out WITHOUT them, still
+    /// labelled <see cref="AutocompleteResponse.IsComplete"/> = <c>true</c>. Under load the caller
+    /// could not tell a settled snapshot from a truncated one, and
+    /// <c>ChatCompletionOrchestrator</c> treated the truncated batch as final.</para>
     ///
-    /// <para>The three ways this now always answers, first one wins: the snapshot goes quiet for
-    /// <see cref="AutocompleteSettleWindow"/>; the deadline arrives and we answer with the best
-    /// snapshot so far; or no provider ever produced anything, in which case an empty response goes
-    /// out rather than nothing at all. A one-shot request must produce exactly one answer — never
-    /// a hang, which is indistinguishable from "still thinking".</para>
+    /// <para>The authoritative signal is the providers' own lifecycle, and the
+    /// <see cref="IAutocompleteProvider.GetItems"/> contract already names it: <i>the stream
+    /// completes when the provider has settled</i>. CombineLatest completes when every source has,
+    /// so the LAST value of the merged stream is the fully-merged, every-provider-in answer. No
+    /// clock is involved and nothing is tuned: under load the answer simply arrives later, and it
+    /// arrives COMPLETE.</para>
+    ///
+    /// <para>What remains is a HANG bound, which a one-shot request genuinely needs:
+    /// <see cref="AutocompleteBounds.AnswerDeadline"/>. Reaching it means some provider violated
+    /// the completion contract, so the response is marked <c>IsComplete = false</c> AND a warning
+    /// names the offending provider — a truncated answer is never passed off as settled again.
+    /// (The previous <c>LastAsync()</c> shape hung forever on such a provider and posted NOTHING,
+    /// which is #2276; a deadline that always answers is what fixes that, not a settle window.)</para>
     /// </summary>
     private static IMessageDelivery HandleAutocompleteRequest(
         IMessageHub hub,
         IMessageDelivery<AutocompleteRequest> request)
     {
-        var providers = hub.ServiceProvider.GetServices<IAutocompleteProvider>();
+        var providers = hub.ServiceProvider.GetServices<IAutocompleteProvider>().ToArray();
         var query = request.Message.Query;
         var contextPath = request.Message.Context;
 
-        // ONE upstream subscription shared by the three racers below — RefCount, so the providers'
-        // queries are not issued twice.
-        var combined = AutocompleteSnapshots.Combine(
-                providers.Select(p => p.GetItems(query, contextPath)
-                    .Catch<IReadOnlyCollection<AutocompleteItem>, Exception>(
-                        _ => Observable.Return(AutocompleteSnapshots.Empty))),
-                AutocompleteAggregateTopN)
-            .Publish()
-            .RefCount();
+        // Which providers have not yet honoured the completion contract. Concurrent because the
+        // provider streams complete on whatever thread their I/O landed on; per-REQUEST and local,
+        // so there is no shared/static state — it exists only to NAME the offender if the deadline
+        // has to fire.
+        var pending = new System.Collections.Concurrent.ConcurrentDictionary<string, byte>();
+        var sources = providers.Select(p =>
+        {
+            var providerName = p.GetType().FullName ?? p.GetType().Name;
+            pending.TryAdd(providerName, 0);
+            return p.GetItems(query, contextPath)
+                // A provider that FAILS has still said all it is going to say — Catch substitutes a
+                // completing empty snapshot, so it counts as settled (below) rather than holding
+                // the answer to the deadline.
+                .Catch<IReadOnlyCollection<AutocompleteItem>, Exception>(
+                    _ => Observable.Return(AutocompleteSnapshots.Empty))
+                .Do(_ => { }, () => pending.TryRemove(providerName, out _));
+        });
 
-        Observable.Amb(
-                combined.Throttle(AutocompleteSettleWindow).Take(1),
-                combined.Sample(AutocompleteAnswerDeadline).Take(1),
-                Observable.Timer(AutocompleteSilenceFloor).Select(_ => AutocompleteSnapshots.Empty))
-            .Subscribe(
-                snapshot =>
+        AutocompleteSnapshots.Combine(sources, AutocompleteAggregateTopN)
+            // Materialize so the terminal notification is data: the fold below can tell "every
+            // provider settled" (OnCompleted seen) from "the deadline cut us off" (TakeUntil), and
+            // the answer carries that distinction to the caller.
+            .Materialize()
+            .TakeUntil(Observable.Timer(AutocompleteBounds.AnswerDeadline))
+            .Aggregate(
+                (Snapshot: AutocompleteSnapshots.Empty, Settled: false, Fault: (Exception?)null),
+                (acc, notification) => notification.Kind switch
                 {
-                    // Apply relevance filtering: boost items that match the query text,
-                    // suppress zero-priority items that don't match.
-                    var searchText = ExtractAutocompleteSearchText(query);
-                    IEnumerable<AutocompleteItem> result = snapshot;
-                    if (!string.IsNullOrEmpty(searchText))
-                    {
-                        result = snapshot
-                            .Select(item => item.Priority > 0
-                                ? item // Provider already scored this item
-                                : item with { Priority = ScoreAutocompleteItem(item, searchText) })
-                            .Where(item => item.Priority > 0)
-                            .OrderByDescending(item => item.Priority);
-                    }
+                    NotificationKind.OnNext => (notification.Value, acc.Settled, acc.Fault),
+                    NotificationKind.OnCompleted => (acc.Snapshot, true, acc.Fault),
+                    _ => (acc.Snapshot, acc.Settled, notification.Exception),
+                })
+            .Subscribe(
+                answer =>
+                {
+                    var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
+                        ?.CreateLogger("MeshWeaver.Data.Autocomplete");
+                    if (answer.Fault is not null)
+                        logger?.LogWarning(answer.Fault,
+                            "Autocomplete aggregation faulted for query {Query} on {Address}",
+                            query, hub.Address);
+                    if (!answer.Settled)
+                        // 🚨 Not a tuning signal. IAutocompleteProvider.GetItems must COMPLETE when
+                        // the provider has settled; a provider that never does costs every caller
+                        // the full deadline and truncates the answer. Name it so the defect is
+                        // greppable instead of showing up as "autocomplete feels slow".
+                        logger?.LogWarning(
+                            "Autocomplete answered query {Query} on {Address} at the {Deadline} "
+                            + "deadline with an UNSETTLED snapshot — provider(s) {Providers} never "
+                            + "completed their snapshot stream, against the "
+                            + "IAutocompleteProvider.GetItems contract. The response is marked "
+                            + "IsComplete=false.",
+                            query, hub.Address, AutocompleteBounds.AnswerDeadline,
+                            string.Join(", ", pending.Keys));
 
-                    hub.Post(new AutocompleteResponse(result.ToList()), o => o.ResponseFor(request));
+                    PostAutocompleteResponse(hub, request, answer.Snapshot, answer.Settled);
                 },
-                _ => hub.Post(new AutocompleteResponse([]), o => o.ResponseFor(request)));
+                ex =>
+                {
+                    hub.ServiceProvider.GetService<ILoggerFactory>()
+                        ?.CreateLogger("MeshWeaver.Data.Autocomplete")
+                        .LogWarning(ex, "Autocomplete failed for query {Query} on {Address}",
+                            query, hub.Address);
+                    PostAutocompleteResponse(
+                        hub, request, AutocompleteSnapshots.Empty, isComplete: false);
+                });
 
         return request.Processed();
+    }
+
+    /// <summary>
+    /// Applies relevance filtering to the settled snapshot and posts the single
+    /// <see cref="AutocompleteResponse"/>. <paramref name="isComplete"/> is the honest answer to
+    /// "did every provider settle" — see <see cref="AutocompleteBounds"/>.
+    /// </summary>
+    private static void PostAutocompleteResponse(
+        IMessageHub hub,
+        IMessageDelivery<AutocompleteRequest> request,
+        IReadOnlyCollection<AutocompleteItem> snapshot,
+        bool isComplete)
+    {
+        // Boost items that match the query text, suppress zero-priority items that don't.
+        var searchText = ExtractAutocompleteSearchText(request.Message.Query);
+        IEnumerable<AutocompleteItem> result = snapshot;
+        if (!string.IsNullOrEmpty(searchText))
+        {
+            result = snapshot
+                .Select(item => item.Priority > 0
+                    ? item // Provider already scored this item
+                    : item with { Priority = ScoreAutocompleteItem(item, searchText) })
+                .Where(item => item.Priority > 0)
+                .OrderByDescending(item => item.Priority);
+        }
+
+        hub.Post(new AutocompleteResponse(result.ToList(), isComplete), o => o.ResponseFor(request));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/AggregatingProviders.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AggregatingProviders.md
@@ -144,7 +144,26 @@ AutocompleteSnapshots.Combine(
     topN);
 ```
 
-For a request/response consumer (cross-hub `AutocompleteRequest`), take the settled snapshot (`LastOrDefaultAsync`) and post that. For a streaming UI consumer (the completion widget), subscribe to `IAutocompleteStreamProvider.Stream` directly.
+For a streaming UI consumer (the completion widget), subscribe to the merged stream directly and repaint on every emission. For a request/response consumer (cross-hub `AutocompleteRequest`), take the **settled** snapshot and post that — and settled has exactly one meaning, below.
+
+### 🚨 "Settled" means CONVERGED, never QUIET
+
+A one-shot request has to pick a moment on a stream that is deliberately progressive. There is only one correct way to pick it, and one very tempting wrong one.
+
+> **The rule: the merged stream's LAST value is the answer.** `Combine` is a `CombineLatest`, so it completes exactly when every provider's snapshot stream has completed — which is what the `IAutocompleteProvider.GetItems` contract already promises ("the stream completes when the provider has settled"). Taking the value at completion is *derived from the providers' own lifecycle*: no clock, nothing to tune, and under load the answer simply arrives later and arrives COMPLETE.
+
+The wrong one is a **quiet period** — "the snapshot has not changed for N ms, so it must be done". It is not done. `Combine` seeds every provider with an empty snapshot precisely so it can emit progressively, so a partial is always emitted first; any provider whose rows land more than N ms after the fast in-memory ones misses the window and the answer goes out without them. That was live in `HandleAutocompleteRequest` at N = 150 ms, and it truncated silently: the response still carried `AutocompleteResponse.IsComplete = true`, so no caller could tell a settled snapshot from a truncated one, and the chat orchestrator treated a truncated `Nearby` batch as final ([#3094](https://github.com/Systemorph/MeshWeaver/issues/3094)). Under parallel load a cross-partition row appeared and disappeared run to run; alone, the same test passed in 2.1 s. **Widening N would only move the threshold — the answer would still be a function of the clock rather than of the providers.**
+
+Two bounds remain, both in `AutocompleteBounds`, and neither is a settle window:
+
+| Bound | Who uses it | What it means |
+|---|---|---|
+| `AnswerDeadline` (2 s) | the handler | A **hang** bound. A one-shot request must always answer — the previous `LastAsync()` shape posted *nothing at all* when a provider never completed ([#2276](https://github.com/Systemorph/MeshWeaver/issues/2276)), which is indistinguishable from "still thinking". Reaching it means a provider violated the completion contract, so the answer is posted with `IsComplete = false` **and** a warning naming the offending provider type. |
+| `CallerBound` (= `AnswerDeadline` + `CallerGrace`) | every caller of `AutocompleteRequest` | A caller's bound must strictly **dominate** the producer's, never equal it. `ChatCompletionOrchestrator.SendAutocompleteRequest` and `UnifiedReferenceAutocompleteProvider`'s node delegation both waited exactly 2 s — the same value the handler answers at — so an answer that legitimately took the full deadline raced its own caller's timeout. Invisible while the handler answered at 150 ms; a coin toss the moment it is allowed to wait for convergence. Same rule as `LateResponseWatchBound` + `VerdictBoundGrace` on the write path. |
+
+> 🚨 **A provider that never completes is a defect in the provider, not a reason to move a number.** Live/synced-query sources (`hub.GetQuery`, `ObserveSnapshot`) never complete by design; a provider built on one must bound itself — `.Take(1)` on the first authoritative snapshot — before returning it from `GetItems`. Otherwise it costs every caller on that hub the full deadline and marks every answer incomplete.
+
+Note the same convergence rule already governs the query path: `MeshQuery.Query` emits its merged `Initial` only once **every** provider has produced an `Initial` (`EmitMergedInitialIfComplete`). Autocomplete's request/response leg is the same question with the same answer.
 
 ### Testing progressive-snapshot providers
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-autocomplete-waits-for-every-source-before-it-answers.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-autocomplete-waits-for-every-source-before-it-answers.md
@@ -1,0 +1,29 @@
+---
+Name: Autocomplete waits for every source before it answers
+Category: Fix
+Description: A suggestion list could go out before the slower sources had answered — most visibly, results from another partition were missing when the portal was busy and present when it was not. The list now waits until every source has actually finished, and says so when one of them never does.
+Icon: Search
+Order: -20260902
+---
+
+# Autocomplete waits for every source before it answers
+
+Typing `@` gathers suggestions from several places at once: what is nearby in the node you are
+editing, what the search index knows, what other partitions hold. Some of those answer in a
+millisecond; the ones that reach across partitions take longer.
+
+The list used to be sent out as soon as it had stopped changing for a moment. That reads as
+"everything has answered", and most of the time it was — but a moment of quiet is not the same
+thing as being finished. On a busy portal the slower sources simply arrived after the pause, and
+the list you saw was the one assembled without them. Nothing reported this: the suggestions
+carried a flag meaning *this is the complete list*, and it was set whether or not it was true. The
+symptom people met was a name that was there yesterday and missing today, with no way to tell
+which of the two was right.
+
+Suggestions now go out when every source has finished, which each of them reports for itself.
+Waiting for the slowest costs nothing when they are all fast, and when one of them is slow the
+list is simply a little later — and correct.
+
+A source that never finishes at all can no longer hold your suggestions hostage either: after two
+seconds the best list so far is sent anyway, and it is now honestly marked as incomplete, with the
+misbehaving source named in the portal's log so it can be fixed rather than absorbed.

--- a/src/MeshWeaver.Hosting/Completion/ChatCompletionOrchestrator.cs
+++ b/src/MeshWeaver.Hosting/Completion/ChatCompletionOrchestrator.cs
@@ -60,7 +60,8 @@ internal sealed class ChatCompletionOrchestrator(
     // fires even if a backend hangs (chat input then hides its spinner). The
     // window is generous because cold-start fan-out across partitions can be
     // slow (initial schema provisioning, JSON deserialization). Per-call hub
-    // timeouts (e.g., SendAutocompleteRequest = 2s) handle the fast paths.
+    // timeouts (SendAutocompleteRequest = AutocompleteBounds.CallerBound) handle
+    // the fast paths.
     private static readonly TimeSpan ProducerInactivityTimeout = TimeSpan.FromSeconds(30);
 
     /// <inheritdoc />
@@ -483,9 +484,15 @@ internal sealed class ChatCompletionOrchestrator(
 
     /// <summary>
     /// Sends an AutocompleteRequest to the given address via Post+Observe and emits the
-    /// response (or null) within a 2-second inactivity timeout. Pure reactive — no Task,
-    /// no async; the hub.Observe stream provides the response and Rx's Timeout enforces
+    /// response (or null) within <see cref="AutocompleteBounds.CallerBound"/>. Pure reactive — no
+    /// Task, no async; the hub.Observe stream provides the response and Rx's Timeout enforces
     /// the deadline.
+    ///
+    /// <para>🚨 The bound is DERIVED from the producer's, never written here. It used to be a
+    /// literal 2 s — exactly the handler's own answer deadline — so a response the handler
+    /// legitimately took its full deadline to produce raced this timeout and was dropped as often
+    /// as it was kept. Invisible while the handler answered on a 150 ms settle window; a coin toss
+    /// the moment it is allowed to wait for every provider to settle (#3094).</para>
     /// </summary>
     private IObservable<AutocompleteResponse?> SendAutocompleteRequest(
         string query, string? context, Address target)
@@ -501,7 +508,7 @@ internal sealed class ChatCompletionOrchestrator(
                 .Take(1)
                 .Select(d => d.Message as AutocompleteResponse);
         })
-        .Timeout(TimeSpan.FromSeconds(2))
+        .Timeout(AutocompleteBounds.CallerBound)
         .Catch<AutocompleteResponse?, Exception>(ex =>
         {
             if (ex is not (TimeoutException or OperationCanceledException))

--- a/src/MeshWeaver.Mesh.Contract/Completion/UnifiedReferenceAutocompleteProvider.cs
+++ b/src/MeshWeaver.Mesh.Contract/Completion/UnifiedReferenceAutocompleteProvider.cs
@@ -430,11 +430,14 @@ internal class UnifiedReferenceAutocompleteProvider(
                     .ToList());
     }
 
-    /// <summary>2-second cap on a delegated per-node round-trip. Without this we
-    /// inherit the framework's 30 s <c>RequestTimeout</c>, which means a hung /
-    /// non-responding remote node hub stalls the entire autocomplete result for
-    /// the whole 30 s.</summary>
-    private static readonly TimeSpan NodeDelegationTimeout = TimeSpan.FromSeconds(2);
+    /// <summary>Cap on a delegated per-node round-trip. Without it we inherit the framework's 30 s
+    /// <c>RequestTimeout</c>, which means a hung / non-responding remote node hub stalls the entire
+    /// autocomplete result for the whole 30 s.
+    /// <para>🚨 DERIVED from the producer's own answer deadline
+    /// (<see cref="AutocompleteBounds.CallerBound"/>), never written here. It was a literal 2 s —
+    /// the same value the delegate answers at — so a delegated answer that took the full deadline
+    /// raced this cap. A caller's bound must strictly dominate the producer's (#3094).</para></summary>
+    private static readonly TimeSpan NodeDelegationTimeout = AutocompleteBounds.CallerBound;
 
     private IObservable<AutocompleteResponse?> GetCompletionsViaHub(string nodePath, string currentSegment)
     {

--- a/test/MeshWeaver.Data.Test/AutocompleteSettlesOnConvergenceTest.cs
+++ b/test/MeshWeaver.Data.Test/AutocompleteSettlesOnConvergenceTest.cs
@@ -1,0 +1,160 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Data.Completion;
+using MeshWeaver.Fixture;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// 🚨 Pins that the one-shot <see cref="AutocompleteRequest"/> answers on CONVERGENCE — every
+/// registered <see cref="IAutocompleteProvider"/> has settled — and never on a quiet period.
+///
+/// <para><b>The defect this replaces (#3094).</b> The handler used to answer when the merged
+/// snapshot had been unchanged for 150 ms. <see cref="AutocompleteSnapshots.Combine"/> seeds every
+/// provider with an empty snapshot so the merge can emit progressively, so a partial is ALWAYS
+/// emitted first; whenever the fast in-memory providers had landed and a slower one's rows arrived
+/// after the window, the timer fired and the answer went out WITHOUT them — and still carried
+/// <see cref="AutocompleteResponse.IsComplete"/> = <c>true</c>, so no caller could tell. The
+/// measured symptom was a cross-partition autocomplete row that appears when the suite runs alone
+/// and disappears under parallel load.</para>
+///
+/// <para><b>Why these two tests and not a timing assertion.</b> The discriminator is not "how
+/// long" but "what the answer is a function of". <see cref="TheAnswerWaitsForEveryProviderToSettle"/>
+/// holds a provider silent and asserts NOTHING is answered while it is — the negative has no
+/// positive signal to wait on, which is the one sanctioned fixed window — then releases it and
+/// asserts the answer CONTAINS its item. Against the settle window the first half fails outright
+/// (an answer arrives ~150 ms in) and the second half fails too (that answer can never contain the
+/// late item). <see cref="AProviderThatNeverSettlesIsLabelledIncomplete"/> pins the other half of
+/// the contract: the deadline still always answers — never a hang, which was #2276 — but says so.</para>
+/// </summary>
+public class AutocompleteSettlesOnConvergenceTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>The query both providers answer. Its search text is <c>item</c>.</summary>
+    private const string Query = "@item";
+
+    // Both labels CONTAIN the query's search text, and both carry a non-zero Priority. Either alone
+    // would survive the handler's relevance filter (which only re-scores zero-priority items and
+    // drops the ones that then score zero); together they keep this test about WHEN the answer is
+    // posted rather than about scoring.
+    private static readonly AutocompleteItem PromptItem =
+        new(Label: "prompt-item", InsertText: "@prompt-item", Category: "Test", Priority: 10);
+
+    private static readonly AutocompleteItem LateItem =
+        new(Label: "late-item", InsertText: "@late-item", Category: "Test", Priority: 10);
+
+    /// <summary>
+    /// The window in which a premature answer would appear. Derived from the production deadline,
+    /// not guessed: it must dominate the 150 ms settle window this test exists to forbid, and stay
+    /// clear of <see cref="AutocompleteBounds.AnswerDeadline"/> so the deadline cannot fire inside
+    /// it and make the negative assertion pass for the wrong reason.
+    /// </summary>
+    private static TimeSpan PrematureAnswerWindow => AutocompleteBounds.AnswerDeadline / 2;
+
+    /// <summary>
+    /// The slow provider's snapshot stream, driven by the test. Replay(1) so the handler sees the
+    /// snapshot whether it subscribed before or after the test pushed it — the assertion is about
+    /// WHEN the answer is posted, not about winning a subscribe race.
+    /// </summary>
+    private readonly ReplaySubject<IReadOnlyCollection<AutocompleteItem>> lateSnapshots = new(1);
+
+    /// <summary>A provider that settles immediately: one snapshot, then completes.</summary>
+    private sealed class PromptProvider : IAutocompleteProvider
+    {
+        public IObservable<IReadOnlyCollection<AutocompleteItem>> GetItems(
+            string query, string? contextPath = null)
+            => Observable.Return<IReadOnlyCollection<AutocompleteItem>>([PromptItem]);
+    }
+
+    /// <summary>
+    /// A provider that settles only when the test says so — the cross-partition query whose rows
+    /// arrive after the fast providers have gone quiet.
+    /// </summary>
+    private sealed class LateProvider(IObservable<IReadOnlyCollection<AutocompleteItem>> snapshots)
+        : IAutocompleteProvider
+    {
+        public IObservable<IReadOnlyCollection<AutocompleteItem>> GetItems(
+            string query, string? contextPath = null)
+            => snapshots;
+    }
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration)
+            .AddData()
+            .WithServices(services => services
+                .AddSingleton<IAutocompleteProvider>(new PromptProvider())
+                .AddSingleton<IAutocompleteProvider>(new LateProvider(lateSnapshots)));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration)
+        => base.ConfigureClient(configuration).AddData();
+
+    /// <summary>
+    /// Posts the request ONCE and republishes the single response into a subject, so the two
+    /// assertions below can both observe it. Subscribing to <c>hub.Observe</c> twice is not an
+    /// option: disposing one of those subscriptions unregisters the hub's response callback.
+    /// </summary>
+    private IObservable<AutocompleteResponse> AnswerTo(
+        IMessageHub client, IMessageHub host, out IDisposable subscription)
+    {
+        var answers = new ReplaySubject<AutocompleteResponse>(1);
+        subscription = client
+            .Observe<AutocompleteResponse>(
+                new AutocompleteRequest(Query, null), o => o.WithTarget(host.Address))
+            .Select(d => d.Message)
+            .Subscribe(answers);
+        return answers;
+    }
+
+    [HubFact]
+    public async Task TheAnswerWaitsForEveryProviderToSettle()
+    {
+        var host = GetHost();
+        var client = GetClient();
+
+        var answers = AnswerTo(client, host, out var subscription);
+        using var _ = subscription;
+
+        // The late provider has produced nothing, so there IS no settled snapshot yet and there
+        // must be no answer. This is where the old 150 ms settle window answered — with the prompt
+        // provider's row only, and still labelled IsComplete = true.
+        await answers.Should().NotEmit(PrematureAnswerWindow,
+            "the late provider has not produced its snapshot, so no answer can be settled");
+
+        lateSnapshots.OnNext([LateItem]);
+        lateSnapshots.OnCompleted();
+
+        var settled = await answers.Should().Within(TestTimeouts.Quick).Match(
+            r => r.Items.Any(i => i.InsertText == LateItem.InsertText),
+            "the answer must carry the late provider's rows once it has settled");
+
+        settled.Items.Select(i => i.InsertText)
+            .Should().Contain(PromptItem.InsertText,
+                "the fast provider's rows survive the wait for the slow one");
+        settled.IsComplete.Should().BeTrue(
+            "every provider completed its snapshot stream, so the answer IS settled");
+    }
+
+    [HubFact]
+    public async Task AProviderThatNeverSettlesIsLabelledIncomplete()
+    {
+        var host = GetHost();
+        var client = GetClient();
+
+        var answers = AnswerTo(client, host, out var subscription);
+        using var _ = subscription;
+
+        // lateSnapshots is never pushed: the provider violates the GetItems contract by never
+        // completing. The deadline must still answer — a one-shot request that hangs is #2276 —
+        // but the response must SAY the snapshot is not settled, which is the whole difference
+        // between this and a silently truncated one.
+        var answer = await answers.Should().Within(TestTimeouts.Quick).Match(
+            _ => true, "the deadline must always produce an answer, never a hang");
+
+        answer.IsComplete.Should().BeFalse(
+            "a provider never completed, so this snapshot is explicitly NOT settled");
+        answer.Items.Select(i => i.InsertText)
+            .Should().Contain(PromptItem.InsertText,
+                "the best snapshot so far is still the answer");
+    }
+}


### PR DESCRIPTION
Fixes #3094.

## The settle window was NOT load-bearing — it was the defect

The issue asked whether a fixed 150 ms "settle window" is compensating for something real. It is not compensating for anything that a correct signal does not cover. It exists only because the handler consumed the *progressive* merged stream and then had to **guess** when that stream was done.

`AutocompleteSnapshots.Combine` is a `CombineLatest` that seeds every provider with an empty snapshot **so the merge can emit progressively**. So the merge always emits a partial first, and "unchanged for 150 ms" measures the clock, not the providers:

```csharp
Observable.Amb(
    combined.Throttle(AutocompleteSettleWindow /* 150 ms */).Take(1),   // ← the defect
    combined.Sample(AutocompleteAnswerDeadline /* 2 s */).Take(1),
    Observable.Timer(AutocompleteSilenceFloor /* 2.5 s */).Select(_ => Empty))
```

Worse, the truncation was **unreportable**: `AutocompleteResponse.IsComplete` already exists in the contract, is documented as "true when this is the settled (final) snapshot" — and was hard-coded `true` on every response, settled or not. It had **zero readers** repo-wide. So `ChatCompletionOrchestrator` could not have told a truncated `Nearby` batch from a final one even if it had wanted to.

## The authoritative source was already specified — the code had drifted from it

Two places in the repo already state the correct rule:

* `IAutocompleteProvider.GetItems` — *"the stream completes when the provider has settled"*.
* `Doc/Architecture/AggregatingProviders.md` — *"For a request/response consumer (cross-hub `AutocompleteRequest`), take the settled snapshot (`LastOrDefaultAsync`) and post that."*

`CombineLatest` completes exactly when every source has, so the **last value of the merged stream is the fully-merged, every-provider-in answer**. That is derived from the providers' own lifecycle: no clock, nothing to tune, and under load the answer simply arrives later and arrives complete. It is also the same convergence rule the query path already uses — `MeshQuery.Query` emits its merged `Initial` only once `initialCount == initialTarget` (`EmitMergedInitialIfComplete`). The autocomplete request/response leg was the odd one out.

The handler now folds `Materialize().TakeUntil(deadline).Aggregate(...)`, which is one subscription and emits **exactly once** by construction — so the 2.5 s silence floor is subsumed and deleted.

## What is left is a hang bound, and it is now honest

`AutocompleteBounds` (new, `MeshWeaver.Data.Contract`) holds the two remaining numbers, neither of them a settle window:

| Bound | Meaning |
|---|---|
| `AnswerDeadline` (2 s) | A one-shot request must **always** answer — the pre-#2276 `LastAsync()` shape posted *nothing at all* when a provider never completed. Reaching it now means a provider violated the completion contract, so the response is `IsComplete = false` **and** a warning names the offending provider type. A silent 2 s cost becomes a greppable defect. |
| `CallerBound` = `AnswerDeadline + CallerGrace` | **A caller's bound must strictly dominate the producer's.** `ChatCompletionOrchestrator.SendAutocompleteRequest` and `UnifiedReferenceAutocompleteProvider`'s node delegation both waited exactly 2 s — the same value the handler answers at — so an answer that legitimately took the full deadline raced its own caller's timeout. Invisible while the handler answered at 150 ms; a coin toss the moment it is allowed to wait for convergence. Same rule as `LateResponseWatchBound` + `VerdictBoundGrace`. |

## Measurement (re-run, not quoted)

The issue's numbers were not trusted. The defect is reproduced **deterministically in core**, with no sleep and no timing assertion — two registered providers, one that settles at once and one the test holds silent:

Against the parent commit, both legs fail:

```
AProviderThatNeverSettlesIsLabelledIncomplete [FAIL]
  Expected value to be false because a provider never completed, so this snapshot
  is explicitly NOT settled, but found True.

TheAnswerWaitsForEveryProviderToSettle [FAIL]
  Expected the observable not to emit within 1s because the late provider has not
  produced its snapshot, so no answer can be settled, but it emitted
  AutocompleteResponse { Items = …, IsComplete = True, Version = 0 }.

Failed!  - Failed: 2, Passed: 0
```

With the fix: `Passed! - Failed: 0, Passed: 2`.

The negative leg is the one sanctioned fixed window (`NotEmit` — a "nothing happened" assertion has no positive signal to wait on) and its width is **derived** from `AutocompleteBounds.AnswerDeadline / 2`, not written as a literal. The positive leg waits on the actual condition.

## Cost of the change

A hub whose providers are all fast now answers *sooner* than before (on completion, instead of 150 ms after it). A hub with a genuinely slow provider now waits for it — that is the fix. A hub with a provider that never completes pays the 2 s deadline and gets a named warning; in core there is no such provider — every one of them completes, by `Observable.Return`, by `AutocompleteSnapshots.FromItems` over a completing source, or by `Combine` over completing sources.

## Cross-repo

`MeshWeaver.Plugins`' `SkillAutocompleteProvider` is the one known provider that never completes (`ObserveSkillQueries → ObserveSnapshot → Switch`, both live synced queries). It is registered **only** on the `app/Agents` hub — never on the per-node hubs the chat orchestrator queries — and the only sender to that hub in production code is the currently-unreferenced `AutocompleteClient`, so nothing regresses and no Plugins test goes red (`AgentsApplicationInstallTest` only asserts a non-null response, with a 30 s bound). It does now cost that hub the deadline and log the warning, which is the point: the follow-up half makes it honour the contract. Core first, as the contract owner.

No public top-level type is removed by this diff, so the cross-repo pair gate does not apply.

## i18n

Not applicable, deliberately. Autocomplete entries are node **paths and names** — data, not chrome — and the only strings added here are server-side log messages, which are never translated.

## Verification

* `dotnet build -c Release -warnaserror`, one project per invocation, `0 Error(s)` on: `MeshWeaver.Data.Contract`, `MeshWeaver.Data`, `MeshWeaver.Mesh.Contract`, `MeshWeaver.Hosting`, `MeshWeaver.Graph`, `MeshWeaver.Layout`, `MeshWeaver.Documentation`, and the three touched test projects.
* Full unfiltered test projects (Release, `--no-build`): `MeshWeaver.Data.Test`, `MeshWeaver.Documentation.Test`, `MeshWeaver.Hosting.Test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
