### PR TITLE
memex build plugin composes the PORTAL's reference set — no fallback to the tester's /app (#3113)

### DIFF
--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -73,6 +73,7 @@
     <File Path="test/Directory.Build.props" />
     <File Path="test/Directory.Packages.props" />
     <Project Path="test/MeshWeaver.Hosting.Monolith.TestBase/MeshWeaver.Hosting.Monolith.TestBase.csproj" />
+    <Project Path="test/MeshWeaver.Cli.Test/MeshWeaver.Cli.Test.csproj" />
     <Project Path="test/MeshWeaver.ContentCollections.Test/MeshWeaver.ContentCollections.Test.csproj" />
     <Project Path="test/MeshWeaver.Data.Test/MeshWeaver.Data.Test.csproj" />
     <Project Path="test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj" />

--- a/src/MeshWeaver.Cli/BuildPluginCommand.cs
+++ b/src/MeshWeaver.Cli/BuildPluginCommand.cs
@@ -14,6 +14,12 @@ namespace MeshWeaver.Cli;
 /// then the gate runs with <c>--seed /bake</c> and stands a mesh up on <b>those bytes</b>. Testing
 /// the baked bytes is a strictly stronger claim than a fused pass, because the bytes judged are the
 /// bytes that ship.</para>
+///
+/// <para><b>Two IMAGES, and that split is deliberate too (#3022 for the lanes, #3113 here).</b> The
+/// TESTER image executes; the PLATFORM (portal) image supplies the reference set, the framework
+/// identity and the runtime. Both stages run from a host composed of the portal's <c>/app</c> with
+/// the tester CLI beside it — see <see cref="GateHost"/> for what the tester's subset <c>/app</c>
+/// cannot compile and why there is no fallback to it.</para>
 /// </summary>
 public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
 {
@@ -29,6 +35,24 @@ public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
     private const string BakeIdentityFile = "framework-mvid.txt";
 
     public async Task<int> RunAsync(BuildPluginOptions options, CancellationToken ct)
+    {
+        // Two /app extractions plus the composed host is roughly a gigabyte per invocation, and
+        // the path carries this process's id — so a later run never reuses it and stale copies
+        // accumulate until the disk is full. The bake is deliberately NOT in here: the caller asked
+        // for it and may well read it after this returns.
+        var hostRoot = Path.Combine(Path.GetTempPath(), $"memex-host-{Environment.ProcessId}");
+        try
+        {
+            return await RunCoreAsync(options, hostRoot, ct);
+        }
+        finally
+        {
+            await GateHost.DiscardTree(hostRoot, output);
+        }
+    }
+
+    private async Task<int> RunCoreAsync(
+        BuildPluginOptions options, string hostRoot, CancellationToken ct)
     {
         var repo = Path.GetFullPath(options.PluginPath);
         if (!Directory.Exists(repo))
@@ -51,21 +75,139 @@ public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
             return 6;
         }
 
+        // ── the PLATFORM image is REQUIRED, and there is no fallback to the tester's /app ────────
+        // 🚨 #3113. Composing only the tester's /app is not "backwards compatible", it is the
+        // defect: content that binds a portal-shipped assembly cannot compile against a strict
+        // subset of the portal's reference set, and the failure reads as a CONTENT error on source
+        // nobody changed. node-repo-gate.yml refuses the same way (`platform-image-digest is empty
+        // and allow-unpinned is not set … There is no fallback to the tester's /app`), so this
+        // refuses rather than silently compiling against the wrong reference set.
+        if (options.PlatformImage is not { Length: > 0 })
+        {
+            await error.WriteLineAsync(
+                "error: --platform-image is required — pass the PORTAL image "
+                + "(e.g. meshweaver.azurecr.io/memex-portal-ai@sha256:…, pinned from the SAME CD wave "
+                + "as --image). The tester image only EXECUTES; the portal supplies the reference "
+                + "set, the framework identity and the runtime. There is no fallback to the tester's "
+                + "/app: it is a strict subset of the portal's (88 vs 219 assemblies on "
+                + "3.0.0-rc9.ci.7534), so content binding MeshWeaver.Maps, .AI or .Indexing fails to "
+                + "compile against it (MeshWeaver#3022 / #3113).");
+            return 9;
+        }
+        if (GateHost.NamesTheTesterImage(options.PlatformImage))
+        {
+            await error.WriteLineAsync(
+                $"error: --platform-image names the TESTER image ('{options.PlatformImage}') — pass "
+                + "the PORTAL image (meshweaver.azurecr.io/memex-portal-ai); the tester only executes. "
+                + "Accepting it would silently restore the reference-set gap this argument closes.");
+            return 9;
+        }
+
         // Pin by DIGEST once, and use it for both stages. The workflow this replaces already did
         // this (`${IMAGE%%:*}@${DIGEST}`) for a reason: a tag can move between the compile and the
         // gate, and then the bytes tested are not the bytes baked — which is the one claim the
         // two-stage split exists to make.
         var pinned = await _runner.PullImage(options.Image, ct);
         if (pinned is null) return 4;
-        await output.WriteLineAsync($"image: {pinned}");
+        await output.WriteLineAsync($"tester image: {pinned}");
+        var platform = await _runner.PullImage(options.PlatformImage, ct);
+        if (platform is null) return 4;
+        await output.WriteLineAsync($"platform image: {platform}");
+
+        // ── the composed GATE HOST: the portal's /app with the tester CLI beside it ──────────────
+        // (hostRoot is created by RunAsync, which also removes it however this returns.)
+        var testerApp = Path.Combine(hostRoot, "tester-app");
+        var portalApp = Path.Combine(hostRoot, "portal-app");
+        var gateHost = Path.Combine(hostRoot, "gate-host");
+        if (!await _runner.ExtractApp(pinned, testerApp, ct)) return 10;
+        if (!await _runner.ExtractApp(platform, portalApp, ct)) return 10;
+        if (!File.Exists(Path.Combine(testerApp, GateHost.TesterCli)))
+        {
+            await error.WriteLineAsync(
+                $"error: {pinned} ships no /app/{GateHost.TesterCli} — --image must be the "
+                + "mw-plugin-test image.");
+            return 10;
+        }
+        var manifest = new FileInfo(Path.Combine(portalApp, GateHost.SurfaceManifest));
+        if (!manifest.Exists || manifest.Length == 0)
+        {
+            await error.WriteLineAsync(
+                $"error: {platform} ships no /app/{GateHost.SurfaceManifest} — --platform-image must "
+                + "be the PORTAL image; a host without one resolves the fallback identity no bake may "
+                + "be keyed to.");
+            return 10;
+        }
+        await output.WriteLineAsync(
+            $"tester /app: {Directory.GetFiles(testerApp, "*.dll").Length} assemblies; "
+            + $"platform /app: {Directory.GetFiles(portalApp, "*.dll").Length} assemblies");
+
+        // 🚨 ONE BUILD, ASSERTED. The bake is keyed to the PORTAL's identity and executed by the
+        // TESTER's toolchain, which is honest only when the two images are one build. The tester's
+        // own `framework-identity` verb reads the portal's /app as FILES and compares — naming the
+        // canonical assemblies each side lacks on a mismatch (#1814) — and it never degrades to a
+        // fallback identity, so this comparison cannot pass on a manifest-less directory.
+        var (testerRc, testerLine) = await _runner.CaptureVerbose("docker",
+            ["run", "--rm", "--init", "--entrypoint", "/app/mw-plugin-test", pinned,
+             "--print-framework-identity"], ct);
+        var idIdx = testerLine.IndexOf("identity=", StringComparison.Ordinal);
+        var testerIdentity = testerRc == 0 && idIdx >= 0
+            ? testerLine[(idIdx + "identity=".Length)..].Split(' ', '\n', '\r')[0].Trim()
+            : "";
+        if (testerIdentity.Length == 0)
+        {
+            await error.WriteLineAsync(
+                $"error: could not resolve the tester image's framework identity (got: '{testerLine.Trim()}').");
+            return 10;
+        }
+        var (identityRc, identityOut) = await _runner.CaptureVerbose("docker",
+            ["run", "--rm", "--init", "-v", $"{portalApp}:/portal:ro",
+             "--entrypoint", "/app/mw-plugin-test", pinned,
+             "framework-identity", "/portal", "--expect", testerIdentity], ct);
+        var frameworkIdentity = identityOut
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+            .LastOrDefault() ?? "";
+        if (identityRc != 0 || frameworkIdentity.Length == 0)
+        {
+            await error.WriteLineAsync(
+                "error: the tester image and the platform image do NOT resolve one framework identity "
+                + "— they are not one build (the verb's verdict above names the canonical assemblies "
+                + "each side lacks). Pin --image and --platform-image from the SAME CD wave.");
+            return 10;
+        }
+        await output.WriteLineAsync(
+            $"framework identity: {frameworkIdentity} (the platform's; the tester resolves the same)");
+
+        // The composition rules are the LANES' rules — one implementation, extracted and run, never
+        // reimplemented here. It fails closed and names the file it is missing.
+        var script = GateHost.ExtractComposeScript(hostRoot);
+        var composed = await _runner.Exec("bash", [script, portalApp, testerApp, gateHost], ct);
+        if (composed != 0)
+        {
+            await error.WriteLineAsync(
+                composed == 127
+                    ? $"error: could not run {GateHost.ComposeScriptName} — 'bash' is not on PATH. "
+                      + "Composing the gate host is not optional: without it the build has no portal "
+                      + "reference set."
+                    : $"error: composing the gate host failed (exit {composed}) — the refusal above "
+                      + "names the file that was missing.");
+            return 10;
+        }
+        // The two extractions are CONSUMED by the composition above (and by the identity check
+        // before it); only the composed host is mounted from here on. Dropping them now keeps peak
+        // disk at one copy instead of three across the compile and the gate, which are the long
+        // stages — the finally in RunAsync is the backstop, not the whole answer.
+        await GateHost.DiscardTree(portalApp, output);
+        await GateHost.DiscardTree(testerApp, output);
+
+        var invokingUser = await _runner.ResolveInvokingUser(ct);
 
         var bake = options.BakeOutput is { Length: > 0 }
             ? Path.GetFullPath(options.BakeOutput)
             : Path.Combine(Path.GetTempPath(), $"memex-bake-{Environment.ProcessId}");
         Directory.CreateDirectory(bake);
-        // 🚨 The tester image runs as a NON-ROOT user, so the bake mount must be writable by it —
-        // the `chmod 777 "$OWN_BAKE"` every docker-run gate performs. Proven the hard way on the
-        // verb's first production run (Manufacturing #37): 15/15 NodeTypes compiled, then
+        // 🚨 The container may run as a user this host never provisioned, so the bake mount must be
+        // writable by it — the `chmod 777 "$OWN_BAKE"` every docker-run gate performs. Proven the
+        // hard way on the verb's first production run (Manufacturing #37): 15/15 NodeTypes compiled, then
         // `UnauthorizedAccessException: Access to the path '/bake/Manufacturing.zip' is denied`
         // writing the first bundle. Applied to a caller-supplied directory too: the caller asked
         // for a bake THERE, and a mount the container cannot write is a promise this command
@@ -78,33 +220,19 @@ public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
         // upstream types were DECLINED ('MeshWeaver.AI built against mvid:699963b6…, live is
         // 813bec7e…') because the composed module and the publication disagreed. The reusable gate
         // never has this skew: with an upstream seed, compose-sealed-modules takes the modules FROM
-        // the publication, identity-matched. Same here — the identity is asked of the IMAGE
-        // (--print-framework-identity, the gate's own pre-bake step), the seed is fetched before
-        // stage 1, and the requested modules come from the publication's SEALED MODULE SET
+        // the publication, identity-matched. Same here — the seed is fetched before stage 1, and the
+        // requested modules come from the publication's SEALED MODULE SET
         // (`…/prebuilt/{identity}/{source}/modules`, MeshWeaver#2698/#2707). Round 5's lesson: the
         // seed's own zips are the NODE-REPO content packs — no module bundle is among them, so
         // scanning them for 'AI'/'Essentials' refuses on every run. Only a build with NO upstream
         // seed falls back to the package index's latest.
+        //
+        // 🚨 The address is the PLATFORM's identity, resolved above from the portal's /app — not the
+        // tester's. The bake this run produces is keyed to the host it compiles on, and a seed
+        // fetched under the tester's identity would address a publication this gate never adopts.
         var seedDir = bake; // the gate consumes one dir: own bake + upstream bundles
-        string? sealedIdentity = null;
         if (options.UpstreamSeed is { Length: > 0 } upstreams)
         {
-            var line = await ImageRunner.Capture("docker",
-                ["run", "--rm", "--init", "--entrypoint", "/app/mw-plugin-test", pinned,
-                 "--print-framework-identity"], ct);
-            var idIdx = line.IndexOf("identity=", StringComparison.Ordinal);
-            var frameworkIdentity = idIdx >= 0
-                ? line[(idIdx + "identity=".Length)..].Split(' ', '\n', '\r')[0].Trim()
-                : "";
-            if (frameworkIdentity.Length == 0)
-            {
-                await error.WriteLineAsync(
-                    $"error: could not resolve a framework identity from the image (got: '{line.Trim()}') "
-                    + "— cannot address an upstream publication.");
-                return 8;
-            }
-            await output.WriteLineAsync($"framework identity: {frameworkIdentity} (from the image)");
-            sealedIdentity = frameworkIdentity;
             var seeded = await FetchUpstreamSeed(
                 options.RegistryUrl!, options.RegistryKey!, upstreams, frameworkIdentity, seedDir, ct);
             if (!seeded) return 8;
@@ -118,9 +246,9 @@ public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
         if (options is { RegistryModules.Length: > 0 })
         {
             extDir ??= Path.Combine(Path.GetTempPath(), $"memex-ext-{Environment.ProcessId}");
-            var fetched = options.UpstreamSeed is { Length: > 0 } sources && sealedIdentity is { Length: > 0 }
+            var fetched = options.UpstreamSeed is { Length: > 0 } sources
                 ? await ComposeSealedModules(
-                    options.RegistryUrl!, options.RegistryKey!, sources, sealedIdentity,
+                    options.RegistryUrl!, options.RegistryKey!, sources, frameworkIdentity,
                     options.RegistryModules!, extDir, ct)
                 : await FetchRegistryModules(
                     options.RegistryUrl!, options.RegistryKey!, options.RegistryModules!, extDir, ct);
@@ -143,10 +271,17 @@ public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
         // Module args go to BOTH stages: the compile needs the externals to RESOLVE their types,
         // the gate needs them to REGISTER them (the node-repo gate passes them to both for exactly
         // this reason, and dropping either half reintroduces one of the two failures).
-        var compile = await RunInImage(pinned, repo, extDir,
+        //
+        // 🚨 `--app /app --shared-frameworks …` makes the reference set the PLATFORM's /app plus its
+        // IMPLEMENTATION frameworks — what a portal's runtime compile sees — and keys the bake to the
+        // portal's identity. Same shape as node-repo-gate.yml, on purpose: the CLI and the lanes must
+        // not disagree about what a portal contains.
+        var compile = await RunOnHost(platform, gateHost, invokingUser, repo, extDir,
             mounts: [$"{bake}:/bake"],
             env: [],
-            args: ["compile", "/repo", ..AllowArgs(repo, options), ..moduleArgs, ..options.ExtraArgs,
+            args: ["compile", "/repo", "--app", "/app",
+                   "--shared-frameworks", GateHost.SharedFrameworks,
+                   ..AllowArgs(repo, options), ..moduleArgs, ..options.ExtraArgs,
                    "--output", "/bake", ..SourceShaArgs(options)],
             ct);
         if (compile != 0) return compile;
@@ -159,13 +294,25 @@ public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
                 + "— the bake stage regressed. Refusing to test bytes that were never produced.");
             return 5;
         }
-
+        var baked = File.ReadAllText(identity).Trim();
+        if (!string.Equals(baked, frameworkIdentity, StringComparison.Ordinal))
+        {
+            await error.WriteLineAsync(
+                $"error: the run's own bake is keyed to '{baked}' but the platform's /app resolves "
+                + $"'{frameworkIdentity}' — the compile did not run against the platform host. Bundles "
+                + "published under an identity no portal asks for are INERT.");
+            return 5;
+        }
 
         // ── stage 2: CONSUME — stand a mesh up on the bytes stage 1 produced ───────────────────
-        return await RunInImage(pinned, repo, extDir,
+        // `--app /app`: the gate must RUN AS the platform host (it resolves the portal's identity),
+        // and is refused before a mesh boots otherwise — a gate running as another host would decline
+        // every bundle and compile the tree itself, passing without judging the bytes that ship.
+        return await RunOnHost(platform, gateHost, invokingUser, repo, extDir,
             mounts: [$"{bake}:/seed:ro"],
             env: ["MW_INSTALL_DIFF=1"],
-            args: ["/repo", ..AllowArgs(repo, options), ..moduleArgs, ..options.ExtraArgs, "--seed", "/seed"],
+            args: ["/repo", "--app", "/app", ..AllowArgs(repo, options), ..moduleArgs,
+                   ..options.ExtraArgs, "--seed", "/seed"],
             ct);
     }
 
@@ -498,8 +645,12 @@ public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
         return true;
     }
 
-    private Task<int> RunInImage(
-        string image, string repo,
+    /// <summary>
+    /// Runs the tester CLI out of the composed gate host, inside the PLATFORM image, with this
+    /// verb's standing mounts (<c>/repo</c> and, when there are external modules, <c>/ext</c>).
+    /// </summary>
+    private Task<int> RunOnHost(
+        string platformImage, string hostDirectory, string? user, string repo,
         string? extDir,
         IEnumerable<string> mounts, IEnumerable<string> env, IEnumerable<string> args,
         CancellationToken ct)
@@ -508,7 +659,7 @@ public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
         all.AddRange(mounts);
         if (extDir is { Length: > 0 } ext)
             all.Add($"{ext}:/ext");
-        return _runner.RunInImage(image, all, env, args, ct);
+        return _runner.RunOnComposedHost(platformImage, hostDirectory, user, all, env, args, ct);
     }
 }
 
@@ -536,6 +687,13 @@ public sealed record BuildPluginOptions(
     /// <summary>Space-separated upstream SOURCES whose sealed publication seeds the gate's mesh
     /// (e.g. "plugins") — the packages a `requires` chain reaches, not merely their DLLs.</summary>
     public string? UpstreamSeed { get; init; }
+
+    /// <summary>
+    /// The PORTAL image — REQUIRED (#3113). It supplies the reference set, the framework identity
+    /// and the runtime; <see cref="Image"/> only executes. There is deliberately no default and no
+    /// fallback to the tester's <c>/app</c>: see <see cref="GateHost"/>.
+    /// </summary>
+    public string? PlatformImage { get; init; }
 
     public IReadOnlyList<string> ExtraArgs => Extra ?? [];
 }

--- a/src/MeshWeaver.Cli/GateHost.cs
+++ b/src/MeshWeaver.Cli/GateHost.cs
@@ -1,0 +1,155 @@
+using System.Reflection;
+
+namespace MeshWeaver.Cli;
+
+/// <summary>
+/// The <b>two-image contract</b> on the CLI path: the TESTER image EXECUTES, the PLATFORM (portal)
+/// image SUPPLIES the reference set, the framework identity and the runtime — and both stages run
+/// from a COMPOSED HOST, the portal's <c>/app</c> with the tester CLI laid beside it.
+///
+/// <para>🚨 <b>Why this exists (#3113).</b> Every reusable lane moved to this shape in #3022/#3071;
+/// <c>memex build plugin</c> did not, and kept running <c>--entrypoint /app/mw-plugin-test</c>
+/// straight from the tester image. The tester's <c>/app</c> is a strict SUBSET of the portal's
+/// (measured on 3.0.0-rc9.ci.7534: 88 vs 219 assemblies — <c>MeshWeaver.Maps</c>, <c>.AI</c>,
+/// <c>.ContentCollections.Indexing</c>, the Blazor and hosting halves exist only in the portal), so
+/// content binding a portal-shipped assembly cannot compile. On MeshWeaver.Manufacturing#48 that
+/// read as <c>CS0234 The type or namespace name 'Maps' does not exist in the namespace
+/// 'MeshWeaver'</c> against <c>AppleMaps/Gallery</c> and <c>Cornerstone/Pricing</c> — a CONTENT-shaped
+/// failure with an INFRASTRUCTURE cause, on source nobody had changed.</para>
+///
+/// <para>🚨 <b>The composition rules are NOT reimplemented here.</b> They live in exactly one place —
+/// <c>.github/scripts/compose-gate-host.sh</c>, which the lanes fetch from the platform at their
+/// pinned ref and this assembly EMBEDS byte-for-byte (<c>&lt;EmbeddedResource&gt;</c> on the very
+/// same file; <c>GateHostCompositionTest</c> pins the equality byte-for-byte and drives the
+/// script's own <c>--self-test</c> through the bytes this CLI puts on disk). Its ordering and its
+/// fail-closed refusals were derived from measured incidents, and a second copy of them here would
+/// be the drift trap this repository has paid for repeatedly. The CLI extracts that script and runs
+/// it; it never composes a host itself.</para>
+///
+/// <para>The identity PRECONDITION is deliberately outside the script (which is pure file logic),
+/// exactly as in the lanes: the tester's own <c>framework-identity</c> verb must report that the
+/// tester and the portal resolve ONE identity before the composition is trusted.</para>
+/// </summary>
+public static class GateHost
+{
+    /// <summary>
+    /// The composition script, embedded from <c>.github/scripts/compose-gate-host.sh</c> — the SAME
+    /// file the reusable lanes fetch. One implementation, not a copy.
+    /// </summary>
+    public const string ComposeScriptName = "compose-gate-host.sh";
+
+    /// <summary>The tester CLI the composed host is started with.</summary>
+    public const string TesterCli = "mw-plugin-test.dll";
+
+    /// <summary>
+    /// The file whose presence identifies a PORTAL <c>/app</c>. A host without one resolves the
+    /// fallback framework identity — which no bake may be published under — so its absence is a
+    /// refusal, never a degraded pass.
+    /// </summary>
+    public const string SurfaceManifest = "meshweaver-surface.manifest";
+
+    /// <summary>
+    /// Where the composed host is mounted inside the container. The tester CLI is started from here
+    /// (<c>dotnet /host/mw-plugin-test.dll</c>) while <c>--app /app</c> keeps the reference set and
+    /// the identity the PORTAL image's own <c>/app</c>.
+    /// </summary>
+    public const string HostMount = "/host";
+
+    /// <summary>
+    /// The platform host's IMPLEMENTATION frameworks, passed to <c>compile</c> as
+    /// <c>--shared-frameworks</c> so the reference set is what the portal's runtime compile sees.
+    /// </summary>
+    public const string SharedFrameworks = "/usr/share/dotnet/shared";
+
+    /// <summary>
+    /// 🚨 The one wrong value nothing else can refuse for us: the TESTER passed as the platform,
+    /// which would silently restore the very reference-set gap the platform image closes.
+    /// </summary>
+    /// <param name="image">The image reference given as <c>--platform-image</c>.</param>
+    /// <returns>True when the reference names the tester image.</returns>
+    public static bool NamesTheTesterImage(string image) =>
+        image.Contains("mw-plugin-test", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
+    /// Writes the embedded <see cref="ComposeScriptName"/> into <paramref name="directory"/> and
+    /// returns its path.
+    /// </summary>
+    /// <param name="directory">Directory to write the script into; created if absent.</param>
+    /// <returns>The full path of the extracted script.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// The resource is not in this assembly — i.e. the <c>&lt;EmbeddedResource&gt;</c> link to
+    /// <c>.github/scripts/compose-gate-host.sh</c> was dropped from the .csproj. Failing here is the
+    /// point: a CLI that silently composed nothing would run the gate against an empty host.
+    /// </exception>
+    public static string ExtractComposeScript(string directory)
+    {
+        Directory.CreateDirectory(directory);
+        var path = Path.Combine(directory, ComposeScriptName);
+        File.WriteAllBytes(path, ComposeScriptBytes());
+        // 🚨 `chmod +x`, the same line every lane runs after fetching this script — and not
+        // cosmetic even though the CLI starts it as `bash <script>`: the script re-invokes ITSELF
+        // by path (`"$self" …`) to prove each of its rules, so without the bit its own --self-test
+        // dies on "Permission denied" having verified nothing. A file written 0644 is exactly the
+        // shape in which a proof stops being a proof.
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(
+                path,
+                UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute |
+                UnixFileMode.GroupRead | UnixFileMode.GroupExecute |
+                UnixFileMode.OtherRead | UnixFileMode.OtherExecute);
+        return path;
+    }
+
+    /// <summary>
+    /// Removes a temporary tree the gate host was built from or in, REPORTING a failure rather than
+    /// swallowing it.
+    ///
+    /// <para>Two <c>/app</c> extractions plus the composed host are roughly a gigabyte per
+    /// invocation, and the temp path carries the process id — so a later run never reuses it and
+    /// stale copies accumulate until the disk is full.</para>
+    ///
+    /// <para>🚨 The narrow catch is deliberate and hides no fault: a directory that cannot be removed
+    /// must not decide the build's verdict. A green gate turned red by a failed <c>rmdir</c>, or a
+    /// red one whose real cause is buried under an IO exception raised on the cleanup path, are both
+    /// worse than a note naming what was left behind — and a SILENT swallow would be worse than
+    /// either, which is why this writes one.</para>
+    /// </summary>
+    /// <param name="directory">The tree to remove; a path that does not exist is a no-op.</param>
+    /// <param name="notes">Where a failure to remove it is reported.</param>
+    /// <returns>A task that completes when the tree is gone or the note is written.</returns>
+    public static async Task DiscardTree(string directory, TextWriter notes)
+    {
+        if (!Directory.Exists(directory)) return;
+        try
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            await notes.WriteLineAsync(
+                $"note: could not remove the temporary directory '{directory}' ({ex.Message}). It "
+                + "holds a copy of an image's /app or the composed gate host — remove it by hand.");
+        }
+    }
+
+    /// <summary>
+    /// The embedded composition script's bytes — the same bytes as
+    /// <c>.github/scripts/compose-gate-host.sh</c> in this repository.
+    /// </summary>
+    /// <returns>The script's content.</returns>
+    /// <exception cref="InvalidOperationException">The resource is absent from this assembly.</exception>
+    public static byte[] ComposeScriptBytes()
+    {
+        var assembly = typeof(GateHost).Assembly;
+        using var stream = assembly.GetManifestResourceStream(ComposeScriptName)
+            ?? throw new InvalidOperationException(
+                $"'{ComposeScriptName}' is not embedded in {assembly.GetName().Name}. It is linked "
+                + "from .github/scripts/compose-gate-host.sh by MeshWeaver.Cli.csproj so the CLI and "
+                + "the reusable lanes compose the gate host by ONE set of rules; without it there is "
+                + "no composition and no portal reference set. Restore the <EmbeddedResource>. "
+                + $"Resources present: {string.Join(", ", assembly.GetManifestResourceNames())}");
+        using var memory = new MemoryStream();
+        stream.CopyTo(memory);
+        return memory.ToArray();
+    }
+}

--- a/src/MeshWeaver.Cli/ImageRunner.cs
+++ b/src/MeshWeaver.Cli/ImageRunner.cs
@@ -108,6 +108,174 @@ public sealed class ImageRunner(TextWriter output, TextWriter error)
     }
 
     /// <summary>
+    /// The docker argv for a run on the COMPOSED GATE HOST (#3113): the PLATFORM (portal) image's
+    /// own <c>dotnet</c> starting the tester CLI out of <paramref name="hostDirectory"/>, mounted
+    /// read-only at <see cref="GateHost.HostMount"/>.
+    ///
+    /// <para>Pure, and therefore pinned by a test rather than by a docker-shaped run CI would have
+    /// to skip — the defect this shape exists to prevent is not a crash but a run that succeeds
+    /// against the WRONG reference set, which looks identical from outside. Same reason
+    /// <c>DockerImageGateArgsTest</c> pins the combo gate's argv.</para>
+    ///
+    /// <para>🚨 Everything before the image reference is DOCKER's and everything after it is the
+    /// tool's. A flag that drifts past the image is not a flag any more: docker never sees it and
+    /// <c>mw-plugin-test</c> receives it as an unknown argument, so the run silently stops being
+    /// composed while still looking correct.</para>
+    /// </summary>
+    /// <param name="platformImage">The PORTAL image reference — it supplies <c>dotnet</c>, the
+    /// <c>/app</c> reference set and the implementation frameworks.</param>
+    /// <param name="hostDirectory">The composed host on this machine (portal <c>/app</c> + tester CLI).</param>
+    /// <param name="user">
+    /// <c>uid:gid</c> to run as, or null to accept the image's own user. The portal image runs as
+    /// ROOT, so without this every file the run writes into a mounted output directory lands
+    /// root-owned and a later step of the caller's job cannot rewrite it — the reason both
+    /// node-repo-publish-bake.yml and node-repo-module-pack.yml pass <c>$(id -u):$(id -g)</c>.
+    /// </param>
+    /// <param name="mounts">Bind mounts, each already in <c>host:container[:ro]</c> form.</param>
+    /// <param name="env">Environment assignments, each <c>NAME=value</c>.</param>
+    /// <param name="toolArgs">Arguments for the tester CLI.</param>
+    /// <returns>The complete argv for <c>docker</c>.</returns>
+    public static string[] ComposedHostRunArgs(
+        string platformImage,
+        string hostDirectory,
+        string? user,
+        IEnumerable<string> mounts,
+        IEnumerable<string> env,
+        IEnumerable<string> toolArgs)
+    {
+        // --init for the same reason as every other run of this tool here (#1741): without it the
+        // tool is the container's PID 1, and a PID-namespace init with SIG_DFL for SIGABRT is
+        // SIGNAL_UNKILLABLE — a crashed process SPINS at 100% CPU instead of exiting.
+        var docker = new List<string> { "run", "--rm", "--init" };
+        if (user is { Length: > 0 })
+        {
+            docker.Add("--user");
+            docker.Add(user);
+        }
+        // HOME=/tmp keeps the runtime's probes off the image's read-only paths — a run as a uid the
+        // image never provisioned has no home otherwise.
+        docker.Add("-e");
+        docker.Add("HOME=/tmp");
+        docker.Add("-v");
+        docker.Add($"{hostDirectory}:{GateHost.HostMount}:ro");
+        foreach (var mount in mounts) { docker.Add("-v"); docker.Add(mount); }
+        foreach (var assignment in env) { docker.Add("-e"); docker.Add(assignment); }
+        // 🚨 `dotnet`, not /app/mw-plugin-test: the ENTRY ASSEMBLY must live on the composed host,
+        // because the framework identity and the TPA are read from the entry assembly's directory.
+        // Starting the portal image's own /app/mw-plugin-test would be starting a binary that is
+        // not there; starting the tester image would restore the subset reference set (#3113).
+        docker.Add("--entrypoint"); docker.Add("dotnet");
+        docker.Add(platformImage);
+        docker.Add($"{GateHost.HostMount}/{GateHost.TesterCli}");
+        docker.AddRange(toolArgs);
+        return [.. docker];
+    }
+
+    /// <summary>Runs the tester CLI out of a composed gate host inside the platform image.</summary>
+    /// <param name="platformImage">The PORTAL image reference.</param>
+    /// <param name="hostDirectory">The composed host on this machine.</param>
+    /// <param name="user"><c>uid:gid</c> to run as, or null for the image's own user.</param>
+    /// <param name="mounts">Bind mounts, each already in <c>host:container[:ro]</c> form.</param>
+    /// <param name="env">Environment assignments, each <c>NAME=value</c>.</param>
+    /// <param name="toolArgs">Arguments for the tester CLI.</param>
+    /// <param name="ct">Cancellation.</param>
+    /// <returns>The container's exit code.</returns>
+    public Task<int> RunOnComposedHost(
+        string platformImage,
+        string hostDirectory,
+        string? user,
+        IEnumerable<string> mounts,
+        IEnumerable<string> env,
+        IEnumerable<string> toolArgs,
+        CancellationToken ct) =>
+        Exec("docker", ComposedHostRunArgs(platformImage, hostDirectory, user, mounts, env, toolArgs), ct);
+
+    /// <summary>
+    /// Extracts an image's <c>/app</c> onto this machine — <c>docker create</c>, <c>docker cp</c>,
+    /// <c>docker rm</c>, the same three commands the lanes run.
+    /// </summary>
+    /// <param name="image">The image reference to extract from.</param>
+    /// <param name="destination">Where <c>/app</c> lands; removed first if it exists.</param>
+    /// <param name="ct">Cancellation.</param>
+    /// <returns>True when the directory was extracted.</returns>
+    public async Task<bool> ExtractApp(string image, string destination, CancellationToken ct)
+    {
+        if (Directory.Exists(destination)) Directory.Delete(destination, recursive: true);
+        Directory.CreateDirectory(Path.GetDirectoryName(destination)!);
+        var container = (await Capture("docker", ["create", image], ct)).Trim();
+        if (container.Length == 0)
+        {
+            await error.WriteLineAsync($"error: could not create a container from '{image}' to read its /app.");
+            return false;
+        }
+        try
+        {
+            if (await Exec("docker", ["cp", $"{container}:/app", destination], ct) != 0)
+            {
+                await error.WriteLineAsync($"error: could not copy /app out of '{image}'.");
+                return false;
+            }
+        }
+        finally
+        {
+            await Exec("docker", ["rm", container], ct);
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// The <c>uid:gid</c> a container should run as so its output is owned by whoever invoked the
+    /// CLI, or null when this platform has no such mapping (Windows) or cannot report one.
+    /// </summary>
+    /// <param name="ct">Cancellation.</param>
+    /// <returns>The <c>uid:gid</c> pair, or null.</returns>
+    public async Task<string?> ResolveInvokingUser(CancellationToken ct)
+    {
+        if (OperatingSystem.IsWindows()) return null;
+        var uid = (await Capture("id", ["-u"], ct)).Trim();
+        var gid = (await Capture("id", ["-g"], ct)).Trim();
+        if (uid.Length > 0 && gid.Length > 0) return $"{uid}:{gid}";
+        await output.WriteLineAsync(
+            "note: could not resolve this user's uid/gid ('id' unavailable) — the run uses the "
+            + "platform image's own user, so anything it writes into an output directory will be "
+            + "owned by that user.");
+        return null;
+    }
+
+    /// <summary>
+    /// Runs a process, echoing its stderr to this runner's error writer, and returns its exit code
+    /// with its stdout.
+    ///
+    /// <para>🚨 Unlike <see cref="Capture"/> this does NOT discard the diagnostic. The
+    /// <c>framework-identity</c> verb writes its verdict — the canonical assemblies each side's
+    /// manifest lacks — to stderr, and that text IS the actionable half of a mismatch (#1814). A
+    /// refusal that swallowed it would report "the images disagree" and name nothing.</para>
+    /// </summary>
+    /// <param name="file">The executable.</param>
+    /// <param name="args">Its arguments.</param>
+    /// <param name="ct">Cancellation.</param>
+    /// <returns>The exit code (127 when the process could not be started) and standard output.</returns>
+    public async Task<(int ExitCode, string StdOut)> CaptureVerbose(
+        string file, IEnumerable<string> args, CancellationToken ct)
+    {
+        var psi = new ProcessStartInfo(file)
+        { UseShellExecute = false, RedirectStandardOutput = true, RedirectStandardError = true };
+        foreach (var a in args) psi.ArgumentList.Add(a);
+        await output.WriteLineAsync($"$ {file} {string.Join(' ', psi.ArgumentList)}");
+        using var p = Process.Start(psi);
+        if (p is null)
+        {
+            await error.WriteLineAsync($"error: could not start '{file}' — is it installed and on PATH?");
+            return (127, string.Empty);
+        }
+        var stdout = await p.StandardOutput.ReadToEndAsync(ct);
+        var stderr = await p.StandardError.ReadToEndAsync(ct);
+        await p.WaitForExitAsync(ct);
+        if (stderr.Length > 0) await error.WriteAsync(stderr);
+        return (p.ExitCode, stdout);
+    }
+
+    /// <summary>
     /// Resolves an image that must NOT be pulled — a locally built one, which no registry has.
     ///
     /// <para>🚨 Never a fallback for a failed pull, and never inferred: <c>docker buildx</c> stamps

--- a/src/MeshWeaver.Cli/MeshWeaver.Cli.csproj
+++ b/src/MeshWeaver.Cli/MeshWeaver.Cli.csproj
@@ -20,4 +20,12 @@
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- 🚨 THE gate-host composition rules, embedded from the ONE file that holds them. The reusable
+         lanes fetch this same path from the platform at their pinned ref; `memex build plugin`
+         extracts it and runs it. A second copy of the rules in C# is exactly the drift trap this
+         repository has paid for repeatedly, so the CLI links the script rather than reimplementing
+         it, and GateHostCompositionTest pins the two to the same bytes. -->
+    <EmbeddedResource Include="..\..\.github\scripts\compose-gate-host.sh" LogicalName="compose-gate-host.sh" />
+  </ItemGroup>
 </Project>

--- a/src/MeshWeaver.Cli/Program.cs
+++ b/src/MeshWeaver.Cli/Program.cs
@@ -282,7 +282,11 @@ static string? PromptForToken()
     var pathArg = new Argument<string>("path")
     { Description = "Path to the plugin repo (the directory mounted as /repo)." };
     var imageOpt = new Option<string>("--image")
-    { Description = "Image to build against, e.g. meshweaver.azurecr.io/mw-plugin-test:<tag>. Pulled and pinned by digest.", Required = true };
+    { Description = "TESTER image, e.g. meshweaver.azurecr.io/mw-plugin-test:<tag>. Pulled and pinned by digest. It EXECUTES the build; it does not supply the reference set.", Required = true };
+    // 🚨 Not `Required = true` on the option: the refusal in BuildPluginCommand explains WHY there is
+    // no fallback to the tester's /app, and "Option '--platform-image' is required." would not.
+    var platformImageOpt = new Option<string?>("--platform-image")
+    { Description = "PORTAL image, e.g. meshweaver.azurecr.io/memex-portal-ai@sha256:… — REQUIRED. It supplies the reference set, the framework identity and the runtime; pin it from the SAME CD wave as --image." };
     var bakeOpt = new Option<string?>("--bake-output")
     { Description = "Directory for the bake (bundles + framework-mvid.txt). Default: a temp dir." };
     var extOpt = new Option<string?>("--external-modules")
@@ -301,7 +305,7 @@ static string? PromptForToken()
     { Description = "Space-separated upstream SOURCES whose sealed publication seeds the gate's mesh (e.g. \"plugins\") — the packages a requires chain reaches, not merely their DLLs." };
 
     var plugin = new Command("plugin", "Build a plugin: install its dependencies, bake its packages, then test the BAKED bytes.")
-    { pathArg, imageOpt, bakeOpt, extOpt, shaOpt, allowOpt, regUrlOpt, regModulesOpt, regKeyOpt, upstreamOpt };
+    { pathArg, imageOpt, platformImageOpt, bakeOpt, extOpt, shaOpt, allowOpt, regUrlOpt, regModulesOpt, regKeyOpt, upstreamOpt };
 
     plugin.SetAction((result, ct) => new BuildPluginCommand(Console.Out, Console.Error).RunAsync(
         new BuildPluginOptions(
@@ -316,6 +320,7 @@ static string? PromptForToken()
             RegistryModules = result.GetValue(regModulesOpt),
             RegistryKey = result.GetValue(regKeyOpt) ?? Environment.GetEnvironmentVariable("MW_REGISTRY_KEY"),
             UpstreamSeed = result.GetValue(upstreamOpt),
+            PlatformImage = result.GetValue(platformImageOpt),
         },
         ct));
 

--- a/src/MeshWeaver.Cli/README.md
+++ b/src/MeshWeaver.Cli/README.md
@@ -25,11 +25,34 @@ The whole CI contract for a plugin repo, in three lines:
 ```yaml
 - uses: actions/checkout@v7
 - run: dotnet tool install -g MeshWeaver.Cli
-- run: memex build plugin . --image meshweaver.azurecr.io/mw-plugin-test:<tag>
+- run: |
+    memex build plugin . \
+      --image meshweaver.azurecr.io/mw-plugin-test@${{ vars.MW_IMAGE_DIGEST }} \
+      --platform-image meshweaver.azurecr.io/memex-portal-ai@${{ vars.MW_PORTAL_IMAGE_DIGEST }}
 ```
 
-The tool pulls the image, **pins it by digest**, and runs the platform's own builder and tester
-inside it. Nothing in the job needs to know about docker, mounts, seeds or allow-files.
+The tool pulls both images, **pins them by digest**, and runs the platform's own builder and tester
+inside them. Nothing in the job needs to know about docker, mounts, seeds or allow-files.
+
+### Two images, two roles
+
+**`--image` EXECUTES; `--platform-image` supplies the reference set.** The tester image's `/app` is a
+strict SUBSET of the portal's — 88 vs 219 assemblies on `3.0.0-rc9.ci.7534`; `MeshWeaver.Maps`,
+`.AI`, `.ContentCollections.Indexing`, the Blazor and hosting halves exist only in the portal — so a
+build that compiled against the tester's could not see what every portal compiles against. Content
+binding a portal-shipped assembly then fails with `CS0234 … does not exist in the namespace
+'MeshWeaver'`: a CONTENT-shaped failure with an INFRASTRUCTURE cause, on source nobody changed.
+
+Both stages therefore run from a **composed gate host** — the portal's `/app` with the tester CLI
+laid beside it, started by the portal image's own `dotnet` — composed by
+`.github/scripts/compose-gate-host.sh`, the same file the reusable node-repo lanes fetch. The CLI
+embeds that script and runs it; it does not carry a second copy of the rules.
+
+🚨 **There is no fallback to the tester's `/app`.** Omit `--platform-image` and the build is REFUSED
+before anything is pulled, and passing the tester image as the platform is refused by name. Pin the
+two digests from ONE CD wave: the run asserts, with the tester's own `framework-identity` verb, that
+the two images resolve ONE framework identity, and that the bake it produces is keyed to the identity
+the platform host resolves.
 
 It runs the two stages the plugin build contract defines, in order:
 
@@ -41,14 +64,15 @@ It runs the two stages the plugin build contract defines, in order:
 
 | option | meaning |
 |---|---|
-| `--image` *(required)* | image to build against; pulled and pinned by digest |
+| `--image` *(required)* | the TESTER image (`mw-plugin-test`); pulled and pinned by digest. It executes the build |
+| `--platform-image` *(required)* | the PORTAL image (`memex-portal-ai`); pulled and pinned by digest. It supplies the reference set, the framework identity and the runtime. No default, no fallback |
 | `--bake-output <dir>` | where the bundles land (default: a temp dir) |
 | `--external-modules <dir>` | module DLLs to mount at `/ext` |
 | `--source-sha <sha>` | commit stamped into the bake |
 | `--allow <file>` | allow-file relative to the plugin path (default `plugin-gate.allow`, used only if present) |
 
-The image is an **argument, not an ambient**: which image a plugin is built against decides the
-result, so it belongs where a reader can see it. A gate that resolves its framework from an
+The images are **arguments, not ambients**: which images a plugin is built against decide the
+result, so they belong where a reader can see them. A gate that resolves its framework from an
 environment variable while advertising a branch name will eventually report a missing type against
 the wrong repository — which is exactly what happened on 2026-08-30.
 
@@ -101,7 +125,9 @@ contains it. From a platform checkout it runs directly:
 
 ```bash
 dotnet run --project src/MeshWeaver.Cli -c Release -- \
-  build plugin ../MeshWeaver.Plugins --image meshweaver.azurecr.io/mw-plugin-test:<tag>
+  build plugin ../MeshWeaver.Plugins \
+  --image meshweaver.azurecr.io/mw-plugin-test:<tag> \
+  --platform-image meshweaver.azurecr.io/memex-portal-ai:<same-wave-tag>
 ```
 
 Same behaviour, no install — useful for trying it on a repo before the tool version is out.

--- a/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InMeshBuildAndTest.md
@@ -132,23 +132,68 @@ The maintainer's shape for a CI job, in four lines:
 ```yaml
 - uses: actions/checkout@v7                                   # 0. checkout git
 - run: dotnet tool install -g MeshWeaver.Cli                  # 1. install the CLI
-- run: memex build plugin <path> --image <image>              # 2. pull it, run in it, build + test
+- run: memex build plugin <path>                              # 2. pull them, run in them, build + test
+    --image <tester> --platform-image <portal>
 ```
 
-**`memex build plugin <path> --image <image>` is the whole contract.** A workflow says *which plugin
-this job is about* and *which image to build it against*; the tool pulls that image, runs the build
-inside it, works out what actually changed, closes over everything that depends on it, builds that,
-runs its tests, and publishes. Nothing else in the job knows about modules, closures, bundles,
-registries or the mesh — and a plugin repo's CI stops being a program about MeshWeaver and becomes
-three lines.
+**`memex build plugin <path> --image <tester> --platform-image <portal>` is the whole contract.** A
+workflow says *which plugin this job is about* and *which images to build it against*; the tool pulls
+them, runs the build inside them, works out what actually changed, closes over everything that
+depends on it, builds that, runs its tests, and publishes. Nothing else in the job knows about
+modules, closures, bundles, registries or the mesh — and a plugin repo's CI stops being a program
+about MeshWeaver and becomes three lines.
 
 The verb shape matters as much as the behaviour: `build` is the command group and `plugin` names
 the subject, so the same tool has room for the other subjects CI needs without every repo growing
 its own script for each.
 
+### Two IMAGES, two roles — the tester executes, the portal is the reference set
+
+**`--image` is the TESTER; `--platform-image` is the PORTAL, and both are required.** The tester
+image's `/app` is a strict SUBSET of the portal's — measured on `3.0.0-rc9.ci.7534`, 88 assemblies
+against 219: `MeshWeaver.Maps`, `MeshWeaver.AI`, `MeshWeaver.ContentCollections.Indexing`, the Blazor
+and hosting halves are in the portal and nowhere else. A build that took its reference set from the
+tester therefore could not see what every portal compiles against, and content binding one of those
+assemblies failed with `CS0234 The type or namespace name 'Maps' does not exist in the namespace
+'MeshWeaver'` — a CONTENT-shaped failure with an INFRASTRUCTURE cause, reported against source nobody
+had changed.
+
+The reusable node-repo lanes moved to the two-image shape first. The CLI path kept running
+`--entrypoint /app/mw-plugin-test` straight from the tester image until
+MeshWeaver.Manufacturing's first adoption went red on `AppleMaps/Gallery` and `Cornerstone/Pricing`
+at the `3.0.0-rc9.ci.7574` pin — the same defect, one lane later.
+
+Both stages now run from a **composed gate host**: the portal's `/app`, complete, with the tester CLI
+laid beside it, started by the portal image's own `dotnet` as
+`dotnet /host/mw-plugin-test.dll … --app /app --shared-frameworks /usr/share/dotnet/shared`. The
+composition rules live in exactly one file, `.github/scripts/compose-gate-host.sh` — the portal's
+files win any collision because the process IS the portal, the tester's surface manifest and
+`deps.json` are never copied, and a directory missing any of those is refused by name. The lanes
+fetch that file from the platform at their pinned ref; the CLI embeds it and runs it. Neither
+carries a second copy of the rules, and a test pins the two to the same bytes.
+
+Embedding rather than fetching also closes the skew the lanes have to live with. A workflow pinned by
+its caller's `uses:` and a script fetched at `platform-ref` are two INDEPENDENTLY pinned artefacts,
+and an old workflow driving a new script is how an empty module set was once sealed while every
+signal stayed green. The CLI ships the caller and the script in ONE package, so the version that
+composes and the version that decides what to do with the composition cannot disagree.
+
+🚨 **There is no fallback to the tester's `/app`, and that is deliberate.** A missing
+`--platform-image` is a refusal before anything is pulled, and the tester passed as the platform is
+refused by name. Silently compiling against the subset is not backwards compatibility — it is the
+defect, and it is invisible on any plugin that happens not to bind a portal-only assembly.
+
+The two pins must come from ONE CD wave, and that is asserted rather than assumed: the tester's own
+`framework-identity` verb reads the portal's `/app` as files and must resolve the identity the tester
+resolves, naming the canonical assemblies each side lacks when it does not. The bake the run produces
+is then checked against that same identity — bundles published under an identity no portal asks for
+are inert, which is how a whole release wave once recompiled everything at boot while CI stayed
+green.
+
 ### The image is an ARGUMENT, not an ambient
 
-`memex build plugin <path> --image <image>` — **the image to build against is passed in.**
+`memex build plugin <path> --image <tester> --platform-image <portal>` — **the images to build
+against are passed in.**
 
 A plugin is built by taking the MeshWeaver image and installing its dependencies as built artifacts
 into it ([the four steps](/Doc/Architecture/PluginBuildContract)). Which image that is decides the

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-plugin-builds-compile-against-the-portal.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-plugin-builds-compile-against-the-portal.md
@@ -1,0 +1,37 @@
+---
+Name: Plugin builds compile against the portal, not the test runner
+Category: Fix
+Description: A plugin built with the memex CLI was compiled against the test runner's smaller set of libraries, so content using a library that only the portal ships failed to build — and the error blamed the content. The build now uses the portal's own libraries, and refuses to start if it is not told which portal to use.
+Icon: Box
+Order: -20260902
+---
+
+# Plugin builds compile against the portal, not the test runner
+
+A plugin is built inside a MeshWeaver image, and until now `memex build plugin` used a single one:
+the test runner. That image carries only what running the tests needs — a little under half of what
+a portal actually ships. Anything a portal has and the test runner does not simply was not there
+while the plugin compiled.
+
+For most plugins that made no difference, which is what made it hard to see. For a plugin using one
+of the portal-only libraries — maps, for instance — the build stopped with *"the type or namespace
+name 'Maps' does not exist"*, pointing at a page that had not been touched in weeks. The message was
+accurate about what the compiler could see and completely misleading about the cause: nothing was
+wrong with the page, the build was simply looking at the wrong shelf.
+
+The build now takes the portal image as well, and compiles against the portal's libraries while the
+test runner does the running. The same page that failed yesterday builds today, unchanged.
+
+Two things follow from that, both deliberate:
+
+- **The portal image has to be named.** `memex build plugin` now takes `--platform-image` alongside
+  `--image`, and refuses to start without it rather than quietly falling back to the test runner. A
+  build against the wrong set of libraries is not a smaller version of a correct build — it is a
+  green result you cannot trust, on every plugin that happens not to touch the missing half.
+- **The two images have to belong together.** The build checks that they come from the same release
+  before it compiles anything, and says which pieces differ when they do not. Mixing them produced
+  packages addressed to a framework no portal ever asks for — packages that sit intact on disk while
+  every portal rebuilds everything from scratch at startup, with nothing reporting it.
+
+The repository's own CI pipelines already worked this way. This brings the command-line tool in
+line, so a plugin repository gets the same answer whichever route it builds through.

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -75,7 +75,8 @@
          not reference, so naming them is honest; adding a ProjectReference just to satisfy a using
          would be the wrong direction. -->
     <Using Include="MeshWeaver.Messaging"
-           Condition="'$(MSBuildProjectName)' != 'MeshWeaver.Json.Test'
+           Condition="'$(MSBuildProjectName)' != 'MeshWeaver.Cli.Test'
+                  and '$(MSBuildProjectName)' != 'MeshWeaver.Json.Test'
                   and '$(MSBuildProjectName)' != 'MeshWeaver.PluginImage.Test'
                   and '$(MSBuildProjectName)' != 'MeshWeaver.Portal.E2E.Test'
                   and '$(MSBuildProjectName)' != 'MeshWeaver.Testing.Xunit'

--- a/test/MeshWeaver.Cli.Test/GateHostCompositionTest.cs
+++ b/test/MeshWeaver.Cli.Test/GateHostCompositionTest.cs
@@ -1,0 +1,302 @@
+using System.Security.Cryptography;
+using MeshWeaver.Cli;
+using Xunit;
+
+namespace MeshWeaver.Cli.Test;
+
+/// <summary>
+/// 🚨 <b><c>memex build plugin</c> composes the PORTAL's reference set, by the LANES' rules</b>
+/// (#3113, the CLI half of #3022/#3071).
+///
+/// <para>The tester image's <c>/app</c> is a strict subset of the portal's — 88 vs 219 assemblies on
+/// 3.0.0-rc9.ci.7534 — so a build that ran straight from the tester's entrypoint could not compile
+/// content binding <c>MeshWeaver.Maps</c>, <c>.AI</c> or <c>.ContentCollections.Indexing</c>. On
+/// MeshWeaver.Manufacturing#48 that surfaced as <c>CS0234 … 'Maps' does not exist in the namespace
+/// 'MeshWeaver'</c> against <c>AppleMaps/Gallery</c> and <c>Cornerstone/Pricing</c>: a CONTENT-shaped
+/// failure with an INFRASTRUCTURE cause, on source nobody had changed.</para>
+///
+/// <para>Every assertion here is over a PURE seam. The failure being defended against is not a crash
+/// but a run that SUCCEEDS against the wrong reference set, which is indistinguishable from a real
+/// pass anywhere except in the argv and in which rules composed the host — so those are what is
+/// pinned, and neither needs a docker daemon CI would have to skip.</para>
+/// </summary>
+public class GateHostCompositionTest
+{
+    private const string Portal = "meshweaver.azurecr.io/memex-portal-ai@sha256:0123456789abcdef";
+    private const string Tester = "meshweaver.azurecr.io/mw-plugin-test@sha256:fedcba9876543210";
+    private const string Host = "/tmp/memex-host-1/gate-host";
+
+    // ── the composition rules are ONE implementation ──────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 <b>THE DRIFT GUARD.</b> The CLI carries <c>.github/scripts/compose-gate-host.sh</c> — the
+    /// very file the reusable lanes fetch from the platform at their pinned ref — not a C# port of
+    /// its rules. Its ordering (portal first and complete; tester files added only where the portal
+    /// has none; the tester's manifest and <c>deps.json</c> never copied) and its fail-closed
+    /// refusals were each derived from a measured incident, and a second copy of them would be the
+    /// trap this repository has paid for repeatedly: three defects in one day were N drifted copies
+    /// of a rule whose own comment claimed it had one.
+    ///
+    /// <para>Byte equality, not "contains the same rules": a paraphrase is a copy.</para>
+    /// </summary>
+    [Fact]
+    public void TheEmbeddedComposeScript_IsTheLanesScript_ByteForByte()
+    {
+        var onDisk = Path.Combine(FindRepoRoot(), ".github", "scripts", "compose-gate-host.sh");
+        Assert.True(File.Exists(onDisk),
+            $"{onDisk} is missing — it is the ONE implementation of the gate-host composition rules, "
+            + "fetched by node-repo-gate.yml / node-repo-publish-bake.yml / node-repo-module-pack.yml "
+            + "and embedded by MeshWeaver.Cli.");
+
+        var embedded = GateHost.ComposeScriptBytes();
+        Assert.Equal(
+            Convert.ToHexString(SHA256.HashData(File.ReadAllBytes(onDisk))),
+            Convert.ToHexString(SHA256.HashData(embedded)));
+    }
+
+    /// <summary>
+    /// The CLI extracts that script to run it — the extraction is the whole of its composition, so a
+    /// silently empty or partial write would leave the build with no portal reference set at all.
+    /// </summary>
+    [Fact]
+    public void ExtractComposeScript_WritesTheScriptWhereTheCliRunsIt()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"mw-cli-compose-{Guid.NewGuid():N}");
+        try
+        {
+            var path = GateHost.ExtractComposeScript(dir);
+            Assert.Equal(Path.Combine(dir, "compose-gate-host.sh"), path);
+            Assert.Equal(GateHost.ComposeScriptBytes(), File.ReadAllBytes(path));
+            // The lanes `chmod +x` the script they fetch, and so must this: the script re-invokes
+            // itself by path to prove its own rules, so a 0644 copy cannot run its self-test.
+            if (!OperatingSystem.IsWindows())
+                Assert.True(File.GetUnixFileMode(path).HasFlag(UnixFileMode.UserExecute),
+                    "the extracted compose script must be executable");
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 The extracted script RUNS, and its rules FIRE. Byte equality proves the CLI stores the
+    /// lanes' file; this proves the CLI can execute it — the same <c>--self-test</c> the platform's
+    /// own preflight runs on <c>.github/scripts/compose-gate-host.sh</c>, driven from the bytes the
+    /// CLI would actually put on disk. It asserts that the portal wins a shared file, that
+    /// tester-only files ride, that the tester's manifest and <c>deps.json</c> do not, and that every
+    /// refusal is non-zero.
+    ///
+    /// <para>No skip: <c>bash</c> is a hard requirement of this verb (it is how the host gets
+    /// composed at all), so its absence is a failure here exactly as it is a failure in the build.
+    /// A test that skipped instead would render the same green tick as a passing one.</para>
+    /// </summary>
+    [Fact]
+    public async Task TheExtractedScript_PassesItsOwnSelfTest()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"mw-cli-selftest-{Guid.NewGuid():N}");
+        try
+        {
+            var script = GateHost.ExtractComposeScript(dir);
+            var psi = new System.Diagnostics.ProcessStartInfo("bash")
+            { UseShellExecute = false, RedirectStandardOutput = true, RedirectStandardError = true };
+            psi.ArgumentList.Add(script);
+            psi.ArgumentList.Add("--self-test");
+
+            using var process = System.Diagnostics.Process.Start(psi);
+            Assert.NotNull(process);
+            var stdout = await process.StandardOutput.ReadToEndAsync(TestContext.Current.CancellationToken);
+            var stderr = await process.StandardError.ReadToEndAsync(TestContext.Current.CancellationToken);
+            await process.WaitForExitAsync(TestContext.Current.CancellationToken);
+
+            Assert.True(process.ExitCode == 0,
+                $"the embedded compose-gate-host.sh failed its own self-test:\n{stdout}\n{stderr}");
+            Assert.Contains("self-test: OK", stdout);
+        }
+        finally
+        {
+            if (Directory.Exists(dir)) Directory.Delete(dir, recursive: true);
+        }
+    }
+
+    // ── the temp trees are removed, and cleanup cannot decide the verdict ─────────────────────
+
+    /// <summary>
+    /// Two <c>/app</c> extractions plus the composed host is roughly a gigabyte, and the temp path
+    /// carries the process id — so nothing ever reuses it and stale copies accumulate until the
+    /// disk is full.
+    /// </summary>
+    [Fact]
+    public async Task DiscardTree_RemovesTheTree()
+    {
+        var dir = Path.Combine(Path.GetTempPath(), $"mw-cli-discard-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(Path.Combine(dir, "portal-app", "modules", "X"));
+        await File.WriteAllTextAsync(
+            Path.Combine(dir, "portal-app", "modules", "X", "X.dll"), "bytes",
+            TestContext.Current.CancellationToken);
+
+        var notes = new StringWriter();
+        await GateHost.DiscardTree(dir, notes);
+
+        Assert.False(Directory.Exists(dir));
+        Assert.Equal(string.Empty, notes.ToString());
+    }
+
+    /// <summary>A path that is already gone is a no-op, not a throw — every early refusal in the
+    /// verb returns before anything is extracted and still runs the cleanup.</summary>
+    [Fact]
+    public async Task DiscardTree_OnAnAbsentPath_IsSilent()
+    {
+        var notes = new StringWriter();
+        await GateHost.DiscardTree(
+            Path.Combine(Path.GetTempPath(), $"mw-cli-absent-{Guid.NewGuid():N}"), notes);
+        Assert.Equal(string.Empty, notes.ToString());
+    }
+
+    /// <summary>
+    /// 🚨 A tree that CANNOT be removed must not decide the build's verdict — and must not vanish
+    /// in silence either. Arranged for real by taking write permission off the parent, so the
+    /// delete genuinely fails rather than being simulated.
+    /// </summary>
+    [Fact]
+    public async Task DiscardTree_ThatCannotBeRemoved_ReportsAndDoesNotThrow()
+    {
+        Assert.SkipWhen(OperatingSystem.IsWindows(),
+            "arranged through unix directory permissions; the Windows model differs");
+        // SkipWhen already ended the test above; CA1416 cannot see that a throwing helper is a
+        // platform guard, so this is the check the analyzer reads. Not a second policy.
+        if (OperatingSystem.IsWindows()) return;
+
+        var parent = Path.Combine(Path.GetTempPath(), $"mw-cli-locked-{Guid.NewGuid():N}");
+        var child = Path.Combine(parent, "gate-host");
+        Directory.CreateDirectory(child);
+        await File.WriteAllTextAsync(
+            Path.Combine(child, "mw-plugin-test.dll"), "bytes", TestContext.Current.CancellationToken);
+        File.SetUnixFileMode(parent, UnixFileMode.UserRead | UnixFileMode.UserExecute);
+        try
+        {
+            var notes = new StringWriter();
+            await GateHost.DiscardTree(child, notes);   // must not throw
+
+            Assert.Contains("could not remove the temporary directory", notes.ToString());
+            Assert.Contains(child, notes.ToString());
+        }
+        finally
+        {
+            File.SetUnixFileMode(
+                parent, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+            Directory.Delete(parent, recursive: true);
+        }
+    }
+
+    // ── the argv: what the two stages actually run ────────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 <b>THE REGRESSION GUARD for #3113.</b> The run starts the PLATFORM image's own
+    /// <c>dotnet</c> on the tester CLI taken from the COMPOSED HOST. Point the entrypoint back at
+    /// the tester image (<c>--entrypoint /app/mw-plugin-test &lt;tester&gt;</c>, what this verb did
+    /// until now) and every assertion below fails — which is the only way the wrong reference set
+    /// is observable, since the run itself would still exit 0 on content that binds nothing
+    /// portal-only.
+    /// </summary>
+    [Fact]
+    public void EveryRun_StartsThePlatformImagesDotnet_OnTheComposedHostsTesterCli()
+    {
+        var args = ImageRunner.ComposedHostRunArgs(Portal, Host, "1001:1001", [], [], ["/repo"]);
+
+        var image = Array.IndexOf(args, Portal);
+        Assert.True(image > 0, "the PLATFORM image reference must appear in the argv");
+        Assert.DoesNotContain(args, a => a.Contains("mw-plugin-test@", StringComparison.Ordinal));
+
+        // Everything before the image is docker's; everything after it is the tool's. A flag that
+        // drifts past the image is not a flag any more — docker never sees it and mw-plugin-test
+        // takes it as an unknown argument, so the run silently stops being composed.
+        var docker = args[..image];
+        Assert.Contains("--rm", docker);
+        Assert.Contains("--init", docker);
+        AssertAdjacent(docker, "--entrypoint", "dotnet");
+        AssertAdjacent(docker, "-v", $"{Host}:/host:ro");
+
+        // The ENTRY ASSEMBLY must be the one on the composed host: the framework identity and the
+        // TPA are both read from the entry assembly's directory.
+        Assert.Equal("/host/mw-plugin-test.dll", args[image + 1]);
+        Assert.Equal("/repo", args[image + 2]);
+    }
+
+    /// <summary>
+    /// The portal image runs as root, so a run that did not adopt the invoking user's uid would
+    /// leave every bundle it writes root-owned and unrewritable by the rest of the caller's job —
+    /// the reason node-repo-publish-bake.yml and node-repo-module-pack.yml both pass
+    /// <c>$(id -u):$(id -g)</c>. <c>HOME</c> rides with it: a uid the image never provisioned has no
+    /// home, and the runtime's probes would fall on the image's read-only paths.
+    /// </summary>
+    [Fact]
+    public void TheRun_AdoptsTheInvokingUser_AndGivesItAWritableHome()
+    {
+        var args = ImageRunner.ComposedHostRunArgs(Portal, Host, "1001:123", [], [], ["/repo"]);
+        AssertAdjacent(args[..Array.IndexOf(args, Portal)], "--user", "1001:123");
+        AssertAdjacent(args[..Array.IndexOf(args, Portal)], "-e", "HOME=/tmp");
+    }
+
+    /// <summary>On a platform with no uid mapping the flag is omitted rather than invented.</summary>
+    [Fact]
+    public void WithoutAnInvokingUser_NoUserFlagIsInvented()
+    {
+        var args = ImageRunner.ComposedHostRunArgs(Portal, Host, user: null, [], [], ["/repo"]);
+        Assert.DoesNotContain("--user", args);
+        AssertAdjacent(args[..Array.IndexOf(args, Portal)], "-e", "HOME=/tmp");
+    }
+
+    /// <summary>Mounts and environment reach docker, in docker's half of the argv.</summary>
+    [Fact]
+    public void MountsAndEnvironment_LandBeforeTheImage()
+    {
+        var args = ImageRunner.ComposedHostRunArgs(
+            Portal, Host, "0:0", ["/w/repo:/repo", "/w/bake:/seed:ro"], ["MW_INSTALL_DIFF=1"],
+            ["/repo", "--seed", "/seed"]);
+        var docker = args[..Array.IndexOf(args, Portal)];
+        AssertAdjacent(docker, "-v", "/w/repo:/repo");
+        AssertAdjacent(docker, "-v", "/w/bake:/seed:ro");
+        AssertAdjacent(docker, "-e", "MW_INSTALL_DIFF=1");
+    }
+
+    /// <summary>
+    /// The reference set the compile stage names: the platform's <c>/app</c> plus its IMPLEMENTATION
+    /// frameworks — what a portal's runtime compile sees. Both halves, because <c>--app</c> and
+    /// <c>--shared-frameworks</c> are refused separately by the tester ("they go together").
+    /// </summary>
+    [Fact]
+    public void TheSharedFrameworksRoot_IsThePlatformsImplementationRuntime() =>
+        Assert.Equal("/usr/share/dotnet/shared", GateHost.SharedFrameworks);
+
+    // ── the refusal: the tester passed as the platform ────────────────────────────────────────
+
+    /// <summary>
+    /// 🚨 The one wrong value nothing else can refuse: the TESTER handed in as
+    /// <c>--platform-image</c>, which would silently restore the very reference-set gap the argument
+    /// closes. node-repo-gate.yml refuses it by name; so does this.
+    /// </summary>
+    [Theory]
+    [InlineData("meshweaver.azurecr.io/mw-plugin-test:3.0.0-rc9.ci.7574", true)]
+    [InlineData("meshweaver.azurecr.io/MW-Plugin-Test@sha256:abc", true)]
+    [InlineData("meshweaver.azurecr.io/memex-portal-ai@sha256:abc", false)]
+    [InlineData("ghcr.io/systemorph/memex-portal-ai:main", false)]
+    public void ATesterReference_IsRecognisedAsTheWrongPlatformImage(string image, bool isTester) =>
+        Assert.Equal(isTester, GateHost.NamesTheTesterImage(image));
+
+    private static void AssertAdjacent(string[] args, string flag, string value)
+    {
+        for (var i = 0; i + 1 < args.Length; i++)
+            if (args[i] == flag && args[i + 1] == value)
+                return;
+        Assert.Fail($"expected '{flag} {value}' in: {string.Join(' ', args)}");
+    }
+
+    internal static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        return dir?.FullName ?? throw new InvalidOperationException("repo root not found");
+    }
+}

--- a/test/MeshWeaver.Cli.Test/MeshWeaver.Cli.Test.csproj
+++ b/test/MeshWeaver.Cli.Test/MeshWeaver.Cli.Test.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <!-- The CLI is an Exe; a test project referencing it gets memex.dll in its bin, which is all
+         these tests need — every assertion here is over PURE seams (the docker argv, the embedded
+         composition script, the argument refusals). Nothing here starts docker: the defect #3113
+         guards against is not a crash but a run that succeeds against the WRONG reference set, and
+         that is decided in the argv, which needs no daemon. A docker-shaped test would have to be
+         skipped on CI, and a skipped gate renders the same green tick as a passing one. -->
+    <ProjectReference Include="..\..\src\MeshWeaver.Cli\MeshWeaver.Cli.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/MeshWeaver.Cli.Test/PlatformImageIsRequiredTest.cs
+++ b/test/MeshWeaver.Cli.Test/PlatformImageIsRequiredTest.cs
@@ -1,0 +1,90 @@
+using MeshWeaver.Cli;
+using Xunit;
+
+namespace MeshWeaver.Cli.Test;
+
+/// <summary>
+/// 🚨 <b>There is NO fallback to the tester's <c>/app</c></b> (#3113). <c>memex build plugin</c>
+/// refuses when no PORTAL image is supplied, exactly as <c>node-repo-gate.yml</c> does
+/// (<i>"platform-image-digest is empty and allow-unpinned is not set … There is no fallback to the
+/// tester's /app"</i>).
+///
+/// <para>Silently compiling against the tester's subset reference set is not backwards
+/// compatibility, it IS the defect: it produces a green run for content that binds nothing
+/// portal-only and a <c>CS0234</c> on content that does, attributed to the content. A refusal is
+/// legible; a wrong reference set is not.</para>
+///
+/// <para>🚨 Each case asserts that <b>nothing was run</b> as well as the exit code. <see
+/// cref="ImageRunner"/> echoes every process it starts to stdout (<c>$ docker pull …</c>), so an
+/// empty stdout is the positive evidence that the refusal happened BEFORE the first pull — the
+/// property that makes a misconfigured job fail in seconds naming its input rather than minutes
+/// later inside a container. The verb's first version put a check after stage 1 and the "proof" of
+/// its refusal path had actually died at the container entrypoint before ever reaching it.</para>
+/// </summary>
+public class PlatformImageIsRequiredTest : IDisposable
+{
+    private readonly string _repo = Path.Combine(Path.GetTempPath(), $"mw-cli-repo-{Guid.NewGuid():N}");
+    private readonly StringWriter _out = new();
+    private readonly StringWriter _err = new();
+
+    public PlatformImageIsRequiredTest() => Directory.CreateDirectory(_repo);
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_repo)) Directory.Delete(_repo, recursive: true);
+        GC.SuppressFinalize(this);
+    }
+
+    private Task<int> Run(string? platformImage) =>
+        new BuildPluginCommand(_out, _err).RunAsync(
+            new BuildPluginOptions(_repo, "meshweaver.azurecr.io/mw-plugin-test@sha256:deadbeef")
+            { PlatformImage = platformImage },
+            TestContext.Current.CancellationToken);
+
+    [Fact]
+    public async Task WithoutAPlatformImage_TheBuildIsRefusedBeforeAnythingIsPulled()
+    {
+        Assert.Equal(9, await Run(null));
+
+        var message = _err.ToString();
+        Assert.Contains("--platform-image is required", message);
+        // The refusal must say WHY, or the next reader "fixes" it by removing the argument again.
+        Assert.Contains("no fallback to the tester's", message);
+        Assert.Equal(string.Empty, _out.ToString());
+    }
+
+    [Fact]
+    public async Task AnEmptyPlatformImage_IsTheSameAsNone()
+    {
+        Assert.Equal(9, await Run(""));
+        Assert.Contains("--platform-image is required", _err.ToString());
+        Assert.Equal(string.Empty, _out.ToString());
+    }
+
+    [Fact]
+    public async Task TheTesterImagePassedAsThePlatform_IsRefusedByName()
+    {
+        Assert.Equal(9, await Run("meshweaver.azurecr.io/mw-plugin-test@sha256:deadbeef"));
+
+        var message = _err.ToString();
+        Assert.Contains("names the TESTER image", message);
+        Assert.Contains("memex-portal-ai", message);
+        Assert.Equal(string.Empty, _out.ToString());
+    }
+
+    /// <summary>
+    /// The refusals above must not shadow the checks that already ran first — a plugin path that
+    /// does not exist is still the first thing reported, and it is reported as itself.
+    /// </summary>
+    [Fact]
+    public async Task AMissingPluginPath_IsStillTheFirstThingReported()
+    {
+        var rc = await new BuildPluginCommand(_out, _err).RunAsync(
+            new BuildPluginOptions(
+                Path.Combine(_repo, "nope"), "meshweaver.azurecr.io/mw-plugin-test@sha256:deadbeef"),
+            TestContext.Current.CancellationToken);
+
+        Assert.Equal(2, rc);
+        Assert.Contains("does not exist", _err.ToString());
+    }
+}


### PR DESCRIPTION
Fixes #3113.

## The defect

`memex build plugin` ran `docker run … --entrypoint /app/mw-plugin-test <tester>` directly, so it
compiled against the **tester** image's `/app` — a strict SUBSET of the portal's (88 vs 219
assemblies on `3.0.0-rc9.ci.7534`; `MeshWeaver.Maps`, `.AI`, `.ContentCollections.Indexing`, the
Blazor and hosting halves exist only in the portal). Content binding a portal-shipped assembly could
not compile, and the failure read as a CONTENT error on source nobody had changed:

```
fail: MeshNodeCompilationService Failed to compile assembly for node 'AppleMaps/Gallery' …
      CS0234 (line 33): The type or namespace name 'Maps' does not exist in the namespace 'MeshWeaver'
fail: MeshNodeCompilationService Failed to compile assembly for node 'Cornerstone/Pricing' … CS0234
```

This is the **same defect #3022/#3071 fixed for every reusable lane**, surviving on the CLI path. It
blocks MeshWeaver.Manufacturing#48, whose `memex build plugin (new build process)` job is red on
every run at the current pin.

## The fix — the lanes' two-image contract, on the CLI

* **`--platform-image` is REQUIRED** beside `--image`. The tester EXECUTES; the portal supplies the
  reference set, the framework identity and the runtime. **No fallback to the tester's `/app`** —
  omitting it is a refusal, and passing the tester as the platform is refused by name. Both happen
  BEFORE the first `docker pull`, so a misconfigured job fails in seconds naming its input.
* **Both `/app` are extracted and their shapes asserted** — the tester must ship
  `mw-plugin-test.dll`, the portal a non-empty `meshweaver-surface.manifest` (a host without one
  resolves the fallback identity no bake may be keyed to).
* **ONE BUILD, asserted.** The tester's own `framework-identity … --expect` verb must report that
  the two images resolve one identity, and its stderr verdict — which names the canonical assemblies
  each side lacks (#1814) — is forwarded rather than swallowed.
* **The gate host is composed by `.github/scripts/compose-gate-host.sh`**, and both stages run
  `--entrypoint dotnet <portal> /host/mw-plugin-test.dll … --app /app` (plus
  `--shared-frameworks /usr/share/dotnet/shared` on the compile), as the invoking uid with
  `HOME=/tmp`. Same shape as `node-repo-gate.yml`, deliberately.
* **The run's own bake is checked against the platform's identity** — bundles published under an
  identity no portal asks for are inert.
* **The upstream seed and the sealed module set are addressed by the PLATFORM's identity**, not the
  tester's. Previously the seed was fetched under the tester's; that addressed a publication the
  gate would never adopt.

### One implementation of the composition rules, not two

🚨 The composition rules are **not** reimplemented in C#. `MeshWeaver.Cli.csproj` embeds
`.github/scripts/compose-gate-host.sh` — the very file the lanes fetch from the platform at their
pinned ref — and the CLI extracts and runs it. `GateHostCompositionTest` pins the two to the same
SHA-256, so a divergent copy fails the build rather than drifting silently.

## Verification

* `dotnet build -c Release -warnaserror`: `MeshWeaver.Cli`, `MeshWeaver.Documentation`,
  `MeshWeaver.Documentation.Test`, `MeshWeaver.Cli.Test` — **0 Error(s), 0 Warning(s)** each.
* `test/MeshWeaver.Cli.Test` (new): **16/16**, unfiltered. `test/MeshWeaver.Documentation.Test`:
  **202/202**, unfiltered.
* **Proven to fail without the fix.** With the entrypoint pointed back at the tester image and the
  `--platform-image` guard replaced by a fall-back-to-`--image`, 7 of 15 went red — including the
  three refusal tests, which then spent 20 s each actually reaching `docker pull`. That is the
  property the tests assert: `ImageRunner` echoes every process it starts, so an **empty stdout** is
  the positive evidence that the refusal happened before anything was pulled.
* `bash .github/scripts/compose-gate-host.sh --self-test` → OK; `bash -n` clean;
  `shellcheck -S warning` clean. (The script itself is unchanged — it is reused, not edited.) The
  new `TheExtractedScript_PassesItsOwnSelfTest` drives that same self-test from the bytes the CLI
  puts on disk.
* `dotnet pack` succeeds and the shipped `tools/net10.0/any/memex.dll` carries the script.

### A finding the test produced

The first run of `TheExtractedScript_PassesItsOwnSelfTest` failed with `Permission denied`:
`File.WriteAllBytes` writes 0644, and the script re-invokes **itself by path** to prove each of its
rules. The lanes `chmod +x` the script they fetch; `ExtractComposeScript` now does the same. The
production path (`bash <script> …`) would have worked either way — but a self-test that cannot
execute is a proof that verified nothing, which is exactly the shape this repo's rules forbid.

## Strings

Every string added is an **operator diagnostic** on a CI tool's stdout/stderr — a build refusal
naming an image, a `/app`, a framework identity. English by the
[Localization](https://github.com/Systemorph/MeshWeaver/blob/main/src/MeshWeaver.Documentation/Data/Architecture/Localization.md)
boundary ("a viewer's message vs. an owner's diagnostic"), consistent with the rest of this CLI,
which contains zero `Localize(` calls. Nothing here reaches a portal viewer.

## Docs

`Doc/Architecture/InMeshBuildAndTest` gains a "Two IMAGES, two roles" section (what the tester's
subset cannot compile, why there is no fallback, where the one copy of the rules lives);
`src/MeshWeaver.Cli/README.md` is updated; a What's New entry (`Category: Fix`) ships with it.

## Follow-up (separate repo, after this publishes)

MeshWeaver.Manufacturing#48's `memex build plugin` job must add
`--platform-image meshweaver.azurecr.io/memex-portal-ai@${{ vars.MW_PORTAL_IMAGE_DIGEST }}` once a
`MeshWeaver.Cli` carrying this lands — the variable its own `node-repo-*` lanes already read. Until
then that job refuses with a named reason instead of failing on `CS0234` against innocent content.

Pairs-with: none — no public type is removed; `GateHost` and the `ImageRunner` members are additions,
and `PlatformImage` is an init-property (not a primary-constructor parameter, so the record's
synthesized arity is unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
