### PR TITLE
fix: a build grant committed after its candidate stood down no longer wedges the build

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BuildCoordination.md
@@ -306,7 +306,26 @@ never run — holding the claim at `Planning`, never heartbeating, and never tak
 process is alive and the takeover rule below defends a live holder by design (a stopped heartbeat on
 a live process means busy, not dead). The *next* image's fingerprint could then never be claimed and never get a GO, holding
 every silo's readiness down. `WithdrawBuildClaim` removes the registration and gives back a claim
-that raced it; both halves are conditional, so they are safe against a concurrent grant.
+that raced it.
+
+🚨 **Standing down cannot be made safe from the candidate's side alone (#1193).** Both halves of
+`WithdrawBuildClaim` are conditional on state the arbiter is about to change, and an arbitration
+pass spans two storage round-trips: it reads the candidate set off the mirror, reads the lock,
+commits the compare-and-set, and only then publishes the grant. A follower that stands down inside
+that window removes a registration the pass has already captured, and finds no lock of its own to
+release — so the pass commits a grant to a process that has finished with the build. **Conditional
+writes make each half safe on its own; they cannot order two writers.** Depending on the
+interleaving the debris is either the mirror's claim projection or the durable lock, and the
+takeover rule then defends it *because the process really is alive*. Measured on
+`BuildCoordinationTest.Follower_StandsDown_SoTheNextBuildCanStillBeClaimed`: 2 failures in 15 runs
+on an **idle** machine, the build node left at `ClaimedBy=<the follower>, Status=Planning`.
+
+So the arbiter re-checks at the point where it can: **`ApplyGrant` refuses to publish a grant whose
+winner is neither the holder the mirror already names nor still a candidate**, and a refused
+publication **hands the lock straight back** (`HandBackAStoodDownGrant`) — the arbiter is the lock's
+only writer, so undoing its own commit is the only place this can be closed. The guard's first
+clause is load-bearing: a holder *mid-bake* has no registration left either, its own grant having
+consumed it.
 
 There is deliberately **no timer and no bound bolted onto the wait**. A bound would end the wait by
 guessing, and a follower that guesses "the build finished" certifies a share it never probed — a

--- a/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/BuildNodeType.cs
@@ -414,10 +414,80 @@ public static class BuildNodeType
                 // ObserveBuildClaim emits — the field set only, never a wholesale replace: a
                 // registration written milliseconds ago may not have reached storage, and replacing
                 // the mirror would drop it and strand its candidate.
+                //
+                // 🚨 …and the publish may REFUSE (#1193). `pending` was read off this mirror two
+                // storage round-trips ago, and a candidate is free to stand down inside that
+                // window. ApplyGrant is the serialised point that can still see it did, so the
+                // refusal is authoritative — and it is the arbiter's job, not the candidate's, to
+                // put the lock back where it found it.
                 return workspace.GetMeshNodeStream()
                     .Update(current => ApplyGrant(current, granted, options))
-                    .Select(_ => Unit.Default);
+                    .Take(1)
+                    .SelectMany(published => HandBackAStoodDownGrant(
+                        storage, options, logger, granted, claimPath, published));
             });
+    }
+
+    /// <summary>
+    /// Undoes a grant the mirror REFUSED to publish, by releasing the lock this pass just took
+    /// (#1193).
+    ///
+    /// <para><b>Why a grant can need undoing.</b> The candidate set is read off the mirror at the
+    /// START of an arbitration pass and the grant is committed two storage round-trips later. A
+    /// follower that reaches its answer some other way stands down inside that window
+    /// (<c>WithdrawBuildClaim</c>), and BOTH of its halves are conditional on state this pass is
+    /// about to change: it removes its registration, then finds no lock of its own to release. The
+    /// pass then commits a grant to a process that has already finished with the build and is no
+    /// longer listening.</para>
+    ///
+    /// <para>Where the debris lands depends on how the two writers interleave, and neither
+    /// half converges on its own:</para>
+    /// <list type="bullet">
+    /// <item>the mirror's claim PROJECTION keeps naming the withdrawn candidate at
+    /// <see cref="BuildStatus.Planning"/> — measured, and on a host whose arbiter decides on the
+    /// mirror (<c>GrantOnMirror</c>: no durable store, or the fail-open path) that projection IS
+    /// the claim;</item>
+    /// <item>or the claim LOCK does — the one witness every cluster's arbiter decides on — when the
+    /// stand-down read it a moment before this pass wrote it.</item>
+    /// </list>
+    ///
+    /// <para>Either way <see cref="HolderStillHoldsIt"/> then defends it BY DESIGN, because the
+    /// process really is alive (#1355: a stopped heartbeat on a running process means busy, not
+    /// dead). With cluster membership the claim is never taken over at all; without it every later
+    /// candidate waits out <see cref="ClaimStaleAfter"/> and is handed the same dead claim again.
+    /// No builder, no bake, no ready pod — the readiness stall #1440 fixed from the candidate's
+    /// side, arriving instead through the arbiter's own commit.</para>
+    ///
+    /// <para>Level-triggered on real state, with no timing anywhere: the mirror either names our
+    /// winner as holder (published — nothing to do) or it does not (refused), and the lock is
+    /// dropped only while it still names that winner, so a pass that lost a later race removes
+    /// nothing. The delete publishes on the store's change feed, which is the arbiter's own
+    /// trigger, so a queued candidate is elected immediately rather than at the slow tick.</para>
+    /// </summary>
+    internal static IObservable<Unit> HandBackAStoodDownGrant(
+        IStorageAdapter storage,
+        System.Text.Json.JsonSerializerOptions options,
+        ILogger? logger,
+        BuildState granted,
+        string claimPath,
+        MeshNode? published)
+    {
+        if (published?.ContentAs<BuildState>(options)?.ClaimedBy == granted.ClaimedBy)
+            return Observable.Return(Unit.Default);
+
+        logger?.LogInformation(
+            "Build claim {ClaimPath}: {Holder} won the lock but had already STOOD DOWN before the "
+            + "grant could be published, so the build would have stayed locked to a live process "
+            + "that is no longer listening. Releasing the lock — the next candidate elects freely.",
+            claimPath, granted.ClaimedBy);
+
+        return storage.Read(claimPath, options)
+            .Take(1)
+            .SelectMany(held =>
+                held is not null
+                && held.ContentAs<BuildState>(options)?.ClaimedBy == granted.ClaimedBy
+                    ? storage.DeleteIfExists(claimPath).Take(1).Select(_ => Unit.Default)
+                    : Observable.Return(Unit.Default));
     }
 
     /// <summary>
@@ -439,13 +509,30 @@ public static class BuildNodeType
     /// Applies a grant this cluster WON durably onto its own mirror — the claim field set only, so
     /// nothing the mirror holds and storage has not seen yet is lost.
     /// </summary>
-    private static MeshNode ApplyGrant(
+    internal static MeshNode ApplyGrant(
         MeshNode node, BuildState granted, System.Text.Json.JsonSerializerOptions options)
     {
         if (node is null) return node!;
         var state = node.ContentAs<BuildState>(options) ?? new BuildState();
         if (state.ClaimedBy == granted.ClaimedBy && state.Status == granted.Status)
             return node;   // already reflects this grant — a redundant pass writes nothing
+
+        // 🚨 THE WINNER MUST STILL BE A CANDIDATE AT PUBLISH TIME (#1193). The election ran on a
+        // candidate set read before two storage round-trips, and a follower that reached its answer
+        // some other way stands down inside that window (WithdrawBuildClaim). This lambda runs on
+        // the node's own serialised write path, so it is the last — and only — point that can still
+        // see that it did. Publishing anyway leaves the projection naming a live process that will
+        // never act on the build and never release it, and the takeover rule then defends that
+        // holder BY DESIGN; see HandBackAStoodDownGrant for the whole failure and its measurement.
+        //
+        // The guard is "neither holder nor candidate", and the first clause is load-bearing: a
+        // holder MID-BAKE has no registration left either — its own grant consumed it — so a bare
+        // "is it still queued?" test would read a running bake as a candidate that stood down.
+        if (state.ClaimedBy != granted.ClaimedBy
+            && granted.ClaimedBy is { } winner
+            && state.RequestedClaims?.ContainsKey(winner) != true)
+            return node;
+
         return node with
         {
             Content = state with

--- a/test/MeshWeaver.Graph.Test/BuildGrantPublicationTest.cs
+++ b/test/MeshWeaver.Graph.Test/BuildGrantPublicationTest.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// PUBLISHING a grant the election already decided — the second half of an arbitration pass, and
+/// the half that wedged a build (#1193).
+///
+/// <para><b>The defect.</b> <c>ArbitrateDurably</c> reads the candidate set off this cluster's
+/// mirror, then reads the claim LOCK, then commits with a compare-and-set, then publishes the grant
+/// on the Build node. Two storage round-trips separate the election from the publication, and a
+/// candidate is free to STAND DOWN inside that window: a follower that saw the GO calls
+/// <c>WithdrawBuildClaim</c>, which removes its registration and then finds the lock still unheld,
+/// so its release half is a no-op. The pass then writes the lock naming a process that is not
+/// listening and never will be.</para>
+///
+/// <para><b>Why that is permanent rather than merely wrong.</b> The takeover rule defends a LIVE
+/// holder by design (<c>#1355</c>: a stopped heartbeat on a running process means busy, not dead).
+/// With cluster membership the claim is therefore never taken over at all; without it every later
+/// candidate waits out <c>ClaimStaleAfter</c> and is handed the same dead claim again. No builder
+/// is elected, no NodeType is baked, no pod reaches ready — the readiness stall #1440 fixed from
+/// the candidate's side, arriving instead through the arbiter's own commit.</para>
+///
+/// <para><b>Measured</b>, on <c>MeshWeaver.Hosting.Monolith.Test.BuildCoordinationTest
+/// .Follower_StandsDown_SoTheNextBuildCanStillBeClaimed</c>: <b>2 failures in 15 runs on a
+/// completely idle machine</b> — so load was not the cause; the control ran without any. The state
+/// dumped at the failure was <c>Admin/Build</c> carrying
+/// <c>ClaimedBy=&lt;the follower&gt;, Status=Planning, RequestedClaims=[], Ready=[fp]</c>, i.e. a
+/// build node locked to a process whose driver had already completed. Which of the two records is
+/// left behind depends on how the two writers interleave — the mirror's projection (measured) or
+/// the durable claim LOCK, when the stand-down read it a moment before this pass wrote it — and
+/// refusing the publication closes both, because the arbiter is the lock's only writer and hands
+/// it straight back.</para>
+///
+/// <para>Everything here is a decision over constructed state with no wall-clock and no
+/// concurrency, in the same family as <c>BuildNodeType.Arbitrate</c>'s tests: the interleaving is
+/// BUILT, never raced for.</para>
+/// </summary>
+public class BuildGrantPublicationTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+    private static readonly DateTime T0 = new(2026, 9, 2, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>The candidate the election picked — and, in most tests here, the one that withdrew.</summary>
+    private const string Winner = "pod-7/2c9f";
+
+    private static BuildState Granted() => new()
+    {
+        ClaimedBy = Winner,
+        ClaimedAt = T0,
+        HeartbeatAt = T0,
+        FrameworkVersion = "fp",
+        Status = BuildStatus.Planning,
+    };
+
+    private static MeshNode Mirror(BuildState state) =>
+        new("Build", "Admin") { NodeType = BuildNodeType.NodeType, Content = state };
+
+    private static MeshNode Lock(BuildState state) =>
+        new("_Claim", "Admin/Build") { NodeType = BuildNodeType.NodeType, Content = state };
+
+    // ── the decision: is this winner still a candidate? ─────────────────────────────────────────
+
+    /// <summary>
+    /// The mirror exactly as <c>WithdrawBuildClaim</c> leaves it — registration gone, nobody
+    /// holding, the GO recorded. The election that produced the grant ran two round-trips ago, on a
+    /// candidate set that still contained this follower. Publishing now is what locks the build to
+    /// a process that has already finished with it.
+    /// </summary>
+    [Fact]
+    public void AGrantIsNotPublished_ToACandidateThatStoodDownWhileThePassRan()
+    {
+        var mirror = Mirror(new BuildState
+        {
+            Status = BuildStatus.Ready,
+            Ready = ImmutableDictionary<string, BuildGo>.Empty
+                .Add("fp", new BuildGo("fp", T0)),
+        });
+
+        BuildNodeType.ApplyGrant(mirror, Granted(), Options).Should().BeSameAs(mirror);
+    }
+
+    /// <summary>
+    /// Still a candidate when the pass commits: the grant lands, and the registration it consumed
+    /// goes with it while every OTHER candidate stays queued.
+    /// </summary>
+    [Fact]
+    public void AGrantIsPublished_WhileTheWinnerIsStillACandidate()
+    {
+        var mirror = Mirror(new BuildState
+        {
+            RequestedClaims = ImmutableDictionary<string, BuildClaimRequest>.Empty
+                .Add(Winner, new BuildClaimRequest("fp", T0))
+                .Add("other-pod", new BuildClaimRequest("fp", T0.AddSeconds(1))),
+        });
+
+        var published = BuildNodeType.ApplyGrant(mirror, Granted(), Options)
+            .ContentAs<BuildState>(Options)!;
+
+        published.ClaimedBy.Should().Be(Winner);
+        published.Status.Should().Be(BuildStatus.Planning);
+        published.FrameworkVersion.Should().Be("fp");
+        published.RequestedClaims.Should().NotContainKey(Winner);
+        published.RequestedClaims.Should().ContainKey("other-pod");
+    }
+
+    /// <summary>
+    /// 🚨 The guard that keeps the fix from becoming a worse bug. A holder that is already BUILDING
+    /// has no registration left — its own grant consumed it — so a bare "is it still queued?" test
+    /// would read a running bake as a candidate that stood down and pull the lock out from under
+    /// it. What distinguishes them is that the mirror already NAMES this holder; the refusal
+    /// applies only to a winner that is neither holder nor candidate.
+    /// </summary>
+    [Fact]
+    public void AHolderMidBake_IsNotMistakenForACandidateThatStoodDown()
+    {
+        var mirror = Mirror(new BuildState
+        {
+            ClaimedBy = Winner,
+            ClaimedByIdentity = "silo-a",
+            ClaimedAt = T0,
+            HeartbeatAt = T0.AddMinutes(1),
+            FrameworkVersion = "fp",
+            Status = BuildStatus.Building,
+        });
+
+        BuildNodeType.ApplyGrant(mirror, Granted(), Options)
+            .ContentAs<BuildState>(Options)!.ClaimedBy
+            .Should().Be(Winner);
+    }
+
+    /// <summary>A redundant pass over a mirror that already reflects the grant writes nothing.</summary>
+    [Fact]
+    public void ARedundantPass_OverAMirrorThatAlreadyReflectsTheGrant_WritesNothing()
+    {
+        var mirror = Mirror(Granted());
+
+        BuildNodeType.ApplyGrant(mirror, Granted(), Options).Should().BeSameAs(mirror);
+    }
+
+    // ── the consequence: a refused publication must not leave the lock behind ────────────────────
+
+    /// <summary>
+    /// The half that actually frees the build. The compare-and-set already took the lock before the
+    /// mirror refused, so the arbiter — the lock's only writer — has to put it back. Without this
+    /// the mirror says "unclaimed" while the durable witness every cluster decides on still names
+    /// the withdrawn follower, and no later candidate is ever granted.
+    /// </summary>
+    [Fact]
+    public async Task ARefusedPublication_ReleasesTheLockItJustTook()
+    {
+        var storage = new InMemoryStorageAdapter();
+        var claimPath = BuildNodeType.ClaimPath(BuildNodeType.RootPath);
+        await storage.Write(Lock(Granted()), Options).Await();
+
+        // The publication came back WITHOUT our winner as holder: it was refused.
+        var refused = Mirror(new BuildState { Status = BuildStatus.Ready });
+
+        await BuildNodeType
+            .HandBackAStoodDownGrant(storage, Options, null, Granted(), claimPath, refused)
+            .Await();
+
+        (await storage.Read(claimPath, Options).Take(1).Await()).Should().BeNull();
+    }
+
+    /// <summary>The negative control: a grant that WAS published keeps the lock it won.</summary>
+    [Fact]
+    public async Task APublishedGrant_KeepsItsLock()
+    {
+        var storage = new InMemoryStorageAdapter();
+        var claimPath = BuildNodeType.ClaimPath(BuildNodeType.RootPath);
+        await storage.Write(Lock(Granted()), Options).Await();
+
+        await BuildNodeType
+            .HandBackAStoodDownGrant(storage, Options, null, Granted(), claimPath, Mirror(Granted()))
+            .Await();
+
+        var held = await storage.Read(claimPath, Options).Take(1).Await();
+        held.Should().NotBeNull();
+        held!.ContentAs<BuildState>(Options)!.ClaimedBy.Should().Be(Winner);
+    }
+
+    /// <summary>
+    /// The hand-back is conditional, like every other write to the lock: a pass whose grant was
+    /// superseded removes NOTHING. Deleting unconditionally here would turn a lost race into a
+    /// second builder — the exact storm the lock exists to prevent.
+    /// </summary>
+    [Fact]
+    public async Task ARefusedPublication_LeavesALockThatHasAlreadyMovedOn_Alone()
+    {
+        var storage = new InMemoryStorageAdapter();
+        var claimPath = BuildNodeType.ClaimPath(BuildNodeType.RootPath);
+        await storage.Write(
+            Lock(Granted() with { ClaimedBy = "someone-else", FrameworkVersion = "fp-next" }),
+            Options).Await();
+
+        await BuildNodeType.HandBackAStoodDownGrant(
+                storage, Options, null, Granted(), claimPath,
+                Mirror(new BuildState { Status = BuildStatus.Ready }))
+            .Await();
+
+        var held = await storage.Read(claimPath, Options).Take(1).Await();
+        held.Should().NotBeNull();
+        held!.ContentAs<BuildState>(Options)!.ClaimedBy.Should().Be("someone-else");
+    }
+}


### PR DESCRIPTION
## The defect

`BuildNodeType.ArbitrateDurably` runs one arbitration pass as four steps:

1. read the candidate set (`RequestedClaims`) off **this cluster's mirror**,
2. read the claim **LOCK** (`Admin/Build/_Claim`),
3. commit the grant with `WriteIfVersion` (the compare-and-set that makes it exclusive across clusters),
4. publish the grant onto the Build node so `ObserveBuildClaim` emits.

**Two storage round-trips separate step 1 from step 4, and a candidate is free to stand down inside that window.** A follower that sees the GO calls `WithdrawBuildClaim`, whose two halves are *both* conditional on state this pass is about to change:

- it removes its registration — one the pass captured in step 1;
- it then reads the lock to release it, and finds no lock of its own, because step 3 has not happened yet.

Conditional writes make each half safe on its own. **They cannot order two writers.** The pass then commits the build to a process that has already finished with it and stopped listening.

Nothing converges afterwards, and which record is left behind depends on the interleaving:

| interleaving | debris |
|---|---|
| the withdrawal's mirror write lands first | the **mirror's claim projection** names the withdrawn candidate at `Planning` — and on a `GrantOnMirror` host (no durable store, or the fail-open path) that projection **is** the claim |
| the withdrawal's lock read lands before the CAS | the **durable lock** names it — the one witness every cluster's arbiter decides on |

Either way `HolderStillHoldsIt` then defends it **by design**, because the process really is alive (#1355 — a stopped heartbeat on a running process means busy, not dead). With cluster membership the claim is never taken over at all; without it, every later candidate waits out `ClaimStaleAfter` and is handed the same dead claim again. **No builder elected, no NodeType baked, no pod ready** — the readiness stall #1440 fixed from the candidate's side, arriving instead through the arbiter's own commit.

The doc asserted the opposite (`BuildCoordination.md`: *"both halves are conditional, so they are safe against a concurrent grant"*). That sentence is corrected here.

## Evidence

Reproduced from `MeshWeaver.Hosting.Monolith.Test.BuildCoordinationTest.Follower_StandsDown_SoTheNextBuildCanStillBeClaimed` (MeshWeaver.Plugins), which reddens the required `Build + test the portal hosts` gate — Systemorph/MeshWeaver.Plugins#1193.

**Control first: this is not a load flake.**

| condition | result |
|---|---|
| idle, unfixed | **2 failures / 15 runs** |
| idle, unfixed (second batch, with a state dump) | **1 failure / 10 runs** |
| idle, fixed | **0 failures / 25 runs** |

The state dumped at a failure — the mechanism, not an inference:

```
MIRROR claimedBy=Rolands-MacBook-Pro/3283624a…  status=Planning  requested=[]  ready=[fp-stand-down]
LOCK   present=False
```

A build node locked, at `Planning`, to a holder whose driver had already completed, with the GO recorded and no candidate queued. The CI signature matches exactly: `TimeoutException` at 32.1 s (`Admin/Build` never becomes free), on shard 2, per-method evidence log.

## The fix

The arbiter re-checks at the one point that can still see the stand-down.

- **`ApplyGrant` refuses** to publish a grant whose winner is *neither the holder the mirror already names nor still a candidate*. It runs inside the node's own serialised write lambda, so the check and the publication are one step — no residual window.
- **A refused publication hands the lock straight back** (`HandBackAStoodDownGrant`). The CAS already took it, and the arbiter is the lock's **only** writer, so undoing its own commit is the only place this can be closed. The delete rides the store's change feed, which is the arbiter's own trigger, so a queued candidate is elected immediately rather than at the 2-minute tick.

🚨 **The guard's first clause is load-bearing.** A holder *mid-bake* has no registration left either — its own grant consumed it — so a bare "is it still queued?" test would read a running bake as a candidate that stood down and pull the lock out from under it. `AHolderMidBake_IsNotMistakenForACandidateThatStoodDown` pins that.

Both writes stay conditional, like every other write to the lock: a pass that lost a later race removes nothing.

## Tests

`test/MeshWeaver.Graph.Test/BuildGrantPublicationTest.cs` — 7 cases, **no wall-clock and no concurrency anywhere**: the interleaving is *constructed*, not raced for, in the same family as the existing `BuildNodeType.Arbitrate` tests.

- refusal for a candidate that stood down (**fails on `main`**: verified by deleting the guard — 1 failed / 6 passed);
- publication for a candidate still registered, consuming only its own registration;
- the mid-bake holder guard;
- a redundant pass writes nothing;
- the lock is released on refusal, kept on publication, and **left alone when it has already moved on**.

`Fixes` is deliberately omitted: the plugins-side PR closes Systemorph/MeshWeaver.Plugins#1193, because it also adds the assertion this failure could otherwise hide from — the durable **lock** being free, not just the projection.

Pairs-with: none — no public type is removed; two private members become `internal` for the tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
