### PR TITLE
A leaving hub never touches shared NodeType state — the adoption sweep observes host shutdown (#3129)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -1122,6 +1122,26 @@ internal static class NodeTypeCompilationHelpers
         string hubPath,
         ILogger? logger)
     {
+        // 🚨 #3129 — A LEAVING OWNER JUDGES NOTHING. Every branch below either stamps the record
+        // or, on a refusal, CLEARS the assembly coordinates and flips Pending — a Roslyn compile
+        // dispatched on THIS hub. On a pod under SIGTERM (a 30-minute grace period, circuits still
+        // held) that compile's result write is the one its own flush bound NACKs, so the type is
+        // left with no coordinates on a node every other generation shares: the healthy pods'
+        // instances sit on the fallback card until the 120 s self-heal fires. The request is left
+        // STANDING, untouched, for the owner activation on a pod that will live to compile —
+        // exactly the shape #3109 gave BuildupActions and SubscribeHubWatcher gives emissions.
+        // Reached from all three call sites (the stamp watcher, the sources watcher's fold and the
+        // release watcher's fold), which is why the guard is here and not in any one of them.
+        if (hub.IsLeaving())
+        {
+            logger?.LogInformation(
+                "[AdoptedSourceStamp] {HubPath}: this hub is leaving (#3129) — the adoption is not "
+                + "judged here; its stamp request stays standing for the next owner activation, and "
+                + "nothing on this shared NodeType record is stamped, cleared or dispatched",
+                hubPath);
+            return def;
+        }
+
         var canCompileLocally = !PrebuiltAssemblySeeder.RequirePrebuilt(hub.ServiceProvider);
         var result = ApplyAdoptedSourceStamp(def, snapshot, canCompileLocally);
 
@@ -1218,6 +1238,20 @@ internal static class NodeTypeCompilationHelpers
             {
                 var observed = (NodeTypeDefinition)node!.Content!;
                 var requestedAt = observed.RequestedSourceStampAt!.Value;
+                // 🚨 #3129 — checked BEFORE the high-water mark moves. SubscribeHubWatcher already
+                // drops emissions once IsShuttingDown, but a pod under SIGTERM reads that false for
+                // its whole grace period (the mesh disposes at the END of host shutdown); the host
+                // lifetime is the signal that is live. Advancing the mark and then declining in the
+                // lambda would log the next emission as non-convergence — so decline here, leaving
+                // the request standing for the owner activation on a pod that stays.
+                if (hub.IsLeaving())
+                {
+                    logger?.LogInformation(
+                        "[AdoptedSourceStamp] {HubPath}: this hub is leaving (#3129) — request "
+                        + "{RequestedAt} is left standing for the next owner activation",
+                        hubPath, requestedAt);
+                    return;
+                }
                 if (!stampHighWater.IsPast(requestedAt))
                 {
                     // We already committed a stamp for this very trigger and it is STILL standing.
@@ -1245,6 +1279,9 @@ internal static class NodeTypeCompilationHelpers
                     // publication or a release dispatch got there first) — a legitimate no-op.
                     if (def.RequestedSourceStampAt is null) return curr;
                     if (def.CurrentSourceVersions is not { } liveSources) return curr;
+                    // #3129 — shutdown may have begun between the emission and this lambda; an
+                    // unchanged node is a NO-OP write, and the mark stays where it was.
+                    if (hub.IsLeaving()) return curr;
                     stampHighWater.Advance(def.RequestedSourceStampAt.Value);
                     return curr with { Content = ApplyAdoptedSourceStampAndReport(
                         def, liveSources, hub, hubPath, logger) };

--- a/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
@@ -339,116 +339,211 @@ public static class PrebuiltAssemblySeeder
             return Observable.Return(false);
         }
 
-        var workspace = hub.GetWorkspace();
-
-        // 🚨 RESERVE BEFORE TOUCHING THE STREAM (#1763). Opening the type's node stream ACTIVATES
-        // its hub, and activation is what arms the first-build kickoff — so without the
-        // reservation the seeder's own probe started the Roslyn compile this adoption exists to
-        // avoid, and that compile overwrote the adopted build milliseconds later. The reservation
-        // has to be taken before the subscribe below, which is why it wraps the whole pipeline in
-        // an Observable.Using rather than sitting inside a SelectMany. See
-        // NodeTypeAdoptionRegistry for the measured trace.
-        var reservations = hub.ServiceProvider.GetService<NodeTypeAdoptionRegistry>();
-
-        return Observable.Using(
-            () => reservations?.Reserve(nodeTypePath) ?? NoReservation.Instance,
-            _ => workspace.GetMeshNodeStream(nodeTypePath)
-            .Where(node => node is not null)
-            .Take(1)
-            .SelectMany(node =>
+        // 🚨 DEFERRED — the leaving check below must run at SUBSCRIBE time, not at call time. The
+        // bundle seeder builds one Seed per assembly and runs them under Concat, so each is
+        // subscribed only when its predecessor completes; a check taken when the pipeline was
+        // BUILT would describe the process as it was minutes earlier. Evaluated here, it is the
+        // per-node boundary at which a pass in flight stops once shutdown begins.
+        return Observable.Defer(() =>
+        {
+            // 🚨 #3129 — A LEAVING HUB WRITES NOTHING ON A NODE EVERY GENERATION SHARES. The
+            // NodeType node is one record for the whole deployment; a pod under SIGTERM (a 30-minute
+            // termination grace period, circuits still held) is not the pod that will serve this
+            // type, and its adoption is exactly as authoritative as a healthy pod's — which is the
+            // problem: the stamp below REPLACES the coordinates the live build serves under, and
+            // when the owner then refuses the adoption (#2813) it CLEARS them. On the roll measured
+            // in #3129 the terminating pod did that 1424 times in 25 minutes, and every healthy
+            // pod's instances of the type sat on the fallback card for the 120 s self-heal bound,
+            // per type, per roll. Same rule as #3109 gave BuildupActions: nothing starts on a hub
+            // that is leaving. Emits false — "not adopted", the caller's ordinary compile signal —
+            // so a seeding pass is never parked on it. IsLeaving reads the host lifetime too, not
+            // only IsShuttingDown: the mesh is disposed at the very END of host shutdown, so the
+            // hub signal alone is false for the whole grace period (see HubLeavingExtensions).
+            if (hub.IsLeaving())
             {
-                if (node!.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions) is null)
+                logger?.LogInformation(
+                    "Prebuilt assembly for {NodeTypePath} NOT seeded: this hub is leaving (#3129) — "
+                    + "a shutting-down process writes nothing on a NodeType every generation shares; "
+                    + "the next generation seeds its own bundles",
+                    nodeTypePath);
+                return Observable.Return(false);
+            }
+
+            var workspace = hub.GetWorkspace();
+
+            // 🚨 RESERVE BEFORE TOUCHING THE STREAM (#1763). Opening the type's node stream ACTIVATES
+            // its hub, and activation is what arms the first-build kickoff — so without the
+            // reservation the seeder's own probe started the Roslyn compile this adoption exists to
+            // avoid, and that compile overwrote the adopted build milliseconds later. The reservation
+            // has to be taken before the subscribe below, which is why it wraps the whole pipeline in
+            // an Observable.Using rather than sitting inside a SelectMany. See
+            // NodeTypeAdoptionRegistry for the measured trace.
+            var reservations = hub.ServiceProvider.GetService<NodeTypeAdoptionRegistry>();
+
+            return Observable.Using(
+                () => reservations?.Reserve(nodeTypePath) ?? NoReservation.Instance,
+                _ => workspace.GetMeshNodeStream(nodeTypePath)
+                .Where(node => node is not null)
+                .Take(1)
+                .SelectMany(node => SeedObserved(
+                    hub, workspace, node!, nodeTypePath, assemblyBytes, pdbBytes, logger,
+                    dependencies, sourceFingerprint)));
+        });
+    }
+
+    /// <summary>The half of <see cref="Seed(IMessageHub, string, byte[], byte[], string, ILogger, IReadOnlyDictionary{string, string}, string)"/>
+    /// that runs once the owner's current snapshot of the node is in hand.</summary>
+    private static IObservable<bool> SeedObserved(
+        IMessageHub hub,
+        IWorkspace workspace,
+        MeshNode node,
+        string nodeTypePath,
+        byte[] assemblyBytes,
+        byte[]? pdbBytes,
+        ILogger? logger,
+        IReadOnlyDictionary<string, string>? dependencies,
+        string? sourceFingerprint)
+    {
+        var observed = node.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
+        if (observed is null)
+        {
+            logger?.LogInformation(
+                "Prebuilt assembly for {NodeTypePath} DECLINED: node content is not a "
+                + "NodeTypeDefinition", nodeTypePath);
+            return Observable.Return(false);
+        }
+
+        // 🚨 #2813 / #3129 — DECLINE BEFORE WRITING WHEN THE REFUSAL IS ALREADY DECIDABLE. The
+        // owner's three-way check (ApplyAdoptedSourceStamp) exists because this write is
+        // cross-hub and the owner's live source set may not be published yet (#1834) — an
+        // INCONCLUSIVE snapshot must not refuse. But the snapshot in hand here is the owner's own
+        // current state, and when it ALREADY carries a live fingerprint that disagrees with the
+        // producer's, the refusal is certain: sources only ever move the live fingerprint further
+        // from a bundle baked earlier. Writing anyway is what #3129 measured as the clobber — the
+        // stamp REPLACES the coordinates of the build actually serving with the stale bundle's,
+        // the owner refuses, and the refusal has nothing left to leave in place but the rejected
+        // build's coordinates, so it clears them and every other pod's instances lose the type
+        // until a fresh compile lands. Declining here leaves the live build's record untouched,
+        // exactly like the framework and dependency declines above; the caller compiles, as it
+        // would have after the refusal. The owner's check stays for the pre-publication window
+        // this snapshot cannot decide (no live fingerprint yet) and as the last line of defence.
+        // A decline is always safe (a compile follows); a write that a refusal must undo is not.
+        if (sourceFingerprint is { Length: > 0 } producerFingerprint
+            && observed.CurrentSourceFingerprint is { Length: > 0 } liveFingerprint
+            && !string.Equals(producerFingerprint, liveFingerprint, StringComparison.Ordinal))
+        {
+            logger?.LogWarning(
+                "Prebuilt assembly for {NodeTypePath} DECLINED before writing (#2813): the bundle "
+                + "records source fingerprint {Producer} but the live sources are {Live} — the owner "
+                + "would refuse the adoption, so the live build's coordinates are left in place and "
+                + "the live source compiles instead. Rebake this package to adopt again.",
+                nodeTypePath, producerFingerprint, liveFingerprint);
+            return Observable.Return(false);
+        }
+
+        // 🚨 ONE version, used twice. ApplyCompileSuccess documents why: the stamp must name
+        // the SAME version the store upload used, or activation resolves a store key with no
+        // bytes behind it, TryGetAssemblyPath misses, and the instance silently falls back
+        // to the default configuration.
+        var version = node.Version;
+        var store = hub.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;
+        // Set by the lambda on the run that produced the write; false when every run declined
+        // (the hub began leaving between the upload and the write), so the caller is told the
+        // truth — "not adopted" — rather than the ADOPTED line below over a write that no-opped.
+        var stamped = false;
+
+        return store
+            .PutWithLocation(nodeTypePath, version, assemblyBytes, pdbBytes)
+            .SelectMany(location => workspace.GetMeshNodeStream(nodeTypePath)
+                .Update(current =>
                 {
-                    logger?.LogInformation(
-                        "Prebuilt assembly for {NodeTypePath} DECLINED: node content is not a "
-                        + "NodeTypeDefinition", nodeTypePath);
-                    return Observable.Return(false);
-                }
+                    var def = current?.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
+                    if (current is null || def is null)
+                        return current!;
 
-                // 🚨 ONE version, used twice. ApplyCompileSuccess documents why: the stamp must name
-                // the SAME version the store upload used, or activation resolves a store key with no
-                // bytes behind it, TryGetAssemblyPath misses, and the instance silently falls back
-                // to the default configuration.
-                var version = node.Version;
-                var store = hub.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;
-
-                return store
-                    .PutWithLocation(nodeTypePath, version, assemblyBytes, pdbBytes)
-                    .SelectMany(location => workspace.GetMeshNodeStream(nodeTypePath)
-                        .Update(current =>
-                        {
-                            var def = current?.ContentAs<NodeTypeDefinition>(hub.JsonSerializerOptions);
-                            if (current is null || def is null)
-                                return current!;
-
-                            return current with
-                            {
-                                Content = def with
-                                {
-                                    CompilationStatus = CompilationStatus.Ok,
-                                    CompilationError = null,
-                                    CompilationDiagnostics = null,
-                                    LastCompileSucceededAt = DateTimeOffset.UtcNow,
-                                    LastCompiledVersion = version,
-                                    LatestAssemblyCollection = location.Collection,
-                                    LatestAssemblyPath = location.ContentPath,
-                                    // The adopted bytes' own identity (#2471), read from the image
-                                    // in hand — no file, no load. An adopted build is exactly the
-                                    // case where a path says least: several pods adopt the same
-                                    // bundle under the same key, and a replica that later serves a
-                                    // different build is invisible to a path comparison.
-                                    LatestAssemblyMvid =
-                                        ServedBuildIdentity.OfBytes(assemblyBytes)
-                                        ?? def.LatestAssemblyMvid,
-                                    CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
-                                    // The adopted build retires any standing FAILURE verdict, so
-                                    // the inputs it was formed from go with it (#1793) — exactly as
-                                    // ApplyCompileSuccess does. A token left behind would describe a
-                                    // verdict this node no longer holds.
-                                    FailedBuildInputs = null,
-                                    // 🚨 The source snapshot is stamped BY THE OWNER, not here
-                                    // (#1834). The producer's own ticks are meaningless on this
-                                    // mesh (the bake writes zeros), so adoption asserts "these
-                                    // bytes correspond to the LIVE source set" — and only the
-                                    // owner knows that set. This write is CROSS-HUB: the lambda
-                                    // diffs against the MIRROR's snapshot, which predates the
-                                    // first-activation write of CurrentSourceVersions that this
-                                    // very subscribe triggers (InstallSourcesWatcher). Reading the
-                                    // field here therefore stamped CompiledSources = null under a
-                                    // non-empty CurrentSourceVersions — IsDirty — and the release
-                                    // request PackageInstaller issues one step later recompiled
-                                    // the type that had just been adopted. Requesting the stamp
-                                    // instead has no ordering to lose: whichever of the two writes
-                                    // lands second carries the owner's authoritative pair.
-                                    RequestedSourceStampAt = DateTimeOffset.UtcNow,
-                                    // 🚨 #2813 — WHAT the producer says these bytes were built
-                                    // from. The owner checks it against its own live source set
-                                    // when it fulfils the request above; it cannot be checked
-                                    // here, for the same cross-hub reason the request exists.
-                                    // Null (a legacy bundle) is carried as null, never as a
-                                    // match: the owner then records AdoptedUnverified rather
-                                    // than AdoptedVerified.
-                                    AdoptedSourceFingerprint = sourceFingerprint,
-                                    // The producer's dependency record (#1707 slice 2) — validated
-                                    // above; stamped so ongoing validity checks judge the adopted
-                                    // build like a locally-compiled one. Legacy bundles (null)
-                                    // leave any prior stamp untouched.
-                                    CompiledDependencies = dependencies is null
-                                        ? def.CompiledDependencies
-                                        : dependencies.ToImmutableSortedDictionary(
-                                            kv => kv.Key, kv => kv.Value, StringComparer.Ordinal),
-                                },
-                            };
-                        }))
-                    .Select(_ =>
+                    // 🚨 #3129 — re-checked at the write itself: the store upload above is real
+                    // I/O, and a shutdown that began during it must not land a stamp from a hub
+                    // that is leaving. Returning the node unchanged makes Update a NO-OP (nothing
+                    // is posted), so the record other generations read is exactly as it was.
+                    if (hub.IsLeaving())
                     {
                         logger?.LogInformation(
-                            "Prebuilt assembly ADOPTED for {NodeTypePath} at version {Version} "
-                            + "(framework {Framework}) — no compile needed",
-                            nodeTypePath, version, NodeTypeCompilationHelpers.FrameworkVersion);
-                        return true;
-                    });
-            }));
+                            "Prebuilt assembly for {NodeTypePath} NOT stamped: this hub began "
+                            + "leaving during the upload (#3129) — the node is left as it was",
+                            nodeTypePath);
+                        return current;
+                    }
+
+                    stamped = true;
+                    return current with
+                    {
+                        Content = def with
+                        {
+                            CompilationStatus = CompilationStatus.Ok,
+                            CompilationError = null,
+                            CompilationDiagnostics = null,
+                            LastCompileSucceededAt = DateTimeOffset.UtcNow,
+                            LastCompiledVersion = version,
+                            LatestAssemblyCollection = location.Collection,
+                            LatestAssemblyPath = location.ContentPath,
+                            // The adopted bytes' own identity (#2471), read from the image
+                            // in hand — no file, no load. An adopted build is exactly the
+                            // case where a path says least: several pods adopt the same
+                            // bundle under the same key, and a replica that later serves a
+                            // different build is invisible to a path comparison.
+                            LatestAssemblyMvid =
+                                ServedBuildIdentity.OfBytes(assemblyBytes)
+                                ?? def.LatestAssemblyMvid,
+                            CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
+                            // The adopted build retires any standing FAILURE verdict, so
+                            // the inputs it was formed from go with it (#1793) — exactly as
+                            // ApplyCompileSuccess does. A token left behind would describe a
+                            // verdict this node no longer holds.
+                            FailedBuildInputs = null,
+                            // 🚨 The source snapshot is stamped BY THE OWNER, not here
+                            // (#1834). The producer's own ticks are meaningless on this
+                            // mesh (the bake writes zeros), so adoption asserts "these
+                            // bytes correspond to the LIVE source set" — and only the
+                            // owner knows that set. This write is CROSS-HUB: the lambda
+                            // diffs against the MIRROR's snapshot, which predates the
+                            // first-activation write of CurrentSourceVersions that this
+                            // very subscribe triggers (InstallSourcesWatcher). Reading the
+                            // field here therefore stamped CompiledSources = null under a
+                            // non-empty CurrentSourceVersions — IsDirty — and the release
+                            // request PackageInstaller issues one step later recompiled
+                            // the type that had just been adopted. Requesting the stamp
+                            // instead has no ordering to lose: whichever of the two writes
+                            // lands second carries the owner's authoritative pair.
+                            RequestedSourceStampAt = DateTimeOffset.UtcNow,
+                            // 🚨 #2813 — WHAT the producer says these bytes were built
+                            // from. The owner checks it against its own live source set
+                            // when it fulfils the request above; it cannot be checked
+                            // here, for the same cross-hub reason the request exists.
+                            // Null (a legacy bundle) is carried as null, never as a
+                            // match: the owner then records AdoptedUnverified rather
+                            // than AdoptedVerified.
+                            AdoptedSourceFingerprint = sourceFingerprint,
+                            // The producer's dependency record (#1707 slice 2) — validated
+                            // above; stamped so ongoing validity checks judge the adopted
+                            // build like a locally-compiled one. Legacy bundles (null)
+                            // leave any prior stamp untouched.
+                            CompiledDependencies = dependencies is null
+                                ? def.CompiledDependencies
+                                : dependencies.ToImmutableSortedDictionary(
+                                    kv => kv.Key, kv => kv.Value, StringComparer.Ordinal),
+                        },
+                    };
+                }))
+            .Select(_ =>
+            {
+                if (!stamped)
+                    return false;
+                logger?.LogInformation(
+                    "Prebuilt assembly ADOPTED for {NodeTypePath} at version {Version} "
+                    + "(framework {Framework}) — no compile needed",
+                    nodeTypePath, version, NodeTypeCompilationHelpers.FrameworkVersion);
+                return true;
+            });
     }
 
     /// <summary>The no-op reservation handle for a host with no adoption registry (an older or

--- a/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/PrebuiltAssemblySeeder.cs
@@ -362,9 +362,10 @@ public static class PrebuiltAssemblySeeder
             if (hub.IsLeaving())
             {
                 logger?.LogInformation(
-                    "Prebuilt assembly for {NodeTypePath} NOT seeded: this hub is leaving (#3129) — "
-                    + "a shutting-down process writes nothing on a NodeType every generation shares; "
-                    + "the next generation seeds its own bundles",
+                    "Prebuilt assembly for {NodeTypePath} NOT seeded: this hub is LEAVING (#3129: "
+                    + "shutting down, or hosted by a process that has begun stopping) — a leaving hub "
+                    + "writes nothing on a NodeType every generation shares; the next generation seeds "
+                    + "its own bundles",
                     nodeTypePath);
                 return Observable.Return(false);
             }

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -1062,6 +1062,92 @@ recently synced or baked: suspect a degraded-but-Ready replica, not a global wed
 pods far above their siblings in BOTH memory and CPU in `kubectl top pods` is this incident;
 `kubectl delete pod` them (grace-drain — the Deployment replaces them) and read #2194.
 
+### 🚨 A LEAVING pod never touches shared NodeType state — the adoption sweep observes host shutdown
+
+The NodeType node is **one record for the whole deployment**. Every generation of pods reads its
+assembly coordinates, and every generation's adoption sweep writes them — which is fine while every
+writer is a pod that will go on serving the type, and a clobber the moment one of them is not.
+
+**What was measured (issue #3129, memex.systemorph.com, 2026-09-02).** A rollout left the old pod
+terminating for 27 minutes (`terminationGracePeriodSeconds=1800`, circuits still held, 11.8 GB,
+3–5 s GC stalls every ~4 s). While draining it kept running the prebuilt-bundle adoption sweep
+against the shared NodeType nodes, and Loki shows the loop verbatim:
+
+```
+ADOPTION REFUSED for Underwriting/Workbench (#2813): bundle fingerprint aa0e63c8… vs live 572495ee…
+→ coordinates cleared, Roslyn compile dispatched
+→ LATE_NACK_TERMINAL code=Unknown TimeoutException (+10 s)   [UpdateQueue] FAILED path=Underwriting/Workbench elapsedMs=12344
+→ ShippedPrebuiltBundles: seeding … did not complete — the sweep compiles it instead
+→ next access repeats (Workbench/Guideline every 30–90 s; Crm/Client 388× in 30 min)
+```
+
+All 1424 `ADOPTION REFUSED` and 350 `[UpdateQueue] FAILED` lines of the window were on the dying
+pod; the two new pods logged 0 of either. **The cross-generation effect IS the reported
+navigation hang:** because the old pod kept clearing `Underwriting/Workbench`'s coordinates, the
+NEW pods logged `Overlay self-heal: instance 'Underwriting/Desk' still stuck on NodeType
+'Underwriting/Workbench' after 120s` → self-heal compile → Release, ~2 minutes later. A ≥120 s
+hang per Underwriting type, per roll — three rolls that day.
+
+**The clobber, step by step.** `PrebuiltAssemblySeeder.Seed` stamps the bundle's assembly
+coordinates onto the node *first* and asks the owner to judge the adoption *second*
+(`RequestedSourceStampAt`, #1834 — the seeder's snapshot may predate the owner's source
+publication, so only the owner can compare fingerprints). When the bundle is stale the owner
+**refuses** (#2813) and, because the coordinates on the node at that moment are the *rejected*
+bundle's, it **clears** them so proven-stale bytes stop executing — that clear is required by the
+#2813 design and stays. The build that was actually serving on the healthy pods is already gone at
+that point: the stamp replaced it one write earlier. Each access on the draining pod re-ran the
+sequence (the Pending flip's on-demand adoption), so the shared record was wiped every 30–90 s for
+as long as the pod lived.
+
+**Why the grace period is the amplifier, not the cause.** Thirty minutes is how long the wrong
+writer stayed alive; the defect is that it wrote at all. Cutting the grace period would shorten the
+window and leave the same clobber in it — a band-aid.
+
+**The rule.** *A hub that is leaving does not START a sweep pass, does not STAMP, does not CLEAR
+coordinates, and does not DISPATCH a compile through the refusal path.* The predicate is
+`hub.IsLeaving()` (`HubLeavingExtensions`, `MeshWeaver.Mesh.Contract`), and it reads **two**
+signals:
+
+- `IMessageHub.IsShuttingDown` — this hub's own teardown or an ancestor's cascade; the shape #3109
+  gave BuildupActions and `SubscribeHubWatcher` gives emissions.
+- `IHostApplicationLifetime.ApplicationStopping` — the **process** is leaving. This is the signal
+  that was live for the whole window above and the reason the hub signal alone would have changed
+  nothing: the mesh is disposed by `MeshTeardownHostedService.StoppedAsync`, i.e. at the very END
+  of host shutdown, after Kestrel has finished with the circuits the pod still holds. Every one of
+  the 1424 refusals was issued by a watcher `SubscribeHubWatcher` would have dropped had
+  `IsShuttingDown` been true — so on a draining pod it was false the entire time. It is the same
+  token `OrleansRoutingService` already consults for its shutdown routing decisions.
+
+It is asked at four places, and every route into adoption converges on them: the start of a
+`ShippedPrebuiltBundles` pass (no pass starts — boot, on-demand from the compile watcher, a push's
+recompile, an install); `PrebuiltAssemblySeeder.Seed` at **subscribe** time (the seeder runs one
+`Seed` per assembly under `Concat`, so a pass in flight stops at its next node boundary) and again
+inside the write lambda (an unchanged node is a no-op `Update`); and
+`ApplyAdoptedSourceStampAndReport` on the **owner**, reached from the stamp watcher, the sources
+watcher's fold and the release watcher's fold — a leaving owner judges nothing and leaves the
+request standing for the owner activation on a pod that stays. The answer everywhere is the
+caller's ordinary "not adopted / nothing to do" signal, so nothing is ever parked on it.
+
+**Decline before you write.** The seeder also now refuses to *start* the stamp-then-refuse
+sequence when the refusal is already decidable from the owner's snapshot in hand: a bundle whose
+`SourceFingerprint` disagrees with a **published** live `CurrentSourceFingerprint` is declined
+before any write, exactly like a framework or dependency mismatch, and the live build's
+coordinates are never replaced. The owner's three-way check stays for the pre-publication window
+the snapshot cannot decide (no live fingerprint yet) and as the last line of defence. A decline is
+always safe — a compile follows; a write a refusal must undo is not.
+
+**What a leaving pod still does, deliberately.** A user still held on the draining pod who opens a
+type with no usable build gets a compile dispatched by the ordinary first-access kickoff — that
+result is a *new* version, clobbers nothing, and #3115 made its result write land under the pod's
+own flush bound. Only the refusal-driven clear-and-compile, whose sole effect on a shared record
+is destructive, is withheld.
+
+**Triage fingerprint** — `Overlay self-heal: … still stuck on NodeType … after 120s` on the new
+pods right after a roll, while a pod of the *previous* ReplicaSet is still `Terminating`: read
+that pod's log for `ADOPTION REFUSED`. Pinned by `LeavingHubAdoptionSweepTest`
+(`MeshWeaver.Compiler.Pipeline.Test`): the same seed on a shutting-down hub leaves the shared
+record byte-for-byte untouched, and on a live hub adopts.
+
 ---
 
 ## 🚨 That recompile can FAIL — and nothing upstream can warn you

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-retiring-portal-replica-no-longer-stalls-the-new-ones.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-retiring-portal-replica-no-longer-stalls-the-new-ones.md
@@ -1,0 +1,27 @@
+---
+Name: A retiring portal replica no longer stalls the new ones
+Category: Fix
+Description: Fixed a fault where a portal replica being replaced during an update kept rewriting shared build records for minutes, so pages of the affected types on the new replicas showed a "preparing" card for two minutes or more after every deployment.
+Icon: Bug
+Order: -20260902
+---
+
+# A retiring portal replica no longer stalls the new ones
+
+When the portal is updated, the old replica keeps serving the people still connected to it for a
+while before it exits. Until now it also kept running its background housekeeping during that time
+— including the step that adopts pre-built code for your custom types — and that step writes to
+records the whole portal shares.
+
+On a replica that is on its way out, that write was worse than useless: it replaced the coordinates
+of the build the new replicas were happily serving with an older bundle's, then rejected that bundle
+and cleared the coordinates again. Every new replica saw a type with no usable build and fell back to
+a "preparing" card until its two-minute self-heal ran. On a busy deployment that was a two-minute
+stall per type, on every update.
+
+A replica that has begun shutting down now leaves those shared records alone: it starts no adoption
+pass, stamps nothing, clears nothing, and dispatches no compile whose result it might not live to
+record. The replicas that stay do that work, once. Separately, a pre-built bundle whose source no
+longer matches what the portal holds is now turned away before it writes anything at all, instead of
+being written and then rejected — so the build you already have keeps serving while a fresh one
+compiles.

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -304,6 +304,24 @@ public static class ShippedPrebuiltBundles
         ImmutableHashSet<string>? typePathFilter = null, Action<string>? onCovered = null)
         => Observable.Defer(() =>
         {
+            // 🚨 #3129 — NO ADOPTION PASS STARTS ON A HUB THAT IS LEAVING. Every route into
+            // seeding converges here (boot, on-demand from the compile watcher, a push's recompile,
+            // an install), and every one of them stamps NodeType nodes the whole deployment
+            // shares. A pod under SIGTERM is not the pod that will serve those types; on the roll
+            // measured in #3129 the terminating pod re-ran this pass on every access for 25
+            // minutes, and each run replaced the live build's coordinates with a stale bundle's,
+            // which the owner then refused and cleared. Answering 0 — "nothing adopted", the
+            // caller's ordinary compile-instead signal — is the same rule #3109 gave
+            // BuildupActions. A pass already in flight stops at its next node boundary: each
+            // PrebuiltAssemblySeeder.Seed re-asks at subscribe time.
+            if (mesh.IsLeaving())
+            {
+                logger?.LogInformation(
+                    "ShippedPrebuiltBundles: this process is leaving (#3129) — no adoption pass "
+                    + "starts on a hub that is shutting down; the next generation seeds its own bundles");
+                return Observable.Return(0);
+            }
+
             if (!Directory.Exists(dir))
             {
                 logger?.LogDebug(

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -317,8 +317,9 @@ public static class ShippedPrebuiltBundles
             if (mesh.IsLeaving())
             {
                 logger?.LogInformation(
-                    "ShippedPrebuiltBundles: this process is leaving (#3129) — no adoption pass "
-                    + "starts on a hub that is shutting down; the next generation seeds its own bundles");
+                    "ShippedPrebuiltBundles: this hub is LEAVING (#3129: shutting down, or hosted by a "
+                    + "process that has begun stopping) — no adoption pass starts on it; the next "
+                    + "generation seeds its own bundles");
                 return Observable.Return(0);
             }
 

--- a/src/MeshWeaver.Mesh.Contract/HubLeavingExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/HubLeavingExtensions.cs
@@ -1,0 +1,52 @@
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// "Is this hub LEAVING?" — the one predicate a background sweep asks before it touches state that
+/// other generations of this deployment share (issue #3129).
+/// </summary>
+/// <remarks>
+/// <para>Two signals answer it, and a sweep needs BOTH:</para>
+/// <list type="bullet">
+///   <item><see cref="IMessageHub.IsShuttingDown"/> — this hub's own teardown, or an ancestor's
+///     cascade. The shape #3109 gave <c>HandleInitialize</c> (no BuildupAction starts after it) and
+///     <c>SubscribeHubWatcher</c> (no emission is delivered after it).</item>
+///   <item><see cref="IHostApplicationLifetime.ApplicationStopping"/> — the PROCESS is leaving.
+///     On a pod this fires at SIGTERM, minutes before any hub disposes: the mesh is drained by
+///     <c>MeshTeardownHostedService.StoppedAsync</c>, i.e. at the very END of host shutdown, after
+///     every other hosted service has stopped and after Kestrel has finished with the circuits the
+///     pod still holds. Under a 30-minute termination grace period that is a 30-minute window in
+///     which every hub in the process reads <c>IsShuttingDown == false</c> while the pod is
+///     already being replaced.</item>
+/// </list>
+/// <para>🚨 <b>Why the hub signal alone is UNREACHABLE for the case that hurt.</b> During the roll
+/// measured in #3129 a terminating pod logged 1424 <c>ADOPTION REFUSED</c> lines over 25 minutes,
+/// every one issued from a watcher that <c>SubscribeHubWatcher</c> would have dropped had the hub
+/// been shutting down. So a guard reading only <see cref="IMessageHub.IsShuttingDown"/> would have
+/// changed nothing on that pod. The host lifetime is the signal that WAS live for the whole
+/// window, and it is what <c>OrleansRoutingService</c> already consults for its own shutdown
+/// routing decisions.</para>
+/// <para>Optional by construction: a bare mesh in a unit test has no application lifetime, and
+/// then the predicate degrades to the hub signal alone — exactly the behaviour every caller had
+/// before this existed.</para>
+/// </remarks>
+public static class HubLeavingExtensions
+{
+    /// <summary>
+    /// True when <paramref name="hub"/> is shutting down OR the hosting process has begun
+    /// stopping. Cheap enough to evaluate at every node boundary of a sweep.
+    /// </summary>
+    public static bool IsLeaving(this IMessageHub hub)
+    {
+        ArgumentNullException.ThrowIfNull(hub);
+        if (hub.IsShuttingDown)
+            return true;
+        // Resolved per call, not cached: the lifetime is a host singleton (one lookup), and a
+        // cached token read across a hub's own disposal would be a use-after-dispose of its scope.
+        var lifetime = hub.ServiceProvider.GetService<IHostApplicationLifetime>();
+        return lifetime?.ApplicationStopping.IsCancellationRequested ?? false;
+    }
+}

--- a/test/MeshWeaver.Compiler.Pipeline.Test/LeavingHubAdoptionSweepTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/LeavingHubAdoptionSweepTest.cs
@@ -1,0 +1,181 @@
+using System;
+using System.IO;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Compiler.Pipeline.Test;
+
+/// <summary>
+/// Systemorph/MeshWeaver#3129 — the prebuilt-bundle adoption sweep on a hub that is LEAVING.
+///
+/// <para><b>What was measured.</b> A pod terminating under a 30-minute grace period kept running
+/// the adoption sweep against NodeType nodes the whole deployment shares: each pass stamped a
+/// stale bundle's coordinates over the live build's, the owner refused the adoption (#2813) and
+/// cleared them, and the healthy pods' instances of the type sat on the fallback card for the
+/// 120 s self-heal bound — per type, per roll. Every one of the 1424 refusals came from the pod
+/// that was leaving.</para>
+///
+/// <para><b>The rule, and the controlled experiment that pins it.</b> A leaving hub does not seed:
+/// <see cref="PrebuiltAssemblySeeder.Seed(IMessageHub, string, byte[], byte[], string, Microsoft.Extensions.Logging.ILogger, System.Collections.Generic.IReadOnlyDictionary{string, string}, string)"/>
+/// answers "not adopted" and the shared record is byte-for-byte what it was. The control arm is
+/// the SAME call on a live hub against the SAME node, which adopts — without it the leaving arm
+/// would pass just as well against a seeder that had stopped writing altogether. The hub is
+/// flipped the way #3109's test flips it: <c>Dispose()</c> begins teardown synchronously, so
+/// <see cref="IMessageHub.IsShuttingDown"/> is true before the seed is even built.</para>
+///
+/// <para>The second test pins the seeder-side half of the #2813 refusal: a bundle whose source
+/// fingerprint already disagrees with the owner's published live fingerprint is declined BEFORE
+/// it writes, so the live build's coordinates are never replaced and never cleared — the clobber
+/// #3129 measured is unreachable even on a healthy hub. Control arm: the same call with the
+/// matching fingerprint writes.</para>
+/// </summary>
+public class LeavingHubAdoptionSweepTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string LiveAssemblyPath = "live/LeavingSweepType.dll";
+    private const string LiveMvid = "11ee0000aaaa0000";
+    private const string FixtureLiveFingerprint = "live-fingerprint-fixture";
+
+    private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+
+    /// <summary>A hub standing in for the sweep's hub — a child of the mesh so that disposing it
+    /// flips ITS <see cref="IMessageHub.IsShuttingDown"/> while the mesh (and the node's owner)
+    /// keep running. Carries a workspace, as every hub the seeder runs on does (the seeder
+    /// writes through <c>hub.GetWorkspace()</c>).</summary>
+    private IMessageHub SweepHub(string id) =>
+        Mesh.GetHostedHub(
+            new Address("adoption-sweep", id),
+            c => c.AddData().WithGraphTypes(),
+            HostedHubCreation.Always)
+        ?? throw new InvalidOperationException("HostedHubCreation.Always always yields a hub");
+
+    /// <summary>Real PE bytes with a real MVID — the test assembly itself. The seeder stamps
+    /// <see cref="NodeTypeDefinition.LatestAssemblyMvid"/> from the bytes it is handed, so this
+    /// identity is the positive signal that an adoption LANDED, independent of what the store
+    /// answers for a location.</summary>
+    private static byte[] BundleBytes() =>
+        File.ReadAllBytes(typeof(LeavingHubAdoptionSweepTest).Assembly.Location);
+
+    /// <summary>A NodeType that already serves a usable build compiled on this mesh — the record
+    /// a sweep on another generation would clobber.</summary>
+    private async Task CreateLiveType(string typePath)
+    {
+        var typeNode = MeshNode.FromPath(typePath) with
+        {
+            Name = typePath[(typePath.LastIndexOf('/') + 1)..],
+            NodeType = MeshNode.NodeTypePath,
+            State = MeshNodeState.Active,
+            Content = new NodeTypeDefinition
+            {
+                CompilationStatus = CompilationStatus.Ok,
+                LatestAssemblyCollection = "assemblies",
+                LatestAssemblyPath = LiveAssemblyPath,
+                LatestAssemblyMvid = LiveMvid,
+                CompiledFrameworkVersion = NodeTypeCompilationHelpers.FrameworkVersion,
+                CurrentSourceFingerprint = FixtureLiveFingerprint,
+            },
+        };
+        await MeshService.CreateNode(typeNode).Should().Within(20.Seconds()).Emit();
+        await Mesh.GetMeshNodeStream(typePath).Should().Within(20.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition { LatestAssemblyMvid: LiveMvid });
+    }
+
+    private static IObservable<bool> Seed(IMessageHub hub, string typePath, byte[] bytes, string? fingerprint) =>
+        PrebuiltAssemblySeeder.Seed(
+            hub, typePath, bytes, pdbBytes: null,
+            frameworkMvid: PrebuiltAssemblySeeder.LiveFrameworkMvid,
+            logger: null, dependencies: null, sourceFingerprint: fingerprint);
+
+    /// <summary>True for any write the sweep could have made: a standing stamp request, a moved
+    /// assembly identity, or a compile dispatched (Pending) — the three things #3129 saw.</summary>
+    private static bool Touched(MeshNode? n) =>
+        n?.Content is NodeTypeDefinition d
+        && (d.RequestedSourceStampAt is not null
+            || !string.Equals(d.LatestAssemblyMvid, LiveMvid, StringComparison.Ordinal)
+            || d.CompilationStatus != CompilationStatus.Ok
+            || d.BuildProvenance == BuildProvenance.AdoptionRefused);
+
+    [Fact]
+    public async Task ALeavingHub_LeavesTheSharedNodeTypeUntouched_AndALiveHubAdopts()
+    {
+        const string typePath = "type/LeavingSweepType";
+        await CreateLiveType(typePath);
+        var bytes = BundleBytes();
+        var bundleMvid = ServedBuildIdentity.OfBytes(bytes);
+        bundleMvid.Should().NotBeNullOrEmpty("the test assembly is a real PE image with an MVID")
+            .And.NotBe(LiveMvid, "the adopted identity must be distinguishable from the live one");
+
+        // THE LEAVING ARM — the hub the sweep runs on has begun shutting down.
+        var leaving = SweepHub("leaving");
+        leaving.Dispose();
+        leaving.IsShuttingDown.Should().BeTrue("Dispose() begins this hub's teardown synchronously");
+        leaving.IsLeaving().Should().BeTrue("a hub that is shutting down is leaving");
+
+        var adopted = await Seed(leaving, typePath, bytes, fingerprint: null)
+            .Should().Within(20.Seconds())
+            .Emit("a leaving hub answers 'not adopted' — it never parks the seeding pass");
+        adopted.Should().BeFalse("nothing is adopted on a hub that is leaving");
+
+        await Mesh.GetMeshNodeStream(typePath).Where(Touched)
+            .Should()
+            .NotEmit(3.Seconds(), "a leaving hub must neither stamp, clear nor dispatch on a NodeType every "
+                     + "generation shares — that write is what starved the healthy pods in #3129");
+
+        // THE CONTROL ARM — the same call, the same node, a hub that stays.
+        var live = SweepHub("live");
+        live.IsLeaving().Should().BeFalse("the control hub is neither disposing nor hosted by a stopping process");
+
+        var adoptedLive = await Seed(live, typePath, bytes, fingerprint: null)
+            .Should().Within(20.Seconds()).Emit("a live hub's seed completes");
+        adoptedLive.Should().BeTrue("on a live hub the same bundle IS adopted — without this arm the "
+                                    + "leaving arm would prove nothing");
+        await Mesh.GetMeshNodeStream(typePath).Should().Within(20.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                        && string.Equals(d.LatestAssemblyMvid, bundleMvid, StringComparison.Ordinal),
+                "the live hub's adoption lands on the shared record");
+    }
+
+    [Fact]
+    public async Task ABundleWhoseFingerprintDisagreesWithTheLiveSource_IsDeclinedBeforeItWrites()
+    {
+        const string typePath = "type/StaleBundleType";
+        await CreateLiveType(typePath);
+        var bytes = BundleBytes();
+        var bundleMvid = ServedBuildIdentity.OfBytes(bytes);
+
+        // The seeder decides on the owner's CURRENT snapshot of the node. The fixture's published
+        // fingerprint stands for the one the owner's sources watcher writes on a real deployment;
+        // a sourceless fixture type publishes nothing that could move it (CreateLiveType waited
+        // for the record to be observable as written).
+        const string liveFingerprint = FixtureLiveFingerprint;
+
+        // THE STALE ARM — the producer names sources that are not the ones this mesh holds.
+        var sweep = SweepHub("sweep");
+        var adopted = await Seed(sweep, typePath, bytes, fingerprint: liveFingerprint + "-stale")
+            .Should().Within(20.Seconds()).Emit("a decline completes like any other");
+        adopted.Should().BeFalse("a bundle the owner would refuse is declined before it writes");
+
+        await Mesh.GetMeshNodeStream(typePath).Where(Touched)
+            .Should()
+            .NotEmit(3.Seconds(), "declining before the write leaves the live build's coordinates in place — "
+                     + "the stamp-then-refuse-then-clear sequence never starts");
+
+        // THE CONTROL ARM — the same bundle, now naming the live sources: it writes.
+        var adoptedLive = await Seed(sweep, typePath, bytes, fingerprint: liveFingerprint)
+            .Should().Within(20.Seconds()).Emit("a matching fingerprint seeds");
+        adoptedLive.Should().BeTrue("the fingerprint is the ONLY difference between the two arms");
+        await Mesh.GetMeshNodeStream(typePath).Should().Within(20.Seconds())
+            .Match(n => n?.Content is NodeTypeDefinition d
+                        && string.Equals(d.LatestAssemblyMvid, bundleMvid, StringComparison.Ordinal),
+                "the matching bundle's adoption lands on the shared record");
+    }
+}


### PR DESCRIPTION
Closes #3129

## What was wrong

A pod terminating under the 30-minute grace period (circuits still held, `IsShuttingDown == false` on every hub because the mesh is disposed by `MeshTeardownHostedService.StoppedAsync`, i.e. at the END of host shutdown) kept running the prebuilt-bundle adoption sweep against the NodeType nodes the whole deployment shares. Each pass stamped a stale bundle's coordinates over the live build's (`PrebuiltAssemblySeeder.Seed` writes first, asks the owner second — #1834), the owner refused the adoption (#2813) and cleared them, and the healthy pods' instances of the type sat on the fallback card for the 120 s self-heal bound — per type, per roll. 1424 `ADOPTION REFUSED` / 350 `[UpdateQueue] FAILED` in 25 min, all on the dying pod. The grace period is the amplifier, not the cause.

## The fix (framework, core)

- **`hub.IsLeaving()`** (`HubLeavingExtensions`, `MeshWeaver.Mesh.Contract`) — `IsShuttingDown` **or** `IHostApplicationLifetime.ApplicationStopping`. The host signal is the one that was live for the whole window; the hub signal alone would have changed nothing on that pod (every refusal was issued by a watcher `SubscribeHubWatcher` drops once `IsShuttingDown`). Same token `OrleansRoutingService` already consults.
- **No adoption pass starts on a leaving hub** — `ShippedPrebuiltBundles.SeedBundles` (every route: boot, on-demand from the compile watcher, push recompile, install) answers 0.
- **A pass in flight stops at the next node boundary** — `PrebuiltAssemblySeeder.Seed` re-asks at subscribe time (the seeder runs one `Seed` per assembly under `Concat`) and again inside the write lambda (an unchanged node is a no-op `Update`). Emits `false` — the caller's ordinary compile-instead signal — so nothing is parked.
- **A leaving owner judges nothing** — `ApplyAdoptedSourceStampAndReport` (reached from the stamp watcher, the sources watcher's fold and the release watcher's fold) leaves the stamp request standing for the owner activation on a pod that stays; the stamp watcher checks before the high-water mark moves so the next emission is not logged as non-convergence.
- **Decline before you write** (the answer to "should a refusal clear at all"): the refusal's clear is required by the #2813 design — at that moment the coordinates on the node ARE the rejected bundle's, `Seed` replaced the live ones one write earlier. So the seeder now declines up-front when the owner's snapshot already carries a published live fingerprint that disagrees with the bundle's — exactly like a framework/dependency mismatch — and the live build's coordinates are never replaced or cleared. The owner's three-way check stays for the pre-publication window (#1834) and as the last line of defence.

Deliberately NOT withheld: the ordinary first-access compile for a user still held on the draining pod — its result is a new version, clobbers nothing, and #3115 made its result write land under the pod's own flush bound. No timers, no retries, no widened bound, no grace-period change.

## Tests

`LeavingHubAdoptionSweepTest` (`MeshWeaver.Compiler.Pipeline.Test`, `MonolithMeshTestBase`): (a) the same `Seed` on a hub flipped to shutting down (`Dispose()`, the #3109 shape) answers `false` and the shared NodeType record stays byte-for-byte untouched (`NotEmit` on stamp / MVID / Pending / AdoptionRefused); (b) control arm — the same call on a live hub adopts (`LatestAssemblyMvid` = the bundle's MVID). Second test: a bundle whose fingerprint disagrees with the published live fingerprint is declined before it writes; the matching fingerprint writes. No `Task.Delay`, no `.ToTask()`, no `Timeout =` literal.

## Conserved

`Doc/Architecture/NodeTypeCompilation` → new section "A LEAVING pod never touches shared NodeType state" (Loki shape, the cross-generation clobber, why the grace period is the amplifier, the two-signal predicate, the decline-before-write rule, triage fingerprint). What's New: `Category: Fix`.

Pairs-with: none — no public type removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
