### PR TITLE
Module build ledger: content-addressed module builds coordinated through memex (Plugins#889, #931)

### DIFF
--- a/.github/scripts/module-build-key.py
+++ b/.github/scripts/module-build-key.py
@@ -1,0 +1,462 @@
+#!/usr/bin/env python3
+"""module-build-key.py — the CONTENT ADDRESS of one module build (Plugins#889, #931).
+
+(The name on this first line is load-bearing: the module-pack lane fetches this file at the
+platform pin and refuses a body whose first 400 bytes do not name it — the same shape as
+check-workflow-timeouts.py's check.)
+
+WHY THIS EXISTS (maintainer, 2026-09-02: "if Plugin X was built against Platform version Y, we don't
+have to rebuild this" · "we should not start the same build multiple times")
+-----------------------------------------------------------------------------------------------------
+A module bundle's bytes and its test verdict are a FUNCTION of a finite set of inputs. Name them,
+hash them, and two runs that share the hash share the result — the second run can reuse the first
+run's bundle, verdict and publication instead of paying 7–17 minutes to reproduce them. That
+requires the hash to cover EVERYTHING the lane feeds the compiler and the test host, and nothing
+else: an input left out makes two different builds collide (a silent under-build — the failure mode
+`node-repo-scope.py` is biased against); an input that is really noise (a timestamp, a run id) makes
+every build unique and the ledger useless.
+
+THE KEY
+-------
+    K = sha256( canonical JSON of {
+          recipe:          RECIPE_VERSION                (the lane's build recipe; bump on a byte-changing lane edit)
+          package, module: the matrix entry's identity
+          entry:           {build: sdk|container, accept: sorted tokens}
+          moduleVersion:   <package>/manifest.lock → moduleVersion   (the package's own content hash, Plugins#878)
+          closure:         {project dir → tree hash}  for the entry project, its sibling <dir>.Test
+                           project (the lane RUNS it) and every in-repo ProjectReference either
+                           reaches, transitively — module-owned MeshWeaver.* siblings RIDE the bundle
+                           (module-owned-platform.sh), so their bytes are the bundle's bytes
+          packages:        {package → moduleVersion}  for every package whose module project is in
+                           that closure, and every package the entry package `requires`, transitively
+          globals:         {path → sha256 | null}  for the repo-level build inputs that change what
+                           EVERY project compiles (src/Directory.Build.props, platform-shipped.txt, …);
+                           null records ABSENCE, which is an input too
+          testerDigest, platformDigest, platformRef:  the compiler, the reference set, and the
+                           platform source the tests build core from
+        } )
+
+A `$(MeshWeaverRoot)`-relative ProjectReference is the PLATFORM's and is never an edge here: the
+platform enters the key through platformDigest (what the module compiles against) and platformRef
+(what `dotnet test` builds from source) — not through a walk of another repository.
+
+🚨 platformRef is in the key ON PURPOSE, and it is the lever a satellite pulls to get reuse: a caller
+whose MW_PLATFORM_REF tracks `main` gets a new key on every core commit, because its test host really
+does build core from that commit. Pin the ref to the promoted set's commit and identical trees key
+identically across runs.
+
+USAGE
+-----
+  module-build-key.py --root REPO --entry '<matrix entry JSON>' --tester-digest T --platform-digest D --platform-ref R
+  module-build-key.py --root REPO --modules @matrix.json …      # every entry → JSON list on stdout
+  module-build-key.py --self-test
+
+Output: `--entry` prints the key alone (or `--json` for {key, inputs}); `--modules` prints a JSON
+list of {package, module, key, inputs}. Exit 2 on a package with no manifest.lock — a package that
+cannot be keyed must not be silently keyed on nothing.
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# 🚨 Bump this when the LANE changes in a way that alters the bytes it packs or the verdict it
+# records for the SAME source (a packer flag, a new closure rule, a different test invocation).
+# Never for a cosmetic lane edit — that would throw away every recorded build for nothing.
+RECIPE_VERSION = "1"
+
+# Repo-level files that change what EVERY project compiles or tests. Presence and content both
+# count; a file the repo does not have hashes as null so adding it later changes the key.
+GLOBAL_INPUTS = (
+    "src/Directory.Build.props",
+    "src/Directory.Build.targets",
+    "src/platform-shipped.txt",
+    "Directory.Build.props",
+    "Directory.Build.targets",
+    "Directory.Packages.props",
+    "global.json",
+    "nuget.config",
+    "NuGet.config",
+    "NuGet.Config",
+)
+
+# Directories a tree hash never descends into: build outputs and editor state are not source.
+SKIP_DIRS = {"bin", "obj", ".vs", "node_modules", "TestResults", "test-logs"}
+
+_INCLUDE = r"<ProjectReference\s[^>]*Include=(?:\"([^\"]+)\"|'([^']+)')"
+
+
+def sha256_bytes(data: bytes) -> str:
+    return hashlib.sha256(data).hexdigest()
+
+
+def file_hash(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 16), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def tree_hash(root: Path, rel_dir: str) -> str:
+    """sha256 over (relative path, content hash) of every source file under rel_dir, sorted."""
+    base = root / rel_dir
+    entries: list[str] = []
+    for dirpath, dirnames, filenames in os.walk(base):
+        dirnames[:] = sorted(d for d in dirnames if d not in SKIP_DIRS)
+        for name in sorted(filenames):
+            p = Path(dirpath) / name
+            rel = p.relative_to(base).as_posix()
+            entries.append(f"{rel}={file_hash(p)}")
+    return sha256_bytes("\n".join(entries).encode("utf-8"))
+
+
+def project_references(root: Path, csproj: Path) -> list[Path]:
+    """In-repo ProjectReference targets of csproj, resolved; $(…)-relative ones are the platform's."""
+    text = csproj.read_text(encoding="utf-8", errors="replace")
+    found: list[Path] = []
+    for a, b in re.findall(_INCLUDE, text):
+        include = (a or b).strip()
+        if "$(" in include:
+            continue
+        target = (csproj.parent / include.replace("\\", "/")).resolve()
+        try:
+            target.relative_to(root.resolve())
+        except ValueError:
+            continue  # resolves outside this checkout — not this repo's edge
+        if target.is_file():
+            found.append(target)
+    return found
+
+
+def closure_dirs(root: Path, entry_project: str) -> list[str]:
+    """The entry project's dir, its sibling <dir>.Test, and every in-repo project either reaches."""
+    root = root.resolve()
+    start = [root / entry_project]
+    test_dir = (root / entry_project).parent.with_name((root / entry_project).parent.name + ".Test")
+    if test_dir.is_dir():
+        start += sorted(test_dir.glob("*.csproj"))
+    seen: set[Path] = set()
+    queue = [p.resolve() for p in start if p.is_file()]
+    while queue:
+        p = queue.pop()
+        if p in seen:
+            continue
+        seen.add(p)
+        queue.extend(project_references(root, p))
+    return sorted({p.parent.relative_to(root).as_posix() for p in seen})
+
+
+def read_json(path: Path) -> dict | None:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def node_packages(root: Path) -> dict[str, dict]:
+    """Top-level dirs carrying an index.json → their index (the caller's node packages)."""
+    skip = {".git", ".github", ".claude", ".worktrees", "scripts", "src", "test", "docs", "e2e",
+            "app", "clients", "legacy", "meshweaver", "tools"}
+    out: dict[str, dict] = {}
+    for d in sorted(root.iterdir()):
+        if d.is_dir() and d.name not in skip and (d / "index.json").is_file():
+            idx = read_json(d / "index.json")
+            if isinstance(idx, dict):
+                out[d.name] = idx
+    return out
+
+
+def module_version(root: Path, package: str) -> str | None:
+    lock = read_json(root / package / "manifest.lock")
+    if not isinstance(lock, dict):
+        return None
+    mv = lock.get("moduleVersion")
+    return mv if isinstance(mv, str) and mv else None
+
+
+def requires_of(index: dict) -> list[str]:
+    """`content.requires` as package ids — strings, or objects naming id/package."""
+    content = index.get("content") if isinstance(index.get("content"), dict) else {}
+    req = content.get("requires") or index.get("requires") or []
+    ids: list[str] = []
+    for r in req if isinstance(req, list) else []:
+        if isinstance(r, str):
+            ids.append(r.split("@")[0].split("/")[-1])
+        elif isinstance(r, dict):
+            v = r.get("id") or r.get("package") or r.get("name")
+            if isinstance(v, str):
+                ids.append(v.split("/")[-1])
+    return ids
+
+
+def compute(root: Path, entry: dict, tester_digest: str, platform_digest: str, platform_ref: str,
+            recipe: str = RECIPE_VERSION) -> dict:
+    """{key, inputs} for one matrix entry. Raises KeyError-shaped ValueError on an unkeyable entry."""
+    package = entry.get("package") or ""
+    module = entry.get("module") or ""
+    project = entry.get("project") or ""
+    if not package or not module or not project:
+        raise ValueError(f"matrix entry lacks package/module/project: {entry}")
+    if not (root / project).is_file():
+        raise ValueError(f"{module}: project {project} does not exist under {root}")
+    own = module_version(root, package)
+    if own is None:
+        raise ValueError(f"{package}/manifest.lock is missing or carries no moduleVersion — the "
+                         "package cannot be keyed (run scripts/gen-manifests.py)")
+
+    dirs = closure_dirs(root, project)
+    closure = {d: tree_hash(root, d) for d in dirs}
+
+    packages = node_packages(root)
+    reached: dict[str, str] = {}
+    # packages whose module project lives in the closure — their moduleVersion covers their content
+    for pid, idx in packages.items():
+        content = idx.get("content") if isinstance(idx.get("content"), dict) else {}
+        mod = content.get("module")
+        if not isinstance(mod, str):
+            continue
+        if any(Path(d).name == mod for d in dirs) and pid != package:
+            mv = module_version(root, pid)
+            reached[pid] = mv or "<no manifest.lock>"
+    # the requires chain, transitively
+    queue = list(requires_of(packages.get(package, {})))
+    seen: set[str] = set()
+    while queue:
+        pid = queue.pop()
+        if pid in seen or pid == package:
+            continue
+        seen.add(pid)
+        reached[pid] = module_version(root, pid) or "<no manifest.lock>"
+        queue.extend(requires_of(packages.get(pid, {})))
+
+    globals_: dict[str, str | None] = {}
+    for rel in GLOBAL_INPUTS:
+        p = root / rel
+        globals_[rel] = file_hash(p) if p.is_file() else None
+
+    accept = " ".join(sorted((entry.get("accept") or "").split()))
+    inputs = {
+        "recipe": recipe,
+        "package": package,
+        "module": module,
+        "entry": {"build": entry.get("build") or "sdk", "accept": accept},
+        "moduleVersion": own,
+        "closure": closure,
+        "packages": dict(sorted(reached.items())),
+        "globals": globals_,
+        "testerDigest": tester_digest or "",
+        "platformDigest": platform_digest or "",
+        "platformRef": platform_ref or "",
+    }
+    canonical = json.dumps(inputs, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return {"key": sha256_bytes(canonical.encode("utf-8")), "inputs": inputs}
+
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────────
+
+def _csproj(refs: list[str]) -> str:
+    return "<Project><ItemGroup>%s</ItemGroup></Project>\n" % "".join(
+        f'<ProjectReference Include="{r}" />' for r in refs)
+
+
+def _fixture(root: Path) -> None:
+    for pkg, module, requires in (("Alpha", "Acme.Alpha", ["Beta"]), ("Beta", "Acme.Beta", []),
+                                  ("Gamma", None, [])):
+        (root / pkg).mkdir(parents=True, exist_ok=True)
+        content = {"requires": requires}
+        if module:
+            content["module"] = module
+        (root / pkg / "index.json").write_text(json.dumps({"id": pkg, "content": content}),
+                                               encoding="utf-8")
+        (root / pkg / "manifest.lock").write_text(
+            json.dumps({"moduleVersion": f"mv-{pkg}", "version": "1.0.0"}), encoding="utf-8")
+    for name, refs in (
+            ("Acme.Alpha", ["../Acme.Shared/Acme.Shared.csproj",
+                            "$(MeshWeaverRoot)/src/MeshWeaver.Graph/MeshWeaver.Graph.csproj"]),
+            ("Acme.Alpha.Test", ["../Acme.Alpha/Acme.Alpha.csproj", "../Acme.Kit/Acme.Kit.csproj"]),
+            ("Acme.Beta", []), ("Acme.Shared", []), ("Acme.Kit", []), ("Acme.Other", [])):
+        d = root / "src" / name
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{name}.csproj").write_text(_csproj(refs), encoding="utf-8")
+        (d / "Code.cs").write_text(f"// {name}\n", encoding="utf-8")
+        (d / "bin").mkdir(exist_ok=True)
+        (d / "bin" / "out.dll").write_bytes(b"\x00")
+    (root / "src" / "Directory.Build.props").write_text("<Project />\n", encoding="utf-8")
+    (root / "docs").mkdir(exist_ok=True)
+    (root / "docs" / "guide.md").write_text("x\n", encoding="utf-8")
+
+
+_ENTRY = {"package": "Alpha", "module": "Acme.Alpha",
+          "project": "src/Acme.Alpha/Acme.Alpha.csproj", "build": "container", "accept": "targets"}
+
+
+def self_test() -> int:
+    import tempfile
+    failures: list[str] = []
+    ran = 0
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        nonlocal ran
+        ran += 1
+        print(f"  {'✓' if ok else '✗'} {name}{'' if ok else ': ' + detail}")
+        if not ok:
+            failures.append(name)
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        _fixture(root)
+        base = compute(root, _ENTRY, "sha256:t", "sha256:p", "abc123")
+        k0 = base["key"]
+        check("the key is 64 hex characters", re.fullmatch(r"[0-9a-f]{64}", k0) is not None, k0)
+        check("the key is deterministic",
+              compute(root, _ENTRY, "sha256:t", "sha256:p", "abc123")["key"] == k0)
+        check("the closure is the entry, its .Test sibling and what they reach — not the platform",
+              sorted(base["inputs"]["closure"]) == ["src/Acme.Alpha", "src/Acme.Alpha.Test",
+                                                    "src/Acme.Kit", "src/Acme.Shared"],
+              str(sorted(base["inputs"]["closure"])))
+        check("the requires chain's moduleVersions are in the key",
+              base["inputs"]["packages"] == {"Beta": "mv-Beta"}, str(base["inputs"]["packages"]))
+        check("absent global inputs are recorded as null (absence is an input)",
+              base["inputs"]["globals"]["global.json"] is None
+              and base["inputs"]["globals"]["src/Directory.Build.props"] is not None)
+
+        def flips(label: str, mutate, restore) -> None:
+            mutate()
+            try:
+                k = compute(root, _ENTRY, "sha256:t", "sha256:p", "abc123")["key"]
+            finally:
+                restore()
+            check(f"{label} changes the key", k != k0)
+            check(f"…and restoring it restores the key",
+                  compute(root, _ENTRY, "sha256:t", "sha256:p", "abc123")["key"] == k0)
+
+        def edit(rel: str, text: str):
+            p = root / rel
+            old = p.read_text(encoding="utf-8")
+            return (lambda: p.write_text(text, encoding="utf-8")), (lambda: p.write_text(old, encoding="utf-8"))
+
+        print("every input flips the key:")
+        flips("the entry project's source", *edit("src/Acme.Alpha/Code.cs", "// changed\n"))
+        flips("a referenced (riding) project's source", *edit("src/Acme.Shared/Code.cs", "// changed\n"))
+        flips("the .Test sibling's source", *edit("src/Acme.Alpha.Test/Code.cs", "// changed\n"))
+        flips("a project reached only through the .Test project", *edit("src/Acme.Kit/Code.cs", "// c\n"))
+        flips("the package's own moduleVersion",
+              *edit("Alpha/manifest.lock", json.dumps({"moduleVersion": "mv-Alpha2", "version": "1.0.1"})))
+        flips("a required package's moduleVersion",
+              *edit("Beta/manifest.lock", json.dumps({"moduleVersion": "mv-Beta2", "version": "1.0.0"})))
+        flips("src/Directory.Build.props", *edit("src/Directory.Build.props", "<Project><PropertyGroup/></Project>\n"))
+        flips("a new file in the entry project",
+              (lambda: (root / "src/Acme.Alpha/New.cs").write_text("//\n", encoding="utf-8")),
+              (lambda: (root / "src/Acme.Alpha/New.cs").unlink()))
+        flips("a new global input appearing (global.json)",
+              (lambda: (root / "global.json").write_text("{}\n", encoding="utf-8")),
+              (lambda: (root / "global.json").unlink()))
+        for label, kwargs in (("the tester digest", dict(tester_digest="sha256:t2")),
+                              ("the platform digest", dict(platform_digest="sha256:p2")),
+                              ("the platform ref", dict(platform_ref="def456")),
+                              ("the recipe version", dict(recipe="2"))):
+            args = dict(tester_digest="sha256:t", platform_digest="sha256:p", platform_ref="abc123")
+            args.update(kwargs)
+            check(f"{label} changes the key", compute(root, _ENTRY, **args)["key"] != k0)
+        check("the build mode changes the key",
+              compute(root, {**_ENTRY, "build": "sdk"}, "sha256:t", "sha256:p", "abc123")["key"] != k0)
+        check("the accept set changes the key",
+              compute(root, {**_ENTRY, "accept": "targets embedded-resource"}, "sha256:t", "sha256:p",
+                      "abc123")["key"] != k0)
+        check("accept token ORDER does not change the key (it is a set)",
+              compute(root, {**_ENTRY, "accept": "b a"}, "sha256:t", "sha256:p", "abc123")["key"]
+              == compute(root, {**_ENTRY, "accept": "a b"}, "sha256:t", "sha256:p", "abc123")["key"])
+
+        print("noise does NOT flip the key:")
+        for label, rel in (("an unrelated project", "src/Acme.Other/Code.cs"),
+                           ("a docs file", "docs/guide.md"),
+                           ("a package with no module (Gamma)", "Gamma/index.json")):
+            mutate, restore = edit(rel, "// noise\n")
+            mutate()
+            try:
+                k = compute(root, _ENTRY, "sha256:t", "sha256:p", "abc123")["key"]
+            finally:
+                restore()
+            check(f"{label} leaves the key unchanged", k == k0)
+        (root / "src/Acme.Alpha/bin/out.dll").write_bytes(b"\x01\x02")
+        check("build output (bin/) leaves the key unchanged",
+              compute(root, _ENTRY, "sha256:t", "sha256:p", "abc123")["key"] == k0)
+
+        print("refusals:")
+        (root / "Alpha" / "manifest.lock").unlink()
+        try:
+            compute(root, _ENTRY, "sha256:t", "sha256:p", "abc123")
+            check("a package without manifest.lock is refused", False, "no error raised")
+        except ValueError as exc:
+            check("a package without manifest.lock is refused", "manifest.lock" in str(exc))
+        (root / "Alpha" / "manifest.lock").write_text(
+            json.dumps({"moduleVersion": "mv-Alpha", "version": "1.0.0"}), encoding="utf-8")
+        try:
+            compute(root, {**_ENTRY, "project": "src/Nope/Nope.csproj"}, "sha256:t", "sha256:p", "abc123")
+            check("a missing project is refused", False, "no error raised")
+        except ValueError as exc:
+            check("a missing project is refused", "does not exist" in str(exc))
+
+    if failures:
+        print(f"\n::error title=module-build-key self-test failed::{len(failures)} case(s) — this script "
+              "decides when two builds are THE SAME build; a collision is a silent under-build.")
+        return 1
+    print(f"\n✓ module-build-key self-test: {ran} cases green — determinism, every input flips the key, "
+          "noise does not, and the two refusals.")
+    return 0
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("--root", default=".")
+    p.add_argument("--entry", help="one matrix entry as JSON")
+    p.add_argument("--modules", help="a JSON array of matrix entries, or @file")
+    p.add_argument("--tester-digest", default="")
+    p.add_argument("--platform-digest", default="")
+    p.add_argument("--platform-ref", default="")
+    p.add_argument("--recipe-version", default=RECIPE_VERSION, help=argparse.SUPPRESS)
+    p.add_argument("--json", action="store_true", help="with --entry: print {key, inputs}")
+    p.add_argument("--self-test", action="store_true", dest="self_test")
+    a = p.parse_args()
+    if a.self_test:
+        return self_test()
+    root = Path(a.root)
+    if not root.is_dir():
+        print(f"::error::--root {a.root} is not a directory", file=sys.stderr)
+        return 2
+    try:
+        if a.entry:
+            got = compute(root, json.loads(a.entry), a.tester_digest, a.platform_digest, a.platform_ref,
+                          a.recipe_version)
+            print(json.dumps(got, indent=2) if a.json else got["key"])
+            return 0
+        if a.modules:
+            raw = a.modules
+            if raw.startswith("@"):
+                raw = Path(raw[1:]).read_text(encoding="utf-8")
+            entries = json.loads(raw)
+            out = []
+            for e in entries:
+                got = compute(root, e, a.tester_digest, a.platform_digest, a.platform_ref, a.recipe_version)
+                out.append({"package": e.get("package"), "module": e.get("module"),
+                            "key": got["key"], "inputs": got["inputs"]})
+                print(f"  {e.get('module')}: {got['key']} (moduleVersion {got['inputs']['moduleVersion']}, "
+                      f"{len(got['inputs']['closure'])} project dir(s), "
+                      f"{len(got['inputs']['packages'])} reached package(s))", file=sys.stderr)
+            print(json.dumps(out))
+            return 0
+    except ValueError as exc:
+        print(f"::error title=module build key::{exc}", file=sys.stderr)
+        return 2
+    p.error("one of --entry, --modules or --self-test is required")
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/module-build-ledger.py
+++ b/.github/scripts/module-build-ledger.py
@@ -44,8 +44,12 @@ THE PROTOCOL
                phase, failure text) — never silently.
 
 🚨 A read that could not reach a verdict (a 5xx, a timeout, an "Error: …" answer) is UNAVAILABLE, not
-"absent": it is retried a bounded number of times honouring Retry-After and then FAILS the job. Claiming
-on an unavailable read would be the fault-becomes-fact defect (#2695) one more time.
+"absent": it is retried a bounded number of times honouring Retry-After, and then the lane proceeds AS IF
+THERE WERE NO RECORD — the module is BUILT, without coordination, and the job summary says so in yellow.
+Never claimed-on-faith (that would be the fault-becomes-fact defect, #2695) and never red: the ledger is
+a coordination layer over a build that is correct without it, so its unavailability may cost a duplicate
+build and may never cost a green (maintainer, 2026-09-02, after the registry answered 503 to three
+Reinsurance bakes — core #3119). Every write command degrades the same way: a `::warning`, exit 0.
 
 USAGE (the lane's steps; every command reads the run identity from GITHUB_* and the endpoint from
 MW_LEDGER_URL / MW_LEDGER_TOKEN)
@@ -85,6 +89,7 @@ BLOCKING_TEST_ATTEMPTS = 2       # a test failure blocks from this many failed a
 PROTOCOL_VERSION = "2025-06-18"
 HTTP_TIMEOUT_S = 60
 HTTP_ATTEMPTS = 3
+RETRY_DELAY_S = float(os.environ.get("MW_LEDGER_RETRY_DELAY_S", "10"))
 FAILURE_TEXT_CAP = 4000
 TEST_NAMES_CAP = 50
 
@@ -165,6 +170,9 @@ class Ledger:
         self._next_id = 0
         self._initialized = False
         self.say = say or (lambda *_: None)
+        # Set once the endpoint has exhausted its retries: every later caller answers "unavailable" at
+        # once instead of paying the retry budget again for each of 30 modules.
+        self.down: str | None = None
 
     def _headers(self) -> dict:
         h = {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json",
@@ -179,6 +187,8 @@ class Ledger:
             self._next_id += 1
             body["id"] = self._next_id
         data = json.dumps(body).encode("utf-8")
+        if self.down:
+            raise LedgerError(f"{method}: the ledger is unavailable ({self.down})")
         last = ""
         for attempt in range(1, HTTP_ATTEMPTS + 1):
             req = urllib.request.Request(self.endpoint, data=data, headers=self._headers(), method="POST")
@@ -196,20 +206,24 @@ class Ledger:
                 text = exc.read().decode("utf-8", "replace")[:500]
                 if exc.code in (429, 502, 503, 504) and attempt < HTTP_ATTEMPTS:
                     wait = exc.headers.get("Retry-After")
-                    delay = float(wait) if wait and wait.replace(".", "", 1).isdigit() else 10.0
+                    delay = float(wait) if wait and wait.replace(".", "", 1).isdigit() else RETRY_DELAY_S
                     self.say(f"ledger: HTTP {exc.code} from {self.endpoint} (attempt {attempt}) — retrying in {delay:g}s "
                              f"(a retryable fault, NOT a verdict): {text}")
                     time.sleep(min(delay, 60.0))
                     last = f"HTTP {exc.code}: {text}"
                     continue
+                if exc.code in (429, 502, 503, 504):
+                    self.down = f"HTTP {exc.code} after {HTTP_ATTEMPTS} attempts: {text}"
+                    raise LedgerError(f"{method}: the ledger stayed unavailable ({self.down})") from exc
                 raise LedgerError(f"{method} → HTTP {exc.code} from {self.endpoint}: {text}") from exc
             except (urllib.error.URLError, TimeoutError, OSError) as exc:
                 last = str(exc)
                 if attempt < HTTP_ATTEMPTS:
-                    self.say(f"ledger: {self.endpoint} unreachable (attempt {attempt}: {exc}) — retrying in 10s")
-                    time.sleep(10.0)
+                    self.say(f"ledger: {self.endpoint} unreachable (attempt {attempt}: {exc}) — retrying in {RETRY_DELAY_S:g}s")
+                    time.sleep(RETRY_DELAY_S)
                     continue
-        raise LedgerError(f"{method}: the ledger stayed unavailable after {HTTP_ATTEMPTS} attempts ({last})")
+        self.down = f"unreachable after {HTTP_ATTEMPTS} attempts: {last}"
+        raise LedgerError(f"{method}: the ledger stayed unavailable ({self.down})")
 
     @staticmethod
     def _parse(raw: bytes, ctype: str, want_id) -> dict:
@@ -411,12 +425,20 @@ def decide(ledger: Ledger, matrix: list[dict], keys: list[dict], me: dict, publi
     problems: list[str] = []
     deadline = time.monotonic() + wait_max_s
     first = True
+    def uncoordinated(e: dict, k: dict | None, why: str) -> None:
+        # 🚨 The ledger's unavailability costs a duplicate build at worst — never a red. The module is
+        # built exactly as it was before the ledger existed, and the summary says so in yellow.
+        say(f"  {e['module']}: BUILD without coordination — {why}")
+        decided[e["module"]] = {**e, "ledger": {"key": k["key"] if k else "", "decision": "build",
+                                                "attempts": None, "unavailable": why[:300]}}
+
     while pending:
         if not first:
             if time.monotonic() > deadline:
                 for e in pending:
-                    problems.append(f"{e['module']}: another run still holds key {by_module[e['module']]['key'][:12]}… "
-                                    f"after {int(wait_max_s)}s — it is neither finished nor stale; read its run and re-run this one")
+                    uncoordinated(e, by_module.get(e["module"]),
+                                  f"another run still holds this key after {int(wait_max_s)}s — neither finished nor "
+                                  "stale; building anyway rather than holding this run hostage (a duplicate build, not a red)")
                 break
             time.sleep(poll_s)
         first = False
@@ -424,9 +446,16 @@ def decide(ledger: Ledger, matrix: list[dict], keys: list[dict], me: dict, publi
         for e in pending:
             k = by_module.get(e["module"])
             if k is None:
-                problems.append(f"{e['module']}: no build key was computed for it")
+                uncoordinated(e, None, "no build key was computed for it")
                 continue
-            verdict, detail = decide_one(ledger, e, k, me, publishing, say)
+            if ledger.down:
+                uncoordinated(e, k, f"the ledger is unavailable ({ledger.down})")
+                continue
+            try:
+                verdict, detail = decide_one(ledger, e, k, me, publishing, say)
+            except LedgerError as exc:
+                uncoordinated(e, k, f"the ledger is unavailable ({str(exc)[:200]})")
+                continue
             if verdict == "wait":
                 say(f"  {e['module']}: WAITING — {detail['status']} by {detail['holder']} (heartbeat {detail['heartbeatAgeS']}s ago)")
                 still.append(e)
@@ -650,6 +679,8 @@ def self_test() -> int:
             failures.append(name)
 
     quiet = lambda *a: None
+    global RETRY_DELAY_S
+    RETRY_DELAY_S = 0.01   # the self-test pays no real retry delays; the CLI children read the env below
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
         (root / "fake.py").write_text(_FAKE_SERVER_SRC, encoding="utf-8")
@@ -819,11 +850,54 @@ def self_test() -> int:
                   not problems and by["Acme.Alpha"]["decision"] == "reuse" and by["Acme.Beta"]["decision"] == "build", f"{problems} {by}")
             store(**{f"{ROOT}/{key}": {**claim_content(entry, kinfo, run(run_id="950"), 1, None)}})
             out, problems = decide(L(), [entry], [kinfo], run(run_id="951"), False, 0.5, 0.2, quiet)
-            check("a holder that neither finishes nor goes stale within the budget is a named problem, not a build",
-                  len(problems) == 1 and "still holds" in problems[0] and out == [], f"{problems} {out}")
+            check("a holder that neither finishes nor goes stale within the budget ⇒ build anyway, flagged (never a red)",
+                  not problems and out[0]["ledger"]["decision"] == "build" and "still holds" in out[0]["ledger"]["unavailable"],
+                  f"{problems} {out}")
         finally:
             server.kill()
             server.wait()
+
+        print("the ledger is DOWN — a coordination layer may cost a duplicate build, never a green:")
+        dead = Ledger(url, "mw_test", quiet)
+        t0 = time.monotonic()
+        out, problems = decide(dead, [entry, entry2], [kinfo, kinfo2], run(run_id="960"), True, 10, 0.2, quiet)
+        check("an unreachable ledger ⇒ every module is BUILT without coordination, none blocked, no exception",
+              not problems and [e["ledger"]["decision"] for e in out] == ["build", "build"]
+              and all("unavailable" in e["ledger"] for e in out), f"{problems} {out}")
+        check("…and the retry budget is paid ONCE, not once per module",
+              dead.down is not None and time.monotonic() - t0 < 5, f"down={dead.down} took {time.monotonic() - t0:.1f}s")
+        rc = record(Ledger(url, "mw_test", quiet), argparse.Namespace(key=key, status="Published", trx=None, version=None,
+                    platform_identity=None, bundle=None, artifact_name=None, retention_days=7, phase=None, failure_file=None),
+                    run(run_id="960"), quiet) if False else None
+        try:
+            simple_patch(Ledger(url, "mw_test", quiet), key, run(run_id="960"), {"heartbeatAt": iso(now_utc())}, quiet, "hb")
+            check("a write against a dead ledger raises LedgerError (main() turns it into a ::warning, exit 0)", False, "no error")
+        except LedgerError:
+            check("a write against a dead ledger raises LedgerError (main() turns it into a ::warning, exit 0)", True)
+        del rc
+        env = {**os.environ, "MW_LEDGER_URL": url, "MW_LEDGER_TOKEN": "mw_test", "MW_LEDGER_RETRY_DELAY_S": "0.01"}
+        proc = subprocess.run([sys.executable, str(Path(__file__).resolve()), "heartbeat", "--key", key],
+                              capture_output=True, text=True, env=env, timeout=120)
+        check("the CLI: a write to a dead ledger exits 0 with a ::warning, never 1",
+              proc.returncode == 0 and "::warning" in proc.stderr, f"exit={proc.returncode} {proc.stderr[-200:]}")
+        mfile = root / "m.json"
+        mfile.write_text(json.dumps([entry]), encoding="utf-8")
+        kfile = root / "k.json"
+        kfile.write_text(json.dumps([kinfo]), encoding="utf-8")
+        proc = subprocess.run([sys.executable, str(Path(__file__).resolve()), "decide", "--keys", f"@{kfile}", "--matrix", f"@{mfile}",
+                               "--publish", "true", "--out-matrix", str(root / "om.json"), "--out-build", str(root / "ob.json")],
+                              capture_output=True, text=True, env=env, timeout=120)
+        got = json.loads((root / "om.json").read_text(encoding="utf-8")) if (root / "om.json").is_file() else []
+        check("the CLI: decide against a dead ledger exits 0 and hands the lane a full BUILD matrix",
+              proc.returncode == 0 and got and got[0]["ledger"]["decision"] == "build" and got[0]["ledger"].get("unavailable"),
+              f"exit={proc.returncode} {proc.stderr[-200:]} {got}")
+        proc = subprocess.run([sys.executable, str(Path(__file__).resolve()), "decide", "--keys", f"@{kfile}", "--matrix", f"@{mfile}",
+                               "--publish", "true", "--out-matrix", str(root / "om2.json"), "--out-build", str(root / "ob2.json")],
+                              capture_output=True, text=True, env={**env, "MW_LEDGER_TOKEN": ""}, timeout=120)
+        got = json.loads((root / "om2.json").read_text(encoding="utf-8")) if (root / "om2.json").is_file() else []
+        check("the CLI: decide with NO token configured exits 0, builds everything, and says why",
+              proc.returncode == 0 and got and got[0]["ledger"].get("unavailable") and "MW_LEDGER_TOKEN" in proc.stderr,
+              f"exit={proc.returncode} {proc.stderr[-200:]}")
 
     if failures:
         print(f"\n::error title=module-build-ledger self-test failed::{len(failures)} case(s) — this script decides "
@@ -873,6 +947,12 @@ def main() -> int:
 
     say = lambda *parts: print(*parts, file=sys.stderr, flush=True)
     me = run_identity(a.lane)
+
+    def summary(lines: list[str]) -> None:
+        if os.environ.get("GITHUB_STEP_SUMMARY"):
+            with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+                fh.write("\n".join(lines) + "\n")
+
     try:
         ledger = Ledger(os.environ.get("MW_LEDGER_URL", ""), os.environ.get("MW_LEDGER_TOKEN", ""), say)
         if a.command == "decide":
@@ -894,6 +974,8 @@ def main() -> int:
                 if lg["decision"] == "reuse":
                     lines.append(f"- `{e['module']}` — **reused** ({lg['status']}) from {lg['holder']}"
                                  + (" — tests still run" if lg["needTest"] else "") + (" — published by this run" if lg["needPublish"] else ""))
+                elif lg["decision"] == "build" and lg.get("unavailable"):
+                    lines.append(f"- 🟡 `{e['module']}` — **build WITHOUT coordination**: {lg['unavailable']}")
                 elif lg["decision"] == "build":
                     lines.append(f"- `{e['module']}` — **build** (attempt {lg['attempts']}"
                                  + (f", taken over from {lg.get('previous')}" if lg.get("takeover") else "") + f") key `{lg['key'][:12]}…`")
@@ -901,9 +983,7 @@ def main() -> int:
                     lines.append(f"- `{e['module']}` — **BLOCKED** by {lg['holder']} ({lg.get('phase')})")
             for pr in problems:
                 lines.append(f"- 🚨 {pr.splitlines()[0]}")
-            if os.environ.get("GITHUB_STEP_SUMMARY"):
-                with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
-                    fh.write("\n".join(lines) + "\n")
+            summary(lines)
             if problems:
                 for pr in problems:
                     print(f"::error title=module build ledger::{pr}", file=sys.stderr)
@@ -927,8 +1007,21 @@ def main() -> int:
                 p.error("record needs --status")
             return record(ledger, a, me, say)
     except LedgerError as exc:
-        print(f"::error title=module build ledger::{exc}", file=sys.stderr)
-        return 1
+        # 🚨 Never red on the ledger's account. A decide that cannot even construct or reach the ledger
+        # builds every selected module without coordination; a write that fails is a warning.
+        why = str(exc)[:400]
+        print(f"::warning title=module build ledger unavailable::{why}", file=sys.stderr)
+        summary(["### Module build ledger", "", f"🟡 **unavailable** — {why}", "",
+                 "Every selected module is built without coordination (a duplicate build at worst, never a red)."
+                 if a.command == "decide" else f"`{a.command}` for key `{(a.key or '')[:12]}…` was not recorded."])
+        if a.command == "decide" and a.matrix and a.out_matrix and a.out_build:
+            matrix = load_json_arg(a.matrix)
+            keys = {k.get("module"): k for k in (load_json_arg(a.keys) if a.keys else [])}
+            out = [{**e, "ledger": {"key": (keys.get(e.get("module")) or {}).get("key", ""), "decision": "build",
+                                    "attempts": None, "unavailable": why[:300]}} for e in matrix]
+            Path(a.out_matrix).write_text(json.dumps(out), encoding="utf-8")
+            Path(a.out_build).write_text(json.dumps(out), encoding="utf-8")
+        return 0
     return 2
 
 

--- a/.github/scripts/module-build-ledger.py
+++ b/.github/scripts/module-build-ledger.py
@@ -1,0 +1,936 @@
+#!/usr/bin/env python3
+"""module-build-ledger.py — the fleet's CI MODULE BUILD LEDGER on the registry portal (Plugins#889, #931).
+
+(The name on this first line is load-bearing: the module-pack lane fetches this file at the
+platform pin and refuses a body whose first 400 bytes do not name it.)
+
+WHY THIS EXISTS (maintainer, 2026-09-02: "we should not start the same build multiple times ⇒
+coordinate which packages are in progress; track progress through memex")
+------------------------------------------------------------------------------------------------
+Every satellite calls the same reusable module-pack lane, and until this script every call built
+every selected module from scratch — a PR run and the push-to-main run that followed it minutes later
+compiled and tested the SAME bytes twice, two concurrent PRs touching the same module built it twice
+at once, and a platform release rebuilt 31 bundles whether or not each one's inputs had moved. Nothing
+recorded what had been built against what.
+
+The ledger is one MeshNode per BUILD KEY (module-build-key.py: the content address of one module
+build — package, moduleVersion, in-repo closure, both image digests, platform ref, recipe) at
+
+    Admin/ModuleBuilds/<key>          nodeType ModuleBuild, content $type ModuleBuildRecord
+
+on the registry portal (memex.meshweaver.cloud), written through its MCP endpoint (JSON-RPC over
+HTTP at /mcp, `Authorization: Bearer <mw_ ApiToken>`) as a dedicated CI user holding a partition-admin
+grant on exactly that root — never a global admin (Doc/Architecture/AccessControl → "The Admin partition").
+
+THE PROTOCOL
+------------
+  claim      = CREATE the node. Creation fails on an existing path, so exactly one run holds a key;
+               "already exists" is the follower's SUCCESS case — it then reads the holder's record.
+               After every create the claimant re-reads the node and holds the key only if the record
+               names ITS run: a claim you cannot read back is a claim you do not hold.
+  heartbeat  = the holder proves it is alive. A claim whose heartbeat is older than STALE_AFTER (the
+               fleet's 45-minute job cap) is dead by construction and may be taken over — a job that
+               cannot heartbeat inside its own cap has been killed.
+  reuse      = a terminal record (Built/Tested/Published) whose bundle artifact this run can fetch is
+               not rebuilt: the pack job downloads that bundle, runs only the phases the record lacks
+               (tests if this run needs a verdict, publish if this run publishes), and records them.
+  wait       = a fresh, unfinished claim by ANOTHER run: the follower polls (30 s) until the holder
+               finishes or goes stale, then reuses or takes over — the same key is never built twice
+               at once.
+  tolerance  = a Failed record BLOCKS a later run of the same key only when the same inputs give the
+               same result: a COMPILE failure blocks; a TEST failure blocks from the second failed
+               attempt on (one re-claim, so a flaky suite does not pin the fleet); a cancelled or
+               aborted build never blocks. Blocked runs fail with the holder's evidence (run URL,
+               phase, failure text) — never silently.
+
+🚨 A read that could not reach a verdict (a 5xx, a timeout, an "Error: …" answer) is UNAVAILABLE, not
+"absent": it is retried a bounded number of times honouring Retry-After and then FAILS the job. Claiming
+on an unavailable read would be the fault-becomes-fact defect (#2695) one more time.
+
+USAGE (the lane's steps; every command reads the run identity from GITHUB_* and the endpoint from
+MW_LEDGER_URL / MW_LEDGER_TOKEN)
+  decide    --keys @keys.json --matrix @matrix.json --publish true|false --lane L --out-matrix F --out-build F
+  heartbeat --key K
+  record    --key K --status Built --bundle FILE --artifact-name N --retention-days 7 [--version V] [--platform-identity I]
+  record    --key K --status Tested [--trx FILE]
+  record    --key K --status Published
+  record    --key K --status Failed --phase compile|pack|test|publish|workspace [--failure-file F]
+  finish    --key K                 the holder's leg ended with a non-terminal status (Built/Tested, no publish)
+  release   --key K                 the holder was cancelled: the key becomes reclaimable at once
+  get       --key K
+  --self-test                       an in-process fake MCP server; every rule above is exercised
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+ROOT = "Admin/ModuleBuilds"
+NODE_TYPE = "ModuleBuild"
+CONTENT_TYPE = "ModuleBuildRecord"
+STATUSES = ("Claimed", "Built", "Tested", "Published", "Failed")
+STALE_AFTER_S = 45 * 60          # the fleet's job cap (check-workflow-timeouts.py)
+BLOCKING_TEST_ATTEMPTS = 2       # a test failure blocks from this many failed attempts on
+PROTOCOL_VERSION = "2025-06-18"
+HTTP_TIMEOUT_S = 60
+HTTP_ATTEMPTS = 3
+FAILURE_TEXT_CAP = 4000
+TEST_NAMES_CAP = 50
+
+
+class LedgerError(RuntimeError):
+    """The ledger could not be read or written — unavailable, refused, or malformed. Never 'absent'."""
+
+
+class ToolError(LedgerError):
+    """A tool answered an error string ("Error: …") instead of a result."""
+
+
+def now_utc() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def iso(t: dt.datetime) -> str:
+    return t.astimezone(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def parse_time(s) -> dt.datetime | None:
+    """Tolerant ISO-8601: .NET writes up to 7 fractional digits, Python reads at most 6."""
+    if not isinstance(s, str) or not s:
+        return None
+    m = re.fullmatch(r"(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(Z|[+-]\d{2}:\d{2})?", s.strip())
+    if not m:
+        return None
+    frac = (m.group(2) or "")[:7]
+    tz = m.group(3) or "Z"
+    text = m.group(1) + frac + ("+00:00" if tz == "Z" else tz)
+    try:
+        t = dt.datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    return t if t.tzinfo else t.replace(tzinfo=dt.timezone.utc)
+
+
+# ── the run this process speaks for ──────────────────────────────────────────────────────────
+
+def run_identity(lane: str | None = None) -> dict:
+    env = os.environ
+    repo = env.get("GITHUB_REPOSITORY", "")
+    run_id = env.get("GITHUB_RUN_ID", "")
+    attempt = env.get("GITHUB_RUN_ATTEMPT", "1")
+    server = env.get("GITHUB_SERVER_URL", "https://github.com")
+    return {
+        "repo": repo,
+        "runId": run_id,
+        "attempt": attempt,
+        "url": f"{server}/{repo}/actions/runs/{run_id}/attempts/{attempt}" if repo and run_id else "",
+        "event": env.get("GITHUB_EVENT_NAME", ""),
+        "lane": lane or env.get("MW_LEDGER_LANE") or None,
+    }
+
+
+def same_run(rec_run: dict | None, me: dict) -> bool:
+    if not isinstance(rec_run, dict):
+        return False
+    if (rec_run.get("repo"), str(rec_run.get("runId")), str(rec_run.get("attempt"))) != \
+            (me["repo"], str(me["runId"]), str(me["attempt"])):
+        return False
+    return rec_run.get("lane") in (None, "", me.get("lane")) or me.get("lane") in (None, "")
+
+
+# ── MCP over HTTP ────────────────────────────────────────────────────────────────────────────
+
+class Ledger:
+    """Speaks JSON-RPC to the portal's /mcp (Streamable HTTP; JSON or SSE answers) with a bearer token."""
+
+    def __init__(self, base_url: str, token: str, say=None):
+        if not base_url or not token:
+            raise LedgerError("MW_LEDGER_URL and MW_LEDGER_TOKEN are required — the ledger has nowhere to write "
+                              "and nothing to write as. Provision the registry portal's ledger token (a mw_ "
+                              "ApiToken of the CI user) as the caller's ledger-token secret.")
+        self.endpoint = base_url.rstrip("/") + "/mcp"
+        self.token = token
+        self.session_id: str | None = None
+        self._next_id = 0
+        self._initialized = False
+        self.say = say or (lambda *_: None)
+
+    def _headers(self) -> dict:
+        h = {"Authorization": f"Bearer {self.token}", "Content-Type": "application/json",
+             "Accept": "application/json, text/event-stream", "MCP-Protocol-Version": PROTOCOL_VERSION}
+        if self.session_id:
+            h["Mcp-Session-Id"] = self.session_id
+        return h
+
+    def _post(self, method: str, params: dict, notification: bool = False) -> dict | None:
+        body: dict = {"jsonrpc": "2.0", "method": method, "params": params}
+        if not notification:
+            self._next_id += 1
+            body["id"] = self._next_id
+        data = json.dumps(body).encode("utf-8")
+        last = ""
+        for attempt in range(1, HTTP_ATTEMPTS + 1):
+            req = urllib.request.Request(self.endpoint, data=data, headers=self._headers(), method="POST")
+            try:
+                with urllib.request.urlopen(req, timeout=HTTP_TIMEOUT_S) as resp:
+                    sid = resp.headers.get("Mcp-Session-Id")
+                    if sid:
+                        self.session_id = sid
+                    raw = resp.read()
+                    ctype = (resp.headers.get("Content-Type") or "").lower()
+                    if notification or resp.status == 202 or not raw:
+                        return None
+                    return self._parse(raw, ctype, body.get("id"))
+            except urllib.error.HTTPError as exc:
+                text = exc.read().decode("utf-8", "replace")[:500]
+                if exc.code in (429, 502, 503, 504) and attempt < HTTP_ATTEMPTS:
+                    wait = exc.headers.get("Retry-After")
+                    delay = float(wait) if wait and wait.replace(".", "", 1).isdigit() else 10.0
+                    self.say(f"ledger: HTTP {exc.code} from {self.endpoint} (attempt {attempt}) — retrying in {delay:g}s "
+                             f"(a retryable fault, NOT a verdict): {text}")
+                    time.sleep(min(delay, 60.0))
+                    last = f"HTTP {exc.code}: {text}"
+                    continue
+                raise LedgerError(f"{method} → HTTP {exc.code} from {self.endpoint}: {text}") from exc
+            except (urllib.error.URLError, TimeoutError, OSError) as exc:
+                last = str(exc)
+                if attempt < HTTP_ATTEMPTS:
+                    self.say(f"ledger: {self.endpoint} unreachable (attempt {attempt}: {exc}) — retrying in 10s")
+                    time.sleep(10.0)
+                    continue
+        raise LedgerError(f"{method}: the ledger stayed unavailable after {HTTP_ATTEMPTS} attempts ({last})")
+
+    @staticmethod
+    def _parse(raw: bytes, ctype: str, want_id) -> dict:
+        text = raw.decode("utf-8", "replace")
+        messages: list[dict] = []
+        if "text/event-stream" in ctype:
+            for block in text.replace("\r\n", "\n").split("\n\n"):
+                payload = "\n".join(line[5:].lstrip() for line in block.split("\n") if line.startswith("data:"))
+                if payload.strip():
+                    try:
+                        messages.append(json.loads(payload))
+                    except json.JSONDecodeError:
+                        continue
+        else:
+            try:
+                parsed = json.loads(text)
+            except json.JSONDecodeError as exc:
+                raise LedgerError(f"the ledger answered non-JSON ({ctype or 'no content-type'}): {text[:300]}") from exc
+            messages = parsed if isinstance(parsed, list) else [parsed]
+        for m in messages:
+            if isinstance(m, dict) and m.get("id") == want_id and ("result" in m or "error" in m):
+                if "error" in m:
+                    err = m["error"]
+                    raise LedgerError(f"JSON-RPC error {err.get('code')}: {err.get('message')} {err.get('data') or ''}".strip())
+                return m["result"] if isinstance(m["result"], dict) else {"value": m["result"]}
+        raise LedgerError(f"no JSON-RPC response for id {want_id} in: {text[:300]}")
+
+    def initialize(self) -> None:
+        if self._initialized:
+            return
+        self._post("initialize", {"protocolVersion": PROTOCOL_VERSION, "capabilities": {},
+                                  "clientInfo": {"name": "module-build-ledger", "version": "1"}})
+        self._post("notifications/initialized", {}, notification=True)
+        self._initialized = True
+
+    def call(self, tool: str, arguments: dict) -> str:
+        self.initialize()
+        result = self._post("tools/call", {"name": tool, "arguments": arguments}) or {}
+        parts = [c.get("text", "") for c in result.get("content", []) if isinstance(c, dict) and c.get("type") == "text"]
+        text = "".join(parts)
+        if result.get("isError"):
+            raise ToolError(text or f"{tool} answered isError with no text")
+        return text
+
+    # ── the three tools the ledger uses ──
+
+    def get(self, key: str) -> dict | None:
+        """The record's CONTENT, or None when the node is ABSENT. Unavailable/erroring reads RAISE."""
+        text = self.call("get", {"path": f"@{ROOT}/{key}"}).strip()
+        if text.startswith("Not found"):
+            return None
+        if text.startswith("Error"):
+            raise LedgerError(f"get {ROOT}/{key}: {text[:300]}")
+        try:
+            node = json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise LedgerError(f"get {ROOT}/{key} answered non-JSON: {text[:300]}") from exc
+        content = node.get("content") if isinstance(node, dict) else None
+        if not isinstance(content, dict):
+            raise LedgerError(f"get {ROOT}/{key}: the node carries no content object: {text[:300]}")
+        return content
+
+    def create(self, key: str, name: str, content: dict) -> str:
+        node = {"id": key, "namespace": ROOT, "name": name, "nodeType": NODE_TYPE,
+                "content": {"$type": CONTENT_TYPE, **content}}
+        text = self.call("create", {"node": json.dumps(node)}).strip()
+        if not text.startswith("Created"):
+            raise ToolError(text)
+        return text
+
+    def patch(self, key: str, content_fields: dict) -> str:
+        text = self.call("patch", {"path": f"@{ROOT}/{key}", "fields": json.dumps({"content": content_fields})}).strip()
+        if text.startswith("Error") or text.startswith("Not found"):
+            raise ToolError(text)
+        return text
+
+
+# ── record helpers ───────────────────────────────────────────────────────────────────────────
+
+def status_of(rec: dict | None) -> str | None:
+    if not rec:
+        return None
+    s = rec.get("status")
+    if isinstance(s, int) and 0 <= s < len(STATUSES):
+        return STATUSES[s]
+    return s if isinstance(s, str) else None
+
+
+def heartbeat_age_s(rec: dict) -> float:
+    t = parse_time(rec.get("heartbeatAt")) or parse_time(rec.get("claimedAt"))
+    return float("inf") if t is None else (now_utc() - t).total_seconds()
+
+
+def summary_of(rec: dict) -> dict:
+    """What a re-claim keeps of the previous holder: evidence, not authority."""
+    keep = ("status", "phase", "blocking", "attempts", "run", "claimedAt", "heartbeatAt", "finishedAt",
+            "failure", "tests", "bundleSha256", "version", "platformIdentity")
+    return {k: rec.get(k) for k in keep if rec.get(k) is not None}
+
+
+def artifact_fetchable(rec: dict, me: dict, say) -> tuple[bool, str]:
+    """Can THIS run download the record's bundle artifact? Same repo (GITHUB_TOKEN is repo-scoped) and
+    the artifact still exists and is not expired — asked of the API, never assumed from a date."""
+    art = rec.get("bundleArtifact")
+    if not isinstance(art, dict) or not art.get("name") or not art.get("runId"):
+        return False, "the record names no bundle artifact"
+    if art.get("repo") != me["repo"]:
+        return False, f"the bundle lives in {art.get('repo')}'s run {art.get('runId')} — this run's token reads only {me['repo']}"
+    gh = os.environ.get("MW_LEDGER_GH", "gh")
+    try:
+        proc = subprocess.run([gh, "api", f"repos/{art['repo']}/actions/runs/{art['runId']}/artifacts?name={art['name']}"],
+                              capture_output=True, text=True, timeout=120)
+    except (OSError, subprocess.SubprocessError) as exc:
+        return False, f"gh api failed: {exc}"
+    if proc.returncode != 0:
+        return False, (f"gh api answered exit {proc.returncode} for run {art['runId']}'s artifacts — "
+                       f"{(proc.stderr or proc.stdout).strip()[:200]} (the caller's job needs `permissions: actions: read` to reuse bundles)")
+    try:
+        found = [a for a in json.loads(proc.stdout).get("artifacts", []) if a.get("name") == art["name"]]
+    except json.JSONDecodeError:
+        return False, "gh api answered non-JSON"
+    live = [a for a in found if not a.get("expired")]
+    if not live:
+        return False, f"artifact {art['name']} of run {art['runId']} is gone or expired"
+    return True, f"artifact {art['name']} of run {art['runId']}"
+
+
+# ── the decision ─────────────────────────────────────────────────────────────────────────────
+
+def claim_content(entry: dict, key_info: dict, me: dict, attempts: int, previous: dict | None) -> dict:
+    inputs = key_info.get("inputs", {})
+    content = {
+        "key": key_info["key"], "package": entry["package"], "module": entry["module"],
+        "moduleVersion": inputs.get("moduleVersion", ""), "platformRef": inputs.get("platformRef", ""),
+        "testerDigest": inputs.get("testerDigest") or None, "platformDigest": inputs.get("platformDigest") or None,
+        "status": "Claimed", "phase": None, "blocking": False, "attempts": attempts, "run": me,
+        "claimedAt": iso(now_utc()), "heartbeatAt": iso(now_utc()), "finishedAt": None,
+        "bundleSha256": None, "bundleArtifact": None, "tests": None, "failure": None,
+        "previous": previous,
+    }
+    return content
+
+
+def decide_one(ledger: Ledger, entry: dict, key_info: dict, me: dict, publishing: bool, say) -> tuple[str, dict]:
+    """One pass: ('build'|'reuse'|'wait'|'blocked', detail). 'wait' asks the caller to poll and call again."""
+    key = key_info["key"]
+    need_test = entry.get("test", True) is not False
+    rec = ledger.get(key)
+    if rec is None:
+        try:
+            ledger.create(key, f"{entry['module']} @ {key[:12]}", claim_content(entry, key_info, me, 1, None))
+        except ToolError as exc:
+            say(f"  {entry['module']}: create did not succeed ({str(exc)[:160]}) — reading who holds {key[:12]}")
+        rec = ledger.get(key)
+        if rec is None:
+            raise LedgerError(f"{entry['module']}: the claim for {key} wrote nothing readable — the create was refused "
+                              "for a reason other than 'already exists' (see the message above) and no other run holds it")
+    st = status_of(rec)
+    if same_run(rec.get("run"), me):
+        return "build", {"attempts": rec.get("attempts", 1), "status": st, "takeover": False}
+    fresh = heartbeat_age_s(rec) < STALE_AFTER_S
+    finished = parse_time(rec.get("finishedAt")) is not None
+    holder = (rec.get("run") or {}).get("url") or json.dumps(rec.get("run"))
+    if st in ("Claimed", "Built", "Tested") and not finished and fresh:
+        return "wait", {"holder": holder, "status": st, "heartbeatAgeS": int(heartbeat_age_s(rec))}
+    if st == "Failed" and rec.get("blocking") is True:
+        return "blocked", {"holder": holder, "phase": rec.get("phase"), "failure": (rec.get("failure") or "")[:1500],
+                           "attempts": rec.get("attempts"), "tests": rec.get("tests")}
+    if st in ("Built", "Tested", "Published"):
+        ok, why = artifact_fetchable(rec, me, say)
+        if ok:
+            more_test = need_test and st not in ("Tested", "Published")
+            more_publish = publishing and st != "Published"
+            if more_test or more_publish:
+                # this run completes the record: it becomes the holder for the remaining phases
+                ledger.patch(key, {"run": me, "heartbeatAt": iso(now_utc()), "finishedAt": None})
+                after = ledger.get(key)
+                if after is None or not same_run(after.get("run"), me):
+                    return "wait", {"holder": holder, "status": st, "heartbeatAgeS": 0}
+            return "reuse", {"holder": holder, "status": st, "needTest": more_test, "needPublish": more_publish,
+                             "artifact": rec.get("bundleArtifact"), "bundleSha256": rec.get("bundleSha256"),
+                             "platformIdentity": rec.get("platformIdentity"), "source": why}
+        say(f"  {entry['module']}: {st} record at {holder} is not reusable — {why}")
+    # stale claim, non-blocking failure, or a terminal record whose bundle is gone: take the key over
+    attempts = int(rec.get("attempts") or 0) + 1
+    ledger.patch(key, {**claim_content(entry, key_info, me, attempts, summary_of(rec))})
+    after = ledger.get(key)
+    if after is None or not same_run(after.get("run"), me):
+        return "wait", {"holder": holder, "status": st, "heartbeatAgeS": 0}
+    return "build", {"attempts": attempts, "status": st, "takeover": True, "previous": holder}
+
+
+def decide(ledger: Ledger, matrix: list[dict], keys: list[dict], me: dict, publishing: bool,
+           wait_max_s: float, poll_s: float, say) -> tuple[list[dict], list[str]]:
+    """Every entry annotated with a `ledger` object; returns (annotated matrix, blocking problems)."""
+    by_module = {k["module"]: k for k in keys}
+    pending = list(matrix)
+    decided: dict[str, dict] = {}
+    problems: list[str] = []
+    deadline = time.monotonic() + wait_max_s
+    first = True
+    while pending:
+        if not first:
+            if time.monotonic() > deadline:
+                for e in pending:
+                    problems.append(f"{e['module']}: another run still holds key {by_module[e['module']]['key'][:12]}… "
+                                    f"after {int(wait_max_s)}s — it is neither finished nor stale; read its run and re-run this one")
+                break
+            time.sleep(poll_s)
+        first = False
+        still: list[dict] = []
+        for e in pending:
+            k = by_module.get(e["module"])
+            if k is None:
+                problems.append(f"{e['module']}: no build key was computed for it")
+                continue
+            verdict, detail = decide_one(ledger, e, k, me, publishing, say)
+            if verdict == "wait":
+                say(f"  {e['module']}: WAITING — {detail['status']} by {detail['holder']} (heartbeat {detail['heartbeatAgeS']}s ago)")
+                still.append(e)
+                continue
+            if verdict == "blocked":
+                problems.append(f"{e['module']}: key {k['key'][:12]}… FAILED in phase '{detail.get('phase')}' at "
+                                f"{detail['holder']} (attempt {detail.get('attempts')}) and the same inputs give the same "
+                                f"result:\n{detail.get('failure') or '(no failure text recorded)'}")
+                decided[e["module"]] = {**e, "ledger": {"key": k["key"], "decision": "blocked", **detail}}
+                continue
+            decided[e["module"]] = {**e, "ledger": {"key": k["key"], "decision": verdict, **detail}}
+            say(f"  {e['module']}: {verdict.upper()} — key {k['key'][:12]}… " + (
+                f"(reusing {detail['status']} bundle from {detail['holder']}; tests {'needed' if detail['needTest'] else 'recorded'}, "
+                f"publish {'needed' if detail['needPublish'] else 'not needed'})" if verdict == "reuse"
+                else f"(attempt {detail['attempts']}{', taken over from ' + detail['previous'] if detail.get('takeover') else ''})"))
+        pending = still
+    out = [decided[e["module"]] for e in matrix if e["module"] in decided]
+    return out, problems
+
+
+# ── transitions ──────────────────────────────────────────────────────────────────────────────
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def parse_trx(path: Path) -> dict:
+    """{passed, failed, names[]} from a VSTest .trx — names are the FAILED tests, capped."""
+    tree = ET.parse(path)
+    root = tree.getroot()
+    counters = None
+    failed_names: list[str] = []
+    for el in root.iter():
+        tag = el.tag.split("}")[-1]
+        if tag == "Counters":
+            counters = el.attrib
+        elif tag == "UnitTestResult" and el.attrib.get("outcome") == "Failed":
+            failed_names.append(el.attrib.get("testName", "?"))
+    passed = int((counters or {}).get("passed", 0))
+    failed = int((counters or {}).get("failed", 0))
+    return {"passed": passed, "failed": failed, "names": sorted(failed_names)[:TEST_NAMES_CAP]}
+
+
+def holder_or_warn(ledger: Ledger, key: str, me: dict, say) -> dict | None:
+    rec = ledger.get(key)
+    if rec is None:
+        say(f"::warning::ledger record {ROOT}/{key} does not exist — nothing to write")
+        return None
+    if not same_run(rec.get("run"), me):
+        say(f"::warning::this run does not hold key {key[:12]}… (holder: {(rec.get('run') or {}).get('url')}) — not writing")
+        return None
+    return rec
+
+
+def record(ledger: Ledger, a: argparse.Namespace, me: dict, say) -> int:
+    rec = holder_or_warn(ledger, a.key, me, say)
+    if rec is None:
+        return 0
+    now = iso(now_utc())
+    fields: dict = {"status": a.status, "heartbeatAt": now}
+    if a.version:
+        fields["version"] = a.version
+    if a.platform_identity:
+        fields["platformIdentity"] = a.platform_identity
+    if a.status == "Built":
+        if not a.bundle or not a.artifact_name:
+            print("::error::record --status Built needs --bundle FILE and --artifact-name NAME", file=sys.stderr)
+            return 2
+        fields["bundleSha256"] = sha256_file(Path(a.bundle))
+        fields["bundleArtifact"] = {"repo": me["repo"], "runId": me["runId"], "name": a.artifact_name,
+                                    "expiresAt": iso(now_utc() + dt.timedelta(days=a.retention_days))}
+        fields["phase"] = None
+    elif a.status == "Tested":
+        if a.trx and Path(a.trx).is_file():
+            fields["tests"] = parse_trx(Path(a.trx))
+        else:
+            fields["tests"] = {"passed": 0, "failed": 0, "names": []}
+            say("::warning::record --status Tested without a readable --trx — the verdict carries no counts")
+    elif a.status == "Published":
+        fields["finishedAt"] = now
+    elif a.status == "Failed":
+        if not a.phase:
+            print("::error::record --status Failed needs --phase", file=sys.stderr)
+            return 2
+        attempts = int(rec.get("attempts") or 1)
+        blocking = a.phase == "compile" or (a.phase == "test" and attempts >= BLOCKING_TEST_ATTEMPTS)
+        text = ""
+        if a.failure_file and Path(a.failure_file).is_file():
+            text = Path(a.failure_file).read_text(encoding="utf-8", errors="replace")[-FAILURE_TEXT_CAP:]
+        fields.update({"phase": a.phase, "blocking": blocking, "failure": text or f"failed in {a.phase}", "finishedAt": now})
+        if a.trx and Path(a.trx).is_file():
+            fields["tests"] = parse_trx(Path(a.trx))
+    else:
+        print(f"::error::unknown status {a.status}", file=sys.stderr)
+        return 2
+    ledger.patch(a.key, fields)
+    say(f"ledger: {a.key[:12]}… → {a.status}" + (f" ({a.phase}, blocking={fields.get('blocking')})" if a.status == "Failed" else ""))
+    return 0
+
+
+def simple_patch(ledger: Ledger, key: str, me: dict, fields: dict, say, label: str) -> int:
+    if holder_or_warn(ledger, key, me, say) is None:
+        return 0
+    ledger.patch(key, fields)
+    say(f"ledger: {key[:12]}… {label}")
+    return 0
+
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────────
+
+_FAKE_SERVER_SRC = r'''
+import json, sys, threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+STORE = {}
+FLAGS = {"sse": False, "fail503": 0, "create_refuses": True}
+
+def merge(target, patch):
+    for k, v in patch.items():
+        if v is None:
+            target.pop(k, None)
+        elif isinstance(v, dict) and isinstance(target.get(k), dict):
+            merge(target[k], v)
+        else:
+            target[k] = v
+
+class H(BaseHTTPRequestHandler):
+    def log_message(self, *a): pass
+    def _send(self, status, payload, sse=False, headers=None):
+        body = b""
+        if payload is not None:
+            if sse:
+                body = ("event: message\ndata: " + json.dumps(payload) + "\n\n").encode()
+            else:
+                body = json.dumps(payload).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "text/event-stream" if sse else "application/json")
+        for k, v in (headers or {}).items(): self.send_header(k, v)
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+    def do_POST(self):
+        if self.path == "/__ctl":
+            n = int(self.headers.get("Content-Length", 0)); FLAGS.update(json.loads(self.rfile.read(n) or b"{}"))
+            return self._send(200, {"ok": True})
+        if self.path == "/__store":
+            n = int(self.headers.get("Content-Length", 0)); body = json.loads(self.rfile.read(n) or b"{}")
+            for path, content in body.items():
+                if content is None: STORE.pop(path, None)
+                else: STORE[path] = content
+            return self._send(200, {"ok": True})
+        if self.headers.get("Authorization") != "Bearer mw_test":
+            return self._send(401, {"error": "unauthorized"})
+        if FLAGS["fail503"] > 0:
+            FLAGS["fail503"] -= 1
+            return self._send(503, {"error": "token validation unavailable"}, headers={"Retry-After": "0"})
+        n = int(self.headers.get("Content-Length", 0)); req = json.loads(self.rfile.read(n))
+        method = req.get("method"); rid = req.get("id")
+        if method == "notifications/initialized":
+            return self._send(202, None)
+        if method == "initialize":
+            return self._send(200, {"jsonrpc": "2.0", "id": rid, "result": {"protocolVersion": "2025-06-18", "capabilities": {}, "serverInfo": {"name": "fake"}}})
+        name = req["params"]["name"]; args = req["params"]["arguments"]
+        if name == "get":
+            path = args["path"].lstrip("@")
+            text = json.dumps({"path": path, "content": STORE[path]}) if path in STORE else "Not found: " + path
+        elif name == "create":
+            node = json.loads(args["node"]); path = node["namespace"] + "/" + node["id"]
+            if path in STORE and FLAGS["create_refuses"]:
+                text = "Error creating node: A node already exists at " + path
+            else:
+                STORE[path] = node["content"]; text = "Created: " + path
+        elif name == "patch":
+            path = args["path"].lstrip("@"); fields = json.loads(args["fields"])
+            if path not in STORE: text = "Error: node not found at " + path
+            else: merge(STORE[path], fields.get("content", {})); text = "Patched: " + path
+        else:
+            text = "Error: unknown tool " + name
+        sse = FLAGS["sse"]; FLAGS["sse"] = not sse
+        self._send(200, {"jsonrpc": "2.0", "id": rid, "result": {"content": [{"type": "text", "text": text}], "isError": False}}, sse=sse)
+
+srv = ThreadingHTTPServer(("127.0.0.1", 0), H)
+print(srv.server_address[1], flush=True)
+srv.serve_forever()
+'''
+
+_STUB_GH = '''#!/usr/bin/env python3
+import json, os, sys
+if os.environ.get("STUB_GH_FAIL") == "1":
+    sys.stderr.write("HTTP 403: Resource not accessible by integration\\n"); sys.exit(1)
+name = sys.argv[-1].split("name=")[-1]
+print(json.dumps({"artifacts": [{"name": name, "expired": os.environ.get("STUB_GH_EXPIRED") == "1"}]}))
+'''
+
+_TRX = '''<?xml version="1.0" encoding="utf-8"?>
+<TestRun xmlns="http://microsoft.com/schemas/VisualStudio/TeamTest/2010">
+  <Results>
+    <UnitTestResult testName="Acme.Alpha.Test.Thing.Works" outcome="Passed" />
+    <UnitTestResult testName="Acme.Alpha.Test.Thing.Breaks" outcome="Failed" />
+  </Results>
+  <ResultSummary outcome="Failed"><Counters total="2" executed="2" passed="1" failed="1" /></ResultSummary>
+</TestRun>
+'''
+
+
+def self_test() -> int:
+    import tempfile
+    import threading
+    failures: list[str] = []
+    ran = 0
+
+    def check(name: str, ok: bool, detail: str = "") -> None:
+        nonlocal ran
+        ran += 1
+        print(f"  {'✓' if ok else '✗'} {name}{'' if ok else ': ' + detail}")
+        if not ok:
+            failures.append(name)
+
+    quiet = lambda *a: None
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        (root / "fake.py").write_text(_FAKE_SERVER_SRC, encoding="utf-8")
+        gh = root / "gh"
+        gh.write_text(_STUB_GH, encoding="utf-8")
+        gh.chmod(0o755)
+        os.environ["MW_LEDGER_GH"] = str(gh)
+        server = subprocess.Popen([sys.executable, str(root / "fake.py")], stdout=subprocess.PIPE, text=True)
+        try:
+            port = int((server.stdout.readline() or "0").strip())
+            url = f"http://127.0.0.1:{port}"
+
+            def ctl(**flags):
+                urllib.request.urlopen(urllib.request.Request(f"{url}/__ctl", data=json.dumps(flags).encode(),
+                                                              headers={"Content-Type": "application/json"}, method="POST")).read()
+
+            def store(**nodes):
+                urllib.request.urlopen(urllib.request.Request(f"{url}/__store", data=json.dumps(nodes).encode(),
+                                                              headers={"Content-Type": "application/json"}, method="POST")).read()
+
+            def run(repo="Systemorph/Acme", run_id="100", attempt="1", event="pull_request", lane="l1"):
+                os.environ.update({"GITHUB_REPOSITORY": repo, "GITHUB_RUN_ID": run_id, "GITHUB_RUN_ATTEMPT": attempt,
+                                   "GITHUB_EVENT_NAME": event, "GITHUB_SERVER_URL": "https://github.com"})
+                return run_identity(lane)
+
+            entry = {"package": "Alpha", "module": "Acme.Alpha", "project": "src/Acme.Alpha/Acme.Alpha.csproj", "test": True}
+            key = "k" * 64
+            kinfo = {"module": "Acme.Alpha", "key": key, "inputs": {"moduleVersion": "mv1", "platformRef": "abc",
+                                                                       "testerDigest": "sha256:t", "platformDigest": "sha256:p"}}
+            L = lambda: Ledger(url, "mw_test", quiet)
+
+            print("auth + transport:")
+            try:
+                Ledger(url, "mw_wrong", quiet).get(key)
+                check("a wrong token is a hard error, never 'absent'", False, "no error raised")
+            except LedgerError as exc:
+                check("a wrong token is a hard error, never 'absent'", "401" in str(exc), str(exc)[:80])
+            ctl(fail503=1)
+            check("a 503 + Retry-After is retried, then answered (unavailable is not a verdict)", L().get(key) is None)
+
+            print("the claim IS the mutex:")
+            me = run()
+            v, d = decide_one(L(), entry, kinfo, me, False, quiet)
+            check("an absent key is claimed and built (attempt 1)", v == "build" and d["attempts"] == 1, f"{v} {d}")
+            rec = L().get(key)
+            check("the record names the claiming run and carries the key's inputs",
+                  rec is not None and same_run(rec["run"], me) and rec["moduleVersion"] == "mv1"
+                  and rec["status"] == "Claimed" and rec["$type"] == CONTENT_TYPE, json.dumps(rec)[:200])
+            check("SSE and JSON answers both parse (the fake alternates)", L().get(key) is not None)
+            other = run(run_id="200")
+            v, d = decide_one(L(), entry, kinfo, other, False, quiet)
+            check("a second run sees the fresh claim and WAITS (never builds the same key twice)", v == "wait" and "100" in d["holder"], f"{v} {d}")
+            v, d = decide_one(L(), entry, kinfo, me, False, quiet)
+            check("the holder itself re-deciding is still 'build' (idempotent within the run)", v == "build" and not d["takeover"], f"{v} {d}")
+
+            print("transitions, as the holder:")
+            bundle = root / "b.nupkg"
+            bundle.write_bytes(b"bundle-bytes")
+            ns = argparse.Namespace(key=key, status="Built", bundle=str(bundle), artifact_name="module-bundle-Acme.Alpha",
+                                    retention_days=7, version="1.2.3", platform_identity="s1234", trx=None, phase=None, failure_file=None)
+            record(L(), ns, me, quiet)
+            rec = L().get(key)
+            check("Built records sha256, the artifact locator, version and the PLATFORM identity",
+                  rec["status"] == "Built" and rec["bundleSha256"] == hashlib.sha256(b"bundle-bytes").hexdigest()
+                  and rec["bundleArtifact"]["runId"] == "100" and rec["version"] == "1.2.3" and rec["platformIdentity"] == "s1234", json.dumps(rec)[:300])
+            trx = root / "r.trx"
+            trx.write_text(_TRX, encoding="utf-8")
+            record(L(), argparse.Namespace(key=key, status="Tested", trx=str(trx), version=None, platform_identity=None,
+                                           bundle=None, artifact_name=None, retention_days=7, phase=None, failure_file=None), me, quiet)
+            rec = L().get(key)
+            check("Tested carries counts and the FAILED names from the trx",
+                  rec["status"] == "Tested" and rec["tests"] == {"passed": 1, "failed": 1, "names": ["Acme.Alpha.Test.Thing.Breaks"]}, json.dumps(rec.get("tests")))
+            record(L(), argparse.Namespace(key=key, status="Tested", trx=None, version=None, platform_identity=None, bundle=None,
+                                           artifact_name=None, retention_days=7, phase=None, failure_file=None), other, quiet)
+            check("a run that does not hold the key cannot write it", L().get(key)["run"]["runId"] == "100")
+            v, d = decide_one(L(), entry, kinfo, other, False, quiet)
+            check("Tested but not FINISHED still makes a follower wait (the holder may be publishing)", v == "wait", f"{v} {d}")
+            simple_patch(L(), key, me, {"finishedAt": iso(now_utc())}, quiet, "finished")
+
+            print("reuse:")
+            v, d = decide_one(L(), entry, kinfo, other, False, quiet)
+            check("a finished Tested record with a fetchable artifact is REUSED with nothing left to do",
+                  v == "reuse" and d["needTest"] is False and d["needPublish"] is False and d["artifact"]["name"] == "module-bundle-Acme.Alpha", f"{v} {d}")
+            pub = run(run_id="300", event="push")
+            v, d = decide_one(L(), entry, kinfo, pub, True, quiet)
+            check("a PUBLISHING run reuses the tested bundle and only publishes — and becomes the holder for that",
+                  v == "reuse" and d["needPublish"] is True and d["needTest"] is False and L().get(key)["run"]["runId"] == "300", f"{v} {d}")
+            record(L(), argparse.Namespace(key=key, status="Published", trx=None, version=None, platform_identity=None, bundle=None,
+                                           artifact_name=None, retention_days=7, phase=None, failure_file=None), pub, quiet)
+            rec = L().get(key)
+            check("Published is terminal (finishedAt set)", rec["status"] == "Published" and rec.get("finishedAt"))
+            v, d = decide_one(L(), entry, kinfo, run(run_id="400", event="push"), True, quiet)
+            check("push of an already-Published key: reuse, nothing to publish (the #889 baseline)",
+                  v == "reuse" and d["needPublish"] is False, f"{v} {d}")
+            v, d = decide_one(L(), {**entry, "test": False}, kinfo, run(run_id="401"), False, quiet)
+            check("a floor-only entry (test=false) reuses without needing tests", v == "reuse" and d["needTest"] is False, f"{v} {d}")
+            os.environ["STUB_GH_EXPIRED"] = "1"
+            v, d = decide_one(L(), entry, kinfo, run(run_id="500", event="push"), True, quiet)
+            check("an EXPIRED artifact is not reusable: the key is taken over and rebuilt (attempt 2, previous kept)",
+                  v == "build" and d["takeover"] and d["attempts"] == 2 and L().get(key)["previous"]["status"] == "Published", f"{v} {d}")
+            os.environ.pop("STUB_GH_EXPIRED", None)
+            simple_patch(L(), key, run(run_id="500", event="push"), {"status": "Tested", "finishedAt": iso(now_utc()),
+                                                                   "bundleArtifact": {"repo": "Systemorph/Acme", "runId": "500", "name": "module-bundle-Acme.Alpha"}}, quiet, "x")
+            os.environ["STUB_GH_FAIL"] = "1"
+            v, d = decide_one(L(), entry, kinfo, run(run_id="600"), False, quiet)
+            check("a token that cannot read artifacts (403) means BUILD, loudly — never a silent reuse", v == "build" and d["takeover"], f"{v} {d}")
+            os.environ.pop("STUB_GH_FAIL", None)
+            store(**{f"{ROOT}/{key}": {**L().get(key), "bundleArtifact": {"repo": "Systemorph/Other", "runId": "1", "name": "x"},
+                                      "status": "Tested", "finishedAt": iso(now_utc())}})
+            v, d = decide_one(L(), entry, kinfo, run(run_id="601"), False, quiet)
+            check("a bundle in ANOTHER repo's run is not fetchable with this token → build", v == "build", f"{v} {d}")
+
+            print("staleness:")
+            old = iso(now_utc() - dt.timedelta(seconds=STALE_AFTER_S + 60))
+            store(**{f"{ROOT}/{key}": {**claim_content(entry, kinfo, run(run_id="700"), 3, None), "heartbeatAt": old, "claimedAt": old}})
+            v, d = decide_one(L(), entry, kinfo, run(run_id="701"), False, quiet)
+            check("a claim whose heartbeat is older than the job cap is taken over", v == "build" and d["takeover"] and d["attempts"] == 4, f"{v} {d}")
+            simple_patch(L(), key, run(run_id="701"), {"heartbeatAt": iso(now_utc())}, quiet, "hb")
+            v, d = decide_one(L(), entry, kinfo, run(run_id="702"), False, quiet)
+            check("…and a heartbeat makes it fresh again", v == "wait", f"{v} {d}")
+
+            print("tolerance:")
+            store(**{f"{ROOT}/{key}": {**claim_content(entry, kinfo, run(run_id="800"), 1, None)}})
+            fail = root / "fail.txt"
+            fail.write_text("error CS0246: The type or namespace name 'Foo' could not be found\n", encoding="utf-8")
+            record(L(), argparse.Namespace(key=key, status="Failed", phase="compile", failure_file=str(fail), trx=None, version=None,
+                                           platform_identity=None, bundle=None, artifact_name=None, retention_days=7), run(run_id="800"), quiet)
+            v, d = decide_one(L(), entry, kinfo, run(run_id="801"), False, quiet)
+            check("a COMPILE failure blocks the same key, with the holder's evidence",
+                  v == "blocked" and "CS0246" in d["failure"] and d["phase"] == "compile", f"{v} {d}")
+            store(**{f"{ROOT}/{key}": {**claim_content(entry, kinfo, run(run_id="810"), 1, None)}})
+            record(L(), argparse.Namespace(key=key, status="Failed", phase="test", failure_file=None, trx=str(trx), version=None,
+                                           platform_identity=None, bundle=None, artifact_name=None, retention_days=7), run(run_id="810"), quiet)
+            check("the first TEST failure does not block", L().get(key)["blocking"] is False)
+            v, d = decide_one(L(), entry, kinfo, run(run_id="811"), False, quiet)
+            check("…so the next run re-claims it (attempt 2)", v == "build" and d["attempts"] == 2, f"{v} {d}")
+            record(L(), argparse.Namespace(key=key, status="Failed", phase="test", failure_file=None, trx=str(trx), version=None,
+                                           platform_identity=None, bundle=None, artifact_name=None, retention_days=7), run(run_id="811"), quiet)
+            v, d = decide_one(L(), entry, kinfo, run(run_id="812"), False, quiet)
+            check("the second TEST failure blocks, naming the failed tests",
+                  v == "blocked" and d["tests"]["names"] == ["Acme.Alpha.Test.Thing.Breaks"], f"{v} {d}")
+            store(**{f"{ROOT}/{key}": {**claim_content(entry, kinfo, run(run_id="820"), 1, None)}})
+            record(L(), argparse.Namespace(key=key, status="Failed", phase="workspace", failure_file=None, trx=None, version=None,
+                                           platform_identity=None, bundle=None, artifact_name=None, retention_days=7), run(run_id="820"), quiet)
+            v, d = decide_one(L(), entry, kinfo, run(run_id="821"), False, quiet)
+            check("a workspace abort (another module's error) never blocks", v == "build", f"{v} {d}")
+            store(**{f"{ROOT}/{key}": {**claim_content(entry, kinfo, run(run_id="830"), 1, None)}})
+            simple_patch(L(), key, run(run_id="830"), {"status": "Failed", "phase": "cancelled", "blocking": False,
+                                                       "finishedAt": iso(now_utc()), "failure": "cancelled"}, quiet, "released")
+            v, d = decide_one(L(), entry, kinfo, run(run_id="831"), False, quiet)
+            check("a released (cancelled) claim is reclaimable at once", v == "build", f"{v} {d}")
+
+            print("decide over a matrix, with a holder that finishes while we wait:")
+            store(**{f"{ROOT}/{key}": {**claim_content(entry, kinfo, run(run_id="900"), 1, None)}})
+            k2 = "m" * 64
+            kinfo2 = {**kinfo, "module": "Acme.Beta", "key": k2}
+            entry2 = {**entry, "module": "Acme.Beta", "package": "Beta"}
+
+            def finish_later():
+                time.sleep(0.6)
+                store(**{f"{ROOT}/{key}": {**L().get(key), "status": "Tested", "finishedAt": iso(now_utc()),
+                                          "bundleArtifact": {"repo": "Systemorph/Acme", "runId": "900", "name": "module-bundle-Acme.Alpha"}}})
+            threading.Thread(target=finish_later, daemon=True).start()
+            out, problems = decide(L(), [entry, entry2], [kinfo, kinfo2], run(run_id="901"), False, 10, 0.2, quiet)
+            by = {e["module"]: e["ledger"] for e in out}
+            check("the waited-for key is reused once its holder finishes; the free key is claimed and built",
+                  not problems and by["Acme.Alpha"]["decision"] == "reuse" and by["Acme.Beta"]["decision"] == "build", f"{problems} {by}")
+            store(**{f"{ROOT}/{key}": {**claim_content(entry, kinfo, run(run_id="950"), 1, None)}})
+            out, problems = decide(L(), [entry], [kinfo], run(run_id="951"), False, 0.5, 0.2, quiet)
+            check("a holder that neither finishes nor goes stale within the budget is a named problem, not a build",
+                  len(problems) == 1 and "still holds" in problems[0] and out == [], f"{problems} {out}")
+        finally:
+            server.kill()
+            server.wait()
+
+    if failures:
+        print(f"\n::error title=module-build-ledger self-test failed::{len(failures)} case(s) — this script decides "
+              "what is NOT rebuilt and who builds; a wrong answer is a silent under-build or a double build.")
+        return 1
+    print(f"\n✓ module-build-ledger self-test: {ran} cases green — auth, transport (JSON + SSE, 503 retry), the claim "
+          "mutex, every transition, reuse (tested / publish-only / floor / expired / 403 / foreign repo), staleness, "
+          "the tolerance rules, and a matrix decision with a waiting follower.")
+    return 0
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────────────────────
+
+def load_json_arg(raw: str):
+    if raw.startswith("@"):
+        raw = Path(raw[1:]).read_text(encoding="utf-8")
+    return json.loads(raw)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    p.add_argument("command", nargs="?", choices=["decide", "heartbeat", "record", "finish", "release", "get"])
+    p.add_argument("--key")
+    p.add_argument("--keys", help="JSON list of {module, key, inputs} (module-build-key.py --modules), or @file")
+    p.add_argument("--matrix", help="the selected matrix entries (JSON or @file)")
+    p.add_argument("--publish", default="false")
+    p.add_argument("--lane")
+    p.add_argument("--out-matrix")
+    p.add_argument("--out-build")
+    p.add_argument("--wait-max", type=float, default=2400.0, help="seconds a follower waits on a live holder")
+    p.add_argument("--poll", type=float, default=30.0)
+    p.add_argument("--status", choices=["Built", "Tested", "Published", "Failed"])
+    p.add_argument("--phase")
+    p.add_argument("--bundle")
+    p.add_argument("--artifact-name")
+    p.add_argument("--retention-days", type=int, default=7)
+    p.add_argument("--version")
+    p.add_argument("--platform-identity")
+    p.add_argument("--trx")
+    p.add_argument("--failure-file")
+    p.add_argument("--self-test", action="store_true", dest="self_test")
+    a = p.parse_args()
+    if a.self_test:
+        return self_test()
+    if not a.command:
+        p.error("a command or --self-test is required")
+
+    say = lambda *parts: print(*parts, file=sys.stderr, flush=True)
+    me = run_identity(a.lane)
+    try:
+        ledger = Ledger(os.environ.get("MW_LEDGER_URL", ""), os.environ.get("MW_LEDGER_TOKEN", ""), say)
+        if a.command == "decide":
+            if not (a.keys and a.matrix and a.out_matrix and a.out_build):
+                p.error("decide needs --keys, --matrix, --out-matrix and --out-build")
+            matrix = load_json_arg(a.matrix)
+            keys = load_json_arg(a.keys)
+            publishing = str(a.publish).lower() == "true"
+            say(f"ledger: deciding {len(matrix)} module(s) as {me['url']} (publish={publishing})")
+            out, problems = decide(ledger, matrix, keys, me, publishing, a.wait_max, a.poll, say)
+            build = [e for e in out if e["ledger"]["decision"] == "build"]
+            Path(a.out_matrix).write_text(json.dumps(out), encoding="utf-8")
+            Path(a.out_build).write_text(json.dumps(build), encoding="utf-8")
+            lines = ["### Module build ledger", "",
+                     f"{len(build)} of {len(matrix)} selected module(s) will be BUILT; "
+                     f"{sum(1 for e in out if e['ledger']['decision'] == 'reuse')} reused from an earlier run.", ""]
+            for e in out:
+                lg = e["ledger"]
+                if lg["decision"] == "reuse":
+                    lines.append(f"- `{e['module']}` — **reused** ({lg['status']}) from {lg['holder']}"
+                                 + (" — tests still run" if lg["needTest"] else "") + (" — published by this run" if lg["needPublish"] else ""))
+                elif lg["decision"] == "build":
+                    lines.append(f"- `{e['module']}` — **build** (attempt {lg['attempts']}"
+                                 + (f", taken over from {lg.get('previous')}" if lg.get("takeover") else "") + f") key `{lg['key'][:12]}…`")
+                else:
+                    lines.append(f"- `{e['module']}` — **BLOCKED** by {lg['holder']} ({lg.get('phase')})")
+            for pr in problems:
+                lines.append(f"- 🚨 {pr.splitlines()[0]}")
+            if os.environ.get("GITHUB_STEP_SUMMARY"):
+                with open(os.environ["GITHUB_STEP_SUMMARY"], "a", encoding="utf-8") as fh:
+                    fh.write("\n".join(lines) + "\n")
+            if problems:
+                for pr in problems:
+                    print(f"::error title=module build ledger::{pr}", file=sys.stderr)
+                return 1
+            return 0
+        if not a.key:
+            p.error(f"{a.command} needs --key")
+        if a.command == "get":
+            print(json.dumps(ledger.get(a.key), indent=2))
+            return 0
+        if a.command == "heartbeat":
+            return simple_patch(ledger, a.key, me, {"heartbeatAt": iso(now_utc())}, say, "heartbeat")
+        if a.command == "finish":
+            return simple_patch(ledger, a.key, me, {"finishedAt": iso(now_utc()), "heartbeatAt": iso(now_utc())}, say, "finished")
+        if a.command == "release":
+            return simple_patch(ledger, a.key, me, {"status": "Failed", "phase": "cancelled", "blocking": False,
+                                                    "failure": "the holding run was cancelled", "finishedAt": iso(now_utc()),
+                                                    "heartbeatAt": iso(now_utc())}, say, "released (cancelled)")
+        if a.command == "record":
+            if not a.status:
+                p.error("record needs --status")
+            return record(ledger, a, me, say)
+    except LedgerError as exc:
+        print(f"::error title=module build ledger::{exc}", file=sys.stderr)
+        return 1
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/node-repo-scope.py
+++ b/.github/scripts/node-repo-scope.py
@@ -116,7 +116,9 @@ FULL_REASONS = {
                 "container pack path copies every module-owned MeshWeaver.* sibling INTO the "
                 "bundle, so a sibling's change moves the bundle's bytes and not its version. "
                 "Diffing github.event.before instead would silently skip every module whose commit "
-                "belonged to a cancelled, superseded or red run. Packing every module.",
+                "belonged to a cancelled, superseded or red run. Packing every module — the module "
+                "build ledger (module-build-ledger.py, when the caller sets ledger: required) then "
+                "reuses every entry whose content key is already Published.",
         "repository_dispatch": "a framework-release dispatch moves the platform pin every module is "
                                "built against — every bundle must be rebuilt and republished or "
                                "every portal reads FrameworkDeclined and adopts nothing "

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -333,9 +333,38 @@ on:
         required: false
         type: string
         default: install
+      ledger:
+        description: >
+          The CI MODULE BUILD LEDGER on the registry portal (Doc/Architecture/ModuleBuildArchitecture →
+          "Content-addressed outputs"; Plugins#889). Two values, both printed in the job summary on
+          every run so the two outcomes can never be told apart only by what is missing:
+
+          `off` — the DEFAULT, and what a caller that says nothing inherits: every selected module is
+          built, exactly as before the ledger existed.
+
+          `required` — `select` computes the content address of every selected module
+          (module-build-key.py: package, moduleVersion, in-repo closure, both image digests,
+          platform-ref, recipe) and asks the ledger at `registry-url` what is already built, tested
+          or published under that key: a usable record is REUSED (the pack job downloads that run's
+          bundle and runs only the phases the record lacks), a fresh claim by another run is WAITED
+          for (never the same key built twice at once), a compile failure of the same key is a hard
+          red with the holder's evidence, everything else is CLAIMED and every transition recorded.
+          Needs the `ledger-token` secret — asserted RED in `select` when empty, never skipped. When
+          the registry portal itself is unavailable (5xx, unreachable) the lane builds WITHOUT
+          coordination and says so in yellow: the ledger may cost a duplicate build, never a green.
+
+          Anything else — the empty string included — is RED.
+        required: false
+        type: string
+        default: off
     secrets:
       publish-token:
         description: The registry's Plugins:Registry:PublishToken. Required when publish is true.
+        required: false
+      ledger-token:
+        description: >-
+          A `mw_` ApiToken of the registry portal's CI user for the module build ledger
+          (`Admin/ModuleBuilds`). Required when ledger is `required`; asserted RED, never skipped.
         required: false
       acr-username:
         description: Pull credential for platform-image's registry. Required when platform-image-digest is set.
@@ -378,7 +407,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     outputs:
-      modules: ${{ steps.scope.outputs.modules }}
+      # The matrix the pack job expands: the scope's selection, each entry annotated by the ledger
+      # (`ledger.decision` build|reuse, `ledger.key`, …) when the ledger is on.
+      modules: ${{ steps.ledger.outputs.modules }}
+      # The SUBSET the one-workspace build compiles — every entry the ledger did not hand a reusable
+      # bundle for. The postcondition in build-workspace is fed the SAME list.
+      build-modules: ${{ steps.ledger.outputs.build }}
       count: ${{ steps.scope.outputs.count }}
       selected: ${{ steps.scope.outputs.selected }}
       scope: ${{ steps.scope.outputs.scope }}
@@ -479,6 +513,8 @@ jobs:
           set -euo pipefail
           python3 meshweaver/.github/scripts/node-repo-scope.py --self-test
           python3 meshweaver/.github/scripts/node-repo-pack-verify.py --self-test
+          python3 meshweaver/.github/scripts/module-build-key.py --self-test
+          python3 meshweaver/.github/scripts/module-build-ledger.py --self-test
       - name: Decide which module bundles this diff can reach
         id: scope
         env:
@@ -503,6 +539,76 @@ jobs:
           python3 meshweaver/.github/scripts/node-repo-scope.py \
             --for modules --root repo --modules "@$RUNNER_TEMP/matrix.json" \
             --event "$EVENT" --base-ref "${BASE_REF:-}" --always "${ALWAYS:-}" > "$RUNNER_TEMP/scope.json"
+      # ───────────── THE LEDGER: what of this selection is ALREADY BUILT, and who builds the rest ─────────────
+      # 🚨 "we should not start the same build multiple times ⇒ coordinate which packages are in
+      # progress; track progress through memex … if Plugin X was built against Platform version Y,
+      # we don't have to rebuild this" (maintainer, 2026-09-02). Every selected entry gets a CONTENT
+      # ADDRESS (module-build-key.py) and the ledger on the registry portal answers per key: reuse,
+      # wait, build, or blocked. The scope above still decides what this diff REACHES; the ledger
+      # decides what of that must actually be COMPILED. On a `push` the scope is FULL by policy
+      # (a publishing run has no diff baseline) and the ledger narrows it to "every module whose key
+      # has no Published record" — which is exactly the baseline argument Plugins#889 asked for: a
+      # cancelled, red or superseded run left no Published record, so its modules are rebuilt.
+      #
+      # ONE step, unconditional, that prints which way it went. `off` passes the selection through
+      # untouched (today's behaviour); `required` asserts the token RED (a skipped ledger and a
+      # consulted one must never look alike) and runs the two scripts. A registry portal that is
+      # UNAVAILABLE degrades to "build everything, uncoordinated", in yellow — the ledger is a
+      # coordination layer over a build that is correct without it, and its outage may cost a
+      # duplicate build, never a green (core #3119).
+      - name: Consult the module build ledger
+        id: ledger
+        env:
+          LEDGER: ${{ inputs.ledger }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ steps.lane.outputs.id }}
+          GH_TOKEN: ${{ github.token }}
+          SCOPE_MODULES: ${{ steps.scope.outputs.modules }}
+          COUNT: ${{ steps.scope.outputs.count }}
+          PUBLISH: ${{ inputs.publish }}
+          TESTER_DIGEST: ${{ inputs.tester-image-digest }}
+          PLATFORM_DIGEST: ${{ inputs.platform-image-digest }}
+          PLATFORM_REF: ${{ inputs.platform-ref }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${SCOPE_MODULES:-[]}" > "$RUNNER_TEMP/selection.json"
+          case "$LEDGER" in
+            off)
+              echo "module build ledger: OFF — every selected module is built (set ledger: required on the caller to coordinate builds across runs)"
+              printf '### Module build ledger\n\nOFF — every one of the %s selected module(s) is built. Set `ledger: required` on the caller to reuse builds across runs.\n' "$COUNT" >> "$GITHUB_STEP_SUMMARY"
+              modules="$(cat "$RUNNER_TEMP/selection.json")"
+              echo "modules=$modules" >> "$GITHUB_OUTPUT"
+              echo "build=$modules" >> "$GITHUB_OUTPUT"
+              ;;
+            required)
+              [ -n "${MW_LEDGER_TOKEN:-}" ] || { echo "::error::inputs.ledger is 'required' but the ledger-token secret is empty. Mint a mw_ ApiToken for the registry portal's CI user (a partition admin on Admin/ModuleBuilds — see Doc/Architecture/ModuleBuildArchitecture), store it as a repository secret, and pass it as secrets.ledger-token. A ledger that silently does not run and one that ran must never look alike."; exit 1; }
+              if [ "${COUNT:-0}" = "0" ]; then
+                echo "module build ledger: nothing selected — nothing to key"
+                echo "modules=[]" >> "$GITHUB_OUTPUT"
+                echo "build=[]" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+              echo "module build ledger: REQUIRED — keying $COUNT selected module(s) against $MW_LEDGER_URL"
+              python3 meshweaver/.github/scripts/module-build-key.py --root repo \
+                --modules "@$RUNNER_TEMP/selection.json" \
+                --tester-digest "$TESTER_DIGEST" --platform-digest "$PLATFORM_DIGEST" --platform-ref "$PLATFORM_REF" \
+                > "$RUNNER_TEMP/keys.json"
+              # Waits at most 40 of this job's 45 minutes on a live holder; a holder still busy then is
+              # built anyway (a duplicate build, flagged), never a red. Exit 1 ONLY for a key the same
+              # inputs already compiled RED elsewhere — that is a verdict, not the ledger's outage.
+              python3 meshweaver/.github/scripts/module-build-ledger.py decide \
+                --keys "@$RUNNER_TEMP/keys.json" --matrix "@$RUNNER_TEMP/selection.json" \
+                --publish "$PUBLISH" --lane "$MW_LEDGER_LANE" --wait-max 2400 --poll 30 \
+                --out-matrix "$RUNNER_TEMP/matrix.out.json" --out-build "$RUNNER_TEMP/build.out.json"
+              echo "modules=$(jq -c . "$RUNNER_TEMP/matrix.out.json")" >> "$GITHUB_OUTPUT"
+              echo "build=$(jq -c . "$RUNNER_TEMP/build.out.json")" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::inputs.ledger is '$LEDGER'. The only values are 'off' (the default) and 'required'. An unreadable flag must NEVER resolve to 'do not coordinate' — that is a skipped check wearing a green tick."
+              exit 1
+              ;;
+          esac
 
   # ─────────────────── THE SHARED BUILD ENVIRONMENT, WARMED ONCE ───────────────────
   # "see we update *once at beginning for everyone* and not by module" (maintainer, 2026-08-31).
@@ -527,6 +633,10 @@ jobs:
     if: needs.select.result == 'success' && needs.select.outputs.count != '0'
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    outputs:
+      # The framework identity the PLATFORM host resolves for its /app — what every ledger record
+      # and bundle is keyed to (the portal adopts, so the portal's identity is the honest one).
+      platform-identity: ${{ steps.identity.outputs.identity }}
     steps:
       - name: Check out Systemorph/MeshWeaver at the pinned ref
         uses: actions/checkout@v7
@@ -629,6 +739,41 @@ jobs:
             docker rm "$tcid" >/dev/null
             [ -f "$RUNNER_TEMP/tester-app/mw-plugin-test.dll" ] || { echo "::error::the tester image's /app carries no mw-plugin-test.dll — not a tester image"; exit 1; }
           fi
+      # ───────── THE PLATFORM'S FRAMEWORK IDENTITY — resolved by the PORTAL's own /app (#3022) ─────────
+      # The ledger records which framework a bundle was built against, and the honest identity is the
+      # one the ADOPTING host resolves: the tester's `framework-identity <dir>` verb, run with the
+      # platform image's dotnet over the platform image's /app — the same reading the node-repo bake
+      # takes, never the tester image's own identity (a strict subset of the portal's). Metadata for
+      # the ledger only: an older tester without the verb yields an empty identity and a warning, not
+      # a red — nothing verifies against it here.
+      - name: Resolve the platform's framework identity (for the ledger)
+        id: identity
+        if: inputs.ledger == 'required' && inputs.platform-image-digest != '' && inputs.tester-image-digest != ''
+        env:
+          IMAGE: ${{ inputs.platform-image }}
+          DIGEST: ${{ inputs.platform-image-digest }}
+        run: |
+          set -euo pipefail
+          case "${IMAGE##*/}" in *:*) NOTAG="${IMAGE%:*}" ;; *) NOTAG="$IMAGE" ;; esac
+          img="${NOTAG}@${DIGEST}"
+          if ! docker image inspect "$img" >/dev/null 2>&1; then
+            zstd -dc "$RUNNER_TEMP/platform-image/image.tar.zst" | docker load >/dev/null
+            img="$(cat "$RUNNER_TEMP/platform-image/image-id.txt")"
+          fi
+          # `if out=…` rather than `|| true`: a failing verb still PRINTS, and that text must not be
+          # read as the identity.
+          identity=""
+          if out=$(docker run --rm --init --platform linux/amd64 --user "$(id -u):$(id -g)" -e HOME=/tmp \
+                     -v "$RUNNER_TEMP/tester-app:/tester:ro" --entrypoint dotnet "$img" \
+                     /tester/mw-plugin-test.dll framework-identity /app 2>&1); then
+            identity=$(printf '%s\n' "$out" | tail -1 | tr -d '[:space:]')
+          fi
+          if [ -z "$identity" ]; then
+            echo "::warning::could not resolve the platform image's framework identity (the tester's framework-identity verb answered: ${out:-<nothing>}) — ledger records for this run carry no platformIdentity"
+          else
+            echo "platform framework identity: $identity (resolved by the portal's /app)"
+          fi
+          echo "identity=$identity" >> "$GITHUB_OUTPUT"
 
   # ─────────────────────── ONE GLOBAL BUILD — LOCAL BUILDS ARE DISCONTINUED ───────────────────────
   # "we want *one* central build *no* per project build … just collect all under scope in global
@@ -692,10 +837,12 @@ jobs:
         with:
           path: ${{ runner.temp }}/tester-app
           key: tester-app-${{ inputs.tester-image-digest }}
+      # 🚨 `build-modules`, not `modules`: the ledger handed some entries a reusable bundle, and those
+      # are NOT compiled here. The postcondition below is fed the SAME list — one enumerator.
       - name: Build every selected container entry in ONE workspace
         id: build
         env:
-          MODULES: ${{ needs.select.outputs.modules }}
+          MODULES: ${{ needs.select.outputs.build-modules }}
           IMAGE: ${{ inputs.platform-image }}
           DIGEST: ${{ inputs.platform-image-digest }}
           TESTER_IMAGE: ${{ inputs.tester-image }}
@@ -706,7 +853,7 @@ jobs:
           set -euo pipefail
           mapfile -t projects < <(jq -r '.[] | select(.build == "container") | .project' <<< "$MODULES")
           if [ "${#projects[@]}" -eq 0 ]; then
-            echo "no container entries in the selection — the global build has nothing to do (sdk-only selection)"
+            echo "no container entries to compile — the global build has nothing to do (sdk-only selection, or every container entry is reused from the ledger)"
             echo "built=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
@@ -801,7 +948,7 @@ jobs:
       # exactly the thing #1051 is about.
       - name: The global build emitted every selected module (postcondition)
         env:
-          MODULES: ${{ needs.select.outputs.modules }}
+          MODULES: ${{ needs.select.outputs.build-modules }}
         run: |
           set -euo pipefail
           python3 meshweaver/.github/scripts/workspace-build-verify.py --self-test
@@ -809,6 +956,49 @@ jobs:
           python3 meshweaver/.github/scripts/workspace-build-verify.py \
             --modules "@$RUNNER_TEMP/selection.json" \
             --output "$RUNNER_TEMP/module-build"
+      # ───────── THE LEDGER HEARS ABOUT THIS JOB — a heartbeat on success, the verdict on failure ─────────
+      # A claim taken in `select` must stay fresh across this job (queue + up to 30 min of compile);
+      # a heartbeat here keeps a follower from taking the key over mid-build. On failure the verdict
+      # is per key: an entry whose assembly the workspace never emitted and whose project the log
+      # names in a compiler error FAILED in `compile` (blocking — same inputs, same result); every
+      # other claimed entry was ABORTED by fail-fast on someone else's error (`workspace`, never
+      # blocking). Neither step can red the job: the ledger is coordination, not verification.
+      - name: Ledger — heartbeat every claimed key
+        if: inputs.ledger == 'required'
+        env:
+          MODULES: ${{ needs.select.outputs.build-modules }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: |
+          set -euo pipefail
+          while IFS= read -r key; do
+            [ -n "$key" ] || continue
+            python3 meshweaver/.github/scripts/module-build-ledger.py heartbeat --key "$key"
+          done < <(jq -r '.[] | select(.build == "container") | .ledger.key // empty' <<< "$MODULES")
+      - name: Ledger — record the compile verdict of a failed workspace
+        if: failure() && inputs.ledger == 'required'
+        env:
+          MODULES: ${{ needs.select.outputs.build-modules }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: |
+          set -uo pipefail
+          out="$RUNNER_TEMP/module-build"
+          log="$out/workspace-build.log"
+          while IFS=$'\t' read -r module project key; do
+            [ -n "$key" ] || continue
+            phase=workspace
+            evidence="$RUNNER_TEMP/failure-$module.txt"
+            if [ ! -f "$out/$module/$module.dll" ] && [ -f "$log" ] && grep -F "$(dirname "$project")/" "$log" | grep -q 'error CS'; then
+              phase=compile
+              grep -F "$(dirname "$project")/" "$log" | grep 'error CS' | head -50 > "$evidence"
+            else
+              { echo "the one-workspace build failed before this module's verdict; log tail:"; tail -40 "$log" 2>/dev/null; } > "$evidence"
+            fi
+            python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$key" --status Failed --phase "$phase" --failure-file "$evidence" || true
+          done < <(jq -r '.[] | select(.build == "container") | select(.ledger.key != null) | [.module, .project, .ledger.key] | @tsv' <<< "$MODULES")
       - name: Hand the workspace to the matrix
         if: steps.build.outputs.built == 'true'
         uses: actions/upload-artifact@v7

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1185,6 +1185,52 @@ jobs:
           echo "floor=$floor" >> "$GITHUB_OUTPUT"
           echo "packing $MODULE as $PACKAGE@$version, platform floor $floor"
 
+      # ───────────── THE LEDGER'S PLAN FOR THIS ENTRY — build it, or reuse another run's bundle ─────────────
+      # `select` annotated the entry (`ledger.decision`, `ledger.key`, what is still needed). ONE
+      # step reads it, prints it, and hands the rest of the job three booleans; with the ledger off
+      # the plan is "build, test if the entry says so, publish if the caller says so" — today's leg.
+      # A `reuse` leg downloads the recorded run's bundle artifact (sha256 verified against the
+      # record), runs only the phases the record lacks, and drops the same artifact, marker and
+      # receipt a built leg drops — a caller composing this bundle cannot tell the two apart, and
+      # must not need to. The heartbeat keeps the claim fresh across this job's queue time.
+      - name: Ledger — this entry's plan
+        id: plan
+        env:
+          LEDGER: ${{ inputs.ledger }}
+          ENTRY_LEDGER: ${{ toJSON(matrix.entry.ledger) }}
+          RUN_TESTS: ${{ matrix.entry.test != false }}
+          PUBLISH: ${{ inputs.publish }}
+          MODULE: ${{ matrix.entry.module }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: |
+          set -euo pipefail
+          decision=build; key=""; need_test="$RUN_TESTS"; need_publish="$PUBLISH"; art_run=""; art_name=""; sha=""; holder=""
+          if [ "$LEDGER" = "required" ] && [ "$ENTRY_LEDGER" != "null" ] && [ -n "$ENTRY_LEDGER" ]; then
+            decision=$(jq -r '.decision // "build"' <<< "$ENTRY_LEDGER")
+            key=$(jq -r '.key // ""' <<< "$ENTRY_LEDGER")
+            if [ "$decision" = "reuse" ]; then
+              need_test=$(jq -r 'if .needTest then "true" else "false" end' <<< "$ENTRY_LEDGER")
+              need_publish=$(jq -r 'if .needPublish then "true" else "false" end' <<< "$ENTRY_LEDGER")
+              art_run=$(jq -r '.artifact.runId // ""' <<< "$ENTRY_LEDGER")
+              art_name=$(jq -r '.artifact.name // ""' <<< "$ENTRY_LEDGER")
+              sha=$(jq -r '.bundleSha256 // ""' <<< "$ENTRY_LEDGER")
+              holder=$(jq -r '.holder // ""' <<< "$ENTRY_LEDGER")
+              [ -n "$art_run" ] && [ -n "$art_name" ] || { echo "::error::the ledger said REUSE for $MODULE but named no bundle artifact — nothing to reuse; this is a select-step defect, not a build failure"; exit 1; }
+              echo "plan: REUSE $MODULE from run $art_run ($art_name, sha256 ${sha:-unrecorded}; holder $holder) — tests: $need_test, publish: $need_publish"
+            else
+              echo "plan: BUILD $MODULE (ledger key ${key:-<none>}; $(jq -r 'if .unavailable then "WITHOUT coordination: " + .unavailable else "attempt " + (.attempts|tostring) end' <<< "$ENTRY_LEDGER")) — tests: $need_test, publish: $need_publish"
+              [ -z "$key" ] || python3 meshweaver/.github/scripts/module-build-ledger.py heartbeat --key "$key"
+            fi
+          else
+            echo "plan: BUILD $MODULE (ledger off) — tests: $need_test, publish: $need_publish"
+          fi
+          {
+            echo "decision=$decision"; echo "key=$key"; echo "need_test=$need_test"; echo "need_publish=$need_publish"
+            echo "art_run=$art_run"; echo "art_name=$art_name"; echo "sha=$sha"; echo "holder=$holder"
+          } >> "$GITHUB_OUTPUT"
+
       # 🚨 THE PLATFORM IS THE IMAGE. When the caller pins platform-image-digest, the module is
       # compiled against the assemblies the portal actually runs (docker cp of /app, cached per
       # digest so a run pulls it once), and the platform checkout above serves only restore
@@ -1255,13 +1301,18 @@ jobs:
       # The global workspace build's outputs — every container entry's assemblies, closure
       # manifests and the one build log. Container packs consume THIS; sdk entries ignore it.
       - name: Fetch the global workspace build
-        if: ${{ (matrix.entry.build || 'sdk') == 'container' }}
+        if: ${{ (matrix.entry.build || 'sdk') == 'container' && steps.plan.outputs.decision == 'build' }}
         uses: actions/download-artifact@v8
         with:
           name: workspace-build-${{ needs.select.outputs.lane }}
           path: ${{ runner.temp }}/workspace-build
+      # 🚨 `if: decision == 'build'` on the build/pack/inspect trio is a MODE SWITCH on the ledger's
+      # plan, not a skip-trapdoor: the reuse leg below runs in their place, is itself unconditional
+      # within its mode, verifies the bytes it fetched, and drops the same artifact/marker/receipt —
+      # so `verify` still counts this entry, and a leg that did neither is still RED there.
       - name: Build the module — and say which compiler produced it
         id: build
+        if: steps.plan.outputs.decision == 'build'
         env:
           MODE: ${{ matrix.entry.build || 'sdk' }}
           ACCEPT: ${{ matrix.entry.accept || '' }}
@@ -1426,16 +1477,61 @@ jobs:
             echo "- closure args: \`$( (tr '\n' ' ' < "$packargs") || true )\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # ───────────── THE REUSE LEG — another run already built these bytes ─────────────
+      # The ledger's record names the run and the artifact; `select` already asked the API that the
+      # artifact exists and is not expired. Download it with this run's token (the caller's job needs
+      # `permissions: actions: read` — without it `select` never says reuse), and verify the sha256
+      # against the record: bytes that do not match the ledger are a FAULT (a re-uploaded artifact,
+      # a torn download), never something to pack anyway.
+      - name: Reuse the bundle another run built (ledger)
+        id: reused
+        if: steps.plan.outputs.decision == 'reuse'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ART_RUN: ${{ steps.plan.outputs.art_run }}
+          ART_NAME: ${{ steps.plan.outputs.art_name }}
+          EXPECTED_SHA: ${{ steps.plan.outputs.sha }}
+          HOLDER: ${{ steps.plan.outputs.holder }}
+          PACKAGE: ${{ matrix.entry.package }}
+          MODULE: ${{ matrix.entry.module }}
+          VERSION: ${{ steps.identity.outputs.version }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/bundles"
+          gh run download "$ART_RUN" -R "$GITHUB_REPOSITORY" -n "$ART_NAME" -D "$RUNNER_TEMP/bundles"
+          bundle="$RUNNER_TEMP/bundles/MeshWeaver.Plugin.$PACKAGE.$VERSION.module.nupkg"
+          if [ ! -f "$bundle" ]; then
+            found=$(find "$RUNNER_TEMP/bundles" -name '*.module.nupkg' | head -1)
+            echo "::error::run $ART_RUN's artifact $ART_NAME carries no MeshWeaver.Plugin.$PACKAGE.$VERSION.module.nupkg (found: ${found:-nothing}) — the ledger record and this checkout's manifest.lock disagree about the version; the key should have differed. Not reusing."
+            exit 1
+          fi
+          actual=$(sha256sum "$bundle" | cut -d' ' -f1)
+          if [ -n "$EXPECTED_SHA" ] && [ "$actual" != "$EXPECTED_SHA" ]; then
+            echo "::error::the downloaded bundle's sha256 $actual is not the ledger's $EXPECTED_SHA (record by $HOLDER) — the bytes are not the ones the record attests. Not reusing."
+            exit 1
+          fi
+          echo "reused: $bundle (sha256 $actual) from run $ART_RUN — built and inspected there ($HOLDER); no compile, no pack, no inspection in this job"
+          echo "path=$bundle" >> "$GITHUB_OUTPUT"
+          {
+            echo "### \`$MODULE\` — **reused** from run $ART_RUN"
+            echo
+            echo "- record: $HOLDER"
+            echo "- sha256: \`$actual\` (verified against the ledger)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
       # Published ONCE by the prepare job — `dotnet build` here cost 48–79s in EVERY job (measured
       # across Plugins#1032). A missing artifact fails this download RED rather than quietly
       # rebuilding a maybe-different tool.
       - name: Fetch the module-pack tool (built once by prepare)
+        if: steps.plan.outputs.decision == 'build'
         uses: actions/download-artifact@v8
         with:
           name: module-pack-tool-${{ needs.select.outputs.lane }}
           path: ${{ runner.temp }}/pack-tool
 
       - name: Pack the module bundle
+        id: pack
+        if: steps.plan.outputs.decision == 'build'
         env:
           PACKDIR: ${{ steps.build.outputs.packdir }}
           COMPILER: ${{ steps.build.outputs.compiler }}
@@ -1466,6 +1562,7 @@ jobs:
       # consumer's landing gate will read, loudly, instead of trusting the packer's exit code.
       - name: Inspect the bundle (manifest + assemblies)
         id: bundle
+        if: steps.plan.outputs.decision == 'build'
         env:
           PACKAGE: ${{ matrix.entry.package }}
           MODULE: ${{ matrix.entry.module }}
@@ -1557,13 +1654,34 @@ jobs:
           echo "path=$bundle" >> "$GITHUB_OUTPUT"
           echo "bundle OK:"; jq . "$manifest"
 
+      # 7 days, not 3: this artifact is what a LATER run downloads when the ledger says the key is
+      # already built — the reuse window is exactly its retention (the ledger records the expiry).
       - name: Upload the bundle artifact
         uses: actions/upload-artifact@v7
         with:
           name: module-bundle-${{ matrix.entry.module }}
           path: ${{ runner.temp }}/bundles/*.module.nupkg
-          retention-days: 3
+          retention-days: 7
           if-no-files-found: error
+      # AFTER the upload, never before: `Built` means "a later run can fetch this bundle", and the
+      # record names the artifact the upload above just created. Carries the PLATFORM's identity as
+      # `prepare` resolved it (#931's producer half: the record says which framework these bytes are for).
+      - name: Ledger — Built
+        if: inputs.ledger == 'required' && steps.plan.outputs.decision == 'build' && steps.plan.outputs.key != ''
+        env:
+          KEY: ${{ steps.plan.outputs.key }}
+          BUNDLE: ${{ steps.bundle.outputs.path }}
+          MODULE: ${{ matrix.entry.module }}
+          VERSION: ${{ steps.identity.outputs.version }}
+          PLATFORM_IDENTITY: ${{ needs.prepare.outputs.platform-identity }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: |
+          set -euo pipefail
+          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Built \
+            --bundle "$BUNDLE" --artifact-name "module-bundle-$MODULE" --retention-days 7 \
+            --version "$VERSION" ${PLATFORM_IDENTITY:+--platform-identity "$PLATFORM_IDENTITY"}
 
       # ───────── THE BUILT MARKER — "this bundle exists AND is composable", from THIS lane ─────────
       # Dropped the moment the bundle artifact is up, BEFORE the tests and the hand-over, so a
@@ -1592,9 +1710,10 @@ jobs:
           PACKAGE: ${{ matrix.entry.package }}
           MODULE: ${{ matrix.entry.module }}
           VERSION: ${{ steps.identity.outputs.version }}
-          COMPILER: ${{ steps.build.outputs.compiler }}
-          CLOSURE: ${{ steps.build.outputs.closure }}
-          BUNDLE: ${{ steps.bundle.outputs.path }}
+          # A reused leg has no compiler of its own: the marker says so, and names the run that did.
+          COMPILER: ${{ steps.plan.outputs.decision == 'reuse' && 'reused' || steps.build.outputs.compiler }}
+          CLOSURE: ${{ steps.plan.outputs.decision == 'reuse' && format('reused from run {0} ({1}, sha256 verified against the ledger)', steps.plan.outputs.art_run, steps.plan.outputs.art_name) || steps.build.outputs.closure }}
+          BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/built"
@@ -1622,8 +1741,11 @@ jobs:
       # Runs AFTER the bundle artifact and its built marker exist and BEFORE the hand-over: a
       # failing suite never publishes — and never un-builds.
       # The built module DLL as a run-scoped artifact, IMMEDIATELY — this is what lets a
+      # `need_test`: the entry's own `test` flag AND, with the ledger on, "no earlier run recorded a
+      # verdict for this key" — a reused Tested/Published bundle is not re-tested.
       - name: Run the module's tests, when it ships any
-        if: ${{ matrix.entry.test != false }}
+        id: tests
+        if: ${{ matrix.entry.test != false && steps.plan.outputs.need_test == 'true' }}
         env:
           PROJECT: ${{ matrix.entry.project }}
           # 🚨 THE TRAIL A FLAKE LEAVES. A red here on a diff that cannot reach the module is a
@@ -1648,11 +1770,23 @@ jobs:
           # src/<Module>.Test. Absent is fine; present and red is not.
           tests="$(dirname "$PROJECT").Test"
           if [ -d "$tests" ]; then
+            # The trx is the ledger's evidence: counts, and the FAILED names a follower is handed.
             dotnet test "$tests" -c Release -warnaserror \
-              -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver
+              -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver \
+              --logger "trx;LogFileName=ledger.trx" --results-directory "$RUNNER_TEMP/trx"
           else
             echo "no test project at $tests — nothing to run"
           fi
+      - name: Ledger — Tested
+        if: inputs.ledger == 'required' && steps.plan.outputs.key != '' && steps.tests.outcome == 'success'
+        env:
+          KEY: ${{ steps.plan.outputs.key }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: |
+          set -euo pipefail
+          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/ledger.trx"
 
       # 🚨 Only on FAILURE, and only what a diagnosis needs: the failing suite's per-test logs, the
       # phase trace, the straggler captures and any dump. A green run uploads nothing — the point
@@ -1691,8 +1825,12 @@ jobs:
       # inspected — and reaches nobody, because a registry serves only bytes it holds. A missing
       # token here FAILS the job rather than skipping quietly: "published nothing" and "published
       # fine" must never look the same (the same reason a gate may not skip green).
+      # `need_publish`: the caller's `publish` AND, with the ledger on, "no earlier run published this
+      # key" — a key the registry already serves at these bytes is not re-handed (Plugins#889: a push
+      # publishes every module whose key has no Published record, and only those).
       - name: Hand the bundle to the registry
-        if: ${{ inputs.publish }}
+        id: publish
+        if: ${{ inputs.publish && steps.plan.outputs.need_publish == 'true' }}
         env:
           TOKEN: ${{ secrets.publish-token }}
           REGISTRY: ${{ inputs.registry-url }}
@@ -1700,7 +1838,7 @@ jobs:
           PACKAGE: ${{ matrix.entry.package }}
           MODULE: ${{ matrix.entry.module }}
           VERSION: ${{ steps.identity.outputs.version }}
-          BUNDLE: ${{ steps.bundle.outputs.path }}
+          BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}
         run: |
           set -euo pipefail
           if [ -z "${TOKEN:-}" ]; then
@@ -1717,6 +1855,60 @@ jobs:
             2*) echo "$MODULE@$VERSION is now served by $REGISTRY" ;;
             *)  echo "::error::registry refused $MODULE@$VERSION (HTTP $code)"; exit 1 ;;
           esac
+      - name: Ledger — Published
+        if: inputs.ledger == 'required' && steps.plan.outputs.key != '' && steps.publish.outcome == 'success'
+        env:
+          KEY: ${{ steps.plan.outputs.key }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: |
+          set -euo pipefail
+          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Published
+
+      # ───────── THE LEDGER'S VERDICT WHEN THIS LEG DID NOT GET HERE — never a reason for red ─────────
+      # `failure()`: the phase is read off the step outcomes, so the record says WHERE it failed and the
+      # tolerance rule (compile blocks; a test failure blocks from the 2nd attempt; pack/publish never)
+      # is applied by the script. `cancelled()`: the claim is released at once instead of expiring.
+      # Both steps are best-effort by construction — the script exits 0 with a ::warning when the
+      # registry is unavailable, and `|| true` keeps a failed leg's own failure as the job's verdict.
+      - name: Ledger — Failed
+        if: failure() && inputs.ledger == 'required' && steps.plan.outputs.key != ''
+        env:
+          KEY: ${{ steps.plan.outputs.key }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+          REUSED_OUTCOME: ${{ steps.reused.outcome }}
+          PACK_OUTCOME: ${{ steps.pack.outcome }}
+          INSPECT_OUTCOME: ${{ steps.bundle.outcome }}
+          TESTS_OUTCOME: ${{ steps.tests.outcome }}
+          PUBLISH_OUTCOME: ${{ steps.publish.outcome }}
+          MODE: ${{ matrix.entry.build || 'sdk' }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: |
+          set -uo pipefail
+          phase="pack"
+          if   [ "$TESTS_OUTCOME" = "failure" ]; then phase="test"
+          elif [ "$PUBLISH_OUTCOME" = "failure" ]; then phase="publish"
+          elif [ "$BUILD_OUTCOME" = "failure" ] && [ "$MODE" = "sdk" ]; then phase="compile"
+          elif [ "$BUILD_OUTCOME" = "failure" ] || [ "$PACK_OUTCOME" = "failure" ] || [ "$INSPECT_OUTCOME" = "failure" ] || [ "$REUSED_OUTCOME" = "failure" ]; then phase="pack"
+          fi
+          printf 'step outcomes — build:%s reused:%s pack:%s inspect:%s tests:%s publish:%s (%s)\n' \
+            "$BUILD_OUTCOME" "$REUSED_OUTCOME" "$PACK_OUTCOME" "$INSPECT_OUTCOME" "$TESTS_OUTCOME" "$PUBLISH_OUTCOME" "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" > "$RUNNER_TEMP/failure.txt"
+          trx="$RUNNER_TEMP/trx/ledger.trx"
+          trxarg=()
+          if [ -f "$trx" ]; then trxarg=(--trx "$trx"); fi
+          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Failed --phase "$phase" \
+            --failure-file "$RUNNER_TEMP/failure.txt" ${trxarg[@]+"${trxarg[@]}"} || true
+      - name: Ledger — released (cancelled)
+        if: cancelled() && inputs.ledger == 'required' && steps.plan.outputs.key != ''
+        env:
+          KEY: ${{ steps.plan.outputs.key }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: python3 meshweaver/.github/scripts/module-build-ledger.py release --key "$KEY" || true
 
       # ─────────────────────────── THE RECEIPT ───────────────────────────
       # 🚨 POSITIVE EVIDENCE THAT THIS LEG RAN. A skipped matrix leg renders with the same tick as
@@ -1736,8 +1928,10 @@ jobs:
           PACKAGE: ${{ matrix.entry.package }}
           MODULE: ${{ matrix.entry.module }}
           VERSION: ${{ steps.identity.outputs.version }}
-          COMPILER: ${{ steps.build.outputs.compiler }}
+          COMPILER: ${{ steps.plan.outputs.decision == 'reuse' && 'reused' || steps.build.outputs.compiler }}
           PUBLISHED: ${{ inputs.publish }}
+          LEDGER_KEY: ${{ steps.plan.outputs.key }}
+          LEDGER_DECISION: ${{ steps.plan.outputs.decision }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/receipts"
@@ -1745,7 +1939,8 @@ jobs:
           jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
                 --arg v "$VERSION" --arg c "$COMPILER" \
                 --argjson pub "$PUBLISHED" \
-             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, published:$pub}' \
+                --arg lk "$LEDGER_KEY" --arg ld "$LEDGER_DECISION" \
+             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, published:$pub, ledger:{key:$lk, decision:$ld}}' \
              > "$RUNNER_TEMP/receipts/$MODULE.json"
           cat "$RUNNER_TEMP/receipts/$MODULE.json"
       - name: Upload the receipt
@@ -1755,6 +1950,16 @@ jobs:
           path: ${{ runner.temp }}/receipts/*.json
           retention-days: 1
           if-no-files-found: error
+      # The leg is over: a record left at Built/Tested (no publish on this event) is marked finished so
+      # a follower stops waiting for a publish that will never come. Idempotent on a Published record.
+      - name: Ledger — finished
+        if: inputs.ledger == 'required' && steps.plan.outputs.key != ''
+        env:
+          KEY: ${{ steps.plan.outputs.key }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: python3 meshweaver/.github/scripts/module-build-ledger.py finish --key "$KEY"
 
   # ═══════════════ THE COUNT GATE — one STABLE context, on every run ═══════════════
   # 🚨 A dynamic matrix cannot be a fixed list of required status checks: the per-module contexts
@@ -1906,11 +2111,15 @@ jobs:
               [ .[] | select((.module as $m | $mine | index($m)) and .compiler == "container") | .module ]
               | sort | join(", ")' "${receipts[@]}")"
           legacy="$(jq -s --argjson mine "$mine" -r '
-              [ .[] | select((.module as $m | $mine | index($m)) and .compiler != "container") | .module ]
+              [ .[] | select((.module as $m | $mine | index($m)) and .compiler != "container" and .compiler != "reused") | .module ]
+              | sort | join(", ")' "${receipts[@]}")"
+          reused="$(jq -s --argjson mine "$mine" -r '
+              [ .[] | select((.module as $m | $mine | index($m)) and .compiler == "reused") | .module ]
               | sort | join(", ")' "${receipts[@]}")"
           echo "compiler split: $split module bundle(s) built by \`memex build project\` in the platform image"
           echo "  container: ${containers:-<none>}"
           echo "  dotnet SDK: ${legacy:-<none>}"
+          echo "  reused (ledger): ${reused:-<none>}"
           {
             echo "### Compiler split"
             echo
@@ -1918,4 +2127,5 @@ jobs:
             echo
             echo "- container: ${containers:-_none yet_}"
             echo "- dotnet SDK (legacy): ${legacy:-_none_}"
+            echo "- reused from an earlier run (module build ledger): ${reused:-_none_}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -84,21 +84,132 @@ selected modules beside them, so "emitted but not selected" is normal and is not
 opens, and assert them where they are produced. One accurate failure upstream is worth N accurate
 failures downstream, and a downstream failure can only ever describe its own shard.
 
-## Content-addressed outputs in blob storage = incremental CI
+## Content-addressed outputs = the module build ledger (as built, 2026-09-02)
 
-Build outputs are keyed by **(module source tree hash × tester-image digest × platform-image
-digest)** in the actions cache. Consumers restore by key; producers publish once.
+*"For Plugins, merge as quickly as possible, as tolerant as possible; only hard conflicts flagged. We
+should not start the same build multiple times ⇒ coordinate which packages are in progress; track
+progress through memex. Build and test only when we have to: if Plugin X was built against Platform
+version Y, we don't have to rebuild this."* (maintainer, 2026-09-02; Plugins#889, #931)
 
-Two consequences, both load-bearing:
+Every module build has a **content address**, and the fleet keeps a **ledger** of what happened at
+each address — on the registry portal, as mesh nodes. The lane consults it before it compiles, and
+writes it at every transition. This section is the contract; the two scripts that implement it are
+`.github/scripts/module-build-key.py` and `.github/scripts/module-build-ledger.py`, both self-tested
+on every lane run, and `ModuleBuildLedgerLaneGuard` pins the lane's wiring.
 
-* **"Build only what changed" falls out for free, below the selector**: an unchanged module on
-  unchanged toolchain digests is a pure cache hit — the restore IS the build, zero compile.
-  This composes with (does not replace) diff selection.
-* **No producer/consumer races**: downstream jobs `needs:` the build job and restore its
-  outputs — no artifact polling, no bounded waits.
+### The key — what a build is a function of
 
-Own-account blob storage would add auth and distance for nothing; the actions cache is the
-same Azure blob, colocated, already carrying the images.
+```
+K = sha256( canonical JSON of {
+      recipe          the lane's build-recipe version (a constant in module-build-key.py; bumped on a
+                      byte-changing lane edit, never on a cosmetic one)
+      package, module the matrix entry
+      entry           {build: sdk|container, accept: <sorted tokens>}
+      moduleVersion   <package>/manifest.lock → moduleVersion (the package's content hash, Plugins#878)
+      closure         {project dir → tree hash} — the entry project, its sibling <dir>.Test (the lane RUNS
+                      it) and every in-repo ProjectReference either reaches, transitively: module-owned
+                      MeshWeaver.* siblings RIDE the bundle, so their bytes are the bundle's bytes
+      packages        {package → moduleVersion} for every package whose module project is in that
+                      closure, and every package the entry `requires`, transitively
+      globals         {path → sha256 | null} for src/Directory.Build.props, src/Directory.Build.targets,
+                      src/platform-shipped.txt, Directory.Packages.props, global.json, nuget.config …
+                      (null records ABSENCE — an input too)
+      testerDigest, platformDigest, platformRef
+    } )
+```
+
+Design decisions, and why:
+
+* **Tree hashes over `moduleVersion` alone.** The version derivation covers the module's own project
+  (and, since Plugins#1118, its riders); the key hashes the whole compiled+tested closure directly,
+  so it cannot inherit a blind spot in `gen-manifests.py` — `MeshWeaver.Blazor` riding in seven
+  bundles unhashed (see [ModuleVersioning](../ModuleVersioning)) is exactly the shape the key must
+  never have. A `$(MeshWeaverRoot)`-relative reference is the platform's and never an edge: the
+  platform enters through the two digests and `platformRef`.
+* **`platformRef` IS in the key, deliberately.** `dotnet test` builds core FROM SOURCE at that ref,
+  so the verdict really depends on it. This is also the lever a satellite pulls: a caller whose
+  `MW_PLATFORM_REF` tracks `main` gets a new key on every core commit; a caller that pins the ref to
+  the promoted set's commit keys identical trees identically across runs. The lane cannot make that
+  choice for the caller, and must not hide it.
+* **Refusals, not guesses.** A package with no `manifest.lock`, or an entry whose project does not
+  exist, cannot be keyed and fails the selection RED — keying on nothing would collide every build.
+
+### The ledger — one node per key
+
+`Admin/ModuleBuilds/<K>`, nodeType `ModuleBuild`, content `ModuleBuildRecord`
+(`src/MeshWeaver.Graph.Contract/ModuleBuildRecord.cs`; the type ships in the framework, like `Build`,
+so every registry portal has it without a content package): package, module, moduleVersion, version,
+platformRef, both digests, **platformIdentity**, status ∈ {Claimed, Built, Tested, Published, Failed},
+phase, blocking, attempts, run {repo, runId, attempt, url, event, lane}, claimedAt, heartbeatAt,
+finishedAt, bundleSha256, bundleArtifact {repo, runId, name, expiresAt}, tests {passed, failed,
+names[]}, failure, previous.
+
+* **Why `Admin/ModuleBuilds` and not `Admin/Build/…`.** `Admin/Build` is the in-portal NodeType
+  bake's coordination root ([BuildCoordination](../BuildCoordination)) — its hub arbitrates claims over
+  its children with cluster-membership takeover. The CI ledger is a different protocol with a
+  different writer, and must not sit where that arbiter enumerates chunks. It stays in the Admin
+  partition because the subject of a build decision must not be able to write the decision for
+  everyone; the CI user gets a **partition-admin grant scoped to exactly that root**
+  (`Admin/ModuleBuilds/_Access/{user}_Access`, `MainNode = "Admin/ModuleBuilds"`) — never a
+  global-admin one ([AccessControl](../AccessControl) → "The Admin partition").
+* **The wire.** The lane speaks MCP JSON-RPC over HTTP to the portal's `/mcp` (`initialize`, then
+  `tools/call` `get` / `create` / `patch`; JSON or SSE answers), `Authorization: Bearer <mw_ token>`
+  — the same three tools every MCP client uses, no bespoke route.
+* **`platformIdentity` is the PORTAL's.** `prepare` runs the tester's `framework-identity /app` verb
+  with the platform image's own `dotnet` over the platform image's `/app` — the `s…` surface identity
+  the adopting host resolves (#3022), not the tester image's own and not the `g…` provenance stamp of
+  one assembly. That is #931's producer half: the record says which framework these bytes are for.
+  The consumer half (comparing it in `ModuleUpdateDecision`) is a separate change.
+
+### The protocol
+
+| step | what it is |
+|---|---|
+| **claim** | CREATE the node. Creation fails on an existing path, so exactly one run holds a key; *"already exists" is the follower's success case*. After every create the claimant re-reads the node and holds the key only if the record names ITS run — a claim you cannot read back is a claim you do not hold. |
+| **heartbeat** | the holder's sign of life: at claim, at pack-job start, after the workspace build, at every transition. A claim whose heartbeat is older than **45 min — the fleet's job cap** — is dead by construction (a job that cannot heartbeat inside its own cap has been killed) and may be taken over; the takeover is itself re-read for the same reason as the claim. |
+| **reuse** | a terminal record (Built/Tested/Published) whose bundle **artifact** this run can fetch is not rebuilt. The pack job downloads that run's `module-bundle-<module>` artifact, verifies its sha256 against the record, and runs ONLY the phases the record lacks — tests if this run needs a verdict and none is recorded, publish if this run publishes and nobody has. It drops the same artifact, built marker and receipt a built leg drops, so a caller composing the bundle cannot tell the two apart. |
+| **wait** | a fresh, unfinished claim by ANOTHER run: the follower polls the ledger every 30 s (bounded to 40 of `select`'s 45 min). The same key is never built twice at once. |
+| **tolerance** | a `Failed` record blocks a later run of the same key only when the same inputs give the same result: a **compile** failure blocks (RED with the holder's run URL and the compiler lines); a **test** failure blocks from the **second** failed attempt on — one re-claim, so a flaky suite does not pin the fleet (`attempts` counts); pack, publish, workspace-abort and cancellation never block. |
+| **degrade** | the registry portal answering 5xx or unreachable is **not** a verdict: after a bounded retry honouring `Retry-After`, `select` builds every affected module *without coordination* and says so in yellow in the job summary; every later write is a `::warning`. The ledger may cost a duplicate build, never a green (core #3119). |
+
+**Why run ARTIFACTS, not the actions cache.** The first design keyed bundles in the actions cache
+(`module-bundle-<K>`). The cache is **branch-scoped**: a run on `main` can restore only what `main`
+created, so the one flow that matters most — the PR built it, the push to `main` reuses it — is
+structurally impossible there. Run artifacts are repo-wide; the bundle artifact's retention is 7 days
+(the reuse window; the record carries the expiry) and the caller's job needs
+`permissions: actions: read` for `gh run download` — without it `select` observes the 403 and answers
+*build*, loudly. A bundle in ANOTHER repository's run is never fetchable with this run's token, so
+cross-repo keys (the platform CD packing Plugins) are rebuilt rather than reused.
+
+### What this does to the scope
+
+`node-repo-scope.py` still decides what a diff REACHES (a PR narrows; `push`, release-follow and
+manual dispatch are FULL). The ledger decides what of that must be COMPILED. So the `push` row is no
+longer "full by fiat": it is *every module whose key has no usable Published record* — which is
+exactly the baseline Plugins#889 asked for, derived correctly: a cancelled, red or superseded run left
+no Published record, so its modules are rebuilt and published; a PR that built and tested the same
+bytes minutes earlier is reused and only the hand-over runs. Release-follow (`repository_dispatch` /
+`schedule`) still builds everything, correctly: a new platform digest is a new key for every module.
+
+### What a satellite passes
+
+```yaml
+    permissions:
+      contents: read
+      actions: read          # gh run download of an earlier run's bundle — without it, no reuse
+    uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-pack.yml@<sha>
+    with:
+      ledger: required       # default `off` = today's behaviour; the summary says which on every run
+      …
+    secrets:
+      publish-token: ${{ secrets.REGISTRY_PUBLISH_TOKEN }}
+      ledger-token:  ${{ secrets.REGISTRY_LEDGER_TOKEN }}   # a mw_ ApiToken of the registry's CI user
+```
+
+One-time on the registry portal (as a global admin): create the `Admin/ModuleBuilds` root node,
+grant the CI user the `Admin` role there (`MainNode = "Admin/ModuleBuilds"`), mint that user an API
+token, store it as the satellite's `REGISTRY_LEDGER_TOKEN`. `ledger: required` with an empty token
+is RED in `select` — a ledger that silently did not run and one that ran must never look alike.
 
 ## The compiler is the platform image
 
@@ -245,10 +356,10 @@ No component ever publishes from the mesh router — the router names a spokesma
 
 ## Roadmap (agreed, in flight)
 
-* **The one-workspace lane** — the builder takes every selected module as entries of one graph
-  (it already graph-builds with shared references and fail-fast); the per-module compile jobs
-  collapse into one `build-workspace` job publishing content-addressed outputs; pack/tests fan
-  out from it. *"After global build ⇒ run tests."*
+* **The one-workspace lane** — landed: one `build-workspace` job compiles the ledger's build subset
+  as one graph; pack/tests fan out from it. Still open: the consumer half of #931 (compare the
+  ledger's `platformIdentity` in `ModuleUpdateDecision`), and pinning satellites' `MW_PLATFORM_REF`
+  to the promoted set so keys survive core commits.
 * **`pack-module`, `compile-check` and test verbs inside the tester** — the last runner-side
   `dotnet`/python uses move into the image the fleet already ships.
 * **Self-hosted runners with a mounted git mirror + warm image store** (MeshWeaver#2926): bare

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleVersioning.md
@@ -176,9 +176,14 @@ So the two lanes differ deliberately:
 
 The `push` row is the only one where the two lanes differ, and the difference is a **missing
 marker, not a policy**: `bake-scope.sh` reads a `source-commit.txt` sealed beside the bundles, so it
-knows the commit its own last publication covered. The module lane has no equivalent, so
-`node-repo-scope.py` answers FULL and says why in the log and the job summary. Closing that gap is
-Plugins#889 — and the baseline it needs is a **commit**, not a version.
+knows the commit its own last publication covered. The module lane's scope still answers FULL on a
+push — but since 2026-09-02 the **module build ledger** sits below the scope
+([ModuleBuildArchitecture](/Doc/Architecture/ModuleBuildArchitecture) → "Content-addressed outputs"):
+every selected module is keyed by its whole compiled+tested closure plus both image digests and the
+platform ref, and a key the ledger already holds as Published is reused, not rebuilt. So a push
+compiles *every module whose key has no usable Published record* — the Plugins#889 baseline, derived
+from content rather than from a version or a commit, which is what makes it immune to the riding
+blind spot above. Callers opt in with `ledger: required`.
 
 ## Before you open the PR
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-module-built-once-is-not-built-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-module-built-once-is-not-built-again.md
@@ -1,0 +1,34 @@
+---
+Name: A module built once is not built again
+Category: Feature
+Description: The module build lane now records every build on the registry portal, keyed by everything that went into it — so a second run of the same bytes reuses the first, two runs never build the same thing at once, and a platform release rebuilds only what its new identity actually changes.
+Icon: ArrowSync
+Order: -20260902
+---
+
+# A module built once is not built again
+
+Every package that ships a module used to be compiled, packed and tested from scratch on every run
+that reached it: once on the pull request, again on the push to `main` minutes later, and once more
+in every concurrent pull request that happened to touch the same module. A platform release rebuilt
+every module in the fleet, whether or not the release changed anything the module could see.
+
+The lane now writes a **module build ledger** on the registry portal. Every selected module gets a
+content address — the package's content hash, the source of every in-repo project the bundle carries
+or its tests reach, both image digests, the platform commit and the lane's own recipe — and the ledger
+says, per address, what has already happened: built, tested, published, failed, or in progress right
+now in another run.
+
+- **Same address, built before?** The run downloads that bundle and runs only what is still missing
+  — the tests if nobody recorded a verdict, the hand-over to the registry if nobody published it.
+- **Same address, another run is on it?** The run waits for that one to finish rather than building
+  the same thing beside it.
+- **Same address, compile failed?** The run stops with the other run's evidence — the same inputs
+  give the same result. A test failure is allowed one more attempt, so a flaky suite does not pin
+  the fleet.
+
+The registry portal being unavailable never turns a green build red: the lane then builds without
+coordination and says so in the job summary.
+
+Where the design decisions live: [Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture)
+→ "Content-addressed outputs".

--- a/src/MeshWeaver.Graph.Contract/ModuleBuildRecord.cs
+++ b/src/MeshWeaver.Graph.Contract/ModuleBuildRecord.cs
@@ -1,0 +1,148 @@
+using System;
+using System.Collections.Immutable;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>Where a CI module build stands — the ledger states of <see cref="ModuleBuildRecord"/>.</summary>
+public enum ModuleBuildStatus
+{
+    /// <summary>A run holds this key and is building. A fresh heartbeat makes every other run WAIT.</summary>
+    Claimed,
+    /// <summary>The bundle exists as a run artifact (built + packed + inspected); tests not yet run.</summary>
+    Built,
+    /// <summary>The bundle exists and its module's test suite passed.</summary>
+    Tested,
+    /// <summary>The bundle was handed to the registry.</summary>
+    Published,
+    /// <summary>The build failed; <see cref="ModuleBuildRecord.Phase"/> and <see cref="ModuleBuildRecord.Blocking"/> say what that means for the next run.</summary>
+    Failed,
+}
+
+/// <summary>Which CI run holds or held a <see cref="ModuleBuildRecord"/>.</summary>
+/// <param name="Repo">GitHub repository of the run (<c>Systemorph/MeshWeaver.Plugins</c>).</param>
+/// <param name="RunId">The run id.</param>
+/// <param name="Attempt">The run attempt.</param>
+/// <param name="Url">The run's URL, for a human reading the record.</param>
+/// <param name="Event">The triggering event (<c>pull_request</c>, <c>push</c>, <c>schedule</c>, …).</param>
+/// <param name="Lane">The lane key of the reusable-workflow call inside the run (a repo may call the lane twice per run).</param>
+public sealed record ModuleBuildRun(
+    string Repo, string RunId, string Attempt, string Url, string Event, string? Lane = null);
+
+/// <summary>Where the bundle a record attests can be fetched from — a run artifact, never a branch-scoped cache.</summary>
+/// <param name="Repo">The repository whose run uploaded it.</param>
+/// <param name="RunId">The run id.</param>
+/// <param name="Name">The artifact name (<c>module-bundle-&lt;module&gt;</c>).</param>
+/// <param name="ExpiresAt">When GitHub deletes it (the upload's retention).</param>
+public sealed record ModuleBuildArtifact(string Repo, string RunId, string Name, DateTime? ExpiresAt);
+
+/// <summary>The test verdict a <see cref="ModuleBuildRecord"/> carries.</summary>
+/// <param name="Passed">Passed test count.</param>
+/// <param name="Failed">Failed test count.</param>
+/// <param name="Names">The FAILED tests' fully qualified names (capped by the writer) — the evidence a follower is handed.</param>
+public sealed record ModuleBuildTests(int Passed, int Failed, ImmutableList<string>? Names = null);
+
+/// <summary>
+/// Content of a <c>ModuleBuild</c> node — one row of the fleet's CI MODULE BUILD LEDGER at
+/// <c>Admin/ModuleBuilds/{Key}</c> (<c>Doc/Architecture/ModuleBuildArchitecture</c> →
+/// "Content-addressed outputs").
+///
+/// <para>The <see cref="Key"/> is the content address of one module build: sha256 over the package
+/// id, the package's <c>manifest.lock</c> <c>moduleVersion</c>, the in-repo project closure the lane
+/// compiles and tests (tree hashes) plus the <c>moduleVersion</c> of every package that closure or the
+/// <c>requires</c> chain reaches, the tester-image and platform-image digests, the platform ref, and
+/// the lane's build-recipe version (<c>.github/scripts/module-build-key.py</c>). Same key ⇒ same
+/// inputs ⇒ same bytes and the same verdict, so a second run of the same key REUSES the first run's
+/// record instead of building again.</para>
+///
+/// <para><b>The claim IS the mutex.</b> A run claims a key by CREATING this node; creation fails on an
+/// existing path, so exactly one run holds a key and every later one reads the holder's record —
+/// "already exists" is the follower's success case. A holder proves it is alive with
+/// <see cref="HeartbeatAt"/>; a claim whose heartbeat is older than the fleet's job cap (45 min) is
+/// dead by construction and may be taken over. Writers are the CI lane's ledger script, through the
+/// registry portal's MCP endpoint, as a dedicated CI user holding a partition-admin grant on
+/// <c>Admin/ModuleBuilds</c> — never a global admin.</para>
+/// </summary>
+public sealed record ModuleBuildRecord
+{
+    /// <summary>The build key — the node id. 64 hex characters.</summary>
+    public string Key { get; init; } = "";
+
+    /// <summary>The Store package id (<c>AI</c>, <c>Import</c>, …).</summary>
+    public string Package { get; init; } = "";
+
+    /// <summary>The module's entry assembly name (<c>MeshWeaver.AI</c>).</summary>
+    public string Module { get; init; } = "";
+
+    /// <summary>The package's <c>manifest.lock</c> <c>moduleVersion</c> — the content hash the key folds in.</summary>
+    public string ModuleVersion { get; init; } = "";
+
+    /// <summary>The package's derived SemVer at build time (<c>manifest.lock</c> <c>version</c>).</summary>
+    public string? Version { get; init; }
+
+    /// <summary>The Systemorph/MeshWeaver commit the module was built and tested against.</summary>
+    public string PlatformRef { get; init; } = "";
+
+    /// <summary>The digest of the tester image that compiled it.</summary>
+    public string? TesterDigest { get; init; }
+
+    /// <summary>The digest of the platform (portal) image it compiled against.</summary>
+    public string? PlatformDigest { get; init; }
+
+    /// <summary>
+    /// The framework identity the PLATFORM host resolves for that image's <c>/app</c> — the
+    /// <c>s…</c> surface identity <c>FrameworkBuildIdentity</c> computes, as the tester's
+    /// <c>framework-identity</c> verb reads it off the extracted portal <c>/app</c>. Not the tester
+    /// image's own identity: the tester compiles, the portal adopts, and the bundle is keyed to the
+    /// host that adopts it (#3130). Written when the lane has resolved it (the pack job), null on a
+    /// bare claim.
+    /// </summary>
+    public string? PlatformIdentity { get; init; }
+
+    /// <summary>The ledger state.</summary>
+    public ModuleBuildStatus Status { get; init; }
+
+    /// <summary>
+    /// The phase a <see cref="ModuleBuildStatus.Failed"/> record failed in: <c>compile</c>,
+    /// <c>pack</c>, <c>test</c>, <c>publish</c>, or <c>workspace</c> (the one-workspace build
+    /// aborted on ANOTHER module's error before this one was compiled).
+    /// </summary>
+    public string? Phase { get; init; }
+
+    /// <summary>
+    /// Whether this record blocks a later run of the same key. Same inputs give the same compile
+    /// result, so a <c>compile</c> failure blocks; a <c>test</c> failure blocks only from the second
+    /// failed attempt on (one re-claim is allowed, so a flaky suite does not pin the fleet); every
+    /// other failure and every cancelled build is reclaimable.
+    /// </summary>
+    public bool Blocking { get; init; }
+
+    /// <summary>How many runs have claimed this key (the first claim is 1).</summary>
+    public int Attempts { get; init; }
+
+    /// <summary>The run holding (or that last held) this key.</summary>
+    public ModuleBuildRun? Run { get; init; }
+
+    /// <summary>When the current holder claimed the key.</summary>
+    public DateTime? ClaimedAt { get; init; }
+
+    /// <summary>The holder's last sign of life; a claim older than the job cap is reclaimable.</summary>
+    public DateTime? HeartbeatAt { get; init; }
+
+    /// <summary>When the holder reached a terminal status.</summary>
+    public DateTime? FinishedAt { get; init; }
+
+    /// <summary>sha256 of the packed bundle (<c>.module.nupkg</c>).</summary>
+    public string? BundleSha256 { get; init; }
+
+    /// <summary>Where the bundle can be downloaded from for reuse.</summary>
+    public ModuleBuildArtifact? BundleArtifact { get; init; }
+
+    /// <summary>The test verdict, when the suite ran.</summary>
+    public ModuleBuildTests? Tests { get; init; }
+
+    /// <summary>The failure text (log tail), when <see cref="Status"/> is <see cref="ModuleBuildStatus.Failed"/>.</summary>
+    public string? Failure { get; init; }
+
+    /// <summary>The previous holder's outcome, kept when a key is re-claimed (evidence for the reader, not authority).</summary>
+    public ModuleBuildRecord? Previous { get; init; }
+}

--- a/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
+++ b/src/MeshWeaver.Graph/Configuration/GraphConfigurationExtensions.cs
@@ -37,6 +37,7 @@ public static class GraphConfigurationExtensions
                 .AddScopeType()
                 .AddReleaseType()
                 .AddBuildType()
+                .AddModuleBuildType()
                 .AddMarkdownType()
                 // Slide/Deck are NOT built-in any more: the Publish pack owns them as dynamic
                 // NodeTypes (Publish/Slide, Publish/Deck) with in-mesh layout areas; V53 retyped

--- a/src/MeshWeaver.Graph/Configuration/ModuleBuildNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/ModuleBuildNodeType.cs
@@ -1,0 +1,78 @@
+using System.Collections.Generic;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+
+namespace MeshWeaver.Graph.Configuration;
+
+/// <summary>
+/// Registers <c>ModuleBuild</c> as a first-class NodeType — the rows of the fleet's CI module build
+/// ledger at <see cref="Root"/><c>/{key}</c>, each carrying a <see cref="ModuleBuildRecord"/>
+/// (<c>Doc/Architecture/ModuleBuildArchitecture</c> → "Content-addressed outputs").
+///
+/// <para>The writer is <c>.github/scripts/module-build-ledger.py</c> in the reusable module-pack
+/// lane, speaking to the registry portal's MCP endpoint as a dedicated CI user. The type ships in
+/// the framework (like <see cref="BuildNodeType"/>) so every registry portal has it without a content
+/// package to install, and the schema the lane writes against is this record — one definition.</para>
+///
+/// <para>🚨 <b>Deliberately NOT under <c>Admin/Build</c>.</b> That root is the in-portal NodeType
+/// bake's coordination node (<see cref="BuildNodeType.RootPath"/>), whose hub arbitrates claims over
+/// its children; the CI ledger is a different protocol (create-if-absent IS the mutex, heartbeat
+/// staleness IS the takeover rule) and must not sit where the arbiter enumerates chunks. It is still
+/// in the Admin partition, because the subject of a build decision must not be able to write the
+/// decision for everyone — and the CI user gets a partition-admin grant scoped to exactly
+/// <see cref="Root"/> (<c>Admin/ModuleBuilds/_Access/{user}_Access</c>, <c>MainNode = "Admin/ModuleBuilds"</c>),
+/// never a global-admin one.</para>
+/// </summary>
+public static class ModuleBuildNodeType
+{
+    /// <summary>The node-type identifier string for ModuleBuild nodes.</summary>
+    public const string NodeType = "ModuleBuild";
+
+    /// <summary>The ledger root — every record is a direct child named by its build key.</summary>
+    public const string Root = "Admin/ModuleBuilds";
+
+    /// <summary>
+    /// Registers the ModuleBuild node type on the mesh builder: the MeshNode definition, the
+    /// autocomplete exclusion (a 64-hex key is nothing a human links to), and the record types in
+    /// the hub's type registry so the typed payload survives a cross-silo write.
+    /// </summary>
+    /// <typeparam name="TBuilder">The mesh builder type.</typeparam>
+    /// <param name="builder">The mesh builder to configure.</param>
+    /// <returns>The same builder, to allow fluent chaining.</returns>
+    public static TBuilder AddModuleBuildType<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
+    {
+        builder.AddMeshNodes(CreateMeshNode());
+        builder.AddAutocompleteExcludedTypes(NodeType);
+        builder.ConfigureHub(config => config
+            .WithType<ModuleBuildRecord>(nameof(ModuleBuildRecord))
+            .WithType<ModuleBuildRun>(nameof(ModuleBuildRun))
+            .WithType<ModuleBuildArtifact>(nameof(ModuleBuildArtifact))
+            .WithType<ModuleBuildTests>(nameof(ModuleBuildTests)));
+        return builder;
+    }
+
+    /// <summary>
+    /// Builds the MeshNode definition for the ModuleBuild node type: the record payload, no UI create
+    /// (only the CI lane writes these nodes), the default views.
+    /// </summary>
+    /// <returns>The ModuleBuild MeshNode definition.</returns>
+    public static MeshNode CreateMeshNode() => new(NodeType)
+    {
+        Name = "Module Build",
+        NodeType = MeshNode.NodeTypePath,   // this MeshNode IS a NodeType definition
+        Icon = "/static/NodeTypeIcons/task-list.svg",
+        ExcludeFromContext = new HashSet<string> { "create" }, // no UI create — only the CI ledger script writes these
+        Content = new NodeTypeDefinition
+        {
+            Description = "One row of the CI module build ledger: which run built (or is building) a "
+                + "module at a given content address, against which platform, with what verdict — "
+                + "so a second run of the same key reuses the first instead of building again.",
+        },
+        HubConfiguration = config => config
+            .AddMeshDataSource(source => source
+                .WithContentType<ModuleBuildRecord>())
+            .AddDefaultLayoutAreas()
+    };
+}

--- a/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
@@ -33,7 +33,8 @@ public class ModuleBuildLedgerLaneGuard
     public void TheLane_DeclaresTheLedgerFlagAndItsToken_DefaultingToOff()
     {
         var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
-        var input = Regex.Match(text, @"\n      ledger:\n(?<body>(?:        .*\n)+)");
+        // The folded (`>`) description carries blank lines, so the body is "8-space-indented or empty".
+        var input = Regex.Match(text, @"\n      ledger:\n(?<body>(?:(?:        .*)?\n)+)");
         Assert.True(input.Success, $"{Lane} must declare a `ledger` input");
         Assert.Contains("default: off", input.Groups["body"].Value, StringComparison.Ordinal);
         Assert.True(Regex.IsMatch(text, @"\n      ledger-token:\n"), $"{Lane} must declare the `ledger-token` secret");

--- a/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
@@ -1,0 +1,141 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for the module build LEDGER in the reusable module-pack lane (Plugins#889,
+/// #931; <c>Doc/Architecture/ModuleBuildArchitecture</c> → "Content-addressed outputs").
+///
+/// <para>The ledger is a protocol between a CI lane and the registry portal, and its properties live
+/// in YAML, not in the product: that the lane KEYS every selected module and CONSULTS the ledger before
+/// the one-workspace build; that the build compiles the ledger's <c>build-modules</c> subset and feeds
+/// the SAME list to its postcondition; that the pack job records the three transitions (Built after the
+/// artifact upload, Tested after the suite, Published after the hand-over) plus the Failed and cancelled
+/// verdicts; and that every ledger write is best-effort while the two scripts' self-tests run on every
+/// run. A lane that quietly dropped one of those would still be green — a duplicate build costs money
+/// silently, a missing <c>Built</c> record makes every later run rebuild, and a <c>Tested</c> recorded
+/// before the suite ran would hand followers a verdict nobody reached. Nothing in a green run
+/// distinguishes those shapes; this does.</para>
+/// </summary>
+public class ModuleBuildLedgerLaneGuard
+{
+    private const string Lane = ".github/workflows/node-repo-module-pack.yml";
+    private const string KeyScript = ".github/scripts/module-build-key.py";
+    private const string LedgerScript = ".github/scripts/module-build-ledger.py";
+
+    [Fact]
+    public void TheLane_DeclaresTheLedgerFlagAndItsToken_DefaultingToOff()
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
+        var input = Regex.Match(text, @"\n      ledger:\n(?<body>(?:        .*\n)+)");
+        Assert.True(input.Success, $"{Lane} must declare a `ledger` input");
+        Assert.Contains("default: off", input.Groups["body"].Value, StringComparison.Ordinal);
+        Assert.True(Regex.IsMatch(text, @"\n      ledger-token:\n"), $"{Lane} must declare the `ledger-token` secret");
+    }
+
+    [Fact]
+    public void Select_SelfTestsBothScripts_KeysTheSelection_AndConsultsTheLedger()
+    {
+        var select = JobBody("select");
+        Assert.Contains("module-build-key.py --self-test", select, StringComparison.Ordinal);
+        Assert.Contains("module-build-ledger.py --self-test", select, StringComparison.Ordinal);
+        Assert.Contains("module-build-key.py --root repo", select, StringComparison.Ordinal);
+        Assert.Contains("module-build-ledger.py decide", select, StringComparison.Ordinal);
+        // The flag is a three-way case with a RED default arm — an unreadable value never means "off".
+        Assert.Contains("inputs.ledger is '$LEDGER'. The only values are 'off' (the default) and 'required'", select, StringComparison.Ordinal);
+        // The token is asserted, never tested-and-skipped.
+        Assert.Contains("[ -n \"${MW_LEDGER_TOKEN:-}\" ] ||", select, StringComparison.Ordinal);
+        // Both outputs the downstream jobs key on.
+        Assert.Contains("build-modules: ${{ steps.ledger.outputs.build }}", select, StringComparison.Ordinal);
+        Assert.Contains("modules: ${{ steps.ledger.outputs.modules }}", select, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void BuildWorkspace_CompilesTheLedgersBuildSubset_AndFeedsThePostconditionTheSameList()
+    {
+        var build = JobBody("build-workspace");
+        var uses = Regex.Matches(build, @"MODULES: \$\{\{ needs\.select\.outputs\.(?<which>[a-z-]+) \}\}")
+            .Select(m => m.Groups["which"].Value).Distinct().ToArray();
+        Assert.True(uses.Length == 1 && uses[0] == "build-modules",
+            $"build-workspace must read ONLY `build-modules` (the entries the ledger did not hand a reusable bundle for) — "
+            + $"the compile and its postcondition must share one enumerator. Found: {string.Join(", ", uses)}");
+        Assert.Contains("module-build-ledger.py heartbeat", build, StringComparison.Ordinal);
+        Assert.Contains("--status Failed --phase \"$phase\"", build, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Pack_RecordsTheThreeTransitions_InOrder_AndTheTwoVerdicts()
+    {
+        var pack = JobBody("pack");
+        int At(string needle)
+        {
+            var i = pack.IndexOf(needle, StringComparison.Ordinal);
+            Assert.True(i >= 0, $"the pack job must contain: {needle}");
+            return i;
+        }
+
+        var upload = At("name: module-bundle-${{ matrix.entry.module }}");
+        var built = At("--status Built");
+        var tests = At("dotnet test \"$tests\"");
+        var tested = At("--status Tested --trx");
+        var publish = At("-X POST \"$REGISTRY/api/plugins/bundles/$PACKAGE");
+        var published = At("--status Published");
+        var failed = At("--status Failed --phase \"$phase\"");
+        var released = At("module-build-ledger.py release --key");
+        var finished = At("module-build-ledger.py finish --key");
+
+        // Built AFTER the artifact upload it names; Tested AFTER the suite; Published AFTER the hand-over.
+        Assert.True(upload < built, "`Built` must be recorded AFTER the bundle artifact upload — the record names that artifact");
+        Assert.True(tests < tested, "`Tested` must be recorded AFTER the suite ran");
+        Assert.True(publish < published, "`Published` must be recorded AFTER the registry accepted the bundle");
+        Assert.True(published < failed && failed < released && released < finished, "the Failed / released / finished steps come last");
+
+        // Tested and Published are gated on the OUTCOME of the step they attest, not on the job's mood.
+        Assert.Contains("steps.tests.outcome == 'success'", pack, StringComparison.Ordinal);
+        Assert.Contains("steps.publish.outcome == 'success'", pack, StringComparison.Ordinal);
+        // The verdict steps run on failure / cancellation only.
+        Assert.Contains("if: failure() && inputs.ledger == 'required' && steps.plan.outputs.key != ''", pack, StringComparison.Ordinal);
+        Assert.Contains("if: cancelled() && inputs.ledger == 'required' && steps.plan.outputs.key != ''", pack, StringComparison.Ordinal);
+        // The reuse leg verifies the bytes against the record and never packs anyway.
+        Assert.Contains("gh run download \"$ART_RUN\"", pack, StringComparison.Ordinal);
+        Assert.Contains("is not the ledger's $EXPECTED_SHA", pack, StringComparison.Ordinal);
+        // The suite writes the evidence the ledger records.
+        Assert.Contains("--logger \"trx;LogFileName=ledger.trx\"", pack, StringComparison.Ordinal);
+        // The reuse window is the artifact's retention.
+        Assert.Contains("retention-days: 7", pack, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheScripts_NameThemselvesOnTheirFirstLine_ForTheFetchCheck()
+    {
+        foreach (var script in new[] { KeyScript, LedgerScript })
+        {
+            var head = File.ReadAllText(Path.Combine(FindRepoRoot(), script));
+            head = head[..Math.Min(400, head.Length)];
+            Assert.Contains(Path.GetFileName(script), head, StringComparison.Ordinal);
+        }
+    }
+
+    private static string JobBody(string job)
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
+        var match = Regex.Match(text, @"\n  " + Regex.Escape(job) + @":\n(?<body>(?:(?:    .*|  #.*)\n|\n)+?)(?=  [a-z][a-z-]*:\n|\z)");
+        Assert.True(match.Success, $"{Lane} must have a `{job}` job");
+        return string.Join('\n', match.Groups["body"].Value.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.True(dir is not null, "could not locate the repository root (MeshWeaver.slnx) above the test bin");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
Closes Systemorph/MeshWeaver.Plugins#889. Producer half of Systemorph/MeshWeaver.Plugins#931 (the consumer half — comparing the recorded platform identity in `ModuleUpdateDecision` — is a separate PR).

Maintainer directive (2026-09-02): *"we should not start the same build multiple times ⇒ coordinate which packages are in progress; track progress through memex. Build and test only when we have to: if Plugin X was built against Platform version Y, we don't have to rebuild this."*

## What lands

**A content address per module build** — `.github/scripts/module-build-key.py` (self-tested, 36 cases: determinism, every input flips the key, noise does not, two refusals). `K = sha256(package, manifest.lock moduleVersion, tree hashes of the in-repo compiled+tested closure, reached packages' moduleVersions, repo-level build inputs, tester digest, platform digest, platform-ref, recipe version)`.

**A ledger on the registry portal** — `.github/scripts/module-build-ledger.py` (self-tested against an in-process fake MCP server, 35 cases). One node per key at `Admin/ModuleBuilds/<K>` (nodeType `ModuleBuild`, content `ModuleBuildRecord` — shipped in the framework, `src/MeshWeaver.Graph.Contract/ModuleBuildRecord.cs` + `src/MeshWeaver.Graph/Configuration/ModuleBuildNodeType.cs`), written over MCP JSON-RPC at `/mcp` with a `mw_` ApiToken of a CI user holding a partition-admin grant on that root. Claim = create-if-absent (the mutex; "already exists" is the follower's success), heartbeat staleness = the 45-min job cap, reuse = download the recorded run's bundle artifact (sha256-verified) and run only the missing phases, wait = poll 30 s on a live holder, tolerance = compile failures block, test failures block from the 2nd attempt, nothing else blocks. **The registry being unavailable never reds a build**: the lane builds without coordination and says so in yellow (core #3119).

**Lane** (`node-repo-module-pack.yml`): new input `ledger: off|required` (default `off` = today's behaviour, printed every run; `required` asserts the `ledger-token` secret RED), `select` keys + consults, `build-workspace` compiles the ledger's `build-modules` subset and feeds its postcondition the same list, `prepare` resolves the PORTAL's framework identity (tester's `framework-identity /app` under the platform image's dotnet), `pack` gains a reuse leg and records Built (after the artifact upload) / Tested (after the suite, from the trx) / Published (after the hand-over) / Failed (phase from step outcomes) / released (cancelled) / finished. Bundle artifact retention 3 → 7 days (the reuse window). Every job ≤ 45 min (gate green).

**Guard**: `test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs` pins the flag + token, the self-tests, the single enumerator, the three transitions in order gated on step outcomes, the two verdict steps, the reuse verification.

**Docs**: `ModuleBuildArchitecture.md` "Content-addressed outputs" rewritten from roadmap to as-built (key, ledger, protocol, why `Admin/ModuleBuilds` not `Admin/Build`, why run artifacts not the branch-scoped actions cache, what a satellite passes); `ModuleVersioning.md` push row; What's New `Category: Feature`.

## Deviations from the brief, and why

- **Run artifacts, not `actions/cache` `module-bundle-<K>`**: the actions cache is branch-scoped, so a bundle cached by a PR run is invisible to the push-to-main run — the one flow that matters most. Artifacts are repo-wide (7-day retention); the caller needs `permissions: actions: read` for reuse, otherwise `select` sees the 403 and builds, loudly.
- **`Admin/ModuleBuilds`, not `Build/Modules`**: the bake's `Admin/Build` root has an arbiter over its children; the ledger is a different protocol. Admin partition kept so the subject cannot write the decision; the CI user is a partition admin on exactly that root, never a global admin.
- **`ledger` defaults to `off`**: the token cannot be provisioned from a PR (a `mw_` token must be minted on memex.meshweaver.cloud by an admin), and a required-by-default flag would red every satellite and the platform CD (`main-cd.yml plugins-modules`) at pin move. The summary says OFF on every run so the state cannot be mistaken for a consulted ledger.
- **`platformRef` is in the key on purpose** (`dotnet test` builds core from source at it). Satellites tracking `MW_PLATFORM_REF: main` get a new key per core commit; pinning the ref to the promoted set is the lever, and is theirs.
- **Type in C#, not as content**: like `Build`, so every registry portal has it with no content package and no cross-repo half.

## Verification

- `module-build-key.py --self-test` 36/36, `module-build-ledger.py --self-test` 35/35, `node-repo-scope.py --self-test` 44/44
- `check-workflow-timeouts.py --root .` 0 violations; `check-workflow-shell.py` 0 live findings
- `dotnet build src/MeshWeaver.Graph -c Release -warnaserror` and `test/MeshWeaver.Documentation.Test -c Release -warnaserror`: 0 warnings, 0 errors
- `dotnet test test/MeshWeaver.Documentation.Test` (whole project): see the CI run

## Adoption (per satellite; not in this PR)

1. Once, on the registry portal (as a global admin): create `Admin/ModuleBuilds`, grant the CI user the `Admin` role there with `MainNode = "Admin/ModuleBuilds"`, mint that user a `mw_` ApiToken → repo secret `REGISTRY_LEDGER_TOKEN`.
2. Move the lane pin to this PR's merge sha; add `ledger: required`, `secrets.ledger-token`, and `permissions: actions: read` on the calling job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
