### PR TITLE
Arm auto-merge is ONE lane, called by seven repos

### DIFF
--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -7,19 +7,22 @@
 # nothing was landing either. A green PR nobody arms is indistinguishable from a red one.
 #
 # 🚨 THIS FILE IS THE FLEET'S ONLY COPY OF THE ARM LANE. It runs directly here on
-# `pull_request_target`, and every satellite (MeshWeaver.Plugins, .SocialMedia, .Reinsurance,
-# .Manufacturing, .Education, .Crm, Memex) reaches it through `workflow_call` with a two-line
-# caller that forwards the App credential and nothing else. The repos are NOT identical — core
-# runs a merge queue and the others do not — so the arm step handles both shapes rather than the
-# file forking per repo.
+# `pull_request_target`, and every OTHER repo in the fleet reaches it through `workflow_call` with
+# a caller that forwards the App credential and nothing else. (Deliberately no list of repo names
+# here: an enumeration in a comment is a copy of the fleet roster and would drift exactly the way
+# the copies below did. `gh search code --owner Systemorph "auto-arm.yml@"` answers who calls it.)
+# The repos are NOT identical — core runs a merge queue and the others do not — so the arm step
+# handles both shapes rather than the file forking per repo.
 #
-# It used to be hand-copied into all seven, and the copies DRIFTED exactly as AGENTS.md warns a
-# copy-pasted lane does. Measured 2026-09-02: core had already been moved to a minted App token
-# (below) while every satellite copy was still arming with `secrets.GITHUB_TOKEN` — so every
-# satellite was living the #2916 outage this file's header documents, silently. MeshWeaver.Reinsurance's
-# `main` had not seen a `push`-event run since 09:11Z despite PRs merging all afternoon. On top of
-# that, only .Crm carried the "landed:" read-back fix below, and several copies had no
-# `timeout-minutes` at all. One lane, called from seven repos, cannot drift.
+# It used to be hand-copied into every one of them, and the copies DRIFTED exactly as AGENTS.md
+# warns a copy-pasted lane does. Measured 2026-09-02 — the numbers below are a record of that
+# measurement, not a live count: core had already been moved to a minted App token (below) while
+# every satellite copy was still arming with `secrets.GITHUB_TOKEN`, so every satellite was living
+# the #2916 outage this file's header documents, silently. MeshWeaver.Reinsurance's `main` had not
+# seen a `push`-event run since 09:11Z despite PRs merging all afternoon. On top of that, only
+# .Crm carried the "landed:" read-back fix below, and several copies had no `timeout-minutes` at
+# all — four distinct variants of a file whose header claimed all copies were identical. One lane,
+# called from everywhere, cannot drift.
 #
 # 🚨 The `workflow_call` secrets are named `MESHWEAVER_APP_ID` / `MESHWEAVER_APP_PRIVATE_KEY` — the
 # SAME names as the repository secrets the direct `pull_request_target` trigger reads. That is
@@ -100,7 +103,7 @@ jobs:
     # Four API calls and a mint — the same shape as arm-credential.yml, capped the same way. The
     # fleet ceiling is 45 (check-workflow-timeouts.py); a lane whose whole job is to call gh three
     # times has no business sitting on a billed runner for three quarters of an hour because a
-    # socket hung. This cap now applies to seven repos at once.
+    # socket hung. This cap now applies to every repo that calls this lane.
     timeout-minutes: 10
     # A draft is the opt-out, and a fork must never arm itself. Both are properties of the
     # event, not configuration — there is no variable here to forget to set.

--- a/.github/workflows/auto-arm.yml
+++ b/.github/workflows/auto-arm.yml
@@ -6,10 +6,27 @@
 # CLEAN and unarmed with an empty merge queue — nothing was failing, nothing was blocked, and
 # nothing was landing either. A green PR nobody arms is indistinguishable from a red one.
 #
-# 🚨 This file is IDENTICAL in every repo (MeshWeaver, MeshWeaver.Plugins, .SocialMedia,
-# .Reinsurance, .Manufacturing, .Education, .Crm). The repos are NOT identical — core runs a
-# merge queue and the others do not — so the arm step handles both shapes rather than the file
-# forking per repo. Divergent copies of a shared lane are a recorded failure mode here.
+# 🚨 THIS FILE IS THE FLEET'S ONLY COPY OF THE ARM LANE. It runs directly here on
+# `pull_request_target`, and every satellite (MeshWeaver.Plugins, .SocialMedia, .Reinsurance,
+# .Manufacturing, .Education, .Crm, Memex) reaches it through `workflow_call` with a two-line
+# caller that forwards the App credential and nothing else. The repos are NOT identical — core
+# runs a merge queue and the others do not — so the arm step handles both shapes rather than the
+# file forking per repo.
+#
+# It used to be hand-copied into all seven, and the copies DRIFTED exactly as AGENTS.md warns a
+# copy-pasted lane does. Measured 2026-09-02: core had already been moved to a minted App token
+# (below) while every satellite copy was still arming with `secrets.GITHUB_TOKEN` — so every
+# satellite was living the #2916 outage this file's header documents, silently. MeshWeaver.Reinsurance's
+# `main` had not seen a `push`-event run since 09:11Z despite PRs merging all afternoon. On top of
+# that, only .Crm carried the "landed:" read-back fix below, and several copies had no
+# `timeout-minutes` at all. One lane, called from seven repos, cannot drift.
+#
+# 🚨 The `workflow_call` secrets are named `MESHWEAVER_APP_ID` / `MESHWEAVER_APP_PRIVATE_KEY` — the
+# SAME names as the repository secrets the direct `pull_request_target` trigger reads. That is
+# deliberate: `secrets.MESHWEAVER_APP_ID` then resolves correctly in BOTH modes (the repo secret
+# when this workflow is triggered here, the forwarded value when it is called), so the body needs
+# no `||` fallback and there is no second name to get wrong. A caller passes them explicitly —
+# never `secrets: inherit`, which would hand this lane every secret the calling repo owns.
 #
 # Deliberately NOT here:
 #   * no `if: ${{ vars.X != '' }}` — invariant #3; a skipped job renders like a passed one.
@@ -45,20 +62,46 @@ name: Arm auto-merge
 on:
   pull_request_target:
     types: [opened, reopened, ready_for_review, synchronize]
+  # The satellites' entry point. A caller keeps the SAME `pull_request_target` trigger and one job
+  # that `uses:` this file — so `github.event` inside is the caller's pull-request event, and
+  # `github.repository` / `github.event.repository.name` are the CALLING repository, which is what
+  # the mint scopes to and what `gh pr merge` is pointed at. Nothing below needs to know whether it
+  # is running here or there.
+  workflow_call:
+    secrets:
+      MESHWEAVER_APP_ID:
+        description: >-
+          App id of the org's meshweaver-cloud GitHub App, installed on every repo in the fleet.
+          Required: an arm performed with secrets.GITHUB_TOKEN merges as github-actions[bot], whose
+          push triggers no workflows at all (#2916).
+        required: true
+      MESHWEAVER_APP_PRIVATE_KEY:
+        description: >-
+          That App's private key (PEM). Source of truth is Key Vault Systemorph/github-app-privatekey.
+        required: true
 
 permissions:
   contents: write
   pull-requests: write
 
-concurrency:
-  group: auto-arm-${{ github.event.pull_request.number }}
-  cancel-in-progress: true
-
 jobs:
   arm:
     name: Arm auto-merge on this PR
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    # 🚨 Job-level, not workflow-level, and that is load-bearing now that this file is also called.
+    # A concurrency group is per-repository, and a CALLER run and the job it dispatches into this
+    # workflow are two separate holders of it: if both named `auto-arm-<n>` the inner job would
+    # queue behind the caller run that is waiting for it, and the lane would deadlock until the
+    # cap fired. Declared on the job, the group is held once per run in either mode. Callers must
+    # therefore NOT add a `concurrency:` block of their own — this one already covers them.
+    concurrency:
+      group: auto-arm-${{ github.repository }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    # Four API calls and a mint — the same shape as arm-credential.yml, capped the same way. The
+    # fleet ceiling is 45 (check-workflow-timeouts.py); a lane whose whole job is to call gh three
+    # times has no business sitting on a billed runner for three quarters of an hour because a
+    # socket hung. This cap now applies to seven repos at once.
+    timeout-minutes: 10
     # A draft is the opt-out, and a fork must never arm itself. Both are properties of the
     # event, not configuration — there is no variable here to forget to set.
     if: >-

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -543,7 +543,7 @@ If the same check name appears in every PR's failure list, stop triaging PRs and
 repository. `UNSTABLE` means the required set passed and something non-required did not — it is
 mergeable, and it is the state a hoistable assertion leaves behind.
 
-## 🚨 A lane that was hand-copied into seven repos is SEVEN lanes, and six of them are stale
+## 🚨 A lane hand-copied into N repos is N lanes, and N−1 of them are stale
 
 The arm lane is a single file, `.github/workflows/auto-arm.yml` in this repository, and every
 satellite reaches it through `workflow_call`:
@@ -564,14 +564,16 @@ jobs:
       MESHWEAVER_APP_PRIVATE_KEY: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
 ```
 
-It was not always. Until 2026-09-02 the file was hand-copied into all seven repos with a comment at
-the top asserting the copies were identical, and **they were not** — a comment claiming "the single
-implementation, so they cannot drift" is a hypothesis, and this one was false in three separate
-ways at once. Core had been moved to a minted App installation token; every satellite copy was
-still arming with `secrets.GITHUB_TOKEN`. Only `.Crm` carried the `landed:` read-back branch. Some
-copies had no `timeout-minutes` at all.
+It was not always. Until 2026-09-02 the file was hand-copied into every repo in the fleet with a
+comment at the top asserting the copies were identical, and **they were not** — a comment claiming
+"the single implementation, so they cannot drift" is a hypothesis, and this one was false in three
+separate ways at once. Core had been moved to a minted App installation token; every satellite copy
+was still arming with `secrets.GITHUB_TOKEN`. Only `.Crm` carried the `landed:` read-back branch.
+Some copies had no `timeout-minutes` at all. (Figures below are a record of that day's measurement,
+not a live inventory of the fleet — the roster is read with
+`gh search code --owner Systemorph "auto-arm.yml@"`, never from prose.)
 
-**The consequence is the #2916 outage, running unnoticed in six repositories.** An auto-merge is
+**The consequence is the #2916 outage, running unnoticed in every satellite.** An auto-merge is
 performed as the identity that armed it; a push created with `GITHUB_TOKEN` does not trigger
 workflow runs; so each satellite's `main` was accumulating merges that started nothing.
 MeshWeaver.Reinsurance's `main` had no `push`-event run after 09:11Z that day, while PRs merged all

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -543,6 +543,58 @@ If the same check name appears in every PR's failure list, stop triaging PRs and
 repository. `UNSTABLE` means the required set passed and something non-required did not — it is
 mergeable, and it is the state a hoistable assertion leaves behind.
 
+## 🚨 A lane that was hand-copied into seven repos is SEVEN lanes, and six of them are stale
+
+The arm lane is a single file, `.github/workflows/auto-arm.yml` in this repository, and every
+satellite reaches it through `workflow_call`:
+
+```yaml
+# MeshWeaver.<Satellite>/.github/workflows/auto-arm.yml — the whole file
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, synchronize]
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  arm:
+    uses: Systemorph/MeshWeaver/.github/workflows/auto-arm.yml@<sha>
+    secrets:
+      MESHWEAVER_APP_ID: ${{ secrets.MESHWEAVER_APP_ID }}
+      MESHWEAVER_APP_PRIVATE_KEY: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
+```
+
+It was not always. Until 2026-09-02 the file was hand-copied into all seven repos with a comment at
+the top asserting the copies were identical, and **they were not** — a comment claiming "the single
+implementation, so they cannot drift" is a hypothesis, and this one was false in three separate
+ways at once. Core had been moved to a minted App installation token; every satellite copy was
+still arming with `secrets.GITHUB_TOKEN`. Only `.Crm` carried the `landed:` read-back branch. Some
+copies had no `timeout-minutes` at all.
+
+**The consequence is the #2916 outage, running unnoticed in six repositories.** An auto-merge is
+performed as the identity that armed it; a push created with `GITHUB_TOKEN` does not trigger
+workflow runs; so each satellite's `main` was accumulating merges that started nothing.
+MeshWeaver.Reinsurance's `main` had no `push`-event run after 09:11Z that day, while PRs merged all
+afternoon. Nothing was red anywhere, because the evidence that would have been red is precisely the
+run that never existed.
+
+**How to see it — ask main whether its last commits produced runs, not whether the runs passed:**
+
+```bash
+gh api repos/Systemorph/<repo>/actions/runs --jq \
+  '[.workflow_runs[] | select(.event=="push" and .head_branch=="main")][0]
+   | "\(.created_at)  \(.name)  \(.conclusion)"'
+gh api repos/Systemorph/<repo>/commits/main --jq '.commit.committer.date'
+```
+
+A last-push-run timestamp older than main's HEAD commit is the signature. `github-actions[bot]` as
+the merging identity on recent merges is the cause. Neither is visible from any pull request.
+
+**The rule this generalises to** is already in AGENTS.md and `/ci`: a satellite's CI *calls* this
+repository's reusable workflows, it does not copy them. A copied lane costs nothing on the day it
+is copied and diverges silently forever after — and the divergence is invisible from inside any one
+repo, because each copy is self-consistent. Only a fleet-wide read finds it.
+
 ## 🚨 Delivery can stop for hours with every dashboard green — look for CANCELLED, not failed
 
 A cancelled run is not a failed run, and nothing alerts on it. `alert-on-failure` keys on failure;


### PR DESCRIPTION
## The defect

`.github/workflows/auto-arm.yml` was **hand-copied into all seven repos** of the fleet, with a
header comment asserting the copies were identical. Measured 2026-09-02 ~18:00Z, they were not:

| | arm credential | `landed:` read-back (Crm#43) | `timeout-minutes` |
|---|---|---|---|
| MeshWeaver (core) | minted App token ✅ | ✅ | 45 |
| .Plugins / .Reinsurance / .SocialMedia / .Manufacturing / .Education / Memex | `secrets.GITHUB_TOKEN` ❌ | ❌ | missing on several |
| .Crm | `secrets.GITHUB_TOKEN` ❌ | ✅ | — |

The first column is **#2916 running unnoticed in six repositories**. GitHub performs an auto-merge
as the identity that *armed* it, and a push created with `GITHUB_TOKEN` deliberately triggers no
workflow runs — so those repos' `main` branches were accumulating merges that started nothing.
`MeshWeaver.Reinsurance`'s `main` had no `push`-event run after 09:11Z that day while PRs merged
all afternoon. **Nothing was red anywhere**, because the evidence that would have been red is
precisely the run that never existed.

## What this changes

Make the lane **callable** rather than copyable — the shape AGENTS.md and `/ci` already mandate for
satellite CI ("never hand-roll or copy-paste a node repo's CI").

- **`workflow_call:` beside the existing `pull_request_target:`**, with required secrets
  `MESHWEAVER_APP_ID` / `MESHWEAVER_APP_PRIVATE_KEY`. They deliberately carry the **same names** as
  the repository secrets the direct trigger reads, so `secrets.MESHWEAVER_APP_ID` resolves
  correctly in *both* modes — the body needs no `||` fallback and there is no second name to get
  wrong. Callers pass them explicitly; never `secrets: inherit`.
- **`concurrency` moves from the workflow to the job.** A concurrency group is per-repository, and
  a caller run plus the job it dispatches into this workflow are two separate holders of it: with
  the same group name the inner job would queue behind the caller run that is waiting for it, and
  the lane would deadlock until the cap fired. The group also gains `github.repository`, since it
  is now shared by seven repos' PR numbers.
- **`timeout-minutes: 45` → `10`.** Four API calls and a mint; `arm-credential.yml` is already
  capped exactly that way. This cap now applies to seven repos at once.

Nothing about the gate shape changes: the credential assert step still fails **RED** naming exactly
what to provision, there is no `if:` asking whether a secret is set, and the only `if:` is on the
**event** (draft, fork). `ArmedMergeMustTriggerMainsPushLanesGuard` is untouched and still holds
(`continue-on-error` on the mint is still coupled to `arm-credential.yml`).

## Follow-up (satellite PRs, opened against this sha)

Each of MeshWeaver.Plugins, .Reinsurance, .SocialMedia, .Crm, .Manufacturing, .Education and Memex
gets its `auto-arm.yml` replaced by a thin caller keeping the identical triggers and job id:

```yaml
jobs:
  arm:
    uses: Systemorph/MeshWeaver/.github/workflows/auto-arm.yml@<this merge sha>
    secrets:
      MESHWEAVER_APP_ID: ${{ secrets.MESHWEAVER_APP_ID }}
      MESHWEAVER_APP_PRIVATE_KEY: ${{ secrets.MESHWEAVER_APP_PRIVATE_KEY }}
```

**Known residual, deliberately not in scope here:** `arm-credential.yml` — the repo-scoped lane
that asserts the App can actually *mint* `Contents: write` + `Pull requests: write` and *reaches*
the repo — exists only in core. A satellite whose secret is present but whose installation lacks
the grant will warn rather than fail. The per-PR *presence* assert does fail red there, which is
what the satellites have today (nothing).

## Work products

`Doc/Architecture/ReadingCiSignals` gains the fleet-read that finds this class of defect — a
last-`push`-run timestamp older than `main`'s HEAD commit — because it is invisible from inside any
single repo, every copy being self-consistent.

Internal CI plumbing; no user-visible change, so no What's New entry.

Pairs-with: none — no public type is removed; this PR touches one workflow and one doc page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
