### PR TITLE
fix(orleans): a dead-silo rendezvous registration is transient, not terminal (#3139)

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -773,7 +773,8 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     internal static bool IsDirectoryUnstable(Exception ex) =>
         (ex is global::Orleans.Runtime.OrleansException
          && (ex.Message.Contains(DirectoryRetryLaterMarker, StringComparison.OrdinalIgnoreCase)
-             || ex.Message.Contains(DirectoryHopLimitMarker, StringComparison.OrdinalIgnoreCase)))
+             || ex.Message.Contains(DirectoryHopLimitMarker, StringComparison.OrdinalIgnoreCase)
+             || ex.Message.Contains(DirectoryInvalidSiloMarker, StringComparison.OrdinalIgnoreCase)))
         // Walks its own inner chain rather than relying on a caller's: this is consulted BOTH from
         // IsTransientFailure (which walks) and from RoutingGrain.ClassifyDeliveryException (which
         // does not, and which is handed an AggregateException by PostFailure's two-transport arm).
@@ -793,6 +794,31 @@ public class OrleansRoutingService : IRoutingService, IDisposable
     /// two rolling deploys (issue #2357).
     /// </summary>
     internal const string DirectoryHopLimitMarker = "hop limit is reached";
+
+    /// <summary>
+    /// The REGISTRATION-side variant, from <c>"Trying to register {grainId} on invalid silo:
+    /// {siloAddress}. Known status: Dead"</c> — thrown by
+    /// <c>LocalGrainDirectoryPartition.AddSingleActivation</c> when the directory resolves an owner
+    /// that membership has already buried (issue #3139).
+    ///
+    /// <para>🚨 <b>The other two markers are LOOKUP-side, and that is why this one was needed.</b>
+    /// Both existing phrases come from <c>LocalGrainDirectory.LookupAsync</c> — reading an entry.
+    /// Attaching a stream subscription <i>writes</i> one: <c>SubscribeAsync</c> registers the
+    /// stream's <c>PubSubRendezvousGrain</c>, and when the directory hands that registration to a
+    /// silo the membership oracle has since marked <c>Dead</c>, Orleans throws a bare
+    /// <see cref="global::Orleans.Runtime.OrleansException"/> carrying THIS text and neither of the
+    /// other two. So <see cref="IsTransientFailure"/> returned false on attempt 0, the bounded
+    /// attach retry added by #2633 was never entered, and the hub latched into "cross-process
+    /// routing DISABLED" for the rest of its life — 13 occurrences on memex-cloud across three
+    /// ReplicaSet generations, 2026-08-23 → 2026-09-02, every one of them a membership-churn window
+    /// that was over in seconds.</para>
+    ///
+    /// <para>It is the same inert-classifier shape as #1742/#2357/#2451 and needs no new machinery:
+    /// the attach retry already re-invokes <c>AttachSubscriptionAsync</c> from scratch, so Orleans
+    /// re-resolves the rendezvous grain against settled membership. Recognising the condition is
+    /// what makes the existing cure reachable.</para>
+    /// </summary>
+    internal const string DirectoryInvalidSiloMarker = "on invalid silo";
 
     /// <summary>
     /// How the SENDER should read a delivery the grain returned <see cref="MessageDeliveryState.Failed"/>:

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-hub-stops-going-deaf-after-one-bad-moment.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-hub-stops-going-deaf-after-one-bad-moment.md
@@ -1,0 +1,34 @@
+---
+Name: One bad moment no longer deafens a hub for good
+Category: Fix
+Description: A hub that started up during a cluster reshuffle could lose its cross-pod messaging permanently — silently, and for as long as it kept running. It now rides the reshuffle out.
+Icon: ArrowSync
+Order: -20260902
+---
+
+# One bad moment no longer deafens a hub for good
+
+A portal runs as several replicas, and the pieces of it that hold your data announce themselves to
+the rest of the cluster when they start. Part of that announcement is a subscription: *"send me
+anything addressed to me, wherever it comes from."*
+
+The cluster reorganises its address book every time a replica joins or leaves — every deploy, every
+scale-up, every restart. A subscription being announced during that window can be handed to a
+replica that has just been declared gone. That is a normal, seconds-long condition with an obvious
+answer: ask again once the reshuffle settles.
+
+The platform already knew how to ask again. It just could not recognise this particular way of being
+told to. The retry it would have used only recognised the phrasings the cluster uses when *reading*
+the address book, and this failure comes from *writing* to it — a different sentence, and one nothing
+was looking for. So the piece gave up on its very first attempt and marked its own cross-replica
+messaging **disabled for the rest of its life**.
+
+What that looked like from the outside: everything worked for anyone whose request happened to land
+on the same replica, and quietly did not for anyone else. Updates that never arrived, an import whose
+progress never moved, a page waiting on data that was never going to come. Nothing failed loudly,
+because from each replica's own point of view nothing was wrong.
+
+**The condition is now recognised, so the retry that already existed actually runs** — the
+subscription is re-announced against a settled address book, and the hub keeps its cross-replica
+messaging. On our own cloud portal this had happened thirteen times over the preceding ten days,
+across three deploys, every one of them a reshuffle that was over in seconds.

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansDirectoryInstabilityClassificationTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansDirectoryInstabilityClassificationTest.cs
@@ -66,9 +66,20 @@ public class OrleansDirectoryInstabilityClassificationTest
         + "grainId messagehub/Doc (it maps to S10.244.3.44:11111:146515001, which is not a valid silo). "
         + "Retry later.";
 
+    /// <summary>
+    /// Verbatim from the production log (#3139) — the REGISTRATION-side variant, thrown by
+    /// <c>LocalGrainDirectoryPartition.AddSingleActivation</c> when a stream subscription's
+    /// rendezvous grain is handed to a silo membership has already buried. Neither of the two
+    /// texts above appears in it, which is exactly why it was never retried.
+    /// </summary>
+    private const string InvalidSiloRegistrationText =
+        "Trying to register pubsubrendezvous/Memory/null/activity/_tracking on invalid silo: "
+        + "S10.244.4.125:11111:146517689. Known status: Dead";
+
     [Theory]
     [InlineData(HopLimitText)]
     [InlineData(NotStableText)]
+    [InlineData(InvalidSiloRegistrationText)]
     public void DirectoryInstability_IsTransient(string message)
     {
         // The bare OrleansException the caller actually receives — NOT an
@@ -230,5 +241,95 @@ public class OrleansDirectoryInstabilityClassificationTest
             + "LocalGrainDirectory. If Orleans reworded it, the classifier no longer recognises a "
             + "grain directory mid-handoff — deliveries stop being retried and are NACK'd as "
             + "permanent again (#1742/#2357). REPAIR THE MARKER; do not delete this assertion");
+    }
+
+    /// <summary>
+    /// 🚨 <b>Issue #3139 — the ATTACH leg, and the half the delivery-leg tests above cannot see.</b>
+    ///
+    /// <para>Both existing markers are <c>LookupAsync</c>'s — READING a directory entry. Attaching a
+    /// hub's cross-process stream subscription WRITES one: <c>SubscribeAsync</c> registers the
+    /// stream's <c>PubSubRendezvousGrain</c>, and a registration handed to a silo the membership
+    /// oracle has already marked <c>Dead</c> throws a bare <see cref="OrleansException"/> carrying
+    /// neither phrase. So <see cref="OrleansRoutingService.IsTransientFailure"/> said "terminal" on
+    /// attempt 0, <c>AttachWithBoundedRetry</c>'s budget was never entered, and the hub latched into
+    /// "cross-process routing DISABLED" for the rest of its life. 13 occurrences on memex-cloud
+    /// across three ReplicaSet generations, 2026-08-23 → 2026-09-02.</para>
+    ///
+    /// <para>This asserts the CURE, not just the classification: the retry primitive re-invokes the
+    /// attach, which is what re-resolves the rendezvous grain against settled membership. Pre-fix
+    /// this observes <c>attempts == 1</c> and a faulted observable.</para>
+    /// </summary>
+    [Fact]
+    public async Task AnInvalidSiloRegistration_ReAttachesWithAFreshResolve_RatherThanLatchingDisabled()
+    {
+        var attempts = 0;
+
+        var handle = await OrleansRoutingService.AttachWithBoundedRetry(
+                attach: () =>
+                {
+                    attempts++;
+                    // Two membership-churn rejections, then the directory settles — the shape every
+                    // rolling deploy produces, and the one the log shows recurring per churn window.
+                    return attempts <= 2
+                        ? Task.FromException<string>(new OrleansException(InvalidSiloRegistrationText))
+                        : Task.FromResult("attached");
+                },
+                isTransient: OrleansRoutingService.IsTransientFailure,
+                onTransientRetry: (_, _, _) => { },
+                backoff: NoBackoff,
+                scheduler: Scheduler.Immediate)
+            .Await(TestContext.Current.CancellationToken);
+
+        attempts.Should().Be(3,
+            "the registration failed against a silo membership had already buried, and a fresh "
+            + "SubscribeAsync re-resolves the rendezvous grain — pre-fix the classifier did not "
+            + "match this text, so the attach was tried exactly once and the hub's cross-process "
+            + "routing was disabled for the rest of its life (#3139)");
+        handle.Should().Be("attached");
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE ANTI-INERT PIN for the registration-side marker. If this fails after an Orleans
+    /// upgrade the classifier has gone SILENTLY INERT — repair the marker, never delete the test.</b>
+    /// Same contract as <see cref="RetryLaterMarker_IsStillTheShippedOrleansWording"/>, and the
+    /// phrase is likewise a literal of the SHIPPED <c>Orleans.Runtime</c> rather than a copy of it.
+    /// </summary>
+    [Fact]
+    public void InvalidSiloMarker_IsStillTheShippedOrleansWording()
+    {
+        var runtimeAssembly = Path.Combine(AppContext.BaseDirectory, "Orleans.Runtime.dll");
+
+        File.Exists(runtimeAssembly).Should().BeTrue(
+            $"this fact reads Orleans' own string literals out of {runtimeAssembly}; without the "
+            + "file it would pass having verified nothing");
+
+        ShippedLiteralPresent(runtimeAssembly, OrleansRoutingService.DirectoryInvalidSiloMarker)
+            .Should().BeTrue(
+                $"'{OrleansRoutingService.DirectoryInvalidSiloMarker}' is the phrase "
+                + "IsDirectoryUnstable matches a rendezvous-grain registration against a dead silo "
+                + "on, and it comes from Orleans' own LocalGrainDirectoryPartition. If Orleans "
+                + "reworded it, a hub's cross-process routing latches DISABLED on the first "
+                + "membership-churn window again (#3139). REPAIR THE MARKER; do not delete this");
+    }
+
+    /// <summary>
+    /// 🚨 <b>Reads the #US heap at BOTH byte alignments, and that is load-bearing.</b> A managed
+    /// string literal's UTF-16 payload follows a compressed-integer length, so a blob can begin at
+    /// an ODD file offset — decoding the file from offset 0 only, as this pin originally did, then
+    /// misses a phrase that is genuinely present. That is a FALSE RED on the one assertion whose
+    /// entire value is being believed when it fires: it reports "Orleans reworded the message" for
+    /// a heap layout that shifted. Measured 2026-09-02 — searching from offset 0 alone reports
+    /// <c>on invalid silo</c> ABSENT from the pinned 10.2.2 build, where it is in fact present.
+    /// </summary>
+    private static bool ShippedLiteralPresent(string assemblyPath, string phrase)
+    {
+        var raw = File.ReadAllBytes(assemblyPath);
+
+        // OrdinalIgnoreCase on both decodes, matching the classifier — a recasing Orleans could
+        // make freely is one the classifier still handles, so it must not red this pin.
+        return Encoding.Unicode.GetString(raw)
+                   .Contains(phrase, StringComparison.OrdinalIgnoreCase)
+            || Encoding.Unicode.GetString(raw, 1, raw.Length - 1)
+                   .Contains(phrase, StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
Addresses the reported mechanism in #3139. **Deliberately not `Fixes`** — see *What this does not close* below.

## The defect

`OrleansRoutingService` attaches each hub's Orleans stream subscription once at registration. #2633 gave that attach a bounded retry for transient failures, because the grain directory is unstable during every membership change. **That budget was never entered for the condition production actually hits.**

`IsDirectoryUnstable` matches two phrases, and both come from `LocalGrainDirectory.LookupAsync` — **reading** a directory entry. Attaching a subscription **writes** one: `SubscribeAsync` registers the stream's `PubSubRendezvousGrain`, and when that registration is handed to a silo the membership oracle has already buried, `LocalGrainDirectoryPartition.AddSingleActivation` throws a bare `OrleansException`:

```
Trying to register pubsubrendezvous/Memory/null/activity/_tracking on invalid silo:
S10.244.4.125:11111:146517689. Known status: Dead
```

Neither `Retry later` nor `hop limit is reached` appears in it. So `IsTransientFailure` answered **false on attempt 0**, `AttachWithBoundedRetry` was skipped entirely, and the hub latched into *"cross-process routing for this hub is DISABLED"* for the rest of its life.

That is why the log shows the `Critical` give-up with **no preceding retry `Warning`s** — the evidence that the budget was never spent.

## The fix

One marker, `DirectoryInvalidSiloMarker = "on invalid silo"`, added to `IsDirectoryUnstable`.

**Nothing new spins.** `AttachWithBoundedRetry` already re-invokes the attach from scratch — a fresh `GetStream` and a fresh `SubscribeAsync`, hence a fresh grain resolution against settled membership. This is the same inert-classifier shape as #1742 / #2357 / #2451: the machinery was unreachable because the predicate gating it could not read its input. Recognising the condition is the whole change.

The marker widens `RoutingGrain.ClassifyDeliveryException` too, which is correct and deliberate: a registration refused against a dead silo *is* a membership transition, so the sender should read `ShuttingDown` — the address answers again once membership settles — exactly as it already does for `Retry later`.

## 🚨 A second, latent defect in the guard itself

The anti-inert pin that protects these markers read Orleans' `#US` heap as `Encoding.Unicode.GetString(File.ReadAllBytes(...))` — **decoding from byte offset 0 only**. A literal's UTF-16 payload follows a compressed-integer length, so a blob can begin at an **odd** offset.

Measured 2026-09-02: searching one alignment reports `on invalid silo` **ABSENT** from the pinned Orleans 10.2.2, where a raw UTF-16LE byte search finds it present in `Orleans.Runtime.dll`. I drew that wrong conclusion myself before checking the other alignment.

That is a **false RED on the one assertion whose entire value is being believed when it fires** — it would report "Orleans reworded the message" for a heap layout that merely shifted. `ShippedLiteralPresent` now decodes at both alignments, keeping `OrdinalIgnoreCase`.

## Verification

- **Control arm** — constant kept, only the predicate clause removed (so the test still compiles and the measurement is behavioural, not a compile break):

  ```
  Failed!  - Failed: 2, Passed: 9, Total: 11
    DirectoryInstability_IsTransient(message: "Trying to register pubsubrendezvous/Memory/null/ac"…)
    AnInvalidSiloRegistration_ReAttachesWithAFreshResolve_RatherThanLatchingDisabled
  ```

- **With the fix** — `Passed! - Failed: 0, Passed: 11, Total: 11`.
- `dotnet build -c Release -warnaserror` on `MeshWeaver.Hosting.Orleans.Test` (32 projects): **0 Warning(s), 0 Error(s)**.

`AnInvalidSiloRegistration_ReAttachesWithAFreshResolve_RatherThanLatchingDisabled` asserts the **cure**, not just the classification: the attach is re-invoked and succeeds on the third attempt, which is the fresh resolve.

## 🚨 What this does NOT close — the residual is real

#3139 also asks the larger question, and this PR does not answer it:

> A transient failure at startup should either retry or **re-attach on the next hub activity**, not latch the "DISABLED" state.

After this change a churn window **longer than the ~7.75 s budget** still gives up, and the give-up is still permanent for the hub's lifetime. #2633 chose that deliberately ("bounded, loud, and still terminal").

The pod-hub claim made exactly this journey in **#2938** — *"landing is not a terminal"* — and re-asserts on every membership change via `ClaimTriggers`, because the grain directory is re-partitioned then. **`IClusterMembershipFeed` is already injected into this very class**, so the seam for doing the same to the stream subscription exists.

It is not folded in here because it needs its own evidence and carries a real hazard the classifier fix does not: re-attaching a subscription that is still **live** would duplicate every inbound delivery, so the trigger has to be conditioned on the attach having actually given up. That wants the `PodHubClaimReassertionTest` harness extended with a stream provider, and a wiring test on the two-silo cluster — a separate change, with a separate review.

**#3139 stays open for that half.**

Pairs-with: none — no public type is removed; one `internal const` is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
