### PR TITLE
fix(activity): three terminal _Activity writers share the release seam (#3117)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-finished-runs-let-go-straight-away.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-finished-runs-let-go-straight-away.md
@@ -1,0 +1,35 @@
+---
+Name: Finished runs let go straight away
+Category: Fix
+Description: A script, compile or build that finished kept part of the portal awake for another ten minutes. Three of them did — including the most common one of all. Now they release as soon as they end.
+Icon: Sparkle
+Order: -20260902
+---
+
+# Finished runs let go straight away
+
+Every run the portal does for you — a script, a notebook cell, a compile, a build, a test — writes
+its progress to an *activity*. While the run is going, the portal keeps a small live connection open
+so the page showing you that progress updates as it happens. That connection is not free: it checks
+in every 45 seconds, on purpose, to keep the machinery behind it from being cleaned up mid-run.
+
+When the run ends, that connection should end with it. The end of a run is a fact, not a guess, so
+there is nothing left to wait for.
+
+For most runs it already worked that way. **Three kinds did not** — including, awkwardly, the most
+common one in the whole platform: the ordinary log a script or a test writes as it goes. Those runs
+finished, and their connection stayed open for up to **ten more minutes**, until a periodic sweep
+noticed nobody was using it. One stale run is nothing. A busy portal doing this all day is carrying
+ten minutes of finished work at all times, for no reason.
+
+All three now release the moment the run reaches its end state.
+
+There was a related problem at one of the three, and it is fixed in the same change: when a code run
+failed because nothing was there to execute it, the step meant to mark it **failed** could quietly
+do nothing at all, depending on the exact shape the data happened to arrive in. The run then sat at
+*Running* for ever, showing a spinner for something that had already given up. It is now marked
+failed reliably.
+
+One detail worth stating, because it is what makes this safe: a finished run whose page **you are
+still looking at** keeps its connection. The release asks first, and simply declines while anyone is
+watching.

--- a/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
@@ -454,7 +454,9 @@ public static class CodeNodeType
     /// carries the caller's AccessContext across the Subscribe boundary); <see cref="ActivityLog.Fail"/>
     /// appends the error and stamps <c>End</c>, so the Output pane leaves "Running…" with the reason.
     /// </summary>
-    private static void FailActivity(IMessageHub hub, string activityPath, string error,
+    // internal, not private: MeshWeaver.Graph.Test drives this directly to pin the #3117
+    // release and the ContentAs fix. Nothing outside the test assembly can see it.
+    internal static void FailActivity(IMessageHub hub, string activityPath, string error,
         Exception? exception = null)
     {
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
@@ -472,12 +474,20 @@ public static class CodeNodeType
                 "CodeNodeType: failing run {Activity} dispatched from {Hub}: {Error}",
                 activityPath, hub.Address, error);
         hub.GetWorkspace().GetMeshNodeStream(activityPath).Update(curr =>
-            curr.Content is ActivityLog log
-                ? curr with { Content = log.Fail(error) }
-                : curr)
+                // 🚨 ContentAs, never `is ActivityLog`. This lambda runs against a LOCAL mirror whose
+                // Content can be a degraded JsonElement, and a plain type test is then null — the
+                // lambda no-ops, no patch is sent, and the run this method exists to FAIL is left
+                // Running for ever. Exactly the trap ActivityLogAppender.Append's own lambda names.
+                curr.ContentAs<ActivityLog>(hub.JsonSerializerOptions, logger) is { } log
+                    ? curr with { Content = log.Fail(error) }
+                    : curr)
             .Subscribe(
                 _ => { },
                 ex => logger?.LogWarning(ex,
-                    "CodeNodeType: failed to reconcile ActivityLog {Activity} to Failed", activityPath));
+                    "CodeNodeType: failed to reconcile ActivityLog {Activity} to Failed", activityPath),
+                // #3117 — retire the activity's per-node hub on the terminal write rather than
+                // leaving it to the 10-minute idle sweep. Completion, never emission.
+                () => ActivityLogAppender.ReleaseMirrorWhenFinal(
+                    hub, activityPath, ActivityStatus.Failed, logger));
     }
 }

--- a/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
+++ b/src/MeshWeaver.Hosting/BuildProtocolDriver.cs
@@ -358,14 +358,23 @@ public static class BuildProtocolDriver
             });
     }
 
-    private static IObservable<MeshNode> FinishActivity(
+    // internal, not private: MeshWeaver.Graph.Test drives this directly to pin the #3117
+    // release. Nothing outside the test assembly can see it.
+    internal static IObservable<MeshNode> FinishActivity(
         IMessageHub mesh, string activityPath, ActivityStatus status) =>
         mesh.GetWorkspace().GetMeshNodeStream(activityPath).Update(node =>
-        {
-            var log = node?.ContentAs<ActivityLog>(mesh.JsonSerializerOptions);
-            if (node is null || log is null || log.Status.IsTerminal()) return node!;
-            return node with { Content = log.Finish(log.Version + 1, status) };
-        });
+            {
+                var log = node?.ContentAs<ActivityLog>(mesh.JsonSerializerOptions);
+                if (node is null || log is null || log.Status.IsTerminal()) return node!;
+                return node with { Content = log.Finish(log.Version + 1, status) };
+            })
+            // #3117 — a build-protocol completion is a terminal _Activity write that bypasses
+            // ActivityLogAppender.Append, so it never retired the activity's per-node hub. On
+            // COMPLETION, never on the emission — the write is still in flight when its value is
+            // emitted. An already-terminal log takes the no-op arm above and is released here too,
+            // which is correct: the status IS terminal, whoever wrote it.
+            .Do(_ => { },
+                () => ActivityLogAppender.ReleaseMirrorWhenFinal(mesh, activityPath, status));
 
     // ── the follower ────────────────────────────────────────────────────────────────────────────
 

--- a/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
+++ b/src/MeshWeaver.Kernel.Hub/ActivityLogLogger.cs
@@ -318,7 +318,19 @@ internal sealed class ActivityLogLogger(IMessageHub hub, string activityLogPath)
                         _ => { },
                         ex => _diagnostics?.LogDebug(ex,
                             "ActivityLogLogger: publishing the log snapshot for {Path} failed",
-                            activityLogPath));
+                            activityLogPath),
+                        // 🚨 #3117 — the highest-volume terminal _Activity writer in the platform
+                        // (every kernel run, script, markdown execution and test run) bypasses
+                        // ActivityLogAppender.Append, so it never fired the release that retires the
+                        // activity's per-node hub. Its hubs waited out the 10-minute idle sweep
+                        // instead. `status` is what THIS write asserted, so a Running snapshot is a
+                        // no-op inside the seam.
+                        //
+                        // On COMPLETION, never on the emission: releasing tears the path's upstream
+                        // sync streams down, and the write is still in flight when its value is
+                        // emitted. Same rule, same reason, as Append's own Do arm.
+                        () => ActivityLogAppender.ReleaseMirrorWhenFinal(
+                            hub, activityLogPath, status, _diagnostics));
         }
         catch { /* never let logging break the script */ }
     }

--- a/src/MeshWeaver.Mesh.Contract/ActivityLogAppender.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityLogAppender.cs
@@ -150,14 +150,56 @@ public static class ActivityLogAppender
         System.Text.Json.JsonSerializerOptions options,
         ILogger? logger)
     {
-        if (final.ContentAs<ActivityLog>(options, logger) is not { } log || !log.Status.IsTerminal())
+        if (final.ContentAs<ActivityLog>(options, logger) is not { } log)
+            return;
+        ReleaseMirrorWhenFinal(hub, activityPath, log.Status, logger);
+    }
+
+    /// <summary>
+    /// THE release, for a writer that already knows the status it just wrote — the shared seam every
+    /// terminal <c>_Activity</c> writer calls, whether or not it goes through <see cref="Append"/>.
+    ///
+    /// <para>🚨 <b>Why this is a seam and not a line of code copied three more times (#3117).</b>
+    /// Three terminal writers bypass <see cref="Append"/> entirely and so never fired this release:
+    /// <c>ActivityLogLogger.PublishSnapshotLocked</c> — by far the highest volume, every kernel run,
+    /// script, markdown execution and test run — <c>CodeNodeType.FailActivity</c>, and
+    /// <c>BuildProtocolDriver.FinishActivity</c>. Their hubs stayed pinned until the ten-minute idle
+    /// sweep instead of retiring on the terminal write.</para>
+    ///
+    /// <para>Giving each of them its own <c>ReleaseIfUnwatched</c> call would be the exact shape that
+    /// caused #3110: <c>EvictFaultedEntry</c> documented itself as "the single teardown … so they
+    /// cannot drift", and a fourth site had a hand-rolled copy that disposed only half the state. One
+    /// implementation, four callers — never four implementations.</para>
+    ///
+    /// <para><b>Best-effort by construction, exactly as on the <see cref="Append"/> path.</b> A
+    /// non-terminal status is a no-op; a mesh with no cache is a no-op; a reader still watching the
+    /// activity keeps it, because <c>ReleaseIfUnwatched</c> makes the same atomic zero-subscriber
+    /// check the idle sweep makes and simply declines. Nothing here may fail the write that reported
+    /// the status — if the release does not happen, the sweep still gets there.</para>
+    ///
+    /// <para>🚨 <b>Call it on the write's COMPLETION, never on its emission.</b> Releasing tears the
+    /// path's upstream sync streams down, and the write is still in flight when its value is emitted
+    /// — cutting the stream out from under it strands the write's own terminal and leaves the
+    /// per-path queue to advance on its 5 s backstop. See the <c>Do</c> arm in <see cref="Append"/>.</para>
+    /// </summary>
+    /// <param name="hub">The hub that performed the terminal write.</param>
+    /// <param name="activityPath">Path of the activity node.</param>
+    /// <param name="status">The status just written. A non-terminal status is a no-op.</param>
+    /// <param name="logger">Logger for best-effort diagnostics.</param>
+    public static void ReleaseMirrorWhenFinal(
+        IMessageHub hub,
+        string activityPath,
+        ActivityStatus status,
+        ILogger? logger = null)
+    {
+        if (!status.IsTerminal())
             return;
         var cache = hub.ServiceProvider.GetService<IMeshNodeStreamCache>();
         if (cache is null)
             return;
         if (cache.ReleaseIfUnwatched(activityPath))
             logger?.LogDebug(
-                "Activity {Path}: reached {Status} — released its shared mirror", activityPath, log.Status);
+                "Activity {Path}: reached {Status} — released its shared mirror", activityPath, status);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Graph.Test/TerminalActivityWriterReleaseTest.cs
+++ b/test/MeshWeaver.Graph.Test/TerminalActivityWriterReleaseTest.cs
@@ -1,0 +1,173 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Utils;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #3117 — three terminal <c>_Activity</c> writers bypassed
+/// <c>ActivityLogAppender.Append</c>, so none of them retired the activity's per-node hub.</b>
+///
+/// <para><b>The invariant.</b> <c>Append</c> fires <c>IMeshNodeStreamCache.ReleaseIfUnwatched</c> on
+/// the terminal write (#1435/#1324). That is what retires an activity's mirror when the activity
+/// finishes, instead of leaving it to the ten-minute idle sweep — and the mirror is not a passive
+/// cache entry, it posts a <c>HeartBeatEvent</c> every 45 s for the express purpose of keeping its
+/// grain alive.</para>
+///
+/// <para><b>The gap.</b> Three writers reach a terminal status without going through
+/// <c>Append</c> at all: <c>ActivityLogLogger.PublishSnapshotLocked</c> (by far the highest volume —
+/// every kernel run, script, markdown execution and test run), <c>CodeNodeType.FailActivity</c>, and
+/// <c>BuildProtocolDriver.FinishActivity</c>. Bounded rather than a leak, because the idle sweep
+/// still reaches them — but a ten-minute retention multiplied by every kernel and test run is a real
+/// steady-state footprint.</para>
+///
+/// <para>🚨 <b>Why the fix is a SEAM and not three copies of one line.</b> #3110's root cause was
+/// exactly that: <c>EvictFaultedEntry</c> documents itself as "the single teardown … so they cannot
+/// drift", and a fourth site had a hand-rolled copy that disposed only half the state. So the
+/// release became <c>ActivityLogAppender.ReleaseMirrorWhenFinal</c> — one implementation, four
+/// callers.</para>
+///
+/// <para><b>What this observes, and why it is not a watcher.</b> The subject is the real
+/// <c>MeshNodeStreamCache</c> on a real monolith mesh; the signal is its own
+/// <c>ReadStreamEvictions</c> feed, which the cache documents as being there for "diagnostics and
+/// deterministic tests", filtered to the <c>"final"</c> reason that ONLY
+/// <c>ReleaseIfUnwatched</c> emits. That matters: <c>ReleaseIfUnwatched</c> declines while anyone is
+/// subscribed to the path, so a test that waited for the release by watching the activity node would
+/// suppress the very thing it is asserting. This subscribes to the eviction feed instead, which is a
+/// different stream, and never to the path.</para>
+///
+/// <para><b>Fails on unfixed code:</b> both writer facts time out with no <c>"final"</c> eviction,
+/// because nothing released the mirror.</para>
+/// </summary>
+public class TerminalActivityWriterReleaseTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Partition = "TestData";
+
+    private MeshNodeStreamCache Cache =>
+        (MeshNodeStreamCache)Mesh.ServiceProvider.GetRequiredService<IMeshNodeStreamCache>();
+
+    /// <summary>
+    /// A real, Running activity node — the state every one of these writers finds when it lands.
+    /// </summary>
+    private async Task<string> ARunningActivity(string prefix)
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var id = prefix + Guid.NewGuid().ToString("N")[..8];
+        await meshService.CreateNode(new MeshNode(id, $"{Partition}/_Activity")
+        {
+            Name = "terminal-writer release probe",
+            NodeType = ActivityNodeType.NodeType,
+            MainNode = Partition,
+            State = MeshNodeState.Active,
+            Content = new ActivityLog(ActivityCategory.DataUpdate)
+            {
+                Id = id,
+                HubPath = Partition,
+                Status = ActivityStatus.Running,
+            },
+        }).FirstAsync().Timeout(60.Seconds());
+        return $"{Partition}/_Activity/{id}";
+    }
+
+    /// <summary>
+    /// The release, armed BEFORE the write that should cause it. <c>Replay</c> + <c>Connect</c> is
+    /// load-bearing: the eviction can land while the write's own observable is still completing, and
+    /// a subscription taken afterwards would miss it — a race the test would usually win, which is
+    /// the worst kind of green.
+    /// </summary>
+    private (IConnectableObservable<ReadStreamEviction> Released, IDisposable Connection) ArmRelease(string path)
+    {
+        var released = Cache.ReadStreamEvictions
+            .Where(e => e.Path == path && e.Reason == "final")
+            .Take(1)
+            .Replay();
+        return (released, released.Connect());
+    }
+
+    /// <summary>
+    /// 🚨 THE PIN for <c>BuildProtocolDriver.FinishActivity</c> — every build-protocol completion.
+    /// </summary>
+    [Fact]
+    public async Task ABuildProtocolCompletion_RetiresTheActivitysMirror()
+    {
+        var path = await ARunningActivity("build");
+        var (released, connection) = ArmRelease(path);
+        using var _ = connection;
+
+        // 🚨 LastAsync, never FirstAsync. The release rides the write's COMPLETION (see the seam's
+        // remarks — releasing on the emission strands the still-in-flight write), and FirstAsync
+        // UNSUBSCRIBES as soon as the node is emitted, so the completion arm would never run and
+        // this test would report the regression it exists to catch. Production reaches completion:
+        // CloseChunk's result is consumed through `.Concat().ToList()`, which waits for it.
+        await BuildProtocolDriver.FinishActivity(Mesh, path, ActivityStatus.Succeeded)
+            .LastAsync().Timeout(60.Seconds());
+
+        var eviction = await released.FirstAsync().Timeout(60.Seconds());
+
+        eviction.Reason.Should().Be("final",
+            "the terminal status is the EVENT that proves the mirror is dead, so the release is "
+            + "event-driven rather than a shorter timer — pre-fix this writer bypassed "
+            + "ActivityLogAppender.Append entirely and its hub waited out the 10-minute idle sweep");
+    }
+
+    /// <summary>
+    /// 🚨 THE PIN for <c>CodeNodeType.FailActivity</c> — every failed code-node activity.
+    ///
+    /// <para>This also covers the second defect found at that call site: the lambda tested
+    /// <c>curr.Content is ActivityLog</c>, and a local mirror's Content can be a degraded
+    /// <c>JsonElement</c>. The type test is then null, the lambda no-ops, no patch is sent, and the
+    /// run this method exists to FAIL stays Running for ever — so there would be no terminal write
+    /// to release on either.</para>
+    /// </summary>
+    [Fact]
+    public async Task AFailedCodeRun_RetiresTheActivitysMirror()
+    {
+        var path = await ARunningActivity("code");
+        var (released, connection) = ArmRelease(path);
+        using var _ = connection;
+
+        CodeNodeType.FailActivity(Mesh, path, "no worker connected — release probe");
+
+        var eviction = await released.FirstAsync().Timeout(60.Seconds());
+
+        eviction.Reason.Should().Be("final",
+            "a failed code run is a terminal activity write like any other, and it bypassed the "
+            + "Append seam that fires the release");
+    }
+
+    /// <summary>
+    /// 🚨 The rule must stay NARROW: the seam releases on a TERMINAL status and on nothing else. A
+    /// release fired for a Running activity would tear the mirror out from under a run that is still
+    /// writing to it — the ten-minute sweep exists precisely because "is it done?" is otherwise a
+    /// heuristic, and the terminal status is what replaces the heuristic with proof.
+    /// </summary>
+    [Fact]
+    public async Task ARunningStatus_ReleasesNothing()
+    {
+        var path = await ARunningActivity("running");
+        var (released, connection) = ArmRelease(path);
+        using var _ = connection;
+
+        ActivityLogAppender.ReleaseMirrorWhenFinal(Mesh, path, ActivityStatus.Running);
+
+        var sawRelease = await released
+            .Select(_ => true)
+            .Timeout(2.Seconds(), Observable.Return(false))
+            .FirstAsync();
+
+        sawRelease.Should().BeFalse(
+            "a Running activity is still writing to its mirror — releasing it would be the very "
+            + "race the terminal-status proof exists to avoid");
+    }
+}


### PR DESCRIPTION
Fixes #3117.

## The invariant, and the gap

`ActivityLogAppender.Append` fires `IMeshNodeStreamCache.ReleaseIfUnwatched` on the terminal write (#1435/#1324). That is what retires an activity's per-node hub when the activity finishes rather than leaving it for the ten-minute idle sweep — and the mirror is not a passive cache entry: it posts a `HeartBeatEvent` every 45 s **for the express purpose of keeping its grain alive**.

Three terminal writers bypass `Append` entirely, so none of them ever fired it. Re-verified on `origin/main` before touching anything, as the issue asked:

| writer | volume |
|---|---|
| `ActivityLogLogger.PublishSnapshotLocked` | **the highest in the platform** — every kernel run, script, markdown execution and test run |
| `CodeNodeType.FailActivity` | every failed code-node activity |
| `BuildProtocolDriver.FinishActivity` | every build-protocol completion |

Bounded rather than a leak — the idle sweep still reaches these — so the cost is a **retention window**, up to ~10 minutes per activity. Multiplied by every kernel and test run, that is a real steady-state footprint.

## One seam, four callers — deliberately

The release is now `ActivityLogAppender.ReleaseMirrorWhenFinal(hub, path, status, logger)`, with `Append`'s existing node-shaped overload delegating to it.

Giving each of the three writers its own `ReleaseIfUnwatched` call was the obvious cheap move and is exactly what #3110's root cause was: `EvictFaultedEntry` documented itself as *"the single teardown … so they cannot drift"*, and a fourth site had a hand-rolled copy that disposed only half the state. So: one implementation, four callers — never four implementations.

Each call site releases on the write's **completion**, never on its emission. That is not stylistic — `Append`'s own `Do` arm explains it: releasing tears the path's upstream sync streams down, and the write is still in flight when its value is emitted, so releasing early strands the write's own terminal and leaves the per-path queue to advance on its 5 s backstop.

## 🚨 A second defect, found at one of the call sites

`CodeNodeType.FailActivity`'s update lambda tested:

```csharp
curr.Content is ActivityLog log
```

That lambda diffs against a **local mirror**, whose `Content` can be a degraded `JsonElement`. The type test is then null, the lambda no-ops, **no patch is sent** — and the run this method exists to mark **Failed** stays `Running` for ever, showing a spinner for something that already gave up. It is precisely the trap `Append`'s own lambda names in a comment three files away. Now `ContentAs<ActivityLog>(hub.JsonSerializerOptions, logger)`.

This also means the release fix alone would not have worked at that site: with no terminal write, there is nothing to release on.

## Verification

`test/MeshWeaver.Graph.Test/TerminalActivityWriterReleaseTest.cs` — a real monolith mesh, the real `MeshNodeStreamCache`, no mocks.

**The signal is the cache's own `ReadStreamEvictions` feed** (which the cache documents as existing for "diagnostics and deterministic tests"), filtered to the `"final"` reason that only `ReleaseIfUnwatched` emits. That choice is load-bearing: `ReleaseIfUnwatched` **declines while anyone is subscribed to the path**, so a test that waited for the release by watching the activity node would suppress the very thing it asserts. This subscribes to a different stream, and never to the path.

| | control arm (release calls removed) | with the fix |
|---|---|---|
| `ABuildProtocolCompletion_RetiresTheActivitysMirror` | **FAILED** (60 s, no eviction) | passed |
| `AFailedCodeRun_RetiresTheActivitysMirror` | **FAILED** (60 s, no eviction) | passed |
| `ARunningStatus_ReleasesNothing` | passed | passed |
| | `Failed: 2, Passed: 1` | `Passed: 3` in 2 s |

The narrowness fact passing in **both** arms is the point of including it: it tests the seam directly, so it cannot be what the writer facts are measuring.

Builds, one project per invocation, `-c Release -warnaserror`: `MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph`, `MeshWeaver.Hosting`, `MeshWeaver.Kernel.Hub`, `MeshWeaver.Graph.Test` — all **0 Warning(s), 0 Error(s)**.

## Notes for review

- **`ActivityLogLogger` is pinned by construction, not by a test.** Its assembly's `InternalsVisibleTo` names `MeshWeaver.Kernel.Test` / `MeshWeaver.Hosting.Monolith.Test` / `MeshWeaver.AI.Test`, none of which exist in this repo — the first has no core home and the other two live in MeshWeaver.Plugins. Its change is the same one-line completion arm as the other two, using the `status` local the write itself asserted. Saying so rather than implying the test covers all three.
- **Two private members became `internal`** so `MeshWeaver.Graph.Test` — the one core test project that sees `Graph`, `Hosting` **and** `Mesh.Contract` internals — can drive the writers directly. Same move as #3131's.
- **`FirstAsync` is a trap here and the test says so.** It unsubscribes on the first emission, so the completion arm never runs; the first draft of this test failed for exactly that reason. Production reaches completion — `CloseChunk`'s result is consumed through `.Concat().ToList()`, which waits for it.

Pairs-with: none — no public type is removed; one public method is added to `ActivityLogAppender`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
