### PR TITLE
fix(install): the root recycle and its readiness ping issue off the router

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-installs-stop-making-the-switchboard-do-the-work.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-installs-stop-making-the-switchboard-do-the-work.md
@@ -1,0 +1,29 @@
+---
+Name: Installs stop making the switchboard do the work
+Category: Fix
+Description: While installing a package the portal was routing two of its own messages through the component whose only job is to route everyone else's. Under a large install that is how other traffic gets held up.
+Icon: ArrowRouting
+Order: -20260902
+---
+
+# Installs stop making the switchboard do the work
+
+Inside the portal there is one component whose entire job is to pass messages between all the others.
+It is a switchboard: it should be forwarding, never doing. When it does its own work, everything
+waiting to be forwarded waits behind it — and the busier the moment, the worse that is.
+
+Installing a package is exactly such a moment: dozens of packages arriving at once, each one
+recycling its root and then waiting for it to come back up. Two of the messages in that sequence —
+the one asking a root to stand down, and the check asking whether it has come back — were being sent
+**from the switchboard itself**. So during the largest bursts of traffic the portal ever handles, the
+part that must stay free to forward was itself an endpoint.
+
+Nothing failed because of it, which is why it lasted: the messages arrived, the installs completed.
+What it cost was headroom, at the exact moment there was least of it.
+
+Both now go out from the dedicated hub that already handles this kind of work — the same one the rest
+of the install path has used for a while. The switchboard goes back to forwarding.
+
+The portal has been reporting this to itself the whole time; the lines are how it was found, in a
+plugin build's own log. That report stays, and stays loud, because the next time something starts
+doing work in the wrong place it is the only thing that will say so.

--- a/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
+++ b/src/MeshWeaver.PluginCatalog/PackageInstaller.cs
@@ -1510,8 +1510,17 @@ public static class PackageInstaller
                 // Impersonated for the same reason as the pings below: the recycle runs from the
                 // installer's chain, where no ambient AccessContext exists on a fresh boot.
                 var accessService = hub.ServiceProvider.GetService<AccessService>();
+                // 🚨 Off-router issuing, exactly as the CreateOrUpdateNodeRequest below already does.
+                // The installer's boot path runs ON the mesh hub, and the mesh hub is the ROUTER: a
+                // DisposeRequest posted there reaches the root stamped `Sender = mesh/{id}`, which is
+                // what the ROUTER_TRAFFIC detector reports. Measured on the Manufacturing gate run
+                // 33623113056: `RawJson has the mesh hub as sender (sender: mesh/…, target: Store)`
+                // and the same for `Analysis` — this post, arriving packed as RawJson at a root whose
+                // hub has no DisposeRequest in its TypeRegistry. NodeOperationIssuingHub is a NO-OP
+                // for every other caller, so nothing else changes.
                 using (accessService?.ImpersonateAsSystem())
-                    hub.Post(new DisposeRequest(), o => o.WithTarget(new Address(rootPath!)));
+                    hub.NodeOperationIssuingHub()
+                        .Post(new DisposeRequest(), o => o.WithTarget(new Address(rootPath!)));
                 return WaitForRootReady(hub, rootPath!, logger);
             });
     }
@@ -1531,6 +1540,15 @@ public static class PackageInstaller
     {
         var address = new Address(rootPath);
         var accessService = hub.ServiceProvider.GetService<AccessService>();
+        // 🚨 Off-router issuing, same rule as the DisposeRequest that precedes this wait. A ping
+        // issued ON the mesh hub makes the router BOTH an end of the request and the target of the
+        // reply — measured on the Manufacturing gate run 33623113056 as
+        // `PingResponse has the mesh hub as target (sender: Store, target: mesh/…)`. That is the
+        // role RouterTrafficRule reports deliberately, because "a response ADDRESSED AT the router
+        // proves the router issued a request, which is the violation the issuing seam exists to
+        // remove". Issuing off-router puts BOTH ends on the same non-router hub, so the exchange is
+        // local and never routed at all. A NO-OP for every non-mesh caller.
+        var issuingHub = hub.NodeOperationIssuingHub();
         return Observable.Defer(Probe)
             .Repeat()
             .Where(alive => alive)
@@ -1555,7 +1573,7 @@ public static class PackageInstaller
         // #1790); an infrastructure probe posts under SYSTEM at its call site, never off ambient.
         IObservable<bool> Probe() =>
             accessService.RunAsSystem(() =>
-                    hub.Observe<PingResponse>(new PingRequest(), o => o.WithTarget(address)))
+                    issuingHub.Observe<PingResponse>(new PingRequest(), o => o.WithTarget(address)))
                 .Take(1)
                 .Timeout(RootPingTimeout)
                 .Select(_ => true)


### PR DESCRIPTION
The `ROUTER_TRAFFIC` half of #3112 — the part that stands on its own regardless of how that race resolved, and which @meshweaver-37 handed over rather than folding into #2543.

## Measured, and it accounts for BOTH reported shapes

Pulled the job log for the run #3112 was filed from — MeshWeaver.Manufacturing run [33623113056](https://github.com/Systemorph/MeshWeaver.Manufacturing/actions/runs/33623113056), job `memex build plugin (new build process)`:

```
11:10:59.987 fail: ROUTER_TRAFFIC: RawJson has the mesh hub as sender (sender: mesh/Qz-…, target: Store)
11:11:01.493 fail: ROUTER_TRAFFIC: PingResponse has the mesh hub as target (sender: Store, target: mesh/Qz-…)
11:11:09.252 fail: ROUTER_TRAFFIC: RawJson has the mesh hub as sender (sender: mesh/Qz-…, target: Analysis)
```

`PackageInstaller`'s root-recycle sequence has exactly two posts, and they are these two:

| site | delivery | how it appears |
|---|---|---|
| `SettleRetypedRoot` — `hub.Post(new DisposeRequest(), …)` | router is the **sender** | packed as `RawJson` at a root whose hub has no `DisposeRequest` in its `TypeRegistry` |
| `WaitForRootReady` — `hub.Observe<PingResponse>(new PingRequest(), …)` | router is the **target of the reply** | `PingResponse` addressed back at `mesh/{id}` |

On the boot/install path the caller's hub **is** the root mesh hub, so both were issued on the router.

The second is reported on purpose — `RouterTrafficRule`'s own note: *"a response ADDRESSED AT the router still reports: it proves the router issued a request, which is the violation the issuing seam exists to remove."*

## The fix

Both go through `hub.NodeOperationIssuingHub()` — the seam `MeshService` uses for precisely this, and which **this same file already uses two call sites away** for `CreateOrUpdateNodeRequest` (`PackageInstaller.cs:1932`) and again for the boot default-install seed (`:3435`). The recycle path was simply never brought along.

```csharp
hub.NodeOperationIssuingHub().Post(new DisposeRequest(), …)
var issuingHub = hub.NodeOperationIssuingHub();   // then issuingHub.Observe<PingResponse>(…)
```

It is a **no-op for every non-mesh caller** (`hub.Address.Type != "mesh"` returns `hub` unchanged), so nothing outside the boot/install path changes. Where it does apply, both ends of the exchange become the same non-router hub, so the post is local and never routed at all.

Identity is unaffected — both sites keep their existing `ImpersonateAsSystem` / `RunAsSystem` scopes, and neither ever depended on which hub the post originated from.

## Why it is not cosmetic

The router doing work is a **starvation** shape, not a tidiness one. The detector's own record names it: node-CRUD bursts starving `SubscribeRequest` in prod, 2026-06-11. A mass install is the largest message burst the mesh handles, and this put the router at both ends of two messages per package root, right inside it.

## Verification, and what is NOT pinned

`dotnet build -c Release -warnaserror` on `MeshWeaver.PluginCatalog`: **0 Warning(s), 0 Error(s)**.

🚨 **There is no new test, and I want to be explicit about why rather than quiet about it.**

The obvious guard would be a source ratchet over `src/` for "request issued on the mesh hub", in the family of `RouterAsTestRequestOriginRatchetGuard`. That guard deliberately covers **tests only**, and I believe that scope is principled rather than an oversight: in a test `Mesh` is *definitionally* the router, so the pattern is statically decidable. In `src/` a method takes an `IMessageHub` parameter and whether it is the router depends on the caller — undecidable by a scanner, so such a ratchet would be either noisy or inert. I would rather say that than add a guard that cannot see its subject.

The regression signal that does exist is the `ROUTER_TRAFFIC` detector itself, which fires at `Error` in the CI logs — it is how this was found, and it is deduplicated per role+type so it stays readable. The `RouterTrafficDetectorTest` facts that pin the detector still firing for a mesh-hub sender and a mesh-hub target are untouched.

Pairs-with: none — no public type is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
