### PR TITLE
fix(import): a refused content sync is not a successful import (#3101)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-space-that-cannot-sync-its-files-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-space-that-cannot-sync-its-files-says-so.md
@@ -1,0 +1,36 @@
+---
+Name: A space that cannot sync its files now says so
+Category: Fix
+Description: When a space's images and videos were too large to transfer, the sync reported success and skipped that space on every attempt afterwards. It now reports the refusal — and keeps trying.
+Icon: CloudArrowUp
+Order: -20260902
+---
+
+# A space that cannot sync its files now says so
+
+A space keeps its pages in step with a git repository, and that includes the files the pages point
+at — images, posters, course videos. Those files travel with the sync.
+
+Some spaces have a lot of them. When a transfer was too large to carry, it was refused — correctly,
+by a guard that exists to stop one oversized transfer taking a server down with it. The trouble was
+what happened next: **the sync counted the refused files as "nothing to do" and reported success.**
+
+Zero files transferred is exactly what a space with no files reports. So there was no way, from the
+outside, to tell a space that was perfectly in sync from one whose entire media library had been
+refused on every attempt.
+
+It got worse from there. A successful sync is *remembered* — the platform records "this space
+already matches this version of the repository" and, on every later run, skips it without looking.
+So one refusal did not just go unreported: it was written down as success, and from then on nothing
+re-tried. The space stayed frozen exactly as it was, indefinitely.
+
+The person who eventually found out was a learner opening a lesson with a missing video.
+
+**A refused transfer is now recorded as what it is.** The sync reports it, names the spaces whose
+files did not arrive, and — the part that actually matters — **does not write down a success it did
+not have**, so the next run tries again instead of skipping. When the underlying problem is fixed,
+the files arrive on the next sync with nobody having to remember to force one.
+
+This does not, on its own, make very large media libraries transferable; that is a separate piece of
+work. What it changes is that a space in that state now tells you, instead of looking identical to
+one that is fine.

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -855,6 +855,11 @@ public static class StaticRepoImporter
                                 result.Outcome switch
                                 {
                                     "ImportedWithErrors" => ActivityStatus.Warning,
+                                    // 🚨 #3101 — a Space whose assets the transport refused has NOT
+                                    // succeeded. Falling through to the `_ => Succeeded` default would
+                                    // stamp the content-addressed marker green and skip the Space on
+                                    // every later boot, which is the defect itself.
+                                    "ImportedWithRefusedContent" => ActivityStatus.Warning,
                                     // 🚨 The LOCK's status is the durable short-circuit the next boot
                                     // reads. An import a claim stopped from creating declared nodes has
                                     // NOT succeeded, so it must not stamp Succeeded here either —
@@ -1510,15 +1515,18 @@ public static class StaticRepoImporter
 
                         // Sync content-collection files (the assets behind @@content/<file> embeds)
                         // collection→collection into each owning node — AFTER the node upsert.
-                        return SyncContentImports(hub, source, logger).SelectMany(embedCount =>
+                        return SyncContentImports(hub, source, logger).SelectMany(embedContent =>
                         // Mirror inline (byte-carrying) content into each owning node's content
                         // collection — the git-committed {Space}/content/** binaries a GitSync import
                         // supplies. Binary-safe + mirroring (writes what the repo has, prunes what the
                         // SOURCE dropped) so committed course videos/posters land and stop getting wiped,
                         // while user uploads the source never tracked are preserved (issue #435).
-                        SyncInlineContent(hub, source, previousContentPaths, logger).SelectMany(inlineCount =>
+                        SyncInlineContent(hub, source, previousContentPaths, logger).SelectMany(inlineContent =>
                         {
-                        var contentCount = embedCount + inlineCount;
+                        var contentCount = embedContent.Written + inlineContent.Written;
+                        // 🚨 #3101 — the owning nodes whose content sync did NOT succeed. Folded into
+                        // the terminal status below so a refused Space cannot stamp Succeeded.
+                        var refusedContent = embedContent.Refused.AddRange(inlineContent.Refused);
                         // Persist the per-node manifest LAST (after upserts + prune) so the NEXT import's
                         // diff sees exactly what's now in the partition. One write; survives prune (_Activity).
                         return WriteManifest(hub, source.Partition, nodes, manifest, changedNodePaths,
@@ -1554,7 +1562,13 @@ public static class StaticRepoImporter
                             // blank and nothing says why" shape, one level up. It is self-clearing —
                             // the pruned type is gone from `existing` next pass, so it can never be a
                             // prune candidate again and the very next import stamps Succeeded.
+                            // 🚨 #3101 joins the Warning side for the SAME reason as a blocked create,
+                            // argued above: the source declares the assets, the transport refuses them,
+                            // and no boot can change that. Succeeded at this fingerprint IS the durable
+                            // short-circuit, so stamping it froze a Space's assets out of the mesh
+                            // permanently and invisibly — the content-layer twin of #2211.
                             var status = failed > 0 || blockedCreates.Count > 0 || stranded.Count > 0
+                                             || refusedContent.Count > 0
                                 ? ActivityStatus.Warning
                                 : ActivityStatus.Succeeded;
                             // Two-way preserved local changes: kept-not-overwritten (upsert conflicts) PLUS
@@ -1580,6 +1594,19 @@ public static class StaticRepoImporter
                                   + ". Un-claim them, import the source that defines the missing NodeType, "
                                   + "or drop them from the source."
                                 : "";
+                            // NAMED, not counted — "synced 0 content file(s)" is exactly what a Space
+                            // with no content says, which is the ambiguity #3101 is about.
+                            var refusedNote = refusedContent.Count > 0
+                                ? $" 📦 {refusedContent.Count} node(s) whose CONTENT SYNC WAS REFUSED — their "
+                                  + "assets are NOT in the mesh (most often a delivery over the transport's "
+                                  + "size budget): "
+                                  + string.Join(", ", refusedContent.Take(BlockedPathsNamed))
+                                  + (refusedContent.Count > BlockedPathsNamed
+                                      ? $", … (+{refusedContent.Count - BlockedPathsNamed} more)"
+                                      : "")
+                                  + ". Recorded as Warning so the next boot re-attempts instead of "
+                                  + "short-circuiting on a green marker."
+                                : "";
                             // The summary NAMES the pruned nodes (issue #604) — the count alone left
                             // a destructive import unauditable ("pruned 7" — which seven? unknown).
                             var prunedNote = prunedPaths.Count > 0
@@ -1590,8 +1617,8 @@ public static class StaticRepoImporter
                             // reads as routine housekeeping unless it says what the prune broke.
                             var strandedNote = strandedReport is null ? "" : " " + strandedReport;
                             var summary = failed > 0
-                                ? $"Imported {count.Imported} node(s), {failed} FAILED (see ⚠ above){preservedNote}{claimedNote}, {prunedNote}, synced {contentCount} content file(s).{blockedNote}{strandedNote}"
-                                : $"Imported {count.Imported} node(s){preservedNote}{claimedNote}, {prunedNote}, synced {contentCount} content file(s).{blockedNote}{strandedNote}";
+                                ? $"Imported {count.Imported} node(s), {failed} FAILED (see ⚠ above){preservedNote}{claimedNote}, {prunedNote}, synced {contentCount} content file(s).{blockedNote}{refusedNote}{strandedNote}"
+                                : $"Imported {count.Imported} node(s){preservedNote}{claimedNote}, {prunedNote}, synced {contentCount} content file(s).{blockedNote}{refusedNote}{strandedNote}";
                             NodeTypeCompilationActivity.Complete(hub, activityPath, status,
                                 new[]
                                 {
@@ -1619,9 +1646,15 @@ public static class StaticRepoImporter
                                 + "failed {Failed}, claimed {Claimed}, pruned {Pruned}, content {Content} at {Fingerprint}.",
                                 source.Partition, count.Imported, tally.Requests, failed, count.Claimed,
                                 prunedPaths.Count, contentCount, fingerprint);
+                            // 🚨 #3101 — THE OUTCOME, not just the attempt's status. The attempt
+                            // activity is the human-readable log; the OUTCOME is what StampLock turns
+                            // into the marker, and the marker is the durable short-circuit. Colouring
+                            // only the attempt would have left the lock stamped Succeeded and the Space
+                            // skipped for ever — the fix would have looked right and changed nothing.
                             return new StaticRepoImportResult(source.Partition, fingerprint,
                                 failed > 0 ? "ImportedWithErrors"
-                                    : blockedCreates.Count > 0 ? "ImportedWithBlockedCreates" : "Imported",
+                                    : blockedCreates.Count > 0 ? "ImportedWithBlockedCreates"
+                                    : refusedContent.Count > 0 ? "ImportedWithRefusedContent" : "Imported",
                                 count.Imported, preserved)
                             {
                                 WrittenPaths = count.Written,
@@ -1810,28 +1843,68 @@ public static class StaticRepoImporter
     /// under System (never a hand-rolled cross-hub write). Per-entry failures log and continue. Returns
     /// the total files imported.
     /// </summary>
-    private static IObservable<int> SyncContentImports(IMessageHub hub, IStaticRepoSource source, ILogger? logger)
+    /// <summary>
+    /// What one content-sync pass did: how many files landed, and which owning nodes the sync was
+    /// REFUSED for.
+    ///
+    /// <para>🚨 <b>Issue #3101 — the refused set is the point.</b> Both content passes used to fold
+    /// a failure into <c>0</c> files, which is indistinguishable from a Space that simply has no
+    /// content. The import then summed zero, stamped <c>Succeeded</c>, and — because Succeeded at a
+    /// fingerprint IS the durable short-circuit — every later import skipped the Space without
+    /// looking. A Space whose assets are refused on every attempt reported exactly the same thing as
+    /// one that was fully in sync, for ever, and the person who found out was a learner opening a
+    /// page with a missing video.</para>
+    ///
+    /// <para>This is the same argument this method's own terminal-status block already makes for a
+    /// blocked create (#2211): <i>"the source declares it, the claim refuses its creation, and no
+    /// boot can ever change that … recording it there froze the divergence permanently and
+    /// invisibly."</i> A transport that refuses a Space's assets is that shape verbatim.</para>
+    /// </summary>
+    /// <param name="Written">Files actually written by the pass.</param>
+    /// <param name="Refused">Owning node paths whose sync did not succeed.</param>
+    private sealed record ContentSyncCount(int Written, ImmutableList<string> Refused)
+    {
+        public static readonly ContentSyncCount None = new(0, ImmutableList<string>.Empty);
+
+        public ContentSyncCount Add(ContentSyncCount other) =>
+            new(Written + other.Written, Refused.AddRange(other.Refused));
+    }
+
+    private static IObservable<ContentSyncCount> SyncContentImports(IMessageHub hub, IStaticRepoSource source, ILogger? logger)
     {
         var imports = source.EnumerateContentImports();
         if (imports.Count == 0)
-            return Observable.Return(0);
+            return Observable.Return(ContentSyncCount.None);
 
         return imports
             .Select(import => AsSystem(hub, () => hub.ImportContent(import.NodePath)
                     .From(import.SourceCollection, import.SourcePath)
                     .To(import.TargetCollection, import.TargetPath)
                     .Post())
-                .Select(r => r.Success ? r.FilesImported : 0)
-                .Catch<int, Exception>(ex =>
+                // 🚨 #3101 — a refusal is NOT "zero files". The unsuccessful arm used to map to 0
+                // silently, with no log at all, so a Space whose content was refused was
+                // indistinguishable from one that has none.
+                .Select(r =>
+                {
+                    if (r.Success)
+                        return new ContentSyncCount(r.FilesImported, ImmutableList<string>.Empty);
+                    logger?.LogWarning(
+                        "[StaticRepoImport] {Partition}: content import for {Node} was REFUSED — "
+                        + "its assets are NOT in the mesh. Recorded on the import activity so this "
+                        + "fingerprint does not stamp Succeeded and skip the Space next boot.",
+                        source.Partition, import.NodePath);
+                    return new ContentSyncCount(0, ImmutableList.Create(import.NodePath));
+                })
+                .Catch<ContentSyncCount, Exception>(ex =>
                 {
                     logger?.LogWarning(ex,
                         "[StaticRepoImport] {Partition}: content import for {Node} failed (continuing).",
                         source.Partition, import.NodePath);
-                    return Observable.Return(0);
+                    return Observable.Return(new ContentSyncCount(0, ImmutableList.Create(import.NodePath)));
                 }))
             .ToObservable()
             .Merge(BatchSize)
-            .Sum();
+            .Aggregate(ContentSyncCount.None, (total, one) => total.Add(one));
     }
 
     /// <summary>
@@ -1847,7 +1920,7 @@ public static class StaticRepoImporter
     /// paths are persisted as the content manifest so the next import knows what it owns.</para>
     /// Per-group failures log and continue. Returns the total files written.
     /// </summary>
-    private static IObservable<int> SyncInlineContent(
+    private static IObservable<ContentSyncCount> SyncInlineContent(
         IMessageHub hub, IStaticRepoSource source,
         IReadOnlyList<string> previouslyOwnedContentPaths, ILogger? logger)
     {
@@ -1856,7 +1929,7 @@ public static class StaticRepoImporter
             // No content this import → don't touch the collection (never an empty mirror that would wipe
             // user uploads) and leave the prior content manifest intact (conservative — a removed-to-zero
             // source set is not pruned, matching ContentAssetMapper's zero-asset behavior).
-            return Observable.Return(0);
+            return Observable.Return(ContentSyncCount.None);
 
         // The full collection-relative paths this source owns THIS import. Persisted as the content
         // manifest below so the NEXT import can tell a genuinely-removed source file (prune) from a user
@@ -1875,17 +1948,33 @@ public static class StaticRepoImporter
                     // Prune only files the source PREVIOUSLY owned — preserves user uploads (#435).
                     .SourceOwned(previouslyOwnedContentPaths)
                     .Post())
-                .Select(r => r.Success ? r.FilesImported : 0)
-                .Catch<int, Exception>(ex =>
+                // 🚨 #3101 — a REFUSED sync is not "zero files". This is the arm that made
+                // AgenticEngineering's 106 MB of assets stop syncing silently: the oversized-delivery
+                // guards (#1890/#2897/#3018/#3032) began refusing the delivery, `Success` came back
+                // false, and it folded to 0 with no log — identical to a Space with no content.
+                .Select(r =>
+                {
+                    if (r.Success)
+                        return new ContentSyncCount(r.FilesImported, ImmutableList<string>.Empty);
+                    logger?.LogWarning(
+                        "[StaticRepoImport] {Partition}: inline content sync for {Node} was REFUSED — "
+                        + "its assets are NOT in the mesh. A transport refusal is correct behaviour at "
+                        + "the transport and a DELIVERY FAILURE at the content layer; recorded on the "
+                        + "import activity so this fingerprint does not stamp Succeeded and skip the "
+                        + "Space next boot.",
+                        source.Partition, sync.NodePath);
+                    return new ContentSyncCount(0, ImmutableList.Create(sync.NodePath));
+                })
+                .Catch<ContentSyncCount, Exception>(ex =>
                 {
                     logger?.LogWarning(ex,
                         "[StaticRepoImport] {Partition}: inline content sync for {Node} failed (continuing).",
                         source.Partition, sync.NodePath);
-                    return Observable.Return(0);
+                    return Observable.Return(new ContentSyncCount(0, ImmutableList.Create(sync.NodePath)));
                 }))
             .ToObservable()
             .Merge(BatchSize)
-            .Sum()
+            .Aggregate(ContentSyncCount.None, (total, one) => total.Add(one))
             // Persist the current source-owned content set LAST (after the mirror) so the next import's
             // prune preserves user uploads. Best-effort: a failed write only makes the next import prune
             // nothing (conservative), never wrong.

--- a/test/MeshWeaver.Graph.Test/RefusedContentSyncIsNotSuccessTest.cs
+++ b/test/MeshWeaver.Graph.Test/RefusedContentSyncIsNotSuccessTest.cs
@@ -1,0 +1,129 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Utils;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #3101 — a Space whose content sync is refused stopped syncing SILENTLY.</b>
+///
+/// <para><b>The mechanism.</b> Both content passes folded a failed sync into <c>0</c> files:</para>
+///
+/// <code>
+/// .Select(r => r.Success ? r.FilesImported : 0)   // no log at all on the false arm
+/// </code>
+///
+/// <para>Zero files is exactly what a Space with no content reports, so the import summed zero,
+/// returned <c>"Imported"</c>, and <c>StampLock</c> wrote <b>Succeeded</b> at that fingerprint. And
+/// Succeeded at a fingerprint IS the durable short-circuit: every later import of the same repo
+/// content skipped the Space <i>without reading it</i>. A Space whose assets were refused on every
+/// attempt was indistinguishable from one fully in sync — permanently, and the person who found out
+/// was a learner opening a page with a missing video.</para>
+///
+/// <para>This is not a new argument. The importer's own terminal-status block already makes it for a
+/// blocked create (#2211): <i>"the source declares it, the claim refuses its creation, and no boot
+/// can ever change that … recording it there froze the divergence permanently and invisibly."</i>
+/// A transport that refuses a Space's assets is that shape verbatim, and it was missing the same
+/// escalation.</para>
+///
+/// <para>🚨 <b>What this pins is the OUTCOME, not the log.</b> The attempt activity is the
+/// human-readable record; the <c>Outcome</c> is what becomes the marker, and the marker is what
+/// decides whether the next boot looks at the Space at all. A fix that coloured only the attempt
+/// would leave the lock green and the Space skipped for ever — it would look right and change
+/// nothing, so that is the assertion.</para>
+/// </summary>
+public class RefusedContentSyncIsNotSuccessTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>A source that ships nodes and, optionally, one inline content sync.</summary>
+    private sealed class ContentRepoSource(string partition) : IStaticRepoSource
+    {
+        public string Partition => partition;
+        public bool Versioned => false;
+        public List<MeshNode> Nodes { get; init; } = [];
+        public MeshNode? Root { get; init; }
+        public List<StaticContentSync> Syncs { get; init; } = [];
+
+        public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
+        public MeshNode? PartitionRoot => Root;
+        public IReadOnlyList<StaticContentSync> EnumerateInlineContentSyncs() => Syncs;
+    }
+
+    private static MeshNode Space(string partition) =>
+        new(partition) { Name = partition, NodeType = "Space", State = MeshNodeState.Active };
+
+    private static MeshNode Page(string partition, string id) =>
+        new(id, partition) { Name = id, NodeType = "Markdown", State = MeshNodeState.Active };
+
+    /// <summary>
+    /// 🚨 THE PIN. A refused content sync must NOT produce the outcome that stamps a green marker.
+    ///
+    /// <para>The sync is aimed at a node in a partition this source does not own and that does not
+    /// exist, so the delivery cannot land — the deterministic stand-in for the oversized-delivery
+    /// refusal that took <c>AgenticEngineering</c>'s 106 MB of assets out of the mesh. What matters
+    /// is that the sync did not succeed, not which of the two ways it failed: both arms previously
+    /// folded to <c>0</c> and neither reached the outcome.</para>
+    ///
+    /// <para>Pre-fix this returns <c>"Imported"</c> → the lock is stamped <b>Succeeded</b> → the
+    /// Space is skipped for ever.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task ARefusedContentSync_DoesNotStampAGreenMarker()
+    {
+        var partition = "Rc" + Guid.NewGuid().ToString("N")[..8];
+        var source = new ContentRepoSource(partition)
+        {
+            Root = Space(partition),
+            Nodes = [Page(partition, "Lesson")],
+            Syncs =
+            [
+                new StaticContentSync(
+                    // A node that does not exist, in a partition this source does not own.
+                    NodePath: $"{partition}Missing/Nowhere",
+                    Files: [new InlineContentFile("video.mp4", "bytes"u8.ToArray())]),
+            ],
+        };
+
+        var result = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(240.Seconds());
+
+        Output.WriteLine($"outcome = {result.Outcome}");
+
+        result.Outcome.Should().Be("ImportedWithRefusedContent",
+            "the source declares assets the sync could not deliver, so this pass did NOT put the "
+            + "Space in the state the marker would claim — pre-fix it returned \"Imported\", the "
+            + "lock was stamped Succeeded, and every later import skipped the Space without "
+            + "reading it (#3101)");
+    }
+
+    /// <summary>
+    /// 🚨 The case that could have FALSIFIED the one above. A rule that escalated every import would
+    /// satisfy it just as well and would be far worse: no partition would ever short-circuit again,
+    /// so every boot would re-import every Space — the cost the marker exists to avoid.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task AnImportWithNoContentAtAll_StillStampsAGreenMarker()
+    {
+        var partition = "Rc" + Guid.NewGuid().ToString("N")[..8];
+        var source = new ContentRepoSource(partition)
+        {
+            Root = Space(partition),
+            Nodes = [Page(partition, "Lesson")],
+            // No content syncs at all — the overwhelmingly common case.
+        };
+
+        var result = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(240.Seconds());
+
+        Output.WriteLine($"outcome = {result.Outcome}");
+
+        result.Outcome.Should().Be("Imported",
+            "a Space with no content has nothing to refuse — escalating it would stop every "
+            + "partition short-circuiting and make every boot re-import the whole mesh");
+    }
+}


### PR DESCRIPTION
Addresses the part of #3101 that does not depend on measuring a live portal:

> **a Space whose assets are being refused should say so.**

## The silence, exactly

Both content passes in `StaticRepoImporter` folded a failed sync into `0`:

```csharp
.Select(r => r.Success ? r.FilesImported : 0)   // ← no log at all on the false arm
```

**Zero files is exactly what a Space with no content reports.** So the import summed zero, returned `"Imported"`, and `StampLock` wrote **Succeeded** at that fingerprint.

🚨 And Succeeded at a fingerprint **is** the durable short-circuit — the importer skips that Space on every later run *without reading it*. So a refusal was not merely unreported: it was recorded as success, and from then on nothing re-attempted. A Space whose assets were refused on every attempt was indistinguishable from one fully in sync, permanently.

Of the two failure arms, only one logged anything, and neither reached the outcome.

## This argument is already made in this method, for a different input

The terminal-status block a few lines below says it about a blocked create (#2211):

> **A CLAIM THAT BLOCKS A CREATE IS DRIFT THE IMPORT CANNOT CLOSE, AND IT MUST NOT BE RECORDED AS SUCCESS** … the source declares it, the claim refuses its creation, and no boot can ever change that … Succeeded at this fingerprint IS the durable short-circuit, so recording it there **froze the divergence permanently and invisibly**.

A transport that refuses a Space's assets is that shape verbatim. The escalation existed; content was simply not wired into it.

## The change

- A new `ContentSyncCount(Written, Refused)` replaces the bare `int` both passes returned, so a refusal survives as a **named set of owning nodes** instead of decaying into a count.
- The previously-silent `Success == false` arm now logs, naming the node and saying its assets are **not in the mesh**.
- `refusedContent` joins `failed` / `blockedCreates` / `stranded` in the terminal-status decision, and the summary **names** the refused nodes (bounded), because *"synced 0 content file(s)"* is precisely the ambiguity at issue.

🚨 **And — the load-bearing half — the refusal reaches the `Outcome`, not just the attempt's status:**

```csharp
failed > 0 ? "ImportedWithErrors"
    : blockedCreates.Count > 0 ? "ImportedWithBlockedCreates"
    : refusedContent.Count > 0 ? "ImportedWithRefusedContent" : "Imported",
```

…with `"ImportedWithRefusedContent" => ActivityStatus.Warning` added to the outcome→status map.

I had the first version colouring only the attempt activity. That would have **looked right and changed nothing**: the attempt is the human-readable log, but the *lock* is stamped from the `Outcome`, and the lock is what the short-circuit reads. The Space would still have been skipped for ever, under a fix everyone believed had landed. Both edits are needed and the map entry is not optional — without it the new outcome falls through `_ => Succeeded`.

The practical effect: a refused Space is stamped **Warning**, so **the next boot re-attempts** instead of short-circuiting on a green marker. When the underlying transport problem is fixed, the assets arrive on the next sync with nobody forcing one.

## Verification

`RefusedContentSyncIsNotSuccessTest` — real monolith mesh, real importer:

| | control arm (refusal removed from the `Outcome`) | with the fix |
|---|---|---|
| `ARefusedContentSync_DoesNotStampAGreenMarker` | **FAILED** — `outcome = Imported` | passed |
| `AnImportWithNoContentAtAll_StillStampsAGreenMarker` | passed | passed |
| | `Failed: 1, Passed: 1` | `Passed: 2` in 794 ms |

The control arm removes **only** the `Outcome` arm, leaving the attempt's status coloured — so it reproduces exactly the half-fix described above, and the failure prints the pre-fix value.

The second fact is the case that could have falsified the first: a rule that escalated *every* import would satisfy the pin and be far worse — no partition would ever short-circuit again and every boot would re-import the whole mesh.

`dotnet build -c Release -warnaserror` on `MeshWeaver.Graph` and `MeshWeaver.Graph.Test`: **0 Warning(s), 0 Error(s)**.

## What this does NOT do

- **It does not make oversized Spaces transferable.** `AgenticEngineering`'s ~106 MB (~141 MB base64) is over the frame limit outright; #3097 partitions by aggregate, and a single file over budget still travels whole. That residual is recorded in `Doc/Architecture/OversizedDeliveryRefusal` and needs a content-store handle — a design change, not a bound.
- **It does not answer the issue's question 1** (*does `AgenticEngineering` sync now?*). That needs a measurement on a quiet portal; mine returned *"this read reached no verdict"* mid-roll, and I would not build on that.

What it does is make the difference **observable**, which is the prerequisite for answering question 1 at all — and stops a refusal being written down as success in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
