### PR TITLE
fix(orleans): a given-up stream attach re-attaches on a membership change (#3139)

### DIFF
--- a/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
+++ b/src/MeshWeaver.Connection.Orleans/OrleansRoutingService.cs
@@ -915,6 +915,12 @@ public class OrleansRoutingService : IRoutingService, IDisposable
         // stream provider's Init stage — so the first touch of the provider is valid by construction.
         var cts = new CancellationTokenSource();
         var subscriptionTask = SubscribeWhenStreamingReadyAsync(address, callback, cts.Token);
+        // 🚨 #3139 — the attach's give-up is no longer the hub's lifetime. The slot holds whatever
+        // attach is CURRENT (a re-attach replaces it), and the re-attach fires only on a cluster
+        // membership change and only when nothing is attached — see ShouldReattach for why both
+        // halves of that condition are load-bearing.
+        var attachSlot = new StreamAttachSlot(subscriptionTask);
+        var reattach = ReattachOnMembershipChange(address, callback, attachSlot, cts);
         // Gate for OUTBOUND grain dispatches from this address (issue #1081 — see DeliverMessage):
         // completes when the inbound subscription is attached, and ALWAYS completes — a given-up
         // (null) or cancelled attach must degrade to today's behavior, never hold outbound
@@ -945,6 +951,9 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             // reconnecting is the everyday case) must not leave a pinned activation behind on the
             // pod it left, or the new owner's Attach lands on the old one and has to bounce off it.
             podHub.Dispose();
+            // Stop re-attaching BEFORE cancelling: a change arriving between the two would otherwise
+            // start an attach whose token is already cancelled.
+            reattach.Dispose();
             cts.Cancel();
             // 🚨 ENQUEUED, not fire-and-forget. This used to be `ioPool.Invoke(...).Subscribe(_ => {})`
             // — the handle dropped on the floor — so Dispose() reported "torn down" while the Orleans
@@ -960,8 +969,107 @@ public class OrleansRoutingService : IRoutingService, IDisposable
             // reactive disposal has completed and BEFORE the DI scope is torn down. Enqueuing is what
             // makes the drain WAIT for this work instead of racing it — the await stays inside the
             // queued lambda, off this turn, which is why no hub scheduler is parked.
-            EnqueueStreamTeardown(address, subscriptionTask, cts);
+            // The slot's CURRENT attach, not the first one: after a re-attach the live handle is
+            // the newer task's, and unsubscribing the original would leave the real subscription
+            // running past teardown.
+            EnqueueStreamTeardown(address, attachSlot.Current, cts);
         });
+    }
+
+    /// <summary>
+    /// The CURRENT attach for one registered address. Mutable by design: a re-attach replaces it, and
+    /// teardown must unsubscribe whatever is live NOW rather than the first attempt's result.
+    /// Instance state owned by one <see cref="RegisterStream"/> registration — never static.
+    /// </summary>
+    private sealed class StreamAttachSlot(Task<StreamSubscriptionHandle<IMessageDelivery>?> initial)
+    {
+        private Task<StreamSubscriptionHandle<IMessageDelivery>?> current = initial;
+
+        public Task<StreamSubscriptionHandle<IMessageDelivery>?> Current => Volatile.Read(ref current);
+
+        public void Set(Task<StreamSubscriptionHandle<IMessageDelivery>?> next) =>
+            Volatile.Write(ref current, next);
+    }
+
+    /// <summary>
+    /// Whether a membership change should RE-ATTACH this address's stream subscription.
+    ///
+    /// <para>🚨 <b>Issue #3139, the half the classifier fix left standing.</b> Recognising the
+    /// dead-silo registration made the bounded attach retry reachable, which covers a churn window
+    /// that is over in seconds. It does not cover one that outlasts the budget: past it the attach
+    /// gives up, and the give-up is permanent for the hub's LIFETIME — the hub keeps in-process
+    /// routing and silently stops receiving anything from another pod.</para>
+    ///
+    /// <para><b>Why a membership change is the right trigger and not a poll.</b> The subscription
+    /// registers the stream's <c>PubSubRendezvousGrain</c> in Orleans' grain directory, and that
+    /// directory is re-partitioned on every membership change — the same fact that makes
+    /// <see cref="AttachPodHub"/> re-assert its claim there (#2938). This is that argument applied
+    /// to the sibling registration: the event that can invalidate it is the event that should
+    /// repair it.</para>
+    ///
+    /// <para>🚨 <b>The condition is the whole safety argument.</b> A re-attach of a subscription
+    /// that is still LIVE would add a SECOND subscription to the same stream, and every inbound
+    /// delivery would be handled twice — a silent duplication far worse than the outage being
+    /// fixed. So this re-attaches ONLY when the attach has finished and produced no handle:</para>
+    /// <list type="bullet">
+    ///   <item>still running (the gate has not opened, or a retry is in flight) — leave it alone,
+    ///     it may yet succeed and a second attempt would race it;</item>
+    ///   <item>completed WITH a handle — the subscription is live; touching it is the duplication
+    ///     above;</item>
+    ///   <item>completed with <c>null</c>, faulted, or cancelled — nothing is attached, so there is
+    ///     nothing to duplicate and everything to regain.</item>
+    /// </list>
+    ///
+    /// <para>Pure, so the rule is an assertion rather than a cluster observation.</para>
+    /// </summary>
+    /// <param name="current">The address's current attach, or null when none was ever started.</param>
+    /// <returns><c>true</c> when a fresh attach should be made.</returns>
+    internal static bool ShouldReattach(Task<StreamSubscriptionHandle<IMessageDelivery>?>? current) =>
+        current is { IsCompleted: true }
+        && (current.Status != TaskStatus.RanToCompletion || current.Result is null);
+
+    /// <summary>
+    /// Re-attaches <paramref name="address"/>'s stream subscription on every cluster membership
+    /// change for which <see cref="ShouldReattach"/> holds. A no-op where membership cannot change
+    /// under this process (client, monolith, bare mesh) — there the give-up stays terminal, which is
+    /// exactly the behaviour that existed before.
+    /// </summary>
+    private IDisposable ReattachOnMembershipChange(
+        Address address, AsyncDelivery callback, StreamAttachSlot slot, CancellationTokenSource cts)
+    {
+        if (membershipFeed is null)
+            return Disposable.Empty;
+
+        // Concat, never Merge: one re-attach at a time per address, so two changes in quick
+        // succession cannot have two attaches in flight for the same stream.
+        return membershipFeed.Changes
+            .Select(seq => Observable.Defer(() =>
+            {
+                if (disposed || cts.IsCancellationRequested || !ShouldReattach(slot.Current))
+                    return Observable.Empty<Unit>();
+
+                OrleansRouteTrace.Write(
+                    $"OrleansRoutingService.SubscribeAsync REATTACH addr={address} membershipChange={seq}");
+                logger.LogInformation(
+                    "Orleans '{Provider}' stream subscription for {Address} is re-attached after a "
+                    + "cluster membership change — its previous attach gave up, which left this hub's "
+                    + "cross-process routing disabled (in-process routing was unaffected throughout).",
+                    StreamProviders.Memory, address);
+
+                var next = SubscribeWhenStreamingReadyAsync(address, callback, cts.Token);
+                slot.Set(next);
+                // The attach never faults (it returns null on give-up); the arm is here because a
+                // cancelled teardown surfaces as OperationCanceledException and must not tear the
+                // trigger sequence down with it.
+                return next.ToObservable()
+                    .Select(_ => Unit.Default)
+                    .Catch<Unit, Exception>(_ => Observable.Empty<Unit>());
+            }))
+            .Concat()
+            .Subscribe(
+                _ => { },
+                ex => logger.LogDebug(ex,
+                    "Orleans stream re-attach sequence for {Address} ended", address));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-deafened-replica-recovers-on-its-own.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-deafened-replica-recovers-on-its-own.md
@@ -3,7 +3,7 @@ Name: A deafened replica now recovers on its own
 Category: Fix
 Description: If a piece of the portal lost its cross-replica messaging during a long cluster reshuffle, it stayed lost until a restart. It now gets it back the next time the cluster changes.
 Icon: ArrowSync
-Order: -20260903
+Order: -20260902
 ---
 
 # A deafened replica now recovers on its own

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-deafened-replica-recovers-on-its-own.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-deafened-replica-recovers-on-its-own.md
@@ -1,0 +1,34 @@
+---
+Name: A deafened replica now recovers on its own
+Category: Fix
+Description: If a piece of the portal lost its cross-replica messaging during a long cluster reshuffle, it stayed lost until a restart. It now gets it back the next time the cluster changes.
+Icon: ArrowSync
+Order: -20260903
+---
+
+# A deafened replica now recovers on its own
+
+This finishes the repair described in *One bad moment no longer deafens a hub for good*.
+
+That change taught the platform to recognise a particular way the cluster says "not now, ask again",
+so the retry it already had actually ran. The retry gives up after a few seconds — which covers the
+ordinary reshuffle, and those are over almost immediately.
+
+**What it did not cover was a long one.** If the cluster took longer than that to settle, the piece
+gave up — and the giving up was final. It kept working perfectly for anyone whose request happened
+to land on the same replica, and silently received nothing from any other, for as long as that
+replica kept running. Only a restart brought it back.
+
+That is a bad shape for an outage: everything looks healthy, because from the affected replica's own
+point of view everything *is* healthy. It is simply no longer being spoken to.
+
+**It now re-announces itself whenever the cluster's membership changes** — which is exactly the
+moment the announcement can be lost, and exactly the moment it can be re-made. Not a timer and not a
+retry loop: the same event that breaks it is the one that repairs it. A replica that misses its slot
+during a fifteen-minute reshuffle gets it back when the reshuffle ends, instead of staying deaf until
+someone notices and restarts it.
+
+One deliberate limit worth stating, because it is what makes this safe: a piece that is **still
+connected** is never re-announced. Announcing twice would mean receiving every message twice — a
+quieter and considerably worse fault than the one being fixed — so the recovery only ever runs when
+there is genuinely nothing connected.

--- a/test/MeshWeaver.Hosting.Orleans.Test/StreamReattachRuleTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/StreamReattachRuleTest.cs
@@ -1,0 +1,137 @@
+using System;
+using System.Threading.Tasks;
+using MeshWeaver.Connection.Orleans;
+using MeshWeaver.Messaging;
+using Orleans.Streams;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #3139, the half the classifier fix left standing.</b>
+///
+/// <para>Teaching <c>IsDirectoryUnstable</c> the registration-side phrase made the bounded attach
+/// retry reachable, which covers a membership-churn window that is over in seconds. It does not
+/// cover one that outlasts the budget: past it the attach gives up, and <b>the give-up is permanent
+/// for the hub's lifetime</b>. The hub keeps in-process routing — so it looks healthy — and silently
+/// stops receiving anything sent from another pod.</para>
+///
+/// <para>The repair is the same move <c>AttachPodHub</c> already makes for the sibling registration
+/// (#2938): the stream subscription registers a <c>PubSubRendezvousGrain</c> in Orleans' grain
+/// directory, that directory is re-partitioned on every membership change, so the event that can
+/// invalidate the registration is the event that should repair it. Not a timer, not a poll.</para>
+///
+/// <para>🚨 <b>What this pins is the CONDITION, because the condition is the whole safety
+/// argument.</b> Re-attaching a subscription that is still LIVE adds a SECOND subscription to the
+/// same stream and every inbound delivery is then handled twice — a silent duplication strictly
+/// worse than the outage being fixed, and one that would show up as "the message was processed
+/// twice" long after anyone connects it to a routing fix. So the rule is not "re-attach on
+/// membership change"; it is "re-attach on membership change <i>when nothing is attached</i>".</para>
+///
+/// <para>Pure — no cluster, no scheduler, no mocks.</para>
+/// </summary>
+public class StreamReattachRuleTest
+{
+    /// <summary>
+    /// A stand-in handle. Orleans' <see cref="StreamSubscriptionHandle{T}"/> is abstract and none of
+    /// its members are ever called here — only its PRESENCE decides — so the minimum that compiles
+    /// is the right amount of fake.
+    /// </summary>
+    private sealed class FakeHandle : StreamSubscriptionHandle<IMessageDelivery>
+    {
+        public override Guid HandleId => Guid.Empty;
+        public override string ProviderName => "fake";
+        public override StreamId StreamId => default;
+
+        public override Task UnsubscribeAsync() => Task.CompletedTask;
+
+        public override Task<StreamSubscriptionHandle<IMessageDelivery>> ResumeAsync(
+            IAsyncObserver<IMessageDelivery> observer, StreamSequenceToken? token = null) =>
+            Task.FromResult<StreamSubscriptionHandle<IMessageDelivery>>(this);
+
+        public override Task<StreamSubscriptionHandle<IMessageDelivery>> ResumeAsync(
+            IAsyncBatchObserver<IMessageDelivery> observer, StreamSequenceToken? token = null) =>
+            Task.FromResult<StreamSubscriptionHandle<IMessageDelivery>>(this);
+
+        public override bool Equals(StreamSubscriptionHandle<IMessageDelivery>? other) =>
+            ReferenceEquals(this, other);
+    }
+
+    private static StreamSubscriptionHandle<IMessageDelivery> AHandle() => new FakeHandle();
+
+    /// <summary>
+    /// 🚨 THE HAZARD. A live subscription must never be re-attached — that is the duplicate-delivery
+    /// bug this condition exists to prevent, and it is the reason a bare "re-assert on every
+    /// membership change" (which is correct for the pod-hub CLAIM, an idempotent activation) is
+    /// NOT correct for a stream subscription.
+    /// </summary>
+    [Fact]
+    public void ALiveSubscription_IsNeverReattached()
+        => OrleansRoutingService.ShouldReattach(Task.FromResult<StreamSubscriptionHandle<IMessageDelivery>?>(AHandle()))
+            .Should().BeFalse(
+                "re-attaching a live subscription adds a SECOND subscription to the same stream and "
+                + "every inbound delivery is handled twice — silent duplication, worse than the "
+                + "outage it would be fixing");
+
+    /// <summary>
+    /// 🚨 The other half of the hazard, and the easier one to miss. An attach that is still running
+    /// has not failed — the readiness gate may not have opened yet, or a bounded retry may be
+    /// mid-backoff. Starting a second one races it, and if BOTH land the result is the duplication
+    /// above by a different route.
+    /// </summary>
+    [Fact]
+    public void AnAttachStillInFlight_IsNotReattached()
+    {
+        var pending = new TaskCompletionSource<StreamSubscriptionHandle<IMessageDelivery>?>();
+
+        OrleansRoutingService.ShouldReattach(pending.Task).Should().BeFalse(
+            "an attach that has not finished may still succeed; a second one would race it, and two "
+            + "that both land are two subscriptions");
+    }
+
+    /// <summary>
+    /// THE PIN. A give-up produced <c>null</c> — nothing is attached, so there is nothing to
+    /// duplicate and a whole hub's cross-process routing to regain.
+    /// </summary>
+    [Fact]
+    public void AGivenUpAttach_IsReattached()
+        => OrleansRoutingService.ShouldReattach(Task.FromResult<StreamSubscriptionHandle<IMessageDelivery>?>(null))
+            .Should().BeTrue(
+                "this is the latched state #3139 reports — the hub kept in-process routing, so it "
+                + "looked healthy while nothing from another pod could reach it, for the rest of "
+                + "its life");
+
+    /// <summary>
+    /// A faulted attach attached nothing either. The production path returns null rather than
+    /// faulting, so this is defence for a future caller — but the rule must not depend on which of
+    /// the two shapes "it did not attach" arrives as.
+    /// </summary>
+    [Fact]
+    public void AFaultedAttach_IsReattached()
+        => OrleansRoutingService.ShouldReattach(
+                Task.FromException<StreamSubscriptionHandle<IMessageDelivery>?>(new InvalidOperationException("nope")))
+            .Should().BeTrue("nothing is attached, whichever way the attach ended");
+
+    /// <summary>
+    /// A cancelled attach is teardown in progress. Re-attaching is still harmless by the rule above
+    /// (nothing is attached), and the CALLER — not this predicate — is what declines: the re-attach
+    /// checks the cancellation token and the disposed flag first. Pinned so the two layers are not
+    /// silently collapsed into one and the guard moved out of the caller.
+    /// </summary>
+    [Fact]
+    public void ACancelledAttach_SatisfiesTheRule_AndIsDeclinedByTheCallerInstead()
+        => OrleansRoutingService.ShouldReattach(
+                Task.FromCanceled<StreamSubscriptionHandle<IMessageDelivery>?>(new(canceled: true)))
+            .Should().BeTrue(
+                "nothing is attached; teardown is excluded by the token/disposed check at the call "
+                + "site, which is where the lifetime is known");
+
+    /// <summary>
+    /// No attach was ever started for this address — there is nothing to re-attach, and treating
+    /// "absent" as "gave up" would attach a stream for an address that never registered one.
+    /// </summary>
+    [Fact]
+    public void NoAttachAtAll_IsNotReattached()
+        => OrleansRoutingService.ShouldReattach(null).Should().BeFalse(
+            "absent is not the same as given up");
+}


### PR DESCRIPTION
Closes #3139 — the half #3142 deliberately left standing, and said so.

## What was left

#3142 taught `IsDirectoryUnstable` the registration-side phrase, which made the bounded attach retry *reachable* for the condition production actually hits. That covers a churn window over in seconds.

It does not cover one that outlasts the ~7.75 s budget. Past it the attach gives up — and **the give-up is permanent for the hub's lifetime.** The hub keeps in-process routing, so it looks perfectly healthy, and silently receives nothing from any other pod until it is recycled or the pod restarts. That is the "permanently disables" in the issue's title, and it survived the first fix by design.

## The repair, and why it is not a watchdog

Exactly the move `AttachPodHub` already makes for the sibling registration (#2938): a stream subscription registers its `PubSubRendezvousGrain` in Orleans' grain directory, **that directory is re-partitioned on every membership change**, so the event that can invalidate the registration is the event that should repair it.

`IClusterMembershipFeed` was already injected into this class for precisely that purpose — `ClaimTriggers` uses it two hundred lines up. No timer, no poll, no retry loop; the trigger is the causing event.

Where membership cannot change under this process (client, monolith, bare mesh) the feed is absent and the give-up stays terminal — exactly the behaviour that exists today.

## 🚨 Why this is not the same one-liner as the pod-hub claim

A claim is an **idempotent activation**; re-asserting it costs nothing. A subscription is not.

**Re-attaching a LIVE subscription adds a SECOND subscription to the same stream, and every inbound delivery is then handled twice.** That is silent duplication — strictly worse than the outage being fixed, and it would surface much later as "this message was processed twice" with nothing connecting it to a routing change.

So the condition, not the trigger, is where the safety lives:

```csharp
internal static bool ShouldReattach(Task<StreamSubscriptionHandle<IMessageDelivery>?>? current) =>
    current is { IsCompleted: true }
    && (current.Status != TaskStatus.RanToCompletion || current.Result is null);
```

| state | decision | why |
|---|---|---|
| still running | **no** | may yet succeed; a second attempt races it, and two that land are two subscriptions |
| completed **with** a handle | **no** | live — this is the duplication above |
| `null` / faulted / cancelled | yes | nothing attached, so nothing to duplicate |
| never started | **no** | absent is not the same as given up |

Two lifetime details that would otherwise bite:

- **Teardown unsubscribes the slot's CURRENT attach**, not the first attempt's — after a re-attach the live handle belongs to the newer task, and unsubscribing the original would leave the real subscription running past teardown.
- **The re-attach subscription is disposed BEFORE the token is cancelled**, so a membership change arriving between the two cannot start an attach on an already-cancelled token.

## Verification

`StreamReattachRuleTest` — 6 facts, pure: no cluster, no scheduler, no mocks.

| | control arm (naive unconditional re-assert) | with the fix |
|---|---|---|
| `ALiveSubscription_IsNeverReattached` | **FAILED** | passed |
| `AnAttachStillInFlight_IsNotReattached` | **FAILED** | passed |
| `NoAttachAtAll_IsNotReattached` | **FAILED** | passed |
| `AGivenUpAttach` / `AFaulted` / `ACancelled` | passed | passed |
| | `Failed: 3, Passed: 3` | `Passed: 6` |

The control arm is the *plausible wrong fix* — copying the pod-hub claim's "re-assert on every membership change" verbatim — and it fails exactly the three hazard facts while passing the three recovery ones. That is the discrimination worth having: a green run on the recovery half alone would not have distinguished the two.

Both suites in the project together: **17/17**. `dotnet build -c Release -warnaserror` on `MeshWeaver.Connection.Orleans` and `MeshWeaver.Hosting.Orleans.Test`: **0 Warning(s), 0 Error(s)**.

## A note on what is NOT pinned

There is no end-to-end fact that a real silo re-attaches after a real membership change. `PodHubClaimReassertionTest` manages that for the claim because its readiness gate is never fired — the attach then parks on `OrleansStreamingReadiness` and never reaches a give-up state, so the same harness cannot manufacture the input this rule consumes without a fake stream provider.

What is pinned is the decision, which is where the regression risk actually is: the trigger is one line reusing an existing feed, and the condition is the part someone would "simplify" later. The wiring's counterpart for the claim is `PodHubClaimMembershipWiringTest` on the two-silo cluster, and extending it to the subscription is the honest follow-up if that gap matters.

Pairs-with: none — no public type is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
