### PR TITLE
The fold's root policy leg reads by PATH — no more 199-schema UNION for a row that cannot exist (#2194)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CrossSchemaFanOutElimination.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CrossSchemaFanOutElimination.md
@@ -59,7 +59,7 @@ schema(s)".
 |---|---|---|---|---|
 | 1 | **Notification bell + panel** — `NotificationCenter.razor` / `NotificationCenterPanel.razor` (MeshWeaver.Plugins, `MeshWeaver.Blazor.Portal`) | `nodeType:Notification sort:CreatedAt-desc` — unanchored, unbounded, LIVE (re-queries on matching change) | `notifications` | **To eliminate** — see plan 1 |
 | 2 | **Security fold globals** — `SecurityQueries.Roles` / `.Memberships` / `.GatedNodes(type)` (per gated type!) via `PermissionEvaluator` | `nodeType:Role scope:subtree … complete`, `nodeType:GroupMembership …`, `nodeType:{gated} …` | `mesh_nodes` | **To eliminate** — see plan 2 |
-| 3 | **Root-scope grants/policies** — `SecurityQueries.Scoped` on `namespace:_Access` / root `_Policy` (the root scope resolves to no partition, falls through to fan-out) | `namespace:_Access nodeType:AccessAssignment …` | `access` | **To eliminate** — see plan 2 |
+| 3 | **Root-scope grants/policies** — `SecurityQueries.RootAssignments` / `.RootPolicy` | `namespace:_Access nodeType:AccessAssignment …` / `path:_Policy nodeType:PartitionAccessPolicy …` | `system_access.access` / — | **Done** 2026-09-02 (#2194) — the grants leg never fanned out (the router pins `_Access` to its registered schema); the policy leg was `namespace: id:_Policy`, path-less, and DID fan out 179×/5 min for a row that cannot exist on Postgres — now read by path, see below |
 | 4 | `node_type ILIKE $1` wildcard (seen live; caller not yet named) | suffix/wildcard nodeType | `mesh_nodes` | **Identify via the shape log** (Plugins #1035), then anchor or fold into plan 2 |
 | 5 | `Admin/Menu/{X}` per-render route misses | point probes | `mesh_nodes` | **Fixed** 2026-08-29 (`83b1892be`, anchored existence query) |
 
@@ -77,6 +77,66 @@ They are now per-PARTITION (`path:{partition} scope:descendants …`), which is 
 32-node listing 69; both are 5 now. Rows 2 and 3 of the census are unchanged — the *global* legs
 still fan out, and [Unanchored Security Reads](/Doc/Architecture/UnanchoredSecurityReads) says why
 they must.
+
+### The 2026-09-02 census — memex-cloud on ci.7616, after #3125 (#2194)
+
+Maintainer directive (2026-09-02 19:40Z): *"profile it and improve"* — the portal was still slow
+after rolling to ci.7616, which carries #3125's per-partition fold. Measured on the new pods: the
+portal pods were **light (0.1–1.3 cores each)** while Azure Postgres `memexaks-pg`
+(Standard_D8ds_v5) ran at **94–98 % CPU with 225–292 active connections**; `[CrossSchema] SLOW`
+averaged **4.0 s (max 9.8 s), 2 917 lines in five minutes across 8 pods**. So the bottleneck had
+moved entirely into the database, and the fan-outs were what it was doing. The shapes, by count in
+that window (the shape is what `DescribeQueryShape` logs — `nodeType path scope`), each attributed
+to its reader:
+
+| Lines / 5 min | Shape | Reader | Verdict |
+|---|---|---|---|
+| 444 | `Notification path:- scope:Exact` | the bell — `NotificationCenter.razor:45` + `NotificationCenterPanel.razor:247` (MeshWeaver.Plugins, per CIRCUIT, live), plus `NotificationTriageService.cs:75` | **Plan 1** (recipient delivery) — a Plugins change; nothing in core issues this shape |
+| 313 | `AccessAssignment path:- scope:Subtree` | **unattributed.** Not the fold: `SecurityQueryShapesTest.TheFoldNeverIssuesAMeasuredFanOutShape` pins that no fold shape describes to it. No `.cs`/`.razor` in this repo or in MeshWeaver.Plugins builds it (the two `scope:subtree nodeType:AccessAssignment` builders — `PackageInstaller.ContradictingDenies`, `Store/Licensing/Source/PluginGate.SnapshotQueries` — both carry `path:{partition}`); a `search_chunks` sweep of the live mesh answered `"searched": false` (no embedding provider on that MCP endpoint), i.e. the in-mesh sweep FAILED and is still owed | **Open** — find the caller (Plugins #1035's shape log names it per line; correlate with `select:`/`limit:` on the same line) |
+| 278 | `Email path:- scope:Exact` | **unattributed** — no source in either repo spells a path-less `nodeType:Email` (`EmailInboundProcessor.cs:339` is `namespace:`-anchored); the in-mesh sweep failed as above | **Open** |
+| 179 | `PartitionAccessPolicy path:- scope:Children` | the fold's ROOT policy leg — `PermissionEvaluator.ObserveScopePolicies`, spelled `namespace: id:_Policy` | **Fixed here** — see "What moved" |
+| 172 | `GroupMembership path:- scope:Subtree` | `SecurityQueries.Memberships` (`PermissionEvaluator.ObserveAllMembershipNodes`) | **Cannot be anchored** — memberships live under the GROUP node in any partition ([Unanchored Security Reads](../UnanchoredSecurityReads)); the count is the multiplier below, not the subscription count |
+| 103 | `User path:- scope:Exact` | `UserIdentityCache.DirectoryQuery` (`nodeType:User`, process-wide), `SpaceInviteService.cs:66` / `GroupInviteExtensions.cs:93` (`content.email:` filtered), `EventSubscriptionRunner.Reconcile`/`WatchTriggerNodeType` for `TriggerNodeType = "User"` | **Already pinned**: `UserNodeType.cs:76` registers the `nodeType:User` → `Auth` routing rule and `PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync` consumes it (the "inert hint" note on the companion page is out of date). These lines are therefore the provider's *"ALREADY PINNED … look at the statement itself"* variant — slow because the database was saturated, not because they fanned out. Inferred from the code paths; the census counted lines by shape without separating the two variants |
+| 53 | `Store/Plugin path:- scope:Subtree` | `SecurityQueries.GatedNodes("Store/Plugin")` | Cannot be anchored (gate map matched against every partition) — multiplier below |
+| 49 | `Thread path:- scope:Exact` | `ThreadQueries.cs:43/50`, `ChatHistorySelector.razor:236` (Plugins, `createdBy:` filtered) | Plugins; a thread lives at `{owner}/_Thread` in every partition |
+| 39 | `UiContribution path:- scope:Exact` | `UiContributionCatalog.cs:95` (process-wide live) | contributions are authored wherever the plugin lives |
+
+**The multiplier — why a "process-wide cached subscription" shows up 170 times in five minutes.**
+A fan-out live query re-runs when a change notification is *relevant*, and
+`PostgreSqlPartitionedMeshQuery.FanOutQuery`'s relevance filter classifies a notification by its
+`Entity`: a `MeshNode` is matched against the query (`_evaluator.Matches`, node type included), but
+`n.Entity is not MeshNode → return true` — *"unclassifiable — re-query rather than miss it"*. Every
+notification that arrives from ANOTHER process is unclassifiable by construction:
+`PostgreSqlChangeListener.cs:211` builds `new DataChangeNotification(path, kind, null, …)` because
+the `pg_notify('mesh_node_changes', …)` payload carries only `path` and `op`. On an 8-pod portal
+7/8 of all writes arrive that way, so **every write anywhere in the fleet re-runs every unanchored
+live query on every pod** — memberships, roles, gated types, the root policy leg, the user
+directory, the UI-contribution catalog, and every circuit's bell. That is the 172 / 179 / 53 / 39
+above, and it is why the fold's globals were "the single biggest DB load" on code that reads them
+once per process. The lever is in MeshWeaver.Plugins: put `node_type` on the notify payload and
+classify the cross-process notification by it (a node type that no fan-out query names cannot
+enter its result set), keeping the fail-safe re-query for a payload without one. It removes the
+multiplier from every fan-out that survives, and it is independent of anchoring.
+
+**What moved (this change, core):**
+
+- The root **policy** leg is spelled `path:_Policy nodeType:PartitionAccessPolicy`
+  (`SecurityQueries.RootPolicy`) instead of `namespace: id:_Policy …`. The two name the same node
+  (namespace `""` + id `_Policy` IS the path `_Policy`), but the old spelling had no first segment,
+  so the router UNION-ed every partition schema for it — 179 times in the window, every one
+  necessarily empty: an unregistered `_`-prefixed first segment is unroutable, so no write can land
+  a root `_Policy` row on Postgres at all. With a first segment the router never fans out; today it
+  answers empty (nothing registered for `_Policy`), and registering `_Policy` as a global satellite
+  the way `_Access` is would make the read pinned without touching the query.
+- The root **grants** leg is `SecurityQueries.RootAssignments` and is reclassified: `_Access` is a
+  REGISTERED global satellite (`DefaultPartitionProvider` → schema `system_access`), and the router
+  resolves a `_`-prefixed first segment through that registry — so this leg was served by one schema
+  all along. The census on both pages called it a fan-out on the strength of a comment; it never
+  appeared in the Loki shape counts, which is the measurement that should have been consulted.
+- `SecurityQueryShapesTest` now classifies every fold shape into the router's three real outcomes
+  (`Pinned` / `Unroutable` / `FanOut`), pins the four measured `path:-` shapes as never-the-fold's,
+  and mirrors the global-satellite registry; `SecurityQueryRootLegRegistryTest` asserts that mirror
+  against the real registry of a running mesh.
 
 ## The elimination plan
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/UnanchoredSecurityReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UnanchoredSecurityReads.md
@@ -62,13 +62,26 @@ the overwhelming majority at runtime — so "everything is unanchored" cannot pa
 | `SecurityQueries.Roles` | a custom `Role` definition may live in any partition; a truncated role set silently drops every permission derived from the missing role |
 | `SecurityQueries.Memberships` | the group and the grant that names it live in different partitions (above) |
 | `SecurityQueries.GatedNodes(type)` | instances of a gated NodeType are authored wherever their owner lives, and the gate map is matched against target paths from every partition |
-| root `namespace:_Access` | the ROOT scope's anchor is the satellite segment `_Access`, which resolves to **no partition** — there is no partition name to write |
-| root `namespace:` + `id:_Policy` | the root scope's policy leg carries the EMPTY namespace by construction, for the same reason |
+
+**Struck from this table on 2026-09-02 (#2194) — the two ROOT legs.** Earlier revisions listed
+`namespace:_Access` ("resolves to no partition") and `namespace: id:_Policy` here. Both were wrong
+about the router, not about the data: a `_`-prefixed first segment is resolved through the
+REGISTERED global-satellite definitions (`DefaultPartitionProvider`: `_Access` → schema
+`system_access`), so the grants leg (`SecurityQueries.RootAssignments`) was always served by ONE
+schema. The policy leg had no first segment at all and DID fan out — 179 `[CrossSchema] SLOW` lines
+in five minutes on memex-cloud, for a row that cannot exist on Postgres (an unregistered `_` first
+segment is unroutable for writes too). It is now `SecurityQueries.RootPolicy` = `path:_Policy …`:
+the same node, with a first segment, so the router never UNIONs for it. Neither move anchors a read
+to the VIEWER — the root scope has exactly one home — so neither is the truncation this page is
+about. Measurement and attribution: [Cross-Schema Fan-Out Elimination](../CrossSchemaFanOutElimination)
+→ "The 2026-09-02 census".
 
 Note what is NOT on the list: the **per-partition** legs (`path:{partition} scope:descendants
 nodeType:AccessAssignment`, and its `_Policy` twin) pin their partition through the first path
-segment. The global legs are five process-wide cached subscriptions, not a per-render storm — which
-is why the ordering below matters.
+segment. The global legs are three process-wide cached subscriptions, not a per-render storm — but
+a process-wide subscription still RE-RUNS on every relevant change, and on a multi-pod portal every
+cross-process notification counts as relevant (it carries no entity to classify); that multiplier,
+not the subscription count, is what the Loki census counts. See the same section.
 
 ## The distinction that makes one anchoring sound and the other a regression (#3093)
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-one-fewer-mesh-wide-question-on-every-page.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-one-fewer-mesh-wide-question-on-every-page.md
@@ -1,0 +1,26 @@
+---
+Name: One fewer mesh-wide question on every page
+Category: Fix
+Description: Every permission check used to ask the database, across every space at once, for a platform-wide access policy that cannot exist there — hundreds of times a minute on a busy portal. It now asks the one place such a policy could live, so that question stopped competing with your pages for the database.
+Icon: ShieldCheckmark
+Order: -20260902
+---
+
+# One fewer mesh-wide question on every page
+
+Everything you see is filtered by what you may see, and part of that filter is a platform-wide
+access policy that would apply to every space. Reading it was spelled in a way that gave the
+database no idea where to look, so it looked everywhere: one combined scan across every space on the
+portal, repeated whenever anything anywhere changed. On a portal with a couple of hundred spaces and
+eight servers that was a few hundred scans every five minutes, each taking seconds and each holding
+locks that every other page was waiting behind — for an answer that was always empty, because the
+storage layer cannot even hold such a policy today.
+
+The read now names the one place the policy could live. The database answers it from there in
+microseconds, and the pages that used to queue behind those scans get the database back. Nothing
+about who may see what has changed: the same policy, if it existed, would be read from the same place.
+
+Two things this did NOT change, so the numbers are honest: the notification bell and mail listings
+still ask across every space (that is a separate change in the portal shell), and the group
+membership read genuinely has to look everywhere, because a group can live in a different space
+than the content it opens.

--- a/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/PermissionEvaluator.cs
@@ -887,13 +887,12 @@ internal static class PermissionEvaluator
     private static IObservable<IEnumerable<MeshNode>> ObserveEffectiveAssignments(
         IMessageHub hub, IMeshNodeStreamCache cache, string nodePath, IReadOnlyList<MeshNode> staticNodes)
     {
-        // The ROOT scope's grants live under the `_Access` namespace of no partition, so this leg
-        // stays global (declared in SecurityQueryShapesTest.DeliberatelyGlobal) and stays ONE
-        // process-wide cached subscription for the whole mesh.
+        // The ROOT scope's grants live at `_Access/{id}` — the registered global satellite whose
+        // schema is `system_access`, so the router pins this read to that ONE schema
+        // (SecurityQueryShapesTest.TheRootAccessLegPinsTheRegisteredGlobalSchema). ONE process-wide
+        // cached subscription for the whole mesh.
         var root = SecurityQuery(cache, "$security-access:", hub.JsonSerializerOptions,
-            SecurityQueries.Scoped(
-                $"namespace:_Access nodeType:{SecurityCollections.AccessAssignmentNodeType} "
-                + SecurityQueries.ContentProjection));
+            SecurityQueries.RootAssignments);
 
         var statics = Observable.Return<IEnumerable<MeshNode>>(staticNodes.ToArray());
         var partition = GetPartition(nodePath);
@@ -920,11 +919,12 @@ internal static class PermissionEvaluator
         IMessageHub hub, IMeshNodeStreamCache cache, string scope,
         IReadOnlyDictionary<string, PartitionAccessPolicy> staticPolicies)
     {
-        // Root: the empty namespace belongs to no partition — global, one subscription, declared.
+        // Root: the node at exactly `_Policy`, read by PATH so the router has a first segment and
+        // never fans out (#2194 — the path-less spelling UNION-ed every partition schema 179× per
+        // five minutes on memex-cloud for a row that cannot exist there; see SecurityQueries.RootPolicy).
+        // One process-wide subscription.
         var root = SecurityQuery(cache, "$security-policy:", hub.JsonSerializerOptions,
-            SecurityQueries.Scoped(
-                $"namespace: id:_Policy nodeType:{SecurityCollections.PartitionAccessPolicyNodeType} "
-                + SecurityQueries.ContentProjection));
+            SecurityQueries.RootPolicy);
 
         var partition = GetPartition(scope);
         var nodes = string.IsNullOrEmpty(partition)

--- a/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
@@ -107,13 +107,60 @@ public static class SecurityQueries
 
     /// <summary>
     /// A security read anchored to one scope — the root <c>AccessAssignment</c> and <c>_Policy</c>
-    /// legs. Anchored reads are normally served by a single partition's delegate, but the ROOT
-    /// scope's anchor (<c>_Access</c> / the empty namespace) resolves to no partition and falls
-    /// through to the same cross-schema fan-out, so these are stamped too.
+    /// legs (<see cref="RootAssignments"/>, <see cref="RootPolicy"/>). Anchored reads are served by
+    /// a single schema's delegate; they are stamped like every other fold read because the
+    /// completeness rule in the class remarks does not depend on WHERE a read is served.
     /// </summary>
     /// <param name="query">The anchored query string.</param>
     /// <returns>The query string, stamped as an enumeration.</returns>
     public static string Scoped(string query) => Enumeration(query);
+
+    /// <summary>
+    /// The ROOT scope's satellite namespace for grants — a root-scope <c>AccessAssignment</c> lives
+    /// at <c>_Access/{id}</c>. A <c>_</c>-prefixed first segment is not a partition: the Postgres
+    /// router resolves it ONLY through the REGISTERED global-satellite definitions
+    /// (<c>DefaultPartitionProvider</c> registers <c>_Access</c> with schema <c>system_access</c>),
+    /// so a read anchored here is served by that ONE schema and never by the cross-schema fan-out.
+    /// </summary>
+    public const string RootAccessNamespace = "_Access";
+
+    /// <summary>
+    /// The ROOT scope's policy node — <c>{scope}/_Policy</c> with the empty root scope, i.e. the
+    /// node whose path is exactly <c>_Policy</c>.
+    /// </summary>
+    public const string RootPolicyPath = "_Policy";
+
+    /// <summary>
+    /// Every root-scope <c>AccessAssignment</c> (<c>$security-access:</c>) — the grants that apply
+    /// across every partition (platform-wide viewer / admin). Anchored on
+    /// <see cref="RootAccessNamespace"/>, which the router pins to the registered
+    /// <c>system_access</c> schema: one schema, not 199.
+    /// </summary>
+    public static string RootAssignments
+        => Scoped($"namespace:{RootAccessNamespace} "
+            + $"nodeType:{SecurityCollections.AccessAssignmentNodeType} {ContentProjection}");
+
+    /// <summary>
+    /// The root-scope <c>_Policy</c> (<c>$security-policy:</c>), read as the node at exactly
+    /// <see cref="RootPolicyPath"/>.
+    ///
+    /// <para>🚨 <b>Why <c>path:_Policy</c> and not <c>namespace: id:_Policy</c></b> (issue #2194,
+    /// measured on memex-cloud 2026-09-02). The two name the SAME node — a namespace of <c>""</c>
+    /// plus an id of <c>_Policy</c> IS the path <c>_Policy</c> — but the old spelling carried no
+    /// path, so the Postgres router had no first segment to route on and answered it with a
+    /// <c>UNION ALL</c> over every partition schema: 179 <c>[CrossSchema] SLOW</c> lines in five
+    /// minutes (<c>nodeType:PartitionAccessPolicy path:- scope:Children</c>), each 1–4 s of
+    /// <c>LWLock/LockManager</c> contention shared with every other query on the database — and
+    /// every one of them necessarily EMPTY: an unregistered <c>_</c>-prefixed first segment is
+    /// unroutable, so no write can ever land a root <c>_Policy</c> row in Postgres in the first
+    /// place. The anchored spelling gives the router a concrete first segment, so it never fans
+    /// out: today it answers empty (no schema is registered for <c>_Policy</c>), and registering
+    /// <c>_Policy</c> as a global satellite the way <c>_Access</c> is would make it pinned WITHOUT
+    /// touching this query. In-memory and static-node providers answer both spellings identically.</para>
+    /// </summary>
+    public static string RootPolicy
+        => Scoped($"path:{RootPolicyPath} "
+            + $"nodeType:{SecurityCollections.PartitionAccessPolicyNodeType} {ContentProjection}");
 
     /// <summary>
     /// Every <c>AccessAssignment</c> in ONE partition — the grants for every scope on any path
@@ -168,8 +215,8 @@ public static class SecurityQueries
         Roles,
         Memberships,
         GatedNodes("Store/Plugin"),
-        Scoped("namespace:_Access nodeType:AccessAssignment " + ContentProjection),
-        Scoped("namespace: id:_Policy nodeType:PartitionAccessPolicy " + ContentProjection),
+        RootAssignments,
+        RootPolicy,
         PartitionAssignments("acme"),
         PartitionPolicies("acme"),
     ];

--- a/test/MeshWeaver.Hosting.Test/SecurityQueryRootLegRegistryTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SecurityQueryRootLegRegistryTest.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// Pins <see cref="SecurityQueryShapesTest.RegisteredGlobalSatellites"/> — the mirror the pure
+/// shapes test classifies <c>_</c>-prefixed first segments with — against the REAL registry of a
+/// running mesh: the <c>Partition</c> nodes the static providers ship, which is what the Postgres
+/// router's <c>TryGetRegisteredPartition</c> is seeded from at boot. A mirror that nothing compares
+/// to the thing it mirrors is a hypothesis (#2194 was one: the census called the root
+/// <c>_Access</c> leg a fan-out for a year on the strength of a comment).
+///
+/// <para>Two facts carry the root legs' routing verdicts:</para>
+/// <list type="bullet">
+///   <item><c>_Access</c> IS registered, with schema <c>system_access</c> — so
+///     <see cref="SecurityQueries.RootAssignments"/> is served by ONE schema.</item>
+///   <item><c>_Policy</c> is NOT registered — so <see cref="SecurityQueries.RootPolicy"/> is
+///     unroutable rather than pinned, and (the same fact from the write side) no root
+///     <c>_Policy</c> row can exist on Postgres, which is why the path-less spelling's 199-schema
+///     fan-out was always empty. Register it and BOTH tests here tell you which assertions move.</item>
+/// </list>
+/// </summary>
+public class SecurityQueryRootLegRegistryTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private Dictionary<string, string?> RegisteredGlobalSatellites()
+    {
+        var options = Mesh.JsonSerializerOptions;
+        return Mesh.ServiceProvider.GetServices<IStaticNodeProvider>()
+            .SelectMany(p => p.GetStaticNodes())
+            .Where(n => string.Equals(n.NodeType, PartitionNodeType.NodeType, StringComparison.Ordinal))
+            .Select(n => n.ContentAs<PartitionDefinition>(options))
+            .Where(d => d is { Namespace.Length: > 0 } && d.Namespace.StartsWith('_'))
+            .ToDictionary(d => d!.Namespace, d => d!.Schema, StringComparer.Ordinal);
+    }
+
+    [Fact]
+    public void TheShapesTestMirrorMatchesTheRealRegistry()
+    {
+        var real = RegisteredGlobalSatellites();
+        real.Should().NotBeEmpty("DefaultPartitionProvider registers at least _Access");
+        var mirror = SecurityQueryShapesTest.RegisteredGlobalSatellites;
+        real.Keys.OrderBy(k => k, StringComparer.Ordinal).Should().Equal(
+            mirror.Keys.OrderBy(k => k, StringComparer.Ordinal),
+            "the shapes test classifies `_`-prefixed first segments with this mirror; when a global "
+            + "satellite is registered or removed, update the mirror in the same change");
+        foreach (var (ns, schema) in mirror)
+            real[ns].Should().Be(schema, $"the mirror's schema for {ns} must be the registered one");
+    }
+
+    [Fact]
+    public void TheRootAccessNamespaceIsRegistered_AndTheRootPolicyPathIsNot()
+    {
+        var real = RegisteredGlobalSatellites();
+        real.Should().ContainKey(SecurityQueries.RootAccessNamespace)
+            .WhoseValue.Should().Be("system_access",
+                "the root grants leg is served by this one schema, never by the cross-schema fan-out");
+        real.Should().NotContainKey(SecurityQueries.RootPolicyPath,
+            "no schema is registered for the root policy, so the read is unroutable (answered "
+            + "empty without a fan-out) and no write can land a root _Policy on Postgres — if this "
+            + "fails, SecurityQueryShapesTest.TheRootPolicyLegNeverFansOut moves to Pinned");
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/SecurityQueryShapesTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SecurityQueryShapesTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
 using MeshWeaver.Mesh;
@@ -91,11 +92,21 @@ public class SecurityQueryShapesTest
         }
     }
 
-    // ————————————————————————— the anchoring census (#2640)
+    // ————————————————————————— the anchoring census (#2640, #2194)
 
     /// <summary>
     /// The declared population of security reads that CANNOT be anchored, with the reason each is
-    /// global. A shape that is not on this list and does not pin a partition fails the test below.
+    /// global. A shape that is not on this list and fans out fails the test below.
+    ///
+    /// <para>🚨 #2194 struck the two ROOT legs from this list — not because they were anchored to
+    /// the viewer (the truncation this class forbids), but because the router never treated them as
+    /// the census assumed. <c>namespace:_Access</c> has a first segment, and a <c>_</c>-prefixed
+    /// first segment resolves through the REGISTERED global-satellite definitions (<c>_Access</c> →
+    /// <c>system_access</c>): ONE schema. The root <c>_Policy</c> leg was spelled <c>namespace:
+    /// id:_Policy</c> — no first segment at all — and so it DID fan out, 179 times in five minutes on
+    /// memex-cloud (2026-09-02), for a row that cannot exist on Postgres: an unregistered <c>_</c>
+    /// first segment is unroutable, so no write can land a root <c>_Policy</c> there. It is now
+    /// spelled <c>path:_Policy</c>, the same node with a first segment.</para>
     /// </summary>
     private static readonly (string Shape, string Reason)[] DeliberatelyGlobal =
     [
@@ -110,12 +121,6 @@ public class SecurityQueryShapesTest
         (SecurityQueries.GatedNodes("Store/Plugin"),
             "instances of a gated NodeType are authored wherever their owner lives; the gate map "
             + "is matched against a target path from any partition"),
-        (SecurityQueries.Scoped("namespace:_Access nodeType:AccessAssignment " + SecurityQueries.ContentProjection),
-            "the ROOT scope's anchor is the satellite segment _Access, which resolves to no "
-            + "partition — there is no partition name to write"),
-        (SecurityQueries.Scoped("namespace: id:_Policy nodeType:PartitionAccessPolicy " + SecurityQueries.ContentProjection),
-            "the root scope's policy leg carries the EMPTY namespace by construction, for the same "
-            + "reason"),
     ];
 
     [Fact]
@@ -124,7 +129,7 @@ public class SecurityQueryShapesTest
         var declared = DeliberatelyGlobal.Select(x => x.Shape).ToHashSet(StringComparer.Ordinal);
 
         var undeclared = SecurityQueries.AllShapes
-            .Where(shape => PinnedPartition(shape) is null && !declared.Contains(shape))
+            .Where(shape => RouteOf(shape).Kind == Route.FanOut && !declared.Contains(shape))
             .ToArray();
 
         undeclared.Should().BeEmpty(
@@ -133,27 +138,110 @@ public class SecurityQueryShapesTest
             + "model of #2640, and a shape added without one is invisible until it shows up as a "
             + "two-second floor on every page");
 
-        // …and the reverse: a declared entry that has since been ANCHORED must be struck, or the
-        // list becomes a fiction that outlives its subject.
+        // …and the reverse: a declared entry that has since stopped fanning out must be struck, or
+        // the list becomes a fiction that outlives its subject.
         foreach (var (shape, reason) in DeliberatelyGlobal)
-            PinnedPartition(shape).Should().BeNull(
-                $"'{shape}' is declared global because {reason} — if it now pins a partition, "
+            RouteOf(shape).Kind.Should().Be(Route.FanOut,
+                $"'{shape}' is declared global because {reason} — if it no longer fans out, "
                 + "remove it from the list rather than leaving a stale justification behind");
     }
 
     /// <summary>
-    /// 🚨 The positive control that makes the census non-vacuous. Every entry above is unanchored,
-    /// so a classifier that simply answered "unanchored" to everything would pass the test and
-    /// prove nothing. These are the shapes the fold ALSO issues — the per-scope legs, which are the
-    /// overwhelming majority at runtime — and they must come back PINNED.
+    /// The root grants leg (#2194). <c>_Access</c> is a REGISTERED global satellite, so the router
+    /// serves this read from its one registered schema — it was never a fan-out, and the census
+    /// that declared it one was wrong about the router, not about the data. The registry this
+    /// mirrors is asserted against the real mesh by <see cref="SecurityQueryRootLegRegistryTest"/>.
+    /// </summary>
+    [Fact]
+    public void TheRootAccessLegPinsTheRegisteredGlobalSchema()
+    {
+        var route = RouteOf(SecurityQueries.RootAssignments);
+        route.Kind.Should().Be(Route.Pinned,
+            "a root-scope AccessAssignment lives at _Access/{id}, and _Access resolves through the "
+            + "registered global-satellite definitions to ONE schema");
+        route.Target.Should().Be("system_access");
+    }
+
+    /// <summary>
+    /// The root policy leg (#2194). Spelled by PATH it has a first segment, so the router never
+    /// UNIONs every partition schema for it; the path-less spelling it replaced is kept here as the
+    /// control that DID fan out. Today the segment is unregistered, so the read is unroutable (and
+    /// answered empty — exactly what the fan-out returned, 179 times per five minutes); registering
+    /// <c>_Policy</c> as a global satellite flips this to <see cref="Route.Pinned"/> with no change
+    /// to the query, at which point this assertion is the one to update.
+    /// </summary>
+    [Fact]
+    public void TheRootPolicyLegNeverFansOut()
+    {
+        RouteOf(SecurityQueries.RootPolicy).Kind.Should().Be(Route.Unroutable,
+            "path:_Policy names the same node as `namespace: id:_Policy` but gives the router a first "
+            + "segment; no global satellite is registered for _Policy, so it routes to no schema "
+            + "rather than to all of them");
+
+        // The control: the spelling #2194 replaced fanned out, and would again.
+        RouteOf("namespace: id:_Policy nodeType:PartitionAccessPolicy limit:all").Kind
+            .Should().Be(Route.FanOut, "the path-less spelling has no first segment to route on");
+    }
+
+    /// <summary>
+    /// 🚨 The guard for the shapes MEASURED fanning out on memex-cloud (2026-09-02, five-minute
+    /// Loki window, <c>[CrossSchema] SLOW</c>, image ci.7616 — the shape is what
+    /// <c>PostgreSqlCrossSchemaQueryProvider.DescribeQueryShape</c> logs). The fold must not be the
+    /// source of any of these again. <c>PartitionAccessPolicy path:- scope:Children</c> WAS the
+    /// fold's root policy leg (179 lines); the three <c>AccessAssignment path:-</c> shapes never
+    /// were — <c>scope:Subtree</c> (313 lines) is unattributed in this repo and
+    /// <c>scope:Exact</c> is <c>UserActivityLayoutAreas.ObserveSharedTargets</c>, a home-page
+    /// band, not a permission read — but a fold shape that DESCRIBED to one would be exactly the
+    /// regression this census exists to catch, so all four are pinned.
+    /// </summary>
+    [Theory]
+    [InlineData("nodeType:PartitionAccessPolicy path:- scope:Children")]
+    [InlineData("nodeType:AccessAssignment path:- scope:Children")]
+    [InlineData("nodeType:AccessAssignment path:- scope:Exact")]
+    [InlineData("nodeType:AccessAssignment path:- scope:Subtree")]
+    public void TheFoldNeverIssuesAMeasuredFanOutShape(string measured)
+        => SecurityQueries.AllShapes.Select(Describe).Should().NotContain(measured,
+            "this shape was measured fanning out across every partition schema on memex-cloud; a "
+            + "fold read must carry a first segment (path:/namespace:) — see "
+            + "Doc/Architecture/CrossSchemaFanOutElimination");
+
+    /// <summary>
+    /// The census in the vocabulary of the log line: every <c>path:-</c> shape the fold issues is
+    /// one of the declared globals — so a reader of the Loki census can tell, from the shape alone,
+    /// whether a line came from a DECLARED fold read or from a new caller.
+    /// </summary>
+    [Fact]
+    public void EveryPathLessShapeTheFoldIssuesIsADeclaredGlobal()
+    {
+        var declared = DeliberatelyGlobal.Select(x => Describe(x.Shape)).ToHashSet(StringComparer.Ordinal);
+        declared.Should().NotBeEmpty();
+        foreach (var shape in SecurityQueries.AllShapes)
+        {
+            var described = Describe(shape);
+            if (described.Contains(" path:- ", StringComparison.Ordinal))
+                declared.Should().Contain(described,
+                    $"'{shape}' carries no first segment, so its log shape must be a declared global");
+        }
+    }
+
+    /// <summary>
+    /// 🚨 The positive control that makes the census non-vacuous. Every declared entry is a fan-out,
+    /// so a classifier that simply answered "fan-out" to everything would pass the test and prove
+    /// nothing. These are the shapes the fold ALSO issues — the per-partition legs, which are the
+    /// overwhelming majority at runtime — and they must come back PINNED to the router's schema
+    /// (the lowercased first segment, exactly as <c>PostgreSqlPartitionedMeshQuery</c> spells it).
     /// </summary>
     [Theory]
     [InlineData("path:rbuergi scope:descendants nodeType:AccessAssignment select:path,id limit:all", "rbuergi")]
     [InlineData("path:acme scope:descendants nodeType:AccessAssignment limit:all", "acme")]
-    [InlineData("path:Admin scope:descendants nodeType:AccessAssignment limit:all", "Admin")]
-    [InlineData("path:Doc scope:descendants id:_Policy nodeType:PartitionAccessPolicy limit:all", "Doc")]
+    [InlineData("path:Admin scope:descendants nodeType:AccessAssignment limit:all", "admin")]
+    [InlineData("path:Doc scope:descendants id:_Policy nodeType:PartitionAccessPolicy limit:all", "doc")]
     public void AnAnchoredScopeLegPinsItsPartition(string query, string expected)
-        => PinnedPartition(query).Should().Be(expected);
+    {
+        var route = RouteOf(query);
+        route.Kind.Should().Be(Route.Pinned);
+        route.Target.Should().Be(expected);
+    }
 
     /// <summary>
     /// The two shapes the fold actually issues per partition (#3093) come back PINNED — the same
@@ -171,10 +259,10 @@ public class SecurityQueryShapesTest
     [Fact]
     public void ThePerPartitionLegsPinTheirPartition()
     {
-        PinnedPartition(SecurityQueries.PartitionAssignments("acme")).Should().Be("acme");
-        PinnedPartition(SecurityQueries.PartitionPolicies("acme")).Should().Be("acme");
+        RouteOf(SecurityQueries.PartitionAssignments("acme")).Should().Be((Route.Pinned, "acme"));
+        RouteOf(SecurityQueries.PartitionPolicies("acme")).Should().Be((Route.Pinned, "acme"));
         // "Admin" is PermissionEvaluator.AdminScope, which is internal to Mesh.Contract.
-        PinnedPartition(SecurityQueries.PartitionAssignments("Admin")).Should().Be("Admin",
+        RouteOf(SecurityQueries.PartitionAssignments("Admin")).Should().Be((Route.Pinned, "admin"),
                 "the Admin partition is excluded from searchable_schemas, so its grants are only "
                 + "reachable through a path-anchored read — that is why the fold used to carry an "
                 + "Admin special case, and why every partition now takes that route");
@@ -183,49 +271,83 @@ public class SecurityQueryShapesTest
     [Theory]
     [InlineData("nodeType:Role scope:subtree limit:all")]
     [InlineData("namespace: id:_Policy limit:all")]
-    [InlineData("namespace:_Access nodeType:AccessAssignment limit:all")]
     [InlineData("path:*/Source scope:subtree nodeType:Code")]
-    public void AnUnanchoredShapePinsNothing(string query)
-        => PinnedPartition(query).Should().BeNull();
+    public void AnUnanchoredShapeFansOut(string query)
+        => RouteOf(query).Kind.Should().Be(Route.FanOut);
+
+    // ————————————————————————— the classifier
+
+    /// <summary>How the Postgres router answers a query — the three outcomes it actually has.</summary>
+    private enum Route
+    {
+        /// <summary>One concrete schema: the lowercased first segment, or a registered global satellite's schema.</summary>
+        Pinned,
+        /// <summary>A first segment the router refuses to route (an unregistered <c>_</c>-prefixed segment): no schema, no fan-out, no write can ever land there.</summary>
+        Unroutable,
+        /// <summary>No first segment, or a wildcard one: a <c>UNION ALL</c> over every partition schema.</summary>
+        FanOut,
+    }
 
     /// <summary>
-    /// The partition a query resolves to, or <c>null</c> when it fans out — the rule the Postgres
-    /// router applies (<c>PostgreSqlPartitionedMeshQuery</c> routes purely by the first path
-    /// segment), reproduced here on the shared <see cref="QueryParser"/> so the census is measured
-    /// rather than asserted.
-    ///
-    /// <para>A leading <c>_</c> segment is NOT a partition: <c>_Access</c>, <c>_Thread</c> and
-    /// friends are satellite names, and the fold's root leg (<c>namespace:_Access</c>) is exactly
-    /// the case <c>SecurityQueries</c> documents as resolving to no partition and falling through
-    /// to the cross-schema fan-out. A <c>*</c> first segment is a wildcard over partitions, which
-    /// is a fan-out by definition.</para>
+    /// The global satellite namespaces the platform registers with an explicit schema
+    /// (<c>DefaultPartitionProvider.CreateGlobalSatellitePartition</c>) — the registry the router's
+    /// <c>ResolveGlobalSchema</c> consults for a <c>_</c>-prefixed first segment. Mirrored here so
+    /// the shapes test stays a pure parser test; <see cref="SecurityQueryRootLegRegistryTest"/>
+    /// asserts this mirror against the REAL registry of a running mesh, so it cannot drift silently.
     /// </summary>
-    private static string? PinnedPartition(string query)
+    internal static readonly ImmutableDictionary<string, string> RegisteredGlobalSatellites =
+        ImmutableDictionary<string, string>.Empty.Add(SecurityQueries.RootAccessNamespace, "system_access");
+
+    /// <summary>
+    /// The route a query takes, reproduced on the shared <see cref="QueryParser"/> from the rules
+    /// <c>PostgreSqlPartitionedMeshQuery</c> / <c>PostgreSqlPathRoutingAdapter</c> apply — first
+    /// segment of <c>path:</c> (which a single <c>namespace:</c> also sets), lowercased, unless it
+    /// is a wildcard (fan-out), empty (fan-out), or <c>_</c>-prefixed (registered → its schema,
+    /// otherwise unroutable) — so the census is measured rather than asserted.
+    /// </summary>
+    private static (Route Kind, string? Target) RouteOf(string query)
     {
         var parsed = new QueryParser().Parse(query);
-        var fromPath = PartitionSegment(parsed.Path);
-        if (fromPath is not null)
+        var fromPath = RouteOfSegment(parsed.Path);
+        if (fromPath.Kind != Route.FanOut)
             return fromPath;
         foreach (var ns in parsed.ExtractNamespaces())
         {
-            var fromNamespace = PartitionSegment(ns);
-            if (fromNamespace is not null)
+            var fromNamespace = RouteOfSegment(ns);
+            if (fromNamespace.Kind != Route.FanOut)
                 return fromNamespace;
         }
-        return null;
+        return (Route.FanOut, null);
     }
 
-    private static string? PartitionSegment(string? path)
+    private static (Route Kind, string? Target) RouteOfSegment(string? path)
     {
         if (string.IsNullOrWhiteSpace(path))
-            return null;
+            return (Route.FanOut, null);
         var trimmed = path.Trim().Trim('/');
         if (trimmed.Length == 0)
-            return null;
+            return (Route.FanOut, null);
         var slash = trimmed.IndexOf('/');
         var first = slash > 0 ? trimmed[..slash] : trimmed;
-        return first.Length == 0 || first == "*" || first.StartsWith('_') || first.Contains('*')
-            ? null
-            : first;
+        if (first.Length == 0 || first == "*" || first.Contains('*'))
+            return (Route.FanOut, null);
+        if (first.StartsWith('_'))
+            return RegisteredGlobalSatellites.TryGetValue(first, out var schema)
+                ? (Route.Pinned, schema)
+                : (Route.Unroutable, null);
+        return (Route.Pinned, first.ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// The shape <c>PostgreSqlCrossSchemaQueryProvider.DescribeQueryShape</c> puts on the
+    /// <c>[CrossSchema] SLOW</c> line — <c>nodeType:{type|*} path:{path|-} scope:{Scope}</c> — so
+    /// the census here and the Loki census speak the same vocabulary.
+    /// </summary>
+    private static string Describe(string query)
+    {
+        var parsed = new QueryParser().Parse(query);
+        return $"nodeType:{parsed.ExtractNodeType() ?? "*"}"
+            + $" path:{(string.IsNullOrEmpty(parsed.Path) ? "-" : parsed.Path)}"
+            + $" scope:{parsed.Scope}";
     }
 }


### PR DESCRIPTION
Part of #2194 — the remaining render-path fan-outs, measured on memex-cloud AFTER the roll to ci.7616 (#3125's per-partition fold).

## What was measured (2026-09-02, five-minute Loki window, 8 pods, image ci.7616)

Portal pods light (0.1–1.3 cores) while Azure Postgres `memexaks-pg` ran at **94–98 % CPU, 225–292 active connections**; `[CrossSchema] SLOW` averaged **4.0 s (max 9.8 s), 2 917 lines**. By shape (`nodeType path scope`, as `DescribeQueryShape` logs it), attributed to its reader:

| Lines | Shape | Reader (core `src/` unless noted) | Verdict |
|---|---|---|---|
| 444 | `Notification path:- Exact` | bell — `NotificationCenter.razor:45` / `NotificationCenterPanel.razor:247` (Plugins, per circuit, live) | Plugins, plan 1 |
| 313 | `AccessAssignment path:- Subtree` | **unattributed** — not the fold (pinned by test below); no builder in either repo (`PackageInstaller.ContradictingDenies` and `Store/Licensing/Source/PluginGate.SnapshotQueries` both carry `path:{partition}`); live-mesh `search_chunks` sweep answered `"searched": false` (a FAILED sweep, not a clean one) | open |
| 278 | `Email path:- Exact` | **unattributed** — no path-less `nodeType:Email` in either repo's source (`EmailInboundProcessor.cs:339` is `namespace:`-anchored); same failed sweep | open |
| 179 | `PartitionAccessPolicy path:- Children` | the fold's ROOT policy leg — `PermissionEvaluator.ObserveScopePolicies`, spelled `namespace: id:_Policy` | **fixed here** |
| 172 | `GroupMembership path:- Subtree` | `SecurityQueries.Memberships` | cannot be anchored (a membership lives under the GROUP node, in any partition — #2011); the count is the multiplier below |
| 103 | `User path:- Exact` | `UserIdentityCache.DirectoryQuery` (`nodeType:User`), `SpaceInviteService.cs:66` / `GroupInviteExtensions.cs:93` (`content.email:`), `EventSubscriptionRunner` for `TriggerNodeType = "User"` | **already pinned** — `UserNodeType.cs:76` registers `nodeType:User → Auth` and `PostgreSqlPartitionedMeshQuery.EnumerateFanOutAsync` consumes the rule; these are the provider's *"ALREADY PINNED … look at the statement itself"* variant (the DB was saturated). Inferred from the code paths — the census counted lines by shape without separating the two variants |
| 53 / 49 / 39 | `Store/Plugin Subtree` / `Thread Exact` / `UiContribution Exact` | `SecurityQueries.GatedNodes` / Plugins `ThreadQueries.cs:43,50` / `UiContributionCatalog.cs:95` | gate map cannot anchor; Plugins; catalog is global |

## Root cause of the fold's share — two defects, one fixed here

1. **The root policy leg had no first segment.** `namespace: id:_Policy nodeType:PartitionAccessPolicy` names the node at exactly `_Policy` (namespace `""` + id), but the Postgres router routes purely by first segment and this shape had none → a `UNION ALL` over all 199 partition schemas, 179× per five minutes, **every one necessarily empty**: an unregistered `_`-prefixed first segment is unroutable, so no write can land a root `_Policy` row on Postgres at all. Now `SecurityQueries.RootPolicy` = `path:_Policy nodeType:PartitionAccessPolicy …` — the same node with a concrete first segment; the router never fans out for it (answers empty today; registering `_Policy` as a global satellite would pin it with no query change). In-memory and static-node providers answer both spellings identically.
2. **The root grants leg never fanned out** — both doc pages' census was wrong about the ROUTER, not the data: `_Access` is a REGISTERED global satellite (`DefaultPartitionProvider` → `system_access`) and `ResolveGlobalSchema` pins a `_`-prefixed first segment through that registry. Reclassified as `SecurityQueries.RootAssignments`; no runtime change.
3. **The multiplier (MeshWeaver.Plugins — named, not changed here):** `PostgreSqlPartitionedMeshQuery.FanOutQuery`'s relevance filter re-runs a fan-out live query for any notification whose `Entity is not MeshNode` (*"unclassifiable — re-query rather than miss it"*), and `PostgreSqlChangeListener.cs:211` builds EVERY cross-process notification with `Entity = null` — the `pg_notify('mesh_node_changes', …)` payload carries only `path` + `op`. On 8 pods 7/8 of all writes are cross-process, so **every write anywhere re-runs every unanchored live query on every pod**. That is why process-wide singletons (memberships, roles, gated types, the root legs, the user directory, UiContribution, every circuit's bell) show 40–450 lines per five minutes. Fix: `node_type` on the notify payload + classify by it (a node type no fan-out query names cannot enter its result set), keeping the fail-safe re-query for a payload without one. Independent of anchoring; removes the multiplier from every surviving fan-out.

## Before / after — fold reads per permission check, per process

- Before: 3 global fan-outs (Roles, Memberships, GatedNodes × gates) + **1 path-less root policy fan-out** + 1 pinned root grants read + 2 pinned per-partition legs.
- After: 3 global fan-outs + **0** path-less root reads + 2 pinned per-partition legs. The 179 `PartitionAccessPolicy path:- Children` lines per five minutes go to zero; no other fold read changes shape, and no read is anchored to the VIEWER (the truncation `UnanchoredSecurityReads` forbids — the root scope has exactly one home).

## Guard

- `SecurityQueryShapesTest`: every fold shape is classified into the router's three real outcomes (`Pinned` / `Unroutable` / `FanOut`); the fan-out set must equal the three declared globals; the four measured `path:-` shapes (`PartitionAccessPolicy … Children`, `AccessAssignment … Children|Exact|Subtree`) are pinned as never described by a fold shape; every path-less fold shape must be a declared global in the log line's own vocabulary; positive controls (per-partition legs pinned) and the negative control (the OLD `namespace: id:_Policy` spelling still classifies as `FanOut`).
- New `SecurityQueryRootLegRegistryTest` (Monolith mesh): the classifier's global-satellite mirror equals the REAL registered `Partition` definitions of a running mesh — `_Access → system_access` registered, `_Policy` not.

## Verified

- `dotnet build -c Release -warnaserror` → `0 Warning(s) 0 Error(s)`: `src/MeshWeaver.Mesh.Contract`, `test/MeshWeaver.Hosting.Test`, `test/MeshWeaver.Graph.Test`, `test/MeshWeaver.Documentation.Test`.
- Whole `test/MeshWeaver.Hosting.Test` (Release, `.trx`), `SecurityQueryScaleTest` (Graph.Test), `DocumentationLinkIntegrityTest` — results in the checklist comment below.

## Docs

- `CrossSchemaFanOutElimination.md`: new **"The 2026-09-02 census"** — the measurement, per-shape attribution, the multiplier, what moved; census row 3 updated.
- `UnanchoredSecurityReads.md`: the two root legs struck from the cannot-anchor table, with the reason.
- What's New (`Category: Fix`): *One fewer mesh-wide question on every page*.

## Deliberately not done here

- The bell (444) and Thread (49) readers live in MeshWeaver.Plugins — plan 1 of the elimination page.
- `AccessAssignment path:- Subtree` (313) and `Email path:- Exact` (278): no builder in either repo; the live-mesh sweep FAILED (`searched:false`), so they are reported unattributed rather than guessed at.
- GroupMembership / Roles / gated types: anchoring is truncation (a group DENY fails open, #2011) — left global on purpose; their line counts are the Plugins-side multiplier above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
