### PR TITLE
fix(gitsync): a green build of the default branch is a publish signal however it was triggered

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginUpdateOnGreenBuild.md
@@ -31,6 +31,47 @@ per installed module:  ModuleVersion changed?
    └── yes ──▶ opted in ? install the delta : raise an "Update available" reminder
 ```
 
+## 🚨 Which green runs count as a publish signal
+
+`workflow_run` fires for far more than a repo's content CI, so the webhook applies **two independent
+guards** before a delivery becomes a `BuildCompletion` (`GitHubWebhookProcessor.ProcessWorkflowRun`):
+
+1. **The trigger must be on the allow-list** — `push`, `repository_dispatch`, `schedule`,
+   `workflow_dispatch`. Each of those means *a build of the default branch's own tree*.
+2. **`head_branch` must BE the repository's default branch.**
+
+Both fail closed: an unknown trigger is refused, and a payload whose branch cannot be read records
+nothing.
+
+| Trigger | Admitted | Why |
+|---|---|---|
+| `push` | ✅ | The branch moved and its CI ran — the original case. |
+| `repository_dispatch` | ✅ | GitHub only ever runs a dispatched workflow from the **default branch**, and `head_sha` is that branch's tip. This is how a platform release re-verifies every satellite repo: no commit to push, same tree, a genuine green verdict on it. |
+| `schedule` | ✅ | Same — a cron run only ever exists on the default branch. |
+| `workflow_dispatch` | ✅ | May target any ref, so guard 2 does the discriminating. On the default branch it is a manual re-verification of that tree, and the only recovery lever when a merge burst cancelled the push-triggered run. |
+| `pull_request` / `pull_request_target` | ❌ | Green **unmerged** code. Note both can report `head_branch=main`, so guard 1 — not guard 2 — is what rejects them. |
+| `dynamic` | ❌ | GitHub's Copilot reviewer. Completes green on the default branch and is not a build at all. |
+| `merge_group` | ❌ | A merge-queue run's `head_branch` is the temporary `gh-readonly-queue/{base}/pr-{n}-{sha}` ref, so guard 2 already rejects it. Listing it would be unreachable. |
+| anything else | ❌ | Fail closed. An allow-list means the next trigger GitHub invents does not publish by accident. |
+
+**Widening the list cannot cause churn.** A sync source already sitting on the built sha is skipped
+("already at this commit"), so a scheduled or dispatched re-verification of an unchanged default
+branch triggers no import at all.
+
+### 🚨 The single-value test that dropped real signals (2026-09-02)
+
+Guard 1 was `event == "push"` — one value, not a set — and it discarded green builds that *were* the
+default branch's tree. `Systemorph/MeshWeaver.Reinsurance`'s `main` built green three times at
+`636ebd5` that day (11:17, 12:27, 12:55Z), every one with `event=repository_dispatch` from the
+release-follow lane, which rebuilds every module against a new platform pin **without a commit to
+push**. All three were dropped, and `Underwriting/_GitSync` on `memex.systemorph.com` sat 38 hours
+behind a merged main — with the webhook armed, every delivery answering 200 OK, and nothing anywhere
+reporting a problem. A dropped publish signal has no symptom except content that quietly stops
+arriving; there is no scheduled poll behind it to paper over the gap, by design.
+
+The decision table above is pinned by `GreenBuildPublishSignalTest`, in both directions — a test that
+only listed the admitted triggers would go green against a gate that admits everything.
+
 ## 🚨 Two inputs, one decision — and which one your installation has
 
 The path above needs a **GitHub webhook on the plugin repo**. An installation that installs from a
@@ -231,7 +272,7 @@ install-time seed.
 
 | Symptom | Cause |
 |---|---|
-| Nothing happens on a green build | The webhook does not send **Workflow runs**; or no catalog's `SourceRepoPath` matches the repo; or the run's conclusion was not `success` — only completed+successful runs are recorded; or the run was **not triggered by a push** (`workflow_run` also fires for `pull_request`, `schedule`, `workflow_dispatch`, … — none of those record); or the run was **not on the repository's default branch** — a green PR-branch build is unmerged code and is deliberately never recorded (fail-closed: a payload with no readable branch records nothing either). |
+| Nothing happens on a green build | The webhook does not send **Workflow runs**; or no catalog's `SourceRepoPath` matches the repo; or the run's conclusion was not `success` — only completed+successful runs are recorded; or the run's **trigger is not on the allow-list** (`push`, `repository_dispatch`, `schedule`, `workflow_dispatch` record; `pull_request`, `dynamic` and anything unknown do not — see *Which green runs count as a publish signal* above); or the run was **not on the repository's default branch** — a green PR-branch build is unmerged code and is deliberately never recorded (fail-closed: a payload with no readable branch records nothing either). |
 | A module never updates, and the log says it "has no module content identity" | The module's `manifest.lock` is missing or unparseable, so there is no `ModuleVersion` to compare and "has it changed" is unanswerable. A missing hash is the **absence of evidence**, not evidence of a change: treating it as changed would re-install the module on every green build of the repo *and* on every pod start, which is acting on the event rather than the content. It is refused, loudly, and the catalog card's manual **Update** stays available. Fix the module's CI to emit the sidecar. |
 | Nothing happens on a green build, **and the log says the delivery "matched NONE of the N sync config(s)"** | No `_GitSync` targets that repository — usually because the repository was **renamed** and the configs still store its old name. The matcher falls back to GitHub's canonical `full_name` (which follows the rename redirect) and repoints the config when it finds one, so this line surviving means the lookup could not be made either: the repository is unreachable with the config creator's credential, or the hook really is installed on a repository this mesh does not sync. The Warning names both sides — the incoming repository and everything it was compared against. |
 | Build node updates but no installation reacts | The package is not installed on that instance. A catalog lists far more packages than any instance installs; only packages with an install record are considered. |

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-rebuilt-repository-syncs-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-rebuilt-repository-syncs-again.md
@@ -1,0 +1,44 @@
+---
+Name: A rebuilt repository syncs again
+Category: Fix
+Description: A content repository whose build was started by something other than a commit — a platform release re-verifying it, a nightly run, a manual re-run — went green without its content ever reaching the spaces that sync it. One space sat 38 hours behind, with every part of the chain reporting success. Those builds now count.
+Icon: ArrowSyncCheckmark
+Order: -20260902
+---
+
+# A rebuilt repository syncs again
+
+Content that lives in a git repository reaches your installation when that repository's **build goes
+green** — never on the merge itself, and never on a timer. The build is the evidence: it is the only
+thing that knows whether what was merged is actually installable, so the space waits for it.
+
+That works exactly as intended when the build was started by a commit. It did not work when the build
+was started by anything else — and increasingly, builds are.
+
+A platform release asks every content repository to rebuild itself against the new platform, to
+confirm it still works. Nightly runs do the same. Someone re-running a build by hand does the same.
+In all three cases the repository builds the *same* branch, the *same* files, and reports the *same*
+green verdict — there is simply no new commit behind it. The chain that listens for green builds was
+looking for a commit, found none, and quietly dropped the result.
+
+Quietly is the problem. Nothing failed: the connection was live, every delivery was accepted, every
+build was green, and every dashboard agreed. The only visible symptom was content that had stopped
+arriving. One space stayed **38 hours** behind a change that had been merged and verified, and it
+would have stayed there indefinitely — there is no background poll behind this to eventually notice,
+because a poll would import content no build had vetted.
+
+**A green build of a repository's main branch now counts as a publish signal however it was
+started** — a commit, a platform release, a schedule, or a person pressing the button. The two things
+that must be true are unchanged, and one of them is now stated rather than implied:
+
+- the build must be of the **main branch's own content** — a pull-request build is unmerged code and
+  is still refused, as is anything that merely *reports* green without building the branch (a
+  code-review bot, for instance);
+- and it must have **passed**.
+
+Anything not on that list is refused rather than admitted, so a new kind of build event cannot start
+publishing by accident.
+
+Re-verifying a repository that has not changed stays silent: a space already holding the built
+version is skipped, so a nightly rebuild of an untouched branch does nothing at all — exactly as
+before.

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -402,6 +402,76 @@ public sealed class GitHubWebhookProcessor
     // ── workflow_run → build-completion record ───────────────────────────────
 
     /// <summary>
+    /// 🚨 <b>The <c>workflow_run</c> triggers that mean "a completed build of THE DEFAULT BRANCH'S
+    /// OWN TREE" — an ALLOW-LIST, so an event name nobody has considered is REFUSED rather than
+    /// admitted.</b> A deny-list here fails open: the next trigger GitHub invents would publish.
+    ///
+    /// <para><b>Why each one is admitted.</b>
+    /// <list type="bullet">
+    /// <item><c>push</c> — the branch moved and its CI ran. The original case.</item>
+    /// <item><c>repository_dispatch</c> — GitHub only ever runs a dispatched workflow from the
+    /// DEFAULT branch, and the run's <c>head_sha</c> is that branch's tip. This is how a platform
+    /// release re-verifies every satellite repo: no commit to push, the same tree, a genuine green
+    /// verdict on it.</item>
+    /// <item><c>schedule</c> — same reason: a cron run only ever exists on the default branch.</item>
+    /// <item><c>workflow_dispatch</c> — may target ANY ref, so it is admitted here and
+    /// DISCRIMINATED by the head_branch check. Aimed at the default branch it is a manual
+    /// re-verification of that tree — and the only recovery lever when a merge burst cancelled the
+    /// push-triggered run.</item>
+    /// </list></para>
+    ///
+    /// <para><b>Deliberately NOT admitted.</b> <c>pull_request</c> / <c>pull_request_target</c> are
+    /// green UNMERGED code; <c>dynamic</c> is GitHub's Copilot reviewer, which completes green on the
+    /// default branch and is not a build at all; anything unknown fails closed. <c>merge_group</c> is
+    /// absent ON PURPOSE — a queue run's <c>head_branch</c> is the temporary
+    /// <c>gh-readonly-queue/{base}/pr-{n}-{sha}</c> ref (measured on this repository's own queue,
+    /// 2026-09-02), so the head_branch guard already rejects it and an entry here would be a line no
+    /// test could reach.</para>
+    ///
+    /// <para>🚨 <b>The measurement that widened this (2026-09-02,
+    /// <c>Systemorph/MeshWeaver.Plugins#1194</c>).</b> The test was <c>event == "push"</c> alone, and
+    /// it DISCARDED REAL PUBLISH SIGNALS. <c>Systemorph/MeshWeaver.Reinsurance</c>'s <c>main</c> built
+    /// green three times at <c>636ebd5</c> — 11:17, 12:27 and 12:55Z — every one of them
+    /// <c>event=repository_dispatch</c> (the release-follow lane, which rebuilds every module against
+    /// a new platform pin without a commit to push). All three were dropped here, and
+    /// <c>Underwriting/_GitSync</c> on <c>memex.systemorph.com</c> sat <b>38 h</b> behind a merged
+    /// main while the webhook was armed and healthy and every delivery answered 200 OK — no error, no
+    /// warning, nothing to grep. (The other half of that incident was a genuinely red push lane,
+    /// where this gate behaved correctly and is meant to.)</para>
+    ///
+    /// <para><b>Widening this cannot cause churn.</b> A sync source already sitting on the built sha
+    /// is skipped by <see cref="SkipReason"/> ("already at this commit"), so a scheduled or dispatched
+    /// re-verification of an unchanged default branch triggers no import at all.</para>
+    /// </summary>
+    private static readonly ImmutableHashSet<string> PublishSignalTriggers =
+        ImmutableHashSet.Create(
+            StringComparer.OrdinalIgnoreCase,
+            "push", "repository_dispatch", "schedule", "workflow_dispatch");
+
+    /// <summary>The admitted triggers as log copy — ordered so the line is stable, built once so the
+    /// rejection log cannot drift from the set it is reporting.</summary>
+    private static readonly string PublishSignalTriggerList =
+        string.Join(", ", PublishSignalTriggers.OrderBy(t => t, StringComparer.Ordinal));
+
+    /// <summary>
+    /// Whether a <c>workflow_run</c> trigger means "a build of the default branch's own tree".
+    /// Fail-closed: an empty, missing or unrecognised event name is NOT a publish signal.
+    /// </summary>
+    /// <remarks>See <see cref="PublishSignalTriggers"/> for why each admitted trigger is admitted,
+    /// and for the 2026-09-02 measurement that replaced the single-value <c>== "push"</c> test.</remarks>
+    internal static bool IsPublishSignalTrigger(string? runEvent)
+        => runEvent is { Length: > 0 } && PublishSignalTriggers.Contains(runEvent);
+
+    /// <summary>
+    /// Whether a run's <c>head_branch</c> IS the repository's default branch — the second, independent
+    /// guard, and the one that discriminates the admitted triggers that can target any ref. Fail-closed:
+    /// a payload whose branch or default branch cannot be read is not publishable.
+    /// </summary>
+    internal static bool IsDefaultBranchBuild(string? headBranch, string? defaultBranch)
+        => headBranch is { Length: > 0 } && defaultBranch is { Length: > 0 }
+           && string.Equals(headBranch, defaultBranch, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// A verified <c>workflow_run</c> → the repository's <see cref="BuildCompletion"/> node.
     ///
     /// <para>GitSync records a FACT and stops there: "repo X built green at sha Y". It does not know
@@ -416,6 +486,12 @@ public sealed class GitHubWebhookProcessor
     /// re-runs of an unchanged tree — because deciding "did anything change" needs content identity,
     /// which is the consumer's business, not the webhook's.</para>
     ///
+    /// <para><b>Two independent guards decide "is this a publish signal".</b> The run's TRIGGER must
+    /// be one of <see cref="PublishSignalTriggers"/> (an allow-list — unknown events fail closed),
+    /// AND its <c>head_branch</c> must be the repository's default branch
+    /// (<see cref="IsDefaultBranchBuild"/>). Neither subsumes the other: the trigger check states the
+    /// requirement, the branch check discriminates the triggers that can target any ref.</para>
+    ///
     /// <para>Written under the SYSTEM identity: the webhook request is anonymous (its authorization
     /// is the verified HMAC signature), so an ambient-identity write would be refused on an
     /// access-gated portal. Same identity model as the issue upsert and the push auto-update.</para>
@@ -429,37 +505,42 @@ public sealed class GitHubWebhookProcessor
         if (!string.Equals(GetString(run, "conclusion"), "success", StringComparison.OrdinalIgnoreCase))
             return Observable.Return(0);
 
-        // 🚨 The run must have been triggered BY A PUSH. `workflow_run` fires for far more than the
-        // repo's content CI: measured on the education hook, GitHub's own Copilot reviewer arrives as
-        // action=completed / conclusion=success with event="dynamic", and every `pull_request` run of
-        // the content workflow arrives green too. Those are green builds of code the default branch
-        // has not accepted; importing on one would publish a feature branch. The branch check below
-        // catches most of them, but only because a PR's head_branch is its source branch — filtering
-        // on the trigger states the actual requirement instead of relying on that coincidence.
+        // 🚨 The run must be a build of THE DEFAULT BRANCH'S OWN TREE, expressed as an ALLOW-LIST of
+        // triggers (see PublishSignalTriggers) — never a deny-list. `workflow_run` fires for far more
+        // than the repo's content CI: measured on the education hook, GitHub's own Copilot reviewer
+        // arrives as action=completed / conclusion=success with event="dynamic", and every
+        // `pull_request` run of the content workflow arrives green too. Those are green builds of code
+        // the default branch has not accepted; importing on one would publish a feature branch. The
+        // branch check below catches most of them, but only because a PR's head_branch is its source
+        // branch — filtering on the trigger states the actual requirement instead of relying on that
+        // coincidence.
         var runEvent = GetString(run, "event") ?? "";
-        if (!string.Equals(runEvent, "push", StringComparison.OrdinalIgnoreCase))
+        if (!IsPublishSignalTrigger(runEvent))
         {
             logger?.LogDebug(
-                "workflow_run webhook: green '{Workflow}' run was triggered by '{Event}', not a push — "
-                + "not a publish signal.", GetString(run, "name"), runEvent);
+                "workflow_run webhook: green '{Workflow}' run was triggered by '{Event}', which is not a "
+                + "build of the default branch's own tree (admitted: {Admitted}) — not a publish signal.",
+                GetString(run, "name"), runEvent, PublishSignalTriggerList);
             return Observable.Return(0);
         }
 
         if (!TryGetRepoUrl(payload, out var repoUrl))
             return Observable.Return(0);
 
-        // 🚨 Only the DEFAULT branch's green builds are publishable. A PR-branch run is green
-        // UNMERGED code — recording it would make the plugin-update watcher offer (or, for an
-        // opted-in record, unattended-install) content the default branch never accepted, at that
-        // branch's sha (Copilot catch). Fail closed: no branch match, no record — a payload whose
-        // branch we cannot read must not become an update either.
+        // 🚨 Only the DEFAULT branch's green builds are publishable — the SECOND, INDEPENDENT guard,
+        // deliberately not folded into the trigger check above. A PR-branch run is green UNMERGED
+        // code — recording it would make the plugin-update watcher offer (or, for an opted-in record,
+        // unattended-install) content the default branch never accepted, at that branch's sha
+        // (Copilot catch). Fail closed: no branch match, no record — a payload whose branch we cannot
+        // read must not become an update either. This is also what discriminates the one admitted
+        // trigger that can target any ref (`workflow_dispatch`), and what already rejects a
+        // merge-queue run, whose head_branch is the temporary `gh-readonly-queue/…` ref.
         var headBranch = GetString(run, "head_branch") ?? "";
         var defaultBranch = payload.TryGetProperty("repository", out var repoElement)
                             && repoElement.ValueKind == JsonValueKind.Object
             ? GetString(repoElement, "default_branch") ?? ""
             : "";
-        if (headBranch.Length == 0 || defaultBranch.Length == 0
-            || !string.Equals(headBranch, defaultBranch, StringComparison.OrdinalIgnoreCase))
+        if (!IsDefaultBranchBuild(headBranch, defaultBranch))
         {
             logger?.LogDebug(
                 "workflow_run webhook for {Repo}: green build on '{Branch}' is not the default branch "

--- a/src/MeshWeaver.GitSync/MeshWeaver.GitSync.csproj
+++ b/src/MeshWeaver.GitSync/MeshWeaver.GitSync.csproj
@@ -12,8 +12,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!-- The settings-tab layout area is internal; the test project renders it directly. -->
+    <!-- The settings-tab layout area is internal; the test project renders it directly.
+         MeshWeaver.GitSync.Test itself lives in MeshWeaver.Plugins since the boots-a-mesh split — it
+         needs a mesh. -->
     <InternalsVisibleTo Include="MeshWeaver.GitSync.Test" />
+    <!-- The webhook's publish-signal predicates are pure functions of a payload and need no mesh, so
+         their decision table is pinned in core (GreenBuildPublishSignalTest) rather than travelling
+         to the satellite with the suite that boots one. -->
+    <InternalsVisibleTo Include="MeshWeaver.Documentation.Test" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/MeshWeaver.Documentation.Test/GreenBuildPublishSignalTest.cs
+++ b/test/MeshWeaver.Documentation.Test/GreenBuildPublishSignalTest.cs
@@ -1,0 +1,200 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using MeshWeaver.GitSync;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// 🚨 The decision table behind "a green build reaches every installation": which
+/// <c>workflow_run</c> deliveries become a <c>BuildCompletion</c> record and trigger the GitSync
+/// import, and which are discarded.
+///
+/// <para><b>Why this lives here, and why it is a pure test.</b> The suite that boots a mesh and
+/// drives <c>GitHubWebhookProcessor.Process</c> end to end (<c>MeshWeaver.GitSync.Test</c>) moved to
+/// MeshWeaver.Plugins with the boots-a-mesh split, and it pins the WIRING — that a green default-branch
+/// run records and imports while a PR-branch one does not. The POLICY — which triggers count as "a
+/// build of the default branch's own tree" — is two pure functions of a payload, needs no mesh, and
+/// is the part that was wrong; so it is pinned in core, next to the code it governs.</para>
+///
+/// <para><b>The failure it exists for (2026-09-02,
+/// <c>Systemorph/MeshWeaver.Plugins#1194</c>).</b> The trigger test was <c>event == "push"</c>, a
+/// single value rather than a set. <c>MeshWeaver.Reinsurance</c>'s <c>main</c> built green three
+/// times at <c>636ebd5</c> that day — 11:17, 12:27 and 12:55Z — every one of them
+/// <c>event=repository_dispatch</c>, because the release-follow lane rebuilds every module against a
+/// new platform pin with no commit to push. All three were discarded, and
+/// <c>Underwriting/_GitSync</c> on <c>memex.systemorph.com</c> stayed 38 hours behind a merged main
+/// with the webhook armed, every delivery 200 OK, and nothing anywhere reporting a problem. A
+/// dropped publish signal has no symptom other than content that quietly stops arriving.</para>
+///
+/// <para>🚨 <b>Every case is stated as data, both directions.</b> A test that only listed the
+/// admitted triggers would go green against a gate that admits EVERYTHING — which is the failure a
+/// deny-list would produce, and the reason the gate is an allow-list.</para>
+/// </summary>
+public class GreenBuildPublishSignalTest
+{
+    private const string Default = "main";
+
+    /// <summary>
+    /// Every trigger admitted as "a build of the default branch's own tree", with why. Stated here
+    /// rather than read off the production set: a test that enumerates its subject's own list
+    /// asserts nothing about what that list should contain.
+    /// </summary>
+    public static TheoryData<string, string> AdmittedTriggers() => new()
+    {
+        { "push", "the branch moved and its CI ran — the original case" },
+        { "repository_dispatch", "only ever runs on the default branch; how a platform release "
+                                 + "re-verifies a satellite with no commit to push (#1194)" },
+        { "schedule", "a cron run only ever exists on the default branch" },
+        { "workflow_dispatch", "may target any ref — admitted here, discriminated by head_branch" },
+    };
+
+    /// <summary>
+    /// Every trigger that must stay REFUSED, with why. <c>merge_group</c> is not here because it is
+    /// rejected one guard later — it has its own case below, asserting the mechanism that rejects it.
+    /// </summary>
+    public static TheoryData<string, string> RefusedTriggers() => new()
+    {
+        { "pull_request", "green UNMERGED code" },
+        { "pull_request_target", "same, with the base repo's token" },
+        { "dynamic", "GitHub's Copilot reviewer — completes green on the default branch, not a build" },
+        { "check_run", "not a build of the tree" },
+        { "issues", "not a build at all" },
+        { "release", "a tag's tree, not necessarily the branch's" },
+        { "deployment", "not a build of the tree" },
+        { "a_trigger_github_has_not_invented_yet", "fail closed: unknown means refused" },
+        { "", "an unreadable event is not a publish signal" },
+    };
+
+    // ── the trigger half ─────────────────────────────────────────────────────
+
+    [Theory]
+    [MemberData(nameof(AdmittedTriggers))]
+    public void AnAdmittedTriggerOnTheDefaultBranch_IsAPublishSignal(string trigger, string why)
+    {
+        Assert.True(GitHubWebhookProcessor.IsPublishSignalTrigger(trigger), $"{trigger}: {why}");
+        Assert.True(IsPublishSignal(trigger, headBranch: Default), $"{trigger}: {why}");
+    }
+
+    [Theory]
+    [MemberData(nameof(RefusedTriggers))]
+    public void ARefusedTrigger_IsNotAPublishSignal_EvenOnTheDefaultBranch(string trigger, string why)
+    {
+        Assert.False(GitHubWebhookProcessor.IsPublishSignalTrigger(trigger), $"{trigger}: {why}");
+        // 🚨 On the DEFAULT branch specifically. The branch guard cannot save us here — a Copilot
+        // review and a pull_request run of the content workflow both report head_branch=main — so if
+        // the trigger guard ever fails open, this is the assertion that catches it.
+        Assert.False(IsPublishSignal(trigger, headBranch: Default), $"{trigger}: {why}");
+    }
+
+    [Fact]
+    public void TheTriggerGuardFailsClosedOnAMissingEvent()
+    {
+        Assert.False(GitHubWebhookProcessor.IsPublishSignalTrigger(null));
+        Assert.False(GitHubWebhookProcessor.IsPublishSignalTrigger(""));
+        Assert.False(GitHubWebhookProcessor.IsPublishSignalTrigger("   "));
+    }
+
+    [Fact]
+    public void TheTriggerGuardIsCaseInsensitive_BecauseTheWireIsNotOurs()
+    {
+        Assert.True(GitHubWebhookProcessor.IsPublishSignalTrigger("Repository_Dispatch"));
+        Assert.True(GitHubWebhookProcessor.IsPublishSignalTrigger("PUSH"));
+        Assert.False(GitHubWebhookProcessor.IsPublishSignalTrigger("Pull_Request"));
+    }
+
+    // ── the branch half: the second, independent guard ───────────────────────
+
+    [Theory]
+    [MemberData(nameof(AdmittedTriggers))]
+    public void AnAdmittedTriggerOffTheDefaultBranch_IsNotAPublishSignal(string trigger, string why)
+    {
+        // A workflow_dispatch aimed at a feature branch is the live shape of this; the others cannot
+        // reach it today, and are asserted anyway so the guard stays independent of that fact.
+        Assert.False(IsPublishSignal(trigger, headBranch: "feat/x"), $"{trigger}: {why}");
+        Assert.False(IsPublishSignal(trigger, headBranch: ""), $"{trigger}: {why}");           // a tag run
+        Assert.False(IsPublishSignal(trigger, headBranch: Default, defaultBranch: ""), why);   // unreadable repo
+    }
+
+    /// <summary>
+    /// 🚨 <c>merge_group</c> is absent from the allow-list ON PURPOSE, and this is the measurement
+    /// that says it may stay absent: a merge-queue run's <c>head_branch</c> is the temporary
+    /// <c>gh-readonly-queue/…</c> ref, so the branch guard rejects it whatever the trigger list says.
+    /// Measured on <c>Systemorph/MeshWeaver</c>'s own queue, 2026-09-02.
+    /// </summary>
+    [Fact]
+    public void AMergeQueueRunIsRejectedByTheBranchGuard_WhichIsWhyItIsNotOnTheAllowList()
+    {
+        const string queueRef = "gh-readonly-queue/main/pr-3143-508c1ee373c66aba2999622fa21c395ffc0a9480";
+        Assert.False(GitHubWebhookProcessor.IsDefaultBranchBuild(queueRef, Default));
+        Assert.False(IsPublishSignal("merge_group", headBranch: queueRef));
+        // …and admitting the trigger would still not publish it — the entry would be unreachable.
+        Assert.False(IsPublishSignal("push", headBranch: queueRef));
+    }
+
+    [Fact]
+    public void TheBranchGuardMatchesCaseInsensitivelyAndFailsClosedOnEitherSideMissing()
+    {
+        Assert.True(GitHubWebhookProcessor.IsDefaultBranchBuild("Main", "main"));
+        Assert.False(GitHubWebhookProcessor.IsDefaultBranchBuild(null, "main"));
+        Assert.False(GitHubWebhookProcessor.IsDefaultBranchBuild("main", null));
+        Assert.False(GitHubWebhookProcessor.IsDefaultBranchBuild("", ""));
+        Assert.False(GitHubWebhookProcessor.IsDefaultBranchBuild("mainline", "main"));
+    }
+
+    // ── the composition is the processor's, not this file's ──────────────────
+
+    /// <summary>
+    /// 🚨 <b>Control arm.</b> Everything above tests two predicates; this asserts that
+    /// <c>ProcessWorkflowRun</c> still CALLS BOTH of them — otherwise a refactor that drops one guard
+    /// leaves every assertion above green while the gate is gone, which is exactly the shape
+    /// AGENTS.md warns about ("a guard whose subject moved and whose roots did not passes having
+    /// checked nothing").
+    /// </summary>
+    [Fact]
+    public void ProcessWorkflowRunStillRunsBothGuards()
+    {
+        var source = File.ReadAllText(Path.Combine(
+            SourceScan.FindRepoRoot(), "src", "MeshWeaver.GitSync", "GitHubWebhookProcessor.cs"));
+
+        var body = MethodBody(source, "private IObservable<int> ProcessWorkflowRun(JsonElement payload)");
+        Assert.Contains("IsPublishSignalTrigger(", body, StringComparison.Ordinal);
+        Assert.Contains("IsDefaultBranchBuild(", body, StringComparison.Ordinal);
+        // The conclusion gate is the third leg of the same decision and is asserted end-to-end by the
+        // mesh suite; pinned here too because losing it would publish RED builds, silently.
+        Assert.Contains("\"success\"", body, StringComparison.Ordinal);
+    }
+
+    /// <summary>The braces-balanced body of the method whose signature line is given.</summary>
+    private static string MethodBody(string source, string signature)
+    {
+        var start = source.IndexOf(signature, StringComparison.Ordinal);
+        Assert.True(start >= 0,
+            $"'{signature}' was not found in GitHubWebhookProcessor.cs — the signature moved, and this "
+            + "guard would otherwise report green having read nothing.");
+
+        var open = source.IndexOf('{', start + signature.Length);
+        Assert.True(open >= 0, "no method body found after " + signature);
+
+        var depth = 0;
+        for (var i = open; i < source.Length; i++)
+        {
+            if (source[i] == '{') depth++;
+            else if (source[i] == '}' && --depth == 0)
+                return source[open..(i + 1)];
+        }
+
+        Assert.Fail("unbalanced braces while reading the body of " + signature);
+        return string.Empty;
+    }
+
+    /// <summary>
+    /// The processor's own composition, in the order it applies it: a delivery publishes when the
+    /// trigger is admitted AND the run is on the default branch.
+    /// </summary>
+    private static bool IsPublishSignal(string trigger, string headBranch, string defaultBranch = Default)
+        => GitHubWebhookProcessor.IsPublishSignalTrigger(trigger)
+           && GitHubWebhookProcessor.IsDefaultBranchBuild(headBranch, defaultBranch);
+}


### PR DESCRIPTION
## What

The `workflow_run` webhook gate tested `event == "push"` — **one value, not a set** — and so
discarded green builds that *were* the default branch's own tree. It becomes an **allow-list** of
triggers that mean "a build of the default branch's own tree", with unknown event names refused.

Origin: investigation of Systemorph/MeshWeaver.Plugins#1194 (no closing keyword — that issue's
*primary* cause was a genuinely red push lane on `MeshWeaver.Reinsurance`, where this gate behaved
correctly and refused to ship a red tree. This PR fixes the **secondary**, separate defect.)

## The measurement (2026-09-02)

`MeshWeaver.Reinsurance`'s `main` built **green three times at `636ebd5`** — 11:17, 12:27, 12:55Z —
every one with `event: repository_dispatch`, from the release-follow lane, which rebuilds every
module against a new platform pin **without a commit to push**. All three were discarded by the
`runEvent != "push"` early return.

`Underwriting/_GitSync` on `memex.systemorph.com` then sat **38 hours** behind a merged main — hook
664846394 armed and healthy, every delivery 200 OK, nothing red anywhere. There is deliberately no
scheduled poll behind this, so a dropped publish signal has no symptom except content that quietly
stops arriving.

## The gate now

Two independent guards, both fail-closed:

| Trigger | Admitted | Why |
|---|---|---|
| `push` | ✅ | The branch moved and its CI ran — the original case. |
| `repository_dispatch` | ✅ | GitHub only ever runs a dispatched workflow from the **default branch**; `head_sha` is that branch's tip. This is how a platform release re-verifies every satellite repo. **The bug.** |
| `schedule` | ✅ | Same — a cron run only ever exists on the default branch. |
| `workflow_dispatch` | ✅ | May target any ref, so the head_branch guard discriminates. On the default branch it is a manual re-verification, and the only recovery lever when a merge burst cancelled the push run. |
| `pull_request` / `pull_request_target` | ❌ | Green **unmerged** code. Both can report `head_branch=main`, so the *trigger* guard is what rejects them. |
| `dynamic` | ❌ | GitHub's Copilot reviewer — completes green on the default branch, not a build at all. |
| anything unknown | ❌ | Fail closed: an allow-list means the next trigger GitHub invents cannot publish by accident. |

**`head_branch == default_branch` is unchanged** and stays the second, independent guard.

### Why `merge_group` is deliberately absent

A merge-queue run's `head_branch` is the temporary
`gh-readonly-queue/{base}/pr-{n}-{sha}` ref, so the branch guard already rejects it. Measured on this
repository's own queue (2026-09-02):

```
event: merge_group
head_branch: gh-readonly-queue/main/pr-3143-508c1ee373c66aba2999622fa21c395ffc0a9480
```

Listing it would be a line no test could ever reach. The test asserts the mechanism that rejects it
instead.

### Widening cannot cause churn

A sync source already sitting on the built sha is skipped by `SkipReason` ("already at this commit"),
so a scheduled or dispatched re-verification of an unchanged default branch triggers **no import at
all**.

## Tests

`test/MeshWeaver.Documentation.Test/GreenBuildPublishSignalTest.cs` — 22 cases. The end-to-end suite
(`MeshWeaver.GitSync.Test`) lives in MeshWeaver.Plugins since the boots-a-mesh split and pins the
*wiring*; this policy is a pure function of a payload, so it is pinned here next to the code. Both
guards are extracted as pure statics (`IsPublishSignalTrigger`, `IsDefaultBranchBuild`) reached via a
new `InternalsVisibleTo`.

The table is stated in **both directions** — a test that only listed the admitted triggers would go
green against a gate that admits everything — plus a **control arm** asserting `ProcessWorkflowRun`
still calls both guards, so a refactor that drops one cannot leave every other assertion green.

**Red-then-green, run locally:**

- allow-list narrowed back to `{"push"}` → `Failed: 4, Passed: 18` (`repository_dispatch`,
  `schedule`, `workflow_dispatch`, case-insensitivity)
- with the fix → `Failed: 0, Passed: 22`
- full project → `Failed: 0, Passed: 233` (includes `DocumentationLinkIntegrityTest` and
  `WhatsNewEntryIntegrityTest`)

Release + `-warnaserror` builds clean for `MeshWeaver.GitSync`, `MeshWeaver.Documentation.Test`,
`MeshWeaver.PluginCatalog` and `Memex.Portal.Shared`.

## Docs

- `Doc/Architecture/PluginUpdateOnGreenBuild` — new section *Which green runs count as a publish
  signal* (the decision table + the 2026-09-02 incident); the failure-modes row no longer claims
  "not triggered by a push".
- What's New entry (`Category: Fix`): *A rebuilt repository syncs again*.

## Follow-up (not in this PR)

`MeshWeaver.Plugins/src/MeshWeaver.GitSync.Test/GitHubWebhookProcessorTest.cs` still passes
unchanged (every one of its assertions covers behaviour this PR preserves), but its docstring for
`Process_WorkflowRun_RecordsOnlyDefaultBranchPushTriggeredGreenBuilds` says "push-triggered" and
would be worth widening with a `repository_dispatch` case in a satellite PR.

Pairs-with: none — no public top-level type is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
