### PR TITLE
fix: "already landed" means this content against this FRAMEWORK (Plugins#931 consumer half)

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -714,11 +714,22 @@ public static class PluginBundleEndpoints
                         // instance can actually serve its bytes, so a consumer never downloads for
                         // a module section that will not be there. Additive: an older client's
                         // BundleRef simply ignores it.
-                        module = modules.TryGetValue(p.PluginId, out var moduleName) ? moduleName : null,
+                        module = modules.TryGetValue(p.PluginId, out var servable)
+                            ? servable.Name : null,
                         // The module's declared platform FLOOR — the consumer's gate (a semver
                         // floor, never MVID equality; the index-level frameworkMvid above stays
-                        // the NodeType lane's strict gate and, for modules, diagnostics).
-                        minMeshVersion = modules.ContainsKey(p.PluginId) ? p.MinMeshVersion : null,
+                        // the NodeType lane's strict gate).
+                        minMeshVersion = servable is null ? null : p.MinMeshVersion,
+                        // 🚨 The framework identity of THIS bundle's MODULE bytes, as their
+                        // producer recorded it at publish (Plugins#931). Not the index-level
+                        // identity above: that is this portal's own bake, and a module is not
+                        // baked here. A consumer compares it against what it has landed, so a
+                        // rebuild of unchanged source against a new platform — which republishes
+                        // under the SAME version — is visible without downloading a byte
+                        // (Plugins#723: without it the updater goes quiet and the fleet cannot
+                        // converge). Additive: a pre-#931 client ignores it, and a pre-#931
+                        // registry simply omits it, which reads as unknown rather than as a match.
+                        frameworkMvid = servable?.FrameworkMvid,
                     }).ToArray(),
                 })))
             .FirstAsync()
@@ -981,23 +992,45 @@ public static class PluginBundleEndpoints
     /// is listed too, deliberately: the index surfaces its <c>minMeshVersion</c> and each
     /// consumer's own gate decides loadability THERE, before a byte travels. One
     /// activation-sidecar read for the whole index.
+    ///
+    /// <para>🚨 Each entry also carries the framework identity the SHELF recorded for those module
+    /// bytes (Plugins#931). It is the producer's value, written when the owning repo's CI published
+    /// them (<c>ModulePublish.Accepted.FrameworkMvid</c> → <c>ShelveModule</c>) — never this
+    /// portal's own bake identity, which the index states separately and which says nothing about a
+    /// module the registry did not build. Without it a consumer cannot tell a REBUILD of the same
+    /// source against a new platform from a no-op, because such a rebuild republishes under the
+    /// same version; that is the whole defect. Null when the producer recorded none, or for a
+    /// module that rides the image and has no sidecar entry — read downstream as "unknown", never
+    /// as "matches", and never inferred from anything.</para>
     /// </summary>
-    private static IObservable<IReadOnlyDictionary<string, string>> ServableModules(
+    private static IObservable<IReadOnlyDictionary<string, ServableModule>> ServableModules(
         IMessageHub rootHub, IReadOnlyList<BundleEntry> packages)
     {
         var landing = rootHub.ServiceProvider.GetService<ModuleLandingService>();
         var declaring = packages.Where(p => !string.IsNullOrWhiteSpace(p.Module)).ToArray();
         if (landing is null || declaring.Length == 0)
-            return Observable.Return<IReadOnlyDictionary<string, string>>(
-                new Dictionary<string, string>());
+            return Observable.Return<IReadOnlyDictionary<string, ServableModule>>(
+                new Dictionary<string, ServableModule>());
 
         return landing.GetActivation().Take(1)
-            .Select(activation => (IReadOnlyDictionary<string, string>)declaring
+            .Select(activation => (IReadOnlyDictionary<string, ServableModule>)declaring
                 .Where(p => ModuleBundleSource.Collect(
                         landing.BaseDirectory, p.Module!, activation)
                     .DeclineReason is null)
-                .ToDictionary(p => p.PluginId, p => p.Module!, StringComparer.OrdinalIgnoreCase));
+                .ToDictionary(
+                    p => p.PluginId,
+                    p => new ServableModule(
+                        p.Module!,
+                        activation.Entries
+                            .FirstOrDefault(e => string.Equals(
+                                e.Name, p.Module, StringComparison.OrdinalIgnoreCase))
+                            ?.FrameworkMvid),
+                    StringComparer.OrdinalIgnoreCase));
     }
+
+    /// <summary>One servable module on the index: its assembly name and the framework identity the
+    /// shelf recorded for its bytes (null = the producer stated none).</summary>
+    private sealed record ServableModule(string Name, string? FrameworkMvid);
 
     /// <summary>
     /// One plugin's bundle: each of its NodeTypes' compiled assemblies, plus the manifest saying

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -159,7 +159,12 @@ names[]}, failure, previous.
   with the platform image's own `dotnet` over the platform image's `/app` — the `s…` surface identity
   the adopting host resolves (#3022), not the tester image's own and not the `g…` provenance stamp of
   one assembly. That is #931's producer half: the record says which framework these bytes are for.
-  The consumer half (comparing it in `ModuleUpdateDecision`) is a separate change.
+  The consumer half landed beside it: the registry advertises a module bundle's identity **per
+  bundle** on `/api/plugins/bundles/index.json`, and `ModuleUpdateDecision` skips as up to date
+  only when the version AND that identity match what is landed — so a rebuild of unchanged
+  source against a new platform, which republishes under the same version, is no longer
+  invisible to the updater ([Modules](../Modules) → "Already landed means this content against
+  this FRAMEWORK").
 
 ### The protocol
 
@@ -357,9 +362,11 @@ No component ever publishes from the mesh router — the router names a spokesma
 ## Roadmap (agreed, in flight)
 
 * **The one-workspace lane** — landed: one `build-workspace` job compiles the ledger's build subset
-  as one graph; pack/tests fan out from it. Still open: the consumer half of #931 (compare the
-  ledger's `platformIdentity` in `ModuleUpdateDecision`), and pinning satellites' `MW_PLATFORM_REF`
-  to the promoted set so keys survive core commits.
+  as one graph; pack/tests fan out from it. The consumer half of #931 landed too —
+  `ModuleUpdateDecision` compares the served bundle's framework identity, not the version alone.
+  Still open: making a bundle that cannot state what it was built against UNPUBLISHABLE (a served
+  identity is optional today, so a consumer can only skip-and-say-so when it is missing), and
+  pinning satellites' `MW_PLATFORM_REF` to the promoted set so keys survive core commits.
 * **`pack-module`, `compile-check` and test verbs inside the tester** — the last runner-side
   `dotnet`/python uses move into the image the fleet already ships.
 * **Self-hosted runners with a mounted git mirror + warm image store** (MeshWeaver#2926): bare

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -538,11 +538,12 @@ transport end to end — there is deliberately no second distribution channel:
    bundle, verifies the **platform floor** (`ModulePlatformFloor.DeclineReason` — the one notion
    of the module platform requirement, checked at the index, at the manifest, and again at
    placement), and lands it through `ModuleLandingService` into `modules/<name>/` with its
-   activation entry (version + floor recorded; the built-against MVID recorded as diagnostics).
-   Deliberately **not** MVID equality — that is bake semantics, the NodeType lane's gate: a
-   module binds by simple name, so a bundle built against an older platform installs ex post on
-   any deployment satisfying its floor. Restart-as-activation as above: `PendingRestart` is the
-   signal, the next restart loads it.
+   activation entry (version + floor recorded, plus the **framework identity the registry
+   advertised for those bytes** — the producer's value, which the update decision reads back).
+   The landing GATE is deliberately **not** MVID equality — that is bake semantics, the NodeType
+   lane's gate: a module binds by simple name, so a bundle built against an older platform
+   installs ex post on any deployment satisfying its floor. Restart-as-activation as above:
+   `PendingRestart` is the signal, the next restart loads it.
 
 ### Auto-update
 
@@ -550,11 +551,43 @@ Store-installed modules **update themselves by default**. The boot reconcile
 (`RegistryUpdateReconciler`) runs a module pass after the content pass: for every installed
 module-declaring package it consults the registry's bundle index and applies the one pure decision
 (`ModuleUpdateDecision`) — a newer version whose **floor this platform satisfies** lands via
-`ModuleLandingService` and flags `PendingRestart`; the same served version is skipped without a
-download; a bundle whose floor **exceeds** the running platform is skipped silently-with-log (it
-becomes installable once the platform has updated, and the same reconcile lands it then). Nothing
-is ever rolled back unattended — and an ordinary platform update needs no module re-land at all:
-landed modules keep loading across platform builds.
+`ModuleLandingService` and flags `PendingRestart`; the same served version **built against the same
+framework** is skipped without a download; a bundle whose floor **exceeds** the running platform is
+skipped silently-with-log (it becomes installable once the platform has updated, and the same
+reconcile lands it then). Nothing is ever rolled back unattended.
+
+#### "Already landed" means this content against this FRAMEWORK
+
+🚨 **A module's version encodes its CONTENT only.** Rebuild the same source against a new platform
+and it republishes under the *same* version — so a reconcile that compared the version alone
+answered "already landed" for an artifact the deployment does not hold, and nothing ever looked
+again (Plugins#931). Measured in Plugins#723: after a platform identity flip the updater landed the
+~12 modules whose versions had moved and then went quiet with no new `MeshWeaver.AI.OpenAI` build,
+because OpenAI's had not; rolling the image anyway crash-looped deterministically (the pre-flip
+build cannot resolve `ProviderModelLister` on the new platform, whose registration had moved) and
+the fleet was held on an old image.
+
+So the skip is keyed on **(version, framework identity)**. The registry records the identity of a
+module's bytes when their owning repo's CI publishes them (`ModulePublish` → `ShelveModule`) and
+advertises it **per bundle** on the index (`BundleRef.FrameworkMvid` — never the index's top-level
+identity, which is the registry's own bake and says nothing about a module it did not build); the
+consumer records what it landed on the activation entry and compares the two before downloading a
+byte.
+
+**The two sides are deliberately not symmetric, and that asymmetry is what stops the fix becoming a
+download loop:**
+
+| landed | served | verdict |
+|---|---|---|
+| known | known, **different** | **Land** — same content, different platform build. The reason names both identities. |
+| **unknown** (entry predates the field) | known | **Land**, once. The landing writes the identity back, so the next reconcile has two known values. |
+| any | **unknown** | **Skip**, and the reason SAYS the identity could not be checked. Landing could never turn "the registry states nothing" into evidence — it would state nothing next time too — so answering Land there re-downloads every module on every reconcile, forever, against any registry that predates the field. |
+| known | known, equal | **Skip** — the genuine no-op, with the framework named. |
+
+The remaining blind spot (a registry that states no identity) is closed **where it is created**, not
+by churning consumers: a bundle that cannot say what it was built against must not be publishable.
+See [Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture) → "Content-addressed outputs" for the
+producer half.
 
 The policy gate is the deployment's **existing update policy — `Admin/UpdatePolicy`**, the same
 single surface that governs the platform image roll; there is no module-specific knob.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-rebuilt-module-reaches-your-installation.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-rebuilt-module-reaches-your-installation.md
@@ -1,0 +1,39 @@
+---
+Name: A rebuilt module reaches your installation
+Category: Fix
+Description: A module rebuilt against a new platform used to republish under the same version, so installations holding the old build answered "already up to date" and never fetched it. The update check now compares the framework the bytes were built against, not just the version.
+Icon: ArrowSync
+Order: -20260902
+---
+
+# A rebuilt module reaches your installation
+
+A module's version describes its **source**. Rebuild the very same source against a new platform
+build and it publishes again under the *same* version — different bytes, identical label. Until now
+an installation's update check compared the version alone, so it answered "already landed", fetched
+nothing, and no later check ever looked again. The installation kept running a build made for a
+platform it no longer runs.
+
+That is not a theoretical gap. After one platform release the updater landed the dozen modules whose
+versions had moved and then went quiet: one AI provider module had been rebuilt but not renumbered,
+so nobody pulled it, and rolling the image anyway crash-looped the portal — the older build could no
+longer find a service the new platform had moved. The fleet sat on the previous image until it was
+sorted out by hand.
+
+The registry now states, per module bundle, which platform build produced its bytes, and the update
+check compares that alongside the version. Concretely:
+
+- **Same version, different platform build** → the module is fetched and lands, and the log line
+  names both builds instead of saying "already landed".
+- **Same version, same platform build** → still skipped without downloading anything, exactly as
+  before.
+- **An installation whose record predates this** → it lands once and records the build, then settles.
+- **A registry too old to state a build** → nothing is downloaded on speculation, and the log says
+  the build could not be checked rather than implying everything matched.
+
+Nothing about *which* modules may be installed changed: the platform floor
+(`minMeshVersion`) is still the only gate on whether a bundle can land. The framework identity only
+answers a different question — whether there is anything new to land at all.
+
+Where the design decisions live: [Modules](/Doc/Architecture/Modules) → "Already landed means this
+content against this FRAMEWORK".

--- a/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleUpdateDecision.cs
@@ -67,6 +67,19 @@ public sealed record ModuleUpdateVerdict(ModuleUpdateAction Action, string? Reas
 /// <c>minMeshVersion</c> expresses. A bundle built against an OLDER platform whose floor this
 /// deployment satisfies LANDS (the ex-post Store install across platform versions the lane exists
 /// for); MVID equality is bake semantics and stays with the NodeType assembly lane.</para>
+///
+/// <para>🚨 <b>The floor decides whether a bundle MAY land; the framework identity decides whether
+/// there is anything NEW to land</b> (Plugins#931 consumer half). Those are different questions and
+/// conflating them is what produced the defect: a module's published version encodes its CONTENT
+/// only, so a rebuild of the same source against a new platform republishes under the SAME version
+/// — and a consumer holding the old bytes answered "already landed" and skipped an update it
+/// needed. Measured in Plugins#723: after a platform identity flip the updater went quiet with no
+/// new <c>MeshWeaver.AI.OpenAI</c> build because its version had not moved, the pre-flip build then
+/// crash-looped in DI on the new platform (<c>OpenAICompatibleModelSync</c> could not resolve
+/// <c>ProviderModelLister</c>, whose registration had moved), and the fleet was held on an old
+/// image. So <see cref="ModuleUpdateAction.SkipUpToDate"/> means <i>this content against this
+/// framework</i>, never <i>this content</i>. The floor is unchanged and still never MVID equality:
+/// an identity difference makes a bundle NEWER, never UNINSTALLABLE.</para>
 /// </summary>
 public static class ModuleUpdateDecision
 {
@@ -114,13 +127,45 @@ public static class ModuleUpdateDecision
     /// <see cref="ModuleActivationBoot"/>'s skip reason). Nothing on the install path acted on it.
     /// This is that action.</para>
     /// </param>
+    /// <param name="bundleFrameworkMvid">
+    /// 🚨 The framework identity the registry states the SERVED module bytes were built against —
+    /// the producer's value, as the bundle index advertises it per bundle
+    /// (<c>PluginBundleClient.BundleRef.FrameworkMvid</c>), compared against
+    /// <see cref="ModuleActivationEntry.FrameworkMvid"/> on the landed entry. This is the input
+    /// that makes "already landed" mean <i>this content against this framework</i>
+    /// (Plugins#931/#723 — see the type doc).
+    ///
+    /// <para><b>The rule: a STATED identity that differs from the landed one LANDS.</b> Ordinal
+    /// equality, and "the entry recorded none" counts as differing — so an entry written before the
+    /// identity was recorded heals by landing once, exactly the shape
+    /// <see cref="ModuleActivationEntry.Version"/> already documents for a pre-field entry.</para>
+    ///
+    /// <para>🚨 <b>The two sides are deliberately NOT symmetric, and the asymmetry is what keeps
+    /// this from looping.</b> Landing can cure an unknown on the LANDED side — it writes back the
+    /// identity that was compared, so the next reconcile has two known values. It can never cure an
+    /// unknown on the SERVED side: a registry that states no identity will state none next time
+    /// either, so answering Land there would re-download every module on every reconcile, forever,
+    /// on every deployment pointed at a pre-#931 registry. That is the loop, and it is not a price
+    /// worth paying for a comparison that would still have nothing to compare.</para>
+    ///
+    /// <para>So an unstated served identity SKIPS — and the verdict SAYS the identity could not be
+    /// checked rather than implying the two agree. It is absence of evidence, not evidence of
+    /// agreement, and the place to remove that blind spot is where it is created: part 3 of the
+    /// agreed shape makes a bundle that cannot state what it was built against unpublishable, so
+    /// the served identity stops being optional at the source instead of being guessed at here.</para>
+    ///
+    /// <para>Defaulting to null is therefore the LEGACY shape (the answer this decision gave before
+    /// Plugins#931), not a fail-safe. Production passes it — <c>PluginBundleClient.AdoptModule</c>
+    /// off <c>BundleRef.FrameworkMvid</c> — and any new caller must.</para>
+    /// </param>
     public static ModuleUpdateVerdict Decide(
         string? bundleVersion,
         string? bundleMinMeshVersion,
         Func<string?, string?> platformGate,
         ModuleActivationEntry? landed,
         string? policyDecline,
-        Func<ModuleActivationEntry, bool> landedBytesPresent)
+        Func<ModuleActivationEntry, bool> landedBytesPresent,
+        string? bundleFrameworkMvid = null)
     {
         if (string.IsNullOrWhiteSpace(bundleVersion))
             return new(ModuleUpdateAction.SkipNoBundle,
@@ -142,23 +187,61 @@ public static class ModuleUpdateDecision
             ? NuGetVersionComparer.Instance.Compare(bundleVersion, landed.Version)
             : (int?)null;
 
-        // Already landed at the served version: nothing travels — PROVIDED the bytes are there.
-        // The version alone still keys the no-op (landed bytes stay loadable across platform
-        // builds, simple-name binding, so there is no "re-land the same version for a new build"
-        // case) — but a version is a claim about the disk, not the disk.
+        // Already landed at the served version: nothing travels — PROVIDED the bytes are there AND
+        // they are the bytes for the framework the registry is serving now. A version is a claim
+        // about the disk, not the disk; and it is a claim about CONTENT, not about the artifact.
         //
-        // 🚨 #2417: this branch used to end here, and that single missing question is what made
-        // the whole lane SELF-SEALING. A recorded version with no assembly behind it answered
+        // 🚨 #2417: this branch used to end at the version. That single missing question is what
+        // made the whole lane SELF-SEALING. A recorded version with no assembly behind it answered
         // "up to date" forever, on every deployment and every reconcile, while the package was in
         // fact half-installed. Note the ordering: SkipUninstalled above still wins, because a
         // disabled entry with no bytes is a completed uninstall, not damage to repair.
+        //
+        // 🚨 Plugins#931/#723: and it used to end at the BYTES. A module rebuilt against a new
+        // platform republishes under the same version, so version equality answered "up to date"
+        // for an artifact this deployment does not hold — the updater went quiet and the fleet
+        // could not converge. The identity is checked AFTER the presence probe on purpose: an
+        // absent assembly is the more actionable diagnosis, and both answers are Land anyway.
         if (landedComparison == 0)
-            return landedBytesPresent(landed!)
-                ? new(ModuleUpdateAction.SkipUpToDate, $"version {bundleVersion} is already landed")
-                : new(ModuleUpdateAction.Land,
+        {
+            if (!landedBytesPresent(landed!))
+                return new(ModuleUpdateAction.Land,
                     $"version {bundleVersion} is recorded as landed but its assembly is ABSENT — "
                     + "the landing never completed or its bytes were lost; re-landing (no restart "
                     + "would have fixed it, and nothing else would ever have looked again)");
+
+            var landedMvid = string.IsNullOrWhiteSpace(landed!.FrameworkMvid)
+                ? null : landed.FrameworkMvid;
+            var servedMvid = string.IsNullOrWhiteSpace(bundleFrameworkMvid)
+                ? null : bundleFrameworkMvid;
+
+            // 🚨 A STATED served identity is the only evidence a rebuild happened; an unstated one
+            // is absence of evidence, and landing could never turn it into evidence — the registry
+            // would say nothing next time too. Hence the asymmetry: unknown on the LANDED side
+            // lands once and heals (the landing writes the identity back), unknown on the SERVED
+            // side skips and SAYS SO. See the parameter doc.
+            if (servedMvid is not null && !string.Equals(landedMvid, servedMvid, StringComparison.Ordinal))
+                // 🚨 The reason NAMES which half differed. "version X is already landed" hiding a
+                // framework mismatch is the exact shape of the bug being fixed here: a verdict
+                // that reads as agreement while the two sides describe different artifacts.
+                return new(ModuleUpdateAction.Land,
+                    $"version {bundleVersion} is landed, but built against framework "
+                    + $"{landedMvid ?? "(unrecorded)"} while the registry serves that same version "
+                    + $"built against {servedMvid} — same content, different platform build; "
+                    + "re-landing so this deployment holds the artifact for the framework it is "
+                    + "being served");
+
+            return new(ModuleUpdateAction.SkipUpToDate,
+                servedMvid is null
+                    // The registry states no framework identity for these bytes. Not agreement —
+                    // no answer. Said out loud, because a bare "already landed" is exactly the
+                    // sentence that made the defect unreadable in the logs it was printing to.
+                    ? $"version {bundleVersion} is already landed; the registry states no framework "
+                      + "identity for it, so a rebuild against a new platform cannot be seen from "
+                      + "here"
+                    : $"version {bundleVersion} is already landed, built against framework "
+                      + $"{servedMvid}");
+        }
 
         // Never roll BACK unattended: a registry serving an older version than what is landed is a
         // deliberate operator situation (a pinned rollback, a lagging registry), and silently

--- a/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginBundleClient.cs
@@ -110,7 +110,30 @@ public sealed class PluginBundleClient
     /// so a consumer can skip an uninstallable bundle without downloading it. Null = none.</param>
     public sealed record BundleRef(
         string Plugin, string Version, string Url, string? Module = null,
-        string? MinMeshVersion = null);
+        string? MinMeshVersion = null)
+    {
+        /// <summary>
+        /// 🚨 The framework identity the registry states THIS bundle's MODULE bytes were built
+        /// against — the producer's value, recorded when the bytes were shelved
+        /// (<c>ModulePublish.Accepted.FrameworkMvid</c> → <c>ModuleLandingService.ShelveModule</c>)
+        /// and surfaced here so a consumer can tell a REBUILD from a no-op without downloading a
+        /// byte (Plugins#931).
+        ///
+        /// <para>Distinct from <see cref="BundleIndex.FrameworkMvid"/>, which is the registry's own
+        /// bake identity and governs the NodeType lane. A module is not baked by the registry: it
+        /// arrives from the CI of the repo that owns it, so its identity is per BUNDLE and the
+        /// index-level one says nothing about it. <see cref="ModuleUpdateDecision"/> compares this
+        /// against <see cref="ModuleActivationEntry.FrameworkMvid"/>.</para>
+        ///
+        /// <para>Null from a registry that predates this field, or for a module whose producer
+        /// recorded no identity — read as "unknown", never as "matches".</para>
+        ///
+        /// <para>An INIT property, not a sixth primary-constructor parameter: adding one replaces a
+        /// public record's constructor signature and is a binary break across the fleet (the same
+        /// rule <c>BundleReader.AssemblyRef.SourceFingerprint</c> follows).</para>
+        /// </summary>
+        public string? FrameworkMvid { get; init; }
+    }
 
     /// <summary>
     /// Reads the registry's bundle index. Emits an empty index rather than throwing when the
@@ -310,7 +333,14 @@ public sealed class PluginBundleClient
                         var verdict = ModuleUpdateDecision.Decide(
                             bundle?.Version, bundle?.MinMeshVersion,
                             ModulePlatformFloor.DeclineReason, entry, declined,
-                            e => ModuleActivationBoot.LandedModuleDllExists(landing.BaseDirectory, e));
+                            e => ModuleActivationBoot.LandedModuleDllExists(landing.BaseDirectory, e),
+                            // 🚨 Plugins#931: the version alone answered "already landed" for an
+                            // artifact this deployment does not hold — a module rebuilt against a
+                            // new platform republishes under the SAME version. The identity the
+                            // registry advertises for these module bytes is the other half of
+                            // "already landed", and it is the value LandFromBundle records below,
+                            // so the two sides converge after one landing.
+                            bundle?.FrameworkMvid);
 
                         if (verdict.Action != ModuleUpdateAction.Land)
                         {
@@ -327,7 +357,8 @@ public sealed class PluginBundleClient
                             .SelectMany(result => result.Bytes is null
                                 ? Miss(pluginId, result.Kind, result.Reason)
                                 : LandFromBundle(
-                                    pluginId, moduleName, packagePath, bundle.Version, result.Bytes));
+                                    pluginId, moduleName, packagePath, bundle.Version, result.Bytes,
+                                    bundle.FrameworkMvid));
                     })))
             .Catch((Exception ex) =>
             {
@@ -353,9 +384,27 @@ public sealed class PluginBundleClient
     /// declining twice is cheaper than debugging a MissingMethodException once). The MVID the
     /// bundle records is logged as DIAGNOSTIC metadata, never refused.
     /// </summary>
+    /// <param name="advertisedFrameworkMvid">
+    /// 🚨 The framework identity the registry advertised for THESE module bytes
+    /// (<see cref="BundleRef.FrameworkMvid"/>) — recorded on the activation entry in preference to
+    /// the archive's manifest-level value, and the reason the update decision converges
+    /// (Plugins#931).
+    ///
+    /// <para>The manifest-level <c>frameworkMvid</c> is the identity the CONSUMER REQUESTED on the
+    /// download URL — the registry stamps the served bundle with the lane it resolved NodeType
+    /// assemblies for. For a module that is the wrong claim: the bytes come off the registry's
+    /// shelf exactly as their producer's CI packed them, whatever lane asked. Recording the
+    /// requested identity is what made the comparison in <see cref="ModuleUpdateDecision"/>
+    /// impossible to converge — every reconcile would re-land, because the entry could never come
+    /// to agree with what the index advertises.</para>
+    ///
+    /// <para>Null falls back to the manifest's value, which is the pre-#931 behaviour and what an
+    /// older registry's index leaves us with.</para>
+    /// </param>
     // Internal for the ModuleFunnelTest pin (InternalsVisibleTo): the land half without HTTP.
     internal IObservable<int> LandFromBundle(
-        string pluginId, string moduleName, string? packagePath, string version, byte[] bundleBytes) =>
+        string pluginId, string moduleName, string? packagePath, string version, byte[] bundleBytes,
+        string? advertisedFrameworkMvid = null) =>
         _httpPool.InvokeBlocking(_ => BundleReader.ReadModule(bundleBytes))
             .SelectMany(payload =>
             {
@@ -393,12 +442,15 @@ public sealed class PluginBundleClient
                     .LandModule(
                         moduleName,
                         files.Select(f => (f.FileName, f.Bytes)).ToArray(),
-                        // Diagnostic metadata (which exact platform build produced these bytes),
-                        // recorded on the activation entry and logged at landing — never a gate.
-                        manifest!.FrameworkMvid,
+                        // Which exact platform build produced these bytes — the registry's
+                        // per-bundle claim first, the archive's requested-lane stamp only as the
+                        // legacy fallback. Still never a LANDING gate (the floor is), but no
+                        // longer merely diagnostic: ModuleUpdateDecision reads it back to tell a
+                        // rebuild from a no-op (Plugins#931).
+                        advertisedFrameworkMvid ?? manifest!.FrameworkMvid,
                         packagePath,
                         version,
-                        manifest.Module?.MinMeshVersion,
+                        manifest!.Module?.MinMeshVersion,
                         // A view pack's wwwroot rides the bundle (#1724's provider serves it from
                         // the module folder); without this the pack lands unstyled and its
                         // collocated JS 404s.

--- a/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
@@ -136,6 +136,12 @@ public class ModulePublishShelfTest : IDisposable
         Assert.Equal("MeshWeaver.Speech", entry.Name);
         Assert.True(entry.Enabled);
         Assert.Equal("999.0.0", entry.MinMeshVersion);
+        // 🚨 The PRODUCER's framework identity survives the publish, verbatim (Plugins#931). The
+        // index projects exactly this per bundle, and a consumer compares it against what it has
+        // landed to tell a rebuild of unchanged source from a no-op — a rebuild republishes under
+        // the SAME version, so if the shelf drops the identity here the whole comparison downstream
+        // silently reads "unknown" and the defect is back.
+        Assert.Equal("test-build", entry.FrameworkMvid);
         Assert.False(list.PendingRestart);
         Assert.True(File.Exists(Path.Combine(
             ModuleLandingService.ModuleDirectoryFor(root, "MeshWeaver.Speech", entry),

--- a/test/Memex.Portal.Shared.Test/ModuleUpdateIdentityTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModuleUpdateIdentityTest.cs
@@ -1,0 +1,269 @@
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>"Already landed" must mean THIS CONTENT AGAINST THIS FRAMEWORK</b> — the consumer half of
+/// Systemorph/MeshWeaver.Plugins#931, pinned pure (no registry, no filesystem, no mesh).
+///
+/// <para><b>The defect.</b> A module's published version encodes its CONTENT only. Rebuild the same
+/// source against a new platform and it republishes under the same version — so
+/// <see cref="ModuleUpdateDecision"/>, which compared the version alone, answered
+/// <see cref="ModuleUpdateAction.SkipUpToDate"/> for an artifact the deployment does not hold, and
+/// nothing ever looked again.</para>
+///
+/// <para><b>It is not hypothetical.</b> Plugins#723: after a platform identity flip, core CD baked
+/// all 53 packages, the portals' updater landed ~12 rebuilt modules whose versions had moved — and
+/// then went quiet with no new <c>MeshWeaver.AI.OpenAI</c> build, because OpenAI's version had not.
+/// Rolling the image anyway crash-looped deterministically (the pre-flip build cannot resolve
+/// <c>ProviderModelLister</c> on the new platform, whose registration had moved) and the fleet was
+/// held on an old image. The updater "went quiet" for exactly the reason pinned below.</para>
+///
+/// <para><b>What the producer half writes.</b> The registry records the framework identity of the
+/// module bytes when their owning repo's CI publishes them (<c>ModulePublish.Accepted</c> →
+/// <c>ModuleLandingService.ShelveModule</c>) and advertises it per bundle on the index
+/// (<c>PluginBundleClient.BundleRef.FrameworkMvid</c>); the consumer records what it landed on
+/// <see cref="ModuleActivationEntry.FrameworkMvid"/>. These tests compare exactly those two.</para>
+///
+/// <para>🚨 The FLOOR is untouched and is still never MVID equality — a differing identity makes a
+/// bundle NEWER, never UNINSTALLABLE. <c>ModuleUpdateDecisionTest</c> (MeshWeaver.Plugins) keeps
+/// the floor, policy and ordering rules; this fixture is only about the identity half.</para>
+/// </summary>
+public class ModuleUpdateIdentityTest
+{
+    private const string Running = "3.2.0";
+
+    /// <summary>The build these bytes came from — the flip's "before".</summary>
+    private const string OldFramework = "s2b488317c0de0000c0de0000c0de0000";
+
+    /// <summary>The build the platform flipped TO — same source, different bytes.</summary>
+    private const string NewFramework = "se0f09bc8f00d0000f00d0000f00d0000";
+
+    /// <summary>The production gate's shape, bound to a fixed running platform version.</summary>
+    private static string? Gate(string? floor) => ModulePlatformFloor.DeclineReason(floor, Running);
+
+    private static ModuleActivationEntry Landed(
+        string? version, string? frameworkMvid, bool enabled = true) => new()
+        {
+            Name = "MeshWeaver.AI.OpenAI",
+            FrameworkMvid = frameworkMvid,
+            Version = version,
+            Enabled = enabled,
+        };
+
+    private static bool BytesPresent(ModuleActivationEntry _) => true;
+
+    private static bool BytesGone(ModuleActivationEntry _) => false;
+
+    private static ModuleUpdateVerdict Decide(
+        string? bundleVersion,
+        ModuleActivationEntry? landed,
+        string? bundleFrameworkMvid,
+        Func<ModuleActivationEntry, bool>? bytes = null) =>
+        ModuleUpdateDecision.Decide(
+            bundleVersion, bundleMinMeshVersion: "3.0.0", Gate, landed, policyDecline: null,
+            bytes ?? BytesPresent, bundleFrameworkMvid);
+
+    /// <summary>The no-op that must stay a no-op: same content, same framework, bytes on disk.</summary>
+    [Fact]
+    public void SameVersion_SameIdentity_Skips()
+    {
+        var verdict = Decide("1.1.0", Landed("1.1.0", OldFramework), OldFramework);
+
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
+        Assert.Contains("1.1.0", verdict.Reason);
+        // The reason states the framework it agreed on — a verdict that merely says "already
+        // landed" is what hid the mismatch in the first place.
+        Assert.Contains(OldFramework, verdict.Reason);
+    }
+
+    /// <summary>
+    /// 🚨 <b>#723, reproduced.</b> The registry serves the SAME version built against a DIFFERENT
+    /// platform: the bytes on this deployment are the pre-flip build, and skipping is what left the
+    /// fleet unable to converge. This is the one case the whole change exists for.
+    /// </summary>
+    [Fact]
+    public void SameVersion_DifferentIdentity_Lands()
+    {
+        var verdict = Decide("1.1.0", Landed("1.1.0", OldFramework), NewFramework);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+        // 🚨 The reason must NAME WHICH HALF DIFFERED. "version 1.1.0 is already landed" concealing
+        // a framework mismatch is the shape of the original bug; a reason that names both
+        // identities is what makes the next incident readable from one log line.
+        Assert.Contains(OldFramework, verdict.Reason);
+        Assert.Contains(NewFramework, verdict.Reason);
+        Assert.Contains("1.1.0", verdict.Reason);
+    }
+
+    /// <summary>
+    /// The convergence proof for the case above: landing records the identity that was compared, so
+    /// the very next reconcile agrees. Without this the fix would trade a silent skip for an
+    /// unbounded re-download.
+    /// </summary>
+    [Fact]
+    public void AfterLanding_TheNextReconcileSkips()
+    {
+        var landed = Landed("1.1.0", OldFramework);
+        Assert.Equal(ModuleUpdateAction.Land, Decide("1.1.0", landed, NewFramework).Action);
+
+        // What PluginBundleClient.LandFromBundle writes: the ADVERTISED identity, not the archive's
+        // requested-lane stamp. That is the whole reason the two sides can ever come to agree.
+        var afterLanding = landed with { FrameworkMvid = NewFramework };
+
+        Assert.Equal(
+            ModuleUpdateAction.SkipUpToDate, Decide("1.1.0", afterLanding, NewFramework).Action);
+    }
+
+    /// <summary>
+    /// An entry written before the identity was recorded. Unknown is NOT a match — landing once
+    /// records it and the reconcile after that is stable, which is the same shape
+    /// <see cref="ModuleActivationEntry.Version"/> already has for a pre-field entry.
+    /// </summary>
+    [Fact]
+    public void SameVersion_LandedIdentityUnknown_Lands()
+    {
+        var verdict = Decide("1.1.0", Landed("1.1.0", frameworkMvid: null), NewFramework);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+        Assert.Contains("unrecorded", verdict.Reason);
+        Assert.Contains(NewFramework, verdict.Reason);
+    }
+
+    /// <summary>
+    /// 🚨 <b>The asymmetry, and the reason it is not symmetric.</b> A registry that states no
+    /// identity offers no evidence a rebuild happened — and landing could never turn that into
+    /// evidence, because the registry would state nothing next time either. Answering Land here
+    /// would re-download every module on every reconcile, forever, on every deployment pointed at a
+    /// pre-#931 registry: the infinite loop, bought for a comparison that still has nothing to
+    /// compare. So it skips — and the verdict SAYS the identity could not be checked, because a
+    /// bare "already landed" is the sentence that hid the defect. The blind spot is closed where it
+    /// is created (part 3 of the agreed shape: a bundle that cannot state what it was built against
+    /// is not publishable), never by churning consumers.
+    /// </summary>
+    [Fact]
+    public void SameVersion_ServedIdentityUnknown_SkipsAndSaysItCouldNotBeChecked()
+    {
+        var verdict = Decide("1.1.0", Landed("1.1.0", OldFramework), bundleFrameworkMvid: null);
+
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
+        Assert.Contains("states no framework identity", verdict.Reason);
+    }
+
+    /// <summary>Neither side states one: the same answer, for the same reason.</summary>
+    [Fact]
+    public void SameVersion_NeitherSideStatesAnIdentity_SkipsButSaysSo()
+    {
+        var verdict = Decide(
+            "1.1.0", Landed("1.1.0", frameworkMvid: null), bundleFrameworkMvid: null);
+
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, verdict.Action);
+        Assert.Contains("states no framework identity", verdict.Reason);
+    }
+
+    /// <summary>
+    /// An empty or blank string is a recorded nothing, not an identity — on EITHER side it must
+    /// read exactly like an absent one. A producer that writes "" would otherwise turn the gate
+    /// back off while looking populated, and a landed "" would land on every reconcile.
+    /// </summary>
+    [Theory]
+    [InlineData("", null, ModuleUpdateAction.SkipUpToDate)]
+    [InlineData(null, "", ModuleUpdateAction.SkipUpToDate)]
+    [InlineData("   ", "  ", ModuleUpdateAction.SkipUpToDate)]
+    [InlineData(OldFramework, "   ", ModuleUpdateAction.SkipUpToDate)]
+    [InlineData("", NewFramework, ModuleUpdateAction.Land)]
+    [InlineData("  ", NewFramework, ModuleUpdateAction.Land)]
+    public void BlankIdentitiesReadAsUnknown_OnBothSides(
+        string? landedMvid, string? servedMvid, ModuleUpdateAction expected)
+        => Assert.Equal(expected, Decide("1.1.0", Landed("1.1.0", landedMvid), servedMvid).Action);
+
+    /// <summary>A version that moved lands regardless of identity — the ordinary update path is
+    /// untouched by this change.</summary>
+    [Fact]
+    public void ANewerVersion_LandsWhateverTheIdentitySays()
+    {
+        Assert.Equal(
+            ModuleUpdateAction.Land,
+            Decide("1.2.0", Landed("1.1.0", OldFramework), OldFramework).Action);
+        Assert.Equal(
+            ModuleUpdateAction.Land,
+            Decide("1.2.0", Landed("1.1.0", OldFramework), NewFramework).Action);
+    }
+
+    /// <summary>
+    /// 🚨 An identity difference must never become a DOWNGRADE. The registry serving an older
+    /// version is an operator situation, and a differing framework does not make rolling back
+    /// unattended any more this lane's call than it was before.
+    /// </summary>
+    [Fact]
+    public void AnOlderServedVersion_IsStillNeverRolledBack()
+    {
+        var verdict = Decide("1.0.0", Landed("1.1.0", OldFramework), NewFramework);
+
+        Assert.Equal(ModuleUpdateAction.SkipOlder, verdict.Action);
+    }
+
+    /// <summary>
+    /// Ordering: the ABSENT-assembly diagnosis (#2417) wins over the identity one. Both answer
+    /// Land, so nothing is lost — but "its assembly is ABSENT" is the actionable sentence, and a
+    /// half-installed module must not be reported as a framework mismatch.
+    /// </summary>
+    [Fact]
+    public void AbsentBytes_AreReportedAsAbsent_NotAsAnIdentityMismatch()
+    {
+        var verdict = Decide("1.1.0", Landed("1.1.0", OldFramework), NewFramework, BytesGone);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+        Assert.Contains("ABSENT", verdict.Reason);
+    }
+
+    /// <summary>
+    /// A deliberately uninstalled module stays uninstalled. The identity check sits INSIDE the
+    /// same-version branch, below the uninstall check, so an operator's choice is never overturned
+    /// by a platform rebuild.
+    /// </summary>
+    [Fact]
+    public void AnUninstalledModule_IsNotReinstalledByAnIdentityDifference()
+    {
+        var verdict = Decide(
+            "1.1.0", Landed("1.1.0", OldFramework, enabled: false), NewFramework);
+
+        Assert.Equal(ModuleUpdateAction.SkipUninstalled, verdict.Action);
+    }
+
+    /// <summary>
+    /// A FIRST landing is unaffected: there is no recorded identity to disagree with, and the
+    /// never-landed branch already lands.
+    /// </summary>
+    [Fact]
+    public void ANeverLandedModule_LandsAsBefore()
+    {
+        var verdict = Decide("1.1.0", landed: null, NewFramework);
+
+        Assert.Equal(ModuleUpdateAction.Land, verdict.Action);
+        Assert.Contains("never landed here", verdict.Reason);
+    }
+
+    /// <summary>
+    /// 🚨 The omitted argument is the LEGACY shape, stated on purpose so nobody reads the default
+    /// as a safety net. Omitting it is indistinguishable from a registry that states no identity,
+    /// which is exactly the pre-#931 answer — so every caller must pass it, and the one production
+    /// caller (<c>PluginBundleClient.AdoptModule</c>, off <c>BundleRef.FrameworkMvid</c>) does.
+    /// The parameter is optional rather than required only because the six-argument form is called
+    /// from a suite in another repository (<c>ModuleUpdateDecisionTest</c>, MeshWeaver.Plugins) and
+    /// a platform change must not red a satellite's whole CI to land.
+    /// </summary>
+    [Fact]
+    public void OmittingTheIdentityArgument_IsTheLegacyAnswer_NotASafetyNet()
+    {
+        var legacy = ModuleUpdateDecision.Decide(
+            "1.1.0", "3.0.0", Gate, Landed("1.1.0", OldFramework), policyDecline: null,
+            BytesPresent);
+
+        Assert.Equal(ModuleUpdateAction.SkipUpToDate, legacy.Action);
+        Assert.Equal(
+            Decide("1.1.0", Landed("1.1.0", OldFramework), bundleFrameworkMvid: null).Reason,
+            legacy.Reason);
+    }
+}


### PR DESCRIPTION
## The defect

A module's published version encodes its **content** only. Rebuild the same source against a new
platform and it republishes under the *same* version — so `ModuleUpdateDecision`, which compared the
version alone (`ModuleUpdateDecision.cs:157`), answered `SkipUpToDate` for an artifact the
deployment does not hold, and nothing on the lane ever looked again.

Measured, not reasoned — Systemorph/MeshWeaver.Plugins#723: after a platform identity flip the
updater landed the ~12 modules whose versions had moved and then **went quiet** with no new
`MeshWeaver.AI.OpenAI` build, because OpenAI's version had not moved. Rolling the image anyway
crash-looped deterministically (the pre-flip build cannot resolve `ProviderModelLister` on the new
platform, whose registration had moved) and the fleet was held on an old image.

Refs Systemorph/MeshWeaver.Plugins#931 (and #723, absorbed into it).

## What #3135 had already done, and what it had not

#3135 landed the **producer** half: `.github/scripts/module-build-{key,ledger}.py` and
`ModuleBuildRecord.PlatformIdentity` — the CI ledger records the platform framework identity a
module was built against, so two builds of the same content against two platforms are two keys.
`ModuleBuildArchitecture.md` said so explicitly: *"The consumer half (comparing it in
`ModuleUpdateDecision`) is a separate change."* That is this PR.

Nothing in #3135 touched the runtime distribution path, and the identity was **not reachable from
the consumer at all**: the index carried only the registry's own bake identity (top-level
`frameworkMvid`), `BundleRef` carried none, and the value the consumer recorded at landing was the
identity it had **requested** on the download URL — not what the module was built against. Comparing
those two would never have converged.

## The change

1. **The registry advertises a module bundle's framework identity PER BUNDLE**
   (`/api/plugins/bundles/index.json` → `bundles[].frameworkMvid`), read off the shelf entry its
   publisher wrote (`ModulePublish.Accepted.FrameworkMvid` → `ShelveModule`). Deliberately *not* the
   index's top-level identity — that is the registry's own bake, and a module is not baked there; it
   arrives from the CI of the repo that owns it. Additive both ways: an older client ignores it, an
   older registry omits it.
2. **`ModuleUpdateDecision.Decide` compares (version, identity)** before answering `SkipUpToDate`,
   and the reason string **names which half differed** — a verdict reading as agreement while the
   two sides describe different artifacts is the shape of the original bug.
3. **`LandFromBundle` records the ADVERTISED identity** on the activation entry, in preference to
   the archive's manifest-level value. This is what makes the comparison converge: after one landing
   the two sides agree by construction.

The platform **floor** is untouched and is still never MVID equality — an identity difference makes
a bundle *newer*, never *uninstallable*.

## The absent-identity case, and why it is asymmetric

Requested explicitly in review, so here is the reasoning rather than the rule.

Only one side can be **healed by landing**. Landing writes back the identity that was compared, so
an unknown on the **landed** side becomes known after one fetch. It can never cure an unknown on the
**served** side: a registry that states no identity will state none next time either.

| landed | served | verdict |
|---|---|---|
| known | known, **different** | **Land** — reason names both identities |
| **unknown** (pre-field entry) | known | **Land**, once — then it records the identity and settles. Same shape `ModuleActivationEntry.Version` already documents for a pre-field entry |
| any | **unknown** | **Skip**, and the reason says the identity *could not be checked* |
| known | known, equal | **Skip** — the genuine no-op, with the framework named |

Row 3 is the one that needs defending. It is *not* "unknown treated as a match": the verdict refuses
to imply agreement and says out loud that the registry stated nothing. Answering `Land` there would
re-download **every module on every reconcile, forever**, on every deployment pointed at a registry
that predates the field — the loop, bought for a comparison that still has nothing to compare. The
blind spot is closed **where it is created** — part 3 of the agreed shape in #931, making a bundle
that cannot state what it was built against unpublishable — not by churning consumers. That is
recorded in the roadmap section of `ModuleBuildArchitecture.md` as the remaining open item.

The new parameter is optional (defaulting to the legacy answer) rather than required: the six-argument
form is called ~20 times by `ModuleUpdateDecisionTest` in **MeshWeaver.Plugins**, and a platform
change must not red a satellite's whole CI to land. `OmittingTheIdentityArgument_IsTheLegacyAnswer_NotASafetyNet`
pins that the default is the legacy shape so nobody reads it as a safety net; the one production
caller passes it.

## Tests — red then green

`test/Memex.Portal.Shared.Test/ModuleUpdateIdentityTest.cs` (the core-side home of the module
distribution lane, beside `ModulePublishShelfTest` / `PluginBundle*Test`), plus one assertion in
`ModulePublishShelfTest` that the shelf preserves the producer's identity verbatim — the input the
index projects.

RED (the identity comparison stubbed out, everything else identical) — **8 failed, 12 passed**:

```
Failed …ModuleUpdateIdentityTest.SameVersion_DifferentIdentity_Lands
       Expected: Land   Actual: SkipUpToDate
Failed …ModuleUpdateIdentityTest.SameVersion_LandedIdentityUnknown_Lands
Failed …ModuleUpdateIdentityTest.SameVersion_ServedIdentityUnknown_SkipsAndSaysItCouldNotBeChecked
Failed …ModuleUpdateIdentityTest.SameVersion_NeitherSideStatesAnIdentity_SkipsButSaysSo
Failed …ModuleUpdateIdentityTest.SameVersion_SameIdentity_Skips
Failed …ModuleUpdateIdentityTest.AfterLanding_TheNextReconcileSkips
Failed …ModuleUpdateIdentityTest.BlankIdentitiesReadAsUnknown_OnBothSides(landedMvid: "", …expected: Land)
Failed …ModuleUpdateIdentityTest.BlankIdentitiesReadAsUnknown_OnBothSides(landedMvid: "  ", …expected: Land)
```

GREEN with the fix: `Passed! - Failed: 0, Passed: 20` for the two fixtures, and
`Passed! - Failed: 0, Passed: 58` for the whole `PluginBundle*`/`Module*` subset of
`Memex.Portal.Shared.Test`. `MeshWeaver.Documentation.Test` link/embed/What's-New integrity green.
Release + `-warnaserror` builds clean for `MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`,
`Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test`, `MeshWeaver.PluginTester`,
`MeshWeaver.ComboAssembler`, `MeshWeaver.ComboVerifier`.

Coverage: same version + same identity ⇒ skip; same version + different identity ⇒ Land (#723's
repro); landed-unknown ⇒ Land once; served-unknown ⇒ skip-and-say-so; both unknown ⇒ ditto; blank
strings read as unknown on both sides; convergence after landing; a newer version still lands; an
older served version is still never rolled back; absent bytes are still reported as absent (#2417
keeps its ordering); an uninstalled module is not resurrected by an identity difference; a first
landing is unchanged.

## Cross-repo

No public type removed → the `Cross-repo pair (public surface)` gate does not apply.
`Pairs-with: none` — the change is additive in both directions. MeshWeaver.Plugins'
`MeshWeaver.PluginCatalog.Test` keeps compiling (`Decide` 6-arg, `LandFromBundle` 5-arg) and keeps
passing (it passes no served identity, which is the skip branch); no assertion there reads the
up-to-date reason string.

**Opened as a draft on purpose** — `auto-arm.yml` arms every non-draft PR for the merge queue, and
this one is not to be merged without a maintainer look: it changes what the module updater does on
every installation, and the fleet-wide consequence of an identity moving is a re-land of every
affected module.

## Docs

`Doc/Architecture/Modules` gains "Already landed means this content against this FRAMEWORK" (the
decision table and the reason for the asymmetry); `ModuleBuildArchitecture` has its roadmap and the
producer-half note corrected; What's New entry `A rebuilt module reaches your installation`
(`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RYNsBU7fcFsvvo6wLNinGP
