### PR TITLE
ci: take a module's own test suite off its consumers' critical path

### DIFF
--- a/.github/scripts/node-repo-pack-verify.py
+++ b/.github/scripts/node-repo-pack-verify.py
@@ -52,6 +52,18 @@ carries the bundle it attests and the closure evidence its build resolved, and a
 either is refused here rather than trusted because of where its step happened to sit in the job.
 🚨 None of this touches the module's TESTS: the marker is still dropped BEFORE them (#2710,
 Plugins#937) so a red suite cannot read as "bundle missing" to a gate that only composes.
+
+🚨 …BUT THE SUITE ITSELF IS ACCOUNTED FOR HERE TOO, because it no longer always runs in the pack
+job. On a run that PUBLISHES, the suite stays inline in `pack` so a red suite can never publish;
+on a run that does not, it runs in a `tests` job beside the pack matrix, so a caller whose gates
+consume only the bundle artifact does not wait 12.7 minutes for a verdict they never read
+(MeshWeaver.Plugins run 33656010754). Two mutually exclusive conditions can BOTH be false, and a
+suite that ran in neither lane renders exactly like one that passed — so each pack receipt records
+which lane OWNS its suite (`tests`: `none` | `inline` | `lane`), the tests lane drops a receipt of
+its own, and `--test-receipts` / `--tests-result` make the pairing checkable: a delegated module
+with no test receipt, a test receipt for a module that delegated nothing, and a tests lane that
+did not succeed are each RED, under this job's own unchanged context name. `bundles-built` is
+deliberately untouched by all of it.
 """
 from __future__ import annotations
 
@@ -265,6 +277,78 @@ def bundles_built(expected: list[str], built: set[str], declared: set[str] | Non
     return True, (f"bundles-built: true — {len(want)} of {len(want)} selected bundle(s) exist as "
                   f"this call's artifacts, each recording the bundle and the closure it was "
                   f"composed from" + aside)
+
+
+def own_receipts(receipts: dict[str, dict], lane: str,
+                 declared: set[str] | None) -> dict[str, dict]:
+    """The receipts THIS call produced — the same two filters `verify` applies internally, exposed
+    so the test-lane accounting below sees exactly the set the count gate counted."""
+    out = receipts
+    if lane:
+        out = {m: r for m, r in out.items() if r.get("lane") == lane}
+    if declared is not None:
+        out = {m: r for m, r in out.items() if m in declared}
+    return out
+
+
+def test_lane(receipts: dict[str, dict], test_receipts: dict[str, dict], broken: list[str],
+              tests_result: str) -> tuple[list[str], list[str]]:
+    """(errors, notes) — did every suite this call DELEGATED actually run?
+
+    🚨 THE FAILURE THIS EXISTS TO CATCH IS "NEITHER LANE RAN IT". The suite runs inline in `pack`
+    when the call publishes and in the `tests` job when it does not; those two `if:` conditions are
+    complements today and one edit away from both being false, at which point nothing is red and
+    nothing is missing — a suite simply stops existing. So the answer is not read off a condition:
+    the pack leg WRITES which lane owns its suite and the tests lane WRITES that it ran one, and
+    this pairs them.
+
+    `tests_result` is `needs.tests.result`. A lane that FAILED is red here as well as on its own
+    job, so the lane's one stable context still goes red on a red suite — which is the whole
+    reason moving the suite off the critical path does not move it out of the gate. An empty
+    string means the caller did not ask for this accounting (an older workflow against a newer
+    script) and the check stands down, saying so."""
+    errors: list[str] = []
+    notes: list[str] = []
+    if not tests_result:
+        return errors, notes
+
+    delegated = sorted(m for m, r in receipts.items() if r.get("tests") == "lane")
+    ran = sorted(test_receipts)
+
+    if tests_result not in ("success", "skipped"):
+        errors.append(f"the module TEST lane reported '{tests_result}' — the suites run beside the "
+                      f"pack matrix on a non-publishing run, and a red suite must red this context "
+                      f"exactly as it did when it ran inside the pack job. Read that job.")
+    if broken:
+        errors.append(f"{len(broken)} test receipt file(s) could not be read as a receipt: "
+                      + ", ".join(broken))
+    if delegated and tests_result == "skipped":
+        errors.append(f"{len(delegated)} module(s) delegated their suite to the tests lane and that "
+                      f"lane did NOT RUN AT ALL (result: skipped) — the suite ran in neither lane, "
+                      f"which renders exactly like one that passed: " + ", ".join(delegated))
+    missing = sorted(set(delegated) - set(ran))
+    if missing and tests_result != "skipped":
+        errors.append(f"{len(missing)} module(s) delegated their suite to the tests lane but no "
+                      f"test receipt arrived for them — the suite did not get to the end: "
+                      + ", ".join(missing))
+    # A test receipt for a module whose OWN pack receipt says the suite belongs elsewhere: the two
+    # halves of the switch disagree. Modules with no pack receipt at all are not judged here — that
+    # is already the count gate's finding, and blaming the suite for it would misname the cause.
+    disagree = sorted(m for m in ran
+                      if m in receipts and receipts[m].get("tests") != "lane")
+    if disagree:
+        errors.append(f"{len(disagree)} module(s) ran a suite in the tests lane while their own "
+                      f"pack receipt says the suite was "
+                      + ", ".join(f"{m} ({receipts[m].get('tests')!r})" for m in disagree)
+                      + " — the two halves of the switch disagree, so one of them is wrong about "
+                        "where the verdict came from.")
+    if not errors:
+        inline = sorted(m for m, r in receipts.items() if r.get("tests") == "inline")
+        none = sorted(m for m, r in receipts.items() if r.get("tests") == "none")
+        notes.append(f"suites: {len(delegated)} ran in the tests lane beside the pack matrix, "
+                     f"{len(inline)} inline in the pack job (this call publishes, so a red suite "
+                     f"cannot publish), {len(none)} not owed a run by the selection")
+    return errors, notes
 
 
 def parse_declared(text: str) -> set[str] | None:
@@ -518,6 +602,57 @@ def self_test() -> int:
               code == 1 and any("ZERO" in e and "receipts arrived" in e for e in errors),
               f"{errors}")
 
+        # ── THE TESTS LANE ────────────────────────────────────────────────────────────────
+        # 🚨 Every case here is a mutation of a green run in which the suites ran BESIDE the pack
+        # matrix. The one that matters most is the SKIP: two mutually exclusive `if:`s can both be
+        # false, and "the suite ran nowhere" is otherwise indistinguishable from "the suite passed".
+        print("the tests lane — the suite may move off the critical path, never out of the gate:")
+
+        def packr(mode: str) -> dict[str, dict]:
+            return {m: {"lane": "floor-abc123", "module": m, "tests": mode} for m in three}
+
+        def testr(modules) -> dict[str, dict]:
+            return {m: {"lane": "floor-abc123", "module": m, "tests": "lane",
+                        "suite": "present", "result": "passed"} for m in modules}
+
+        delegated, ran = packr("lane"), testr(three)
+        errs, nts = test_lane(delegated, ran, [], "success")
+        check("every delegated suite has a receipt and the lane is green ⇒ pass",
+              not errs and bool(nts), f"{errs}")
+        for bad in ("failure", "cancelled"):
+            errs, _ = test_lane(delegated, ran, [], bad)
+            check(f"a {bad.upper()} tests lane reds this context — the gate MOVED, it did not "
+                  f"vanish", any(f"reported '{bad}'" in e for e in errs), f"{errs}")
+        errs, _ = test_lane(delegated, {}, [], "skipped")
+        check("delegated suites + a SKIPPED lane ⇒ red: the suite ran in NEITHER lane, which "
+              "renders exactly like one that passed",
+              any("did NOT RUN AT ALL" in e for e in errs), f"{errs}")
+        errs, _ = test_lane(delegated, testr(m for m in three if m != "MeshWeaver.Mcp"), [],
+                            "success")
+        check("a delegated module whose suite never reached its receipt ⇒ red, naming it",
+              any("MeshWeaver.Mcp" in e and "no test receipt" in e for e in errs), f"{errs}")
+        errs, _ = test_lane(packr("inline"), ran, [], "success")
+        check("a test receipt for a module whose pack receipt says the suite ran INLINE ⇒ red "
+              "(the two halves of the switch disagree)",
+              any("disagree" in e for e in errs), f"{errs}")
+        errs, _ = test_lane(delegated, ran, ["MeshWeaver.Ghost.json"], "success")
+        check("a corrupt test receipt is not a receipt ⇒ red, naming the file",
+              any("could not be read" in e for e in errs), f"{errs}")
+
+        print("…and the shapes that must stay GREEN, so the gate is not merely loud:")
+        errs, nts = test_lane(packr("inline"), {}, [], "skipped")
+        check("a PUBLISHING run — every suite inline, the lane deliberately skipped ⇒ pass",
+              not errs and bool(nts), f"{errs}")
+        errs, nts = test_lane(packr("none"), {}, [], "skipped")
+        check("a selection that owes no test run at all + a skipped lane ⇒ pass",
+              not errs and bool(nts), f"{errs}")
+        errs, nts = test_lane(delegated, {}, [], "")
+        check("no --tests-result ⇒ the accounting stands down (an older caller against a newer "
+              "script), silently adding nothing", not errs and not nts, f"{errs}")
+        errs, _ = test_lane({}, ran, [], "success")
+        check("test receipts whose pack legs produced NO receipt are the COUNT gate's finding, "
+              "not this one's — it must not misname the cause", not errs, f"{errs}")
+
     if failures:
         print(f"\n::error title=node-repo-pack-verify self-test failed::{len(failures)} case(s) — "
               "this gate is the only thing standing between a narrowed matrix and a silently "
@@ -528,8 +663,11 @@ def self_test() -> int:
           "receipt LANE cases (own stamp counts, a sibling lane's does not — even for a module "
           "both calls declared), 12 built-marker cases (foreign lane, unstamped, no closure, no "
           "bundle, corrupt, zero markers — every one fail-closed — plus #2710's red-suite "
-          "survival), and 5 empty-selection cases including the scope=full contradiction lock — "
-          "all green.")
+          "survival), 5 empty-selection cases including the scope=full contradiction lock, and 11 "
+          "TESTS-LANE cases (a failed or cancelled lane is red, a skipped lane with delegated "
+          "suites is red because the suite then ran NOWHERE, a missing or corrupt test receipt is "
+          "red, the inline/lane halves disagreeing is red — and the publishing, nothing-owed, "
+          "older-caller and pack-failed shapes must stay green) — all green.")
     return 0
 
 
@@ -556,6 +694,15 @@ def main() -> int:
                    help="directory the module-built-* markers were merged into; with --github-output, "
                         "writes bundles_built=true|false — the receipt-independent 'this call built "
                         "a complete, composable bundle' claim")
+    p.add_argument("--test-receipts", default="", dest="test_receipts",
+                   help="directory the module-tests-receipt-* artifacts were merged into — the "
+                        "positive evidence that a DELEGATED suite ran. Paired with --tests-result.")
+    p.add_argument("--tests-result", default="", dest="tests_result",
+                   help="the tests lane's aggregated result (needs.tests.result). A lane that did "
+                        "not succeed is RED here too, so a red suite still reds this context; a "
+                        "SKIPPED lane with delegated suites is red because the suite then ran "
+                        "nowhere. Empty ⇒ the caller does not run a tests lane and the check "
+                        "stands down.")
     p.add_argument("--github-output", default="", dest="github_output",
                    help="the $GITHUB_OUTPUT file to append bundles_built to")
     p.add_argument("--self-test", action="store_true", dest="self_test")
@@ -579,6 +726,21 @@ def main() -> int:
         if args.github_output:
             with open(args.github_output, "a", encoding="utf-8") as fh:
                 fh.write(f"bundles_built={'true' if ok else 'false'}\n")
+
+    # 🚨 AFTER the bundles-built answer and deliberately unable to change it: a red suite must red
+    # THIS context and must NOT read as "bundle missing" to a gate that only composes the bundle
+    # (#2710, Plugins#937). Those are two different questions and this is the second one.
+    if args.test_receipts or args.tests_result:
+        declared_set = parse_declared(args.declared)
+        t_receipts, t_broken = (read_receipts(Path(args.test_receipts))
+                                if args.test_receipts else ({}, []))
+        t_errors, t_notes = test_lane(own_receipts(receipts, args.lane, declared_set),
+                                      own_receipts(t_receipts, args.lane, declared_set),
+                                      t_broken, args.tests_result)
+        notes.extend(t_notes)
+        errors.extend(t_errors)
+        if t_errors:
+            code = 1
     for note in notes:
         print(f"✓ {note}")
     for error in errors:

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -72,6 +72,43 @@ name: node-repo module pack
 # A caller that ships neither scripts/affected-modules.py nor scripts/project-closure.py is simply
 # not narrowable: the scope script says FULL and says why. Nothing to opt into, nothing to skip.
 #
+# ──────────── Where the module's own suite runs (`pack` inline vs the `tests` lane) ────────────
+# 🚨 A CONSUMER THAT ONLY WANTS THE BUNDLE MUST NOT WAIT FOR THE SUITE. A `needs:` on a `uses:`
+# job waits for the WHOLE called workflow, so anything inside the last job of this lane is on the
+# critical path of every gate the caller hangs off it. Measured on MeshWeaver.Plugins run
+# 33656010754 (a 39-minute PR): `Module bundle (MeshWeaver.AI)` ran 13.4 minutes, of which 12.7
+# were `Run the module's tests` and 0.2 were the build — so the bundle ARTIFACT the two required
+# gates compose was ready 0.2 minutes in, and they started at 32.8. It also blocks the RETRY loop:
+# a run cannot be re-run until it completes, so a flaked portal-host shard waits out a suite whose
+# verdict nobody is reading.
+#
+# So the suite's position is decided by `publish`, the input that already means "trunk" here:
+#
+#   * `publish: true`  — the suite runs INLINE in `pack`, after the bundle upload and BEFORE the
+#     hand-over. That ordering buys exactly one property, and it is worth its cost here: a failing
+#     suite never publishes, and every installation reads what the registry serves.
+#   * `publish: false` — the hand-over step cannot fire at all (its own `if:` is `inputs.publish
+#     && …`), so the ordering protects nothing. The suite runs in the `tests` job, in PARALLEL
+#     with select → prepare → build-workspace → pack, and the lane finishes when the slower of the
+#     two ends instead of when their sum does.
+#
+# It is a switch on the INPUT, not on `github.event_name`: this repo's own main-cd calls the lane
+# with `publish: false` for the bake's compose set, and that call is not a pull request — it wants
+# the fast path for the same reason, because it publishes nothing either.
+#
+# 🚨 THE SUITE STILL GATES, and not because a comment says so:
+#   * the `tests` job is part of this called workflow, so a red suite fails the caller's `uses:`
+#     job exactly as a red inline suite did;
+#   * `verify` — `All selected bundles built`, this lane's one stable context and the one a repo's
+#     protection requires — `needs:` the tests lane and is RED when it did not succeed. No context
+#     is renamed and no protection changes;
+#   * and a suite that ran in NEITHER lane is caught by receipts rather than by re-reading the two
+#     conditions: every pack receipt records which lane owns its suite, the tests lane drops a
+#     receipt of its own, and `node-repo-pack-verify.py` fails when the two disagree.
+#
+# `bundles-built` is untouched: it still answers from the built markers dropped before any suite,
+# so a red suite still does not read as "bundle missing" to a gate that only COMPOSES the bundle.
+#
 # ─────────────────── Which compiler builds a module (`build`) ───────────────────
 # 🚨 "we want to use memex build plugin and not dotnet build" (maintainer, 2026-08-31).
 #
@@ -389,7 +426,8 @@ on:
           the tests, recording the bundle it attests and the closure evidence the build resolved.
           This is the claim a caller's gate should depend on when it only COMPOSES the bundles: a
           red suite in this call must not read as "bundle missing" there (Plugins #937 — one AI
-          flake turned both required gates red). Nothing about the test run reaches it.
+          flake turned both required gates red). Nothing about the test run reaches it — whether
+          the suite ran inline in `pack` (a publishing run) or in the `tests` lane beside it.
           🚨 It FAILS CLOSED. Zero markers, a marker stamped with another call's lane, an unstamped
           one, and one that does not record what it attests are all "not built" for the module in
           question — a truthy answer derived from absent or foreign evidence is the defect this
@@ -413,6 +451,11 @@ jobs:
       # The SUBSET the one-workspace build compiles — every entry the ledger did not hand a reusable
       # bundle for. The postcondition in build-workspace is fed the SAME list.
       build-modules: ${{ steps.ledger.outputs.build }}
+      # The SUBSET whose own test suite must RUN in this call — the entries the pack job's plan
+      # would answer `need_test=true` for. It is the `tests` job's matrix; see that job for why
+      # the suites are a lane of their own on a non-publishing run.
+      test-modules: ${{ steps.suites.outputs.modules }}
+      test-count: ${{ steps.suites.outputs.count }}
       count: ${{ steps.scope.outputs.count }}
       selected: ${{ steps.scope.outputs.selected }}
       scope: ${{ steps.scope.outputs.scope }}
@@ -609,6 +652,36 @@ jobs:
               exit 1
               ;;
           esac
+
+      # ───────────── WHICH OF THE SELECTION STILL OWES A TEST RUN ─────────────
+      # The `tests` job's matrix. The predicate is EXACTLY the one the pack job's `Ledger — this
+      # entry's plan` step answers as `need_test`, restated here because a matrix has to be known
+      # before the job it drives exists:
+      #
+      #     need_test = (ledger says REUSE) ? ledger.needTest : (entry.test != false)
+      #
+      # 🚨 TWO PLACES COMPUTING ONE PREDICATE IS A DRIFT RISK, SO THE VERIFIER CROSS-CHECKS THEM
+      # rather than trusting them to agree: the pack leg records in its receipt which lane owns its
+      # suite (`tests: none|inline|lane`), the tests lane drops a receipt of its own, and
+      # `node-repo-pack-verify.py` fails the run when a module the pack leg DELEGATED has no test
+      # receipt, or a test receipt arrives for a module that delegated nothing. A drift between
+      # these two expressions therefore surfaces as a RED count gate naming the module, never as a
+      # suite that quietly did not run.
+      - name: Which selected modules still owe a test run
+        id: suites
+        env:
+          SELECTION: ${{ steps.ledger.outputs.modules }}
+        run: |
+          set -euo pipefail
+          printf '%s' "${SELECTION:-[]}" > "$RUNNER_TEMP/final.json"
+          jq -c '[ .[] | select(
+                    if (.ledger.decision // "build") == "reuse"
+                    then (.ledger.needTest == true)
+                    else (.test != false) end) ]' "$RUNNER_TEMP/final.json" > "$RUNNER_TEMP/suites.json"
+          count=$(jq 'length' "$RUNNER_TEMP/suites.json")
+          echo "modules=$(cat "$RUNNER_TEMP/suites.json")" >> "$GITHUB_OUTPUT"
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+          echo "$count of $(jq 'length' "$RUNNER_TEMP/final.json") selected module(s) still owe a test run: $(jq -r 'if length == 0 then "<none>" else [.[].module] | join(", ") end' "$RUNNER_TEMP/suites.json")"
 
   # ─────────────────── THE SHARED BUILD ENVIRONMENT, WARMED ONCE ───────────────────
   # "see we update *once at beginning for everyone* and not by module" (maintainer, 2026-08-31).
@@ -1734,18 +1807,33 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+      # ═══════ THE SUITE, INLINE — ON A PUBLISHING RUN ONLY (see the `tests` job below) ═══════
       # 🚨 Only when THIS diff reaches the module (or on a full run): a floor-only entry — built
       # because the caller's gates compose it — carries test=false from the selection, and its
       # suite is skipped rather than answering a question nobody asked. The AI engine's suite
       # (~13 min, 1,600 tests) ran on every PR that never touched AI until 2026-08-29.
-      # Runs AFTER the bundle artifact and its built marker exist and BEFORE the hand-over: a
-      # failing suite never publishes — and never un-builds.
-      # The built module DLL as a run-scoped artifact, IMMEDIATELY — this is what lets a
       # `need_test`: the entry's own `test` flag AND, with the ledger on, "no earlier run recorded a
       # verdict for this key" — a reused Tested/Published bundle is not re-tested.
+      #
+      # 🚨 AND ONLY WHEN THIS CALL PUBLISHES. Inline, the suite sits AFTER the bundle upload and
+      # BEFORE the hand-over, and the property that buys is exactly one: *a failing suite never
+      # publishes*. That property is worth its cost on a trunk/release-follow run, where the step
+      # below POSTs these bytes to the registry and every installation then reads them. It buys
+      # NOTHING on a run with `publish: false` — the hand-over step's own `if:` cannot fire there,
+      # so there is nothing for the ordering to protect, and the ordering instead costs every
+      # consumer of this call the whole suite: a `needs:` on a `uses:` job waits for the WHOLE
+      # called workflow, so MeshWeaver.Plugins' two required gates, which consume only the bundle
+      # ARTIFACT, waited 12.7 minutes for a MeshWeaver.AI suite they never read (run 33656010754:
+      # the bundle was ready 0.2 min into a 13.4-minute job; the gates started at 32.8 min).
+      #
+      # So on a non-publishing run the suite moves to the `tests` job below and runs in PARALLEL
+      # with prepare → build-workspace → pack instead of after them. The two are mutually
+      # exclusive by construction (`inputs.publish` here, `!inputs.publish` there), the leg
+      # RECORDS which of them owned its suite in the receipt, and `verify` refuses a run where
+      # the two disagree — a suite may not silently belong to neither.
       - name: Run the module's tests, when it ships any
         id: tests
-        if: ${{ matrix.entry.test != false && steps.plan.outputs.need_test == 'true' }}
+        if: ${{ inputs.publish && matrix.entry.test != false && steps.plan.outputs.need_test == 'true' }}
         env:
           PROJECT: ${{ matrix.entry.project }}
           # 🚨 THE TRAIL A FLAKE LEAVES. A red here on a diff that cannot reach the module is a
@@ -1792,7 +1880,7 @@ jobs:
       # phase trace, the straggler captures and any dump. A green run uploads nothing — the point
       # is that the ONE red run in five leaves something to read instead of a re-run button.
       - name: Keep the failing suite's evidence
-        if: ${{ failure() && matrix.entry.test != false }}
+        if: ${{ failure() && inputs.publish && matrix.entry.test != false }}
         env:
           PROJECT: ${{ matrix.entry.project }}
         run: |
@@ -1812,7 +1900,7 @@ jobs:
           fi
           echo "kept $(ls "$out" | wc -l | tr -d ' ') file(s):"; ls -la "$out" | head -40
       - name: Upload the failing suite's evidence
-        if: ${{ failure() && matrix.entry.test != false }}
+        if: ${{ failure() && inputs.publish && matrix.entry.test != false }}
         uses: actions/upload-artifact@v7
         with:
           name: test-evidence-${{ matrix.entry.module }}-${{ github.run_id }}-${{ github.run_attempt }}
@@ -1930,17 +2018,27 @@ jobs:
           VERSION: ${{ steps.identity.outputs.version }}
           COMPILER: ${{ steps.plan.outputs.decision == 'reuse' && 'reused' || steps.build.outputs.compiler }}
           PUBLISHED: ${{ inputs.publish }}
+          # 🚨 WHICH LANE OWNS THIS MODULE'S SUITE, written down rather than inferred from an `if:`
+          # nobody can read after the fact. `none` — the selection says this entry owes no test run
+          # (a floor-only entry, or a ledger record that already carries a verdict); `inline` — the
+          # step above ran it in this job, which is what a PUBLISHING run does so a red suite can
+          # never publish; `lane` — this call does not publish, so the `tests` job ran it beside
+          # this one. `verify` pairs every `lane` against a test receipt and fails when one is
+          # missing: two mutually exclusive conditions can BOTH be false, and this is what makes
+          # that impossible to do quietly.
+          TESTS: ${{ steps.plan.outputs.need_test != 'true' && 'none' || (inputs.publish && 'inline' || 'lane') }}
           LEDGER_KEY: ${{ steps.plan.outputs.key }}
           LEDGER_DECISION: ${{ steps.plan.outputs.decision }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/receipts"
-          [ -n "$LANE" ] || { echo "::error::the lane key is empty — the select job did not produce one, so this receipt could not be attributed to this call."; exit 1; }
+          [ -n "$LANE" ]  || { echo "::error::the lane key is empty — the select job did not produce one, so this receipt could not be attributed to this call."; exit 1; }
+          [ -n "$TESTS" ] || { echo "::error::this leg recorded no owner for $MODULE's suite — a receipt that cannot say whether the suite ran here, ran in the tests lane, or was not owed leaves 'it ran nowhere' reading as green."; exit 1; }
           jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
-                --arg v "$VERSION" --arg c "$COMPILER" \
+                --arg v "$VERSION" --arg c "$COMPILER" --arg t "$TESTS" \
                 --argjson pub "$PUBLISHED" \
                 --arg lk "$LEDGER_KEY" --arg ld "$LEDGER_DECISION" \
-             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, published:$pub, ledger:{key:$lk, decision:$ld}}' \
+             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, tests:$t, published:$pub, ledger:{key:$lk, decision:$ld}}' \
              > "$RUNNER_TEMP/receipts/$MODULE.json"
           cat "$RUNNER_TEMP/receipts/$MODULE.json"
       - name: Upload the receipt
@@ -1961,6 +2059,238 @@ jobs:
           MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
         run: python3 meshweaver/.github/scripts/module-build-ledger.py finish --key "$KEY"
 
+  # ════════ THE MODULE SUITES — A LANE OF THEIR OWN ON A NON-PUBLISHING RUN ════════
+  # 🚨 THE MEASUREMENT THIS JOB EXISTS FOR (MeshWeaver.Plugins run 33656010754, a 39-minute PR):
+  #
+  #    19.1 -> 32.5  Module bundles (floor) / Module bundle (MeshWeaver.AI)   <-- 13.4 min
+  #                    12.7 min  Run the module's tests, when it ships any
+  #                     0.2 min  Build the module — and say which compiler produced it
+  #    32.5 -> 32.7  Module bundles (floor) / All selected bundles built
+  #    32.8 -> 37.0  Compile every NodeType (vs core)          (a REQUIRED context)
+  #    32.9 -> 38.6  test-repos / Compile + render node repos  (the Tests-area gate)
+  #
+  # The bundle ARTIFACT — the only thing those two gates consume — was ready 0.2 minutes in. The
+  # gates waited another 12.7 for a suite they never read, because a `needs:` on a `uses:` job
+  # waits for the WHOLE called workflow, and the suite sat inside the last job of it. The floor
+  # call exists precisely so the gates do not wait for the other 30 bundles (Plugins#892); the
+  # suite put the wait straight back.
+  #
+  # It costs a SECOND thing, measured 2026-09-02: a run cannot be re-run until it fully completes
+  # (`gh run rerun --failed` answers "This workflow is already running"). So when a portal-host
+  # shard flakes, the retry is blocked by a suite whose verdict nobody is waiting on — every flake
+  # pays it, which makes the recovery loop the compounding half of the cost.
+  #
+  # 🚨 WHY IT IS SAFE TO RELAX HERE AND NOT ON TRUNK. Inline, the suite's position buys exactly one
+  # property: a failing suite never publishes. On a run with `publish: false` the hand-over step
+  # cannot fire at all — its own `if:` is `inputs.publish && …` — so the ordering protects nothing
+  # and delays everything. On a publishing run it protects the registry, and every installation
+  # reads what the registry serves, so there the suite stays INLINE and this job does not run. The
+  # switch is `inputs.publish`, not the event name: `publish` is the input that already means
+  # "trunk" by this file's caller contract, and core's own main-cd calls this lane with
+  # `publish: false` for the bake's compose set — that call gets the fast path and is not a PR.
+  #
+  # 🚨 IT IS NOT A WAY TO STOP TESTING, AND THREE THINGS MAKE THAT STRUCTURAL:
+  #   1. This job is part of THIS called workflow, so a red suite fails the CALLER's `uses:` job
+  #      exactly as a red inline suite did.
+  #   2. `verify` — the lane's one stable context, `All selected bundles built`, the context a
+  #      repo's protection requires — `needs:` this job and goes RED when it did not succeed. The
+  #      name is unchanged and so is what a red suite does to it.
+  #   3. A suite that silently ran NOWHERE is caught by receipts, not by reading a condition: the
+  #      pack leg records which lane owns its suite, this job drops a receipt of its own, and
+  #      node-repo-pack-verify.py fails when a delegated module has no test receipt (or a test
+  #      receipt arrives for a module that delegated nothing). Two mutually exclusive `if:`s can
+  #      BOTH be false; the receipts are what make that impossible to do quietly.
+  #
+  # `bundles-built` is deliberately untouched: it still answers from the built markers dropped
+  # before any suite, so a red suite still does not read as "bundle missing" to a gate that only
+  # COMPOSES the bundle (#2710, Plugins#937).
+  tests:
+    name: Module tests (${{ matrix.entry.module }})
+    # 🚨 `select` ONLY — not prepare, not build-workspace, not pack. The suite is a `dotnet test`
+    # against the content checkout with `-p:MeshWeaverRoot=<the platform checkout>`; it consumes
+    # no platform image, no workspace build and no bundle. Depending on any of them would put it
+    # back on the very chain this job exists to run beside.
+    needs: select
+    # 🚨 The exact COMPLEMENT of the inline step's `inputs.publish &&`, on the same input. A
+    # matrix with zero vectors does not evaluate, so `test-count` is asserted the way `pack`
+    # asserts `count` — and `verify` runs unconditionally and refuses the pairing when a
+    # delegated suite produced no receipt, which is what keeps this from being a skip-trapdoor.
+    if: >-
+      !inputs.publish
+      && needs.select.result == 'success'
+      && needs.select.outputs.test-count != '0'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    strategy:
+      # One module's red suite must not hide the rest — a sweep wants every verdict in one run.
+      fail-fast: false
+      matrix:
+        entry: ${{ fromJson(needs.select.outputs.test-modules) }}
+    steps:
+      - name: Resolve the content repository's credential
+        id: content-repo
+        if: inputs.content-repository != ''
+        env:
+          REPO: ${{ inputs.content-repository }}
+          APP_ID: ${{ secrets.content-app-id }}
+          APP_KEY: ${{ secrets.content-app-private-key }}
+        run: |
+          set -euo pipefail
+          [ -n "$APP_ID" ]  || { echo "::error::content-repository is '$REPO' but secrets.content-app-id is empty — the caller's GITHUB_TOKEN cannot read another repository, so the checkout would 404. Pass a GitHub App installed on '$REPO' with Contents: Read."; exit 1; }
+          [ -n "$APP_KEY" ] || { echo "::error::content-repository is '$REPO' but secrets.content-app-private-key is empty — see content-app-id."; exit 1; }
+          echo "owner=${REPO%%/*}" >> "$GITHUB_OUTPUT"
+          echo "name=${REPO#*/}"   >> "$GITHUB_OUTPUT"
+      - name: Mint a read token for the content repository
+        id: content-token
+        if: inputs.content-repository != ''
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.content-app-id }}
+          private-key: ${{ secrets.content-app-private-key }}
+          owner: ${{ steps.content-repo.outputs.owner }}
+          repositories: ${{ steps.content-repo.outputs.name }}
+          permission-contents: read
+      - uses: actions/checkout@v7
+        with:
+          repository: ${{ inputs.content-repository || github.repository }}
+          ref: ${{ inputs.content-ref || github.sha }}
+          token: ${{ steps.content-token.outputs.token || github.token }}
+      - name: Check out Systemorph/MeshWeaver at the pinned ref
+        uses: actions/checkout@v7
+        with:
+          repository: Systemorph/MeshWeaver
+          ref: ${{ inputs.platform-ref }}
+          path: meshweaver
+      # 🚨 UNCONDITIONAL, and the log says why. `dotnet-sdk: by-declaration` exists so a job that
+      # compiles nothing on the runner stops installing an SDK by reflex — but this job's ONLY
+      # work is `dotnet test`, a verb the platform image's build-project does not have at all. So
+      # the SDK is a declared consumer here whichever way the caller's flag reads, and saying so
+      # out loud is the point: the flag chooses a COMPILER, it never chooses whether to verify.
+      - name: The .NET SDK is this job's one declared need
+        env:
+          POLICY: ${{ inputs.dotnet-sdk }}
+          MODULE: ${{ matrix.entry.module }}
+        run: |
+          set -euo pipefail
+          case "$POLICY" in
+            install|by-declaration) ;;
+            *) echo "::error::inputs.dotnet-sdk is '$POLICY'. The only values are 'install' (the default) and 'by-declaration'. An unreadable flag must NEVER resolve to 'do not install' — that is a skipped check wearing a green tick."; exit 1 ;;
+          esac
+          echo ".NET SDK on the runner: INSTALLED — policy '$POLICY'; this job's one declared consumer is the module's own suite ('dotnet test' for $MODULE), which the pinned platform image cannot run."
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: "10.0.x"
+      # The same command, the same evidence trail and the same tolerance for a module that ships
+      # no suite as the inline step in `pack` — this is a MOVE, not a rewrite. See that step for
+      # what each environment variable buys when a flake has to be diagnosed from the artifacts.
+      - name: Run the module's tests, when it ships any
+        id: tests
+        env:
+          PROJECT: ${{ matrix.entry.project }}
+          MESHWEAVER_TEST_FILE_LOGS: "1"
+          DOTNET_DbgEnableMiniDump: "1"
+          DOTNET_DbgMiniDumpType: "2"
+          DOTNET_DbgMiniDumpName: /tmp/coredumps/%e-%p.dmp
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/coredumps
+          tests="$(dirname "$PROJECT").Test"
+          if [ -d "$tests" ]; then
+            echo "suite=present" >> "$GITHUB_OUTPUT"
+            dotnet test "$tests" -c Release -warnaserror \
+              -p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver \
+              --logger "trx;LogFileName=ledger.trx" --results-directory "$RUNNER_TEMP/trx"
+          else
+            echo "suite=absent" >> "$GITHUB_OUTPUT"
+            echo "no test project at $tests — nothing to run"
+          fi
+      - name: Ledger — Tested
+        if: inputs.ledger == 'required' && steps.tests.outcome == 'success' && matrix.entry.ledger.key != ''
+        env:
+          KEY: ${{ matrix.entry.ledger.key }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: |
+          set -euo pipefail
+          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Tested --trx "$RUNNER_TEMP/trx/ledger.trx"
+      - name: Keep the failing suite's evidence
+        if: ${{ failure() }}
+        env:
+          PROJECT: ${{ matrix.entry.project }}
+        run: |
+          set -uo pipefail
+          tests="$(dirname "$PROJECT").Test"
+          out="$RUNNER_TEMP/test-evidence"; mkdir -p "$out"
+          find "$tests" -path '*/test-logs/*.log' -print0 2>/dev/null | while IFS= read -r -d '' f; do
+            cp "$f" "$out/" || true
+          done
+          [ -f /tmp/meshweaver-test-trace.log ] && cp /tmp/meshweaver-test-trace.log "$out/_meshweaver-test-trace.log" || true
+          [ -f /tmp/meshweaver-msg-trace.log ] && cp /tmp/meshweaver-msg-trace.log "$out/_meshweaver-msg-trace.log" || true
+          if compgen -G '/tmp/coredumps/*.dmp' > /dev/null; then
+            sudo chmod a+r /tmp/coredumps/*.dmp || true
+            cp /tmp/coredumps/*.dmp "$out/" || true
+            dotnet --list-runtimes > "$out/_runtimes.txt" 2>/dev/null || true
+          fi
+          echo "kept $(ls "$out" | wc -l | tr -d ' ') file(s):"; ls -la "$out" | head -40
+      - name: Upload the failing suite's evidence
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-evidence-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/test-evidence
+          if-no-files-found: ignore
+          retention-days: 14
+          compression-level: 9
+      # ─────────── THE TEST RECEIPT — positive evidence that this suite RAN ───────────
+      # 🚨 The whole reason the split is allowed to exist. Two mutually exclusive `if:`s can BOTH
+      # evaluate false, and a suite that ran in neither lane renders exactly like one that passed.
+      # So the pack leg records which lane OWNS its suite (`tests: none|inline|lane` in its
+      # receipt), this job records that the lane actually ran it, and `verify` refuses a run where
+      # the two do not line up — naming the module. Lane-stamped for the same reason as every
+      # other artifact here: artifacts are RUN-WIDE and a repo may call this lane twice.
+      # LAST step on purpose: a receipt means the suite got here green.
+      - name: Drop the test receipt
+        env:
+          LANE: ${{ needs.select.outputs.lane }}
+          PACKAGE: ${{ matrix.entry.package }}
+          MODULE: ${{ matrix.entry.module }}
+          SUITE: ${{ steps.tests.outputs.suite }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/test-receipts"
+          [ -n "$LANE" ]  || { echo "::error::the lane key is empty — the select job did not produce one, so this receipt could not be attributed to this call and the verifier would refuse it anyway."; exit 1; }
+          [ -n "$SUITE" ] || { echo "::error::the suite step recorded neither 'present' nor 'absent' for $MODULE — a receipt that cannot say whether a suite existed attests nothing."; exit 1; }
+          jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" --arg s "$SUITE" \
+             '{lane:$l, package:$p, module:$m, tests:"lane", suite:$s, result:"passed"}' \
+             > "$RUNNER_TEMP/test-receipts/$MODULE.json"
+          cat "$RUNNER_TEMP/test-receipts/$MODULE.json"
+      - name: Upload the test receipt
+        uses: actions/upload-artifact@v7
+        with:
+          name: module-tests-receipt-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}
+          path: ${{ runner.temp }}/test-receipts/*.json
+          retention-days: 1
+          if-no-files-found: error
+      # Best-effort, exactly as in `pack`: the script exits 0 with a ::warning when the registry is
+      # unavailable, and `|| true` keeps this leg's own failure as the job's verdict.
+      - name: Ledger — Failed
+        if: failure() && inputs.ledger == 'required' && matrix.entry.ledger.key != ''
+        env:
+          KEY: ${{ matrix.entry.ledger.key }}
+          MODULE: ${{ matrix.entry.module }}
+          MW_LEDGER_URL: ${{ inputs.registry-url }}
+          MW_LEDGER_TOKEN: ${{ secrets.ledger-token }}
+          MW_LEDGER_LANE: ${{ needs.select.outputs.lane }}
+        run: |
+          set -uo pipefail
+          printf 'the module suite failed in the tests lane — %s/%s/actions/runs/%s\n' "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$GITHUB_RUN_ID" > "$RUNNER_TEMP/failure.txt"
+          trx="$RUNNER_TEMP/trx/ledger.trx"
+          trxarg=()
+          if [ -f "$trx" ]; then trxarg=(--trx "$trx"); fi
+          python3 meshweaver/.github/scripts/module-build-ledger.py record --key "$KEY" --status Failed --phase test \
+            --failure-file "$RUNNER_TEMP/failure.txt" ${trxarg[@]+"${trxarg[@]}"} || true
+
   # ═══════════════ THE COUNT GATE — one STABLE context, on every run ═══════════════
   # 🚨 A dynamic matrix cannot be a fixed list of required status checks: the per-module contexts
   # appear and disappear with the diff, so requiring one means requiring a context that will
@@ -1971,9 +2301,14 @@ jobs:
   #
   # `if: always()` because the failure it exists to catch is a SKIP, and a job that skips when the
   # thing it watches skipped watches nothing.
+  # 🚨 IT IS ALSO WHERE A RED SUITE LANDS. Since the suites may run beside `pack` rather than
+  # inside it (the `tests` job above), this job `needs:` BOTH and asserts both: a failed or
+  # cancelled tests lane is RED here, under the same context name a repo's protection already
+  # requires, and a module whose pack leg DELEGATED its suite but produced no test receipt is RED
+  # too. Moving the suite off the consumer's critical path may not move it out of the gate.
   verify:
     name: All selected bundles built
-    needs: [select, pack]
+    needs: [select, pack, tests]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -2018,18 +2353,29 @@ jobs:
           pattern: module-built-${{ needs.select.outputs.lane }}-*
           merge-multiple: true
           path: ${{ runner.temp }}/built
+      # The suites' own positive evidence, when they ran in the `tests` lane. Same rule as above:
+      # a pattern matching nothing must REACH the verifier as zero evidence, never fail here — a
+      # delegated suite with no receipt is precisely the finding.
+      - name: Collect the test receipts
+        uses: actions/download-artifact@v8
+        continue-on-error: true
+        with:
+          pattern: module-tests-receipt-${{ needs.select.outputs.lane }}-*
+          merge-multiple: true
+          path: ${{ runner.temp }}/test-receipts
       - name: Exactly the selected bundles were built
         id: verify
         env:
           EXPECTED: ${{ needs.select.outputs.selected }}
           PACK_RESULT: ${{ needs.pack.result }}
+          TESTS_RESULT: ${{ needs.tests.result }}
           SCOPE: ${{ needs.select.outputs.scope }}
           COUNT: ${{ needs.select.outputs.count }}
           DECLARED: ${{ inputs.modules }}
           LANE: ${{ needs.select.outputs.lane }}
         run: |
           set -euo pipefail
-          echo "scope=$SCOPE, selection named $COUNT module bundle(s); pack job: $PACK_RESULT"
+          echo "scope=$SCOPE, selection named $COUNT module bundle(s); pack job: $PACK_RESULT, tests lane: $TESTS_RESULT"
           # 🚨 An INDEPENDENT recount, because the count and the selection come from the same
           # call and therefore agree by construction — they cannot catch a selection that is
           # simply wrong. This one has a second source: on a FULL scope the answer must be every
@@ -2078,6 +2424,8 @@ jobs:
             --declared "$DECLARED" \
             --lane "$LANE" \
             --built "$RUNNER_TEMP/built" \
+            --test-receipts "$RUNNER_TEMP/test-receipts" \
+            --tests-result "$TESTS_RESULT" \
             --github-output "$GITHUB_OUTPUT"
 
       # ─────────── WHICH COMPILER BUILT WHAT — a NUMBER, on every run ───────────

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -19,8 +19,10 @@ Never hand-roll a repo's build.
 ## The pipeline, end to end
 
 ```
-select ──► prepare (ONCE) ──► build (ONE workspace) ──► pack ─┬─► verify
-                                                      tests ──┘
+select ─┬─► prepare (ONCE) ──► build (ONE workspace) ──► pack ─┬─► verify
+        │                                                      │
+        └─► tests  (a lane of its own — publish: false) ────────┘
+             …or INLINE inside pack, before the hand-over, when the call publishes
 ```
 
 1. **select** — which bundles this diff can reach. The selector can say "these" or
@@ -38,10 +40,63 @@ select ──► prepare (ONCE) ──► build (ONE workspace) ──► pack �
    body pass like csc (parse+declaration diagnostics up front, body diagnostics from the single
    `Emit`), **fail-fast** (the first red blocks every not-yet-started node by name — a sweep
    that must enumerate every verdict opts out of fail-fast instead).
-4. **pack and tests fan out from the build's outputs** — they consume, they never recompile.
-   Tests are the honest per-module cost and parallelize across jobs.
-5. **verify** — unconditionally pairs the selection against the receipts; a skipped pack with a
-   non-zero selection is RED.
+4. **pack fans out from the build's outputs** — it consumes, it never recompiles.
+5. **tests — beside the chain, or inline, and `publish` decides which.** See below.
+6. **verify** — unconditionally pairs the selection against the receipts; a skipped pack with a
+   non-zero selection is RED, and so is a delegated suite that produced no test receipt.
+
+### Where a module's own suite runs — and why `publish` decides
+
+A `needs:` on a `uses:` job waits for the **whole** called workflow, so anything inside the last
+job of this lane sits on the critical path of every gate the caller hangs off it. Measured on
+MeshWeaver.Plugins run 33656010754, a 39-minute pull request:
+
+```
+19.1 -> 32.5  Module bundles (floor) / Module bundle (MeshWeaver.AI)   <-- 13.4 min
+                12.7 min  Run the module's tests, when it ships any
+                 0.2 min  Build the module — and say which compiler produced it
+32.5 -> 32.7  Module bundles (floor) / All selected bundles built
+32.8 -> 37.0  Compile every NodeType (vs core)          (a REQUIRED context)
+32.9 -> 38.6  test-repos / Compile + render node repos  (the Tests-area gate)
+```
+
+The bundle **artifact** — the only thing those two gates consume — was ready 0.2 minutes in. They
+waited another 12.7 for a suite they never read. The floor call exists precisely so the gates do
+not wait for the other 30 bundles (Plugins#892); the suite put the wait straight back. It also
+lengthens the **recovery loop**: a run cannot be re-run until it completes, so a flaked shard's
+retry waits out a suite whose verdict nobody is reading — every flake pays that.
+
+So the suite's position is a function of `publish`, the input that already means *trunk* in this
+lane's caller contract:
+
+| `publish` | where the suite runs | what the position buys |
+|---|---|---|
+| `true` | **inline in `pack`**, after the bundle upload, before the hand-over | *a failing suite never publishes* — the registry serves what every installation reads |
+| `false` | the **`tests` job**, in parallel with select → prepare → build → pack | nothing is publishable on such a run (the hand-over step's own `if:` is `inputs.publish && …`), so the ordering protected nothing and delayed everything |
+
+It is a switch on the **input**, never on `github.event_name`: the platform's own `main-cd` calls
+this lane with `publish: false` for the bake's compose set, and that call is not a pull request —
+it wants the fast path for exactly the same reason.
+
+**Moving the suite off the critical path does not move it out of the gate**, and three structural
+things say so rather than a comment:
+
+* the `tests` job is part of the called workflow, so a red suite fails the caller's `uses:` job
+  exactly as a red inline suite did;
+* `verify` — `All selected bundles built`, this lane's one stable context and the one a repo's
+  branch protection requires — `needs:` the tests lane and goes RED when it did not succeed. **No
+  context is renamed**, so no repo's protection changes;
+* a suite that ran in **neither** lane is caught by receipts, not by re-reading two conditions.
+  Two mutually exclusive `if:`s can both be false, and a suite that ran nowhere renders exactly
+  like one that passed. So every pack receipt records which lane owns its suite
+  (`tests: none | inline | lane`), the tests lane drops a receipt of its own, and
+  `node-repo-pack-verify.py` fails when a delegated module has no test receipt, when a test
+  receipt arrives for a module that delegated nothing, or when the tests lane skipped while
+  modules delegated to it.
+
+`bundles-built` is deliberately untouched by all of this: it still answers from the built markers
+dropped *before* any suite, so a red suite still does not read as "bundle missing" to a gate that
+only COMPOSES the bundle (#2710, Plugins#937). Those are two different questions.
 
 ## Every stage asserts its OWN postcondition — never the next one's
 

--- a/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleBuildLedgerLaneGuard.cs
@@ -17,8 +17,9 @@ namespace MeshWeaver.Documentation.Test;
 /// the one-workspace build; that the build compiles the ledger's <c>build-modules</c> subset and feeds
 /// the SAME list to its postcondition; that the pack job records the three transitions (Built after the
 /// artifact upload, Tested after the suite, Published after the hand-over) plus the Failed and cancelled
-/// verdicts; and that every ledger write is best-effort while the two scripts' self-tests run on every
-/// run. A lane that quietly dropped one of those would still be green — a duplicate build costs money
+/// verdicts — and, since the suite moved to a lane of its own on non-publishing runs, that the
+/// <c>tests</c> job records the same Tested / test-phase-Failed verdicts there; and that every ledger
+/// write is best-effort while the two scripts' self-tests run on every run. A lane that quietly dropped one of those would still be green — a duplicate build costs money
 /// silently, a missing <c>Built</c> record makes every later run rebuild, and a <c>Tested</c> recorded
 /// before the suite ran would hand followers a verdict nobody reached. Nothing in a green run
 /// distinguishes those shapes; this does.</para>
@@ -110,6 +111,33 @@ public class ModuleBuildLedgerLaneGuard
         Assert.Contains("--logger \"trx;LogFileName=ledger.trx\"", pack, StringComparison.Ordinal);
         // The reuse window is the artifact's retention.
         Assert.Contains("retention-days: 7", pack, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 The suite does not always run in the pack job any more: on a call with
+    /// <c>publish: false</c> it runs in the <c>tests</c> lane beside the pack matrix, so the
+    /// verdict a follower reads must be recorded THERE with the same rules — <c>Tested</c> only
+    /// after the suite it attests, the <c>test</c>-phase <c>Failed</c> verdict on the way out, and
+    /// both best-effort. A lane that moved the suite and left its bookkeeping behind would make
+    /// every later run of the same key re-run a suite that had already passed, silently.
+    /// </summary>
+    [Fact]
+    public void TestsLane_RecordsTestedAfterItsSuite_AndTheTestPhaseVerdict()
+    {
+        var tests = JobBody("tests");
+        var suite = tests.IndexOf("dotnet test \"$tests\"", StringComparison.Ordinal);
+        var tested = tests.IndexOf("--status Tested --trx", StringComparison.Ordinal);
+        Assert.True(suite >= 0, "the tests lane must run the module's suite");
+        Assert.True(tested > suite, "`Tested` must be recorded AFTER the suite it attests");
+        // Gated on the OUTCOME of the step it attests — never on the job's mood.
+        Assert.Contains("if: inputs.ledger == 'required' && steps.tests.outcome == 'success' && matrix.entry.ledger.key != ''",
+            tests, StringComparison.Ordinal);
+        // The suite writes the evidence the ledger records, exactly as the inline one does.
+        Assert.Contains("--logger \"trx;LogFileName=ledger.trx\"", tests, StringComparison.Ordinal);
+        // The way out: this lane can only fail in one phase, so it names it rather than deriving it.
+        Assert.Contains("--status Failed --phase test", tests, StringComparison.Ordinal);
+        Assert.Contains("if: failure() && inputs.ledger == 'required' && matrix.entry.ledger.key != ''",
+            tests, StringComparison.Ordinal);
     }
 
     [Fact]

--- a/test/MeshWeaver.Documentation.Test/ModuleSuiteLaneGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleSuiteLaneGuard.cs
@@ -1,0 +1,168 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for WHERE a module's own test suite runs in the reusable module-pack lane.
+///
+/// <para>A <c>needs:</c> on a <c>uses:</c> job waits for the WHOLE called workflow, so anything
+/// inside the last job of that lane sits on the critical path of every gate the caller hangs off
+/// it. Measured on MeshWeaver.Plugins run 33656010754 (a 39-minute pull request):
+/// <c>Module bundle (MeshWeaver.AI)</c> took 13.4 minutes, of which 12.7 were the module's own
+/// suite and 0.2 the build — so the bundle artifact the two required gates COMPOSE was ready 0.2
+/// minutes in, and those gates started at 32.8. So on a run that does not publish the suite moves
+/// to a lane of its own beside the pack matrix; on a run that DOES publish it stays inline, before
+/// the hand-over, because there the ordering buys the one property worth its cost: a failing suite
+/// never publishes.</para>
+///
+/// <para>🚨 The whole construction is only safe while three things hold, and none of them is
+/// visible in a green run — which is why they are asserted here. The two conditions must be
+/// COMPLEMENTS of one input (two `if:`s can both be false, and a suite that ran nowhere renders
+/// exactly like one that passed); the tests lane must not depend on the pack chain it is meant to
+/// run beside; and <c>verify</c> — the lane's one stable context, <c>All selected bundles built</c>,
+/// the context a repo's branch protection requires — must still go RED when a suite does, and must
+/// pair every DELEGATED suite against positive evidence that it ran.</para>
+/// </summary>
+public class ModuleSuiteLaneGuard
+{
+    private const string Lane = ".github/workflows/node-repo-module-pack.yml";
+    private const string Verifier = ".github/scripts/node-repo-pack-verify.py";
+
+    [Fact]
+    public void TheInlineSuite_RunsOnlyWhenThisCallPublishes()
+    {
+        var pack = JobBody("pack");
+        Assert.Contains(
+            "if: ${{ inputs.publish && matrix.entry.test != false && steps.plan.outputs.need_test == 'true' }}",
+            pack, StringComparison.Ordinal);
+        // Still AFTER the bundle upload and BEFORE the hand-over when it does run: that ordering is
+        // the entire reason a publishing run keeps paying for it.
+        var upload = pack.IndexOf("name: module-bundle-${{ matrix.entry.module }}", StringComparison.Ordinal);
+        var suite = pack.IndexOf("dotnet test \"$tests\"", StringComparison.Ordinal);
+        var publish = pack.IndexOf("-X POST \"$REGISTRY/api/plugins/bundles/$PACKAGE", StringComparison.Ordinal);
+        Assert.True(upload >= 0 && suite >= 0 && publish >= 0, "the pack job must still upload, test and publish");
+        Assert.True(upload < suite && suite < publish,
+            "on a publishing run the inline suite must sit AFTER the bundle upload and BEFORE the hand-over — "
+            + "a failing suite may not publish, and may not un-build either");
+    }
+
+    [Fact]
+    public void TheTestsLane_IsTheExactComplement_AndDependsOnNothingItShouldRunBeside()
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
+        Assert.True(Regex.IsMatch(text, @"\n  tests:\n"), $"{Lane} must have a `tests` job");
+
+        var tests = JobBody("tests");
+        // The complement of the inline step's `inputs.publish &&`, on the SAME input — never on
+        // github.event_name, which would diverge from what `publish` already means here (core's own
+        // main-cd calls this lane with publish:false and is not a pull request).
+        Assert.Contains("!inputs.publish", tests, StringComparison.Ordinal);
+        Assert.DoesNotContain("github.event_name", tests, StringComparison.Ordinal);
+        // A matrix with zero vectors does not evaluate, so the count is asserted the way `pack`
+        // asserts its own.
+        Assert.Contains("needs.select.outputs.test-count != '0'", tests, StringComparison.Ordinal);
+        Assert.Contains("entry: ${{ fromJson(needs.select.outputs.test-modules) }}", tests, StringComparison.Ordinal);
+
+        // 🚨 `select` ONLY. Depending on prepare / build-workspace / pack would put the suite back
+        // on the very chain this job exists to run beside, and the change would measure as nothing.
+        var needs = Regex.Match(tests, @"\n    needs: (?<needs>.+)\n");
+        Assert.True(needs.Success, "the tests job must declare its needs");
+        Assert.Equal("select", needs.Groups["needs"].Value.Trim());
+
+        // The suite itself is a MOVE, not a rewrite: same command, same evidence trail.
+        Assert.Contains("dotnet test \"$tests\"", tests, StringComparison.Ordinal);
+        Assert.Contains("-p:MeshWeaverRoot=$GITHUB_WORKSPACE/meshweaver", tests, StringComparison.Ordinal);
+        Assert.Contains("MESHWEAVER_TEST_FILE_LOGS", tests, StringComparison.Ordinal);
+        Assert.Contains("DOTNET_DbgEnableMiniDump", tests, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EveryLegRecords_WhichLaneOwnsItsSuite_AndTheTestsLaneProvesItRanOne()
+    {
+        var pack = JobBody("pack");
+        // `none` | `inline` | `lane`, written into the receipt rather than inferred afterwards from
+        // an `if:` — the pairing below is what makes "it ran nowhere" impossible to do quietly.
+        Assert.Contains(
+            "TESTS: ${{ steps.plan.outputs.need_test != 'true' && 'none' || (inputs.publish && 'inline' || 'lane') }}",
+            pack, StringComparison.Ordinal);
+        Assert.Contains("tests:$t", pack, StringComparison.Ordinal);
+
+        var tests = JobBody("tests");
+        Assert.Contains("tests:\"lane\"", tests, StringComparison.Ordinal);
+        // Lane-stamped and lane-named, like every other artifact here: artifacts are RUN-WIDE and a
+        // repo may call this lane twice in one run.
+        Assert.Contains("name: module-tests-receipt-${{ needs.select.outputs.lane }}-${{ matrix.entry.module }}",
+            tests, StringComparison.Ordinal);
+        Assert.Contains("if-no-files-found: error", tests, StringComparison.Ordinal);
+        // The receipt means the suite got to the end green, so it is the LAST evidence step.
+        var suite = tests.IndexOf("dotnet test \"$tests\"", StringComparison.Ordinal);
+        var receipt = tests.IndexOf("name: Drop the test receipt", StringComparison.Ordinal);
+        Assert.True(suite >= 0 && receipt > suite,
+            "the test receipt must be dropped AFTER the suite it attests");
+    }
+
+    [Fact]
+    public void Verify_StaysTheOneStableContext_AndStillRedsOnARedSuite()
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
+        // 🚨 The context NAME is unchanged on purpose: a renamed required context waits forever,
+        // and six repos call this lane.
+        Assert.Contains("    name: All selected bundles built\n", text, StringComparison.Ordinal);
+
+        var verify = JobBody("verify");
+        Assert.Contains("needs: [select, pack, tests]", verify, StringComparison.Ordinal);
+        Assert.Contains("if: always()", verify, StringComparison.Ordinal);
+        Assert.Contains("TESTS_RESULT: ${{ needs.tests.result }}", verify, StringComparison.Ordinal);
+        Assert.Contains("--tests-result \"$TESTS_RESULT\"", verify, StringComparison.Ordinal);
+        Assert.Contains("--test-receipts \"$RUNNER_TEMP/test-receipts\"", verify, StringComparison.Ordinal);
+        Assert.Contains("pattern: module-tests-receipt-${{ needs.select.outputs.lane }}-*", verify, StringComparison.Ordinal);
+
+        // 🚨 …and `bundles-built` must NOT move with it. It is what a gate that only COMPOSES the
+        // bundle depends on, so a red suite may not read as "bundle missing" there (#2710,
+        // Plugins#937). The verifier answers it from the built markers alone.
+        var verifier = File.ReadAllText(Path.Combine(FindRepoRoot(), Verifier));
+        var body = Regex.Match(verifier, @"\ndef bundles_built\((?<b>.*?)\n\ndef ", RegexOptions.Singleline);
+        Assert.True(body.Success, "the verifier must define bundles_built");
+        Assert.DoesNotContain("tests", body.Groups["b"].Value, StringComparison.Ordinal);
+        // The accounting the workflow calls, and its own self-test, both exist.
+        Assert.Contains("def test_lane(", verifier, StringComparison.Ordinal);
+        Assert.Contains("--tests-result", verifier, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void Select_PublishesTheSuiteSubset_UsingThePackPlansOwnPredicate()
+    {
+        var select = JobBody("select");
+        Assert.Contains("test-modules: ${{ steps.suites.outputs.modules }}", select, StringComparison.Ordinal);
+        Assert.Contains("test-count: ${{ steps.suites.outputs.count }}", select, StringComparison.Ordinal);
+        // The same predicate the pack job's plan step answers as `need_test`. The two are
+        // cross-checked by the verifier rather than trusted to agree, but they must at least be
+        // written as one rule.
+        Assert.Contains("if (.ledger.decision // \"build\") == \"reuse\"", select, StringComparison.Ordinal);
+        Assert.Contains("then (.ledger.needTest == true)", select, StringComparison.Ordinal);
+        Assert.Contains("else (.test != false) end", select, StringComparison.Ordinal);
+    }
+
+    private static string JobBody(string job)
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
+        var match = Regex.Match(text, @"\n  " + Regex.Escape(job) + @":\n(?<body>(?:(?:    .*|  #.*)\n|\n)+?)(?=  [a-z][a-z-]*:\n|\z)");
+        Assert.True(match.Success, $"{Lane} must have a `{job}` job");
+        return string.Join('\n', match.Groups["body"].Value.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.True(dir is not null, "could not locate the repository root (MeshWeaver.slnx) above the test bin");
+        return dir!.FullName;
+    }
+}


### PR DESCRIPTION
## The measurement

A pull request in `MeshWeaver.Plugins` takes **50 minutes median**; core takes 13. The critical
path is **not** the test shards. Traced on Plugins run 33656010754, a 39-minute run:

```
 0.0 ->  2   Module bundles (floor) / Warm the shared build environment (once)
 2    ->  8   Module bundles (floor) / Build the workspace (one global build)
19.1 -> 32.5  Module bundles (floor) / Module bundle (MeshWeaver.AI)      <-- 13.4 min
32.5 -> 32.7  Module bundles (floor) / All selected bundles built
32.8 -> 37.0  Compile every NodeType (vs core)          (REQUIRED)
32.9 -> 38.6  test-repos / Compile + render node repos  (the Tests-area gate)
38.9 -> 39.0  Every gate executed
```

Portal-host shards finished at 30.9 min, in parallel, off the critical path.

Step breakdown of that 13.4-minute `Module bundle (MeshWeaver.AI)` job:

```
12.7 min  Run the module's tests, when it ships any
 0.2 min  Build the module — and say which compiler produced it
 0.1 min  Set up job
```

**The bundle artifact is ready after 0.2 min.** The job then spends 12.7 minutes running a suite
its consumers do not read: `compile-check` and the Tests-area gate `needs:` the floor call and
consume only `module-bundle-MeshWeaver.{AI,Markdown.Collaboration,Maps}` — but a `needs:` on a
`uses:` job waits for the **whole** called workflow. The floor call exists precisely so those
gates do not wait for the other 30 bundles (Plugins#892); the suite put the wait straight back.

### It costs a second thing: the recovery loop

A run cannot be re-run until it fully completes — `gh run rerun --failed` answers *"cannot be
rerun; This workflow is already running"*. Measured 2026-09-02 on four Plugins PRs whose required
`Build + test the portal hosts` context had **already** gone red:

```
run 33676248730 (PR #1214)  status=queued
  queued  Module bundles (floor) / Module bundle (MeshWeaver.AI)
  queued  Module bundles (floor) / Module bundle (MeshWeaver.Markdown.Collaboration)

run 33675701470 (PR #1200)  status=queued
  in_progress  Module bundles (floor) / Module bundle (MeshWeaver.AI)
  queued       Module bundles / All selected bundles built
```

So after a shard flakes, the fix is blocked for a further ~13 minutes by a suite whose verdict
nobody is waiting on. That is the compounding half of the cost: every flake pays it.

## The shape

`publish` — the input that already means *trunk* in this lane's caller contract — decides where
the suite runs. No new input; every caller inherits it with no change.

| `publish` | where the suite runs | what the position buys |
|---|---|---|
| `true` | **inline in `pack`**, after the bundle upload, before the hand-over (unchanged, byte for byte) | *a failing suite never publishes* — the registry serves what every installation reads |
| `false` | the new **`tests` job**, in parallel with select → prepare → build-workspace → pack | nothing — see below |

```
select ─┬─► prepare (ONCE) ──► build (ONE workspace) ──► pack ─┬─► verify
        │                                                      │
        └─► tests  (a lane of its own — publish: false) ────────┘
```

The `tests` job `needs: select` **only**: the suite is a `dotnet test` against the content
checkout with `-p:MeshWeaverRoot=<the platform checkout>`; it consumes no platform image, no
workspace build and no bundle. Depending on any of them would put it back on the chain it exists
to run beside.

## Pull request vs trunk push — what I concluded

**Your reading holds, and the workflow proves it rather than suggesting it.** The hand-over step's
own condition is `if: ${{ inputs.publish && steps.plan.outputs.need_publish == 'true' }}`. On a
run with `publish: false` that step **cannot fire at all**, so "the bundle was built before its
suite passed" has no consequence: there is nothing for the ordering to protect, and the ordering
instead costs every consumer of the call the whole suite. On a publishing run the ordering
protects the registry, which every installation reads — so there the suite stays inline and the
`tests` job does not run.

Two refinements to the framing:

* **The switch is the INPUT, not the event.** Core's own `main-cd` calls this lane with
  `publish: false` for the bake's compose set (`plugins-modules`), and that call is not a pull
  request — it wants the fast path for exactly the same reason. Keying on `github.event_name`
  would have missed it and would have duplicated a meaning `publish` already carries.
* **Splitting the suite into a job that runs *after* pack would have bought nothing**, because a
  consumer's `needs:` waits for every job of the called workflow. The win comes from running the
  suite *beside* the pack chain, not merely outside the pack job.

## How a failing module suite still reds the PR

Three mechanisms, none of which is a comment:

1. **The `tests` job is part of this called workflow**, so a red suite fails the caller's `uses:`
   job (`Module bundles (floor)`) exactly as a red inline suite did.
2. **`verify` now `needs: [select, pack, tests]`** and goes RED when the tests lane did not
   succeed — under the same name it already has, `All selected bundles built`. That is the lane's
   one stable context and the one a repo's protection can require. The verifier's new
   `--tests-result` turns `failure` and `cancelled` into a named error.
3. **A suite that ran in NEITHER lane is caught by receipts, not by re-reading two conditions.**
   Two mutually exclusive `if:`s can both be false, and a suite that ran nowhere renders exactly
   like one that passed. So every pack receipt now records which lane owns its suite
   (`tests: none | inline | lane`), the tests lane drops a lane-stamped receipt of its own, and
   `node-repo-pack-verify.py` fails when a delegated module has no test receipt, when a test
   receipt arrives for a module whose pack receipt says `inline`, when a receipt is corrupt, or
   when the tests lane SKIPPED while modules delegated to it.

`bundles-built` is deliberately untouched — it still answers from the built markers dropped
*before* any suite, so a red suite still does not read as "bundle missing" to a gate that only
COMPOSES the bundle (#2710, Plugins#937). A new guard asserts that `bundles_built()` never learns
about tests.

## Status-check contexts

**No context is renamed or removed. No repo's branch protection needs updating.**

* `<caller job> / All selected bundles built` — unchanged name, unchanged meaning (still red on a
  red suite), now additionally asserting the tests lane.
* `<caller job> / Module bundle (<module>)` — unchanged.
* **New, and deliberately not requireable:** `<caller job> / Module tests (<module>)`. Like
  `Module bundle (<name>)`, it is a *dynamic* matrix context that appears and disappears with the
  diff, so it must never be added to branch protection — requiring one means requiring a context
  that will legitimately never report. That is exactly why `verify` carries the verdict too.

One honest note the maintainer should see: I measured Plugins' protection today —
`["Validate node repos", "Compile every NodeType (vs core)", "Build + test the portal hosts"]`,
`strict: false`. `Module bundles (floor) / All selected bundles built` is **not** among them, so a
red module suite did not block the merge button before this change either. This PR preserves the
redness exactly; whether to add that context to protection is a separate, system-changing call.

## Verification run locally

* `python3 -c "import yaml; yaml.safe_load(...)"` — the lane parses; jobs are
  `select, prepare, build-workspace, pack, tests, verify`.
* `node-repo-pack-verify.py --self-test` — green, now **11 tests-lane cases**: a failed lane, a
  cancelled lane, a skipped lane with delegated suites, a missing receipt, a corrupt receipt and
  an inline/lane disagreement each go RED and name the module; the publishing, nothing-owed,
  older-caller and pack-already-failed shapes stay green.
* `node-repo-scope.py --self-test` — 44 cases green (unchanged).
* `check-workflow-timeouts.py` — 65 jobs, 0 violations (the new job carries a literal
  `timeout-minutes: 45`).
* `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` — 0 warnings, 0 errors.
* `ModuleSuiteLaneGuard` (new, 5 facts) + `ModuleBuildLedgerLaneGuard` (extended with the tests
  lane's Tested / test-phase-Failed records) — 11 passed. **Mutation-tested**: reverting
  `needs: [select, pack, tests]` and the inline step's `inputs.publish &&` turns 2 of the 5 new
  facts red; restoring them makes all 5 green again.
* `DocumentationLinkIntegrityTest` — green after the doc edit.

## Compatibility

The two new verifier arguments are optional, so a repo still pinned to an older
`node-repo-module-pack.yml` while resolving `platform-ref` to core's tip (which is what Plugins
does) keeps working: the old workflow simply does not pass them and the accounting stands down,
saying so. The doc — `Doc/Architecture/ModuleBuildArchitecture` — is updated in the same change;
its pipeline diagram already drew `tests` as a lane beside `pack`, which is only now true.

Pairs-with: none — no public type is removed by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
