### PR TITLE
fix(data): a faulted virtual-data-source provider is rebuilt, not frozen (#3155)

### DIFF
--- a/src/MeshWeaver.Data/VirtualDataSource.cs
+++ b/src/MeshWeaver.Data/VirtualDataSource.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reactive.Concurrency;
 using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using MeshWeaver.Data.Serialization;
@@ -49,6 +50,44 @@ public record VirtualDataSource(object Id, IWorkspace Workspace)
         return WithTypeSource(typeof(T), typeSource);
     }
 
+    /// <summary>First backoff step before a faulted provider is rebuilt; doubles per attempt.</summary>
+    internal static readonly TimeSpan ProviderRetryBaseDelay = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// The ceiling the backoff saturates at. A provider whose upstream is genuinely gone is then
+    /// rebuilt once a minute — cheap enough to be irrelevant, slow enough that it can never be
+    /// the load.
+    /// </summary>
+    internal static readonly TimeSpan ProviderRetryMaxDelay = TimeSpan.FromMinutes(1);
+
+    /// <summary>
+    /// Backoff before rebuilding a faulted provider: 1s, 2s, 4s … saturating at
+    /// <see cref="ProviderRetryMaxDelay"/>. Pure, so the policy is an assertion rather than a
+    /// timing observation (issue #3155).
+    /// </summary>
+    /// <param name="attempt">1-based attempt number.</param>
+    /// <returns>How long to wait before the next rebuild.</returns>
+    internal static TimeSpan ProviderRetryDelay(int attempt)
+    {
+        if (attempt <= 0)
+            return ProviderRetryBaseDelay;
+        // Shift on a long and clamp: the loop is unbounded by design, so "the counter cannot get
+        // that high" is not an argument — a naive 1 << (attempt - 1) overflows into a NEGATIVE
+        // delay around attempt 63, and a negative timer delay fires immediately, turning the rate
+        // ceiling into a spin exactly when the outage has lasted longest.
+        var doublings = Math.Min(attempt - 1, 32);
+        var ms = ProviderRetryBaseDelay.TotalMilliseconds * (1L << doublings);
+        return ms >= ProviderRetryMaxDelay.TotalMilliseconds
+            ? ProviderRetryMaxDelay
+            : TimeSpan.FromMilliseconds(ms);
+    }
+
+    /// <summary>
+    /// Scheduler for the provider-rebuild backoff. An INSTANCE seam, never static state: a test
+    /// pins the policy without waiting out real seconds.
+    /// </summary>
+    internal IScheduler ProviderRetryScheduler { get; set; } = TaskPoolScheduler.Default;
+
     /// <summary>
     /// Builds the backing entity-store stream and subscribes to each virtual type source's
     /// stream updates so later emissions from the provider are pushed into the local mirror.
@@ -85,7 +124,32 @@ public record VirtualDataSource(object Id, IWorkspace Workspace)
         {
             var isFirst = true;
             stream.RegisterForDisposal(
-                typeSource.GetStreamUpdates()
+                // 🚨 #3155 — Defer, so every re-subscribe re-ASKS the type source for its chain
+                // rather than re-attaching to the one that faulted. Paired with the eviction in the
+                // fault arm below, that is what makes the rebuild real: the cached chain is
+                // Replay(1).RefCount(), whose subject latches OnError, so a re-subscribe without
+                // the eviction replays the same fault for ever.
+                Observable.Defer(typeSource.GetStreamUpdates)
+                    .RetryWhen(faults => faults
+                        .Select((error, i) => (Error: error, Attempt: i + 1))
+                        .SelectMany(f =>
+                        {
+                            var delay = ProviderRetryDelay(f.Attempt);
+                            // Reported every time, never swallowed — the fault is real and the
+                            // collection IS stale until the rebuild lands. What changed is the
+                            // second sentence: it used to say "frozen … will receive no further
+                            // updates", which was true and permanent.
+                            Logger.LogError(f.Error,
+                                "Virtual data source {DataSource}: the provider for collection "
+                                + "'{Collection}' faulted (attempt {Attempt}) on hub {Address}. That "
+                                + "collection is stale until the provider is rebuilt, which is "
+                                + "scheduled in {Delay}.",
+                                Id, typeSource.CollectionName, f.Attempt, Workspace.Hub.Address, delay);
+                            // Drop the latched chain BEFORE the timer, so the re-subscribe above
+                            // builds a fresh one instead of replaying this fault.
+                            typeSource.EvictCachedStream();
+                            return Observable.Timer(delay, ProviderRetryScheduler);
+                        }))
                     .Subscribe(instances =>
                     {
                         // Skip the first emission since it's handled by initialization
@@ -130,10 +194,17 @@ public record VirtualDataSource(object Id, IWorkspace Workspace)
                     // the SAME faulted Replay(1) (VirtualTypeSource.StreamUpdates), so a fault
                     // during init still fails the hub's startup through the normal path — this arm
                     // exists so a fault can never take the process with it.
+                    // With the unbounded RetryWhen above this arm is the LAST LINE OF DEFENCE
+                    // rather than the policy — but it must stay, and for the reason spelled out
+                    // above: Rx's default one-argument onError is Stubs.Throw, which rethrows on
+                    // whatever thread carried the fault, and that thread is almost never one with a
+                    // catch (#2468: a TimerQueue thread, an unhandled exception, a core-dumped
+                    // host, and a gate that "failed before it produced a verdict").
                     error => Logger.LogError(error,
                         "Virtual data source {DataSource}: the provider for collection "
-                        + "'{Collection}' faulted. That collection is frozen at its last emission "
-                        + "and will receive no further updates on hub {Address}",
+                        + "'{Collection}' terminated on hub {Address} — the rebuild sequence itself "
+                        + "ended, so this collection is frozen at its last emission until the hub "
+                        + "is recycled.",
                         Id, typeSource.CollectionName, Workspace.Hub.Address))
             );
         }
@@ -157,6 +228,22 @@ public abstract record VirtualTypeSource : TypeSource<VirtualTypeSource>
     /// <summary>Returns an observable that emits the current set of instances whenever the underlying stream changes.</summary>
     /// <returns>An observable of the type's instances as untyped objects.</returns>
     public abstract IObservable<IEnumerable<object>> GetStreamUpdates();
+
+    /// <summary>
+    /// Drops the cached provider chain so the NEXT <see cref="GetStreamUpdates"/> rebuilds it from
+    /// the configured provider.
+    ///
+    /// <para>🚨 <b>Without this a retry is inert — issue #3155.</b> The cached chain is
+    /// <c>Replay(1).RefCount()</c>, and a <c>ReplaySubject</c> that has seen <c>OnError</c> LATCHES
+    /// it: every later subscriber gets the same fault replayed immediately, for the lifetime of the
+    /// object. So re-subscribing to a faulted provider is recovery inside the failed component —
+    /// it would spin at whatever rate the retry allows and never recover. The corpse has to be
+    /// dropped first.</para>
+    ///
+    /// <para>Virtual by design rather than abstract: a source with no cache has nothing to evict,
+    /// and this is public surface on a shipped contract.</para>
+    /// </summary>
+    public virtual void EvictCachedStream() { }
 }
 
 /// <summary>
@@ -198,6 +285,9 @@ public record VirtualTypeSource<T>(
     {
         return StreamUpdates().Select(items => items.Cast<object>());
     }
+
+    /// <inheritdoc />
+    public override void EvictCachedStream() => cachedStream = null;
 
     /// <summary>
     /// Pure observable composition over the type's stream provider — no <c>await</c>,

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-stalled-listing-recovers-instead-of-freezing.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-02-a-stalled-listing-recovers-instead-of-freezing.md
@@ -1,0 +1,36 @@
+---
+Name: A stalled listing recovers instead of freezing
+Category: Fix
+Description: When a data feed's connection to its source timed out once, that listing stopped updating for as long as the server kept running. It now rebuilds itself and says so while it is stale.
+Icon: ArrowSync
+Order: -20260902
+---
+
+# A stalled listing recovers instead of freezing
+
+Some listings in the portal are kept live by a feed: a component subscribes to whatever supplies the
+data, and pushes each change into the page. The store's package listing is one of these.
+
+Setting that feed up means asking another component for a subscription, and asking can fail — the
+other side is busy, restarting, or a reply gets lost in transit. That is ordinary and momentary.
+
+**What was not momentary was the consequence.** A single failed request ended the feed. The listing
+kept displaying whatever it had at that moment and never updated again, for as long as that server
+process kept running. Nothing retried it, and from the outside it looked completely normal: the page
+rendered, the data was there, it was simply frozen in the past. The only cure was restarting the
+component.
+
+The feed now **rebuilds itself** after a failure, backing off a little further each time up to once a
+minute, for as long as it takes. It reports each failure and says the listing is stale until the
+rebuild lands — where before it reported, accurately and once, that the listing would receive no
+further updates at all.
+
+There was a subtlety that made this more than adding a retry, and it is worth recording because it
+would have been an easy thing to get wrong: the feed **remembers** its connection so that several
+parts of the page can share one. That memory also remembers the failure. So simply asking again
+would have handed back the same failure instantly, for ever — a retry that looked completely correct
+and could never have worked. The remembered failure is now discarded before the rebuild, which is
+what makes asking again mean anything.
+
+This does not address why the original request timed out; that is tracked separately. What changes is
+that one lost reply no longer costs a listing until the next restart.

--- a/test/MeshWeaver.Data.Test/FaultedProviderIsRebuiltTest.cs
+++ b/test/MeshWeaver.Data.Test/FaultedProviderIsRebuiltTest.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using MeshWeaver.Fixture;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #3155 — one lost reply froze a collection for the life of the hub.</b>
+///
+/// <para>A <c>SubscribeRequest</c> from the per-pod cache hub to the <c>Store</c> hub timed out
+/// after 60 s. The provider faulted, and <c>VirtualDataSource</c>'s error arm logged
+/// <i>"that collection is frozen at its last emission and will receive no further updates"</i> —
+/// accurately. The store/package listing on that pod was then stale permanently, from a single
+/// timed-out request, until the hub was recycled.</para>
+///
+/// <para>The error arm itself is not the bug and must stay: Rx's default one-argument
+/// <c>onError</c> is <c>Stubs.Throw</c>, which rethrows on whatever thread carried the fault, and
+/// in #2468 that was a TimerQueue thread — an unhandled exception, a core-dumped host, and a gate
+/// that "failed before it produced a verdict". What was missing is any recovery after it.</para>
+///
+/// <para>🚨 <b>And a plain retry would have been inert.</b> The cached chain is
+/// <c>Replay(1).RefCount()</c>, and a <c>ReplaySubject</c> that has seen <c>OnError</c> LATCHES it:
+/// every later subscriber gets the same fault replayed immediately, for ever. Re-subscribing
+/// without dropping the cache is recovery inside the failed component — it would spin at whatever
+/// rate the retry allows and never recover. That is the property this fixture pins first, because
+/// it is the reason the fix has two halves rather than one.</para>
+/// </summary>
+public class FaultedProviderIsRebuiltTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private sealed record Item(string Id);
+
+    /// <summary>
+    /// The bare host registers no <c>IWorkspace</c>; a virtual type source needs one because its
+    /// <c>TypeDefinition</c> is resolved off <c>Workspace.Hub.TypeRegistry</c> at construction.
+    /// One trivial data source is enough — nothing here reads from it.
+    /// </summary>
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration) =>
+        base.ConfigureHost(configuration)
+            .AddData(data => data.AddSource(source =>
+                source.WithType<Item>(type => type
+                    .WithKey(instance => instance.Id)
+                    .WithInitialData(_ => Observable.Return<IEnumerable<Item>>([])))));
+
+    /// <summary>
+    /// 🚨 THE TRAP. A faulted cached chain replays its fault to every later subscriber — so a retry
+    /// that merely re-subscribes can never recover, however long it waits.
+    /// </summary>
+    [Fact]
+    public void AFaultedCachedChain_ReplaysTheFaultToEveryLaterSubscriber()
+    {
+        var workspace = GetHost().GetWorkspace();
+        var builds = 0;
+        var source = new Subject<IEnumerable<Item>>();
+
+        var typeSource = new VirtualTypeSource<Item>(
+            workspace, "probe", _ => { builds++; return source; });
+
+        using var first = typeSource.GetStreamUpdates().Subscribe(_ => { }, _ => { });
+        builds.Should().Be(1, "the first subscriber starts the provider");
+
+        source.OnError(new TimeoutException("no response received within 00:01:00"));
+
+        Exception? replayed = null;
+        using var second = typeSource.GetStreamUpdates().Subscribe(_ => { }, ex => replayed = ex);
+
+        replayed.Should().BeOfType<TimeoutException>(
+            "Replay(1) latches OnError — a later subscriber gets the SAME fault back immediately, "
+            + "which is why re-subscribing alone can never rebuild a faulted provider (#3155)");
+        builds.Should().Be(1,
+            "and the provider was NOT re-invoked — the corpse was served from cache");
+    }
+
+    /// <summary>
+    /// THE PIN. Evicting the cached chain makes the next subscribe rebuild it from the configured
+    /// provider — which is what turns the retry from inert into a recovery.
+    /// </summary>
+    [Fact]
+    public void EvictingTheCachedChain_RebuildsFromTheProvider()
+    {
+        var workspace = GetHost().GetWorkspace();
+        var builds = 0;
+        var sources = new List<Subject<IEnumerable<Item>>>();
+
+        var typeSource = new VirtualTypeSource<Item>(
+            workspace,
+            "probe",
+            _ =>
+            {
+                builds++;
+                var s = new Subject<IEnumerable<Item>>();
+                sources.Add(s);
+                return s;
+            });
+
+        using var first = typeSource.GetStreamUpdates().Subscribe(_ => { }, _ => { });
+        sources[0].OnError(new TimeoutException("no response received within 00:01:00"));
+
+        typeSource.EvictCachedStream();
+
+        IEnumerable<object>? seen = null;
+        Exception? faulted = null;
+        using var second = typeSource.GetStreamUpdates().Subscribe(x => seen = x, ex => faulted = ex);
+
+        builds.Should().Be(2, "the provider is asked again once the latched chain is dropped");
+        faulted.Should().BeNull("the rebuilt chain carries none of the old chain's fault");
+
+        sources[1].OnNext([new Item("recovered")]);
+        seen.Should().NotBeNull("and it delivers again — the collection is no longer frozen");
+    }
+
+    /// <summary>
+    /// 🚨 Unbounded in COUNT — a budget would only be a slower version of the same defect, since the
+    /// collection's life is the hub's — and bounded in RATE, which is what keeps that safe.
+    /// </summary>
+    [Theory]
+    [InlineData(1, 1)]
+    [InlineData(2, 2)]
+    [InlineData(3, 4)]
+    [InlineData(7, 60)]     // 64s would exceed the ceiling
+    [InlineData(40, 60)]
+    public void TheBackoffDoublesThenSaturates(int attempt, int expectedSeconds)
+        => VirtualDataSource.ProviderRetryDelay(attempt).Should()
+            .Be(TimeSpan.FromSeconds(expectedSeconds),
+                "a provider whose upstream is genuinely gone must cost one rebuild a minute, not a spin");
+
+    /// <summary>
+    /// 🚨 The loop is unbounded, so "the counter cannot get that high" is not an argument. A naive
+    /// <c>1 &lt;&lt; (attempt - 1)</c> overflows into a NEGATIVE delay around attempt 63, and a
+    /// negative timer delay fires immediately — turning the rate ceiling into a spin at exactly the
+    /// moment the outage has lasted longest.
+    /// </summary>
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-5)]
+    [InlineData(63)]
+    [InlineData(int.MaxValue)]
+    public void TheBackoffIsNeverNegative_HoweverManyAttemptsHavePassed(int attempt)
+    {
+        var delay = VirtualDataSource.ProviderRetryDelay(attempt);
+
+        delay.Should().BeGreaterThan(TimeSpan.Zero, "a non-positive delay fires immediately — a spin");
+        delay.Should().BeLessThanOrEqualTo(VirtualDataSource.ProviderRetryMaxDelay,
+            "the ceiling is the whole safety argument for retrying without a budget");
+    }
+}


### PR DESCRIPTION
Addresses the actionable half of #3155, which the issue names itself:

> **the provider's reaction to a single timed-out subscribe is to freeze the collection forever.** One lost reply should not leave a data feed dead until hub recycle.

## What stood here

```csharp
error => Logger.LogError(error,
    "… the provider for collection '{Collection}' faulted. That collection is frozen at its
     last emission and will receive no further updates on hub {Address}", …)
```

Accurate, and permanent. One `SubscribeRequest` timeout and the store/package listing on that pod was stale for the life of the hub.

**The error arm is not the bug and stays.** Rx's default one-argument `onError` is `Stubs.Throw`, which rethrows on whatever thread carried the fault — in #2468 a TimerQueue thread, producing an unhandled exception, a core-dumped host, and a gate that *"failed before it produced a verdict"*. What was missing is any recovery *after* it.

## 🚨 A plain retry would have been inert — this is why the fix has two halves

```csharp
return cachedStream ??= StreamProvider(Workspace).DistinctUntilChanged().Replay(1).RefCount();
```

A `ReplaySubject` that has seen `OnError` **latches** it. Every later subscriber gets the same fault replayed immediately, for the lifetime of the object. So re-subscribing to a faulted provider is recovery *inside the failed component* — it would spin at whatever rate the retry allows and never recover, while looking entirely correct in review.

That is measured, not asserted. `AFaultedCachedChain_ReplaysTheFaultToEveryLaterSubscriber`:

- provider builds stay at **1** — the second subscriber never reaches the provider;
- the second subscriber receives the **same `TimeoutException`** back, synchronously.

So the corpse has to be dropped before the rebuild:

- `VirtualTypeSource.EvictCachedStream()` — **virtual, no-op on the base**, not abstract: a source with no cache has nothing to evict, and this is shipped public surface. `VirtualTypeSource<T>` overrides it to null `cachedStream`.
- the subscription becomes `Observable.Defer(typeSource.GetStreamUpdates)` so each re-subscribe **re-asks**, wrapped in a `RetryWhen` that logs the fault, evicts, then waits.

Same division of labour as #3138's fix, where `MeshNodeStreamCache.GetQuery` already evicts a faulted chain (#1316) so re-resolution builds a new one. Here nothing evicted, so the eviction had to be added.

## Unbounded in count, bounded in rate

A retry budget would only be a slower version of the same defect — the collection's life is the hub's, not the first fault's. What makes that safe is the ceiling: 1s → 2s → 4s … saturating at **1 minute**.

🚨 `ProviderRetryDelay` clamps its shift. The loop is unbounded by design, so "the counter cannot get that high" is not an argument: a naive `1 << (attempt - 1)` overflows to a **negative** delay around attempt 63, and a negative `Observable.Timer` delay fires immediately — turning the rate ceiling into a spin at exactly the moment the outage has lasted longest. A theory pins it at `int.MaxValue`.

Every fault is still reported at `Error`, with its attempt number and the next delay. The wording changed from *"will receive no further updates"* to *"stale until the provider is rebuilt, scheduled in {Delay}"*, because the old sentence is no longer true.

## Verification

`FaultedProviderIsRebuiltTest` — 11 facts, real workspace, no mocks.

| | control arm (`EvictCachedStream` a no-op) | with the fix |
|---|---|---|
| `EvictingTheCachedChain_RebuildsFromTheProvider` | **FAILED** | passed |
| `AFaultedCachedChain_ReplaysTheFaultToEveryLaterSubscriber` | passed | passed |
| backoff / overflow theories (9) | passed | passed |
| | `Failed: 1, Passed: 10` | `Passed: 11` in 629 ms |

The latch fact passing in **both** arms is correct and deliberate — it documents Rx's behaviour, not this fix, and it is the fact that justifies the eviction existing at all.

`dotnet build -c Release -warnaserror` on `MeshWeaver.Data` and `MeshWeaver.Data.Test`: **0 Warning(s), 0 Error(s)**.

🚨 **Not pinned, stated plainly:** the *wiring* — that a real provider fault inside `SetupDataSourceStream` triggers evict-then-resubscribe. That needs a data source with a faulting provider on a live workspace. What is pinned is the **policy** and the **eviction**, which are the two parts a later change could plausibly break; the wiring between them is a `Defer` and a `RetryWhen` in one expression.

## What this does NOT address

The issue's primary question — *why* the subscribe timed out — is untouched and undecidable from the waiting hub's evidence, as the issue says. Its two candidate arms (a wedged `Store` hub per #2896, or a reply lost on the pod-process stream transport per `Doc/Architecture/OrleansStreamPubSubDurability`) both remain open. This change means that whichever it was, it costs a rebuild rather than a dead listing.

Pairs-with: none — no public type is removed; one virtual method is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
