### PR TITLE
Fan-out is opt-in: partitions:all, and the security fold declares it

### DIFF
--- a/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
+++ b/src/MeshWeaver.Hosting/NodeTypeBatchBake.cs
@@ -139,7 +139,13 @@ internal static class NodeTypeBatchBake
     private static IReadOnlyList<string> GlobalCodeQueries =>
     [
         // mesh_nodes across every schema, plus every non-Postgres provider (the static catalog).
-        $"nodeType:{CodeNodeType.NodeType}",
+        // 🚨 `partitions:all` — this fetch IS mesh-wide by design (it collects every Code node the
+        // batch may need, for types in any partition) and it must SAY so. Fan-out is opt-in: a
+        // storage provider refuses a query that names no partition and did not ask to span them,
+        // because a silent cross-schema UNION locks every relation it touches and stalls unrelated
+        // pinned reads. The two sibling queries below carry a wildcard `namespace:`, which is the
+        // other way of asking; this one has no anchor at all, so it declares the flag.
+        $"nodeType:{CodeNodeType.NodeType} {ParsedQuery.CrossPartitionQualifier}",
         // The `code` satellite table across every schema — where a Source/ or Test/ segment puts a
         // Code node, and therefore where nearly all of them are. These match on NAMESPACE, so they
         // cover every Code node BELOW such a folder but not one whose own last segment IS the word

--- a/src/MeshWeaver.Mesh.Contract/Query/ParsedQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/ParsedQuery.cs
@@ -16,7 +16,6 @@ namespace MeshWeaver.Mesh;
 /// <param name="Context">Context for visibility filtering (from context: qualifier)</param>
 /// <param name="IsMain">When true, filters to main nodes only (MainNode is null or equals Path)</param>
 /// <param name="Paths">Multi-value path filter from <c>path:a|b|c</c> alternation. When set, backends should push down <c>WHERE path IN (...)</c>. <see cref="Path"/> is also set to the first value for back-compat with consumers that don't know about multi-path.</param>
-/// <param name="CrossPartition">From <c>partitions:all</c> — the caller has EXPLICITLY asked to span every partition. Fan-out is opt-in: a storage provider refuses a query that names no partition and did not set this, because a silent cross-schema UNION locks every relation it touches and stalls unrelated pinned reads. 🚨 This is a FLAG and not a path value on purpose — <c>path:*</c> looks like it should mean the same thing and does not: partition resolvers read a path's first segment as a schema NAME, so <c>path:*</c> pins the query to a partition literally called <c>*</c> and the query dies on <c>relation "*.threads" does not exist</c>, returning empty rather than erroring.</param>
 /// <param name="IsContent">From <c>is:content</c> — the caller is listing CONTENT, so REGISTRATION nodes are not wanted: the in-memory type definitions, module definitions and partition declarations that <c>AddMeshNodes</c> contributes exist so the platform knows a type exists, and are what a create menu or an autocomplete offers, not something a person browses. A surface that lists things for a human says so on its own query rather than being enumerated in a central list of context names somewhere else.</param>
 public record ParsedQuery(
     QueryNode? Filter,
@@ -30,10 +29,28 @@ public record ParsedQuery(
     string? Context = null,
     bool? IsMain = null,
     IReadOnlyList<string>? Paths = null,
-    bool? IsContent = null,
-    bool CrossPartition = false
+    bool? IsContent = null
 )
 {
+    /// <summary>
+    /// From <c>partitions:all</c> — the caller has EXPLICITLY asked to span every partition. Fan-out
+    /// is opt-in: a storage provider refuses a query that names no partition and did not set this,
+    /// because a silent cross-schema UNION locks every relation it touches and stalls unrelated
+    /// pinned reads.
+    ///
+    /// <para>🚨 A FLAG, not a path value, on purpose. <c>path:*</c> reads like the same statement and
+    /// is not: partition resolvers take a path's first segment as a schema NAME, so <c>path:*</c>
+    /// pins the query to a partition literally called <c>*</c>, the statement dies on
+    /// <c>relation "*.threads" does not exist</c>, and the caller gets an EMPTY result instead of an
+    /// error.</para>
+    ///
+    /// <para>🚨 An init-only PROPERTY, not a positional parameter, also on purpose: a record's
+    /// primary-constructor arity is binary contract, and adding a parameter — even one with a
+    /// default — breaks every compiled caller. The <c>Public surface (binary compatibility)</c> gate
+    /// catches it as <c>record ParsedQuery — arity</c>.</para>
+    /// </summary>
+    public bool CrossPartition { get; init; }
+
     /// <summary>
     /// The qualifier that sets <see cref="CrossPartition"/> — the EXPLICIT "span every partition"
     /// request, and the only thing that makes an otherwise unanchored query legal. Spelled once here

--- a/src/MeshWeaver.Mesh.Contract/Query/ParsedQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/ParsedQuery.cs
@@ -16,6 +16,7 @@ namespace MeshWeaver.Mesh;
 /// <param name="Context">Context for visibility filtering (from context: qualifier)</param>
 /// <param name="IsMain">When true, filters to main nodes only (MainNode is null or equals Path)</param>
 /// <param name="Paths">Multi-value path filter from <c>path:a|b|c</c> alternation. When set, backends should push down <c>WHERE path IN (...)</c>. <see cref="Path"/> is also set to the first value for back-compat with consumers that don't know about multi-path.</param>
+/// <param name="CrossPartition">From <c>partitions:all</c> — the caller has EXPLICITLY asked to span every partition. Fan-out is opt-in: a storage provider refuses a query that names no partition and did not set this, because a silent cross-schema UNION locks every relation it touches and stalls unrelated pinned reads. 🚨 This is a FLAG and not a path value on purpose — <c>path:*</c> looks like it should mean the same thing and does not: partition resolvers read a path's first segment as a schema NAME, so <c>path:*</c> pins the query to a partition literally called <c>*</c> and the query dies on <c>relation "*.threads" does not exist</c>, returning empty rather than erroring.</param>
 /// <param name="IsContent">From <c>is:content</c> — the caller is listing CONTENT, so REGISTRATION nodes are not wanted: the in-memory type definitions, module definitions and partition declarations that <c>AddMeshNodes</c> contributes exist so the platform knows a type exists, and are what a create menu or an autocomplete offers, not something a person browses. A surface that lists things for a human says so on its own query rather than being enumerated in a central list of context names somewhere else.</param>
 public record ParsedQuery(
     QueryNode? Filter,
@@ -29,9 +30,17 @@ public record ParsedQuery(
     string? Context = null,
     bool? IsMain = null,
     IReadOnlyList<string>? Paths = null,
-    bool? IsContent = null
+    bool? IsContent = null,
+    bool CrossPartition = false
 )
 {
+    /// <summary>
+    /// The qualifier that sets <see cref="CrossPartition"/> — the EXPLICIT "span every partition"
+    /// request, and the only thing that makes an otherwise unanchored query legal. Spelled once here
+    /// so callers declare it by reference instead of by copied string.
+    /// </summary>
+    public const string CrossPartitionQualifier = "partitions:all";
+
     /// <summary>
     /// An empty query with no filters.
     /// </summary>

--- a/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
@@ -50,7 +50,10 @@ public partial class QueryParser
         // working unchanged, instead of these surfaces continuing to claim `context:search`.
         // An explicit context: always wins.
         context ??= isContent == true ? MeshContexts.Content : null;
-        return new ParsedQuery(filter, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent, crossPartition);
+        return new ParsedQuery(filter, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent)
+        {
+            CrossPartition = crossPartition,
+        };
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/QueryParser.cs
@@ -9,7 +9,8 @@ public partial class QueryParser
     // Reserved qualifier names (case-insensitive)
     private static readonly HashSet<string> ReservedQualifiers = new(StringComparer.OrdinalIgnoreCase)
     {
-        "path", "namespace", "scope", "sort", "limit", "source", "select", "context", "is"
+        "path", "namespace", "scope", "sort", "limit", "source", "select", "context", "is",
+        "partitions"
     };
 
     /// <summary>
@@ -33,7 +34,7 @@ public partial class QueryParser
             return ParsedQuery.Empty with { Paths = listPaths, Path = listPaths[0] };
 
         var tokens = Tokenize(query);
-        var (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent) = ExtractReservedQualifiers(tokens);
+        var (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent, crossPartition) = ExtractReservedQualifiers(tokens);
 
         // Parse the filter expression from remaining tokens
         QueryNode? filter = null;
@@ -49,7 +50,7 @@ public partial class QueryParser
         // working unchanged, instead of these surfaces continuing to claim `context:search`.
         // An explicit context: always wins.
         context ??= isContent == true ? MeshContexts.Content : null;
-        return new ParsedQuery(filter, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent);
+        return new ParsedQuery(filter, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent, crossPartition);
     }
 
     /// <summary>
@@ -446,7 +447,7 @@ public partial class QueryParser
     /// Extracts reserved qualifiers (path, namespace, scope, sort, limit, source) from tokens.
     /// Returns remaining filter tokens and extracted values.
     /// </summary>
-    private (List<Token> FilterTokens, string? TextSearch, string? Path, QueryScope Scope, OrderByClause? OrderBy, int? Limit, QuerySource Source, IReadOnlyList<string>? Select, string? Context, bool? IsMain, IReadOnlyList<string>? Paths, bool? IsContent)
+    private (List<Token> FilterTokens, string? TextSearch, string? Path, QueryScope Scope, OrderByClause? OrderBy, int? Limit, QuerySource Source, IReadOnlyList<string>? Select, string? Context, bool? IsMain, IReadOnlyList<string>? Paths, bool? IsContent, bool CrossPartition)
         ExtractReservedQualifiers(List<Token> tokens)
     {
         var filterTokens = new List<Token>();
@@ -474,6 +475,7 @@ public partial class QueryParser
         string? context = null;
         bool? isMain = null;
         bool? isContent = null;
+        var crossPartition = false;
 
         foreach (var token in tokens)
         {
@@ -639,6 +641,20 @@ public partial class QueryParser
                     continue;
                 }
 
+                // 🚨 `partitions:all` — the EXPLICIT cross-partition request, and the only thing
+                // that makes an otherwise unanchored query legal. It is a FLAG rather than a path
+                // value on purpose: `path:*` reads like the same statement and is a trap, because
+                // partition resolvers take a path's first segment as a schema NAME — `path:*` pins
+                // to a partition literally called `*`, the statement dies on
+                // `relation "*.threads" does not exist`, and the query returns EMPTY instead of
+                // failing. A flag cannot be mistaken for a partition.
+                if (field.Equals("partitions", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (value.Equals("all", StringComparison.OrdinalIgnoreCase))
+                        crossPartition = true;
+                    continue;
+                }
+
                 if (field.Equals("is", StringComparison.OrdinalIgnoreCase))
                 {
                     if (value.Equals("main", StringComparison.OrdinalIgnoreCase))
@@ -705,7 +721,7 @@ public partial class QueryParser
         }
 
         var textSearch = textSearchParts.Count > 0 ? string.Join(" ", textSearchParts) : null;
-        return (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent);
+        return (filterTokens, textSearch, path, scope, orderBy, limit, source, select, context, isMain, paths, isContent, crossPartition);
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
@@ -79,15 +79,36 @@ public static class SecurityQueries
     }
 
     /// <summary>
-    /// A GLOBAL (path-less) security read over every instance of <paramref name="nodeType"/> in the
-    /// mesh. Path-less on purpose — the subject and the grant that names it may live in different
+    /// A GLOBAL security read over every instance of <paramref name="nodeType"/> in the mesh.
+    /// Mesh-wide on purpose — the subject and the grant that names it may live in different
     /// partitions — and therefore always an enumeration.
+    ///
+    /// <para>🚨 <b><c>path:*</c> is what makes the fan-out DECLARED, and it is load-bearing.</b>
+    /// Fan-out is opt-in: a storage provider refuses a query that names no partition and did not ask
+    /// to span them, because a silent cross-schema UNION locks every relation it touches and stalls
+    /// unrelated pinned reads (measured memex-cloud 2026-09-02: 7 786 fan-outs in 30 min, 4 328 over
+    /// 199 of 199 schemas). These reads are the legitimate exception — so they SAY SO here rather
+    /// than being the accident that the refusal exists to catch.</para>
+    ///
+    /// <para>🚨 <b>Do not "fix" this by anchoring it.</b> Narrowing the fold to a viewer's partition
+    /// is TRUNCATION, not optimisation: a <c>GroupMembership</c> lives under its GROUP while the
+    /// grant naming it lives elsewhere, so a partition-scoped read silently drops memberships — and
+    /// a group-scoped DENY that loses its membership rows fails OPEN (#2011), with nothing logged.
+    /// The cost is real and the lever is materialisation, never a narrower query. See
+    /// <c>Doc/Architecture/CrossSchemaFanOutElimination</c> and <c>Doc/Architecture/UnanchoredSecurityReads</c>.</para>
     /// </summary>
     /// <param name="nodeType">The node type to enumerate.</param>
     /// <param name="projection">The <c>select:</c> projection; content by default.</param>
     /// <returns>The query string.</returns>
     public static string Global(string nodeType, string projection = ContentProjection)
-        => Enumeration($"nodeType:{nodeType} scope:subtree {projection}");
+        => Enumeration($"nodeType:{nodeType} {ExplicitFanOut} scope:subtree {projection}");
+
+    /// <summary>
+    /// The qualifier that turns an unanchored read into an EXPLICITLY cross-partition one. A query
+    /// carrying it has said "every partition" out loud; a query without any anchor at all has said
+    /// nothing, and is refused rather than silently served the most expensive plan the mesh has.
+    /// </summary>
+    public const string ExplicitFanOut = "path:*";
 
     /// <summary>Every custom <c>Role</c> definition in the mesh (<c>$security-roles</c>).</summary>
     public static string Roles => Global(RoleNodeType);

--- a/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
@@ -83,7 +83,7 @@ public static class SecurityQueries
     /// Mesh-wide on purpose — the subject and the grant that names it may live in different
     /// partitions — and therefore always an enumeration.
     ///
-    /// <para>🚨 <b><c>path:*</c> is what makes the fan-out DECLARED, and it is load-bearing.</b>
+    /// <para>🚨 <b><c>partitions:all</c> is what makes the fan-out DECLARED, and it is load-bearing.</b>
     /// Fan-out is opt-in: a storage provider refuses a query that names no partition and did not ask
     /// to span them, because a silent cross-schema UNION locks every relation it touches and stalls
     /// unrelated pinned reads (measured memex-cloud 2026-09-02: 7 786 fan-outs in 30 min, 4 328 over
@@ -108,7 +108,7 @@ public static class SecurityQueries
     /// carrying it has said "every partition" out loud; a query without any anchor at all has said
     /// nothing, and is refused rather than silently served the most expensive plan the mesh has.
     /// </summary>
-    public const string ExplicitFanOut = "path:*";
+    public const string ExplicitFanOut = ParsedQuery.CrossPartitionQualifier;
 
     /// <summary>Every custom <c>Role</c> definition in the mesh (<c>$security-roles</c>).</summary>
     public static string Roles => Global(RoleNodeType);

--- a/test/MeshWeaver.Hosting.Test/SecurityQueryShapesTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SecurityQueryShapesTest.cs
@@ -206,21 +206,49 @@ public class SecurityQueryShapesTest
             + "Doc/Architecture/CrossSchemaFanOutElimination");
 
     /// <summary>
-    /// The census in the vocabulary of the log line: every <c>path:-</c> shape the fold issues is
-    /// one of the declared globals — so a reader of the Loki census can tell, from the shape alone,
-    /// whether a line came from a DECLARED fold read or from a new caller.
+    /// 🚨 <b>NO shape the fold issues is path-LESS any more.</b> Fan-out is opt-in: a storage
+    /// provider refuses a query that names no partition and did not ask to span them, so a fold read
+    /// is now either anchored to a partition or carries <see cref="SecurityQueries.ExplicitFanOut"/>
+    /// and has said "every partition" out loud. A shape that logs as <c>path:-</c> would be REFUSED
+    /// at runtime, which for the fold means a permission that cannot be evaluated.
+    ///
+    /// <para>This replaces the older, weaker form of this census ("every path-less shape is one of
+    /// the declared globals"). That version became VACUOUS the moment the globals started declaring
+    /// themselves: its loop body only ran for <c>path:-</c> shapes, so with none left it asserted
+    /// nothing at all while still passing green. The invariant below has the opposite shape — it
+    /// fails when a path-less one appears — so it cannot pass by finding nothing.</para>
     /// </summary>
     [Fact]
-    public void EveryPathLessShapeTheFoldIssuesIsADeclaredGlobal()
+    public void NoShapeTheFoldIssuesIsPathLess()
     {
-        var declared = DeliberatelyGlobal.Select(x => Describe(x.Shape)).ToHashSet(StringComparer.Ordinal);
-        declared.Should().NotBeEmpty();
-        foreach (var shape in SecurityQueries.AllShapes)
+        SecurityQueries.AllShapes.Should().NotBeEmpty("a census over nothing proves nothing");
+
+        var pathLess = SecurityQueries.AllShapes
+            .Where(shape => Describe(shape).Contains(" path:- ", StringComparison.Ordinal))
+            .ToArray();
+
+        pathLess.Should().BeEmpty(
+            "a query with no first segment is refused by the storage provider as insufficiently "
+            + "specified — anchor it, or declare the fan-out with SecurityQueries.ExplicitFanOut. "
+            + "See Doc/Architecture/CrossSchemaFanOutElimination");
+    }
+
+    /// <summary>
+    /// The other half: the deliberately mesh-wide reads still ARE mesh-wide. Making them explicit
+    /// must not have quietly anchored them — anchoring the fold is truncation, and a truncated
+    /// membership set makes a group-scoped deny fail open (#2011). So each declared global must
+    /// still route as a fan-out, and must carry the marker that makes that legal.
+    /// </summary>
+    [Fact]
+    public void EveryDeliberateGlobalDeclaresItsFanOutAndStillFansOut()
+    {
+        DeliberatelyGlobal.Should().NotBeEmpty();
+        foreach (var (shape, reason) in DeliberatelyGlobal)
         {
-            var described = Describe(shape);
-            if (described.Contains(" path:- ", StringComparison.Ordinal))
-                declared.Should().Contain(described,
-                    $"'{shape}' carries no first segment, so its log shape must be a declared global");
+            shape.Should().Contain(SecurityQueries.ExplicitFanOut,
+                $"a mesh-wide fold read must declare it — {reason}");
+            RouteOf(shape).Kind.Should().Be(Route.FanOut,
+                $"declaring the fan-out must not have anchored it — {reason}");
         }
     }
 

--- a/test/MeshWeaver.Hosting.Test/SecurityQueryShapesTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SecurityQueryShapesTest.cs
@@ -219,18 +219,27 @@ public class SecurityQueryShapesTest
     /// fails when a path-less one appears — so it cannot pass by finding nothing.</para>
     /// </summary>
     [Fact]
-    public void NoShapeTheFoldIssuesIsPathLess()
+    public void EveryShapeTheFoldIssuesSaysWhereToLook()
     {
         SecurityQueries.AllShapes.Should().NotBeEmpty("a census over nothing proves nothing");
 
-        var pathLess = SecurityQueries.AllShapes
-            .Where(shape => Describe(shape).Contains(" path:- ", StringComparison.Ordinal))
+        var parser = new QueryParser();
+        var mute = SecurityQueries.AllShapes
+            .Select(shape => (Shape: shape, Parsed: parser.Parse(shape)))
+            // 🚨 The same three ways the storage provider accepts, in the same order — a concrete
+            // anchor, an explicit `partitions:all`, or a wildcard namespace pattern. Testing only
+            // for a Path would MISS the declared globals: `partitions:all` sets a FLAG and leaves
+            // Path null, so a path-based census reports a correctly-declared read as unanchored.
+            .Where(x => string.IsNullOrEmpty(x.Parsed.Path)
+                        && !x.Parsed.CrossPartition
+                        && x.Parsed.ExtractNamespacePatterns().Count == 0)
+            .Select(x => x.Shape)
             .ToArray();
 
-        pathLess.Should().BeEmpty(
-            "a query with no first segment is refused by the storage provider as insufficiently "
-            + "specified — anchor it, or declare the fan-out with SecurityQueries.ExplicitFanOut. "
-            + "See Doc/Architecture/CrossSchemaFanOutElimination");
+        mute.Should().BeEmpty(
+            "a query that names no partition and does not ask to span them is refused by the "
+            + "storage provider as insufficiently specified — anchor it, or declare the fan-out "
+            + "with SecurityQueries.ExplicitFanOut. See Doc/Architecture/CrossSchemaFanOutElimination");
     }
 
     /// <summary>
@@ -245,7 +254,7 @@ public class SecurityQueryShapesTest
         DeliberatelyGlobal.Should().NotBeEmpty();
         foreach (var (shape, reason) in DeliberatelyGlobal)
         {
-            shape.Should().Contain(SecurityQueries.ExplicitFanOut,
+            new QueryParser().Parse(shape).CrossPartition.Should().BeTrue(
                 $"a mesh-wide fold read must declare it — {reason}");
             RouteOf(shape).Kind.Should().Be(Route.FanOut,
                 $"declaring the fan-out must not have anchored it — {reason}");


### PR DESCRIPTION
## Why

`SecurityQueries.Global` built a **path-less** query and the Postgres provider answered it with a `UNION ALL` over every searchable schema.

Measured on memex-cloud, 2026-09-02, 30 minutes: **7 786 fan-out warnings, 4 328 spanning 199 of 199 schemas.** A live pod's only MeshWeaver stack frames were `EnumerateFanOutAsync` / `QueryAcrossSchemasAsync`, with **2 699 queued thread-pool work items against 6 threads**. The fold's own shapes: `AccessAssignment` 1 127, `PartitionAccessPolicy` 360, `GroupMembership` 251.

One 199-schema UNION takes heavyweight locks on 500+ relations against a backend's **16 fast-path lock slots**, so the lock manager serialises and unrelated **pinned point-reads were measured waiting 2–5 s**.

## What

1. **`partitions:all`** — a reserved qualifier setting `ParsedQuery.CrossPartition`. The explicit "span every partition" request, and the only thing that makes an otherwise unanchored query legal.
2. **`SecurityQueries.Global` declares it.** Same rows, same plan, same cost — the span is now *declared*, which is what lets the paired Plugins change refuse the queries that never asked.
3. **`NodeTypeBatchBake`'s bare `nodeType:Code` global fetch declares it** (its two siblings already carry a wildcard `namespace:`).

## 🚨 Why it is a flag and not `path:*`

This branch's first commit used `path:*`. That was wrong in the worst possible way, and the tests caught it:

```
[FanOut] pinned fast-path: partition=* table=threads
[CrossSchema] Skipping satellite query — relation "*.threads" does not exist
[CrossSchema] threads: 0/0 rows
```

Partition resolution reads a path's **first segment as a schema name**, so `path:*` pins to a partition literally called `*` — no error, no log, an **empty result**. On `SecurityQueries.Global` that is every permission in the mesh silently evaluating to nothing. A flag cannot be mistaken for a partition name.

## What this deliberately does NOT do

It does not **anchor** the fold. Narrowing these reads to a viewer's partition is truncation: a `GroupMembership` lives under its **group** while the grant naming it lives elsewhere, so a partition-scoped read drops memberships and a group-scoped **DENY fails open** (#2011). The lever for the cost is materialisation, never a narrower query.

## The guard follows its subject — twice

- `EveryPathLessShapeTheFoldIssuesIsADeclaredGlobal` would have gone **vacuous**: its loop body ran only for `path:-` shapes, so with none left it asserted nothing and still passed.
- Its replacement then failed for the *right* reason: `Describe` derives `path:` from `ParsedQuery.Path`, and `partitions:all` sets a flag while leaving Path **null** — so a path-based census reports a correctly-declared read as unanchored.

`EveryShapeTheFoldIssuesSaysWhereToLook` now applies the same three rules the storage provider applies (concrete anchor / `CrossPartition` / wildcard namespace), so test and runtime agree by construction. Plus `EveryDeliberateGlobalDeclaresItsFanOutAndStillFansOut` as the positive control that declaring did not quietly anchor them.

## Verification

- `MeshWeaver.Hosting.Test` query + security suites: **64/64 pass**, `.trx` written.
- Release `-warnaserror`: 0 warnings, 0 errors.
- Paired against the Plugins refusal: that repo's PostgreSql suite is **939/939 green**, from 70 failures when the refusal first landed.

## Sequencing

🚨 **Merge this BEFORE** `Systemorph/MeshWeaver.Plugins` `perf/no-fanout-by-default`. It supplies `ParsedQuery.CrossPartition` and declares the fold's fan-out; the other way round, permission evaluation returns "cannot be established" (it fails *closed* — nothing opens up — but admin surfaces stop rendering).

Pairs-with: Systemorph/MeshWeaver.Plugins `perf/no-fanout-by-default`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPuf8cduViBpyJp9mKDDK
