### PR TITLE
fix: three races that redden the merge queue — a truncated teardown, a frozen policy read, a fixture that races the owner

### DIFF
--- a/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
+++ b/memex/Memex.Portal.Shared/SelfUpdate/SelfUpdateHostedService.cs
@@ -304,8 +304,22 @@ public class SelfUpdateHostedService : IHostedService
     /// the RetryWhen, so a retry re-establishes the read silently (Copilot review on #611).</item>
     /// </list>
     /// Retries are delayed, Rx-composed resubscribes at the polling cadence — not a hot retry loop,
-    /// not a watchdog. <c>DistinctUntilChanged</c> sits outermost so only a REAL policy change (or
-    /// the initial value) re-drives the Switch.
+    /// not a watchdog.
+    ///
+    /// <para>🚨 <b>Nothing de-duplicates the CONTENT here, and that is deliberate.</b> This source
+    /// used to end in <c>DistinctUntilChanged(c =&gt; (c.Policy, c.RequireCiGreen))</c> — a leftover
+    /// from the <c>Switch</c>-based shape, whose comment still said "re-switch only on a REAL policy
+    /// change" long after the <c>Switch</c> was gone. With the watch moved OUT of the policy stream
+    /// there is nothing left to re-drive, so the operator no longer prevented a resubscribe; it
+    /// FILTERED the content, and this stream is also what <c>StartAsync</c> reads AT DECISION TIME
+    /// (<c>policy.Take(1)</c> off the <c>Replay(1)</c>). Every field other than those two was
+    /// therefore pinned to the first emission for the life of the pod: a combo verdict landed by
+    /// <c>mw-combo-verify</c> after startup was invisible to the gate that exists to honour it, and
+    /// the poller rolled to an image it had been told this instance's modules cannot run. The
+    /// trigger stream keeps its OWN <c>DistinctUntilChanged(content =&gt; content.Policy)</c>, so a
+    /// content change that is not a policy change still triggers nothing — including this service's
+    /// own <c>LastCheckedAt</c>/<c>LastCheckVerdict</c> bookkeeping writes, which is why letting
+    /// them through cannot loop.</para>
     /// </summary>
     private IObservable<UpdatePolicyContent> CreatePolicySource()
     {
@@ -318,8 +332,7 @@ public class SelfUpdateHostedService : IHostedService
                 .Defer(ReadPolicyStream)
                 // The gate has opened: from here a fault costs freshness, not the feature.
                 .Do(_ => Interlocked.Exchange(ref _policyEstablished, 1))
-                .RetryWhen(ResubscribeAfterRetryInterval("policy stream")))
-            .DistinctUntilChanged(c => (c.Policy, c.RequireCiGreen)); // <-- re-switch only on a REAL policy change
+                .RetryWhen(ResubscribeAfterRetryInterval("policy stream")));
     }
 
     /// <summary>

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -908,6 +908,21 @@ public static class DataExtensions
         string hubPath,
         Func<bool> tryClaimAck)
     {
+        // 🚨 BOTH dependencies are resolved HERE, on the handler's turn, and closed over — never
+        // from inside the disposal action below. MessageHub's own ShutDown phase states the rule
+        // ("Never call DI from a disposal path") because a hub's lifetime scope, or an ancestor of
+        // it, can already be closed by the time disposal actions run: HostedHubsCollection closes a
+        // hosted hub's scope on DisposalCompleted, and the watchdog's out-of-band
+        // ForceTeardownAfterWatchdog runs hostedHubs.Dispose() BEFORE DisposeImpl(). A resolve then
+        // throws ObjectDisposedException ("Instances cannot be resolved … from this LifetimeScope"),
+        // which costs this NACK twice over: the verdict is never dispatched — so the writer burns
+        // the full 31 s WriteVerdictBound and reports OwnerUnreachable, the exact acked-write-loss
+        // this registration exists to prevent — and, because the hub's synchronous cleanups live in
+        // one Rx CompositeDisposable whose Dispose stops at the first throw, EVERY disposal action
+        // registered after this one is skipped as well. Observed on main shard 4, 2026-09-02
+        // (LateNackReenqueueTest, run 33630685580).
+        var lateVerdicts = hub.ServiceProvider.GetService<ILatePatchVerdictSink>();
+        var parent = hub.Configuration.ParentHub;
         hub.RegisterForDisposal(_ =>
         {
             if (!tryClaimAck())
@@ -947,7 +962,6 @@ public static class DataExtensions
             // teardown is still waiting, and it is the one guaranteed to get silence instead of its
             // NACK, then to burn the full 31 s WriteVerdictBound (#2778). Dispatch RETURNS whether
             // a caller was armed, so the question is now answered rather than assumed.
-            var lateVerdicts = hub.ServiceProvider.GetService<ILatePatchVerdictSink>();
             if (lateVerdicts is not null && lateVerdicts.Dispatch(request.Id, resp))
                 return;
 
@@ -956,7 +970,9 @@ public static class DataExtensions
             // cannot see. The existing post remains that case's only route, with its run-level
             // guard unchanged: removing it is the ~10x regression above, and a cross-process
             // caller during owner teardown is not the case #2778 reproduced.
-            var parent = hub.Configuration.ParentHub;
+            // (`parent` was captured at registration — Configuration.ParentHub re-resolves from
+            // ParentServiceProvider, the DI touch this path must not make. Its RunLevel is read
+            // here, live, because that is the guard's whole subject.)
             if (parent is not null && parent.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
                 parent.Post(resp, o => o.ResponseFor(request));
         });
@@ -2475,6 +2491,12 @@ public static class DataExtensions
         var state = 0;
         bool TryClaimSilentTerminal() => Interlocked.CompareExchange(ref state, 2, 0) == 0;
 
+        // 🚨 Captured on the handler's turn, while the scope is provably alive — the disposal arm
+        // below runs where Configuration.ParentHub's re-resolve out of ParentServiceProvider can
+        // throw ObjectDisposedException, and the parent post is the ONLY route left for the answer
+        // at that point. Same rule (and same reason) as RegisterOwnerDisposingNack.
+        var parentHub = hub.Configuration.ParentHub;
+
         var subscription = RunReadValidators(hub, request.Message.Reference)
             .SelectMany(validationResult =>
             {
@@ -2551,7 +2573,7 @@ public static class DataExtensions
                     // away" and the rate run came back 10/100 with every remaining failure being
                     // that missing marker — a product regression, not merely a red assertion.
                     // Both causes are named, but the marker stays.
-                    NackSilentRead(hub, request,
+                    NackSilentRead(hub, parentHub, request,
                         "the read faulted because the owning hub is shutting down — its hosted-hub "
                         + "creation is frozen or its service scope has been closed, so the data "
                         + $"stream for this reference could not be created ({cause.GetType().Name}: "
@@ -2569,7 +2591,7 @@ public static class DataExtensions
                     // otherwise stay silent here and let the disposal arm below be the one that
                     // speaks, since it cannot run except during teardown.
                     if (IsWindingDown(hub) && TryClaimSilentTerminal())
-                        NackSilentRead(hub, request,
+                        NackSilentRead(hub, parentHub, request,
                             "the data stream for this reference completed without ever producing a value "
                             + "while the owner is shutting down (the stream was disposed before the initial "
                             + "state landed). Retry against the fresh activation.");
@@ -2585,7 +2607,7 @@ public static class DataExtensions
         {
             subscription.Dispose();
             if (TryClaimSilentTerminal())
-                NackSilentRead(hub, request,
+                NackSilentRead(hub, parentHub, request,
                     "the owning hub was disposed while this read was still outstanding — it is "
                     + "shutting down and never produced a value. Retry against the fresh activation.");
         }));
@@ -2677,7 +2699,7 @@ public static class DataExtensions
     /// teardown the parent is past that mark too, the post is skipped, and nobody is waiting.</para>
     /// </summary>
     private static void NackSilentRead(
-        IMessageHub hub, IMessageDelivery<GetDataRequest> request, string reason)
+        IMessageHub hub, IMessageHub? parent, IMessageDelivery<GetDataRequest> request, string reason)
     {
         var message =
             $"GetDataRequest({request.Message.Reference}) at '{hub.Address}': {reason}";
@@ -2703,7 +2725,6 @@ public static class DataExtensions
                 hub.Post(failure, o => o.ResponseFor(request));
                 return;
             }
-            var parent = hub.Configuration.ParentHub;
             if (parent is not null && parent.RunLevel < MessageHubRunLevel.DisposeHostedHubs)
                 parent.Post(failure, o => o.ResponseFor(request));
         }

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -915,12 +915,15 @@ public static class DataExtensions
         // hosted hub's scope on DisposalCompleted, and the watchdog's out-of-band
         // ForceTeardownAfterWatchdog runs hostedHubs.Dispose() BEFORE DisposeImpl(). A resolve then
         // throws ObjectDisposedException ("Instances cannot be resolved … from this LifetimeScope"),
-        // which costs this NACK twice over: the verdict is never dispatched — so the writer burns
-        // the full 31 s WriteVerdictBound and reports OwnerUnreachable, the exact acked-write-loss
-        // this registration exists to prevent — and, because the hub's synchronous cleanups live in
-        // one Rx CompositeDisposable whose Dispose stops at the first throw, EVERY disposal action
-        // registered after this one is skipped as well. Observed on main shard 4, 2026-09-02
+        // and the verdict is then never dispatched — so the writer burns the full 31 s
+        // WriteVerdictBound and reports OwnerUnreachable, the exact acked-write-loss this
+        // registration exists to prevent. Observed on main shard 4, 2026-09-02
         // (LateNackReenqueueTest, run 33630685580).
+        //
+        // MessageHub.GuardRegistrant now stops such a throw from also cancelling the cleanups
+        // registered BEHIND this one — that was the second half of the same incident — but it
+        // cannot mint a verdict this registrant failed to produce. The isolation makes the blast
+        // radius one registrant; capturing eagerly is what keeps this registrant out of it.
         var lateVerdicts = hub.ServiceProvider.GetService<ILatePatchVerdictSink>();
         var parent = hub.Configuration.ParentHub;
         hub.RegisterForDisposal(_ =>

--- a/src/MeshWeaver.Documentation/Data/Architecture/ComboGateWiring.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ComboGateWiring.md
@@ -149,6 +149,33 @@ three places at once:
 Only `Red` reads as held. A `NotVerifiable` is not a hold — nothing refused that build — and
 rendering it as one would send an operator to fix an incompatibility that was never diagnosed.
 
+## 🚨 The verdict is read at DECISION time, never once at start-up
+
+`ComboVerificationGate.Recorded` folds `policy.VerificationFor(tag)` off the
+`UpdatePolicyContent` **the poller hands it**, so the gate is only ever as fresh as that read.
+And the shape production always has is a verdict that lands *after* the pod started: a portal
+runs for days, and `mw-combo-verify` records its verdict when a candidate is published.
+
+`SelfUpdateHostedService.CreatePolicySource` used to end in
+`DistinctUntilChanged(c => (c.Policy, c.RequireCiGreen))` — a leftover from the `Switch`-based
+shape it outlived. Once the build watch moved out of the policy stream there was nothing left
+for it to re-drive, so it no longer prevented a resubscribe; it filtered the **content**, and
+that same stream is what `StartAsync` reads at decision time (`policy.Take(1)` off the
+`Replay(1)`). Recording a verdict changes neither of those two fields, so the emission carrying
+it was dropped and every later check kept deciding on the content as it stood at start-up. Every
+other field went with it — `HeldTag`, `LastRolledTag`, an operator's edit on the Updates tab.
+
+The gate was therefore recorded, rendered on the tab, and **unable to refuse anything** — #2274's
+"built, documented, tested, and called by nothing" with one extra step. Nothing de-duplicates the
+content now. The trigger stream keeps its own `DistinctUntilChanged(content => content.Policy)`,
+so a content change that is not a policy change still triggers nothing — including the poller's
+own `LastCheckedAt`/`LastCheckVerdict` bookkeeping writes, which is why letting them through
+cannot loop.
+
+Pinned by `ComboGateRollTest.AVerdictRecordedAfterTheFirstCheck_RefusesTheNextRoll`, whose second
+check is driven by the **safety net** on purpose: a policy change would refresh the content even
+with the defect present, because it moves the very field the filter keyed on.
+
 ## Cost, and why the walk is cheap
 
 `VersionSelect.PickTargets` returns every eligible tag newest-first and the poller takes the first

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -565,8 +565,60 @@ assertion that a probe wrote no fault line is complete once `DisposalCompleted` 
 because the `ShutdownRequest` is queued behind the init turn and the teardown has written
 whatever it writes by then.
 
+## 🚨 A disposal path never resolves from DI — and never truncates itself
+
+Two rules, one incident. Both are enforced in `MessageHub`, and code that registers
+disposal work has to obey the first.
+
+**1. Never call DI from a disposal path.** By the time a hub's registered clean-ups run,
+its lifetime scope — or an ancestor of it — may already be closed:
+`HostedHubsCollection.CloseScopeWhenDisposed` closes a hosted hub's scope on
+`DisposalCompleted`, and the watchdog's `ForceTeardownAfterWatchdog` runs
+`hostedHubs.Dispose()` *before* `DisposeImpl()`. A resolve then throws
+
+```
+ObjectDisposedException: Instances cannot be resolved and nested lifetimes cannot be
+created from this LifetimeScope as it (or one of its parent scopes) has already been disposed.
+```
+
+`hub.Configuration.ParentHub` counts as a resolve — it re-reads `ParentServiceProvider`.
+So does `GetService<ILoggerFactory>()`. **Capture what the clean-up needs at REGISTRATION
+time**, on the handler's turn, and close over it:
+
+```csharp
+// ✅ resolved while the scope is provably alive, used later
+var sink = hub.ServiceProvider.GetService<ILatePatchVerdictSink>();
+var parent = hub.Configuration.ParentHub;
+hub.RegisterForDisposal(_ => { if (!sink!.Dispatch(id, verdict)) parent?.Post(verdict); });
+
+// ❌ resolved on the disposal path — throws once the scope is closed
+hub.RegisterForDisposal(_ =>
+    hub.ServiceProvider.GetService<ILatePatchVerdictSink>()!.Dispatch(id, verdict));
+```
+
+**2. A failing clean-up is isolated, not fatal to the rest.** The hub's synchronous
+clean-ups live in one Rx `CompositeDisposable`, and `CompositeDisposable.Dispose` walks
+its list with **no per-item guard**: the first registrant that throws ends the walk, and
+every clean-up registered behind it is skipped in silence. `RegisterForDisposal` therefore
+wraps every registrant (`MessageHub.GuardRegistrant`): a fault is logged as
+`[DISPOSE-REGISTRANT] {Address}: a registered cleanup ({Registrant}) faulted…` and the
+walk continues. This is the same per-leg isolation the *reactive* dispose actions already
+had — it is isolation, not tolerance: nothing is swallowed, and a registrant that throws
+is still a bug in that registrant.
+
+**What it cost, measured.** Main shard 4, 2026-09-02 (run 33630685580): a per-node owner
+hub went down through the watchdog's out-of-band teardown; one clean-up resolved from an
+already-closed scope; the walk stopped there; and the `OwnerDisposing` NACK behind it — the
+verdict that tells a writer "this did not apply, retry against the fresh activation" — was
+never minted. Its writer heard nothing and burned the full 31 s `WriteVerdictBound` before
+reporting `OwnerUnreachable`. An acked write lost to a teardown that had truncated itself.
+Pinned by `DisposalRegistrantFaultIsolationTest`.
+
 ## Adding disposal work — the rule
 
+- **Anything the clean-up needs from DI?** Resolve it at REGISTRATION time and close over
+  it — see the rule above. A disposal action that calls `GetService`, `GetRequiredService`
+  or `Configuration.ParentHub` is a defect even when it happens to work today.
 - **Installing a WATCHER the hub owns?** `SubscribeHubWatcher(hub, …)`, then hand the
   result to `RegisterForDisposal` as before. The registration is the backstop; the
   `ShuttingDown` signal is what actually ends the watcher — see the section above.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-save-still-gets-its-answer-when-a-node-shuts-down.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-save-still-gets-its-answer-when-a-node-shuts-down.md
@@ -1,0 +1,35 @@
+---
+Name: A save still gets its answer when a node shuts down
+Category: Fix
+Description: When the part of the mesh that owns a node was shutting down mid-save, the answer it had already prepared could be discarded — and the save sat unanswered for half a minute before reporting itself unconfirmed.
+Icon: SaveEdit
+Order: -20260903
+---
+
+# A save still gets its answer when a node shuts down
+
+Every save is confirmed by the part of the mesh that owns the thing being saved. When that owner is
+shutting down at the moment a save arrives, it does not simply go quiet: it prepares a specific
+answer — *"this did not apply; it is safe to retry"* — which is what lets the save be re-applied
+against the fresh owner and land, rather than being lost.
+
+That answer could be thrown away before anyone saw it. A shutdown runs a list of clean-up steps in
+order, and the list stopped at the first step that failed. One step failing therefore silently
+cancelled every step behind it — including the one that hands over the prepared answer. The save
+then heard nothing at all, waited out its full confirmation window of about half a minute, and
+reported itself **unconfirmed**: not an error you could act on, just an edit whose fate you were
+told nobody could establish.
+
+Two things changed:
+
+- **A failing clean-up step no longer cancels the rest.** Each step now runs on its own, the
+  failure is recorded naming the step that raised it, and everything behind it still runs. Nothing
+  is hidden — a step that fails is a bug in that step, and it is now reported as one instead of as
+  a shutdown that quietly stopped half-way.
+- **The step that hands over the answer no longer depends on anything that can be gone by then.**
+  It now takes hold of what it needs while the owner is still fully alive, so it cannot be the step
+  that fails.
+
+The visible effect is that a save caught by a shutdown gets its answer immediately and is retried
+and applied, instead of hanging for thirty seconds and coming back unconfirmed. Saves that were not
+caught by a shutdown are unaffected — this changes nothing on the ordinary path.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-verification-that-arrives-later-still-counts.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-verification-that-arrives-later-still-counts.md
@@ -1,0 +1,36 @@
+---
+Name: A verification that arrives later still counts
+Category: Fix
+Description: Your installation checks whether a new platform build can actually run the packages you have installed. It was only ever reading that answer once, at start-up — so an answer produced afterwards was ignored and the update went ahead anyway.
+Icon: ShieldCheckmark
+Order: -20260903
+---
+
+# A verification that arrives later still counts
+
+Before your installation updates itself to a new platform build, something has to answer a question
+the version number cannot: **can that build still run the packages you actually have installed?**
+A platform change can be perfectly good and still be unable to serve a package built against the
+previous one, and the failure lands at start-up — a portal that comes back up broken rather than
+one that never moved.
+
+That answer is produced elsewhere and delivered to your installation, where it is recorded and
+shown on the **Updates** settings tab. Your installation then refuses any build the answer says
+would break a package you run, and says which package.
+
+**The answer almost always arrives after your portal has already been running for a while** — it is
+produced when a new build is published, which is days or weeks after your pod last started. And
+that was exactly the case being missed: the update watcher read the record once, when it started,
+and then went on deciding from that first reading for the entire life of the pod. An answer landing
+afterwards changed the stored record, was visible on the Updates tab, and reached the decision
+never. In practice that meant the refusal almost never happened — the check existed, was recorded,
+was displayed, and did not stop anything.
+
+**The watcher now decides against the record as it stands at that moment.** A verification that
+lands while your portal is running is honoured on the next check, the hold appears on the Updates
+tab naming the package that would break, and the update waits for a build that can serve you.
+
+Nothing else changed about how updates are paced: this reads the same record more freshly, it does
+not check more often, and a clean verification still lets the update straight through. The
+same freshness applies to everything else the record carries — a hold cleared by hand, a policy
+detail edited on the tab — none of which used to reach a running watcher either.

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -2079,10 +2079,14 @@ public sealed class MessageHub : IMessageHub
             try { registrant.Dispose(); }
             catch (Exception e)
             {
-                TryLog(LogLevel.Warning,
-                    "[DISPOSE-REGISTRANT] {Address}: a registered cleanup ({Registrant}) faulted: "
-                    + "{Type}: {Message}. The remaining cleanups still ran.",
-                    Address, registrant.GetType().Name, e.GetType().Name, e.Message);
+                // 🚨 The EXCEPTION, not its ToString(): a registrant that throws here is a bug in
+                // that registrant, and the only thing that says WHICH line raised it is the stack
+                // trace. Type+message alone names the symptom and hides the site — and this arm is
+                // now the ONLY report of that fault, since the walk no longer ends on it.
+                TryLog(LogLevel.Warning, e,
+                    "[DISPOSE-REGISTRANT] {Address}: a registered cleanup ({Registrant}) faulted. "
+                    + "The remaining cleanups still ran.",
+                    Address, registrant.GetType().Name);
             }
         });
 

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -345,7 +345,7 @@ public sealed class MessageHub : IMessageHub
         // Also register in the disposables composite so a NORMAL teardown kills the
         // timer promptly (rather than waiting for the next tick after GC). Double-dispose
         // with the explicit Quiescing-phase dispose is harmless (Rx is idempotent).
-        disposables.Add(sub);
+        disposables.Add(GuardRegistrant(sub));
     }
 
     /// <summary>Single scan tick — extracted so the timer closure captures only a
@@ -1610,7 +1610,10 @@ public sealed class MessageHub : IMessageHub
         // CompositeDisposable. If disposal has already started the composite is
         // disposed and Add disposes the registrant immediately — late registrants
         // never leak. No bag, no imperative drain.
-        disposables.Add(disposable);
+        // Wrapped so a registrant that throws is named rather than truncating the
+        // whole teardown walk — see GuardRegistrant. Applies to the late-registrant
+        // path above too, which disposes through the same wrapper.
+        disposables.Add(GuardRegistrant(disposable));
         return this;
     }
 
@@ -2048,9 +2051,40 @@ public sealed class MessageHub : IMessageHub
         }
 
         // 2. Synchronous teardown of every registered subscription / Action cleanup —
-        //    normal Rx subscription logic, no bag.
+        //    normal Rx subscription logic, no bag. Every registrant went in wrapped by
+        //    GuardRegistrant, so one that throws is named and the walk continues.
         disposables.Dispose();
     }
+
+    /// <summary>
+    /// Wraps a registered cleanup so a fault in it is NAMED and the teardown continues.
+    ///
+    /// <para>🚨 Rx's <c>CompositeDisposable.Dispose</c> walks its list with no per-item guard, so
+    /// the FIRST registrant that throws ends the walk and every cleanup registered after it is
+    /// silently skipped — a subscription left live, a NACK never minted, and nothing in the log
+    /// naming which registrant did it (the caller sees one warning attributed to
+    /// <c>DisposeImpl</c> as a whole). Measured on main shard 4, 2026-09-02: one disposal action
+    /// resolving out of an already-closed lifetime scope threw <c>ObjectDisposedException</c>
+    /// here, and the <c>OwnerDisposing</c> NACK behind it never reached its waiting writer, which
+    /// then burned the full 31 s verdict budget (<c>LateNackReenqueueTest</c>, run 33630685580).</para>
+    ///
+    /// <para>This swallows nothing: the fault is logged with the registrant that raised it, and
+    /// the remaining cleanups still run. A registrant that throws is a bug IN THAT REGISTRANT —
+    /// it is now visible as one instead of as a truncated teardown. It is the same per-leg
+    /// isolation the reactive dispose actions already have in <see cref="DisposeImpl"/>.</para>
+    /// </summary>
+    private IDisposable GuardRegistrant(IDisposable registrant) =>
+        System.Reactive.Disposables.Disposable.Create(() =>
+        {
+            try { registrant.Dispose(); }
+            catch (Exception e)
+            {
+                TryLog(LogLevel.Warning,
+                    "[DISPOSE-REGISTRANT] {Address}: a registered cleanup ({Registrant}) faulted: "
+                    + "{Type}: {Message}. The remaining cleanups still ran.",
+                    Address, registrant.GetType().Name, e.GetType().Name, e.Message);
+            }
+        });
 
     /// <summary>
     /// Multi-line snapshot of the hub's disposal state. Reports own RunLevel + disposal

--- a/test/Memex.Portal.Shared.Test/ComboGateRollTest.cs
+++ b/test/Memex.Portal.Shared.Test/ComboGateRollTest.cs
@@ -192,6 +192,76 @@ public class ComboGateRollTest(ITestOutputHelper output) : MonolithMeshTestBase(
             "an absence nobody can act on is how a gate stays unwired for months");
     }
 
+    /// <summary>
+    /// 🚨 <b>A verdict that lands AFTER this pod started has to be honoured — and that is the only
+    /// shape production ever has.</b>
+    ///
+    /// <para>Every other test here records the verdict BEFORE the poller starts, so all of them pass
+    /// against a service that reads the policy node exactly once and then decides off that frozen
+    /// snapshot forever. Production is the other way round: a portal pod runs for days, and
+    /// <c>mw-combo-verify</c> lands its verdict on <c>Admin/UpdatePolicy</c> whenever a candidate is
+    /// published — always after startup, never before it. A gate that cannot see such a verdict is
+    /// not a gate; it is #2274's original "built, documented, tested, and called by nothing" with
+    /// one extra step.</para>
+    ///
+    /// <para>It WAS frozen: <c>CreatePolicySource</c> ended in
+    /// <c>DistinctUntilChanged(c =&gt; (c.Policy, c.RequireCiGreen))</c>, a leftover from the
+    /// <c>Switch</c>-based shape it outlived. With the watch moved out of the policy stream that
+    /// operator no longer prevented a resubscribe — it filtered the CONTENT, and the same stream is
+    /// what the poller reads at decision time. Recording a verdict changes neither of those two
+    /// fields, so the emission carrying it was dropped and every check kept deciding on the content
+    /// as it stood at startup.</para>
+    ///
+    /// <para>The check that must honour it is driven by the SAFETY NET, deliberately: a policy
+    /// change would refresh the content even with the defect present (it changes the very field the
+    /// filter keyed on), so a test that triggered one would pass either way.</para>
+    /// </summary>
+    [Fact(Timeout = 240_000)]
+    public async Task AVerdictRecordedAfterTheFirstCheck_RefusesTheNextRoll()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        await Seed();
+        var updater = new RecordingUpdater();
+        var service = new GatedSelfUpdateService(
+            Mesh, new FakeAcrTagLister(), updater, FastPollWithSafetyNet(),
+            Mesh.ServiceProvider.GetService<ILogger<SelfUpdateHostedService>>(),
+            new AlwaysAvailable(Mesh, new ConfigurationBuilder().Build()), ComboGate());
+
+        await service.StartAsync(CancellationToken.None);
+        try
+        {
+            // Wait for the service to have EVALUATED, never for a state to appear inside a bound —
+            // the same rule RunOneCheck follows and for the same reason.
+            await service.Evaluations.FirstAsync().Timeout(Budget).Await(ct);
+            updater.Tags.Should().Contain(CandidateTag,
+                "nothing is recorded yet, so the first check rolls UNVERIFIED — which is what makes "
+                + "the verdict arriving next the thing under test");
+
+            // The mw-combo-verify moment: the verdict lands while the poller is already running.
+            await Record(Red());
+
+            // The check's own verdict stamp is the LAST write of a check, so a content carrying it
+            // carries every earlier write of that check — the hold included. Waiting on IsHeld
+            // alone returns the content BETWEEN the two writes and reads a previous check's stamp.
+            var held = await WaitForContent(
+                c => c.LastCheckVerdict?.Contains("BLOCKED by the combo gate") == true);
+
+            held.IsHeld(CandidateTag).Should().BeTrue(
+                "the verdict arrived while the poller was running, and a refusal that leaves no "
+                + "trace is the silent freeze this gate must never become");
+            held.HeldReason.Should().Contain("Widget",
+                "the refusal must name the module that breaks, exactly as it does when the verdict "
+                + "was there from the start");
+            held.HeldIndeterminate.Should().BeFalse(
+                "the gate LOOKED and found an incompatibility — that is a candidate to re-verify, "
+                + "not an availability incident");
+        }
+        finally
+        {
+            await service.StopAsync(CancellationToken.None);
+        }
+    }
+
     // ══════════════════════════════════════════════════════════════════════════
     //  The wiring pin: InstanceComboVerifier is actually RUN
     // ══════════════════════════════════════════════════════════════════════════
@@ -297,6 +367,14 @@ public class ComboGateRollTest(ITestOutputHelper output) : MonolithMeshTestBase(
             await service.StopAsync(CancellationToken.None);
         }
     }
+
+    /// <summary>The same poller, plus a fast SAFETY NET so a SECOND check runs without an admin
+    /// touching the policy. The safety net is the only trigger that re-decides on unchanged policy
+    /// — which is exactly the shape a verdict landing mid-life has to be honoured through.</summary>
+    private static SelfUpdateOptions FastPollWithSafetyNet() => FastPoll() with
+    {
+        SafetyNetCheckInterval = TimeSpan.FromMilliseconds(250),
+    };
 
     private static SelfUpdateOptions FastPoll() => new()
     {

--- a/test/MeshWeaver.Compiler.Pipeline.Test/LeavingHubAdoptionSweepTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/LeavingHubAdoptionSweepTest.cs
@@ -43,7 +43,27 @@ public class LeavingHubAdoptionSweepTest(ITestOutputHelper output) : MonolithMes
 {
     private const string LiveAssemblyPath = "live/LeavingSweepType.dll";
     private const string LiveMvid = "11ee0000aaaa0000";
-    private const string FixtureLiveFingerprint = "live-fingerprint-fixture";
+    /// <summary>
+    /// 🚨 The fingerprint the OWNER will hold for this fixture type — computed with the product's
+    /// own function over the type's live source set, which for a fixture type is EMPTY.
+    ///
+    /// <para>It used to be the literal <c>"live-fingerprint-fixture"</c>, on the reasoning that "a
+    /// sourceless fixture type publishes nothing that could move it". That is false: a sourceless
+    /// type publishes the fingerprint of the empty source set, and the owner's sources watcher
+    /// writes it over whatever the fixture seeded — at a moment nothing in the test controls. When
+    /// it landed mid-test the CONTROL arm's matching bundle stopped matching, the owner refused the
+    /// adoption it was supposed to accept, cleared the coordinates and dispatched a fresh compile,
+    /// and the final assertion waited 20 s for an MVID that was never going to arrive. Twice on the
+    /// merge queue for PR #3143 (runs 33673071012 and 33669188031), where a queue red costs every
+    /// PR behind it.</para>
+    ///
+    /// <para>Stating the value the product itself computes removes the race rather than narrowing
+    /// it: the watcher's recompute now writes the SAME value, so there is no window in which the
+    /// two arms mean something different. The two arms still differ by exactly one thing — whether
+    /// the producer's fingerprint equals the live one — which is the whole subject of the test.</para>
+    /// </summary>
+    private static readonly string FixtureLiveFingerprint =
+        NodeTypeSourceFingerprint.Compute([], "type/FixtureLiveSources");
 
     private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
 
@@ -85,8 +105,14 @@ public class LeavingHubAdoptionSweepTest(ITestOutputHelper output) : MonolithMes
             },
         };
         await MeshService.CreateNode(typeNode).Should().Within(20.Seconds()).Emit();
+        // Wait for BOTH fields, not just the MVID: the live fingerprint is what the seeder's
+        // pre-write check and the owner's stamp check both read, so a test that proceeds before it
+        // is observable is deciding against a record it has not established.
         await Mesh.GetMeshNodeStream(typePath).Should().Within(20.Seconds())
-            .Match(n => n?.Content is NodeTypeDefinition { LatestAssemblyMvid: LiveMvid });
+            .Match(n => n?.Content is NodeTypeDefinition d
+                        && string.Equals(d.LatestAssemblyMvid, LiveMvid, StringComparison.Ordinal)
+                        && string.Equals(d.CurrentSourceFingerprint, FixtureLiveFingerprint,
+                            StringComparison.Ordinal));
     }
 
     private static IObservable<bool> Seed(IMessageHub hub, string typePath, byte[] bytes, string? fingerprint) =>
@@ -152,11 +178,11 @@ public class LeavingHubAdoptionSweepTest(ITestOutputHelper output) : MonolithMes
         var bytes = BundleBytes();
         var bundleMvid = ServedBuildIdentity.OfBytes(bytes);
 
-        // The seeder decides on the owner's CURRENT snapshot of the node. The fixture's published
-        // fingerprint stands for the one the owner's sources watcher writes on a real deployment;
-        // a sourceless fixture type publishes nothing that could move it (CreateLiveType waited
-        // for the record to be observable as written).
-        const string liveFingerprint = FixtureLiveFingerprint;
+        // The seeder decides on the owner's CURRENT snapshot of the node, and this IS that value:
+        // the owner's sources watcher computes the same function over the same (empty) source set,
+        // so its recompute writes the fingerprint back unchanged and cannot move under either arm.
+        // See FixtureLiveFingerprint for what a hand-picked literal cost here.
+        var liveFingerprint = FixtureLiveFingerprint;
 
         // THE STALE ARM — the producer names sources that are not the ones this mesh holds.
         var sweep = SweepHub("sweep");

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalRegistrantFaultIsolationTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalRegistrantFaultIsolationTest.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>One registered cleanup that throws must not silently cancel every cleanup behind it.</b>
+///
+/// <para>A hub's synchronous cleanups all live in one Rx <c>CompositeDisposable</c>, and
+/// <c>CompositeDisposable.Dispose</c> walks its list with NO per-item guard: the first registrant
+/// that throws ends the walk. Everything registered after it is skipped — a subscription left live,
+/// a NACK never minted — and the only trace is one warning attributed to <c>DisposeImpl</c> as a
+/// whole, naming neither the registrant that threw nor the work that was dropped.</para>
+///
+/// <para><b>What that cost, measured.</b> On main shard 4, 2026-09-02 (run 33630685580) a per-node
+/// owner hub went down through the disposal watchdog's out-of-band teardown. One of its disposal
+/// actions resolved a service out of a lifetime scope that was already closed —
+/// <c>ObjectDisposedException: Instances cannot be resolved … from this LifetimeScope</c> — the walk
+/// stopped there, and the <c>OwnerDisposing</c> NACK behind it was never minted. Its writer heard
+/// nothing and burned the full 31 s <c>WriteVerdictBound</c> before reporting
+/// <c>OwnerUnreachable</c>: an acked write lost to a teardown that had truncated itself
+/// (<c>LateNackReenqueueTest</c>). The registrant that threw was a real bug; skipping every OTHER
+/// registrant was the framework turning that bug into silent data loss.</para>
+///
+/// <para>🚨 This is isolation, not tolerance. Nothing is swallowed: the fault is logged NAMING the
+/// registrant that raised it, and the remaining cleanups still run — the same per-leg isolation the
+/// reactive dispose actions in <c>DisposeImpl</c> already had, and which the synchronous ones did
+/// not.</para>
+/// </summary>
+public class DisposalRegistrantFaultIsolationTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>Throws on disposal — the registrant that used to end the walk.</summary>
+    private sealed class ThrowsOnDispose : IDisposable
+    {
+        public bool WasDisposed { get; private set; }
+
+        public void Dispose()
+        {
+            WasDisposed = true;
+            throw new ObjectDisposedException(
+                "SomeLifetimeScope",
+                "Instances cannot be resolved and nested lifetimes cannot be created from this "
+                + "LifetimeScope as it (or one of its parent scopes) has already been disposed.");
+        }
+    }
+
+    /// <summary>Records that it ran — the cleanup that used to be skipped.</summary>
+    private sealed class RecordsItsDisposal : IDisposable
+    {
+        public bool WasDisposed { get; private set; }
+
+        public void Dispose() => WasDisposed = true;
+    }
+
+    /// <summary>
+    /// The contract: a throwing registrant is isolated, and every LATER registrant still runs —
+    /// both the <see cref="IDisposable"/> overload and the <c>Action&lt;IMessageHub&gt;</c> one,
+    /// because the NACK that was actually lost was registered through the second.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task AThrowingCleanup_DoesNotCancelTheCleanupsRegisteredAfterIt()
+    {
+        var host = GetHost();
+        var hub = host.GetHostedHub(new Address("dispose-registrant-isolation", "1"), c => c);
+
+        var thrower = new ThrowsOnDispose();
+        var afterDisposable = new RecordsItsDisposal();
+        var afterActionRan = false;
+
+        // Registration ORDER is the whole subject: the composite walks in insertion order, so the
+        // thrower has to go in first for the two behind it to be at risk at all.
+        hub.RegisterForDisposal(thrower);
+        hub.RegisterForDisposal(afterDisposable);
+        hub.RegisterForDisposal(_ => afterActionRan = true);
+
+        hub.Dispose();
+        await hub.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(TimeSpan.FromSeconds(120));
+
+        Assert.True(thrower.WasDisposed, "precondition: the throwing registrant was reached at all");
+        Assert.True(afterDisposable.WasDisposed,
+            "a registrant that throws is a bug in that registrant; it must not also cancel the "
+            + "IDisposable cleanups registered behind it — that is how a teardown truncates itself "
+            + "and leaves subscriptions live");
+        Assert.True(afterActionRan,
+            "nor the Action<IMessageHub> cleanups: RegisterOwnerDisposingNack registers through "
+            + "this overload, and skipping it is what lost an acked write for 31 s on main "
+            + "shard 4, 2026-09-02");
+    }
+}


### PR DESCRIPTION
The merge queue is drained and `main` is green — but three distinct flakes were holding open
PRs red on tests their own diffs cannot reach, and two of them had already ejected a PR from
the queue. Each is root-caused here and pinned by a test that **fails without its fix** (each
new test was run with the fix reverted; the control arms are recorded below).

## 1. A teardown that truncates itself loses an acked write

**Where:** `MeshWeaver.Graph.Test.LateNackReenqueueTest` — red on #3096, main shard 4, run
[33630685580](https://github.com/Systemorph/MeshWeaver/actions/runs/33630685580).

```
[FORCE-TEARDOWN] TestData/late-nack-node: DisposeImpl faulted: ObjectDisposedException:
  Instances cannot be resolved and nested lifetimes cannot be created from this LifetimeScope…
… 23 s later …
[UpdateRemote] VERDICT_TIMEOUT … bound=31s — the owner produced no terminal for this patch
```

A hub's synchronous cleanups all live in one Rx `CompositeDisposable`, and
`CompositeDisposable.Dispose` walks its list **with no per-item guard**: the first registrant
that throws ends the walk, and every cleanup behind it is skipped in silence.

One of those registrants resolved `ILatePatchVerdictSink` out of a lifetime scope that was
already closed — `HostedHubsCollection.CloseScopeWhenDisposed` closes a hosted hub's scope on
`DisposalCompleted`, and the watchdog's `ForceTeardownAfterWatchdog` runs `hostedHubs.Dispose()`
*before* `DisposeImpl()`. So the walk stopped there and the `OwnerDisposing` NACK behind it —
the verdict that tells a writer *"this did not apply, retry against the fresh activation"* — was
never minted. Its writer heard nothing and burned the full 31 s `WriteVerdictBound` before
reporting `OwnerUnreachable`: an acked write lost to a teardown that had truncated itself.

**Both halves fixed:**

- `RegisterForDisposal` wraps every registrant (`MessageHub.GuardRegistrant`): a fault is logged
  **naming the registrant that raised it** and the walk continues. This is the same per-leg
  isolation the *reactive* dispose actions already had. It is isolation, not tolerance — nothing
  is swallowed, and a registrant that throws is still a bug in that registrant, now visible as
  one instead of as a truncated teardown.
- `RegisterOwnerDisposingNack` captures the sink **and** the parent hub at registration time, on
  the handler's turn, so its disposal path makes no DI touch at all. `NackSilentRead`'s parent is
  captured the same way (`hub.Configuration.ParentHub` re-resolves from `ParentServiceProvider`,
  so it is a DI touch too). `MessageHub`'s own ShutDown phase already stated the rule — *"Never
  call DI from a disposal path"* — and it is now documented and enforced.

**Pin:** `DisposalRegistrantFaultIsolationTest`. Control arm (guard reverted) fails with exactly
the CI stack: `CompositeDisposable.Dispose() → MessageHub.DisposeImpl()`.

## 2. The combo gate could not refuse anything

**Where:** `Memex.Portal.Shared.Test.ComboGateRollTest` — red on #3152, run
[33676592694](https://github.com/Systemorph/MeshWeaver/actions/runs/33676592694).

`SelfUpdateHostedService.CreatePolicySource` ended in
`DistinctUntilChanged(c => (c.Policy, c.RequireCiGreen))` — a leftover from the `Switch`-based
shape it outlived, whose comment still read *"re-switch only on a REAL policy change"* long
after the `Switch` was gone. With the build watch moved out of the policy stream there was
nothing left for it to re-drive, so it no longer prevented a resubscribe: **it filtered the
content**, and that same stream is what `StartAsync` reads at decision time (`policy.Take(1)`
off the `Replay(1)`).

Recording a combo verdict changes neither of those two fields, so the emission carrying it was
dropped and every later check kept deciding on the content **as it stood at start-up**. And
`mw-combo-verify` always lands its verdict *after* a pod started — a portal runs for days, the
verdict is produced when a candidate is published. So the gate was recorded, rendered on the
Updates tab, and **unable to stop a roll**: #2274's "built, documented, tested, and called by
nothing" with one extra step. Every other field went with it — `HeldTag`, `LastRolledTag`, an
operator's edit on the tab.

Removed. The trigger stream keeps its own `DistinctUntilChanged(content => content.Policy)`, so
a content change that is not a policy change still triggers nothing — including the poller's own
`LastCheckedAt`/`LastCheckVerdict` bookkeeping writes, which is why letting them through cannot
loop.

**Pin:** `ComboGateRollTest.AVerdictRecordedAfterTheFirstCheck_RefusesTheNextRoll`. Its second
check is driven by the **safety net** deliberately — a policy change would refresh the content
even with the defect present, because it moves the very field the filter keyed on. Control arm
(filter restored) fails, timing out after 36 s waiting for a refusal that never comes.

## 3. `LeavingHubAdoptionSweepTest` raced the owner's sources watcher

**Where:** ejected #3143 from the merge queue **twice** — runs
[33673071012](https://github.com/Systemorph/MeshWeaver/actions/runs/33673071012) and
[33669188031](https://github.com/Systemorph/MeshWeaver/actions/runs/33669188031).

The fixture published `CurrentSourceFingerprint = "live-fingerprint-fixture"`, on the stated
reasoning that *"a sourceless fixture type publishes nothing that could move it"*. It does: a
sourceless type publishes the fingerprint of the **empty source set** (`e3b0c44298fc1c14`), and
the owner's sources watcher writes that over the fixture's value at a moment nothing in the test
controls.

When it landed mid-test the CONTROL arm's matching bundle stopped matching, the owner refused
the adoption it was supposed to accept, cleared the coordinates, dispatched a fresh compile, and
the final assertion waited 20 s for an MVID that was never going to arrive — visible in the run
as `ADOPTION REFUSED … records source fingerprint live-fingerprint-fixture but this mesh's live
sources are e3b0c44298fc1c14`.

The fixture now states the value **the product itself computes**
(`NodeTypeSourceFingerprint.Compute([], …)`), so the watcher's recompute writes it back
unchanged and there is no window in which the two arms mean something different. They still
differ by exactly one thing — whether the producer's fingerprint equals the live one — which is
the whole subject of the test. `CreateLiveType` also now waits for the fingerprint, not only the
MVID, so the test never decides against a record it has not established.

## Verification

Release, `-warnaserror`, one project per invocation: **0 warnings, 0 errors** across
`MeshWeaver.Messaging.Hub`, `MeshWeaver.Data`, `MeshWeaver.Documentation`,
`Memex.Portal.Shared` and the six affected test projects.

**3,466 tests green in Release** — Documentation 217, Messaging.Hub 361, Data 448, Graph 1225,
Memex.Portal.Shared 614, Compiler.Pipeline 601.

## Work products committed

- `Doc/Architecture/HubDisposalModel` — new section *"A disposal path never resolves from DI —
  and never truncates itself"*, with the incident, both rules and the ✅/❌ shapes.
- `Doc/Architecture/ComboGateWiring` — new section *"The verdict is read at DECISION time, never
  once at start-up"*.
- Two What's New entries (`Category: Fix`) for the two user-visible fixes.

`Pairs-with: none — no public top-level type is removed by this diff.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGD7fT2W9kEF1EuwM3AVTu
