### PR TITLE
fix: a control-plane request filed by a CREATE now runs — this is main's deterministic bake-gate red (#3153)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/RequestViaStreamUpdate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/RequestViaStreamUpdate.md
@@ -123,6 +123,41 @@ The canonical reference for both helpers is [ActivityControlPlane.md](/Doc/Archi
 
 ---
 
+## 🚨 The watcher runs on ACTIVATION — so a CREATE has to wake the owner
+
+The watcher is installed by the owning per-node hub's `WithInitialization`, which means it runs **if
+and only if that hub is activated**. A create only writes the row. Nothing else in a create opens the
+node, so before #3153 a request filed *by* a create was never seen: it sat at `Requested` with **no
+error, no failed state, no log line** — and then ran, correctly and immediately, the next time
+anything happened to open the node (a page view, a stream subscription, an MCP `get`).
+
+Measured on memex.meshweaver.cloud: a `Store/Subscription` created via MCP sat untouched for **4.5
+hours** and completed 20 s after the first read. The same node created from the admin UI activated in
+31 s — because the open page held a stream handle, which activated the owner as a side effect.
+
+That side effect is also why the pattern's own tests could not catch it. **A control-plane test that
+subscribes to the node to await its terminal state is the thing making the watcher run**, so it
+passes with the defect fully present. A test that means to pin this must file the request with
+`IMeshService.CreateNode` and observe the outcome through a channel that does not activate the owner
+— durable storage (`IStorageAdapter.Read`) is the one that qualifies. See
+`ControlPlaneRunsWhenTheRequestArrivesByCreateTest`.
+
+`MeshExtensions.ActivatePendingControlPlane` now closes it: after the create response is posted, a
+node whose content carries a pending `RequestedXxx` has its owner opened once, so the watcher sees
+the request. Two properties matter and are deliberate:
+
+- **Strictly after the response, fire-and-forget.** A cold per-node activation can take 5–45 s in CI
+  (NodeType compile, dependency load, JIT), so it must never gate, delay or fail a create. An owner
+  that cannot be woken is a warning naming the path; the node is created and unchanged.
+- **Gated on the content, not done for every create.** A bulk install fans `CreateOrUpdateNodeRequest`
+  out into an inner `CreateNodeRequest` per node, so activating unconditionally would wake a hub per
+  imported file — 141 for `Hosting`, 425 for the core samples. Inert data needs no watcher; only a
+  node that actually carries a pending request does. **This is the load-bearing reason `RequestedXxx`
+  is a naming convention and not a free choice**: it is the only thing that tells the create path a
+  request is present without this assembly knowing any domain type.
+
+---
+
 ## When to Use This Pattern
 
 **Use it when:**

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-request-filed-by-a-script-or-an-agent-now-runs.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-request-filed-by-a-script-or-an-agent-now-runs.md
@@ -1,0 +1,42 @@
+---
+Name: A request filed by a script or an agent now runs
+Category: Fix
+Description: Asking for something by creating a node — from an agent, a script, the API or a webhook rather than a page — filed the request correctly and then nothing happened, with no error anywhere, until somebody happened to open that node.
+Icon: PlayCircle
+Order: -20260903
+---
+
+# A request filed by a script or an agent now runs
+
+Several things in the platform are asked for by **writing the request down**: you set "activate this
+subscription", "enrol this person", "cancel this job" on a node, and the part of the platform that
+owns that node notices and carries it out. That is the normal way work gets requested here, and it
+is deliberately the same whether the request comes from a page, an agent, a script, the API, or a
+billing webhook.
+
+It only actually ran when the request came from a **page**.
+
+The piece that watches for these requests starts when the node it belongs to is first opened. A page
+opens the node as a side effect of showing it, so the watcher was already running and the request
+was picked up within seconds. A request created any other way wrote the node correctly — and then
+nothing opened it, so nothing was watching, and the request sat there. Not failed, not queued:
+**sat**, with no error, no failed status, and nothing in any log that would have said so. It would
+then run, correctly and immediately, the next time anybody happened to look at that node — which
+could be minutes or hours later, or never.
+
+One measured case: a subscription activated by an agent sat untouched for **four and a half hours**,
+then completed twenty seconds after the first person opened it. The same subscription created from
+the admin page had activated in thirty-one seconds. The only difference was who asked.
+
+The people this hit are exactly the ones least able to see it: an operator running a script, an
+agent doing a task on your behalf, and an automated payment confirmation. The visible symptom was
+somebody who had been granted a plan and still saw the paywall.
+
+**A node created with a pending request now wakes its owner**, so the watcher sees the request and
+acts on it straight away regardless of who filed it. Two details worth knowing:
+
+- **It happens after the create is confirmed**, so this cannot slow down, fail, or block creating
+  anything. If the owner cannot be woken, the request is left exactly as filed and the reason is
+  recorded rather than swallowed.
+- **Only nodes that actually carry a pending request wake anything.** Ordinary content — a page, an
+  image, a document — is not a request and starts nothing, so bulk imports are unaffected.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -926,6 +926,8 @@ public static class MeshExtensions
                                 logger.LogDebug("[CreateNode] step=post-handlers-done path={Path} — posting Ok", resultNode.Path);
                                 hub.NoteRequestStage(request.Id, "CREATE_POST_HANDLERS_DONE");
                                 Respond(CreateNodeResponse.Ok(resultNode));
+                                // 🚨 STRICTLY AFTER the response (#3153) — see the method's remarks.
+                                ActivatePendingControlPlane(hub, resultNode, logger);
                             });
                 },
                 ex =>
@@ -3713,6 +3715,114 @@ public static class MeshExtensions
             })
             .Take(1)
             .DefaultIfEmpty(null);
+    }
+
+    /// <summary>
+    /// 🚨 <b>#3153 — a control-plane request filed by a CREATE must actually run.</b>
+    ///
+    /// <para>A <c>RequestedXxx</c> field is a request addressed to a watcher the owning per-node
+    /// hub installs in its <c>WithInitialization</c> (see
+    /// <c>Doc/Architecture/RequestViaStreamUpdate</c>), and that watcher runs <b>on activation</b>.
+    /// A create only writes the row: nothing activates the owner, so the watcher never sees the
+    /// request. It sits at <c>Requested</c> with no error, no log line and no failed state — until
+    /// something unrelated happens to open the node (a page view, a stream subscription, an MCP
+    /// <c>get</c>), at which point it runs within seconds. Measured on memex.meshweaver.cloud: a
+    /// <c>Store/Subscription</c> created via MCP sat untouched for 4.5 h and completed 20 s after
+    /// the first read. The same node created from the admin UI activated in 31 s, because the open
+    /// page kept the hub alive — which is why this never showed up from the UI.</para>
+    ///
+    /// <para>Every non-UI writer hits it: MCP and agents, scripts, and the billing webhook the
+    /// control plane explicitly anticipates as "one more authorized writer of this same node".
+    /// <c>Problem()</c> validators exist so a bad request cannot sit silently forever; this
+    /// reintroduced exactly that failure for a <b>well-formed</b> one.</para>
+    ///
+    /// <para>🚨 <b>Why it is gated on the content and not done for every create.</b> Opening the
+    /// stream is what activates the owner, and a cold per-node activation can take 5–45 s in CI
+    /// (NodeType compile, dependency load, JIT) — the same cost the delete path documents avoiding.
+    /// A bulk install fans <c>CreateOrUpdateNodeRequest</c> out into an inner <c>CreateNodeRequest</c>
+    /// per node, so activating unconditionally would wake a hub per imported file — 141 for
+    /// <c>Hosting</c>, 425 for the core samples. Inert data needs no watcher; only a node that
+    /// actually carries a pending request does.</para>
+    ///
+    /// <para>🚨 <b>Fire-and-forget, strictly after the response.</b> The caller is already answered,
+    /// so activation can never delay, fail or gate a create — a control plane that could not be
+    /// woken is a warning naming the path, and the node is still exactly as created. Subscribed
+    /// (never left cold), bounded, and errors are surfaced rather than swallowed.</para>
+    /// </summary>
+    private static void ActivatePendingControlPlane(IMessageHub hub, MeshNode node, ILogger logger)
+    {
+        if (!CarriesPendingRequest(node.Content, hub.JsonSerializerOptions, node.Path, logger))
+            return;
+
+        logger.LogDebug(
+            "[CreateNode] {Path} carries a pending control-plane request — activating its owner so "
+            + "the WithInitialization watcher observes it.", node.Path);
+
+        // The read IS the activation (SubscribeRequest to the owner). One emission is enough: the
+        // watcher is installed during activation and keeps running on the now-live hub, so nothing
+        // here has to stay subscribed for it to finish its work.
+        hub.GetMeshNodeStream(node.Path)
+            .Where(n => n is not null)
+            .Take(1)
+            .Timeout(ControlPlaneActivationBudget)
+            .Subscribe(
+                _ => logger.LogDebug("[CreateNode] {Path}: owner activated for its control plane.", node.Path),
+                ex => logger.LogWarning(ex,
+                    "[CreateNode] {Path} was created with a pending control-plane request, but its "
+                    + "owner could not be activated within {Budget}s — the request will not run until "
+                    + "something next opens this node. The node itself is created and unchanged.",
+                    node.Path, ControlPlaneActivationBudget.TotalSeconds));
+    }
+
+    /// <summary>
+    /// How long the activation above may take before it is abandoned. Generous, because it bounds a
+    /// COLD per-node activation (NodeType compile, dependency load, JIT — 5–45 s in CI), not a
+    /// healthy one. Abandoning costs only the warning: nothing downstream waits on it.
+    /// </summary>
+    private static readonly TimeSpan ControlPlaneActivationBudget = TimeSpan.FromMinutes(2);
+
+    /// <summary>
+    /// TRUE when <paramref name="content"/> carries a pending <c>RequestedXxx</c> — the ONE
+    /// convention <c>Doc/Architecture/RequestViaStreamUpdate</c> defines for addressing the owning
+    /// hub's watcher ("Add a <c>RequestedXxx</c> field to the node's content and watch it from the
+    /// owning hub"). Read off the SERIALIZED shape so it works for a typed CLR content and for the
+    /// JSON a cross-hub create arrives as, without this assembly knowing any domain type.
+    ///
+    /// <para>Null, absent and empty-string values are not requests — <c>RequestedStatus = null</c>
+    /// is precisely "nothing is being asked for". Never throws: a content that cannot be
+    /// serialized here is answered "no pending request", which costs at most the pre-#3153
+    /// behaviour for that node rather than failing a create that has already succeeded.</para>
+    /// </summary>
+    private static bool CarriesPendingRequest(
+        object? content, JsonSerializerOptions options, string path, ILogger logger)
+    {
+        if (content is null)
+            return false;
+        try
+        {
+            var element = content as JsonElement? ?? JsonSerializer.SerializeToElement(content, options);
+            if (element.ValueKind != JsonValueKind.Object)
+                return false;
+            foreach (var property in element.EnumerateObject())
+            {
+                if (!property.Name.StartsWith("requested", StringComparison.OrdinalIgnoreCase))
+                    continue;
+                if (property.Value.ValueKind is JsonValueKind.Null or JsonValueKind.Undefined)
+                    continue;
+                if (property.Value.ValueKind == JsonValueKind.String
+                    && string.IsNullOrEmpty(property.Value.GetString()))
+                    continue;
+                return true;
+            }
+            return false;
+        }
+        catch (Exception ex)
+        {
+            logger.LogDebug(ex,
+                "[CreateNode] could not inspect the content of {Path} for a pending control-plane "
+                + "request; treating it as carrying none.", path);
+            return false;
+        }
     }
 
     /// <summary>

--- a/test/MeshWeaver.Graph.Test/ControlPlaneRunsWhenTheRequestArrivesByCreateTest.cs
+++ b/test/MeshWeaver.Graph.Test/ControlPlaneRunsWhenTheRequestArrivesByCreateTest.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>#3153 — a control-plane request filed by a CREATE has to actually run.</b>
+///
+/// <para>A <c>RequestedXxx</c> field is a request addressed to a watcher the owning per-node hub
+/// installs in its <c>WithInitialization</c> (<c>Doc/Architecture/RequestViaStreamUpdate</c>), and
+/// that watcher runs <b>on activation</b>. A create only writes the row — so the request sat at
+/// <c>Requested</c> with no error, no log line and no failed state, until something unrelated
+/// happened to open the node. Measured on memex.meshweaver.cloud: a <c>Store/Subscription</c>
+/// created via MCP sat untouched for 4.5 h and completed 20 s after the first read.</para>
+///
+/// <para><b>Why this never showed up from the UI, and why the existing suites miss it.</b> Creating
+/// the same node from a page leaves the page's own stream handle open, which activates the owner as
+/// a side effect. Every control-plane test in the fleet does the equivalent — it subscribes to the
+/// node to await a terminal state — and <b>the subscription is what makes the watcher run</b>. Such
+/// a test passes with the defect fully present.</para>
+///
+/// <para>🚨 So this test never opens the node's stream. It files the request with
+/// <see cref="IMeshService.CreateNode"/> and then polls DURABLE STORAGE
+/// (<see cref="IStorageAdapter"/>) for the terminal state — the one observation channel that does
+/// not itself activate the owner. Reading through <c>GetMeshNodeStream</c> here would be the
+/// assertion causing the very thing it claims to observe.</para>
+/// </summary>
+public class ControlPlaneRunsWhenTheRequestArrivesByCreateTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string ControlPlaneNodeType = "Test/ControlPlane";
+    private const string Activate = "Activate";
+    private const string Done = "Done";
+
+    /// <summary>Minimal control-plane content: the request field and the state it drives.</summary>
+    public record ControlPlaneContent
+    {
+        [JsonPropertyName("requestedAction")]
+        public string? RequestedAction { get; init; }
+
+        [JsonPropertyName("status")]
+        public string? Status { get; init; }
+    }
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .AddMeshNodes(CreateControlPlaneNodeType())
+            .ConfigureHub(config =>
+                config.WithType<ControlPlaneContent>(nameof(ControlPlaneContent)));
+
+    /// <summary>
+    /// The node type under test, wired exactly the way the production control planes are: the
+    /// watcher is installed by the per-node hub's own initialization, so it runs if and only if
+    /// that hub is activated.
+    /// </summary>
+    private static MeshNode CreateControlPlaneNodeType() => new(ControlPlaneNodeType)
+    {
+        Name = "Control Plane Probe",
+        HubConfiguration = config => config
+            .AddMeshDataSource(s => s.WithContentType<ControlPlaneContent>())
+            .WithInitialization(hub =>
+            {
+                var path = hub.Address.ToString();
+                hub.GetMeshNodeStream(path)
+                    .Where(node => node?.ContentAs<ControlPlaneContent>(hub.JsonSerializerOptions)
+                        is { RequestedAction: Activate, Status: null })
+                    .Take(1)
+                    .SelectMany(_ => hub.GetMeshNodeStream(path).Update(node =>
+                    {
+                        var content = node.ContentAs<ControlPlaneContent>(hub.JsonSerializerOptions)
+                                      ?? new ControlPlaneContent();
+                        return node with
+                        {
+                            Content = content with { RequestedAction = null, Status = Done },
+                        };
+                    }))
+                    // Cold — subscribe or the write never happens — with an explicit error arm.
+                    .Subscribe(_ => { }, _ => { });
+            }),
+    };
+
+    // 180_000 ms, not TestTimeouts.TestMilliseconds: an attribute argument must be a constant, so
+    // the outer cap cannot be computed. The WAIT inside uses TestTimeouts.Convergence — that is the
+    // bound the ratchet guard is about; this one only stops a wedge from running forever.
+    [Fact(Timeout = 180_000)]
+    public async Task ARequestFiledByCreate_RunsWithoutAnybodyOpeningTheNode()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var storage = Mesh.ServiceProvider.GetRequiredService<IStorageAdapter>();
+        var path = $"{TestPartition}/control-plane-on-create";
+
+        // File the request the way every non-UI writer does: MCP, a script, a billing webhook.
+        await meshService.CreateNode(
+                new MeshNode("control-plane-on-create", TestPartition)
+                {
+                    NodeType = ControlPlaneNodeType,
+                    Name = "Control plane on create",
+                    State = MeshNodeState.Active,
+                    Content = new ControlPlaneContent { RequestedAction = Activate },
+                })
+            .Should().Within(TestTimeouts.Convergence).Emit("the create itself must succeed");
+
+        // 🚨 Nothing here opens the node's stream — storage is the only channel that does not
+        // activate the owner, and activating it is the whole subject.
+        var settled = await Observable.Interval(TimeSpan.FromMilliseconds(200)).StartWith(0L)
+            .SelectMany(_ => storage.Read(path, Mesh.JsonSerializerOptions))
+            .Where(node => node?.ContentAs<ControlPlaneContent>(Mesh.JsonSerializerOptions)
+                is { Status: Done })
+            .FirstAsync()
+            .Timeout(TestTimeouts.Convergence)
+            .Await(ct);
+
+        settled!.ContentAs<ControlPlaneContent>(Mesh.JsonSerializerOptions)!.Status
+            .Should().Be(Done,
+                "a control-plane request is addressed to a watcher that only runs when the owning "
+                + "hub is activated; a create that files one and activates nothing leaves it at "
+                + "Requested forever, with no error and nothing that would ever surface it");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ControlPlaneRunsWhenTheRequestArrivesByCreateTest.cs
+++ b/test/MeshWeaver.Graph.Test/ControlPlaneRunsWhenTheRequestArrivesByCreateTest.cs
@@ -9,6 +9,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 
 namespace MeshWeaver.Graph.Test;
@@ -70,7 +71,12 @@ public class ControlPlaneRunsWhenTheRequestArrivesByCreateTest(ITestOutputHelper
             .AddMeshDataSource(s => s.WithContentType<ControlPlaneContent>())
             .WithInitialization(hub =>
             {
-                var path = hub.Address.ToString();
+                // 🚨 Address.Path, never ToString(): a hosted address renders as `path~host`, and
+                // Address's own docs say to use Path "when you need the node path for persistence".
+                // ToString() here would build a node path that does not exist, so the watcher would
+                // silently never see the request — and the test would then be measuring the wrong
+                // absence.
+                var path = hub.Address.Path;
                 hub.GetMeshNodeStream(path)
                     .Where(node => node?.ContentAs<ControlPlaneContent>(hub.JsonSerializerOptions)
                         is { RequestedAction: Activate, Status: null })
@@ -84,8 +90,14 @@ public class ControlPlaneRunsWhenTheRequestArrivesByCreateTest(ITestOutputHelper
                             Content = content with { RequestedAction = null, Status = Done },
                         };
                     }))
-                    // Cold — subscribe or the write never happens — with an explicit error arm.
-                    .Subscribe(_ => { }, _ => { });
+                    // Cold — subscribe or the write never happens. The error arm REPORTS: a fault
+                    // in this pipeline and "the watcher never ran" are the two outcomes this test
+                    // has to tell apart, and a swallowed OnError makes them identical.
+                    .Subscribe(
+                        _ => { },
+                        ex => hub.ServiceProvider.GetService<ILoggerFactory>()
+                            ?.CreateLogger("Test.ControlPlaneProbe")
+                            .LogError(ex, "control-plane probe failed for {Path}", path));
             }),
     };
 


### PR DESCRIPTION
## This is what has been reddening `main`

`main`'s CD **bake gate** — the only place in-mesh NodeType source compiles, and therefore invisible
to `dotnet build` and to Build-and-Test — has failed on `Store/Licensing` in **every** run:

```
RED Store/Licensing: compile=Ok render=ok tests=FAILED
  | 🚨 Coupon (live): a tier coupon lands an Active plan, with no expiry
  | ❌ the coupon's tier never reached an Active subscription —
  |    the control plane did not run the activation the redemption filed
GATE FAILED — tests: Store/Licensing
```

That is #3153. No image publishes while the gate is red, so every self-updating install stays put —
which is what #3144 keeps re-filing.

## The defect

A `RequestedXxx` field is a request addressed to a watcher the owning per-node hub installs in its
`WithInitialization` ([RequestViaStreamUpdate](/Doc/Architecture/RequestViaStreamUpdate)) — and that
watcher runs **on activation**. A create only writes the row. Nothing in a create opens the node, so
the request sat at `Requested` with **no error, no failed state, no log line** — and then ran,
correctly and immediately, the next time anything happened to open the node.

Measured on memex.meshweaver.cloud: a `Store/Subscription` created via MCP sat untouched for **4.5
hours** and completed 20 s after the first read. The same node created from the admin UI activated in
**31 s** — the open page held a stream handle, which activates the owner as a side effect.

Every non-UI writer hits it: MCP and agents, scripts, and the billing webhook the control plane
explicitly anticipates as *"one more authorized writer of this same node"*. `Problem()` validators
exist precisely so a bad request cannot sit silently forever; this reintroduced that failure for a
**well-formed** one. The user-visible symptom is somebody granted a plan who still sees the paywall.

## Why every existing test missed it

That same side effect. **A control-plane test that subscribes to the node to await its terminal state
IS what makes the watcher run**, so it passes with the defect fully present — including
`SubscriptionTests.ActivateLive_*`, whose `AwaitTerminal` the issue names.

So this test never opens the node's stream. It files the request with `IMeshService.CreateNode` and
observes **durable storage** (`IStorageAdapter.Read`) — the one channel that does not itself activate
the owner. Reading through `GetMeshNodeStream` here would be the assertion causing the very thing it
claims to observe.

| arm | result |
|---|---|
| fix reverted | **fails at 36 s** — the request never runs |
| fix in place | **passes in 0.9 s** |

## The fix

`MeshExtensions.ActivatePendingControlPlane`, called strictly after the create response is posted.

🚨 **Gated on the content, not done for every create.** A bulk install fans
`CreateOrUpdateNodeRequest` out into an inner `CreateNodeRequest` per node, so activating
unconditionally would wake a hub per imported file — **141 for `Hosting`, 425 for the core samples**
— at a 5–45 s cold activation each (the cost the delete path already documents avoiding). That would
have made the #2543 bake wedge worse, not better. Inert data needs no watcher; only a node that
actually carries a pending request does. This is the load-bearing reason `RequestedXxx` is a naming
*convention*: it is the only thing that tells the create path a request is present without
`Mesh.Contract` knowing any domain type.

🚨 **Fire-and-forget, strictly after the response** — it can never delay, fail or gate a create. An
owner that cannot be woken inside the budget is a warning naming the path, and the node is created
and unchanged.

## Verification

Release with `-warnaserror`, one project per invocation: **0 warnings, 0 errors** across
`Mesh.Contract`, `Graph`, `Hosting`, `Documentation` and their test projects.
**2,014 tests green** — Graph 1239, Data 448, Hosting 327 — plus Documentation 239.

The `TestTimeoutLiteralRatchetGuard` caught a `30.Seconds()` in my first draft; converted to
`TestTimeouts.Convergence` rather than raising the baseline.

## Scope

This clears the **deterministic** half of main's red. The other half — `install: Hosting`, a write
wedge (`VERDICT_TIMEOUT bound=31s` / `OwnerUnreachable`) — is **intermittent** and is #2543; it is not
addressed here.

## Work products committed

- [RequestViaStreamUpdate](/Doc/Architecture/RequestViaStreamUpdate) — new section *"The watcher runs
  on ACTIVATION — so a CREATE has to wake the owner"*, including why a subscribing test cannot pin it.
- A What's New entry (`Category: Fix`).

Closes #3153.

`Pairs-with: none — no public top-level type is removed by this diff.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGD7fT2W9kEF1EuwM3AVTu
