### PR TITLE
fix: a hub disposed with a request outstanding is a TYPED teardown, not an anonymous failure (#3148)

### DIFF
--- a/src/MeshWeaver.Graph/MeshNodeExtensions.cs
+++ b/src/MeshWeaver.Graph/MeshNodeExtensions.cs
@@ -455,9 +455,32 @@ public static class MeshNodeExtensions
             .Finally(() => inFlight?.Dispose())
             .Subscribe(
                 _ => logger?.LogDebug("TrackActivity DONE: {Path}", activityPath),
-                ex => logger?.LogError(ex,
-                    "Failed to track activity for user={UserId} path={Path}",
-                    req.UserId, req.NodePath));
+                ex =>
+                {
+                    // 🚨 A TEARDOWN IS NOT A TRACKING FAILURE (#3148). This write is detached and
+                    // fire-and-forget by design, so a hub recycle, a grain deactivation or a closed
+                    // circuit can always land between the post and the response — and when it does,
+                    // the request can never be answered. That is the platform behaving correctly,
+                    // and reporting it at `fail` with a stack trace made an ordinary pod recycle
+                    // look like a defect while telling nobody anything actionable: the entry is
+                    // lost either way and there is nothing to fix.
+                    //
+                    // Classified, never swallowed — every OTHER fault still surfaces at Error,
+                    // which is what keeps a real tracking bug visible.
+                    if (HubDisposedBeforeResponseException.IsHubDisposedBeforeResponse(ex)
+                        || HubDisposingException.IsHubDisposal(ex)
+                        || HubDisposingException.IsDisposedContainer(ex))
+                    {
+                        logger?.LogDebug(ex,
+                            "TrackActivity for user={UserId} path={Path} ended in a hub teardown — "
+                            + "this activity entry is not recorded. Expected during a recycle.",
+                            req.UserId, req.NodePath);
+                        return;
+                    }
+                    logger?.LogError(ex,
+                        "Failed to track activity for user={UserId} path={Path}",
+                        req.UserId, req.NodePath);
+                });
         return delivery.Processed();
     }
 

--- a/src/MeshWeaver.Messaging.Contract/HubDisposedBeforeResponseException.cs
+++ b/src/MeshWeaver.Messaging.Contract/HubDisposedBeforeResponseException.cs
@@ -1,0 +1,70 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// TRANSIENT: a request was in flight when its ISSUING hub went down, so the response can never
+/// arrive. Raised by <c>MessageHub.CancelCallbacks</c> for every pending response subject at
+/// disposal.
+///
+/// <para>🚨 <b>Why it is a type and not just a message.</b> This is a TEARDOWN fact — the hub was
+/// recycled, the silo deactivated the grain, the circuit closed — and not a fault of the work that
+/// hit it. Every other teardown shape in the framework already carries that fact in its TYPE so
+/// each layer classifies it identically instead of re-deriving it from a string
+/// (<see cref="HubDisposingException"/>, and the disposed-container check beside it). This one did
+/// not: it was a bare <see cref="ObjectDisposedException"/>, so
+/// <see cref="HubDisposingException.IsHubDisposal"/> answered <c>false</c> for it and callers had
+/// no way to tell "the hub went away underneath me" from a real defect. The visible cost was small
+/// and the shape is not: a fire-and-forget activity-tracking write logged a full <c>fail</c>-level
+/// stack for an ordinary pod recycle (#3148), and any caller wanting to tell the two apart had to
+/// match on the message text this class now owns.</para>
+///
+/// <para>🚨 <b>The message is deliberately UNCHANGED</b> from the bare exception it replaces.
+/// Several classifiers in the GUI and the stream cache match teardown on message text
+/// (<c>AreaErrorClassifier.IsTransientHubFailure</c>,
+/// <c>MeshNodeStreamCache.IsTransientOwnerFailure</c>), and log fingerprints group incidents by it.
+/// Adding the type is additive; changing the words would not be, so it does not.</para>
+///
+/// <para>Derives from <see cref="ObjectDisposedException"/>, which is what this already was — so
+/// every existing <c>catch (ObjectDisposedException)</c> keeps working unchanged. Only the
+/// classification is new.</para>
+/// </summary>
+public sealed class HubDisposedBeforeResponseException : ObjectDisposedException
+{
+    /// <summary>The hub that was disposed while the request was outstanding.</summary>
+    public Address HubAddress { get; }
+
+    /// <summary>The request type that will never be answered (diagnostics).</summary>
+    public string? RequestType { get; }
+
+    /// <summary>The target the request was addressed to (diagnostics).</summary>
+    public string? Target { get; }
+
+    /// <summary>
+    /// Creates the exception. <paramref name="objectName"/> is <c>nameof(MessageHub)</c> and the
+    /// message is composed exactly as the untyped exception composed it — see the remarks on why
+    /// neither may drift.
+    /// </summary>
+    /// <param name="objectName">The disposed object's name, as <see cref="ObjectDisposedException"/> reports it.</param>
+    /// <param name="hubAddress">Address of the hub that was disposed.</param>
+    /// <param name="requestType">The outstanding request's type name.</param>
+    /// <param name="target">The address the request was sent to.</param>
+    public HubDisposedBeforeResponseException(
+        string objectName, Address hubAddress, string? requestType, string? target)
+        : base(objectName,
+            $"Hub {hubAddress} was disposed before the response arrived "
+            + $"(request type {requestType}, target {target}).")
+    {
+        HubAddress = hubAddress;
+        RequestType = requestType;
+        Target = target;
+    }
+
+    /// <summary>
+    /// True when <paramref name="exception"/> is (or wraps) this teardown. Walks the chain for the
+    /// same reason <see cref="HubDisposingException.IsHubDisposal"/> does: the fault is routinely
+    /// re-wrapped before a caller sees it.
+    /// </summary>
+    /// <param name="exception">The exception to classify; may be null.</param>
+    /// <returns><c>true</c> when the issuing hub was disposed with the request outstanding.</returns>
+    public static bool IsHubDisposedBeforeResponse(Exception? exception)
+        => ExceptionChain.Contains<HubDisposedBeforeResponseException>(exception);
+}

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -2653,8 +2653,13 @@ public sealed class MessageHub : IMessageHub
         {
             try
             {
-                entry.Subject.OnError(new ObjectDisposedException(nameof(MessageHub),
-                    $"Hub {Address} was disposed before the response arrived (request type {entry.RequestType}, target {entry.Target})."));
+                // 🚨 TYPED, so callers can classify it (#3148). This is a teardown fact — the hub
+                // was recycled or deactivated with the request outstanding — not a fault of the
+                // work that hit it, and until it had a type the only way to tell the two apart was
+                // to match this message. The message itself is unchanged on purpose; see
+                // HubDisposedBeforeResponseException.
+                entry.Subject.OnError(new HubDisposedBeforeResponseException(
+                    nameof(MessageHub), Address, entry.RequestType, entry.Target?.ToString()));
             }
             catch
             {

--- a/test/MeshWeaver.Messaging.Hub.Test/HubDisposedBeforeResponseIsClassifiedTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/HubDisposedBeforeResponseIsClassifiedTest.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh.Security;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>#3148 — a request outstanding when its hub goes down is a TEARDOWN, and it has to say so
+/// in its TYPE.</b>
+///
+/// <para><c>MessageHub.CancelCallbacks</c> errors every pending response subject at disposal. It
+/// used to raise a bare <see cref="ObjectDisposedException"/>, so
+/// <see cref="HubDisposingException.IsHubDisposal"/> answered <c>false</c> for it and no caller
+/// could tell "the hub went away underneath me" from a real defect. Every other teardown shape in
+/// the framework carries that fact in its type precisely so each layer classifies it identically
+/// instead of re-deriving it from a string.</para>
+///
+/// <para>The visible cost was small and the shape is not: a detached, fire-and-forget
+/// activity-tracking write logged a full <c>fail</c>-level stack for an ordinary pod recycle, which
+/// reads as a defect and is not one — the request cannot be answered, there is nothing to fix, and
+/// the entry is lost either way.</para>
+///
+/// <para>🚨 <b>The message is asserted UNCHANGED.</b> Several classifiers match teardown on message
+/// text (<c>AreaErrorClassifier.IsTransientHubFailure</c>,
+/// <c>MeshNodeStreamCache.IsTransientOwnerFailure</c>) and log fingerprints group incidents by it,
+/// so adding the type had to be additive. A future edit that "tidies" the wording would silently
+/// re-classify live incidents — this test is what stops it.</para>
+/// </summary>
+public class HubDisposedBeforeResponseIsClassifiedTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record NeverAnswered : IRequest<NeverAnsweredResponse>;
+
+    private record NeverAnsweredResponse;
+
+    /// <summary>
+    /// A request that is accepted and deliberately never answered, so it is still outstanding when
+    /// the hub is disposed — the exact state <c>CancelCallbacks</c> exists to terminate.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ARequestOutstandingAtDisposal_FailsAsATypedTeardown()
+    {
+        var host = GetHost();
+        var hub = host.GetHostedHub(
+            new Address("disposed-before-response", "1"),
+            c => c.WithHandler<NeverAnswered>((_, delivery) => delivery.Processed()));
+
+        Exception? observed = null;
+        // 🚨 An identity is required or PostPipeline refuses the post outright (fail-closed, by
+        // design) — and the request would then never be OUTSTANDING, which is the state this test
+        // is about. The scope is opened and closed synchronously around Subscribe: impersonation is
+        // an AsyncLocal, so it must not be disposed on whichever thread the sequence terminates on.
+        var access = hub.ServiceProvider.GetRequiredService<AccessService>();
+        IDisposable sub;
+        using (access.ImpersonateAsHub(hub))
+            sub = hub.Observe<NeverAnsweredResponse>(
+                    new NeverAnswered(), o => o.WithTarget(hub.Address))
+                .Subscribe(_ => { }, ex => observed = ex);
+        using var _sub = sub;
+
+        hub.Dispose();
+        await hub.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(TimeSpan.FromSeconds(120));
+
+        Assert.NotNull(observed);
+
+        Assert.True(
+            HubDisposedBeforeResponseException.IsHubDisposedBeforeResponse(observed),
+            "a caller must be able to classify 'the issuing hub was disposed with my request "
+            + "outstanding' from the exception itself; while it was an untyped "
+            + "ObjectDisposedException the only way to tell it from a real fault was to match the "
+            + "message text");
+
+        // Still an ObjectDisposedException, so every existing catch keeps working.
+        Assert.IsAssignableFrom<ObjectDisposedException>(observed);
+
+        // 🚨 The wording is contract — see the class remarks.
+        Assert.Contains("was disposed before the response arrived", observed!.Message);
+        Assert.Contains(nameof(NeverAnswered), observed.Message);
+    }
+}


### PR DESCRIPTION
## What was reported, and what it actually is

memex-cloud, 2026-09-02 19:27:33Z, one occurrence:

```
fail: MeshWeaver.Graph.ActivityTracking[0]
      Failed to track activity for user=rbuergi path=rbuergi
      System.ObjectDisposedException: Hub cache/pwE2jqagS0eM1InM7Aknow was disposed before the
      response arrived (request type SubscribeRequest, target rbuergi/_UserActivity/rbuergi).
```

The issue reads this as "the tracking path should tolerate the race". It is worth one level deeper:
**the framework could not tell anyone this was a teardown.**

`MessageHub.CancelCallbacks` errors every pending response subject at disposal, and it raised a
**bare** `ObjectDisposedException`. So `HubDisposingException.IsHubDisposal` answered `false` for it,
and a caller had no way to distinguish *"the hub went away underneath me"* from a real defect except
by matching the message text. Every other teardown shape in the framework carries that fact in its
**type** — that is the whole reason `HubDisposingException` and the disposed-container check exist
side by side, *"kept HERE so every layer classifies it identically instead of each re-deriving it"*.
This one was the exception.

The reported cost is small; the shape is not. A detached, fire-and-forget telemetry write logged a
full `fail`-level stack for an ordinary pod recycle. The request cannot be answered, the entry is
lost either way, and there is nothing to fix — it reads as a defect and is not one.

## The change

- **`HubDisposedBeforeResponseException : ObjectDisposedException`**, with
  `IsHubDisposedBeforeResponse(ex)` walking the exception chain for the same reason
  `IsHubDisposal` does — the fault is routinely re-wrapped before a caller sees it.
- **The tracking site classifies, never swallows.** A teardown logs at Debug, naming the entry that
  will not be recorded. **Every other fault still surfaces at Error**, which is what keeps a real
  tracking bug visible.

## 🚨 The message is deliberately unchanged

`AreaErrorClassifier.IsTransientHubFailure` and `MeshNodeStreamCache.IsTransientOwnerFailure` match
teardown on **message text**, and log fingerprints group incidents by it. So adding the type had to
be purely additive: same words, same `ObjectName`, new type. The test asserts the wording, so a
later tidy-up cannot silently re-classify live incidents. It remains an `ObjectDisposedException`,
so every existing `catch` keeps working.

**Considered and rejected:** raising `HubDisposingException` instead. That would be the tidier
hierarchy, but its message is composed by `ShutdownNack` and is *itself* contract for those same
matchers — re-wording a widely-observed failure is a behaviour change I cannot verify cheaply, and
certainly not while `main` is red.

## Test

`HubDisposedBeforeResponseIsClassifiedTest` posts a request to a handler that deliberately never
answers, then disposes the hub — the exact state `CancelCallbacks` exists to terminate — and asserts
the classification, the base type, and the wording.

One thing worth recording from writing it: the first version failed for the *wrong* reason. The post
carried no `AccessContext`, so `PostPipeline` refused it outright (fail-closed, by design) and the
request was never **outstanding** — which is the state under test. It now opens an
`ImpersonateAsHub` scope synchronously around the subscribe.

## Verification

Release with `-warnaserror`: **0 warnings, 0 errors** across 7 projects. **2,375 tests green** —
Messaging.Hub 362, Graph 1238, Data 448, Hosting 327.

Closes #3148.

`Pairs-with: none — no public top-level type is removed by this diff.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGD7fT2W9kEF1EuwM3AVTu
