### PR TITLE
The liveness probe comment says what /alive now measures (#2194 item 6)

### DIFF
--- a/deploy/helm/templates/memex-portal/deployment.yaml
+++ b/deploy/helm/templates/memex-portal/deployment.yaml
@@ -307,6 +307,24 @@ spec:
           livenessProbe:
             # Self-heal a genuinely wedged pod (the connection-exhaustion wedge we hit). Conservative
             # — only a sustained /alive failure restarts it, so a transient blip never loops.
+            #
+            # 🚨 /alive MEASURES PROGRESS; it is not a synonym for /healthz (MeshWeaver#2194 item 4).
+            # It answers 503 once GC pause share has stayed above 60% for five consecutive checks —
+            # the shape of a silo whose superseded NodeType assemblies (ALCs) have accumulated until
+            # it is GC-bound. On 2026-08-25 two replicas held exactly that state for THREE AND A HALF
+            # HOURS while passing every probe, because /alive had no handler at all and was answered
+            # by the renderer; they stayed in the Service endpoints serving hung pages.
+            #
+            # 🚨 Do NOT point readinessProbe here. Readiness must stay on the trivial /healthz: a
+            # readiness check that fails under load removes the pod, and the survivors inherit its
+            # traffic — the 2026-07-21 death-spiral. Liveness restarting ONE pegged replica has no
+            # such feedback loop.
+            #
+            # Ready-but-degraded triage: one replica far heavier than its siblings is the fingerprint
+            # (`kubectl top pods -n <ns>`); the PortalReplicaWorkingSetDiverged alert in
+            # values.observability.yaml watches for it, and the fix is convergence
+            # (Modules:AutoRecycleOnStaleBuild, on fleet-wide) plus prebuilt-only modules
+            # (Modules:RequirePrebuilt).
             httpGet: { path: /alive, port: 8080 }
             periodSeconds: 15
             timeoutSeconds: 10


### PR DESCRIPTION
Comment-only. Pairs with **MeshWeaver.Plugins#1234**, which makes `/alive` a real progress measurement.

## Why

The chart comment described `/alive` as a path only a "genuinely wedged" pod fails. That was already optimistic — **`/alive` had no handler at all** and was answered by the renderer (it is absent from `FrontendSelection.ExcludedPrefixes` while `/healthz` is present). A reader who inherits the old comment inherits exactly the assumption that let two replicas serve hung pages for three and a half hours on 2026-08-25 while passing every probe.

## What it now records

- What `/alive` answers: 503 after five consecutive checks above a 60% GC pause share, and the superseded-ALC accumulation shape that produces it.
- 🚨 **Why `readinessProbe` must not be pointed here** — the 2026-07-21 death-spiral: a readiness check that fails under load removes the pod and hands the survivors its traffic. Liveness restarting one pegged replica has no such feedback loop.
- The Ready-but-degraded triage fingerprint (`kubectl top pods -n <ns>`), the `PortalReplicaWorkingSetDiverged` alert that watches for it, and the two fixes that address the cause (`Modules:AutoRecycleOnStaleBuild`, `Modules:RequirePrebuilt`) rather than the symptom.

## Verification

18 added lines, all comments; no rendered output changes. `check-chart-drift.sh` cannot run locally — it requires a live namespace and the values files from the private `Systemorph/Memex` repo, and says so rather than rendering against chart defaults. The block's anchors and indentation are unchanged and there are no tabs.

Completes item 6 of #2194 (chart probe comments); the runbook half lives in the private deployment repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DYPuf8cduViBpyJp9mKDDK
