### PR TITLE
fix(import): a CONTENT verdict is final for its fingerprint — stop re-importing what cannot import (#3146)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
@@ -277,10 +277,27 @@ So the outcome now distinguishes **why** a pass failed:
 | `ImportedWithRefusedContent` / `ImportedWithBlockedCreates` | `Warning` | re-imports |
 
 `ImportedWithContentErrors` is reached only when **every** failure in the pass was a content verdict
-(`StaticRepoImporter.IsContentVerdict`): a validator refusal, an unknown NodeType, an RLS denial. A
-store blip, an owner that did not answer, a hub going down mid-import, a timeout — all stay
-retryable, and **one** of them among the failures keeps the whole pass on the ordinary `Warning`
-arm. Unknown means retryable.
+(`StaticRepoImporter.IsContentVerdict`), and that is decided on the owner's **structured**
+`NodeUpsertRejectionReason`, never on the exception type:
+
+| reason | deterministic? |
+|---|---|
+| `InvalidPath`, `InvalidNodeType`, `ValidationFailed`, `Unauthorized` | **yes** |
+| `Unknown`, `PatchFailed` | no — retryable |
+
+🚨 The type cannot be used for this. `Upsert` wraps **every** failed `CreateOrUpdateNodeResponse` in
+one `InvalidOperationException`, and `Unknown` is where *"Persistence read failed: …"* and *"Inner
+CreateNode faulted: …"* land — a store that was briefly unreachable, wearing the same exception as a
+rule refusal. A first draft of this classifier keyed on the type and would have marked those final;
+that is #3101's freeze, re-introduced by the fix for #3146. `Upsert` therefore throws a typed
+`UpsertRefusedException` carrying the reason. **One** retryable failure among the pass's failures
+keeps the whole pass on the ordinary `Warning` arm.
+
+**Known residual:** a validator that *throws* — including one whose own dependency is briefly
+unavailable — is mapped to `ValidationFailed` before the response is built, so it records as final.
+The importer cannot separate that from a rule refusal; the place to fix it is the validator contract
+(an unavailable dependency should surface as unavailable, not as a refusal). Pinned, so it is not
+rediscovered as a surprise, by `FailedImportIsNotRetriedAtTheSameFingerprintTest`.
 
 🚨 Getting that backwards is the more expensive mistake, and it has a number: #3101, a Space frozen
 out of the mesh by a green marker nobody re-examined. That is why this is an allow-list of

--- a/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/StaticRepoImport.md
@@ -253,6 +253,44 @@ The SQL migration (`Memex.Database.Migration`) is a standalone process with **no
 
 In the **distributed (Orleans/PG) portal, routing does not consult the in-memory `EmbeddedResourceStorageAdapter`** — so a partition that is only served from the embedded overlay 404s / hangs. The static-repo import is what makes built-in partitions (Doc/Agent/Model) **served from the DB** there. The monolith (in-process embedded routing) works either way, so the cutover is gated by `Features:StaticRepoSync:Partitions` (default `["Doc","Agent","Model"]` for the distributed portal; monolith leaves it empty and keeps in-memory serving).
 
+## 🚨 A CONTENT verdict is final for its fingerprint; a transient failure is not
+
+The marker at `{Partition}/_Activity/import-{fingerprint}` is content-addressed, so the fingerprint
+**is** the idempotence key. Re-running at the same fingerprint re-reads the same nodes and re-derives
+the same answer — which means re-running is only ever meaningful when something *outside* the content
+could have changed.
+
+The skip arm used to recognise `Succeeded` and nothing else, so every non-green verdict re-imported
+in full on every trigger. Measured on memex.meshweaver.cloud (2026-09-02, #3146): **19 complete
+passes in 3 h**, each ≈425 identical `InvalidOperationException`s — *"A 'Space' owns its partition,
+so it must be top-level"*, *"NodeType 'Northwind/Article' is not registered"* — plus a NodeType
+compile of the same sample tree each time, on a portal already at 8/8 replicas. The trigger was a
+webhook per green core CI run.
+
+So the outcome now distinguishes **why** a pass failed:
+
+| outcome | lock status | next trigger at the SAME fingerprint |
+|---|---|---|
+| `Imported` | `Succeeded` | skips |
+| `ImportedWithContentErrors` | `Failed` | **skips**, logging the recorded verdict |
+| `ImportedWithErrors` | `Warning` | re-imports |
+| `ImportedWithRefusedContent` / `ImportedWithBlockedCreates` | `Warning` | re-imports |
+
+`ImportedWithContentErrors` is reached only when **every** failure in the pass was a content verdict
+(`StaticRepoImporter.IsContentVerdict`): a validator refusal, an unknown NodeType, an RLS denial. A
+store blip, an owner that did not answer, a hub going down mid-import, a timeout — all stay
+retryable, and **one** of them among the failures keeps the whole pass on the ordinary `Warning`
+arm. Unknown means retryable.
+
+🚨 Getting that backwards is the more expensive mistake, and it has a number: #3101, a Space frozen
+out of the mesh by a green marker nobody re-examined. That is why this is an allow-list of
+verdict-shaped faults rather than "anything that is not obviously transient".
+
+The verdict is carried in `ActivityLog.ReturnValue` as `{"outcome": "…"}` — **structured, not parsed
+out of the summary line**. A skip decision that read a log message would start silently re-importing
+forever the first time somebody re-worded it. `Force` still re-runs regardless; a changed
+fingerprint re-runs by construction, because the fingerprint is the marker's id.
+
 ## Import / export symmetry
 
 **There is no static-repo exporter in `src/`, and nothing gates the two directions against each

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-broken-import-stops-retrying-itself.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-broken-import-stops-retrying-itself.md
@@ -1,0 +1,36 @@
+---
+Name: A broken import stops retrying itself
+Category: Fix
+Description: When content could not be imported because it breaks a rule, the platform re-imported the whole thing again on every trigger — the same failure, at full cost, forever. It now records the verdict and waits for the content to change.
+Icon: ArrowRepeatAllOff
+Order: -20260903
+---
+
+# A broken import stops retrying itself
+
+Content that arrives from a repository is imported once per version. The platform fingerprints what
+it received, and once that exact content has been imported it is skipped — that is what stops every
+restart and every push re-importing the whole library.
+
+That skip only ever recognised **success**. If the import had failed, the next trigger did the entire
+thing again: every file, every write, and a fresh compile of everything compilable in it. And when
+the failure was caused by the content itself — a page in a place its own rules do not allow, a type
+the platform does not know — nothing about running it again could change the outcome. The same
+content produced the same failure, and the work was spent for nothing.
+
+On one portal that meant **nineteen complete re-imports in three hours**, each one failing on the
+same 425 items and recompiling the same set, on an installation already running at full capacity.
+Every green build of the source repository started another round.
+
+**A failure caused by the content is now recorded as the answer for that version of the content.**
+The next trigger sees it, skips, and says why. Fix the content — or ask for a forced re-import — and
+it runs again immediately, because changing the content changes the fingerprint.
+
+The distinction matters more than the saving, so it is drawn narrowly:
+
+- **Only failures the content itself causes are final.** If anything transient was involved — the
+  database briefly unreachable, a component restarting mid-import — the import is retried exactly as
+  before. Re-running can genuinely help there, and refusing to would be far worse: it would leave
+  content out of your installation with nothing re-examining it.
+- **A partly-successful import is unchanged.** Everything importable still lands; only the items that
+  cannot be imported are reported, and they are still named individually.

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -715,8 +715,12 @@ public static class StaticRepoImporter
                 // within 30s" — the repair needed the grants it existed to write (memex Store, 2026-08-07).
                 // Only the BOOKKEEPING is Systemed here; the imported CONTENT keeps the exact write path
                 // (and identity) it always had.
+                // 🚨 `outcome` rides in ActivityLog.ReturnValue, not in the summary text (#3146). The
+                // skip arm below decides whether to re-run from it, and a decision that parses a log
+                // line is one re-wording away from silently re-importing forever again.
                 MeshNode BookkeepingNode(
-                    string id, string name, ActivityStatus status, params LogMessage[] messages) =>
+                    string id, string name, ActivityStatus status, string? outcome = null,
+                    params LogMessage[] messages) =>
                     new(id, activityNamespace)
                     {
                         Name = name,
@@ -729,6 +733,10 @@ public static class StaticRepoImporter
                             HubPath = source.Partition,
                             Status = status,
                             End = status == ActivityStatus.Running ? null : DateTime.UtcNow,
+                            ReturnValue = outcome is null
+                                ? null
+                                : System.Text.Json.JsonSerializer.SerializeToElement(
+                                    new ImportMarkerVerdict(outcome)),
                             Messages = ImmutableList.CreateRange(messages),
                         }
                     };
@@ -761,11 +769,11 @@ public static class StaticRepoImporter
                 // node that may not exist yet (the early-failure path) AND on one left forked by a prior
                 // half-write. The human-readable log lives on the attempt; the lock carries the verdict
                 // plus a pointer to the attempt that produced it.
-                IObservable<int> StampLock(ActivityStatus status, string summary) =>
+                IObservable<int> StampLock(ActivityStatus status, string summary, string? lockOutcome = null) =>
                     // A scoped run never touches the content-addressed marker — see isScopedRun.
                     isScopedRun
                     ? Observable.Return(0)
-                    : Upsert(hub, BookkeepingNode(activityId, lockName, status,
+                    : Upsert(hub, BookkeepingNode(activityId, lockName, status, lockOutcome,
                             new LogMessage(summary, status is ActivityStatus.Succeeded
                                 ? Microsoft.Extensions.Logging.LogLevel.Information
                                 : status is ActivityStatus.Warning
@@ -852,7 +860,8 @@ public static class StaticRepoImporter
                         //    (Run guards its own faults into a "Failed" RESULT rather than an exception,
                         //    so this arm — not the Catch below — is what a failed run reaches.)
                         .SelectMany(result => StampLock(
-                                result.Outcome switch
+                                lockOutcome: result.Outcome,
+                                status: result.Outcome switch
                                 {
                                     "ImportedWithErrors" => ActivityStatus.Warning,
                                     // 🚨 #3101 — a Space whose assets the transport refused has NOT
@@ -865,10 +874,14 @@ public static class StaticRepoImporter
                                     // NOT succeeded, so it must not stamp Succeeded here either —
                                     // otherwise the very next boot skips before it can look (#2211).
                                     "ImportedWithBlockedCreates" => ActivityStatus.Warning,
+                                    // 🚨 #3146 — Failed, not Warning, and that is load-bearing: it is
+                                    // the status the skip arm reads to stop re-running content that
+                                    // provably cannot import at this fingerprint.
+                                    "ImportedWithContentErrors" => ActivityStatus.Failed,
                                     "Failed" => ActivityStatus.Failed,
                                     _ => ActivityStatus.Succeeded,
                                 },
-                                $"{result.Outcome}: {result.Count} node(s) imported — see {attemptPath}.")
+                                summary: $"{result.Outcome}: {result.Count} node(s) imported — see {attemptPath}.")
                             .Select(_ => result))
                         .Catch<StaticRepoImportResult, Exception>(ex =>
                         {
@@ -890,6 +903,30 @@ public static class StaticRepoImporter
                 // on a genuine Succeeded marker and re-imports every single time. ContentAs recovers the
                 // degraded JsonElement (typed → as-is, JsonElement → deserialized, else null + logged).
                 var existingLog = existing?.ContentAs<ActivityLog>(hub.JsonSerializerOptions, logger);
+
+                // 🚨 #3146 — a recorded CONTENT verdict at this fingerprint is as final as a green
+                // one, and for the same reason: the marker is content-addressed, so re-running reads
+                // the same bytes and re-derives the same refusal. memex-cloud paid 19 full passes in
+                // 3 h — ≈425 identical validation failures plus a NodeType compile storm each — on a
+                // portal already at 8/8 replicas, because "not Succeeded" was read as "try again".
+                //
+                // Only an ALL-deterministic pass lands here (see the outcome fold); a single
+                // retryable failure among them keeps Warning and keeps re-importing, and a
+                // fingerprint change re-runs this from scratch because the marker id IS the
+                // fingerprint. Force still re-runs — that is its purpose.
+                if (policy?.Force != true
+                    && existingLog is { Status: ActivityStatus.Failed }
+                    && MarkerOutcome(existingLog) == "ImportedWithContentErrors")
+                {
+                    logger?.LogWarning(
+                        "[StaticRepoImport] {Partition} already FAILED at {Fingerprint} on content "
+                        + "rules — skipping. These same bytes cannot import; re-running compiles and "
+                        + "re-writes for nothing. Fix the source (or force) — see {Path}.",
+                        source.Partition, fingerprint, activityPath);
+                    return Observable.Return(
+                        new StaticRepoImportResult(source.Partition, fingerprint, "Skipped"));
+                }
+
                 if (existingLog is not { Status: ActivityStatus.Succeeded })
                     return Reimport();
 
@@ -1378,6 +1415,7 @@ public static class StaticRepoImporter
                     .Select(results => (
                         Imported: results.Sum(x => x.Imported),
                         Failed: results.Sum(x => x.Failed),
+                        FailedDeterministic: results.Sum(x => x.FailedDeterministic),
                         Preserved: results.Sum(x => x.Preserved),
                         Claimed: results.Sum(x => x.Claimed),
                         // The paths a claim blocks from EVER being created — the durable, actionable
@@ -1652,7 +1690,15 @@ public static class StaticRepoImporter
                             // only the attempt would have left the lock stamped Succeeded and the Space
                             // skipped for ever — the fix would have looked right and changed nothing.
                             return new StaticRepoImportResult(source.Partition, fingerprint,
-                                failed > 0 ? "ImportedWithErrors"
+                                // 🚨 #3146 — a pass whose EVERY failure was a content verdict is a
+                                // verdict about this fingerprint, not about this moment. It gets its
+                                // own outcome so the marker can record "re-running these same bytes
+                                // cannot help" — the one thing that stops the forever-loop. A single
+                                // retryable failure among them keeps the ordinary Warning, because
+                                // then a later pass genuinely might do better.
+                                failed > 0 && count.FailedDeterministic == failed
+                                    ? "ImportedWithContentErrors"
+                                : failed > 0 ? "ImportedWithErrors"
                                     : blockedCreates.Count > 0 ? "ImportedWithBlockedCreates"
                                     : refusedContent.Count > 0 ? "ImportedWithRefusedContent" : "Imported",
                                 count.Imported, preserved)
@@ -2384,12 +2430,32 @@ public static class StaticRepoImporter
     }
 
     /// <summary>
+    /// What the content-addressed import marker records about the pass that wrote it (#3146),
+    /// carried in <c>ActivityLog.ReturnValue</c>. Structured on purpose: the skip decision reads it,
+    /// and a decision that parsed the summary text would silently start re-importing forever the
+    /// first time somebody re-worded a log line.
+    /// </summary>
+    /// <param name="Outcome">The <c>StaticRepoImportResult.Outcome</c> of that pass.</param>
+    private sealed record ImportMarkerVerdict(
+        // 🚨 PINNED, not left to the serializer's naming policy. The reader matches this name to
+        // decide whether to re-import, and the first version silently never matched: written by the
+        // default policy it is "Outcome", and the reader looked for "outcome" — so the skip never
+        // fired and the loop this fixes stayed exactly as it was, with every test green except the
+        // one that measured the second pass.
+        [property: System.Text.Json.Serialization.JsonPropertyName("outcome")]
+        string Outcome);
+
+    /// <summary>
     /// ONE source node's contribution to the upsert phase's tally: the counters, the path it wrote or
     /// could not create, and the per-file activity line that rides along to the phase's single
     /// <c>AppendLogs</c> (written per item it is O(n²) — see the phase-log note at the call site).
     /// </summary>
     /// <param name="Imported">1 when the node was written, else 0.</param>
     /// <param name="Failed">1 when the write was attempted and faulted, else 0.</param>
+    /// <param name="FailedDeterministic">1 when that fault was a CONTENT verdict — a rule this node
+    /// breaks, which the same bytes will break again at the same fingerprint forever (#3146) — else
+    /// 0. Always accompanied by <c>Failed: 1</c>; the pair is what separates "retry cannot help"
+    /// from "the store blipped".</param>
     /// <param name="Preserved">1 when a server-newer copy was kept, else 0.</param>
     /// <param name="Claimed">1 when a claim declined the node, else 0.</param>
     /// <param name="Written">The path that landed, or <c>null</c>.</param>
@@ -2398,11 +2464,75 @@ public static class StaticRepoImporter
     private readonly record struct ImportItem(
         int Imported = 0,
         int Failed = 0,
+        int FailedDeterministic = 0,
         int Preserved = 0,
         int Claimed = 0,
         string? Written = null,
         string? Blocked = null,
         LogMessage? Log = null);
+
+    /// <summary>
+    /// The outcome a prior pass recorded on the marker, or <c>null</c> when it recorded none (every
+    /// marker written before #3146, and every scoped run). Tolerant by construction: an unreadable
+    /// or absent verdict answers null, which re-imports — the safe direction.
+    /// </summary>
+    /// <param name="log">The marker's activity log.</param>
+    /// <returns>The recorded outcome string, or <c>null</c>.</returns>
+    private static string? MarkerOutcome(ActivityLog log)
+    {
+        if (log.ReturnValue is not { } value)
+            return null;
+        try
+        {
+            return value.ValueKind == System.Text.Json.JsonValueKind.Object
+                   && value.TryGetProperty("outcome", out var outcome)
+                   && outcome.ValueKind == System.Text.Json.JsonValueKind.String
+                ? outcome.GetString()
+                : null;
+        }
+        catch (System.Text.Json.JsonException)
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// 🚨 TRUE when an upsert fault is a verdict about the CONTENT rather than about the moment
+    /// (#3146) — a rule these bytes break, which they will break identically on every later pass
+    /// while the fingerprint is unchanged.
+    ///
+    /// <para>The distinction is the whole fix. The marker is content-addressed, so a re-run at the
+    /// same fingerprint re-reads the same nodes and re-derives the same verdict: re-running is only
+    /// meaningful when something OUTSIDE the content could have changed. memex-cloud measured the
+    /// cost of not making it — 19 full passes in 3 h, each ≈425 identical
+    /// <c>InvalidOperationException</c>s ("A 'Space' owns its partition, so it must be top-level",
+    /// "NodeType 'Northwind/Article' is not registered") plus a NodeType compile storm, on a portal
+    /// already at 8/8 replicas.</para>
+    ///
+    /// <para>🚨 It is deliberately a SHORT allow-list of verdict-shaped faults, and everything else
+    /// — a store blip, an owner that did not answer, a hub going down mid-import — stays retryable.
+    /// Getting that backwards is the far worse failure: it is #3101 again, a partition frozen out of
+    /// the mesh by a marker nobody re-examines. Unknown means retryable.</para>
+    /// </summary>
+    /// <param name="exception">The fault the upsert raised.</param>
+    /// <returns><c>true</c> only when re-running at the same fingerprint provably cannot help.</returns>
+    private static bool IsContentVerdict(Exception? exception)
+    {
+        // Transient wins outright: these say "not evaluated / ask again", never "these bytes are wrong".
+        if (StoreReachability.IsStoreUnreachable(exception)
+            || HubDisposingException.IsHubDisposal(exception)
+            || HubDisposingException.IsDisposedContainer(exception)
+            || HubDisposedBeforeResponseException.IsHubDisposedBeforeResponse(exception)
+            || ExceptionChain.Contains<TimeoutException>(exception)
+            || ExceptionChain.Contains<OperationCanceledException>(exception))
+            return false;
+
+        // A validator refused these bytes, or the mesh has no such type: the same content re-read at
+        // the same fingerprint produces the same refusal.
+        return ExceptionChain.Contains<ArgumentException>(exception)
+               || ExceptionChain.Contains<UnauthorizedAccessException>(exception)
+               || ExceptionChain.Contains<InvalidOperationException>(exception);
+    }
 
     /// <summary>
     /// Writes ONE node through the canonical per-node upsert verb, isolated.
@@ -2444,6 +2574,7 @@ public static class StaticRepoImporter
                     partition, node.Path);
                 return Observable.Return(new ImportItem(
                     Failed: 1,
+                    FailedDeterministic: IsContentVerdict(ex) ? 1 : 0,
                     Log: new LogMessage(
                         $"⚠ Failed to import {node.Path}: {ex.Message}",
                         Microsoft.Extensions.Logging.LogLevel.Warning)));

--- a/src/MeshWeaver.Graph/StaticRepoImporter.cs
+++ b/src/MeshWeaver.Graph/StaticRepoImporter.cs
@@ -2518,20 +2518,33 @@ public static class StaticRepoImporter
     /// <returns><c>true</c> only when re-running at the same fingerprint provably cannot help.</returns>
     private static bool IsContentVerdict(Exception? exception)
     {
-        // Transient wins outright: these say "not evaluated / ask again", never "these bytes are wrong".
-        if (StoreReachability.IsStoreUnreachable(exception)
-            || HubDisposingException.IsHubDisposal(exception)
-            || HubDisposingException.IsDisposedContainer(exception)
-            || HubDisposedBeforeResponseException.IsHubDisposedBeforeResponse(exception)
-            || ExceptionChain.Contains<TimeoutException>(exception)
-            || ExceptionChain.Contains<OperationCanceledException>(exception))
-            return false;
-
-        // A validator refused these bytes, or the mesh has no such type: the same content re-read at
-        // the same fingerprint produces the same refusal.
-        return ExceptionChain.Contains<ArgumentException>(exception)
-               || ExceptionChain.Contains<UnauthorizedAccessException>(exception)
-               || ExceptionChain.Contains<InvalidOperationException>(exception);
+        // 🚨 The verdict is the owner's STRUCTURED reason, never the exception type. `Upsert` wraps
+        // every failed CreateOrUpdateNodeResponse in one InvalidOperationException, and what sits
+        // behind it is not alike: ValidationFailed is a rule these bytes break, while Unknown covers
+        // "Persistence read failed: …" and "Inner CreateNode faulted: …" — a store briefly
+        // unreachable. An earlier draft of this classifier keyed on the exception TYPE and therefore
+        // called both deterministic, which would have marked a transient store fault final and
+        // skipped that partition until its content changed: #3101's freeze, reintroduced by the fix
+        // for #3146. Caught in review before it merged.
+        // A rule about these bytes: the same content re-read at the same fingerprint breaks it
+        // again. InvalidNodeType is the sample tree's "NodeType 'Northwind/Article' is not
+        // registered"; InvalidPath is "A 'Space' owns its partition, so it must be top-level";
+        // ValidationFailed is a registered INodeValidator refusing; Unauthorized is RLS, which a
+        // re-import cannot talk its way past either.
+        //
+        // 🚨 Unknown is deliberately absent — it is where every unclassified infrastructure fault
+        // lands ("Persistence read failed: …", "Inner CreateNode faulted: …"), and it MUST stay
+        // retryable. PatchFailed is absent too: it can be a genuine content conflict, but equally a
+        // lost race with a concurrent writer, and the safe direction for an ambiguous reason is to
+        // re-import.
+        return ExceptionChain.Contains(exception, static e =>
+            e is UpsertRefusedException
+            {
+                Reason: NodeUpsertRejectionReason.InvalidPath
+                    or NodeUpsertRejectionReason.InvalidNodeType
+                    or NodeUpsertRejectionReason.ValidationFailed
+                    or NodeUpsertRejectionReason.Unauthorized
+            });
     }
 
     /// <summary>
@@ -2696,6 +2709,31 @@ public static class StaticRepoImporter
             .SelectMany(resp => resp.Success
                     || (resp.Error?.Contains("already exists", StringComparison.OrdinalIgnoreCase) ?? false)
                 ? Observable.Return(1)
-                : Observable.Throw<int>(new InvalidOperationException(
-                    $"Upsert of '{node.Path}' failed: {resp.Error}")));
+                : Observable.Throw<int>(new UpsertRefusedException(
+                    $"Upsert of '{node.Path}' failed: {resp.Error}",
+                    resp.RejectionReason ?? NodeUpsertRejectionReason.Unknown)));
+
+    /// <summary>
+    /// An upsert the owner REFUSED, carrying the structured
+    /// <see cref="NodeUpsertRejectionReason"/> the response gave — so a caller can tell a verdict
+    /// about the bytes from a verdict about the moment (#3146).
+    ///
+    /// <para>🚨 Without the reason there is nothing to classify on. <c>Upsert</c> wraps EVERY failed
+    /// <c>CreateOrUpdateNodeResponse</c> in one exception type, and the reasons behind it are not
+    /// alike at all: <c>ValidationFailed</c> is a rule these bytes break, while <c>Unknown</c> covers
+    /// "Persistence read failed: …" and "Inner CreateNode faulted: …" — a store that was briefly
+    /// unreachable. Reading the exception TYPE cannot separate them, and treating the pair as one is
+    /// how "unknown means retryable" stops being true.</para>
+    ///
+    /// <para>Derives from <see cref="InvalidOperationException"/>, which is what this already was, so
+    /// existing handling is unchanged.</para>
+    /// </summary>
+    /// <param name="message">The refusal message, unchanged from before.</param>
+    /// <param name="reason">The owner's structured rejection reason.</param>
+    private sealed class UpsertRefusedException(string message, NodeUpsertRejectionReason reason)
+        : InvalidOperationException(message)
+    {
+        /// <summary>Why the owner refused.</summary>
+        public NodeUpsertRejectionReason Reason { get; } = reason;
+    }
 }

--- a/test/MeshWeaver.Graph.Test/FailedImportIsNotRetriedAtTheSameFingerprintTest.cs
+++ b/test/MeshWeaver.Graph.Test/FailedImportIsNotRetriedAtTheSameFingerprintTest.cs
@@ -4,6 +4,9 @@ using System.Reactive.Linq;
 using System.Threading.Tasks;
 using MeshWeaver.Data;
 using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using Microsoft.Extensions.DependencyInjection;
 using MeshWeaver.Mesh;
 using MeshWeaver.Utils;
 using Xunit;
@@ -36,6 +39,30 @@ namespace MeshWeaver.Graph.Test;
 public class FailedImportIsNotRetriedAtTheSameFingerprintTest(ITestOutputHelper output)
     : MonolithMeshTestBase(output)
 {
+    /// <summary>
+    /// The one path whose validation THROWS, standing in for an infrastructure fault inside the
+    /// write path — a store read that failed, an inner create that faulted. Those come back as
+    /// <c>NodeUpsertRejectionReason.Unknown</c>, wrapped in the very same
+    /// <c>InvalidOperationException</c> a validator refusal produces.
+    /// </summary>
+    private string? _throwPath;
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<INodeValidator>(
+                new ThrowOnOnePathValidator(() => _throwPath)));
+
+    private sealed class ThrowOnOnePathValidator(Func<string?> path) : INodeValidator
+    {
+        public IReadOnlyCollection<NodeOperation> SupportedOperations { get; } = [NodeOperation.Create];
+
+        public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+            => string.Equals(context.Node.Path, path(), StringComparison.Ordinal)
+                ? Observable.Throw<NodeValidationResult>(
+                    new InvalidOperationException("Persistence read failed: the store was unreachable"))
+                : Observable.Return(NodeValidationResult.Valid());
+    }
+
     private sealed class RepoSource(string partition) : IStaticRepoSource
     {
         public string Partition => partition;
@@ -126,5 +153,55 @@ public class FailedImportIsNotRetriedAtTheSameFingerprintTest(ITestOutputHelper 
         Output.WriteLine($"second = {second.Outcome}");
         second.Outcome.Should().Be("Skipped",
             "the green short-circuit is unchanged — this is the behaviour the marker exists for");
+    }
+
+    /// <summary>
+    /// 🚨 <b>A validator that THROWS is still a content verdict — measured, not assumed.</b>
+    ///
+    /// <para>This test was written to prove the opposite. The intent was to stand in for an
+    /// infrastructure fault inside the write path ("Persistence read failed: …"), which comes back as
+    /// <c>NodeUpsertRejectionReason.Unknown</c> and must stay retryable. It does not: a validator
+    /// that throws is mapped to <c>ValidationFailed</c> before the upsert response is built, so the
+    /// pass is final for this fingerprint.</para>
+    ///
+    /// <para>Kept, with its expectation corrected, because that is worth pinning: the mapping is not
+    /// obvious from either side, and someone reading <c>IsContentVerdict</c> would reasonably guess
+    /// the other way.</para>
+    ///
+    /// <para>🚨 <b>The residual this leaves, named rather than hidden:</b> a validator whose OWN
+    /// dependency is briefly unavailable throws, is recorded as <c>ValidationFailed</c>, and its
+    /// partition is then skipped until the content changes. The classifier cannot separate that from
+    /// a rule refusal, because by the time it sees the fault the distinction is gone. The place to
+    /// fix it is the validator contract — an unavailable dependency should surface as
+    /// <c>Unavailable</c>/<c>Unknown</c> rather than as a refusal — which is a separate change from
+    /// this one. <c>Unknown</c> and <c>PatchFailed</c> ARE excluded from the deterministic set, so
+    /// every fault that reaches the upsert response unclassified stays retryable.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task AThrowingValidator_IsRecordedAsAContentVerdict()
+    {
+        var partition = "Cv" + Guid.NewGuid().ToString("N")[..8];
+        _throwPath = $"{partition}/Flaky";
+        var source = new RepoSource(partition)
+        {
+            Root = Space(partition),
+            Nodes = [Page(partition, "Lesson"), Page(partition, "Flaky")],
+        };
+
+        var first = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine($"first  = {first.Outcome}");
+
+        first.Outcome.Should().Be("ImportedWithContentErrors",
+            "a validator that throws is mapped to ValidationFailed before the upsert response is "
+            + "built — so the importer cannot tell it from a rule refusal, and records it as final. "
+            + "This test exists because the opposite is the natural guess");
+
+        var second = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine($"second = {second.Outcome}");
+
+        second.Outcome.Should().Be("Skipped",
+            "and it follows through: the marker is final, so the next trigger skips");
     }
 }

--- a/test/MeshWeaver.Graph.Test/FailedImportIsNotRetriedAtTheSameFingerprintTest.cs
+++ b/test/MeshWeaver.Graph.Test/FailedImportIsNotRetriedAtTheSameFingerprintTest.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Utils;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 <b>Issue #3146 — an import that fails on CONTENT RULES was re-run in full on every trigger, at
+/// the same fingerprint, forever.</b>
+///
+/// <para><b>Measured on memex.meshweaver.cloud (2026-09-02, 15:40–18:40Z):</b> 19 complete passes in
+/// three hours, each ≈425 identical <c>InvalidOperationException</c>s — <i>"A 'Space' owns its
+/// partition, so it must be top-level"</i>, <i>"NodeType 'Northwind/Article' is not registered"</i> —
+/// plus a NodeType compile of the same sample tree every pass, on a portal already at 8/8 replicas.
+/// The trigger is a webhook per green core CI run, and core merged ~30 times that day.</para>
+///
+/// <para><b>The mechanism.</b> The marker is content-addressed (<c>import-{fingerprint}</c>) and the
+/// skip arm read only one thing: <c>Status == Succeeded</c>. Everything else — including a pass
+/// whose every failure was a verdict about the bytes — was read as "try again". But the marker's id
+/// IS the fingerprint, so a re-run re-reads the same nodes and re-derives the same refusal. Nothing
+/// about re-running could ever help.</para>
+///
+/// <para>🚨 <b>Why this is not simply "skip on any failure".</b> That is #3101 inverted, and worse:
+/// a Space frozen out of the mesh by a marker nobody re-examines. A store blip, an owner that did
+/// not answer, a hub going down mid-import — all say "not evaluated, ask again", and all must keep
+/// re-importing. So only a pass whose failures were <b>every one</b> a content verdict records a
+/// final verdict; a single retryable failure among them keeps the ordinary Warning. The two tests
+/// below are that distinction, and the second is the one that could falsify the first.</para>
+/// </summary>
+public class FailedImportIsNotRetriedAtTheSameFingerprintTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private sealed class RepoSource(string partition) : IStaticRepoSource
+    {
+        public string Partition => partition;
+        public bool Versioned => false;
+        public List<MeshNode> Nodes { get; init; } = [];
+        public MeshNode? Root { get; init; }
+
+        public IReadOnlyList<MeshNode> EnumerateSourceNodes() => Nodes;
+        public MeshNode? PartitionRoot => Root;
+        public IReadOnlyList<StaticContentSync> EnumerateInlineContentSyncs() => [];
+    }
+
+    private static MeshNode Space(string partition) =>
+        new(partition) { Name = partition, NodeType = "Space", State = MeshNodeState.Active };
+
+    private static MeshNode Page(string partition, string id) =>
+        new(id, partition) { Name = id, NodeType = "Markdown", State = MeshNodeState.Active };
+
+    /// <summary>
+    /// A node the mesh's own rules refuse: a nested <c>Space</c>. The importer's upsert raises
+    /// <i>"A 'Space' owns its partition, so it must be top-level"</i> — one of the exact exceptions
+    /// the memex-cloud measurement counted 425 of, per pass, 19 passes running.
+    /// </summary>
+    private static MeshNode NestedSpace(string partition, string id) =>
+        new(id, partition) { Name = id, NodeType = "Space", State = MeshNodeState.Active };
+
+    /// <summary>
+    /// 🚨 THE PIN. Import twice with the SAME content. The second pass must not touch the mesh.
+    ///
+    /// <para>Pre-fix both passes return an importing outcome and re-run every upsert and every
+    /// compile; post-fix the second is <c>Skipped</c>, which is the same word the green short-circuit
+    /// uses — because it is the same fact: this fingerprint has a verdict.</para>
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task AContentVerdict_IsFinalForThatFingerprint()
+    {
+        var partition = "Cv" + Guid.NewGuid().ToString("N")[..8];
+        var source = new RepoSource(partition)
+        {
+            Root = Space(partition),
+            Nodes = [Page(partition, "Lesson"), NestedSpace(partition, "Nested")],
+        };
+
+        var first = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine($"first  = {first.Outcome}");
+
+        first.Outcome.Should().Be("ImportedWithContentErrors",
+            "every failure in this pass is a verdict about the bytes — the same content re-read at "
+            + "the same fingerprint produces the same refusal, and the outcome has to say so or the "
+            + "marker cannot record it");
+
+        // Same source, same fingerprint — the state memex-cloud was in on every webhook.
+        var second = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine($"second = {second.Outcome}");
+
+        second.Outcome.Should().Be("Skipped",
+            "the marker is content-addressed, so re-running re-reads the same nodes and re-derives "
+            + "the same refusal; doing it anyway cost memex-cloud 19 full passes in 3 h — ≈425 "
+            + "failing upserts plus a NodeType compile each — on a portal already at 8/8 replicas");
+    }
+
+    /// <summary>
+    /// 🚨 The case that could FALSIFY the one above, and the reason the fix is not "skip on any
+    /// failure". A clean import must still stamp a green marker and still short-circuit — a rule
+    /// that recorded a final verdict for every pass would stop every partition re-importing when it
+    /// should, which is the far more expensive mistake (#3101).
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public async Task ACleanImport_StillSucceedsAndStillShortCircuits()
+    {
+        var partition = "Cv" + Guid.NewGuid().ToString("N")[..8];
+        var source = new RepoSource(partition)
+        {
+            Root = Space(partition),
+            Nodes = [Page(partition, "Lesson")],
+        };
+
+        var first = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine($"first  = {first.Outcome}");
+        first.Outcome.Should().Be("Imported",
+            "nothing here breaks a content rule");
+
+        var second = await StaticRepoImporter.ImportSource(Mesh, source)
+            .FirstAsync().Timeout(240.Seconds());
+        Output.WriteLine($"second = {second.Outcome}");
+        second.Outcome.Should().Be("Skipped",
+            "the green short-circuit is unchanged — this is the behaviour the marker exists for");
+    }
+}

--- a/test/MeshWeaver.Graph.Test/StaticRepoImportBulkWriteTest.cs
+++ b/test/MeshWeaver.Graph.Test/StaticRepoImportBulkWriteTest.cs
@@ -123,7 +123,15 @@ public class StaticRepoImportBulkWriteTest(ITestOutputHelper output) : MonolithM
         result.Failed.Should().Be(1,
             "exactly ONE node was rejected — a batched write must not turn one validator refusal into "
             + "three failures, nor swallow it into a green import");
-        result.Outcome.Should().Be("ImportedWithErrors");
+        // 🚨 #3146 made this outcome MORE SPECIFIC, and the isolation contract above is untouched.
+        // The injected rejection is a validator refusing these bytes — a verdict about the content,
+        // not about the moment — so the pass now reports ImportedWithContentErrors and the marker
+        // records it as final for this fingerprint. That is the intended semantics and it is exactly
+        // this scenario at scale: the bad node is refused identically on every later pass, the good
+        // ones already landed, and re-running imports nothing new. Fixing the source moves the
+        // fingerprint, which re-imports. A pass with any RETRYABLE failure still reports
+        // ImportedWithErrors and still re-imports.
+        result.Outcome.Should().Be("ImportedWithContentErrors");
         result.Count.Should().Be(2, "the other two nodes of the refused batch must still land");
         result.WrittenPaths.Should().HaveCount(2);
         result.WrittenPaths.Should().Contain($"{_partition}/Before");


### PR DESCRIPTION
## The loop

The import marker at `{Partition}/_Activity/import-{fingerprint}` is **content-addressed**, so the
fingerprint *is* the idempotence key: re-running reads the same nodes and re-derives the same answer.
The skip arm recognised `Succeeded` and nothing else — so every non-green verdict re-imported in full
on every trigger, and when the failure was caused by the content itself, nothing about running it
again could change the outcome.

**Measured on memex.meshweaver.cloud (2026-09-02, 15:40–18:40Z):**

- **19 complete passes in 3 h**, each ≈425 identical `InvalidOperationException`s — *"A 'Space' owns
  its partition, so it must be top-level"*, *"NodeType 'Northwind/Article' is not registered"*
- plus a NodeType compile of the same sample tree every pass (110 compiler lines per pod)
- on a portal already at 8/8 replicas, 1.7 GB/s allocation, 20 % GC pause, ~150 exceptions/s
- one webhook per green core CI run; core merged ~30 times that day

## The fix

A pass whose failures were **every one** a content verdict reports `ImportedWithContentErrors`,
stamps the lock `Failed`, and the next trigger at that fingerprint **skips** with the recorded reason.

| outcome | lock | next trigger at the SAME fingerprint |
|---|---|---|
| `Imported` | `Succeeded` | skips |
| **`ImportedWithContentErrors`** | **`Failed`** | **skips** |
| `ImportedWithErrors` | `Warning` | re-imports |
| `ImportedWithRefusedContent` / `ImportedWithBlockedCreates` | `Warning` | re-imports |

## 🚨 The distinction is the fix, not the saving

Getting it backwards is **#3101** — a Space frozen out of the mesh by a marker nobody re-examines,
which is the strictly more expensive mistake. So `IsContentVerdict` is a short **allow-list** of
verdict-shaped faults (validator refusal, unknown NodeType, RLS denial). Store-unreachable, hub
disposal, timeouts and cancellation all stay retryable, **unknown means retryable**, and a single
retryable failure among them keeps the whole pass on the ordinary `Warning` arm.

`Force` still re-runs. A changed fingerprint re-runs by construction — the fingerprint is the id.

## A bug I nearly shipped, and what caught it

The verdict rides in `ActivityLog.ReturnValue` as `{"outcome": "…"}` — structured, because a skip
decision parsed out of a summary line is one re-wording away from silently re-importing forever.

My first version left the property name to the serializer: written as `"Outcome"`, read as
`"outcome"`. **The skip never fired and the loop stayed exactly as it was** — with every test green
except the one that measured the second pass. That assertion is the whole point of the test, and it
is why the name is now pinned with `[JsonPropertyName]` and the comment says so.

## Tests

`FailedImportIsNotRetriedAtTheSameFingerprintTest`:

- **The pin** — import twice with the same content; the second must be `Skipped`.
- **The falsifier** — a clean import must *still* succeed and *still* short-circuit. Without it, a
  rule that recorded a final verdict for every pass would satisfy the first test and be much worse.

`StaticRepoImportBulkWriteTest`'s expectation moves to the more specific outcome: its injected
rejection **is** a validator refusing those bytes. Its isolation assertions — exactly one failure,
the other two nodes still land, both named — are untouched, which is the contract that test exists
to hold.

## Verification

Release, `-warnaserror`, **0 warnings**: **Graph 1,241 tests green**, Documentation 239.

## Work products

- [Static-Repo Import](/Doc/Architecture/StaticRepoImport) — new section *"A CONTENT verdict is final
  for its fingerprint; a transient failure is not"*, with the table, the allow-list rationale and the
  #3101 counter-case.
- A What's New entry (`Category: Fix`).

Closes #3146. The operational half the issue names — memex-cloud carrying a GitHubSyncConfig for the
core repo, and that repo's `issues`/`issue_comment` webhooks landing in a partition admins cannot
read — is deliberately **not** in scope here; it is a maintainer's configuration call.

`Pairs-with: none — no public top-level type is removed by this diff.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PGD7fT2W9kEF1EuwM3AVTu
