### PR TITLE
feat(#2511): ThreadChatControl declares an InitialDraft — the server half the client is waiting on

### DIFF
--- a/src/MeshWeaver.Layout/ThreadChatControl.cs
+++ b/src/MeshWeaver.Layout/ThreadChatControl.cs
@@ -48,6 +48,21 @@ public record ThreadChatControl() : UiControl<ThreadChatControl>(ModuleSetup.Mod
     public bool ShowThreadNav { get; init; }
 
     /// <summary>
+    /// A draft the SERVER declares for the composer — text the reader finds already typed in, and
+    /// is free to edit or clear before sending.
+    ///
+    /// <para>The first caller is the markdown <c>```prompt</c> fence (#2511): a page author's
+    /// suggested prompt becomes the initial draft, the reader edits it in place, and Submit starts
+    /// a real thread. It exists because that composer is RENDERED rather than opened by a click, so
+    /// there is no interaction to carry a draft in on.</para>
+    ///
+    /// <para>🚨 Seeding it is the CLIENT's decision and must be one-shot: a composer the user has
+    /// deliberately emptied must not find the prompt typed back in on the next render. The control
+    /// only declares the text; it says nothing about when it is applied.</para>
+    /// </summary>
+    public string? InitialDraft { get; init; }
+
+    /// <summary>
     /// Data-bound thread view model (via JsonPointerReference).
     /// Contains ThreadPath, InitialContext, Messages — all thread state.
     /// Null when control is created directly (side panel, dashboard).
@@ -72,6 +87,9 @@ public record ThreadChatControl() : UiControl<ThreadChatControl>(ModuleSetup.Mod
     /// <summary>Returns a copy with <paramref name="show"/> controlling whether the collapsible threads side menu renders even without an open thread.</summary>
     /// <param name="show">When <c>true</c>, the threads side menu renders beside the chat.</param>
     public ThreadChatControl WithShowThreadNav(bool show = true) => this with { ShowThreadNav = show };
+    /// <summary>Returns a copy with <paramref name="draft"/> as the text the composer opens pre-filled with.</summary>
+    /// <param name="draft">The draft text; <c>null</c> or empty leaves the composer empty.</param>
+    public ThreadChatControl WithInitialDraft(string? draft) => this with { InitialDraft = draft };
     /// <summary>Returns a copy with <paramref name="threadViewModel"/> as the data-bound thread view model.</summary>
     /// <param name="threadViewModel">A data-bound thread view model or pointer reference; <c>null</c> for direct-path mode.</param>
     public ThreadChatControl WithThreadViewModel(object? threadViewModel) => this with { ThreadViewModel = threadViewModel };


### PR DESCRIPTION
`Systemorph/MeshWeaver.Plugins#1181` (*"the #2511 client half"*) has been red and parked as a draft since 2026-09-02 on exactly one compile error:

```
ThreadChatView.razor.cs: error CS1061: 'ThreadChatControl' does not contain a
  definition for 'InitialDraft'
```

It cannot leave draft until this property exists, because the property belongs to this repo.

## What it is

`InitialDraft` is text the **server** declares for the composer — the reader finds it already typed in, and is free to edit or clear it before sending.

The first caller is the markdown ` ```prompt ` fence (#2511): a page author's suggested prompt becomes the initial draft, the reader edits it in place, and Submit starts a real thread. It exists because that composer is **rendered** rather than opened by a click, so there is no interaction to carry a draft in on — which is what `SidePanelState`'s one-shot pending draft does for the "new thread from cell" hand-off.

## 🚨 The control declares the text; it does not say when to apply it

Seeding is the **client's** decision and must be **one-shot**: a composer the user has deliberately emptied must not find the prompt typed back in on the next render. That rule is written on the property, so the next consumer does not have to rediscover it by reading the client.

## Binary safety

Additive: an `init` property plus a `WithInitialDraft` builder, following the shape of every other option on this record. It does **not** touch the primary constructor, so it cannot produce the signature-replacement break that makes a mixed module/platform set abort a host at boot.

`src/MeshWeaver.Layout` builds `-warnaserror` clean.

Refs #2511

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B94wX4FHVE2CFUE9Vc1Tao