### PR TITLE
Availability confirms a CONSISTENT sealed set; the bake refuses a doubly-produced module (#3175)

### DIFF
--- a/.github/scripts/compose-gate-host.sh
+++ b/.github/scripts/compose-gate-host.sh
@@ -10,7 +10,7 @@
 # deliberately runs that same adoption code rather than a gate-only reader, so a gate can only judge
 # the platform's bake when its process IS the platform host. Until #3022 the gate ran as the TESTER
 # image — whose /app is a strict subset of the portal's (measured on 3.0.0-rc9.ci.7534: 88 vs 219
-# assemblies; MeshWeaver.Maps, .AI, .ContentCollections.Indexing, the Blazor and hosting halves exist
+# assemblies; on that image MeshWeaver.Maps, .AI, .ContentCollections.Indexing — modules since — and the Blazor and hosting halves existed
 # only in the portal) — so content binding a portal-shipped assembly could neither compile in the bake
 # nor load in the gate, and every such failure read as a CONTENT error on source nobody had changed.
 #
@@ -24,7 +24,7 @@
 #     tester's identity, which is the exact confusion this host exists to end;
 #   * the tester's mw-plugin-test.deps.json is NEVER copied — 🚨 load-bearing, not tidiness: with an
 #     app-local deps.json the dotnet host builds the TPA from THAT file's entries only, and every
-#     portal-only assembly (Maps…) would be on disk yet unloadable ("could not load file or assembly").
+#     portal-only assembly (a Blazor half…) would be on disk yet unloadable ("could not load file or assembly").
 #     Without it the host probes the application directory and every assembly in it is in the TPA
 #     (documented host behaviour: no deps.json ⇒ all assemblies in the app directory are added).
 #     The portal's own <Host>.deps.json stays; the runtime reads only <entry>.deps.json.
@@ -51,9 +51,9 @@ if [ "${1:-}" = "--self-test" ]; then
   fail() { echo "SELF-TEST FAILED: $1"; exit 1; }
   portal="$tmp/portal"; tester="$tmp/tester"; out="$tmp/host"
   mkdir -p "$portal/modules/X" "$tester/razor-generators/linux-x64" "$tester/cs"
-  printf 'MeshWeaver.Layout=aaaa\nMeshWeaver.Maps=bbbb\n' > "$portal/meshweaver-surface.manifest"
+  printf 'MeshWeaver.Layout=aaaa\nMeshWeaver.PortalOnly=bbbb\n' > "$portal/meshweaver-surface.manifest"
   printf 'PORTAL' > "$portal/MeshWeaver.Layout.dll"
-  printf 'PORTAL' > "$portal/MeshWeaver.Maps.dll"
+  printf 'PORTAL' > "$portal/MeshWeaver.PortalOnly.dll"
   printf 'PORTAL' > "$portal/Newtonsoft.Json.dll"
   printf '{}' > "$portal/Memex.Portal.Distributed.deps.json"
   printf '{}' > "$portal/Memex.Portal.Distributed.runtimeconfig.json"
@@ -70,7 +70,7 @@ if [ "${1:-}" = "--self-test" ]; then
 
   "$self" "$portal" "$tester" "$out" > "$tmp/log" || fail "the happy path exited non-zero: $(cat "$tmp/log")"
   [ "$(cat "$out/Newtonsoft.Json.dll")" = "PORTAL" ]      || fail "a file both images carry must keep the PORTAL's bytes"
-  [ "$(cat "$out/MeshWeaver.Maps.dll")" = "PORTAL" ]      || fail "portal-only assemblies must be in the host"
+  [ "$(cat "$out/MeshWeaver.PortalOnly.dll")" = "PORTAL" ]      || fail "portal-only assemblies must be in the host"
   [ -f "$out/mw-plugin-test.dll" ]                        || fail "the tester CLI must be in the host"
   [ -f "$out/MeshWeaver.Hosting.Monolith.dll" ]           || fail "tester-only assemblies must ride"
   [ -f "$out/razor-generators/linux-x64/Razor.dll" ]      || fail "tester-only subdirectories must ride"

--- a/.github/workflows/node-repo-gate.yml
+++ b/.github/workflows/node-repo-gate.yml
@@ -39,7 +39,8 @@ name: Node repo gate (reusable)
 # the portal's /app with the tester CLI beside it (compose-gate-host.sh) — started by the portal
 # image's own `dotnet`. The tester's /app is a strict subset of the portal's (88 vs 219 assemblies
 # on 3.0.0-rc9.ci.7534), so a gate compiling against the tester's /app reports every NodeType
-# that binds a portal-only assembly (MeshWeaver.Maps, .AI, .Indexing…) as a CONTENT error.
+# that binds a portal-only assembly (the Blazor and hosting halves; on ci.7534 also MeshWeaver.Maps
+# and .AI, both modules since) as a CONTENT error.
 #     secrets:
 #       acr-username: ${{ secrets.ACR_USERNAME }}
 #       acr-password: ${{ secrets.ACR_PASSWORD }}

--- a/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
+++ b/memex/Memex.Portal.Shared/Memex.Portal.Shared.csproj
@@ -32,18 +32,16 @@
          deployment turns each on by listing its DLL, which is what that switch is for. Their
          collocated JS and OpenStreetMap's vendored wwwroot/leaflet/ are already addressed as
          ./_content/<Pack>/... — exactly what the module static-asset provider serves (#1724). -->
-    <!-- 🚨 DIRECT ON PURPOSE, and it must not be "tidied away" as unused. MeshWeaver.Maps is a
-         CANONICAL CONTENT-SURFACE assembly (FrameworkBuildIdentity.ContentSurfaceAssemblies), and
-         until the view packs flipped (#1974) this host reached it only through them — every map
-         pack references it. Losing it from the COMPILE closure does not fail a build: the surface
-         manifest is written from @(ReferencePathWithRefAssemblies), so the line simply vanishes,
-         this host hashes Maps as 'absent' while mw-plugin-test still hashes a real surface id, and
-         the two hosts of ONE commit resolve DIFFERENT framework identities. Every bake then lands
-         at an address no portal reads — publication green, pods compiling everything at boot, every
-         cover serving a compilation-fallback card. That is the 2026-08-17 outage (#1814); it
-         recurred here the moment the map packs left, and
-         FrameworkBuildIdentityTest.CanonicalContentSurface_IsRecordedByEverySurfaceManifestHost
-         is what caught it. No portal code uses these types — the reference IS the point. -->
+    <!-- 🚨 MeshWeaver.Maps is NOT referenced, and must never be again (maintainer, 2026-09-03:
+         "all maps should be in plugins and removed from core — move 100% to plugins"). It WAS a
+         direct reference here while it was a canonical content-surface assembly (#1814 needed
+         every surface-manifest host to carry it, or two hosts of one commit resolved two
+         identities). It left the content surface and this repo (#2941) and is a Store MODULE in
+         MeshWeaver.Plugins — landed from the registry, composed into bakes with the tester's
+         module flag. A portal host that referenced it again became the SECOND PRODUCER of one
+         assembly: the bake recorded the module's build (mvid:…) while every portal carried the
+         app-closure copy (ref:…), and every map gallery was declined at adoption fleet-wide
+         (#3175). BakeHost refuses that double by name now; this comment is the other half. -->
     <!-- MeshWeaver.Blazor.EntityViews is deliberately NOT referenced (the Analysis/#1974 shape):
          it ships via the registry as a module, its EntityViewsViewPackModuleAttribute registers
          the views when the DLL is listed under Modules:Assemblies, and Modules:Required declares

--- a/src/MeshWeaver.Cli/BuildPluginCommand.cs
+++ b/src/MeshWeaver.Cli/BuildPluginCommand.cs
@@ -90,7 +90,7 @@ public sealed class BuildPluginCommand(TextWriter output, TextWriter error)
                 + "as --image). The tester image only EXECUTES; the portal supplies the reference "
                 + "set, the framework identity and the runtime. There is no fallback to the tester's "
                 + "/app: it is a strict subset of the portal's (88 vs 219 assemblies on "
-                + "3.0.0-rc9.ci.7534), so content binding MeshWeaver.Maps, .AI or .Indexing fails to "
+                + "3.0.0-rc9.ci.7534), so content binding a portal-only assembly fails to "
                 + "compile against it (MeshWeaver#3022 / #3113).");
             return 9;
         }

--- a/src/MeshWeaver.Documentation/Data/Architecture/CandidateReleaseProtocol.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CandidateReleaseProtocol.md
@@ -141,6 +141,26 @@ So the gate moves to the deploy boundary:
 This is a *deploy* gate, not a release gate. A broken candidate stops at whichever instances it would
 break and rolls everywhere else.
 
+### Availability is a CONSISTENT sealed set, not a present file (#3175)
+
+The first gate a candidate meets — before the combo — is `ReleaseAvailabilityService`: does every
+installed package have a sealed bake under the candidate's framework identity? Until 2026-09-03 that
+question was answered by PRESENCE, and memex-cloud rolled to ci.7621 on it: every bundle was there,
+and the portal then declined SocialMedia at adoption because its NodeTypes had been built against a
+`MeshWeaver.Markdown.Collaboration` build the same identity's sealed module set did not carry.
+
+**Available now means CONSISTENT**: every dependency record inside every installed package's sealed
+bundle names module builds that ARE the module builds sealed for that identity, and no module is
+sealed twice at different builds. Anything else is `SealedSetInconsistent` — a hold naming the
+bundle, the NodeType, the module and both MVIDs — and "nothing goes" (maintainer, 2026-09-03: *"we
+must have a clear confirmation that all plugins deployed to an instance are available for the
+correct platform version; if not ⇒ nothing goes"*). An unreadable module set is `Indeterminate`,
+which also holds; a false "available" rolls a fleet, a false "hold" freezes it, and the two are
+told apart in the verdict on purpose. The mechanism and its limit — a module an instance installed
+from the registry outside any publication is not visible to this check — are in
+[ModuleBuildArchitecture](../ModuleBuildArchitecture) → "One producer per (module, framework
+identity)".
+
 ### The unit of verification is the COMBO, and it includes TESTS
 
 Two things are easy to get subtly wrong here, and both were wrong in earlier drafts of this page.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -396,6 +396,67 @@ No component ever publishes from the mesh router — the router names a spokesma
 | Module pack tool | 48–79s `dotnet build` × N jobs | ~5s download, built once |
 | Orleans test suite | ~90 silo boots + disposal drain | **3 clusters** (the mesh pool; see WritingTests § The Mesh Pool) |
 
+## One producer per (module, framework identity) — and the set is what is gated (#3175)
+
+**A module's bytes have exactly one producer for a given framework identity, and every dependent in
+a sealed publication was built against THAT build.** This is not a style preference; it is the
+invariant the adoption contract already assumes, and on 2026-09-03 it was broken twice in one
+morning, with no diff in any repo:
+
+| where | what the record said | what the consumer held | outcome |
+|---|---|---|---|
+| every satellite gate (Reinsurance 33727661313, Manufacturing 33727661850) | `'MeshWeaver.Maps' built against mvid:4d04617…` | `live is ref:1D8FDE5B…` | 4 of 240 DECLINED, `GATE FAILED`, nothing sealed, memex-cloud `HOLDING` |
+| memex.meshweaver.cloud on ci.7621 | `'MeshWeaver.Markdown.Collaboration' built against mvid:A` | `live is mvid:B` | SocialMedia adopted 0/4, `/Posts` rendered empty (#3174) |
+
+The first row is a **second producer in space**: a portal host had taken a direct project reference
+to `MeshWeaver.Maps`, a Store module. The bake composed Maps with `--module` — the id resolver puts
+modules first, so every record said `mvid:` — while every portal and every gate host carried the
+app-closure copy and resolved the name from its surface manifest as `ref:`. Two schemes, never
+equal, every map gallery declined. The maintainer's ruling closes it structurally: *"all maps should
+be in plugins and removed from core — move 100% to plugins."* The portal host references no module
+project; a module is landed from the registry and composed into bakes, nowhere else.
+
+The second row is a **second producer in time**: core CD's `plugins-modules` rebuilds
+`MeshWeaver.Markdown.Collaboration` per platform release to feed the Plugins seal (mvid A), while
+the registry's package endpoint serves the Plugins lane's last content-versioned publication (mvid
+B) — the bytes a portal actually installs. This row is NOT closed by this change (core holds no
+registry credential, so its bake cannot compose the registry's bytes); what changed is that the
+availability gate now sees it (below) instead of rolling onto it.
+
+### The two controls
+
+1. **The bake refuses a double by name** (`BakeHost.ShippedByHostProblem`, run by `compile` /
+   `--bake-output` under both `--app` and in-process). A module composed with `--module` whose
+   simple name the host also ships in its application directory — or lists in its surface manifest —
+   fails the bake RED: *"two builds of one assembly name in one bake … remove the assembly from the
+   platform host's closure or stop composing it."* Caught where both provenances are in one hand,
+   never sealed and discovered at the fleet. Pinned by
+   `BakeAgainstPlatformHostTest.AComposedModuleTheHostAlsoShips_IsRefusedByName`.
+2. **Availability asserts the SET** (`ReleaseAvailability.IsUpdatable` over the observation
+   `PublishedBundleCatalogue.ArtifactsForIdentity` makes). For the candidate identity the registry
+   reads every complete source's sealed module set — each module bundle's entry assembly, PE header
+   only, for its MVID — and every sealed bundle's per-NodeType dependency record (manifest only,
+   never assembly bytes). Then: every `mvid:` entry naming a module the set carries must equal the
+   MVID sealed for it, and no module may be sealed at two MVIDs by two sources. A violation is
+   `PackageAvailabilityKind.SealedSetInconsistent` — a HOLD that names the bundle, the NodeType, the
+   module and both builds — and it is consumed unchanged by the self-update poll, CD's post-promote
+   assertion and `/api/plugins/is-updatable`, because all three call the same predicate. Both
+   failure directions are pinned (`SealedSetConsistencyTest`): an unreadable or pre-module-sealing
+   module set is `Indeterminate` (hold, named — never "compatible"), and a module the set does not
+   carry is not judged, because the gate cannot see the bytes a registry install landed.
+
+### What the gate still cannot see
+
+The registry's package endpoint (`/api/plugins/bundles/<pkg>/<version>`) is content-versioned
+(Plugins #931): an instance that installed a module from it holds whatever that lane published last,
+and a platform release that rebuilds the module for the seal produces a *consistent* sealed set whose
+module MVID differs from the instance's landed one. The set check passes; the instance still
+declines. Closing that needs ONE producer in time as well — either the seal composes the registry's
+bytes for the root source (`registry-modules` in core CD, which needs a registry credential core
+does not hold today), or the instance adopts module bytes for its identity from the sealed
+publication it already adopts bundles from. Until one of those lands, `ShippedPrebuiltBundles`'
+`dependency record mismatch … live is mvid:` line on a portal is that gap, not a new defect.
+
 ## Adoption contract (every repo)
 
 1. Pin the reusable lanes (`node-repo-*.yml`) at a MeshWeaver main SHA — never copy them.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-an-update-is-held-when-its-packages-do-not-fit-together.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-an-update-is-held-when-its-packages-do-not-fit-together.md
@@ -1,0 +1,33 @@
+---
+Name: An update is held when its packages do not fit together
+Category: Fix
+Description: Before your installation moves to a new platform build, it checks that every installed package has been prepared for that build. It was only checking that the prepared packages existed — not that they had all been prepared against the same pieces — so an update could go through and then leave a package's pages empty.
+Icon: ShieldCheckmark
+Order: -20260903
+---
+
+# An update is held when its packages do not fit together
+
+Every package you install carries pages and views that are compiled ahead of time, for the exact
+platform build your installation runs. Before your installation updates itself, it asks whether that
+preparation exists for the new build — and refuses the update if a package would otherwise have to
+be compiled from scratch at start-up, which is slow and can fail.
+
+That check had a gap. It confirmed that each package **had been prepared**, but not that the
+packages had been prepared **against the same pieces**. Some packages build on others — a social
+feed on the collaboration tools, a map gallery on the map control — and when the piece a package was
+prepared against is not the piece your installation actually receives, the preparation is unusable.
+Your installation notices this only after the update, when it quietly discards the prepared package
+and the pages that depend on it come up empty or slow. That is what happened to the **Posts** page
+on one portal on 2 September.
+
+**The check now looks at the whole set.** For the candidate build it reads what each prepared
+package was built against and compares it with what is actually being shipped for that build. If any
+package does not fit, the update is **held**, and the **Updates** settings tab names the package, the
+piece it depends on, and the two versions that disagree — so the mismatch is fixed in the build
+pipeline instead of being discovered on your pages.
+
+The same morning, the map galleries (Apple Maps, Google Maps, OpenStreetMap and the Cornerstone
+pricing map) were failing this fit test everywhere, because the map control was being shipped
+twice — once inside the platform and once as its own package. The map control now ships only as a
+package, and the build refuses to prepare a package against a piece that is shipped both ways.

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -1,7 +1,12 @@
 using System.Collections.Immutable;
+using System.IO.Compression;
 using System.Reactive.Linq;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using MeshWeaver.Compiler;
 using MeshWeaver.Hosting;
 using MeshWeaver.Mesh.Threading;
+using MeshWeaver.Plugin.Packaging;
 using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.PluginCatalog;
@@ -104,7 +109,7 @@ public static class PublishedBundleCatalogue
 
             return new ReleaseObservation(
                 new ReleaseTarget(targetVersion, identity),
-                new ReleaseArtifacts(SealedBundlesForIdentity(publishedRoot, identity, logger)));
+                ArtifactsForIdentity(Path.Combine(publishedRoot, identity), logger));
         }
         catch (Exception ex)
         {
@@ -145,6 +150,134 @@ public static class PublishedBundleCatalogue
         if (!Directory.Exists(identityDirectory))
             return ReleaseArtifacts.Of([]).SealedBundles;
         return ReleaseArtifacts.Of(SealedBundleNames(identityDirectory, logger)).SealedBundles;
+    }
+
+    /// <summary>
+    /// 🚨 The FULL observation of one identity (#3175): the sealed bundle ids, the module set every
+    /// complete source sealed (each module bundle's entry assembly read for its MVID, spelt as the
+    /// dependency records spell it), and every sealed bundle's per-NodeType dependency record. The
+    /// bytes were always on disk — <see cref="SealedModulesOf"/> already refused a torn set — and
+    /// <see cref="ReleaseAvailability"/> can only assert CONSISTENCY when it is handed both halves.
+    /// Reads manifests and one PE header per module; never a bundle's assembly bytes.
+    /// </summary>
+    /// <remarks>A module bundle that cannot be read, or a source sealed before module sealing
+    /// existed, becomes the set's <see cref="SealedModuleSet.Refusal"/> — a named unreadability the
+    /// gate turns into a HOLD — and never a silent omission that would read as "no module here".</remarks>
+    internal static ReleaseArtifacts ArtifactsForIdentity(string identityDirectory, ILogger? logger)
+    {
+        var bundles = new List<string>();
+        var records = ImmutableArray.CreateBuilder<BundleDependencyRecord>();
+        var sealedBy = new Dictionary<string, (string Mvid, string Source)>(StringComparer.Ordinal);
+        var conflicts = ImmutableArray.CreateBuilder<string>();
+        var refusals = new List<string>();
+
+        foreach (var sourceDirectory in Directory.EnumerateDirectories(identityDirectory)
+                     .OrderBy(d => d, StringComparer.Ordinal))
+        {
+            var complete = CompleteBundlesOf(sourceDirectory, logger);
+            if (complete is null)
+                continue;
+            var source = Path.GetFileName(sourceDirectory)!;
+            bundles.AddRange(complete);
+            foreach (var bundle in complete)
+                records.AddRange(DependencyRecordsOf(Path.Combine(sourceDirectory, bundle), bundle));
+
+            var modules = SealedModulesOf(sourceDirectory, logger);
+            if (modules.Modules is null)
+            {
+                refusals.Add($"source '{source}': {modules.Refusal}");
+                continue;
+            }
+            foreach (var moduleBundle in modules.Modules)
+            {
+                var path = Path.Combine(sourceDirectory, ModulesDirectoryName, moduleBundle);
+                string name, mvid;
+                try
+                {
+                    (name, mvid) = SealedModuleMvidOf(path);
+                }
+                catch (Exception ex) when (ex is IOException or InvalidDataException or BadImageFormatException or InvalidOperationException)
+                {
+                    refusals.Add($"source '{source}': module bundle '{moduleBundle}' is unreadable — {ex.Message}");
+                    continue;
+                }
+                if (sealedBy.TryGetValue(name, out var existing))
+                {
+                    if (!string.Equals(existing.Mvid, mvid, StringComparison.Ordinal))
+                        conflicts.Add(
+                            $"module {name}: source '{existing.Source}' sealed {existing.Mvid}, "
+                            + $"source '{source}' sealed {mvid}");
+                    continue;
+                }
+                sealedBy[name] = (mvid, source);
+            }
+        }
+
+        var conflicted = conflicts.Select(c => c[..c.IndexOf(':')]["module ".Length..]).ToHashSet(StringComparer.Ordinal);
+        return new ReleaseArtifacts(ReleaseArtifacts.Of(bundles).SealedBundles)
+        {
+            Modules = new SealedModuleSet(
+                sealedBy.Where(kv => !conflicted.Contains(kv.Key))
+                    .ToImmutableDictionary(kv => kv.Key, kv => kv.Value.Mvid, StringComparer.Ordinal),
+                conflicts.ToImmutable(),
+                refusals.Count == 0 ? null : string.Join("; ", refusals)),
+            DependencyRecords = records.ToImmutable(),
+        };
+    }
+
+    /// <summary>
+    /// A sealed module bundle's entry assembly and its MVID in the dependency-record spelling
+    /// (<c>mvid:&lt;N&gt;</c> — <c>NodeTypeCompilationHelpers.ModuleMvidsOf</c>'s projection, so the
+    /// gate compares the id the seeder will compute). The entry is the manifest's
+    /// <c>module.assemblyName</c>, else the single assembly under the module folder — the same
+    /// resolution the lanes apply when they compose the bundle.
+    /// </summary>
+    internal static (string Name, string Mvid) SealedModuleMvidOf(string moduleBundlePath)
+    {
+        var manifest = BundleReader.ReadManifest(moduleBundlePath);
+        using var file = File.OpenRead(moduleBundlePath);
+        using var archive = new ZipArchive(file, ZipArchiveMode.Read);
+        var name = manifest?.Module?.AssemblyName;
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            var candidates = archive.Entries
+                .Where(e => e.FullName.StartsWith(NuGetPackageWriter.ModuleFolder + "/", StringComparison.Ordinal)
+                            && e.FullName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                            && !e.FullName[(NuGetPackageWriter.ModuleFolder.Length + 1)..].Contains('/'))
+                .ToList();
+            if (candidates.Count != 1)
+                throw new InvalidOperationException(
+                    $"cannot identify the module's entry assembly (no manifest module.assemblyName; "
+                    + $"{NuGetPackageWriter.ModuleFolder}/ holds {candidates.Count} dll(s))");
+            name = Path.GetFileNameWithoutExtension(candidates[0].FullName);
+        }
+        var entry = archive.GetEntry($"{NuGetPackageWriter.ModuleFolder}/{name}.dll")
+            ?? throw new InvalidOperationException(
+                $"{NuGetPackageWriter.ModuleFolder}/{name}.dll is missing from the bundle");
+        using var stream = entry.Open();
+        using var bytes = new MemoryStream();
+        stream.CopyTo(bytes);
+        bytes.Position = 0;
+        using var pe = new PEReader(bytes);
+        var metadata = pe.GetMetadataReader();
+        var mvid = metadata.GetGuid(metadata.GetModuleDefinition().Mvid);
+        return (name, CompiledDependencies.MvidScheme + mvid.ToString("N"));
+    }
+
+    private static IEnumerable<BundleDependencyRecord> DependencyRecordsOf(string bundlePath, string bundleFileName)
+    {
+        var id = bundleFileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)
+            ? bundleFileName[..^4]
+            : bundleFileName;
+        var manifest = BundleReader.ReadManifest(bundlePath);
+        foreach (var assembly in manifest?.Assemblies ?? [])
+        {
+            if (assembly.Dependencies is null || string.IsNullOrEmpty(assembly.NodePath))
+                continue;
+            yield return new BundleDependencyRecord(
+                id, assembly.NodePath,
+                assembly.Dependencies.ToImmutableDictionary(StringComparer.Ordinal));
+        }
     }
 
     private static IEnumerable<string> SealedBundleNames(string identityDirectory, ILogger? logger)

--- a/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
+++ b/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using MeshWeaver.Compiler;
 
 namespace MeshWeaver.PluginCatalog;
 
@@ -119,7 +120,79 @@ public static class ReleaseAvailability
                 + $"bundle '{package.BundleName}' is not published for release {target.Version}, so "
                 + "this instance would recompile it at boot");
 
+        // 🚨 PRESENT is not CONSISTENT (#3175). A sealed bundle is adoptable only if the module
+        // bytes its NodeTypes were built against are the module bytes sealed for the SAME identity.
+        if (package.HasContent && SealedSetProblem(package, target, artifacts) is { } inconsistent)
+            return inconsistent;
+
         return new PackageAvailability(package.Name, PackageAvailabilityKind.Available, null);
+    }
+
+    /// <summary>
+    /// 🚨 <b>The set, not the file (#3175).</b> memex-cloud rolled to ci.7621 on a verdict that
+    /// checked PRESENCE — every installed package had a sealed bundle under the target's identity —
+    /// and the portal then DECLINED SocialMedia at adoption: its NodeTypes recorded
+    /// <c>MeshWeaver.Markdown.Collaboration</c> at one MVID, the module sealed for the same identity
+    /// carried another. Two producers of one module for one identity; a set that was complete and
+    /// mutually inconsistent; a half-broken portal the gate exists to prevent. Same morning, every
+    /// satellite gate declined four map galleries whose records named <c>MeshWeaver.Maps</c> at an
+    /// MVID nothing composed. This is the assertion the maintainer asked for — <i>"a clear
+    /// confirmation that all plugins deployed to an instance are available for the correct platform
+    /// version; if not ⇒ nothing goes"</i>.
+    ///
+    /// <para>The rule: every <c>mvid:</c> entry in a bundle's dependency records that names a module
+    /// the identity's sealed module set carries must equal the MVID sealed for it, and no module may
+    /// be sealed at two MVIDs by two sources. A module the sealed set does NOT carry is one the
+    /// instance lands from the registry outside any publication — this gate cannot see those bytes
+    /// and does not pretend to. Records that cannot be checked because the module set is unreadable
+    /// answer <see cref="PackageAvailabilityKind.Indeterminate"/> — a HOLD, never an incompatibility
+    /// verdict, and never a pass: an unsealed or torn module set is exactly the case that let ci.7621
+    /// through.</para>
+    /// </summary>
+    private static PackageAvailability? SealedSetProblem(
+        RequiredPackage package, ReleaseTarget target, ReleaseArtifacts artifacts)
+    {
+        foreach (var record in artifacts.DependencyRecords
+                     .Where(r => string.Equals(r.Bundle, package.BundleName, StringComparison.OrdinalIgnoreCase)))
+        {
+            foreach (var (name, id) in record.Dependencies.OrderBy(d => d.Key, StringComparer.Ordinal))
+            {
+                if (name.StartsWith('!')
+                    || !id.StartsWith(CompiledDependencies.MvidScheme, StringComparison.Ordinal))
+                    continue;
+
+                var set = artifacts.Modules;
+                if (set is null || set.Refusal is not null)
+                    return new PackageAvailability(
+                        package.Name,
+                        PackageAvailabilityKind.Indeterminate,
+                        $"'{package.BundleName}' ({record.NodePath}) was built against module {name} {id}, "
+                        + $"but the module set sealed for framework identity {target.FrameworkIdentity} "
+                        + $"could not be read ({set?.Refusal ?? "it was not observed"}) — cannot determine "
+                        + "whether the bundle and the module are one build, which is not clearance to proceed");
+
+                if (set.Conflicts.FirstOrDefault(c => c.StartsWith($"module {name}:", StringComparison.Ordinal))
+                    is { } conflict)
+                    return new PackageAvailability(
+                        package.Name,
+                        PackageAvailabilityKind.SealedSetInconsistent,
+                        $"'{package.BundleName}' ({record.NodePath}) binds module {name}, which two sources "
+                        + $"sealed as DIFFERENT builds for framework identity {target.FrameworkIdentity} "
+                        + $"({conflict}) — whichever the instance composes, the other's NodeTypes are "
+                        + "declined at adoption; the set is inconsistent and nothing rolls");
+
+                if (set.MvidByModule.TryGetValue(name, out var sealedMvid)
+                    && !string.Equals(sealedMvid, id, StringComparison.Ordinal))
+                    return new PackageAvailability(
+                        package.Name,
+                        PackageAvailabilityKind.SealedSetInconsistent,
+                        $"'{package.BundleName}' ({record.NodePath}) was built against module {name} {id}, "
+                        + $"but the module set sealed for framework identity {target.FrameworkIdentity} "
+                        + $"carries {sealedMvid} — the bundle and the module it binds are two builds, and "
+                        + "the instance would decline it at adoption (dependency record mismatch)");
+            }
+        }
+        return null;
     }
 
     private static string Describe(ReleaseTarget target) =>
@@ -170,6 +243,19 @@ public sealed record ReleaseArtifacts(
     ImmutableHashSet<string> SealedBundles,
     string? ReadFailure = null)
 {
+    /// <summary>
+    /// The module bundles sealed for the target's identity across every complete source — simple
+    /// name → the <c>mvid:</c> id the dependency records spell — or null when the observation did
+    /// not read them. Null is NOT "consistent": a record naming a module then answers
+    /// <see cref="PackageAvailabilityKind.Indeterminate"/> (#3175).
+    /// </summary>
+    public SealedModuleSet? Modules { get; init; }
+
+    /// <summary>The per-NodeType dependency records of every sealed bundle — what each bundle's
+    /// assemblies were BUILT against — keyed by bundle id. Empty when the observation carried
+    /// none, in which case there is nothing to check and presence decides.</summary>
+    public ImmutableArray<BundleDependencyRecord> DependencyRecords { get; init; } = [];
+
     /// <summary>An observation that failed — the fail-safe constructor.</summary>
     public static ReleaseArtifacts Unreadable(string reason) =>
         new(ImmutableHashSet.Create<string>(StringComparer.OrdinalIgnoreCase), reason);
@@ -219,7 +305,46 @@ public enum PackageAvailabilityKind
     /// serialized by an older build still deserializes correctly.</para>
     /// </summary>
     ComboVerificationFailed,
+
+    /// <summary>
+    /// 🚨 The bundle IS sealed under the target's identity, and it is still not adoptable: its
+    /// NodeTypes were built against a module build the SAME identity's sealed module set does not
+    /// carry (or two sources sealed two builds of one module). The instance would decline every
+    /// such NodeType at adoption — "dependency record mismatch" — which is what memex-cloud did on
+    /// ci.7621 after a presence-only verdict let it roll (#3175). A definite inconsistency of the
+    /// published SET, not an absence and not an unreadability. Appended, never inserted.
+    /// </summary>
+    SealedSetInconsistent,
 }
+
+/// <summary>
+/// The module bundles one framework identity's sealed publications composed, read across every
+/// complete source: what a consumer pinned to that identity composes, and therefore what every
+/// dependency record sealed for it must name (#3175).
+/// </summary>
+/// <param name="MvidByModule">Module simple name → its id in the dependency-record spelling
+/// (<c>mvid:&lt;32 hex&gt;</c>), for every module exactly one source sealed.</param>
+/// <param name="Conflicts">One line per module two sources sealed as DIFFERENT builds, each starting
+/// <c>module &lt;name&gt;:</c> and naming both sources and both ids. A conflict is an inconsistency
+/// of the set itself, whatever any bundle recorded.</param>
+/// <param name="Refusal">Why the set could not be read completely (a source sealed before module
+/// sealing existed, a torn module index, an unreadable module bundle), or null when it was. Non-null
+/// makes every record that names a module <see cref="PackageAvailabilityKind.Indeterminate"/>.</param>
+public sealed record SealedModuleSet(
+    ImmutableDictionary<string, string> MvidByModule,
+    ImmutableArray<string> Conflicts,
+    string? Refusal);
+
+/// <summary>One NodeType's dependency record inside one sealed bundle — the producer's
+/// <c>(referenced assembly → surface id)</c> pairs, exactly as the boot seeder validates them.</summary>
+/// <param name="Bundle">The bundle id (file name without <c>.zip</c>).</param>
+/// <param name="NodePath">The NodeType the assembly implements.</param>
+/// <param name="Dependencies">The record: module names carry <c>mvid:</c> ids, platform assemblies
+/// <c>ref:</c> hashes, and the reserved <c>!</c>-prefixed keys carry the toolchain and content key.</param>
+public sealed record BundleDependencyRecord(
+    string Bundle,
+    string NodePath,
+    ImmutableDictionary<string, string> Dependencies);
 
 /// <summary>One package's answer.</summary>
 /// <param name="Package">The package, as named to a human.</param>

--- a/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
+++ b/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
@@ -1,0 +1,304 @@
+#pragma warning disable CS1591
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using MeshWeaver.Compiler;
+using MeshWeaver.Hosting;
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 <b>Availability is a CONSISTENT sealed set, not the presence of a file (#3175).</b>
+///
+/// <para>memex-cloud rolled to ci.7621 on a verdict that checked presence — every installed package
+/// had a sealed bundle under the target's identity — and the portal then DECLINED SocialMedia at
+/// adoption: its NodeTypes recorded <c>MeshWeaver.Markdown.Collaboration</c> at one MVID while the
+/// module sealed for the same identity carried another. The same morning every satellite gate
+/// declined four map galleries whose records named <c>MeshWeaver.Maps</c> at an MVID nothing
+/// composed. Both are one defect seen twice: two producers of one module for one identity, and a
+/// gate that could not see it because it never read the bytes that carry the answer.</para>
+///
+/// <para>These pin <see cref="PublishedBundleCatalogue.ArtifactsForIdentity"/> — the observation
+/// now reads each sealed module bundle's entry assembly for its MVID and each sealed bundle's
+/// dependency records — and <see cref="ReleaseAvailability.IsUpdatable"/>'s rule over them. Both
+/// failure directions are pinned on purpose: a false "available" rolls a fleet onto a half-broken
+/// platform; a false "hold" freezes every install (#1754), so an UNREADABLE module set is
+/// <see cref="PackageAvailabilityKind.Indeterminate"/> and a module the set does not carry is not
+/// judged at all.</para>
+/// </summary>
+public class SealedSetConsistencyTest
+{
+    private const string Identity = "s3175consistency0000000000000000";
+    private const string Version = "3.0.0-rc9.ci.3175";
+    private const string Module = "MeshWeaver.ProbeModule";
+    private const string Bundle = "Widget";
+
+    /// <summary>The module bundle carries a REAL managed assembly under the module folder — this
+    /// test assembly's dependency, chosen because its MVID is knowable from the running process —
+    /// so the observation's PE read is exercised against genuine bytes, not a stub.</summary>
+    private static readonly System.Reflection.Assembly ModuleBytesOf = typeof(ReleaseAvailability).Assembly;
+
+    private static string SealedMvid =>
+        CompiledDependencies.MvidScheme + ModuleBytesOf.ManifestModule.ModuleVersionId.ToString("N");
+
+    private static string AnotherBuild =>
+        CompiledDependencies.MvidScheme + Guid.NewGuid().ToString("N");
+
+    // ── the observation: the bytes on disk become a module set and dependency records ───────────
+
+    [Fact]
+    public void ASealedPublication_IsObservedWithItsModuleSetAndItsRecords()
+    {
+        var root = PublishedRoot(recorded: SealedMvid);
+        try
+        {
+            var observation = PublishedBundleCatalogue.Read(root, Version);
+
+            Assert.Equal(Identity, observation.Target.FrameworkIdentity);
+            Assert.Null(observation.Artifacts.ReadFailure);
+            Assert.Contains(Bundle, observation.Artifacts.SealedBundles);
+
+            var modules = observation.Artifacts.Modules;
+            Assert.NotNull(modules);
+            Assert.Null(modules.Refusal);
+            Assert.Empty(modules.Conflicts);
+            Assert.Equal(SealedMvid, modules.MvidByModule[Module]);
+
+            var record = Assert.Single(observation.Artifacts.DependencyRecords);
+            Assert.Equal(Bundle, record.Bundle);
+            Assert.Equal("Widget/Thing", record.NodePath);
+            Assert.Equal(SealedMvid, record.Dependencies[Module]);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void ABundleBuiltAgainstTheSealedModule_IsAvailable()
+    {
+        var root = PublishedRoot(recorded: SealedMvid);
+        try
+        {
+            var verdict = Verdict(root);
+            Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+            Assert.Equal(PackageAvailabilityKind.Available, Assert.Single(verdict.Packages).Kind);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>THE incident: sealed, present, and built against a module build the same identity's
+    /// sealed set does not carry. Presence said "available"; the portal declined it at adoption.</summary>
+    [Fact]
+    public void ABundleBuiltAgainstAnotherBuildOfTheSealedModule_IsHeld_NamingBothBuilds()
+    {
+        var recorded = AnotherBuild;
+        var root = PublishedRoot(recorded);
+        try
+        {
+            var verdict = Verdict(root);
+            Assert.False(verdict.IsUpdatable);
+            var package = Assert.Single(verdict.Packages);
+            Assert.Equal(PackageAvailabilityKind.SealedSetInconsistent, package.Kind);
+            Assert.False(verdict.IsIndeterminate,
+                "two builds of one module is a DEFINITE inconsistency of the set, not an unreadability");
+            Assert.NotNull(package.Reason);
+            Assert.Contains(Bundle, package.Reason, StringComparison.Ordinal);
+            Assert.Contains(Module, package.Reason, StringComparison.Ordinal);
+            Assert.Contains(recorded, package.Reason, StringComparison.Ordinal);
+            Assert.Contains(SealedMvid, package.Reason, StringComparison.Ordinal);
+            Assert.Contains("dependency record mismatch", package.Reason, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    // ── the rule, on hand-built observations ────────────────────────────────────────────────────
+
+    [Fact]
+    public void TwoSourcesSealingTwoBuildsOfOneModule_IsInconsistent_ForEveryBundleBindingIt()
+    {
+        var conflict = $"module {Module}: source 'plugins' sealed mvid:aaaa, source 'socialmedia' sealed mvid:bbbb";
+        var artifacts = ReleaseArtifacts.Of([Bundle + ".zip"]) with
+        {
+            Modules = new SealedModuleSet(
+                ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.Ordinal),
+                [conflict],
+                null),
+            DependencyRecords = [Record(Module, "mvid:aaaa")],
+        };
+
+        var verdict = ReleaseAvailability.IsUpdatable(Target, [Required], artifacts);
+
+        Assert.False(verdict.IsUpdatable);
+        var package = Assert.Single(verdict.Packages);
+        Assert.Equal(PackageAvailabilityKind.SealedSetInconsistent, package.Kind);
+        Assert.Contains(conflict, package.Reason!, StringComparison.Ordinal);
+    }
+
+    /// <summary>🚨 The other failure direction. A module set that could not be read is NOT an
+    /// incompatibility and NOT a pass — it is "cannot determine", which holds and says so.</summary>
+    [Fact]
+    public void AnUnreadableModuleSet_IsIndeterminate_NeverAnIncompatibilityVerdict()
+    {
+        var artifacts = ReleaseArtifacts.Of([Bundle + ".zip"]) with
+        {
+            Modules = new SealedModuleSet(
+                ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.Ordinal),
+                [],
+                "source 'plugins': the publication is sealed but carries no module set"),
+            DependencyRecords = [Record(Module, "mvid:aaaa")],
+        };
+
+        var verdict = ReleaseAvailability.IsUpdatable(Target, [Required], artifacts);
+
+        Assert.False(verdict.IsUpdatable);
+        Assert.True(verdict.IsIndeterminate);
+        var package = Assert.Single(verdict.Packages);
+        Assert.Equal(PackageAvailabilityKind.Indeterminate, package.Kind);
+        Assert.Contains("not clearance to proceed", package.Reason!, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void AModuleSetThatWasNeverObserved_IsIndeterminate_WhenARecordNamesAModule()
+    {
+        var artifacts = ReleaseArtifacts.Of([Bundle + ".zip"]) with
+        {
+            Modules = null,
+            DependencyRecords = [Record(Module, "mvid:aaaa")],
+        };
+
+        var verdict = ReleaseAvailability.IsUpdatable(Target, [Required], artifacts);
+
+        Assert.True(verdict.IsIndeterminate);
+        Assert.Equal(PackageAvailabilityKind.Indeterminate, Assert.Single(verdict.Packages).Kind);
+    }
+
+    /// <summary>A module the sealed set does not carry is one the instance lands from the registry
+    /// outside any publication. The gate cannot see those bytes and does not pretend to.</summary>
+    [Fact]
+    public void AModuleOutsideTheSealedSet_IsNotJudged()
+    {
+        var artifacts = ReleaseArtifacts.Of([Bundle + ".zip"]) with
+        {
+            Modules = new SealedModuleSet(
+                ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.Ordinal)
+                    .Add("MeshWeaver.SomethingElse", "mvid:cccc"),
+                [],
+                null),
+            DependencyRecords = [Record(Module, "mvid:aaaa")],
+        };
+
+        var verdict = ReleaseAvailability.IsUpdatable(Target, [Required], artifacts);
+
+        Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+    }
+
+    /// <summary>Platform surfaces (<c>ref:</c>) and the reserved toolchain entry are not modules;
+    /// a record binding only those needs no module set at all.</summary>
+    [Fact]
+    public void ARecordBindingNoModule_NeedsNoModuleSet()
+    {
+        var artifacts = ReleaseArtifacts.Of([Bundle + ".zip"]) with
+        {
+            Modules = null,
+            DependencyRecords =
+            [
+                new BundleDependencyRecord(Bundle, "Widget/Thing",
+                    ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.Ordinal)
+                        .Add("MeshWeaver.Layout", CompiledDependencies.RefAsmScheme + "abc")
+                        .Add(CompiledDependencies.ToolchainKey, CompiledDependencies.MvidScheme + "toolchain")),
+            ],
+        };
+
+        var verdict = ReleaseAvailability.IsUpdatable(Target, [Required], artifacts);
+
+        Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+    }
+
+    // ── fixtures ────────────────────────────────────────────────────────────────────────────────
+
+    private static ReleaseTarget Target => new(Version, Identity);
+
+    private static RequiredPackage Required => new(Bundle, Bundle);
+
+    private static UpdatabilityVerdict Verdict(string root)
+    {
+        var observation = PublishedBundleCatalogue.Read(root, Version);
+        return ReleaseAvailability.IsUpdatable(observation.Target, [Required], observation.Artifacts);
+    }
+
+    private static BundleDependencyRecord Record(string module, string id) =>
+        new(Bundle, "Widget/Thing",
+            ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.Ordinal)
+                .Add(module, id)
+                .Add(CompiledDependencies.ToolchainKey, CompiledDependencies.MvidScheme + "toolchain"));
+
+    /// <summary>
+    /// One sealed publication under one identity, exactly as <c>publish-bake-bundles.sh</c> lays it
+    /// out: the release marker, the module set (index + one module bundle carrying a real assembly),
+    /// one content bundle whose manifest records what its NodeType was built against, and the
+    /// <c>_complete</c> sentinel written last.
+    /// </summary>
+    private static string PublishedRoot(string recorded)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-sealed-set-" + Guid.NewGuid().ToString("N"));
+        var source = Path.Combine(root, Identity, "plugins");
+        var modules = Path.Combine(source, PublishedBundleCatalogue.ModulesDirectoryName);
+        Directory.CreateDirectory(Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName));
+        Directory.CreateDirectory(modules);
+        File.WriteAllText(
+            Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName, Version), Identity);
+
+        WriteZip(Path.Combine(modules, "probe.module.nupkg"),
+            (NuGetPackageWriter.ManifestEntry,
+                Encoding.UTF8.GetBytes($$$"""{"plugin":"Probe","module":{"assemblyName":"{{{Module}}}"}}""")),
+            ($"{NuGetPackageWriter.ModuleFolder}/{Module}.dll", File.ReadAllBytes(ModuleBytesOf.Location)));
+        File.WriteAllText(
+            Path.Combine(modules, PublishedBundleCatalogue.ModulesIndexFileName), "probe.module.nupkg\n");
+
+        var manifest = new BundleReader.Manifest(
+            Bundle, "1.0", Identity,
+            [
+                new BundleReader.AssemblyRef("Widget/Thing", "Widget_Thing.dll",
+                    new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        [Module] = recorded,
+                        ["MeshWeaver.Layout"] = CompiledDependencies.RefAsmScheme + "abc",
+                        [CompiledDependencies.ToolchainKey] = CompiledDependencies.MvidScheme + "toolchain",
+                    }),
+            ]);
+        WriteZip(Path.Combine(source, Bundle + ".zip"),
+            (NuGetPackageWriter.ManifestEntry,
+                JsonSerializer.SerializeToUtf8Bytes(manifest, new JsonSerializerOptions(JsonSerializerDefaults.Web))));
+        File.WriteAllText(
+            Path.Combine(source, ShippedPrebuiltBundles.CompletionSentinelFileName), Bundle + ".zip\n");
+        return root;
+    }
+
+    private static void WriteZip(string path, params (string Entry, byte[] Bytes)[] entries)
+    {
+        using var file = File.Create(path);
+        using var zip = new ZipArchive(file, ZipArchiveMode.Create);
+        foreach (var (entry, bytes) in entries)
+        {
+            using var stream = zip.CreateEntry(entry).Open();
+            stream.Write(bytes);
+        }
+    }
+}

--- a/test/MeshWeaver.PluginTester.Test/BakeAgainstPlatformHostTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeAgainstPlatformHostTest.cs
@@ -335,6 +335,58 @@ public class BakeAgainstPlatformHostTest(ITestOutputHelper output)
         }
     }
 
+    /// <summary>
+    /// 🚨 ONE PRODUCER PER ASSEMBLY NAME (#3175). On 2026-09-03 every satellite gate declined four
+    /// map galleries — <i>"'MeshWeaver.Maps' built against mvid:4d04617…, live is ref:1D8FDE5B…"</i>
+    /// — because the portal host had taken a direct project reference to what is a Store module:
+    /// the bake composed Maps with <c>--module</c> (records say <c>mvid:</c>) while every portal
+    /// carried it in its app closure (resolves <c>ref:</c>). Nothing in any repo had changed. The
+    /// bake now refuses the double by name, at the moment both provenances are in one hand.
+    /// </summary>
+    [Fact(Timeout = 300_000)]
+    public void AComposedModuleTheHostAlsoShips_IsRefusedByName()
+    {
+        var repo = TempDirectory("mw-two-producers-repo");
+        var host = TempDirectory("mw-two-producers-app");
+        var mounted = TempDirectory("mw-two-producers-module");
+        var bake = TempDirectory("mw-two-producers-bake");
+        try
+        {
+            WriteWidget(repo);
+            SynthesizeHost(host);
+            // The host SHIPS the module in its app closure…
+            EmitModule(host, "MeshWeaver.DoublyShipped");
+            // …and the bake ALSO composes it, from a mount.
+            var modulePath = EmitModule(mounted, "MeshWeaver.DoublyShipped");
+
+            var log = new StringWriter();
+            var report = TreeBake.Run(new TreeBake.Options
+            {
+                RepoRoot = repo,
+                OutputDirectory = bake,
+                Output = log,
+                AppDirectory = host,
+                SharedFrameworksRoot = SharedFrameworksRoot(),
+                ModuleAssemblyPaths = [modulePath],
+            });
+            output.WriteLine(log.ToString());
+
+            Assert.NotNull(report.FatalError);
+            Assert.Contains("MeshWeaver.DoublyShipped", report.FatalError, StringComparison.Ordinal);
+            Assert.Contains("two builds of one assembly name", report.FatalError, StringComparison.Ordinal);
+            Assert.Contains("mvid:", report.FatalError, StringComparison.Ordinal);
+            Assert.Contains("ref:", report.FatalError, StringComparison.Ordinal);
+            Assert.Empty(report.Types);
+        }
+        finally
+        {
+            Cleanup(repo);
+            Cleanup(host);
+            Cleanup(mounted);
+            Cleanup(bake);
+        }
+    }
+
     [Fact]
     public void TheGateRefusesToRunAsAHostItIsNot_AndAcceptsTheOneItIs()
     {
@@ -441,12 +493,18 @@ public class BakeAgainstPlatformHostTest(ITestOutputHelper output)
         Write(repo, "Widget/Thing/Source/Thing.cs", ThingSource);
     }
 
-    private static string EmitProbeModule(string directory)
+    private static string EmitProbeModule(string directory) =>
+        EmitModule(directory, "MeshWeaver.ProbeModule");
+
+    /// <summary>The probe module's source under another assembly name. <c>Assembly.LoadFrom</c>
+    /// binds a simple name once per process, so a test that loads its own copy of a module must
+    /// not reuse a name another test in this class has already loaded from a different path.</summary>
+    private static string EmitModule(string directory, string assemblyName)
     {
         Directory.CreateDirectory(directory);
-        var path = Path.Combine(directory, "MeshWeaver.ProbeModule.dll");
+        var path = Path.Combine(directory, assemblyName + ".dll");
         var compilation = CSharpCompilation.Create(
-            "MeshWeaver.ProbeModule",
+            assemblyName,
             [CSharpSyntaxTree.ParseText(ProbeModuleSource)],
             [
                 MetadataReference.CreateFromFile(typeof(object).Assembly.Location),

--- a/tools/MeshWeaver.PluginTester/BakeHost.cs
+++ b/tools/MeshWeaver.PluginTester/BakeHost.cs
@@ -71,6 +71,48 @@ internal sealed class BakeHost
     public string? Note { get; init; }
 
     /// <summary>
+    /// 🚨 <b>One producer per assembly name (#3175).</b> A module composed with <c>--module</c> that
+    /// the host ALSO ships in its application directory — or lists in its surface manifest — is two
+    /// builds of one simple name inside one bake. The id resolver puts modules first, so every
+    /// dependency record this bake writes says <c>mvid:&lt;the module's&gt;</c>; the portal that
+    /// consumes the bundle carries the name in its app closure, refuses the same-identity module at
+    /// landing (409), and resolves the name from its surface manifest as <c>ref:&lt;hash&gt;</c>. The
+    /// two schemes never compare equal, so EVERY NodeType binding the name is declined at adoption
+    /// — <i>"dependency record mismatch — 'MeshWeaver.Maps' built against mvid:4d04617…, live is
+    /// ref:1D8FDE5B…"</i> on four galleries of every satellite gate on 2026-09-03, after a portal
+    /// host had taken a direct project reference to what is a Store module. Nothing in any repo
+    /// had changed. The maintainer's ruling: a module lives in exactly one place, and this is the
+    /// assertion that makes a second producer RED at bake time instead of DECLINED fleet-wide.
+    /// </summary>
+    /// <param name="appDirectory">The host's application directory.</param>
+    /// <param name="surfacePairs">The host's surface-manifest pairs (what it compiled against).</param>
+    /// <param name="modules">The composed module assemblies.</param>
+    /// <returns>The refusal naming every doubly-produced assembly, or null when there is none.</returns>
+    internal static string? ShippedByHostProblem(
+        string appDirectory,
+        IReadOnlyDictionary<string, string> surfacePairs,
+        IReadOnlyList<InstalledModuleAssembly> modules)
+    {
+        var shipped = modules
+            .Select(module => module.Assembly.GetName().Name ?? string.Empty)
+            .Where(name => name.Length > 0)
+            .Where(name => surfacePairs.ContainsKey(name)
+                           || File.Exists(Path.Combine(appDirectory, name + ".dll")))
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(name => name, StringComparer.Ordinal)
+            .ToImmutableArray();
+        if (shipped.Length == 0)
+            return null;
+        return $"module(s) {string.Join(", ", shipped)} are composed with --module AND shipped by the "
+               + $"platform host at '{appDirectory}' — two builds of one assembly name in one bake. "
+               + "The records this bake would write name the module's build (mvid:…) while a portal "
+               + "carrying the name in its app closure resolves the platform's (ref:…), so every "
+               + "NodeType binding it would be DECLINED at adoption (\"dependency record mismatch\"). "
+               + "A module has exactly one producer: remove the assembly from the platform host's "
+               + "closure (it is a module, landed from the registry) or stop composing it (#3175).";
+    }
+
+    /// <summary>
     /// The host every bake resolved before <c>--app</c> existed: this process — its
     /// <c>TRUSTED_PLATFORM_ASSEMBLIES</c> composed with the modules, its manifest, its MVIDs, its
     /// live identity. Correct exactly when the process IS the platform (the portal compiling its
@@ -196,6 +238,10 @@ internal sealed class BakeHost
 
         var pairs = FrameworkBuildIdentity.ParseSurfaceManifest(
             File.ReadAllText(Path.Combine(app, FrameworkBuildIdentity.SurfaceManifestFileName)));
+        // 🚨 ONE PRODUCER PER ASSEMBLY NAME (#3175) — refused here, where both provenances are in
+        // one hand, never sealed and discovered at the fleet.
+        if (ShippedByHostProblem(app, pairs, modules) is { } twoProducers)
+            return (null, twoProducers);
         string? HostMvidOf(string name) => FrameworkBuildIdentity.ImplMvidInDirectory(app, name);
         var live = PrebuiltAssemblySeeder.LiveFrameworkMvid;
         return (new BakeHost

--- a/tools/MeshWeaver.PluginTester/GateHostCheck.cs
+++ b/tools/MeshWeaver.PluginTester/GateHostCheck.cs
@@ -14,7 +14,7 @@ namespace MeshWeaver.PluginTester;
 /// gate can judge the platform's bake is to run AS the platform: the platform image's <c>/app</c>
 /// with this CLI laid beside it (<c>compose-gate-host.sh</c>), started from the platform image's
 /// runtime. Then the manifest is the platform's, the MVIDs are the platform's, every
-/// platform-shipped assembly (<c>MeshWeaver.Maps</c>…) is in the TPA and LOADS, and adoption is
+/// platform-shipped assembly (the Blazor and hosting halves…) is in the TPA and LOADS, and adoption is
 /// decided exactly as a portal would decide it.</para>
 ///
 /// <para>🚨 A gate running as a DIFFERENT host would not fail — it would decline every bundle the

--- a/tools/MeshWeaver.PluginTester/TreeBake.cs
+++ b/tools/MeshWeaver.PluginTester/TreeBake.cs
@@ -226,7 +226,10 @@ public static class TreeBake
         // (Modules resolve FIRST inside the id resolver and by exact-build MVID, so the record a
         // consumer checks names the same build it will bind — the second half of #2563.)
         var (host, hostProblem) = options.AppDirectory is null
-            ? ((BakeHost?)BakeHost.InProcess(modules), (string?)null)
+            ? BakeHost.ShippedByHostProblem(
+                  AppContext.BaseDirectory, FrameworkBuildIdentity.ProcessSurfacePairs, modules) is { } twoProducers
+                ? ((BakeHost?)null, (string?)twoProducers)
+                : ((BakeHost?)BakeHost.InProcess(modules), (string?)null)
             : BakeHost.ResolveDirectory(options.AppDirectory, options.SharedFrameworksRoot!, modules);
         if (host is null)
             return new Report(processIdentity, [], [], hostProblem);


### PR DESCRIPTION
## Availability must confirm a CONSISTENT sealed set — one producer per (module, identity)

Closes #3175

**Maps is a Plugins module only (maintainer, 2026-09-03: "all maps should be in plugins and removed from core — move 100% to plugins").**

### Root cause (measured 2026-09-03 07:21–07:33Z)

Every satellite release-follow gate failed its consumption postcondition — Reinsurance run 33727661313 `adopted 236 of 240 … 4 DECLINED`, Manufacturing 33727661850 `97 of 102 … 5 DECLINED`:

```
Prebuilt assembly for AppleMaps/Gallery DECLINED: dependency record mismatch —
  'MeshWeaver.Maps' built against mvid:4d04617292154b2d9b7a3aa5e9b6a815,
  live is ref:1D8FDE5B7D25D8F515066B7D925ACF33D46910F6EB75E2D8DD169671B1FC8F15
```

`ref:` is the surface-manifest scheme: the gate host — the portal's `/app` — SHIPS `MeshWeaver.Maps.dll` and lists it in its manifest. `mvid:` is the module scheme: the Plugins bake COMPOSED Maps with `--module` (the id resolver puts modules first). Two producers of one assembly for one identity: the portal host in MeshWeaver.Plugins (`Memex.Portal.Gui.csproj`) had kept a direct `ProjectReference` to `src/MeshWeaver.Maps` from before Maps became a Store module (core #2941 / Plugins #1057). Core itself already carried no Maps project, no reference and no `ContentSurfaceAssemblies` entry — only stale comments and a self-test fixture claiming otherwise. Nothing had changed in any repo; no satellite could seal; memex-cloud held at ci.7652 ("no sealed content bake").

The same morning memex-cloud (ci.7621) declined `SocialMedia/Post|PostsHub|Profile` — `'MeshWeaver.Markdown.Collaboration' built against mvid:A, live is mvid:B` — because the availability gate checked PRESENCE of a sealed bundle, not CONSISTENCY of the set (#3175's finding).

### What this PR does (core half)

1. **The bake refuses a second producer by name** — `BakeHost.ShippedByHostProblem`, applied under `--app` and in-process: a `--module` whose simple name the host also ships in its app directory or lists in its surface manifest fails the bake RED ("two builds of one assembly name in one bake … remove the assembly from the platform host's closure or stop composing it"). Pinned by `BakeAgainstPlatformHostTest.AComposedModuleTheHostAlsoShips_IsRefusedByName`.
2. **Availability asserts the SET** — `PublishedBundleCatalogue.ArtifactsForIdentity` now reads, for the candidate identity, every complete source's sealed module set (each module bundle's entry assembly → MVID, PE header only) and every sealed bundle's per-NodeType dependency records (manifest only). `ReleaseAvailability.IsUpdatable` then holds with the new `PackageAvailabilityKind.SealedSetInconsistent` when a record names a module build the set does not carry, or two sources sealed one module at two MVIDs — naming bundle, NodeType, module and both builds. An unreadable module set is `Indeterminate` (hold, named); a module outside the set is not judged. Consumed unchanged by the self-update poll, CD's post-promote assertion and `/api/plugins/is-updatable`. Pinned by `SealedSetConsistencyTest` (8 cases, both failure directions).
3. Maps remnants in core rewritten to past tense / neutral fixture: `Memex.Portal.Shared.csproj` (the "DIRECT ON PURPOSE" block described a reference that no longer exists and would have sent the next reader to re-add it), `compose-gate-host.sh` self-test fixture, `node-repo-gate.yml`, `GateHostCheck.cs`, `BuildPluginCommand.cs` error text.
4. Docs: `ModuleBuildArchitecture.md` → "One producer per (module, framework identity)" (the incident table, the two controls, and what the gate still cannot see); `CandidateReleaseProtocol.md` → "Availability is a CONSISTENT sealed set". What's New `Category: Fix`.

### Deliberately not in this PR

- The **second producer in time** for `MeshWeaver.AI` / `MeshWeaver.Markdown.Collaboration`: core CD's `plugins-modules` rebuilds them per release to feed the Plugins seal while the registry's package endpoint serves the Plugins lane's content-versioned build — the bytes a portal installs. Core holds no registry credential (`MW_REGISTRY_KEY` is not among its secrets), so its bake cannot compose the registry's bytes today; the alternative is the instance adopting module bytes for its identity from the sealed publication. The new gate now HOLDS on the set it can see rather than rolling; the remaining gap is documented in ModuleBuildArchitecture.
- Seal-time (bash) MVID verification in `publish-bake-bundles.sh`: a single bake's set is consistent by construction against its own composed modules once (1) refuses the double; cross-source consistency is asserted by (2).

### Counterpart

Counterpart (independent halves, either order merges cleanly): Systemorph/MeshWeaver.Plugins#1242 — drops the `MeshWeaver.Maps` project reference from `Memex.Portal.Gui` / `MeshWeaver.AI.Test` and makes AppleMaps/GoogleMaps/OpenStreetMap/Cornerstone `require` Maps. No public type leaves core in this PR.

### Acceptance

The next Reinsurance release-follow gate after both halves are in the promoted set adopts N of N (`seed: adopted 240 of 240` — the control arm was run 33623801785). Verified locally: `Memex.Portal.Shared.Test` 622/622, `MeshWeaver.PluginTester.Test` 319/319, `MeshWeaver.Documentation.Test` 239/239, all `-c Release -warnaserror`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
