### PR TITLE
Follow-up to #3187: pre-size the module stream; state what the availability observation reads

### DIFF
--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -158,7 +158,8 @@ public static class PublishedBundleCatalogue
     /// dependency records spell it), and every sealed bundle's per-NodeType dependency record. The
     /// bytes were always on disk — <see cref="SealedModulesOf"/> already refused a torn set — and
     /// <see cref="ReleaseAvailability"/> can only assert CONSISTENCY when it is handed both halves.
-    /// Reads manifests and one PE header per module; never a bundle's assembly bytes.
+    /// Reads every bundle's MANIFEST, and for each sealed module bundle inflates its entry assembly into
+    /// memory to read the MVID from its PE metadata — never a content bundle's NodeType assembly bytes.
     /// </summary>
     /// <remarks>A module bundle that cannot be read, or a source sealed before module sealing
     /// existed, becomes the set's <see cref="SealedModuleSet.Refusal"/> — a named unreadability the
@@ -255,7 +256,7 @@ public static class PublishedBundleCatalogue
             ?? throw new InvalidOperationException(
                 $"{NuGetPackageWriter.ModuleFolder}/{name}.dll is missing from the bundle");
         using var stream = entry.Open();
-        using var bytes = new MemoryStream();
+        using var bytes = new MemoryStream(checked((int)entry.Length));
         stream.CopyTo(bytes);
         bytes.Position = 0;
         using var pe = new PEReader(bytes);

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -256,7 +256,10 @@ public static class PublishedBundleCatalogue
             ?? throw new InvalidOperationException(
                 $"{NuGetPackageWriter.ModuleFolder}/{name}.dll is missing from the bundle");
         using var stream = entry.Open();
-        using var bytes = new MemoryStream(checked((int)entry.Length));
+        if (entry.Length is < 0 or > int.MaxValue)
+            throw new InvalidOperationException(
+                $"{entry.FullName} declares an implausible length ({entry.Length} bytes) — the module bundle is corrupt");
+        using var bytes = new MemoryStream((int)entry.Length);
         stream.CopyTo(bytes);
         bytes.Position = 0;
         using var pe = new PEReader(bytes);


### PR DESCRIPTION
## Follow-up to #3187: pre-size the module stream; state what the observation reads

Two review threads on #3187 landed after its branch was locked in the merge queue (the protected-branch hook rejected the push), so they are addressed here:

- `PublishedBundleCatalogue.SealedModuleMvidOf` sizes its `MemoryStream` from the zip entry's `Length` instead of growing a default one — the availability poll inflates one module assembly per sealed module bundle, and that should not reallocate its way up on a large module.
- `ArtifactsForIdentity`'s summary said "one PE header per module; never a bundle's assembly bytes". It now states the real cost: every bundle's MANIFEST, plus each sealed module bundle's entry assembly inflated into memory for its PE metadata — never a content bundle's NodeType assembly bytes.

No behaviour change; `Memex.Portal.Shared.Test` 622/622 and `MeshWeaver.PluginCatalog` build `-c Release -warnaserror` clean. Pure-internal — no What's New entry.

Refs #3175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
