### PR TITLE
docs: an aggregate watching for a rare event is not a check that cannot fail (#3189 follow-up)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/InMeshTestsAndTheSeal.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/InMeshTestsAndTheSeal.md
@@ -145,8 +145,23 @@ ran and *failed*.
 
 An aggregate job is therefore **not** a substitute for requiring the gate itself. It closes the
 skip hole; the failure hole is closed only by the gate's own context being required, or by the
-aggregate also asserting `result == 'success'` for each need. A wall of ticks that includes an
-aggregate which cannot go red is the same defect as a gate that skips on missing input.
+aggregate also asserting `result == 'success'` for each need.
+
+🚨 Read that narrowness precisely, because the obvious inference from the table is wrong. `Every
+gate executed` is **not** a check that cannot fail: it goes red the moment any gate `skipped`, which
+is exactly the hole it was built to close. Its 28/28 is the honest report that no gate skipped in
+those runs — not evidence of inertness. The two look identical in a run list and are opposites, and
+only the job's source tells them apart:
+
+```yaml
+# it fails if any gate reached a terminal state that is neither success nor an
+# honest failure — which is what a `skipped` is.
+```
+
+So the defect to look for is never "this tick is always green" — a gate watching for something rare
+*should* be. It is **a required context whose green does not mean what the wall implies it means**.
+Here the wall implies "every gate is satisfied"; the tick only means "every gate ran". That gap is
+closed by requiring the gate itself, not by removing or distrusting the aggregate.
 
 ## The lever
 


### PR DESCRIPTION
Follow-up to #3189, correcting one sentence I got wrong before it becomes durable guidance.

## The error

The aggregate section closed with:

> A wall of ticks that includes an aggregate which **cannot go red** is the same defect as a gate that skips on missing input.

`Every gate executed` **can** go red — it does so the moment any gate `skipped`, which is precisely the hole it was built to close. Its 28/28 is the honest report that no gate skipped in those runs, not evidence of inertness.

The rest of that section was already correct — it says the job "is honest about its narrow job … it asserts that no gate `skipped`", and concludes an aggregate "is **not** a substitute for requiring the gate itself". Only the closing analogy overreached, and it contradicted the paragraph directly above it.

## Why replace it rather than delete it

I reached the wrong conclusion first, from exactly the evidence the page presents: 28 rows of run history showing a green aggregate above a red gate. That looks identical to a skip-trapdoor. It is the opposite of one, and **no amount of outcome history can tell them apart** — only the job's source can:

```yaml
# it fails if any gate reached a terminal state that is neither success nor an
# honest failure — which is what a `skipped` is.
```

So the replacement states the distinction as a rule:

> the defect to look for is never "this tick is always green" — a gate watching for something rare *should* be. It is **a required context whose green does not mean what the wall implies it means**. Here the wall implies "every gate is satisfied"; the tick only means "every gate ran".

That is the durable lesson, and it is the one the page's own measurement most invites a reader to get backwards.

## Unchanged

The remedy the page recommends — require `test-repos / Compile + render node repos (MeshWeaver from ACR)` — is unaffected. The aggregate is not to be removed or distrusted; it closes the skip hole and should arguably be armed for that reason.

Plugins#1251, which I filed on the wrong reading, is closed as invalid with the correction recorded.

## Verification

- `dotnet build … -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**
- `DocumentationLinkIntegrityTest` → **Passed 1/1**

Pairs-with: none — documentation only.
