### PR TITLE
fix: a write's base read bounds the wait for a USABLE base, not for mirror chatter (#2543)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-write-base-read-no-longer-hangs.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-write-base-read-no-longer-hangs.md
@@ -1,0 +1,19 @@
+---
+Name: Saving no longer hangs silently when a node is slow to load
+Category: Fix
+Description: A save whose node was still loading could wait forever with no error; it now fails after 30 seconds with a message that says what happened.
+Icon: Sparkle
+Order: -20260903
+---
+
+# Saving no longer hangs silently when a node is slow to load
+
+Before a change is saved, the platform first reads the node's current state so it can work out
+exactly what you edited. That read was meant to give up after 30 seconds and report a clear error.
+In one case it never gave up at all: if the node kept reporting activity without ever handing over
+its content, the 30-second clock was restarted each time and the save simply waited — with no error,
+no progress and nothing in the log.
+
+The wait is now measured against what it is actually waiting for, so such a save fails promptly and
+says so instead of hanging. Anything that batches many saves together — installing or updating a
+package, for instance — no longer stalls as a whole because one of them never finished.

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -137,6 +137,61 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
     private static readonly TimeSpan ConflictRebaseBound = TimeSpan.FromSeconds(5);
 
     /// <summary>
+    /// 🚨 How long a write waits for a USABLE base state — a mirror emission that actually carries
+    /// the node. Authored once, here, because both base-read sites need the same number and
+    /// <see cref="BaseStateSource"/> is the only place either of them may spell it.
+    /// </summary>
+    internal static readonly TimeSpan BaseStateWaitBound = TimeSpan.FromSeconds(30);
+
+    /// <summary>
+    /// 🚨 The BOUNDED base read — issue #2543. Both write paths read this hub's mirror, drop the
+    /// emissions that carry no node, and wait <see cref="BaseStateWaitBound"/> for one that does.
+    /// The order of those two steps is the whole point.
+    ///
+    /// <para><b>The defect.</b> Both sites composed it as
+    /// <c>mirror.Timeout(30s).Where(c =&gt; c.Value is not null).Select(...)</c> — the bound applied to
+    /// the RAW mirror, upstream of the filter. Rx's <c>Timeout(TimeSpan)</c> is an INTER-EMISSION
+    /// deadline: it restarts on every <c>OnNext</c> it sees. A mirror that keeps emitting change
+    /// items whose <c>Value</c> is <c>null</c> therefore resets that clock forever while the filter
+    /// discards every one of them, so the subscriber downstream never runs and the bound that was
+    /// written to rescue it can never fire. The comment it sat under — "a 30 s outer timeout bounds
+    /// the wait so a missing per-node hub surfaces with a precise TimeoutException" — states the
+    /// intent exactly; the composition did not deliver it.</para>
+    ///
+    /// <para>The consequence is spelled out verbatim in <see cref="RequireBaseState"/>: no
+    /// <c>OnNext</c>, no <c>OnError</c>, no <c>OnCompleted</c> on the caller's observer, no patch
+    /// posted, and not even the outer <c>VERDICT_TIMEOUT</c> — that deadline is armed inside the
+    /// response wait, which a write with no base never reaches. <b>The writer hangs for the life of
+    /// the process, silently.</b> #3001 closed the sibling case (the mirror COMPLETES having carried
+    /// nothing) through <see cref="RequireBaseState"/>; this one — the mirror never completes and
+    /// never carries anything usable — was left with an unreachable bound.</para>
+    ///
+    /// <para><b>What it costs.</b> One such write parks whatever composed it. In the CD bake+seal
+    /// gate, <c>PackageInstaller</c>'s release wave is
+    /// <c>nodeTypePaths.Select(ObserveNodeTypeRelease).Merge().ToList()</c> — no per-leg bound and
+    /// no outer bound — so ONE non-terminating leg parks the entire package install, silently, until
+    /// the gate's own 600 s <c>InstallTimeout</c> reports <c>install: TimeoutException</c> against a
+    /// package that installed fine 8 minutes earlier
+    /// (Doc/Architecture/BakeSealNodeOpsSaturation).</para>
+    ///
+    /// <para><b>The fix is the ORDER, not the number.</b> 30 s is unchanged; it now measures what
+    /// the caller actually waits for. This can only ADD terminals: a mirror that yields a usable
+    /// base is untouched, and one that never does now faults instead of parking.</para>
+    ///
+    /// <para>Static, with the mirror and the scheduler as seams, so the rule is asserted
+    /// deterministically — no hub, no cluster, no wall clock.</para>
+    /// </summary>
+    /// <param name="mirror">This hub's view of the node.</param>
+    /// <param name="scheduler">Timer seam for tests.</param>
+    internal static IObservable<MeshNode> BaseStateSource(
+        IObservable<ChangeItem<MeshNode>> mirror,
+        IScheduler? scheduler = null)
+        => mirror
+            .Where(change => change.Value is not null)
+            .Select(change => change.Value!)
+            .Timeout(BaseStateWaitBound, scheduler ?? Scheduler.Default);
+
+    /// <summary>
     /// 🚨 The emission a (re)attempt rebuilds its patch from — and the whole of the #1910 fix.
     ///
     /// <para><b>The defect.</b> A cross-hub <c>stream.Update</c> reads this hub's MIRROR, runs the
@@ -1451,11 +1506,11 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             // resolved it, one reclaimed mid-write, or one whose every emission the null-filter
             // drops — would settle nothing at all and park the caller forever.
             var initialSub = RequireBaseState(
-                    remoteStream
-                        .Timeout(TimeSpan.FromSeconds(30))
-                        .Where(change => change.Value is not null)
-                        .Select(change => change.Value!)
-                        .Take(1),
+                    // 🚨 BOUNDED AFTER the null-filter — see BaseStateSource (#2543). The comment
+                    // above names the third case: "one whose every emission the null-filter drops".
+                    // RequireBaseState covers that only when the mirror COMPLETES; a mirror that
+                    // keeps emitting null-valued changes reset the old upstream timer forever.
+                    BaseStateSource(remoteStream).Take(1),
                     refusedBaseVersion: 0)
                 .Subscribe(
                     _ =>
@@ -1509,7 +1564,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             // as a TimeoutException too, and flattening it to this sentence is
                             // what made the boot-install failures unreadable (#2387).
                             observer.OnError(new TimeoutException(
-                                $"Update aborted: no initial state arrived for '{_path}' within 30s.", ex));
+                                $"Update aborted: no initial state arrived for '{_path}' within {BaseStateWaitBound.TotalSeconds:0}s.", ex));
                         else observer.OnError(ex);
                     });
             composite.Add(initialSub);
@@ -1593,10 +1648,10 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
             // happened (#2305 / #2291). See PatchBaseSource.
             var initialSub = PatchBaseSource(
                     RebaseSource(
-                        remoteStream
-                            .Timeout(TimeSpan.FromSeconds(30))
-                            .Where(change => change.Value is not null)
-                            .Select(change => change.Value!),
+                        // 🚨 BOUNDED AFTER the null-filter — see BaseStateSource (#2543). The bound
+                        // used to sit upstream of it, where Rx's inter-emission timer was reset by
+                        // every emission the filter then dropped, so it could not fire at all.
+                        BaseStateSource(remoteStream),
                         refusedBaseVersion,
                         staleVersion => diagLogger?.LogWarning(
                             "[UpdateRemote] STALE_MIRROR hub={Hub} target={Path} attempt={Attempt} — the "
@@ -2329,7 +2384,7 @@ public sealed class MeshNodeStreamHandle : IObservable<MeshNode>
                             // the boot-install failures claiming a 30s wait that never happened
                             // (#2387).
                             observer.OnError(new TimeoutException(
-                                $"Update aborted: no initial state arrived for '{_path}' within 30s. " +
+                                $"Update aborted: no initial state arrived for '{_path}' within {BaseStateWaitBound.TotalSeconds:0}s. " +
                                 "Likely causes — (1) RLS silently rejected the prior CreateNode, " +
                                 "(2) the path is misspelled / points at a namespace no NodeType claims, " +
                                 "(3) the node was deleted between create and update, or (4) the per-node " +

--- a/test/MeshWeaver.Graph.Test/BaseReadBoundIsReachableTest.cs
+++ b/test/MeshWeaver.Graph.Test/BaseReadBoundIsReachableTest.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 A write's base read must reach a terminal even when its mirror never stops talking —
+/// issue #2543, the sibling #3001 left open.
+///
+/// <para><b>The defect.</b> Both cross-hub write paths composed the base read as
+/// <c>mirror.Timeout(30s).Where(c =&gt; c.Value is not null).Select(...)</c>: the bound applied to the
+/// RAW mirror, upstream of the filter. Rx's <c>Timeout(TimeSpan)</c> is an INTER-EMISSION deadline —
+/// it restarts on every <c>OnNext</c> it sees — so a mirror that keeps emitting change items whose
+/// <c>Value</c> is <c>null</c> resets that clock forever while the filter discards every one of
+/// them. The subscriber downstream never runs, and the bound written to rescue it can never fire.
+/// The comment it sat under said the opposite: "a 30 s outer timeout bounds the wait so a missing
+/// per-node hub surfaces with a precise TimeoutException".</para>
+///
+/// <para><b>Why silence and not a slow write.</b> <c>UpdateRemote</c> raises EVERY verdict a caller
+/// can receive from inside the base read's <c>onNext</c>/<c>onError</c> — including the outer
+/// <c>VERDICT_TIMEOUT</c>, which is armed inside the response wait a write with no base never
+/// reaches. So this is not a late write: no patch is posted, nothing is logged, and the writer parks
+/// for the life of the process. <c>RequireBaseState</c> (#3001) closes the case where the mirror
+/// COMPLETES having carried nothing; this test covers the case where it never completes.</para>
+///
+/// <para><b>What it cost.</b> The CD bake+seal gate's release wave is
+/// <c>nodeTypePaths.Select(ObserveNodeTypeRelease).Merge().ToList()</c> — no per-leg bound and no
+/// outer bound — so one parked leg parks the whole package install until the gate's own 600 s
+/// <c>InstallTimeout</c> reports <c>install: TimeoutException</c> against a package that installed
+/// in 111 s eight minutes earlier (Doc/Architecture/BakeSealNodeOpsSaturation).</para>
+///
+/// <para>Deterministic by construction: a <see cref="TestScheduler"/> supplies virtual time, so the
+/// assertions are about ORDER and CAUSE, never about wall-clock duration. No mesh, no cluster,
+/// no sleep.</para>
+/// </summary>
+public class BaseReadBoundIsReachableTest
+{
+    private const string Path = "Hosting/LogEntry";
+
+    /// <summary>What a subscriber actually observed — all three Rx terminations, separately.</summary>
+    private sealed record Observed(List<MeshNode> Values, Exception? Error, bool Completed);
+
+    private static Observed Run(
+        Func<TestScheduler, IObservable<ChangeItem<MeshNode>>> mirror,
+        TimeSpan runFor)
+    {
+        var scheduler = new TestScheduler();
+        var values = new List<MeshNode>();
+        Exception? error = null;
+        var completed = false;
+
+        // `.Take(1)` exactly as BOTH production call sites compose it — directly at the
+        // WriteViaSyncStream site, and inside RebaseSource at the UpdateRemote one. A write wants ONE
+        // base; without it the bound would keep running against a mirror the writer stopped reading.
+        using var subscription = MeshNodeStreamHandle
+            .BaseStateSource(mirror(scheduler), scheduler)
+            .Take(1)
+            .Subscribe(values.Add, ex => error = ex, () => completed = true);
+
+        scheduler.AdvanceBy(runFor.Ticks);
+        return new Observed(values, error, completed);
+    }
+
+    /// <summary>A change item the null-filter drops — the mirror is talking, carrying nothing.</summary>
+    private static ChangeItem<MeshNode> Empty() => new(null, StreamId: Path, Version: 0);
+
+    /// <summary>A change item that carries the node — a usable base.</summary>
+    private static ChangeItem<MeshNode> Carrying(long version) =>
+        new(new MeshNode("LogEntry", "Hosting") { Version = version }, StreamId: Path, Version: version);
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. The mirror never stops emitting, and never carries the node. RED before
+    /// the fix: the inter-emission timer was reset by every dropped emission, so nothing was ever
+    /// raised and the writer parked forever. GREEN: the bound measures the wait the caller actually
+    /// has — for a USABLE base — and faults on it.
+    /// </summary>
+    [Fact]
+    public void MirrorThatNeverCarriesTheNode_FaultsOnTheBound_InsteadOfParkingForever()
+    {
+        // One null-valued change every 10 virtual seconds — three of them inside a 30 s bound, so
+        // an upstream (pre-filter) timer is reset twice and can never expire.
+        var observed = Run(
+            s => Observable.Interval(TimeSpan.FromSeconds(10), s).Select(_ => Empty()),
+            runFor: TimeSpan.FromSeconds(120));
+
+        observed.Values.Should().BeEmpty("no emission ever carried the node, so there is no base");
+        observed.Completed.Should().BeFalse(
+            "a live mirror does not end, and a fault is not a completion — that is the whole point");
+        observed.Error.Should().BeOfType<TimeoutException>(
+            "the bound must measure the wait for a USABLE base; applied upstream of the null-filter "
+            + "it was reset by every emission the filter dropped and could never fire, so the write "
+            + "raised no terminal at all and its caller parked for the life of the process (#2543)");
+    }
+
+    /// <summary>
+    /// The bound is a bound on the WAIT, never on the mirror's chatter: a mirror that talks
+    /// constantly and eventually carries the node hands that node through, with no fault.
+    /// </summary>
+    [Fact]
+    public void MirrorThatEventuallyCarriesTheNode_EmitsIt_WithNoFault()
+    {
+        var observed = Run(
+            s => Observable.Interval(TimeSpan.FromSeconds(10), s)
+                .Select(tick => tick == 1 ? Carrying(7) : Empty()),
+            runFor: TimeSpan.FromSeconds(120));
+
+        observed.Error.Should().BeNull(
+            "a usable base arrived at 20 s, inside the 30 s wait — the bound is on the wait for a "
+            + "base, and it was satisfied");
+        observed.Values.Should().ContainSingle().Which.Version.Should().Be(7,
+            "the write diffs against the state the mirror actually carried");
+    }
+
+    /// <summary>
+    /// A SILENT mirror still faults on the bound — the behaviour the old composition did deliver,
+    /// pinned so the reorder cannot regress it.
+    /// </summary>
+    [Fact]
+    public void SilentMirror_StillFaultsOnTheBound()
+    {
+        var observed = Run(
+            _ => Observable.Never<ChangeItem<MeshNode>>(),
+            runFor: TimeSpan.FromSeconds(120));
+
+        observed.Values.Should().BeEmpty();
+        observed.Error.Should().BeOfType<TimeoutException>(
+            "a mirror that says nothing at all was already bounded, and must stay bounded");
+    }
+}


### PR DESCRIPTION
## The bound that was supposed to rescue a stuck write could never fire

Both cross-hub write paths composed the base read as

```csharp
mirror.Timeout(TimeSpan.FromSeconds(30))
      .Where(change => change.Value is not null)
      .Select(change => change.Value!)
```

— the bound applied to the **raw** mirror, **upstream of the filter**. Rx's `Timeout(TimeSpan)` is an **inter-emission** deadline: it restarts on every `OnNext` it sees. A mirror that keeps emitting change items whose `Value` is `null` therefore **resets that clock forever** while the filter discards every one of them, so the subscriber downstream never runs and the 30 s bound can never expire.

The comment it sat under states the intent exactly — *"a 30 s outer timeout bounds the wait so a missing per-node hub surfaces with a precise TimeoutException"*. The composition did not deliver it.

### Why the result is silence, not a slow write

`RequireBaseState`'s own remarks spell out the consequence verbatim: *"no `OnNext`, no `OnError`, no `OnCompleted` on the caller's observer, no patch posted, and not even the outer `VERDICT_TIMEOUT` — that deadline is armed inside the response wait, which this write never reaches. **The writer hangs for the life of the process, silently.**"*

#3001 closed the **sibling** case — the mirror COMPLETES having carried nothing — through `RequireBaseState`. This one, where the mirror never completes and never carries anything usable, was left with an unreachable bound. `RequireBaseState`'s remarks even name the trigger (*"one whose every emission the null-filter drops"*) while covering only its completing half.

### What it costs

`PackageInstaller`'s release wave is `nodeTypePaths.Select(ObserveNodeTypeRelease).Merge().ToList()` — no per-leg bound and no outer bound — so **one parked leg parks the entire package install**, silently, until the plugin gate's own 600 s `InstallTimeout` reports `install: [install] TimeoutException` against a package that installed in **111 s** eight minutes earlier.

That is the recurring core CD bake+seal failure: measured **6/6** on 2026-09-03, always on `Hosting`, always at exactly T+600 s, always after ~8.5 minutes of total process silence following the last log line. Background and the full method are in `Doc/Architecture/BakeSealNodeOpsSaturation` (#3190).

### The fix is the ORDER, not the number

30 s is unchanged; it now measures what the caller actually waits for — a **usable** base. This can only **add** terminals: a mirror that yields a usable base is untouched, one that never does now faults instead of parking, and the fault it raises is the write path's existing retryable `TimeoutException`.

Both sites now share one `BaseStateSource` composition and one named `BaseStateWaitBound`, so neither can be re-authored independently, and the `"within 30s"` in the abort message derives from that constant instead of being spelled a third time (`Doc/Architecture/BoundsMustBeOrdered`).

### Verification

- `BaseReadBoundIsReachableTest` — three cases on a `TestScheduler` (virtual time; no mesh, no cluster, no sleep): a chatty mirror that never carries the node **faults on the bound**; one that carries it at 20 s **emits with no fault**; a silent mirror **still faults** (the behaviour the old shape did deliver, pinned so the reorder cannot regress it).
- 🚨 **The test can fail.** With the operator order flipped back to the pre-fix composition, the regression case fails and the other two pass; restored, all three pass. `MeshWeaver.Graph.Test`: `Failed: 0, Passed: 6` including the three existing `WriteBaseStateTotalityTest` cases.
- `dotnet build -c Release -warnaserror`: `MeshWeaver.Mesh.Contract` 0/0, `MeshWeaver.Hosting` (dependent) 0/0, `MeshWeaver.Graph.Test` 0/0.

### Not fixed here, deliberately

`RequestReleases`' unbounded `Merge().ToList()` is the **amplifier** — it is what turns one parked write into a parked install — but with each leg now reaching a terminal it is no longer a hang, and bounding it without a cause would be a band-aid. Named in `Doc/Architecture/BakeSealNodeOpsSaturation` alongside the other four owner-side totality gaps found while eliminating this one.

`Pairs-with: none` — no public type or member removed; `BaseStateSource` / `BaseStateWaitBound` are new **internal** members.

Refs #2543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
