### PR TITLE
Availability observation degrades PER BUNDLE — an unreadable archive no longer unreads the identity (unblocks Plugins main)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-one-damaged-package-no-longer-holds-every-update.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-one-damaged-package-no-longer-holds-every-update.md
@@ -1,0 +1,25 @@
+---
+Name: One damaged package no longer holds every update
+Category: Fix
+Description: Before your installation updates itself, it reads the prepared packages published for the new build. A single package file that could not be opened made that whole reading fail — so your portal stopped offering updates, with a reason nobody could act on. The reading now skips just the damaged file and judges the rest.
+Icon: ShieldCheckmark
+Order: -20260903
+---
+
+# One damaged package no longer holds every update
+
+Before your installation moves to a new platform build, it looks at the packages that have been
+prepared for that build and checks that they fit together (see *An update is held when its packages
+do not fit together*). To do that it opens each prepared package and reads what it was built against.
+
+If one of those files could not be opened — a partial upload, a corrupt archive, a file that was
+never a package at all — the whole reading gave up. Your installation then treated the entire build
+as unreadable: no update was offered, and the **Updates** settings tab showed a hold that named the
+build but nothing you could do about it. One damaged file, and every installation reading that
+published set was stuck.
+
+**The reading now fails one file at a time.** A package that cannot be opened is noted in the log
+and counts only as "present" — there is nothing in it to compare — while every other package is
+still read and judged as before. An update that is genuinely inconsistent is still held, naming the
+package and the mismatch; an update that is fine is offered, even when a stray unreadable file sits
+beside it.

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -181,7 +181,7 @@ public static class PublishedBundleCatalogue
             var source = Path.GetFileName(sourceDirectory)!;
             bundles.AddRange(complete);
             foreach (var bundle in complete)
-                records.AddRange(DependencyRecordsOf(Path.Combine(sourceDirectory, bundle), bundle));
+                records.AddRange(DependencyRecordsOf(Path.Combine(sourceDirectory, bundle), bundle, logger));
 
             var modules = SealedModulesOf(sourceDirectory, logger);
             if (modules.Modules is null)
@@ -268,20 +268,48 @@ public static class PublishedBundleCatalogue
         return (name, CompiledDependencies.MvidScheme + mvid.ToString("N"));
     }
 
-    private static IEnumerable<BundleDependencyRecord> DependencyRecordsOf(string bundlePath, string bundleFileName)
+    /// <summary>
+    /// The per-NodeType dependency records one sealed bundle carries — or NONE, logged, when the
+    /// bundle is not a readable archive or its manifest does not parse.
+    ///
+    /// <para>🚨 Per-bundle, never per-identity. The first cut let a bundle that was not a zip throw
+    /// out of <see cref="Read"/>'s outer catch, so ONE unreadable file made the whole identity
+    /// <see cref="ReleaseArtifacts.Unreadable"/> AND lost the resolved framework identity — which is
+    /// how core #3187 reddened MeshWeaver.Plugins main within the hour: its catalogue tests publish
+    /// bundles as literal bytes and pin the contract this observation had before records existed
+    /// (presence counts, the identity resolves, names match case-insensitively). Those rules still
+    /// hold. A bundle without readable records simply has nothing for the consistency check to
+    /// judge, exactly as a legacy bundle recorded before #1707 slice 2 has none.</para>
+    /// </summary>
+    private static IReadOnlyList<BundleDependencyRecord> DependencyRecordsOf(
+        string bundlePath, string bundleFileName, ILogger? logger)
     {
         var id = bundleFileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)
             ? bundleFileName[..^4]
             : bundleFileName;
-        var manifest = BundleReader.ReadManifest(bundlePath);
+        BundleReader.Manifest? manifest;
+        try
+        {
+            manifest = BundleReader.ReadManifest(bundlePath);
+        }
+        catch (Exception ex) when (ex is IOException or InvalidDataException or NotSupportedException or System.Text.Json.JsonException)
+        {
+            logger?.LogWarning(ex,
+                "ReleaseAvailability: sealed bundle {Bundle} carries no readable manifest — it counts "
+                + "for presence, and its dependency records cannot be checked for consistency",
+                bundlePath);
+            return [];
+        }
+        var records = new List<BundleDependencyRecord>();
         foreach (var assembly in manifest?.Assemblies ?? [])
         {
             if (assembly.Dependencies is null || string.IsNullOrEmpty(assembly.NodePath))
                 continue;
-            yield return new BundleDependencyRecord(
+            records.Add(new BundleDependencyRecord(
                 id, assembly.NodePath,
-                assembly.Dependencies.ToImmutableDictionary(StringComparer.Ordinal));
+                assembly.Dependencies.ToImmutableDictionary(StringComparer.Ordinal)));
         }
+        return records;
     }
 
     private static IEnumerable<string> SealedBundleNames(string identityDirectory, ILogger? logger)

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -269,8 +269,10 @@ public static class PublishedBundleCatalogue
     }
 
     /// <summary>
-    /// The per-NodeType dependency records one sealed bundle carries — or NONE, logged, when the
-    /// bundle is not a readable archive or its manifest does not parse.
+    /// The per-NodeType dependency records one sealed bundle carries. EMPTY when the archive carries
+    /// no manifest entry or its manifest lists no records (a legacy bundle — nothing to judge, not an
+    /// error); EMPTY and LOGGED when the bundle is not a readable archive or its manifest does not
+    /// parse.
     ///
     /// <para>🚨 Per-bundle, never per-identity. The first cut let a bundle that was not a zip throw
     /// out of <see cref="Read"/>'s outer catch, so ONE unreadable file made the whole identity

--- a/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
+++ b/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
@@ -128,6 +128,45 @@ public class SealedSetConsistencyTest
         }
     }
 
+    /// <summary>
+    /// 🚨 The contract that predates records still holds: a sealed bundle that is NOT a readable
+    /// archive counts for presence, the identity resolves, and the verdict is available — with
+    /// nothing for the consistency check to judge. The first cut let that bundle throw out of
+    /// <c>Read</c>'s outer catch, turning the WHOLE identity unreadable and losing its resolved
+    /// identity; MeshWeaver.Plugins' catalogue tests (which publish bundles as literal bytes) went
+    /// red on main within the hour of #3187 merging.
+    /// </summary>
+    [Fact]
+    public void ABundleThatIsNotAReadableArchive_StillCountsForPresence_AndTheIdentityResolves()
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-sealed-set-" + Guid.NewGuid().ToString("N"));
+        try
+        {
+            var source = Path.Combine(root, Identity, "plugins");
+            Directory.CreateDirectory(Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName));
+            Directory.CreateDirectory(source);
+            File.WriteAllText(
+                Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName, Version), Identity);
+            File.WriteAllText(Path.Combine(source, "Doc.zip"), "bytes");
+            File.WriteAllText(
+                Path.Combine(source, ShippedPrebuiltBundles.CompletionSentinelFileName), "Doc.zip\n");
+
+            var observation = PublishedBundleCatalogue.Read(root, Version);
+
+            Assert.Equal(Identity, observation.Target.FrameworkIdentity);
+            Assert.Null(observation.Artifacts.ReadFailure);
+            Assert.Contains("Doc", observation.Artifacts.SealedBundles);
+            Assert.Empty(observation.Artifacts.DependencyRecords);
+            var verdict = ReleaseAvailability.IsUpdatable(
+                observation.Target, [new RequiredPackage("Doc", "doc")], observation.Artifacts);
+            Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
     // ── the rule, on hand-built observations ────────────────────────────────────────────────────
 
     [Fact]

--- a/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
+++ b/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
@@ -129,37 +129,58 @@ public class SealedSetConsistencyTest
     }
 
     /// <summary>
-    /// 🚨 The contract that predates records still holds: a sealed bundle that is NOT a readable
-    /// archive counts for presence, the identity resolves, and the verdict is available — with
-    /// nothing for the consistency check to judge. The first cut let that bundle throw out of
-    /// <c>Read</c>'s outer catch, turning the WHOLE identity unreadable and losing its resolved
-    /// identity; MeshWeaver.Plugins' catalogue tests (which publish bundles as literal bytes) went
-    /// red on main within the hour of #3187 merging.
+    /// 🚨 THE case that could falsify the fix: one sealed bundle that is NOT a readable archive — a
+    /// file of literal bytes, deliberately not a zip — beside a readable, INCONSISTENT one. The read
+    /// must still resolve the identity, count the unreadable bundle for presence (nothing for the
+    /// consistency check to judge, as for a legacy bundle), and still JUDGE the rest of the set:
+    /// the readable bundle built against another module build holds, by name. The first cut let the
+    /// unreadable file throw out of <c>Read</c>'s outer catch, turning the WHOLE identity unreadable
+    /// and losing its resolved identity — MeshWeaver.Plugins' catalogue tests (which stage bundles as
+    /// literal bytes) went red on main within the hour of #3187 merging, and every portal reading
+    /// such a root would have held every update with a reason nobody could act on.
     /// </summary>
     [Fact]
-    public void ABundleThatIsNotAReadableArchive_StillCountsForPresence_AndTheIdentityResolves()
+    public void AnUnreadableBundle_CountsForPresence_AndTheRestOfTheSetIsStillJudged()
     {
-        var root = Path.Combine(Path.GetTempPath(), "mw-sealed-set-" + Guid.NewGuid().ToString("N"));
+        var recorded = AnotherBuild;
+        var root = PublishedRoot(recorded);
         try
         {
-            var source = Path.Combine(root, Identity, "plugins");
-            Directory.CreateDirectory(Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName));
-            Directory.CreateDirectory(source);
+            // A second source whose only bundle is NOT an archive, sealed with an EMPTY module set
+            // ("composed nothing" — a legitimate seal, distinct from "predates module sealing").
+            var education = Path.Combine(root, Identity, "education");
+            Directory.CreateDirectory(Path.Combine(education, PublishedBundleCatalogue.ModulesDirectoryName));
+            File.WriteAllText(Path.Combine(education, "Doc.zip"), "bytes");
             File.WriteAllText(
-                Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName, Version), Identity);
-            File.WriteAllText(Path.Combine(source, "Doc.zip"), "bytes");
+                Path.Combine(education, PublishedBundleCatalogue.ModulesDirectoryName,
+                    PublishedBundleCatalogue.ModulesIndexFileName), string.Empty);
             File.WriteAllText(
-                Path.Combine(source, ShippedPrebuiltBundles.CompletionSentinelFileName), "Doc.zip\n");
+                Path.Combine(education, ShippedPrebuiltBundles.CompletionSentinelFileName), "Doc.zip\n");
 
             var observation = PublishedBundleCatalogue.Read(root, Version);
 
             Assert.Equal(Identity, observation.Target.FrameworkIdentity);
             Assert.Null(observation.Artifacts.ReadFailure);
             Assert.Contains("Doc", observation.Artifacts.SealedBundles);
-            Assert.Empty(observation.Artifacts.DependencyRecords);
+            Assert.Contains(Bundle, observation.Artifacts.SealedBundles);
+            // The unreadable bundle contributed no records; the readable one did.
+            Assert.Equal([Bundle], observation.Artifacts.DependencyRecords.Select(r => r.Bundle).Distinct());
+            Assert.NotNull(observation.Artifacts.Modules);
+            Assert.Null(observation.Artifacts.Modules.Refusal);
+
             var verdict = ReleaseAvailability.IsUpdatable(
-                observation.Target, [new RequiredPackage("Doc", "doc")], observation.Artifacts);
-            Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+                observation.Target,
+                [new RequiredPackage("Doc", "Doc"), Required],
+                observation.Artifacts);
+
+            Assert.False(verdict.IsUpdatable);
+            Assert.False(verdict.IsIndeterminate, "an unreadable BUNDLE is not an unreadable SET");
+            var doc = Assert.Single(verdict.Packages, p => p.Package == "Doc");
+            Assert.Equal(PackageAvailabilityKind.Available, doc.Kind);
+            var widget = Assert.Single(verdict.Packages, p => p.Package == Bundle);
+            Assert.Equal(PackageAvailabilityKind.SealedSetInconsistent, widget.Kind);
+            Assert.Contains(recorded, widget.Reason!, StringComparison.Ordinal);
+            Assert.Contains(SealedMvid, widget.Reason!, StringComparison.Ordinal);
         }
         finally
         {


### PR DESCRIPTION
## Availability observation degrades PER BUNDLE — an unreadable archive no longer unreads the identity

**Fleet blocker.** #3187 (`3b903d683`) reddened MeshWeaver.Plugins main (required `Build + test the portal hosts`, shard 1): `PublishedBundleCatalogueTest.{BundleNamesAreMatchedCaseInsensitively, AMarkedRelease_ResolvesItsIdentity_AndTheSealedBundlesAcrossEverySource, ATornPublication_DoesNotCount_BecauseTheBootSeederWouldSkipItToo}` — 3 failed / 723 passed. Bisected by another session: Plugins `816c8edd` green against core main before #3187, red after.

### Decision: core broke a contract it should have kept — fix core

Those tests publish bundles as literal bytes (`File.WriteAllText(bundle, "bytes")`) and pin the observation's pre-records contract: presence counts, the framework identity resolves, bundle names match case-insensitively. All three rules are still the intended contract. The new record reader (`ArtifactsForIdentity` → `BundleReader.ReadManifest`) let `InvalidDataException` escape to `Read`'s outer catch, so ONE non-zip bundle made the whole identity `Unreadable` and dropped its resolved identity — a per-bundle condition promoted to a per-identity verdict.

### Fix

`DependencyRecordsOf` is per-bundle best-effort: a bundle whose archive or manifest cannot be read contributes no dependency records (logged, named), exactly what a legacy bundle recorded before #1707 slice 2 contributes; presence decides for it as before, and the consistency check has nothing to judge. Module bundles were already per-module (their failure is a named `Refusal`). No change to the consistency rule itself.

### Verified locally
- `Memex.Portal.Shared.Test` (whole project) `-c Release -warnaserror`: green, incl. the new pin `AnUnreadableBundle_CountsForPresence_AndTheRestOfTheSetIsStillJudged` — the falsifying case: a literal-bytes (non-zip) bundle beside a readable INCONSISTENT one; the identity resolves, the unreadable bundle counts for presence, and the readable one is still HELD by name.
- Plugins `MeshWeaver.PluginCatalog.Test` (whole project) built against THIS core (`-p:MeshWeaverRoot=<this worktree>`): **726/726 passed**, incl. the three that were red on main (`BundleNamesAreMatchedCaseInsensitively`, `AMarkedRelease_ResolvesItsIdentity_AndTheSealedBundlesAcrossEverySource`, `ATornPublication_DoesNotCount_BecauseTheBootSeederWouldSkipItToo`).

Refs #3175. What's New `Category: Fix`: "One damaged package no longer holds every update" — the user-visible symptom was a portal that stopped offering updates with a reason nobody could act on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
