### PR TITLE
fix(data,mesh): every leg of the owner-side patch pipeline reaches a terminal on a checked route, and the late-verdict bound stops asserting a deleted cap (#3194, #3195, #3196, #3197)

### DIFF
--- a/src/MeshWeaver.Data.Contract/ILatePatchVerdictSink.cs
+++ b/src/MeshWeaver.Data.Contract/ILatePatchVerdictSink.cs
@@ -39,4 +39,29 @@ public interface ILatePatchVerdictSink
     /// this mesh was waiting — which the caller may then treat as a checked fact rather than a
     /// guess.</returns>
     bool Dispatch(string requestId, PatchDataResponse response);
+
+    /// <summary>
+    /// 🚨 Whether a late verdict for <paramref name="requestId"/> would still be ACTED ON — an
+    /// armed, unexpired watch (#3197).
+    ///
+    /// <para><b>Why a predicate exists at all.</b> The owner's ack watcher deliberately posts
+    /// NOTHING when the owner is shutting down, deferring the verdict to the ShutDown-phase
+    /// disposal NACK, whose transport still reaches the waiter. That deferral rested on an
+    /// assumption — "the disposal NACK is coming, and soon" — which the code could not check and
+    /// which the hosted-hub drain stopped guaranteeing when its flat 5 s cap was removed (#1317).
+    /// Standing aside for a route that will not deliver converts an answerable write into
+    /// silence.</para>
+    ///
+    /// <para>It answers "is a route armed NOW", not "will it still be armed then" — no
+    /// implementation can promise the latter. A stand-aside that clears this check and is
+    /// nevertheless overtaken by expiry is reported by the registry rather than dropped in
+    /// silence, which is the other half of the same issue.</para>
+    ///
+    /// <para>The default is <c>true</c> — the assumption this predicate replaces — so an
+    /// implementation that cannot answer keeps the previous behaviour rather than silently
+    /// changing it.</para>
+    /// </summary>
+    /// <param name="requestId">The originating <c>PatchDataRequest</c> delivery id.</param>
+    /// <returns><c>true</c> when a late verdict would still be delivered.</returns>
+    bool IsAdmissible(string requestId) => true;
 }

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1926,7 +1926,15 @@ public static class DataExtensions
                         AckOnce,
                         d => hub.RegisterForDisposal(d),
                         hubPath,
-                        () => hub.IsShuttingDown,
+                        // 🚨 Stand aside for the disposal NACK only while a route is ARMED to receive it
+                        // (#3197). The deferral used to rest on "the disposal NACK is coming, and soon" — an
+                        // assumption the code could not check, and one the hosted-hub drain stopped
+                        // guaranteeing when its flat 5 s cap was removed in #1317 (the watchdog that replaced
+                        // it is a STALL detector, re-armed on every RunLevel transition in the subtree, so a
+                        // large subtree making steady progress never trips it). With no sink, or with the
+                        // caller's watch already gone, standing aside converts an answerable write into
+                        // silence — so answer now, on whatever transport is still open.
+                        () => hub.IsShuttingDown && lateVerdicts is not null && lateVerdicts.IsAdmissible(request.Id),
                         hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"));
                     hub.RegisterForDisposal(postSub);
 
@@ -2054,7 +2062,15 @@ public static class DataExtensions
             AckOnce,
             d => hub.RegisterForDisposal(d),
             hubPath,
-            () => hub.IsShuttingDown,
+            // 🚨 Stand aside for the disposal NACK only while a route is ARMED to receive it
+            // (#3197). The deferral used to rest on "the disposal NACK is coming, and soon" — an
+            // assumption the code could not check, and one the hosted-hub drain stopped
+            // guaranteeing when its flat 5 s cap was removed in #1317 (the watchdog that replaced
+            // it is a STALL detector, re-armed on every RunLevel transition in the subtree, so a
+            // large subtree making steady progress never trips it). With no sink, or with the
+            // caller's watch already gone, standing aside converts an answerable write into
+            // silence — so answer now, on whatever transport is still open.
+            () => hub.IsShuttingDown && lateVerdicts is not null && lateVerdicts.IsAdmissible(request.Id),
             hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"));
         hub.RegisterForDisposal(postSub);
         // Registered AFTER postSub so the composite disposes the watcher FIRST, then this NACK

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Immutable;
 using System.Reactive;
+using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.Json;
@@ -880,6 +881,156 @@ public static class DataExtensions
     }
 
     /// <summary>
+    /// 🚨 A one-shot owner-side read that reaches a terminal on ALL FOUR of Rx's outcomes — the
+    /// seam #3194 and #3195 close, and the ORDER #3193 got wrong made structural.
+    ///
+    /// <para><c>Subscribe(onNext, onError)</c> covers two. <see cref="WhenCompletesEmpty{T}"/>
+    /// (#3033) added the third. The fourth — <b>never emits and never completes</b> — is settled as
+    /// silence by all three, and it is not hypothetical: a stream's <c>Store</c> is a
+    /// <c>ReplaySubject</c>, so one that has never published and is never disposed hands
+    /// <c>Take(1)</c> nothing, forever.</para>
+    ///
+    /// <list type="bullet">
+    ///   <item><b>Emits</b> → the value passes through; <c>Take(1)</c>'s completion is NOT a
+    ///     verdict, so work started in <c>onNext</c> is undisturbed.</item>
+    ///   <item><b>Errors</b> → <c>onError</c>.</item>
+    ///   <item><b>Completes empty</b> → <paramref name="onEmptyCompletion"/>, then completion.</item>
+    ///   <item><b>Neither</b> → <c>onError(TimeoutException)</c> at <paramref name="bound"/>.</item>
+    /// </list>
+    ///
+    /// <para>🚨 <b>The Timeout sits BELOW the caller's filter and below the <c>Take(1)</c>, and that
+    /// is the point of having a seam at all.</b> A <c>Timeout</c> placed upstream of an operator
+    /// that DROPS emissions is re-armed by every dropped one, so it can never fire on a busy
+    /// stream — the bound is present, reviewed, and unreachable. That is #3193 exactly. Callers
+    /// hand in their already-filtered source and cannot get the order wrong.</para>
+    ///
+    /// <para>Internal, and a PURE composition over <see cref="IObservable{T}"/> — no hub, no mesh —
+    /// so <c>OneShotReadTotalityTest</c> drives all four outcomes on a <c>TestScheduler</c>.</para>
+    /// </summary>
+    /// <param name="source">The already-filtered source; its FIRST emission is the one awaited.</param>
+    /// <param name="bound">The wait for that emission.</param>
+    /// <param name="onEmptyCompletion">Runs when the source ends without ever emitting.</param>
+    /// <param name="scheduler">Timer scheduler; null ⇒ <see cref="Scheduler.Default"/>.</param>
+    internal static IObservable<T> ArmedOneShotRead<T>(
+        this IObservable<T> source,
+        TimeSpan bound,
+        Action onEmptyCompletion,
+        IScheduler? scheduler = null)
+        => source
+            .Take(1)
+            .Timeout(bound, scheduler ?? Scheduler.Default)
+            .WhenCompletesEmpty(onEmptyCompletion);
+
+    /// <summary>
+    /// 🚨 Routes an owner-side patch verdict and REPORTS whether a route took it (#3196) — the
+    /// decision half of <see cref="PostPatchVerdict"/>, kept a pure composition over two delegates
+    /// so <c>PatchVerdictRoutingTest</c> can drive it without a hub (the house rule: never mock
+    /// <see cref="IMessageHub"/>).
+    ///
+    /// <para>Post FIRST, sink SECOND — the reverse of <see cref="RegisterOwnerDisposingNack"/>,
+    /// deliberately. That one runs at disposal, where no <c>Observe</c> callback is pending and the
+    /// message is only a long way round to the registry. This runs on the LIVE path, where the
+    /// caller's callback IS armed and the post is the designed seam; sending every ordinary ack to
+    /// the late-verdict registry instead would change the transport for writes that are working.</para>
+    ///
+    /// <para>A <c>null</c> or <see cref="MessageDeliveryState.Failed"/> delivery is the refusal:
+    /// <c>MessageService.PostImplGeneric</c> stamps <c>POST_REFUSED_SHUTTING_DOWN</c> and returns
+    /// exactly that when the owner AND its parent are past <c>DisposeHostedHubs</c>, and its own
+    /// comment says "This site does NOT answer the sender itself".</para>
+    /// </summary>
+    /// <returns><c>true</c> when the post was accepted or the sink found an armed caller.</returns>
+    internal static bool RoutePatchVerdict(
+        PatchDataResponse response,
+        string requestId,
+        Func<PatchDataResponse, IMessageDelivery?> post,
+        Func<string, PatchDataResponse, bool>? dispatchLate)
+    {
+        var delivery = post(response);
+        if (delivery is not null && delivery.State != MessageDeliveryState.Failed)
+            return true;
+        return dispatchLate is not null && dispatchLate(requestId, response);
+    }
+
+    /// <summary>
+    /// How long the GENERIC (non-MeshNode / no-primary-data-source) patch path waits for its
+    /// initial base read before answering (#3194).
+    ///
+    /// <para>🚨 This bound covers Rx's FOURTH outcome — <b>never emits and never completes</b> —
+    /// which is the one a <c>Subscribe(onNext, onError)</c> plus a
+    /// <see cref="WhenCompletesEmpty{T}"/> arm still settles as silence. The stream's
+    /// <c>Store</c> is a <c>ReplaySubject</c>, so a stream that has never published and is never
+    /// disposed hands <c>Take(1)</c> nothing, forever; and the only other bounded watcher on this
+    /// path (<c>postSub</c>) is armed INSIDE the <c>onNext</c> arm, so on that stream it is never
+    /// armed at all.</para>
+    ///
+    /// <para>Ten seconds, matching the in-turn path's cold-activation defer, because it is the same
+    /// question — has the owner's store produced state yet. It is the FIRST thing on this path, so
+    /// it composes with nothing else and sits well inside the caller's 31 s
+    /// <c>WriteVerdictBound</c> (Doc/Architecture/BoundsMustBeOrdered). Expiry is not a lost write:
+    /// the merge provably never ran, so the verdict is the auto-retried
+    /// <see cref="MeshNodeErrorCode.OwnerNotReady"/> rather than the 31 s
+    /// <c>OwnerUnreachable</c> the caller reports today.</para>
+    /// </summary>
+    private static readonly TimeSpan GenericBaseReadBound = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// Posts an owner-side patch verdict and VERIFIES that a route accepted it (#3196).
+    ///
+    /// <para>🚨 <b>Why the post's result cannot be discarded.</b> Both ack gates latch their
+    /// once-only <c>ackPosted</c> flag BEFORE posting, which is right — two racing legs must not
+    /// both answer. But latching is also what disables the ONLY route that still works during
+    /// teardown: once the gate is claimed, <see cref="RegisterOwnerDisposingNack"/>'s
+    /// <c>tryClaimAck()</c> returns false and its <see cref="ILatePatchVerdictSink"/> dispatch is
+    /// skipped. So a post that is REFUSED — the owner past <c>DisposeHostedHubs</c> with a parent
+    /// past it too, where <c>MessageService.PostImplGeneric</c> stamps
+    /// <c>POST_REFUSED_SHUTTING_DOWN</c> and returns a <see cref="MessageDeliveryState.Failed"/>
+    /// delivery whose own comment says "This site does NOT answer the sender itself" — threw the
+    /// verdict away AND closed the door behind it. The caller then burned its full 31 s
+    /// <c>WriteVerdictBound</c> and reported <c>OwnerUnreachable</c> for a write the owner had
+    /// already judged.</para>
+    ///
+    /// <para>Claim-then-VERIFY: the gate still latches first, but the verdict now falls through to
+    /// the sink when the transport refuses it — the same order
+    /// <see cref="RegisterOwnerDisposingNack"/> already demonstrates ("Dispatch RETURNS whether a
+    /// caller was armed, so the question is now answered rather than assumed"). The post stays
+    /// FIRST here, unlike there: this runs on the live path where the caller's <c>Observe</c>
+    /// callback is still pending and the message IS the designed seam; the registry is the
+    /// late-verdict route, and hijacking every ordinary ack onto it would change the transport for
+    /// writes that are working.</para>
+    ///
+    /// <para>A miss on both routes is a checked fact, not a guess: nobody in this mesh is armed and
+    /// the transport is gone. It is logged rather than swallowed, because the remaining case — a
+    /// caller in another process — is one this registry cannot see.</para>
+    /// </summary>
+    /// <param name="hub">The owning per-node hub answering the patch.</param>
+    /// <param name="request">The in-flight patch request being answered.</param>
+    /// <param name="response">The verdict.</param>
+    /// <param name="lateVerdicts">The late-verdict sink, resolved on the handler's TURN by the
+    /// caller and closed over — never resolved from here, which can run at disposal time.</param>
+    /// <param name="logger">Optional logger for the both-routes-missed case.</param>
+    private static void PostPatchVerdict(
+        IMessageHub hub,
+        IMessageDelivery<PatchDataRequest> request,
+        PatchDataResponse response,
+        ILatePatchVerdictSink? lateVerdicts,
+        ILogger? logger)
+    {
+        if (RoutePatchVerdict(
+                response,
+                request.Id,
+                resp => hub.Post(resp, o => o.ResponseFor(request)),
+                lateVerdicts is null ? null : lateVerdicts.Dispatch))
+            return;
+
+        logger?.LogWarning(
+            "Patch verdict for request {RequestId} on {Address} reached no route: the post was refused "
+            + "(run level {RunLevel}) and no caller was armed in this mesh. A same-mesh caller would "
+            + "have been served by the late-verdict sink; a cross-process one now waits out its "
+            + "WriteVerdictBound.",
+            request.Id, hub.Address, hub.RunLevel);
+    }
+
+    /// <summary>
     /// 🚨 Owner-side disposal NACK for an in-flight <see cref="PatchDataRequest"/>. The patch
     /// pipeline registers its ack watcher / merge turn on structures that DIE SILENTLY with the
     /// hub (postSub / deferSub / flushSub are <c>hub.RegisterForDisposal</c>'d; the merge turn's
@@ -1581,6 +1732,13 @@ public static class DataExtensions
         // Once-only ack gate at METHOD scope (not inside the Take(1) callback): the disposal
         // NACK below must be able to claim it even when the hub dies BEFORE the stream's first
         // emission released the callback — the deferred path's silent-death window.
+        // 🚨 Resolved HERE, on the handler's TURN, and closed over — the identical rule (and the
+        // identical incident) as RegisterOwnerDisposingNack: a DI touch from an ack path that can
+        // run at disposal time throws once the lifetime scope is closed, and the verdict is then
+        // never produced at all.
+        var lateVerdicts = hub.ServiceProvider.GetService<ILatePatchVerdictSink>();
+        var ackLogger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Data.PatchAck");
         var ackPosted = 0;
         void AckOnce(bool success, MeshNodeError? error = null)
         {
@@ -1588,30 +1746,38 @@ public static class DataExtensions
             var resp = new PatchDataResponse(success, hub.Version);
             if (error is not null)
                 resp = resp with { Error = error.Message, NodeError = error };
-            hub.Post(resp, o => o.ResponseFor(request));
+            // Claim-then-VERIFY (#3196): claiming the gate above is what disables
+            // RegisterOwnerDisposingNack's sink route, so a refused post must fall through to it
+            // here or the verdict is lost with the door shut behind it.
+            PostPatchVerdict(hub, request, resp, lateVerdicts, ackLogger);
         }
         RegisterOwnerDisposingNack(hub, request, hubPath,
             () => System.Threading.Interlocked.Exchange(ref ackPosted, 1) == 0);
 
         stream
-            .Take(1)
-            // 🚨 Totality (#3033): this initial read had NEITHER an error nor a completion arm. A
-            // stream that faults or ENDS before delivering the state to merge against left the
-            // request accepted and silently unanswered — the writer then burned its full
-            // confirmation window and reported OwnerUnreachable. Here the merge provably never
-            // ran, so OwnerDisposing ("the patch was NOT applied; safe to retry") is exact — unless
-            // the stream ended because the OWNER is shutting down, in which case the ShutDown-phase
-            // disposal NACK (RegisterOwnerDisposingNack, above) owns the verdict: minted here it
-            // would be one phase too early and on the wrong transport (see ArmPatchAckWatcher).
-            .WhenCompletesEmpty(() =>
-            {
-                if (hub.IsShuttingDown)
-                    return;
-                AckOnce(false, new MeshNodeError(
-                    MeshNodeErrorCode.OwnerDisposing, hubPath,
-                    "the owner's stream ended before it delivered the current state to merge against — "
-                    + "the patch was NOT applied; safe to retry against the fresh activation"));
-            })
+            // 🚨 All four Rx outcomes (#3194 — the fourth had NOTHING here: no Timeout anywhere
+            // between the stream and the Subscribe, and postSub, this path's only other bounded
+            // watcher, is armed INSIDE the onNext arm, so a stream that never emits never arms it).
+            // The bound's verdict is minted in the onError arm below rather than by
+            // ClassifyPatchException, which would settle a TimeoutException as Unknown — true of an
+            // echo that may have committed, wrong here, where the merge provably never ran.
+            .ArmedOneShotRead(GenericBaseReadBound, () =>
+                // 🚨 Totality (#3033): the empty-completion arm. A stream that ENDS before
+                // delivering the state to merge against left the request accepted and silently
+                // unanswered. Here the merge provably never ran, so OwnerDisposing ("the patch was
+                // NOT applied; safe to retry") is exact — unless the stream ended because the OWNER
+                // is shutting down, in which case the ShutDown-phase disposal NACK
+                // (RegisterOwnerDisposingNack, above) owns the verdict: minted here it would be one
+                // phase too early and on the wrong transport (see ArmPatchAckWatcher).
+                {
+                    if (hub.IsShuttingDown)
+                        return;
+                    AckOnce(false, new MeshNodeError(
+                        MeshNodeErrorCode.OwnerDisposing, hubPath,
+                        "the owner's stream ended before it delivered the current state to merge "
+                        + "against — the patch was NOT applied; safe to retry against the fresh "
+                        + "activation"));
+                })
             .Subscribe(change =>
             {
                 try
@@ -1774,7 +1940,18 @@ public static class DataExtensions
                     AckOnce(false, ClassifyPatchException(ex, hubPath));
                 }
             },
-            ex => AckOnce(false, ClassifyPatchException(ex, hubPath)));
+            ex => AckOnce(false, ex is TimeoutException
+                // The store never produced a base within the bound: an activation that has not
+                // LOADED, not an owner answering. Same reading — and same auto-retried code — as
+                // the in-turn path's cold-activation defer, and deliberately NOT NotFound, which
+                // would poison existence checks and the stream cache's negative cache for a node
+                // that exists (#667).
+                ? new MeshNodeError(
+                    MeshNodeErrorCode.OwnerNotReady, hubPath,
+                    "the owner's stream did not deliver the current state to merge against within "
+                    + $"{GenericBaseReadBound.TotalSeconds:0}s — the patch was NOT applied; safe to "
+                    + "retry once the activation has loaded")
+                : ClassifyPatchException(ex, hubPath)));
     }
 
     /// <summary>
@@ -1806,6 +1983,13 @@ public static class DataExtensions
         var mergeGuardLogger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger("MeshWeaver.Data.MergeGuard");
 
+        // 🚨 Resolved HERE, on the handler's TURN, and closed over — the identical rule (and the
+        // identical incident) as RegisterOwnerDisposingNack: a DI touch from an ack path that can
+        // run at disposal time throws once the lifetime scope is closed, and the verdict is then
+        // never produced at all.
+        var lateVerdicts = hub.ServiceProvider.GetService<ILatePatchVerdictSink>();
+        var ackLogger = hub.ServiceProvider.GetService<ILoggerFactory>()
+            ?.CreateLogger("MeshWeaver.Data.PatchAck");
         var ackPosted = 0;
         void AckOnce(bool success, MeshNodeError? error = null)
         {
@@ -1813,7 +1997,10 @@ public static class DataExtensions
             var resp = new PatchDataResponse(success, hub.Version);
             if (error is not null)
                 resp = resp with { Error = error.Message, NodeError = error };
-            hub.Post(resp, o => o.ResponseFor(request));
+            // Claim-then-VERIFY (#3196): claiming the gate above is what disables
+            // RegisterOwnerDisposingNack's sink route, so a refused post must fall through to it
+            // here or the verdict is lost with the door shut behind it.
+            PostPatchVerdict(hub, request, resp, lateVerdicts, ackLogger);
         }
 
         // 🚨 Write-identity stamps — set by the merge lambda AT COMMIT TIME (the same
@@ -1963,8 +2150,34 @@ public static class DataExtensions
                             var deferSub = primary
                                 .Where(ci => ci.Value?.Collections.GetValueOrDefault(collectionName)
                                     is { Instances.Count: > 0 })
-                                .Take(1)
-                                .Timeout(TimeSpan.FromSeconds(10))
+                                // 🚨 Through the shared seam: Take(1) + bound + empty-completion
+                                // arm, with the bound BELOW the Where above — a Timeout placed over
+                                // the unfiltered primary would be re-armed by every sibling emission
+                                // the filter drops, which is #3193's unreachable bound exactly.
+                                .ArmedOneShotRead(TimeSpan.FromSeconds(10), () =>
+                                // 🚨 The THIRD termination (#3195). Two arms cover three: if the
+                                // primary's store COMPLETES inside the bound — a documented,
+                                // non-hypothetical shape, see RequireBaseState's remarks on the
+                                // three producers of it — the completion passes Take(1) and CANCELS
+                                // the Timeout above (a terminal notification disposes its timer), so
+                                // neither arm below can ever run. The merge turn that armed this
+                                // already returned null, so nothing else is in flight and this leg
+                                // produces no verdict at all. Placed LAST so it sees every terminal
+                                // that reaches the subscriber, and guarded on "never emitted" so the
+                                // happy path — Take(1) completing right after its value, while
+                                // RunMergeTurn is still in flight — cannot trip it.
+                                {
+                                    // Stand aside for a shutting-down owner, exactly as the generic
+                                    // path's base read does: the ShutDown-phase disposal NACK owns
+                                    // that verdict, on the transport that still reaches the waiter.
+                                    if (hub.IsShuttingDown)
+                                        return;
+                                    AckOnce(false, new MeshNodeError(
+                                        MeshNodeErrorCode.OwnerDisposing, hubPath,
+                                        "the owner's store ended before the activation finished "
+                                        + "loading — the patch was NOT applied; safe to retry "
+                                        + "against the fresh activation"));
+                                })
                                 .Subscribe(
                                     _ => RunMergeTurn(deferred: true),
                                     // 🚨 NOT NotFound (#667): the store never initialized within the

--- a/src/MeshWeaver.Documentation/Data/Architecture/BoundsMustBeOrdered.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BoundsMustBeOrdered.md
@@ -120,6 +120,50 @@ And **prove it by mutation**: restore the old literal and confirm the guard goes
 and `1` cases and stays green on `3` and `10`. That asymmetry is itself the evidence — it shows the
 guard is measuring the ordering and not merely the size of the number.
 
+## A bound's JUSTIFICATION is a claim about other code, and it rots
+
+Derivation keeps two numbers ordered. It does nothing for the sentence that says *why* a number is
+big enough — and that sentence is usually a claim about code somewhere else, which can change
+without ever touching the bound.
+
+`LateResponseWatchBound` (30 s) was stated as **protocol, not tuning**: it had to dominate every
+owner-side terminal path, enumerated as the disposal NACK after a teardown whose *"hosted-hub drain
+[is] capped at 5 s"*, the cold-store defer (~10 s), and the ack watcher's 20 s. Two years of edits
+later (#3197):
+
+- **The 5 s cap was gone.** `HostedHubsCollection.DisposeHubsReactive` deliberately dropped its flat
+  `Timeout(5s)` in #1317, and what replaced it is a *stall* detector re-armed on every `RunLevel`
+  transition anywhere in the subtree — so a large subtree that keeps making progress never trips it.
+  The drain has no duration bound at all, and the claim's first term was unsupported.
+- **The terms were being added wrongly.** They were enumerated as alternatives, taking their maximum
+  (20 s). On the in-turn path they compose *additively*: cold-store defer → identity-gated echo →
+  durable flush.
+- **Two different clocks.** The owner's starts at handler entry, the caller's at post, with unbounded
+  routing latency between them — measured at 33–49 s during a bake.
+
+Nothing failed a build. A comment cannot go red. The next reader inherits a number presented as
+proven and reasons from it.
+
+> 🚨 **When a bound's justification enumerates other people's bounds, it is a dependency — and it
+> needs the same treatment as any other: re-measure it, or stop asserting it.**
+
+Where re-establishing the guarantee would mean reverting a deliberate change — as it would here —
+the honest repair is to **say what is actually guaranteed** and make the gap *visible* rather than
+asserted away. Two shapes do that:
+
+- **Check the premise where it is used.** The owner's ack watcher stands aside for the disposal NACK
+  instead of posting its own verdict. That deferral assumed "the NACK is coming, and soon". It now
+  asks: `ILatePatchVerdictSink.IsAdmissible(requestId)` — is a route actually armed? With no sink, or
+  a watch already gone, standing aside would convert an answerable write into silence, so it answers
+  now on whatever transport is still open. The predicate answers *"is a route armed now"*, not *"will
+  it still be armed then"* — no implementation can promise the latter, which is exactly why the
+  second shape is also needed.
+- **Make the overrun observable.** A verdict arriving past the window is still not delivered — acting
+  on it is what the bound exists to prevent — but it used to return the same `false` as a request
+  nobody ever armed, so a failing run showed `VERDICT_TIMEOUT` with zero late-terminal records and
+  "never produced" was indistinguishable from "produced, too late". Those are two different
+  investigations. The registry now logs `VERDICT_EXPIRED` with how late it was, and counts it.
+
 ## Where else to look
 
 The same shape appears wherever a wait wraps a wait. When you write a bound, ask what *else* bounds

--- a/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WriteVerdictTotality.md
@@ -130,6 +130,68 @@ flush started in `onNext` is still in flight, and a bare completion arm would NA
 about to succeed. Which verdict each path posts, and why the code is `OwnerDisposing`, is in
 [Reading a Write Verdict](../ReadingAWriteVerdict).
 
+## The FOURTH outcome — never emits, never completes
+
+The three terminations above are the ones Rx *delivers*. There is a fourth outcome, and it delivers
+nothing at all: **a source that neither emits nor completes**. `WhenCompletesEmpty` cannot see it —
+there is no completion to observe — and neither can an `onError` arm. It is settled as silence by
+every guard on this page.
+
+It is not hypothetical. A stream's `Store` is a `ReplaySubject`, so one that has never published and
+is never disposed hands `Take(1)` nothing, for the life of the process. Two owner-side legs had it,
+in different shapes (#3194, #3195):
+
+| Leg | What it had | What was missing |
+|---|---|---|
+| The generic patch path's initial base read | `Take(1)` + empty-completion arm | **No bound anywhere.** The only other bounded watcher on that path is armed *inside* the `onNext` arm, so a stream that never emits never arms it |
+| The cold-activation defer | a 10 s bound | **No completion arm.** A completing primary store passes `Take(1)` and *cancels the Timeout* — a terminal disposes the timer — so neither arm runs |
+
+Both now compose through one seam, `DataExtensions.ArmedOneShotRead`:
+
+```csharp
+source                      // already filtered by the caller
+    .Take(1)
+    .Timeout(bound, scheduler)
+    .WhenCompletesEmpty(onEmptyCompletion);
+```
+
+Four outcomes, four terminals. And the seam exists rather than three hand-written chains for a
+second reason: **the bound sits below the caller's filter.** A `Timeout` placed *above* an operator
+that drops emissions is re-armed by every dropped one, so on a busy stream it can never fire — a
+bound that is present, reviewed, and unreachable, which is exactly what
+[Bounds must be ordered](../BoundsMustBeOrdered) is about. Handing the seam an already-filtered
+source makes that order structural instead of remembered.
+
+Expiry is not a lost write. On both legs the merge provably never ran, so the verdict is the
+auto-retried `OwnerNotReady` / `OwnerDisposing` rather than the caller's 31 s `OwnerUnreachable` —
+see [Reading a Write Verdict](../ReadingAWriteVerdict).
+
+## A verdict also needs a route that is CHECKED
+
+Totality is about producing a verdict. It is not finished until one has been *delivered*, and the
+two ack gates produced theirs and then discarded it (#3196):
+
+```csharp
+if (Interlocked.Exchange(ref ackPosted, 1) != 0) return;   // gate claimed HERE
+…
+hub.Post(resp, o => o.ResponseFor(request));               // result DISCARDED
+```
+
+Claiming first is right — two racing legs must not both answer. But claiming is *also* what disables
+the fallback: `RegisterOwnerDisposingNack`'s `tryClaimAck()` now returns false, so its
+`ILatePatchVerdictSink` dispatch — the one route that still reaches an armed waiter with no message
+routed at all — is skipped. And the post can be refused: with the owner past `DisposeHostedHubs` and
+its parent past it too, `MessageService.PostImplGeneric` stamps `POST_REFUSED_SHUTTING_DOWN` and
+returns a `Failed` delivery, its own comment noting that *"This site does NOT answer the sender
+itself"*. The verdict was thrown away and the door shut behind it.
+
+**Claim, then VERIFY.** The gate still latches first; the verdict now falls through to the sink when
+the transport refuses it. The post stays first here, unlike in the disposal NACK — this runs on the
+live path, where the caller's `Observe` callback is armed and the message *is* the designed seam.
+Missing both routes is then a checked fact (nobody in this mesh is armed, and the transport is gone)
+and is logged rather than swallowed, because the remaining case — a caller in another process — is
+one the registry cannot see.
+
 ## What this is NOT
 
 **It is not a timeout, a retry, or a watchdog.** No bound moves; nothing is re-attempted; no poller is

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-save-the-owner-already-judged-no-longer-times-out.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-save-the-owner-already-judged-no-longer-times-out.md
@@ -1,0 +1,39 @@
+---
+Name: A save the owner already judged no longer times out
+Category: Fix
+Description: Three ways a save could wait out its full half-minute and then report the owner unreachable — when the owner had accepted it, was still holding it, or had already decided. Each one now answers.
+Icon: ClipboardCheckmark
+Order: -20260903
+---
+
+# A save the owner already judged no longer times out
+
+When you save something, the node that owns it decides what happened and tells your session. That
+answer is what turns the spinner into a saved state, releases the next queued edit, and lets a retry
+know whether it is safe. If it never arrives, your session waits out its full confirmation window —
+about half a minute — and then reports that the owner could not be reached.
+
+Three separate paths could produce exactly that, and in each of them **the owner had not gone
+anywhere**.
+
+**It was still waiting for its own data.** One of the two save paths began by reading the node's
+current state and had no time limit on that read at all. If the source never produced anything —
+which can happen to an activation that has not finished loading — the save sat there indefinitely.
+It now gives up after ten seconds and says so, and because nothing was written in that time the
+answer is the retryable "the owner has not loaded yet" rather than "unreachable".
+
+**It was waiting for an activation that had already gone.** When a save arrives at a node that is
+still warming up, it waits for the load to finish and then applies. That wait was bounded, but if
+the underlying source *ended* instead of producing data, the bound was cancelled along with it and
+that branch fell silent. It now answers "the owner's store ended before it finished loading — the
+save was not applied, safe to retry".
+
+**It had already decided, and the answer was dropped.** During a shutdown, the message carrying the
+verdict can be refused. Nothing checked whether it had been accepted, and the act of sending it
+closed off the one remaining route that still works at that point. The verdict now falls back to
+that route when the message is refused, and if neither route can reach anyone, that is written to
+the log rather than passed over in silence.
+
+None of these changes what a save does or how long a healthy one takes. They change what happens
+when something goes wrong: an answer, promptly, instead of half a minute of silence followed by a
+misleading one.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-save-waiting-on-a-shutdown-no-longer-waits-for-nobody.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-save-waiting-on-a-shutdown-no-longer-waits-for-nobody.md
@@ -1,0 +1,30 @@
+---
+Name: A save waiting on a shutdown no longer waits for nobody
+Category: Fix
+Description: When a node is shutting down, its answer to an in-flight save is deliberately deferred to a later step. Nothing checked that anyone was still listening for it — and if the answer then arrived too late, it was dropped without a trace.
+Icon: ClockAlarm
+Order: -20260903
+---
+
+# A save waiting on a shutdown no longer waits for nobody
+
+When a node is shutting down while one of your saves is still in flight, the answer is deliberately
+held back and sent from a later step in the shutdown instead. There is a good reason: that later
+route still reaches your session, and an answer sent from the earlier one might not.
+
+But nothing checked whether your session was still listening. If it was not — because it had already
+been answered, because the wait had run out, or because the save came from a different process
+entirely — the answer was held back for a route that would deliver it to nobody, and your save was
+left with silence until its own window ran out. **The hold-back now happens only when there is
+somewhere for the answer to go.** Otherwise the node answers immediately, on whatever route is still
+open.
+
+There was a second, quieter problem behind it. An answer that arrives after the window closes is not
+delivered — past that point it cannot be told apart from a stale repeat of an older one, and acting
+on it would be worse than ignoring it. That part is unchanged and deliberate. What has changed is
+that it used to be **completely silent**, and indistinguishable from an answer that was never
+produced at all. Those are two different problems with two different causes, and the logs showed the
+same nothing for both. A late answer is now recorded, with how late it was.
+
+Nothing waits longer as a result — no window was widened. A save that could be answered is answered
+sooner, and when one genuinely cannot be, the reason is now written down instead of inferred.

--- a/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
+++ b/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using MeshWeaver.Data;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Mesh;
 
@@ -54,12 +55,31 @@ namespace MeshWeaver.Mesh;
 public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
 {
     /// <summary>
-    /// 🚨 How long after the patch post a late owner response is still acted upon. This is
-    /// PROTOCOL, not tuning: it must dominate every owner-side terminal path — the disposal
-    /// NACK after the owner's phased teardown (hosted-hub drain capped at 5 s), the
-    /// cold-store-defer NotFound (up to ~10 s after reactivation), and the owner ack watcher's
-    /// own 20 s bound. A response beyond this window is indistinguishable from a re-delivered
-    /// stale verdict and is ignored.
+    /// 🚨 How long after the patch post a late owner response is still acted upon. A response
+    /// beyond this window is indistinguishable from a re-delivered stale verdict and is ignored.
+    ///
+    /// <para>🚨 <b>What this window actually dominates, and what it does not (#3197).</b> It was
+    /// justified as PROTOCOL — a bound chosen to exceed every owner-side terminal path, enumerated
+    /// as the disposal NACK after a teardown whose hosted-hub drain was "capped at 5 s", the
+    /// cold-store-defer (~10 s), and the ack watcher's 20 s. <b>That cap no longer exists</b>:
+    /// <c>HostedHubsCollection.DisposeHubsReactive</c> deliberately dropped its flat
+    /// <c>Timeout(5s)</c> in #1317, and the only backstop left over that phase is the disposal
+    /// WATCHDOG — a STALL detector, re-armed on every <c>RunLevel</c> transition anywhere in the
+    /// subtree, so a large subtree that keeps making progress never trips it. The drain therefore
+    /// has no duration bound, and this window cannot be said to dominate it.</para>
+    ///
+    /// <para>Two further corrections to the old claim. The owner-side paths were enumerated as
+    /// ALTERNATIVES, taking their maximum (20 s); in <c>ApplyMeshNodePatchInTurn</c> they compose
+    /// ADDITIVELY — cold-store defer (10 s) → identity-gated echo (20 s) → durable flush (10 s).
+    /// And the two clocks differ: the owner's starts at HANDLER ENTRY, the caller's at POST, with
+    /// unbounded routing/queue latency between them (measured at 33–49 s during a bake, #2543).</para>
+    ///
+    /// <para>So the honest statement is the operational one: this is the window in which a verdict
+    /// is still useful to a caller, not a number proven to exceed every path that can produce one.
+    /// What the code now guarantees instead is that the gap is VISIBLE — the ack watcher stands
+    /// aside for the disposal NACK only while <see cref="IsAdmissible"/> says a route is armed, and
+    /// a verdict that arrives past this window is REPORTED rather than dropped in silence, so
+    /// "nothing was ever produced" and "something arrived too late" stop looking identical.</para>
     ///
     /// <para>🚨 Since #2661 this is ALSO the caller's outer verdict bound: <c>UpdateRemote</c> no
     /// longer completes a write on the bounded-wait expiry, so this window is how long a caller
@@ -108,6 +128,29 @@ public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
     // RequestId property).
     private readonly ConcurrentDictionary<string, Entry> entries = new();
 
+    private readonly ILogger<LatePatchResponseRegistry>? logger;
+
+    /// <summary>
+    /// The clock every expiry decision reads. Injectable so the window can be crossed in a test
+    /// WITHOUT waiting it out — a 30 s sleep is not a test, and a test-only "expire everything"
+    /// method on production code is a backdoor. <see cref="TimeProvider.System"/> in every real
+    /// mesh.
+    /// </summary>
+    private readonly TimeProvider clock;
+
+    /// <summary>
+    /// Creates the registry. Both dependencies are OPTIONAL so a bare fixture — one with no logging
+    /// registered — can still construct it; the logger carries only the VERDICT_EXPIRED report,
+    /// which must never be the reason a mesh fails to start.
+    /// </summary>
+    public LatePatchResponseRegistry(
+        ILogger<LatePatchResponseRegistry>? logger = null,
+        TimeProvider? clock = null)
+    {
+        this.logger = logger;
+        this.clock = clock ?? TimeProvider.System;
+    }
+
     /// <summary>
     /// Arms the late watch for the patch posted as <paramref name="requestId"/>. Registered
     /// BEFORE the post so no response can slip between the caller's bounded wait dying and the
@@ -128,7 +171,7 @@ public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
         Action<PatchDataResponse> onLateResponse,
         Action<DeliveryFailure> onLateFailure)
     {
-        var now = DateTimeOffset.UtcNow;
+        var now = clock.GetUtcNow();
         foreach (var kv in entries)
         {
             if (kv.Value.ExpiresAt < now)
@@ -171,7 +214,7 @@ public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
     {
         if (!entries.TryRemove(requestId, out var entry))
             return false;
-        if (entry.ExpiresAt < DateTimeOffset.UtcNow)
+        if (ReportIfExpired(requestId, entry, "PatchDataResponse"))
             return false;
         entry.OnLateResponse(response);
         return true;
@@ -191,11 +234,55 @@ public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
     {
         if (!entries.TryRemove(requestId, out var entry))
             return false;
-        if (entry.ExpiresAt < DateTimeOffset.UtcNow)
+        if (ReportIfExpired(requestId, entry, nameof(DeliveryFailure)))
             return false;
         entry.OnLateFailure(failure);
         return true;
     }
+
+    /// <summary>
+    /// 🚨 An EXPIRED verdict is a fact, not silence (#3197). The registry used to remove the entry,
+    /// see it was past <see cref="LateResponseWatchBound"/> and return <c>false</c> — the same
+    /// answer it gives for a request nobody ever armed. So a failing run showed
+    /// <c>VERDICT_TIMEOUT</c> with ZERO late-terminal records, and there was no way to tell "the
+    /// owner never produced a verdict" from "the owner produced one and it arrived too late" —
+    /// two different investigations, one indistinguishable symptom (measured, #2543).
+    ///
+    /// <para>The verdict is still NOT delivered: past the window it is indistinguishable from a
+    /// re-delivered stale one, and acting on it is the bug this bound exists to prevent. It is
+    /// reported, and counted, so the next reader can see which case they are in.</para>
+    /// </summary>
+    /// <returns>True when the entry had expired — the caller must not deliver it.</returns>
+    private bool ReportIfExpired(string requestId, Entry entry, string verdictKind)
+    {
+        var now = clock.GetUtcNow();
+        if (entry.ExpiresAt >= now)
+            return false;
+
+        System.Threading.Interlocked.Increment(ref expiredVerdicts);
+        logger?.LogWarning(
+            "[LateWatch] VERDICT_EXPIRED path={Path} request={RequestId} kind={VerdictKind} "
+            + "late_by={LateBy}ms window={Window}s — the owner DID answer; it arrived past the late "
+            + "watch window and was not delivered. This is not 'no verdict was produced': the "
+            + "caller's OwnerUnreachable for this write is a reporting artefact of the delay, not "
+            + "evidence that the owner stayed silent.",
+            entry.Path, requestId, verdictKind,
+            (long)(now - entry.ExpiresAt).TotalMilliseconds,
+            (long)LateResponseWatchBound.TotalSeconds);
+        return true;
+    }
+
+    /// <summary>Number of verdicts that arrived past the window and were therefore not delivered —
+    /// the counterpart of the log line, for tests and for a health surface that wants the rate
+    /// rather than the individual lines.</summary>
+    public int ExpiredVerdicts => System.Threading.Volatile.Read(ref expiredVerdicts);
+
+    private int expiredVerdicts;
+
+    /// <inheritdoc />
+    public bool IsAdmissible(string requestId)
+        => entries.TryGetValue(requestId, out var entry)
+           && entry.ExpiresAt >= clock.GetUtcNow();
 
     /// <summary>Number of armed watches — test seam.</summary>
     public int ArmedCount => entries.Count;

--- a/test/MeshWeaver.Data.Test/OneShotReadTotalityTest.cs
+++ b/test/MeshWeaver.Data.Test/OneShotReadTotalityTest.cs
@@ -1,0 +1,193 @@
+using System;
+using System.Collections.Generic;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// 🚨 A one-shot owner-side read must reach a terminal on ALL FOUR of Rx's outcomes — issues #3194
+/// and #3195, the successors to #3033 (<see cref="PatchAckTotalityTest"/>).
+///
+/// <para><b>The defect.</b> <c>Subscribe(onNext, onError)</c> covers two outcomes; #3033 added the
+/// third (<c>WhenCompletesEmpty</c>). The fourth — <b>never emits and never completes</b> — was
+/// still settled as silence, and the two live sites had it in different shapes:</para>
+/// <list type="bullet">
+///   <item><b>#3194</b>, the generic patch path's initial base read: NO bound at all, anywhere
+///     between the stream and the <c>Subscribe</c>. The only other bounded watcher on that path is
+///     armed INSIDE the <c>onNext</c> arm, so a stream that never emits never arms it. A stream's
+///     <c>Store</c> is a <c>ReplaySubject</c>, so one that has never published and is never disposed
+///     hands <c>Take(1)</c> nothing forever — and the handler had already returned
+///     <c>Processed()</c>, so the caller burned its full 31 s bound and reported
+///     <c>OwnerUnreachable</c> for a request the owner was still holding.</item>
+///   <item><b>#3195</b>, the cold-activation defer: a bound, but only two arms. A COMPLETING primary
+///     store passes <c>Take(1)</c> and <b>cancels the Timeout</b> — a terminal notification disposes
+///     the timer — so neither arm runs and the leg produces no verdict at all.</item>
+/// </list>
+///
+/// <para><b>What is pinned.</b> <c>DataExtensions.ArmedOneShotRead</c> is a PURE composition over
+/// <see cref="IObservable{T}"/>, so all four outcomes are driven on a <see cref="TestScheduler"/>
+/// with no mesh and no wall clock. Two properties beyond the four: the empty arm must NOT fire after
+/// an emission (a bare completion arm NACKs every successful write — the #3033 twist), and the bound
+/// must sit BELOW the caller's filter, because a <c>Timeout</c> over a stream whose emissions are
+/// later dropped is re-armed by every dropped one and can never fire. That last one is #3193's
+/// unreachable bound, and it is the reason this is a seam rather than three hand-written chains.</para>
+/// </summary>
+public class OneShotReadTotalityTest
+{
+    private static readonly TimeSpan Bound = TimeSpan.FromSeconds(10);
+
+    /// <summary>Outcome 1 — it emits. The value passes through and NOTHING else fires.</summary>
+    [Fact]
+    public void Emission_PassesThrough_AndTheEmptyArmStaysSilent()
+    {
+        var scheduler = new TestScheduler();
+        var source = new Subject<int>();
+        var values = new List<int>();
+        var errors = new List<Exception>();
+        var emptyArms = 0;
+
+        using var sub = source
+            .ArmedOneShotRead(Bound, () => emptyArms++, scheduler)
+            .Subscribe(values.Add, errors.Add);
+
+        source.OnNext(7);
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(60).Ticks);
+
+        values.Should().Equal(7);
+        errors.Should().BeEmpty();
+        // 🚨 The #3033 twist. Take(1) completes the instant it has its value, while the work started
+        // in onNext is still in flight — a bare completion arm here NACKs every successful write.
+        emptyArms.Should().Be(0, "an emission preceded the completion");
+    }
+
+    /// <summary>Outcome 2 — it errors. The error passes through; the empty arm stays silent.</summary>
+    [Fact]
+    public void Error_PassesThrough_AndTheEmptyArmStaysSilent()
+    {
+        var scheduler = new TestScheduler();
+        var source = new Subject<int>();
+        var errors = new List<Exception>();
+        var emptyArms = 0;
+
+        using var sub = source
+            .ArmedOneShotRead(Bound, () => emptyArms++, scheduler)
+            .Subscribe(_ => { }, errors.Add);
+
+        source.OnError(new InvalidOperationException("boom"));
+
+        errors.Should().HaveCount(1);
+        errors[0].Should().BeOfType<InvalidOperationException>();
+        emptyArms.Should().Be(0);
+    }
+
+    /// <summary>
+    /// Outcome 3 — it completes without ever emitting. THE #3195 REGRESSION: the completion passes
+    /// <c>Take(1)</c> and cancels the bound, so before the fix neither arm ran and the leg produced
+    /// no verdict at all.
+    /// </summary>
+    [Fact]
+    public void EmptyCompletion_RunsTheArm_EvenThoughItCancelsTheBound()
+    {
+        var scheduler = new TestScheduler();
+        var source = new Subject<int>();
+        var errors = new List<Exception>();
+        var emptyArms = 0;
+
+        using var sub = source
+            .ArmedOneShotRead(Bound, () => emptyArms++, scheduler)
+            .Subscribe(_ => { }, errors.Add);
+
+        source.OnCompleted();
+
+        emptyArms.Should().Be(1, "the source ended without ever carrying a value");
+        errors.Should().BeEmpty("a completion is not a fault");
+
+        // The completion really did cancel the timer: nothing more arrives afterwards.
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(60).Ticks);
+        emptyArms.Should().Be(1);
+        errors.Should().BeEmpty();
+    }
+
+    /// <summary>
+    /// Outcome 4 — THE #3194 REGRESSION: it neither emits nor completes. Before the fix the generic
+    /// path had no bound at all here, so this parked forever and the caller burned its 31 s window.
+    /// </summary>
+    [Fact]
+    public void NeitherEmitsNorCompletes_FaultsAtTheBound()
+    {
+        var scheduler = new TestScheduler();
+        var errors = new List<Exception>();
+        var emptyArms = 0;
+
+        // Observable.Never IS a ReplaySubject that has never published and is never disposed.
+        using var sub = Observable.Never<int>()
+            .ArmedOneShotRead(Bound, () => emptyArms++, scheduler)
+            .Subscribe(_ => { }, errors.Add);
+
+        scheduler.AdvanceBy(Bound.Ticks - 1);
+        errors.Should().BeEmpty("the bound has not elapsed yet");
+
+        scheduler.AdvanceBy(2);
+
+        errors.Should().HaveCount(1);
+        errors[0].Should().BeOfType<TimeoutException>();
+        emptyArms.Should().Be(0, "a timeout is not an empty completion — the two verdicts differ");
+    }
+
+    /// <summary>
+    /// 🚨 #3193's lesson, made structural. The bound sits BELOW the caller's filter, so emissions the
+    /// filter DROPS do not re-arm it — a busy stream whose interesting emission never comes still
+    /// faults on time. Placing the Timeout above the filter is what made that bound unreachable.
+    /// </summary>
+    [Fact]
+    public void DroppedEmissions_DoNotReArmTheBound()
+    {
+        var scheduler = new TestScheduler();
+        var source = new Subject<int>();
+        var errors = new List<Exception>();
+
+        using var sub = source
+            .Where(i => i > 100)                       // nothing the source sends will pass
+            .ArmedOneShotRead(Bound, () => { }, scheduler)
+            .Subscribe(_ => { }, errors.Add);
+
+        // Churn all the way to the edge of the bound; every one of these is dropped by the filter.
+        for (var i = 0; i < 9; i++)
+        {
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+            source.OnNext(i);
+        }
+        errors.Should().BeEmpty("9s of churn, bound is 10s");
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(1).Ticks + 1);
+
+        errors.Should().HaveCount(1, "a dropped emission must not extend the wait");
+        errors[0].Should().BeOfType<TimeoutException>();
+    }
+
+    /// <summary>Control arm: the identical stream WITH a passing emission does not fault — so the
+    /// test above cannot be green merely because the composition always times out.</summary>
+    [Fact]
+    public void APassingEmission_SatisfiesTheSameChain()
+    {
+        var scheduler = new TestScheduler();
+        var source = new Subject<int>();
+        var values = new List<int>();
+        var errors = new List<Exception>();
+
+        using var sub = source
+            .Where(i => i > 100)
+            .ArmedOneShotRead(Bound, () => { }, scheduler)
+            .Subscribe(values.Add, errors.Add);
+
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(9).Ticks);
+        source.OnNext(101);
+        scheduler.AdvanceBy(TimeSpan.FromSeconds(60).Ticks);
+
+        values.Should().Equal(101);
+        errors.Should().BeEmpty();
+    }
+}

--- a/test/MeshWeaver.Data.Test/PatchVerdictRoutingTest.cs
+++ b/test/MeshWeaver.Data.Test/PatchVerdictRoutingTest.cs
@@ -1,0 +1,117 @@
+using System;
+using System.Collections.Generic;
+using MeshWeaver.Data;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Data.Test;
+
+/// <summary>
+/// 🚨 An owner-side patch verdict must reach a route that is CHECKED, not assumed — issue #3196.
+///
+/// <para><b>The defect.</b> Both ack gates latch their once-only <c>ackPosted</c> flag and then
+/// <c>hub.Post(...)</c>, discarding the delivery. Latching first is correct — two racing legs must
+/// not both answer — but it is also what disables the fallback: once the gate is claimed,
+/// <c>RegisterOwnerDisposingNack</c>'s <c>tryClaimAck()</c> returns false and its
+/// <c>ILatePatchVerdictSink</c> dispatch is skipped. So when the post is REFUSED — owner past
+/// <c>DisposeHostedHubs</c> with a parent past it too, where <c>MessageService.PostImplGeneric</c>
+/// stamps <c>POST_REFUSED_SHUTTING_DOWN</c> and returns a <see cref="MessageDeliveryState.Failed"/>
+/// delivery whose own comment reads "This site does NOT answer the sender itself" — the verdict was
+/// thrown away AND the door was shut behind it. The caller then burned its full 31 s
+/// <c>WriteVerdictBound</c> and reported <c>OwnerUnreachable</c> for a write the owner had already
+/// judged.</para>
+///
+/// <para><b>What is pinned.</b> <c>DataExtensions.RoutePatchVerdict</c> is a pure composition over
+/// two delegates, so the decision is driven with no hub at all — the house rule is that
+/// <see cref="IMessageHub"/> is never mocked, and here it does not need to be.</para>
+/// </summary>
+public class PatchVerdictRoutingTest
+{
+    private const string RequestId = "req-1";
+
+    private static readonly PatchDataResponse Verdict = new(false, 7L) { Error = "nope" };
+
+    /// <summary>A delivery in whatever state the post is being made to answer with.</summary>
+    private static IMessageDelivery Delivered(MessageDeliveryState state)
+    {
+        var delivery = (IMessageDelivery)new MessageDelivery<PatchDataResponse>();
+        return state == MessageDeliveryState.Failed
+            ? delivery.Failed("Hub is shutting down", ErrorType.ShuttingDown)
+            : delivery;
+    }
+
+    /// <summary>The ordinary path: the post is accepted, so the sink is never consulted at all.</summary>
+    [Fact]
+    public void AnAcceptedPost_SettlesTheVerdict_WithoutTouchingTheSink()
+    {
+        var sinkCalls = new List<string>();
+
+        var routed = DataExtensions.RoutePatchVerdict(
+            Verdict, RequestId,
+            _ => Delivered(MessageDeliveryState.Submitted),
+            (id, _) => { sinkCalls.Add(id); return true; });
+
+        routed.Should().BeTrue();
+        // 🚨 The live path must keep posting: the caller's Observe callback is armed and the message
+        // IS the designed seam. Sending every ordinary ack to the late-verdict registry instead
+        // would change the transport for writes that are working.
+        sinkCalls.Should().BeEmpty("an accepted post needs no fallback");
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. The post is refused during teardown. Before the fix the verdict was
+    /// discarded here and the gate stayed claimed, so nothing else could answer either.
+    /// </summary>
+    [Fact]
+    public void ARefusedPost_FallsThroughToTheSink()
+    {
+        var dispatched = new List<(string Id, PatchDataResponse Response)>();
+
+        var routed = DataExtensions.RoutePatchVerdict(
+            Verdict, RequestId,
+            _ => Delivered(MessageDeliveryState.Failed),
+            (id, resp) => { dispatched.Add((id, resp)); return true; });
+
+        routed.Should().BeTrue("the sink found an armed caller");
+        dispatched.Should().HaveCount(1);
+        dispatched[0].Id.Should().Be(RequestId, "the sink is keyed on the request's delivery id");
+        dispatched[0].Response.Should().BeSameAs(Verdict, "the verdict is delivered, not re-minted");
+    }
+
+    /// <summary>A post that returns NOTHING is a refusal too — <c>Post</c> is nullable.</summary>
+    [Fact]
+    public void ANullDelivery_FallsThroughToTheSink()
+    {
+        var dispatched = 0;
+
+        var routed = DataExtensions.RoutePatchVerdict(
+            Verdict, RequestId, _ => null, (_, _) => { dispatched++; return true; });
+
+        routed.Should().BeTrue();
+        dispatched.Should().Be(1);
+    }
+
+    /// <summary>
+    /// Both routes miss: refused post, nobody armed in this mesh. That is a CHECKED fact — the
+    /// caller is in another process, or is not waiting — and it is reported as such rather than
+    /// assumed, which is what lets the call site log it instead of swallowing it.
+    /// </summary>
+    [Fact]
+    public void RefusedPost_WithNobodyArmed_ReportsThatNoRouteTookIt()
+    {
+        DataExtensions.RoutePatchVerdict(
+                Verdict, RequestId,
+                _ => Delivered(MessageDeliveryState.Failed),
+                (_, _) => false)
+            .Should().BeFalse();
+    }
+
+    /// <summary>No sink registered at all (a minimal fixture) degrades the same way — no throw.</summary>
+    [Fact]
+    public void RefusedPost_WithNoSinkRegistered_ReportsThatNoRouteTookIt()
+    {
+        DataExtensions.RoutePatchVerdict(
+                Verdict, RequestId, _ => Delivered(MessageDeliveryState.Failed), null)
+            .Should().BeFalse();
+    }
+}

--- a/test/MeshWeaver.Graph.Test/LateVerdictAdmissibilityTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateVerdictAdmissibilityTest.cs
@@ -1,0 +1,145 @@
+using System;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 The late-verdict watch must answer two questions the owner side used to ASSUME — issue #3197.
+///
+/// <para><b>The assumption.</b> The owner's ack watcher deliberately posts NOTHING when the owner is
+/// shutting down, deferring the verdict to the ShutDown-phase disposal NACK. Its justification —
+/// and the justification for <c>LateResponseWatchBound</c> itself — enumerated the owner-side paths
+/// this window has to dominate, including "the disposal NACK after the owner's phased teardown
+/// (hosted-hub drain capped at 5 s)". <b>That cap was deleted in #1317</b>:
+/// <c>HostedHubsCollection.DisposeHubsReactive</c> carries no <c>Timeout</c>, and the disposal
+/// watchdog that remains is a STALL detector re-armed on every <c>RunLevel</c> transition in the
+/// subtree, so a subtree making steady progress never trips it. The stand-aside was therefore
+/// waiting on a route with no duration bound, and could not check that the route existed at all.</para>
+///
+/// <para><b>And the drop was silent.</b> <c>Dispatch</c> removed the entry, saw it was expired, and
+/// returned <c>false</c> — the identical answer it gives for a request nobody ever armed. So a
+/// failing run showed <c>VERDICT_TIMEOUT</c> with ZERO late-terminal records, and "the owner never
+/// produced a verdict" and "the owner produced one that arrived too late" were indistinguishable
+/// (measured, #2543). Two different investigations, one symptom.</para>
+///
+/// <para>These pins are over the registry alone — plain dictionary state, no mesh, no hub.</para>
+/// </summary>
+public class LateVerdictAdmissibilityTest
+{
+    private const string RequestId = "patch-1";
+    private const string Path = "acme/Doc";
+
+    /// <summary>
+    /// A clock the test moves by hand. The window is 30 s and no test waits it out — expiry is
+    /// reached by advancing this, never by a sleep.
+    /// </summary>
+    private sealed class TestClock : TimeProvider
+    {
+        private DateTimeOffset now = DateTimeOffset.UnixEpoch;
+        public override DateTimeOffset GetUtcNow() => now;
+        public void Advance(TimeSpan by) => now += by;
+    }
+
+    /// <summary>An armed, unexpired watch is admissible — so standing aside for it is justified.</summary>
+    [Fact]
+    public void AnArmedWatch_IsAdmissible()
+    {
+        var registry = new LatePatchResponseRegistry();
+        registry.Register(RequestId, Path, _ => { }, _ => { });
+
+        registry.IsAdmissible(RequestId).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 🚨 Nobody armed: standing aside would convert an answerable write into silence, so the
+    /// predicate says no and the ack watcher answers on whatever transport is still open. This is
+    /// the cross-process caller, and the no-sink fixture.
+    /// </summary>
+    [Fact]
+    public void AnUnarmedRequest_IsNotAdmissible()
+        => new LatePatchResponseRegistry().IsAdmissible(RequestId).Should().BeFalse();
+
+    /// <summary>
+    /// A watch the caller's own bounded wait already settled is not admissible either — its
+    /// verdict has been delivered, and there is nothing left to defer to.
+    /// </summary>
+    [Fact]
+    public void ACompletedWatch_IsNotAdmissible()
+    {
+        var registry = new LatePatchResponseRegistry();
+        registry.Register(RequestId, Path, _ => { }, _ => { });
+        registry.Complete(RequestId);
+
+        registry.IsAdmissible(RequestId).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. A verdict past the window is still NOT delivered — acting on it is the bug
+    /// the bound exists to prevent — but it is now COUNTED, so "arrived too late" stops looking
+    /// exactly like "never produced".
+    /// </summary>
+    [Fact]
+    public void AnExpiredVerdict_IsNotDelivered_ButIsCounted()
+    {
+        var clock = new TestClock();
+        var registry = new LatePatchResponseRegistry(clock: clock);
+        var delivered = 0;
+        registry.Register(RequestId, Path, _ => delivered++, _ => { });
+        clock.Advance(LatePatchResponseRegistry.LateResponseWatchBound + TimeSpan.FromSeconds(1));
+
+        var dispatched = registry.Dispatch(RequestId, new PatchDataResponse(false, 1L));
+
+        dispatched.Should().BeFalse("a verdict past the window is indistinguishable from a stale one");
+        delivered.Should().Be(0, "and must not reach the caller");
+        registry.ExpiredVerdicts.Should().Be(1, "but it must not vanish without a trace either");
+    }
+
+    /// <summary>The #2661 failure seam carries the identical rule.</summary>
+    [Fact]
+    public void AnExpiredFailure_IsNotDelivered_ButIsCounted()
+    {
+        var clock = new TestClock();
+        var registry = new LatePatchResponseRegistry(clock: clock);
+        var delivered = 0;
+        registry.Register(RequestId, Path, _ => { }, _ => delivered++);
+        clock.Advance(LatePatchResponseRegistry.LateResponseWatchBound + TimeSpan.FromSeconds(1));
+
+        registry.DispatchFailure(RequestId, new DeliveryFailure(null!)).Should().BeFalse();
+        delivered.Should().Be(0);
+        registry.ExpiredVerdicts.Should().Be(1);
+    }
+
+    /// <summary>
+    /// 🚨 The control arm, and the discriminator the counter exists for: a request NOBODY armed is
+    /// also `false` from Dispatch — and must NOT be counted as expired, or the two cases collapse
+    /// again in the other direction.
+    /// </summary>
+    [Fact]
+    public void AnUnarmedRequest_IsNotCountedAsExpired()
+    {
+        var registry = new LatePatchResponseRegistry();
+
+        registry.Dispatch(RequestId, new PatchDataResponse(false, 1L)).Should().BeFalse();
+
+        registry.ExpiredVerdicts.Should().Be(0,
+            "nothing was produced late here — nothing was produced at all");
+    }
+
+    /// <summary>Control arm: an unexpired verdict is delivered and is never counted as expired, so
+    /// the assertions above cannot be green because dispatch stopped working.</summary>
+    [Fact]
+    public void AnInTimeVerdict_IsDelivered_AndNotCounted()
+    {
+        var registry = new LatePatchResponseRegistry();
+        var delivered = 0;
+        registry.Register(RequestId, Path, _ => delivered++, _ => { });
+
+        registry.Dispatch(RequestId, new PatchDataResponse(true, 1L)).Should().BeTrue();
+        delivered.Should().Be(1);
+        registry.ExpiredVerdicts.Should().Be(0);
+    }
+
+}


### PR DESCRIPTION
Closes #3194. Closes #3195. Closes #3196. Closes #3197.

> **This PR absorbed #3205.** It was opened stacked on this branch; `auto-arm` arms every non-draft PR and a feature branch carries no required checks, so it merged into this branch immediately. Nothing reached `main` untested — this PR's own gate now covers both change sets, which is the outcome stacking was for. The #3197 half is the second commit.


Three legs of the cross-hub patch pipeline could answer the caller with **nothing at all** — each one leaving the writer to burn its full 31 s `WriteVerdictBound` and report `OwnerUnreachable` for an owner that had accepted the request, was still holding it, or had already judged it. All three verified against `main` before changing anything.

## #3194 — the generic path's base read had no bound at all

`Subscribe(onNext, onError)` covers two of Rx's outcomes; #3033 added the third. The fourth — **never emits and never completes** — had nothing. A stream's `Store` is a `ReplaySubject`, so one that has never published and is never disposed hands `Take(1)` nothing forever; and `postSub`, the path's only other bounded watcher, is armed **inside** the `onNext` arm, so on that stream it is never armed.

## #3195 — the cold-activation defer had a bound it could not reach

Two arms for three terminations. A **completing** primary store passes `Take(1)` and **cancels the `Timeout`** — a terminal notification disposes the timer — so neither arm runs and the leg produces no verdict. `RequireBaseState`'s own remarks list three producers of that shape, so it is documented, not hypothetical.

## Both now compose through one seam

```csharp
internal static IObservable<T> ArmedOneShotRead<T>(
    this IObservable<T> source, TimeSpan bound, Action onEmptyCompletion, IScheduler? scheduler = null)
    => source.Take(1).Timeout(bound, scheduler ?? Scheduler.Default).WhenCompletesEmpty(onEmptyCompletion);
```

Four outcomes, four terminals. **A seam rather than two hand-written chains for a second reason:** the bound sits *below* the caller's filter. A `Timeout` above an operator that drops emissions is re-armed by every dropped one — present, reviewed, and unreachable, which is #3193 exactly. Handing the seam an already-filtered source makes that order structural instead of remembered.

Expiry is not a lost write on either leg: the merge provably never ran, so the verdict is the auto-retried `OwnerNotReady` / `OwnerDisposing`, not `OwnerUnreachable`.

## #3196 — the verdict was produced, then thrown away

Both ack gates latched `ackPosted` and then discarded `hub.Post`'s result. Latching first is correct — two racing legs must not both answer — but it is **also what disables the fallback**: `RegisterOwnerDisposingNack`'s `tryClaimAck()` then returns false, so its `ILatePatchVerdictSink` dispatch (the one route that reaches an armed waiter with no message routed at all) is skipped. With the owner past `DisposeHostedHubs` and its parent past it too, `PostImplGeneric` stamps `POST_REFUSED_SHUTTING_DOWN` and returns a `Failed` delivery whose own comment reads *"This site does NOT answer the sender itself"*. The verdict was gone and the door was shut behind it.

Now **claim-then-verify**. The post stays first — unlike in the disposal NACK, this runs on the live path where the caller's `Observe` callback is armed and the message *is* the designed seam; routing every ordinary ack to the late-verdict registry would change the transport for writes that work. A refusal falls through to the sink; missing both routes is a checked fact and is logged, since the remaining case (a caller in another process) is one the registry cannot see.

## Verification

Both seams are **pure compositions**, so the pins need no mesh and no wall clock — and `IMessageHub` is not mocked, per the house rule; `RoutePatchVerdict` takes the post and the dispatch as delegates.

- `OneShotReadTotalityTest` — all four Rx outcomes on a `TestScheduler`, plus the #3033 twist (the empty arm must **not** fire after an emission) and the dropped-emission ordering property, with a control arm proving the chain does not simply always time out.
- `PatchVerdictRoutingTest` — accepted post (sink untouched), refused post, null delivery, both-routes-miss, and no-sink-registered.
- **The pins discriminate** — measured, not assumed: neutering `ArmedOneShotRead` to the old `Take(1)` reds exactly the three regression cases (`3 Failed, 3 Passed`) and leaves the pass-through and control cases green. Restored and re-verified green afterwards.
- `MeshWeaver.Data.Test` in full: **459 passed, 0 failed**.
- `-c Release -warnaserror`: `MeshWeaver.Data`, `MeshWeaver.Data.Test`, `MeshWeaver.Graph`, `MeshWeaver.Mesh.Contract`, `MeshWeaver.Documentation.Test` — `0 Warning(s), 0 Error(s)` each.
- `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest`: 2 passed, against a `MeshWeaver.Documentation.dll` rebuilt after the doc edits.

`Pairs-with: none` — the diff removes no public type or member (measured: `git diff origin/main -- src/ | grep -E "^-.*\bpublic\b"` is empty). Everything added is `internal` or `private`.

## Docs

`Doc/Architecture/WriteVerdictTotality` gains two sections: **the fourth outcome** (with the table of what each leg had and lacked, and why the seam's operator order is the point) and **a verdict also needs a route that is checked**. What's New entry: `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

# The #3197 half (absorbed from #3205)


`LateResponseWatchBound` (30 s) is stated as **PROTOCOL, not tuning** — chosen to dominate every owner-side terminal path, enumerated as the disposal NACK after a teardown whose *"hosted-hub drain [is] capped at 5 s"*, the cold-store defer (~10 s), and the ack watcher's 20 s.

**That cap does not exist.** `HostedHubsCollection.DisposeHubsReactive` deliberately dropped its flat `Timeout(5s)` in #1317 — its comment says so — and what replaced it is the disposal *watchdog*, a **stall** detector re-armed on every `RunLevel` transition anywhere in the subtree. A large subtree that keeps making progress never trips it, so the drain has no duration bound and the claim's first term is unsupported.

Two further corrections to the same comment, both from the issue:
- the paths were enumerated as **alternatives** taking their max (20 s); on the in-turn path they compose **additively** — cold-store defer → identity-gated echo → durable flush;
- the two **clocks differ** — the owner's starts at handler entry, the caller's at post, with unbounded routing latency between them (measured 33–49 s during a bake, #2543).

Re-establishing the cap would mean reverting a deliberate change, so the claim is rewritten to say what is actually guaranteed — and the two things it used to *assert* are now things the code **checks**.

## The stand-aside now checks its premise

`ArmPatchAckWatcher` posts nothing when the owner is shutting down, deferring to the ShutDown-phase disposal NACK whose transport still reaches the waiter. The premise — *"the NACK is coming, and soon"* — was uncheckable, and with the drain uncapped it was also unbounded.

It now asks `ILatePatchVerdictSink.IsAdmissible(requestId)`. With no sink, or a watch already settled or expired, standing aside converts an answerable write into **silence**, so the watcher answers now on whatever transport is still open.

The predicate answers *"is a route armed now"*, never *"will it still be armed then"* — no implementation can promise the latter, which is exactly why the next section matters. It ships as a **default interface method returning `true`** (the assumption it replaces), so an implementation that cannot answer keeps today's behaviour rather than silently changing it.

## The silent drop is now a fact

`Dispatch` removed the entry, saw it was past the window, and returned `false` — **the identical answer it gives for a request nobody ever armed**. So a failing run showed `VERDICT_TIMEOUT` with zero late-terminal records, and "the owner never produced a verdict" was indistinguishable from "the owner produced one that arrived too late". Two different investigations, one symptom (measured, #2543).

The verdict is still **not delivered** — past the window it cannot be told from a stale repeat, and acting on it is what the bound exists to prevent. It is now logged as `VERDICT_EXPIRED` with how late it was, and counted on `ExpiredVerdicts`.

## Verification

- `LateVerdictAdmissibilityTest` — 7 pins over the registry alone (no mesh, no hub): admissible/unarmed/completed, expired response and expired failure both undelivered-but-counted, plus **two control arms** — an unarmed request must **not** be counted as expired (or the two cases collapse in the other direction), and an in-time verdict is delivered and not counted.
- The registry's **clock is injectable**, so the pins cross a 30 s window without waiting it out — and without a test-only "expire everything" backdoor on production code.
- 🚨 **The two named regression tests the stand-aside was built around pass unchanged**: `LateNackReenqueueTest` and `NackReachesTheWaiterDuringTeardownTest`. In both a caller IS armed, so `IsAdmissible` is true and the deferral still happens — the behaviour changes only where nobody was listening.
- `MeshWeaver.Graph.Test` in full: **1266 passed, 0 failed**.
- `-c Release -warnaserror`: `MeshWeaver.Data.Contract`, `MeshWeaver.Mesh.Contract`, `MeshWeaver.Data`, `MeshWeaver.Hosting`, `MeshWeaver.Graph.Test`, `MeshWeaver.Documentation.Test` — `0 Warning(s), 0 Error(s)` each.
- Doc link + What's New integrity: 2 passed, against a DLL rebuilt after the doc edits.

`Pairs-with: none` — no public type or member is removed (measured: `git diff origin/main -- src/ | grep -E "^-.*\bpublic\b"` is empty). The additions are a default interface method and two **optional** constructor parameters; MeshWeaver.Plugins reaches `LatePatchResponseRegistry` only through `GetRequiredService<T>()` and the static `LateResponseWatchBound`, never `new`, so there is no binary break either. The `Dependent suites (MeshWeaver.Plugins)` job covers the fuller integration versions of both regression tests.

## Docs

`Doc/Architecture/BoundsMustBeOrdered` gains **"A bound's JUSTIFICATION is a claim about other code, and it rots"** — derivation keeps two numbers ordered but does nothing for the sentence explaining why one is big enough, and a comment cannot go red. What's New entry: `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
