### PR TITLE
fix(mesh): the late-verdict bound stops asserting a cap that was deleted, and the stand-aside checks its own premise (#3197)

### DIFF
--- a/src/MeshWeaver.Data.Contract/ILatePatchVerdictSink.cs
+++ b/src/MeshWeaver.Data.Contract/ILatePatchVerdictSink.cs
@@ -39,4 +39,29 @@ public interface ILatePatchVerdictSink
     /// this mesh was waiting — which the caller may then treat as a checked fact rather than a
     /// guess.</returns>
     bool Dispatch(string requestId, PatchDataResponse response);
+
+    /// <summary>
+    /// 🚨 Whether a late verdict for <paramref name="requestId"/> would still be ACTED ON — an
+    /// armed, unexpired watch (#3197).
+    ///
+    /// <para><b>Why a predicate exists at all.</b> The owner's ack watcher deliberately posts
+    /// NOTHING when the owner is shutting down, deferring the verdict to the ShutDown-phase
+    /// disposal NACK, whose transport still reaches the waiter. That deferral rested on an
+    /// assumption — "the disposal NACK is coming, and soon" — which the code could not check and
+    /// which the hosted-hub drain stopped guaranteeing when its flat 5 s cap was removed (#1317).
+    /// Standing aside for a route that will not deliver converts an answerable write into
+    /// silence.</para>
+    ///
+    /// <para>It answers "is a route armed NOW", not "will it still be armed then" — no
+    /// implementation can promise the latter. A stand-aside that clears this check and is
+    /// nevertheless overtaken by expiry is reported by the registry rather than dropped in
+    /// silence, which is the other half of the same issue.</para>
+    ///
+    /// <para>The default is <c>true</c> — the assumption this predicate replaces — so an
+    /// implementation that cannot answer keeps the previous behaviour rather than silently
+    /// changing it.</para>
+    /// </summary>
+    /// <param name="requestId">The originating <c>PatchDataRequest</c> delivery id.</param>
+    /// <returns><c>true</c> when a late verdict would still be delivered.</returns>
+    bool IsAdmissible(string requestId) => true;
 }

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1926,7 +1926,15 @@ public static class DataExtensions
                         AckOnce,
                         d => hub.RegisterForDisposal(d),
                         hubPath,
-                        () => hub.IsShuttingDown,
+                        // 🚨 Stand aside for the disposal NACK only while a route is ARMED to receive it
+                        // (#3197). The deferral used to rest on "the disposal NACK is coming, and soon" — an
+                        // assumption the code could not check, and one the hosted-hub drain stopped
+                        // guaranteeing when its flat 5 s cap was removed in #1317 (the watchdog that replaced
+                        // it is a STALL detector, re-armed on every RunLevel transition in the subtree, so a
+                        // large subtree making steady progress never trips it). With no sink, or with the
+                        // caller's watch already gone, standing aside converts an answerable write into
+                        // silence — so answer now, on whatever transport is still open.
+                        () => hub.IsShuttingDown && lateVerdicts is not null && lateVerdicts.IsAdmissible(request.Id),
                         hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"));
                     hub.RegisterForDisposal(postSub);
 
@@ -2054,7 +2062,15 @@ public static class DataExtensions
             AckOnce,
             d => hub.RegisterForDisposal(d),
             hubPath,
-            () => hub.IsShuttingDown,
+            // 🚨 Stand aside for the disposal NACK only while a route is ARMED to receive it
+            // (#3197). The deferral used to rest on "the disposal NACK is coming, and soon" — an
+            // assumption the code could not check, and one the hosted-hub drain stopped
+            // guaranteeing when its flat 5 s cap was removed in #1317 (the watchdog that replaced
+            // it is a STALL detector, re-armed on every RunLevel transition in the subtree, so a
+            // large subtree making steady progress never trips it). With no sink, or with the
+            // caller's watch already gone, standing aside converts an answerable write into
+            // silence — so answer now, on whatever transport is still open.
+            () => hub.IsShuttingDown && lateVerdicts is not null && lateVerdicts.IsAdmissible(request.Id),
             hub.ServiceProvider.GetService<ILoggerFactory>()?.CreateLogger("MeshWeaver.Data.PatchAck"));
         hub.RegisterForDisposal(postSub);
         // Registered AFTER postSub so the composite disposes the watcher FIRST, then this NACK

--- a/src/MeshWeaver.Documentation/Data/Architecture/BoundsMustBeOrdered.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BoundsMustBeOrdered.md
@@ -120,6 +120,50 @@ And **prove it by mutation**: restore the old literal and confirm the guard goes
 and `1` cases and stays green on `3` and `10`. That asymmetry is itself the evidence — it shows the
 guard is measuring the ordering and not merely the size of the number.
 
+## A bound's JUSTIFICATION is a claim about other code, and it rots
+
+Derivation keeps two numbers ordered. It does nothing for the sentence that says *why* a number is
+big enough — and that sentence is usually a claim about code somewhere else, which can change
+without ever touching the bound.
+
+`LateResponseWatchBound` (30 s) was stated as **protocol, not tuning**: it had to dominate every
+owner-side terminal path, enumerated as the disposal NACK after a teardown whose *"hosted-hub drain
+[is] capped at 5 s"*, the cold-store defer (~10 s), and the ack watcher's 20 s. Two years of edits
+later (#3197):
+
+- **The 5 s cap was gone.** `HostedHubsCollection.DisposeHubsReactive` deliberately dropped its flat
+  `Timeout(5s)` in #1317, and what replaced it is a *stall* detector re-armed on every `RunLevel`
+  transition anywhere in the subtree — so a large subtree that keeps making progress never trips it.
+  The drain has no duration bound at all, and the claim's first term was unsupported.
+- **The terms were being added wrongly.** They were enumerated as alternatives, taking their maximum
+  (20 s). On the in-turn path they compose *additively*: cold-store defer → identity-gated echo →
+  durable flush.
+- **Two different clocks.** The owner's starts at handler entry, the caller's at post, with unbounded
+  routing latency between them — measured at 33–49 s during a bake.
+
+Nothing failed a build. A comment cannot go red. The next reader inherits a number presented as
+proven and reasons from it.
+
+> 🚨 **When a bound's justification enumerates other people's bounds, it is a dependency — and it
+> needs the same treatment as any other: re-measure it, or stop asserting it.**
+
+Where re-establishing the guarantee would mean reverting a deliberate change — as it would here —
+the honest repair is to **say what is actually guaranteed** and make the gap *visible* rather than
+asserted away. Two shapes do that:
+
+- **Check the premise where it is used.** The owner's ack watcher stands aside for the disposal NACK
+  instead of posting its own verdict. That deferral assumed "the NACK is coming, and soon". It now
+  asks: `ILatePatchVerdictSink.IsAdmissible(requestId)` — is a route actually armed? With no sink, or
+  a watch already gone, standing aside would convert an answerable write into silence, so it answers
+  now on whatever transport is still open. The predicate answers *"is a route armed now"*, not *"will
+  it still be armed then"* — no implementation can promise the latter, which is exactly why the
+  second shape is also needed.
+- **Make the overrun observable.** A verdict arriving past the window is still not delivered — acting
+  on it is what the bound exists to prevent — but it used to return the same `false` as a request
+  nobody ever armed, so a failing run showed `VERDICT_TIMEOUT` with zero late-terminal records and
+  "never produced" was indistinguishable from "produced, too late". Those are two different
+  investigations. The registry now logs `VERDICT_EXPIRED` with how late it was, and counts it.
+
 ## Where else to look
 
 The same shape appears wherever a wait wraps a wait. When you write a bound, ask what *else* bounds

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-save-waiting-on-a-shutdown-no-longer-waits-for-nobody.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-save-waiting-on-a-shutdown-no-longer-waits-for-nobody.md
@@ -1,0 +1,30 @@
+---
+Name: A save waiting on a shutdown no longer waits for nobody
+Category: Fix
+Description: When a node is shutting down, its answer to an in-flight save is deliberately deferred to a later step. Nothing checked that anyone was still listening for it — and if the answer then arrived too late, it was dropped without a trace.
+Icon: ClockAlarm
+Order: -20260903
+---
+
+# A save waiting on a shutdown no longer waits for nobody
+
+When a node is shutting down while one of your saves is still in flight, the answer is deliberately
+held back and sent from a later step in the shutdown instead. There is a good reason: that later
+route still reaches your session, and an answer sent from the earlier one might not.
+
+But nothing checked whether your session was still listening. If it was not — because it had already
+been answered, because the wait had run out, or because the save came from a different process
+entirely — the answer was held back for a route that would deliver it to nobody, and your save was
+left with silence until its own window ran out. **The hold-back now happens only when there is
+somewhere for the answer to go.** Otherwise the node answers immediately, on whatever route is still
+open.
+
+There was a second, quieter problem behind it. An answer that arrives after the window closes is not
+delivered — past that point it cannot be told apart from a stale repeat of an older one, and acting
+on it would be worse than ignoring it. That part is unchanged and deliberate. What has changed is
+that it used to be **completely silent**, and indistinguishable from an answer that was never
+produced at all. Those are two different problems with two different causes, and the logs showed the
+same nothing for both. A late answer is now recorded, with how late it was.
+
+Nothing waits longer as a result — no window was widened. A save that could be answered is answered
+sooner, and when one genuinely cannot be, the reason is now written down instead of inferred.

--- a/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
+++ b/src/MeshWeaver.Mesh.Contract/LatePatchWriteWatch.cs
@@ -1,6 +1,7 @@
 using System.Collections.Concurrent;
 using MeshWeaver.Data;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
 
 namespace MeshWeaver.Mesh;
 
@@ -54,12 +55,31 @@ namespace MeshWeaver.Mesh;
 public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
 {
     /// <summary>
-    /// 🚨 How long after the patch post a late owner response is still acted upon. This is
-    /// PROTOCOL, not tuning: it must dominate every owner-side terminal path — the disposal
-    /// NACK after the owner's phased teardown (hosted-hub drain capped at 5 s), the
-    /// cold-store-defer NotFound (up to ~10 s after reactivation), and the owner ack watcher's
-    /// own 20 s bound. A response beyond this window is indistinguishable from a re-delivered
-    /// stale verdict and is ignored.
+    /// 🚨 How long after the patch post a late owner response is still acted upon. A response
+    /// beyond this window is indistinguishable from a re-delivered stale verdict and is ignored.
+    ///
+    /// <para>🚨 <b>What this window actually dominates, and what it does not (#3197).</b> It was
+    /// justified as PROTOCOL — a bound chosen to exceed every owner-side terminal path, enumerated
+    /// as the disposal NACK after a teardown whose hosted-hub drain was "capped at 5 s", the
+    /// cold-store-defer (~10 s), and the ack watcher's 20 s. <b>That cap no longer exists</b>:
+    /// <c>HostedHubsCollection.DisposeHubsReactive</c> deliberately dropped its flat
+    /// <c>Timeout(5s)</c> in #1317, and the only backstop left over that phase is the disposal
+    /// WATCHDOG — a STALL detector, re-armed on every <c>RunLevel</c> transition anywhere in the
+    /// subtree, so a large subtree that keeps making progress never trips it. The drain therefore
+    /// has no duration bound, and this window cannot be said to dominate it.</para>
+    ///
+    /// <para>Two further corrections to the old claim. The owner-side paths were enumerated as
+    /// ALTERNATIVES, taking their maximum (20 s); in <c>ApplyMeshNodePatchInTurn</c> they compose
+    /// ADDITIVELY — cold-store defer (10 s) → identity-gated echo (20 s) → durable flush (10 s).
+    /// And the two clocks differ: the owner's starts at HANDLER ENTRY, the caller's at POST, with
+    /// unbounded routing/queue latency between them (measured at 33–49 s during a bake, #2543).</para>
+    ///
+    /// <para>So the honest statement is the operational one: this is the window in which a verdict
+    /// is still useful to a caller, not a number proven to exceed every path that can produce one.
+    /// What the code now guarantees instead is that the gap is VISIBLE — the ack watcher stands
+    /// aside for the disposal NACK only while <see cref="IsAdmissible"/> says a route is armed, and
+    /// a verdict that arrives past this window is REPORTED rather than dropped in silence, so
+    /// "nothing was ever produced" and "something arrived too late" stop looking identical.</para>
     ///
     /// <para>🚨 Since #2661 this is ALSO the caller's outer verdict bound: <c>UpdateRemote</c> no
     /// longer completes a write on the bounded-wait expiry, so this window is how long a caller
@@ -108,6 +128,29 @@ public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
     // RequestId property).
     private readonly ConcurrentDictionary<string, Entry> entries = new();
 
+    private readonly ILogger<LatePatchResponseRegistry>? logger;
+
+    /// <summary>
+    /// The clock every expiry decision reads. Injectable so the window can be crossed in a test
+    /// WITHOUT waiting it out — a 30 s sleep is not a test, and a test-only "expire everything"
+    /// method on production code is a backdoor. <see cref="TimeProvider.System"/> in every real
+    /// mesh.
+    /// </summary>
+    private readonly TimeProvider clock;
+
+    /// <summary>
+    /// Creates the registry. Both dependencies are OPTIONAL so a bare fixture — one with no logging
+    /// registered — can still construct it; the logger carries only the VERDICT_EXPIRED report,
+    /// which must never be the reason a mesh fails to start.
+    /// </summary>
+    public LatePatchResponseRegistry(
+        ILogger<LatePatchResponseRegistry>? logger = null,
+        TimeProvider? clock = null)
+    {
+        this.logger = logger;
+        this.clock = clock ?? TimeProvider.System;
+    }
+
     /// <summary>
     /// Arms the late watch for the patch posted as <paramref name="requestId"/>. Registered
     /// BEFORE the post so no response can slip between the caller's bounded wait dying and the
@@ -128,7 +171,7 @@ public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
         Action<PatchDataResponse> onLateResponse,
         Action<DeliveryFailure> onLateFailure)
     {
-        var now = DateTimeOffset.UtcNow;
+        var now = clock.GetUtcNow();
         foreach (var kv in entries)
         {
             if (kv.Value.ExpiresAt < now)
@@ -171,7 +214,7 @@ public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
     {
         if (!entries.TryRemove(requestId, out var entry))
             return false;
-        if (entry.ExpiresAt < DateTimeOffset.UtcNow)
+        if (ReportIfExpired(requestId, entry, "PatchDataResponse"))
             return false;
         entry.OnLateResponse(response);
         return true;
@@ -191,11 +234,55 @@ public sealed class LatePatchResponseRegistry : ILatePatchVerdictSink
     {
         if (!entries.TryRemove(requestId, out var entry))
             return false;
-        if (entry.ExpiresAt < DateTimeOffset.UtcNow)
+        if (ReportIfExpired(requestId, entry, nameof(DeliveryFailure)))
             return false;
         entry.OnLateFailure(failure);
         return true;
     }
+
+    /// <summary>
+    /// 🚨 An EXPIRED verdict is a fact, not silence (#3197). The registry used to remove the entry,
+    /// see it was past <see cref="LateResponseWatchBound"/> and return <c>false</c> — the same
+    /// answer it gives for a request nobody ever armed. So a failing run showed
+    /// <c>VERDICT_TIMEOUT</c> with ZERO late-terminal records, and there was no way to tell "the
+    /// owner never produced a verdict" from "the owner produced one and it arrived too late" —
+    /// two different investigations, one indistinguishable symptom (measured, #2543).
+    ///
+    /// <para>The verdict is still NOT delivered: past the window it is indistinguishable from a
+    /// re-delivered stale one, and acting on it is the bug this bound exists to prevent. It is
+    /// reported, and counted, so the next reader can see which case they are in.</para>
+    /// </summary>
+    /// <returns>True when the entry had expired — the caller must not deliver it.</returns>
+    private bool ReportIfExpired(string requestId, Entry entry, string verdictKind)
+    {
+        var now = clock.GetUtcNow();
+        if (entry.ExpiresAt >= now)
+            return false;
+
+        System.Threading.Interlocked.Increment(ref expiredVerdicts);
+        logger?.LogWarning(
+            "[LateWatch] VERDICT_EXPIRED path={Path} request={RequestId} kind={VerdictKind} "
+            + "late_by={LateBy}ms window={Window}s — the owner DID answer; it arrived past the late "
+            + "watch window and was not delivered. This is not 'no verdict was produced': the "
+            + "caller's OwnerUnreachable for this write is a reporting artefact of the delay, not "
+            + "evidence that the owner stayed silent.",
+            entry.Path, requestId, verdictKind,
+            (long)(now - entry.ExpiresAt).TotalMilliseconds,
+            (long)LateResponseWatchBound.TotalSeconds);
+        return true;
+    }
+
+    /// <summary>Number of verdicts that arrived past the window and were therefore not delivered —
+    /// the counterpart of the log line, for tests and for a health surface that wants the rate
+    /// rather than the individual lines.</summary>
+    public int ExpiredVerdicts => System.Threading.Volatile.Read(ref expiredVerdicts);
+
+    private int expiredVerdicts;
+
+    /// <inheritdoc />
+    public bool IsAdmissible(string requestId)
+        => entries.TryGetValue(requestId, out var entry)
+           && entry.ExpiresAt >= clock.GetUtcNow();
 
     /// <summary>Number of armed watches — test seam.</summary>
     public int ArmedCount => entries.Count;

--- a/test/MeshWeaver.Graph.Test/LateVerdictAdmissibilityTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateVerdictAdmissibilityTest.cs
@@ -1,0 +1,145 @@
+using System;
+using MeshWeaver.Data;
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 The late-verdict watch must answer two questions the owner side used to ASSUME — issue #3197.
+///
+/// <para><b>The assumption.</b> The owner's ack watcher deliberately posts NOTHING when the owner is
+/// shutting down, deferring the verdict to the ShutDown-phase disposal NACK. Its justification —
+/// and the justification for <c>LateResponseWatchBound</c> itself — enumerated the owner-side paths
+/// this window has to dominate, including "the disposal NACK after the owner's phased teardown
+/// (hosted-hub drain capped at 5 s)". <b>That cap was deleted in #1317</b>:
+/// <c>HostedHubsCollection.DisposeHubsReactive</c> carries no <c>Timeout</c>, and the disposal
+/// watchdog that remains is a STALL detector re-armed on every <c>RunLevel</c> transition in the
+/// subtree, so a subtree making steady progress never trips it. The stand-aside was therefore
+/// waiting on a route with no duration bound, and could not check that the route existed at all.</para>
+///
+/// <para><b>And the drop was silent.</b> <c>Dispatch</c> removed the entry, saw it was expired, and
+/// returned <c>false</c> — the identical answer it gives for a request nobody ever armed. So a
+/// failing run showed <c>VERDICT_TIMEOUT</c> with ZERO late-terminal records, and "the owner never
+/// produced a verdict" and "the owner produced one that arrived too late" were indistinguishable
+/// (measured, #2543). Two different investigations, one symptom.</para>
+///
+/// <para>These pins are over the registry alone — plain dictionary state, no mesh, no hub.</para>
+/// </summary>
+public class LateVerdictAdmissibilityTest
+{
+    private const string RequestId = "patch-1";
+    private const string Path = "acme/Doc";
+
+    /// <summary>
+    /// A clock the test moves by hand. The window is 30 s and no test waits it out — expiry is
+    /// reached by advancing this, never by a sleep.
+    /// </summary>
+    private sealed class TestClock : TimeProvider
+    {
+        private DateTimeOffset now = DateTimeOffset.UnixEpoch;
+        public override DateTimeOffset GetUtcNow() => now;
+        public void Advance(TimeSpan by) => now += by;
+    }
+
+    /// <summary>An armed, unexpired watch is admissible — so standing aside for it is justified.</summary>
+    [Fact]
+    public void AnArmedWatch_IsAdmissible()
+    {
+        var registry = new LatePatchResponseRegistry();
+        registry.Register(RequestId, Path, _ => { }, _ => { });
+
+        registry.IsAdmissible(RequestId).Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 🚨 Nobody armed: standing aside would convert an answerable write into silence, so the
+    /// predicate says no and the ack watcher answers on whatever transport is still open. This is
+    /// the cross-process caller, and the no-sink fixture.
+    /// </summary>
+    [Fact]
+    public void AnUnarmedRequest_IsNotAdmissible()
+        => new LatePatchResponseRegistry().IsAdmissible(RequestId).Should().BeFalse();
+
+    /// <summary>
+    /// A watch the caller's own bounded wait already settled is not admissible either — its
+    /// verdict has been delivered, and there is nothing left to defer to.
+    /// </summary>
+    [Fact]
+    public void ACompletedWatch_IsNotAdmissible()
+    {
+        var registry = new LatePatchResponseRegistry();
+        registry.Register(RequestId, Path, _ => { }, _ => { });
+        registry.Complete(RequestId);
+
+        registry.IsAdmissible(RequestId).Should().BeFalse();
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. A verdict past the window is still NOT delivered — acting on it is the bug
+    /// the bound exists to prevent — but it is now COUNTED, so "arrived too late" stops looking
+    /// exactly like "never produced".
+    /// </summary>
+    [Fact]
+    public void AnExpiredVerdict_IsNotDelivered_ButIsCounted()
+    {
+        var clock = new TestClock();
+        var registry = new LatePatchResponseRegistry(clock: clock);
+        var delivered = 0;
+        registry.Register(RequestId, Path, _ => delivered++, _ => { });
+        clock.Advance(LatePatchResponseRegistry.LateResponseWatchBound + TimeSpan.FromSeconds(1));
+
+        var dispatched = registry.Dispatch(RequestId, new PatchDataResponse(false, 1L));
+
+        dispatched.Should().BeFalse("a verdict past the window is indistinguishable from a stale one");
+        delivered.Should().Be(0, "and must not reach the caller");
+        registry.ExpiredVerdicts.Should().Be(1, "but it must not vanish without a trace either");
+    }
+
+    /// <summary>The #2661 failure seam carries the identical rule.</summary>
+    [Fact]
+    public void AnExpiredFailure_IsNotDelivered_ButIsCounted()
+    {
+        var clock = new TestClock();
+        var registry = new LatePatchResponseRegistry(clock: clock);
+        var delivered = 0;
+        registry.Register(RequestId, Path, _ => { }, _ => delivered++);
+        clock.Advance(LatePatchResponseRegistry.LateResponseWatchBound + TimeSpan.FromSeconds(1));
+
+        registry.DispatchFailure(RequestId, new DeliveryFailure(null!)).Should().BeFalse();
+        delivered.Should().Be(0);
+        registry.ExpiredVerdicts.Should().Be(1);
+    }
+
+    /// <summary>
+    /// 🚨 The control arm, and the discriminator the counter exists for: a request NOBODY armed is
+    /// also `false` from Dispatch — and must NOT be counted as expired, or the two cases collapse
+    /// again in the other direction.
+    /// </summary>
+    [Fact]
+    public void AnUnarmedRequest_IsNotCountedAsExpired()
+    {
+        var registry = new LatePatchResponseRegistry();
+
+        registry.Dispatch(RequestId, new PatchDataResponse(false, 1L)).Should().BeFalse();
+
+        registry.ExpiredVerdicts.Should().Be(0,
+            "nothing was produced late here — nothing was produced at all");
+    }
+
+    /// <summary>Control arm: an unexpired verdict is delivered and is never counted as expired, so
+    /// the assertions above cannot be green because dispatch stopped working.</summary>
+    [Fact]
+    public void AnInTimeVerdict_IsDelivered_AndNotCounted()
+    {
+        var registry = new LatePatchResponseRegistry();
+        var delivered = 0;
+        registry.Register(RequestId, Path, _ => delivered++, _ => { });
+
+        registry.Dispatch(RequestId, new PatchDataResponse(true, 1L)).Should().BeTrue();
+        delivered.Should().Be(1);
+        registry.ExpiredVerdicts.Should().Be(0);
+    }
+
+}


### PR DESCRIPTION
Closes #3197.

> **Stacked on #3200** (`fix/3194-every-patch-leg-reaches-a-terminal`) — both touch the same region of `DataExtensions.cs`, and #3200 is what puts `lateVerdicts` in scope at the two `ArmPatchAckWatcher` call sites. GitHub retargets this to `main` when #3200 merges. Review the top commit only.

## The stale claim, verified

`LateResponseWatchBound` (30 s) is stated as **PROTOCOL, not tuning** — chosen to dominate every owner-side terminal path, enumerated as the disposal NACK after a teardown whose *"hosted-hub drain [is] capped at 5 s"*, the cold-store defer (~10 s), and the ack watcher's 20 s.

**That cap does not exist.** `HostedHubsCollection.DisposeHubsReactive` deliberately dropped its flat `Timeout(5s)` in #1317 — its comment says so — and what replaced it is the disposal *watchdog*, a **stall** detector re-armed on every `RunLevel` transition anywhere in the subtree. A large subtree that keeps making progress never trips it, so the drain has no duration bound and the claim's first term is unsupported.

Two further corrections to the same comment, both from the issue:
- the paths were enumerated as **alternatives** taking their max (20 s); on the in-turn path they compose **additively** — cold-store defer → identity-gated echo → durable flush;
- the two **clocks differ** — the owner's starts at handler entry, the caller's at post, with unbounded routing latency between them (measured 33–49 s during a bake, #2543).

Re-establishing the cap would mean reverting a deliberate change, so the claim is rewritten to say what is actually guaranteed — and the two things it used to *assert* are now things the code **checks**.

## The stand-aside now checks its premise

`ArmPatchAckWatcher` posts nothing when the owner is shutting down, deferring to the ShutDown-phase disposal NACK whose transport still reaches the waiter. The premise — *"the NACK is coming, and soon"* — was uncheckable, and with the drain uncapped it was also unbounded.

It now asks `ILatePatchVerdictSink.IsAdmissible(requestId)`. With no sink, or a watch already settled or expired, standing aside converts an answerable write into **silence**, so the watcher answers now on whatever transport is still open.

The predicate answers *"is a route armed now"*, never *"will it still be armed then"* — no implementation can promise the latter, which is exactly why the next section matters. It ships as a **default interface method returning `true`** (the assumption it replaces), so an implementation that cannot answer keeps today's behaviour rather than silently changing it.

## The silent drop is now a fact

`Dispatch` removed the entry, saw it was past the window, and returned `false` — **the identical answer it gives for a request nobody ever armed**. So a failing run showed `VERDICT_TIMEOUT` with zero late-terminal records, and "the owner never produced a verdict" was indistinguishable from "the owner produced one that arrived too late". Two different investigations, one symptom (measured, #2543).

The verdict is still **not delivered** — past the window it cannot be told from a stale repeat, and acting on it is what the bound exists to prevent. It is now logged as `VERDICT_EXPIRED` with how late it was, and counted on `ExpiredVerdicts`.

## Verification

- `LateVerdictAdmissibilityTest` — 7 pins over the registry alone (no mesh, no hub): admissible/unarmed/completed, expired response and expired failure both undelivered-but-counted, plus **two control arms** — an unarmed request must **not** be counted as expired (or the two cases collapse in the other direction), and an in-time verdict is delivered and not counted.
- The registry's **clock is injectable**, so the pins cross a 30 s window without waiting it out — and without a test-only "expire everything" backdoor on production code.
- 🚨 **The two named regression tests the stand-aside was built around pass unchanged**: `LateNackReenqueueTest` and `NackReachesTheWaiterDuringTeardownTest`. In both a caller IS armed, so `IsAdmissible` is true and the deferral still happens — the behaviour changes only where nobody was listening.
- `MeshWeaver.Graph.Test` in full: **1266 passed, 0 failed**.
- `-c Release -warnaserror`: `MeshWeaver.Data.Contract`, `MeshWeaver.Mesh.Contract`, `MeshWeaver.Data`, `MeshWeaver.Hosting`, `MeshWeaver.Graph.Test`, `MeshWeaver.Documentation.Test` — `0 Warning(s), 0 Error(s)` each.
- Doc link + What's New integrity: 2 passed, against a DLL rebuilt after the doc edits.

`Pairs-with: none` — no public type or member is removed (measured: `git diff origin/main -- src/ | grep -E "^-.*\bpublic\b"` is empty). The additions are a default interface method and two **optional** constructor parameters; MeshWeaver.Plugins reaches `LatePatchResponseRegistry` only through `GetRequiredService<T>()` and the static `LateResponseWatchBound`, never `new`, so there is no binary break either. The `Dependent suites (MeshWeaver.Plugins)` job covers the fuller integration versions of both regression tests.

## Docs

`Doc/Architecture/BoundsMustBeOrdered` gains **"A bound's JUSTIFICATION is a claim about other code, and it rots"** — derivation keeps two numbers ordered but does nothing for the sentence explaining why one is big enough, and a comment cannot go red. What's New entry: `Category: Fix`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
