### PR TITLE
Sign-in reads are anchored; every mesh-wide read says so (#3202)

### DIFF
--- a/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
@@ -296,7 +296,10 @@ public static class SeoEndpoints
         var candidates = CandidateNodeTypes
             .Select(type => Observable.Using(
                 () => accessService?.ImpersonateAsSystem() ?? System.Reactive.Disposables.Disposable.Empty,
-                _ => mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{type} is:main limit:500"))
+                // Mesh-wide by nature: the sitemap enumerates the partition ROOTS of every
+                // partition, so there is no partition to anchor to (#3202 — fan-out is opt-in).
+                _ => mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                    MeshWideQuery.Declare($"nodeType:{type} is:main limit:500")))
                     .Take(1)
                     .Select(change => change.Items
                         .Where(n => !n.Path.Contains('/'))     // top-level roots only

--- a/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/SeoEndpoints.cs
@@ -293,12 +293,14 @@ public static class SeoEndpoints
         // Candidate enumeration runs as System (an anonymous HTTP entry has no query identity);
         // ANONYMOUS readability is then decided per node by the fail-closed gate — the sitemap
         // can never list more than a logged-out visitor can open.
+        // RunAsSystem, never `Observable.Using(() => ImpersonateAsSystem(), …)`: the scope's store
+        // and restore must land on the SAME thread (AGENTS.md; #1790), and Using disposes on
+        // whichever thread the inner stream terminates on.
         var candidates = CandidateNodeTypes
-            .Select(type => Observable.Using(
-                () => accessService?.ImpersonateAsSystem() ?? System.Reactive.Disposables.Disposable.Empty,
+            .Select(type => accessService.RunAsSystem(() =>
                 // Mesh-wide by nature: the sitemap enumerates the partition ROOTS of every
                 // partition, so there is no partition to anchor to (#3202 — fan-out is opt-in).
-                _ => mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(
                     MeshWideQuery.Declare($"nodeType:{type} is:main limit:500")))
                     .Take(1)
                     .Select(change => change.Items

--- a/memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs
@@ -472,9 +472,9 @@ public sealed class MeshWeaverInstanceService(
             Query = MeshWideQuery.Declare(
                 $"nodeType:{MeshWeaverInstanceNodeType.NodeType} id:{instanceId}"),
         };
-        return Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => meshService.Query(request))
+        // RunAsSystem, never `Observable.Using(() => ImpersonateAsSystem(), …)` — store and restore
+        // of the identity must land on the same thread (AGENTS.md; #1790).
+        return accessService.RunAsSystem(() => meshService.Query(request))
             .Take(1)
             .Timeout(TimeSpan.FromSeconds(10))
             .SelectMany(results =>
@@ -550,9 +550,9 @@ public sealed class MeshWeaverInstanceService(
             Query = MeshWideQuery.Declare(
                 $"nodeType:{MeshWeaverInstanceNodeType.NodeType} id:{instanceId}"),
         };
-        return Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => meshService.Query(request))
+        // RunAsSystem, never `Observable.Using(() => ImpersonateAsSystem(), …)` — store and restore
+        // of the identity must land on the same thread (AGENTS.md; #1790).
+        return accessService.RunAsSystem(() => meshService.Query(request))
             .Take(1)
             .Timeout(TimeSpan.FromSeconds(10))
             .Select(results => results.Count == 0);

--- a/memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs
+++ b/memex/Memex.Portal.Shared/Authentication/MeshWeaverInstanceService.cs
@@ -463,9 +463,14 @@ public sealed class MeshWeaverInstanceService(
             return Observable.Throw<Unit>(new ArgumentException("instanceId is required", nameof(instanceId)));
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        // An instance is keyed by its id but LIVES under whichever user registered it
+        // ({user}/MeshWeaverInstance/{id}), so a lookup by id has no partition to anchor to and
+        // must say so (#3202 — fan-out is opt-in). The durable fix is an id → owner index in a
+        // pinned partition, the way RegistrationKeyIndex already indexes keys.
         var request = new MeshQueryRequest
         {
-            Query = $"nodeType:{MeshWeaverInstanceNodeType.NodeType} id:{instanceId}",
+            Query = MeshWideQuery.Declare(
+                $"nodeType:{MeshWeaverInstanceNodeType.NodeType} id:{instanceId}"),
         };
         return Observable.Using(
                 () => accessService.ImpersonateAsSystem(),
@@ -536,9 +541,14 @@ public sealed class MeshWeaverInstanceService(
     {
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        // An instance is keyed by its id but LIVES under whichever user registered it
+        // ({user}/MeshWeaverInstance/{id}), so a lookup by id has no partition to anchor to and
+        // must say so (#3202 — fan-out is opt-in). The durable fix is an id → owner index in a
+        // pinned partition, the way RegistrationKeyIndex already indexes keys.
         var request = new MeshQueryRequest
         {
-            Query = $"nodeType:{MeshWeaverInstanceNodeType.NodeType} id:{instanceId}",
+            Query = MeshWideQuery.Declare(
+                $"nodeType:{MeshWeaverInstanceNodeType.NodeType} id:{instanceId}"),
         };
         return Observable.Using(
                 () => accessService.ImpersonateAsSystem(),

--- a/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
+++ b/memex/Memex.Portal.Shared/Authentication/OnboardingMiddleware.cs
@@ -407,7 +407,7 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
     internal static IObservable<IdentityReadOutcome<MeshNode>> FindUserByEmail(
         IWorkspace workspace, string email, ILogger? logger)
     {
-        var query = $"nodeType:User content.email:{email} limit:1";
+        var query = UserByEmailQuery(email);
         var accessService = workspace.Hub.ServiceProvider.GetService<AccessService>();
 
         // As System, for the reason given on LoadUserRoles — and this read needs it MORE, being
@@ -494,7 +494,8 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
     }
 
     /// <summary>
-    /// Reactive load of the user's role names from AccessAssignment nodes via the
+    /// Reactive load of the user's PLATFORM role names from the three anchored
+    /// <see cref="RoleQueries"/> legs (root, <c>Admin</c>, own partition — #3202) via the
     /// canonical synced query (<c>workspace.GetQuery</c>). Same machinery as
     /// <c>FindUserByEmail</c> — bypasses RLS, dedupes, gates on Initial,
     /// includes static providers. Bearer auth uses this via
@@ -544,17 +545,9 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
         // ratchet guard fails the build at any new site).
         return IdentityRead.Bounded(
             accessService.RunAsSystem(() =>
-                workspace.GetQuery(
-                        $"auth:userRoles:{username}",
-                        // Through the SecurityQueries seam, which overwrites any limit with
-                        // `limit:all`. This query carried `limit:10`: a viewer with more than ten
-                        // AccessAssignment nodes got an arbitrary ten and the rest of their roles
-                        // vanished, silently — the truncation #2011 fixed for the security fold,
-                        // which that class exists to make structurally impossible. "A query string
-                        // that never reaches this class is the only way back to the defect", and
-                        // this was one. It fires on GROWTH, so the largest install first.
-                        SecurityQueries.Enumeration(
-                            $"nodeType:AccessAssignment content.accessObject:\"{username}\" scope:subtree"))
+                // The (id, query set) pair is the cache key, so the three anchored legs below get
+                // their own process-wide snapshot; the synced layer UNIONs them, deduped by path.
+                workspace.GetQuery($"auth:userRoles:{username}", RoleQueries(username))
                     .Do(items => logger?.LogDebug(
                         "LoadUserRoles({User}): synced query emit, items={Count}",
                         username, items.Count()))
@@ -562,6 +555,69 @@ public class OnboardingMiddleware(RequestDelegate next, ILogger<OnboardingMiddle
                     .Select(items => (IReadOnlyCollection<string>?)FoldRoles(items, jsonOptions))),
             budget ?? LookupTimeout, $"LoadUserRoles({username})", logger);
     }
+
+    /// <summary>
+    /// The partition that holds the platform-admin grants — "global admin" has exactly one meaning,
+    /// <c>Permission.All</c> at scope <c>Admin</c>, i.e. an <c>AccessAssignment</c> in
+    /// <c>Admin/_Access</c> (AGENTS.md → "Global admin"; <c>hub.IsGlobalAdmin()</c> keys off it).
+    /// </summary>
+    internal const string AdminPartition = "Admin";
+
+    /// <summary>
+    /// The account lookup: <c>nodeType:User</c> with no path. That is deliberate and it is PINNED,
+    /// not unanchored — <c>UserNodeType</c> registers a <c>QueryRoutingRule</c> that routes a
+    /// path-less <c>nodeType:User</c> query to the <c>Auth</c> partition (the auth-mirror of every
+    /// User node in the mesh, excluded from cross-schema search), and the Postgres planner consults
+    /// that rule BEFORE refusing a query as unanchored. <c>SignInReadsAreAnchoredTest</c> pins that
+    /// the rule resolves this exact text on the real mesh configuration.
+    /// </summary>
+    /// <param name="email">The sign-in email.</param>
+    /// <returns>The query string.</returns>
+    internal static string UserByEmailQuery(string email) =>
+        $"nodeType:User content.email:{email} limit:1";
+
+    /// <summary>
+    /// The three ANCHORED reads whose union is the user's platform role set (#3202) — each pinned to
+    /// ONE schema, none a mesh-wide fan-out:
+    /// <list type="number">
+    ///   <item>the ROOT scope — <c>_Access/{id}</c>, the registered global satellite
+    ///     (<c>system_access</c>): platform-wide viewer/admin grants;</item>
+    ///   <item>the <see cref="AdminPartition"/> — <c>Admin/_Access/{id}</c>: the platform-admin
+    ///     grant, the ONE meaning of "global admin";</item>
+    ///   <item>the user's OWN partition — <c>{user}/_Access/{id}</c>: the Admin-of-my-own-home
+    ///     grant onboarding writes.</item>
+    /// </list>
+    ///
+    /// <para><b>Why not every partition.</b> The read this replaces,
+    /// <c>nodeType:AccessAssignment content.accessObject:"{user}" scope:subtree</c>, named no
+    /// partition: on Postgres that was a UNION over every partition schema on EVERY request (199
+    /// schemas on memex-cloud, ~4 s each under load — #2194), and since MeshWeaver.Plugins #1231
+    /// made fan-out opt-in it was REFUSED outright, so every signed-in user got a 503. The obvious
+    /// remedy — <c>partitions:all</c> — would restore the fan-out, not remove it.</para>
+    ///
+    /// <para><b>Why three homes are the COMPLETE answer.</b> <c>AccessContext.Roles</c> is read by
+    /// no permission decision: <c>PermissionEvaluator</c> deliberately ignores claim roles (a claim
+    /// role used to be a global, undeniable grant — the 2026-08-05 paywall bypass), and its only
+    /// consumer in core or MeshWeaver.Plugins is the per-viewer access-cache KEY. What the set
+    /// means is "this user's PLATFORM roles", and a platform role is granted in exactly these three
+    /// places by contract (<c>Doc/Architecture/AccessControl</c> → "Where to look"). A grant in an
+    /// arbitrary space (Editor on <c>acme</c>) is a DATA permission the fold evaluates from the
+    /// space's own <c>_Access</c> at check time; folding it into the platform roles was incidental
+    /// to the mesh-wide query, not a requirement of any caller.</para>
+    ///
+    /// <para><b>Why the #2011 deny hazard does not apply.</b> Narrowing a fold read is dangerous
+    /// where a DENY may live outside the anchor — a group deny that loses its membership rows fails
+    /// OPEN. <see cref="FoldRoles"/> honours no deny at all (it collects non-denied role names and
+    /// subtracts nothing), so no scope's deny can be lost by not reading that scope.</para>
+    /// </summary>
+    /// <param name="username">The mesh user id whose grants to read.</param>
+    /// <returns>The three anchored query strings, each stamped complete.</returns>
+    internal static string[] RoleQueries(string username) =>
+    [
+        SecurityQueries.RootAssignmentsFor(username),
+        SecurityQueries.PartitionAssignmentsFor(AdminPartition, username),
+        SecurityQueries.PartitionAssignmentsFor(username, username),
+    ];
 
     /// <summary>Back-compat overload used by callers that don't yet pass a logger.</summary>
     internal static IObservable<IdentityReadOutcome<IReadOnlyCollection<string>>> LoadUserRoles(

--- a/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
+++ b/memex/Memex.Portal.Shared/Email/OutboundEmailSender.cs
@@ -57,7 +57,10 @@ public sealed class OutboundEmailSender(
     /// </summary>
     public const string WatchQuery =
         $"nodeType:{EmailNodeType.NodeType} content.direction:Outbound "
-        + "-content.status:Sending -content.status:Sent -content.status:Failed";
+        + "-content.status:Sending -content.status:Sent -content.status:Failed "
+        // A process-wide watch: an outbound mail is filed under whoever sent it, in any partition,
+        // so the ONE live subscription spans them all and says so (#3202 — fan-out is opt-in).
+        + ParsedQuery.CrossPartitionQualifier;
 
     private readonly CompositeDisposable subscriptions = new();
     private IServiceScope? scope;

--- a/memex/Memex.Portal.Shared/Settings/WhatsNewSettingsTab.cs
+++ b/memex/Memex.Portal.Shared/Settings/WhatsNewSettingsTab.cs
@@ -67,7 +67,9 @@ public static class WhatsNewSettingsTab
     public static readonly string[] ListingQueries =
     [
         $"path:{WhatsNewNamespace} scope:children",
-        $"nodeType:{EntryNodeType}",
+        // The type lane is mesh-wide BY DESIGN — a satellite files its entries in its own tree —
+        // and says so (#3202 — fan-out is opt-in).
+        MeshWideQuery.OfType(EntryNodeType),
     ];
 
     /// <summary>

--- a/src/MeshWeaver.Compiler.Pipeline/CellSurfaceAssemblyProvider.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CellSurfaceAssemblyProvider.cs
@@ -54,7 +54,9 @@ internal sealed class CellSurfaceAssemblyProvider(
             return Observable.Using(
                 () => accessService?.ImpersonateAsSystem() ?? Disposable.Empty,
                 _ => meshService
-                    .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
+                    // Every NodeType definition in the mesh — a catalog whose members live wherever
+                    // their owner does, so mesh-wide by nature (#3202 — fan-out is opt-in).
+                    .Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.OfType(MeshNode.NodeTypePath)))
                     .Take(1)
                     .Timeout(DiscoveryBudget)
                     .SelectMany(change => ResolveAll(

--- a/src/MeshWeaver.Compiler.Pipeline/CompletionUsageIndex.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompletionUsageIndex.cs
@@ -93,7 +93,9 @@ internal sealed class CompletionUsageIndex(IMessageHub hub, ILogger logger)
 
         // Accumulate the chunked query, settle after a quiet second, take one snapshot — the
         // standard bounded read. Timeout + Catch make every failure mode "no prior".
-        mesh.Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:Code limit:{MaxNodes}"))
+        // Every Code node in the mesh — the usage prior is built over everyone's cells, so
+        // mesh-wide by nature (#3202 — fan-out is opt-in).
+        mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.Declare($"nodeType:Code limit:{MaxNodes}")))
             .Scan(ImmutableDictionary<string, MeshNode>.Empty, (map, change) =>
             {
                 if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)

--- a/src/MeshWeaver.Documentation/Data/Architecture/UnanchoredSecurityReads.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/UnanchoredSecurityReads.md
@@ -105,6 +105,64 @@ The test to apply is not "is it anchored" but **"can the subject live outside th
 can, anchoring loses a permission. Where it provably cannot, per-scope reads were only ever paying
 for the same rows N times.
 
+## The sign-in path is anchored — and fan-out is opt-in now (#3202)
+
+On 2026-09-03 every signed-in user of a portal built from MeshWeaver.Plugins `main` ≥ `fe20fe2a`
+got a 503 on every page. Plugins #1231 had made fan-out **opt-in**: the Postgres planner refuses a
+query that names no partition and did not ask to span them (`UnanchoredQueryException`), because a
+silent 199-schema UNION locks 500+ relations and queues every other query behind it (the 2026-09-02
+census above). The sign-in role read — `OnboardingMiddleware.LoadUserRoles`,
+`nodeType:AccessAssignment content.accessObject:"{user}" scope:subtree` — was exactly that shape,
+and the middleware did what #637 requires with an infrastructure fault: 503, never "you have no
+account". Both production portals were frozen on older images until the fix landed.
+
+**The refusal's rule, which every core query now satisfies.** A query is served iff
+`IsSufficientlySpecified(parsed) || ResolvesByRoutingHint(parsed)`: a concrete `path:`/`namespace:`
+first segment, a multi-path, a wildcard namespace pattern, the explicit `partitions:all` — or a
+registered `QueryRoutingRule` that pins the node type (`nodeType:User` → `Auth`,
+`nodeType:Invitation` → `Admin`; the "inert hint" note that used to stand on this page is out of
+date — the planner consults the rules before refusing, and `SignInReadsAreAnchoredTest` pins that
+`UserNodeType`'s rule resolves the account lookup's exact text). `QueryRouteClassifier`
+(`test/MeshWeaver.Fixture`) is the one test-side mirror of that decision, and
+`UnanchoredQueryCensusTest` (`test/Memex.Portal.Shared.Test`) feeds it every runtime query core
+issues — the refused set is printed on every run and asserted empty.
+
+**Why the sign-in fold is ANCHORED and not declared.** `LoadUserRoles` folds a user's *platform*
+roles, and `AccessContext.Roles` is read by no permission decision — `PermissionEvaluator` ignores
+claim roles on purpose (a claim role used to be a global, undeniable grant: the 2026-08-05 paywall
+bypass), and its only consumer in core or MeshWeaver.Plugins is the per-viewer access-cache key. A
+platform role is granted in exactly three places by contract ([Access Control](../AccessControl) →
+"Where to look"), so the complete read is three single-schema legs, via `SecurityQueries`:
+
+| Leg | Query | Schema |
+|---|---|---|
+| Root scope | `RootAssignmentsFor(user)` — `namespace:_Access … content.accessObject:"{user}"` | `system_access` (the registered global satellite) |
+| Platform admin | `PartitionAssignmentsFor("Admin", user)` — `path:Admin scope:descendants …` | `admin` — excluded from cross-schema search, so reachable ONLY anchored |
+| Own home | `PartitionAssignmentsFor(user, user)` — `path:{user} scope:descendants …` | `{user}` |
+
+`partitions:all` would have restored the per-request 199-schema UNION, not removed it. The #2011
+deny hazard does not apply: `FoldRoles` honours no deny at all (it collects non-denied role names
+and subtracts nothing), so no scope's deny can be lost by not reading that scope. A grant in an
+arbitrary space is a *data* permission the fold evaluates from that space's own `_Access` at check
+time; folding it into the platform roles was incidental to the mesh-wide query.
+
+**What is DECLARED instead, and why.** `MeshWideQuery.Declare` / `.OfType` (`MeshWeaver.Mesh.Contract`)
+appends `partitions:all` for the reads whose answer genuinely lives in every partition, each with
+its reason at the call site: the `NodeType` catalog (pre-warm, compile sweep, recompile, prebuilt
+adoption, cell surfaces, the create menu, the MCP catalog), `UiContribution`, every `Space` root
+(the home page's root leg, the namespace picker, the sitemap), every `{Space}/_GitSync` config,
+the outbound-mail watch, the event-subscription runner, the stranded-instance probe, the root
+subject picker, the plugin-catalog watcher, the What's New type lane, and the home's "shared with
+me" leg (a share grant lives in the granting partition — see below). The instance registry's
+id lookups (`MeshWeaverInstance id:…`) are declared too, with the durable fix named at the site: an
+id → owner index in a pinned partition, the way `RegistrationKeyIndex` already indexes keys.
+
+**Fan-out grace in the storage layer.** Because a cross-repo caller sweep cannot land atomically
+and a refusal on a live request path must never be the first signal, the planner carries an
+explicit allow-file of offender shapes (`unanchored-queries.allow`, MeshWeaver.Plugins) for which it
+fans out with a warning instead of throwing; the file may only shrink, a listed shape no longer
+issued is a stale entry that fails the build, and an empty file is the refuse-everything default.
+
 ## What IS tractable, and what needs a decision
 
 Measured on `origin/main`, core only. The provider (`MeshWeaver.Hosting.PostgreSql`) left this
@@ -145,15 +203,16 @@ materialization of the fold's global sets on the `partition_access` precedent �
   routing and the Admin-partition routing rule. Collapsing therefore silently changes which TABLE a
   query reads for any gated type that is also a satellite type. The prerequisite is an
   alternation-aware `ExtractNodeTypes` whose consumers route only when every value agrees.
-- **Making `QueryRoutingHints` live.** `MeshConfiguration.ResolveRoutingHints` registers rules that
-  would pin `nodeType:Role`, `nodeType:Partition`, `nodeType:GlobalSettings` to `Admin`, and the
-  in-repo comment on `InvitationNodeType` states plainly that *"the PostgreSQL query router routes
-  purely by the path's first segment and does NOT consume these QueryRoutingHints yet, so this rule
-  is currently inert"*. Several docstrings in this repo describe their query as pinned on the
-  strength of a rule that does not run. Honouring the hints would remove real fan-outs — and would
-  ALSO silently truncate any `Role` authored outside `Admin`, which is the failure this whole page
-  is about. It is a deliberate scope decision, and it belongs with the fold materialization
-  (plan 2 of the elimination page), not ahead of it.
+- **`QueryRoutingHints` ARE live — mind what that pins.** `MeshConfiguration.ResolveRoutingHints`
+  registers rules that pin `nodeType:User` to `Auth` and `nodeType:Role`, `nodeType:Partition`,
+  `nodeType:GlobalSettings`, `nodeType:Invitation`, `nodeType:EventSubscription` to `Admin`, and
+  since Plugins #1231 the planner consumes them — both to pin a path-less query's enumeration and
+  to accept it instead of refusing it (the `InvitationNodeType` comment calling the rule "inert" is
+  out of date). The `Role` pin therefore silently truncates any `Role` authored outside `Admin`
+  for a path-less `nodeType:Role` read — which is exactly why the fold reads roles through
+  `SecurityQueries.Roles` with `partitions:all` (an explicit fan-out is enumerated in full; the
+  pin applies only to the path-less, undeclared shape). Any new rule must be weighed against this
+  page before it is registered.
 
 ## The other half: what an area SHOWS when the store cannot be reached
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-signing-in-no-longer-depends-on-a-mesh-wide-query.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-signing-in-no-longer-depends-on-a-mesh-wide-query.md
@@ -1,0 +1,36 @@
+---
+Name: Signing in no longer depends on a mesh-wide query
+Category: Fix
+Description: On portals built with the newest storage layer every signed-in user was answered "We could not check your account just now" on every page. The sign-in path now reads your roles from the three places they are granted instead of searching the whole mesh, and every other whole-mesh read the platform makes says so explicitly.
+Icon: ShieldCheckmark
+Order: -20260903
+---
+
+# Signing in no longer depends on a mesh-wide query
+
+If your portal was built from the newest platform packages, signing in ended on a 503 for
+everyone — *"We could not check your account just now. This is a temporary problem on our side, not
+a problem with your account."* — on every page, every time. The message was honest: the portal had
+refused to guess at your account rather than tell a signed-in user they had none. But the problem
+was not temporary.
+
+**What happened.** Checking who you are involved a query for your role grants that named no
+partition — it asked the whole mesh. On a large portal that was a union over every partition schema
+on every request (measured the day before at around four seconds each under load), and the storage
+layer had just, deliberately, stopped serving such queries: a read that does not say where to look
+is now refused rather than silently paid for by everyone else. The sign-in path was the first caller
+to meet that refusal, and it met it on every request.
+
+**What changed.**
+
+- Your platform roles are read from the three places they are granted — the platform-wide grants,
+  the platform-admin grants, and the grants on your own home — each a single, pinned read. The
+  result is the same set of roles; what is gone is the search of every partition to find them.
+- Every other read the platform makes across the whole mesh — the list of node types, the menu
+  contributions plugins add, the Spaces on your home page, the sitemap, the outbound-mail sender —
+  now declares that it is mesh-wide, so the storage layer serves it knowingly instead of refusing
+  it. Nothing about what those pages show has changed.
+- A test now classifies every such query the platform issues with the storage layer's own rule, so a
+  new mesh-wide read cannot arrive unannounced.
+
+If you saw the 503, no action is needed: reload after your portal has been updated.

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -393,7 +393,9 @@ public sealed class GitHubWebhookProcessor
             () => accessService.ImpersonateAsSystem(),
             _ => meshService
                 .Query<MeshNode>(MeshQueryRequest
-                    .FromQuery($"nodeType:{GitHubSyncService.ConfigNodeType}")
+                    // Every {Space}/_GitSync config — the webhook cannot know which space a push
+                    // belongs to until it has read them all, so mesh-wide by nature (#3202).
+                    .FromQuery(MeshWideQuery.OfType(GitHubSyncService.ConfigNodeType))
                     .Complete())
                 .Where(c => c.ChangeType == QueryChangeType.Initial)
                 .Take(1));

--- a/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
+++ b/src/MeshWeaver.GitSync/GitHubWebhookProcessor.cs
@@ -389,16 +389,16 @@ public sealed class GitHubWebhookProcessor
     private IObservable<QueryResultChange<MeshNode>> QueryConfigNodesAsSystem()
     {
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
-        return Observable.Using(
-            () => accessService.ImpersonateAsSystem(),
-            _ => meshService
-                .Query<MeshNode>(MeshQueryRequest
-                    // Every {Space}/_GitSync config — the webhook cannot know which space a push
-                    // belongs to until it has read them all, so mesh-wide by nature (#3202).
-                    .FromQuery(MeshWideQuery.OfType(GitHubSyncService.ConfigNodeType))
-                    .Complete())
-                .Where(c => c.ChangeType == QueryChangeType.Initial)
-                .Take(1));
+        // RunAsSystem, never `Observable.Using(() => ImpersonateAsSystem(), …)` — store and restore
+        // of the identity must land on the same thread (AGENTS.md; #1790).
+        return accessService.RunAsSystem(() => meshService
+            .Query<MeshNode>(MeshQueryRequest
+                // Every {Space}/_GitSync config — the webhook cannot know which space a push
+                // belongs to until it has read them all, so mesh-wide by nature (#3202).
+                .FromQuery(MeshWideQuery.OfType(GitHubSyncService.ConfigNodeType))
+                .Complete())
+            .Where(c => c.ChangeType == QueryChangeType.Initial)
+            .Take(1));
     }
 
     // ── workflow_run → build-completion record ───────────────────────────────

--- a/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
+++ b/src/MeshWeaver.Graph/Configuration/CreatableTypesProvider.cs
@@ -153,8 +153,9 @@ internal sealed class CreatableTypesProvider(
         if (string.IsNullOrEmpty(nodePath))
         {
             // Root listing: no namespace bound. Surface every NodeType
-            // definition so the create UI can offer the full menu.
-            return ["nodeType:NodeType"];
+            // definition so the create UI can offer the full menu — a catalog, mesh-wide by
+            // nature, and it says so (#3202 — fan-out is opt-in).
+            return [MeshWideQuery.OfType("NodeType")];
         }
 
         // Q1: NodeTypes along the ancestor chain of <myself> — picks up

--- a/src/MeshWeaver.Graph/Configuration/UiContributionCatalog.cs
+++ b/src/MeshWeaver.Graph/Configuration/UiContributionCatalog.cs
@@ -92,7 +92,9 @@ public sealed class UiContributionCatalog : IDisposable
                 using (accessService?.ImpersonateAsSystem())
                 {
                     return meshService
-                        .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{UiContributionNodeType.NodeType}"))
+                        // Contributions are authored wherever the contributing plugin lives, so the
+                        // catalog is mesh-wide by nature (#3202 — fan-out is opt-in).
+                        .Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.OfType(UiContributionNodeType.NodeType)))
                         .Subscribe(OnChange, ex =>
                         {
                             // Degrade to the last known set; the compiled menu is unaffected.

--- a/src/MeshWeaver.Graph/CreateLayoutArea.cs
+++ b/src/MeshWeaver.Graph/CreateLayoutArea.cs
@@ -659,7 +659,9 @@ public static class CreateLayoutArea
             Label = "Namespace",
             Placeholder = "Search a space to nest under...",
             DataContext = dataContext
-        }.WithQueries("nodeType:Space")
+        // Every Space root in the mesh — the picker offers every partition, so mesh-wide by
+        // nature (#3202 — fan-out is opt-in).
+        }.WithQueries(MeshWideQuery.OfType("Space"))
          .WithMaxResults(15)
          .WithStyle("width: 100%; margin-bottom: 16px;");
     }

--- a/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
+++ b/src/MeshWeaver.Graph/EventSubscriptionRunner.cs
@@ -209,7 +209,11 @@ public sealed class EventSubscriptionRunner(
 
     private void Reconcile(EventSubscription subscription)
     {
-        var query = $"nodeType:{subscription.TriggerNodeType}";
+        // A trigger type's instances live wherever they were written, so the reconcile is
+        // mesh-wide by nature and says so (#3202 — fan-out is opt-in). A type with a registered
+        // routing pin (User → Auth) is still served from its one schema: the planner narrows a
+        // declared fan-out by the pin before it enumerates.
+        var query = MeshWideQuery.Declare($"nodeType:{subscription.TriggerNodeType}");
         if (subscription is { MatchField.Length: > 0, MatchValue.Length: > 0 })
             query += $" content.{subscription.MatchField}:{subscription.MatchValue}";
 
@@ -253,7 +257,8 @@ public sealed class EventSubscriptionRunner(
         if (!nodeChangeSubs.TryAdd(nodeType, slot))
             return;   // lost the race — another emission just established this node type
         slot.Disposable = AsSystem(() => meshService.Query<MeshNode>(
-                MeshQueryRequest.FromQuery($"nodeType:{nodeType}")))
+                // Same mesh-wide shape as Reconcile, for the same reason (#3202).
+                MeshQueryRequest.FromQuery(MeshWideQuery.OfType(nodeType))))
             // Every ChangeType EXCEPT Removed means "a matching node exists now" and is a valid
             // existence-based reconcile trigger: Initial/Reset carry the full snapshot, Added a just-
             // created invitee (the deferred-grant case), Updated an existing one re-emitted. EXCLUDE

--- a/src/MeshWeaver.Graph/NodeTypeInstanceProbe.cs
+++ b/src/MeshWeaver.Graph/NodeTypeInstanceProbe.cs
@@ -128,7 +128,9 @@ public static class NodeTypeInstanceProbe
         return types
             .Select(type => meshService
                 .Query<MeshNode>(MeshQueryRequest
-                    .FromQuery($"nodeType:{type}")
+                    // A stranded instance may sit in any partition — the probe is mesh-wide by
+                    // nature and says so (#3202 — fan-out is opt-in).
+                    .FromQuery(MeshWideQuery.OfType(type))
                     .AsSystem() with { Limit = ProbeLimit })
                 .Take(1)
                 .Select(change =>

--- a/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/NodeTypeLayoutAreas.cs
@@ -152,7 +152,8 @@ public static class NodeTypeLayoutAreas
         // the fault logged — the type's own progress keeps rendering.
         var sweepStream = host.Workspace
             .GetQuery("nodetypes-compile-sweep",
-                "nodeType:NodeType select:path,id,name,nodeType,content")
+                // Every NodeType definition — a catalog, mesh-wide by nature (#3202).
+                MeshWideQuery.Declare("nodeType:NodeType select:path,id,name,nodeType,content"))
             .Catch((Exception ex) =>
             {
                 host.Hub.ServiceProvider.GetService<ILoggerFactory>()

--- a/src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs
+++ b/src/MeshWeaver.Graph/NodeTypeRecompileExtensions.cs
@@ -103,7 +103,8 @@ public static class NodeTypeRecompileExtensions
         // this scope leaking past the query.
         return accessService.RunAsSystem(
                 () => meshService
-                    .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
+                    // Every NodeType definition — a catalog, mesh-wide by nature (#3202).
+                    .Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.OfType(MeshNode.NodeTypePath)))
                     .Take(1)
                     .Timeout(TypeEnumerationBudget))
             .Select(change =>

--- a/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
+++ b/src/MeshWeaver.Graph/UserActivityLayoutAreas.cs
@@ -544,7 +544,10 @@ public static class UserActivityLayoutAreas
             return Observable.Return<IReadOnlyList<string>>([]);
         return mesh
             .Query<MeshNode>(MeshQueryRequest.FromQuery(
-                $"nodeType:AccessAssignment content.accessObject:{ownerId}"))
+                // A share grant lives in the GRANTING partition — that is what makes it a share —
+                // so "shared with me" cannot be anchored to the viewer and says so (#3202 —
+                // fan-out is opt-in). Doc/Architecture/UnanchoredSecurityReads → "Needs a decision".
+                MeshWideQuery.Declare($"nodeType:AccessAssignment content.accessObject:{ownerId}")))
             .Scan(ImmutableDictionary<string, MeshNode>.Empty,
                 (map, change) =>
                 {
@@ -694,7 +697,9 @@ public static class UserActivityLayoutAreas
     /// (leading-space <c>-nodeType:…</c> clauses) applies to the OWN leg only — the root leg has
     /// nothing left to exclude.</summary>
     private static string FirstLevelUnion(string ownerId, string sortSuffix, string exclusions = "") =>
-        $"namespace: is:main is:content{RootTypeFilter} {sortSuffix}\n" +
+        // The root leg enumerates the partition roots of EVERY partition — mesh-wide by nature, and
+        // it says so (#3202 — fan-out is opt-in). The own leg is anchored to the user's home.
+        $"namespace: is:main is:content{RootTypeFilter} {sortSuffix} {ParsedQuery.CrossPartitionQualifier}\n" +
         $"namespace:{ownerId} is:main is:content{exclusions} {sortSuffix}";
 
     /// <summary>The catalog query for a scope + sort suffix: the first-level union (the SPACES the viewer
@@ -705,7 +710,8 @@ public static class UserActivityLayoutAreas
     /// <c>Subtree</c> is the admin's explicit "show me everything" and keeps the deny-list shape.</summary>
     private static string CatalogQuery(HomeCatalogScope scope, string ownerId, string sortSuffix, string exclusions = "") =>
         scope == HomeCatalogScope.Subtree
-            ? $"is:main is:content -nodeType:User{exclusions} {sortSuffix}"
+            // "Show me everything" is every partition by definition (#3202 — fan-out is opt-in).
+            ? $"is:main is:content -nodeType:User{exclusions} {sortSuffix} {ParsedQuery.CrossPartitionQualifier}"
             : FirstLevelUnion(ownerId, sortSuffix, exclusions);
 
     // The three user-selectable sort orders (the view-options "Sort by" dropdown). LAST ACCESSED:

--- a/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
+++ b/src/MeshWeaver.Hosting/DynamicTypePreWarmer.cs
@@ -349,7 +349,8 @@ public static class DynamicTypePreWarmer
         // the way out of that same Subscribe.
         return accessService.RunAsSystem(
             () => meshService
-                .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
+                // Every NodeType definition — a catalog, mesh-wide by nature (#3202 — fan-out is opt-in).
+                .Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.OfType(MeshNode.NodeTypePath)))
                 .Take(1)
                 .Timeout(EnumerationBudget)
                 .SelectMany(change =>
@@ -458,7 +459,8 @@ public static class DynamicTypePreWarmer
         // `Observable.Using(AccessContextScope.AsSystem, …)` — see WarmDynamicTypes (#1444/#1790).
         return accessService.RunAsSystem(
             () => meshService
-                .Query<MeshNode>(MeshQueryRequest.FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
+                // Every NodeType definition — a catalog, mesh-wide by nature (#3202 — fan-out is opt-in).
+                .Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.OfType(MeshNode.NodeTypePath)))
                 .Take(1)
                 .Timeout(EnumerationBudget)
                 .SelectMany(change => NodeTypeBakeStatus.Probe(

--- a/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
+++ b/src/MeshWeaver.Hosting/ShippedPrebuiltBundles.cs
@@ -355,7 +355,8 @@ public static class ShippedPrebuiltBundles
                     typePathFilter, ImmutableDictionary<string, MeshNode>.Empty))
                 : meshService!
                     .Query<MeshNode>(MeshQueryRequest
-                        .FromQuery($"nodeType:{MeshNode.NodeTypePath}"))
+                        // Every NodeType definition — a catalog, mesh-wide by nature (#3202).
+                        .FromQuery(MeshWideQuery.OfType(MeshNode.NodeTypePath)))
                     .Take(1)
                     .Timeout(EnumerationBudget)
                     .Select(change =>

--- a/src/MeshWeaver.Mesh.Contract/Query/MeshWideQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/MeshWideQuery.cs
@@ -1,3 +1,5 @@
+using MeshWeaver.Mesh.Services;
+
 namespace MeshWeaver.Mesh;
 
 /// <summary>
@@ -39,7 +41,9 @@ public static class MeshWideQuery
 {
     /// <summary>
     /// <paramref name="query"/> with <see cref="ParsedQuery.CrossPartitionQualifier"/> appended
-    /// (idempotent — a query that already carries it is returned trimmed and unchanged).
+    /// (idempotent — a query the parser already reads as <see cref="ParsedQuery.CrossPartition"/> is
+    /// returned trimmed and unchanged; the decision is the parser's, not a substring's, so a value
+    /// that merely contains the text does not count and a token the parser sees always does).
     /// </summary>
     /// <param name="query">The query text, which names no partition on purpose.</param>
     /// <returns>The same query, declared mesh-wide.</returns>
@@ -47,7 +51,7 @@ public static class MeshWideQuery
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(query);
         var trimmed = query.Trim();
-        return trimmed.Contains(ParsedQuery.CrossPartitionQualifier, StringComparison.OrdinalIgnoreCase)
+        return new QueryParser().Parse(trimmed).CrossPartition
             ? trimmed
             : $"{trimmed} {ParsedQuery.CrossPartitionQualifier}";
     }

--- a/src/MeshWeaver.Mesh.Contract/Query/MeshWideQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Query/MeshWideQuery.cs
@@ -1,0 +1,63 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// Declares a query as MESH-WIDE — one whose answer genuinely lives in every partition, so the
+/// storage layer may UNION every partition schema for it (#3202).
+///
+/// <para>🚨 <b>Fan-out is opt-in, not the fallback.</b> Since MeshWeaver.Plugins #1231 the Postgres
+/// planner REFUSES a query that names no partition (no concrete <c>path:</c>/<c>namespace:</c>
+/// first segment, no registered node-type pin) and did not ask to span them — because a silent
+/// cross-schema UNION over 199 schemas takes heavyweight locks on 500+ relations and stalls every
+/// other query on the database (memex-cloud, 2026-09-02: 7 786 such fan-outs in 30 minutes). The
+/// refusal arrives at RUNTIME, as an <c>UnanchoredQueryException</c> faulting the caller's stream;
+/// nothing compiles differently and no test fails — which is how the sign-in path broke for every
+/// user on every image built after that change (#3202).</para>
+///
+/// <para>So a caller that reads across the whole mesh says so HERE, by construction, instead of
+/// relying on a fallback that no longer exists. The three legitimate reasons, and every call site
+/// carries one of them in its comment:</para>
+/// <list type="bullet">
+///   <item><b>A catalog whose instances live wherever their owner lives</b> — every
+///     <c>NodeType</c> definition, every <c>UiContribution</c>, every <c>Space</c> root, every
+///     <c>{Space}/_GitSync</c> config. There is no partition to anchor to because the set of
+///     partitions IS the answer.</item>
+///   <item><b>A record keyed by a value, not a location</b> — a <c>MeshWeaverInstance</c> looked
+///     up by id lives under whichever user registered it. The durable fix is an index in a pinned
+///     partition; until then the read declares its cost.</item>
+///   <item><b>A process-wide watch</b> — the outbound-mail sender, the event-subscription runner.
+///     One live subscription per process, re-run on relevant changes.</item>
+/// </list>
+///
+/// <para>🚨 <b>What this is NOT for.</b> A read whose subject provably lives in ONE partition —
+/// a user's own records, a partition's grants, a node by path — must be ANCHORED, never declared
+/// mesh-wide: the sign-in role fold (#3202) reads three pinned homes, not the whole mesh. And the
+/// security fold's own globals (<c>Role</c>, <c>GroupMembership</c>, gated types) go through
+/// <c>SecurityQueries.Global</c>, which stamps completeness as well — see
+/// <c>Doc/Architecture/UnanchoredSecurityReads</c>.</para>
+/// </summary>
+public static class MeshWideQuery
+{
+    /// <summary>
+    /// <paramref name="query"/> with <see cref="ParsedQuery.CrossPartitionQualifier"/> appended
+    /// (idempotent — a query that already carries it is returned trimmed and unchanged).
+    /// </summary>
+    /// <param name="query">The query text, which names no partition on purpose.</param>
+    /// <returns>The same query, declared mesh-wide.</returns>
+    public static string Declare(string query)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(query);
+        var trimmed = query.Trim();
+        return trimmed.Contains(ParsedQuery.CrossPartitionQualifier, StringComparison.OrdinalIgnoreCase)
+            ? trimmed
+            : $"{trimmed} {ParsedQuery.CrossPartitionQualifier}";
+    }
+
+    /// <summary>Every instance of <paramref name="nodeType"/> in the mesh — the catalog shape.</summary>
+    /// <param name="nodeType">The node type whose instances live in every partition.</param>
+    /// <returns><c>nodeType:{nodeType} partitions:all</c>.</returns>
+    public static string OfType(string nodeType)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(nodeType);
+        return Declare($"nodeType:{nodeType}");
+    }
+}

--- a/src/MeshWeaver.Mesh.Contract/Security/AccessSubjectQueries.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/AccessSubjectQueries.cs
@@ -38,7 +38,9 @@ public static class AccessSubjectQueries
     {
         var partition = Partition(scopePath);
         return string.IsNullOrEmpty(partition)
-            ? "nodeType:Group"
+            // The root scope's subject picker offers every group in the mesh — mesh-wide by
+            // nature, and it says so (#3202 — fan-out is opt-in).
+            ? MeshWideQuery.OfType("Group")
             : $"nodeType:Group namespace:{partition} scope:subtree";
     }
 

--- a/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
+++ b/src/MeshWeaver.Mesh.Contract/Security/SecurityQueries.cs
@@ -227,6 +227,46 @@ public static class SecurityQueries
             + $"nodeType:{SecurityCollections.PartitionAccessPolicyNodeType} {ContentProjection}");
 
     /// <summary>
+    /// The root-scope <c>AccessAssignment</c>s naming ONE subject — <see cref="RootAssignments"/>
+    /// narrowed to <paramref name="accessObject"/>, served by the same single registered schema.
+    ///
+    /// <para>One of the three legs of the SIGN-IN role fold (#3202): a user's platform roles are the
+    /// grants on the ROOT scope, on the <c>Admin</c> partition, and on their OWN partition — three
+    /// pinned homes, read with <see cref="PartitionAssignmentsFor"/> for the latter two. The read
+    /// used to be <c>nodeType:AccessAssignment content.accessObject:"{user}" scope:subtree</c>, no
+    /// partition named: a 199-schema UNION on every request, and — once the storage layer stopped
+    /// serving unanchored queries — a refusal that answered 503 to every signed-in user.</para>
+    /// </summary>
+    /// <param name="accessObject">The subject (user id) whose root grants to read.</param>
+    /// <returns>The query string.</returns>
+    public static string RootAssignmentsFor(string accessObject)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessObject);
+        return Scoped($"namespace:{RootAccessNamespace} "
+            + $"nodeType:{SecurityCollections.AccessAssignmentNodeType} "
+            + $"content.accessObject:\"{accessObject}\" {ContentProjection}");
+    }
+
+    /// <summary>
+    /// The <c>AccessAssignment</c>s in ONE partition naming ONE subject —
+    /// <see cref="PartitionAssignments"/> narrowed to <paramref name="accessObject"/>. Anchored by
+    /// <c>path:</c> for the reason given there: the partition IS where every scope of a path keeps
+    /// its grants, and <c>Admin</c> is excluded from cross-schema search, so a platform-admin grant
+    /// is reachable ONLY through a path-anchored read.
+    /// </summary>
+    /// <param name="partition">The partition (first path segment) to read.</param>
+    /// <param name="accessObject">The subject (user id) whose grants to read.</param>
+    /// <returns>The query string.</returns>
+    public static string PartitionAssignmentsFor(string partition, string accessObject)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(partition);
+        ArgumentException.ThrowIfNullOrWhiteSpace(accessObject);
+        return Enumeration($"path:{partition} scope:descendants "
+            + $"nodeType:{SecurityCollections.AccessAssignmentNodeType} "
+            + $"content.accessObject:\"{accessObject}\" {ContentProjection}");
+    }
+
+    /// <summary>
     /// Every query shape this class produces, for the completeness test that pins them. A member
     /// added without an entry here is not covered — which is why the test also asserts the fold's
     /// own builders against <see cref="Enumeration"/>.
@@ -240,5 +280,8 @@ public static class SecurityQueries
         RootPolicy,
         PartitionAssignments("acme"),
         PartitionPolicies("acme"),
+        RootAssignmentsFor("rbuergi"),
+        PartitionAssignmentsFor("Admin", "rbuergi"),
+        PartitionAssignmentsFor("rbuergi", "rbuergi"),
     ];
 }

--- a/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
+++ b/src/MeshWeaver.Mesh.Operations/MeshOperations.cs
@@ -1370,7 +1370,8 @@ public class MeshOperations
     /// </summary>
     public IObservable<string> Catalog()
     {
-        return mesh.Query<MeshNode>(new MeshQueryRequest { Query = "nodeType:NodeType", Limit = 1000 })
+        // Every NodeType definition — the catalog is mesh-wide by nature (#3202 — fan-out is opt-in).
+        return mesh.Query<MeshNode>(new MeshQueryRequest { Query = MeshWideQuery.OfType("NodeType"), Limit = 1000 })
             .Take(1)
             .Select(change =>
             {

--- a/src/MeshWeaver.PluginCatalog/InstanceComboReader.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceComboReader.cs
@@ -99,14 +99,16 @@ public sealed class InstanceComboReader(IMessageHub hub, ILogger<InstanceComboRe
         var readAt = DateTimeOffset.UtcNow;
         return Observable.Zip(
             // Every {Space}/_GitSync and {Space}/_GitSync/{sourceId} on the instance.
-            QuerySet($"nodeType:{GitHubSyncService.ConfigNodeType}", "sync entries ({Space}/_GitSync)"),
+            // Every space's _GitSync — mesh-wide by nature (#3202 — fan-out is opt-in).
+            QuerySet(MeshWideQuery.OfType(GitHubSyncService.ConfigNodeType), "sync entries ({Space}/_GitSync)"),
             // Every install record the package installer wrote.
             QuerySet(
                 $"path:{PackageInstaller.InstalledPartition} scope:children "
                 + $"nodeType:{PackageInstaller.PackageNodeType}",
                 $"install records ({PackageInstaller.InstalledPartition}/*)"),
             // Enrichment only — see the type remarks.
-            QuerySet($"nodeType:{ModuleDiscovery.NodeType}", "module-discovery records"),
+            // Discovery records are written next to the space they describe — mesh-wide (#3202).
+            QuerySet(MeshWideQuery.OfType(ModuleDiscovery.NodeType), "module-discovery records"),
             (sync, installs, discovery) => Fold(readAt, sync, installs, discovery));
     }
 

--- a/src/MeshWeaver.PluginCatalog/InstanceGrantAdminSettingsTab.cs
+++ b/src/MeshWeaver.PluginCatalog/InstanceGrantAdminSettingsTab.cs
@@ -388,7 +388,9 @@ public static class InstanceGrantAdminSettingsTab
             .WithView(meshService
                 .Query(new MeshQueryRequest
                 {
-                    Query = $"nodeType:{MeshWeaverInstanceNodeType.RegistrationKeyNodeType}",
+                    // Keys live under their owners; the admin view lists them all (#3202 — fan-out
+                    // is opt-in, so the mesh-wide read says so).
+                    Query = MeshWideQuery.OfType(MeshWeaverInstanceNodeType.RegistrationKeyNodeType),
                 })
                 .Select(results => results
                     // The node type covers keys AND their routing-index rows; the index rows live
@@ -598,7 +600,8 @@ public static class InstanceGrantAdminSettingsTab
             .WithView(meshService
                 .Query(new MeshQueryRequest
                 {
-                    Query = $"nodeType:{MeshWeaverInstanceNodeType.NodeType}",
+                    // Instances live under whichever user registered them (#3202 — see above).
+                    Query = MeshWideQuery.OfType(MeshWeaverInstanceNodeType.NodeType),
                 })
                 .Select(results => results
                     .Select(r => new GrantRow(r.Id ?? r.Path.Split('/').Last(), r.Name ?? "", r.Path))

--- a/src/MeshWeaver.PluginCatalog/InstancePlanService.cs
+++ b/src/MeshWeaver.PluginCatalog/InstancePlanService.cs
@@ -42,9 +42,13 @@ public sealed class InstancePlanService(IMessageHub hub, ILogger<InstancePlanSer
 
         var meshService = hub.ServiceProvider.GetRequiredService<IMeshService>();
         var accessService = hub.ServiceProvider.GetRequiredService<AccessService>();
+        // Keyed by id, filed under whichever user registered it — no partition to anchor to, so
+        // the read declares its cost (#3202 — fan-out is opt-in); the durable fix is an id → owner
+        // index in a pinned partition.
         var request = new MeshQueryRequest
         {
-            Query = $"nodeType:{MeshWeaverInstanceNodeType.NodeType} id:{instanceId.Trim()}",
+            Query = MeshWideQuery.Declare(
+                $"nodeType:{MeshWeaverInstanceNodeType.NodeType} id:{instanceId.Trim()}"),
         };
         return accessService.RunAsSystem(() => meshService.Query(request))
             .Take(1)

--- a/src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs
+++ b/src/MeshWeaver.PluginCatalog/ModuleDiscoveryService.cs
@@ -306,7 +306,8 @@ public sealed class ModuleDiscoveryService : IHostedService, IDisposable
         var installed = Query(
             $"path:{PackageInstaller.InstalledPartition} scope:children "
             + $"nodeType:{PackageInstaller.PackageNodeType}");
-        var syncConfigs = Query($"nodeType:{GitHubSyncService.ConfigNodeType}");
+        // Every space's _GitSync — mesh-wide by nature (#3202 — fan-out is opt-in).
+        var syncConfigs = Query(MeshWideQuery.OfType(GitHubSyncService.ConfigNodeType));
 
         return Observable.Zip(installed, syncConfigs, (records, configs) => new InstanceState(
             records.Select(n => n.Id).ToImmutableHashSet(StringComparer.OrdinalIgnoreCase),

--- a/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
@@ -101,14 +101,14 @@ public sealed class PluginUpdateWatcher : Microsoft.Extensions.Hosting.IHostedSe
 
         // Catalogs are read as SYSTEM: this runs on mesh startup with no ambient user, and a
         // catalog node is not anonymous-readable on an access-gated portal.
-        var sub = Observable.Using(
-                () => accessService.ImpersonateAsSystem(),
-                _ => meshService
-                    .Query<MeshNode>(MeshQueryRequest.FromQuery(
-                        // A catalog node is authored wherever its registry lives — mesh-wide by
-                        // nature (#3202 — fan-out is opt-in).
-                        MeshWideQuery.OfType(PluginCatalogConfigurationExtensions.CatalogNodeType)))
-                    .Take(1))
+        // RunAsSystem, never `Observable.Using(() => ImpersonateAsSystem(), …)` — store and restore
+        // of the identity must land on the same thread (AGENTS.md; #1790).
+        var sub = accessService.RunAsSystem(() => meshService
+                .Query<MeshNode>(MeshQueryRequest.FromQuery(
+                    // A catalog node is authored wherever its registry lives — mesh-wide by
+                    // nature (#3202 — fan-out is opt-in).
+                    MeshWideQuery.OfType(PluginCatalogConfigurationExtensions.CatalogNodeType)))
+                .Take(1))
             .Subscribe(
                 change =>
                 {

--- a/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
+++ b/src/MeshWeaver.PluginCatalog/PluginUpdateWatcher.cs
@@ -105,7 +105,9 @@ public sealed class PluginUpdateWatcher : Microsoft.Extensions.Hosting.IHostedSe
                 () => accessService.ImpersonateAsSystem(),
                 _ => meshService
                     .Query<MeshNode>(MeshQueryRequest.FromQuery(
-                        $"nodeType:{PluginCatalogConfigurationExtensions.CatalogNodeType}"))
+                        // A catalog node is authored wherever its registry lives — mesh-wide by
+                        // nature (#3202 — fan-out is opt-in).
+                        MeshWideQuery.OfType(PluginCatalogConfigurationExtensions.CatalogNodeType)))
                     .Take(1))
             .Subscribe(
                 change =>

--- a/test/Memex.Portal.Shared.Test/SignInReadsAreAnchoredTest.cs
+++ b/test/Memex.Portal.Shared.Test/SignInReadsAreAnchoredTest.cs
@@ -1,0 +1,167 @@
+using System.Reactive.Linq;
+using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 SIGNING IN MUST NOT DEPEND ON A MESH-WIDE QUERY. Issue #3202.
+///
+/// <para><b>What production showed.</b> Every page on a portal built from MeshWeaver.Plugins main at
+/// or after <c>fe20fe2a</c> answered 503 to every signed-in user — <i>"We could not check your
+/// account just now"</i> — with the log naming the cause:
+/// <c>LoadUserRoles(…) faulted: UnanchoredQueryException</c>. Plugins #1231 made fan-out opt-in
+/// (a query that names no partition and does not ask to span them is REFUSED), and the sign-in
+/// role read was exactly that shape:
+/// <c>nodeType:AccessAssignment content.accessObject:"{user}" scope:subtree</c>. The middleware
+/// behaved to the #637 contract — an infrastructure fault is never presented as "you have no
+/// account" — so the refusal became a 503 on every request instead of a silent privilege strip.
+/// Both production portals were frozen on older images until this landed.</para>
+///
+/// <para><b>The fix is three ANCHORED reads, not <c>partitions:all</c>.</b> A user's PLATFORM roles
+/// are granted in exactly three places by contract (<c>Doc/Architecture/AccessControl</c> → "Where
+/// to look"): the root scope (<c>_Access</c>, the registered global satellite — ONE schema), the
+/// <c>Admin</c> partition (the one meaning of "global admin"), and the user's own partition. Each
+/// pins one schema; the union is the complete answer, and <c>AccessContext.Roles</c> is read by no
+/// permission decision (see <see cref="OnboardingMiddleware.RoleQueries"/>). Declaring the fan-out
+/// instead would have restored the 199-schema UNION on every request that #2194 measured at ~4 s.</para>
+///
+/// <para>Two tests here, and both are needed: the GUARD classifies every query the middleware
+/// issues with the planner's own decision (so a future edit that re-introduces an unanchored read
+/// fails here, in this repo, instead of at runtime in another), and the BEHAVIOURAL test proves
+/// the three legs return the grants they are meant to — a guard alone could pass over three
+/// anchored reads that read the wrong homes.</para>
+/// </summary>
+public class SignInReadsAreAnchoredTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    /// <summary>The user with a grant in every home the fold reads, and one it must not.</summary>
+    private const string GrantedUser = "sign-in-granted";
+
+    /// <summary>A user with no grants anywhere: the fold RESOLVES to empty, it does not fault.</summary>
+    private const string UngrantedUser = "sign-in-ungranted";
+
+    /// <summary>A partition that is none of the three homes — a data grant, not a platform role.</summary>
+    private const string Elsewhere = "SignInElsewhere";
+
+    private static TimeSpan Budget => TestTimeouts.Convergence;
+
+    // ConfigureMeshBase, not base.ConfigureMesh: PublicAdminAccess would hand Public the Admin
+    // role in every default partition and blur what the three legs return.
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => ConfigureMeshBase(builder)
+            .AddMeshNodes(
+                new MeshNode(GrantedUser) { Name = "Granted", NodeType = "User" },
+                new MeshNode(Elsewhere) { Name = "Elsewhere", NodeType = "Markdown" },
+                // Root scope: _Access/{user}_Access — the registered global satellite.
+                AssignmentNodeFactory.UserRole(GrantedUser, "Viewer"),
+                // The Admin partition: Admin/_Access/{user}_Access — the platform-admin grant.
+                AssignmentNodeFactory.UserRole(GrantedUser, "Admin", OnboardingMiddleware.AdminPartition),
+                // The user's own partition: {user}/_Access/{user}_Access — Admin of my own home.
+                AssignmentNodeFactory.UserRole(GrantedUser, "Editor", GrantedUser),
+                // A grant in an arbitrary space: a DATA permission the fold evaluates from that
+                // space's own _Access at check time, not a platform role.
+                AssignmentNodeFactory.UserRole(GrantedUser, "Owner", Elsewhere));
+
+    // ————————————————————————— the guard
+
+    /// <summary>
+    /// Every query the middleware issues is served by the planner — anchored to one partition,
+    /// or pinned by a registered routing rule. The decision is the planner's own
+    /// (<c>IsSufficientlySpecified || ResolvesByRoutingHint</c>), taken against the REAL routing
+    /// rules of this mesh, so a rule that stopped resolving would fail here too.
+    /// </summary>
+    [Fact]
+    public void EveryQueryTheMiddlewareIssuesIsServedByThePlanner()
+    {
+        var configuration = Mesh.ServiceProvider.GetRequiredService<MeshConfiguration>();
+
+        foreach (var leg in OnboardingMiddleware.RoleQueries(GrantedUser))
+        {
+            QueryRouteClassifier.VerdictOf(leg, configuration).Should().Be(PlannerVerdict.Anchored,
+                $"a sign-in role leg names its partition — '{leg}'");
+            QueryRouteClassifier.RouteOf(leg).Kind.Should().Be(QueryRoute.Pinned,
+                $"and the router serves it from ONE schema — '{leg}'");
+        }
+
+        // The account lookup names no partition ON PURPOSE and is served through UserNodeType's
+        // routing rule (nodeType:User → Auth). The planner consults that rule before refusing, so
+        // this is the verdict it reaches — and the rule must resolve this EXACT text.
+        var userQuery = OnboardingMiddleware.UserByEmailQuery("someone@example.com");
+        QueryRouteClassifier.VerdictOf(userQuery, configuration).Should().Be(PlannerVerdict.PinnedByRoutingRule,
+            "nodeType:User with no path is routed to the Auth partition by UserNodeType's rule");
+        configuration.ResolveRoutingHints(new QueryParser().Parse(userQuery)).Partition
+            .Should().Be("Auth", "the auth-mirror partition holds every User node in the mesh");
+    }
+
+    /// <summary>
+    /// The controls that make the guard non-vacuous: the shape the sign-in read HAD is refused by
+    /// the same decision, and refused for the reason the issue names — no rule pins
+    /// <c>AccessAssignment</c> (it is one of the fold's never-narrowed types).
+    /// </summary>
+    [Fact]
+    public void ThePreviousSignInReadWouldBeRefused()
+    {
+        var configuration = Mesh.ServiceProvider.GetRequiredService<MeshConfiguration>();
+        const string before = "nodeType:AccessAssignment content.accessObject:\"sign-in-granted\" scope:subtree limit:all";
+
+        QueryRouteClassifier.VerdictOf(before, configuration).Should().Be(PlannerVerdict.Refused,
+            "the read #3202 replaced names no partition, declares no fan-out, and no routing rule pins it");
+        // …and the same decision with NO rules at all refuses the user lookup too — the guard can
+        // fail, and it fails on the half that depends on the rule being registered.
+        QueryRouteClassifier.VerdictOf(OnboardingMiddleware.UserByEmailQuery("a@b.c"), configuration: null)
+            .Should().Be(PlannerVerdict.Refused, "without UserNodeType's rule nodeType:User is unanchored");
+    }
+
+    // ————————————————————————— the behaviour
+
+    /// <summary>
+    /// The fold returns the grant from EACH of the three homes — root, Admin, own — and only those:
+    /// a grant in an arbitrary space is a data permission, not a platform role.
+    /// </summary>
+    [Fact]
+    public async Task TheRoleFoldReadsAllThreePlatformHomes()
+    {
+        var logger = Mesh.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(nameof(SignInReadsAreAnchoredTest));
+
+        var outcome = await OnboardingMiddleware.LoadUserRoles(Mesh.GetWorkspace(), GrantedUser, logger, Budget)
+            .Take(1).Timeout(Budget).Await(TestContext.Current.CancellationToken);
+
+        outcome.IsUnavailable.Should().BeFalse($"the read must RESOLVE — {outcome.UnavailableReason}");
+        outcome.Value.Should().NotBeNull();
+        outcome.Value!.Should().Contain("Viewer", "the ROOT grant (_Access) is read from the registered global satellite");
+        outcome.Value.Should().Contain("Admin", "the Admin/_Access grant IS the platform-admin role");
+        outcome.Value.Should().Contain("Editor", "the user's own partition holds the Admin-of-my-home grant");
+        outcome.Value.Should().NotContain("Owner",
+            "a grant in an arbitrary space is a DATA permission the fold evaluates at check time from "
+            + "that space's own _Access — folding it in was incidental to the mesh-wide query, and "
+            + "reading it would mean reading every partition again");
+    }
+
+    /// <summary>
+    /// No grants anywhere is a DEFINITIVE empty set — <c>Resolved([])</c>, never
+    /// <c>Unavailable</c>. The #637 contract: an empty role set means exactly one thing, "the read
+    /// completed and found no grants"; a 503 is reserved for a read that reached no verdict.
+    /// </summary>
+    [Fact]
+    public async Task AUserWithNoGrantsResolvesToNoRoles_NotToUnavailable()
+    {
+        var logger = Mesh.ServiceProvider.GetRequiredService<ILoggerFactory>()
+            .CreateLogger(nameof(SignInReadsAreAnchoredTest));
+
+        var outcome = await OnboardingMiddleware.LoadUserRoles(Mesh.GetWorkspace(), UngrantedUser, logger, Budget)
+            .Take(1).Timeout(Budget).Await(TestContext.Current.CancellationToken);
+
+        outcome.IsUnavailable.Should().BeFalse(
+            $"three anchored reads over partitions holding nothing for this user are an ANSWER — {outcome.UnavailableReason}");
+        outcome.Value.Should().NotBeNull();
+        outcome.Value!.Should().BeEmpty();
+    }
+}

--- a/test/Memex.Portal.Shared.Test/UnanchoredQueryCensusTest.cs
+++ b/test/Memex.Portal.Shared.Test/UnanchoredQueryCensusTest.cs
@@ -1,0 +1,213 @@
+using Memex.Portal.Shared.Authentication;
+using Memex.Portal.Shared.Email;
+using Memex.Portal.Shared.Settings;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.AspNetCore.Portal;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The census of every <c>nodeType:</c> query core issues at RUNTIME that names no partition in its
+/// text, fed to the decision the Postgres planner takes before running it (#3202, Plugins #1231):
+/// <c>IsSufficientlySpecified(parsed) || ResolvesByRoutingHint(parsed)</c>, the latter against the
+/// REAL <see cref="MeshConfiguration"/> of a running mesh. Everything else is refused at runtime
+/// with an <c>UnanchoredQueryException</c> — a fault nothing compiles differently for and no test
+/// used to catch, which is how the sign-in path broke for every user with both repositories green.
+///
+/// <para><b>The finding (2026-09-03, before this change).</b> Of the query literals under
+/// <c>src/</c> and <c>memex/</c> with <c>nodeType:</c> and no <c>path:</c>/<c>namespace:</c>/
+/// <c>partitions:all</c> on the same line, the ones the planner REFUSED — every other one was either
+/// anchored on an adjacent line or pinned by a routing rule — are listed in
+/// <see cref="RefusedBeforeThisChange"/>: the sign-in role fold, the home page's root and
+/// "shared with me" legs, the sitemap, every NodeType-catalog enumeration (compile sweep, pre-warm,
+/// prebuilt adoption, create menu, MCP catalog, cell surfaces), the UI-contribution catalog, the
+/// outbound-mail watch, the event-subscription runner, the GitHub webhook's config scan, the
+/// instance registry's id lookups, the What's New type lane, the Code usage prior, the stranded-
+/// instance probe, the root subject picker and the plugin-catalog watcher. Each is now either
+/// ANCHORED (the sign-in fold — three pinned homes) or DECLARED mesh-wide through
+/// <see cref="MeshWideQuery"/> with the reason at the call site.</para>
+///
+/// <para><b>How this can fail.</b> The corpus is asserted non-empty and every entry must parse to
+/// a query naming a node type (a matcher that matched nothing cannot pass); the known-refused
+/// shapes are asserted REFUSED and the known-anchored ones ANCHORED before the corpus is judged (a
+/// classifier that answered "served" to everything cannot pass); a parse or configuration fault
+/// propagates — nothing here is caught; and <see cref="TheHarnessGoesRedWhenTheRulesAreTakenAway"/>
+/// mutates the decision's input and asserts the verdict moves.</para>
+/// </summary>
+public class UnanchoredQueryCensusTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private MeshConfiguration MeshConfig => Mesh.ServiceProvider.GetRequiredService<MeshConfiguration>();
+
+    /// <summary>
+    /// Every runtime query core issues whose TEXT names no partition, as the code issues it today —
+    /// built from the public builders where the site exposes one, otherwise a literal copy of the
+    /// site's shape with representative substitutions and the site named. A site edited to a new
+    /// shape without updating its row here is exactly the drift the census exists to notice.
+    /// </summary>
+    private static IEnumerable<(string Site, string Query)> Corpus()
+    {
+        // ── sign-in / identity ──────────────────────────────────────────────────────────────
+        foreach (var leg in OnboardingMiddleware.RoleQueries("rbuergi"))
+            yield return ("OnboardingMiddleware.LoadUserRoles", leg);
+        yield return ("OnboardingMiddleware.FindUserByEmail", OnboardingMiddleware.UserByEmailQuery("a@b.c"));
+        yield return ("UserIdentityCache.DirectoryQuery", UserIdentityCache.DirectoryQuery.Query!);
+        yield return ("DevAuthController legacy User fallback", "nodeType:User");
+        yield return ("GroupInviteExtensions / SpaceInviteService", "nodeType:User content.email:a@b.c");
+        foreach (var q in AccessSubjectQueries.ForScope(null))
+            yield return ("AccessSubjectQueries.ForScope(root)", q);
+        foreach (var q in AccessSubjectQueries.ForScope("acme/doc"))
+            yield return ("AccessSubjectQueries.ForScope(acme/doc)", q);
+        foreach (var q in SecurityQueries.AllShapes)
+            yield return ("SecurityQueries", q);
+
+        // ── portal host (memex/Memex.Portal.Shared) ────────────────────────────────────────
+        yield return ("OutboundEmailSender.WatchQuery", OutboundEmailSender.WatchQuery);
+        foreach (var q in WhatsNewSettingsTab.ListingQueries)
+            yield return ("WhatsNewSettingsTab.ListingQueries", q);
+        yield return ("SeoEndpoints sitemap candidates", MeshWideQuery.Declare("nodeType:Space is:main limit:500"));
+        yield return ("MeshWeaverInstanceService id lookup", MeshWideQuery.Declare("nodeType:MeshWeaverInstance id:inst-1"));
+
+        // ── platform (src/) ────────────────────────────────────────────────────────────────
+        yield return ("NodeType catalog enumerations (pre-warm, sweep, recompile, prebuilt, cells, MCP)", MeshWideQuery.OfType("NodeType"));
+        yield return ("NodeTypeLayoutAreas compile sweep", MeshWideQuery.Declare("nodeType:NodeType select:path,id,name,nodeType,content"));
+        yield return ("CompletionUsageIndex", MeshWideQuery.Declare("nodeType:Code limit:2000"));
+        yield return ("UiContributionCatalog", MeshWideQuery.OfType("UiContribution"));
+        yield return ("CreateLayoutArea namespace picker", MeshWideQuery.OfType("Space"));
+        yield return ("EventSubscriptionRunner", MeshWideQuery.OfType("Invitation") + " content.email:a@b.c");
+        yield return ("GitHubWebhookProcessor / ModuleDiscovery / InstanceComboReader", MeshWideQuery.OfType("GitHubSync"));
+        yield return ("NodeTypeInstanceProbe", MeshWideQuery.OfType("Acme/Story"));
+        yield return ("PluginUpdateWatcher", MeshWideQuery.OfType("PluginCatalog"));
+        yield return ("InstanceGrantAdminSettingsTab / InstancePlanService", MeshWideQuery.Declare("nodeType:MeshWeaverInstance id:inst-1"));
+        yield return ("UserActivityLayoutAreas shared-with-me", MeshWideQuery.Declare("nodeType:AccessAssignment content.accessObject:rbuergi"));
+        yield return ("UserActivityLayoutAreas home root leg", "namespace: is:main is:content nodeType:Space sort:Name-asc partitions:all");
+        yield return ("UserActivityLayoutAreas home subtree scope", "is:main is:content -nodeType:User sort:Name-asc partitions:all");
+    }
+
+    /// <summary>
+    /// 🚨 THE FINDING — the shapes the planner refused before this change, one per call site, with
+    /// representative substitutions. Kept as the positive control: a classifier that cannot see a
+    /// refusal in THESE cannot be trusted to see one in the corpus.
+    /// </summary>
+    private static readonly (string Site, string Query)[] RefusedBeforeThisChange =
+    [
+        ("OnboardingMiddleware.LoadUserRoles (the 503 — #3202)", "nodeType:AccessAssignment content.accessObject:\"rbuergi\" scope:subtree limit:all"),
+        ("UserActivityLayoutAreas.ObserveSharedTargets (home: shared with me)", "nodeType:AccessAssignment content.accessObject:rbuergi"),
+        ("UserActivityLayoutAreas.FirstLevelUnion root leg (home: spaces)", "namespace: is:main is:content nodeType:Space sort:Name-asc"),
+        ("UserActivityLayoutAreas.CatalogQuery subtree scope (home: everything)", "is:main is:content -nodeType:User sort:Name-asc"),
+        ("SeoEndpoints sitemap candidates", "nodeType:Space is:main limit:500"),
+        ("MeshWeaverInstanceService.AdoptKeyHash / IsIdAvailable", "nodeType:MeshWeaverInstance id:inst-1"),
+        ("InstancePlanService / InstanceGrantAdminSettingsTab", "nodeType:MeshWeaverInstance"),
+        ("InstanceGrantAdminSettingsTab keys", "nodeType:RegistrationKey"),
+        ("OutboundEmailSender.WatchQuery", "nodeType:Email content.direction:Outbound -content.status:Sending -content.status:Sent -content.status:Failed"),
+        ("WhatsNewSettingsTab type lane", "nodeType:WhatsNew"),
+        ("DynamicTypePreWarmer / NodeTypeRecompileExtensions / ShippedPrebuiltBundles / CellSurfaceAssemblyProvider / CreatableTypesProvider / MeshOperations.Catalog", "nodeType:NodeType"),
+        ("NodeTypeLayoutAreas compile sweep", "nodeType:NodeType select:path,id,name,nodeType,content"),
+        ("CompletionUsageIndex", "nodeType:Code limit:2000"),
+        ("UiContributionCatalog", "nodeType:UiContribution"),
+        ("CreateLayoutArea namespace picker", "nodeType:Space"),
+        ("EventSubscriptionRunner (a trigger type with no routing rule)", "nodeType:Acme/Order content.status:Open"),
+        ("GitHubWebhookProcessor / ModuleDiscoveryService / InstanceComboReader", "nodeType:GitHubSync"),
+        ("InstanceComboReader discovery records", "nodeType:ModuleDiscovery"),
+        ("NodeTypeInstanceProbe", "nodeType:Acme/Story"),
+        ("PluginUpdateWatcher", "nodeType:PluginCatalog"),
+        ("AccessSubjectQueries.Groups(root)", "nodeType:Group"),
+    ];
+
+    /// <summary>
+    /// Shapes that were NOT refused although their text names no partition — the ones a routing
+    /// rule pins. Listed so the census records WHY they are absent from the finding, and so the
+    /// rule's disappearance would show up here.
+    /// </summary>
+    private static readonly (string Site, string Query, string Partition)[] PinnedByRule =
+    [
+        ("OnboardingMiddleware.FindUserByEmail", "nodeType:User content.email:a@b.c limit:1", "Auth"),
+        ("UserIdentityCache.DirectoryQuery", "nodeType:User", "Auth"),
+        ("EventSubscriptionRunner (Invitation trigger)", "nodeType:Invitation", "Admin"),
+        ("EventSubscriptionRunner (EventSubscription trigger)", "nodeType:EventSubscription", "Admin"),
+    ];
+
+    [Fact]
+    public void ThePlannerRefusedEveryShapeInTheFinding_AndPinsTheRuledOnes()
+    {
+        var configuration = MeshConfig;
+        RefusedBeforeThisChange.Should().NotBeEmpty();
+        foreach (var (site, query) in RefusedBeforeThisChange)
+            QueryRouteClassifier.VerdictOf(query, configuration).Should().Be(PlannerVerdict.Refused,
+                $"{site} issued '{query}', which names no partition and is pinned by no rule");
+
+        PinnedByRule.Should().NotBeEmpty();
+        foreach (var (site, query, partition) in PinnedByRule)
+        {
+            QueryRouteClassifier.VerdictOf(query, configuration).Should().Be(PlannerVerdict.PinnedByRoutingRule,
+                $"{site} issues '{query}', which a registered routing rule pins");
+            configuration.ResolveRoutingHints(new QueryParser().Parse(query)).Partition.Should().Be(partition);
+        }
+    }
+
+    /// <summary>
+    /// The census proper: after this change no runtime query core issues is refused. The refused
+    /// set is printed whatever its size — an empty one is the assertion, never a silent pass.
+    /// </summary>
+    [Fact]
+    public void NoRuntimeQueryCoreIssuesIsRefused()
+    {
+        var configuration = MeshConfig;
+        var corpus = Corpus().ToArray();
+        corpus.Should().NotBeEmpty("a census over nothing proves nothing");
+
+        var parser = new QueryParser();
+        foreach (var (site, query) in corpus)
+        {
+            var parsed = parser.Parse(query);
+            (parsed.ExtractNodeType() is not null || parsed.IsMain == true || !string.IsNullOrEmpty(parsed.Path))
+                .Should().BeTrue(
+                    $"{site}: '{query}' must parse to a query the planner can classify — a row the parser "
+                    + "reads as empty is a row the census is not measuring");
+        }
+
+        var verdicts = corpus
+            .Select(x => (x.Site, x.Query, Verdict: QueryRouteClassifier.VerdictOf(x.Query, configuration)))
+            .ToArray();
+        var refused = verdicts.Where(v => v.Verdict == PlannerVerdict.Refused).ToArray();
+
+        Output.WriteLine($"census: {verdicts.Length} queries, {refused.Length} refused");
+        foreach (var (site, query, verdict) in verdicts)
+            Output.WriteLine($"  [{verdict}] {site}: {query}");
+
+        refused.Should().BeEmpty(
+            "every runtime query core issues must be anchored, pinned by a routing rule, or DECLARED "
+            + "mesh-wide through MeshWideQuery with the reason at the call site — the storage layer "
+            + "refuses anything else at runtime, and that refusal is invisible to the compiler (#3202). "
+            + "Refused: " + string.Join("; ", refused.Select(r => $"{r.Site}: '{r.Query}'")));
+
+        // The declared fan-outs are the ones whose cost is knowingly paid — record how many.
+        verdicts.Count(v => v.Verdict == PlannerVerdict.DeclaredFanOut).Should().BePositive(
+            "core has genuine catalogs (NodeType, UiContribution, Space roots) that ARE mesh-wide; a census "
+            + "that finds none of them declared is reading the wrong corpus");
+    }
+
+    /// <summary>
+    /// 🚨 The mutation: the decision's second input is the routing rules. Take them away and the
+    /// rule-pinned rows must flip to REFUSED, so a corpus that passes only because of a rule cannot
+    /// pass under a planner without it. If this stayed green, the harness would be measuring the
+    /// classifier's optimism rather than the planner's decision.
+    /// </summary>
+    [Fact]
+    public void TheHarnessGoesRedWhenTheRulesAreTakenAway()
+    {
+        var withRules = Corpus().Select(x => QueryRouteClassifier.VerdictOf(x.Query, MeshConfig)).ToArray();
+        var withoutRules = Corpus().Select(x => QueryRouteClassifier.VerdictOf(x.Query, configuration: null)).ToArray();
+
+        withRules.Should().NotContain(PlannerVerdict.Refused);
+        withoutRules.Should().Contain(PlannerVerdict.Refused,
+            "the corpus carries rule-pinned reads (nodeType:User), so removing the rules must produce a refusal");
+        withoutRules.Count(v => v == PlannerVerdict.Refused).Should().Be(
+            withRules.Count(v => v == PlannerVerdict.PinnedByRoutingRule),
+            "exactly the rule-pinned rows flip; anchored and declared rows do not depend on rules");
+    }
+}

--- a/test/Memex.Portal.Shared.Test/WhatsNewSatelliteEntryTest.cs
+++ b/test/Memex.Portal.Shared.Test/WhatsNewSatelliteEntryTest.cs
@@ -68,8 +68,11 @@ public class WhatsNewSatelliteEntryTest(ITestOutputHelper output) : MonolithMesh
         WhatsNewSettingsTab.ListingQueries.Should().Contain(
             $"path:{WhatsNewSettingsTab.WhatsNewNamespace} scope:children",
             "the 612 existing entries carry no nodeType — dropping this lane would empty the feed");
+        // The type lane is mesh-wide BY DESIGN (a satellite files entries in its own tree), so it
+        // DECLARES the fan-out — fan-out is opt-in since Plugins #1231, and an undeclared
+        // path-less read is refused at runtime (#3202).
         WhatsNewSettingsTab.ListingQueries.Should().Contain(
-            $"nodeType:{WhatsNewSettingsTab.EntryNodeType}",
-            "the satellite lane is what #2539 adds");
+            MeshWideQuery.OfType(WhatsNewSettingsTab.EntryNodeType),
+            "the satellite lane is what #2539 adds, and it says out loud that it spans every partition");
     }
 }

--- a/test/MeshWeaver.Fixture/QueryRouteClassifier.cs
+++ b/test/MeshWeaver.Fixture/QueryRouteClassifier.cs
@@ -1,0 +1,170 @@
+using System.Collections.Immutable;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+
+namespace MeshWeaver.Fixture;
+
+/// <summary>How the Postgres router answers a query — the three outcomes it actually has.</summary>
+public enum QueryRoute
+{
+    /// <summary>One concrete schema: the lowercased first segment, or a registered global satellite's schema.</summary>
+    Pinned,
+
+    /// <summary>A first segment the router refuses to route (an unregistered <c>_</c>-prefixed segment): no schema, no fan-out, no write can ever land there.</summary>
+    Unroutable,
+
+    /// <summary>No first segment, or a wildcard one: a <c>UNION ALL</c> over every partition schema.</summary>
+    FanOut,
+}
+
+/// <summary>
+/// The decision the Postgres planner takes on a query BEFORE it runs it — the one that, since
+/// MeshWeaver.Plugins #1231, ends in an <c>UnanchoredQueryException</c> for a query that names no
+/// partition and did not ask to span them (#3202).
+/// </summary>
+public enum PlannerVerdict
+{
+    /// <summary>The query names its partition — a concrete <c>path:</c>/<c>namespace:</c> first segment, a multi-path, or a wildcard namespace pattern.</summary>
+    Anchored,
+
+    /// <summary>The query carries <c>partitions:all</c> — the explicit, declared fan-out.</summary>
+    DeclaredFanOut,
+
+    /// <summary>The query text names no partition, but a registered <c>QueryRoutingRule</c> (a node-type pin such as <c>nodeType:User</c> → <c>Auth</c>) does.</summary>
+    PinnedByRoutingRule,
+
+    /// <summary>None of the above: the planner REFUSES the query at runtime.</summary>
+    Refused,
+}
+
+/// <summary>
+/// The ONE test-side reproduction of the Postgres router's routing and refusal rules, shared by
+/// every census that classifies query shapes (<c>SecurityQueryShapesTest</c>, the sign-in guard,
+/// the unanchored-query census) so two copies cannot drift apart — a hand-copied classifier that
+/// "cannot drift because it is the single implementation" is a hypothesis three defects disproved
+/// in one day.
+///
+/// <para><b>Routing</b> (<see cref="RouteOf"/>) mirrors <c>PostgreSqlPartitionedMeshQuery</c> /
+/// <c>PostgreSqlPathRoutingAdapter</c>: the first segment of <c>path:</c> (which a single
+/// <c>namespace:</c> also sets), lowercased, unless it is a wildcard (fan-out), empty (fan-out), or
+/// <c>_</c>-prefixed (registered → its schema, otherwise unroutable).</para>
+///
+/// <para><b>Refusal</b> (<see cref="VerdictOf"/>) mirrors the planner's gate in
+/// <c>PostgreSqlPartitionedMeshQuery.FanOutQuery</c>: a query is served iff
+/// <c>IsSufficientlySpecified(parsed) || ResolvesByRoutingHint(parsed)</c>, where the first is
+/// <c>CrossPartition || concrete first segment || Paths.Count &gt; 0 || a wildcard namespace
+/// pattern</c> and the second is a non-empty <c>MeshConfiguration.ResolveRoutingHints(parsed).Partition</c>.
+/// The planner's own copy is pinned by <c>PostgreSqlPartitionedMeshQueryMappingTests</c> in
+/// MeshWeaver.Plugins; this mirror is pinned against the same corpus so the two agree.</para>
+/// </summary>
+public static class QueryRouteClassifier
+{
+    /// <summary>
+    /// The global satellite namespaces the platform registers with an explicit schema
+    /// (<c>DefaultPartitionProvider.CreateGlobalSatellitePartition</c>) — the registry the router's
+    /// <c>ResolveGlobalSchema</c> consults for a <c>_</c>-prefixed first segment. Mirrored here so
+    /// the shape tests stay pure parser tests; <c>SecurityQueryRootLegRegistryTest</c> asserts this
+    /// mirror against the REAL registry of a running mesh, so it cannot drift silently.
+    /// </summary>
+    public static readonly ImmutableDictionary<string, string> RegisteredGlobalSatellites =
+        ImmutableDictionary<string, string>.Empty.Add(SecurityQueries.RootAccessNamespace, "system_access");
+
+    /// <summary>The route a query takes, reproduced on the shared <see cref="QueryParser"/>.</summary>
+    /// <param name="query">The query text.</param>
+    /// <returns>The route kind and, when pinned, the schema it pins to.</returns>
+    public static (QueryRoute Kind, string? Target) RouteOf(string query)
+    {
+        var parsed = new QueryParser().Parse(query);
+        var fromPath = RouteOfSegment(parsed.Path);
+        if (fromPath.Kind != QueryRoute.FanOut)
+            return fromPath;
+        foreach (var ns in parsed.ExtractNamespaces())
+        {
+            var fromNamespace = RouteOfSegment(ns);
+            if (fromNamespace.Kind != QueryRoute.FanOut)
+                return fromNamespace;
+        }
+        return (QueryRoute.FanOut, null);
+    }
+
+    private static (QueryRoute Kind, string? Target) RouteOfSegment(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return (QueryRoute.FanOut, null);
+        var trimmed = path.Trim().Trim('/');
+        if (trimmed.Length == 0)
+            return (QueryRoute.FanOut, null);
+        var slash = trimmed.IndexOf('/');
+        var first = slash > 0 ? trimmed[..slash] : trimmed;
+        if (first.Length == 0 || first == "*" || first.Contains('*'))
+            return (QueryRoute.FanOut, null);
+        if (first.StartsWith('_'))
+            return RegisteredGlobalSatellites.TryGetValue(first, out var schema)
+                ? (QueryRoute.Pinned, schema)
+                : (QueryRoute.Unroutable, null);
+        return (QueryRoute.Pinned, first.ToLowerInvariant());
+    }
+
+    /// <summary>
+    /// The planner's <c>IsSufficientlySpecified</c>: whether the query text itself says where to
+    /// look. Three ways, and a query needs exactly one — a concrete anchor, the explicit
+    /// <c>partitions:all</c>, or a wildcard namespace pattern (which the parser keeps as a filter,
+    /// leaving <see cref="ParsedQuery.Path"/> null — a Path-only check would refuse exactly the
+    /// satellite browses that are the legitimate spanning reads).
+    /// </summary>
+    /// <param name="parsed">The parsed query.</param>
+    /// <returns>True when the text names a partition or declares the fan-out.</returns>
+    public static bool IsSufficientlySpecified(ParsedQuery parsed) =>
+        parsed.CrossPartition
+        || IsConcreteAnchor(parsed.Path)
+        || parsed.Paths is { Count: > 0 }
+        || parsed.ExtractNamespacePatterns().Count > 0;
+
+    private static bool IsConcreteAnchor(string? path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return false;
+        var trimmed = path.Trim('/');
+        if (trimmed.Length == 0)
+            return false;
+        var slash = trimmed.IndexOf('/');
+        var first = slash < 0 ? trimmed : trimmed[..slash];
+        return first.Length > 0 && first != "*";
+    }
+
+    /// <summary>
+    /// The planner's decision for <paramref name="query"/> under <paramref name="configuration"/>'s
+    /// routing rules — <see cref="PlannerVerdict.Refused"/> is what arrives at runtime as an
+    /// <c>UnanchoredQueryException</c> faulting the caller's stream.
+    /// </summary>
+    /// <param name="query">The query text, exactly as the caller issues it.</param>
+    /// <param name="configuration">The mesh configuration whose <c>QueryRoutingRules</c> the planner consults, or null for a planner with no rules.</param>
+    /// <returns>The verdict.</returns>
+    public static PlannerVerdict VerdictOf(string query, MeshConfiguration? configuration)
+    {
+        var parsed = string.IsNullOrEmpty(query) ? ParsedQuery.Empty : new QueryParser().Parse(query);
+        if (parsed.CrossPartition)
+            return PlannerVerdict.DeclaredFanOut;
+        if (IsSufficientlySpecified(parsed))
+            return PlannerVerdict.Anchored;
+        if (configuration is not null
+            && !string.IsNullOrEmpty(configuration.ResolveRoutingHints(parsed).Partition))
+            return PlannerVerdict.PinnedByRoutingRule;
+        return PlannerVerdict.Refused;
+    }
+
+    /// <summary>
+    /// The shape <c>PostgreSqlCrossSchemaQueryProvider.DescribeQueryShape</c> puts on the
+    /// <c>[CrossSchema] SLOW</c> line — <c>nodeType:{type|*} path:{path|-} scope:{Scope}</c> — so
+    /// a census here and the Loki census speak the same vocabulary.
+    /// </summary>
+    /// <param name="query">The query text.</param>
+    /// <returns>The shape.</returns>
+    public static string Describe(string query)
+    {
+        var parsed = new QueryParser().Parse(query);
+        return $"nodeType:{parsed.ExtractNodeType() ?? "*"}"
+            + $" path:{(string.IsNullOrEmpty(parsed.Path) ? "-" : parsed.Path)}"
+            + $" scope:{parsed.Scope}";
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/SecurityQueryRootLegRegistryTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SecurityQueryRootLegRegistryTest.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using MeshWeaver.Fixture;
 using MeshWeaver.Graph.Configuration;
 using MeshWeaver.Hosting.Monolith.TestBase;
 using MeshWeaver.Mesh;
@@ -12,7 +13,7 @@ using Xunit;
 namespace MeshWeaver.Hosting.Test;
 
 /// <summary>
-/// Pins <see cref="SecurityQueryShapesTest.RegisteredGlobalSatellites"/> — the mirror the pure
+/// Pins <see cref="QueryRouteClassifier.RegisteredGlobalSatellites"/> — the mirror the pure
 /// shapes test classifies <c>_</c>-prefixed first segments with — against the REAL registry of a
 /// running mesh: the <c>Partition</c> nodes the static providers ship, which is what the Postgres
 /// router's <c>TryGetRegisteredPartition</c> is seeded from at boot. A mirror that nothing compares
@@ -47,7 +48,7 @@ public class SecurityQueryRootLegRegistryTest(ITestOutputHelper output) : Monoli
     {
         var real = RegisteredGlobalSatellites();
         real.Should().NotBeEmpty("DefaultPartitionProvider registers at least _Access");
-        var mirror = SecurityQueryShapesTest.RegisteredGlobalSatellites;
+        var mirror = QueryRouteClassifier.RegisteredGlobalSatellites;
         real.Keys.OrderBy(k => k, StringComparer.Ordinal).Should().Equal(
             mirror.Keys.OrderBy(k => k, StringComparer.Ordinal),
             "the shapes test classifies `_`-prefixed first segments with this mirror; when a global "

--- a/test/MeshWeaver.Hosting.Test/SecurityQueryShapesTest.cs
+++ b/test/MeshWeaver.Hosting.Test/SecurityQueryShapesTest.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using MeshWeaver.Fixture;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.Mesh.Services;
@@ -129,7 +129,7 @@ public class SecurityQueryShapesTest
         var declared = DeliberatelyGlobal.Select(x => x.Shape).ToHashSet(StringComparer.Ordinal);
 
         var undeclared = SecurityQueries.AllShapes
-            .Where(shape => RouteOf(shape).Kind == Route.FanOut && !declared.Contains(shape))
+            .Where(shape => RouteOf(shape).Kind == QueryRoute.FanOut && !declared.Contains(shape))
             .ToArray();
 
         undeclared.Should().BeEmpty(
@@ -141,7 +141,7 @@ public class SecurityQueryShapesTest
         // …and the reverse: a declared entry that has since stopped fanning out must be struck, or
         // the list becomes a fiction that outlives its subject.
         foreach (var (shape, reason) in DeliberatelyGlobal)
-            RouteOf(shape).Kind.Should().Be(Route.FanOut,
+            RouteOf(shape).Kind.Should().Be(QueryRoute.FanOut,
                 $"'{shape}' is declared global because {reason} — if it no longer fans out, "
                 + "remove it from the list rather than leaving a stale justification behind");
     }
@@ -156,7 +156,7 @@ public class SecurityQueryShapesTest
     public void TheRootAccessLegPinsTheRegisteredGlobalSchema()
     {
         var route = RouteOf(SecurityQueries.RootAssignments);
-        route.Kind.Should().Be(Route.Pinned,
+        route.Kind.Should().Be(QueryRoute.Pinned,
             "a root-scope AccessAssignment lives at _Access/{id}, and _Access resolves through the "
             + "registered global-satellite definitions to ONE schema");
         route.Target.Should().Be("system_access");
@@ -167,20 +167,20 @@ public class SecurityQueryShapesTest
     /// UNIONs every partition schema for it; the path-less spelling it replaced is kept here as the
     /// control that DID fan out. Today the segment is unregistered, so the read is unroutable (and
     /// answered empty — exactly what the fan-out returned, 179 times per five minutes); registering
-    /// <c>_Policy</c> as a global satellite flips this to <see cref="Route.Pinned"/> with no change
+    /// <c>_Policy</c> as a global satellite flips this to <see cref="QueryRoute.Pinned"/> with no change
     /// to the query, at which point this assertion is the one to update.
     /// </summary>
     [Fact]
     public void TheRootPolicyLegNeverFansOut()
     {
-        RouteOf(SecurityQueries.RootPolicy).Kind.Should().Be(Route.Unroutable,
+        RouteOf(SecurityQueries.RootPolicy).Kind.Should().Be(QueryRoute.Unroutable,
             "path:_Policy names the same node as `namespace: id:_Policy` but gives the router a first "
             + "segment; no global satellite is registered for _Policy, so it routes to no schema "
             + "rather than to all of them");
 
         // The control: the spelling #2194 replaced fanned out, and would again.
         RouteOf("namespace: id:_Policy nodeType:PartitionAccessPolicy limit:all").Kind
-            .Should().Be(Route.FanOut, "the path-less spelling has no first segment to route on");
+            .Should().Be(QueryRoute.FanOut, "the path-less spelling has no first segment to route on");
     }
 
     /// <summary>
@@ -256,7 +256,7 @@ public class SecurityQueryShapesTest
         {
             new QueryParser().Parse(shape).CrossPartition.Should().BeTrue(
                 $"a mesh-wide fold read must declare it — {reason}");
-            RouteOf(shape).Kind.Should().Be(Route.FanOut,
+            RouteOf(shape).Kind.Should().Be(QueryRoute.FanOut,
                 $"declaring the fan-out must not have anchored it — {reason}");
         }
     }
@@ -276,7 +276,7 @@ public class SecurityQueryShapesTest
     public void AnAnchoredScopeLegPinsItsPartition(string query, string expected)
     {
         var route = RouteOf(query);
-        route.Kind.Should().Be(Route.Pinned);
+        route.Kind.Should().Be(QueryRoute.Pinned);
         route.Target.Should().Be(expected);
     }
 
@@ -296,10 +296,10 @@ public class SecurityQueryShapesTest
     [Fact]
     public void ThePerPartitionLegsPinTheirPartition()
     {
-        RouteOf(SecurityQueries.PartitionAssignments("acme")).Should().Be((Route.Pinned, "acme"));
-        RouteOf(SecurityQueries.PartitionPolicies("acme")).Should().Be((Route.Pinned, "acme"));
+        RouteOf(SecurityQueries.PartitionAssignments("acme")).Should().Be((QueryRoute.Pinned, "acme"));
+        RouteOf(SecurityQueries.PartitionPolicies("acme")).Should().Be((QueryRoute.Pinned, "acme"));
         // "Admin" is PermissionEvaluator.AdminScope, which is internal to Mesh.Contract.
-        RouteOf(SecurityQueries.PartitionAssignments("Admin")).Should().Be((Route.Pinned, "admin"),
+        RouteOf(SecurityQueries.PartitionAssignments("Admin")).Should().Be((QueryRoute.Pinned, "admin"),
                 "the Admin partition is excluded from searchable_schemas, so its grants are only "
                 + "reachable through a path-anchored read — that is why the fold used to carry an "
                 + "Admin special case, and why every partition now takes that route");
@@ -310,81 +310,29 @@ public class SecurityQueryShapesTest
     [InlineData("namespace: id:_Policy limit:all")]
     [InlineData("path:*/Source scope:subtree nodeType:Code")]
     public void AnUnanchoredShapeFansOut(string query)
-        => RouteOf(query).Kind.Should().Be(Route.FanOut);
-
-    // ————————————————————————— the classifier
-
-    /// <summary>How the Postgres router answers a query — the three outcomes it actually has.</summary>
-    private enum Route
-    {
-        /// <summary>One concrete schema: the lowercased first segment, or a registered global satellite's schema.</summary>
-        Pinned,
-        /// <summary>A first segment the router refuses to route (an unregistered <c>_</c>-prefixed segment): no schema, no fan-out, no write can ever land there.</summary>
-        Unroutable,
-        /// <summary>No first segment, or a wildcard one: a <c>UNION ALL</c> over every partition schema.</summary>
-        FanOut,
-    }
+        => RouteOf(query).Kind.Should().Be(QueryRoute.FanOut);
 
     /// <summary>
-    /// The global satellite namespaces the platform registers with an explicit schema
-    /// (<c>DefaultPartitionProvider.CreateGlobalSatellitePartition</c>) — the registry the router's
-    /// <c>ResolveGlobalSchema</c> consults for a <c>_</c>-prefixed first segment. Mirrored here so
-    /// the shapes test stays a pure parser test; <see cref="SecurityQueryRootLegRegistryTest"/>
-    /// asserts this mirror against the REAL registry of a running mesh, so it cannot drift silently.
+    /// The SIGN-IN role fold's three legs (#3202) — the identity-side reads that replaced
+    /// <c>nodeType:AccessAssignment content.accessObject:"{user}" scope:subtree</c>, the query that
+    /// UNION-ed every partition schema on every request and, once the storage layer stopped serving
+    /// unanchored queries, answered 503 to every signed-in user. Each pins ONE schema: the root leg
+    /// the registered <c>system_access</c>, the other two the partition they name.
     /// </summary>
-    internal static readonly ImmutableDictionary<string, string> RegisteredGlobalSatellites =
-        ImmutableDictionary<string, string>.Empty.Add(SecurityQueries.RootAccessNamespace, "system_access");
-
-    /// <summary>
-    /// The route a query takes, reproduced on the shared <see cref="QueryParser"/> from the rules
-    /// <c>PostgreSqlPartitionedMeshQuery</c> / <c>PostgreSqlPathRoutingAdapter</c> apply — first
-    /// segment of <c>path:</c> (which a single <c>namespace:</c> also sets), lowercased, unless it
-    /// is a wildcard (fan-out), empty (fan-out), or <c>_</c>-prefixed (registered → its schema,
-    /// otherwise unroutable) — so the census is measured rather than asserted.
-    /// </summary>
-    private static (Route Kind, string? Target) RouteOf(string query)
+    [Fact]
+    public void TheSignInLegsPinTheirSchemas()
     {
-        var parsed = new QueryParser().Parse(query);
-        var fromPath = RouteOfSegment(parsed.Path);
-        if (fromPath.Kind != Route.FanOut)
-            return fromPath;
-        foreach (var ns in parsed.ExtractNamespaces())
-        {
-            var fromNamespace = RouteOfSegment(ns);
-            if (fromNamespace.Kind != Route.FanOut)
-                return fromNamespace;
-        }
-        return (Route.FanOut, null);
+        RouteOf(SecurityQueries.RootAssignmentsFor("rbuergi")).Should().Be((QueryRoute.Pinned, "system_access"));
+        RouteOf(SecurityQueries.PartitionAssignmentsFor("Admin", "rbuergi")).Should().Be((QueryRoute.Pinned, "admin"),
+            "a platform-admin grant lives in Admin/_Access and nowhere else (AGENTS.md → Global admin)");
+        RouteOf(SecurityQueries.PartitionAssignmentsFor("rbuergi", "rbuergi")).Should().Be((QueryRoute.Pinned, "rbuergi"));
+
+        // The control: the shape these replaced is the fan-out.
+        RouteOf("nodeType:AccessAssignment content.accessObject:\"rbuergi\" scope:subtree limit:all").Kind
+            .Should().Be(QueryRoute.FanOut, "the pre-#3202 sign-in read named no partition");
     }
 
-    private static (Route Kind, string? Target) RouteOfSegment(string? path)
-    {
-        if (string.IsNullOrWhiteSpace(path))
-            return (Route.FanOut, null);
-        var trimmed = path.Trim().Trim('/');
-        if (trimmed.Length == 0)
-            return (Route.FanOut, null);
-        var slash = trimmed.IndexOf('/');
-        var first = slash > 0 ? trimmed[..slash] : trimmed;
-        if (first.Length == 0 || first == "*" || first.Contains('*'))
-            return (Route.FanOut, null);
-        if (first.StartsWith('_'))
-            return RegisteredGlobalSatellites.TryGetValue(first, out var schema)
-                ? (Route.Pinned, schema)
-                : (Route.Unroutable, null);
-        return (Route.Pinned, first.ToLowerInvariant());
-    }
+    private static (QueryRoute Kind, string? Target) RouteOf(string query) => QueryRouteClassifier.RouteOf(query);
 
-    /// <summary>
-    /// The shape <c>PostgreSqlCrossSchemaQueryProvider.DescribeQueryShape</c> puts on the
-    /// <c>[CrossSchema] SLOW</c> line — <c>nodeType:{type|*} path:{path|-} scope:{Scope}</c> — so
-    /// the census here and the Loki census speak the same vocabulary.
-    /// </summary>
-    private static string Describe(string query)
-    {
-        var parsed = new QueryParser().Parse(query);
-        return $"nodeType:{parsed.ExtractNodeType() ?? "*"}"
-            + $" path:{(string.IsNullOrEmpty(parsed.Path) ? "-" : parsed.Path)}"
-            + $" scope:{parsed.Scope}";
-    }
+    private static string Describe(string query) => QueryRouteClassifier.Describe(query);
 }


### PR DESCRIPTION
Closes #3202

## What broke

Every signed-in user of a portal built from MeshWeaver.Plugins main ≥ `fe20fe2a` got a 503 on every page. Plugins #1231 made fan-out **opt-in** — the Postgres planner refuses a query that names no partition and did not ask to span them (`UnanchoredQueryException`) — and `OnboardingMiddleware.LoadUserRoles` issued exactly that shape on every request: `nodeType:AccessAssignment content.accessObject:"{user}" scope:subtree`. The middleware did what #637 requires with an infrastructure fault (503, never "you have no account"), so the refusal reached every user. Both production portals are frozen on older images until this lands.

The planner's rule is `IsSufficientlySpecified(parsed) || ResolvesByRoutingHint(parsed)`: a concrete `path:`/`namespace:` first segment, a multi-path, a wildcard namespace pattern, an explicit `partitions:all`, **or** a registered `QueryRoutingRule` (`nodeType:User` → `Auth`). So `LoadUser` (`nodeType:User content.email:…`) was never refused — the planner consults `UserNodeType`'s rule before refusing (verified in `PostgreSqlPartitionedMeshQuery.ResolvesByRoutingHint`, wired with `sp.GetService<MeshConfiguration>()` in production). **No Plugins planner change is needed for the sign-in path.**

## The finding — every core runtime query the planner REFUSED (2026-09-03)

Fed every `nodeType:` literal under `src/` and `memex/` with no `path:`/`namespace:`/`partitions:all` (with representative substitutions) to the same decision, against the real `MeshConfiguration`. Refused, one per call site:

| Site | Shape | Path it breaks |
|---|---|---|
| `OnboardingMiddleware.LoadUserRoles` | `nodeType:AccessAssignment … scope:subtree` | **sign-in — every request** |
| `UserActivityLayoutAreas.ObserveSharedTargets` | `nodeType:AccessAssignment content.accessObject:{me}` | home: "shared with me" |
| `UserActivityLayoutAreas.FirstLevelUnion` root leg | `namespace: is:main is:content nodeType:Space …` | home: the Spaces list |
| `UserActivityLayoutAreas.CatalogQuery` subtree scope | `is:main is:content -nodeType:User …` | home: "everything" |
| `SeoEndpoints` | `nodeType:{Store/Plugin,Store/Catalog,Space} is:main limit:500` | sitemap |
| `MeshWeaverInstanceService.AdoptKeyHash` / `IsIdAvailable`, `InstancePlanService`, `InstanceGrantAdminSettingsTab` | `nodeType:MeshWeaverInstance [id:…]`, `nodeType:RegistrationKey` | instance registry |
| `OutboundEmailSender.WatchQuery` | `nodeType:Email content.direction:Outbound …` | outbound mail (process-wide watch) |
| `WhatsNewSettingsTab.ListingQueries[1]` | `nodeType:WhatsNew` | What's New type lane |
| `DynamicTypePreWarmer` ×2, `NodeTypeRecompileExtensions`, `ShippedPrebuiltBundles`, `CellSurfaceAssemblyProvider`, `CreatableTypesProvider`, `MeshOperations.Catalog`, `NodeTypeLayoutAreas` | `nodeType:NodeType …` | boot pre-warm, recompile, prebuilt adoption, create menu, MCP catalog, compile sweep |
| `CompletionUsageIndex` | `nodeType:Code limit:N` | completion prior |
| `UiContributionCatalog` | `nodeType:UiContribution` | menu contributions |
| `CreateLayoutArea` namespace picker | `nodeType:Space` | create dialog |
| `EventSubscriptionRunner` ×2 | `nodeType:{TriggerNodeType}` (any type without a rule) | event subscriptions |
| `GitHubWebhookProcessor`, `ModuleDiscoveryService`, `InstanceComboReader` | `nodeType:GitHubSync`, `nodeType:ModuleDiscovery` | webhook, discovery |
| `NodeTypeInstanceProbe` | `nodeType:{dynamic type}` | prune probe |
| `PluginUpdateWatcher` | `nodeType:PluginCatalog` | catalog watch |
| `AccessSubjectQueries.Groups(root)` | `nodeType:Group` | root-scope subject picker |

Everything else in the coordinator's list was a false positive: anchored on the adjacent line (`PluginBundleEndpoints`, `ReleaseAvailabilityService`, `InstancesSettingsTab`, the logon actions, `NotificationService`, `UserActivityLayoutAreas.BuildAppsBand`, the PluginCatalog `path:` reads) or pinned by a rule (`nodeType:User` at `DevAuthController`, `UserIdentityCache`, `GroupInviteExtensions`, `SpaceInviteService`, `OnboardingMiddleware.FindUserByEmail`; `Invitation`/`EventSubscription`/`ScheduledAction` → `Admin`). Pinned executably in `UnanchoredQueryCensusTest.RefusedBeforeThisChange` / `PinnedByRule`.

## What changed

- **Sign-in is ANCHORED, not declared.** `LoadUserRoles` reads three single-schema legs — `SecurityQueries.RootAssignmentsFor(user)` (root `_Access` → the registered `system_access`), `PartitionAssignmentsFor("Admin", user)` (the one meaning of global admin), `PartitionAssignmentsFor(user, user)` (own home) — folded through one `workspace.GetQuery`. `partitions:all` would have restored the per-request 199-schema UNION #2194 measured at ~4 s. Why three homes are the complete answer: `AccessContext.Roles` is read by **no** permission decision (`PermissionEvaluator` deliberately ignores claim roles — the 2026-08-05 paywall bypass; its only consumer in core or Plugins is the access-cache KEY), and a platform role is granted in exactly those three places by contract. The #2011 deny hazard does not apply: `FoldRoles` honours no deny at all, so no scope's deny can be lost by not reading it.
- **Every other refused caller DECLARES its fan-out** through the new `MeshWideQuery.Declare` / `.OfType` (`MeshWeaver.Mesh.Contract`), with the reason at each call site — they are genuine catalogs (NodeType, UiContribution, Space roots, `{Space}/_GitSync`), process-wide watches, or a record keyed by value (`MeshWeaverInstance id:…` — the durable fix, an id → owner index in a pinned partition, is named at the site). No `InstanceLocations` pin applies: none of these types has a finite set of homes.
- **Tests.** `QueryRouteClassifier` (`test/MeshWeaver.Fixture`) is the one shared mirror of the router's routing AND refusal rules (the private copy in `SecurityQueryShapesTest` is replaced). `SignInReadsAreAnchoredTest`: guard (every middleware query is Anchored or PinnedByRoutingRule, with the pre-fix shape as the Refused control) + behaviour (a user with a root, an Admin and an own-partition grant gets all three roles, a grant in an arbitrary space is not folded, a user with none resolves to empty — not Unavailable). `UnanchoredQueryCensusTest`: the harness — corpus of every runtime query, refused set printed and asserted empty, positive controls asserted before the corpus, and a mutation test (rules removed ⇒ exactly the rule-pinned rows flip).
- **Docs.** `UnanchoredSecurityReads.md` gains the sign-in section, the planner's rule, the declared set, and corrects the "inert hint" paragraph (the hints are live). What's New `Category: Fix`.

## Verified locally

`dotnet build test/Memex.Portal.Shared.Test -c Release -warnaserror` → 0 errors; `dotnet test` whole project → 629 tests, 627 passed + the 2 that guarded the old shapes (`WhatsNewSatelliteEntryTest` expectation updated, census parse check corrected), then 9/9 on the changed classes; `MeshWeaver.Hosting.Test` `SecurityQuery*` → 23/23; `MeshWeaver.Documentation.Test` link integrity + ratchet guards → 38/38.

Pairs-with: none — this PR removes no public type or member; the Plugins half (grace allow-file for the planner) is a separate PR that does not depend on this one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
