### PR TITLE
IoPool: a subscriber disposing inside its operator gate deadlocked the drain's cancel — unregister the drain registration (MeshNodeLanguageServiceTest teardown DIRTY, Query=1)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/CompletionUsageIndex.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/CompletionUsageIndex.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Reactive.Disposables;
 using System.Reactive.Linq;
 using System.Text.RegularExpressions;
 using MeshWeaver.Mesh;
@@ -27,9 +28,18 @@ namespace MeshWeaver.Graph.Configuration;
 /// ordered as before. A global <c>nodeType:</c> query is exactly the shape that has wedged this
 /// mesh before, so it is never awaited on the request path and every failure resolves to "no
 /// prior" rather than an error.</para>
+///
+/// <para><b>Owned, not fire-and-forget.</b> The scan is a mesh-wide query with its own 30 s
+/// <c>Timeout</c> — a second, unowned 30 s budget that used to run past the request that started
+/// it and into mesh teardown, where its <c>Throttle(1 s)</c> timer met the pool drain
+/// (<c>IoPoolDrainCancelJoinTest</c>). The in-flight subscription is held here and released by
+/// <see cref="Dispose"/>, which <c>MeshNodeLanguageService</c> couples to its hub's lifetime.</para>
 /// </summary>
-internal sealed class CompletionUsageIndex(IMessageHub hub, ILogger logger)
+internal sealed class CompletionUsageIndex(IMessageHub hub, ILogger logger) : IDisposable
 {
+    /// <summary>The in-flight (or last) corpus scan — one at a time, disposed with the owner.</summary>
+    private readonly SerialDisposable build = new();
+
     /// <summary>How many Code nodes the corpus scan reads at most.</summary>
     private const int MaxNodes = 400;
 
@@ -95,7 +105,10 @@ internal sealed class CompletionUsageIndex(IMessageHub hub, ILogger logger)
         // standard bounded read. Timeout + Catch make every failure mode "no prior".
         // Every Code node in the mesh — the usage prior is built over everyone's cells, so
         // mesh-wide by nature (#3202 — fan-out is opt-in).
-        mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.Declare($"nodeType:Code limit:{MaxNodes}")))
+        // Held in `build` so the scan dies with its owner instead of outliving the request into
+        // teardown; the CAS on `building` guarantees the previous scan has terminated before the
+        // next one is assigned here.
+        build.Disposable = mesh.Query<MeshNode>(MeshQueryRequest.FromQuery(MeshWideQuery.Declare($"nodeType:Code limit:{MaxNodes}")))
             .Scan(ImmutableDictionary<string, MeshNode>.Empty, (map, change) =>
             {
                 if (change.ChangeType is QueryChangeType.Initial or QueryChangeType.Reset)
@@ -137,6 +150,13 @@ internal sealed class CompletionUsageIndex(IMessageHub hub, ILogger logger)
                     Interlocked.Exchange(ref building, 0);
                 });
     }
+
+    /// <summary>
+    /// Releases the in-flight corpus scan. Called from the owning hub's disposal — which runs in
+    /// <c>DisposeImpl</c>, strictly before <c>DisposalCompleted</c> and therefore before the pool
+    /// drain — so no scan of this index is live when <c>IoPoolRegistry.DrainAll()</c> cancels.
+    /// </summary>
+    public void Dispose() => build.Dispose();
 
     /// <summary>The node's script text, in whatever shape the content arrived in.</summary>
     private string NodeCode(MeshNode node)

--- a/src/MeshWeaver.Compiler.Pipeline/MeshNodeLanguageService.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/MeshNodeLanguageService.cs
@@ -31,13 +31,13 @@ namespace MeshWeaver.Graph.Configuration;
 /// code-authoring agents can hover / complete / diagnose without a full <c>Compile</c> round-trip.
 /// </para>
 /// </summary>
-internal sealed class MeshNodeLanguageService(
-    MeshNodeCompilationService compilationService,
-    SpeculativeCompilation speculativeCompilation,
-    IMessageHub hub,
-    ILogger<MeshNodeLanguageService> logger)
-    : IMeshLanguageService
+internal sealed class MeshNodeLanguageService : IMeshLanguageService
 {
+    private readonly MeshNodeCompilationService compilationService;
+    private readonly SpeculativeCompilation speculativeCompilation;
+    private readonly IMessageHub hub;
+    private readonly ILogger<MeshNodeLanguageService> logger;
+
     // Path used as the SyntaxTree.FilePath for the generated skeleton tree.
     // Distinct from any user MeshNode path so callers can never address it accidentally.
     // Aliases the toolchain's sentinel — the failure-diagnostics filter keys on the SAME value.
@@ -65,9 +65,7 @@ internal sealed class MeshNodeLanguageService(
     // Task.WaitAsync (see GetScriptCompletionsAsync/GetScriptDiagnosticsAsync) — the FIRST
     // caller's own token never cancels the build (it is shared by every request against this
     // mesh instance), it only governs how long THAT caller waits.
-    private readonly Lazy<Task<ScriptWorkspace>> _scriptWorkspace = new(
-        () => BuildScriptWorkspaceAsync(hub.ServiceProvider),
-        LazyThreadSafetyMode.ExecutionAndPublication);
+    private readonly Lazy<Task<ScriptWorkspace>> _scriptWorkspace;
 
     // Path used as the script document's FilePath — never a real MeshNode path.
     private const string ScriptDocumentPath = "__script__.csx";
@@ -75,11 +73,11 @@ internal sealed class MeshNodeLanguageService(
     // The likely-usage prior (how often each identifier occurs in the Code nodes this mesh
     // already runs). Built lazily in the BACKGROUND and never awaited on a request — see
     // CompletionUsageIndex; until it is ready, ranking simply proceeds without it.
-    private readonly CompletionUsageIndex usageIndex = new(hub, logger);
+    private readonly CompletionUsageIndex usageIndex;
 
     // This user's acceptance history — the per-user half of "likely usage" (VS Code's suggest
     // memory). Used ONLY to preselect; it never reorders what the matcher decided.
-    private readonly CompletionMemoryStore memoryStore = new(hub, logger);
+    private readonly CompletionMemoryStore memoryStore;
 
     // Compile pool: Roslyn LSP work is CPU-bound, so it routes through the bounded
     // Compile pool which caps concurrency so it can't starve other schedulers.
@@ -87,9 +85,38 @@ internal sealed class MeshNodeLanguageService(
     // only moves the subscribe, not the await continuation); the pool runs the leaf
     // with ConfigureAwait(false) behind a gate. Falls back to the unbounded pool
     // when no registry is wired (e.g. tests constructing the service outside DI).
-    private readonly IIoPool _ioPool =
-        hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Compile)
-        ?? IoPool.Unbounded;
+    private readonly IIoPool _ioPool;
+
+    public MeshNodeLanguageService(
+        MeshNodeCompilationService compilationService,
+        SpeculativeCompilation speculativeCompilation,
+        IMessageHub hub,
+        ILogger<MeshNodeLanguageService> logger)
+    {
+        this.compilationService = compilationService;
+        this.speculativeCompilation = speculativeCompilation;
+        this.hub = hub;
+        this.logger = logger;
+        _scriptWorkspace = new Lazy<Task<ScriptWorkspace>>(
+            () => BuildScriptWorkspaceAsync(hub.ServiceProvider),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+        usageIndex = new CompletionUsageIndex(hub, logger);
+        memoryStore = new CompletionMemoryStore(hub, logger);
+        _ioPool = hub.ServiceProvider.GetService<IoPoolRegistry>()?.Get(IoPoolNames.Compile)
+            ?? IoPool.Unbounded;
+
+        // 🚨 The two helpers own subscriptions that outlive the request that started them — the
+        // usage index's mesh-wide corpus scan (its own 30 s Timeout, a 1 s Throttle) and the memory
+        // store's debounced save. Unowned, the scan ran into mesh teardown, where its Throttle timer
+        // met the pool drain and deadlocked the drain's cancel (IoPoolDrainCancelJoinTest —
+        // `pools=[Query=1]` on MeshNodeLanguageServiceTest, 2026-08-28 → 09-03). This service is a
+        // mesh singleton with no IDisposable of its own, and the service provider disposes AFTER the
+        // drain anyway — so the owner lifetime is the hub's: RegisterForDisposal runs in DisposeImpl,
+        // strictly before DisposalCompleted and therefore before IoPoolRegistry.DrainAll(). A hub
+        // already disposing disposes the registrant immediately.
+        hub.RegisterForDisposal(usageIndex);
+        hub.RegisterForDisposal(memoryStore);
+    }
 
     /// <inheritdoc />
     /// <remarks>

--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
@@ -441,6 +441,67 @@ So the mesh teardown awaits **all three**, in order, before the scope is dispose
    continuous influx — a *version-target* wait would not (the queue is a message stream / endless
    messages). `DrainedVersion` advances once per item, the test hook.
 
+### 🚨 A residual with NO site is the CANCEL join — and a subscriber can park it
+
+`IoPool.Drain()` reports three things under one number: gate permits it could not re-acquire, blocking
+leaves still running, and a **cancel that did not return**. The first two always name a site (every
+leaf registers one on entry); the third is not a leaf and had none. So a trace that read
+
+```
+DISPOSE_IOPOOL_DRAIN_DONE elapsed=30016ms leakedIoLeaves=1 pools=[Query=1]
+```
+
+— `Query=1` with nothing in brackets — meant exactly one thing, **`_poolCts.Cancel()` on the Query pool
+never returned**, and nothing on the page said so. It now reads
+`Query=1 [IoPool.Drain: the pool token's cancel did not return within the budget — …]`.
+
+**What parks a cancel.** Cancelling the pool token runs, inline on the `IoPool-cancel` thread, one
+callback per live `SubscribeThroughPool` subscription: `inner.Dispose(); observer.OnCompleted();` —
+that subscription's whole downstream teardown. Two facts about the libraries underneath turn a race
+into a deadlock:
+
+1. **`CancellationTokenRegistration.Dispose()` blocks until a callback executing on another thread has
+   finished** (`WaitForCallbackIfNecessary`; only the callback's own thread is exempt).
+   `Unregister()` never waits.
+2. **Rx operators forward from their timers under their gate.** `Throttle.Propagate` runs
+   `ForwardOnNext` inside `lock (_gate)`, and `Throttle.OnCompleted` takes the same gate; `Take(1)`
+   completes and **disposes upstream synchronously** — still inside that gate.
+
+So a consumer shaped `Query(...).Throttle(1 s).Take(1)` whose timer fires as the drain cancels holds
+the operator gate while its upstream disposal waits in `Dispose()` for the drain callback, and the
+drain callback waits in `Throttle.OnCompleted` for the operator gate. Two locks, two threads, no exit.
+The drain reports the cancel residual after its budget, RSS is flat the whole time (parked, not
+computing), and the two threads stay deadlocked for the life of the process.
+
+**The occurrence.** `MeshNodeLanguageServiceTest` went DIRTY at teardown on 2026-08-28 (#2578,
+#2616), 08-30 (twice), and 09-03 (Plugins #1260 attempt 1, shard 3) — always the same shape: the test
+body PASSES in ~1 s (1018 ms / 1044 ms in the two traces that survived), the drain then spends its
+whole 30 s, and the residual is `Query=1` with no site. The consumer is `CompletionUsageIndex.EnsureFresh()`,
+whose `Throttle(1 s)` lands on exactly those ~1 s bodies; a faster machine ends the test before the
+timer fires, which is why twenty local runs never reproduced it. #2598 fixed a different leaf (the
+first-in-process script-reference build, on the Compile pool) on the strength of the same anonymous
+`1`; the failure recurred unchanged four hours later.
+
+**The rules this leaves behind:**
+
+- **Never put a raw `CancellationTokenRegistration` where a subscriber disposes it.** The
+  subscription's disposable unregisters (`drainReg.Unregister()`); the drain callback stays exactly-once
+  through its latch and completes on its own. More generally: **never dispose a registration from a
+  thread that may hold a lock the callback needs** — in Rx that is every operator gate.
+- **A request-scoped subscription needs an OWNER.** `EnsureFresh()`'s query used to be fire-and-forget
+  with a 30 s `Timeout` — a second, unowned 30 s budget coinciding with the drain's. It is held in a
+  `SerialDisposable` and disposed with the hub (`hub.RegisterForDisposal(...)`, which runs in
+  `DisposeImpl` — strictly before `DisposalCompleted`, hence before `DrainAll()`); the same for the
+  completion memory store's debounced save. Three lifetimes exist for any deferred work — the
+  **caller's** (`WaitAsync(ct)`), the **owner's** (the hub or service that started it), and **never**
+  (a process-wide memo) — and "no caller cancels this" must not silently become "nothing ever does".
+- **Read a residual by its site.** A bracketed site is a leaf; no site is the cancel join, now
+  labelled. `Query=1` and `Compile=1` are different bugs, and so are `Query=1 [MeshQuery…]` and
+  `Query=1 [IoPool.Drain: the pool token's cancel did not return…]`.
+
+Pinned by `IoPoolDrainCancelJoinTest` (deterministic: a `TestScheduler`-driven `Throttle` fired from a
+thread the test owns, with the two interleavings the deadlock needs made explicit).
+
 ### 🚨 `IoPool.Unbounded` is LEDGERLESS — I/O on it does not exist to this drain
 
 The three-phase drain only covers what it can *see*, and `IoPool.Unbounded` is invisible to it **by

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-shutdown-no-longer-stalls-behind-a-closing-search.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-shutdown-no-longer-stalls-behind-a-closing-search.md
@@ -1,0 +1,17 @@
+---
+Name: Shutting down no longer stalls for 30 seconds behind a closing background search
+Category: Fix
+Description: When the portal shut down at the very moment a background search was finishing, shutdown could wait out a 30-second budget and then report work left running; the two can no longer block each other.
+Icon: Sparkle
+Order: -20260903
+---
+
+# Shutting down no longer stalls for 30 seconds behind a closing background search
+
+Code completion keeps a small background search running to learn which names your code actually
+uses, so suggestions can be ranked by likelihood instead of alphabetically. If the portal began
+shutting down at the very moment that search was wrapping up, the two could end up waiting on each
+other: shutdown waited its full 30-second budget for the search to stop, then reported that work had
+been left running — and the search itself was never told that its owner had gone away. Both halves
+are fixed: a closing search can no longer hold up shutdown, and the search is stopped with the
+component that started it, so shutting down is once again as quick as it should be.

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -215,30 +215,55 @@ public sealed class IoPool : IIoPool, IDisposable
     /// <c>MeshQuery+&lt;&gt;c__DisplayClass22_0.&lt;MergeProviderObservables&gt;b__1</c> points at the
     /// exact operation that did not unwind. Empty when the pool drained clean.
     /// </summary>
-    internal IReadOnlyList<string> PendingLeafSites =>
-        _inFlightLeaves.Values
-            .Select(d =>
-            {
-                try
+    internal IReadOnlyList<string> PendingLeafSites
+    {
+        get
+        {
+            var leaves = _inFlightLeaves.Values
+                .Select(d =>
                 {
-                    // A delegate names its enclosing method through the compiler-generated
-                    // lambda; anything else (the subscribe path's observable) can only offer
-                    // its type, which still says WHICH chain is stuck.
-                    if (d is Delegate del)
+                    try
                     {
-                        var m = del.Method;
-                        return $"{m.DeclaringType?.FullName ?? "?"}.{m.Name}";
+                        // A delegate names its enclosing method through the compiler-generated
+                        // lambda; anything else (the subscribe path's observable) can only offer
+                        // its type, which still says WHICH chain is stuck.
+                        if (d is Delegate del)
+                        {
+                            var m = del.Method;
+                            return $"{m.DeclaringType?.FullName ?? "?"}.{m.Name}";
+                        }
+                        return d.GetType().FullName ?? d.GetType().Name;
                     }
-                    return d.GetType().FullName ?? d.GetType().Name;
-                }
-                catch
-                {
-                    // A diagnostic must never be the reason a teardown fails.
-                    return "(unavailable)";
-                }
-            })
-            .Distinct(StringComparer.Ordinal)
-            .ToArray();
+                    catch
+                    {
+                        // A diagnostic must never be the reason a teardown fails.
+                        return "(unavailable)";
+                    }
+                })
+                .Distinct(StringComparer.Ordinal);
+            // The third residual Drain() can report is not a leaf and registers no site of its own:
+            // a cancel that never returned. Label it, or the residual reads as an anonymous count —
+            // the shape that misdirected #2598 (see Drain).
+            return _cancelJoinExpired
+                ? leaves.Prepend(CancelJoinResidualSite).ToArray()
+                : leaves.ToArray();
+        }
+    }
+
+    /// <summary>
+    /// The site <see cref="PendingLeafSites"/> reports when <see cref="Drain"/>'s CANCEL join expired:
+    /// <c>_poolCts.Cancel()</c> did not return within the budget because a registered teardown
+    /// callback is parked. Every leaf names itself on entry; this residual is not a leaf, so it needs
+    /// a name of its own — <c>Query=1</c> with no site is exactly what it used to look like.
+    /// </summary>
+    internal const string CancelJoinResidualSite =
+        "IoPool.Drain: the pool token's cancel did not return within the budget — a registered teardown "
+        + "callback is parked (a subscriber's OnCompleted or unsubscribe waiting on a lock the callback "
+        + "holds; see Doc/Architecture/ControlledIoPooling → 'A residual with NO site is the CANCEL join')";
+
+    // Set by Drain() when its cancel join expires; read by PendingLeafSites, which the registry
+    // consults right after Drain() returns. Never cleared — Drain is terminal.
+    private volatile bool _cancelJoinExpired;
 
     /// <summary>
     /// Runs an async I/O leaf off the calling scheduler under the pool's concurrency gate.
@@ -594,7 +619,31 @@ public sealed class IoPool : IIoPool, IDisposable
                     observer.OnCompleted();
                 });
 
-                return new CompositeDisposable(setup, inner, drainReg);
+                // 🚨 UNREGISTER, NEVER DISPOSE, the drain registration from the subscriber's side.
+                //
+                // CancellationTokenRegistration.Dispose() BLOCKS until a callback that is executing on
+                // another thread has finished (WaitForCallbackIfNecessary; only the callback's own
+                // thread is exempt). Unregister() never waits. The callback above is the subscriber's
+                // downstream teardown run inline on the IoPool-cancel thread — and Rx operators
+                // forward from their timers UNDER THEIR GATE: Throttle.Propagate calls ForwardOnNext
+                // inside `lock (_gate)`, Throttle.OnCompleted takes the same gate, and Take(1)
+                // completes and disposes upstream synchronously, still inside it. So a consumer
+                // shaped `Query(...).Throttle(1 s).Take(1)` whose timer fired as the drain cancelled
+                // held its operator gate while `.Dispose()` here waited for the drain callback, and
+                // the drain callback waited in Throttle.OnCompleted for that gate. Two locks, two
+                // threads, no exit: _poolCts.Cancel() never returned, Drain() reported the cancel
+                // residual after its whole budget (`pools=[Query=1]`, no site, RSS flat — parked, not
+                // computing), and the pair stayed deadlocked for the life of the process.
+                // MeshNodeLanguageServiceTest went DIRTY that way on 2026-08-28 (#2578, #2616), 08-30
+                // and 09-03 (Plugins #1260, attempt 1, shard 3): the body PASSED in ~1 s and the
+                // 1 s Throttle of CompletionUsageIndex.EnsureFresh() landed on the drain. Pinned by
+                // IoPoolDrainCancelJoinTest.
+                //
+                // Unregistering is exactly right for both orders: a callback that has not started is
+                // removed (the consumer left, nothing to terminate); one that IS running finishes on
+                // its own — `inner.Dispose()` is idempotent and the observer's OnCompleted is
+                // exactly-once through Rx's AutoDetachObserver — and nobody waits for it.
+                return new CompositeDisposable(setup, inner, Disposable.Create(() => drainReg.Unregister()));
             }
             finally
             {
@@ -657,6 +706,11 @@ public sealed class IoPool : IIoPool, IDisposable
             // in the residual — which is the whole difference between #2394's silent 8-minute
             // wall-clock kill and a named, failing teardown.
             var cancelResidual = StartCancelOffCallerThread().Join(_drainTimeout) ? 0 : 1;
+            // 🚨 NAME IT. A cancel that does not return is not a leaf, so it registers no site — and
+            // an unlabelled `Query=1` sent two investigations (#2598, then this) into leaves that held
+            // no permit. PendingLeafSites carries the label from here on.
+            if (cancelResidual != 0)
+                _cancelJoinExpired = true;
             var acquired = 0;
             for (var i = 0; i < _maxConcurrency; i++)
             {

--- a/test/MeshWeaver.Hosting.Test/IoPoolDrainCancelJoinTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolDrainCancelJoinTest.cs
@@ -1,0 +1,181 @@
+using System;
+using System.Diagnostics;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using MeshWeaver.Mesh.Threading;
+using Microsoft.Reactive.Testing;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The teardown residual that read <c>pools=[Query=1]</c> — with NO bracketed site — on
+/// <c>MeshNodeLanguageServiceTest</c> from 2026-08-28 (core #2578, #2616) to 2026-09-03 (Plugins
+/// #1260 attempt 1, shard 3), and cost two wrong fixes before it was named.
+///
+/// <para><b>What a residual with no site is.</b> <see cref="IoPool.Drain"/> reports three things:
+/// gate permits it could not re-acquire, blocking leaves still running, and a CANCEL that did not
+/// return. The first two always carry a site (every leaf registers one); the third never did. So
+/// <c>Query=1</c> with nothing in brackets meant exactly one thing — <c>_poolCts.Cancel()</c> on the
+/// Query pool never returned — and nobody could read that off it.</para>
+///
+/// <para><b>What parks the cancel.</b> <see cref="IIoPool.SubscribeThroughPool{T}"/> registers one
+/// callback per live pooled subscription that runs that subscription's downstream teardown inline:
+/// <c>inner.Dispose(); observer.OnCompleted();</c>. It also put the raw
+/// <see cref="CancellationTokenRegistration"/> into the subscription's <c>CompositeDisposable</c>,
+/// and <see cref="CancellationTokenRegistration.Dispose"/> BLOCKS until a callback that is executing
+/// on another thread has finished. Rx's <c>Throttle</c> forwards from its timer INSIDE its gate and
+/// <c>Take(1)</c> disposes upstream synchronously on completion — so a consumer shaped
+/// <c>Query(...).Throttle(1 s).Take(1)</c> whose timer fires as the drain cancels holds the
+/// operator gate while it waits in <c>Dispose()</c> for the drain callback, and the drain callback
+/// waits in <c>Throttle.OnCompleted</c> for the operator gate. Two locks, two threads, no exit; the
+/// drain reports the cancel residual after its budget, RSS flat the whole time (parked, not
+/// computing — #2616's own measurement). The consumer in every occurrence was
+/// <c>CompletionUsageIndex.EnsureFresh()</c>, whose 1 s <c>Throttle</c> lands on the test bodies
+/// that take ~1 s (1018 ms and 1044 ms in the two traces that survived).</para>
+///
+/// <para>Deterministic here because the timer is a <see cref="TestScheduler"/> advanced from a
+/// thread this test owns, and the two interleavings the deadlock needs — "the consumer is inside
+/// its gate" and "the drain callback is executing" — are volatile flags polled under bounded
+/// spins, the sanctioned shape for a release INTO a worker the test deliberately parks.</para>
+/// </summary>
+public class IoPoolDrainCancelJoinTest
+{
+    private static readonly TimeSpan Timeout10 = TimeSpan.FromSeconds(10);
+    private static readonly TimeSpan DrainBudget = TimeSpan.FromMilliseconds(250);
+
+    /// <summary>
+    /// 🚨 THE repro. Fails on the pre-fix pool with <c>Query=1</c> and no site after exactly one
+    /// drain budget — the CI signature — and the two threads stay deadlocked for the life of the
+    /// process, exactly as they did on the runner.
+    /// </summary>
+    [Fact]
+    public void Drain_WhenAConsumerCompletesInsideItsOperatorGateAsTheDrainCancels_TheCancelReturns()
+    {
+        using var registry = new IoPoolRegistry(new IoPoolOptions { DrainTimeout = DrainBudget });
+        var pool = registry.Get(IoPoolNames.Query);
+        var scheduler = new TestScheduler();
+        var feed = new Subject<int>();
+        var subscribed = 0;
+        var drainCallbackEntered = 0;
+        var consumerInsideGate = 0;
+        var consumerReturned = 0;
+
+        // The change feed a query opens: subscribed through the pool (the tracked window), then
+        // left open — a query's feed never completes on its own.
+        var pooled = pool.SubscribeThroughPool(Observable.Create<int>(o =>
+        {
+            var d = feed.Subscribe(o);
+            Volatile.Write(ref subscribed, 1);
+            return d;
+        }));
+
+        // CompletionUsageIndex.EnsureFresh()'s exact operator shape, with the two interleavings
+        // made explicit:
+        //  • the drain's OnCompleted passes the first Do on the IoPool-cancel thread BEFORE it
+        //    reaches Throttle's gate — that is "the drain callback is executing";
+        //  • the second Do runs INSIDE Throttle's gate on the timer thread (Rx forwards from
+        //    Propagate under `lock (_gate)`), and holds it until the callback is executing.
+        // Take(1) then completes and disposes upstream — still under that gate — which is where
+        // CancellationTokenRegistration.Dispose() used to wait for the very callback that is
+        // waiting for the gate.
+        using var subscription = pooled
+            .Do(_ => { }, () => Volatile.Write(ref drainCallbackEntered, 1))
+            .Throttle(TimeSpan.FromSeconds(1), scheduler)
+            .Do(_ =>
+            {
+                Volatile.Write(ref consumerInsideGate, 1);
+                SpinWait.SpinUntil(() => Volatile.Read(ref drainCallbackEntered) == 1, Timeout10);
+            })
+            .Take(1)
+            .Subscribe(_ => { }, _ => { });
+
+        SpinWait.SpinUntil(() => Volatile.Read(ref subscribed) == 1, Timeout10)
+            .Should().BeTrue("precondition: the pooled subscribe ran and the drain registration exists");
+
+        // The timer thread: the feed's Initial arrives, then virtual time reaches the throttle's
+        // due time and Propagate forwards under the gate.
+        var timer = new Thread(() =>
+        {
+            feed.OnNext(1);
+            scheduler.AdvanceBy(TimeSpan.FromSeconds(1).Ticks);
+            Volatile.Write(ref consumerReturned, 1);
+        })
+        {
+            IsBackground = true,
+            Name = "rx-throttle-timer",
+        };
+        timer.Start();
+
+        SpinWait.SpinUntil(() => Volatile.Read(ref consumerInsideGate) == 1, Timeout10)
+            .Should().BeTrue("precondition: the consumer is inside its operator gate, about to complete");
+
+        // Teardown's phase 2: cancel + join every pool. On the pre-fix pool this returns after the
+        // budget with the cancel thread and the timer thread parked on each other.
+        var sw = Stopwatch.StartNew();
+        var residual = registry.DrainAll(out var byPool);
+        sw.Stop();
+
+        residual.Should().Be(0,
+            "a consumer unsubscribing from inside its operator gate must never be able to park the "
+            + "pool's cancel: its unsubscribe must not wait for the drain callback, and the callback "
+            + "then completes on its own. Residual reported: [{0}]",
+            string.Join(", ", byPool));
+        sw.Elapsed.Should().BeLessThan(DrainBudget,
+            "the cancel join must return because the callbacks FINISHED, not because the budget "
+            + "expired — a join that only returns on its budget is the anonymous 30 s teardown");
+        SpinWait.SpinUntil(() => Volatile.Read(ref consumerReturned) == 1, Timeout10)
+            .Should().BeTrue("the consumer's unsubscribe returned — it did not wait on the drain callback");
+    }
+
+    /// <summary>
+    /// The diagnostic half: a cancel that does not return within the budget must be NAMED as the
+    /// cancel join, not reported as an anonymous count. <c>Query=1</c> and <c>Query=1 [the cancel
+    /// did not return]</c> are the difference between a week and an afternoon (#2616 → this file).
+    /// The parked callback here is the subscriber's own <c>OnCompleted</c>, which the drain runs
+    /// inline — the same channel the deadlock above travels, without the deadlock.
+    /// </summary>
+    [Fact]
+    public void Drain_WhenTheCancelJoinExpires_TheResidualNamesTheCancelJoin()
+    {
+        using var registry = new IoPoolRegistry(new IoPoolOptions { DrainTimeout = DrainBudget });
+        var pool = registry.Get(IoPoolNames.Query);
+        var subscribed = 0;
+        var release = 0;
+
+        using var subscription = pool
+            .SubscribeThroughPool(Observable.Create<int>(_ =>
+            {
+                Volatile.Write(ref subscribed, 1);
+                return Disposable.Empty;
+            }))
+            .Subscribe(
+                _ => { },
+                _ => { },
+                // The SUBJECT: a teardown that will not return. Bounded, and released in the
+                // finally below so a failing assertion cannot leave the cancel thread parked.
+                () => SpinWait.SpinUntil(() => Volatile.Read(ref release) == 1, Timeout10));
+
+        try
+        {
+            SpinWait.SpinUntil(() => Volatile.Read(ref subscribed) == 1, Timeout10)
+                .Should().BeTrue("precondition: the pooled subscribe ran and the drain registration exists");
+
+            var residual = registry.DrainAll(out var byPool);
+
+            residual.Should().Be(1, "the parked callback is exactly one residual");
+            byPool.Should().ContainSingle().Which.Pool.Should().Be(IoPoolNames.Query);
+            byPool[0].Sites.Should().ContainSingle(
+                "no leaf held a permit, so the ONLY thing left to name is the cancel join itself")
+                .Which.Should().Contain("cancel",
+                    "the residual must say that the pool token's cancel did not return — an "
+                    + "anonymous 'Query=1' sent two investigations into the wrong leaf");
+        }
+        finally
+        {
+            Volatile.Write(ref release, 1);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the `MeshNodeLanguageServiceTest` dirty-teardown flake — `teardown DIRTY — 1 pooled I/O leaf(s) still running`, 30 s dispose — observed on core #2578 / #2616 (2026-08-28, 08-30 ×2) and on **Plugins #1260, attempt 1, shard 3** today (the `#1222` class). It is a **deadlock inside `IoPool.SubscribeThroughPool`'s drain registration**, not a leaf that ignores its token — which is why #2598 (the fix this PR's brief re-proposed) did not stop it.

## Root cause — measured, not inferred

Attempt-1 shard-3 trace of Plugins run 33743597650 (`_meshweaver-test-trace.log`, artifact `teardown-stragglers-33743597650-1-shard3`):

```
10:36:35.896 TEST_START ScriptCompletions_NoPrefix_RankByLikelyUsage_NotTheAlphabet
10:36:36.915 TEST_END elapsed=1018ms … outcome=Passed
10:36:36.928 DISPOSE_IOPOOL_DRAIN_START
10:36:40 … 10:37:05  MEM_WATCHDOG managed=147MiB rss=849→844MiB   (flat: parked, not computing)
10:37:06.934 DISPOSE_IOPOOL_DRAIN_DONE elapsed=30016ms leakedIoLeaves=1 pools=[Query=1]
```

Three facts rule every leaf hypothesis out: the body **passed in 1 s** (the completion leaf had released its permit before its result was even emitted), the pool is **Query**, and the residual carries **no bracketed site** — every gated and blocking leaf registers one on entry, so a site-less residual can only be `Drain()`'s third component: **the cancel join expired. `_poolCts.Cancel()` never returned.**

What that cancel runs: one callback per live pooled subscription — `inner.Dispose(); observer.OnCompleted();`, the consumer's downstream teardown, inline on the `IoPool-cancel` thread. The subscription's `CompositeDisposable` held the raw `CancellationTokenRegistration`. Two library facts, verified from the decompiled `System.Reactive` 6.1.0 and `System.Private.CoreLib` 10.0.11 this repo runs on:

1. `CancellationTokenRegistration.Dispose()` **blocks until a callback executing on another thread finishes** (`WaitForCallbackIfNecessary`); `Unregister()` never waits.
2. Rx's `Throttle.Propagate` forwards **inside `lock (_gate)`**, `Throttle.OnCompleted` takes the same gate, and `Take(1)` completes and **disposes upstream synchronously**, still inside it.

The consumer in every occurrence is `CompletionUsageIndex.EnsureFresh()`'s `Query(...).Scan().Throttle(1 s).Take(1)`, fire-and-forget with its own 30 s `Timeout`. Its 1 s throttle lands on exactly the ~1 s test bodies (1018 ms today, 1044 ms in #2616's trace): the timer thread holds the operator gate while `Take(1)`'s upstream disposal waits in `Dispose()` for the drain callback; the drain callback waits in `Throttle.OnCompleted` for the gate. Two locks, two threads, no exit; the drain reports the cancel residual after its budget and the pair stays deadlocked for the process lifetime. A fast machine ends the test before the timer fires — hence twenty clean local runs in #2616.

## Fix (root cause, no budget touched)

- `IoPool.SubscribeThroughPoolCore`: the subscriber's disposable **unregisters** the drain registration (`drainReg.Unregister()`) instead of disposing it. A not-yet-started callback is removed; a running one finishes on its own (`inner.Dispose()` is idempotent, `OnCompleted` is exactly-once through Rx's `AutoDetachObserver`) — and nobody waits for it.
- `IoPool.Drain` / `PendingLeafSites`: an expired cancel join is **named** (`Query=1 [IoPool.Drain: the pool token's cancel did not return within the budget — …]`) instead of reported as an anonymous count. That anonymity is what sent #2598 into the wrong leaf.
- `CompletionUsageIndex` owns its in-flight scan (`SerialDisposable`, `IDisposable`); `MeshNodeLanguageService` couples it and `CompletionMemoryStore` to the hub's lifetime via `hub.RegisterForDisposal(...)`, which runs in `DisposeImpl` — strictly before `DisposalCompleted`, hence before `DrainAll()`. The service is a mesh singleton with no `IDisposable`, and the service provider disposes AFTER the drain, so the hub hook is the only ordering that works.

## Deterministic repro — `test/MeshWeaver.Hosting.Test/IoPoolDrainCancelJoinTest.cs`

`TestScheduler`-driven `Throttle` fired from a thread the test owns; the two interleavings the deadlock needs are volatile flags polled under bounded spins. On `origin/main` (`8ffbe476`), built and run with the identical binaries first:

```
IoPoolDrainCancelJoinTest.Drain_WhenAConsumerCompletesInsideItsOperatorGateAsTheDrainCancels_TheCancelReturns [FAIL]
  Expected value to be 0 because a consumer unsubscribing from inside its operator gate must never be able
  to park the pool's cancel … Residual reported: [Query=1], but found 1.
IoPoolDrainCancelJoinTest.Drain_WhenTheCancelJoinExpires_TheResidualNamesTheCancelJoin [FAIL]
  Expected collection to contain a single item because no leaf held a permit, so the ONLY thing left to
  name is the cancel join itself, but found 0.
Failed! - Failed: 2, Passed: 0, Total: 2
```

`Query=1`, no site, after one drain budget — the CI signature, reproduced on demand. After the fix: `Passed! - Passed: 2` (311 ms).

## Ordering finding (brief item 3)

`MeshNodeLanguageService` is not `IDisposable` and is a singleton on the mesh root hub's provider; that provider is disposed only after `DrainAll()` (`TeardownOrderedScopeDisposal` → `MeshTeardownSignal.Completed`). A `Dispose` there would land too late. `hub.RegisterForDisposal` runs in `MessageHub.DisposeImpl`, before `DisposalCompleted`, which every orchestrator awaits before `DrainAll()` — that is the seam used here (the same one `MeshDataSource` uses).

## Why the brief's diagnosis was NOT adopted

The brief named `MeshNodeLanguageService.BuildScriptWorkspaceAsync`'s `CancellationToken.None` (the shared script-reference build) as the leaked Compile-pool leaf. That is #2598's diagnosis (merged 2026-08-28 11:34Z); the failure recurred unchanged at 12:32Z the same day (#2616) and is refuted by the evidence above: the leaf is on the **Query** pool, the build had **completed** (the test got its completions in 1 s), and by construction a leaf whose `WaitAsync(ct)` is cancelled releases its permit in its `finally`. The `None` there is the documented "process-wide memo, per-caller wait" shape and is left as is.

## Siblings (brief item 4) — `CancellationToken.None` sweep of `src/`

None is this defect. `NuGetAssemblyResolver.ResolveAsync` is the same memo-plus-`WaitAsync(ct)` shape as the script-reference build (deliberate, evicts faulted entries); `DeliveryObservable.Run` is the handler bridge on the turn thread (documented); `TypeSourceWithTypeWithDataStorage.LoadFromStorageAsync` is a data-source initial load with no pool involvement; the rest are `TaskFactory`/`ContinueWith` option arguments or the `ShutdownRequest` exemption. The pattern this PR does introduce a rule for — a `CancellationTokenRegistration` disposed cross-thread — has one other instance: `InvokeBlocking`'s per-leaf linked `CancellationTokenSource.Dispose()` on unsubscribe. It waits only for the linked-token callbacks (the blocking task's own cancellation), which take no consumer lock, so it is not the deadlock shape; noted, not changed.

## Verification

- `dotnet build -c Release -warnaserror`, one project per invocation: `MeshWeaver.Mesh.Contract`, `MeshWeaver.Compiler.Pipeline`, `MeshWeaver.Hosting.Test`, `MeshWeaver.Compiler.Pipeline.Test`, `MeshWeaver.Documentation.Test` — each `0 Warning(s) 0 Error(s)`.
- `DOTNET_PROCESSOR_COUNT=4`, `--logger trx`: the two new tests red on main / green after; whole-project runs of the three touched test projects: `MeshWeaver.Hosting.Test` 331/331, `MeshWeaver.Documentation.Test` 240/240 (all ratchet guards, `DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest`), `MeshWeaver.Compiler.Pipeline.Test` 601/601 — all green, a `.trx` written for each.

## Docs

- `Doc/Architecture/ControlledIoPooling` → new section *"A residual with NO site is the CANCEL join — and a subscriber can park it"*: the mechanism, the three lifetimes (caller / owner / never), and how to read a residual by its site.
- What's New: `2026-09-03-shutdown-no-longer-stalls-behind-a-closing-search.md` (Category: Fix).

Observed symptom: Plugins #1260 (attempt 1, shard 3) and the #1222 class; core #2578, #2616. No Plugins PR is touched by this change.

Pairs-with: none — no public surface removed (one `internal` constant and one `internal` property shape added to `IoPool`; `CompletionUsageIndex` gains `IDisposable`; all `internal`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Claude-Session: https://claude.ai/code/session_01G4xPnGYEbdu8AVvR5jytyj
