### PR TITLE
fix(deploy): chart drift compares the inline env entries it only ever counted

### DIFF
--- a/.github/workflows/chart-drift.yml
+++ b/.github/workflows/chart-drift.yml
@@ -76,13 +76,23 @@ name: Chart Drift
 # name, in `deployments/aks/envs.json` in $DEPLOY_REPO, and `discover` reads the matrix from there.
 # Adding or retiring an environment is a one-line change THERE and needs no change here.
 #
-# ⚠️ EXPECT THE FIRST COMPLETING RUN TO BE VERY RED, legitimately. A local run of
-# check-chart-drift.sh against ns memex on 2026-08-17 compared 149 fields and found 121
-# divergences — the accumulated backlog of `kubectl patch`-applied config the chart has never heard
-# of (AzureFoundry/ModelTier routing, probe initialDelaySeconds, replicas 2-vs-1), plus the one
-# that bites hardest: ConfigMap Authentication__Microsoft__ClientId is still
-# `CHANGE_ME_aad_application_client_id` in the chart, so a `helm upgrade` today would overwrite
-# working auth with the placeholder. That backlog is the finding, not a defect in the gate.
+# ⚠️ EXPECT THIS TO BE RED, legitimately. A local run of check-chart-drift.sh against ns memex on
+# 2026-08-17 compared 149 fields and found 121 divergences — the accumulated backlog of
+# `kubectl patch`-applied config the chart has never heard of. That backlog is the finding, not a
+# defect in the gate; it is triaged, by class, in MeshWeaver#2355 and in
+# src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md.
+#
+# 🚨 A WARNING THAT USED TO SIT HERE WAS WRONG, AND IT IS THE REASON THIS PARAGRAPH IS DATED. It
+# read: "ConfigMap Authentication__Microsoft__ClientId is still `CHANGE_ME_aad_application_client_id`
+# in the chart, so a `helm upgrade` today would overwrite working auth with the placeholder." Both
+# halves are false and each was falsifiable from the day it was written:
+#   * NO run has EVER reported an `Authentication__` finding (2026-08-26, 09-02, 09-03). Every
+#     environment sets a real client id in its own overlay, which is layered over the chart default,
+#     so nothing renders the placeholder in the first place.
+#   * A `helm upgrade` does not overwrite a live value with a rendered one anyway — measured, see
+#     check-chart-drift.sh's header. The whole "a deploy would destroy this" model was wrong.
+# Left in place as a correction rather than deleted: this file's own warning is what #2355 was
+# triaged against for a week, and an un-measured hazard in a gate's header propagates as fact.
 
 on:
   schedule:

--- a/deploy/aks/scripts/chart-drift-compare.py
+++ b/deploy/aks/scripts/chart-drift-compare.py
@@ -9,9 +9,10 @@ is test-chart-drift-compare.sh, which chart-gate.yml runs on every pull request.
 
 Arguments, in order:
   desired.yaml  live-configmap.json  live-deployment.json  expect-patch.json
-  live-poddisruptionbudgets.json  live-scaledobjects.json  live-envfrom-secret-keys.txt
+  live-poddisruptionbudgets.json  live-scaledobjects.json  live-envfrom-source-keys.txt
 
-The last file is `secret<TAB>key` lines — the NAMES of the keys each envFrom secret supplies, and
+The last file is `secret/<name><TAB>key` and `configmap/<name><TAB>key` lines — the NAMES of the
+keys every OTHER envFrom source supplies (memex-portal-config is fetched in full separately), and
 nothing else. No secret VALUE is read by this script, and none may be added to it.
 Exit 0 = no drift, 1 = drift or the comparison could not be made.
 """
@@ -19,13 +20,15 @@ import json, sys, yaml
 
 desired_path, live_cm_path, live_dep_path, expect_patch = sys.argv[1:5]
 live_pdb_path, live_so_path = sys.argv[5:7]
-# `secret<TAB>key` lines. Key NAMES only — see the module docstring.
-secret_keys = {}
+# `<kind>/<name><TAB>key` lines. Key NAMES only — see the module docstring. A ConfigMap reaches the
+# container through envFrom exactly as a Secret does, so an inline env shadows either identically;
+# enumerating only the secrets would leave the same blind spot #3204 closed, one source-kind over.
+envfrom_keys = {}
 if len(sys.argv) > 7 and sys.argv[7]:
     for _line in open(sys.argv[7]):
         if "\t" in _line:
-            _sec, _key = _line.rstrip("\n").split("\t", 1)
-            secret_keys.setdefault(_key, []).append(_sec)
+            _src, _key = _line.rstrip("\n").split("\t", 1)
+            envfrom_keys.setdefault(_key, []).append(_src)
 
 findings, comparisons = [], 0
 def finding(kind, what, detail=""):
@@ -115,11 +118,18 @@ def by_lower(d):
         out.setdefault(k.lower(), []).append(k)
     return out
 d_cm_by_lower, l_cm_by_lower = by_lower(d_data), by_lower(l_data)
-# An envFrom SECRET key reaches the container exactly like a ConfigMap key, so an inline env of the
-# same name shadows it identically — the case the ConfigMap-only comparison missed on memex
-# (MeshWeaver#3201). Its value is deliberately unknown here, so such a shadow is reported WITHOUT an
-# agree/disagree verdict rather than with a guessed one.
-sec_by_lower = by_lower(secret_keys)
+# A key from ANY OTHER envFrom source — a Secret, or a second ConfigMap added through
+# .Values.extraEnvFrom — reaches the container exactly like a memex-portal-config key, so an inline
+# env of the same name shadows it identically. The Secret half was the case the ConfigMap-only
+# comparison missed on memex (MeshWeaver#3201); the second-ConfigMap half is the same blind spot one
+# source-kind over, and the chart documents `{configMapRef: {name: …}}` as a supported extraEnvFrom
+# entry. Only the key NAMES of these sources are read, so their values are deliberately unknown here
+# and such a shadow is reported WITHOUT an agree/disagree verdict rather than with a guessed one.
+ext_by_lower = by_lower(envfrom_keys)
+
+def env_shape(e):
+    """The entry minus its literal value — a ref NAME is not a secret, a value may be."""
+    return {k: v for k, v in e.items() if k != "value"}
 
 for n in sorted(d_env | l_env):
     comparisons += 1
@@ -127,11 +137,29 @@ for n in sorted(d_env | l_env):
         finding("CHART-ONLY", f"inline env {n}", "rendered but not on the running pod spec")
         continue
     if n in d_env:
+        # 🚨 On BOTH sides is NOT the same as agreeing, and this branch used to `continue` — so a
+        # `kubectl set env` over an entry the chart renders inline was the one drift shape this
+        # script could not see at all. It compared the NAMES and nothing else, having counted the
+        # comparison. The chart renders five such entries today (the DOTNET_Dbg* crash-dump block
+        # and the self-updater's AZURE_CLIENT_ID), and a wrong AZURE_CLIENT_ID silently breaks the
+        # ACR credential the self-updater pulls with. Values are compared and NEVER printed.
+        d_e, l_e = d_env_v[n], l_env_v[n]
+        if env_shape(d_e) != env_shape(l_e):
+            finding("DIFFERS", f"inline env {n}",
+                    f"the chart renders {json.dumps(env_shape(d_e))} and the pod carries "
+                    f"{json.dumps(env_shape(l_e))} — the entry's SHAPE differs (a literal against a "
+                    f"valueFrom ref, or two different refs), so they cannot be the same setting")
+        elif d_e.get("value") != l_e.get("value"):
+            finding("DIFFERS", f"inline env {n}",
+                    "the chart renders this entry AND the pod carries it, with DIFFERENT values "
+                    "(withheld — an inline env can hold a token). helm owns this entry, so unlike "
+                    "every other class here a `helm upgrade` DOES reset it; until one runs, the pod "
+                    "runs the hand-set value and the chart's is not what is executing")
         continue
     # live-only inline env. Does it collide with a key that reaches the pod via envFrom?
     d_twins = d_cm_by_lower.get(n.lower(), [])
     l_twins = l_cm_by_lower.get(n.lower(), [])
-    s_twins = sec_by_lower.get(n.lower(), [])
+    s_twins = ext_by_lower.get(n.lower(), [])
     twins = sorted(set(d_twins) | set(l_twins) | set(s_twins))
     if not twins:
         finding("CLUSTER-ONLY", f"inline env {n}",
@@ -139,17 +167,18 @@ for n in sorted(d_env | l_env):
                 "PRESERVES it (measured), but it exists in no committed source — so it is lost on "
                 "any rebuild and no reviewer can see it")
         continue
-    # Where the twins come from, for the messages below. A secret twin is NOT a lesser case: a
-    # secret key reaches the container through envFrom exactly like a ConfigMap key, so it collides
-    # and shadows identically. What differs is only that its VALUE is unknown here by design.
-    secs = sorted({sec for k in s_twins for sec in secret_keys.get(k, [])})
+    # Where the twins come from, for the messages below. A twin from another envFrom source is NOT
+    # a lesser case: its key reaches the container exactly like a memex-portal-config key, so it
+    # collides and shadows identically. What differs is only that its VALUE is unknown here by
+    # design — this script reads key names from those sources and nothing more.
+    exts = sorted({src for k in s_twins for src in envfrom_keys.get(k, [])})
     sources = []
     if d_twins or l_twins:
         sources.append("ConfigMap key(s) " + ", ".join(sorted(set(d_twins) | set(l_twins))))
-    if secs:
-        sources.append("key(s) from " + " and ".join("secret/" + x for x in secs))
+    if exts:
+        sources.append("key(s) from " + " and ".join(exts))
     origin = " and ".join(sources)
-    secret_only = bool(s_twins) and not d_twins and not l_twins
+    external_only = bool(s_twins) and not d_twins and not l_twins
 
     # Which ConfigMap value would the pod read if this inline entry were removed? The LIVE map is
     # what is mounted, so it decides the effective value; fall back to the render when the key is
@@ -168,14 +197,14 @@ for n in sorted(d_env | l_env):
                 f"resolves case-insensitively and the last enumerated wins — the effective value is "
                 f"a COIN TOSS PER POD START. Delete the inline entry (`kubectl set env deploy/… "
                 f"{n}-`); adding it to the chart does NOT remove the collision")
-    elif secret_only:
+    elif external_only:
         finding("SHADOWS", f"inline env {n}",
                 f"{origin} supplies '{n}' through envFrom, and an inline env OVERRIDES envFrom — so "
-                f"this entry wins and the SECRET's value is dead. Whether the two agree is NOT "
-                f"checked here (this script never reads a secret value) and must not be assumed: on "
-                f"memex they differed, leaving the pod on a plaintext copy while the Key Vault "
+                f"this entry wins and THAT source's value is dead. Whether the two agree is NOT "
+                f"checked here (only key names are read from that source) and must not be assumed: "
+                f"on memex they differed, leaving the pod on a plaintext copy while the Key Vault "
                 f"credential went unused (MeshWeaver#3201). Establish which value is the live one "
-                f"FIRST, then put it in the secret and delete the inline entry")
+                f"FIRST, then put it in that source and delete the inline entry")
     else:
         in_chart = n in d_data
         # An entry sourced with valueFrom (secretKeyRef/fieldRef) carries no literal to compare —
@@ -411,6 +440,8 @@ print("                 the inline entry — either step alone leaves the pod on
 print("CLUSTER-ONLY  → a `helm upgrade` does NOT drop it (measured); the risk is that it lives in no")
 print("                 committed source. Move it onto the Deployment record + chart, then delete it.")
 print("CHART-ONLY    → apply it: `helm upgrade` for chart-managed fields; nobody is getting it today.")
-print("DIFFERS       → a deploy does NOT resolve it (measured). Decide which side is authoritative,")
-print("                 then make the other match.")
+print("DIFFERS       → a deploy does NOT resolve it (measured) for a ConfigMap key or a probe field:")
+print("                 decide which side is authoritative, then make the other match. The ONE")
+print("                 exception is `inline env` — helm owns an entry it renders, so an upgrade")
+print("                 DOES reset that one; the finding says so.")
 sys.exit(1)

--- a/deploy/aks/scripts/check-chart-drift.sh
+++ b/deploy/aks/scripts/check-chart-drift.sh
@@ -29,10 +29,11 @@
 #
 # WHAT IT COMPARES (portal only — the object a code update actually rolls):
 #   ConfigMap  memex-portal-config       every key and value
-#   Deployment memex-portal-deployment   the portal container's inline env (NAMES only — values
-#                                        are never printed, they hold tokens), envFrom refs,
-#                                        lifecycle.preStop, terminationGracePeriodSeconds, the
-#                                        three probes, and the AVAILABILITY shape below
+#   Deployment memex-portal-deployment   the portal container's inline env — every entry, name AND
+#                                        value; values are COMPARED but never PRINTED, because they
+#                                        hold tokens — plus envFrom refs, lifecycle.preStop,
+#                                        terminationGracePeriodSeconds, the three probes, and the
+#                                        AVAILABILITY shape below
 #   PodDisruptionBudget / ScaledObject   existence and shape
 #
 # 🚨 THE AVAILABILITY SHAPE was added 2026-08-14, because the check as first written would have
@@ -93,7 +94,13 @@
 #                  it is invisible to review. Fleet rule: nothing may live only on the cluster.
 #   CHART-ONLY     rendered, not live   → described but never applied; nobody is getting it
 #   DIFFERS        both, values differ  → chart and cluster disagree; a deploy does NOT resolve it,
-#                  so it persists until somebody decides which side is authoritative
+#                  so it persists until somebody decides which side is authoritative. ONE exception,
+#                  and the finding names it: an `inline env` entry the chart RENDERS is helm-owned,
+#                  so an upgrade does reset that one. Until 2026-09-03 this comparison did not exist
+#                  at all — an entry present on both sides was matched by NAME and skipped, having
+#                  incremented the comparison counter, so `kubectl set env` over one of the chart's
+#                  own entries (the DOTNET_Dbg* crash-dump block, the self-updater's
+#                  AZURE_CLIENT_ID) was the one drift shape this script could not see.
 #
 # EXPECTED post-helm patches. An env's deploy.sh applies portal-patch.json AFTER `helm upgrade`
 # (the CSI envFrom, extra volumes, nodeSelector, resources). Pass that file with --expect-patch
@@ -224,12 +231,12 @@ fetch() { # $1 = resource
 # credentials onto a CI runner's disk for the lifetime of the job — a drift checker must not be
 # the thing that leaks the secrets it is auditing. `-o go-template` over `.data` emits the keys and
 # nothing else, is built into kubectl (no jq on the runner), and works on both transports.
-fetch_secret_keys() { # $1 = secret name
+fetch_data_keys() { # $1 = resource, e.g. secret/foo or configmap/bar
   local tmpl='{{range $k,$v := .data}}{{$k}}{{"\n"}}{{end}}'
   case "$VIA" in
-    kubectl)    kubectl -n "$NS" get "secret/$1" -o go-template="$tmpl" 2>"$WORK/kubectl.err" ;;
+    kubectl)    kubectl -n "$NS" get "$1" -o go-template="$tmpl" 2>"$WORK/kubectl.err" ;;
     aks-invoke) az aks command invoke -g "$RG" -n "$AKS" -o tsv --query logs \
-                   --command "kubectl -n $NS get secret/$1 -o go-template='$tmpl'" 2>"$WORK/kubectl.err" ;;
+                   --command "kubectl -n $NS get $1 -o go-template='$tmpl'" 2>"$WORK/kubectl.err" ;;
   esac
 }
 
@@ -246,34 +253,42 @@ done
 # ---------------------------------------------------------------------------
 # COMPARE
 # ---------------------------------------------------------------------------
-# Every key an envFrom SECRET supplies reaches the portal exactly like a ConfigMap key — so an
-# inline env of the same name shadows it just as silently. memex proves it is not theoretical: the
-# Key-Vault-provisioned PluginCatalog__RegistryToken sits under an inline entry carrying a
+# Every key an envFrom source supplies reaches the portal exactly like a memex-portal-config key —
+# so an inline env of the same name shadows it just as silently. memex proves it is not theoretical:
+# the Key-Vault-provisioned PluginCatalog__RegistryToken sits under an inline entry carrying a
 # DIFFERENT token, so the managed credential is dead and the pod authenticates with a plaintext
 # copy (MeshWeaver#3201). Reading only the names is enough to see that, and is all we read.
-SECRET_KEYS="$WORK/live-envfrom-secret-keys.txt"
-: > "$SECRET_KEYS"
-for sec in $(python3 - "$WORK/live-deployment-memex-portal-deployment.json" <<'PYEOF'
+#
+# 🚨 BOTH source kinds, not just Secrets. `.Values.extraEnvFrom` takes verbatim EnvFromSource
+# objects and the chart documents `{configMapRef: {name: …}}` as one of the two shapes, so
+# enumerating only `secretRef` would leave exactly the blind spot #3204 closed, one source-kind
+# over — a checker that can see half of the class it is named for. memex-portal-config is EXCLUDED
+# here because it is fetched in full above: only for that one are the VALUES known, which is what
+# lets a shadow over it carry an agree/disagree verdict at all.
+SOURCE_KEYS="$WORK/live-envfrom-source-keys.txt"
+: > "$SOURCE_KEYS"
+for src in $(python3 - "$WORK/live-deployment-memex-portal-deployment.json" <<'PYEOF'
 import json, sys
 dep = json.load(open(sys.argv[1]))
 for c in ((dep.get("spec") or {}).get("template") or {}).get("spec", {}).get("containers", []):
     if c.get("name") == "memex-portal":
         for e in c.get("envFrom") or []:
-            n = (e.get("secretRef") or {}).get("name")
-            if n:
-                print(n)
+            for kind, prefix in (("secretRef", "secret"), ("configMapRef", "configmap")):
+                n = (e.get(kind) or {}).get("name")
+                if n and not (prefix == "configmap" and n == "memex-portal-config"):
+                    print(f"{prefix}/{n}")
 PYEOF
 ); do
-  if ! keys=$(fetch_secret_keys "$sec"); then
-    echo "::error::could not read the KEY NAMES of secret/$sec in namespace '$NS'. An envFrom secret"
-    echo "    this script cannot enumerate is a blind spot in the shadow check, not an absence of"
+  if ! keys=$(fetch_data_keys "$src"); then
+    echo "::error::could not read the KEY NAMES of $src in namespace '$NS'. An envFrom source this"
+    echo "    script cannot enumerate is a blind spot in the shadow check, not an absence of"
     echo "    drift — failing rather than reporting on a partial view."
     [ -s "$WORK/kubectl.err" ] && sed 's/^/    /' "$WORK/kubectl.err"
     exit 1
   fi
-  # `sec<TAB>key`, one per line. Nothing else about the secret is read, stored or printed.
+  # `<kind>/<name><TAB>key`, one per line. Nothing else about the source is read, stored or printed.
   printf '%s\n' "$keys" | while IFS= read -r k; do
-    [ -n "$k" ] && printf '%s\t%s\n' "$sec" "$k" >> "$SECRET_KEYS"
+    [ -n "$k" ] && printf '%s\t%s\n' "$src" "$k" >> "$SOURCE_KEYS"
   done
 done
 
@@ -284,7 +299,7 @@ python3 "$SELF_DIR/chart-drift-compare.py" \
   "$EXPECT_PATCH" \
   "$WORK/live-poddisruptionbudgets.json" \
   "$WORK/live-scaledobjects-keda-sh.json" \
-  "$SECRET_KEYS"
+  "$SOURCE_KEYS"
 rc=$?
 
 if [ "$rc" -ne 0 ]; then

--- a/deploy/aks/scripts/test-chart-drift-compare.sh
+++ b/deploy/aks/scripts/test-chart-drift-compare.sh
@@ -27,7 +27,7 @@ run_case() {
     "$DATA/$case/expect-patch.json" \
     "$DATA/$case/live-poddisruptionbudgets.json" \
     "$DATA/$case/live-scaledobjects.json" \
-    "$DATA/$case/envfrom-secret-keys.txt" 2>&1
+    "$DATA/$case/envfrom-source-keys.txt" 2>&1
 }
 
 check() {  # check <description> <expected> <actual>
@@ -116,6 +116,47 @@ if echo "$out" | grep -A1 'SHADOWS *inline env Grpc__TrustedPort' | grep -q 'THE
   fail=1
 else
   echo "  ok   agreeing SHADOWS is not reported as a disagreement"
+fi
+
+# An inline env the CHART renders and the pod also carries, with a different value. Until
+# 2026-09-03 this shape was invisible: the comparator matched the two by NAME and skipped, having
+# counted the comparison, so `kubectl set env` over one of the chart's own entries reported nothing.
+expect_class "DIFFERS"      "inline env AZURE_CLIENT_ID"
+# ...and it must not print either value — an inline env can hold a token.
+if echo "$out" | grep -A1 'DIFFERS *inline env AZURE_CLIENT_ID' | grep -qE '00000000|99999999'; then
+  echo "::error::the inline-env DIFFERS finding PRINTS the values it compared. Inline env entries"
+  echo "         hold tokens; the finding may say that they differ and nothing more."
+  fail=1
+else
+  echo "  ok   an inline-env DIFFERS withholds both values"
+fi
+# The CONTROL for that comparison: an entry identical on both sides must NOT be reported. Without
+# this, a comparator that flagged every both-sides entry would pass the assertion above.
+if echo "$out" | grep -q 'inline env DOTNET_DbgMiniDumpType'; then
+  echo "::error::DOTNET_DbgMiniDumpType is IDENTICAL on both sides and was reported anyway — the"
+  echo "         both-sides comparison flags everything, which is not a comparison."
+  fail=1
+else
+  echo "  ok   an inline env identical on both sides is not reported"
+fi
+# A same-name entry whose SHAPE changed (chart literal vs live valueFrom) is not the same setting.
+expect_class "DIFFERS"      "inline env DOTNET_DbgMiniDumpName"
+# An inline env over a key from a SECOND envFrom ConfigMap. `.Values.extraEnvFrom` takes
+# `{configMapRef: …}` as well as `{secretRef: …}`, so enumerating only secrets would leave exactly
+# the blind spot #3204 closed, one source-kind over.
+expect_class "SHADOWS"      "inline env Commerce__BaseUrl"
+if echo "$out" | grep -A1 'SHADOWS *inline env Commerce__BaseUrl' | grep -q 'configmap/portal-extra'; then
+  echo "  ok   a shadow over a second envFrom ConfigMap names that ConfigMap"
+else
+  echo "::error::the Commerce__BaseUrl finding does not name the envFrom ConfigMap supplying it."
+  fail=1
+fi
+if echo "$out" | grep -A1 'SHADOWS *inline env Commerce__BaseUrl' | grep -q 'THE TWO DISAGREE'; then
+  echo "::error::the second-ConfigMap shadow asserts a value verdict it cannot have — only that"
+  echo "         source's key NAMES are read, so agreement is unknown and must not be stated."
+  fail=1
+else
+  echo "  ok   a shadow over a key-names-only source states no value verdict"
 fi
 
 # An inline entry sourced with valueFrom carries no literal — it must not be compared as if it did.

--- a/deploy/aks/scripts/testdata/chart-drift/clean/envfrom-source-keys.txt
+++ b/deploy/aks/scripts/testdata/chart-drift/clean/envfrom-source-keys.txt
@@ -1,0 +1,1 @@
+configmap/portal-extra	Commerce__BaseUrl

--- a/deploy/aks/scripts/testdata/chart-drift/clean/live-deployment.json
+++ b/deploy/aks/scripts/testdata/chart-drift/clean/live-deployment.json
@@ -1,1 +1,88 @@
-{"kind": "Deployment", "metadata": {"name": "memex-portal-deployment"}, "spec": {"replicas": 2, "template": {"spec": {"terminationGracePeriodSeconds": 1800, "containers": [{"name": "memex-portal", "envFrom": [{"configMapRef": {"name": "memex-portal-config"}}], "lifecycle": {"preStop": {"exec": {"command": ["sleep", "5"]}}}, "startupProbe": {"httpGet": {"path": "/health", "port": 8080, "scheme": "HTTP"}, "periodSeconds": 5, "timeoutSeconds": 5, "failureThreshold": 60, "successThreshold": 1}, "readinessProbe": {"httpGet": {"path": "/alive", "port": 8080, "scheme": "HTTP"}, "periodSeconds": 10, "timeoutSeconds": 5, "failureThreshold": 3, "successThreshold": 1}, "livenessProbe": {"httpGet": {"path": "/alive", "port": 8080, "scheme": "HTTP"}, "periodSeconds": 15, "timeoutSeconds": 10, "failureThreshold": 6, "successThreshold": 1}}]}}}}
+{
+  "kind": "Deployment",
+  "metadata": {
+    "name": "memex-portal-deployment"
+  },
+  "spec": {
+    "replicas": 2,
+    "template": {
+      "spec": {
+        "terminationGracePeriodSeconds": 1800,
+        "containers": [
+          {
+            "name": "memex-portal",
+            "envFrom": [
+              {
+                "configMapRef": {
+                  "name": "memex-portal-config"
+                }
+              },
+              {
+                "configMapRef": {
+                  "name": "portal-extra"
+                }
+              }
+            ],
+            "lifecycle": {
+              "preStop": {
+                "exec": {
+                  "command": [
+                    "sleep",
+                    "5"
+                  ]
+                }
+              }
+            },
+            "startupProbe": {
+              "httpGet": {
+                "path": "/health",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "periodSeconds": 5,
+              "timeoutSeconds": 5,
+              "failureThreshold": 60,
+              "successThreshold": 1
+            },
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/alive",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "periodSeconds": 10,
+              "timeoutSeconds": 5,
+              "failureThreshold": 3,
+              "successThreshold": 1
+            },
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/alive",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "periodSeconds": 15,
+              "timeoutSeconds": 10,
+              "failureThreshold": 6,
+              "successThreshold": 1
+            },
+            "env": [
+              {
+                "name": "DOTNET_DbgMiniDumpType",
+                "value": "2"
+              },
+              {
+                "name": "DOTNET_DbgMiniDumpName",
+                "value": "/data/dumps/coredump.%p.%t"
+              },
+              {
+                "name": "AZURE_CLIENT_ID",
+                "value": "00000000-0000-0000-0000-000000000001"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/deploy/aks/scripts/testdata/chart-drift/desired.yaml
+++ b/deploy/aks/scripts/testdata/chart-drift/desired.yaml
@@ -45,6 +45,25 @@ spec:
                 "configMapRef": {
                   "name": "memex-portal-config"
                 }
+              },
+              {
+                "configMapRef": {
+                  "name": "portal-extra"
+                }
+              }
+            ],
+            "env": [
+              {
+                "name": "DOTNET_DbgMiniDumpType",
+                "value": "2"
+              },
+              {
+                "name": "DOTNET_DbgMiniDumpName",
+                "value": "/data/dumps/coredump.%p.%t"
+              },
+              {
+                "name": "AZURE_CLIENT_ID",
+                "value": "00000000-0000-0000-0000-000000000001"
               }
             ],
             "lifecycle": {

--- a/deploy/aks/scripts/testdata/chart-drift/drifted/envfrom-secret-keys.txt
+++ b/deploy/aks/scripts/testdata/chart-drift/drifted/envfrom-secret-keys.txt
@@ -1,3 +1,0 @@
-portal-secrets	PluginCatalog__RegistryToken
-portal-secrets	ConnectionStrings__memex
-portal-secrets	SPEECH__APIKEY

--- a/deploy/aks/scripts/testdata/chart-drift/drifted/envfrom-source-keys.txt
+++ b/deploy/aks/scripts/testdata/chart-drift/drifted/envfrom-source-keys.txt
@@ -1,0 +1,4 @@
+secret/portal-secrets	PluginCatalog__RegistryToken
+secret/portal-secrets	ConnectionStrings__memex
+secret/portal-secrets	SPEECH__APIKEY
+configmap/portal-extra	Commerce__BaseUrl

--- a/deploy/aks/scripts/testdata/chart-drift/drifted/live-deployment.json
+++ b/deploy/aks/scripts/testdata/chart-drift/drifted/live-deployment.json
@@ -1,1 +1,131 @@
-{"kind": "Deployment", "metadata": {"name": "memex-portal-deployment"}, "spec": {"replicas": 2, "template": {"spec": {"terminationGracePeriodSeconds": 1800, "containers": [{"name": "memex-portal", "envFrom": [{"configMapRef": {"name": "memex-portal-config"}}], "lifecycle": {"preStop": {"exec": {"command": ["sleep", "5"]}}}, "startupProbe": {"httpGet": {"path": "/health", "port": 8080, "scheme": "HTTP"}, "periodSeconds": 5, "timeoutSeconds": 5, "failureThreshold": 60, "successThreshold": 1}, "readinessProbe": {"httpGet": {"path": "/alive", "port": 8080, "scheme": "HTTP"}, "periodSeconds": 10, "timeoutSeconds": 5, "failureThreshold": 3, "successThreshold": 1}, "livenessProbe": {"httpGet": {"path": "/alive", "port": 8080, "scheme": "HTTP"}, "periodSeconds": 15, "timeoutSeconds": 10, "failureThreshold": 6, "successThreshold": 1, "initialDelaySeconds": 60}, "env": [{"name": "EMAIL__CLIENTID", "value": "x"}, {"name": "PreWarm__GateReadiness", "value": "true"}, {"name": "Grpc__TrustedPort", "value": "8082"}, {"name": "Features__Ai__Clis__Copilot", "value": "true"}, {"name": "Tok", "valueFrom": {"secretKeyRef": {"name": "s", "key": "k"}}}, {"name": "PluginCatalog__RegistryToken", "value": "mwi_inline_copy"}, {"name": "Speech__ApiKey", "value": "inline"}]}]}}}}
+{
+  "kind": "Deployment",
+  "metadata": {
+    "name": "memex-portal-deployment"
+  },
+  "spec": {
+    "replicas": 2,
+    "template": {
+      "spec": {
+        "terminationGracePeriodSeconds": 1800,
+        "containers": [
+          {
+            "name": "memex-portal",
+            "envFrom": [
+              {
+                "configMapRef": {
+                  "name": "memex-portal-config"
+                }
+              },
+              {
+                "configMapRef": {
+                  "name": "portal-extra"
+                }
+              }
+            ],
+            "lifecycle": {
+              "preStop": {
+                "exec": {
+                  "command": [
+                    "sleep",
+                    "5"
+                  ]
+                }
+              }
+            },
+            "startupProbe": {
+              "httpGet": {
+                "path": "/health",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "periodSeconds": 5,
+              "timeoutSeconds": 5,
+              "failureThreshold": 60,
+              "successThreshold": 1
+            },
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/alive",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "periodSeconds": 10,
+              "timeoutSeconds": 5,
+              "failureThreshold": 3,
+              "successThreshold": 1
+            },
+            "livenessProbe": {
+              "httpGet": {
+                "path": "/alive",
+                "port": 8080,
+                "scheme": "HTTP"
+              },
+              "periodSeconds": 15,
+              "timeoutSeconds": 10,
+              "failureThreshold": 6,
+              "successThreshold": 1,
+              "initialDelaySeconds": 60
+            },
+            "env": [
+              {
+                "name": "DOTNET_DbgMiniDumpType",
+                "value": "2"
+              },
+              {
+                "name": "AZURE_CLIENT_ID",
+                "value": "99999999-9999-9999-9999-999999999999"
+              },
+              {
+                "name": "DOTNET_DbgMiniDumpName",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "dumps",
+                    "key": "path"
+                  }
+                }
+              },
+              {
+                "name": "Commerce__BaseUrl",
+                "value": "https://commerce.example"
+              },
+              {
+                "name": "EMAIL__CLIENTID",
+                "value": "x"
+              },
+              {
+                "name": "PreWarm__GateReadiness",
+                "value": "true"
+              },
+              {
+                "name": "Grpc__TrustedPort",
+                "value": "8082"
+              },
+              {
+                "name": "Features__Ai__Clis__Copilot",
+                "value": "true"
+              },
+              {
+                "name": "Tok",
+                "valueFrom": {
+                  "secretKeyRef": {
+                    "name": "s",
+                    "key": "k"
+                  }
+                }
+              },
+              {
+                "name": "PluginCatalog__RegistryToken",
+                "value": "mwi_inline_copy"
+              },
+              {
+                "name": "Speech__ApiKey",
+                "value": "inline"
+              }
+            ]
+          }
+        ]
+      }
+    }
+  }
+}

--- a/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
@@ -79,17 +79,23 @@ owned.
 | class | meaning | when it bites |
 |---|---|---|
 | `COLLIDES` | inline `env:` + a ConfigMap key differing **only in case** | **already**, at random, every pod start |
-| `SHADOWS` | inline `env:` + the **same** key from a ConfigMap **or an envFrom secret** | **already** — the shadowed value is dead |
+| `SHADOWS` | inline `env:` + the **same** key from **any** envFrom source | **already** — the shadowed value is dead |
 | `CLUSTER-ONLY` | live, in no committed source | on a rebuild or restore, and at every review |
 | `CHART-ONLY` | rendered, never applied | nobody is getting it today |
-| `DIFFERS` | both sides, values disagree | never resolves itself; needs a decision |
+| `DIFFERS` | both sides, values disagree | never resolves itself; needs a decision — except an `inline env`, which helm owns and an upgrade resets |
 
-### A secret can be shadowed too, and that one is silent in both directions
+### Any envFrom source can be shadowed, and a secret is the silent version
 
-`envFrom` carries **secrets** as well as ConfigMaps, and an inline `env:` overrides both. A shadowed
-secret is the worst version of this: the credential the platform provisioned through Key Vault is
-inert, and the value actually in use sits in plaintext on the Deployment spec, in no committed
-source, readable by anything that can `get deploy`.
+`envFrom` carries **secrets**, the portal's own ConfigMap, and any further source added through
+`.Values.extraEnvFrom` — the chart documents both `{secretRef: …}` and `{configMapRef: …}` as
+entries there. An inline `env:` overrides all of them identically, so the checker enumerates the key
+names of **every** envFrom source, not just the secrets. Enumerating one kind and not the other
+would have left exactly the blind spot MeshWeaver#3201 exposed, one source-kind over: a checker that
+can see half of the class it is named for reports "clean" for a reason its reader cannot guess.
+
+A shadowed secret is the worst version of this: the credential the platform provisioned through Key
+Vault is inert, and the value actually in use sits in plaintext on the Deployment spec, in no
+committed source, readable by anything that can `get deploy`.
 
 That is live on `memex` today (MeshWeaver#3201): `PluginCatalog__RegistryToken` exists both in
 `secret/memex-portal-secrets` and as an inline entry, and **the two values differ** — so the portal
@@ -97,14 +103,13 @@ authenticates to the plugin registry with the plaintext copy while the managed c
 unused. It also means the obvious cleanup is wrong: deleting the inline entry does not restore the
 status quo, it switches the portal onto a different token.
 
-The checker therefore reports a secret-backed `SHADOWS` **without** an agree/disagree verdict. It
-reads only the KEY NAMES of each envFrom secret, projected inside the cluster — a drift checker
-must not become the thing that copies the credentials it audits onto a CI runner's disk. Unknown is
-reported as unknown rather than guessed.
-
-`SHADOWS` over a ConfigMap reports whether the two values **agree today**. Agreeing is not safe — it means the next
-change to the chart will silently fail to take effect. Disagreeing means somebody is already
-reading a setting no pod uses.
+The checker reads only the KEY NAMES of every envFrom source other than `memex-portal-config`,
+projected inside the cluster — a drift checker must not become the thing that copies the credentials
+it audits onto a CI runner's disk. So a `SHADOWS` over one of those sources carries **no**
+agree/disagree verdict: unknown is reported as unknown rather than guessed. A `SHADOWS` over
+`memex-portal-config` — the one source fetched in full — does report whether the two values **agree
+today**. Agreeing is not safe: it means the next change to the chart will silently fail to take
+effect. Disagreeing means somebody is already reading a setting no pod uses.
 
 > Fixing a `SHADOWS` or `COLLIDES` takes **both** steps, in order: put the intended value in the
 > chart, *then* delete the inline entry (`kubectl set env deploy/… KEY-`). Either step alone leaves
@@ -129,12 +134,74 @@ enshrine dead config. The reasoning now lives beside the probes in
 `deploy/helm/templates/memex-portal/deployment.yaml`, so the next reader of the drift report does
 not re-derive the wrong answer.
 
+## The one drift shape the checker could not see at all
+
+Until 2026-09-03 an inline `env:` entry present on **both** sides was matched by NAME and skipped —
+after incrementing the comparison counter, so the run reported it as a field it had compared. The
+chart renders five such entries (the `DOTNET_Dbg*` crash-dump block and the self-updater's
+`AZURE_CLIENT_ID`), and a `kubectl set env` over any of them produced **no finding whatsoever**: a
+wrong `AZURE_CLIENT_ID` breaks the ACR credential the self-updater pulls with, silently, and this
+report would have said the namespace's inline env was clean.
+
+Both entries are now compared in full — values compared, never printed, because an inline env can
+hold a token. It reports `DIFFERS inline env <name>`, and that class carries the one exception to
+the measurement above: **helm owns an entry it renders**, so an upgrade *does* reset that one. The
+finding says so, rather than repeating the generic "a deploy does not resolve this".
+
+## What this report does NOT prove
+
+🚨 **The left-hand side is not the chart a deploy renders.** `chart-drift.yml` renders
+`deploy/helm/values.yaml + deployments/aks/<ns>/values.<release>.public.yaml`. `helm-release.yml`
+(mode `deploy`) renders `<the Key Vault capture> + <that same committed overlay>`, where the capture
+is a `helm get values` of the live release — the whole user-supplied values document, `config:`
+included. The overlay is layered LAST, so:
+
+- for a key the committed overlay **carries**, the two renders agree and the finding is sound;
+- for a key it does **not** carry, the "chart" column is the chart *default*, and a deploy may
+  render something else entirely.
+
+That confines the doubt rather than removing it, and the confinement is checkable per finding: look
+the key up in the overlay before acting on a `DIFFERS`. The durable fix is that the capture carries
+**no `config:` section at all** — the overlay is already generated from the `Hosting/Deployment`
+record (`HelmValues.Render`), so the vault half only needs to hold the secret sections it was
+created for. Asserting that belongs beside the capture, in `Systemorph/Memex`'s `helm-release.yml`;
+until it exists, this report's `DIFFERS` column is an input to a decision and not the decision.
+
+The same boundary in one line: **this check answers "does the cluster match the chart as CI renders
+it". It does not answer "is every committed value live"** — that is `Systemorph/Memex`'s
+`deploy-drift.yml`, which compares git against the deploy record. Neither substitutes for the other,
+and a finding can be produced by an un-run deploy rather than by cluster drift.
+
 ## Reading the report
 
 Findings are printed worst-first and the summary counts each class. Rank the work that way:
 `COLLIDES` and `SHADOWS` are live-wrong now; `CLUSTER-ONLY` is the migration tracked by
 `Systemorph/Memex#148` (*nothing may live only on the cluster* — every value belongs on the
 `Hosting/Deployment` record, rendered by the chart); `DIFFERS` is a decision, not a deploy.
+
+## The backlog, classified — run 33755512452, 2026-09-03
+
+"91 divergences" is not a worklist. **76 today** (`memex` 32 across 188 compared fields,
+`memex-cloud` 44 across 204), and they are seven groups, not seventy-six decisions. Counts are from
+the run's own log; no cluster was touched to produce them.
+
+| # | group | count | what it is | what clears it |
+|---|---|---|---|---|
+| 1 | **Disagreeing `SHADOWS`** | **8** | the pod runs a value the ConfigMap contradicts — `PreWarm__BatchBake`/`PrebuiltBundleRoot` (both), `PluginCatalog__RegistryUrl` (both), `PreWarm__GateReadiness` + `Features__Ai__Providers__AzureOpenAI` (memex) | chart value first, **then** delete the inline entry |
+| 2 | **The registry credential** | **2** | `PluginCatalog__RegistryToken`: on memex a `SHADOWS` over `secret/memex-portal-secrets` whose two values differ; on memex-cloud the inline entry is the ONLY copy | MeshWeaver#3201 — establish the live token, vault it, delete inline, rotate |
+| 3 | **Agreeing `SHADOWS`** | **29** | not wrong today; the ConfigMap is simply not what the pod reads, so the next chart change to any of them silently fails — Kestrel endpoints, `PluginCatalog__Sources__*`, `WebhookInbox__Targets__0` | same two steps, no urgency |
+| 4 | **Chart-retired, inert** | **8** | `FrameworkBroadcast__Subscribers__0..3` on both namespaces. The chart stopped rendering these on 2026-09-03 — the subscriber set is mesh data now — so the live keys feed nothing | delete the keys; drop them from the memex-cloud overlay, which still sets them |
+| 5 | **Cluster-only, now expressible** | **22** | live-edited settings the chart had no key for until MeshWeaver#3199 — AI providers, `LogWatch__*`, `Speech__*`, `Commerce__BaseUrl`, `Features__Ai__Clis__*`, `Portal__ReactAppUrl` | put them on the `Hosting/Deployment` record — `Systemorph/Memex#148` |
+| 6 | **Committed, never deployed** | **5** | memex-cloud's overlay carries `PreWarm__{BatchBake,BuildProtocol,DynamicTypes,GateReadiness}: "true"` and `probes.startup.failureThreshold: 1080`; live runs the shipped defaults | a deploy, not a cleanup — this is `deploy-drift`'s class surfacing here |
+| 7 | **Ruled inert** | **2** | the memex liveness/readiness `initialDelaySeconds` — see above; the chart is authoritative | nothing; do not "fix" it |
+
+Zero `COLLIDES` and zero `CHART-ONLY`. The `EMAIL__*` collisions that crashed memex at boot on
+2026-08-30, and the four blanked `ModelTier__*`, are gone from both namespaces.
+
+**Groups 1–5 all need a Deployment-spec edit, and that is blocked**: MeshWeaver#3207 — the portal
+image is ahead of its schema, so any pod-template change spawns a ReplicaSet that lands on
+`DbVersionGate` and crash-loops, and both portals are pinned under a freeze. The classification is
+the deliverable until the schema is current; nothing here is urgent enough to lift a freeze for.
 
 See also [DeploymentAKS.md](/Doc/Architecture/DeploymentAKS) and
 [Deployment.md](/Doc/Architecture/Deployment).

--- a/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
@@ -160,8 +160,16 @@ included. The overlay is layered LAST, so:
 - for a key it does **not** carry, the "chart" column is the chart *default*, and a deploy may
   render something else entirely.
 
-That confines the doubt rather than removing it, and the confinement is checkable per finding: look
-the key up in the overlay before acting on a `DIFFERS`. The durable fix is that the capture carries
+**`COLLIDES` and `SHADOWS` are immune to this**, which matters because they are the two classes
+ranked first. Their agree/disagree verdict is computed against the **live** ConfigMap — the one the
+pod actually mounts — and falls back to the render only for a key that is rendered but not yet live.
+So the finding "the pod runs one value and the ConfigMap holds another" is a statement about two
+live objects, and no values-layer question can touch it. On the 2026-09-03 run that is 38 of the 76
+findings, of which the 8 disagreeing ones are the whole of the live-wrong list.
+
+For the rest, the doubt is checkable per finding: look the key up in the overlay before acting on a
+`CLUSTER-ONLY` or a `DIFFERS`. A key with **no chart key at all** is also immune — nothing can render
+it whatever the capture says. The durable fix is that the capture carries
 **no `config:` section at all** — the overlay is already generated from the `Hosting/Deployment`
 record (`HelmValues.Render`), so the vault half only needs to hold the secret sections it was
 created for. Asserting that belongs beside the capture, in `Systemorph/Memex`'s `helm-release.yml`;

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentAKS.md
@@ -147,10 +147,21 @@ deploy/aks/scripts/check-chart-drift.sh -n <NS> -r <release> \
 ```
 
 It renders the chart, reads the live `memex-portal-config` and `memex-portal-deployment` plus the
-namespace's `PodDisruptionBudget` and `ScaledObject`, and classifies every difference as
-**CLUSTER-ONLY** (hand-applied — the next `helm upgrade` deletes it), **CHART-ONLY** (described
-but never applied — nobody is getting it), or **DIFFERS**. Secret values are never printed;
-inline `env` is compared by name only.
+namespace's `PodDisruptionBudget` and `ScaledObject`, and classifies every difference into the five
+classes below — **COLLIDES** and **SHADOWS** (an inline `env:` entry that overrides `envFrom`, so
+the value the chart supplies is dead or resolved at random per pod start), then **CLUSTER-ONLY**
+(hand-applied, and in no committed source), **CHART-ONLY** (described but never applied — nobody is
+getting it), and **DIFFERS**.
+
+🚨 **CLUSTER-ONLY does NOT mean "the next `helm upgrade` deletes it".** This page said that until
+2026-09-03 and it is false — measured, and contradicted four paragraphs below by this same page.
+Helm's three-way merge removes only what Helm previously owned, so drift applied out of band
+survives every deploy. Ranking the backlog by "what a deploy would destroy" ranked it by a hazard
+that does not exist and buried the two classes that are wrong *now*.
+
+Secret values are never printed, and neither are inline `env` values — but both are **compared**:
+an entry present on both the chart and the pod with a different value is reported as `DIFFERS`
+without printing either side.
 
 The **availability shape** — `spec.replicas`, the budget, the autoscaler — is compared because
 without it the check cannot see an outage. On 2026-08-14 `memex-cloud` served every request from


### PR DESCRIPTION
Two more blind spots in the drift checker — both the exact shape #3204 closed, one source-kind and one branch over — plus the triage #2355 has never had.

## 1 · The branch that counted a comparison and made none

An inline `env:` entry present on **both** sides was matched by NAME and `continue`d — *after* `comparisons += 1`, so the run reported it as a field it had compared.

The chart renders five such entries: the `DOTNET_Dbg*` crash-dump block and the self-updater's `AZURE_CLIENT_ID`. A `kubectl set env` over any of them produced **no finding whatsoever** — and a wrong `AZURE_CLIENT_ID` breaks the ACR credential the self-updater pulls with, silently, while this report said the namespace's inline env was clean.

Both entries are compared now. Values are compared and **never printed** (an inline env can hold a token) — the finding says they differ and nothing more. It also carries the one exception to #3168's measurement: **helm owns an entry it renders**, so an upgrade *does* reset that one, unlike every other class here. The legend says so rather than repeating the generic line.

## 2 · envFrom carries ConfigMaps too

`.Values.extraEnvFrom` takes verbatim `EnvFromSource` objects and the chart documents **both** `{secretRef: …}` and `{configMapRef: …}`. An inline `env:` overrides both identically — but only `secretRef` sources were enumerated, so a shadow over a second envFrom ConfigMap was filed as a plain `CLUSTER-ONLY`. That is precisely the blind spot #3201 exposed, one source-kind over, and "a detector that silently cannot see half of the class it is named for" is the shape the fleet keeps hitting.

Every envFrom source is enumerated now, key **names** only, projected in-cluster — unchanged from #3204, and still never a secret value on a runner's disk. `memex-portal-config` stays excluded because it is fetched in full; that exclusion is what lets a shadow over *it* carry an agree/disagree verdict at all, while a shadow over any other source correctly carries none.

No live environment uses a second envFrom ConfigMap today. That is the point: the gap was found by reading the chart's own documented contract, not by waiting for it to fire.

## Verification — by mutation, with a control

`test-chart-drift-compare.sh`: **24 assertions, all pass**; `check-chart-invariants` 3/3; `check-values-are-read` 111/111; `check-workflow-timeouts` 64 jobs / 0 violations; `DocumentationLinkIntegrityTest` passes.

| mutation | result |
|---|---|
| restore the `if n in d_env: continue` skip | **red** — `AZURE_CLIENT_ID` and `DOTNET_DbgMiniDumpName` no longer classified |
| ignore every envFrom source that is not a `secret/` | **red** — `Commerce__BaseUrl` demoted, and the finding no longer names the ConfigMap |
| both restored | green, exit 0 |

The clean fixture is the **control** for the new comparison: an entry identical on both sides must NOT be reported, and the self-test asserts its absence. Without that, a comparator that flagged every both-sides entry would have passed.

## 3 · The header warning #2355 asked about, settled

`chart-drift.yml`'s header warned that `Authentication__Microsoft__ClientId` was still `CHANGE_ME_aad_application_client_id` in the chart, "so a `helm upgrade` today would overwrite working auth with the placeholder". Both halves are false:

* **no run has ever reported an `Authentication__` finding** — 2026-08-26, 09-02 and 09-03 all clean. Every environment sets a real client id in its own overlay, layered over the chart default, so the placeholder never renders;
* a `helm upgrade` does not overwrite a live value with a rendered one anyway (#3168, measured).

Corrected in place rather than deleted — that warning is what #2355 was triaged against for a week, and an un-measured hazard in a gate's header propagates as fact.

## 4 · The backlog, classified — and what this report does not prove

`ChartDriftSemantics.md` now records the triage from run [33755512452](https://github.com/Systemorph/MeshWeaver/actions/runs/33755512452) (dispatched read-only today): **76 findings, seven groups** — 8 disagreeing `SHADOWS` that are live-wrong now, 2 registry-credential, 29 latent agreeing `SHADOWS`, 8 chart-retired and inert, 22 cluster-only that #3199 finally made expressible, 5 committed-but-never-deployed, 2 ruled inert. Groups 1–5 all need a Deployment-spec edit and are blocked on #3207.

And the trust boundary, which was nowhere: **CI renders `values.yaml + the committed overlay`; a deploy renders `the Key Vault capture + that same overlay`** (`helm-release.yml` layers the capture first). For a key the overlay carries, the two agree and the finding is sound. For a key it does not, the "chart" column is a chart *default* and not what a deploy would render — so a `DIFFERS` there is an input to a decision, not the decision. The durable fix is asserting the capture holds no `config:` section, and that assertion belongs beside the capture in `Systemorph/Memex`.

Refs #2355, #3201, #3207.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
