### PR TITLE
docs: one rule for chrome rendered inside authored content — the ownership rule, not the content language (#3203 proposal)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ChromeAndContentLanguage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChromeAndContentLanguage.md
@@ -1,0 +1,393 @@
+---
+Name: Chrome and content language
+Category: Architecture
+Description: Whose language a string renders in when the application speaks inside a document the author wrote — the ownership rule, why the content-language alternative was already tried and reverted, and what a per-node language field would cost.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="m5 8 6 6"/><path d="m4 14 6-6 2-3"/><path d="M2 5h12"/><path d="M7 2h1"/><path d="m22 22-5-10-5 10"/><path d="M14 18h6"/></svg>
+---
+
+# Chrome and content language
+
+> **Status: proposal.** This page answers [#3203](https://github.com/Systemorph/MeshWeaver/issues/3203)
+> and is written to be decided, not to be assumed. The rule below is not in force until a maintainer
+> says so; [Localization](../Localization) still describes what the platform does today. Nothing here
+> has been implemented.
+
+## The observation
+
+A German-profile reader opened an English course page. The lesson text was English. The code cell's
+button read **Ausführen**. The node menu read *Bearbeiten · Anheften · Verschieben · Löschen*. The
+quiz beneath the lesson read *Question 6 of 6*.
+
+The reader's reaction was *"language should be applied as consistently as possible."*
+
+Every one of those is correct in isolation. The button and the menu follow the viewer, which is the
+platform's documented rule. The lesson is English because its author wrote English. The quiz is
+English because nobody localized it. The rule is consistent per component and incoherent per page,
+and the page is what a reader sees.
+
+## The rule
+
+**Every user-visible string has exactly one owner, and the owner decides the language.**
+
+| The string is owned by | It renders in | Because |
+|---|---|---|
+| the **platform or a module** — it lives in a string catalog or a module's text table | the **viewer's** language | it is the application talking to the person operating it |
+| the **author** — it comes out of a node's content: the body, `Name`, `Description`, a typed field an author filled in | **the language it was authored in**, untouched | it is the author talking to a reader |
+| **nobody** — a bare literal compiled into a view | this is a **bug** | a string with no owner has no language rule, so it renders whatever the developer typed |
+
+That is the whole language decision, and it is already what the platform does. What #3203 exposes is
+not a wrong answer to it; it is two *other* defects that look like a language problem:
+
+1. **Unowned strings.** The quiz's *"Question 6 of 6"* and *"This is a copy in your own space…"* went
+   through no catalog and no text table. They are unowned, so they render English for everybody — a
+   German reader gets a German frame, German headings, and then an English progress counter. Giving
+   them an owner is the fix, and the owner is the module, so they become *Frage 6 von 6*.
+2. **Owned strings in the wrong form.** `common.run` renders the word **Run**/**Ausführen** on a
+   button that *already* carries a ▶ glyph and an *already localized* tooltip. The word adds no
+   information and puts a German token in the middle of an English paragraph. Nothing about the
+   ownership is wrong; the *form* is.
+
+So the two clauses:
+
+> **Clause 1 — ownership decides the language.** Platform- and module-owned text follows the viewer.
+> Authored content is rendered as authored. An unowned literal is a defect, not a third category.
+>
+> **Clause 2 — in-flow chrome minimises words.** A platform- or module-owned control rendered
+> *inside* the author's flow must carry no translated visible label where a glyph, a number or a
+> symbol conveys the same thing. The localized text moves to the tooltip and the accessible name,
+> which is where a reader who needs it will look and where it cannot land in the middle of a
+> sentence.
+
+Clause 2 is not new doctrine. [User Interface](../UserInterface) already says *"a language-neutral
+glyph plus a translated tooltip beats a translated label"*. Clause 2 makes it **binding** for the
+in-flow case rather than preferred, because that is the only case where ignoring it produces the
+artefact #3203 reports.
+
+## Why the obvious alternative is not recommended
+
+#3203 offers, as option (a), that in-content controls follow the **content's** declared language and
+fall back to the viewer only when the content declares none.
+
+**That is the rule the Edu pack shipped, measured, and deliberately reverted.**
+`Edu/Module/Source/EduTexts.cs` in MeshWeaver.Plugins used to resolve
+`Primary(courseLanguage) ?? Primary(viewerLocale) ?? "en"` — the course first. Its own comment
+records what that cost:
+
+> 🚨 **The order is the fix, and the parameter order states it.** … Since `Primary("de-CH")` is
+> `"de"`, the `??` chain short-circuited and **the viewer was never consulted at all**:
+> AgenticPrimerDe served "Übungen" / "Weiter" to every learner on earth, whatever language they read
+> in.
+
+and then, explicitly:
+
+> 🚨 **Do not restore the old order.** The argument it was written for — "German lessons framed by
+> English headings read as broken" — was answered by drawing the chrome/content line instead … A
+> learner who reads English gets an English frame around German prose, which is what they asked for;
+> the alternative **imposed German buttons on a reader who cannot read them**.
+
+There is a second measurement on the same shape: Store's twin,
+[#1349](https://github.com/Systemorph/MeshWeaver/issues/1349), where content-language chrome cost a
+day of e2e runs — the harness pinned the English label, nothing ever matched, and the retry loop
+timed out presenting as *"the paywall never came up"*.
+
+Option (a) is symmetrical-looking and asymmetrical in effect. It reads well for the case that
+prompted #3203 — a German reader of an English course, who can plainly read English. It reads
+catastrophically for the case that prompted the revert — an English reader of a German course, who
+gets a page whose every control is in a language they do not have. **A rule must be judged on the
+reader it serves worst, and option (a)'s worst reader cannot use the page at all.**
+
+## The mechanical boundary
+
+The brief for this rule was that the boundary be decided mechanically, not string by string.
+
+**Start from what is NOT available.** There is no runtime chrome-vs-content boundary in this codebase,
+and it is not a small gap:
+
+- `UiControl` carries `Id`, `Style`, `Readonly`, `Skins`, `Class`, `IsUpToDate` and click plumbing —
+  **no chrome/content discriminator**. There is no `IChromeControl`/`IContentControl`, no `[Chrome]`
+  attribute, and every control lives in the one `MeshWeaver.Layout` namespace.
+- `RenderingContext` carries `Area`, `Layout`, `DataContext`, `DisplayName`, `Parent`, `Depth` —
+  `Parent`/`Depth` exist as a recursion guard. Nothing says "authored content".
+- The Blazor cascading parameters (`Context`, `ThemeMode`, `DataContext`, `Model`; and
+  `LayoutAreaView`'s `Top`/`Fill`/`DrivesMenu`) are layout and data flags, deliberately decoupled from
+  embedding semantics.
+- **Nothing survives the markdown → embedded-area hop** except an address, an area name, an area id, a
+  spinner style and — on *one* of the two embed paths — `showHeader=false`. The embedded area is a new
+  server subscription on another hub; it does not know a document embedded it. `showHeader` is not a
+  substitute: it is absent from ```` ```layout ```` fences and from every kernel result area, an author
+  can flip it with `?showHeader=true`, and it means "hide this node's own header", not "you are inside
+  someone's prose".
+- `<article class="markdown-body">` exists in the **DOM**, and is invisible to the component tree.
+  `MarkdownCodeCellToolbar` is hydrated out of the host document's HTML, injects `AccessService`
+  *itself*, and has no parameter, cascade or ancestor that could tell it otherwise.
+
+So a position-based rule would have to be *built* first. That matters for the recommendation, because:
+
+> **~722 of the 1104 catalog keys are reachable from a control that can appear inside authored
+> content**, against roughly 113 that are shell-only (login, onboarding, nav, side panel, portal
+> header); the remaining ~268 have no literal C#/Razor/TSX call site to classify from — mostly React
+> `t()` with computed keys. A MeshWeaver layout area is addressable and therefore embeddable, so
+> `MeshWeaver.Graph.Views` and `MeshWeaver.Graph` — node pages, code cells, activity views, catalogs —
+> are the two largest call-site blocks and are all embeddable.
+>
+> *(Counted by matching `Localize` / `LocalizationCatalog.Get` / `localize` / `t(` call sites with a
+> literal key across both repos' non-test sources, then classifying a key as shell-only when **all** its
+> call sites live in a shell project path. It is an estimate; the order of magnitude is the point.)*
+
+A rule that says "in-content controls follow the content" therefore does not resolve ~5% of the
+catalog. It opens a key-by-key or control-by-control decision over **most of it**, with nothing in the
+code able to record the answer. That is the practical reason option (a) is not merely risky but
+unbuildable at its stated scope.
+
+**The classifier that IS mechanical is the string's storage location, not its position on screen** —
+because storage is decided at authoring time, in the source tree, where a developer and a reviewer can
+both see it, and it needs no runtime signal at all.
+
+| Where the string lives | Owner | Language |
+|---|---|---|
+| `src/MeshWeaver.Messaging.Hub/Localization/strings.{en,de}.json` | platform | viewer |
+| a module's own text table (`EduTexts`, `CourseInviteTexts`) | module | viewer |
+| a `[Translation]` beside a `[Description]` on a declaration | platform/module | viewer |
+| `MeshNode.Name` / `.Description` / `.Category`, or overrides in `ILocalizedNodeText.Translations` | author | as authored |
+| the node's body, or any typed content field an author edits | author | as authored |
+| a bare literal in a `.razor` / `.cs` view | **nobody — fix it** | — |
+
+There is no judgement call in that table and no per-string debate: a developer writing a string
+chooses where to put it, and that choice *is* the language decision. The one thing they may not do
+is put it nowhere.
+
+**Position enters only through clause 2**, and there it is an ENUMERATED list, not an inferred
+property. Clause 2 does not need the runtime boundary that does not exist, because it applies to a set
+small enough to name — the controls the markdown pipeline hydrates directly into a document body:
+
+| In-flow surface | Where |
+|---|---|
+| the code-cell toolbar (Blazor) | `MeshWeaver.Plugins/src/MeshWeaver.Blazor/Components/MarkdownCodeCellToolbar.razor` |
+| the fenced code block's copy affordance | `MeshWeaver.Plugins/src/MeshWeaver.Blazor/Components/CodeBlock.razor` |
+| the code-cell toolbar on a Code **node** page | `MeshWeaver.Plugins/src/MeshWeaver.Graph.Views/CodeViews.cs` |
+| the kernel placeholders rendered inside the cell frame | `src/MeshWeaver.Markdown/MarkdownViewLogic.cs` **(this repo)** |
+| the Edu lesson frame, exercise grid and quiz | `MeshWeaver.Plugins/Edu/**` |
+
+Naming the set is the point. A guard over "every control everywhere" is a guard nobody keeps green;
+a guard over five files is one a reviewer can extend deliberately when a sixth in-flow control is
+built. **The list growing is the process working**, and the list is short because embedding a whole
+layout area into prose is rare compared to reading a page.
+
+Everything else — the node menu, navigation, settings, toasts, dialogs, the composer — is shell, and
+clause 2 does not reach it. A German node menu around an English document is the same arrangement as
+a German application menu around an English PDF, and nobody reads that as an inconsistency.
+
+> **The plumbing for a position signal would be cheap; the signal is what is missing.**
+> `ExecutableCodeBlockRenderer` already emits its marker as
+> `<div class="md-code-cell-toolbar" data-submission-id=… data-language=…>`, so stamping a
+> `data-content-language` there and cascading it is a small change. That is worth knowing precisely
+> because it removes plumbing cost from the argument: option (a) is not rejected because it would be
+> hard to wire, but because **there would be nothing true to put in the attribute** — see the next
+> section.
+
+### The code cell, concretely
+
+The change clause 2 asks for is one line in each of two files. The button **already** has everything
+it needs:
+
+```razor
+<FluentButton Appearance="Accent" Title="@RunTitle" IconStart="@RunIcon" OnClick="@Run">
+    @Access.Localize("common.run")     @* ← this, and only this, goes *@
+</FluentButton>
+```
+
+`RunIcon` is already `Icons.Regular.Size16.Play()` (and `ArrowSync()` when the cell is stale).
+`RunTitle` is already localized — `code.runCell` / `code.rerunCell` / `code.kernelUnavailable` — and
+its own comment already gives clause 2's reasoning: *"a tooltip IS the control's accessible name, so
+leaving it English would read as untranslated to exactly the users who need it most."*
+
+So the glyph-plus-localized-tooltip pattern is fully built. The only thing to remove is a redundant
+translated word. `code.staleCell` (*"Code changed — re-run"*) cannot become a glyph without losing
+its meaning; it stays, and it is already inside the toolbar's own visually distinct band
+(`--neutral-layer-2` with a top border), which is where clause 2 puts a word that cannot be removed.
+
+**And the two Run buttons currently disagree with each other**, which is worth fixing in the same
+change because it shows the defect is not really about language policy. `CodeViews.BuildCellToolbar`
+takes `string? locale = null` and its only call site passes nothing, so
+`LocalizationCatalog.Get("common.run", locale)` falls through to English: a **Code node page renders
+"Run" for a German viewer** while a code cell in a markdown body renders "Ausführen" for the same
+viewer on the same portal. The same file passes `locale: host.ViewerLocale()` correctly for its nav
+menu, so this is an omission, not a decision. Under clause 2 both labels go and the disagreement goes
+with them.
+
+## What identifies content language today
+
+**Nothing, on a `MeshNode`.** The record carries `Id`, `Namespace`, `MainNode`, `Name`,
+`Description`, `NodeType`, `Category`, `Icon`, `Order`, the authorship and version fields, `State`,
+`Content`, `PreRenderedHtml`, `DesiredId`, `IsSatelliteType`, `ExcludeFromContext` and
+`SyncBehavior`. There is no language, locale or culture field, and the markdown front-matter parser
+(`MarkdownFileParser.MarkdownFrontMatter`) is an explicit allowlist with no language key.
+
+Two things that look like one and are not:
+
+- **`ILocalizedNodeText.Translations`** declares which languages a node has *display overrides* for —
+  `name`, `description`, `category`, and nothing else. Its own doc scopes it: *"This record touches
+  display text only"*, explicitly not model-facing and not addressable. It says a node **has** a
+  German name; it never says the node **was written in** German.
+- **`AccessContext.Locale` / `User.Locale`** is the viewer's preference. It has never been about
+  content.
+
+**One real signal exists, and it is space-granular.**
+`MeshWeaver.Plugins/Store/Core/Source/PluginContent.cs` carries `string? Language` on a
+`Store/Plugin` root, and its doc states the platform's convention outright:
+
+> BCP-47 language tag of this plugin's CONTENT (e.g. `en`, `de-CH`). The localization convention is
+> **ONE space per language**: a translation is a SEPARATE `Store/Plugin` root (its own partition,
+> price, gating and entitlements), **never mixed-language content inside one space**. Null =
+> unspecified (the original language).
+
+That is already a decision about granularity, and it is the opposite of a per-node field. Measured
+coverage: **5 of 10 course roots in the education repo declare it** (`AgenticPrimer` `en`,
+`AgenticPrimerDe` `de-CH`, `AgenticOffice` `de-CH`, `AgenticBusiness` `en`, `DataImportExport` `en`;
+`AgenticEngineering`, `DataModeling`, `ThinkInStreams`, `AdvancedBusinessRules` and `WhatsNew`
+declare nothing). Across the core repo's `samples/` tree, **530 node JSON files declare it zero
+times**. Every other `language` in the fleet is a *programming* language (`csharp`, `python`,
+`typescript`) or a speech/maps API parameter.
+
+### What a per-node content-language field would cost
+
+Not proposed — recorded so the cost is a measured number rather than a feeling, and so the next
+person to suggest it starts from here.
+
+| Where | What |
+|---|---|
+| Schema | one nullable column at **three** DDL sites in `PostgreSqlSchemaInitializer` (the `public` script, the versioned partition DDL, and the `ensure_partition_schema` proc body, which embeds the same string) |
+| Migration | a `V56` migration over every partition schema, plus `DbVersion.Latest` 55 → 56. `DbVersionGate` stops a portal whose schema is behind, so this is a coupled deploy, not a code change |
+| Adapter | `PostgreSqlStorageAdapter` — guarded column helper, four SELECT lists, the upsert insert/update/CAS fragments, the reader; plus `PostgreSqlCrossSchemaQueryProvider` and `PgMeshNodeReader` |
+| Other backends | Cosmos, Snowflake and Sqlite adapters drift silently if missed |
+| Import/export | `MarkdownFrontMatter` allowlist **and** the matching serializer write, under its byte-stability ordering rule. `.json` nodes round-trip free; `.md` nodes silently import null until this is done |
+| Wire | the MCP `patch` tool's field allowlist refuses any field not on it |
+| Equality | `MeshNode.Equals` enumerates its comparison fields **by hand**; a field missed there is invisible to change detection |
+
+`V46_AddExcludeFromContextColumn` is the precedent and the cautionary tale: `ExcludeFromContext`
+existed on `MeshNode` for a long time with no column, so *"the adapter never wrote/read it — on every
+PG-backed mesh the field silently round-tripped as NULL."*
+
+**And the cost above buys the smaller half of the problem.** The larger half is that nobody would
+populate it. The one place the fleet already declares content language, at a granularity the
+convention endorses, is **half empty**. A per-node field defaults to null on every node that exists
+today and on every node an author creates without thinking about it — and a language rule keyed on a
+field that is usually null is a rule that usually does nothing, while looking from the code as though
+it does something.
+
+## When the content language is unknown
+
+**The rule never asks.** That is the point of making ownership the classifier: rendering authored
+text requires no knowledge of what language it is in, and platform text follows the viewer, who has
+already stated a preference (or been seeded one from `Accept-Language`, or falls back to English).
+Neither branch consults the content's language, so "unknown" has no branch to take.
+
+The one place content language *is* consulted today survives untouched and is a **fallback, not a
+primary**: `EduTexts.ResolveChrome(viewerLocale, courseLanguage)` uses the course's declared language
+only when the viewer states nothing this table carries — an anonymous reader, essentially. It reads
+its signal off the course root it already owns, and it names which signal decided
+(`LocaleSource.Viewer` / `.Course` / `.Default`) so a fallback is a stated fact rather than something
+inferred from the rendered page. That shape is correct and should be the template for any module that
+needs the same fallback.
+
+## Migration
+
+**There is no content migration.** No node changes, no schema changes, no backfill, no re-import. The
+work is a bounded code change list:
+
+1. **Drop the redundant label from the two code-cell toolbars** (clause 2), and pass the locale at
+   `CodeViews.BuildCellToolbar`'s call site so the English-pinned path stops disagreeing with the
+   other one. The glyph and the localized tooltip are already there.
+2. **Give the unowned strings an owner.** This is the bulk of it, and it is NOT only a plugins job —
+   **this repo has instances too**:
+
+   | Unowned string | Where |
+   |---|---|
+   | *"Interactive code execution is unavailable here…"*, *"Starting interactive kernel…"* — both rendered **inside the cell frame** | `src/MeshWeaver.Markdown/MarkdownViewLogic.cs` (**this repo**) |
+   | `aria-label="Copy code"`, sitting beside an already-localized `title` | `MeshWeaver.Plugins/src/MeshWeaver.Blazor/Components/CodeBlock.razor` |
+   | dialog titles *"Save Failed"* (5 sites), *"Copy to your home space?"*, *"Read-only content"*; `"Code Files"`, `"Loading code..."`, `"Enter display name..."`, `"never executed"` | `MeshWeaver.Plugins/src/MeshWeaver.Graph.Views/CodeViews.cs` |
+   | the entire quiz — progress, feedback, score, notices, privacy note, problem block | `MeshWeaver.Plugins/Edu/Quiz/**` and `Edu/Workbook/**`, which contain **zero** localization calls of any kind |
+
+   The Edu half is filed as
+   [MeshWeaver.Plugins#1261](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1261). The owner
+   for a module's strings is the module's own text table, following `EduTexts`, which makes EN/DE
+   parity a **compile** error because every member is `required`; the owner for a platform string is
+   the core catalog.
+3. **Mirror any new core catalog key** into `MeshWeaver.Plugins/clients/react/src/i18n/`, core first —
+   its drift guard compares **values**, not just keys, and stays red until the core change merges.
+4. **Add the guard** below.
+
+No existing content page changes meaning, and no author has to do anything.
+
+## Enforcement — and what cannot be enforced
+
+Be precise about which half is mechanical.
+
+**Mechanical, and worth adding.** Clause 2 over the enumerated in-flow set: assert that each in-flow
+control renders no localized *visible* label, and that its tooltip/accessible name *is* a catalog
+lookup. For the code cell that is a direct assertion on `MarkdownCodeCellToolbar` and on
+`CodeViews`'s run-button area. The set is enumerated deliberately — a guard over "every control
+everywhere" would be a guard nobody can keep green, and [CI](/Doc/Architecture/ReadingCiSignals)
+green on a guard that cannot fail is worse than no guard.
+
+**Already mechanical.** `LocalizationTest.EveryShippedLanguage_CoversEveryEnglishKey` asserts full
+en/de key parity — 1104 keys each, currently zero missing. #3203's option (b) asks for "a
+completeness check so a missing key cannot fall back to English mid-page"; **that check already
+exists and already passes.** The plugins mirror's `localize.test.ts` goes further and compares
+values.
+
+**NOT mechanical, and this is the honest limit.** No test can find clause 1's real failure — a string
+that never became a key at all. `UserPreferencesLocalizationTest` states it exactly: *"a string that
+never became a key is not a missing key, it is an absent one."* A hard-coded literal in a view is
+invisible to every catalog guard by construction. The proof is `Edu/Quiz`: it contains **zero**
+localization calls, so every catalog guard in the fleet is green while a whole feature renders one
+language. The controls that exist for this are review and the enumerated in-flow guard; there is no
+third one, and claiming otherwise would be the kind of guard-that-checks-nothing this repo has been
+bitten by before.
+
+**Also not mechanical, and worth saying because it is the same shape:** the localization docs
+currently cite a guard that no longer exists. `AnonymousCircuitLocaleSeedTest` was lost when
+`MeshWeaver.Hosting.Blazor` moved to MeshWeaver.Plugins and its sibling tests moved without it, so the
+anonymous locale seed has zero coverage on either `main` while four prose sites still describe it as
+what stops the defect regressing
+([MeshWeaver.Plugins#1273](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1273)). A rule that
+is only prose decays exactly this way, which is the argument for keeping clause 2's guard small enough
+to survive a move.
+
+## The trade-off being accepted
+
+Stated plainly, because it is real.
+
+**This rule does not deliver a monolingual page.** A German reader of an English course still gets a
+German node menu, German section headings and English lesson prose. What it removes is the *intrusion*
+— a translated word sitting inside the author's sentence. The thesis is that a page where every word's
+language is explained by **whose word it is** reads as designed, while a page where a German verb
+appears mid-paragraph reads as broken. That is a claim about how the seam is perceived, and it is the
+claim a maintainer is being asked to accept or reject.
+
+The other two costs:
+
+- **Glyph-only controls are less discoverable.** A ▶ is conventional and safe; the next in-flow
+  control may have no conventional glyph, and a tooltip needs a hover that a touch device does not
+  have. Clause 2's escape — a word inside a visually distinct chrome band — is a weaker answer than
+  removing the word, and it will get used.
+- **We are declining to make the platform content-language-aware.** Features that would genuinely
+  need it — per-language search analysers, TTS voice selection, machine translation, telling a reader
+  "this is in German" before they open it — will have to add the field then, at the cost tabled
+  above. This defers that; it does not solve it.
+
+## What this does not decide
+
+- Whether a **module** may ever choose content-language chrome for a surface it fully owns. The rule
+  says no by default; a module with a genuine case should argue it against the Edu revert above, not
+  around it.
+- The **Edu quiz strings themselves** — owned by MeshWeaver.Plugins#1261, not by this page.
+- Whether `PluginContent.Language` should become **required** for a published content package. It is
+  the one signal that exists and it is half populated; requiring it is a Store decision, not a
+  localization one.
+
+## See also
+
+- [Localization](../Localization) — the catalog, `[Translation]`, where the viewer's language comes
+  from, and the existing viewer-message / owner-diagnostic boundary this page's rule sits beside.
+- [User Interface](../UserInterface) — the glyph-plus-tooltip preference clause 2 makes binding.

--- a/src/MeshWeaver.Documentation/Data/Architecture/Localization.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Localization.md
@@ -11,6 +11,13 @@ User.TimeZoneId → AccessContext.TimeZoneId → AccessService.ToDisplayTime
 User.Locale     → AccessContext.Locale     → AccessService.Localize
 ```
 
+> 🚧 **Open question — chrome rendered INSIDE authored content.** "Chrome follows the viewer" is
+> unambiguous for the node menu and settings. It is what puts **Ausführen** on the Run button of an
+> English lesson, and #3203 asks whether that is right. A proposal — the ownership rule, why the
+> content-language alternative was measured and reverted, and what a per-node language field would
+> cost — is at [Chrome and content language](../ChromeAndContentLanguage). **It is not in force.** Until
+> it is decided, this page describes what the platform does.
+
 ## The one rule: resolve explicitly, never from ambient culture
 
 `CultureInfo.CurrentUICulture` is **not** used and must not be introduced. A layout-area render hops
@@ -159,8 +166,13 @@ would reach most visitors and silently miss the rest. SignalR keeps an `IHttpCon
 connection and refreshes it per request, so `HubCallerContext.GetHttpContext()` answers for every
 transport; the filter reads it in the hub invocation that *creates* the circuit handlers. The
 accessor remains only as a fallback for a host that runs the Blazor hub without the filter.
-`AnonymousCircuitLocaleSeedTest` runs its cases over **both** transports — the long-polling rows are
-what caught this, and are what stop it regressing.
+🚨 **The guard that pinned this is GONE.** `AnonymousCircuitLocaleSeedTest` ran its cases over **both**
+transports, and the long-polling rows are what caught the defect above. It lived in core at
+`test/MeshWeaver.Hosting.Blazor.Test/`; when `MeshWeaver.Hosting.Blazor` moved to MeshWeaver.Plugins
+its sibling tests went with it and **this file did not**. It exists on neither repo's `main` today, so
+the anonymous seed currently has **zero** coverage — `Locales.Negotiate` is still tested, but nothing
+tests whether the negotiated value reaches a circuit. Tracked as
+[MeshWeaver.Plugins#1273](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1273).
 
 `Locales.Negotiate` does the parsing: the full RFC 9110 list with `q=` weights, tried in descending
 weight, each matched by `Locales.TryMatch` so region variants fold onto the primary subtag exactly as


### PR DESCRIPTION
## 🚫 Deliberately a DRAFT — production freeze

**Do not mark ready.** A production freeze is in force for this session, and `auto-arm.yml` arms every
green **non-draft** PR for the merge queue, so draft is the hold. It is green-and-mergeable content;
converting it to ready is a deploy decision, not a review one.

## What this is

A design proposal answering #3203, committed as a doc page rather than left in the issue thread.
**Docs only. No behaviour change. Nothing implemented.** The page carries a `Status: proposal` callout
and says explicitly that it is not in force.

#3203 reports a mixed-language page — an English lesson whose Run button reads **Ausführen**, whose
node menu is German, and whose quiz counter reads *"Question 6 of 6"* in English — and asks for one
rule for controls embedded in authored content. It offers as **option (a)** that in-content controls
follow the *content's* declared language.

## The recommendation

**Keep "chrome follows the viewer".** Write the rule about **ownership**, not position:

- **Clause 1 — ownership decides the language.** Every user-visible string has exactly one owner.
  Platform/module-owned (a catalog key, a module text table, a `[Translation]`) → the **viewer**.
  Authored content (body, `Name`, `Description`, a typed field an author filled in) → **as authored**.
  A bare literal compiled into a view is **unowned — a bug**, not a third category.
- **Clause 2 — in-flow chrome minimises words.** A platform/module control rendered inside the author's
  flow carries no translated *visible* label where a glyph, a number or a symbol conveys the same
  thing; the localized text moves to the tooltip and the accessible name.

The reframe the page argues: neither symptom in #3203 is a wrong language rule.

- *"Question 6 of 6"* is **unowned** — `Edu/Quiz` and `Edu/Workbook` contain **zero** localization
  calls of any kind, so every string is a hard-coded English literal. Give it an owner and it becomes
  *Frage 6 von 6*, consistent with the *Übungen* / *Weiter* already on the page.
- *"Ausführen"* is an owned string in the wrong **form**. The button already has
  `IconStart="@RunIcon"` (`Play()`) and an already-localized `Title="@RunTitle"`. The glyph-plus-tooltip
  pattern is fully built; the visible word adds nothing and lands mid-paragraph. Clause 2 deletes one
  line in two files.

## Why option (a) is declined — on evidence

1. **It is the order Edu already shipped and deliberately reverted.** `EduTexts.ResolveChrome` used to
   be `Primary(courseLanguage) ?? Primary(viewerLocale) ?? "en"`, and its own comment records the cost:
   *"the viewer was never consulted at all: AgenticPrimerDe served 'Übungen' / 'Weiter' to every learner
   on earth"*, followed by *"🚨 Do not restore the old order … the alternative imposed German buttons on
   a reader who cannot read them."* #1349 is the second measurement of the same shape, on Store.
2. **It is unbuildable at its stated scope.** There is no runtime chrome-vs-content boundary — no
   discriminator on `UiControl`, nothing content-related on `RenderingContext` or the Blazor cascades,
   and nothing crosses the markdown → embedded-area hop but an address, an area name, an area id and a
   spinner style. Measured: **~722 of the 1104 catalog keys** are reachable from a control that can
   appear inside authored content, against ~113 shell-only. Option (a) opens a per-key decision over
   most of the catalog with nowhere to record the answer.

## The four questions the brief required

| | Answer |
|---|---|
| **Content-language signal** | **None on `MeshNode`.** One exists and is *space*-granular: `PluginContent.Language`, whose doc already fixes the convention — *"ONE space per language … never mixed-language content inside one space."* Coverage **5/10** education course roots, **0/530** sample node JSONs. `NodeTextTranslations` is not one (display overrides for `name`/`description`/`category`). |
| **Cost of adding one** | Three DDL sites in `PostgreSqlSchemaInitializer`, a `V56` migration over every partition schema, `DbVersion.Latest` 55→56 (coupled deploy via `DbVersionGate`), `PostgreSqlStorageAdapter` + `CrossSchemaQueryProvider` + `PgMeshNodeReader`, the Cosmos/Snowflake/Sqlite adapters, the `MarkdownFrontMatter` allowlist **and** its serializer write, the MCP `patch` allowlist, and `MeshNode.Equals` (hand-enumerated). `V46_AddExcludeFromContextColumn` is the precedent *and* the warning. And that buys the smaller half — the larger half is that nobody would populate it. |
| **Unknown content language** | **The rule never asks.** Rendering authored text needs no knowledge of its language; platform text follows the viewer, who always resolves. Neither branch consults it. The one existing consumer (`ResolveChrome`) keeps it as a *fallback* and names which signal decided. |
| **Migration** | **None for content.** No node, schema, backfill or re-import change; nothing for any author. A bounded code list: drop two labels, give the unowned strings an owner, mirror new keys core-first into `clients/react/src/i18n/`, add the enumerated in-flow guard. |

## The trade-off being accepted

Stated in the page rather than glossed: **this does not deliver a monolingual page.** A German reader
of an English course still gets a German node menu and German headings around English prose. What goes
is the *intrusion* — a translated word inside the author's sentence. Secondary costs: glyph-only
controls are less discoverable (no hover on touch), and we defer making the platform
content-language-aware, which search analysers / TTS / machine translation will eventually want.

## Also in this diff

`Localization.md` gains the 🚧 pointer, and **one correction**: it cited `AnonymousCircuitLocaleSeedTest`
as the live guard for the anonymous locale seed. That file exists on **neither repo's `main`** — it was
left behind when `MeshWeaver.Hosting.Blazor` moved to MeshWeaver.Plugins and its sibling tests went with
it, so the seed has zero coverage while four prose sites still describe it as what stops the defect
regressing. Filed as Systemorph/MeshWeaver.Plugins#1273. Correcting it here rather than leaving the doc
asserting a guard that is gone.

## Verification

- `dotnet build test/MeshWeaver.Documentation.Test -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**.
- `DocumentationLinkIntegrityTest` + `DocumentationEmbedIntegrityTest` → **11/11 passed**;
  `WhatsNewEntryIntegrityTest` → **1/1**.
- 🔬 **The link guard was proved to actually read the new page.** A deliberate broken link was added and
  the test went **RED**, naming it:
  ```
  Failed …DocumentationLinkIntegrityTest.AllInternalDocLinks_ResolveToExistingNodes
  Doc/Architecture/ChromeAndContentLanguage: (../ThisPageDoesNotExistProbe) — resolves to
  /Doc/Architecture/ThisPageDoesNotExistProbe, which does not exist
  ```
  then green again once removed — so the earlier pass was not a guard that could not fail.
- The `MeshWeaver.Documentation.dll` was confirmed rebuilt *after* the markdown edit and to contain the
  new page, because `--no-build` after editing an embedded doc asset is a known false pass here.

No What's New entry: docs-only, no user-visible behaviour change.

`Pairs-with: none` — docs only; the diff removes no public type or member.

Refs #3203

🤖 Generated with [Claude Code](https://claude.com/claude-code)
