### PR TITLE
Review #3220: the connection string is a credential, and a configured sign-in route is not editable

### DIFF
--- a/memex/Memex.Portal.Shared/Setup/SetupComposition.cs
+++ b/memex/Memex.Portal.Shared/Setup/SetupComposition.cs
@@ -161,6 +161,16 @@ public static class SetupComposition
                 continue;
             }
 
+            // 🚨 A route this DEPLOYMENT already answers is not recorded, whatever arrives here.
+            // The page disables those fields so a browser submits nothing for them, but the endpoint
+            // must not depend on the markup: the manifest is projected UNDER the host's own
+            // configuration, so an entry written here could never take effect, and a manifest that
+            // CLAIMS a provider the instance does not actually run on is worse than one that stays
+            // quiet — it is the "surface showing its own stored answer while the process runs on a
+            // different one" state (MeshWeaver.Plugins#980), preserved on disk.
+            if (option.AlreadyConfigured)
+                continue;
+
             // A scheme turned on with no secret renders its button and fails at the token
             // exchange — strictly worse than an absent provider, so it is refused.
             if (string.IsNullOrWhiteSpace(answer.ClientSecret))

--- a/memex/Memex.Portal.Shared/Setup/SetupPage.cs
+++ b/memex/Memex.Portal.Shared/Setup/SetupPage.cs
@@ -113,8 +113,13 @@ public static class SetupPage
         var hint = catalog.Storage.Select(o => o.ConnectionStringHint).FirstOrDefault(h => h is not null);
         html.Append("<div class=field>");
         html.Append($"<label for=cs>{Escape(strings.ConnectionStringLabel)}</label>");
+        // 🚨 NEVER echoed back, for exactly the reason a client secret is not: a connection string
+        // CARRIES A PASSWORD, and re-rendering it after a failed submit puts that password in the
+        // page source, the browser cache and any screenshot of the form. This was inconsistent —
+        // the sign-in secrets were already withheld and this one was not (Copilot review). The
+        // operator retypes it, which is the same price the other credentials already pay.
         html.Append(
-            $"<input id=cs name=\"storage.connectionString\" type=password value=\"{Escape(submitted?.ConnectionString)}\" "
+            $"<input id=cs name=\"storage.connectionString\" type=password value=\"\" "
             + $"placeholder=\"{Escape(hint)}\" spellcheck=false>");
         html.Append("</div><div class=field>");
         html.Append($"<label for=bp>{Escape(strings.BasePathLabel)}</label>");
@@ -132,15 +137,21 @@ public static class SetupPage
         var devOption = catalog.SignIn.FirstOrDefault(o => o.IsSwitch);
         if (devOption is not null)
         {
-            var on = submitted?.EnableDevLogin ?? true;
+            var on = submitted?.EnableDevLogin ?? !devOption.AlreadyConfigured || devOption.AlreadyConfigured;
             html.Append("<label class=choice>");
-            html.Append($"<input type=checkbox name=\"signin.dev\" value=on{(on ? " checked" : "")}>");
-            html.Append($"<span>{Escape(strings.DevLoginLabel)}</span></label>");
+            html.Append(
+                $"<input type=checkbox name=\"signin.dev\" value=on{(on ? " checked" : "")}"
+                + $"{Disabled(devOption.AlreadyConfigured)}>");
+            html.Append($"<span>{Escape(strings.DevLoginLabel)}");
+            if (devOption.AlreadyConfigured)
+                html.Append($" <span class=badge>{Escape(strings.AlreadyConfigured)}</span>");
+            html.Append("</span></label>");
             html.Append($"<p class=help>{Escape(strings.DevLoginHelp)}</p>");
             html.Append("<div class=field>");
             html.Append($"<label for=devadmins>{Escape(strings.DevAdminsLabel)}</label>");
             html.Append(
-                $"<input id=devadmins name=\"signin.devAdmins\" type=text value=\"{Escape(submitted?.DevAdminUsers)}\">");
+                $"<input id=devadmins name=\"signin.devAdmins\" type=text "
+                + $"value=\"{Escape(submitted?.DevAdminUsers)}\"{Disabled(devOption.AlreadyConfigured)}>");
             html.Append("</div>");
         }
 
@@ -152,13 +163,24 @@ public static class SetupPage
             if (option.AlreadyConfigured)
                 html.Append($" <span class=badge>{Escape(strings.AlreadyConfigured)}</span>");
             html.Append("</legend>");
-            Field(html, $"signin.{option.Name}.clientId", strings.ClientIdLabel, answer?.ClientId);
+            // 🚨 A route this DEPLOYMENT already answers is REPORTED, never offered for editing —
+            // the fields are disabled, so the browser submits nothing for them. Rendering them
+            // editable was a surface promising an effect it cannot deliver: the manifest is layered
+            // UNDER the host's own configuration, so anything typed here would be accepted, stored,
+            // and then silently outranked at the next boot. That is the shape of MeshWeaver.Plugins#980
+            // — a surface showing its own stored answer while the process runs on a different one
+            // (Copilot review, which caught the doc and the markup disagreeing).
+            var locked = Disabled(option.AlreadyConfigured);
+            Field(html, $"signin.{option.Name}.clientId", strings.ClientIdLabel, answer?.ClientId,
+                extraAttributes: locked);
             if (option.HasTenant)
-                Field(html, $"signin.{option.Name}.tenantId", strings.TenantLabel, answer?.TenantId);
+                Field(html, $"signin.{option.Name}.tenantId", strings.TenantLabel, answer?.TenantId,
+                    extraAttributes: locked);
             // 🚨 A submitted secret is NEVER echoed back into the form. Re-filling a password field
             // after a failed submit is convenient and is also how a credential ends up in a browser
             // cache, a screenshot and a page source. The operator retypes it.
-            Field(html, $"signin.{option.Name}.clientSecret", strings.ClientSecretLabel, null, password: true);
+            Field(html, $"signin.{option.Name}.clientSecret", strings.ClientSecretLabel, null,
+                password: true, extraAttributes: locked);
             html.Append("</fieldset>");
         }
         html.Append("</section>");
@@ -228,16 +250,25 @@ public static class SetupPage
 
     private static void Field(
         StringBuilder html, string name, string label, string? value, bool password = false,
-        string? placeholder = null)
+        string? placeholder = null, string extraAttributes = "")
     {
         var id = name.Replace('.', '-');
         html.Append("<div class=field>");
         html.Append($"<label for=\"{Escape(id)}\">{Escape(label)}</label>");
         html.Append(
             $"<input id=\"{Escape(id)}\" name=\"{Escape(name)}\" type={(password ? "password" : "text")} "
-            + $"value=\"{Escape(value)}\" placeholder=\"{Escape(placeholder)}\" spellcheck=false>");
+            + $"value=\"{Escape(value)}\" placeholder=\"{Escape(placeholder)}\" spellcheck=false{extraAttributes}>");
         html.Append("</div>");
     }
+
+    /// <summary>
+    /// <c>disabled</c> when a route is already answered by this deployment.
+    ///
+    /// <para><b>disabled, not readonly.</b> A disabled control is not submitted at all, so the
+    /// operator cannot send a value that would be silently outranked; a readonly one still posts
+    /// its contents.</para>
+    /// </summary>
+    private static string Disabled(bool locked) => locked ? " disabled" : "";
 
     private static void AppendMessages(
         StringBuilder html, string cssClass, string heading, ImmutableList<string>? messages)

--- a/test/Memex.Portal.Shared.Test/SetupSurfaceTest.cs
+++ b/test/Memex.Portal.Shared.Test/SetupSurfaceTest.cs
@@ -243,6 +243,63 @@ public class SetupSurfaceTest : IDisposable
     }
 
     [Fact]
+    public async Task TheConnectionString_IsNeverEchoedBackIntoTheForm()
+    {
+        // 🚨 A connection string CARRIES A PASSWORD, so it gets exactly the treatment the sign-in
+        // secrets already had. It did not: the field was re-rendered with value="…" after a failed
+        // submit, putting the password in the page source, the browser cache and any screenshot of
+        // the form (Copilot review on #3220 — an inconsistency inside one file).
+        using var app = BuildApp();
+        var token = app.Services.GetRequiredService<SetupAccessToken>().Value;
+        var form = Answers(token);
+        form["storage.type"] = "Cosmos";                       // force a re-render
+        form["storage.connectionString"] = "Host=db;Password=hunter2";
+
+        var response = await app.GetTestClient().PostAsync("/setup", new FormUrlEncodedContent(form));
+        var html = await response.Content.ReadAsStringAsync();
+
+        Assert.DoesNotContain("hunter2", html);
+        Assert.DoesNotContain("Host=db", html);
+    }
+
+    [Fact]
+    public async Task ARouteTheDeploymentAlreadyAnswers_IsReported_NotOfferedForEditing()
+    {
+        // 🚨 The manifest is layered UNDER the host's own configuration, so anything typed for an
+        // already-configured route would be accepted, stored, and then silently outranked at the
+        // next boot. SetupSignInOption.AlreadyConfigured documented exactly this behaviour and the
+        // markup did not implement it (Copilot review on #3220). Disabled, not readonly: a disabled
+        // control is not submitted at all.
+        using var app = BuildApp(catalog: Catalog with
+        {
+            SignIn =
+            [
+                new SetupSignInOption("Dev", "Developer login", "Authentication", IsSwitch: true),
+                new SetupSignInOption("Microsoft", "Microsoft", "Authentication:Microsoft",
+                    HasTenant: true, AlreadyConfigured: true),
+            ],
+        });
+        var token = app.Services.GetRequiredService<SetupAccessToken>().Value;
+        var client = app.GetTestClient();
+
+        var html = await client.GetStringAsync("/setup");
+        Assert.Contains("already configured by this deployment", html);
+        // The client-id field for that route carries `disabled`, so nothing is posted for it.
+        Assert.Matches(@"name=""signin\.Microsoft\.clientId""[^>]*\bdisabled\b", html);
+
+        // …and the endpoint does not depend on the markup: a hand-crafted POST is ignored too,
+        // because a manifest claiming a provider the instance does not run on is worse than silence.
+        var form = Answers(token);
+        form["signin.Microsoft.clientId"] = "smuggled-in";
+        form["signin.Microsoft.clientSecret"] = "smuggled-secret";
+        await client.PostAsync("/setup", new FormUrlEncodedContent(form));
+
+        var manifest = InstanceManifest.Read(root);
+        Assert.NotNull(manifest);
+        Assert.Empty(manifest!.SignIn!.Providers);
+    }
+
+    [Fact]
     public async Task TheGermanHeader_GetsTheGermanPage()
     {
         // The wizard runs pre-mesh, so there is no AccessContext to read a locale from — but that


### PR DESCRIPTION
Two findings from the Copilot review on #3220, which landed after auto-merge had already fired.
Both are correct.

### The connection string is a credential

`SetupPage` deliberately withholds every sign-in client secret from a re-rendered form — and then
echoed the database connection string back into it via `value="…"`. An inconsistency inside one
file. A connection string **carries a password**, so re-rendering it puts that password in the page
source, the browser cache and any screenshot of the form. It now gets exactly the treatment the
other credentials already had: the operator retypes it.

### An already-configured route is reported, not offered for editing

`SetupSignInOption.AlreadyConfigured` documents that the wizard *"shows it as configured and does
not offer to overwrite it"*. The markup rendered editable fields anyway.

That matters because the manifest is projected **under** the host's own configuration: anything
typed for such a route would be accepted, stored, and then silently outranked at the next boot —
the *"surface showing its own stored answer while the process runs on a different one"* state
(MeshWeaver.Plugins#980), this time preserved on disk.

- The fields carry `disabled` — **not** `readonly`, because a disabled control is not submitted at all.
- `SetupComposition` refuses such an answer too, so the guarantee does not rest on the markup: a
  hand-crafted POST cannot write a manifest that claims a provider the instance does not run on.

### Verification

Both pinned by new tests (`TheConnectionString_IsNeverEchoedBackIntoTheForm`,
`ARouteTheDeploymentAlreadyAnswers_IsReported_NotOfferedForEditing`, which also drives the
hand-crafted POST). 57/57 in the setup suite; `Memex.Portal.Shared` builds `-c Release -warnaserror`.

`Pairs-with: none — no public type or member is removed; one optional parameter is added to a private helper.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0155oPabmCjpdBEoTz5bXQRJ
