### PR TITLE
Declare an image assembly SUPERSEDED so a type can move out of it into a module in one wave

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -258,6 +258,34 @@ on:
           selection fall back to the full set and say why.
         type: string
         required: false
+      superseded-image-assemblies:
+        description: >
+          Comma- or whitespace-separated IMAGE assembly names whose copy in the pinned platform
+          image is SUPERSEDED by this repository's source for this run — dropped from the global
+          build's reference set.
+
+
+          Needed in exactly one situation, and it is not rare: a type MOVES OUT of an
+          image-shipped assembly into a module in the same repo. The builder's shadow set
+          subtracts only what the run compiles FROM SOURCE, and membership is reachability-driven
+          through ProjectReference edges — so the edge that would have shadowed the stale copy is
+          the edge the move deletes. The image still defines the moved type, the module defines it
+          too, and the compile fails CS0436. This input is how the caller says which stale copy to
+          drop.
+
+
+          DECLARED, never inferred: resolving such a collision automatically in favour of the
+          source would mask a genuine two-producers-of-one-assembly defect, which
+          `BakeHost.ShippedByHostProblem` (MeshWeaver#3175) exists to make RED.
+
+
+          Fails closed — an empty name, a name the image does not carry (wrong, or the input is
+          STALE now the image dropped it), or a name the run already builds from source, each
+          refuse the build naming the entry. Omitted, nothing is dropped and the lane behaves
+          exactly as before.
+        type: string
+        required: false
+        default: ''
         default: ''
       platform-image:
         description: >
@@ -611,6 +639,7 @@ jobs:
           COUNT: ${{ steps.scope.outputs.count }}
           PUBLISH: ${{ inputs.publish }}
           TESTER_DIGEST: ${{ inputs.tester-image-digest }}
+          SUPERSEDED: ${{ inputs.superseded-image-assemblies }}
           PLATFORM_DIGEST: ${{ inputs.platform-image-digest }}
           PLATFORM_REF: ${{ inputs.platform-ref }}
         run: |
@@ -977,6 +1006,11 @@ jobs:
           rm -rf "$out"; mkdir -p "$out"; chmod 777 "$out"
           accepts=()
           for construct in $ACCEPT; do accepts+=(--accept "$construct"); done
+          # The image's stale copy of a moved type's old home — see superseded-image-assemblies.
+          # Empty ⇒ no flags ⇒ byte-identical invocation to before this input existed.
+          superseded=()
+          for asm in ${SUPERSEDED//,/ }; do superseded+=(--superseded-image-assembly "$asm"); done
+          [ "${#superseded[@]}" -eq 0 ] || echo "superseding ${#superseded[@]} image assembl(y|ies) from the reference set: ${SUPERSEDED}"
           args=()
           for prj in "${projects[@]}"; do args+=("/repo/$prj"); done
           echo "global build: ${#projects[@]} container entr(y|ies) in ONE workspace — ${projects[*]}"
@@ -988,7 +1022,7 @@ jobs:
             -v "$tester_app:/tester:ro" \
             -v "$out:/out" \
             --entrypoint dotnet "$img" \
-            /tester/mw-plugin-test.dll build-project "${args[@]}" --output /out ${accepts[@]+"${accepts[@]}"} 2>&1 | tee "$out/workspace-build.log"
+            /tester/mw-plugin-test.dll build-project "${args[@]}" --output /out ${accepts[@]+"${accepts[@]}"} ${superseded[@]+"${superseded[@]}"} 2>&1 | tee "$out/workspace-build.log"
           echo "built=true" >> "$GITHUB_OUTPUT"
       # 🚨 THE PLATFORM CHECKOUT LANDS **AFTER** THE BUILD, ON PURPOSE. This job mounts
       # `$GITHUB_WORKSPACE` at `/repo:ro` for the container build, so anything checked out beside

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -467,6 +467,52 @@ does not hold today), or the instance adopts module bytes for its identity from 
 publication it already adopts bundles from. Until one of those lands, `ShippedPrebuiltBundles`'
 `dependency record mismatch … live is mvid:` line on a portal is that gap, not a new defect.
 
+### Moving a type OUT of an image-shipped assembly into a module (the shadow set's blind spot)
+
+The reference set for a container build is **the whole image's `/app`, minus
+`Graph.ShadowedAssemblyNames`** — and that set holds only the assemblies *this run compiles from
+source*. Membership is **reachability-driven**: a project joins the graph through a
+`ProjectReference` edge under the source root.
+
+That is exactly right until a type MOVES OUT of an image-shipped assembly into a module **in the same
+repository**. Then:
+
+- the module's source defines the type;
+- the pinned image still ships the assembly that *also* defines it, because the image is one wave
+  behind;
+- and **the `ProjectReference` edge that would have put the old assembly in the graph — and therefore
+  in the shadow set — is precisely the edge the move deletes.**
+
+So the shadow set structurally cannot see the one case that needs it, and the compile fails
+`CS0436: … conflicts with the imported type … in '<OldAssembly>'`. It is the duplicate-producer
+problem of [One producer per (module, framework identity)](#one-producer-per-module-framework-identity--and-the-set-is-what-is-gated-3175)
+one level down: two definitions of one TYPE rather than two producers of one ASSEMBLY, for exactly
+one wave. Measured on MeshWeaver.Plugins#1268, moving three Razor views out of
+`MeshWeaver.Blazor.Views` into the `MeshWeaver.Markdown.Collaboration` module.
+
+**The remedy is a declaration, not an inference.** The pack lane takes
+`superseded-image-assemblies:` (comma- or whitespace-separated), passed to `build-project` as
+`--superseded-image-assembly <name>`; each name is added to the shadow set, so the image's stale copy
+leaves the reference set for that run.
+
+Three properties are load-bearing:
+
+- **Declared, never inferred.** Resolving such a collision automatically in favour of the source
+  would mask a genuine two-producers-of-one-assembly defect — the thing
+  `BakeHost.ShippedByHostProblem` exists to make RED. The caller names the assembly.
+- **Fails closed.** An empty name, a name the image does not carry (wrong — or the entry is STALE
+  now the image dropped it), or a name the run already builds from source, each refuse the build and
+  say which entry. An input that quietly does nothing reads exactly like an input that worked.
+- **No "is anything else still needed from it?" check.** The compiler already answers that with
+  `CS0246`/`CS0234` naming the missing type, which is a positive, specific signal. A second check
+  would only be able to agree.
+
+⏳ **Known gap:** an entry goes stale once a rebuilt image no longer defines the conflicting types —
+the assembly still exists, so nothing detects it. The durable form is a type-name overlap assertion
+(refuse when the image's copy defines none of the names this run's source defines) — tracked in
+[#3223](https://github.com/Systemorph/MeshWeaver/issues/3223). Until it lands, remove the entry in the same change that moves the pin onto an image
+built after the move.
+
 ## Adoption contract (every repo)
 
 1. Pin the reusable lanes (`node-repo-*.yml`) at a MeshWeaver main SHA — never copy them.

--- a/test/MeshWeaver.PluginTester.Test/SupersededImageAssemblyTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/SupersededImageAssemblyTest.cs
@@ -1,0 +1,219 @@
+using System.Reactive;
+using MeshWeaver.Data;
+using Xunit;
+
+namespace MeshWeaver.PluginTester.Test;
+
+/// <summary>
+/// 🚨 <b>The seam for a type that MOVES OUT of an image-shipped assembly into a module in the same
+/// repository</b> (<c>--superseded-image-assembly</c>).
+///
+/// <para>The reference set is the whole container MINUS <c>Graph.ShadowedAssemblyNames</c>, and that
+/// set holds only what the run compiles FROM SOURCE — membership being reachability-driven through
+/// <c>ProjectReference</c> edges. So the edge that would have shadowed the image's stale copy is
+/// exactly the edge such a move DELETES: the image still defines the moved type, the module defines
+/// it too, and the compile dies <c>CS0436</c>. Measured on MeshWeaver.Plugins#1268, where three Razor
+/// views left <c>MeshWeaver.Blazor.Views</c> for <c>MeshWeaver.Markdown.Collaboration</c>.</para>
+///
+/// <para>Both arms are asserted here. A test that only proved the option makes a build green would
+/// not distinguish "the drop worked" from "there was never a collision" — so the control builds the
+/// identical tree WITHOUT the option and requires it to FAIL naming the type.</para>
+/// </summary>
+public class SupersededImageAssemblyTest : IDisposable
+{
+    private readonly string _root = Path.Combine(
+        Path.GetTempPath(), $"mw-superseded-{Guid.NewGuid():N}");
+
+    private string Write(string relativePath, string content)
+    {
+        var full = Path.Combine(_root, relativePath);
+        Directory.CreateDirectory(Path.GetDirectoryName(full)!);
+        File.WriteAllText(full, content);
+        return full;
+    }
+
+    public void Dispose()
+    {
+        if (Directory.Exists(_root))
+            try { Directory.Delete(_root, recursive: true); } catch (IOException) { }
+        GC.SuppressFinalize(this);
+    }
+
+    private string AppDirectory()
+    {
+        var app = Path.Combine(_root, "_container");
+        if (Directory.Exists(app)) return app;
+        Directory.CreateDirectory(app);
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "mw-plugin-test.deps.json"),
+            Path.Combine(app, "mw-plugin-test.deps.json"));
+        File.Copy(Path.Combine(AppContext.BaseDirectory, "MeshWeaver.ShortGuid.dll"),
+            Path.Combine(app, "MeshWeaver.ShortGuid.dll"));
+        return app;
+    }
+
+    private const string LibProject = """
+        <Project Sdk="Microsoft.NET.Sdk">
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <Nullable>enable</Nullable>
+            <ImplicitUsings>enable</ImplicitUsings>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    /// <summary>
+    /// Stages the container the way the platform image stages <c>/app</c>: an assembly named
+    /// <c>Legacy.Home</c> that still defines <c>Moved.Thing</c> — the state an image is in for one
+    /// wave after the type left it in source.
+    /// </summary>
+    private async Task<string> StageImageWithTheOldCopy(CancellationToken ct)
+    {
+        Write("old/Directory.Build.props", "<Project></Project>");
+        var old = Write("old/Legacy.Home/Legacy.Home.csproj", LibProject);
+        Write("old/Legacy.Home/Thing.cs",
+            "namespace Moved; public sealed class Thing { public int Value => 1; }");
+
+        var built = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [old],
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "image-build"),
+            Output = TextWriter.Null,
+        }).Await(ct);
+        built.ExitCode.Should().Be(0, "staging the container is setup, not the assertion");
+
+        var app = AppDirectory();
+        File.Copy(
+            Path.Combine(_root, "image-build", "Legacy.Home", "Legacy.Home.dll"),
+            Path.Combine(app, "Legacy.Home.dll"), overwrite: true);
+        return app;
+    }
+
+    /// <summary>The module that now owns the type: same namespace, same name, new assembly.</summary>
+    private string TheModuleThatNowOwnsIt()
+    {
+        Write("src/Directory.Build.props", "<Project></Project>");
+        var module = Write("src/New.Owner/New.Owner.csproj", LibProject);
+        Write("src/New.Owner/Thing.cs",
+            "namespace Moved; public sealed class Thing { public int Value => 2; }");
+        // 🚨 The collision needs the NAME RESOLVED, not merely declared. CS0436 fires where the
+        // compiler binds `Moved.Thing` and finds it in both the source and an imported assembly;
+        // a declaration alone conflicts with nothing. In the real case (Plugins#1268) the Razor
+        // source generator's `*_razor.g.cs` and the `.razor.cs` code-behind each bind the type,
+        // which is why it surfaced there. Reproducing that binding is what makes the control arm
+        // able to fail — the first version of this test omitted it and the control passed,
+        // proving nothing.
+        Write("src/New.Owner/Uses.cs",
+            "namespace New.Owner; public static class Uses { public static int V => new Moved.Thing().Value; }");
+        return module;
+    }
+
+    [Fact]
+    public async Task WithoutTheOption_TheImagesStaleCopyCollidesWithTheMovedType()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = await StageImageWithTheOldCopy(ct);
+        var module = TheModuleThatNowOwnsIt();
+
+        // The builder's per-project `Failure` carries only a summary ("1 warning(s) under the
+        // no-warn policy"), so the diagnostic CODE is asserted against the builder's own output —
+        // otherwise this arm would pass on any failure at all, which is the whole thing it exists
+        // to rule out.
+        var narration = new StringWriter();
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = app,
+            OutputDirectory = Path.Combine(_root, "out-control"),
+            Output = narration,
+        }).Await(ct);
+
+        report.ExitCode.Should().NotBe(0,
+            "this is the control arm — the image still defines Moved.Thing, so the compile MUST "
+            + "collide. If this ever passes, the other test proves nothing.");
+        narration.ToString().Should().Contain("CS0436",
+            "the collision must be the imported-type conflict, not some other failure");
+    }
+
+    [Fact]
+    public async Task DroppingTheSupersededAssemblyLetsTheMovedTypeCompile()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = await StageImageWithTheOldCopy(ct);
+        var module = TheModuleThatNowOwnsIt();
+
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = app,
+            OutputDirectory = Path.Combine(_root, "out"),
+            Output = TextWriter.Null,
+            SupersededImageAssemblies = ["Legacy.Home"],
+        }).Await(ct);
+
+        report.ExitCode.Should().Be(0,
+            "the image's superseded copy is dropped from the reference set, so the module's own "
+            + "definition is the only one in scope");
+        report.Projects.Select(p => p.Result!.AssemblyName)
+            .Should().Equal(new[] { "New.Owner" });
+    }
+
+    [Fact]
+    public async Task AnEmptyNameIsARefusal()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var module = TheModuleThatNowOwnsIt();
+
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "out-empty"),
+            Output = TextWriter.Null,
+            SupersededImageAssemblies = ["   "],
+        }).Await(ct);
+
+        report.ExitCode.Should().NotBe(0,
+            "an option that silently does nothing reads exactly like an option that worked");
+    }
+
+    [Fact]
+    public async Task AnAssemblyTheImageDoesNotCarryIsARefusal_BecauseTheEntryIsWrongOrStale()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var module = TheModuleThatNowOwnsIt();
+
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "out-absent"),
+            Output = TextWriter.Null,
+            SupersededImageAssemblies = ["Not.In.The.Image"],
+        }).Await(ct);
+
+        report.ExitCode.Should().NotBe(0,
+            "either the name is wrong, or the image already stopped shipping it and the entry is "
+            + "STALE — the case an allow-shaped input rots in silently unless it fails closed");
+    }
+
+    [Fact]
+    public async Task AnAssemblyThisRunAlreadyBuildsIsARefusal_TheOptionWouldBeRedundant()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var module = TheModuleThatNowOwnsIt();
+
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "out-redundant"),
+            Output = TextWriter.Null,
+            SupersededImageAssemblies = ["New.Owner"],
+        }).Await(ct);
+
+        report.ExitCode.Should().NotBe(0,
+            "a project in the graph is shadowed anyway; naming it signals a misunderstanding of "
+            + "what the option is for, and a silent no-op would leave that misunderstanding in place");
+    }
+}

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -209,6 +209,7 @@ static async Task<int> RunBuildProject(string[] args)
     var generatorPaths = new List<string>();
     string? razorGenerators = null;
     var accept = new List<string>();
+    var superseded = new List<string>();
     var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     var allowWarnings = false;
     var maxParallel = Math.Max(1, Environment.ProcessorCount);
@@ -255,6 +256,14 @@ static async Task<int> RunBuildProject(string[] args)
                 break;
             case "--accept" when i + 1 < args.Length:
                 accept.Add(args[++i]);
+                break;
+            // The image's copy of this assembly is SUPERSEDED for this run — dropped from the
+            // reference set because this repository's source now defines types it still contains.
+            // Declared, never inferred: an automatic collision-resolver would mask a real
+            // two-producers defect (#3175). Fails closed in ProjectBuild on an empty name, a name
+            // the container lacks (wrong or STALE), or one the graph already builds.
+            case "--superseded-image-assembly" when i + 1 < args.Length:
+                superseded.Add(args[++i]);
                 break;
             case "--verbose":
                 verbose = true;
@@ -304,6 +313,7 @@ static async Task<int> RunBuildProject(string[] args)
         GeneratorPaths = generatorPaths,
         RazorGeneratorDirectory = razorGenerators,
         Accept = accept,
+        SupersededImageAssemblies = superseded,
         Properties = properties,
         AllowWarnings = allowWarnings,
         Verbose = verbose,
@@ -331,7 +341,8 @@ static string BuildProjectUsage() =>
     "usage: mw-plugin-test build-project <csproj|dir> [--output <dir>] [--app <dir>] "
     + "[--shared-frameworks <dir>] [--prebuilt <dir>]... "
     + "[--extra-refs <dir>]... [--generators <dir|dll>]... [--razor-generators <dir>] "
-    + "[--accept <construct>]... [-p:Name=Value]... [--allow-warnings] [--max-parallel <n>]\n"
+    + "[--accept <construct>]... [--superseded-image-assembly <name>]... "
+    + "[-p:Name=Value]... [--allow-warnings] [--max-parallel <n>]\n"
     + "  Compiles a .NET project with NO dotnet SDK and NO NuGet restore: the .csproj is evaluated "
     + "without MSBuild, every reference is resolved from this container's /app (and its .deps.json), "
     + "ProjectReferences inside the source root are built first in dependency order, and Roslyn runs "

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -165,6 +165,34 @@ public static class ProjectBuild
         public IReadOnlyList<string> PrebuiltDirectories { get; init; } = [];
 
         /// <summary>
+        /// Image assemblies whose copy in the container is SUPERSEDED for this run: this
+        /// repository's source now defines types they still contain, so referencing them would
+        /// import a second definition of a type being compiled here (CS0436).
+        ///
+        /// <para>🚨 <b>An exclusion, not a preference.</b> The shadow set
+        /// (<see cref="Graph.ShadowedAssemblyNames"/>) subtracts only what this run builds FROM
+        /// SOURCE, and membership is reachability-driven through <c>ProjectReference</c> edges. So
+        /// when a type MOVES OUT of an image-shipped assembly into a module in the same repository,
+        /// the very edge that would have shadowed the stale copy is the edge the move deletes — the
+        /// shadow set structurally cannot see it, in the one case that needs it. This input is how a
+        /// caller says so explicitly.</para>
+        ///
+        /// <para><b>Declared, never inferred.</b> Resolving such a collision automatically in favour
+        /// of the source would mask a genuine two-producers-of-one-assembly defect, which is exactly
+        /// what <c>BakeHost.ShippedByHostProblem</c> (#3175) exists to make RED.</para>
+        ///
+        /// <para>No check asserts that the compile needs nothing else from a dropped assembly: the
+        /// compiler already answers that with <c>CS0246</c>/<c>CS0234</c> naming the missing type,
+        /// which is a positive, specific signal. Do not add a redundant one.</para>
+        ///
+        /// <para>⏳ A dropped entry goes STALE once a rebuilt image no longer defines the conflicting
+        /// types — the assembly still exists, so nothing detects it. The durable check is a
+        /// type-name overlap assertion — MeshWeaver#3223, and
+        /// <c>Doc/Architecture/ModuleBuildArchitecture</c>.</para>
+        /// </summary>
+        public IReadOnlyList<string> SupersededImageAssemblies { get; init; } = [];
+
+        /// <summary>
         /// The PLATFORM image's <c>shared/</c> frameworks root — required whenever
         /// <see cref="AppDirectory"/> comes from a different image than the one running this
         /// builder (see <see cref="ContainerReferenceSet.Read"/>). Null = the running runtime's.
@@ -317,6 +345,15 @@ public static class ProjectBuild
         if (graph.Order.IsEmpty)
             return Observable.Return(Fatal(options, sink, wall, container.PlatformAssemblyVersion,
                 "nothing to build. A run that compiles nothing is a failure, never a silent success."));
+
+        try
+        {
+            graph = DropSupersededImageAssemblies(graph, container, options, sink);
+        }
+        catch (InvalidOperationException ex)
+        {
+            return Observable.Return(Fatal(options, sink, wall, container.PlatformAssemblyVersion, ex.Message));
+        }
 
         var workRoot = options.OutputDirectory is { Length: > 0 } outDir
             ? Path.GetFullPath(outDir)
@@ -642,6 +679,50 @@ public static class ProjectBuild
                 PrebuiltReferences = prebuiltReferences.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
             };
         }
+    }
+
+    /// <summary>
+    /// Adds <see cref="Options.SupersededImageAssemblies"/> to the graph's shadow set, so the
+    /// container's copy of each is left OUT of every compile's reference set in this run.
+    /// Fails closed — an input that silently does nothing is the trapdoor a gate must never have.
+    /// </summary>
+    private static Graph DropSupersededImageAssemblies(
+        Graph graph, ContainerReferenceSet container, Options options, Sink sink)
+    {
+        if (options.SupersededImageAssemblies.Count == 0)
+            return graph;
+
+        var dropped = ImmutableHashSet.CreateBuilder<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var raw in options.SupersededImageAssemblies)
+        {
+            var name = raw?.Trim() ?? string.Empty;
+            if (name.Length == 0)
+                throw new InvalidOperationException(
+                    "--superseded-image-assembly was given an empty name. Name the assembly whose "
+                    + "image copy this run supersedes, or omit the option.");
+
+            if (!container.AssembliesByName.ContainsKey(name))
+                throw new InvalidOperationException(
+                    $"--superseded-image-assembly '{name}': the container at {container.AppDirectory} "
+                    + "carries no such assembly. Either the name is wrong, or the image already stopped "
+                    + "shipping it and this input is STALE — remove it. (Refusing rather than ignoring: "
+                    + "an input that does nothing reads exactly like an input that worked.)");
+
+            if (graph.ShadowedAssemblyNames.Contains(name))
+                throw new InvalidOperationException(
+                    $"--superseded-image-assembly '{name}': this run already builds it from source, so "
+                    + "its image copy is shadowed anyway and the option is redundant. Remove it — the "
+                    + "option exists for the assembly a move made UNREACHABLE, not for one in the graph.");
+
+            dropped.Add(name);
+        }
+
+        var names = dropped.ToImmutable();
+        sink.Info(
+            $"superseded: {names.Count} image assembl(y|ies) dropped from the reference set — "
+            + string.Join(", ", names.OrderBy(n => n, StringComparer.Ordinal))
+            + " (this repository's source now defines types they still contain)");
+        return graph with { ShadowedAssemblyNames = graph.ShadowedAssemblyNames.Union(names) };
     }
 
     // ── the compile ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The defect

MeshWeaver.Plugins#1268 moves three Razor views (`CollaborativeMarkdownView`, `CommentableView`,
`MarkdownEditorView`, namespace `MeshWeaver.Blazor.Components`) out of the image-shipped assembly
`MeshWeaver.Blazor.Views` into the registry-served module `MeshWeaver.Markdown.Collaboration`, so that
module has ONE producer (#3175 / plugins#1262). Its global build fails:

```
error CS0436: The type 'CollaborativeMarkdownView' in
'/repo/src/MeshWeaver.Markdown.Collaboration/Components/CollaborativeMarkdownView.razor.cs'
conflicts with the imported type 'CollaborativeMarkdownView' in
'MeshWeaver.Blazor.Views, Version=3.0.0.0, Culture=neutral, PublicKeyToken=null'
```
(same for the other two, from both the `.razor.cs` and the Razor generator's `.g.cs`)

## Why the existing shadow set cannot see it

- `ProjectBuild.Run` reads the image with `ContainerReferenceSet`, then builds the reference set as
  *the whole container MINUS `Graph.ShadowedAssemblyNames`* — `ProjectBuild.cs`, the loop at
  `if (graph.ShadowedAssemblyNames.Contains(assemblyName)) continue;`.
- `shadowed` is `models.Values.Select(m => m.AssemblyName).Concat(prebuiltReferences.Keys)` — only
  assemblies **this run compiles from source**, and graph membership is **reachability-driven**
  through `ProjectReference` edges under the source root.
- **The edge that would put `Blazor.Views` in the graph is exactly the edge #1268 deletes.** So it is
  not shadowed, the image's previous copy is imported, and it still defines the three types.

This is the duplicate-producer problem one level down — two definitions of one TYPE rather than two
producers of one ASSEMBLY — and it lasts exactly one wave. It is also general: it will recur for every
type that leaves an image-shipped assembly for a module in the same repo.

## The change

`superseded-image-assemblies:` (comma/whitespace-separated, **optional**) on
`node-repo-module-pack.yml` → `--superseded-image-assembly <name>` (repeatable) on `build-project`,
which adds each name to the shadow set so the image's stale copy leaves the reference set.

**An exclusion, not a preference.** My first design brief for this said the named assembly must also
be *built by the run's workspace, else fail*. That is wrong and would have refused the only case the
feature exists for: the module's graph does not build `Blazor.Views` and never will — that is the
situation. Recorded here because the mistake is easy to repeat.

Three load-bearing properties:

- **Declared, never inferred.** Automatically resolving a collision in favour of the source would
  mask a genuine two-producers defect, which `BakeHost.ShippedByHostProblem` (#3175) exists to make
  RED. The caller names the assembly.
- **Fails closed** on an empty name, a name the container does not carry (wrong — or the entry is
  STALE now the image dropped it), and a name the run already builds from source (redundant, and a
  silent no-op would leave the misunderstanding in place). An input that quietly does nothing reads
  exactly like an input that worked.
- **No "is anything else still needed from it?" check** — the compiler answers that with
  `CS0246`/`CS0234` naming the missing type, a positive and specific signal. Noted in the code so
  nobody adds a redundant one.

## Five callers are unaffected

`MeshWeaver.Plugins`, `.Education`, `.Reinsurance`, `.SocialMedia`, `.Manufacturing` call this lane. The
input is `required: false` with `default: ''`; parsed by YAML, the lane's required set is still exactly
`['modules', 'platform-ref']` (verified, not assumed — a new REQUIRED input on a reusable workflow is
a silent `startup_failure`: zero jobs, zero contexts, which reads as GREEN). With it empty the shell
builds no flags, so the `docker run` line is byte-identical to before.

## Verification

| | |
|---|---|
| `tools/MeshWeaver.PluginTester` | Release `-warnaserror` → `0 Warning(s) / 0 Error(s)` |
| `src/MeshWeaver.Documentation` | Release `-warnaserror` → `0 Warning(s) / 0 Error(s)` |
| `test/MeshWeaver.PluginTester.Test` (WHOLE project) | `Failed: 0, Passed: 324, Total: 324`, `.trx` at 14:48Z vs 14:48:23Z start |
| `test/MeshWeaver.Documentation.Test` (WHOLE project, rebuilt first — docs are `EmbeddedResource`) | `Failed: 0, Passed: 246, Total: 246` |
| `check-workflow-timeouts.py` | `64 job(s) checked, 2 reusable-call job(s) exempt, 0 violation(s)` |

`SupersededImageAssemblyTest` has **five** cases: the effect, and one per fail-closed path — plus a
**control arm** that builds the identical tree WITHOUT the option and requires `CS0436`.

🚨 **The control arm earned its keep immediately.** My first synthetic repro did *not* collide: a
declared type conflicts with nothing until something RESOLVES the name, so the control passed and the
positive test was proving nothing. Fixed by having the module's source actually bind `Moved.Thing`
(which is why the real case surfaced — the Razor generator's `.g.cs` binds it). Then the control failed
for the wrong reason — the per-project `Failure` carries only `"1 warning(s) under the no-warn policy"`
— so the diagnostic code is now asserted against the builder's captured narration.

**What only Plugins#1268 can confirm:** everything above runs against a synthetic container directory.
The real portal image, the Razor generator inside it, and the actual `MeshWeaver.Blazor.Views` are
exercised for the first time by #1268's next run.

## Follow-up

#3223 — a superseded entry has no staleness check: once the pin moves onto an image built after the
move, that image's copy no longer defines the conflicting types but the assembly still exists, so the
"not carried" check does not fire. Durable form is a type-name overlap assertion; it needs the source's
declared type names and so belongs after the compilations are known, which is why it is not folded in
here. Linked from the code comment and the doc.

Doc: `Doc/Architecture/ModuleBuildArchitecture` gains "Moving a type OUT of an image-shipped assembly
into a module (the shadow set's blind spot)".

No What's New entry — internal build-process change, no user-visible effect.

Pairs-with: none — core lane change; MeshWeaver.Plugins#1268 is the first consumer. (Verified: this
diff removes no public type and no public member.)
