### PR TITLE
Restore always-modules' default — #3225 orphaned it onto the new input and startup-failed every caller

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -258,6 +258,7 @@ on:
           selection fall back to the full set and say why.
         type: string
         required: false
+        default: ''
       superseded-image-assemblies:
         description: >
           Comma- or whitespace-separated IMAGE assembly names whose copy in the pinned platform
@@ -285,7 +286,6 @@ on:
           exactly as before.
         type: string
         required: false
-        default: ''
         default: ''
       platform-image:
         description: >


### PR DESCRIPTION
## What broke

#3225 inserted the `superseded-image-assemblies:` input **between `always-modules:`'s
`required: false` and its `default: ''`**. The orphaned `default` line attached itself to the new
input — which already declared its own — so the file carried a **duplicate `default` key**, and
`always-modules` **silently lost its default**.

GitHub refuses the entire workflow. MeshWeaver.Plugins#1268's run
[33777768374](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/33777768374) concluded
`failure` with **zero jobs and zero contexts** — a `startup_failure`, which renders as an ordinary
red and names nothing. Its previous head ran 29 jobs, which is how the change was isolated.

## 🚨 Why #3225's own verification could not catch it

I validated the lane with `yaml.safe_load`. **PyYAML accepts duplicate mapping keys and silently
keeps the last**, so the parse succeeded, the input's spec read back correctly, and the "required
inputs unchanged" assertion passed. The check I ran **could not fail on this defect** — the exact
"a verification step that cannot fail is not a verification step" shape #3225 was itself written
about. Two hours of cataloguing that pattern did not stop me writing it.

`actionlint` finds it in one line:

```
.github/workflows/node-repo-module-pack.yml:289:9: key "default" is duplicated in input of
workflow_call event. previously defined at line:288,col:9 [syntax-check]
```

**Swept every workflow in the repo with actionlint: no other duplicate-key finding.**

## The fix

Restore `default: ''` to `always-modules` and drop the duplicate from
`superseded-image-assemblies`. One line net. Both inputs verified after the change:

```
always-modules              -> {'type': 'string', 'required': False, 'default': ''}
superseded-image-assemblies -> {'type': 'string', 'required': False, 'default': ''}
```

`actionlint` clean on the file and repo-wide.

## Follow-up worth having, not done here

`check-workflow-timeouts.py` and friends run in CI, but nothing runs `actionlint`. A lane defect that
GitHub only reports as a job-less red on a *consuming repo* is expensive to attribute — it took a
before/after job-count comparison across two repos to find this one. Adding actionlint to the
workflow-validation step would have caught it at the source, in the PR that introduced it. Filing
separately rather than widening this fix.

Pairs-with: none — restores the previous behaviour of an input; no public surface.
No What's New — internal CI fix.
