### PR TITLE
memex-local: an instance awaiting setup is a state, not a failed verification

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -938,6 +938,40 @@ probe_default_install_done() {
 
 # The HTTP half. Echoes the STATUS CODE (000 when no request completed), because judging curl's own
 # exit code instead of the code it fetched is the bug this whole function replaces.
+# Is this instance serving the FIRST-RUN SETUP wizard (i.e. it has no database yet)?
+#
+# 🚨 TWO signals, and the second one is load-bearing. "/setup answers 200" ALONE is not evidence:
+# a configured portal maps no /setup route, so the request falls through to the Blazor SPA
+# fallback — which answers 200 for practically any path. A one-signal probe therefore reports
+# "awaiting setup" for a perfectly healthy portal, and (as the behaviour suite proved on the first
+# draft of this function) turns every RED state in verify_usable into a false green.
+#
+# The discriminator is the redirect: an unconfigured instance sends EVERY other path to /setup,
+# so `/` answers 3xx with a Location naming it. A configured portal serves `/` with 200.
+awaiting_setup() {
+  local caroot ca=() root_code root_location
+  if command -v mkcert >/dev/null 2>&1; then
+    caroot="$(mkcert -CAROOT 2>/dev/null || true)"
+    if [ -n "$caroot" ] && [ -f "$caroot/rootCA.pem" ]; then ca=(--cacert "$caroot/rootCA.pem"); fi
+  fi
+  # One request: the status AND the redirect target of the ROOT. Never --location; following the
+  # redirect would land on /setup and answer 200 either way, which is the very confusion above.
+  root_code="$(curl ${ca[@]+"${ca[@]}"} -sS -o /dev/null -w '%{http_code}' --max-time 15 \
+    "https://${HOSTNAME_LOCAL}:${HOST_PORT}/" 2>/dev/null || true)"
+  case "$root_code" in
+    3??) ;;
+    *)   return 1 ;;
+  esac
+  root_location="$(curl ${ca[@]+"${ca[@]}"} -sS -o /dev/null -w '%{redirect_url}' --max-time 15 \
+    "https://${HOSTNAME_LOCAL}:${HOST_PORT}/" 2>/dev/null || true)"
+  case "$root_location" in
+    */setup) ;;
+    *)       return 1 ;;
+  esac
+  # …and the wizard itself actually serves.
+  [ "$(probe_http /setup)" = "200" ]
+}
+
 probe_http() {
   local path="$1" caroot code ca=()
   if command -v mkcert >/dev/null 2>&1; then
@@ -978,6 +1012,26 @@ verify_usable() {
 
   step "Verifying the portal is USABLE, not merely answering (§14)"
   local failed=0 url="https://${HOSTNAME_LOCAL}:${HOST_PORT}" code
+
+  # ── 0. is this instance AWAITING FIRST-RUN SETUP? ────────────────────────
+  # 🚨 An instance with no database is not a BROKEN portal — it is one waiting for a person, and
+  # the checks below would all condemn it: it has no mesh, therefore no view packs, so check 3
+  # fails and `up` dies with "NOT USABLE" on an install that is working exactly as designed. That
+  # is a false RED, and it lands on the one path a new user takes first.
+  #
+  # Asked over the WIRE, not from the pod log: the surface's own contract is that an unconfigured
+  # instance serves /setup and redirects everything else to it, so that is what is probed. A log
+  # grep would be a second source of truth for the same fact, and it goes stale the moment the log
+  # rotates or the pod restarts.
+  if awaiting_setup; then
+    echo
+    ok "This instance is AWAITING FIRST-RUN SETUP — it has no database yet."
+    info "That is not a failure: the portal is serving the setup wizard and nothing else,"
+    info "which is why it has no sign-in page and no view packs to verify."
+    info "Answer it, and this instance restarts configured:"
+    info "  memex-local setup"
+    return 0
+  fi
 
   # ── 1. the portal serves ─────────────────────────────────────────────────
   code="$(probe_http /)"
@@ -1892,9 +1946,9 @@ each line names its own remedy."
   echo
   # A fresh install is NOT finished at this point, and saying "open the portal" would be
   # the same lie `verify_usable` exists to prevent: the portal is serving a setup wizard
-  # nobody has answered. Which state it is in is a fact about the pod, so read it.
-  if kubectl logs deploy/memex-portal-deployment -n "$NAMESPACE" --tail=-1 2>/dev/null \
-       | grep -q "SETUP wizard only"; then
+  # nobody has answered. Probed over the wire, for the same reason verify_usable probes it —
+  # one source of truth for one fact, and one that a rotated log cannot invalidate.
+  if awaiting_setup; then
     ok "memex is up and waiting to be SET UP — it has no database yet."
     cmd_setup
   else

--- a/deploy/homebrew/test/run-tests.sh
+++ b/deploy/homebrew/test/run-tests.sh
@@ -52,13 +52,34 @@ EOF
 # therefore APPENDED a second '000', and the resulting '000000' matched no arm of the caller's
 # case statement. That is how "nothing is listening on :8443" got reported as a serving-portal
 # fault with the INGRESS as its remedy. The old stub is why this suite never saw it.
+# 🚨 The stub must honour the -w FORMAT, not just the URL. awaiting_setup asks for
+# %{redirect_url} as well as %{http_code}, and a stub that answered a status code to both made the
+# setup branch unreachable — the suite would have gone green over a function it never ran.
 cat > "$STUBS/curl" <<'EOF'
 #!/usr/bin/env bash
 url="${!#}"
+fmt=""
+prev=""
+for a in "$@"; do
+  [ "$prev" = "-w" ] && fmt="$a"
+  prev="$a"
+done
 if [ -n "${FAKE_CURL_FAILS:-}" ]; then printf '000'; exit 7; fi
-case "$url" in
-  */login) printf '%s' "${FAKE_HTTP_LOGIN:-200}" ;;
-  *)       printf '%s' "${FAKE_HTTP_ROOT:-200}" ;;
+case "$fmt" in
+  *redirect_url*)
+    # Only an instance awaiting setup redirects the ROOT to the wizard.
+    case "$url" in
+      *//*/) printf '%s' "${FAKE_REDIRECT_ROOT:-}" ;;
+      *)     printf '' ;;
+    esac
+    ;;
+  *)
+    case "$url" in
+      */login) printf '%s' "${FAKE_HTTP_LOGIN:-200}" ;;
+      */setup) printf '%s' "${FAKE_HTTP_SETUP:-200}" ;;
+      *)       printf '%s' "${FAKE_HTTP_ROOT:-200}" ;;
+    esac
+    ;;
 esac
 EOF
 
@@ -151,6 +172,39 @@ case "$OUT" in
        "check 2 judged the sign-in route through a transport that never connected: $OUT" ;;
   *) ok "a connection failure does not also indict /login" ;;
 esac
+
+# ── an instance AWAITING FIRST-RUN SETUP ────────────────────────────────────────
+# 🚨 It has no mesh, therefore no view packs, so every check below would condemn a portal that is
+# working exactly as designed — a false RED on the first path a new user takes. verify_usable must
+# recognise the state and say what to do about it.
+# `reports` is for RED states — it demands a non-zero exit. Awaiting setup is a green state with
+# an instruction, so it is asserted directly.
+run_verify FAKE_HTTP_ROOT=302 FAKE_REDIRECT_ROOT="https://memex.localhost:8443/setup" \
+  FAKE_HTTP_SETUP=200 FAKE_MODULES=""
+if [ "$RC" -eq 0 ]; then ok "awaiting setup exits 0 — it is a state, not a failure"
+else bad "awaiting setup exits 0 — it is a state, not a failure" "exited $RC: $OUT"; fi
+case "$OUT" in
+  *"AWAITING FIRST-RUN SETUP"*) ok "awaiting setup is reported, not condemned" ;;
+  *) bad "awaiting setup is reported, not condemned" "said nothing about setup: $OUT" ;;
+esac
+case "$OUT" in
+  *"memex-local setup"*) ok "awaiting setup points at the command that answers it" ;;
+  *) bad "awaiting setup points at the command that answers it" "named no next step: $OUT" ;;
+esac
+
+# 🚨 THE NEGATIVE CONTROL, and it is not hypothetical: the first draft of this probe asked only
+# "does /setup answer 200", and a CONFIGURED portal answers 200 there too — its Blazor SPA fallback
+# serves almost any path. Every red state below then short-circuited into "awaiting setup" and the
+# whole verification passed on a broken portal. The root REDIRECT is what discriminates.
+run_verify FAKE_HTTP_ROOT=200 FAKE_HTTP_SETUP=200 FAKE_MODULES=""
+case "$OUT" in
+  *"AWAITING FIRST-RUN SETUP"*)
+    bad "a configured portal is NOT mistaken for one awaiting setup" \
+        "/setup answering 200 through the SPA fallback was read as setup mode: $OUT" ;;
+  *) ok "a configured portal is NOT mistaken for one awaiting setup" ;;
+esac
+if [ "$RC" -ne 0 ]; then ok "…and its missing view packs are still caught"
+else bad "…and its missing view packs are still caught" "exited 0 on a portal with no view packs: $OUT"; fi
 
 reports "a missing view pack is caught" "MeshWeaver.Blazor.Views" \
   FAKE_HTTP_ROOT=200 FAKE_HTTP_LOGIN=200 \


### PR DESCRIPTION
Found by actually running `memex-local up` instead of reasoning about it.

## The false red

`up` runs `verify_usable` **before** it says anything about the wizard, and `verify_usable`
condemns an instance that has no mesh: no view packs ⇒ check 3 fails ⇒ `up` dies with
*"memex is deployed but NOT USABLE"* on an install that is working exactly as designed.

A false RED, on the first path a new user takes. `verify_usable` now recognises the state and says
what to do about it, and `up` no longer greps the pod log for the same fact — one source of truth,
and one a rotated log cannot invalidate.

## 🚨 The first draft of the probe was wrong, and the existing suite caught it

It asked only *"does `/setup` answer 200"*. A **configured** portal answers 200 there too — its
Blazor SPA fallback serves almost any path. So every red state in `verify_usable` short-circuited
into "awaiting setup" and the whole verification passed on a broken portal: 8 existing tests went
red immediately, which is exactly what they are for.

The predicate needs **two** signals — the ROOT redirects to `/setup` **and** the wizard serves —
and the suite now carries that negative control explicitly:

```
ok  awaiting setup exits 0 — it is a state, not a failure
ok  awaiting setup is reported, not condemned
ok  awaiting setup points at the command that answers it
ok  a configured portal is NOT mistaken for one awaiting setup
ok  …and its missing view packs are still caught
```

## The stub could not have run the branch

The curl stub answered a status code to **every** `-w` format, including `%{redirect_url}` — so
`awaiting_setup` could never return true under test and a green suite would have proved nothing
about it. The stub honours the format now.

58/58 in `deploy/homebrew/test/run-tests.sh`.

`Pairs-with: none — shell only; no public type or member changes.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
