### PR TITLE
fix: the NodeType compile kickoffs are gated on teardown (Plugins#1279)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -592,6 +592,33 @@ internal static class NodeTypeCompilationHelpers
                     .Select(_ => node))
             .Subscribe(node =>
             {
+                // 🚨 GATED ON TEARDOWN, and it is not defensive padding.
+                //
+                // This emission can arrive on a TIMER thread — the adoption wait above is
+                // `.Timeout(ReservationWaitBudget)`, so a slow or leaked reservation delivers here
+                // seconds later, by which time the hub may be tearing down. `GetService` then
+                // throws ObjectDisposedException out of a closed Autofac scope, on a NON-TEST
+                // thread, inside a single-argument Subscribe — which Rx RETHROWS rather than
+                // routing to onError. It reaches AppDomain.UnhandledException and takes the
+                // process down: xUnit v3 reports an anonymous "Catastrophic failure … exit code
+                // 139" carrying no stack (Plugins#1279, MeshWeaver.FutuRe.Test).
+                //
+                // The second, quieter cost is the one that was reported first: when this callback
+                // dies, CompilationStatus is never flipped to Pending, so the watcher below never
+                // dispatches — the NodeType compiles FOREVER behind the in-progress overlay with
+                // no status transition and no compile error to find. That is exactly the observed
+                // trace: 48 s of "Slow-path typeStream emission for FutuRe/LocalAnalysis" with
+                // Status stuck and nothing logged.
+                //
+                // Gating, not catching, per the shape the CI gate itself prescribes: a hub that is
+                // going away has nothing to kick off, so there is no work being skipped here.
+                if (hub.IsShuttingDown)
+                {
+                    logger?.LogDebug(
+                        "First-build kickoff: {HubPath} is shutting down — skipping", hubPath);
+                    return;
+                }
+
                 // Flip CompilationStatus directly to Pending. The watcher (above)
                 // observes the Pending transition and drives the actual compile.
                 // Crucially: do NOT touch RequestedReleaseAt. RequestedReleaseAt
@@ -663,6 +690,15 @@ internal static class NodeTypeCompilationHelpers
                 && !IsStaticOnlyNodeType(node, def))
             .Subscribe(node =>
             {
+                // Same gate, same reason as the first-build kickoff above: a DI resolve inside a
+                // single-argument Subscribe is rethrown by Rx and kills the process if the scope
+                // has closed under it. A hub that is shutting down has no compile to recover.
+                if (hub.IsShuttingDown)
+                {
+                    logger?.LogDebug(
+                        "Compile recovery: {HubPath} is shutting down — skipping", hubPath);
+                    return;
+                }
                 logger?.LogWarning(
                     "Compile recovery: {HubPath} came up persisted as Compiling — re-triggering compile (flip Compiling→Pending)",
                     hubPath);


### PR DESCRIPTION
Two single-argument `Subscribe(onNext)` bodies in `InstallCompileWatcher` resolve `AccessService` from DI — the **first-build kickoff** and the **compile-recovery kickoff**. A single-argument `Subscribe` is the one shape where Rx **rethrows** rather than routing to `onError`, so a resolve that throws there escapes onto whatever thread delivered the emission.

Both can be delivered on a thread that is not the caller's. The first-build kickoff waits on the adoption interlock through `.Timeout(NodeTypeAdoptionRegistry.ReservationWaitBudget)`, so a slow or leaked reservation delivers **seconds later** — by which time the hub may be tearing down and its Autofac scope closed.

## Two costs, and the quiet one was reported first

**1 — the process dies.** `ObjectDisposedException` out of a closed scope, on a non-test thread, reaching `AppDomain.UnhandledException`. xUnit v3 reports an anonymous *"Catastrophic failure: Test process crashed with exit code 139"* carrying no stack. Measured on `MeshWeaver.FutuRe.Test`, [Plugins run 33778900486](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/33778900486/job/100727640185). The CI gate's own message names both the shape and the fix:

> typically a DI resolve inside a single-argument `Subscribe(onNext)` body, which Rx RETHROWS rather than routing to `onError` … **Fix it by GATING the callback on the hub's teardown state, not by catching the exception; do not re-run.**

**2 — the compile never finishes.** When that callback dies, nothing flips `CompilationStatus` to `Pending`, so the watcher never dispatches. The NodeType then compiles *forever* behind the compilation-in-progress overlay, with **no status transition and no compile error anywhere**. That is the trace Systemorph/MeshWeaver.Plugins#1279 opens with: 48 s of `Slow-path typeStream emission for FutuRe/LocalAnalysis`, `HubConfig=False` throughout, `Status` never reaching `Compiled`, nothing logged.

Same project, same day, same load conditions. One defect, not two — and it explains why neither reproduces on a quiet machine (`MeshWeaver.FutuRe.Test` is 46/46 in 39 s locally): it needs another mesh to be tearing down while this one is still compiling.

## Gated, not caught

`if (hub.IsShuttingDown) return;` at the top of both callbacks — the seam this repo already uses for exactly this (`AccessControlPipeline`, `DataContext`, `PrebuiltAssemblySeeder`). Nothing is skipped that had work to do: a hub that is going away has no first build to kick off and no compile to recover.

## 🚨 Not covered by a new test — and here is what I tried

I wrote `KickoffOnALeavingHubTest` with a leaving arm and a live control arm, then removed it: **the monolith fixture cannot hold a NodeType in the kickoff's trigger state.** Creating the node activates its real hub, whose production watcher compiles it immediately — measured, the node reached `CompilationStatus = Ok` with a released assembly ~2 s after `CreateNode`, so the fixture's own precondition ("still never built") was already false by the time it could be observed. The recovery arm has the same problem one state along.

A test that raced the production wiring for that window would be precisely the flake this change exists to remove. What ships is two strictly-narrowing guards on a path whose failure mode the CI gate itself diagnoses, with the run above as evidence. I would rather state that plainly than add a test that proves nothing.

If a reviewer wants coverage here, the tractable route is the straggler-capture artifact `MeshWeaver.Fixture` already writes for disposed-scope stragglers — absent on this run, but it would name the site directly on the next occurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
