### PR TITLE
A superseded-image-assembly entry can no longer outlive the image rebuild that retires it

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -279,13 +279,15 @@ on:
           `BakeHost.ShippedByHostProblem` (MeshWeaver#3175) exists to make RED.
 
 
-          Fails closed — an empty name, a name the image does not carry (wrong, or the input is
-          STALE now the image dropped it), or a name the run already builds from source, each
-          refuse the build naming the entry. Omitted, nothing is dropped and the lane behaves
-          exactly as before.
+          Fails closed on four inputs, each refusing the build and NAMING the entry: an empty name,
+          a name the image does not carry, a name the run already builds from source, and — once a
+          rebuilt image has retired it (MeshWeaver#3223) — an entry with nothing left to supersede,
+          i.e. the image's copy defines none of the type names this repository's source declares.
+          That last one is measured against the whole repository, never against a narrowed
+          selection, so an ordinary PR run never mistakes "not compiled here" for "no longer
+          needed". Omitted, nothing is dropped and the lane behaves exactly as before.
         type: string
         required: false
-        default: ''
         default: ''
       platform-image:
         description: >

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -535,10 +535,14 @@ routine:
   root, which the lane mounts and which no selection can shrink.
 - 🚨 **A `.razor` component counts as a definition.** The move that motivated the option
   (MeshWeaver.Plugins#1268) was three Razor views, whose types exist in no `.cs` file — a check that
-  indexed only C# would call the entry stale in precisely the case it was built for. A component
-  matches on its file name plus the directory path it sits under; the namespace PREFIX is the Razor
-  SDK's to compute, and a re-derivation that got the root namespace wrong would produce the false red
-  this check must never produce.
+  indexed only C# would call the entry stale in precisely the case it was built for. And matching on
+  the folder alone is not enough either: `CS0436` needs the SAME fully-qualified name on both sides,
+  so a view that leaves an image-shipped assembly **keeps its old namespace** with an `@namespace`
+  directive (or an `_Imports.razor` covering its folder), and its new folder then says nothing about
+  its namespace. Both declared forms are read and recorded exactly; the file-name-plus-directory-path
+  rule is an additional fallback for the derived case, never the only rule — the `RootNamespace`
+  prefix is the Razor SDK's to compute, and a re-derivation that got it wrong would produce the false
+  red this check must never produce.
 
 Every other ambiguity is resolved the same way — towards quiet. Type FORWARDERS in the image's copy
 count as definitions (a forwarded type is as visible to the compiler as a defined one), and an

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -500,18 +500,56 @@ Three properties are load-bearing:
 - **Declared, never inferred.** Resolving such a collision automatically in favour of the source
   would mask a genuine two-producers-of-one-assembly defect — the thing
   `BakeHost.ShippedByHostProblem` exists to make RED. The caller names the assembly.
-- **Fails closed.** An empty name, a name the image does not carry (wrong — or the entry is STALE
-  now the image dropped it), or a name the run already builds from source, each refuse the build and
-  say which entry. An input that quietly does nothing reads exactly like an input that worked.
+- **Fails closed.** An empty name, a name the image does not carry, a name the run already builds
+  from source, and an entry with **nothing left to supersede** each refuse the build and say which
+  entry. An input that quietly does nothing reads exactly like an input that worked.
 - **No "is anything else still needed from it?" check.** The compiler already answers that with
   `CS0246`/`CS0234` naming the missing type, which is a positive, specific signal. A second check
   would only be able to agree.
 
-⏳ **Known gap:** an entry goes stale once a rebuilt image no longer defines the conflicting types —
-the assembly still exists, so nothing detects it. The durable form is a type-name overlap assertion
-(refuse when the image's copy defines none of the names this run's source defines) — tracked in
-[#3223](https://github.com/Systemorph/MeshWeaver/issues/3223). Until it lands, remove the entry in the same change that moves the pin onto an image
-built after the move.
+#### The entry cannot outlive its reason (#3223)
+
+A superseded entry is correct for exactly **one wave**. The moment the pin moves onto an image built
+AFTER the move, that image's copy no longer defines the moved types — but *the assembly still
+exists*, so "the container carries no such assembly" never fires. Nothing in the first three
+refusals can see this, because all three read the input's SHAPE and this one is about its LIFETIME.
+
+A stale entry is not untidy, it is live: it keeps a real image assembly out of the reference set, so
+the day something legitimately needs a *different* type from it the build dies `CS0246` pointing at
+the consuming code with the declaration that caused it nowhere in the message. An allow-shaped entry
+that outlives its reason with nothing to retire it is a recurring defect class here.
+
+So `SupersededEntryStaleness` refuses the build, **before a single project compiles**, when the
+image's copy of the named assembly defines *none* of the type names this repository's source
+declares — the precise statement of "there is nothing left to supersede", since a collision needs one
+name on both sides. The error names the entry to delete.
+
+Two choices in it are load-bearing, and both were made against a failure that would otherwise be
+routine:
+
+- 🚨 **The source side is the REPOSITORY, never the run's selection.** The pack lane narrows what it
+  compiles — a PR-scoped diff, plus a build ledger that hands back reused bundles — so on most runs
+  the module that owns the moved type is not in the graph at all. Reading "this run's compilations"
+  as the source side would therefore turn the entry RED on ordinary narrowed PRs during exactly the
+  one wave the entry exists to serve. The source side is the whole tree under the workspace's source
+  root, which the lane mounts and which no selection can shrink.
+- 🚨 **A `.razor` component counts as a definition.** The move that motivated the option
+  (MeshWeaver.Plugins#1268) was three Razor views, whose types exist in no `.cs` file — a check that
+  indexed only C# would call the entry stale in precisely the case it was built for. A component
+  matches on its file name plus the directory path it sits under; the namespace PREFIX is the Razor
+  SDK's to compute, and a re-derivation that got the root namespace wrong would produce the false red
+  this check must never produce.
+
+Every other ambiguity is resolved the same way — towards quiet. Type FORWARDERS in the image's copy
+count as definitions (a forwarded type is as visible to the compiler as a defined one), and an
+image copy whose metadata cannot be READ is a refusal of its own rather than a staleness verdict:
+naming the wrong entry to delete is worse than saying nothing.
+
+The index is a syntax parse — no compilation, no semantic model — and it is paid **only on the runs
+that pass the option at all**, which is the rare wave after a move. Measured over core's `src/`:
+1249 files, 2028 top-level type names, **1.76 s**, with `bin`/`obj`/`.git` never descended into. The
+build narrates the file count, the name count and the elapsed time, so a tree that makes it
+expensive says so rather than merely being slow.
 
 ## Adoption contract (every repo)
 

--- a/test/MeshWeaver.PluginTester.Test/SupersededImageAssemblyTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/SupersededImageAssemblyTest.cs
@@ -216,4 +216,320 @@ public class SupersededImageAssemblyTest : IDisposable
             "a project in the graph is shadowed anyway; naming it signals a misunderstanding of "
             + "what the option is for, and a silent no-op would leave that misunderstanding in place");
     }
+
+    // ── the fourth refusal: the entry that OUTLIVED its reason (#3223) ─────────────────────────
+
+    /// <summary>
+    /// The image ONE WAVE LATER: <c>Legacy.Home</c> was rebuilt after the type left it, so the
+    /// assembly is still shipped and still full of types — it just no longer defines the one the
+    /// entry exists to shadow. This is the state no shape-check can see: the name is not empty, the
+    /// container carries it, and the run does not build it.
+    /// </summary>
+    private async Task<string> StageImageRebuiltAfterTheMove(CancellationToken ct)
+    {
+        Write("rebuilt/Directory.Build.props", "<Project></Project>");
+        var rebuilt = Write("rebuilt/Legacy.Home/Legacy.Home.csproj", LibProject);
+        Write("rebuilt/Legacy.Home/Retired.cs",
+            "namespace Legacy; public sealed class Retired { public int Value => 1; }");
+
+        var built = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [rebuilt],
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "image-rebuild"),
+            Output = TextWriter.Null,
+        }).Await(ct);
+        built.ExitCode.Should().Be(0, "staging the container is setup, not the assertion");
+
+        var app = AppDirectory();
+        File.Copy(
+            Path.Combine(_root, "image-rebuild", "Legacy.Home", "Legacy.Home.dll"),
+            Path.Combine(app, "Legacy.Home.dll"), overwrite: true);
+        return app;
+    }
+
+    [Fact]
+    public async Task AStaleEntryIsARefusal_TheImageWasRebuiltAndThereIsNothingLeftToSupersede()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = await StageImageRebuiltAfterTheMove(ct);
+        var module = TheModuleThatNowOwnsIt();
+
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = app,
+            OutputDirectory = Path.Combine(_root, "out-stale"),
+            Output = TextWriter.Null,
+            SupersededImageAssemblies = ["Legacy.Home"],
+        }).Await(ct);
+
+        // 🚨 The build would otherwise be GREEN — nothing collides any more, which is exactly why
+        // an entry rots here in silence. The refusal is the whole point.
+        report.ExitCode.Should().NotBe(0,
+            "the image's copy no longer defines anything this repository declares, so the entry has "
+            + "done its job and keeping it only subtracts a real assembly from the reference set");
+        report.FatalError.Should().NotBeNull();
+        report.FatalError.Should().Contain("STALE").And.Contain("Legacy.Home",
+            "an entry that must be deleted has to be NAMED — a verdict nobody can act on is a "
+            + "warning that scrolls past");
+    }
+
+    [Fact]
+    public async Task AnEntryThatIsStillNeededStaysQUIET_TheOtherControlArm()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = await StageImageWithTheOldCopy(ct);
+        var module = TheModuleThatNowOwnsIt();
+
+        var narration = new StringWriter();
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = app,
+            OutputDirectory = Path.Combine(_root, "out-needed"),
+            Output = narration,
+            SupersededImageAssemblies = ["Legacy.Home"],
+        }).Await(ct);
+
+        report.ExitCode.Should().Be(0,
+            "the image's copy still defines Moved.Thing, so the entry is holding a real collision "
+            + "apart — a staleness check that fires here would break the one wave it exists for");
+        narration.ToString().Should().Contain("'Legacy.Home' is still needed")
+            .And.Contain("Moved.Thing",
+                "the quiet arm must SAY what it measured — a check whose passing verdict is silence "
+                + "cannot be distinguished from a check that never ran");
+    }
+
+    [Fact]
+    public async Task ANarrowedRunDoesNotCallTheEntryStale_TheSourceSideIsTheREPOSITORY()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = await StageImageWithTheOldCopy(ct);
+        TheModuleThatNowOwnsIt();
+        // A second module in the same repository — the only one this run compiles. The pack lane
+        // narrows exactly like this: a PR-scoped diff, and a build ledger that hands back reused
+        // bundles, routinely leave the module that owns the moved type OUT of the selection.
+        var unrelated = Write("src/Other.Module/Other.Module.csproj", LibProject);
+        Write("src/Other.Module/Widget.cs",
+            "namespace Other; public sealed class Widget { public int Value => 3; }");
+
+        var narration = new StringWriter();
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [unrelated],
+            AppDirectory = app,
+            OutputDirectory = Path.Combine(_root, "out-narrowed"),
+            Output = narration,
+            SupersededImageAssemblies = ["Legacy.Home"],
+        }).Await(ct);
+
+        // 🚨 Reading "this run's compilations" as the source side would red THIS — an ordinary
+        // narrowed PR, during the one wave the entry is needed. The source side is the repository.
+        report.ExitCode.Should().Be(0,
+            "New.Owner is not in this run's graph, but it IS in the repository — the entry is still "
+            + "needed and a narrowed selection must never be read as staleness");
+        narration.ToString().Should().Contain("'Legacy.Home' is still needed");
+    }
+
+    /// <summary>
+    /// 🚨 The move that motivated the whole option (MeshWeaver.Plugins#1268) was three
+    /// <c>.razor</c> views, and a Razor component's type exists in no <c>.cs</c> file at all. A
+    /// staleness check that indexed only C# would therefore call the entry stale in precisely the
+    /// case it was built for — the false red that would have made the whole check unusable.
+    /// </summary>
+    [Fact]
+    public async Task ARazorComponentCountsAsSourceThatDefinesTheType_ElseTheMotivatingCaseFalseReds()
+    {
+        var ct = TestContext.Current.CancellationToken;
+
+        // The image still ships the component's old home: same generated name, same namespace.
+        Write("old/Directory.Build.props", "<Project></Project>");
+        var old = Write("old/Legacy.Home/Legacy.Home.csproj", LibProject);
+        Write("old/Legacy.Home/Card.cs",
+            "namespace Widgets.Views; public sealed class Card { public int Value => 1; }");
+        var staged = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [old],
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, "image-razor"),
+            Output = TextWriter.Null,
+        }).Await(ct);
+        staged.ExitCode.Should().Be(0, "staging the container is setup, not the assertion");
+        var app = AppDirectory();
+        File.Copy(
+            Path.Combine(_root, "image-razor", "Legacy.Home", "Legacy.Home.dll"),
+            Path.Combine(app, "Legacy.Home.dll"), overwrite: true);
+
+        // The module that now owns it — a .razor file and nothing else. RootNamespace + the
+        // TargetPath directory is what the Razor SDK turns into `Widgets.Views.Card`.
+        Write("src/Directory.Build.props", "<Project></Project>");
+        var module = Write("src/Razor.Owner/Razor.Owner.csproj", """
+            <Project Sdk="Microsoft.NET.Sdk.Razor">
+              <PropertyGroup>
+                <TargetFramework>net10.0</TargetFramework>
+                <Nullable>enable</Nullable>
+                <ImplicitUsings>enable</ImplicitUsings>
+                <AssemblyName>Razor.Owner</AssemblyName>
+                <RootNamespace>Widgets</RootNamespace>
+              </PropertyGroup>
+            </Project>
+            """);
+        Write("src/Razor.Owner/Views/Card.razor", "<div class=\"card\">card</div>");
+
+        var narration = new StringWriter();
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = app,
+            OutputDirectory = Path.Combine(_root, "out-razor"),
+            Output = narration,
+            SupersededImageAssemblies = ["Legacy.Home"],
+        }).Await(ct);
+
+        narration.ToString().Should().NotContain("STALE",
+            "the component IS this repository's definition of Widgets.Views.Card — it just lives in "
+            + "a .razor file, which is the shape the option exists for");
+        narration.ToString().Should().Contain("'Legacy.Home' is still needed")
+            .And.Contain("Widgets.Views.Card");
+        report.ExitCode.Should().Be(0);
+    }
+
+    /// <summary>Stages <c>Legacy.Home</c> in the container defining exactly the given C# source.</summary>
+    private async Task<string> StageImageDefining(string tag, string source, CancellationToken ct)
+    {
+        Write($"{tag}/Directory.Build.props", "<Project></Project>");
+        var project = Write($"{tag}/Legacy.Home/Legacy.Home.csproj", LibProject);
+        Write($"{tag}/Legacy.Home/Defined.cs", source);
+        var built = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [project],
+            AppDirectory = AppDirectory(),
+            OutputDirectory = Path.Combine(_root, $"image-{tag}"),
+            Output = TextWriter.Null,
+        }).Await(ct);
+        built.ExitCode.Should().Be(0, "staging the container is setup, not the assertion");
+        var app = AppDirectory();
+        File.Copy(
+            Path.Combine(_root, $"image-{tag}", "Legacy.Home", "Legacy.Home.dll"),
+            Path.Combine(app, "Legacy.Home.dll"), overwrite: true);
+        return app;
+    }
+
+    /// <summary>
+    /// A Razor class library whose components live in <c>Components/</c> under a root namespace
+    /// that has nothing to do with the namespace they are generated into.
+    /// </summary>
+    private const string MovedViewsProject = """
+        <Project Sdk="Microsoft.NET.Sdk.Razor">
+          <PropertyGroup>
+            <TargetFramework>net10.0</TargetFramework>
+            <Nullable>enable</Nullable>
+            <ImplicitUsings>enable</ImplicitUsings>
+            <AssemblyName>Moved.Views</AssemblyName>
+            <RootNamespace>Moved.Views</RootNamespace>
+          </PropertyGroup>
+        </Project>
+        """;
+
+    /// <summary>
+    /// 🚨 <b>The real shape of the move.</b> <c>CS0436</c> needs the SAME fully-qualified name on
+    /// both sides, so a view that leaves an image-shipped assembly KEEPS its old namespace with an
+    /// <c>@namespace</c> directive — its new folder then says nothing about its namespace, and the
+    /// directory-suffix rule alone cannot see it. The control below is the same tree with the
+    /// directive removed, which IS stale: that is what makes this arm attributable to the directive
+    /// rather than to the suffix rule quietly matching anyway.
+    /// </summary>
+    [Fact]
+    public async Task ARazorNamespaceDirectiveIsHonoured_AMovedViewKeepsItsOldNamespace()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = await StageImageDefining(
+            "ns-directive",
+            "namespace Legacy.Blazor.Views; public sealed class Panel { public int Value => 1; }",
+            ct);
+
+        Write("src/Directory.Build.props", "<Project></Project>");
+        var module = Write("src/Moved.Views/Moved.Views.csproj", MovedViewsProject);
+        Write("src/Moved.Views/Components/Panel.razor", """
+            @namespace Legacy.Blazor.Views
+
+            <div class="panel">panel</div>
+            """);
+
+        var narration = new StringWriter();
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = app,
+            OutputDirectory = Path.Combine(_root, "out-ns-directive"),
+            Output = narration,
+            SupersededImageAssemblies = ["Legacy.Home"],
+        }).Await(ct);
+
+        narration.ToString().Should().NotContain("STALE");
+        narration.ToString().Should().Contain("'Legacy.Home' is still needed")
+            .And.Contain("Legacy.Blazor.Views.Panel");
+        report.ExitCode.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task WithoutTheDirectiveTheSameTreeISStale_TheControlThatMakesThePreviousArmMeanSomething()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = await StageImageDefining(
+            "ns-nodirective",
+            "namespace Legacy.Blazor.Views; public sealed class Panel { public int Value => 1; }",
+            ct);
+
+        Write("src/Directory.Build.props", "<Project></Project>");
+        var module = Write("src/Moved.Views/Moved.Views.csproj", MovedViewsProject);
+        // No @namespace: the component is generated into Moved.Views.Components, which is a
+        // DIFFERENT type from the image's Legacy.Blazor.Views.Panel — nothing collides, so the
+        // entry really has nothing left to supersede.
+        Write("src/Moved.Views/Components/Panel.razor", "<div class=\"panel\">panel</div>");
+
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = app,
+            OutputDirectory = Path.Combine(_root, "out-ns-nodirective"),
+            Output = TextWriter.Null,
+            SupersededImageAssemblies = ["Legacy.Home"],
+        }).Await(ct);
+
+        report.FatalError.Should().NotBeNull();
+        report.FatalError.Should().Contain("STALE").And.Contain("Legacy.Home");
+    }
+
+    [Fact]
+    public async Task An_ImportsRazorNamespaceCoversTheFolderBeneathIt()
+    {
+        var ct = TestContext.Current.CancellationToken;
+        var app = await StageImageDefining(
+            "ns-imports",
+            "namespace Legacy.Blazor.Views.Inner; public sealed class Panel { public int Value => 1; }",
+            ct);
+
+        Write("src/Directory.Build.props", "<Project></Project>");
+        var module = Write("src/Moved.Views/Moved.Views.csproj", MovedViewsProject);
+        // The SDK applies an _Imports.razor namespace to the folder AND appends the path below it,
+        // so Components/Inner/Panel.razor lands in Legacy.Blazor.Views.Inner.
+        Write("src/Moved.Views/Components/_Imports.razor", "@namespace Legacy.Blazor.Views");
+        Write("src/Moved.Views/Components/Inner/Panel.razor", "<div class=\"panel\">panel</div>");
+
+        var narration = new StringWriter();
+        var report = await ProjectBuild.Run(new()
+        {
+            EntryProjects = [module],
+            AppDirectory = app,
+            OutputDirectory = Path.Combine(_root, "out-ns-imports"),
+            Output = narration,
+            SupersededImageAssemblies = ["Legacy.Home"],
+        }).Await(ct);
+
+        narration.ToString().Should().NotContain("STALE");
+        narration.ToString().Should().Contain("Legacy.Blazor.Views.Inner.Panel");
+        report.ExitCode.Should().Be(0);
+    }
 }

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -261,7 +261,9 @@ static async Task<int> RunBuildProject(string[] args)
             // reference set because this repository's source now defines types it still contains.
             // Declared, never inferred: an automatic collision-resolver would mask a real
             // two-producers defect (#3175). Fails closed in ProjectBuild on an empty name, a name
-            // the container lacks (wrong or STALE), or one the graph already builds.
+            // the container lacks, one the graph already builds — and, once a rebuilt image retires
+            // it, on the entry having nothing left to supersede (#3223: the image's copy defines
+            // none of the type names this repository's source declares).
             case "--superseded-image-assembly" when i + 1 < args.Length:
                 superseded.Add(args[++i]);
                 break;

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -185,10 +185,14 @@ public static class ProjectBuild
         /// compiler already answers that with <c>CS0246</c>/<c>CS0234</c> naming the missing type,
         /// which is a positive, specific signal. Do not add a redundant one.</para>
         ///
-        /// <para>⏳ A dropped entry goes STALE once a rebuilt image no longer defines the conflicting
-        /// types — the assembly still exists, so nothing detects it. The durable check is a
-        /// type-name overlap assertion — MeshWeaver#3223, and
-        /// <c>Doc/Architecture/ModuleBuildArchitecture</c>.</para>
+        /// <para><b>An entry cannot outlive its reason.</b> Once the pin moves onto an image built
+        /// AFTER the move, that image's copy no longer defines the conflicting types — but the
+        /// assembly still exists, so the "not carried by the image" refusal above never fires.
+        /// <see cref="SupersededEntryStaleness"/> closes that (#3223): the entry is refused, by name,
+        /// when the image's copy defines none of the type names this REPOSITORY's source declares.
+        /// The comparison is deliberately against the whole source tree rather than this run's
+        /// selection — a narrowed lane compiles a subset, and the module owning the moved type is
+        /// usually not in it.</para>
         /// </summary>
         public IReadOnlyList<string> SupersededImageAssemblies { get; init; } = [];
 
@@ -567,6 +571,15 @@ public static class ProjectBuild
             ImmutableDictionary<string, string>.Empty.WithComparers(StringComparer.OrdinalIgnoreCase);
 
         /// <summary>
+        /// The ONE source root of the workspace — a <c>ProjectReference</c> inside it is built,
+        /// outside it comes from the container. Carried on the graph because it is also the tree the
+        /// superseded-entry staleness check reads: the answer to "is this entry still needed" is a
+        /// property of the REPOSITORY, never of a narrowed selection. (An <c>init</c> property, not
+        /// a positional parameter — the record signature rule.)
+        /// </summary>
+        public string SourceRoot { get; init; } = string.Empty;
+
+        /// <summary>
         /// One Roslyn reference universe for the whole run — "one workspace": every project in the
         /// graph shares the SAME <see cref="PortableExecutableReference"/> instance per path, so a
         /// reference assembly is opened and its metadata decoded from the filesystem ONCE, and
@@ -677,6 +690,7 @@ public static class ProjectBuild
                 models.ToImmutable(), edges.ToImmutable(), shadowed)
             {
                 PrebuiltReferences = prebuiltReferences.ToImmutableDictionary(StringComparer.OrdinalIgnoreCase),
+                SourceRoot = sourceRoot,
             };
         }
     }
@@ -685,6 +699,15 @@ public static class ProjectBuild
     /// Adds <see cref="Options.SupersededImageAssemblies"/> to the graph's shadow set, so the
     /// container's copy of each is left OUT of every compile's reference set in this run.
     /// Fails closed — an input that silently does nothing is the trapdoor a gate must never have.
+    ///
+    /// <para><b>Four refusals, three about the input's shape and one about its LIFETIME.</b> An
+    /// empty name, a name the image does not carry, and a name the run already builds from source
+    /// are answered from the option and the graph alone. The fourth —
+    /// <see cref="SupersededEntryStaleness"/>, #3223 — answers the question the other three
+    /// structurally cannot: the entry was correct when it was written and has since outlived the
+    /// image rebuild that retired it. It is checked HERE, before a single project compiles, so the
+    /// run that first has a stale entry names the entry instead of dying <c>CS0246</c> somewhere in
+    /// the consuming code with the declaration that caused it nowhere in the message.</para>
     /// </summary>
     private static Graph DropSupersededImageAssemblies(
         Graph graph, ContainerReferenceSet container, Options options, Sink sink)
@@ -718,6 +741,48 @@ public static class ProjectBuild
         }
 
         var names = dropped.ToImmutable();
+
+        // ── the fourth refusal: IS THE ENTRY STILL NEEDED? (#3223) ─────────────────────────────
+        // The three checks above all fire on the input's shape; none of them can see an entry that
+        // was right when it was written and has since been retired by an image rebuild. That entry
+        // is not inert — it keeps a real image assembly out of the reference set, and the day
+        // something needs a different type from it the build dies CS0246 in the consuming code.
+        //
+        // 🚨 The source side is the REPOSITORY, never this run's selection. The pack lane narrows
+        // what it compiles (a PR-scoped diff; a ledger that hands back reused bundles), so on most
+        // runs the module that owns the moved type is not in the graph — reading the run's
+        // compilations as the source side would red ordinary narrowed PRs during exactly the wave
+        // the entry exists to serve.
+        var indexClock = Stopwatch.StartNew();
+        var source = SupersededEntryStaleness.ForSourceRoot(graph.SourceRoot);
+        sink.Info(
+            $"superseded: indexed {source.FilesScanned} source file(s) under {source.SourceRoot} — "
+            + $"{source.DeclaredTypeCount} top-level C# type name(s) in {indexClock.ElapsedMilliseconds} ms "
+            + "(the staleness check's source side is the repository, not this run's selection)");
+
+        foreach (var name in names.OrderBy(n => n, StringComparer.Ordinal))
+        {
+            var path = container.AssembliesByName[name];
+            var overlap = source.Measure(name, path);
+            if (overlap.IsStale)
+                throw new InvalidOperationException(
+                    $"--superseded-image-assembly '{name}': STALE — the image's copy at {path} carries "
+                    + $"{overlap.ImageTypeCount} top-level type(s) and this repository's source under "
+                    + $"{source.SourceRoot} declares NONE of them, so there is nothing left for the "
+                    + "entry to supersede. The pinned image was rebuilt after the move that made the "
+                    + $"entry necessary. DELETE '{name}' from the caller's superseded-image-assemblies "
+                    + "input (and from any --superseded-image-assembly argument). Left in place it "
+                    + "keeps a real image assembly out of the reference set, and the first compile "
+                    + "that needs a different type from it fails CS0246 naming the consuming code "
+                    + "rather than this declaration.");
+            sink.Info(
+                $"superseded: '{name}' is still needed — the image's copy carries {overlap.ImageTypeCount} "
+                + $"top-level type(s), {overlap.StillDefinedInSource.Length} of which this repository also "
+                + "declares (e.g. "
+                + string.Join(", ", overlap.StillDefinedInSource.Take(3))
+                + (overlap.StillDefinedInSource.Length > 3 ? ", …" : "") + ")");
+        }
+
         sink.Info(
             $"superseded: {names.Count} image assembl(y|ies) dropped from the reference set — "
             + string.Join(", ", names.OrderBy(n => n, StringComparer.Ordinal))

--- a/tools/MeshWeaver.PluginTester/SupersededEntryStaleness.cs
+++ b/tools/MeshWeaver.PluginTester/SupersededEntryStaleness.cs
@@ -42,11 +42,14 @@ namespace MeshWeaver.PluginTester;
 /// missed staleness costs what the status quo already costs. So the image side counts type
 /// FORWARDERS as definitions (a forwarded type is just as visible to the compiler), the source side
 /// counts every <c>.cs</c> under the root — in-mesh <c>Source/*.cs</c> nodes included, they are this
-/// repository's source too — and a <c>.razor</c>/<c>.cshtml</c> component matches on its simple name
-/// plus its directory suffix, because its generated namespace is the Razor SDK's to compute and a
-/// re-derivation of it that got the root namespace wrong would produce precisely the false red this
-/// check must never produce. Razor is not a corner case here: the move that motivated the whole
-/// option (MeshWeaver.Plugins#1268) was three <c>.razor</c> views.</para>
+/// repository's source too — and a <c>.razor</c>/<c>.cshtml</c> component contributes BOTH the
+/// namespace it declares (an <c>@namespace</c> directive, or the nearest <c>_Imports.razor</c> plus
+/// the folder path below it — which is how a moved view keeps the old namespace <c>CS0436</c>
+/// requires) AND, as a fallback, its simple name with its directory suffix, since the
+/// <c>RootNamespace</c> prefix is the Razor SDK's to compute and a re-derivation that got it wrong
+/// would produce precisely the false red this check must never produce. Razor is not a corner case
+/// here: the move that motivated the whole option (MeshWeaver.Plugins#1268) was three <c>.razor</c>
+/// views.</para>
 ///
 /// <para>An assembly whose metadata cannot be READ is a refusal of its own, never a staleness
 /// verdict — naming the wrong entry to delete is worse than saying nothing.</para>

--- a/tools/MeshWeaver.PluginTester/SupersededEntryStaleness.cs
+++ b/tools/MeshWeaver.PluginTester/SupersededEntryStaleness.cs
@@ -1,0 +1,444 @@
+using System.Collections.Immutable;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Text;
+
+namespace MeshWeaver.PluginTester;
+
+/// <summary>
+/// The fourth fail-closed check on <c>--superseded-image-assembly</c>: <b>is the entry still
+/// needed?</b> (MeshWeaver#3223.)
+///
+/// <para><b>The hole it closes.</b> The other three refusals — an empty name, a name the image does
+/// not carry, a name the run already builds from source — all fire on the SHAPE of the input. None
+/// of them fires on an entry that has simply outlived its reason. A superseded entry exists for one
+/// wave: a type moved out of an image-shipped assembly into a module in the same repository, and the
+/// pinned image is still a wave behind. The moment the pin moves onto an image built AFTER the move,
+/// that image's copy no longer defines the moved types — but the <i>assembly still exists</i>, so
+/// "the container carries no such assembly" never fires. The entry then keeps a real image assembly
+/// out of the reference set forever, and the day something legitimately needs a DIFFERENT type from
+/// it the build dies <c>CS0246</c> pointing at the consuming code rather than at the declaration
+/// that caused it. An allow-shaped entry that outlives its reason with nothing to retire it is a
+/// recurring defect class here, not a hypothesis.</para>
+///
+/// <para><b>The question, stated exactly.</b> The entry is stale when the image's copy of the named
+/// assembly defines <i>none</i> of the type names this repository's source declares. That is the
+/// precise form of "there is nothing left to supersede": a collision needs one type name defined on
+/// both sides, so an empty intersection means no collision is possible and the drop can only
+/// subtract.</para>
+///
+/// <para>🚨 <b>The comparison is against the REPOSITORY, never against the run's selection.</b> The
+/// pack lane narrows what it compiles — a PR-scoped diff, and a build ledger that hands back reused
+/// bundles — so on most runs the module that owns the moved type is not in the graph at all. Reading
+/// "this run's compilations" as the source side would therefore turn the entry RED on ordinary
+/// narrowed PRs during exactly the one wave the entry exists to serve. The source side is the whole
+/// tree under <c>Graph.SourceRoot</c>, which is what the lane mounts and is independent of the
+/// selection.</para>
+///
+/// <para><b>Every ambiguity is resolved towards QUIET.</b> A false red here blocks a pipeline; a
+/// missed staleness costs what the status quo already costs. So the image side counts type
+/// FORWARDERS as definitions (a forwarded type is just as visible to the compiler), the source side
+/// counts every <c>.cs</c> under the root — in-mesh <c>Source/*.cs</c> nodes included, they are this
+/// repository's source too — and a <c>.razor</c>/<c>.cshtml</c> component matches on its simple name
+/// plus its directory suffix, because its generated namespace is the Razor SDK's to compute and a
+/// re-derivation of it that got the root namespace wrong would produce precisely the false red this
+/// check must never produce. Razor is not a corner case here: the move that motivated the whole
+/// option (MeshWeaver.Plugins#1268) was three <c>.razor</c> views.</para>
+///
+/// <para>An assembly whose metadata cannot be READ is a refusal of its own, never a staleness
+/// verdict — naming the wrong entry to delete is worse than saying nothing.</para>
+/// </summary>
+internal sealed partial class SupersededEntryStaleness
+{
+    /// <summary>Build output and tool caches under the source root declare nothing a human wrote.</summary>
+    private static readonly ImmutableHashSet<string> SkippedDirectories = ImmutableHashSet.Create(
+        StringComparer.OrdinalIgnoreCase, "bin", "obj", ".git", ".vs", ".idea", "node_modules", "packages");
+
+    private readonly ImmutableHashSet<string> declaredTypes;
+    private readonly ImmutableDictionary<string, ImmutableHashSet<string>> razorComponentDirectories;
+
+    private SupersededEntryStaleness(
+        string sourceRoot,
+        int filesScanned,
+        ImmutableHashSet<string> declaredTypes,
+        ImmutableDictionary<string, ImmutableHashSet<string>> razorComponentDirectories)
+    {
+        SourceRoot = sourceRoot;
+        FilesScanned = filesScanned;
+        this.declaredTypes = declaredTypes;
+        this.razorComponentDirectories = razorComponentDirectories;
+    }
+
+    /// <summary>The tree the source side was read from.</summary>
+    public string SourceRoot { get; }
+
+    /// <summary>How many <c>.cs</c> / <c>.razor</c> / <c>.cshtml</c> files contributed.</summary>
+    public int FilesScanned { get; }
+
+    /// <summary>Top-level type names the tree declares in C# source.</summary>
+    public int DeclaredTypeCount => declaredTypes.Count;
+
+    /// <summary>
+    /// Indexes every top-level type name the tree under <paramref name="sourceRoot"/> declares.
+    /// Syntax only — no compilation, no semantic model, nothing loaded: the question is which NAMES
+    /// exist, and a parse answers it for a repository in a couple of seconds. Paid only on the runs
+    /// that actually pass <c>--superseded-image-assembly</c>, which is the rare wave after a move.
+    /// </summary>
+    public static SupersededEntryStaleness ForSourceRoot(string sourceRoot)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(sourceRoot);
+        var root = Path.GetFullPath(sourceRoot);
+        if (!Directory.Exists(root))
+            throw new InvalidOperationException(
+                $"the source root '{root}' does not exist, so whether a --superseded-image-assembly "
+                + "entry is still needed cannot be answered. Refusing rather than guessing.");
+
+        var declared = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+        var razor = new Dictionary<string, ImmutableHashSet<string>.Builder>(StringComparer.Ordinal);
+        var projectDirectoryOf = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+        var importsNamespaceOf = new Dictionary<string, string?>(StringComparer.OrdinalIgnoreCase);
+        var files = 0;
+
+        foreach (var path in SourceFiles(root))
+        {
+            var extension = Path.GetExtension(path);
+            if (extension.Equals(".cs", StringComparison.OrdinalIgnoreCase))
+            {
+                files++;
+                CollectCSharpTypes(path, declared);
+            }
+            else
+            {
+                files++;
+                CollectRazorComponent(root, path, projectDirectoryOf, importsNamespaceOf, declared, razor);
+            }
+        }
+
+        return new SupersededEntryStaleness(
+            root,
+            files,
+            declared.ToImmutable(),
+            razor.ToImmutableDictionary(e => e.Key, e => e.Value.ToImmutable(), StringComparer.Ordinal));
+    }
+
+    /// <summary>
+    /// Does this repository's source declare a top-level type of this exact name? The C# side is an
+    /// exact namespace-qualified match; the Razor side matches the component's simple name and
+    /// requires the namespace to END with the component's directory path (a component at the project
+    /// root matches any namespace — the root namespace is the SDK's to compute, not this index's).
+    /// </summary>
+    public bool Declares(string @namespace, string name)
+    {
+        ArgumentNullException.ThrowIfNull(@namespace);
+        ArgumentException.ThrowIfNullOrEmpty(name);
+        var qualified = @namespace.Length == 0 ? name : @namespace + "." + name;
+        if (declaredTypes.Contains(qualified))
+            return true;
+        if (!razorComponentDirectories.TryGetValue(name, out var directories))
+            return false;
+        foreach (var directory in directories)
+            if (directory.Length == 0
+                || @namespace.Equals(directory, StringComparison.Ordinal)
+                || @namespace.EndsWith("." + directory, StringComparison.Ordinal))
+                return true;
+        return false;
+    }
+
+    /// <summary>
+    /// The type names this repository's source ALSO declares out of the image assembly's own — the
+    /// evidence that the entry is still doing something. Empty ⇒ the entry is stale.
+    /// </summary>
+    /// <param name="entryName">The <c>--superseded-image-assembly</c> value, for the message.</param>
+    /// <param name="assemblyPath">The image's copy of it.</param>
+    public Overlap Measure(string entryName, string assemblyPath)
+    {
+        var imageTypes = ImageTypes(entryName, assemblyPath);
+        var shared = imageTypes
+            .Where(t => Declares(t.Namespace, t.Name))
+            .Select(t => t.Namespace.Length == 0 ? t.Name : t.Namespace + "." + t.Name)
+            .Distinct(StringComparer.Ordinal)
+            .OrderBy(n => n, StringComparer.Ordinal)
+            .ToImmutableArray();
+        return new Overlap(imageTypes.Length, shared);
+    }
+
+    /// <summary>What the image's copy and this repository's source have in common.</summary>
+    /// <param name="ImageTypeCount">Top-level types (definitions + forwarders) the image's copy carries.</param>
+    /// <param name="StillDefinedInSource">Those the repository's source declares too, in name order.</param>
+    public sealed record Overlap(int ImageTypeCount, ImmutableArray<string> StillDefinedInSource)
+    {
+        /// <summary>Nothing left to supersede: the entry has done its job and must be removed.</summary>
+        public bool IsStale => StillDefinedInSource.IsEmpty;
+    }
+
+    // ── the image side ─────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Top-level types the image's copy DEFINES or FORWARDS. Forwarders count: a forwarded type is
+    /// as visible through this assembly as a defined one, so treating one as absent could retire an
+    /// entry that is still load-bearing.
+    /// </summary>
+    private static ImmutableArray<(string Namespace, string Name)> ImageTypes(
+        string entryName, string assemblyPath)
+    {
+        var types = ImmutableArray.CreateBuilder<(string, string)>();
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var pe = new PEReader(stream);
+            if (!pe.HasMetadata)
+                throw Unreadable(entryName, assemblyPath, "the file carries no CLI metadata");
+            var md = pe.GetMetadataReader();
+            foreach (var handle in md.TypeDefinitions)
+            {
+                var definition = md.GetTypeDefinition(handle);
+                if (!definition.GetDeclaringType().IsNil)
+                    continue;
+                if (Simplify(md.GetString(definition.Name)) is { } name)
+                    types.Add((md.GetString(definition.Namespace), name));
+            }
+            foreach (var handle in md.ExportedTypes)
+            {
+                var exported = md.GetExportedType(handle);
+                if (exported.Implementation.Kind == HandleKind.ExportedType)
+                    continue; // a nested forward — its declaring type is already counted
+                if (Simplify(md.GetString(exported.Name)) is { } name)
+                    types.Add((md.GetString(exported.Namespace), name));
+            }
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or UnauthorizedAccessException)
+        {
+            throw Unreadable(entryName, assemblyPath, $"{ex.GetType().Name}: {ex.Message}");
+        }
+        return types.ToImmutable();
+    }
+
+    /// <summary>An unreadable image copy is its OWN refusal — never a staleness verdict.</summary>
+    private static InvalidOperationException Unreadable(string entryName, string path, string reason) =>
+        new($"--superseded-image-assembly '{entryName}': the image's copy at {path} could not be read "
+            + $"as managed metadata ({reason}), so whether the entry is still needed cannot be "
+            + "answered. Refusing rather than guessing — a staleness verdict read off an assembly "
+            + "nobody could open would name the wrong entry to delete.");
+
+    /// <summary>The metadata name a source declaration would carry: no arity suffix, no
+    /// compiler-synthesized <c>&lt;…&gt;</c> names (no source declares one, so they can only
+    /// mislead).</summary>
+    private static string? Simplify(string metadataName)
+    {
+        if (metadataName.Length == 0 || metadataName[0] == '<')
+            return null;
+        var tick = metadataName.IndexOf('`');
+        return tick > 0 ? metadataName[..tick] : metadataName;
+    }
+
+    // ── the source side ────────────────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Walks the tree explicitly rather than with <c>RecurseSubdirectories</c>, so a skipped
+    /// directory is never DESCENDED INTO — the lane's source root is a git checkout, and walking
+    /// <c>.git</c> to discard every file in it costs more than the whole rest of the scan. A
+    /// symlinked directory is not followed: a link out of the tree is not this repository's source,
+    /// and a link back into it is a cycle.
+    /// </summary>
+    private static IEnumerable<string> SourceFiles(string root)
+    {
+        var pending = new Stack<string>();
+        pending.Push(root);
+        while (pending.Count > 0)
+        {
+            var directory = pending.Pop();
+            var files = new List<string>();
+            try
+            {
+                foreach (var file in Directory.EnumerateFiles(directory))
+                {
+                    var extension = Path.GetExtension(file);
+                    if (extension.Equals(".cs", StringComparison.OrdinalIgnoreCase)
+                        || extension.Equals(".razor", StringComparison.OrdinalIgnoreCase)
+                        || extension.Equals(".cshtml", StringComparison.OrdinalIgnoreCase))
+                        files.Add(file);
+                }
+                foreach (var child in Directory.EnumerateDirectories(directory))
+                {
+                    if (SkippedDirectories.Contains(Path.GetFileName(child)))
+                        continue;
+                    if (new DirectoryInfo(child).LinkTarget is not null)
+                        continue;
+                    pending.Push(child);
+                }
+            }
+            catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+            {
+                // An unreadable directory contributes nothing. It cannot make the check FIRE
+                // either: the verdict is "stale" only when the whole tree shares nothing with the
+                // image copy, and a build whose sources are unreadable is red long before here.
+            }
+            foreach (var file in files)
+                yield return file;
+        }
+    }
+
+    private static void CollectCSharpTypes(string path, ImmutableHashSet<string>.Builder declared)
+    {
+        SourceText text;
+        try
+        {
+            using var stream = File.OpenRead(path);
+            text = SourceText.From(stream);
+        }
+        catch (IOException)
+        {
+            // A file that cannot be read contributes no names. It cannot make the check fire
+            // either — the verdict is only ever "stale" when the ENTIRE tree shares nothing with
+            // the image copy, and a build whose sources are unreadable is red long before here.
+            return;
+        }
+        var root = CSharpSyntaxTree.ParseText(text).GetCompilationUnitRoot();
+        CollectFrom(root.Members, string.Empty, declared);
+    }
+
+    private static void CollectFrom(
+        IEnumerable<MemberDeclarationSyntax> members, string @namespace, ImmutableHashSet<string>.Builder declared)
+    {
+        foreach (var member in members)
+            switch (member)
+            {
+                case BaseNamespaceDeclarationSyntax nested:
+                    var inner = nested.Name.ToString();
+                    CollectFrom(
+                        nested.Members,
+                        @namespace.Length == 0 ? inner : @namespace + "." + inner,
+                        declared);
+                    break;
+                // class / struct / record / interface / enum — the whole BaseTypeDeclaration family.
+                case BaseTypeDeclarationSyntax type:
+                    declared.Add(Qualify(@namespace, type.Identifier.ValueText));
+                    break;
+                case DelegateDeclarationSyntax @delegate:
+                    declared.Add(Qualify(@namespace, @delegate.Identifier.ValueText));
+                    break;
+            }
+    }
+
+    private static string Qualify(string @namespace, string name) =>
+        @namespace.Length == 0 ? name : @namespace + "." + name;
+
+    /// <summary>
+    /// A Razor component contributes its FILE NAME plus the dotted directory path from its project,
+    /// which is the suffix its generated namespace always ends with when the namespace is derived —
+    /// the <c>RootNamespace</c> prefix is the SDK's to compute, and guessing it wrong would drop a
+    /// real match, which is a false "stale" on an entry still holding a collision apart.
+    ///
+    /// <para>🚨 <b>When the namespace is DECLARED rather than derived, the suffix rule is not
+    /// enough</b> — and declaring it is exactly what a moved component does. <c>CS0436</c> needs the
+    /// same fully-qualified name on both sides, so a view that leaves <c>MeshWeaver.Blazor.Views</c>
+    /// for another project keeps its old namespace with an <c>@namespace</c> directive (or an
+    /// <c>_Imports.razor</c> covering its folder); its new folder path then has nothing to do with
+    /// its namespace. Both are read here and recorded EXACTLY, in addition to the suffix rule —
+    /// never instead of it, because every extra name can only make the check quieter.</para>
+    /// </summary>
+    private static void CollectRazorComponent(
+        string root,
+        string path,
+        Dictionary<string, string> projectDirectoryOf,
+        Dictionary<string, string?> importsNamespaceOf,
+        ImmutableHashSet<string>.Builder declared,
+        Dictionary<string, ImmutableHashSet<string>.Builder> razor)
+    {
+        var name = Path.GetFileNameWithoutExtension(path);
+        if (name.Length == 0 || name.Equals("_Imports", StringComparison.OrdinalIgnoreCase))
+            return;
+        var directory = Path.GetDirectoryName(path)!;
+        var projectDirectory = ProjectDirectoryOf(root, directory, projectDirectoryOf);
+
+        if (DirectiveNamespace(path) is { } own)
+            declared.Add(Qualify(own, name));
+        else if (ImportsNamespace(directory, projectDirectory, importsNamespaceOf) is { } inherited)
+            declared.Add(Qualify(inherited, name));
+
+        var relative = Path.GetRelativePath(projectDirectory, directory);
+        var dotted = relative is "." or ""
+            ? string.Empty
+            : relative.Replace(Path.DirectorySeparatorChar, '.').Replace(Path.AltDirectorySeparatorChar, '.');
+        if (!razor.TryGetValue(name, out var directories))
+            razor[name] = directories = ImmutableHashSet.CreateBuilder<string>(StringComparer.Ordinal);
+        directories.Add(dotted);
+    }
+
+    /// <summary>The namespace the nearest <c>_Imports.razor</c> at or above <paramref name="directory"/>
+    /// puts this folder in — the base it declares, plus the folder path from there down, which is how
+    /// the Razor SDK applies it. Null when no <c>_Imports.razor</c> up to the project declares one.</summary>
+    private static string? ImportsNamespace(
+        string directory, string projectDirectory, Dictionary<string, string?> memo)
+    {
+        if (memo.TryGetValue(directory, out var cached))
+            return cached;
+        string? resolved = null;
+        var suffix = string.Empty;
+        for (var current = directory; current is not null; current = Path.GetDirectoryName(current))
+        {
+            var imports = Path.Combine(current, "_Imports.razor");
+            if (File.Exists(imports) && DirectiveNamespace(imports) is { } declaredNamespace)
+            {
+                resolved = suffix.Length == 0 ? declaredNamespace : declaredNamespace + "." + suffix;
+                break;
+            }
+            if (current.Equals(projectDirectory, StringComparison.OrdinalIgnoreCase))
+                break;
+            var segment = Path.GetFileName(current);
+            if (segment.Length == 0)
+                break;
+            suffix = suffix.Length == 0 ? segment : segment + "." + suffix;
+        }
+        memo[directory] = resolved;
+        return resolved;
+    }
+
+    /// <summary>The <c>@namespace</c> a Razor file declares, if it declares one.</summary>
+    private static string? DirectiveNamespace(string path)
+    {
+        try
+        {
+            // Razor files are small; the directive is a whole line, so the whole text is the
+            // cheapest correct thing to match against.
+            var match = NamespaceDirective().Match(File.ReadAllText(path));
+            return match.Success ? match.Groups["ns"].Value : null;
+        }
+        catch (Exception ex) when (ex is IOException or UnauthorizedAccessException)
+        {
+            return null;
+        }
+    }
+
+    [GeneratedRegex(
+        // [ \t\r]*$ — a CRLF file leaves the \r before the line end, and a directive that stops
+        // matching on a Windows checkout is a false "stale" nobody would attribute to line endings.
+        @"^[ \t]*@namespace[ \t]+(?<ns>[A-Za-z_][A-Za-z0-9_]*(?:\.[A-Za-z_][A-Za-z0-9_]*)*)[ \t\r]*$",
+        RegexOptions.Multiline)]
+    private static partial Regex NamespaceDirective();
+
+    /// <summary>The nearest ancestor holding a <c>.csproj</c>, memoized per directory — the walk is
+    /// otherwise repeated once per component in the same folder.</summary>
+    private static string ProjectDirectoryOf(string root, string directory, Dictionary<string, string> memo)
+    {
+        if (memo.TryGetValue(directory, out var known))
+            return known;
+        // No project above it ⇒ the file's own directory, which yields an EMPTY relative path and
+        // therefore matches any namespace. Quiet, which is the safe direction.
+        var result = directory;
+        for (var current = directory;
+             current is not null && current.Length >= root.Length;
+             current = current.Equals(root, StringComparison.OrdinalIgnoreCase) ? null : Path.GetDirectoryName(current))
+        {
+            if (!Directory.EnumerateFiles(current, "*.csproj").Any())
+                continue;
+            result = current;
+            break;
+        }
+        memo[directory] = result;
+        return result;
+    }
+}


### PR DESCRIPTION
## The hole

`superseded-image-assemblies` (pack lane) / `--superseded-image-assembly` (`build-project`) fails
closed on three inputs today, and **all three read the input's SHAPE**
(`tools/MeshWeaver.PluginTester/ProjectBuild.cs`, `DropSupersededImageAssemblies`):

1. an empty name;
2. a name the container does not carry;
3. a name the run already builds from source (already shadowed ⇒ redundant).

None of them can see the fourth case, which is about the entry's **LIFETIME**. Once the pin moves
onto an image built AFTER the move, that image's copy no longer defines the conflicting types — but
*the assembly still exists*, so check 2 never fires. The entry then keeps a real image assembly out
of the reference set forever, and the first compile that needs a **different** type from it dies
`CS0246` naming the consuming code, with the declaration that caused it nowhere in the message.

## The check

`tools/MeshWeaver.PluginTester/SupersededEntryStaleness.cs` — refuse the build, **before a single
project compiles**, when the image's copy of the named assembly defines *none* of the type names
this repository's source declares. That is the precise statement of "there is nothing left to
supersede": a collision needs one name on both sides. The error **names the entry to delete**; it is
a refusal, not a warning, and there is no expiry date and no TTL anywhere in it.

Running it before the compile (rather than after) is what makes the `CS0246` case actionable too:
the run that first carries a stale entry names the entry instead of dying somewhere in consuming
code.

### Two decisions that are load-bearing, both about a false red this must never produce

- 🚨 **The source side is the REPOSITORY, never the run's selection.** The pack lane narrows what it
  compiles — a PR-scoped diff, plus a ledger that hands back reused bundles (`build-modules`, not
  `modules`) — so on most runs the module that owns the moved type is not in the graph at all.
  Reading "this run's compilations" as the source side (the issue's sketch) would turn the entry RED
  on ordinary narrowed PRs during **exactly the one wave the entry exists to serve**. The source
  side is the whole tree under the workspace's source root, which no selection can shrink.
- 🚨 **A `.razor` component counts as a definition.** The move that motivated the whole option
  (MeshWeaver.Plugins#1268) was three Razor views, whose types exist in no `.cs` file — and `CS0436`
  needs the same fully-qualified name on both sides, so a moved view **keeps its old namespace** via
  an `@namespace` directive or an `_Imports.razor`. Both are read and recorded exactly; the
  directory-suffix rule is an additional fallback, never the only rule.

Everything else resolves towards quiet, because a false red blocks a pipeline while a missed
staleness only costs what the status quo costs: type FORWARDERS in the image's copy count as
definitions, and an image copy whose metadata cannot be READ is a refusal of its own rather than a
staleness verdict.

## Both control arms — the verification, not a green tick

| arm | expectation | result |
|---|---|---|
| image rebuilt after the move (genuinely stale) | RED, naming the entry | `exit=70`, `FATAL — --superseded-image-assembly 'Legacy.Home': STALE …` |
| image one wave behind (entry needed) | quiet, build green | `exit=0`, `'Legacy.Home' is still needed — … 1 of which this repository also declares (e.g. Moved.Thing)` |
| narrowed run: owner module not compiled, but in the tree | quiet | `exit=0`, still needed |
| moved Razor view keeping its namespace via `@namespace` | quiet | `exit=0`, names `Legacy.Blazor.Views.Panel` |
| same tree with the directive removed (control for the above) | RED | `STALE` |
| no entry at all against the rebuilt image | green | `exit=0` — the drop really was unnecessary |

**Mutation probe** (a verification step that cannot fail is not a verification step): with the
`throw` disabled, **exactly one** test fails — the stale arm — and the other eight pass. The check is
load-bearing and fires nowhere else.

Also exercised directly on the CLI (`mw-plugin-test build-project … --superseded-image-assembly
Legacy.Home`) across all three arms above, not only through the suite.

**Cost, measured** over core's `src/`: 1249 files, 2028 top-level type names, **1.76 s**, with
`bin`/`obj`/`.git` never descended into — and paid only on the runs that pass the option at all.
The build narrates file count, name count and elapsed time, so a tree that makes it expensive says
so rather than merely being slow.

## Local verification

- `dotnet build -c Release -warnaserror` — `MeshWeaver.PluginTester`, `MeshWeaver.PluginTester.Test`,
  `MeshWeaver.Documentation.Test`: `0 Warning(s) 0 Error(s)` each.
- `MeshWeaver.PluginTester.Test`: **331/331** pass (12 in `SupersededImageAssemblyTest`).
- `MeshWeaver.Documentation.Test`: **246/246** pass (doc-link integrity + the two pack-lane guards).
- `check-workflow-timeouts.py`: 64 jobs, 0 violations. `check-record-signatures.py`,
  `check-type-forwards.py`: clean.

## Notes

- **No What's New entry**: pure-internal CI/build tooling with no user-visible effect on the portal
  (the skill's stated skip case) — recorded here deliberately.
- Doc updated in the same change set:
  `Doc/Architecture/ModuleBuildArchitecture` → *"Moving a type OUT of an image-shipped assembly into
  a module"*, whose ⏳ *Known gap* paragraph is replaced by the mechanism, the two load-bearing
  decisions and the measurement. The pack lane's `superseded-image-assemblies` input description now
  documents four refusals instead of three (and loses a duplicated `default: ''` key).
- `Pairs-with: none` — nothing public is removed from `src/`; the only `src/` change is a markdown
  doc page.

Closes #3223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
