### PR TITLE
SUPERSEDED was defined on a step that never reads it — unbound variable for every caller that passes it

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -639,7 +639,6 @@ jobs:
           COUNT: ${{ steps.scope.outputs.count }}
           PUBLISH: ${{ inputs.publish }}
           TESTER_DIGEST: ${{ inputs.tester-image-digest }}
-          SUPERSEDED: ${{ inputs.superseded-image-assemblies }}
           PLATFORM_DIGEST: ${{ inputs.platform-image-digest }}
           PLATFORM_REF: ${{ inputs.platform-ref }}
         run: |
@@ -949,6 +948,7 @@ jobs:
           DIGEST: ${{ inputs.platform-image-digest }}
           TESTER_IMAGE: ${{ inputs.tester-image }}
           TESTER_DIGEST: ${{ inputs.tester-image-digest }}
+          SUPERSEDED: ${{ inputs.superseded-image-assemblies }}
           ACR_USERNAME: ${{ secrets.acr-username }}
           ACR_PASSWORD: ${{ secrets.acr-password }}
         run: |


### PR DESCRIPTION
## What breaks

#3225 put `SUPERSEDED: ${{ inputs.superseded-image-assemblies }}` after the **first** `TESTER_DIGEST:`
in the file. That one belongs to **`Consult the module build ledger`**. The shell that expands it
lives in **`Build every selected container entry in ONE workspace`**, ~370 lines later. Under
`set -euo pipefail`:

```
/home/runner/work/_temp/….sh: line 58: SUPERSEDED: unbound variable
##[error]Process completed with exit code 1.
```

MeshWeaver.Plugins#1268 run
[33781148173](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/33781148173), job
`Module bundles / Build the workspace (one global build)`.

🚨 **It fails only for callers that PASS the input** — so core, which calls none of its own lanes,
could never have seen it, and #3225's tests (which drive `ProjectBuild` directly, not the workflow)
could not either. The first consumer is the first detector, again.

## The fix

Move the definition onto the step that reads it. One line moved, nothing else.

## 🚨 Second instance of ONE root cause in this change set

Both defects in #3225 are the same mistake: **I anchored a YAML insertion on a string that occurs
several times and took the first.**

- #3226: the insertion landed between `always-modules:`'s `required:` and its `default:`, splitting
  the block (duplicate key ⇒ `startup_failure`, 0 jobs).
- this one: the insertion landed in the wrong step entirely (unbound variable).

Care is not the cure; an assertion is. This commit's verification **parses the step boundaries** and
asserts the definition and the use resolve to the same step, instead of reading line numbers:

```
definition step: - name: Build every selected container entry in ONE workspace
use step       : - name: Build every selected container entry in ONE workspace
✓ same step — the unbound-variable failure cannot recur
```

`actionlint` clean. (It does not catch this one — an env var defined on the wrong step is valid
YAML and a valid workflow; only running it, or an assertion like the above, finds it. Worth knowing
when weighing #3228.)

Pairs-with: none — core lane fix; MeshWeaver.Plugins#1268 is the only caller passing the input.
No What's New — internal CI fix.
