### PR TITLE
fix(#3211): a module bundle that cannot state what it was built against is unpublishable

### DIFF
--- a/.github/scripts/module-build-key.py
+++ b/.github/scripts/module-build-key.py
@@ -68,7 +68,12 @@ from pathlib import Path
 # 🚨 Bump this when the LANE changes in a way that alters the bytes it packs or the verdict it
 # records for the SAME source (a packer flag, a new closure rule, a different test invocation).
 # Never for a cosmetic lane edit — that would throw away every recorded build for nothing.
-RECIPE_VERSION = "1"
+# "1" → "2" (MeshWeaver#3211): the pack step now passes `--graph-dll <platform /app anchor>`, so a
+# bundle's manifest carries `frameworkMvid` where it used to omit it. The bytes for the SAME source
+# genuinely differ — and a REUSED pre-#3211 bundle would be refused at the publish step, which is the
+# right verdict for those bytes and the wrong thing to spend a run discovering. One rebuild wave, and
+# every recorded key afterwards attests bytes that state what they were built against.
+RECIPE_VERSION = "2"
 
 # Repo-level files that change what EVERY project compiles or tests. Presence and content both
 # count; a file the repo does not have hashes as null so adding it later changes the key.
@@ -360,7 +365,11 @@ def self_test() -> int:
         for label, kwargs in (("the tester digest", dict(tester_digest="sha256:t2")),
                               ("the platform digest", dict(platform_digest="sha256:p2")),
                               ("the platform ref", dict(platform_ref="def456")),
-                              ("the recipe version", dict(recipe="2"))):
+                              # 🚨 DERIVED from the live default, never a literal: this case read
+                              # `recipe="2"` and silently became a no-op assertion the moment the
+                              # lane bumped RECIPE_VERSION to "2" (MeshWeaver#3211) — a guard whose
+                              # subject moved and whose root did not passes having checked nothing.
+                              ("the recipe version", dict(recipe=RECIPE_VERSION + "-other"))):
             args = dict(tester_digest="sha256:t", platform_digest="sha256:p", platform_ref="abc123")
             args.update(kwargs)
             check(f"{label} changes the key", compute(root, _ENTRY, **args)["key"] != k0)

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1646,6 +1646,12 @@ jobs:
           MODULE: ${{ matrix.entry.module }}
           VERSION: ${{ steps.identity.outputs.version }}
           FLOOR: ${{ steps.identity.outputs.floor }}
+          # 🚨 THE IDENTITY ANCHOR'S HOME — the SAME expression the build step uses, so the anchor
+          # named below and the reference set the bytes were compiled against cannot be two
+          # different things. When a platform image is pinned, `platform-refs` is a `docker cp` of
+          # its /app, which the sdk build passes as `-p:MeshWeaverRefs=$REFS` and the container
+          # build compiles inside; when none is, it is empty and the platform came from source.
+          REFS: ${{ inputs.platform-image-digest != '' && format('{0}/platform-refs', runner.temp) || '' }}
         run: |
           set -euo pipefail
           # 🚨 The closure flags come from the COMPILER THAT RAN, written to a file by the step
@@ -1654,6 +1660,34 @@ jobs:
           # emitted (--with). Re-deriving here would be a second opinion about what ships.
           closure=()
           while IFS= read -r flag; do closure+=("$flag"); done < "$RUNNER_TEMP/pack-args"
+          # ───────── WHAT THIS BUNDLE WAS BUILT AGAINST, STATED — never omitted (#3211) ─────────
+          # Measured on MeshWeaver.Plugins run 33773265959 (2026-09-03): all 34 bundles packed
+          # "built-against MVID (unrecorded)", sdk and container alike, so #3154's
+          # (version, identity) comparison shipped with nothing to compare on every installation in
+          # the fleet. The cause is WHERE the anchor is, and it moves with the platform:
+          #
+          #   * platform pinned as an IMAGE (`REFS` = the docker cp of its /app, which the sdk build
+          #     passes as MeshWeaverRefs and the container build compiles inside) — the anchor is in
+          #     there, and the module's own output deliberately carries no platform assembly. This
+          #     is every satellite call, and it is the case the packer's default probe cannot see.
+          #   * platform built from SOURCE (`REFS` empty — core's own main-cd call) — the platform
+          #     ProjectReferences are real, so MeshWeaver.Compiler.dll IS beside the module in the
+          #     publish output. Measured green on CD run 33779812466:
+          #     "built-against MVID ce81fd4e3f5146c7a6ebaa6dc72da3f2".
+          #
+          # Both arms end in a RED with no anchor — neither is a quiet fallback, and the packer
+          # refuses again behind them, so a bundle whose identity is a guess cannot exist.
+          if [ -n "$REFS" ]; then
+            anchor="$REFS/MeshWeaver.Compiler.dll"
+            where="the pinned platform image's extracted /app"
+          else
+            anchor="$PACKDIR/MeshWeaver.Compiler.dll"
+            where="the module's own build output (no platform image is pinned, so the platform was built from source)"
+          fi
+          if [ ! -f "$anchor" ]; then
+            echo "::error::no identity anchor for $MODULE — expected MeshWeaver.Compiler.dll at '$anchor', i.e. in $where. Every bundle must state the framework build its bytes were compiled against (#3211): a consumer compares it against what it has landed, and an unstated one makes every reconcile answer 'up to date, identity could not be checked' forever. Nothing here may guess it, so the pack stops."
+            exit 1
+          fi
           echo "packing $MODULE from $PACKDIR (compiler: $COMPILER); closure flags: ${closure[*]:-<none>}"
           dotnet "$RUNNER_TEMP/pack-tool/MeshWeaver.Plugin.Build.dll" \
             module-pack "$PACKDIR" \
@@ -1662,6 +1696,7 @@ jobs:
             --plugin "$PACKAGE" \
             --package-version "$VERSION" \
             --min-mesh-version "$FLOOR" \
+            --graph-dll "$anchor" \
             --own-platform "$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src")" \
             --out "$RUNNER_TEMP/bundles"
 
@@ -1695,6 +1730,14 @@ jobs:
             || { echo "::error::manifest module.assemblies misses the entry DLL"; exit 1; }
           jq -e --arg f "$FLOOR" '.module.minMeshVersion == $f' "$manifest" > /dev/null \
             || { echo "::error::manifest floor differs from content.minMeshVersion"; exit 1; }
+          # 🚨 THE BUILT-AGAINST IDENTITY, ASSERTED ON THE BYTES — not inferred from the packer's
+          # exit code (#3211). The packer refuses to omit it, so this reads the artifact back and
+          # says so: a manifest with no `frameworkMvid` is a bundle whose consumers can never tell
+          # a rebuild against a new platform from a no-op (#3154's comparison with nothing to
+          # compare), and it must never leave this job.
+          jq -e '(.frameworkMvid // "") | test("^\\S+$")' "$manifest" > /dev/null \
+            || { echo "::error::the bundle states no framework identity (manifest .frameworkMvid is $(jq -c '.frameworkMvid' "$manifest")). It was built against SOMETHING; a bundle that cannot say what parks every consumer in 'up to date, identity could not be checked' forever (#3211). The pack step names the anchor — this manifest did not get it."; exit 1; }
+          echo "built against: $(jq -r '.frameworkMvid' "$manifest")"
           # A module bundle must NEVER carry a PLATFORM assembly beside its entry — it would
           # shadow the platform's own binary at the consumer (the same trap-door landing refuses
           # for the entry DLL). MODULE-OWNED MeshWeaver.* assemblies (their source lives in THIS
@@ -1967,6 +2010,32 @@ jobs:
             echo "::error::publish was requested but no publish-token secret was provided — the registry would never receive $MODULE, and this job would have reported success"
             exit 1
           fi
+          # ───────── THE PUBLISH-SIDE GATE: a bundle that states no framework identity is
+          # ───────── UNPUBLISHABLE (#3211, part 3 of Plugins#931)
+          # 🚨 HERE, on the bytes about to be POSTed, and NOT only in the inspection above — the
+          # inspection runs on the BUILD leg alone, and the reuse leg hands over an artifact an
+          # earlier run packed, which may predate the packer that refuses to omit the field. This
+          # step is the one every published byte passes through, so this is where the refusal binds.
+          #
+          # Why it must be a refusal and not a warning: the registry shelves what arrives
+          # (ModulePublish.Accepted.FrameworkMvid -> ShelveModule) and advertises it per bundle on
+          # /api/plugins/bundles/index.json. A null there is not "unknown for now" — a registry that
+          # states no identity states none next time either, so ModuleUpdateDecision (#3154) answers
+          # SkipUpToDate-and-say-so for that module on every reconcile of every installation,
+          # forever. Unlike an unknown on the LANDED side, one fetch cannot heal it. Publishing such
+          # a bundle is therefore not a smaller good than refusing: it is the defect.
+          # Neither the exit status nor unzip's own stderr is swallowed: "could not check" must
+          # never render as "checked", and the log has to say WHY it could not.
+          if ! manifest_json="$(unzip -p "$BUNDLE" meshweaver/manifest.json)" || [ -z "$manifest_json" ]; then
+            echo "::error::cannot read meshweaver/manifest.json out of $BUNDLE (see unzip's message above) — refusing to publish bytes whose manifest this lane could not check (#3211)"
+            exit 1
+          fi
+          identity="$(printf '%s' "$manifest_json" | jq -r '.frameworkMvid // ""' | tr -d '[:space:]')"
+          if [ -z "$identity" ]; then
+            echo "::error::REFUSING to publish $MODULE@$VERSION — the bundle states no framework identity (manifest .frameworkMvid is $(printf '%s' "$manifest_json" | jq -c '.frameworkMvid')). The registry would shelve a null and advertise a null, and every consumer of this module would answer 'already landed — the identity could not be checked' on every reconcile, forever (#3154). A rebuild of unchanged source against a new platform republishes under the SAME version, so the identity is the only thing that tells that rebuild from a no-op. Repack with the platform's MeshWeaver.Compiler.dll as --graph-dll (or state it with --framework-mvid); if these bytes were REUSED from an earlier run, that run packed them before the identity was recorded — rebuild them."
+            exit 1
+          fi
+          echo "publishing $MODULE@$VERSION, built against $identity"
           code=$(curl -sS -o "$RUNNER_TEMP/publish-$MODULE.json" -w '%{http_code}' \
             -X POST "$REGISTRY/api/plugins/bundles/$PACKAGE?version=$VERSION&packagePath=$REGISTRY_SOURCE/$PACKAGE" \
             -H "Authorization: Bearer $TOKEN" \

--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -464,6 +464,24 @@ public static class PluginBundleEndpoints
                     return Results.Json(new { error = decline }, statusCode: StatusCodes.Status400BadRequest);
                 }
 
+                // 🚨 #3211 — the arming signal for the LAST refusal, named per publisher.
+                // A bundle stating no framework identity shelves a null, the index advertises a
+                // null, and ModuleUpdateDecision (#3154) then answers "already landed — the
+                // identity could not be checked" for this module on every reconcile of every
+                // installation, forever: an unknown on the SERVED side is the one landing cannot
+                // heal. The producer's own lane already refuses to pack or POST such a bundle, so
+                // reaching here means a publisher on a pin older than #3211. This line is what says
+                // WHICH — the measurement the registry-side 400 waits on, rather than a refusal
+                // armed on faith that would take the fleet's publishes down with it.
+                if (string.IsNullOrWhiteSpace(accepted.FrameworkMvid))
+                    logger?.LogWarning(
+                        "Module publish for {Plugin}: '{Module}' version {Version} states NO "
+                        + "framework identity, so it shelves a null and every consumer of it will "
+                        + "answer 'up to date — identity could not be checked' on every reconcile "
+                        + "(#3154). Its producer packs on a lane older than MeshWeaver#3211; bump "
+                        + "that repo's node-repo-module-pack.yml pin. This becomes a 400.",
+                        plugin, accepted.Module, accepted.Version ?? "(unversioned)");
+
                 ModuleLandingOutcome outcome;
                 try
                 {

--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -179,9 +179,12 @@ public static class MemexConfiguration
             // minMeshVersion FLOOR the running platform no longer satisfies (a rollback below the
             // module's requirement) or a missing DLL SKIPS the entry with a loud stderr line —
             // never a crash, the deployment must boot; the entry stays for when the platform
-            // moves forward again. A landed module's built-against MVID is diagnostic only:
-            // modules bind by simple name across platform builds (the strict MVID gate is the
-            // NodeType bake lane's). Pre-DI, so diagnostics go to stderr (pod stdout/stderr ship
+            // moves forward again. A landed module's built-against framework identity is not a
+            // LOAD gate HERE — modules bind by simple name across platform builds, and the strict
+            // identity gate is the NodeType bake lane's. (It is not merely diagnostic either, since
+            // #3154: ModuleUpdateDecision compares it to tell a rebuild from a no-op, and #3211
+            // makes a bundle that states none unpublishable. That is the UPDATE question, not this
+            // one.) Pre-DI, so diagnostics go to stderr (pod stdout/stderr ship
             // to Loki regardless).
             var moduleAssemblies = configuration.GetSection("Modules:Assemblies").Get<string[]>();
             // 🚨 The SAME root ModuleLandingService writes (ModuleRoot) — never

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -192,7 +192,7 @@ identity, and `ShelveModule` shelves the null the index then advertises. Arming 
 every producer's `node-repo-module-pack.yml` pin has moved would take the fleet's publishes down
 rather than the nulls — the pin is bumped deliberately, per repo, in its own PR. Until then the
 publish endpoint logs a warning naming the package, the module and the version, which is the
-measurement the arming step reads.
+measurement the arming step reads. The criterion and the two repos it waits on are #3240.
 
 ## Content-addressed outputs = the module build ledger (as built, 2026-09-02)
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -181,6 +181,18 @@ heals: a registry that states no identity will state none next time either.
 | pack step | names the anchor explicitly (`--graph-dll`), picking the location from the table above — and **both** arms are RED when the anchor is not there. The branch decides *where to look*, never *whether to check*. The manifest is then read back and the field asserted on the bytes |
 | **publish step** | RED before the POST when the bundle's manifest states none — on the bytes about to be handed over, so the **reuse** leg (an artifact an earlier run packed) is covered too |
 
+**Which identity string lands in the manifest — and why it need not be the portal's.** The packer
+reads the anchor with `FrameworkIdentity.ReadIdentity`, which sees only what is IN the assembly: the
+stamped `MeshWeaverFrameworkIdentity` (`g<sha>` on every CI build) or, failing that, its MVID. It
+cannot see a **surface manifest**, so it never answers the `s<hash>` a portal resolves for itself.
+That is fine, because nothing compares a module bundle's value to a live process: `LandFromBundle`
+only *records* it, and `ModuleUpdateDecision` compares **served against landed** — both the
+producer's own string, so they converge after one landing whatever the flavour. It is also the
+finer discriminator of the two: `s<hash>` is breaking-change-keyed and holds still across many
+platform commits, while `g<sha>` moves with every one — and "the platform this module was compiled
+against moved" is exactly the question being asked. (The `DeclineReason` identity gate lives on the
+*bake* bundle path, `BundleReader.Read`/`SeedAll`, and never sees this value.)
+
 The publish-step refusal is the load-bearing one: the inspection runs on the build leg only, and a
 guard bound to it alone would pass while pre-#3211 bytes went to the registry. `RECIPE_VERSION`
 moved `1` → `2` in `module-build-key.py` for the same reason — the lane now packs different bytes

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -139,6 +139,61 @@ selected modules beside them, so "emitted but not selected" is normal and is not
 opens, and assert them where they are produced. One accurate failure upstream is worth N accurate
 failures downstream, and a downstream failure can only ever describe its own shard.
 
+## A bundle states what it was built against — or it is not published (#3211)
+
+A module's published version encodes its **content only**. Rebuild unchanged source against a new
+platform and the hash is the same, the version is the same, and the bundle overwrites its own
+registry slot with different bytes. So "already landed" can only mean *this content against this
+framework*, which is why `ModuleUpdateDecision.Decide` compares **(version, framework identity)**
+before answering `SkipUpToDate` (#3154, `Doc/Architecture/Modules`).
+
+That comparison needs something to compare, and the producing end was not supplying it.
+
+**Measured, MeshWeaver.Plugins run 33773265959 (2026-09-03):** every one of the 34 bundles packed
+
+```
+warning: MeshWeaver.Compiler.dll not found at …/MeshWeaver.AI.OpenAI/MeshWeaver.Compiler.dll
+packed MeshWeaver.Plugin.OpenAI.1.1.11.module.nupkg — … built-against MVID (unrecorded)
+```
+
+on **both** compilers. The packer probes for the identity anchor *beside the module*, and where the
+anchor is **moves with the platform**:
+
+| how the platform arrives | where `MeshWeaver.Compiler.dll` is |
+|---|---|
+| pinned **image** (every satellite call) — `platform-refs`, the `docker cp` of its `/app`, passed to the sdk build as `MeshWeaverRefs` and compiled inside by the container build | in `platform-refs`; deliberately **not** in the module's output, which carries no platform assembly |
+| built from **source** (core's own `main-cd` call, no image pinned) | beside the module — the platform ProjectReferences are real, so `dotnet publish` copies it |
+
+Only the second case ever matched the default probe, which is why core CD records an identity
+(measured: `built-against MVID ce81fd4e…`, run 33779812466) and every satellite records none. The
+field was optional, so nothing was red; #3154 shipped into a fleet where every consumer of every
+module was permanently in the "up to date — the identity could not be checked" branch.
+
+The asymmetry is why this had to be fixed at the producer. An unknown on the **landed** side heals
+after one fetch, because landing writes the identity back. An unknown on the **served** side never
+heals: a registry that states no identity will state none next time either.
+
+**Three refusals, all naming what is missing:**
+
+| where | what it refuses |
+|---|---|
+| `module-pack` (`ModulePackCommand`) | exit 2 when neither `--framework-mvid` nor `--graph-dll` yields an identity — the bundle is not written at all |
+| pack step | names the anchor explicitly (`--graph-dll`), picking the location from the table above — and **both** arms are RED when the anchor is not there. The branch decides *where to look*, never *whether to check*. The manifest is then read back and the field asserted on the bytes |
+| **publish step** | RED before the POST when the bundle's manifest states none — on the bytes about to be handed over, so the **reuse** leg (an artifact an earlier run packed) is covered too |
+
+The publish-step refusal is the load-bearing one: the inspection runs on the build leg only, and a
+guard bound to it alone would pass while pre-#3211 bytes went to the registry. `RECIPE_VERSION`
+moved `1` → `2` in `module-build-key.py` for the same reason — the lane now packs different bytes
+for the same source, so every recorded key is invalidated and no run reuses a bundle whose publish
+would be refused.
+
+**Still to arm: the registry's own 400.** `ModulePublish.Validate` accepts a manifest stating no
+identity, and `ShelveModule` shelves the null the index then advertises. Arming that refusal before
+every producer's `node-repo-module-pack.yml` pin has moved would take the fleet's publishes down
+rather than the nulls — the pin is bumped deliberately, per repo, in its own PR. Until then the
+publish endpoint logs a warning naming the package, the module and the version, which is the
+measurement the arming step reads.
+
 ## Content-addressed outputs = the module build ledger (as built, 2026-09-02)
 
 *"For Plugins, merge as quickly as possible, as tolerant as possible; only hard conflicts flagged. We
@@ -586,9 +641,12 @@ producer of the same publication and is removed — a follow-up, not part of thi
 * **The one-workspace lane** — landed: one `build-workspace` job compiles the ledger's build subset
   as one graph; pack/tests fan out from it. The consumer half of #931 landed too —
   `ModuleUpdateDecision` compares the served bundle's framework identity, not the version alone.
-  Still open: making a bundle that cannot state what it was built against UNPUBLISHABLE (a served
-  identity is optional today, so a consumer can only skip-and-say-so when it is missing), and
-  pinning satellites' `MW_PLATFORM_REF` to the promoted set so keys survive core commits.
+  The producer half landed with #3211 — a bundle that cannot state what it was built against is
+  refused at the packer, at the pack step and at the hand-over (see *A bundle states what it was
+  built against — or it is not published*, above). Still open:
+  arming the registry's own 400 in `ModulePublish.Validate`, which waits on every producer's lane
+  pin having moved; and pinning satellites' `MW_PLATFORM_REF` to the promoted set so keys survive
+  core commits.
 * **`pack-module`, `compile-check` and test verbs inside the tester** — the last runner-side
   `dotnet`/python uses move into the image the fleet already ships.
 * **Self-hosted runners with a mounted git mirror + warm image store** (MeshWeaver#2926): bare

--- a/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/Modules.md
@@ -127,9 +127,10 @@ folder is deleted, and the change likewise takes effect at restart.
   The gate is `ModulePlatformFloor.DeclineReason` — the ONE notion of the module platform
   requirement, shared with landing and serving. Deliberately a **semver floor, never MVID
   equality**: a module is a plain assembly binding by simple name, so a landed module keeps
-  loading across ordinary platform updates; the MVID it was built with is recorded on the entry
-  as diagnostics only (MVID equality is bake semantics and belongs to the NodeType assembly
-  lane).
+  loading across ordinary platform updates; MVID equality is bake semantics and belongs to the
+  NodeType assembly lane. The identity it was built with, recorded on the entry, is never a
+  LANDING gate — it answers the separate question of whether there is anything new to land
+  ("Already landed" means this content against this FRAMEWORK, below).
 - **Missing DLL** — the entry's `modules/<name>/<name>.dll` does not exist (lost volume, manual
   deletion). Skipped loudly; re-install to heal. The check is that path SPECIFICALLY — a
   same-named DLL in the app closure never satisfies a store-installed entry (the
@@ -518,9 +519,11 @@ transport end to end — there is deliberately no second distribution channel:
    carries them onto the record. A package with content nodes AND a module is one Store product —
    card, price, install funnel, pre-install eligibility all unchanged.
 2. **Build** — `MeshWeaver.Plugin.Build`'s `module-pack` mode packs a built module's closure into
-   a bundle recording the `minMeshVersion` floor (`--min-mesh-version`) and, as diagnostics, the
-   MVID of the identity anchor (`MeshWeaver.Compiler.dll`, #1707) in the build output. It is a
-   plain dotnet invocation over
+   a bundle recording the `minMeshVersion` floor (`--min-mesh-version`) and — **required, not
+   diagnostic, since #3211** — the identity of the anchor assembly the module was compiled against
+   (`MeshWeaver.Compiler.dll`, #1707), named with `--graph-dll` or stated with `--framework-mvid`.
+   A pack that can supply neither exits 2 rather than writing a bundle whose consumers can never
+   tell a rebuild from a no-op. It is a plain dotnet invocation over
    an output folder, so ANY node repo's CI can drive it — SocialMedia builds its own module
    bundle the same way the platform repo does — and because the gate is the floor, ONE bundle
    serves every compatible platform build: nothing is rebundled per CI build. The closure is an
@@ -586,8 +589,14 @@ download loop:**
 
 The remaining blind spot (a registry that states no identity) is closed **where it is created**, not
 by churning consumers: a bundle that cannot say what it was built against must not be publishable.
-See [Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture) → "Content-addressed outputs" for the
-producer half.
+That is #3211, and it matters more than it sounds — measured on MeshWeaver.Plugins run 33773265959
+(2026-09-03), **all 34 bundles** packed `built-against MVID (unrecorded)`, so on the day the
+comparison shipped it had nothing to compare anywhere in the fleet. The producing lane now refuses
+three times over: `module-pack` will not write a bundle with no identity, the pack step names the
+anchor assembly explicitly and is RED when it is not there, and the **hand-over refuses to POST**
+bytes whose manifest states none. See
+[Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture) → "A bundle states what it
+was built against" for the producer half.
 
 The policy gate is the deployment's **existing update policy — `Admin/UpdatePolicy`**, the same
 single surface that governs the platform image roll; there is no module-specific knob.

--- a/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PluginPackaging.md
@@ -200,17 +200,27 @@ so only the identical build is known-good. A module is an ordinary assembly bind
 name**; its contract is API compatibility, which the semver floor expresses. So the consumer lands
 any bundle whose floor its platform satisfies — one bundle serves every compatible platform build
 (nothing is rebundled per CI build), and a module can be installed **ex post** onto a platform
-newer than the one it was built with. The bundle still records its built-against `frameworkMvid`
-as **diagnostic metadata** — logged at landing, surfaced in the index — never a refusal. The one
-gate is `ModulePlatformFloor.DeclineReason`, applied at the index, at the manifest, at placement,
-and again at boot.
+newer than the one it was built with.
 
-Producing a module bundle in CI — from any node repo:
+🚨 The bundle's built-against `frameworkMvid` is **not** diagnostic and is **not optional** — it
+stopped being either when the update decision started reading it (#3154) and #3211 made a bundle
+that cannot state one unpublishable. It is still never a LANDING refusal: the one landing gate is
+`ModulePlatformFloor.DeclineReason`, applied at the index, at the manifest, at placement and again
+at boot. What it decides is whether there is anything new to land — see
+[Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture) → "A bundle states what it was
+built against".
+
+Producing a module bundle in CI — from any node repo. **One of `--graph-dll` (the identity anchor
+assembly of the platform these bytes were compiled against — `MeshWeaver.Compiler.dll`, which on the
+image path lives in the extracted `/app`, not beside the module) or `--framework-mvid` (that
+identity, stated directly) is required; without one the packer exits 2 rather than writing a bundle
+whose consumers can never tell a rebuild from a no-op:**
 
 ```
 dotnet run --project src/MeshWeaver.Plugin.Build -- module-pack ./bin/Release/net10.0 \
     --module-name MeshWeaver.Social --plugin SocialMedia --package-version 1.2.0 \
-    --min-mesh-version 3.0.0 --out ./artifacts/bundles
+    --min-mesh-version 3.0.0 --graph-dll /app/MeshWeaver.Compiler.dll \
+    --out ./artifacts/bundles
 ```
 
 The closure is an explicit statement: `<name>.dll` (+ `.pdb`), plus only the files named with

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-every-module-now-says-which-platform-built-it.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-every-module-now-says-which-platform-built-it.md
@@ -1,0 +1,45 @@
+---
+Name: Every module now says which platform build made it
+Category: Fix
+Description: Module bundles were shipping without recording the platform build behind their bytes, so the update check that compares it had nothing to compare and every module answered "already up to date". Bundles now state it, and one that cannot is refused instead of published.
+Icon: ArrowSync
+Order: -20260903
+---
+
+# Every module now says which platform build made it
+
+A module's version describes its **source**, so a rebuild of unchanged source against a new
+platform publishes again under the same version. The update check was taught to see through that: it
+compares the platform build the bytes were made against, not the version alone, so a genuine rebuild
+reaches your installation instead of being skipped as a no-op.
+
+It compares a value the bundles were not carrying.
+
+Every bundle the fleet published — all thirty-four of them, on both build paths — recorded
+`built-against MVID (unrecorded)`. The packer looked for the platform's identity file *next to the
+module*, and modules are no longer built that way: the platform is a container image, so the file
+sits in the image, not beside the module's output. Nothing was red, because the field was optional.
+The result was an update check that could only ever answer "already up to date — but the platform
+build could not be checked", for every module, on every installation.
+
+Two things change:
+
+- **The bundle states it.** The build lane hands the packer the exact platform assemblies the module
+  was compiled against, and that build's identity is written into the bundle.
+- **A bundle that cannot state it is not published.** The packer refuses to write one, the build
+  step refuses to pack without naming the platform, and — the one that matters — the hand-over to
+  the registry refuses to upload bytes whose manifest is silent about it. Each failure says what is
+  missing and how to supply it.
+
+The reason for refusing rather than publishing-and-warning is that this particular unknown cannot be
+repaired later. An installation that does not yet know what it landed learns it the next time it
+fetches. A registry serving a bundle that never said what it was built against will not say next
+time either — so every installation pointed at it stays in "could not be checked" indefinitely.
+
+Nothing about *which* modules may be installed changed: the platform floor is still the only gate on
+whether a bundle can land.
+
+Where the design decisions live:
+[Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture) → "A bundle states what it was
+built against", and [Modules](/Doc/Architecture/Modules) → "Already landed means this content against
+this FRAMEWORK".

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -25,14 +25,22 @@ namespace MeshWeaver.Plugin.Build;
 /// <c>.pdb</c> when present) plus ONLY the files the caller names with <c>--with</c> — mirroring
 /// the modules/&lt;Name&gt;/ layout rule that for most modules the DLL alone is the closure.</para>
 ///
-/// <para><b>The consumer's gate is the <c>minMeshVersion</c> FLOOR, not an MVID.</b> A module is a
-/// plain assembly binding by simple name; its contract is API compatibility, so the bundle records
-/// the platform floor the module requires (absent = no constraint) and the consumer lands anything
-/// whose floor it satisfies — one bundle serves every compatible platform build, and nothing needs
-/// rebundling per CI build. The MVID of the identity anchor
-/// (<c>MeshWeaver.Compiler.dll</c>, #1707) in the build output is still recorded when found, as
-/// DIAGNOSTIC metadata naming the exact build behind the bytes; MVID equality remains the
-/// NodeType (bake) lane's gate only.</para>
+/// <para><b>The consumer's LANDING gate is the <c>minMeshVersion</c> FLOOR, not an MVID.</b> A
+/// module is a plain assembly binding by simple name; its contract is API compatibility, so the
+/// bundle records the platform floor the module requires (absent = no constraint) and the consumer
+/// lands anything whose floor it satisfies — one bundle serves every compatible platform build, and
+/// nothing needs rebundling per CI build. MVID equality is still never a landing gate here.</para>
+///
+/// <para>🚨 <b>But the framework identity is REQUIRED, and a bundle that cannot state one is not
+/// written at all</b> (#3211). It stopped being diagnostic the moment #3154 merged: a module's
+/// version encodes its CONTENT only, so a rebuild of unchanged source against a new platform
+/// republishes under the SAME version, and <c>ModuleUpdateDecision.Decide</c> now compares
+/// <b>(version, framework identity)</b> to tell that rebuild from a no-op. A bundle stating no
+/// identity puts every consumer of it permanently in the skip-and-say-so branch — the comparison
+/// exists with nothing to compare, which is Plugins#931 arriving from the producing end. So the
+/// identity of the anchor assembly (<c>MeshWeaver.Compiler.dll</c>, #1707) is resolved from
+/// <c>--framework-mvid</c> or <c>--graph-dll</c>, and its absence is an exit-2 naming both, where
+/// it used to be a warning and an omitted field.</para>
 /// </summary>
 public static class ModulePackCommand
 {
@@ -131,10 +139,21 @@ public static class ModulePackCommand
                   --graph-dll <path>          the identity-anchor assembly the module was built
                                               against — MeshWeaver.Compiler.dll since #1707
                                               (default: <moduleOutputDir>/MeshWeaver.Compiler.dll;
-                                              the flag name predates the anchor move). Its MVID is
-                                              recorded as DIAGNOSTIC metadata — the exact build
-                                              behind the bytes — never a gate; a missing DLL warns
-                                              and records none
+                                              the flag name predates the anchor move). Its stamped
+                                              identity (else MVID) becomes the bundle's
+                                              frameworkMvid
+                  --framework-mvid <id>       state the built-against framework identity DIRECTLY,
+                                              for a build whose anchor assembly is not in the
+                                              output folder (the container/MeshWeaverRefs lanes:
+                                              the platform is the IMAGE, so the anchor is in the
+                                              extracted /app, not beside the module). Wins over
+                                              --graph-dll when both are given.
+                                              🚨 ONE of these two must yield an identity: a bundle
+                                              that cannot state what it was built against is
+                                              REFUSED (exit 2), never written with the field
+                                              omitted — #3154 compares it on every consumer's
+                                              update decision, and an unstated one can never be
+                                              healed from the serving side (#3211)
                   --with <fileName>           an additional closure file from <moduleOutputDir>
                                               (repeatable). <name>.dll is always included, and its
                                               .pdb rides along when present.
@@ -169,6 +188,7 @@ public static class ModulePackCommand
         string? packageVersion = null;
         string? minMeshVersion = null;
         string? graphDll = null;
+        string? statedFrameworkMvid = null;
         var extras = new List<string>();
         var ownPlatform = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
         var depsClosure = false;
@@ -195,6 +215,9 @@ public static class ModulePackCommand
                     break;
                 case "--graph-dll" when i + 1 < args.Length:
                     graphDll = Path.GetFullPath(args[++i]);
+                    break;
+                case "--framework-mvid" when i + 1 < args.Length:
+                    statedFrameworkMvid = args[++i].Trim();
                     break;
                 case "--with" when i + 1 < args.Length:
                     extras.Add(args[++i]);
@@ -268,22 +291,49 @@ public static class ModulePackCommand
             return 2;
         }
 
-        // The framework identity is DIAGNOSTIC metadata (which exact platform build produced these
-        // bytes) — recorded when the restored identity-anchor DLL (MeshWeaver.Compiler.dll, #1707)
-        // is at hand, warned-and-omitted when not. It is deliberately not required and never a
-        // gate: the consumer lands on the minMeshVersion floor (API compatibility), and identity
-        // equality stays with the NodeType bake lane. ReadIdentity (not ReadMvid) so a CI-built
-        // anchor records its stamped commit identity — the value the runtime actually compares
-        // (#1660 WS3).
+        // ───────── THE BUILT-AGAINST FRAMEWORK IDENTITY — REQUIRED, and refused when absent ─────────
+        // 🚨 #3211. This used to be diagnostic-and-optional: a missing anchor warned and the field
+        // was omitted. #3154 made it an INPUT TO A DECISION on every installation — a module's
+        // version encodes content only, so a rebuild of unchanged source against a new platform
+        // republishes under the same version, and `ModuleUpdateDecision.Decide` now compares
+        // (version, framework identity) to tell that rebuild from a no-op. A bundle that states no
+        // identity parks every consumer of it in the skip-and-say-so branch FOREVER: unlike an
+        // unknown on the landed side, which one fetch heals, an unstated SERVED identity can never
+        // be healed downstream. So the blind spot is closed where it is created — a bundle that
+        // cannot say what it was built against is not written at all.
+        //
+        // Two ways to state it, because the anchor is not always beside the module: on the
+        // container / MeshWeaverRefs lanes the platform IS the image, so MeshWeaver.Compiler.dll
+        // lives in the extracted /app rather than in the module's output (measured on every one of
+        // MeshWeaver.Plugins' 34 bundles, 2026-09-03: "built-against MVID (unrecorded)", both the
+        // sdk and the container path). ReadIdentity (not ReadMvid) so a CI-built anchor records its
+        // stamped commit identity — the value the runtime actually compares (#1660 WS3).
         graphDll ??= Path.Combine(moduleDirectory, FrameworkIdentity.IdentityAssembly + ".dll");
-        string? frameworkMvid = null;
-        if (File.Exists(graphDll))
+        var frameworkMvid = statedFrameworkMvid;
+        if (string.IsNullOrWhiteSpace(frameworkMvid) && File.Exists(graphDll))
             frameworkMvid = FrameworkIdentity.ReadIdentity(graphDll);
-        else
+        if (string.IsNullOrWhiteSpace(frameworkMvid))
+        {
             Console.Error.WriteLine(
-                $"warning: {FrameworkIdentity.IdentityAssembly}.dll not found at {graphDll} — the "
-                + "bundle records no built-against framework MVID (diagnostic metadata only; the "
-                + "landing gate is --min-mesh-version).");
+                "error: the bundle would state no built-against framework identity, and a bundle "
+                + "that cannot say which platform build produced its bytes is not publishable "
+                + "(#3211). Every consumer compares it against what it has landed "
+                + "(ModuleUpdateDecision, #3154), and an unstated one can never be healed from the "
+                + "serving side — it makes every reconcile answer 'up to date, identity could not "
+                + "be checked'. Provide ONE of: --framework-mvid <identity> (the platform's own "
+                + "reading — use it when the platform is an IMAGE), or --graph-dll <path to "
+                + $"{FrameworkIdentity.IdentityAssembly}.dll> for the platform this module was "
+                + $"compiled against. Probed and not found: {graphDll}");
+            return 2;
+        }
+        if (frameworkMvid.Any(char.IsWhiteSpace))
+        {
+            Console.Error.WriteLine(
+                $"error: --framework-mvid '{frameworkMvid}' contains whitespace — the identity is a "
+                + "single token (s<hash>, g<sha> or a 32-hex MVID), and a value that has to be "
+                + "trimmed downstream is a value two readers can disagree about.");
+            return 2;
+        }
 
         // The closure: entry DLL (+ symbols when present) + the derived private dependency
         // closure when asked for + exactly the files the caller named.
@@ -442,8 +492,9 @@ public static class ModulePackCommand
             {
                 plugin,
                 version = packageVersion,
-                // Diagnostic: the exact platform build behind these bytes. The consumer's GATE is
-                // the module section's minMeshVersion floor below.
+                // The exact platform build behind these bytes — never null by the time we get here
+                // (#3211 refuses above). The consumer's LANDING gate is still the module section's
+                // minMeshVersion floor below; this is what its UPDATE decision compares (#3154).
                 frameworkMvid,
                 module = new { assemblyName = moduleName, assemblies = closure, minMeshVersion,
                     staticAssets = staticAssets.Count > 0 ? staticAssets : null,
@@ -499,7 +550,7 @@ public static class ModulePackCommand
             + $"{closure.Count} file(s), {contentFiles.Count} node file(s) "
             + $"({(includeSource ? "with" : "WITHOUT")} source), "
             + $"floor {minMeshVersion ?? "(none)"}, "
-            + $"built-against MVID {frameworkMvid ?? "(unrecorded)"}");
+            + $"built-against MVID {frameworkMvid}");
         return 0;
     }
 }

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -550,7 +550,12 @@ public static class ModulePackCommand
             + $"{closure.Count} file(s), {contentFiles.Count} node file(s) "
             + $"({(includeSource ? "with" : "WITHOUT")} source), "
             + $"floor {minMeshVersion ?? "(none)"}, "
-            + $"built-against MVID {frameworkMvid}");
+            // "framework", not "MVID": an MVID is only ONE of the three shapes FrameworkBuildIdentity
+            // resolves — a manifest-bearing host answers a surface identity `s<hash>`, a CI build
+            // answers its stamped commit identity `g<sha>`, and the anchor's raw MVID is the last
+            // fallback. A CI-packed bundle therefore almost never carries an MVID, and a log line
+            // calling it one sends the next reader looking for the wrong string.
+            + $"built against framework {frameworkMvid}");
         return 0;
     }
 }

--- a/src/MeshWeaver.PluginCatalog/ModulePublish.cs
+++ b/src/MeshWeaver.PluginCatalog/ModulePublish.cs
@@ -36,7 +36,26 @@ public static class ModulePublish
     /// <param name="Module">Entry-assembly name without extension — the <c>modules/&lt;name&gt;/</c> folder.</param>
     /// <param name="Version">The package version these bytes were packed at, recorded on the activation entry.</param>
     /// <param name="MinMeshVersion">The module's declared platform floor, re-checked at placement.</param>
-    /// <param name="FrameworkMvid">The framework build the producer compiled against — diagnostic only.</param>
+    /// <param name="FrameworkMvid">
+    /// The framework build the producer compiled against.
+    ///
+    /// <para>🚨 <b>NOT diagnostic</b> — that word was left here when #3154 merged and it is exactly
+    /// how an optional field stays optional. <c>ModuleUpdateDecision.Decide</c> reads this value
+    /// back (shelf → <c>ShelveModule</c> → the index's per-bundle <c>frameworkMvid</c>) and compares
+    /// <b>(version, framework identity)</b> on every installation's every reconcile: a module's
+    /// version encodes CONTENT only, so a rebuild of unchanged source against a new platform
+    /// republishes under the same version and the identity is the only thing that tells that
+    /// rebuild from a no-op.</para>
+    ///
+    /// <para>Null here is therefore a permanent skip-and-say-so for every consumer of the bundle —
+    /// an unknown on the SERVED side cannot be healed by landing, only an unknown on the landed
+    /// side can. #3211 closes that where it is created: the packer refuses to write a bundle that
+    /// states no identity (<c>module-pack</c> exit 2) and the module-pack lane refuses to POST one.
+    /// Arming the same refusal HERE — a named 400 out of <see cref="Validate"/> — is the last step,
+    /// and it waits on the fleet: measured 2026-09-03 on MeshWeaver.Plugins run 33773265959, all 34
+    /// bundles packed <c>built-against MVID (unrecorded)</c>, so a refusal armed before every
+    /// producer's pin has moved would take the fleet's publishes down rather than the null.</para>
+    /// </param>
     /// <param name="Files">The module's closure: file name + bytes, entry DLL included.</param>
     public sealed record Accepted(
         string Module,

--- a/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
@@ -1,0 +1,130 @@
+#pragma warning disable CS1591
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace MeshWeaver.Documentation.Test;
+
+/// <summary>
+/// Governance guard for the PUBLISH-SIDE refusal that makes a bundle stating no framework identity
+/// unpublishable (MeshWeaver#3211 — part 3 of Plugins#931;
+/// <c>Doc/Architecture/ModuleBuildArchitecture</c> → "A bundle states what it was built against").
+///
+/// <para><b>What went wrong, measured.</b> #3154 landed the consumer half:
+/// <c>ModuleUpdateDecision.Decide</c> compares <b>(version, framework identity)</b> before answering
+/// <c>SkipUpToDate</c>, because a module's version encodes CONTENT only — a rebuild of unchanged
+/// source against a new platform republishes under the SAME version, and without the identity the
+/// consumer cannot tell that rebuild from a no-op (Plugins#723: a portal held on an old image while
+/// the updater went quiet). It shipped into a fleet where NOTHING stated an identity: on
+/// MeshWeaver.Plugins run 33773265959 (2026-09-03) all 34 bundles packed
+/// <c>built-against MVID (unrecorded)</c>, sdk and container alike, because the packer probes for
+/// <c>MeshWeaver.Compiler.dll</c> BESIDE the module and on both paths the platform is the pinned
+/// IMAGE. So the comparison had nothing to compare, everywhere.</para>
+///
+/// <para><b>Why these assertions and not a green run.</b> The three properties below are invisible
+/// in a green log: a pack that omits the anchor still packs, an inspection that does not read the
+/// field still passes, and a publish step that does not check still POSTs. The refusal must also sit
+/// on the step that actually publishes — the inspection runs on the BUILD leg only, while the reuse
+/// leg hands over an artifact an earlier run packed, so a guard bound to the inspection alone would
+/// pass while pre-#3211 bytes went to the registry.</para>
+/// </summary>
+public class ModuleIdentityPublishGuard
+{
+    private const string Lane = ".github/workflows/node-repo-module-pack.yml";
+    private const string KeyScript = ".github/scripts/module-build-key.py";
+
+    [Fact]
+    public void ThePackStep_NamesTheIdentityAnchor_AndFailsRedWhenThereIsNone()
+    {
+        var pack = JobBody("pack");
+
+        // The anchor is the SAME reference set the build bound against, and WHERE that is moves
+        // with the platform: the pinned image's extracted /app when one is pinned (`platform-refs`
+        // — which the sdk build passes as MeshWeaverRefs and the container build compiles inside),
+        // the module's own output when the platform was built from source. It is never a second
+        // opinion, and never left to the packer's default probe, which is exactly the probe that
+        // found nothing on all 34 of the fleet's bundles.
+        Assert.Contains("anchor=\"$REFS/MeshWeaver.Compiler.dll\"", pack, StringComparison.Ordinal);
+        Assert.Contains("anchor=\"$PACKDIR/MeshWeaver.Compiler.dll\"", pack, StringComparison.Ordinal);
+        Assert.Contains("--graph-dll \"$anchor\"", pack, StringComparison.Ordinal);
+
+        // 🚨 BOTH arms end RED when there is no anchor — the branch picks WHERE to look, never
+        // whether to check. A bundle whose identity is a guess is worse than a pack that stops.
+        Assert.Contains("if [ ! -f \"$anchor\" ]; then", pack, StringComparison.Ordinal);
+        Assert.Contains("::error::no identity anchor for $MODULE", pack, StringComparison.Ordinal);
+        Assert.DoesNotContain("--graph-dll \"${anchor:-", pack, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TheInspection_ReadsTheIdentityBackOffTheBytes()
+    {
+        var pack = JobBody("pack");
+        // Read off the packed manifest, not inferred from the packer's exit code — the same rule
+        // every other assertion in that step follows.
+        Assert.Contains("(.frameworkMvid // \"\") | test(\"^\\\\S+$\")", pack, StringComparison.Ordinal);
+        Assert.Contains("the bundle states no framework identity", pack, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ThePublishStep_RefusesAnUnstatedIdentity_BeforeItPosts()
+    {
+        var pack = JobBody("pack");
+
+        var read = pack.IndexOf("unzip -p \"$BUNDLE\" meshweaver/manifest.json", StringComparison.Ordinal);
+        var refuse = pack.IndexOf("REFUSING to publish $MODULE@$VERSION", StringComparison.Ordinal);
+        var post = pack.IndexOf("-X POST \"$REGISTRY/api/plugins/bundles/$PACKAGE", StringComparison.Ordinal);
+
+        Assert.True(read >= 0,
+            "the publish step must read the manifest out of the bytes it is about to POST — the "
+            + "inspection above runs on the build leg only, and the reuse leg publishes an artifact "
+            + "an earlier run packed");
+        Assert.True(refuse >= 0, "the publish step must REFUSE an unstated framework identity by name");
+        Assert.True(post >= 0, "the publish step must still POST to the registry");
+        Assert.True(read < refuse && refuse < post,
+            "the refusal must sit between reading the manifest and the POST — a check after the "
+            + "hand-over is a check on bytes the registry already shelved");
+
+        // Blank reads as unstated, on the lane exactly as it does in ModuleUpdateDecision: the
+        // value is stripped of whitespace before the emptiness test, so " " cannot publish.
+        Assert.Contains("jq -r '.frameworkMvid // \"\"' | tr -d '[:space:]'", pack, StringComparison.Ordinal);
+        Assert.Contains("if [ -z \"$identity\" ]; then", pack, StringComparison.Ordinal);
+
+        // An unreadable manifest is a refusal too — "could not check" must never render as "checked".
+        Assert.Contains("refusing to publish bytes whose manifest this lane could not check", pack, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The pack step now passes a flag that changes the bytes it writes for the SAME source (the
+    /// manifest gained <c>frameworkMvid</c>), and the ledger's content address must therefore have
+    /// moved — otherwise a later run REUSES a pre-#3211 bundle, whose publish the step above then
+    /// refuses. The recipe version is the lever the script itself documents for exactly this.
+    /// </summary>
+    [Fact]
+    public void TheLedgerRecipeVersion_MovedWithTheBytesTheLanePacks()
+    {
+        var key = File.ReadAllText(Path.Combine(FindRepoRoot(), KeyScript));
+        var recipe = Regex.Match(key, @"^RECIPE_VERSION = ""(?<v>[^""]+)""", RegexOptions.Multiline);
+        Assert.True(recipe.Success, $"{KeyScript} must declare RECIPE_VERSION");
+        Assert.NotEqual("1", recipe.Groups["v"].Value);
+    }
+
+    private static string JobBody(string job)
+    {
+        var text = File.ReadAllText(Path.Combine(FindRepoRoot(), Lane));
+        var match = Regex.Match(text, @"\n  " + Regex.Escape(job) + @":\n(?<body>(?:(?:    .*|  #.*)\n|\n)+?)(?=  [a-z][a-z-]*:\n|\z)");
+        Assert.True(match.Success, $"{Lane} must have a `{job}` job");
+        return string.Join('\n', match.Groups["body"].Value.Split('\n').Where(l => !l.TrimStart().StartsWith('#')));
+    }
+
+    private static string FindRepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.True(dir is not null, "could not locate the repository root (MeshWeaver.slnx) above the test bin");
+        return dir!.FullName;
+    }
+}

--- a/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
@@ -18,6 +18,12 @@ public class ModulePackCommandTest : IDisposable
     private readonly string root =
         Path.Combine(Path.GetTempPath(), "mw-module-pack-" + Guid.NewGuid().ToString("N"));
 
+    /// <summary>
+    /// The built-against framework identity every pack must state (#3211) — shaped like the real
+    /// thing (<c>s&lt;hash&gt;</c> from a surface manifest, <c>g&lt;sha&gt;</c> from a CI stamp).
+    /// </summary>
+    private const string Identity = "s0f1e2d3c4b5a697";
+
     public ModulePackCommandTest()
     {
         Directory.CreateDirectory(Path.Combine(root, "closure"));
@@ -55,6 +61,7 @@ public class ModulePackCommandTest : IDisposable
             "--module-name", "Widget",
             "--plugin", "WidgetPkg",
             "--package-version", "1.0.0",
+            "--framework-mvid", Identity,
             "--out", Path.Combine(root, "out"),
         };
         args[args.IndexOf(option) + 1] = value;
@@ -64,6 +71,89 @@ public class ModulePackCommandTest : IDisposable
         Assert.Equal(2, exit);
         Assert.False(Directory.Exists(Path.Combine(root, "out")),
             "a refused invocation must not have written anything");
+    }
+
+    /// <summary>
+    /// 🚨 THE NEGATIVE CONTROL for #3211 — a bundle that cannot state what it was built against is
+    /// not written at all.
+    ///
+    /// <para>This is the exact invocation that packed all 34 of MeshWeaver.Plugins' bundles on
+    /// 2026-09-03 (run 33773265959): no <c>--framework-mvid</c>, and no
+    /// <c>MeshWeaver.Compiler.dll</c> beside the module — because on both the sdk and the container
+    /// path the platform is the IMAGE, so the anchor is in the extracted <c>/app</c>, never in the
+    /// module's output. It used to print a warning and omit the field, which shipped #3154's
+    /// (version, identity) comparison with nothing to compare on every installation in the
+    /// fleet.</para>
+    /// </summary>
+    [Fact]
+    public void NoStatedIdentity_AndNoAnchorBesideTheModule_IsRefused_AndWritesNothing()
+    {
+        var outDir = Path.Combine(root, "out-no-identity");
+        var exit = ModulePackCommand.Run(
+        [
+            Path.Combine(root, "closure"),
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.2.0",
+            "--min-mesh-version", "3.0.0",
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(2, exit);
+        Assert.False(Directory.Exists(outDir),
+            "a bundle that states no framework identity must not exist at all — it is refused "
+            + "where it is created, not shelved and skipped forever downstream");
+    }
+
+    /// <summary>A stated identity that is only whitespace reads as UNSTATED downstream
+    /// (<c>ModuleUpdateDecision</c> treats blank as unknown on both sides), so it is refused here
+    /// rather than written as a value that means nothing.</summary>
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ABlankStatedIdentity_IsRefused(string blank)
+    {
+        var outDir = Path.Combine(root, "out-blank-identity");
+        var exit = ModulePackCommand.Run(
+        [
+            Path.Combine(root, "closure"),
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.2.0",
+            "--framework-mvid", blank,
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(2, exit);
+        Assert.False(Directory.Exists(outDir));
+    }
+
+    /// <summary>The other half of the pair: with the anchor assembly NAMED, the packer reads its
+    /// identity itself — the shape the lane uses (<c>--graph-dll &lt;platform /app&gt;</c>).</summary>
+    [Fact]
+    public void TheAnchorAssembly_WhenNamed_StatesTheIdentityWithoutTheFlag()
+    {
+        // Any real PE works: FrameworkIdentity.ReadIdentity resolves the stamped identity when the
+        // assembly carries one and the MVID otherwise — the same resolution the runtime compares.
+        var anchor = typeof(ModulePackCommand).Assembly.Location;
+        var expected = FrameworkIdentity.ReadIdentity(anchor);
+
+        var outDir = Path.Combine(root, "out-anchor");
+        var exit = ModulePackCommand.Run(
+        [
+            Path.Combine(root, "closure"),
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.7.0",
+            "--graph-dll", anchor,
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(0, exit);
+        var (manifest, _) = BundleReader.ReadModule(File.ReadAllBytes(
+            Path.Combine(outDir, "MeshWeaver.Plugin.WidgetPkg.1.7.0.module.nupkg")));
+        Assert.False(string.IsNullOrWhiteSpace(expected));
+        Assert.Equal(expected, manifest!.FrameworkMvid);
     }
 
     [Fact]
@@ -76,6 +166,7 @@ public class ModulePackCommandTest : IDisposable
             "--module-name", "Widget",
             "--plugin", "WidgetPkg",
             "--package-version", "1.2.0",
+            "--framework-mvid", Identity,
             "--min-mesh-version", "3.0.0",
             "--out", outDir,
         ]);
@@ -90,9 +181,10 @@ public class ModulePackCommandTest : IDisposable
         Assert.Equal("1.2.0", manifest.Version);
         Assert.Equal("Widget", manifest.Module!.AssemblyName);
         Assert.Equal("3.0.0", manifest.Module.MinMeshVersion);
-        // No MeshWeaver.Graph.dll in the closure folder: the diagnostic MVID is simply
-        // unrecorded — warned, never an error, never a gate.
-        Assert.Null(manifest.FrameworkMvid);
+        // 🚨 #3211: the bundle states what it was built against, always. Every consumer's update
+        // decision compares this against what it has landed (#3154), so an omitted value is not a
+        // missing nicety — it is a permanent "up to date, identity could not be checked".
+        Assert.Equal(Identity, manifest.FrameworkMvid);
         var only = Assert.Single(files);
         Assert.Equal("Widget.dll", only.FileName);
         Assert.Equal("WIDGET", Encoding.UTF8.GetString(only.Bytes));
@@ -133,6 +225,7 @@ public class ModulePackCommandTest : IDisposable
             "--module-name", "Widget",
             "--plugin", "WidgetPkg",
             "--package-version", "1.3.0",
+            "--framework-mvid", Identity,
             "--out", outDir,
         ]);
 
@@ -186,6 +279,7 @@ public class ModulePackCommandTest : IDisposable
             "--module-name", "Widget",
             "--plugin", "WidgetPkg",
             "--package-version", "1.5.0",
+            "--framework-mvid", Identity,
             "--out", outDir,
         ]);
 
@@ -239,6 +333,7 @@ public class ModulePackCommandTest : IDisposable
             "--module-name", "Widget",
             "--plugin", "WidgetPkg",
             "--package-version", "1.6.0",
+            "--framework-mvid", Identity,
             "--out", outDir,
         ]);
 
@@ -284,6 +379,7 @@ public class ModulePackCommandTest : IDisposable
             "--module-name", "Widget",
             "--plugin", "WidgetPkg",
             "--package-version", "1.4.0",
+            "--framework-mvid", Identity,
             "--out", Path.Combine(root, "out-missing"),
         ]);
 


### PR DESCRIPTION
## The defect

#3154 landed the consumer half of Plugins#931: `ModuleUpdateDecision.Decide` compares
**(version, framework identity)** before answering `SkipUpToDate`, because a module's version
encodes **content only** — a rebuild of unchanged source against a new platform republishes under
the *same* version, and the identity is the only thing that tells that rebuild from a no-op. It
deliberately left the producer blind spot open and named where to close it.

**Measured before touching anything — MeshWeaver.Plugins run 33773265959 (2026-09-03):**

```
warning: MeshWeaver.Compiler.dll not found at …/MeshWeaver.AI.OpenAI/MeshWeaver.Compiler.dll
packed MeshWeaver.Plugin.OpenAI.1.1.11.module.nupkg — … built-against MVID (unrecorded)
```

**All 34 bundles, on both compilers.** So the comparison shipped with nothing to compare anywhere
in the fleet: every consumer of every module was permanently in the "up to date — the identity could
not be checked" branch.

The cause is *where the anchor is*, and it moves with the platform:

| how the platform arrives | where `MeshWeaver.Compiler.dll` is |
|---|---|
| pinned **image** (every satellite call) — `platform-refs`, the `docker cp` of its `/app`, passed to the sdk build as `MeshWeaverRefs` and compiled inside by the container build | in `platform-refs`; deliberately **not** beside the module, which carries no platform assembly |
| built from **source** (core's own `main-cd` call, no image pinned) | beside the module — the platform ProjectReferences are real, so `dotnet publish` copies it |

Only the second ever matched the packer's default probe. That is why core CD records an identity
(`built-against MVID ce81fd4e…`, CD run 33779812466) and every satellite records none.

## Why it is closed at the producer, not softened at the consumer

Only the **landed** side of that comparison can be healed: landing writes the identity back, so one
fetch cures an unknown there. An unstated **served** identity can never be cured — a registry that
states nothing will state nothing next time too. `Decide`'s skip-and-say-so is correct and is not
touched here.

## The change — three refusals, each naming what is missing

| where | what it refuses |
|---|---|
| `module-pack` (`ModulePackCommand`) | **exit 2** when neither `--framework-mvid` (new) nor `--graph-dll` yields an identity — the bundle is not written at all, where it used to warn and omit the field |
| pack step | **names** the anchor (`--graph-dll`), picking its location from the table above; **both** arms are RED with no anchor — the branch decides *where to look*, never *whether to check*. The manifest is then read back and the field asserted on the bytes |
| **publish step** | **RED before the POST** when the bundle's manifest states none |

The publish-step refusal is the load-bearing one: the inspection runs on the **build** leg only,
while the **reuse** leg hands over an artifact an earlier run packed — a guard bound to the
inspection alone would pass while pre-#3211 bytes went to the registry.

`RECIPE_VERSION` `1` → `2` in `module-build-key.py` for the same reason: the lane packs different
bytes for the same source now, so every recorded key is invalidated and no run reuses a bundle whose
publish would be refused. **Its own self-test's "the recipe version changes the key" case read a
literal `"2"`** and would have become a no-op assertion the moment the lane bumped to `2` — a guard
whose subject moved and whose root did not. It now derives the differing value from the live default.

## Verification — the negative control, on the shipped lane text

The pack and publish blocks were extracted **verbatim** from `node-repo-module-pack.yml` (not
retyped) and run against real bundles. `ModuleIdentityPublishGuard` pins that same text in CI, so
the correspondence is mechanical.

**The packer**

```
$ module-pack … --framework-mvid s0f1e2d3c4b5a697
packed MeshWeaver.Plugin.WidgetPkg.1.0.0.module.nupkg — … built-against MVID s0f1e2d3c4b5a697
exit=0

$ module-pack …                      # the fleet's exact invocation
error: the bundle would state no built-against framework identity, and a bundle that cannot say
which platform build produced its bytes is not publishable (#3211). … Provide ONE of:
--framework-mvid <identity> …, or --graph-dll <path to MeshWeaver.Compiler.dll> …
Probed and not found: …/MeshWeaver.Compiler.dll
exit=2                               # and the output directory does not exist

$ module-pack … --graph-dll …/MeshWeaver.Compiler.dll
packed … built-against MVID 9d274438277f4ee38ada070fecd688e8      # read off the real anchor
```

**The pack step's anchor refusal** (all four arms)

| REFS | anchor present | verdict |
|---|---|---|
| image pinned | yes | `packing Widget from mod (compiler: container)` — **exit 0** |
| image pinned | no | `::error::no identity anchor for Widget — expected … in the pinned platform image's extracted /app` — **exit 1** |
| source build | yes | **exit 0** |
| source build | no | `::error::… i.e. in the module's own build output …` — **exit 1** |

**The publish step's refusal**

| bundle | verdict |
|---|---|
| states `frameworkMvid` | `publishing Widget@1.0.0, built against s0f1e2d3c4b5a697` — **exit 0** |
| `frameworkMvid` **absent** (what the fleet packs today) | `::error::REFUSING to publish Widget@1.0.0 — the bundle states no framework identity (manifest .frameworkMvid is null)…` — **exit 1** |
| `frameworkMvid: null` | same refusal — **exit 1** |
| `frameworkMvid: "   "` | same refusal (blank reads as unstated, as it does in `ModuleUpdateDecision`) — **exit 1** |
| not a readable archive | `::error::cannot read meshweaver/manifest.json … refusing to publish bytes whose manifest this lane could not check` — **exit 1** |

**Builds / suites** — Release + `-warnaserror` clean for `MeshWeaver.Plugin.Build`,
`MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`, `MeshWeaver.Graph.Test`,
`MeshWeaver.Documentation.Test`, `Memex.Portal.Shared.Test` (one project per invocation).
`ModulePackCommandTest` **13/13** (three new: the negative control, a blank stated identity, the
anchor read); `MeshWeaver.Documentation.Test` **250/250** including link and What's New integrity
and the new `ModuleIdentityPublishGuard`; the `Module*` / `PluginBundlePublish*` subset of
`Memex.Portal.Shared.Test` **23/23**; `module-build-key.py --self-test` **36/36**;
`check-workflow-shell.py` and `check-workflow-timeouts.py` clean (the first one caught a `|| true`
in the first draft of the publish guard — the read no longer swallows unzip's status or its stderr).

## The transition, thought through — the registry's 400 is deliberately NOT armed here

The issue asks for a named 400 out of `ModulePublish.Validate` "with the transition thought
through: every producer CI in the fleet must be emitting the field before the refusal is armed, or
the refusal takes the fleet's publishes down." **Measured: today none of them is.** The registry
rolls from core `main` automatically, while every producer pins
`node-repo-module-pack.yml@<sha>` and bumps it deliberately, per repo, in its own PR
(MeshWeaver.Plugins and MeshWeaver.SocialMedia are the only two; Education and Reinsurance pack no
modules). Arming the 400 on this merge would therefore red every satellite main-push publish until
those pins moved — the nulls would survive and the publishes would not.

So this change closes the blind spot **at the point of publication core owns and that moves with the
pin**, atomically: a satellite bumping its pin gets the identity-recording and the refusal in one
reviewed commit, and there is no window in which it is refused for something its own lane cannot
produce. What remains for the registry side is in the tree, not in a memory:

- `ModulePublish.Accepted.FrameworkMvid`'s doc — the stale **"diagnostic only"** the issue calls out,
  which #3154 missed — is corrected and now states the arming criterion and its measurement.
- The publish endpoint **logs a warning naming package, module and version** when an unstated
  identity is shelved, so "which producer is still on an old pin" is a log query rather than a guess.
- `ModuleBuildArchitecture` → Roadmap records exactly what is left instead of the old
  "still open: making a bundle … UNPUBLISHABLE".

## Cross-repo

No public type or member removed → the `Cross-repo pair (public surface)` gate does not apply.
`Pairs-with: none` — additive in both directions. MeshWeaver.Plugins and MeshWeaver.SocialMedia pin
this lane by sha, so nothing changes for them until they bump; core's own `main-cd`
`plugins-modules` call uses the local workflow and takes the source-build arm, which is measured
recording an identity already.

## Docs

`ModuleBuildArchitecture` gains "A bundle states what it was built against — or it is not published"
(the measurement, the anchor table, the three refusals, and what the registry-side arming waits on)
and its roadmap is corrected; `Modules` and `PluginPackaging` lose their stale "diagnostic" wording;
What's New entry **Every module now says which platform build made it** (`Category: Fix`).

Closes #3211

🤖 Generated with [Claude Code](https://claude.com/claude-code)
