### PR TITLE
fix: a bounded read must not be issued on the node-CRUD execution hub (#2901)

### DIFF
--- a/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
+++ b/src/MeshWeaver.ContentCollections/ContentFileResolver.cs
@@ -159,12 +159,25 @@ public static class ContentFileResolver
             //   target: mesh/IJ1R4…)
             // i.e. the reply WAS produced and had nowhere to go.
             //
-            // NodeOperationIssuingHub is the one shared seam for this: it hops a root-hub caller onto
-            // portal/nodeops-{meshId} — routing-registered so responses land on it cross-silo, and
+            // ReadIssuingHub is the shared seam for this: it hops a root-hub caller onto
+            // portal/reads-{meshId} — routing-registered so responses land on it cross-silo, and
             // sharing the mesh's type registry and permission evaluator — and returns any NON-router
             // hub unchanged, so in-mesh callers (the deck export's SlideAssetInliner, a portal hub,
-            // a test client) keep their identity byte-for-byte. GetMeshNode/GetMeshNodeOutcome and
-            // every node-CRUD path already went this way (2c796d297); this read was the straggler.
+            // a test client) keep their identity byte-for-byte.
+            //
+            // 🚨 …and NOT portal/nodeops-{meshId}, which is where this read used to be issued
+            // (2c796d297, following GetMeshNode and every node-CRUD path). That hub is the mesh's
+            // ONE node-CRUD EXECUTION hub: every CreateNodeRequest / CreateOrUpdateNodeRequest in
+            // the mesh runs on its single action block, one turn at a time, and the turn loop does
+            // not advance until the current turn's observable completes. A reply DELIVERED there
+            // therefore sits in the buffer until the block drains — so this bounded read burned its
+            // whole budget on an answer that had already arrived, for as long as a bulk node-CRUD
+            // burst lasted. A content UPLOAD is exactly such a burst (one indexing activity per
+            // file, each a CreateNode plus a CreateOrUpdateNodeRequest on that block), which is why
+            // a freshly uploaded file 503'd for minutes and then healed untouched — issue #2901,
+            // Cause B in Doc/Architecture/ContentRoute503. The read hub registers NO handlers, so
+            // the only thing its block ever dispatches is the reply we are waiting for.
+            //
             // 🚨 …and BOUND IT. Without a budget of its own this read's only terminal is the hub's
             // 60 s RequestTimeout, which is the framework's last-resort ceiling — the number that
             // has to cover a cold NodeType compile — not a budget an HTTP request ever chose. When
@@ -180,7 +193,7 @@ public static class ContentFileResolver
             // it is idempotent, it cancels nothing, and abandoning it costs only the answer (which
             // is why the "never put a client-side ceiling on a mesh operation" rule in
             // MeshService's remarks — about WRITES that keep running — does not apply here).
-            var issuingHub = hub.NodeOperationIssuingHub();
+            var issuingHub = hub.ReadIssuingHub();
             return issuingHub.Observe(
                     new GetDataRequest(new ContentCollectionReference(candidates)),
                     o =>

--- a/src/MeshWeaver.Documentation/Data/Architecture/BakeSealNodeOpsSaturation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/BakeSealNodeOpsSaturation.md
@@ -219,6 +219,26 @@ consistent with the actor loop awaiting the full rule chain:
 Do **not** raise `InstallTimeout`, `LateResponseWatchBound` or `QueueAdvanceBound` to make the gate
 pass. Every one of those bounds is already reporting the truth: the shared hub is not draining.
 
+### 🚨 One confound has been removed — read `PendingCallbacks` differently from now on
+
+The 2026-08-28 capture reads `PendingCallbacks=26[ GetDataRequest@Store/Core, @Store/Install, … ]`
+alongside `Executing(CreateNodeRequest, 24888ms)`. Those 26 were **not** issued by anything running
+on `nodeops`: they are one-shot `GetMeshNode` reads from mesh-singleton services that hold the DI
+root hub (the plugin catalog's boot services, the credential resolvers, the content route), and
+`NodeOperationIssuingHub()` hopped every one of them onto this hub because it was the only
+off-router hub there was. They then sat in the same block that could not dispatch them.
+
+They now register on `portal/reads-{meshId}` instead — a hub with no handlers at all — via
+`MeshExtensions.ReadIssuingHub()`. See [The /api/content 503](../ContentRoute503) for why, and for
+the deterministic repro of the read side. Two consequences for the next measurement here:
+
+- **A contributor is gone, not the cause.** Those reads no longer add deliveries to this block, and
+  no longer burn 10 s budgets that their callers retry — but nothing about the duration of a
+  node-CRUD turn has changed. If the bimodal latency survives, that is the real answer.
+- **`PendingCallbacks` on `nodeops` is now attributable.** A read still pending there was issued by
+  something running **on this hub**, which is a much smaller set to search than "any mesh singleton
+  in the process".
+
 ## Related
 
 - [Action-Block Wedge Prevention](../ActionBlockWedgePrevention) — the invariants a single-threaded hub

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContentRoute503.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContentRoute503.md
@@ -17,10 +17,17 @@ content file 503s for minutes"*.
 ## 🚨 The one sentence
 
 > **The 10 s is `ReadBudget.Default` expiring on ONE request — the collection-config
-> `GetDataRequest` — and it expires only when no notification reached
-> `portal/nodeops-{meshId}`'s callback in time. Either the reply could not be DELIVERED there
-> (a lost pod-hub claim), or it was delivered and not DISPATCHED (that hub's action block was
-> saturated). Nothing else on the route produces 10.3 s.**
+> `GetDataRequest` — and it expires only when no notification reached the ISSUING hub's callback
+> in time. Either the reply could not be DELIVERED there (a lost pod-hub claim), or it was
+> delivered and not DISPATCHED (that hub's action block was saturated). Nothing else on the route
+> produces 10.3 s.**
+
+🚨 **The issuing hub used to be `portal/nodeops-{meshId}` — the mesh's node-CRUD EXECUTION hub —
+which is what made the second case reachable from an ordinary upload. It is now
+`portal/reads-{meshId}`, a hub that registers no handlers — see *"Cause B's cure"* below. The
+elimination
+below is written against the pre-fix code, because that is what the production occurrences ran, and
+because it is still the map of the route.**
 
 ## The read path, and where the 10 s lives
 
@@ -39,14 +46,16 @@ is an `Observable.Amb` of the request and a 10 s timer; when the timer wins it t
 `BlazorHostingExtensions.ContentFailure` maps to **503** (Plugins, `:746-748`). So a measurement of
 *~10.2–10.8 s then 503* is `ResolvePath` (a few hundred ms) plus the budget, exactly.
 
-**Step 3 is issued from, and answered onto, `portal/nodeops-{meshId}`** — not the caller's own hub.
-`ContentFileResolver.cs:183` calls `hub.NodeOperationIssuingHub()`
-(`MeshExtensions.cs:356-359`), which hops a **root-hub** caller — and the `/api/content` endpoint
-holds the DI-injected `IMessageHub`, which in the mesh's root container *is* the router — onto the
-mesh's one node-operation hub (`MeshExtensions.cs:268-323`). That hop exists so the reply can land
-cross-silo; it also means the reply must be dispatched by *that hub's* single-threaded action block
-before `hub.Observe` emits (`MessageHub.cs:451` registers `HandleCallbacks` as a delivery rule, and
-every delivery — responses included — goes through `EnqueueTurn`, `MessageService.cs:906`).
+**Step 3 is issued from, and answered onto, a hub that is not the caller's own.** The
+`/api/content` endpoint holds the DI-injected `IMessageHub`, which in the mesh's root container *is*
+the router, and the router must be neither end of a delivery — so `ContentFileResolver` hops onto a
+dedicated off-router hub. **Until this page's fix that hop landed on `portal/nodeops-{meshId}`,
+the mesh's one node-operation hub** (`hub.NodeOperationIssuingHub()`); it now lands on
+`portal/reads-{meshId}` (`hub.ReadIssuingHub()`). Either way the reply must be dispatched by *that
+hub's* single-threaded action block before `hub.Observe` emits (`MessageHub.cs:451` registers
+`HandleCallbacks` as a delivery rule, and every delivery — responses included — goes through
+`EnqueueTurn`, `MessageService.cs:906`). Which hub it is decides what else can be in that block's
+way.
 
 ## What is provably NOT the cause
 
@@ -154,6 +163,64 @@ Grep the portal for `Reading content collection config from` and read the `Queue
 changes nothing, and a single-replica or restarted portal removes the *exposure* to Cause A without
 touching Cause B — which is why a 12/12 green probe proves neither.
 
+## 🚨 Cause B's cure — the read does not belong on that block at all
+
+The fix is not to make the node-CRUD hub drain faster. It is that **a bounded read with a person
+waiting on it must never be issued on the hub that EXECUTES the mesh's node CRUD**, whatever that
+CRUD costs. A serial execution hub occupied by a bulk write burst is that hub working as designed;
+a ten-second interactive read queued behind it is not.
+
+`MeshExtensions.ReadIssuingHub()` is the seam. It hops a **router**-held caller onto
+`portal/reads-{meshId}` — a hub wired exactly as `portal/nodeops-{meshId}` is (the mesh's own type
+registry, the mesh hub's permission evaluator, registered with the routing service so replies land
+on it cross-silo) with **one deliberate difference: it registers no handlers.** Nothing executes
+there, so the only thing its action block ever dispatches is the reply to a read issued on it. Two
+call sites moved:
+
+| Read | Was | Now |
+|---|---|---|
+| `ContentFileResolver.Resolve` — the collection-config `GetDataRequest` (step 3 above) | `NodeOperationIssuingHub()` ⇒ `portal/nodeops-{meshId}` | `ReadIssuingHub()` ⇒ `portal/reads-{meshId}` |
+| `MeshNodeStreamExtensions.GetMeshNodeOutcome` — the one-shot node read | same | same |
+
+`NodeOperationIssuingHub()` is unchanged and still correct for a **write**: a target-less
+`CreateOrUpdateNodeRequest` posted there executes on the node-CRUD hub, and a write ack that waits
+behind the writes queued ahead of it is the ordering that hub exists to impose. The two seams differ
+because reads and writes want opposite things from the same block.
+
+### The repro
+
+`ContentReadIsNotQueuedBehindNodeCrudTest` (`test/MeshWeaver.Graph.Test`) — a monolith mesh, no
+sleeps, no cluster. An `INodeValidator` parks the create of ONE node (matched by path, so nothing
+else in the mesh is slowed), which holds the node-CRUD execution hub's turn exactly as a real write
+does; with the block held, `ContentFileResolver.Resolve` must still answer. Reverting the two call
+sites to `NodeOperationIssuingHub()` reproduces this page's Cause B **verbatim**, including the
+discriminator:
+
+```text
+Reading content collection config from 'TestData/ContentProbe' gave up after 10s — the owning hub
+never answered. … Reader: Hub portal/nodeops-GMUrd3FU90aD8lxUt_XUlw RunLevel=Started
+Queue(buffer=1,deferred=0,exec=0) Executing(CreateNodeResponse, 10004ms)
+PendingCallbacks=1[…=GetDataRequest@TestData/ContentProbe(10002ms)]
+```
+
+`Queue(buffer=1)` and an `Executing(…, 10004ms)` line — Cause B by the discriminator above, on a
+run where the owning hub answered promptly. Note *what* is executing: the create's continuation is
+running inside the turn that delivered an intermediate `CreateNodeResponse` to that hub, so the
+chain's remaining legs are charged to a node-CRUD delivery turn. That is the mechanism by which a
+single create can occupy the block far longer than any one of its own steps.
+
+### What it does NOT fix
+
+**Nothing about how long a node-CRUD turn takes.** [#2543](https://github.com/Systemorph/MeshWeaver/issues/2543)
+— the same hub seen from the write side, where a `CreateNodeRequest` turn was captured at 24 888 ms
+and queue latency is bimodal at ≤ 3.2 s / 33–49 s — is untouched and stays open. What this change
+does take off that block is the **router-issued reads**: the `PendingCallbacks=26[GetDataRequest@Store/Core,
+@Store/Install, …]` in #2543's own capture are `GetMeshNode` reads issued from mesh-singleton
+services that hold the DI root hub, and every one of them now registers on `portal/reads-{meshId}`
+instead. That removes a contributor and, more usefully, removes a confound: pending callbacks left on
+`portal/nodeops` after this change were issued by something running **on that hub**, not by a
+router-held caller.
+
 ## Recorded, not fixed
 
 Two unbounded seams on this exact path. Neither causes the 503; both make an occurrence harder to
@@ -164,10 +231,10 @@ read.
    emits — a documented shape, pinned by `PathResolutionCachePoisonTest.HungFirstQuery_DoesNotPoisonCache` —
    never even subscribes step 3's budget timer, so the request hangs until the client aborts with
    **no 503 and no log line**. Strictly worse than the failure this page is about.
-2. **`NodeOperationIssuingHub()` is re-resolved per request** (`ContentFileResolver.cs:183`) rather
-   than cached as `MeshService.cs:93` does. During mesh teardown it returns **the router**
-   (`MeshExtensions.cs:274-275, 358`), reinstating the router-as-both-ends hang the 45-line comment
-   above that call exists to prevent.
+2. **The issuing hub is re-resolved per request** (`ContentFileResolver.cs`, now `ReadIssuingHub()`)
+   rather than cached as `MeshService.cs:93` does. During mesh teardown it returns **the router**
+   (`MeshExtensions.MeshReadHub` returns null past `DisposeHostedHubs`), reinstating the
+   router-as-both-ends hang the long comment above that call exists to prevent.
 
 And one in the plugins repo: the per-file indexing fan-out has **no concurrency bound**, while its
 own sibling walk does.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-file-you-just-uploaded-serves-straight-away.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-file-you-just-uploaded-serves-straight-away.md
@@ -1,0 +1,23 @@
+---
+Name: A file you just uploaded serves straight away
+Category: Fix
+Description: A freshly uploaded image or video could answer "service unavailable" for minutes before it started serving; it now serves immediately, even while the upload is still being indexed.
+Icon: Sparkle
+Order: -20260903
+---
+
+# A file you just uploaded serves straight away
+
+Uploading files kicks off background work — each new file is indexed so it becomes searchable and
+gets a description. While that was running, asking for one of the files you had just uploaded could
+fail: the page waited ten seconds and then reported the file as unavailable, over and over, for as
+long as the indexing took. An editor who uploaded a video and previewed it immediately saw a broken
+player for minutes, with no way to tell whether the upload had failed or was simply not ready — and
+every attempt cost another ten seconds. Then, untouched, it started working.
+
+The two had nothing to do with each other except that they were queued behind one another: reading
+a file's location and writing the indexing results were being handled by the same single worker, in
+order, so a read had to wait for every write ahead of it. Reads now have a worker of their own. A
+file serves as soon as it is uploaded, whatever background work is still in progress — and the same
+applies to ordinary page loads during a bulk import or a package installation, which could
+previously report content as unavailable for the same reason.

--- a/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshExtensions.cs
@@ -359,6 +359,109 @@ public static class MeshExtensions
             : hub;
 
     /// <summary>
+    /// Address-id prefix of the mesh's dedicated READ-issuing hub. A <c>portal/</c> address for the
+    /// same reason <see cref="NodeOperationHubPrefix"/> is one: <c>portal</c> is already a
+    /// stream-routed address type, so a reply addressed here is dispatched cross-silo by the
+    /// existing routing rules — no new address type, no new routing rule.
+    /// </summary>
+    private const string ReadIssuingHubPrefix = "reads-";
+
+    /// <summary>
+    /// The address of <paramref name="mesh"/>'s dedicated read-issuing hub. Pure address
+    /// arithmetic — it does NOT materialise the hub.
+    /// </summary>
+    private static Address ReadIssuingHubAddress(IMessageHub mesh) =>
+        AddressExtensions.CreatePortalAddress($"{ReadIssuingHubPrefix}{mesh.Address.Id}");
+
+    /// <summary>
+    /// The mesh's ONE dedicated read-issuing hub — <c>portal/reads-{meshId}</c>, hosted by the mesh
+    /// hub, created on first use and shared thereafter.
+    ///
+    /// <para>🚨 <b>It deliberately registers NO handlers.</b> That is the whole point: the only
+    /// thing its single-threaded action block ever dispatches is the REPLY to a read a caller is
+    /// waiting on, so a bounded read cannot be starved by unrelated work. Contrast
+    /// <see cref="NodeOperationExecutionHub"/>, which is the mesh's node-CRUD EXECUTION hub — every
+    /// <c>CreateNodeRequest</c>/<c>CreateOrUpdateNodeRequest</c> in the mesh runs on its block, one
+    /// at a time, and the turn loop does not advance until the current turn's observable completes
+    /// (<c>MessageService.DrainOne</c>).</para>
+    ///
+    /// <para>Everything else is wired exactly as the execution hub is, so the two differ in
+    /// precisely one respect: it shares the mesh hub's TYPE REGISTRY (a hub with a private registry
+    /// never learns a dynamically-registered content type, and the payload degrades to an untyped
+    /// <c>JsonElement</c>), it inherits the mesh hub's PERMISSION EVALUATOR (a hub's configuration
+    /// starts empty and <c>ResolveEvaluator</c> does not walk the parent chain, so an uncopied
+    /// evaluator silently grants <see cref="Permission.All"/>), and it registers itself with the
+    /// ROUTING SERVICE so replies land on it cross-silo.</para>
+    ///
+    /// <para>Returns <c>null</c> only when the hub cannot be materialised (the mesh is already
+    /// tearing down); callers then fall back to their own hub.</para>
+    /// </summary>
+    /// <param name="hub">Any hub in the mesh; the read hub is resolved from its mesh root.</param>
+    /// <returns>The shared read-issuing hub, or <c>null</c> while the mesh is disposing.</returns>
+    public static IMessageHub? MeshReadHub(this IMessageHub hub)
+    {
+        var mesh = hub.GetMeshHub();
+        // Teardown: never materialise a hub during disposal (HostedHubsCollection refuses it and
+        // logs a warning). The caller falls back to its own hub, at which point the read is being
+        // abandoned anyway.
+        if (mesh.RunLevel >= MessageHubRunLevel.DisposeHostedHubs)
+            return null;
+
+        var routingService = mesh.ServiceProvider.GetService<IRoutingService>();
+        var permissionEvaluator = mesh.Configuration.Get<EffectivePermissionsDelegate>();
+        return mesh.GetHostedHub(
+            ReadIssuingHubAddress(mesh),
+            config =>
+            {
+                config = config
+                    .WithTypeRegistry(mesh.TypeRegistry)
+                    .WithInitialization(h =>
+                    {
+                        if (routingService is not null)
+                            h.RegisterForDisposal(routingService.RegisterStream(h));
+                    });
+                return permissionEvaluator is null
+                    ? config
+                    : config.WithPermissionEvaluator(permissionEvaluator);
+            },
+            HostedHubCreation.Always);
+    }
+
+    /// <summary>
+    /// The hub a bounded, request/response READ must be ISSUED ON — the caller's own hub, except
+    /// when that hub is the ROOT MESH HUB (the router), where the read hops onto
+    /// <see cref="MeshReadHub"/>.
+    ///
+    /// <para>🚨 <b>Why this is not <see cref="NodeOperationIssuingHub"/>.</b> Both exist to keep the
+    /// router from being an end of a delivery, and for a WRITE the node-operation seam is right: a
+    /// target-less <c>CreateOrUpdateNodeRequest</c> posted there EXECUTES on the mesh's node-CRUD
+    /// hub, and a write ack arriving after the writes queued ahead of it is the ordering that hub
+    /// exists to impose. A READ is the opposite case. It is bounded (<see cref="ReadBudget"/>), a
+    /// person is usually waiting on it, and it shares nothing with node CRUD but the action block —
+    /// so issuing it on the execution hub means its reply, once delivered, waits in that block's
+    /// buffer behind every write in flight. The turn loop advances only when the current turn's
+    /// observable completes, so a bulk node-CRUD burst (a content upload's per-file indexing, a
+    /// package install, a bake) holds the reply for as long as the burst lasts and the read's
+    /// budget expires on an answer that already arrived. On <c>/api/content</c> that is the
+    /// ~10.3 s-then-503 of <see href="https://github.com/Systemorph/MeshWeaver/issues/2901">#2901</see>
+    /// — see <c>Doc/Architecture/ContentRoute503</c>.</para>
+    ///
+    /// <para>For any hub that is NOT the router this returns the hub unchanged, so a per-node,
+    /// portal, session or import-hub caller keeps its identity byte-for-byte — those are real
+    /// actors whose own block is the right place for their own replies.</para>
+    ///
+    /// <para>Identity is unaffected: the ambient <c>AccessService</c> is the mesh-wide singleton
+    /// every hosted hub's provider chains to, so an <c>ImpersonateAsSystem</c> (or any ambient
+    /// context) active at Subscribe time is read identically by this hub's post pipeline.</para>
+    /// </summary>
+    /// <param name="hub">The hub the caller holds — returned unchanged unless it is the root mesh hub.</param>
+    /// <returns>The off-router read-issuing hub.</returns>
+    public static IMessageHub ReadIssuingHub(this IMessageHub hub) =>
+        string.Equals(hub.Address.Type, AddressExtensions.MeshType, StringComparison.Ordinal)
+            ? hub.MeshReadHub() ?? hub
+            : hub;
+
+    /// <summary>
     /// Registers handlers for mesh node operations. Idempotent — calling twice on the
     /// same configuration is a no-op on the second call. Without this guard, every
     /// extra call would add a duplicate set of handlers; each delivery would invoke

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -2695,8 +2695,9 @@ public static class MeshNodeStreamExtensions
     /// </para>
     /// </summary>
     /// <param name="hub">The hub the caller holds. When it is the ROOT MESH HUB (the router), the
-    /// read is issued on <see cref="MeshExtensions.NodeOperationIssuingHub"/> instead — the router
-    /// must be neither end of a delivery (ROUTER_TRAFFIC).</param>
+    /// read is issued on <see cref="MeshExtensions.ReadIssuingHub"/> instead — the router must be
+    /// neither end of a delivery (ROUTER_TRAFFIC), and a bounded read must not queue behind the
+    /// mesh's node CRUD.</param>
     /// <param name="path">The mesh path to read.</param>
     /// <param name="timeout">Wall-clock budget for the read; defaults to 10 seconds.</param>
     /// <param name="onTimeout">
@@ -2758,9 +2759,18 @@ public static class MeshNodeStreamExtensions
             // the GetDataResponse (or, for a missing node, the DeliveryFailure) is addressed straight
             // back at mesh/{id} — both exactly what the ROUTER_TRAFFIC detector reports (production
             // 2026-08: "GetDataResponse has the mesh hub as target (sender: Hosting/_Access/…)" /
-            // "DeliveryFailure … (sender: Plugins/_DefaultInstallLedger)"). Same seam MeshService
-            // uses for CRUD; a non-router caller gets itself back, unchanged.
-            var issuingHub = hub.NodeOperationIssuingHub();
+            // "DeliveryFailure … (sender: Plugins/_DefaultInstallLedger)"). A non-router caller gets
+            // itself back, unchanged.
+            //
+            // 🚨 The READ seam, not the node-operation one. This used to hop onto
+            // portal/nodeops-{meshId} — the mesh's ONE node-CRUD EXECUTION hub — so the reply to
+            // this bounded read had to be dispatched by the same single action block that runs
+            // every create/upsert in the mesh, one turn at a time. Under a bulk node-CRUD burst the
+            // reply is DELIVERED and then waits in that buffer, and this read reports
+            // "the owning per-node hub never answered" about a hub that answered promptly (#2901,
+            // Cause B in Doc/Architecture/ContentRoute503). portal/reads-{meshId} registers no
+            // handlers, so its block only ever dispatches replies to reads issued on it.
+            var issuingHub = hub.ReadIssuingHub();
 
             // ♻️ A TRANSIENT NODE PROBE HAS NO MESH NODE — so reading its OWN address is a CYCLE,
             // and the only way it ever ended was by spending the entire budget.

--- a/test/MeshWeaver.Graph.Test/ContentReadIsNotQueuedBehindNodeCrudTest.cs
+++ b/test/MeshWeaver.Graph.Test/ContentReadIsNotQueuedBehindNodeCrudTest.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.ContentCollections;
+using MeshWeaver.Fixture;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Security;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🚨 A bounded READ must not be issued on the hub that EXECUTES the mesh's node CRUD —
+/// <see href="https://github.com/Systemorph/MeshWeaver/issues/2901">#2901</see>, *"a freshly
+/// uploaded content file 503s for minutes"*.
+///
+/// <para><b>The defect.</b> <c>/api/content/{node}/{collection}/{file}</c> reads the owning node's
+/// collection config with a <c>GetDataRequest</c> bounded by <c>ReadBudget.Default</c> (10 s), and
+/// <c>ContentFileResolver</c> issued it through <c>MeshExtensions.NodeOperationIssuingHub()</c> —
+/// which for the <c>/api/content</c> endpoint (it holds the DI-injected root hub, i.e. the router)
+/// resolves to <c>portal/nodeops-{meshId}</c>, <b>the mesh's ONE node-CRUD execution hub</b>. Every
+/// <c>CreateNodeRequest</c>/<c>CreateOrUpdateNodeRequest</c> in the mesh runs on that hub's single
+/// action block, one turn at a time, and <c>MessageService.DrainOne</c> does not advance until the
+/// current turn's observable completes. <c>HandleCallbacks</c> is an ordinary delivery rule
+/// (<c>MessageHub.cs:451</c>), so the reply to this read — once it has been DELIVERED — sits in
+/// that block's buffer until the block drains. The read then burns its whole budget on an answer
+/// that already arrived, <c>HubUnreachableException</c> is a <c>TimeoutException</c>, and the route
+/// maps it to <b>503</b>.</para>
+///
+/// <para><b>Why an upload produces exactly that.</b> Uploading N files starts N indexing
+/// activities, each costing node-CRUD round trips on that same block, so the block is busy for as
+/// long as the burst lasts — minutes when the slowest leg is a vision-model call. That is #2901's
+/// "503 for minutes, then it heals untouched", and why it is per-file rather than per-route: it is
+/// whichever read lands inside the burst. Full elimination in
+/// <c>Doc/Architecture/ContentRoute503</c>.</para>
+///
+/// <para><b>The repro.</b> No upload burst is needed to pin the mechanism — only a node-CRUD turn
+/// that is genuinely in flight. An <see cref="INodeValidator"/> parks the create of ONE node
+/// (nothing else is affected: it matches on path), which holds the node-CRUD execution hub's turn
+/// exactly as a real write does. With the block held, the content read must still answer. Before
+/// the fix it does not: it errors with <c>HubUnreachableException</c> after the full 10 s budget,
+/// which is the 503. After it, the read answers in milliseconds because it is issued on
+/// <c>portal/reads-{meshId}</c>, a hub that registers no handlers and therefore only ever
+/// dispatches the replies to reads issued on it.</para>
+///
+/// <para>🚨 <b>What this does NOT claim.</b> It does not make the node-CRUD hub drain any faster —
+/// why a single <c>CreateNodeRequest</c> turn can occupy that block for tens of seconds is
+/// <see href="https://github.com/Systemorph/MeshWeaver/issues/2543">#2543</see> and is untouched
+/// here. This pins the read side: an interactive read has no business sharing an action block with
+/// background node CRUD, whatever that CRUD costs.</para>
+/// </summary>
+public class ContentReadIsNotQueuedBehindNodeCrudTest(ITestOutputHelper output)
+    : MonolithMeshTestBase(output)
+{
+    private const string ProbeNodeType = "ContentRoute503Probe";
+    private const string ProbeNodeId = "ContentProbe";
+    private const string ProbeNodePath = $"{TestPartition}/{ProbeNodeId}";
+    private const string ParkedNodeId = "ParkedWrite";
+    private const string ParkedNodePath = $"{TestPartition}/{ParkedNodeId}";
+    private const string UploadedFileName = "uploaded.bin";
+
+    /// <summary>
+    /// The collection's backing directory — per test CLASS instance, so nothing is shared with
+    /// another suite running in the same xUnit process.
+    /// </summary>
+    private readonly string _contentRoot = Path.Combine(
+        AppContext.BaseDirectory, "Files", "ContentRoute503", Guid.NewGuid().ToString("N"));
+
+    /// <summary>Producer → test: the parking validator completes this once its turn is running.</summary>
+    private readonly AsyncSubject<Unit> _parked = new();
+
+    private ParkTheNodeCrudBlock? _park;
+
+    /// <inheritdoc />
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+    {
+        _park = new ParkTheNodeCrudBlock(ParkedNodePath, _parked);
+        Directory.CreateDirectory(_contentRoot);
+        return base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<INodeValidator>(_park))
+            .AddMeshNodes(
+                new MeshNode(ProbeNodeType)
+                {
+                    Name = "Content Route 503 Probe",
+                    // The one thing the node type needs for this test: a content collection, so the
+                    // per-node hub answers the collection-config GetDataRequest the route issues.
+                    HubConfiguration = config => config.AddFileSystemContentCollection(
+                        ContentCollectionsExtensions.DefaultCollectionName, _ => _contentRoot)
+                },
+                new MeshNode(ProbeNodeId, TestPartition)
+                {
+                    Name = "Content Probe",
+                    NodeType = ProbeNodeType,
+                });
+    }
+
+    /// <summary>
+    /// 🚨 THE REGRESSION. A content read must answer while the mesh's node-CRUD execution hub is
+    /// occupied by a write. RED before the fix: the read is issued on that very hub, so its reply
+    /// cannot be dispatched, and it errors with <c>HubUnreachableException</c> after
+    /// <c>ReadBudget.Default</c> — the 503 the issue was filed on.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ContentFileResolution_Answers_WhileANodeWriteHoldsTheExecutionHub()
+    {
+        var uploaded = Path.Combine(_contentRoot, UploadedFileName);
+        await File.WriteAllBytesAsync(uploaded, "uploaded bytes"u8.ToArray(),
+            TestContext.Current.CancellationToken);
+
+        // The write is a REAL node create, posted from a client hub and addressed at
+        // NodeOperationTarget() exactly as production does — so what it occupies is the production
+        // block, not a stand-in.
+        var write = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ParkedNodeId, TestPartition)
+            {
+                Name = "Parked Write",
+                NodeType = "Markdown",
+            }));
+        try
+        {
+            await _parked.Should().Within(TestTimeouts.Convergence)
+                .Emit("the node-CRUD execution hub must actually be busy, or this test proves nothing");
+
+            var reference =
+                $"{ProbeNodePath}/{ContentCollectionsExtensions.DefaultCollectionName}/{UploadedFileName}";
+            var resolution = await ContentFileResolver.Resolve(Mesh, reference)
+                .Should().Within(TestTimeouts.Convergence)
+                .Emit("the content route must answer while an unrelated node write is in flight — "
+                    + "before the fix this read was issued on the write's own action block, so its "
+                    + "reply could not be dispatched and it timed out into a 503 (#2901)");
+
+            resolution.Reason.Should().BeNull(
+                "the collection config resolved, so there is no reason-for-no-resolution");
+            resolution.Resolution.Should().NotBeNull(
+                "the probe node serves a 'content' collection and the file is in it");
+            resolution.Resolution!.Collection.Name.Should().Be(
+                ContentCollectionsExtensions.DefaultCollectionName);
+            resolution.Resolution.FilePath.Should().Be(UploadedFileName);
+            File.Exists(Path.Combine(_contentRoot, resolution.Resolution.FilePath))
+                .Should().BeTrue("the resolution must point at the file that was uploaded");
+        }
+        finally
+        {
+            // In a finally so a failing assertion cannot strand the parked write — and therefore
+            // cannot strand the mesh's teardown behind it.
+            _park!.Release();
+        }
+
+        await write.Should().Within(TestTimeouts.Convergence)
+            .Emit("the parked write must complete once released — a stranded node-CRUD turn would "
+                + "leak into the next test");
+    }
+
+    /// <summary>
+    /// The same seam, from the generic one-shot node read. <c>GetMeshNodeOutcome</c> issued its
+    /// <c>GetDataRequest</c> on the node-CRUD execution hub for the same historical reason, and
+    /// carries the same 10 s budget — the <c>"this read reached no verdict … within 10s"</c> the
+    /// issue also records against ordinary node reads on a loaded portal.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task OneShotNodeRead_Answers_WhileANodeWriteHoldsTheExecutionHub()
+    {
+        var write = ObserveNodeOperation(new CreateNodeRequest(
+            new MeshNode(ParkedNodeId, TestPartition)
+            {
+                Name = "Parked Write",
+                NodeType = "Markdown",
+            }));
+        try
+        {
+            await _parked.Should().Within(TestTimeouts.Convergence)
+                .Emit("the node-CRUD execution hub must actually be busy");
+
+            var node = await Mesh.GetMeshNode(ProbeNodePath)
+                .Should().Within(TestTimeouts.Convergence)
+                .Emit("a one-shot node read must answer while an unrelated node write is in flight");
+
+            node.Should().NotBeNull("the probe node exists");
+            node!.Path.Should().Be(ProbeNodePath);
+        }
+        finally
+        {
+            _park!.Release();
+        }
+
+        await write.Should().Within(TestTimeouts.Convergence)
+            .Emit("the parked write must complete once released");
+    }
+
+    /// <summary>
+    /// The structural invariant behind both facts, asserted directly so a future refactor cannot
+    /// quietly put the read back on the write block: the hub a router-held caller issues a READ on
+    /// is not the hub node CRUD is EXECUTED on.
+    /// </summary>
+    [Fact(Timeout = 60_000)]
+    public void TheReadIssuingHub_IsNotTheNodeOperationExecutionHub()
+    {
+        Mesh.ReadIssuingHub().Address.Should().NotBe(Mesh.NodeOperationTarget(),
+            "a bounded read must not be dispatched by the action block that runs every "
+            + "create/upsert in the mesh (#2901)");
+        Mesh.ReadIssuingHub().Address.Should().NotBe(Mesh.Address,
+            "and it must not be the router either — the router must be neither end of a delivery");
+    }
+
+    /// <summary>
+    /// Holds ONE create's turn on whichever hub executes it — the mesh's node-CRUD execution hub.
+    ///
+    /// <para>No hand-woven gate: producer → test is the <see cref="AsyncSubject{T}"/> this
+    /// completes on entry; test → parked worker is a volatile flag polled under a bounded
+    /// <see cref="SpinWait.SpinUntil(Func{bool}, TimeSpan)"/>, which is what a real long-running
+    /// turn does to that block. Every other path validates instantly, so nothing else in the mesh
+    /// is slowed down.</para>
+    /// </summary>
+    private sealed class ParkTheNodeCrudBlock(string parkPath, AsyncSubject<Unit> parked) : INodeValidator
+    {
+        private int _released;
+
+        public IReadOnlyCollection<NodeOperation> SupportedOperations => [NodeOperation.Create];
+
+        /// <summary>Lets the parked turn finish. Idempotent.</summary>
+        public void Release() => Interlocked.Exchange(ref _released, 1);
+
+        public IObservable<NodeValidationResult> Validate(NodeValidationContext context)
+            => string.Equals(context.Node.Path, parkPath, StringComparison.Ordinal)
+                ? Observable.Defer(() =>
+                {
+                    parked.OnNext(Unit.Default);
+                    parked.OnCompleted();
+                    SpinWait.SpinUntil(() => Volatile.Read(ref _released) == 1,
+                        TestTimeouts.Convergence);
+                    return Observable.Return(NodeValidationResult.Valid());
+                })
+                : Observable.Return(NodeValidationResult.Valid());
+    }
+}

--- a/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloReplyTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/OrleansCrossSiloReplyTest.cs
@@ -32,9 +32,11 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 ///
 /// <para>🚨 <b>READ THIS BEFORE TRUSTING THIS CLASS AS THE /api/content GUARD — it is not, any
 /// more.</b> The paragraph above still describes the ORIGINAL intent, but <c>2c796d297</c>
-/// (2026-08-10) moved <c>GetMeshNode</c>/<c>GetMeshNodeOutcome</c> onto
-/// <c>MeshExtensions.NodeOperationIssuingHub</c>, so the fact below now exercises the
-/// <c>portal/nodeops-…</c> reply path and no longer posts from <c>mesh/{id}</c> at all. That is
+/// (2026-08-10) moved <c>GetMeshNode</c>/<c>GetMeshNodeOutcome</c> off <c>mesh/{id}</c> onto a
+/// dedicated off-router hub — <c>portal/nodeops-…</c> then, and <c>portal/reads-…</c> since #2901
+/// split the READ seam out of the node-operation one
+/// (<c>MeshExtensions.ReadIssuingHub</c>) — so the fact below exercises THAT hub's reply path and
+/// no longer posts from <c>mesh/{id}</c> at all. That is
 /// worth keeping — but it silently stopped covering the static-content endpoint it names, and
 /// issue #1729 is what that cost: <c>ContentFileResolver.Resolve</c> was left posting from the
 /// router and hung ~half of all <c>/api/content</c> requests on the 2-replica memex-cloud portal.
@@ -103,8 +105,8 @@ public class OrleansCrossSiloReplyTest : IClassFixture<TwoSiloCacheUpdateFixture
 
     /// <summary>
     /// 🚨 <b>THE INPUT THIS CLASS LOST — issue #1742.</b> The fact above no longer posts from
-    /// <c>mesh/{id}</c> at all (<c>2c796d297</c> moved <c>GetMeshNode</c> onto
-    /// <c>portal/nodeops-…</c>), so the class named for the root-mesh-hub reply leg stopped
+    /// <c>mesh/{id}</c> at all (<c>2c796d297</c> moved <c>GetMeshNode</c> onto a dedicated
+    /// off-router hub, <c>portal/reads-…</c> today), so the class named for the root-mesh-hub reply leg stopped
     /// exercising it — the gate silently stopped testing its own input, and #1729 is what that cost.
     /// This restores it in the smallest possible shape.
     ///


### PR DESCRIPTION
## The defect, in one sentence

**The `/api/content` collection-config read was issued on `portal/nodeops-{meshId}` — the mesh's ONE
node-CRUD EXECUTION hub — so its reply, once delivered, had to wait in that hub's single action
block behind every write in flight; a content-upload burst holds that block for minutes, and the
read burns its 10 s `ReadBudget` on an answer that had already arrived.** That is the ~10.3 s-then-503
of #2901, and it is why the same file alternates between serving and failing, per file rather than
per route, and "heals untouched".

The chain, all of it read from source:

| link | where |
|---|---|
| `ContentFileResolver.Resolve` issues `GetDataRequest(ContentCollectionReference)` bounded by `ReadBudget.Default` (10 s) | `ContentFileResolver.cs` · `ReadBudget.cs:92` |
| it issued that read through `hub.NodeOperationIssuingHub()`, which for a router-held caller (the `/api/content` endpoint holds the DI-injected root hub) resolves to `portal/nodeops-{meshId}` | `MeshExtensions.cs:356-359` |
| that hub is the fallback EXECUTION target for every `CreateNodeRequest`/`CreateOrUpdateNodeRequest` in the mesh | `MeshExtensions.NodeOperationTarget` |
| `HandleCallbacks` is an ordinary delivery rule, so the reply is dispatched by that hub's turn loop | `MessageHub.cs:451` → `MessageService.ScheduleNotify` → `EnqueueTurn` |
| the turn loop runs exactly one turn at a time and does not advance until the current turn's observable completes | `MessageService.DrainOne` |
| `HubUnreachableException` is a `TimeoutException`, which the content route maps to **503** | Plugins `BlazorHostingExtensions.ContentFailure` |

An upload is a node-CRUD burst — one indexing activity per file, each costing node-CRUD round trips
on that block — which is where *minutes* comes from.

## The repro (written before the change, and it fails without it)

`ContentReadIsNotQueuedBehindNodeCrudTest` in `test/MeshWeaver.Graph.Test` — a monolith mesh, no
sleeps, no cluster, ~0.2 s green. An `INodeValidator` parks the create of ONE node (matched by path,
so nothing else in the mesh is slowed), which holds the node-CRUD execution hub's turn exactly as a
real write does. With that block held, `ContentFileResolver.Resolve` must still answer.

**Verified it can fail**: with the two call sites reverted to `NodeOperationIssuingHub()` the two
behavioural facts go red in exactly the shape #2901 reports, including the queue snapshot that
`Doc/Architecture/ContentRoute503` names as Cause B's discriminator —

```
Reading content collection config from 'TestData/ContentProbe' gave up after 10s — the owning hub
never answered. … Reader: Hub portal/nodeops-GMUrd3FU90aD8lxUt_XUlw RunLevel=Started
Queue(buffer=1,deferred=0,exec=0) Executing(CreateNodeResponse, 10004ms)
PendingCallbacks=1[…=GetDataRequest@TestData/ContentProbe(10002ms)]
```

`Queue(buffer=1)` plus an `Executing(…, 10004ms)` line, on a run where the owning hub answered
promptly — the reply arrived and was not dispatched. (`Executing(CreateNodeResponse, …)` is worth
noting on its own: the create's continuation runs inside the turn that delivered an intermediate
response to that hub, so the rest of the chain is charged to a node-CRUD delivery turn.)

## The fix — a read seam that is not the write seam

`MeshExtensions.ReadIssuingHub()` hops a **router**-held caller onto `portal/reads-{meshId}`, wired
exactly as `portal/nodeops-{meshId}` is — the mesh's own type registry (so a dynamically-registered
content type still resolves rather than degrading to an untyped `JsonElement`), the mesh hub's
permission evaluator (an uncopied evaluator silently grants `Permission.All`), and a routing-service
registration so replies land on it cross-silo — with **one deliberate difference: it registers no
handlers**. Nothing executes there, so the only thing its action block ever dispatches is the reply
to a read issued on it. Two call sites move:

- `ContentFileResolver.Resolve` — the collection-config read (#2901's own 10 s);
- `MeshNodeStreamExtensions.GetMeshNodeOutcome` — the generic one-shot node read, which carries the
  same budget and produced the `"this read reached no verdict … within 10s"` the issue also records.

`NodeOperationIssuingHub()` is unchanged and stays correct for a **write**: a target-less
`CreateOrUpdateNodeRequest` posted there EXECUTES on the node-CRUD hub, and a write ack arriving
after the writes queued ahead of it is the ordering that hub exists to impose. Reads and writes want
opposite things from that block, which is why they now have different seams.

**This is not "give the read more headroom".** No bound moved, no retry, no poller, no spinner. The
coupling itself was the defect — the same argument that moved node CRUD off the router
(*"the mesh hub is the ROUTER — it must not execute work"*), one level down: the node-CRUD execution
hub must not be the reply address for unrelated interactive reads. Even with a perfectly-draining
`nodeops`, a bulk create burst legitimately occupies that block; a read that must answer in ten
seconds cannot be behind it.

## Relationship to #2543 — same hub, different defect, and I am not claiming the other one

#2543 ("per-node hubs stop answering mid-bake") was root-caused to this same hub, and the maintainer
noted on 2026-09-03 that the two issues are likely the same contention. Verified against the code:
the **hub** is shared, the **defects are not**.

- **This PR** removes the read from that block. It does not make a node-CRUD turn one millisecond
  shorter.
- **#2543's remaining question — which rule holds `nodeops`' action block for 25–58 s — is untouched
  and that issue stays open.** The discriminating measurement it needs (a hub-reader dump out of a
  failing seal) is absent from every job log since 2026-08-28; I have no evidence for it and did not
  invent any.

What this *does* do for #2543 is remove a contributor and, more usefully, a confound. The
`PendingCallbacks=26[GetDataRequest@Store/Core, @Store/Install, …]` in #2543's own capture are
`GetMeshNode` reads from mesh-singleton services holding the DI root hub — every one of them was
hopped onto `nodeops` because it was the only off-router hub there was. They now register on
`portal/reads-{meshId}`. **After this lands, a read still pending on `portal/nodeops` was issued by
something running on that hub**, which is a far smaller set to search. Recorded in
`Doc/Architecture/BakeSealNodeOpsSaturation` → *"One confound has been removed"*.

## Conserved

- `Doc/Architecture/ContentRoute503` gains **"Cause B's cure"** — the seam, the two call sites, the
  repro with its captured signature, and an explicit *what it does not fix*. The pre-fix elimination
  is kept as written, because that is what the production occurrences ran.
- `Doc/Architecture/BakeSealNodeOpsSaturation` gains the confound note above, in its *Open* section.
- `OrleansCrossSiloReplyTest`'s class doc, which names the hub the reply leg exercises, follows the
  seam.
- What's New: *"A file you just uploaded serves straight away"* (`Category: Fix`).

## Verification

Local, this worktree:

- `dotnet build -c Release -warnaserror`, one project per invocation, all `0 Warning(s) 0 Error(s)`:
  `MeshWeaver.Mesh.Contract`, `MeshWeaver.ContentCollections`, `MeshWeaver.Documentation`,
  `MeshWeaver.Hosting`, `MeshWeaver.Hosting.AspNetCore`, `MeshWeaver.PluginCatalog`,
  `MeshWeaver.GitSync`, `MeshWeaver.Data`, `MeshWeaver.Graph.Test`,
  `MeshWeaver.Documentation.Test`, `MeshWeaver.Hosting.Orleans.Test`.
- Suites, all green: `MeshWeaver.Graph.Test` **1272/1272** · `MeshWeaver.Hosting.Orleans.Test`
  **243/243** (the two-silo reply facts now exercise `portal/reads-…`) · `MeshWeaver.Hosting.Test`
  **331/331** · `MeshWeaver.Documentation.Test` **246/246** (incl. `DocumentationLinkIntegrityTest`
  and the ratchet guards) · `MeshWeaver.ContentCollections.Test` **22/22**.
- The new test verified to FAIL on the unfixed composition and pass on the fixed one, one variable
  at a time, on the same box.

Closes #2901

Refs #2543

🤖 Generated with [Claude Code](https://claude.com/claude-code)
