### PR TITLE
Availability counts every COPY in the sealed set, riding siblings included (#3221, #3175)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -444,16 +444,27 @@ availability gate now sees it (below) instead of rolling onto it.
    `BakeAgainstPlatformHostTest.AComposedModuleTheHostAlsoShips_IsRefusedByName`.
 2. **Availability asserts the SET** (`ReleaseAvailability.IsUpdatable` over the observation
    `PublishedBundleCatalogue.ArtifactsForIdentity` makes). For the candidate identity the registry
-   reads every complete source's sealed module set — each module bundle's entry assembly, PE header
-   only, for its MVID — and every sealed bundle's per-NodeType dependency record (manifest only,
-   never assembly bytes). Then: every `mvid:` entry naming a module the set carries must equal the
-   MVID sealed for it, and no module may be sealed at two MVIDs by two sources. A violation is
-   `PackageAvailabilityKind.SealedSetInconsistent` — a HOLD that names the bundle, the NodeType, the
-   module and both builds — and it is consumed unchanged by the self-update poll, CD's post-promote
-   assertion and `/api/plugins/is-updatable`, because all three call the same predicate. Both
-   failure directions are pinned (`SealedSetConsistencyTest`): an unreadable or pre-module-sealing
-   module set is `Indeterminate` (hold, named — never "compatible"), and a module the set does not
-   carry is not judged, because the gate cannot see the bytes a registry install landed.
+   reads every complete source's sealed module set — every `MeshWeaver.*` assembly each module
+   bundle CARRIES, PE header only, for its MVID — and every sealed bundle's per-NodeType dependency
+   record (manifest only, never assembly bytes). Then: every `mvid:` entry naming a module the set
+   carries must equal the MVID sealed for it, and no assembly name may appear in the set at two
+   MVIDs. A violation is `PackageAvailabilityKind.SealedSetInconsistent` — a HOLD that names the
+   bundle, the NodeType, the module and both builds — and it is consumed unchanged by the
+   self-update poll, CD's post-promote assertion and `/api/plugins/is-updatable`, because all three
+   call the same predicate. Both failure directions are pinned (`SealedSetConsistencyTest`): an
+   unreadable or pre-module-sealing module set is `Indeterminate` (hold, named — never
+   "compatible"), and a module the set does not carry is not judged, because the gate cannot see the
+   bytes a registry install landed.
+
+   🚨 **"No name at two MVIDs" counts RIDING copies, not just declared ones (#3221).** A
+   module-owned `MeshWeaver.*` sibling rides every bundle that references it, so one name commonly
+   reaches a mesh from many bundles at once — 19 of MeshWeaver.Plugins' 37 module bundles carry a
+   copy of an assembly another package declares. That shape is sanctioned and is NOT refused;
+   excluding declared modules from the closure would invert the package graph and break solo
+   installs. What is refused is the copies DISAGREEING, because the loader keeps whichever it saw
+   first and declines every NodeType that recorded the other. Only the DECLARED entry defines what
+   the identity's module IS. Full reasoning and the measurement:
+   [Module-Owned Siblings Ride](../ModuleOwnedSiblingsRide).
 
 ### What the gate still cannot see
 
@@ -595,6 +606,7 @@ producer of the same publication and is removed — a follow-up, not part of thi
   mirror volume, `git worktree add` per run at the release ref, worktree deleted at job end.
 
 See also: [ModuleClosureAccounting](../ModuleClosureAccounting) ·
+[ModuleOwnedSiblingsRide](../ModuleOwnedSiblingsRide) ·
 [ModuleVersioning](../ModuleVersioning) ·
 [NodeTypeCompilation](../NodeTypeCompilation) · [PluginBuildContract](../PluginBuildContract) ·
 [BuildProcess](../BuildProcess) · [InMeshBuildAndTest](../InMeshBuildAndTest).

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleClosureAccounting.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleClosureAccounting.md
@@ -146,5 +146,6 @@ lane and by the container lane, must declare the same non-framework closure.** A
 lane divergence pretending to be a build decision.
 
 See also: [Module Build Architecture](../ModuleBuildArchitecture) ·
+[Module-Owned Siblings Ride](../ModuleOwnedSiblingsRide) ·
 [Module Versioning](../ModuleVersioning) · [Plugin Build Contract](../PluginBuildContract) ·
 [NodeType Compilation](../NodeTypeCompilation)

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleOwnedSiblingsRide.md
@@ -1,0 +1,142 @@
+---
+Name: Module-Owned Siblings Ride
+Category: Architecture
+Description: The decision behind #3221 — a module-owned MeshWeaver.* sibling that another package DECLARES as its module still rides into a second bundle, and the invariant that closes the double-production hazard is byte equality, not exclusivity.
+Icon: /static/NodeTypeIcons/code.svg
+---
+
+# Module-Owned Siblings Ride
+
+A module-owned `MeshWeaver.*` sibling **rides** every bundle that references it
+([Module Closure Accounting](../ModuleClosureAccounting)). Some of those siblings are *themselves*
+another package's declared module. That makes one assembly name reach a mesh from several bundles at
+once — two module-side producers of one name — which is the shape that
+[#3175](../ModuleBuildArchitecture) exists to be afraid of.
+
+This page records the decision (**it rides**), the evidence, and the invariant that replaces the
+exclusivity the question proposed.
+
+## The question
+
+> Should a sibling that is **itself another package's declared module** ride into a second bundle,
+> or should the closure rule exclude declared modules and let the landing resolve them from their
+> owning package?
+
+`BakeHost.ShippedByHostProblem` already refuses a module composed with `--module` that the *platform
+host* also ships. It does not look at whether a *second module bundle* carries a copy of the same
+assembly name. The proposed extension — refuse a bundle carrying an assembly another package
+declares as its module — is the same shape one hop further out.
+
+## The decision: it rides
+
+**The closure rule is unchanged.** A module-owned sibling rides, whether or not another package
+declares it. The refusing guard is **not** built, and the reason is not caution — it is that the
+rule it would enforce is unsatisfiable.
+
+### 1. It is the dominant shape, not an exception
+
+Measured over `MeshWeaver.Plugins` `main` on 2026-09-03 — every package's `index.json`
+`content.module`, joined against each module project's transitive in-repo `ProjectReference` closure
+minus `src/platform-shipped.txt`:
+
+| | |
+|---|---|
+| Declared modules in the repo | **37** |
+| Module bundles riding at least one *other package's declared module* | **19** |
+| Bundles riding `MeshWeaver.Markdown.Collaboration` (declared by **Essentials**) | 14 |
+| Bundles riding `MeshWeaver.AI` (declared by **AI**) | 12 |
+| Bundles riding `MeshWeaver.Maps` (declared by **Maps**) | 4 |
+
+The issue named one instance (`Chat` riding `MeshWeaver.AI`) as a "pre-existing accepted pattern".
+It is more than half the fleet's modules.
+
+### 2. Excluding declared modules inverts the package graph
+
+If a declared module may not ride, the landing must resolve it from its owning package — so the
+riding package must **depend** on the owning one. It does not, and cannot:
+
+```
+AI/index.json         requires: [Store]                    module: MeshWeaver.AI
+Essentials/index.json requires: [AI, Store, Export, …]     module: MeshWeaver.Markdown.Collaboration
+```
+
+`MeshWeaver.AI` references `MeshWeaver.Markdown.Collaboration`, which **Essentials** declares — and
+Essentials `requires` AI. Making AI resolve the sibling from Essentials is a cycle. The same
+inversion holds for `Mcp`, `Mail`, `Teams`, `Notifications`, `Observability` and every other package
+Essentials requires: each rides an assembly its own dependent declares.
+
+### 3. It would break a supported install
+
+`AI` is installable on its own (`requires: [Store]`). With the sibling excluded, that bundle lands
+without `MeshWeaver.Markdown.Collaboration.dll` and nothing supplies it — the platform image does
+not (Plugins#1268 removed it from `/app`) and no required package brings it. The result is the
+`ReflectionTypeLoadException` on first touch that
+[Module Closure Accounting](../ModuleClosureAccounting) was written after: *"Could not load file or
+assembly …"*, a red trunk in a repo that changed nothing, for eleven hours.
+
+### 4. The host case and the module case are not the same defect
+
+`ShippedByHostProblem` refuses host-vs-module because the two provenances use **incompatible id
+schemes**. The host's copy resolves from the surface manifest as `ref:<hash>`; a composed module
+resolves as `mvid:<guid>`. Those never compare equal *even for byte-identical assemblies*, so the
+conflict is unfixable by agreement — one producer must go.
+
+Module-vs-module is `mvid:` on **both** sides. Identical bytes compare **equal**. The conflict is
+fixable by agreement, and agreement is cheaper than exclusivity.
+
+## The invariant that replaces it
+
+> **One assembly name, one framework identity, one build — across every copy in the sealed set,
+> declared or riding.**
+
+The hazard is real and worth an assertion. `MeshWeaver.*` assemblies bind by a strictly synchronised
+`AssemblyVersion` (see [Module Closure Accounting](../ModuleClosureAccounting) → "the same-identity
+trap"), so two copies under one simple name are **one assembly identity**: `Assembly.LoadFrom` returns
+the already-loaded one and ignores the second path. Whichever copy loads first wins the process, and
+the loser's bytes are never in memory.
+
+What that costs when the copies differ is exactly the `#3175` incident:
+`NodeTypeCompilationHelpers.ModuleMvidsOf` reports the MVID of the assembly that actually loaded, so
+every NodeType whose dependency record named the other build is declined at adoption —
+*"dependency record mismatch — 'MeshWeaver.Markdown.Collaboration' built against mvid:A, live is
+mvid:B"* — and the view renders empty.
+
+Today the copies agree by **accident**: `bake-scope.sh` classifies any change under `src/` as
+affecting ALL modules, and `module-build-key.py` folds each entry's whole in-repo `ProjectReference`
+closure into its content address, so a sibling's change re-keys every bundle that carries it. Both
+are correct and neither is the assertion — they are two mechanisms that happen to preserve the
+property. The assertion is:
+
+**`PublishedBundleCatalogue.ArtifactsForIdentity` reads the MVID of every `MeshWeaver.*` assembly
+each sealed module bundle carries — entry and riding sibling alike — and any name carried at two
+MVIDs becomes a `SealedModuleSet.Conflicts` line naming both producers, their sources, their bundles
+and the ROLE of each copy.** `ReleaseAvailability.IsUpdatable` then answers
+`PackageAvailabilityKind.SealedSetInconsistent` for every package whose records bind that name: a
+HOLD, not a roll. That is the maintainer's requirement — *"we must have a clear confirmation that all
+plugins deployed to an instance are available for the correct platform version. If not the case ⇒
+nothing goes"* — applied to the copies as well as the declarations.
+
+Two boundaries are deliberate:
+
+* **Only the DECLARED entry defines `MvidByModule`.** An instance registers declared modules as
+  `InstalledModuleAssembly`, and that registration is what `ModuleMvidsOf` reports back as "live". An
+  assembly that only ever rides is registered nowhere, so letting it define the set would judge
+  records against bytes the instance never reports — a false HOLD, which
+  [#1754](../ReleaseGates)'s `ReleaseGateApplicabilityTest` already records the cost of.
+* **Only `MeshWeaver.*` names are judged.** A third-party diamond rides by design and versions
+  independently; it does not collapse to one identity. Judging it would hold every bundle in the
+  fleet for a property that was never claimed.
+
+## What this does not close
+
+The **second producer in time** is untouched: an instance that installed a module from the registry's
+content-versioned package endpoint holds whatever *that* lane published last, while the sealed
+publication carries the bytes the platform release rebuilt. Both sets can be internally consistent
+and still disagree with each other. See
+[Module Build Architecture](../ModuleBuildArchitecture) → "What the gate still cannot see" for the
+two ways to close it (the seal composes the registry's bytes, or the instance adopts module bytes
+for its identity from the sealed publication).
+
+See also: [Module Closure Accounting](../ModuleClosureAccounting) ·
+[Module Build Architecture](../ModuleBuildArchitecture) ·
+[Candidate Release Protocol](../CandidateReleaseProtocol) · [Release Gates](../ReleaseGates)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-the-fit-check-now-looks-inside-every-package.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-the-fit-check-now-looks-inside-every-package.md
@@ -1,0 +1,33 @@
+---
+Name: The fit check now looks inside every package
+Category: Fix
+Description: The check that holds an update when your installed packages do not fit together was only comparing the main piece each package ships. Packages also carry copies of pieces that belong to other packages, and those copies were never compared — so a mismatch hiding in one of them could still let an update through.
+Icon: ShieldCheckmark
+Order: -20260903
+---
+
+# The fit check now looks inside every package
+
+Before your installation moves to a new platform build, it checks that every installed package has
+been prepared for that build **and that the packages fit together** — that they were all prepared
+against the same pieces. If they were not, the update is held rather than applied, because a package
+prepared against the wrong piece is quietly discarded at start-up and its pages come up empty.
+
+That check was only comparing the **main piece** each package ships. It turns out most packages
+carry more than one. A package that builds on a small shared piece — the collaboration tools, the AI
+core, the map control — carries a **copy** of it, so the package works even when it is installed on
+its own. On the current package set, 19 of 37 packages carry a copy of a piece that some other
+package owns.
+
+Those copies were never compared with each other, so two of them could disagree and nothing would
+notice. The result would be the failure the fit check exists to prevent, arriving anyway: your
+installation keeps whichever copy it loads first, and every page prepared against the other one is
+discarded.
+
+**The check now reads every copy inside every prepared package**, not only the main piece. If one
+piece appears twice as two different builds, the update is **held** and the **Updates** settings tab
+names both packages, the piece, and the two versions that disagree.
+
+Carrying the copy is deliberate and has not changed — removing it would break installing those
+packages on their own. What changed is that "the copies agree" is now something your installation
+confirms before it updates, instead of something the build pipeline happened to get right.

--- a/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
+++ b/src/MeshWeaver.PluginCatalog/PublishedBundleCatalogue.cs
@@ -154,21 +154,42 @@ public static class PublishedBundleCatalogue
 
     /// <summary>
     /// 🚨 The FULL observation of one identity (#3175): the sealed bundle ids, the module set every
-    /// complete source sealed (each module bundle's entry assembly read for its MVID, spelt as the
-    /// dependency records spell it), and every sealed bundle's per-NodeType dependency record. The
-    /// bytes were always on disk — <see cref="SealedModulesOf"/> already refused a torn set — and
-    /// <see cref="ReleaseAvailability"/> can only assert CONSISTENCY when it is handed both halves.
-    /// Reads every bundle's MANIFEST, and for each sealed module bundle inflates its entry assembly into
-    /// memory to read the MVID from its PE metadata — never a content bundle's NodeType assembly bytes.
+    /// complete source sealed (each module bundle read for the MVID of every <c>MeshWeaver.*</c>
+    /// assembly it CARRIES, spelt as the dependency records spell it), and every sealed bundle's
+    /// per-NodeType dependency record. The bytes were always on disk — <see cref="SealedModulesOf"/>
+    /// already refused a torn set — and <see cref="ReleaseAvailability"/> can only assert CONSISTENCY
+    /// when it is handed both halves. Reads every bundle's MANIFEST, and for each sealed module bundle
+    /// inflates its module-folder assemblies into memory to read the MVID from their PE metadata —
+    /// never a content bundle's NodeType assembly bytes.
     /// </summary>
-    /// <remarks>A module bundle that cannot be read, or a source sealed before module sealing
-    /// existed, becomes the set's <see cref="SealedModuleSet.Refusal"/> — a named unreadability the
-    /// gate turns into a HOLD — and never a silent omission that would read as "no module here".</remarks>
+    /// <remarks>
+    /// <para>A module bundle that cannot be read, or a source sealed before module sealing existed,
+    /// becomes the set's <see cref="SealedModuleSet.Refusal"/> — a named unreadability the gate turns
+    /// into a HOLD — and never a silent omission that would read as "no module here".</para>
+    ///
+    /// <para>🚨 <b>Every COPY is accounted for, not only the declared one (#3221).</b> A module-owned
+    /// <c>MeshWeaver.*</c> sibling RIDES the bundles that reference it
+    /// (<see href="../ModuleClosureAccounting">Module Closure Accounting</see>), so one assembly name
+    /// reaches a mesh from several bundles at once: measured on MeshWeaver.Plugins <c>main</c>
+    /// 2026-09-03, 19 of 37 module bundles carry a copy of an assembly some OTHER package declares as
+    /// its module — <c>MeshWeaver.Markdown.Collaboration</c> (Essentials') rides 14 of them and
+    /// <c>MeshWeaver.AI</c> (AI's) rides 12. Those copies must be the SAME BUILD: the loader collapses
+    /// them to whichever loads first, so a divergence makes the live MVID a coin toss and every
+    /// NodeType binding the name is declined at adoption. Riding copies therefore take part in
+    /// <see cref="SealedModuleSet.Conflicts"/>, while only the DECLARED entry defines
+    /// <see cref="SealedModuleSet.MvidByModule"/> — the entry is what an instance registers as an
+    /// <c>InstalledModuleAssembly</c> and therefore what <c>NodeTypeCompilationHelpers.ModuleMvidsOf</c>
+    /// reports, so a ride-only name must not start standing in for a module nothing declares.</para>
+    /// </remarks>
     internal static ReleaseArtifacts ArtifactsForIdentity(string identityDirectory, ILogger? logger)
     {
         var bundles = new List<string>();
         var records = ImmutableArray.CreateBuilder<BundleDependencyRecord>();
+        // The DECLARED modules — what an instance registers, and therefore what a record must name.
         var sealedBy = new Dictionary<string, (string Mvid, string Source)>(StringComparer.Ordinal);
+        // EVERY copy of every MeshWeaver.* assembly the sealed module bundles carry, declared or
+        // riding: the first one seen per name, against which every later copy must compare equal.
+        var producedBy = new Dictionary<string, SealedCopy>(StringComparer.Ordinal);
         var conflicts = ImmutableArray.CreateBuilder<string>();
         var refusals = new List<string>();
 
@@ -192,25 +213,33 @@ public static class PublishedBundleCatalogue
             foreach (var moduleBundle in modules.Modules)
             {
                 var path = Path.Combine(sourceDirectory, ModulesDirectoryName, moduleBundle);
-                string name, mvid;
+                ImmutableArray<SealedModuleAssembly> carried;
                 try
                 {
-                    (name, mvid) = SealedModuleMvidOf(path);
+                    carried = SealedModuleAssembliesOf(path);
                 }
                 catch (Exception ex) when (ex is IOException or InvalidDataException or BadImageFormatException or InvalidOperationException)
                 {
                     refusals.Add($"source '{source}': module bundle '{moduleBundle}' is unreadable — {ex.Message}");
                     continue;
                 }
-                if (sealedBy.TryGetValue(name, out var existing))
+                foreach (var (name, mvid, isEntry) in carried)
                 {
-                    if (!string.Equals(existing.Mvid, mvid, StringComparison.Ordinal))
-                        conflicts.Add(
-                            $"module {name}: source '{existing.Source}' sealed {existing.Mvid}, "
-                            + $"source '{source}' sealed {mvid}");
-                    continue;
+                    if (producedBy.TryGetValue(name, out var first))
+                    {
+                        if (!string.Equals(first.Mvid, mvid, StringComparison.Ordinal))
+                            conflicts.Add(
+                                $"module {name}: source '{first.Source}' sealed {first.Mvid} "
+                                + $"{RoleOf(first.IsEntry)} '{first.Bundle}', source '{source}' sealed "
+                                + $"{mvid} {RoleOf(isEntry)} '{moduleBundle}'");
+                    }
+                    else
+                    {
+                        producedBy[name] = new SealedCopy(mvid, source, moduleBundle, isEntry);
+                    }
+                    if (isEntry)
+                        sealedBy.TryAdd(name, (mvid, source));
                 }
-                sealedBy[name] = (mvid, source);
             }
         }
 
@@ -227,46 +256,90 @@ public static class PublishedBundleCatalogue
     }
 
     /// <summary>
-    /// A sealed module bundle's entry assembly and its MVID in the dependency-record spelling
+    /// Every <c>MeshWeaver.*</c> assembly a sealed module bundle CARRIES — its declared entry first,
+    /// then each riding sibling — with each MVID in the dependency-record spelling
     /// (<c>mvid:&lt;N&gt;</c> — <c>NodeTypeCompilationHelpers.ModuleMvidsOf</c>'s projection, so the
     /// gate compares the id the seeder will compute). The entry is the manifest's
     /// <c>module.assemblyName</c>, else the single assembly under the module folder — the same
     /// resolution the lanes apply when they compose the bundle.
+    ///
+    /// <para>🚨 <b>What is read, and why that set (#3221).</b> The module folder is FLAT and holds
+    /// the module's private closure, so it carries the entry plus whatever rode with it. Only
+    /// <c>MeshWeaver.*</c> names are folded in: those bind by a strictly synchronised
+    /// <c>AssemblyVersion</c>, so two copies under one simple name are one assembly identity and the
+    /// loader keeps whichever it saw first — that is the double-production hazard. A third-party
+    /// diamond RIDES by design, versions independently, and is deliberately NOT judged here. The
+    /// files are read from the ARCHIVE rather than from <c>module.assemblies</c>, because what lands
+    /// is what the bundle contains, not what its manifest claims.</para>
     /// </summary>
-    internal static (string Name, string Mvid) SealedModuleMvidOf(string moduleBundlePath)
+    internal static ImmutableArray<SealedModuleAssembly> SealedModuleAssembliesOf(string moduleBundlePath)
     {
         var manifest = BundleReader.ReadManifest(moduleBundlePath);
         using var file = File.OpenRead(moduleBundlePath);
         using var archive = new ZipArchive(file, ZipArchiveMode.Read);
+        var flat = archive.Entries
+            .Where(e => e.FullName.StartsWith(NuGetPackageWriter.ModuleFolder + "/", StringComparison.Ordinal)
+                        && e.FullName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
+                        && !e.FullName[(NuGetPackageWriter.ModuleFolder.Length + 1)..].Contains('/'))
+            .OrderBy(e => e.FullName, StringComparer.Ordinal)
+            .ToList();
         var name = manifest?.Module?.AssemblyName;
         if (string.IsNullOrWhiteSpace(name))
         {
-            var candidates = archive.Entries
-                .Where(e => e.FullName.StartsWith(NuGetPackageWriter.ModuleFolder + "/", StringComparison.Ordinal)
-                            && e.FullName.EndsWith(".dll", StringComparison.OrdinalIgnoreCase)
-                            && !e.FullName[(NuGetPackageWriter.ModuleFolder.Length + 1)..].Contains('/'))
-                .ToList();
-            if (candidates.Count != 1)
+            if (flat.Count != 1)
                 throw new InvalidOperationException(
                     $"cannot identify the module's entry assembly (no manifest module.assemblyName; "
-                    + $"{NuGetPackageWriter.ModuleFolder}/ holds {candidates.Count} dll(s))");
-            name = Path.GetFileNameWithoutExtension(candidates[0].FullName);
+                    + $"{NuGetPackageWriter.ModuleFolder}/ holds {flat.Count} dll(s))");
+            name = Path.GetFileNameWithoutExtension(flat[0].FullName);
         }
         var entry = archive.GetEntry($"{NuGetPackageWriter.ModuleFolder}/{name}.dll")
             ?? throw new InvalidOperationException(
                 $"{NuGetPackageWriter.ModuleFolder}/{name}.dll is missing from the bundle");
-        using var stream = entry.Open();
+
+        var carried = ImmutableArray.CreateBuilder<SealedModuleAssembly>(flat.Count);
+        carried.Add(new SealedModuleAssembly(name, MvidOf(entry), IsEntry: true));
+        foreach (var sibling in flat)
+        {
+            var simple = Path.GetFileNameWithoutExtension(sibling.FullName);
+            if (string.Equals(simple, name, StringComparison.Ordinal) || !IsPlatformAssemblyName(simple))
+                continue;
+            carried.Add(new SealedModuleAssembly(simple, MvidOf(sibling), IsEntry: false));
+        }
+        return carried.ToImmutable();
+    }
+
+    /// <summary>The MVID of one archived assembly, in the dependency-record spelling. Inflated into
+    /// memory (a zip entry is not seekable, and <c>PEReader</c> needs to seek).</summary>
+    private static string MvidOf(ZipArchiveEntry entry)
+    {
         if (entry.Length is < 0 or > int.MaxValue)
             throw new InvalidOperationException(
                 $"{entry.FullName} declares an implausible length ({entry.Length} bytes) — the module bundle is corrupt");
+        using var stream = entry.Open();
         using var bytes = new MemoryStream((int)entry.Length);
         stream.CopyTo(bytes);
         bytes.Position = 0;
         using var pe = new PEReader(bytes);
         var metadata = pe.GetMetadataReader();
-        var mvid = metadata.GetGuid(metadata.GetModuleDefinition().Mvid);
-        return (name, CompiledDependencies.MvidScheme + mvid.ToString("N"));
+        return CompiledDependencies.MvidScheme
+               + metadata.GetGuid(metadata.GetModuleDefinition().Mvid).ToString("N");
     }
+
+    /// <summary>The names that bind by a strictly synchronised <c>AssemblyVersion</c> and therefore
+    /// collapse to ONE identity in a loaded process — the same predicate
+    /// <c>MeshWeaver.Plugin.Build.DepsClosure</c> uses to decide what the platform side owns.</summary>
+    private static bool IsPlatformAssemblyName(string name) =>
+        name.StartsWith("MeshWeaver.", StringComparison.OrdinalIgnoreCase)
+        || string.Equals(name, "MeshWeaver", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>Which bundle, from which source, sealed the first copy of one assembly name, and
+    /// whether it was that bundle's DECLARED module or a sibling riding beside it.</summary>
+    private readonly record struct SealedCopy(string Mvid, string Source, string Bundle, bool IsEntry);
+
+    /// <summary>How a copy reached the sealed set — the half of a conflict line that tells an
+    /// operator which producer to change.</summary>
+    private static string RoleOf(bool isEntry) =>
+        isEntry ? "as the declared module of" : "as a sibling riding";
 
     /// <summary>
     /// The per-NodeType dependency records one sealed bundle carries. EMPTY when the archive carries
@@ -460,6 +533,19 @@ public static class PublishedBundleCatalogue
 /// <summary>One reading of a sealed publication's module set: the listed bundle names, or
 /// <c>null</c> with the reason a consumer must not compose from it.</summary>
 public sealed record ModuleSetReading(IReadOnlyList<string>? Modules, string? Refusal);
+
+/// <summary>
+/// One <c>MeshWeaver.*</c> assembly a sealed module bundle carries, and the build it is
+/// (<c>mvid:&lt;N&gt;</c>). <paramref name="IsEntry"/> separates the bundle's DECLARED module — the
+/// one an instance registers, and therefore the one a dependency record must name — from a sibling
+/// RIDING beside it because it is module-owned and exists nowhere in <c>/app</c>
+/// (<see href="../ModuleClosureAccounting">Module Closure Accounting</see>). Both must be the same
+/// build for one framework identity; only the entry defines what the identity's module IS (#3221).
+/// </summary>
+/// <param name="Name">The assembly's simple name.</param>
+/// <param name="Mvid">Its MVID in the dependency-record spelling (<c>mvid:&lt;32 hex&gt;</c>).</param>
+/// <param name="IsEntry">True for the bundle's declared module, false for a riding sibling.</param>
+public readonly record struct SealedModuleAssembly(string Name, string Mvid, bool IsEntry);
 
 /// <summary>One reading of the catalogue: what the target release turned out to be, and what was
 /// published for it.</summary>

--- a/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
+++ b/src/MeshWeaver.PluginCatalog/ReleaseAvailability.cs
@@ -141,13 +141,28 @@ public static class ReleaseAvailability
     /// version; if not ⇒ nothing goes"</i>.
     ///
     /// <para>The rule: every <c>mvid:</c> entry in a bundle's dependency records that names a module
-    /// the identity's sealed module set carries must equal the MVID sealed for it, and no module may
-    /// be sealed at two MVIDs by two sources. A module the sealed set does NOT carry is one the
+    /// the identity's sealed module set carries must equal the MVID sealed for it, and no assembly
+    /// name may appear in the set at two MVIDs. A module the sealed set does NOT carry is one the
     /// instance lands from the registry outside any publication — this gate cannot see those bytes
     /// and does not pretend to. Records that cannot be checked because the module set is unreadable
     /// answer <see cref="PackageAvailabilityKind.Indeterminate"/> — a HOLD, never an incompatibility
     /// verdict, and never a pass: an unsealed or torn module set is exactly the case that let ci.7621
     /// through.</para>
+    ///
+    /// <para>🚨 <b>"No name at two MVIDs" counts RIDING copies, not just declared ones (#3221).</b> A
+    /// module-owned <c>MeshWeaver.*</c> sibling rides every bundle that references it, so one name
+    /// commonly reaches a mesh from many bundles at once — measured on MeshWeaver.Plugins
+    /// <c>main</c> 2026-09-03, 19 of 37 module bundles carry a copy of an assembly some other package
+    /// declares as its module. That is the sanctioned shape and it is NOT refused
+    /// (<see href="../ModuleOwnedSiblingsRide">Module-Owned Siblings Ride</see>): excluding declared
+    /// modules from the closure would invert the package graph — <c>AI</c> requires only <c>Store</c>
+    /// yet would need <c>Essentials</c>' module, while <c>Essentials</c> requires <c>AI</c> — and a
+    /// solo install would fault on its first touch. What IS refused is the copies DISAGREEING: the
+    /// loader binds <c>MeshWeaver.*</c> by a strictly synchronised <c>AssemblyVersion</c> and keeps
+    /// whichever copy it saw first, so two builds under one name make the live MVID a coin toss and
+    /// decline every NodeType that recorded the other. Byte equality per (assembly name, framework
+    /// identity) is the invariant; this is where it is asserted rather than assumed from a uniform
+    /// CD wave.</para>
     /// </summary>
     private static PackageAvailability? SealedSetProblem(
         RequiredPackage package, ReleaseTarget target, ReleaseArtifacts artifacts)
@@ -176,10 +191,11 @@ public static class ReleaseAvailability
                     return new PackageAvailability(
                         package.Name,
                         PackageAvailabilityKind.SealedSetInconsistent,
-                        $"'{package.BundleName}' ({record.NodePath}) binds module {name}, which two sources "
-                        + $"sealed as DIFFERENT builds for framework identity {target.FrameworkIdentity} "
-                        + $"({conflict}) — whichever the instance composes, the other's NodeTypes are "
-                        + "declined at adoption; the set is inconsistent and nothing rolls");
+                        $"'{package.BundleName}' ({record.NodePath}) binds module {name}, which the set "
+                        + $"sealed for framework identity {target.FrameworkIdentity} carries as TWO "
+                        + $"DIFFERENT builds ({conflict}) — the loader keeps whichever it sees first, so "
+                        + "the other's NodeTypes are declined at adoption; the set is inconsistent and "
+                        + "nothing rolls");
 
                 if (set.MvidByModule.TryGetValue(name, out var sealedMvid)
                     && !string.Equals(sealedMvid, id, StringComparison.Ordinal))
@@ -323,10 +339,16 @@ public enum PackageAvailabilityKind
 /// dependency record sealed for it must name (#3175).
 /// </summary>
 /// <param name="MvidByModule">Module simple name → its id in the dependency-record spelling
-/// (<c>mvid:&lt;32 hex&gt;</c>), for every module exactly one source sealed.</param>
-/// <param name="Conflicts">One line per module two sources sealed as DIFFERENT builds, each starting
-/// <c>module &lt;name&gt;:</c> and naming both sources and both ids. A conflict is an inconsistency
-/// of the set itself, whatever any bundle recorded.</param>
+/// (<c>mvid:&lt;32 hex&gt;</c>), for every module exactly one bundle DECLARED. A riding copy never
+/// defines an entry here (#3221): the declared module is what an instance registers as an
+/// <c>InstalledModuleAssembly</c>, so it alone is what a dependency record can be judged against.</param>
+/// <param name="Conflicts">One line per assembly name the identity's sealed set carries at TWO
+/// DIFFERENT builds, each starting <c>module &lt;name&gt;:</c> and naming both producers — source,
+/// module bundle, id, and whether that copy was the bundle's declared module or a sibling riding
+/// beside it (#3221). A conflict is an inconsistency of the set itself, whatever any bundle
+/// recorded, and the two producers may be one source: a module-owned <c>MeshWeaver.*</c> sibling
+/// rides every bundle that references it, so one name commonly reaches a mesh from many bundles at
+/// once and they must all be one build.</param>
 /// <param name="Refusal">Why the set could not be read completely (a source sealed before module
 /// sealing existed, a torn module index, an unreadable module bundle), or null when it was. Non-null
 /// makes every record that names a module <see cref="PackageAvailabilityKind.Indeterminate"/>.</param>

--- a/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
+++ b/test/Memex.Portal.Shared.Test/SealedSetConsistencyTest.cs
@@ -47,11 +47,30 @@ public class SealedSetConsistencyTest
     /// so the observation's PE read is exercised against genuine bytes, not a stub.</summary>
     private static readonly System.Reflection.Assembly ModuleBytesOf = typeof(ReleaseAvailability).Assembly;
 
-    private static string SealedMvid =>
-        CompiledDependencies.MvidScheme + ModuleBytesOf.ManifestModule.ModuleVersionId.ToString("N");
+    private static string SealedMvid => MvidOf(ModuleBytesOf);
 
     private static string AnotherBuild =>
         CompiledDependencies.MvidScheme + Guid.NewGuid().ToString("N");
+
+    /// <summary>The module-owned sibling of the #3221 fixtures — a REAL managed assembly, distinct
+    /// from the entry's, so the observation's PE read answers a genuine MVID for the riding copy.
+    /// Its simple name comes from the FILE name the bundle carries it under, which is exactly how the
+    /// loader and the observation both name it.</summary>
+    private const string Sibling = "MeshWeaver.ProbeSibling";
+
+    private static byte[] SiblingBytes => File.ReadAllBytes(typeof(BundleReader).Assembly.Location);
+
+    private static string SiblingMvid => MvidOf(typeof(BundleReader).Assembly);
+
+    /// <summary>A DIFFERENT real build to stand in for "the same assembly, compiled in another
+    /// wave" — the divergence the negative control needs.</summary>
+    private static byte[] AnotherBuildBytes =>
+        File.ReadAllBytes(typeof(CompiledDependencies).Assembly.Location);
+
+    private static string AnotherBuildMvid => MvidOf(typeof(CompiledDependencies).Assembly);
+
+    private static string MvidOf(System.Reflection.Assembly assembly) =>
+        CompiledDependencies.MvidScheme + assembly.ManifestModule.ModuleVersionId.ToString("N");
 
     // ── the observation: the bytes on disk become a module set and dependency records ───────────
 
@@ -181,6 +200,151 @@ public class SealedSetConsistencyTest
             Assert.Equal(PackageAvailabilityKind.SealedSetInconsistent, widget.Kind);
             Assert.Contains(recorded, widget.Reason!, StringComparison.Ordinal);
             Assert.Contains(SealedMvid, widget.Reason!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    // ── #3221: a module-owned sibling RIDES a second bundle, and every copy must be one build ────
+
+    /// <summary>
+    /// 🚨 THE SANCTIONED SHAPE, and the reason the closure rule was NOT changed (#3221). A
+    /// module-owned <c>MeshWeaver.*</c> sibling rides every bundle that references it, so one
+    /// assembly name is sealed by several bundles at once — measured on MeshWeaver.Plugins
+    /// <c>main</c> 2026-09-03, 19 of 37 module bundles carry a copy of an assembly another package
+    /// declares as its module. This must NOT hold: refusing it would freeze more than half the
+    /// fleet's modules, and excluding declared modules from the closure would invert the package
+    /// graph (<c>AI</c> requires only <c>Store</c> yet would need <c>Essentials</c>' module, while
+    /// <c>Essentials</c> requires <c>AI</c>).
+    /// </summary>
+    [Fact]
+    public void ASiblingRidingASecondBundle_AtTheSameBuild_IsAvailable()
+    {
+        var root = PublishedRootWithRide(
+            recorded: SiblingMvid, declared: SiblingBytes, riding: SiblingBytes);
+        try
+        {
+            var observation = PublishedBundleCatalogue.Read(root, Version);
+            Assert.Empty(observation.Artifacts.Modules!.Conflicts);
+            Assert.Null(observation.Artifacts.Modules.Refusal);
+            // The DECLARED module defines the set; the ride agrees with it.
+            Assert.Equal(SiblingMvid, observation.Artifacts.Modules.MvidByModule[Sibling]);
+
+            var verdict = ReleaseAvailability.IsUpdatable(
+                observation.Target, [Required], observation.Artifacts);
+            Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 <b>THE NEGATIVE CONTROL for #3221.</b> The same set, with the RIDING copy a different build
+    /// from the one its owning package declares. Every declared entry is still distinct and
+    /// self-consistent — <c>MeshWeaver.ProbeModule</c> is sealed once, <c>MeshWeaver.ProbeSibling</c>
+    /// is sealed once as a declared module — so the entry-only reading #3187 shipped sees a perfectly
+    /// consistent set and answers AVAILABLE. Only a reading that accounts for the RIDING copy can
+    /// fail here, which is what makes this a proof that the check binds to the sibling path and not
+    /// merely to the path already covered.
+    ///
+    /// <para>The failure it prevents is the one memex-cloud suffered on ci.7621: the loader binds
+    /// <c>MeshWeaver.*</c> by a strictly synchronised <c>AssemblyVersion</c>, so two copies under one
+    /// simple name collapse to whichever loaded first and every NodeType that recorded the other is
+    /// declined at adoption — <i>"dependency record mismatch — built against mvid:A, live is
+    /// mvid:B"</i>.</para>
+    /// </summary>
+    [Fact]
+    public void ASiblingRidingASecondBundle_AtAnotherBuild_IsHeld_NamingBothProducers()
+    {
+        var root = PublishedRootWithRide(
+            recorded: SiblingMvid, declared: SiblingBytes, riding: AnotherBuildBytes);
+        try
+        {
+            var observation = PublishedBundleCatalogue.Read(root, Version);
+
+            // The set itself says so, naming both producers and the ROLE of each.
+            var conflict = Assert.Single(observation.Artifacts.Modules!.Conflicts);
+            Assert.StartsWith($"module {Sibling}:", conflict, StringComparison.Ordinal);
+            Assert.Contains(AnotherBuildMvid, conflict, StringComparison.Ordinal);
+            Assert.Contains(SiblingMvid, conflict, StringComparison.Ordinal);
+            Assert.Contains("as a sibling riding 'probe.module.nupkg'", conflict, StringComparison.Ordinal);
+            Assert.Contains("as the declared module of 'probe.sibling.nupkg'", conflict, StringComparison.Ordinal);
+            // A name carried at two builds defines nothing — whichever loads first is a coin toss.
+            Assert.DoesNotContain(Sibling, observation.Artifacts.Modules.MvidByModule.Keys);
+            Assert.Null(observation.Artifacts.Modules.Refusal);
+
+            var verdict = ReleaseAvailability.IsUpdatable(
+                observation.Target, [Required], observation.Artifacts);
+
+            Assert.False(verdict.IsUpdatable);
+            Assert.False(verdict.IsIndeterminate,
+                "two builds of one assembly name is a DEFINITE inconsistency of the set, not an unreadability");
+            var package = Assert.Single(verdict.Packages);
+            Assert.Equal(PackageAvailabilityKind.SealedSetInconsistent, package.Kind);
+            Assert.Contains(conflict, package.Reason!, StringComparison.Ordinal);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>
+    /// 🚨 The reading a ride must NOT change. Only the DECLARED module defines
+    /// <see cref="SealedModuleSet.MvidByModule"/>: an instance registers declared modules as
+    /// <c>InstalledModuleAssembly</c>, and that registration is what
+    /// <c>NodeTypeCompilationHelpers.ModuleMvidsOf</c> reports back as "live". An assembly that only
+    /// ever RIDES is registered nowhere, so letting it define the set would start judging records
+    /// against bytes the instance never reports — a false HOLD, the expensive failure direction
+    /// (#1754). Here <c>MeshWeaver.ProbeSibling</c> rides but nothing declares it, and a record naming
+    /// it is left unjudged exactly as a module outside the sealed set is.
+    /// </summary>
+    [Fact]
+    public void ARideOnlyAssembly_DoesNotDefineTheModuleSet()
+    {
+        var root = PublishedRootWithRide(
+            recorded: AnotherBuildMvid, declared: null, riding: SiblingBytes);
+        try
+        {
+            var observation = PublishedBundleCatalogue.Read(root, Version);
+            Assert.Empty(observation.Artifacts.Modules!.Conflicts);
+            Assert.Null(observation.Artifacts.Modules.Refusal);
+            Assert.DoesNotContain(Sibling, observation.Artifacts.Modules.MvidByModule.Keys);
+            Assert.Contains(Module, observation.Artifacts.Modules.MvidByModule.Keys);
+
+            var verdict = ReleaseAvailability.IsUpdatable(
+                observation.Target, [Required], observation.Artifacts);
+            Assert.True(verdict.IsUpdatable, verdict.HoldReason);
+        }
+        finally
+        {
+            Directory.Delete(root, recursive: true);
+        }
+    }
+
+    /// <summary>A non-<c>MeshWeaver.*</c> package riding two bundles at two builds is NOT a conflict:
+    /// a third-party diamond rides by design (Module Closure Accounting) and versions independently,
+    /// so it does not collapse to one identity the way a strictly-version-synchronised
+    /// <c>MeshWeaver.*</c> assembly does. Judging it would hold every bundle in the fleet.</summary>
+    [Fact]
+    public void AThirdPartyDiamondRidingTwoBundles_IsNotJudged()
+    {
+        var root = PublishedRootWithRide(
+            recorded: SiblingMvid, declared: SiblingBytes, riding: SiblingBytes,
+            thirdParty: ("Contoso.Sdk", AnotherBuildBytes));
+        try
+        {
+            var observation = PublishedBundleCatalogue.Read(root, Version);
+            Assert.Empty(observation.Artifacts.Modules!.Conflicts);
+            Assert.DoesNotContain("Contoso.Sdk", observation.Artifacts.Modules.MvidByModule.Keys);
+
+            var verdict = ReleaseAvailability.IsUpdatable(
+                observation.Target, [Required], observation.Artifacts);
+            Assert.True(verdict.IsUpdatable, verdict.HoldReason);
         }
         finally
         {
@@ -340,6 +504,84 @@ public class SealedSetConsistencyTest
                     {
                         [Module] = recorded,
                         ["MeshWeaver.Layout"] = CompiledDependencies.RefAsmScheme + "abc",
+                        [CompiledDependencies.ToolchainKey] = CompiledDependencies.MvidScheme + "toolchain",
+                    }),
+            ]);
+        WriteZip(Path.Combine(source, Bundle + ".zip"),
+            (NuGetPackageWriter.ManifestEntry,
+                JsonSerializer.SerializeToUtf8Bytes(manifest, new JsonSerializerOptions(JsonSerializerDefaults.Web))));
+        File.WriteAllText(
+            Path.Combine(source, ShippedPrebuiltBundles.CompletionSentinelFileName), Bundle + ".zip\n");
+        return root;
+    }
+
+    /// <summary>
+    /// The #3221 layout: ONE identity, ONE source, and an assembly name reaching it from TWO module
+    /// bundles — the live shape of MeshWeaver.Plugins, where 19 of 37 bundles carry a copy of an
+    /// assembly some other package declares.
+    ///
+    /// <list type="bullet">
+    /// <item><description><c>probe.module.nupkg</c> — the AI-shaped bundle: it DECLARES
+    /// <see cref="Module"/> and RIDES <paramref name="riding"/> as <see cref="Sibling"/>.</description></item>
+    /// <item><description><c>probe.sibling.nupkg</c> — the Essentials-shaped bundle: it DECLARES
+    /// <see cref="Sibling"/> as <paramref name="declared"/>. Omitted entirely when
+    /// <paramref name="declared"/> is null, which is the ride-only case.</description></item>
+    /// </list>
+    ///
+    /// The index lists the riding bundle FIRST, so the ride is the copy seen first and the declared
+    /// module the second — both roles are exercised in one conflict line.
+    /// </summary>
+    private static string PublishedRootWithRide(
+        string recorded, byte[]? declared, byte[] riding,
+        (string Name, byte[] Bytes)? thirdParty = null)
+    {
+        var root = Path.Combine(Path.GetTempPath(), "mw-sealed-ride-" + Guid.NewGuid().ToString("N"));
+        var source = Path.Combine(root, Identity, "plugins");
+        var modules = Path.Combine(source, PublishedBundleCatalogue.ModulesDirectoryName);
+        Directory.CreateDirectory(Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName));
+        Directory.CreateDirectory(modules);
+        File.WriteAllText(
+            Path.Combine(root, PublishedBundleCatalogue.ReleaseMarkerDirectoryName, Version), Identity);
+
+        var ridingEntries = new List<(string Entry, byte[] Bytes)>
+        {
+            (NuGetPackageWriter.ManifestEntry,
+                Encoding.UTF8.GetBytes($$$"""{"plugin":"Probe","module":{"assemblyName":"{{{Module}}}"}}""")),
+            ($"{NuGetPackageWriter.ModuleFolder}/{Module}.dll", File.ReadAllBytes(ModuleBytesOf.Location)),
+            ($"{NuGetPackageWriter.ModuleFolder}/{Sibling}.dll", riding),
+        };
+        if (thirdParty is { } third)
+            ridingEntries.Add(($"{NuGetPackageWriter.ModuleFolder}/{third.Name}.dll", third.Bytes));
+        WriteZip(Path.Combine(modules, "probe.module.nupkg"), [.. ridingEntries]);
+
+        var index = new List<string> { "probe.module.nupkg" };
+        if (declared is not null)
+        {
+            var declaredEntries = new List<(string Entry, byte[] Bytes)>
+            {
+                (NuGetPackageWriter.ManifestEntry,
+                    Encoding.UTF8.GetBytes($$$"""{"plugin":"Sibling","module":{"assemblyName":"{{{Sibling}}}"}}""")),
+                ($"{NuGetPackageWriter.ModuleFolder}/{Sibling}.dll", declared),
+            };
+            if (thirdParty is { } alsoThird)
+                // The SAME third-party name at the SAME bytes as the entry's other copy would be no
+                // test at all — give this one the module's bytes so the two copies genuinely differ.
+                declaredEntries.Add((
+                    $"{NuGetPackageWriter.ModuleFolder}/{alsoThird.Name}.dll",
+                    File.ReadAllBytes(ModuleBytesOf.Location)));
+            WriteZip(Path.Combine(modules, "probe.sibling.nupkg"), [.. declaredEntries]);
+            index.Add("probe.sibling.nupkg");
+        }
+        File.WriteAllLines(
+            Path.Combine(modules, PublishedBundleCatalogue.ModulesIndexFileName), index);
+
+        var manifest = new BundleReader.Manifest(
+            Bundle, "1.0", Identity,
+            [
+                new BundleReader.AssemblyRef("Widget/Thing", "Widget_Thing.dll",
+                    new Dictionary<string, string>(StringComparer.Ordinal)
+                    {
+                        [Sibling] = recorded,
                         [CompiledDependencies.ToolchainKey] = CompiledDependencies.MvidScheme + "toolchain",
                     }),
             ]);


### PR DESCRIPTION
## The decision (#3221): a module-owned sibling RIDES — and the invariant is byte equality, not exclusivity

**Maintainer requirement (2026-09-03), which this completes:** *"we must have a clear confirmation that all plugins deployed to an instance are available for the correct platform version. If not the case ⇒ nothing goes."*

Closes #3175
Closes #3221

### Where #3175 stood before this PR

**Part 1 already landed** — #3187 (merged 2026-09-03 08:57Z) built `SealedSetProblem` / `SealedSetInconsistent` and the entry-assembly module-set reading; #3198 made the observation degrade per bundle. Its `Closes #3175` never fired, so the issue stayed open. Part 3 also exists (`check-release-availability.sh` + the `DeploymentAKS` runbook's pre-manual-roll check). What remained was the **hole inside part 1**: `ArtifactsForIdentity` read only each module bundle's **entry** assembly, and the incident's assembly — `MeshWeaver.Markdown.Collaboration` — reaches a mesh from **fifteen** places, not one. This PR closes that hole, and #3221 is the reason it was open.

### The question, and the answer

> Should a sibling that is itself another package's declared module ride into a second bundle, or should the closure rule exclude declared modules?

**It rides. The refusing guard is not built** — not out of caution, but because the rule it would enforce is unsatisfiable. Evidence, measured on `MeshWeaver.Plugins` `main` 2026-09-03 (every package's `index.json` `content.module`, joined against each module project's transitive in-repo `ProjectReference` closure minus `src/platform-shipped.txt`):

| | |
|---|---|
| Declared modules in the repo | **37** |
| Module bundles riding *another package's declared module* | **19** |
| Riding `MeshWeaver.Markdown.Collaboration` (Essentials') | 14 |
| Riding `MeshWeaver.AI` (AI's) | 12 |
| Riding `MeshWeaver.Maps` (Maps') | 4 |

1. **It is the dominant shape**, not the one accepted instance (`Chat`/`MeshWeaver.AI`) the issue named.
2. **Excluding declared modules inverts the package graph.** `AI` requires only `Store` yet references `MeshWeaver.Markdown.Collaboration`, which **Essentials** declares — and Essentials `requires` AI. Same inversion for `Mcp`, `Mail`, `Teams`, `Notifications`, `Observability`: each rides an assembly its own dependent declares.
3. **It would break a supported install.** `AI` installs alone; without the sibling nothing supplies it (Plugins#1268 removed it from `/app`, no required package brings it) and it faults on first touch — the `ReflectionTypeLoadException` outage `ModuleClosureAccounting` was written after.
4. **The host case and the module case are different defects.** `ShippedByHostProblem` refuses host-vs-module because the schemes are incompatible: `ref:<hash>` from the surface manifest vs `mvid:<guid>` from a composed module never compare equal *even for byte-identical assemblies*. Module-vs-module is `mvid:` on both sides — identical bytes compare **equal**, so the conflict is fixable by agreement, and agreement is cheaper than exclusivity.

**This contradicts the prior I was handed** ("the evidence favours *it should not ride*"). The reviewer's supporting observation is still right — #3175's incident IS a two-producer mismatch on exactly the assembly #3221 names — but the cure is to make the producers **agree**, not to forbid the second one.

### What this PR asserts instead

> **One assembly name, one framework identity, one build — across every copy in the sealed set, declared or riding.**

`MeshWeaver.*` binds by a strictly synchronised `AssemblyVersion`, so two copies under one simple name are **one assembly identity**: `Assembly.LoadFrom` returns the already-loaded one and ignores the second path. Whichever loads first wins the process; `ModuleMvidsOf` reports *that* MVID as live; every NodeType that recorded the other is declined — the ci.7621 log line.

Today the copies agree by **accident** (`bake-scope.sh` treats any `src/` change as affecting all modules; `module-build-key.py` folds each entry's whole in-repo `ProjectReference` closure into its content address). Both are correct; neither is an assertion. Now:

- **`PublishedBundleCatalogue.SealedModuleAssembliesOf`** reads the MVID of every `MeshWeaver.*` assembly a sealed module bundle **carries** — entry and riding sibling — from the **archive** (what lands), PE header only. Third-party diamonds ride by design, version independently, and are deliberately **not** judged; judging them would hold every bundle in the fleet.
- **`ArtifactsForIdentity`** folds every copy into conflict detection: a name carried at two MVIDs becomes a `SealedModuleSet.Conflicts` line naming both producers, sources, bundles and the **role** of each copy (`as the declared module of` / `as a sibling riding`).
- **Only the DECLARED entry defines `MvidByModule`** — that is what an instance registers as an `InstalledModuleAssembly` and therefore what `ModuleMvidsOf` reports back as live. A ride-only name never stands in for a module nothing declares; a false HOLD is the expensive direction (#1754's `ReleaseGateApplicabilityTest`).
- `ReleaseAvailability.IsUpdatable` then answers `SealedSetInconsistent` for every package whose records bind that name. Consumers unchanged: the self-update poll, CD's post-promote assertion, `/api/plugins/is-updatable`.

### 🚨 Negative control — the check FAILS on a genuinely double-produced assembly

`SealedSetConsistencyTest` gains 4 cases. The one that matters is `ASiblingRidingASecondBundle_AtAnotherBuild_IsHeld_NamingBothProducers`: one identity, one source, `probe.module.nupkg` declaring `MeshWeaver.ProbeModule` and **riding** `MeshWeaver.ProbeSibling` at build X, `probe.sibling.nupkg` **declaring** `MeshWeaver.ProbeSibling` at build Y. Every *declared* entry is distinct and self-consistent, so the entry-only reading #3187 shipped judges the set consistent and answers AVAILABLE.

Measured by deleting the sibling-reading loop and re-running:

```
Failed  SealedSetConsistencyTest.ASiblingRidingASecondBundle_AtAnotherBuild_IsHeld_NamingBothProducers
        Assert.Single() Failure: The collection was empty
Failed!  - Failed: 1, Passed: 12, Skipped: 0, Total: 13
```

**Exactly one failure of thirteen** — every pre-existing #3175 case still passes — which is what proves the check binds to the riding-sibling path and not to one already covered. Loop restored, 13/13 green. The three companions pin the other directions: an identical ride is **Available** (the 19 live callers must not be refused), a ride-only name does not define the set, and a third-party diamond at two builds is not judged.

### Caller sweep (#3221's working agreement)

The guard that *would* have refused an existing caller — "refuse a bundle carrying another package's declared module" — is **not in this PR**; the sweep above is what killed that design (it would refuse 19 of 37 bundles). What ships refuses only genuinely **divergent** sets, which is what the maintainer asked to refuse, so **no grace mode is needed and none is used**.

Surface sweep for the changed code: `SealedModuleMvidOf` was `internal` with one call site in this file. `scripts/check-type-forwards.py --base origin/main --head HEAD` reports **0 removed, 1 added** (`SealedModuleAssembly`) over 1862→1863 public types / 11635→11638 public members. Repo node trees (`samples/*/Data`, `src/MeshWeaver.Documentation/Data/`) and the MeshWeaver.Plugins tree (`*.cs` **and** node `*.json`) reference only `PublishedBundleCatalogue.{Read, ReleaseMarkerDirectoryName, SealedBundlesForIdentity, SealedSources}` — all public and all untouched.

🚨 **The live-mesh sweep could NOT be performed and I am not claiming it was**: `memex` answered `"searched": false` (*"Content indexing is not active on this deployment"*), and `systemorph` answered *"requires re-authorization (token expired)"*. Per AGENTS.md that is a FAILED sweep, not a clean one — so the `Pairs-with` reason below deliberately does **not** cite one, and rests on the detector's `0 removed` instead.

**Pairs-with: none — this diff removes no public type and no public member from `src/` (`check-type-forwards.py`: `0 removed`, 1862 public types / 11635 members at base). The one removed member, `SealedModuleMvidOf`, is `internal`. Nothing outside this file called it.**

### Docs

New `Architecture/ModuleOwnedSiblingsRide` — the decision, the measurement, the four reasons, the two deliberate boundaries, and what it does **not** close: the second producer *in time* (the registry's content-versioned package endpoint vs the sealed publication), which stays documented in `ModuleBuildArchitecture` → "What the gate still cannot see" and is now tracked as **#3244** so closing #3175 does not lose it. `ModuleBuildArchitecture` control 2 and `ModuleClosureAccounting` cross-linked. What's New `Category: Fix`.

### Verification

All `-c Release -warnaserror`, one project per invocation:

| | |
|---|---|
| `MeshWeaver.PluginCatalog` | `0 Warning(s) / 0 Error(s)`, 13.8 s |
| `Memex.Portal.Shared.Test` | **701/701**, 45 s |
| `DocumentationLinkIntegrityTest` | 1/1 (new page confirmed embedded in the rebuilt `MeshWeaver.Documentation.dll`) |
| `WhatsNewEntryIntegrityTest` | 1/1 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
