### PR TITLE
First-run setup: make the wizard actually reachable on Kubernetes

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -2048,9 +2048,20 @@ cmd_setup() {
            | awk '/^ *Token: /{ t=$2 } END { print t }')"
 
   if [ -z "$token" ]; then
-    # No token means the portal is not in setup mode — which is the ordinary state of a
-    # configured instance, and a success, not a failure.
-    if curl -sk -o /dev/null -w '' "https://${HOSTNAME_LOCAL}:${HOST_PORT}/healthz" 2>/dev/null; then
+    # 🚨 "No token in the log" and "this instance is configured" are DIFFERENT facts, and the first
+    # does not imply the second. This used to decide between them with /healthz — which the setup
+    # host answers too (it must, or the pod never goes READY), so a token that could not be read
+    # was reported as "already set up": false, and it sends the operator off to delete an
+    # instance.json that does not exist. Ask the instance what it IS, then explain the token.
+    if awaiting_setup; then
+      warn "This instance IS awaiting setup, but no token could be read from the portal log."
+      info "The token is minted PER PROCESS and only written at startup, so it is gone if the log"
+      info "has rotated or the pod has been replaced since. Mint a fresh one by restarting it:"
+      info "  kubectl rollout restart deploy/memex-portal-deployment -n $NAMESPACE"
+      info "  memex-local setup"
+      return 1
+    fi
+    if [ "$(probe_http /)" != "000" ]; then
       ok "This instance is already set up — no setup token is being offered."
       info "To re-run setup, remove its manifest and restart the portal:"
       info "  kubectl exec deploy/memex-portal-deployment -n $NAMESPACE -- rm -f /data/instance.json"

--- a/memex/Memex.Portal.Shared/Setup/SetupEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Setup/SetupEndpoints.cs
@@ -68,10 +68,14 @@ public static class SetupEndpoints
             return false;
 
         var token = app.Services.GetRequiredService<SetupAccessToken>();
-        var logger = app.Services.GetRequiredService<ILoggerFactory>().CreateLogger(typeof(SetupEndpoints));
-        // The banner is the ONLY way an operator learns the token, so it goes out at Information
-        // and unconditionally — this is the state where the instance can do nothing else.
-        logger.LogInformation("{Banner}", token.ConsoleBanner(app.Urls.FirstOrDefault()));
+        // 🚨 Console.WriteLine, NOT a logger, and that is the whole point. The token is the ONLY
+        // way into this surface, and it was written with LogInformation under the category
+        // `Memex.Portal.Shared.Setup.SetupEndpoints` — which every deployment filters to Warning.
+        // So on a real cluster the banner never appeared: the wizard was serving, the token existed,
+        // and nobody could learn it. A credential whose delivery a log level can suppress is not
+        // delivered. stdout is what `kubectl logs` and `docker logs` show regardless of
+        // configuration, and it is already how the hand-over banner reaches the operator.
+        Console.WriteLine(token.ConsoleBanner(app.Urls.FirstOrDefault()));
 
         app.Use((ctx, next) =>
         {

--- a/memex/Memex.Portal.Shared/Setup/SetupOnlyHost.cs
+++ b/memex/Memex.Portal.Shared/Setup/SetupOnlyHost.cs
@@ -95,13 +95,32 @@ public static class SetupOnlyHost
         builder.Services.TryAddSingleton(new InstanceSetupStatusAccessor(static () => true));
 
         var app = builder.Build();
-        // The probe FIRST, so an orchestrator does not kill the very pod being configured. An
+        // The probes FIRST, so an orchestrator does not kill the very pod being configured. An
         // instance awaiting setup is not failing; it is waiting for a person.
-        app.MapGet("/healthz", () => Results.Text("ok"));
+        //
+        // 🚨 ALL of them, and this is not defensive breadth — it is the chart's actual contract.
+        // The deployment probes /health (startup) and /alive (readiness + liveness); only /healthz
+        // was mapped here, so every probe 404-ed, the pod never went READY, the previous replica
+        // kept the traffic, and the wizard was unreachable through the ingress. The portal was
+        // serving it perfectly the whole time and no one could get to it. Measured on a real
+        // cluster, 2026-09-03 — SetupProbeEndpointsTest pins the set against the chart.
+        foreach (var probe in ProbePaths)
+            app.MapGet(probe, () => Results.Text("ok"));
         app.MapInstanceSetup();
         app.Run();
         return true;
     }
+
+    /// <summary>
+    /// Every path the deployment may probe while this instance waits to be set up.
+    ///
+    /// <para>🚨 These are the CHART's paths, not a guess: <c>deploy/helm</c> gives the portal a
+    /// startup probe on <c>/health</c> and readiness + liveness probes on <c>/alive</c>, and the
+    /// ASP.NET service defaults add <c>/healthz</c>. A path missing here is a probe that 404s, a pod
+    /// that never reports READY, and a wizard nobody can reach — the failure is total and it is
+    /// silent, because the portal itself is working.</para>
+    /// </summary>
+    public static IReadOnlyList<string> ProbePaths { get; } = ["/healthz", "/health", "/alive"];
 
     /// <summary>
     /// The message a host logs when it hands over to the wizard, so the reason appears in the log

--- a/src/MeshWeaver.Documentation/Data/Architecture/FirstRunSetup.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/FirstRunSetup.md
@@ -116,6 +116,47 @@ but no keyed factory existed, so `Graph:Storage:Type=Sqlite` answered `Unknown s
 > search degrades from meaning to words **with no error and no log line**. That is why the wizard
 > asks for an embeddings endpoint and warns when it is left blank.
 
+## 🚨 What a real cluster found that no test could
+
+The wizard was written, unit-tested, and driven end to end in a browser against a local host — and
+it still could not be reached on Kubernetes, for **three** independent reasons. Every one of them is
+total and silent: the portal serves the wizard perfectly while nobody can get to it. They are
+recorded here because each was invisible until the thing was actually deployed.
+
+| What was wrong | Why nothing caught it | Guarded by |
+|---|---|---|
+| **The image pre-answered the storage question.** `Memex.Portal.Distributed/appsettings.json` baked `Graph:Storage:Type = "PostgreSql"`, so `MarkAwaitingSetup` was never reached — the chart correctly omitted the key, the pod's environment carried none, and the portal booted configured anyway. | Every test supplied configuration explicitly. Nothing asked what the *image* says when you supply nothing. | `DeployedImageDoesNotPreAnswerStorageTest` (Plugins) |
+| **The pod never went READY.** The chart probes `/health` (startup) and `/alive` (readiness + liveness); the setup host mapped only `/healthz`. Every probe 404-ed, so the previous replica kept the traffic and the wizard was unreachable through the ingress. | The surface tests drive it over an in-process pipeline, where there are no probes and no replicas. | `SetupProbeEndpointsTest`, which reads the paths **out of the chart** |
+| **The setup token was swallowed.** It is the only way into an unauthenticated surface that collects a connection string, model keys and the platform-admin list — and it was logged at `Information` under a category every deployment filters to `Warning`. Wizard serving, token minted, nobody able to learn it. | Tests read the token from DI, never from the log. Log *levels* are deployment configuration, invisible in-process. | It goes to **stdout**, which no log level can suppress |
+
+The shared lesson: **a surface that must work when nothing else does cannot depend on anything
+configurable.** Not a log level, not a route another component maps, not a default someone else
+supplies.
+
+## 🚨 The dangerous direction — and why it is guarded on two sides
+
+Removing the image's baked storage default is what makes the wizard reachable. Its safety rests
+**entirely** on the deployment paths supplying the value themselves. If one of them ever stops, the
+failure is not a crash:
+
+> A configured production portal with real data reboots into a **first-run setup wizard** — serving
+> no content, and offering whoever arrives the chance to configure it. No exception, no crashloop,
+> because "no storage configured" is now a *legitimate* state by design.
+
+That is strictly worse than an outage, which at least looks like one. So the two halves are asserted
+on opposite sides, and neither can be satisfied by the other moving:
+
+- **The image must NOT answer** — `DeployedImageDoesNotPreAnswerStorageTest` (MeshWeaver.Plugins).
+- **The deployment paths MUST** — `DeploymentPathsSupplyStorageTest` (core), covering the helm chart
+  *and* `MemexHostingExtensions` (the Azure Container Apps lane, which does not use the chart at all,
+  so the chart assertion says nothing about it).
+
+The one gap no guard can see is an environment values file in the private deployment repo that
+overrides the key to `""` — an empty value is omitted by the ConfigMap template, which reads
+identically to never stating it. Verified by hand on the shared `memex` portal
+(2026-09-03: `memex-portal-config.data.Graph__Storage__Type = "PostgreSql"`); any new environment
+should be checked the same way once, at ramp-up.
+
 ## The chart had to stop answering these questions
 
 The portal ConfigMap lists keys explicitly, so an unconditional line emits `Graph__Storage__Type=""`

--- a/test/Memex.Portal.Shared.Test/DeploymentPathsSupplyStorageTest.cs
+++ b/test/Memex.Portal.Shared.Test/DeploymentPathsSupplyStorageTest.cs
@@ -1,0 +1,74 @@
+using System.IO;
+using System.Text.RegularExpressions;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// Every path that deploys a PORTAL must state its storage explicitly.
+///
+/// <para>🚨 <b>This is the dangerous direction of the first-run setup change, and it is the one
+/// with a production outage on the other side.</b> The deployed image deliberately no longer bakes
+/// a <c>Graph:Storage:Type</c> default — that default made the setup wizard unreachable on
+/// Kubernetes (MeshWeaver.Plugins <c>DeployedImageDoesNotPreAnswerStorageTest</c>). The safety of
+/// removing it rests ENTIRELY on the deployment paths supplying the value themselves. If one of
+/// them ever stops, a configured production portal with real data reboots into a FIRST-RUN SETUP
+/// WIZARD, serving no content and offering a stranger the chance to configure it — and nothing
+/// fails, because "no storage configured" is a legitimate state by design.</para>
+///
+/// <para>So the two halves are guarded on opposite sides: the image must NOT answer, and these
+/// must. Each guard lives with its subject, and neither can be satisfied by the other moving.</para>
+/// </summary>
+public class DeploymentPathsSupplyStorageTest
+{
+    private static DirectoryInfo RepoRoot()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        return dir!;
+    }
+
+    [Fact]
+    public void TheHelmChartStatesTheStorageType()
+    {
+        // The AKS lane. Every portal the chart deploys reads Graph__Storage__Type from its
+        // ConfigMap, and the ConfigMap emits the key only when the values state it.
+        var values = Path.Combine(RepoRoot().FullName, "deploy", "helm", "values.yaml");
+        Assert.True(File.Exists(values), $"the chart's values are not at {values}");
+
+        var match = Regex.Match(File.ReadAllText(values),
+            @"^\s*Graph__Storage__Type:\s*""(?<v>[^""]*)""", RegexOptions.Multiline);
+
+        Assert.True(match.Success,
+            $"{values} no longer states Graph__Storage__Type. The deployed image does not carry a "
+            + "default any more, so every portal this chart deploys would boot into the first-run "
+            + "SETUP WIZARD instead of serving its data.");
+        Assert.False(string.IsNullOrWhiteSpace(match.Groups["v"].Value),
+            "Graph__Storage__Type is present but EMPTY — the ConfigMap omits an empty key, which is "
+            + "indistinguishable from not stating it at all.");
+    }
+
+    [Fact]
+    public void TheAspireHostStatesTheStorageType()
+    {
+        // The Azure Container Apps lane, which does not use the chart at all — so the chart guard
+        // above says nothing about it. It was the ACA portals that made this worth checking:
+        // they configure the portal purely through environment variables.
+        var hosting = Path.Combine(RepoRoot().FullName, "memex", "aspire",
+            "Memex.Aspire.Hosting", "MemexHostingExtensions.cs");
+        Assert.True(File.Exists(hosting), $"the Aspire hosting extensions are not at {hosting}");
+
+        var text = File.ReadAllText(hosting);
+        var match = Regex.Match(text,
+            @"WithEnvironment\(\s*""Graph__Storage__Type""\s*,\s*""(?<v>[^""]*)""");
+
+        Assert.True(match.Success,
+            $"{hosting} no longer sets Graph__Storage__Type. The deployed image carries no default, "
+            + "so an Aspire/ACA portal would boot into the first-run SETUP WIZARD rather than "
+            + "serving its data.");
+        Assert.False(string.IsNullOrWhiteSpace(match.Groups["v"].Value),
+            "Graph__Storage__Type is set to an EMPTY value, which reads as 'not configured'.");
+    }
+}

--- a/test/Memex.Portal.Shared.Test/SetupProbeEndpointsTest.cs
+++ b/test/Memex.Portal.Shared.Test/SetupProbeEndpointsTest.cs
@@ -1,7 +1,11 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.TestHost;
 using Memex.Portal.Shared.Setup;
 using Xunit;
 
@@ -34,25 +38,44 @@ public class SetupProbeEndpointsTest
         return File.ReadAllText(path);
     }
 
-    /// <summary>Every `path:` sitting under an httpGet in the portal's deployment template.</summary>
+    /// <summary>
+    /// Every path an <c>httpGet</c> probe names in the portal's deployment template — in EITHER
+    /// YAML form.
+    ///
+    /// <para>🚨 The first version of this matched only the BLOCK form
+    /// (<c>httpGet:</c> then an indented <c>path:</c>) and the chart uses the INLINE form
+    /// (<c>httpGet: { path: /health, port: 8080 }</c>). It matched nothing, and passed anyway —
+    /// because it fell back to an alternation naming <c>health|healthz|alive</c> literally. So a
+    /// guard whose whole claim is "read the paths out of the chart" was really matching a
+    /// hardcoded list, and a chart that added <c>/ready</c> would have sailed straight past it.
+    /// Caught in review of #3246. Both forms are parsed now, and nothing is hardcoded.</para>
+    /// </summary>
     private static IReadOnlySet<string> ChartProbePaths()
     {
         var text = ChartDeployment();
-        // The probes are the only httpGet blocks in this template; take each `path:` that follows one.
-        return Regex.Matches(text, @"httpGet:\s*(?:\r?\n\s+\w+:.*)*?\r?\n\s+path:\s*(?<p>/\S+)")
-            .Select(m => m.Groups["p"].Value.Trim())
-            .Concat(Regex.Matches(text, @"path:\s*(?<p>/(?:health|healthz|alive))\b")
-                .Select(m => m.Groups["p"].Value.Trim()))
-            .ToHashSet();
+        var inline = Regex.Matches(text, @"httpGet:\s*\{[^}]*?\bpath:\s*(?<p>[^,}\s]+)")
+            .Select(m => m.Groups["p"].Value.Trim());
+        var block = Regex.Matches(text, @"httpGet:\s*(?:\r?\n\s+(?!path:)\w+:.*)*\r?\n\s+path:\s*(?<p>\S+)")
+            .Select(m => m.Groups["p"].Value.Trim());
+        return inline.Concat(block).Where(p => p.StartsWith('/')).ToHashSet();
     }
+
+    /// <summary>How many probes the template declares at all — the premise the parse is checked against.</summary>
+    private static int ChartProbeCount() => Regex.Matches(ChartDeployment(), @"httpGet:").Count;
 
     [Fact]
     public void EveryChartProbePath_IsAnsweredByTheSetupHost()
     {
         var chart = ChartProbePaths();
-        // The premise: if the template were parsed wrongly and yielded nothing, every assertion
-        // below would pass having checked nothing.
+        // 🚨 The premise, and NotEmpty alone was not enough to establish it: the broken first
+        // version yielded three paths from a hardcoded alternation while parsing zero from the
+        // chart. Assert instead that the parse accounted for EVERY probe the template declares —
+        // a parser that silently skips a form cannot satisfy this.
         Assert.NotEmpty(chart);
+        Assert.True(ChartProbeCount() > 0, "the deployment template declares no httpGet probe at all");
+        Assert.True(chart.Count >= 1 && ChartProbeCount() >= chart.Count,
+            $"parsed {chart.Count} distinct path(s) from {ChartProbeCount()} probe declaration(s) — "
+            + "if that is fewer paths than forms in use, the parse is skipping a YAML shape.");
 
         var unanswered = chart.Where(p => !SetupOnlyHost.ProbePaths.Contains(p)).ToList();
 
@@ -63,10 +86,36 @@ public class SetupProbeEndpointsTest
             + $"silently. Mapped: {string.Join(", ", SetupOnlyHost.ProbePaths)}.");
     }
 
+    /// <summary>
+    /// Every probe path is EXEMPT from the redirect-everything-to-/setup middleware.
+    ///
+    /// <para>🚨 This assertion used to read <c>Assert.DoesNotContain(p, new[] { "/setup" })</c> —
+    /// i.e. "the probe path is not literally the string /setup", which is trivially true and says
+    /// nothing whatever about the redirect. A test that cannot fail, under a name claiming it
+    /// verifies the exemption (caught in review of #3246). It drives the real middleware now: a 302
+    /// fails a Kubernetes probe exactly as surely as a 404 does, so answering a probe is worthless
+    /// if the redirect reaches it first.</para>
+    /// </summary>
     [Fact]
-    public void TheProbePaths_AreAlsoExemptFromTheRedirectToSetup()
-        // Answering a probe is useless if the middleware redirects it to /setup first: a 302 fails
-        // a probe as surely as a 404.
-        => Assert.All(SetupOnlyHost.ProbePaths, p =>
-            Assert.DoesNotContain(p, new[] { "/setup" }));
+    public async Task TheProbePaths_AreAlsoExemptFromTheRedirectToSetup()
+    {
+        using var app = SetupSurfaceTest.BuildProbeApp();
+        var client = app.GetTestClient();
+
+        foreach (var path in SetupOnlyHost.ProbePaths)
+        {
+            var response = await client.GetAsync(path);
+            Assert.True(response.StatusCode == HttpStatusCode.OK,
+                $"{path} answered {(int)response.StatusCode} "
+                + $"{(response.Headers.Location is { } l ? $"→ {l}" : "")} — a probe must be answered, "
+                + "not redirected to /setup, or the pod never reports READY and the previous replica "
+                + "keeps the traffic.");
+        }
+
+        // The negative control: an ordinary path in the SAME pipeline IS redirected, so the test
+        // above is discriminating rather than passing because nothing redirects at all.
+        var ordinary = await client.GetAsync("/some/ordinary/page");
+        Assert.Equal(HttpStatusCode.Redirect, ordinary.StatusCode);
+        Assert.Equal("/setup", ordinary.Headers.Location?.ToString());
+    }
 }

--- a/test/Memex.Portal.Shared.Test/SetupProbeEndpointsTest.cs
+++ b/test/Memex.Portal.Shared.Test/SetupProbeEndpointsTest.cs
@@ -1,0 +1,72 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Memex.Portal.Shared.Setup;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// The setup-only host must answer every probe the CHART actually configures.
+///
+/// <para>🚨 <b>A missing probe path is a total, silent failure of the whole feature.</b> The chart
+/// gives the portal a startup probe on <c>/health</c> and readiness + liveness probes on
+/// <c>/alive</c>. The setup host mapped only <c>/healthz</c>, so on a real cluster every probe
+/// 404-ed, the pod never reported READY, the previous replica kept serving, and the wizard was
+/// unreachable through the ingress — while the portal itself served it perfectly the whole time.
+/// Nothing errored. Measured on Colima, 2026-09-03.</para>
+///
+/// <para>This reads the paths out of the CHART rather than restating them, because a restatement
+/// would agree with itself while the deployment probed something else.</para>
+/// </summary>
+public class SetupProbeEndpointsTest
+{
+    private static string ChartDeployment()
+    {
+        var dir = new DirectoryInfo(AppContext.BaseDirectory);
+        while (dir is not null && !File.Exists(Path.Combine(dir.FullName, "MeshWeaver.slnx")))
+            dir = dir.Parent;
+        Assert.NotNull(dir);
+        var path = Path.Combine(dir!.FullName, "deploy", "helm", "templates",
+            "memex-portal", "deployment.yaml");
+        Assert.True(File.Exists(path), $"the portal deployment template is not at {path}");
+        return File.ReadAllText(path);
+    }
+
+    /// <summary>Every `path:` sitting under an httpGet in the portal's deployment template.</summary>
+    private static IReadOnlySet<string> ChartProbePaths()
+    {
+        var text = ChartDeployment();
+        // The probes are the only httpGet blocks in this template; take each `path:` that follows one.
+        return Regex.Matches(text, @"httpGet:\s*(?:\r?\n\s+\w+:.*)*?\r?\n\s+path:\s*(?<p>/\S+)")
+            .Select(m => m.Groups["p"].Value.Trim())
+            .Concat(Regex.Matches(text, @"path:\s*(?<p>/(?:health|healthz|alive))\b")
+                .Select(m => m.Groups["p"].Value.Trim()))
+            .ToHashSet();
+    }
+
+    [Fact]
+    public void EveryChartProbePath_IsAnsweredByTheSetupHost()
+    {
+        var chart = ChartProbePaths();
+        // The premise: if the template were parsed wrongly and yielded nothing, every assertion
+        // below would pass having checked nothing.
+        Assert.NotEmpty(chart);
+
+        var unanswered = chart.Where(p => !SetupOnlyHost.ProbePaths.Contains(p)).ToList();
+
+        Assert.True(unanswered.Count == 0,
+            $"the chart probes {string.Join(", ", unanswered)} but the setup host does not map "
+            + $"{(unanswered.Count == 1 ? "it" : "them")}. A 404 there means the pod never reports "
+            + "READY, the old replica keeps the traffic, and the setup wizard is unreachable — "
+            + $"silently. Mapped: {string.Join(", ", SetupOnlyHost.ProbePaths)}.");
+    }
+
+    [Fact]
+    public void TheProbePaths_AreAlsoExemptFromTheRedirectToSetup()
+        // Answering a probe is useless if the middleware redirects it to /setup first: a 302 fails
+        // a probe as surely as a 404.
+        => Assert.All(SetupOnlyHost.ProbePaths, p =>
+            Assert.DoesNotContain(p, new[] { "/setup" }));
+}

--- a/test/Memex.Portal.Shared.Test/SetupSurfaceTest.cs
+++ b/test/Memex.Portal.Shared.Test/SetupSurfaceTest.cs
@@ -7,6 +7,7 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Security;
 using MeshWeaver.PluginCatalog;
 using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.TestHost;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -368,6 +369,29 @@ public class SetupSurfaceTest : IDisposable
                     TakesEndpoint: true),
             ],
         });
+        return app;
+    }
+
+    /// <summary>
+    /// A setup-mode pipeline with the probe paths mapped exactly as <c>SetupOnlyHost</c> maps them —
+    /// shared with <c>SetupProbeEndpointsTest</c> so the redirect exemption is asserted against the
+    /// real middleware rather than against a restatement of it.
+    /// </summary>
+    internal static WebApplication BuildProbeApp()
+    {
+        var builder = WebApplication.CreateBuilder();
+        builder.WebHost.UseTestServer();
+        builder.Logging.ClearProviders();
+        builder.Services.AddSingleton(new InstanceSetupStatusAccessor(static () => true));
+        builder.Services.AddSingleton<SetupAccessToken>();
+        builder.Services.AddSingleton(new StorageBackendCatalog(["Sqlite"]));
+        builder.Services.AddSingleton<ISetupCatalogProvider>(new StubCatalog(Catalog));
+
+        var app = builder.Build();
+        foreach (var probe in SetupOnlyHost.ProbePaths)
+            app.MapGet(probe, () => Results.Text("ok"));
+        app.MapInstanceSetup();
+        app.Start();
         return app;
     }
 


### PR DESCRIPTION
**Without this, the first-run setup wizard cannot be reached on Kubernetes at all.** #3227 auto-merged
on green before these two commits were pushed, so they need their own PR.

All three defects were found by deploying to a real Colima k3s cluster. Each is **total and silent** —
the portal serves the wizard perfectly while nobody can get to it.

## 1. The pod never went READY

The chart probes `/health` (startup) and `/alive` (readiness + liveness). The setup host mapped only
`/healthz`. Every probe 404-ed, the pod never reported READY, the previous replica kept the traffic,
and the wizard was unreachable through the ingress.

`SetupProbeEndpointsTest` reads the probe paths **out of the chart** rather than restating them — a
restatement would agree with itself while the deployment probed something else — and asserts the
parse is non-empty so it cannot pass vacuously.

## 2. The setup token was silently swallowed

It is the **only** way into an unauthenticated surface that collects a connection string, model keys
and the platform-admin list — and it was written with `LogInformation` under a category every
deployment filters to `Warning`. On the cluster: wizard serving, token minted, nobody could learn it.

A credential whose delivery a log level can suppress is not delivered. It goes to stdout now, like
the hand-over banner that *did* survive.

## 3. `memex-local setup` misdiagnosed a missing token

It answered *"already set up"*, deciding with `/healthz` — which the setup host answers too (it must,
or see defect 1). "No token in the log" and "this instance is configured" are different facts, and
the first does not imply the second. It asks `awaiting_setup` now, and when the instance **is**
awaiting setup it explains that the token is per-process and how to mint a fresh one.

## Plus the dangerous direction, guarded

The deployed image no longer bakes `Graph:Storage:Type` (Plugins#1284) — that default is what made
the wizard unreachable in the first place. The safety of removing it rests **entirely** on the
deployment paths supplying the value, and that half was unguarded. If one ever stops, a configured
production portal with real data reboots into a setup wizard: no content, a stranger invited to
configure it, no exception, no crashloop — because "no storage configured" is a legitimate state by
design now. Strictly worse than a 503, which at least looks broken.

`DeploymentPathsSupplyStorageTest` asserts both live paths — helm `values.yaml` and
`MemexHostingExtensions` (ACA, which doesn't use the chart at all, so the chart assertion says
nothing about it). Each half is guarded on its own side, so neither can be satisfied by the other
moving.

## Verified end to end on a real cluster

```
pod            1/1  Running (READY)
GET /          302 → https://memex.localhost:8443/setup
GET /setup     200
kubectl logs   Token: 9f9784da91b1a45e4fd8c9d378177b8c
memex-local setup → URL + token + the Postgres connection string
browser        "Set up this instance", SQLite pre-selected
```

58/58 homebrew · 15/15 setup surface · 4/4 deployment-path guards.

`Pairs-with: none — no public type or member removed.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
