### PR TITLE
fix(#3060): a layout area can name the viewer it is rendering for

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PerTabSessionState.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PerTabSessionState.md
@@ -1,18 +1,18 @@
 ---
 Name: Per-Tab Session State
 Category: Architecture
-Description: A mesh node is shared by every tab of one account by construction, so "which page is this viewer on" and "navigate ME there" must never live on a per-user node — and a hazard is only a defect once you have found the code that renders it.
+Description: A mesh node is shared by every tab of one account by construction, so "which page is this viewer on" and "navigate ME there" must never live unaddressed on a per-user node — and a hazard is only a defect once you have found the code that renders it.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="9" height="16" rx="1"/><rect x="13" y="4" width="9" height="16" rx="1"/><path d="M6.5 9h0"/><path d="M17.5 9h0"/></svg>
 ---
 
 # Per-Tab Session State
 
-**A `MeshNode` is shared by every viewer who can read it — including the same person in a second browser tab. So any state whose meaning is "*this viewer, right now, in this window*" is wrong on a node, and no amount of care at the call sites can rescue it.** The two questions that always have this shape are:
+**A `MeshNode` is shared by every viewer who can read it — including the same person in a second browser tab. So any state whose meaning is "*this viewer, right now, in this window*" is wrong on a node unless it says WHICH viewer it is for, and no amount of care at the call sites can rescue it.** The two questions that always have this shape are:
 
 - **"Which page is the viewer looking at?"** — the navigation context.
 - **"Take *me* there."** — a navigation command addressed to one window.
 
-This page came out of [MeshWeaver#3060](https://github.com/Systemorph/MeshWeaver/issues/3060) ("chat session cross-talk when the same account opens a second browser tab"). It carries two lessons: the scoping rule above, and a methodological one the investigation learned the hard way — **a mechanism you can read in the code is a hypothesis until you have found the code that RENDERS it.** The most incriminating call sites here turned out to sit in a component with no render site, and the first version of this page reported them as live.
+This page came out of [MeshWeaver#3060](https://github.com/Systemorph/MeshWeaver/issues/3060) ("chat session cross-talk when the same account opens a second browser tab"). It carries three things: the scoping rule, the shape that was actually built for it, and a methodological lesson the investigation learned the hard way — **a mechanism you can read in the code is a hypothesis until you have found the code that RENDERS it.** The most incriminating call sites here turned out to sit in a component with no render site, and the first version of this page reported them as live.
 
 ## The layering that makes this a trap
 
@@ -30,6 +30,18 @@ Everything *above* the node is already correctly per-tab, which is exactly why t
 
 The whole stack is per-circuit right down to the last hop — and then the value is written into a node, where the isolation ends. **The node is the only shared thing in the chain, and it is also the only durable one**, which is precisely why per-tab state keeps drifting into it: persistence and isolation pull in opposite directions here.
 
+## The three shapes, and the one framework primitive
+
+> **Ask what the value would mean to a second window of the same account. If the honest answer is "not that", it does not belong *unaddressed* on a node keyed by user.**
+
+- **Per-viewer *preference*** (last-used model, panel position, theme) → a per-user node is right, plain and unaddressed. Two tabs agreeing is the feature.
+- **Per-viewer *session* state** (which page, which selection, an in-progress form) → either the **layout area's own store**, which is already per-subscriber (`host.UpdateData(...)` / `/data/{id}`), or, when it genuinely has to persist, a node field that **carries its addressee** and is honoured only for the viewer it names.
+- **A command addressed to one window** ("take me there") → **do not put it on a node at all.** Post it, and let the transport carry the addressee.
+
+**The primitive for all three is `LayoutAreaHost.Viewer`** — the area subscription's subscriber, normalized through `Address.Host`, which for a browser tab is `portal/{circuitId}`: exactly one per tab. `LayoutAreaHost.NavigateTo` / `NavigateToSidePanel` already post to that address, so a stamp written from `Viewer` and a command posted by `NavigateTo` name the same tab by construction. (`LayoutAreaViewerTest` pins both halves: an area knows its viewer, and two subscribers to one area get different answers — if they ever agreed, "addressed" would mean nothing.)
+
+And one anti-pattern: **do not "fix" it by minting a node per tab** (`{user}/_Thread/ThreadComposer/{circuitId}`). Circuits are unbounded and short-lived; that trades a correctness bug for unbounded node churn and loses the durability the node was there for. Addressing a field costs one string; a node per circuit costs a node per reload.
+
 ## The concrete instance: the out-of-thread chat composer
 
 The "new chat" composer is a **per-user singleton node**:
@@ -40,51 +52,76 @@ public static string PathFor(string user) => $"{user}/{ThreadNodeType.ThreadPart
 //                                            → {user}/_Thread/ThreadComposer
 ```
 
-Its content (`ThreadComposer`) mixes three different lifetimes in one record:
+Its content (`ThreadComposer`) mixed three lifetimes in one flat record. Each field now says which it is:
 
-| Field | What it really is | Correct scope |
+| Field | Scope | How |
 |---|---|---|
-| `Harness`, `AgentName`, `ModelName`, `Effort` | the user's last-used selection | **per user** — sharing across tabs is the feature |
-| `MessageContent`, `Attachments` | the draft being typed | per tab (debatable: "my draft follows me" is a defensible per-user reading) |
-| `ContextPath`, `ContextReference` | **which page this viewer is on** | **per tab** |
-| `OpenThreadPath` | **"navigate ME to this thread"** | **per tab** |
+| `Harness`, `AgentName`, `ModelName`, `Effort` | **per user** | plain — sharing across tabs is the feature |
+| `MessageContent`, `Attachments` | **per user, deliberately** | plain — see below |
+| `ContextPath`, `ContextReference` | **per tab** | addressed by `ContextAddressee` |
+| `OpenThreadPath` | **per tab** | retired — the command is posted, not stored |
 
-### What is LIVE today
+### Why the draft stayed per user
 
-**The draft and the selections are one live binding across every tab.** The composer's default (`""`) layout area is reached at the composer NODE's own path through `ApplicationPage`'s catch-all — `ThreadNodeType`'s `BuildCreate` redirects "+ new chat" straight to `/{chatInputPath}` (`ThreadNodeType.cs:319`) — and out of a thread `ThreadChatView` also binds it (`_templatePath = ThreadComposerNodeType.PathFor(_userHome)`, `ThreadChatView.razor.cs:565`), projecting `Harness`/`AgentName`/`ModelName` from it (`:827`) and writing the user's default back (`WriteComposerSelection`, `:866`). So typing a draft, attaching a reference, or re-picking a model in one tab is observed live by the other. For the preference fields that is the intent; for the draft it is at best debatable.
+`MessageContent` is the one field where both readings are defensible, and the deciding argument is not taste — it is that **a Blazor circuit dies on every page reload.** Keying the draft by circuit would lose it whenever the tab reloads, the network blips, or the server restarts, which is a regression for the overwhelmingly common single-tab case and destroys the exact durability the node exists to provide. So: one person, one draft. What a second tab can do to it — see the draft, and clear it on New Chat — is the ordinary consequence of one shared draft, not a wrong-target write.
 
-### What is LATENT — and why the reachability check matters more than the code
+### `ContextPath` — addressed, and fails closed
 
-`ContextPath` and `OpenThreadPath` are the two fields whose semantics are unambiguously per-tab, and **their writer and their consumer both live in a component that has no render site**:
-
-- `MeshWeaver.Plugins/src/MeshWeaver.Blazor.Chat/ThreadSidePanelContent.razor.cs:77` → `:89` → `:105` writes `ContextPath` on every navigation, and `:166` → `:195`/`:199` consumes `OpenThreadPath` by navigating *its own* circuit.
-- Nothing renders `ThreadSidePanelContent`. Its only mentions in either repo are its own two files and three doc-comments; `PortalLayoutBase.razor:282-316` renders `DispatchView` over a `ThreadChatControl` instead. The component was orphaned by the #977 module split (`3cc44431`).
-
-So today: **nothing writes `ContextPath` on the per-user composer node**, and `ThreadComposerView.Send` (`:255`) reads `null`, falls to `ns = user`, and creates the thread in the user's own home. The cross-tab wrong-target write is a hazard the design *permits*, not a defect the product currently exhibits — and the one thing that would re-arm it is restoring a live writer for that field, which is exactly what "put the side panel back" would do.
-
-One half of the pair is live and asymmetric, which is its own bug: `StartThreadIn`'s `onCreated` still stamps `OpenThreadPath = node.Path` (`ThreadComposerView.cs:338`), and **no live code consumes it** — so a Send from the composer area creates the thread, never navigates to it, and leaves a stale navigate-signal on the node until something clears it (`ThreadChatView.StartNewComposer`, `:3325`).
-
-### Where the hazard would lead if a writer returned
-
-`ContextPath` is not a label — it is the root the round's writes resolve against, so re-arming it is not a cosmetic regression:
+`ContextPath` is not a label. It is the namespace the thread is created in, and then the root the round's write tools resolve a bare argument against:
 
 ```
-ThreadComposerView.Send            (ThreadComposerView.cs:250)
-  ns = ThreadNodeType.MainNodeOf(edited.ContextPath)          ← read off the SHARED node
-  → StartThreadIn                  (ThreadComposerView.cs:312)
-      hub.StartThread(namespacePath: ns, contextPath: contextPath, …)
-        → the thread NODE is created under {ns}/_Thread/{speakingId}
-        → request.ContextPath
-          → ThreadExecution.cs:1770  client.SetContext(NavigationContextProjection.ToAgentContext(…))
-            → AgentChatPaths.cs:20   MeshOperations.ResolveContextPath(chat.Context?.Context, path)
-              → MeshPlugin.cs:87 patch · :103 edit_content · :130 recycle · :142 move · :156 copy
+ThreadComposerView.Send
+  → ResolveContext(composerPath, storedContextPath, storedAddressee, viewer, user)
+  → StartThreadIn → hub.StartThread(namespacePath: …, contextPath: …)
+      → the thread NODE at {ns}/_Thread/{speakingId}
+      → request.ContextPath → ThreadExecution → client.SetContext(…)
+        → AgentChatPaths.ResolveContextPath → MeshPlugin: patch · edit_content · recycle · move · copy
 ```
 
-`OwningNamespace` (`ThreadComposerView.cs:288`) only redirects to the user's home when they *cannot* `Create` in the namespace, so inside any partition the user can write, the thread would land under the other tab's node — and a bare single-segment argument to an agent write tool (`patch("Notes", …)`) would resolve to `{otherTabsContext}/Notes`.
+So a stored context now wins **only for the viewer `ContextAddressee` names**, and `ResolveContext` is the single place that decides it. The properties that matter:
 
-### What this does NOT explain
+- **A context addressed to another tab is ignored** — the derivation from the composer's own node path stands ([Plugins#1287](https://github.com/Systemorph/MeshWeaver.Plugins/pull/1287)), so a chat started from a node still carries that node.
+- **A context stored with NO addressee is honoured by nobody.** This is the fail-closed half and it is the point: a future writer that forgets to say who it is for produces "my context was not picked up", never "my message was written into someone else's page". Restoring a writer can no longer re-arm the hazard in one commit — an un-addressed writer is inert.
+- **A render with no viewer claims nobody's context**, so "unaddressed" and "addressed to nobody in particular" cannot collapse into each other.
 
-**The live chat surface takes its context per-circuit.** `ThreadChatView` derives `initialContext` from the circuit's own `INavigationService.NavigationContext` and submits with it (`ThreadChatView.razor.cs:1255-1322`); inside a thread the composer is the thread's own embedded `Thread.Composer`. So a *running* chat in tab A following tab B's page is **not** accounted for by anything on this page. The shared-node hazard is real and worth removing; it is not, on the evidence here, the reported symptom.
+On a thread's embedded `Thread.Composer` the same field means something else and needs no addressee: it is the subject *that thread* was started about, fixed at creation. A thread has one context, not one per window — so `StartThread` drops the addressee when it copies the composer onto the thread.
+
+### `OpenThreadPath` — the command left the node entirely
+
+The retired field was the data-bound "navigate here" signal `Send` stamped on the per-user node for a client to observe. That made "take **me** to the thread I just created" a **broadcast**, and a broadcast on shared state is not a command — it is an interrupt for everybody. Two failures, not one: the tab that did not send gets moved, and both tabs race to clear the field, so the tab that *did* send can lose its own navigation to the other tab's clear.
+
+It is now `host.NavigateTo($"/{node.Path}")` in `StartThreadIn`'s `onCreated`. The addressee is the transport's — a `NavigationRequest` posted to the area's own subscriber — so it cannot reach another tab, there is nothing to clear, and there is no race to lose. This also fixes the live one-sided bug that fell out of the same reading ([Plugins#1267](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1267) consequence 1): nothing consumed the field, so a Send from the composer created the thread and left the viewer where they were.
+
+The property is kept, `[Obsolete]`, so content written before the change still deserializes and so `src/` cannot grow a new reader or writer without the compiler saying so. Nothing writes it and nothing reads it.
+
+### What was deleted rather than repaired
+
+`ThreadSidePanelContent`'s `WriteComposerContext` (the only writer `ContextPath` ever had) and its `OpenThreadPath` observer are gone. The component has had no render site since the Plugins#977 module split, so repairing dead code would have been unverifiable; deleting the writer is what makes "restore the side panel" a safe change rather than a re-arming one — and if a writer does come back without an addressee, the read is fail-closed anyway.
+
+## Verifying it — both directions, or it proves nothing
+
+**A suite that only proved isolation would pass a change that broke the sharing**, which is why the committed tests pin both:
+
+| Test | Asserts |
+|---|---|
+| `PerTabComposerIsolationTest.AModelPickedInOneTab_IsSeenByTheOther` | the per-USER selection still crosses tabs — the feature |
+| `PerTabComposerIsolationTest.AContextStoredByOneTab_IsNotTheOtherTabsContext` | both tabs see the shared FIELD (one node — that is the premise), and the DECISION differs: the writer gets its context, the other tab gets its own |
+| `PerTabComposerIsolationTest.SendFromOneTab_NavigatesThatTabAndNotTheOther` | the `NavigationRequest` lands in the tab that clicked and nowhere else |
+| `ComposerContextTest` | the whole `ResolveContext` decision: addressed-to-me wins, addressed-elsewhere loses, un-addressed is inert, no-viewer claims nothing |
+| `LayoutAreaViewerTest` (core) | `LayoutAreaHost.Viewer` names the subscriber, and two subscribers to one area get different answers |
+
+Two independent client hubs stand in for two circuits: each has its own address, its own workspace and its own layout-area subscription — the shape a per-circuit portal hub has.
+
+**And the mutation control, because an assertion that cannot fail is not an assertion.** Reverting each half of the fix independently reddens exactly the tests that cover it, and nothing else:
+
+| mutation | result |
+|---|---|
+| `ResolveContext` ignores the addressee (a stored context always wins) | `AContextStoredByOneTab_IsNotTheOtherTabsContext` + 5 `ComposerContextTest` rows |
+| `StartThreadIn` posts no `NavigationRequest` (the pre-fix stamp-a-field shape) | `SendFromOneTab_NavigatesThatTabAndNotTheOther` |
+| both reverted together | **7 fail / 12 pass** — measured 2026-09-03 |
+| neither | **19 / 19**, ~4 s |
+
+`AModelPickedInOneTab_IsSeenByTheOther` passes under every mutation, which is the point of listing it: the suite is not being held up by the assertion that would also pass if the fix had quietly made the whole record per-tab.
 
 ## The same shape elsewhere
 
@@ -92,23 +129,11 @@ ThreadComposerView.Send            (ThreadComposerView.cs:250)
 
 - `MeshWeaver.Plugins/src/MeshWeaver.AI/Connect/ConnectSessionManager.cs` — sessions keyed `{ownerPath}|{provider}`; `StartConnect` cancels the existing slot before overwriting it, so a provider sign-in started in tab B **kills tab A's live CLI session**.
 - `MeshWeaver.Blazor.Portal/Resize/DimensionManager.cs` — a process-wide singleton holding the *current* viewport, written from every circuit. Currently latent (nothing subscribes), which is the only reason it has not surfaced.
-- `MeshWeaver.Hosting.AspNetCore/Portal/PortalApplication.cs:84` — the off-circuit fallback address `portal/{userId}`. Correct for SSR/prerender by design, but it does mean every non-circuit scope of one account shares a hub.
-
-## The rule
-
-> **Ask what the value would mean to a second window of the same account. If the honest answer is "not that", it does not belong on a node keyed by user.**
-
-Three shapes that are correct:
-
-- **Per-viewer *preference*** (last-used model, panel position, theme) → a per-user node is right. Two tabs agreeing is the feature.
-- **Per-viewer *session* state** (which page, which selection, an in-progress form) → the **layout area's own store**, which is already per-subscriber: `host.UpdateData(...)` / `/data/{id}` on the `LayoutAreaHost`. Nothing else in the stack needs changing, because the subscriber address already *is* the circuit.
-- **A command addressed to one window** → carry the **addressee**. `LayoutAreaHost` can read its own subscriber (`Stream.Get<Address>(nameof(SubscribeRequest.Subscriber))`, `LayoutAreaHost.cs:1587`), which for a Blazor tab is `portal/{circuitId}`; a consumer must then act only on a signal addressed to it. A broadcast signal on shared state is not a command, it is an interrupt for everybody.
-
-And one anti-pattern: **do not "fix" it by minting a node per tab** (`{user}/_Thread/ThreadComposer/{circuitId}`). Circuits are unbounded and short-lived; that trades a correctness bug for unbounded node churn and loses the durability the node was there for in the first place.
+- `MeshWeaver.Hosting.AspNetCore/Portal/PortalApplication.cs` — the off-circuit fallback address `portal/{userId}`. Correct for SSR/prerender by design, but it does mean every non-circuit scope of one account shares a hub.
 
 ## And the second rule: find the render site before you call it a defect
 
-A Blazor component is reachable only if something renders it — a `<Tag />` in a `.razor`, a `DispatchView` over a control the view registry maps to it, or a routable `@page` in an assembly the router was given. **None of those is implied by the file existing, by it compiling, or by it being referenced in a doc-comment.** `ThreadSidePanelContent` has all three of the latter and none of the former.
+A Blazor component is reachable only if something renders it — a `<Tag />` in a `.razor`, a `DispatchView` over a control the view registry maps to it, or a routable `@page` in an assembly the router was given. **None of those is implied by the file existing, by it compiling, or by it being referenced in a doc-comment.** `ThreadSidePanelContent` had all three of the latter and none of the former, and the first version of this page reported its call sites as live.
 
 So for any component-level claim, the check is mechanical and takes one command:
 
@@ -120,38 +145,7 @@ grep -rn "AddAdditionalAssemblies\|AdditionalAssemblies" src/ # which assemblies
 
 An empty result for all three means the code you are reading does not run, and everything downstream of it is a hazard rather than a symptom. This is the same failure mode as a CI gate that never executes: the code is *present*, so it reads as *in force*.
 
-## Reproducing the seam
-
-🚨 **What this reproduces is the SEAM, not a live user journey.** It drives the shared node directly, standing in for the writer that `ThreadSidePanelContent` would be if it were rendered. It proves that a write from one subscriber is observed by another and that `Send`'s namespace decision follows that shared field; it does **not** prove a live writer exists — see "What is LATENT" above. Run it before and after any change that gives `ContextPath` a live writer.
-
-Two independent client hubs stand in for two circuits (each has its own workspace and its own subscription; a Blazor circuit's portal hub is exactly this shape). Against a `MonolithMeshTestBase` mesh with `AddAI()`:
-
-1. Seed `{user}/_Thread/ThreadComposer`.
-2. From hub **B**, `GetMeshNodeStream(composerPath).Update(… ContextPath = "TestData/PageB" …)` — the literal body of `WriteComposerContext`.
-3. From hub **A**, `GetMeshNodeStream(composerPath).Select(ComposerOf)` observes `ContextPath == "TestData/PageB"`. Hub A never navigated.
-4. Run `Send`'s decision on hub A — `ThreadNodeType.MainNodeOf(ContextPath)` → `hub.StartThread(namespacePath: …)` — and the created thread's path starts with `TestData/PageB/`.
-5. Stamp `OpenThreadPath` from hub B; hub A's `Select(…OpenThreadPath).Where(non-empty).DistinctUntilChanged()` — `ThreadSidePanelContent`'s observer verbatim — emits it. That value is the argument to `NavigateTo`.
-
-Steps 2–3 are the bleed, step 4 is the wrong-target write the bleed enables, step 5 is the navigation hijack. All three passed on 2026-09-03 against MeshWeaver.Plugins `6a3bceff`.
-
-**And the negative control**, because an assertion that cannot fail is not an assertion. Re-run with the three expectations flipped to the *isolated* outcome and all three fail, each printing the bleed verbatim:
-
-```text
-ContextPath_WrittenByTabB_IsObservedByTabA
-  Expected the observable to emit a value matching the predicate within 46s, but it did not.
-  Last of 1 emission(s) was: ThreadComposer { … ContextPath = TestData/PageB … }
-      ← hub A's ONLY emission carries hub B's context
-
-SendFromTabA_CreatesTheThreadUnderTabBsContext
-  Expected "TestData/PageB/_Thread/hello-from-tab-a-89dd" to start with "TestData/PageA/"
-      ← the thread hub A started was created under hub B's node
-
-OpenThreadPath_StampedByTabB_ReachesTabAsNavigationObserver
-  Last of 1 emission(s) was: TestData/PageB/_Thread/c2c708d0e008416b9707bc7176972f03
-      ← the argument hub A's observer hands to NavigateTo
-```
-
-The repro is deliberately **not** committed as a test: it asserts the defect, so it would turn red the moment the defect is fixed. The recipe above is the durable form.
+**A dormant hazard is still worth removing** — that is what this change did — but say which it is. The difference decides whether you are fixing a symptom or closing a door.
 
 ## Related
 

--- a/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
+++ b/src/MeshWeaver.Layout/Composition/LayoutAreaHost.cs
@@ -1582,13 +1582,40 @@ public record LayoutAreaHost : IDisposable
     public void NavigateToSidePanel(string uri)
         => PostNavigation(new NavigationRequest(uri) { Target = "SidePanel" });
 
+    /// <summary>
+    /// <b>The viewer this render is FOR</b> — the area subscription's subscriber, normalized to its
+    /// hosting address. For a browser tab that is the portal hub, <c>portal/{circuitId}</c>:
+    /// <see cref="MeshWeaver.Messaging.AddressExtensions.CreatePortalAddress"/> is keyed on the
+    /// circuit id, so there is exactly ONE of these per tab. Null when the area renders with no
+    /// subscriber.
+    ///
+    /// <para>🚨 <b>This is the addressee for anything that means "this viewer, right now, in this
+    /// window".</b> Everything above a mesh node is already per-tab — circuit, portal hub, and this
+    /// subscription, which is keyed <c>(Subscriber, StreamId)</c> — and then a value is written into
+    /// a node, where the isolation ends: a node is shared by every reader, including the same
+    /// person's other tab. State whose honest answer to "what would this mean to my other tab?" is
+    /// "not that" must therefore carry an addressee, and a consumer must act only on a signal
+    /// addressed to IT. See <c>Doc/Architecture/PerTabSessionState</c>.</para>
+    ///
+    /// <para>Prefer <see cref="NavigateTo"/> / <see cref="NavigateToSidePanel"/> where a COMMAND is
+    /// what you need: those already post to this address, so the addressing is the transport's and
+    /// there is no shared field to clear or race. This property is for the cases that genuinely
+    /// have to persist per-viewer state somewhere shared.</para>
+    /// </summary>
+    public Address? Viewer
+    {
+        get
+        {
+            var subscriber = Stream.Get<Address>(nameof(SubscribeRequest.Subscriber));
+            return subscriber is null ? null : subscriber.Host ?? subscriber;
+        }
+    }
+
     private void PostNavigation(NavigationRequest request)
     {
-        var subscriber = Stream.Get<Address>(nameof(SubscribeRequest.Subscriber));
+        var subscriber = Viewer;
         if (subscriber != null)
         {
-            if (subscriber.Host is { })
-                subscriber = subscriber.Host;
             Stream.Hub.Post(request, o => o.WithTarget(subscriber));
         }
         else

--- a/test/MeshWeaver.Layout.Test/LayoutAreaViewerTest.cs
+++ b/test/MeshWeaver.Layout.Test/LayoutAreaViewerTest.cs
@@ -1,0 +1,92 @@
+using System;
+using System.Reactive.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Layout.Client;
+using MeshWeaver.Layout.Composition;
+using MeshWeaver.Messaging;
+using MeshWeaver.Utils;
+
+namespace MeshWeaver.Layout.Test;
+
+/// <summary>
+/// 🚨 <b>A layout area can name the viewer it is rendering for — and two viewers of the SAME area
+/// get different answers.</b>
+///
+/// <para>This is the seam every per-tab decision hangs off. The stack is already per-tab all the
+/// way down: a Blazor circuit is one tab, the portal hub is keyed on the circuit id, and an area
+/// subscription is keyed <c>(Subscriber, StreamId)</c> — so one node rendered into two tabs is two
+/// <see cref="LayoutAreaHost"/>s with two different subscribers. Then a value is written into a mesh
+/// NODE, where the isolation ends: a node is shared by everything that can read it, including the
+/// same person's other tab (<c>Doc/Architecture/PerTabSessionState</c>, MeshWeaver#3060).</para>
+///
+/// <para><see cref="LayoutAreaHost.Viewer"/> is what lets state that means "<i>this viewer, right
+/// now, in this window</i>" carry an ADDRESSEE onto such a node, so a consumer can act only on a
+/// signal addressed to it. It is deliberately the same address, normalized the same way, that
+/// <see cref="LayoutAreaHost.NavigateTo"/> posts to — a stamp written here and a command posted
+/// there must name the same tab, or addressing would be a coin toss.</para>
+/// </summary>
+public class LayoutAreaViewerTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private const string ViewerView = nameof(ViewerView);
+    private const string ViewerArea = "Viewer";
+
+    /// <summary>Renders the area's own viewer, so a subscriber can read back who the server thinks
+    /// it is rendering for.</summary>
+    private static IObservable<UiControl?> Viewer(LayoutAreaHost host, RenderingContext ctx) =>
+        Observable.Return<UiControl?>(
+            Controls.Stack.WithView(
+                Controls.Label(host.Viewer?.ToString() ?? "<none>"), ViewerArea));
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration) =>
+        base.ConfigureHost(configuration)
+            .WithRoutes(r => r.RouteAddress(ClientType, (_, d) => d.Package()))
+            .AddLayout(layout => layout.WithView(ViewerView, Viewer));
+
+    protected override MessageHubConfiguration ConfigureClient(MessageHubConfiguration configuration) =>
+        base.ConfigureClient(configuration).AddLayoutClient(d => d);
+
+    private async Task<string> RenderedViewerFor(IMessageHub client)
+    {
+        var reference = new LayoutAreaReference(ViewerView);
+        var stream = client.GetWorkspace()
+            .GetRemoteStream<JsonElement, LayoutAreaReference>(CreateHostAddress(), reference);
+        var text = await stream.GetControlStream($"{reference.Area}/{ViewerArea}")
+            .Should().Within(10.Seconds())
+            .Match(c => c is LabelControl { Data: string s } && s != "<none>",
+                "the area must render, and must know its subscriber");
+        return (string)((LabelControl)text!).Data!;
+    }
+
+    /// <summary>The area renders for the hub that subscribed to it, and says so.</summary>
+    [HubFact]
+    public async Task AnAreaKnowsWhichViewerItIsRenderingFor()
+    {
+        var client = GetClient();
+        (await RenderedViewerFor(client)).Should().Be(client.Address.ToString(),
+            "the viewer IS the subscriber — in the portal, the tab's own portal hub");
+    }
+
+    /// <summary>
+    /// 🚨 <b>The property the whole per-tab scheme rests on.</b> Two subscribers to the SAME area of
+    /// the SAME host are two renders with two different viewers. If they ever agreed, an addressee
+    /// stamped from one tab would match the other and "addressed" would mean nothing — the exact
+    /// cross-talk of MeshWeaver#3060, one layer lower.
+    /// </summary>
+    [HubFact]
+    public async Task TwoSubscribersToOneArea_EachRenderForThemselves()
+    {
+        var first = GetClient();
+        var second = GetClient();
+
+        var viewerOfFirst = await RenderedViewerFor(first);
+        var viewerOfSecond = await RenderedViewerFor(second);
+
+        viewerOfFirst.Should().Be(first.Address.ToString());
+        viewerOfSecond.Should().Be(second.Address.ToString());
+        viewerOfFirst.Should().NotBe(viewerOfSecond,
+            "two viewers of one area must be distinguishable, or nothing can be addressed to one of them");
+    }
+}


### PR DESCRIPTION
## Two tabs of one account are two viewers of one node

Everything above a mesh node is already per-tab — the Blazor circuit, `ICircuitContextAccessor`, `INavigationService`, the portal hub (`CreatePortalAddress(circuitId)`), and the layout-area subscription, keyed `(Subscriber, StreamId)`. **Then a value is written into a node, where the isolation ends**: a node is shared by everything that can read it, including the same person's other tab. That is [#3060](https://github.com/Systemorph/MeshWeaver/issues/3060), and it is also why the node keeps attracting per-tab state — it is the only shared thing in the chain *and* the only durable one.

## `LayoutAreaHost.Viewer`

The area subscription's subscriber, normalized through `Address.Host`: `portal/{circuitId}`, exactly one per tab. It is **deliberately the same address `NavigateTo` already posts to**, so a per-viewer stamp written from `Viewer` and a command posted by `NavigateTo` name the same tab. `PostNavigation` now reads it rather than re-deriving it, so there is one definition of the rule instead of two that can drift.

`LayoutAreaViewerTest` pins both halves, including the property the whole scheme rests on:

> **two subscribers to ONE area get different answers.** If they ever agreed, an addressee stamped from one tab would match the other and "addressed" would mean nothing — the same cross-talk, one layer lower.

## `PerTabSessionState.md` — from RCA to shipped design

The page was the investigation's write-up ([#3209](https://github.com/Systemorph/MeshWeaver/pull/3209)). It now describes what was built:

- **The three shapes.** Per-viewer *preference* → a plain per-user node field (two tabs agreeing is the feature). Per-viewer *session state* → the layout area's own per-subscriber store, or a node field that **carries its addressee**. A *command* to one window → do not put it on a node at all; post it.
- **Why the chat draft deliberately stayed per user** — and this is an argument, not a scoping dodge: a Blazor circuit dies on every page reload, so a circuit-keyed draft would be lost by exactly the single-tab case the durable node exists for. One person, one draft.
- **Fail-closed addressing.** A stored value with *no* addressee is honoured by nobody, so restoring a writer can no longer re-arm the hazard in one commit.
- **The mutation control**, because an assertion that cannot fail is not an assertion: reverting each half of the fix reddens exactly the tests that cover it (7 fail / 12 pass with both reverted; 19/19 unmutated), and the *sharing* assertion passes throughout — so the suite is not being held up by the one test that would also pass if the fix had quietly made the whole record per-tab.

## Scope, and where the behaviour fix lives

**The user-visible fix is in `MeshWeaver.AI` / `MeshWeaver.Blazor.Chat` and lands in MeshWeaver.Plugins: Systemorph/MeshWeaver.Plugins#1296.** That change needs **no** API from this one — it reads its own subscriber off the already-public `host.Stream`, precisely so it does not require an `MW_PLATFORM_REF` bump — so the two PRs are independent and can merge in either order. The local copy there carries a comment to delete itself in favour of `host.Viewer` when that pin next moves.

No public type or member is removed here (`Viewer` is added), so no `Pairs-with:` applies. No user-visible string changes, hence no What's New entry in this repo — the user-facing note ships with the fix in Plugins.

## Verification

| | |
|---|---|
| `MeshWeaver.Layout` · `MeshWeaver.Layout.Test` · `MeshWeaver.Documentation.Test` | `dotnet build -c Release -warnaserror`, one project per invocation — **0 warnings, 0 errors** |
| `LayoutAreaViewerTest` + `NavigateToSidePanelTest` | **3 / 3** |
| `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` | **2 / 2** |

Closes #3060

🤖 Generated with [Claude Code](https://claude.com/claude-code)
