### PR TITLE
diag: the compilation-in-progress overlay NAMES the state it found (Plugins#1279)

### DIFF
--- a/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
+++ b/src/MeshWeaver.Graph/Configuration/NodeTypeEnrichmentHelpers.cs
@@ -2673,10 +2673,28 @@ internal static class NodeTypeEnrichmentHelpers
         IMessageHub meshHub,
         ILogger? logger)
     {
+        // 🚨 NAME THE STATE, not just the fact. This line used to carry only the type version, so an
+        // operator reading it could not tell a compile that is WORKING from one that will never
+        // terminate — the two look identical here, and the distinguishing fields were only in a
+        // different logger's COMPILE-TRACE lines, leaving whoever is debugging to correlate two
+        // sources by timestamp (Plugins#1279, where a type sat behind this overlay for 48s with no
+        // status transition and no compile error logged anywhere).
+        //
+        // `Status` says which phase it is stuck in — a null status means NOTHING has dispatched the
+        // build at all (the first-build kickoff never ran), which is a different defect from
+        // Compiling-forever. `HubConfig` says whether the type is truly static, which is the other
+        // way a type reaches here without a compile to wait for.
+        var inFlightDefinition = typeNode.Content as NodeTypeDefinition;
         logger?.LogInformation(
             "EnrichWithNodeType: compile for '{NodeType}' still in flight after {Grace:0}s — "
-            + "activating compilation-in-progress overlay for '{InstancePath}' (type version {Version})",
-            nodeType, InFlightOverlayGrace.TotalSeconds, node.Path, typeNode.Version);
+            + "activating compilation-in-progress overlay for '{InstancePath}' "
+            + "(type version {Version}, Status={Status}, HubConfig={HasHubConfig}, "
+            + "dispatched={Dispatched}, lastStarted={LastStarted})",
+            nodeType, InFlightOverlayGrace.TotalSeconds, node.Path, typeNode.Version,
+            inFlightDefinition?.CompilationStatus?.ToString() ?? "(null — nothing dispatched a build)",
+            typeNode.HubConfiguration is not null,
+            inFlightDefinition?.DispatchedBuildInputs ?? "(unstamped)",
+            inFlightDefinition?.LastCompileStartedAt?.ToString("O") ?? "(never)");
 
         var overlay = CreateCompilationInProgressConfiguration(nodeType, node.Path);
         var nack = new UnhandledMessageNack(


### PR DESCRIPTION
The compilation-in-progress overlay logged only the **type version**, so an operator reading that line could not tell a compile that is *working* from one that will *never terminate* — the two look identical there, and the distinguishing fields lived in a different logger's `COMPILE-TRACE` output, leaving whoever is debugging to correlate two sources by timestamp.

Systemorph/MeshWeaver.Plugins#1279 is exactly that: `FutuRe/LocalAnalysis` sat behind this overlay for **48 s** with no status transition and **no compile error logged anywhere**. The issue's first question — *"does the compile ever complete, or is it wedged?"* — could not be answered from the line that actually fired.

## What the line now carries

| field | what it distinguishes |
|---|---|
| `Status` | which phase it is stuck in. 🚨 A **null** status is a *different defect* from Compiling-forever — it means nothing dispatched a build at all — so the message says that in words rather than printing an empty field |
| `HubConfig` | whether the type is truly static, i.e. reached here with no compile to wait for |
| `dispatched` (`DispatchedBuildInputs`) | whether a build was ever stamped |
| `lastStarted` (`LastCompileStartedAt`) | when — which is what separates "slow" from "never started" |

No behaviour change: one log statement, same level, same call site, same overlay. Pure diagnostics.

## What this deliberately does NOT do

The issue also wants a report **at the point the caller gives up**. The overlay logs once at the 5 s grace and never again, so a 48 s hang produces one early line and then silence.

A periodic or long-threshold re-report needs a **timer on the enrichment path** — and a timer whose callback touches a hub is precisely the shape that produced a separate defect today (#3229's neighbourhood, where a `.Timeout(...)`-delayed callback resolving DI after teardown was the hazard). That deserves its own change with its own care, not to be bolted onto a logging fix.

## Verification

`MeshWeaver.Graph.Test` overlay-adjacent suites (`CompileWaitDoesNotTimeoutTest`, `ExecuteTimeInterlockTest`): **17 passed, 0 failed**. `MeshWeaver.Graph` builds clean with `-warnaserror`.

Refs Systemorph/MeshWeaver.Plugins#1279

🤖 Generated with [Claude Code](https://claude.com/claude-code)
