### PR TITLE
ci: CD boots the image pair and signs in before promoting it (2026-09-03 sign-in outage)

### DIFF
--- a/.github/scripts/cd-signin-smoke.sh
+++ b/.github/scripts/cd-signin-smoke.sh
@@ -1,0 +1,379 @@
+#!/usr/bin/env bash
+#
+# Boot the image PAIR a CD run built — migration, then portal — against a fresh Postgres, sign in
+# through DevLogin, and prove that a SIGNED-IN request is served.
+#
+#   .github/scripts/cd-signin-smoke.sh --portal-image REF --migration-image REF [options]
+#   exit 0 = the pair serves a signed-in request   exit 1 = it does not, or the proof could not run
+#
+# 🚨 WHY THIS EXISTS (2026-09-03, MeshWeaver#3206 × Plugins#1263). CD run #7658 built
+# memex-portal-ai:3.0.0-rc9.ci.7658 from core e7f1d699 (08:05Z, BEFORE core #3206 anchored the
+# sign-in reads) paired with the Plugins head at resolve time, 12500c9 (13:31Z, AFTER Plugins #1263
+# made the Postgres planner REFUSE an unanchored query). Every leg was green. `promote` tagged the
+# pair, "Verify every image shipped" found every tag, and the first signed-in request in production
+# faulted in OnboardingMiddleware.LoadUserRoles with UnanchoredQueryException: the portal answered
+# 503 to EVERY signed-in request for 20 minutes, and the Store page died the same way. Nothing in CD
+# had ever BOOTED the pair; nothing had ever SIGNED IN. The two halves can be hours apart because a
+# run's jobs queue for hours, and no job checked that the pair was coherent BEHAVIOURALLY.
+#
+# 🚨 THE ASSERTIONS THAT MATTER CARRY THE COOKIE. ci.7658 answered 200 to an anonymous GET / and to
+# /_blazor/negotiate — only requests carrying a signed-in cookie 503'd. So an unauthenticated 200
+# proves nothing here (the same trap as /api/og answering 200 during a content outage), and this
+# script fails only on what the incident actually broke: the SIGNED-IN GET / and GET /Store, plus
+# the exact log signatures. An anonymous probe is logged for diagnosis and never asserted.
+#
+# 🚨 FAIL CLOSED. A pull that never completes, a migration that never logs its version, a /health
+# that never answers, a DevLogin that answers 400 — every one is exit 1. "Could not check" must
+# never be reported as "checked and fine". There is deliberately no --dry-run: a run of this script
+# that touched no image is not a run of this script.
+#
+# What it cannot prove: anything behind a language model, a registry bundle, Entra sign-in, or
+# multi-replica AdoNet clustering — none of those are in the box. It proves the pair BOOTS on a
+# fresh schema, that the schema the migration wrote is the one the portal accepts (DbVersionGate),
+# and that the sign-in → identity → roles → render path serves a real user. That is the path the
+# incident broke, and it is the path every user takes first.
+#
+# Runnable locally against the real registry, which is how it was verified (positive AND negative
+# control — the pair that shipped fixed passes, the pair that 503'd fails):
+#   az acr login -n meshweaver
+#   .github/scripts/cd-signin-smoke.sh --platform linux/arm64 \
+#     --portal-image meshweaver.azurecr.io/memex-portal-ai:3.0.0-rc9.ci.7693 \
+#     --migration-image meshweaver.azurecr.io/memex-migration:3.0.0-rc9.ci.7693
+set -uo pipefail
+
+PORTAL_IMAGE=""
+MIGRATION_IMAGE=""
+PLATFORM="linux/amd64"
+# pgvector: SchemaInitialization creates `vector` columns, so a bare postgres image fails the
+# migration for a reason that has nothing to do with the pair. Same family the chart and compose
+# ship (pgvector/pgvector:pg17); pg16 is the floor the gate was written against.
+POSTGRES_IMAGE="pgvector/pgvector:pg16"
+CORE_SHA="(not given)"
+PLUGINS_SHA="(not given)"
+STAGING_TAG="(not given)"
+HEALTH_DEADLINE=480
+MIGRATION_DEADLINE=300
+PULL=1
+KEEP=0
+SUMMARY="${GITHUB_STEP_SUMMARY:-}"
+
+usage() {
+  sed -n '2,/^set -uo/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
+  cat <<EOF
+Options:
+  --portal-image REF       the memex-portal-ai image under test (required)
+  --migration-image REF    the memex-migration image under test (required)
+  --platform P             docker platform to pull and run (default: $PLATFORM)
+  --postgres-image REF     the database container (default: $POSTGRES_IMAGE)
+  --core-sha SHA           recorded in the summary — the core commit the pair was built from
+  --plugins-sha SHA        recorded in the summary — the MeshWeaver.Plugins commit
+  --staging-tag TAG        recorded in the summary — the run's staging tag
+  --health-deadline SEC    seconds to wait for /health to answer 200 (default: $HEALTH_DEADLINE)
+  --migration-deadline SEC seconds to wait for the migration to exit (default: $MIGRATION_DEADLINE)
+  --summary FILE           markdown summary target (default: \$GITHUB_STEP_SUMMARY, else none)
+  --no-pull                use the images already present locally
+  --keep                   leave the containers running for inspection
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --portal-image)        PORTAL_IMAGE="$2"; shift 2 ;;
+    --migration-image)     MIGRATION_IMAGE="$2"; shift 2 ;;
+    --platform)            PLATFORM="$2"; shift 2 ;;
+    --postgres-image)      POSTGRES_IMAGE="$2"; shift 2 ;;
+    --core-sha)            CORE_SHA="$2"; shift 2 ;;
+    --plugins-sha)         PLUGINS_SHA="$2"; shift 2 ;;
+    --staging-tag)         STAGING_TAG="$2"; shift 2 ;;
+    --health-deadline)     HEALTH_DEADLINE="$2"; shift 2 ;;
+    --migration-deadline)  MIGRATION_DEADLINE="$2"; shift 2 ;;
+    --summary)             SUMMARY="$2"; shift 2 ;;
+    --no-pull)             PULL=0; shift ;;
+    --keep)                KEEP=1; shift ;;
+    -h|--help)             usage; exit 0 ;;
+    *) echo "::error::unknown argument '$1'"; usage >&2; exit 2 ;;
+  esac
+done
+[ -n "$PORTAL_IMAGE" ]    || { echo "::error::--portal-image is required"; exit 2; }
+[ -n "$MIGRATION_IMAGE" ] || { echo "::error::--migration-image is required"; exit 2; }
+command -v docker >/dev/null || { echo "::error::docker is not on PATH — this gate cannot run"; exit 2; }
+command -v curl   >/dev/null || { echo "::error::curl is not on PATH — this gate cannot run"; exit 2; }
+docker info >/dev/null 2>&1 || { echo "::error::the docker daemon is not reachable — this gate cannot run"; exit 2; }
+
+# ── naming, workspace, summary, cleanup ─────────────────────────────────────────────────────
+RUN="cdsmoke-$(date -u +%s)-$$"
+NET="$RUN-net"; PG="$RUN-pg"; MIG="$RUN-mig"; PORTAL="$RUN-portal"; VOL="$RUN-data"
+WORK="$(mktemp -d "${RUNNER_TEMP:-${TMPDIR:-/tmp}}/$RUN.XXXX")"
+JAR="$WORK/cookies.txt"
+PG_PASSWORD="smoke-$RANDOM$RANDOM"
+CONN="Host=$PG;Port=5432;Username=postgres;Password=$PG_PASSWORD;Database=memex"
+FAILED=""
+MIGRATION_VERSION="(never reached)"
+PORTAL_READY_AFTER="(never)"
+
+summary() { [ -n "$SUMMARY" ] && echo "$1" >> "$SUMMARY"; return 0; }
+ok()      { echo "✅ $1";          summary "- ✅ $1"; }
+info()    { echo "ℹ️  $1";         summary "- $1"; }
+fail()    { echo "::error::$1";    summary "- ❌ $1"; FAILED="${FAILED:+$FAILED; }$1"; }
+
+group()    { [ -n "${GITHUB_ACTIONS:-}" ] && echo "::group::$1" || echo "── $1"; return 0; }
+endgroup() { [ -n "${GITHUB_ACTIONS:-}" ] && echo "::endgroup::"; return 0; }
+
+# On failure the two container logs go into the job log — warnings/errors FIRST, so the line that
+# names the fault is at the top rather than 800 lines down a boot transcript.
+dump_logs() {
+  local name="$1" file="$2"
+  [ -s "$file" ] || { echo "(no log captured for $name)"; return 0; }
+  # Console-logger level prefixes plus the incident vocabulary — not a bare `error`, which the
+  # migration's echoed SQL (`EXCEPTION WHEN …`, `-- Fail-safe: …`) matches on every line.
+  group "$name — warning/error lines"
+  grep -nE '^(warn|fail|crit):|Exception|Refusing to start|UNAVAILABLE for|Error:' "$file" | head -200 || echo "(none)"
+  endgroup
+  group "$name — last 300 lines"
+  tail -n 300 "$file"
+  endgroup
+}
+
+cleanup() {
+  local rc=$?
+  if [ -n "$FAILED" ]; then
+    [ -f "$WORK/migration.log" ] || docker logs "$MIG" > "$WORK/migration.log" 2>&1 || true
+    docker logs "$PORTAL" > "$WORK/portal.log" 2>&1 || true
+    dump_logs "migration ($MIGRATION_IMAGE)" "$WORK/migration.log"
+    dump_logs "portal ($PORTAL_IMAGE)" "$WORK/portal.log"
+  fi
+  if [ "$KEEP" -eq 1 ]; then
+    echo "--keep: leaving $PORTAL / $MIG / $PG on network $NET (volume $VOL); work dir $WORK"
+  else
+    docker rm -f "$PORTAL" "$MIG" "$PG" >/dev/null 2>&1 || true
+    docker network rm "$NET" >/dev/null 2>&1 || true
+    docker volume rm "$VOL" >/dev/null 2>&1 || true
+    rm -rf "$WORK"
+  fi
+  exit "$rc"
+}
+trap cleanup EXIT
+
+echo "Pair under test: core $CORE_SHA + plugins $PLUGINS_SHA (staging tag $STAGING_TAG)"
+echo "  portal    = $PORTAL_IMAGE"
+echo "  migration = $MIGRATION_IMAGE"
+echo "  platform  = $PLATFORM · database = $POSTGRES_IMAGE"
+summary "### Sign-in smoke: boot the image pair and sign in"
+summary "| | |"
+summary "|---|---|"
+summary "| core sha | \`$CORE_SHA\` |"
+summary "| plugins sha | \`$PLUGINS_SHA\` |"
+summary "| staging tag | \`$STAGING_TAG\` |"
+summary "| portal image | \`$PORTAL_IMAGE\` |"
+summary "| migration image | \`$MIGRATION_IMAGE\` |"
+summary "| platform | \`$PLATFORM\` · database \`$POSTGRES_IMAGE\` |"
+summary ""
+
+# ── 1. pull (infra, bounded retry — the same idiom publish-bake uses) ───────────────────────
+pull() {
+  local image="$1" attempts=5 attempt delay
+  for attempt in $(seq 1 $attempts); do
+    if docker pull --quiet --platform "$PLATFORM" "$image" >/dev/null; then return 0; fi
+    if [ "$attempt" -lt "$attempts" ]; then
+      delay=$((5 * 2 ** (attempt - 1)))
+      echo "pull of $image failed (attempt $attempt); retrying in ${delay}s" >&2
+      sleep "$delay"
+    fi
+  done
+  return 1
+}
+if [ "$PULL" -eq 1 ]; then
+  for image in "$MIGRATION_IMAGE" "$PORTAL_IMAGE" "$POSTGRES_IMAGE"; do
+    if ! pull "$image"; then
+      fail "could not pull $image for $PLATFORM after 5 attempts — a REGISTRY/INFRA failure, not a verdict on the pair"
+      exit 1
+    fi
+  done
+  ok "pulled all three images for $PLATFORM"
+else
+  ok "using local images (--no-pull)"
+fi
+
+# ── 2. a fresh database ─────────────────────────────────────────────────────────────────────
+docker network create "$NET" >/dev/null || { fail "could not create docker network $NET"; exit 1; }
+docker run -d --name "$PG" --network "$NET" --platform "$PLATFORM" \
+  -e POSTGRES_PASSWORD="$PG_PASSWORD" -e POSTGRES_DB=memex "$POSTGRES_IMAGE" >/dev/null \
+  || { fail "could not start $POSTGRES_IMAGE"; exit 1; }
+# TCP, not the unix socket: the official image's initdb phase runs a temporary server that listens
+# on the socket only, and pg_isready against it would report ready before the real server is up.
+pg_deadline=$(( $(date +%s) + 90 ))
+until docker exec "$PG" pg_isready -h 127.0.0.1 -U postgres -d memex >/dev/null 2>&1; do
+  if [ "$(date +%s)" -ge "$pg_deadline" ]; then
+    docker logs "$PG" 2>&1 | tail -n 50
+    fail "Postgres did not accept TCP connections within 90s"
+    exit 1
+  fi
+  sleep 2
+done
+ok "Postgres ready (database memex, fresh)"
+
+# ── 3. the migration, with the SAME env names the Helm chart and compose give it ───────────
+docker run -d --name "$MIG" --network "$NET" --platform "$PLATFORM" \
+  -e ConnectionStrings__memex="$CONN" \
+  -e MEMEX_HOST="$PG" -e MEMEX_PORT=5432 -e MEMEX_USERNAME=postgres -e MEMEX_PASSWORD="$PG_PASSWORD" \
+  -e MEMEX_DATABASENAME=memex \
+  -e MEMEX_URI="postgresql://postgres:$PG_PASSWORD@$PG:5432/memex" \
+  -e MEMEX_JDBCCONNECTIONSTRING="jdbc:postgresql://$PG:5432/memex" \
+  "$MIGRATION_IMAGE" >/dev/null || { fail "could not start the migration container"; exit 1; }
+mig_start=$(date +%s)
+mig_deadline=$(( mig_start + MIGRATION_DEADLINE ))
+while [ "$(docker inspect --format '{{.State.Status}}' "$MIG")" = "running" ]; do
+  if [ "$(date +%s)" -ge "$mig_deadline" ]; then
+    docker kill "$MIG" >/dev/null 2>&1 || true
+    docker logs "$MIG" > "$WORK/migration.log" 2>&1 || true
+    fail "the migration was still running after ${MIGRATION_DEADLINE}s — killed. A migration that does not complete cannot certify a schema"
+    exit 1
+  fi
+  sleep 3
+done
+docker logs "$MIG" > "$WORK/migration.log" 2>&1 || true
+mig_exit=$(docker inspect --format '{{.State.ExitCode}}' "$MIG")
+if [ "$mig_exit" != "0" ]; then
+  fail "the migration exited $mig_exit"
+  exit 1
+fi
+# The literal line Program.cs logs LAST, after every phase — its absence with exit 0 is a
+# migration that stopped short, and the version it names is what DbVersionGate will compare.
+MIGRATION_VERSION=$(grep -oE 'Database migration completed\. Version: [0-9]+' "$WORK/migration.log" | tail -n 1 | grep -oE '[0-9]+$')
+if [ -z "$MIGRATION_VERSION" ]; then
+  MIGRATION_VERSION="(not logged)"
+  fail "the migration exited 0 but never logged 'Database migration completed. Version: N'"
+  exit 1
+fi
+ok "migration completed in $(( $(date +%s) - mig_start ))s — Database migration completed. Version: $MIGRATION_VERSION"
+
+# ── 4. the portal, on a writable /data, DevLogin on, single local silo ──────────────────────
+docker volume create "$VOL" >/dev/null || { fail "could not create volume $VOL"; exit 1; }
+# The image runs as APP_UID 1654 and a fresh named volume is root-owned; the chart gives it a PVC
+# and the e2e portal an emptyDir, both writable. Open it the same way rather than run as root.
+docker run --rm --user root --entrypoint chmod -v "$VOL:/data" --platform "$PLATFORM" \
+  "$PORTAL_IMAGE" 1777 /data >/dev/null || { fail "could not make /data writable"; exit 1; }
+docker run -d --name "$PORTAL" --network "$NET" --platform "$PLATFORM" \
+  -p 127.0.0.1::8080 -v "$VOL:/data" \
+  -e ConnectionStrings__memex="$CONN" \
+  -e MEMEX_HOST="$PG" -e MEMEX_PORT=5432 -e MEMEX_USERNAME=postgres -e MEMEX_PASSWORD="$PG_PASSWORD" \
+  -e MEMEX_DATABASENAME=memex \
+  -e MEMEX_URI="postgresql://postgres:$PG_PASSWORD@$PG:5432/memex" \
+  -e MEMEX_JDBCCONNECTIONSTRING="jdbc:postgresql://$PG:5432/memex" \
+  -e ASPNETCORE_HTTP_PORTS=8080 \
+  -e Deployment__Backend=Filesystem \
+  -e Deployment__DataRoot=/data \
+  -e Deployment__Orleans__Clustering=Localhost \
+  -e Storage__Name=content -e Storage__SourceType=FileSystem -e Storage__BasePath=/data/content \
+  -e Graph__Storage__Type=PostgreSql -e Graph__Storage__BasePath=/data/graph \
+  -e Authentication__EnableDevLogin=true \
+  -e Portal__InstanceName="CD smoke" \
+  "$PORTAL_IMAGE" >/dev/null || { fail "could not start the portal container"; exit 1; }
+PORT=$(docker port "$PORTAL" 8080/tcp | head -n 1 | sed 's/.*://')
+[ -n "$PORT" ] || { fail "could not resolve the portal's published port"; exit 1; }
+BASE="http://127.0.0.1:$PORT"
+
+portal_start=$(date +%s)
+health_deadline=$(( portal_start + HEALTH_DEADLINE ))
+while :; do
+  state=$(docker inspect --format '{{.State.Status}}' "$PORTAL")
+  if [ "$state" != "running" ]; then
+    fail "the portal container is '$state' before /health ever answered 200 (exit $(docker inspect --format '{{.State.ExitCode}}' "$PORTAL"))"
+    exit 1
+  fi
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 "$BASE/health" || true)
+  if [ "$code" = "200" ]; then break; fi
+  if [ "$(date +%s)" -ge "$health_deadline" ]; then
+    fail "/health did not answer 200 within ${HEALTH_DEADLINE}s (last: '$code') — the portal never became ready on the schema the paired migration wrote"
+    exit 1
+  fi
+  sleep 5
+done
+PORTAL_READY_AFTER="$(( $(date +%s) - portal_start ))s"
+ok "portal /health answered 200 after $PORTAL_READY_AFTER"
+
+# ── 5. sign in through DevLogin and keep the cookie ─────────────────────────────────────────
+# POST /dev/signin (DevAuthController): form fields personId + returnUrl, answers 302 with the
+# MemexAuth cookie; a brand-new personId is provisioned on first sign-in. A 400 here is
+# "Person not found" — DevLogin is OFF (the host forces it off unless the env is literally true).
+code=$(curl -s -o "$WORK/signin.body" -w '%{http_code}' --max-time 180 -c "$JAR" \
+  -X POST --data-urlencode 'personId=cd-smoke' --data-urlencode 'returnUrl=/' "$BASE/dev/signin" || echo "curl-failed")
+if [ "$code" != "302" ]; then
+  fail "DevLogin POST /dev/signin answered $code, expected 302 — body: $(head -c 300 "$WORK/signin.body" | tr '\n' ' ')"
+  exit 1
+fi
+if ! grep -q 'MemexAuth' "$JAR"; then
+  fail "DevLogin answered 302 but set no MemexAuth cookie"
+  exit 1
+fi
+ok "DevLogin as 'cd-smoke' → 302 + MemexAuth cookie"
+
+# Anonymous probe — DIAGNOSTIC ONLY, never asserted: ci.7658 answered 200 here while 503'ing every
+# signed-in request, so this number says nothing about the pair. It is printed so a future red can
+# be read against it ("anonymous fine, signed-in 503" is exactly the incident's shape).
+anon=$(curl -s -o /dev/null -w '%{http_code}' --max-time 60 "$BASE/" || echo "curl-failed")
+info "anonymous GET / → $anon (diagnostic only — not an assertion)"
+
+# ── 6. the SIGNED-IN requests — the assertions that matter ──────────────────────────────────
+# Status 200 exactly: no redirect is followed, so a 302 to /login (cookie rejected) or /onboarding
+# (identity not resolved) fails here rather than landing on a 200 page that proves nothing. The
+# body must not carry the identity-unavailable text (issue #637's 503 page, in either shipped
+# language) and must be the app shell, not an error page.
+IDENTITY_UNAVAILABLE_EN="We could not check your account just now"
+IDENTITY_UNAVAILABLE_DE="Ihr Konto konnte gerade nicht geprüft werden"
+signed_in_get() { # signed_in_get <path> <label>
+  local path="$1" label="$2" code body
+  body="$WORK/$(echo "$path" | tr '/?' '__').body"
+  code=$(curl -s -o "$body" -w '%{http_code}' --max-time 180 -b "$JAR" "$BASE$path" || echo "curl-failed")
+  if [ "$code" != "200" ]; then
+    fail "signed-in GET $path answered $code, expected 200 ($label) — body: $(head -c 300 "$body" | tr '\n' ' ')"
+    return 1
+  fi
+  if grep -qF "$IDENTITY_UNAVAILABLE_EN" "$body" || grep -qF "$IDENTITY_UNAVAILABLE_DE" "$body"; then
+    fail "signed-in GET $path answered 200 but rendered the identity-unavailable text ($label)"
+    return 1
+  fi
+  if ! grep -qiE 'blazor|<app|<html' "$body"; then
+    fail "signed-in GET $path answered 200 but the body is not the portal shell ($label) — first bytes: $(head -c 200 "$body" | tr '\n' ' ')"
+    return 1
+  fi
+  ok "signed-in GET $path → 200, rendered, no identity-unavailable text ($label)"
+}
+signed_in_get "/"      "home — the request the 2026-09-03 incident 503'd"      || exit 1
+signed_in_get "/Store" "Store — died the same way on ci.7658"                  || exit 1
+
+code=$(curl -s -o "$WORK/negotiate.body" -w '%{http_code}' --max-time 60 -b "$JAR" \
+  -X POST -H 'Content-Length: 0' "$BASE/_blazor/negotiate?negotiateVersion=1" || echo "curl-failed")
+if [ "$code" != "200" ] || ! grep -q 'connectionId' "$WORK/negotiate.body"; then
+  fail "signed-in POST /_blazor/negotiate answered $code (expected 200 with a connectionId) — body: $(head -c 300 "$WORK/negotiate.body" | tr '\n' ' ')"
+  exit 1
+fi
+ok "signed-in POST /_blazor/negotiate → 200 with a connectionId"
+
+# ── 7. the incident's exact log signatures — a status code is not the only evidence ────────
+# `UNAVAILABLE for` is qualified with `answering 503` ON PURPOSE. Every site that turns an
+# unresolved identity into a 503 logs "… UNAVAILABLE for {Path} ({Reason}) — answering 503 +
+# Retry-After" (OnboardingMiddleware — the incident's line — plus the bearer/API-token/instance-key
+# handlers). UserContextMiddleware ALSO logs "mesh user index UNAVAILABLE for {Email} … falling
+# back to the email local-part", a documented cold-start fallback that fires on the first request
+# after every fresh boot and drives nothing — measured on ci.7693: one such line per run, and the
+# request it belongs to answered 200. A bare `UNAVAILABLE for` therefore fails the pair that
+# shipped FIXED, and a gate that fails its own positive control is not a gate.
+docker logs "$PORTAL" > "$WORK/portal.log" 2>&1 || true
+SIGNATURES='UnanchoredQueryException|UNAVAILABLE for .*answering 503|Refusing to start'
+hits=$(grep -cE "$SIGNATURES" "$WORK/portal.log" "$WORK/migration.log" | awk -F: '{s+=$NF} END {print s+0}')
+if [ "$hits" != "0" ]; then
+  group "signature hits"
+  grep -nE "$SIGNATURES" "$WORK/portal.log" "$WORK/migration.log" | head -n 50
+  endgroup
+  fail "$hits log line(s) match the incident signatures ($SIGNATURES) — the pair served the requests but a read faulted underneath"
+  exit 1
+fi
+ok "0 log lines match '$SIGNATURES' across portal + migration"
+
+ready_line=$(grep -oE 'PortalReady[^"]{0,60}' "$WORK/portal.log" | head -n 1)
+[ -n "$ready_line" ] && info "lifecycle: $ready_line"
+summary ""
+summary "**PASS** — the pair boots on a fresh schema (migration version $MIGRATION_VERSION), becomes healthy in $PORTAL_READY_AFTER, and serves a signed-in user."
+echo "PASS: $PORTAL_IMAGE + $MIGRATION_IMAGE serve a signed-in request (migration version $MIGRATION_VERSION, healthy after $PORTAL_READY_AFTER)"
+exit 0

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -30,6 +30,15 @@ name: Continuous Delivery (main)
 # succeed does the `promote` job apply the real tags, and promotion is a MANIFEST-ONLY operation
 # (`docker buildx imagetools create`) — the layers are already in ACR, so it costs seconds.
 #
+# 🚨 "EVERY image built" is necessary, not sufficient (2026-09-03). A set can be complete and
+# still unable to serve a signed-in request: run #7658's portal was built from core e7f1d699
+# (08:05Z) paired with the Plugins head at resolve time, 12500c9 (13:31Z) — hours apart, because
+# the run's jobs queued for hours — and the two halves disagreed about whether the sign-in reads
+# were anchored. Promote tagged it, verify-images found every tag, and production answered 503 to
+# every signed-in request for 20 minutes. So `promote` ALSO needs `signin-smoke`, which boots the
+# run's own staging pair (migration → portal), signs in through DevLogin and asserts the
+# SIGNED-IN GET / and GET /Store are served. A pair that cannot sign in is never tagged.
+#
 # Why this shape and not "build to a tarball, push later": the bytes have to reach the registry
 # for a push to happen at all, and pushing them to a staging tag costs exactly what pushing them
 # to the real tag costs. The only thing worth withholding is the TAG, because the tag IS the
@@ -1330,9 +1339,79 @@ jobs:
   # portalNext is opt-in (chart default enabled: false) and the self-updater never rolls it —
   # nothing waits on it, so it does not belong to this repo's all-or-nothing set.
 
+  # ────────── BOOT THE PAIR AND SIGN IN — the behavioural half of "the set is complete" ──────────
+  # 🚨 A complete image set is not a servable one (2026-09-03). Run #7658 built memex-portal-ai
+  # from core e7f1d699 (08:05Z, before core #3206 anchored the sign-in reads) paired with the
+  # Plugins head at resolve time, 12500c9 (13:31Z, after Plugins #1263 made the Postgres planner
+  # REFUSE an unanchored query). Every leg was green; promote tagged it; verify-images found every
+  # tag. In production the first signed-in request faulted in OnboardingMiddleware.LoadUserRoles
+  # with UnanchoredQueryException and the portal answered 503 to every signed-in request for 20
+  # minutes; the Store page died the same way. The two halves of the pair can be hours apart —
+  # the run's jobs queue for hours — and nothing in CD had ever BOOTED the pair, let alone signed
+  # in. Nothing checked that the pair was coherent BEHAVIOURALLY.
+  #
+  # So this job does, on the run's own staging images, before `promote` can tag them: migration →
+  # portal → /health → DevLogin → the SIGNED-IN GET / and GET /Store → /_blazor/negotiate → grep
+  # the logs for the incident's signatures. `promote` needs it, so a pair that cannot serve a
+  # signed-in request never receives a consumer-selectable tag: the set stays incomplete, the
+  # reconciler re-drives HEAD, and the next Plugins pin or core fix is what heals it. Nothing rolls.
+  #
+  # 🚨 The assertions CARRY THE COOKIE. ci.7658 answered 200 to an anonymous GET / and to
+  # /_blazor/negotiate; only signed-in requests 503'd. An unauthenticated 200 is the /api/og trap
+  # — it proves the process is up and nothing more — so it is logged for diagnosis, never asserted.
+  #
+  # Runs unconditionally when the gate publishes: no continue-on-error, no `if:` on an input. Its
+  # inputs are the OIDC secrets `preflight` already asserts; the images are this run's own legs'.
+  # linux/amd64 only — the fault under test is managed code, identical on both architectures, and
+  # one boot is what the 20-minute cap buys. The gate IS the script (cd-signin-smoke.sh) so the
+  # same proof runs locally against any pair; it was verified against ci.7693 (passes) AND ci.7658
+  # (fails, on the signed-in GET /) before it was wired here. What it cannot prove: anything behind
+  # a language model, a registry bundle, Entra sign-in or multi-replica clustering.
+  signin-smoke:
+    name: "Smoke: boot the image pair and sign in"
+    needs: [gate, portal-image, migration-image]
+    if: needs.gate.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      # The gate is a script, and a script needs a working tree (promote's #2857 lesson). Sparse:
+      # the job needs exactly the scripts, not the repo.
+      - uses: actions/checkout@v7
+        with:
+          sparse-checkout: .github/scripts
+      - name: Ensure Azure CLI
+        run: command -v az >/dev/null || curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - name: ACR login
+        # Bounded transport retry — the same script every image leg uses (#2857).
+        run: bash .github/scripts/acr-login.sh
+      # 🚨 The pairing goes into the job log AND the step summary — core sha, plugins sha, staging
+      # tag, and the migration version reached — so a future skew is diagnosable from the run
+      # summary instead of from a dump. Both shas are `gate`'s once-resolved outputs, never
+      # re-resolved here (#2622).
+      - name: Boot the pair, sign in, and serve a signed-in request
+        env:
+          PORTAL_IMAGE: ${{ env.ACR }}/memex-portal-ai:${{ needs.gate.outputs.staging_tag }}
+          MIGRATION_IMAGE: ${{ env.ACR }}/memex-migration:${{ needs.gate.outputs.staging_tag }}
+          CORE_SHA: ${{ needs.gate.outputs.sha }}
+          PLUGINS_SHA: ${{ needs.gate.outputs.plugins_sha }}
+          STAGING_TAG: ${{ needs.gate.outputs.staging_tag }}
+        run: >
+          bash .github/scripts/cd-signin-smoke.sh
+          --portal-image "$PORTAL_IMAGE" --migration-image "$MIGRATION_IMAGE"
+          --platform linux/amd64
+          --core-sha "$CORE_SHA" --plugins-sha "$PLUGINS_SHA" --staging-tag "$STAGING_TAG"
+
   promote:
     name: "Promote: tag the full set (all-or-nothing)"
-    needs: [gate, portal-image, migration-image, plugin-test-image]
+    # 🚨 `signin-smoke` is a NEED on purpose: it is the behavioural half of "the set is complete"
+    # (see its comment). Removing it re-opens the 2026-09-03 hole exactly.
+    needs: [gate, portal-image, migration-image, plugin-test-image, signin-smoke]
     if: needs.gate.outputs.publish == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -2369,7 +2448,7 @@ jobs:
     name: "CD delivered, or had a good reason not to"
     # 🚨 Every delivery leg is a NEED, not just [gate, promote]. The verdict cannot assert that a
     # publish actually happened while it can only see two of the nine jobs that make it happen.
-    needs: [preflight, gate, portal-image, migration-image, plugin-test-image, promote,
+    needs: [preflight, gate, portal-image, migration-image, plugin-test-image, signin-smoke, promote,
             publish-bake, notify-platform-update, verify-images,
             plugins-modules, plugins-bake-image, plugins-bake]
     if: always()
@@ -2504,6 +2583,7 @@ jobs:
             portal-image=${{ needs.portal-image.result }}
             migration-image=${{ needs.migration-image.result }}
             plugin-test-image=${{ needs.plugin-test-image.result }}
+            signin-smoke=${{ needs.signin-smoke.result }}
             promote=${{ needs.promote.result }}
             publish-bake=${{ needs.publish-bake.result }}
             notify-platform-update=${{ needs.notify-platform-update.result }}
@@ -2560,7 +2640,7 @@ jobs:
     # event that starts the cross-repo rebake wave used to be unfailable, and a failure nobody is
     # paged for is still invisible. A red notify job does NOT mean the images are missing —
     # `verify-images` answers that — it means no satellite learned about them.
-    needs: [preflight, gate, portal-image, migration-image, plugin-test-image, promote, verify-images, publish-bake, notify-platform-update, delivery-verdict]
+    needs: [preflight, gate, portal-image, migration-image, plugin-test-image, signin-smoke, promote, verify-images, publish-bake, notify-platform-update, delivery-verdict]
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContinuousDeliveryContract.md
@@ -1,7 +1,7 @@
 ---
 Name: The Continuous Delivery Contract
 Category: Architecture
-Description: What main-cd.yml guarantees about a published image set — all-or-nothing publication via unselectable staging tags, a promote job whose ordering makes rollback unnecessary, and an hourly reconciler that heals main's HEAD. Plus the standing rule: verify the IMAGE, never the green tick.
+Description: What main-cd.yml guarantees about a published image set — all-or-nothing publication via unselectable staging tags, a sign-in smoke that boots the pair and serves a signed-in request before promote may tag it, a promote job whose ordering makes rollback unnecessary, and an hourly reconciler that heals main's HEAD. Plus the standing rule: verify the IMAGE, never the green tick.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7l9-4 9 4v10l-9 4-9-4z"/><path d="M3 7l9 4 9-4"/><path d="M12 11v10"/><path d="M8.5 15.5l3.5 1.6 3.5-1.6"/></svg>
 ---
 
@@ -90,9 +90,10 @@ by any self-updater on any install, whatever the update policy. That regex is no
 exists because an all-digit git-sha tag once parsed as version `6943991.0.0`, sorted above every real
 `3.x` release, and froze every portal on `ci.122`.
 
-Only after **all five legs succeed** does the `promote` job apply real tags, and promotion is a
-manifest-only operation (`docker buildx imagetools create`) — the layers are already in the registry,
-so it costs seconds.
+Only after **all five legs succeed** — and after `signin-smoke` has booted the portal + migration
+pair and served a signed-in request from it ([Property 3](#property-3--a-pair-that-cannot-sign-in-is-never-tagged))
+— does the `promote` job apply real tags, and promotion is a manifest-only operation
+(`docker buildx imagetools create`) — the layers are already in the registry, so it costs seconds.
 
 **Why staging-then-promote rather than build-to-archive:** the bytes have to reach the registry for a
 push to happen at all, so pushing them to a staging tag costs exactly what pushing them to the real
@@ -414,6 +415,100 @@ OBSERVED publication — the same reason `delivery-verdict` must not pass on an 
 and `FrameworkReleaseBroadcaster` fires on a real release rather than from a CI step that runs
 regardless.
 
+## Property 3 — a pair that cannot sign in is never tagged
+
+**A complete image set is necessary, not sufficient.** Properties 1 and 2 guarantee that every
+image for a commit *exists*; neither says anything about whether the portal and migration images,
+booted together, can serve a user. They are built from **two** commits — core's and
+MeshWeaver.Plugins' (see [Property 1a](#property-1a--how-the-set-already-spans-repos-and-what-the-gui-move-actually-breaks))
+— and those two can be **hours** apart, because a run's jobs queue for hours and `gate` resolves the
+Plugins head when it *starts*.
+
+### The 2026-09-03 incident this closes
+
+CD run #7658 built `memex-portal-ai:3.0.0-rc9.ci.7658` from core `e7f1d699` (08:05Z — **before**
+core #3206 anchored the sign-in reads) paired with the Plugins head at resolve time, `12500c9`
+(13:31Z — **after** Plugins #1263 made the Postgres planner *refuse* an unanchored query instead of
+fanning it out). Every leg was green. `promote` tagged the set; "Verify every image shipped" found
+every tag. Once the pair reached production, `OnboardingMiddleware.LoadUserRoles` faulted with
+`UnanchoredQueryException` on the very first signed-in request, and the portal answered **503 to
+every signed-in request for 20 minutes**; the Store page died the same way. No job in CD had ever
+booted the pair, let alone signed in.
+
+Two details decide what the gate must look like:
+
+- **Anonymous requests were fine.** `ci.7658` answered 200 to an anonymous `GET /` and to
+  `/_blazor/negotiate`; only requests carrying a signed-in cookie 503'd. An unauthenticated probe
+  is the `/api/og` trap — it proves the process is up and nothing more.
+- **The status code was the second symptom.** The first was the log line
+  `Identity resolution UNAVAILABLE for / (LoadUserRoles(…) faulted: UnanchoredQueryException) — answering 503`.
+  A gate that reads only status codes would pass a pair whose reads fault but whose page happens
+  to render.
+
+### What `signin-smoke` does
+
+The job (`main-cd.yml` → `signin-smoke`, "Smoke: boot the image pair and sign in") runs
+unconditionally whenever `gate` decides to publish, needs `portal-image` and `migration-image`, and
+is itself a **need of `promote`** — so a pair that fails it never receives a consumer-selectable
+tag. The set stays incomplete, the reconciler ([Property 2](#property-2--self-healing-and-what-it-heals-to))
+re-drives HEAD on its next tick, and the next Plugins pin or core fix is what heals it. Nothing
+rolls in between. The gate **is** the script `.github/scripts/cd-signin-smoke.sh`, so the same
+proof runs locally against any pair; on the run's own `staging-<sha>-<run_id>` images it:
+
+1. starts a fresh Postgres (pgvector, the family the chart ships) on a private docker network;
+2. runs the **migration image** with the env names the Helm chart and `deploy/compose` give it
+   (`ConnectionStrings__memex`, `MEMEX_*`) and asserts exit 0 **and** the literal
+   `Database migration completed. Version: N` — the version DbVersionGate will compare against;
+3. runs the **portal image** on a writable `/data`, `Deployment__Backend=Filesystem`,
+   `Deployment__Orleans__Clustering=Localhost`, `Graph__Storage__Type=PostgreSql`,
+   `Authentication__EnableDevLogin=true` (the host forces DevLogin off unless the env is
+   literally `true`), and waits for `/health` to answer 200 within a bounded deadline;
+4. signs in through DevLogin (`POST /dev/signin`, a brand-new `personId` is provisioned on first
+   sign-in) and keeps the `MemexAuth` cookie;
+5. asserts the **signed-in** `GET /` and `GET /Store` answer exactly 200 (no redirect is
+   followed — a 302 to `/login` or `/onboarding` is a failure, not a page to land on), that the
+   body carries neither language's identity-unavailable text, and that it is the portal shell;
+   then `POST /_blazor/negotiate?negotiateVersion=1` → 200 with a `connectionId`;
+6. greps the portal **and** migration logs for the incident's signatures —
+   `UnanchoredQueryException`, `UNAVAILABLE for … answering 503`, `Refusing to start` — and fails
+   on any hit. The middle one is qualified with `answering 503` on purpose: `UserContextMiddleware`
+   logs `mesh user index UNAVAILABLE for … falling back` on the first request after every fresh
+   boot, a documented cold-start fallback that drives nothing, and a bare `UNAVAILABLE for` fails
+   the pair that shipped **fixed**. A gate that fails its own positive control is not a gate.
+
+On failure the two container logs go into the job log, warning/error lines first. Whatever the
+outcome, the **pairing** goes into the step summary — core sha and Plugins sha (both `gate`'s
+once-resolved outputs, never re-resolved), the staging tag, both image refs, the platform, and the
+migration version reached — so a future skew is diagnosable from the run summary instead of from a
+dump.
+
+### Verified against both controls before it was wired in
+
+The script was run locally against the real registry on the day it was written:
+
+| pair | migration | `/health` | anonymous `GET /` | signed-in `GET /` | verdict |
+|---|---|---|---|---|---|
+| `ci.7693` (shipped fixed) | v55, exit 0 | 200 in 6 s | 200 | **200**, rendered | PASS |
+| `ci.7658` (the outage) | v55, exit 0 | 200 in 5 s | 200 | **503**, identity-unavailable body | FAIL on step 5; log carries `LoadUserRoles(cd-smoke) faulted: UnanchoredQueryException` |
+
+Every column but the last two is identical between the pair that worked and the pair that did
+not — which is the whole point: nothing CD measured before this gate could tell them apart.
+
+### What it proves, and what it cannot
+
+It proves the pair **boots on a fresh schema**, that the schema the migration wrote is the one the
+portal accepts (DbVersionGate), and that the sign-in → identity → roles → render path serves a
+real user on both the home and the Store page — the path the incident broke and the path every
+user takes first. It runs one architecture (`linux/amd64`) because the fault class is managed code,
+identical on both legs, and one boot is what the 20-minute cap buys.
+
+It does **not** prove anything behind a language model, a registry bundle (the required
+store-delivered modules are absent on a bare pair — `required_modules` reports Degraded, which
+`/health` still answers 200 to), Entra sign-in, multi-replica AdoNet clustering, or an upgrade
+from a populated database — the schema is always fresh, so a versioned repair that faults only
+on existing rows is invisible here. It is a smoke, not the e2e suite; what it removes is the
+class of failure where the two halves of the pair disagree about a read every request performs.
+
 ## Changing the pipeline
 
 Adding a sixth image touches **three** places, and missing any one of them recreates the exact hole
@@ -422,6 +517,11 @@ this contract closes:
 1. its own build job, pushing **only** the staging tag;
 2. the `promote` job — identity tags in phase A, pointers in phase B (never after phase C);
 3. `check-image-set.sh` — otherwise nothing ever asserts it shipped.
+
+Adding a **gate** in front of `promote` (the shape `signin-smoke` has) touches **four**: the job
+itself, `promote`'s `needs`, the `LEGS` list in `delivery-verdict` (a publishing run must have RUN
+every leg — a skipped gate ticks like a passed one), and `alert-on-failure`'s `needs` (a red
+nobody is paged for is still invisible).
 
 One known, deliberate wart: `memex-portal-next` hand-writes `3.0.0-ci.<n>` while every .NET leg
 computes `3.0.0-rc1.ci.<n>`, so its version tag has never matched its siblings'. Nothing selects it


### PR DESCRIPTION
## The incident (measured 2026-09-03)

Core CD run #7658 built `memex-portal-ai:3.0.0-rc9.ci.7658` from core `e7f1d699` (08:05Z, **before** core #3206 anchored the sign-in reads) paired with the Plugins head at resolve time, `12500c9` (13:31Z, **after** Plugins #1263 made the Postgres planner *refuse* unanchored queries). Every leg was green; `promote` tagged the set; "Verify every image shipped" found every tag. In production `OnboardingMiddleware.LoadUserRoles` faulted with `UnanchoredQueryException` and the portal answered **503 to every signed-in request for 20 minutes**; the Store page died the same way. No job in CD had ever booted the image pair, let alone signed in — the two halves can be hours apart because a run's jobs queue for hours, and nothing checked the pair was coherent *behaviourally*.

## What this adds

A new `main-cd.yml` job, **`signin-smoke` — "Smoke: boot the image pair and sign in"**, that `promote` now `needs:`. A pair that cannot serve a signed-in request never receives a consumer-selectable tag; the set stays incomplete and the reconciler re-drives HEAD until a Plugins pin or core fix heals it.

- `needs: [gate, portal-image, migration-image]`, `if: needs.gate.outputs.publish == 'true'`, `ubuntu-latest`, literal `timeout-minutes: 20`. Runs unconditionally when the gate publishes — no `continue-on-error`, no `if:` on an input; its inputs are the OIDC secrets `preflight` already asserts.
- The gate **is** a script, `.github/scripts/cd-signin-smoke.sh`, so the same proof runs locally against any pair. On the run's own `staging-<sha>-<run_id>` images (pulled for `linux/amd64`) it: starts a fresh pgvector Postgres on a private network → runs the **migration** image with the chart's/compose's env names and asserts exit 0 **and** `Database migration completed. Version: N` → runs the **portal** image (`Deployment__Backend=Filesystem`, `Deployment__Orleans__Clustering=Localhost`, `Graph__Storage__Type=PostgreSql`, `Authentication__EnableDevLogin=true`) and waits for `/health` 200 within a bounded deadline → `POST /dev/signin` and keeps the `MemexAuth` cookie → asserts the **signed-in** `GET /` and `GET /Store` are exactly 200 (no redirect followed), carry neither language's identity-unavailable text, and are the portal shell → `POST /_blazor/negotiate?negotiateVersion=1` 200 with a `connectionId` → greps portal + migration logs for `UnanchoredQueryException`, `UNAVAILABLE for … answering 503`, `Refusing to start` and fails on any hit.
- 🚨 The assertions **carry the cookie**. `ci.7658` answered 200 to an anonymous `GET /` and to `/_blazor/negotiate` — only signed-in requests 503'd. The anonymous probe is logged as a diagnostic and never asserted.
- The pairing goes into the job log and the step summary: core sha and Plugins sha (both `gate`'s once-resolved outputs), the staging tag, both image refs, the platform, and the migration version reached — so a future skew is diagnosable from the run summary.
- On failure the two container logs go into the job log, warning/error lines first.
- `signin-smoke` is added to `delivery-verdict`'s `needs` + `LEGS` (a publishing run must have RUN every leg) and to `alert-on-failure`'s `needs` (a red nobody is paged for is invisible).

## Proved locally, both controls (Colima docker, native `linux/arm64` legs of the same multi-arch indexes)

| pair | migration | `/health` | anonymous `GET /` | signed-in `GET /` | verdict |
|---|---|---|---|---|---|
| `ci.7693` (shipped fixed) | v55, exit 0 | 200 in 6 s | 200 | **200**, rendered, no identity text | **PASS** (exit 0) |
| `ci.7658` (the outage) | v55, exit 0 | 200 in 5 s | 200 | **503**, body = "We could not check your account just now…" | **FAIL** (exit 1); log: `Identity resolution UNAVAILABLE for / (LoadUserRoles(cd-smoke) faulted: UnanchoredQueryException) — answering 503` |

Every column but the last two is identical between the pair that worked and the pair that did not — nothing CD measured before this gate could tell them apart.

One thing the controls corrected in the design: a bare `UNAVAILABLE for` grep **fails the positive control** — `UserContextMiddleware` logs `mesh user index UNAVAILABLE for … falling back to the email local-part` on the first request after every fresh boot (documented cold-start fallback; the request answered 200). Every site that actually turns an unresolved identity into a 503 logs `… answering 503 + Retry-After`, so the signature is qualified with that. The script and the doc say why.

## Gates run locally

- `check-workflow-timeouts.py`: 65 jobs, 0 violations (cap 45).
- `check-workflow-shell.py`: 0 live findings (1 pre-existing allow-listed); `shellcheck --severity=warning` clean on the new script.
- `test-cd-steps.py`: all cases pass (steps `release` + `decide` extracted).
- `actionlint`: only pre-existing SC2129/SC2012 style/info notes in `gate`, `plugin-test-image`, `publish-bake` — none in the new job.
- `MeshWeaver.Documentation.Test` (the workflow guards + `DocumentationLinkIntegrityTest`): see the CI run.

## Docs

`Doc/Architecture/ContinuousDeliveryContract` gains **Property 3 — a pair that cannot sign in is never tagged**: the incident, what the job does step by step, the two-control verification table, what it proves and what it cannot (no model, no registry bundle, no Entra, no AdoNet multi-replica, always a fresh schema — an upgrade-only repair fault is invisible here), and the "adding a gate in front of promote touches four places" rule.

## What is NOT verified here

- The job's first execution is on `main` (CD fires on `workflow_run`/`schedule`/`workflow_dispatch`, never on a PR), on `linux/amd64` GitHub runners; the local proof ran the arm64 legs. The fault class is managed code, identical on both architectures, but the runner's boot time under the 480 s `/health` deadline is measured for the first time by the first main run.
- Not a What's New entry (not user-facing).

🚨 **Do not merge yet** — this lands on the CD run AFTER the fleet's first sealable set (coordinator hold), so a first-run failure of the gate costs a cycle rather than the unblock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XMFYZAhUyKtm8SNLQqE5uT
