### PR TITLE
docs: Pin-Boundary Contracts — the platform pin moves BOTH ways

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/PinBoundaryContracts.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/PinBoundaryContracts.md
@@ -1,0 +1,103 @@
+---
+Name: Pin-Boundary Contracts
+Description: "A satellite compiles against a MOVABLE platform pin. Any test or runtime behaviour that encodes a core contract is therefore correct on only one side of that pin — and the pin moves in both directions. Assert the property, or detect which platform you were built against."
+---
+
+# Pin-boundary contracts — the pin moves BOTH ways
+
+Every satellite repo compiles its `src/` against a platform commit named by `MW_PLATFORM_REF`. That
+pin is **deliberately movable**: forward, because a staleness bound forces it (Plugins#1252, #1264);
+backward, because freezing it is a supported response to a bisect or an upstream outage.
+
+So a satellite test — or a runtime behaviour — that encodes a core contract which **changed** is
+correct on exactly one side of that pin, and wrong on the other. It does not fail when someone edits
+it. It fails when someone edits *the pin*, on a PR whose diff cannot reach the subsystem, and it
+looks like that PR's fault.
+
+On 2026-09-03 this class produced **three** incidents in one day, two in tests and one in
+production.
+
+## What it looks like
+
+MeshWeaver#3202 anchored the sign-in reads: `LoadUserRoles` stopped asking one unanchored question
+over every partition and began asking three anchored ones (root `_Access`, `Admin`, the user's own
+partition), and `AccessSubjectQueries.Groups(root)` began declaring its fan-out as `partitions:all`.
+
+Three consequences followed, all from the same boundary:
+
+| where | what happened |
+|---|---|
+| `MeshWeaver.Plugins` tests | Two suites asserted the PRE-#3202 literals. `main` was red the moment the pin resolved core's tip. |
+| the same tests, "fixed" | Replacing them with the POST-#3202 literals failed in the **opposite** direction, because the pin had meanwhile been set to `e7f1d699e`, which predates #3202. |
+| production | Image `ci.7658` paired core `e7f1d699` (pre-#3202) with Plugins `12500c9` (post-#1263 refusal). `LoadUserRoles` faulted with `UnanchoredQueryException` and every signed-in request got a **503**. |
+
+🚨 **Both literals were wrong.** That is the diagnostic signature of this class: a fix that makes the
+red go away, and then produces the mirror-image red the next time the pin moves.
+
+## The rule
+
+### 1. Assert the PROPERTY, not the literal
+
+A test that pins a core contract should assert what is true on both sides, plus the regression
+actually worth guarding.
+
+```csharp
+// The ROOT scope's picker is mesh-wide, and says so once the platform requires it.
+query.Should().StartWith("nodeType:Group");
+query.Should().NotContain("namespace:");
+query.Trim().Should().BeOneOf("nodeType:Group", "nodeType:Group partitions:all");
+
+// …and the thing a regression would actually break:
+foreach (var scoped in new[] { "ACME", "rsalzmann/Games/Lolo" })
+    AccessSubjectQueries.Groups(scoped).Should().NotContain("partitions:all");
+```
+
+The last assertion is the point. Fan-out leaking onto a *scoped* leg is what would silently restore
+the 199-schema union; the exact spelling of the root leg is not.
+
+### 2. Where the contract itself changed, DETECT which platform you were built against
+
+Assert the matching arm, and **print which one it took** so neither outcome can be mistaken for the
+other:
+
+```csharp
+var anchored = typeof(SecurityQueries)
+    .GetMethod("RootAssignmentsFor", new[] { typeof(string) }) is not null;
+Output.WriteLine(anchored
+    ? "platform HAS #3202 — asserting the anchored contract"
+    : "platform PREDATES #3202 — asserting the unanchored contract");
+```
+
+🚨 **By reflection, not by referencing the member.** A direct reference fails to *compile* against
+the older pin — which is the same trunk red one error message earlier.
+
+Both arms must be *run*, not argued. Check core out at the pinned sha and build against it:
+
+```bash
+git -C ~/code/MeshWeaver worktree add .worktrees/pin-<sha> <sha> --detach
+dotnet test <suite> -c Release -p:MeshWeaverRoot=$HOME/code/MeshWeaver/.worktrees/pin-<sha>/
+```
+
+### 3. A refusal that can refuse an existing caller lands with its caller sweep, or in GRACE mode
+
+The production 503 was not a test problem. A runtime refusal reached a caller on the other side of
+the boundary. Grace mode is the shape that survives it: **production serves and reports; CI
+refuses.** Fail **closed** on the default — a policy that defaults to permissive silently loses the
+invariant on every host that does not know the property exists, and a green wall cannot show you
+which hosts those are.
+
+## Why the staleness bound makes this urgent rather than theoretical
+
+Before an age bound, a stale pin merely drifts and these tests stay dormant. After one, the pin
+**will** move within its bound — which converts every latent contract-encoding test from *dormant*
+into *scheduled*. They arrive together, on whichever PR moves the pin, looking like its fault.
+
+That is not an argument against the bound. It is the reason to write the tests in the shape above
+*before* the bound starts moving the pin unattended — because the alternative is finding them the
+way `memex` found the third one.
+
+## Related
+
+- `Doc/Architecture/ReadingCiSignals` — why an absent or skipped required context reads as satisfied
+- `Doc/Architecture/ContinuousDeliveryContract` — the promoted set and why its halves must move together
+- Plugins#1252, #1260, #1264 (the two pins and their bounds) · Plugins#1281 (the test shape)

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-the-pin-moves-both-ways.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-the-pin-moves-both-ways.md
@@ -1,6 +1,8 @@
 ---
 Name: A pinned platform moves in both directions — and tests have to survive it
 Description: Three incidents in one day, two in tests and one a production 503, all from a satellite encoding a core contract that the platform pin can straddle. The new Architecture page says what shape survives it.
+Category: Fix
+Order: -20260903
 ---
 
 A satellite repo compiles against a platform commit named by `MW_PLATFORM_REF`. That pin moves

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-the-pin-moves-both-ways.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-the-pin-moves-both-ways.md
@@ -1,0 +1,25 @@
+---
+Name: A pinned platform moves in both directions — and tests have to survive it
+Description: Three incidents in one day, two in tests and one a production 503, all from a satellite encoding a core contract that the platform pin can straddle. The new Architecture page says what shape survives it.
+---
+
+A satellite repo compiles against a platform commit named by `MW_PLATFORM_REF`. That pin moves
+**forward** — a staleness bound now forces it — and **backward**, because freezing it is a supported
+response to a bisect or an upstream outage.
+
+Anything that encodes a core contract which changed is therefore correct on only one side of it.
+
+On 2026-09-03 that produced three incidents from one change (anchored sign-in reads):
+
+- two `MeshWeaver.Plugins` suites went red when the pin resolved core's tip;
+- **replacing their assertions with the new literals failed in the opposite direction**, because the
+  pin had meanwhile been set to a commit that predates the change;
+- and image `ci.7658` paired a pre-change core with a post-change Plugins half, so every signed-in
+  request got a **503**.
+
+Both literals were wrong. That mirror-image red is the signature of the class.
+
+The new page **Pin-Boundary Contracts** writes down the shape that survives: assert the *property*
+rather than the literal, detect by reflection which platform you were built against where the
+contract itself changed, prove both arms against a real checkout at the pinned sha — and, for a
+runtime refusal, land it in grace mode with production serving-and-reporting while CI refuses.


### PR DESCRIPTION
Three incidents on 2026-09-03 came from one class — two in tests, one a production **503** — and nothing written down said what shape survives it.

MeshWeaver#3202 anchored the sign-in reads. Then:

| | |
|---|---|
| two `MeshWeaver.Plugins` suites | asserted the **pre**-#3202 literals, and reddened `main` the moment the pin resolved core's tip |
| the "fix" | replacing them with the **post**-#3202 literals failed in the **opposite** direction, because the pin had meanwhile been set to `e7f1d699e`, which *predates* #3202 |
| image `ci.7658` | paired core `e7f1d699` with a post-#1263 Plugins half → `LoadUserRoles` faulted with `UnanchoredQueryException` → **every signed-in request got a 503** |

🚨 **Both literals were wrong.** That mirror-image red is the diagnostic signature of the class, and it is why *"fix the test to match the platform"* is not the lesson.

## What the page says

1. **Assert the property, not the literal** — plus the regression actually worth guarding. For `Groups()` that is *"no **scoped** leg ever declares `partitions:all`"*, not the exact spelling of the root leg.
2. **Where the contract itself changed, detect which platform you were built against**, assert that arm, and **print which one it took**. By **reflection** — a direct reference to the new member fails to *compile* against the older pin, which is the same trunk red one error message earlier. And run both arms against a real checkout at the pinned sha rather than arguing about them.
3. **A refusal that can refuse an existing caller lands with its caller sweep, or in grace mode** — production serves and reports, CI refuses, and the policy **defaults closed**, because one that defaults permissive silently loses the invariant on every host that does not know the property exists.

## Why now rather than later

A staleness bound converts every latent contract-encoding test from *dormant* into **scheduled**: the pin *will* move within its bound, and they arrive together on whichever PR moves it, looking like that PR's fault. That is not an argument against the bound — it is the reason to write the tests in this shape *before* it starts moving the pin unattended.

## Why it exists at all

`AGENTS.md` requires a finding to be **committed**, not left in an issue thread: *"issue comments, PR bodies and chat replies are pointers to the committed page, never a substitute."* This one was spread across Plugins#1281, #1252, #1264 and a production incident, and would have been invisible to the next session — which is precisely how the third instance happened after the first two.

Docs only: one new Architecture page (pages are discovered, so no index edit) and one `WhatsNew` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
