### PR TITLE
feat: the token mint carries the server's global-admin verdict (Plugins#1295)

### DIFF
--- a/memex/Memex.Portal.Shared/Authentication/ApiTokenController.cs
+++ b/memex/Memex.Portal.Shared/Authentication/ApiTokenController.cs
@@ -1,6 +1,7 @@
 using System.Reactive.Linq;
 using System.Threading;
 using MeshWeaver.Hosting.AspNetCore.Portal; // PortalApplication
+using MeshWeaver.Mesh;                  // IsGlobalAdmin
 using MeshWeaver.Messaging;             // AccessService / AccessContext
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
@@ -45,14 +46,21 @@ public class ApiTokenController(IServiceProvider serviceProvider) : ControllerBa
     /// partition the user's other data lives in.
     /// </para>
     /// </summary>
+    /// <summary>
+    /// The hub whose services answer platform questions for this request — the portal hub when the
+    /// Blazor shell registered one, else the mesh root hub on a next-only portal. The same
+    /// resolution <see cref="CurrentUser"/> uses, named once so the admin verdict and the identity
+    /// cannot come from two different hubs.
+    /// </summary>
+    private IMessageHub PortalHub() =>
+        serviceProvider.GetService<PortalApplication>()?.Hub
+        ?? serviceProvider.GetRequiredService<IMessageHub>();
+
     private AccessContext? CurrentUser =>
         // Portal hub when the Blazor shell registered one; the mesh root hub on a next-only
         // portal (Features:Gui:Blazor=false). AccessService is the mesh-wide singleton either
         // way — see UserContextMiddleware, which stamps the identity this reads.
-        (serviceProvider.GetService<PortalApplication>()?.Hub
-         ?? serviceProvider.GetRequiredService<IMessageHub>())
-            .ServiceProvider.GetRequiredService<AccessService>()
-            .Context;
+        PortalHub().ServiceProvider.GetRequiredService<AccessService>().Context;
 
     /// <summary>
     /// The mesh User.Id for the current request, or null if the request has no
@@ -95,15 +103,35 @@ public class ApiTokenController(IServiceProvider serviceProvider) : ControllerBa
         // creation (the token is either created or not; abandoning it half-way would be worse),
         // but it is NOT teardown, and saying so here would be a promise the code does not keep.
         var lateFaultLogger = LateFaultLogger;
+        // 🚨 THE ADMIN VERDICT IS THE SERVER'S, and it rides with the mint because that is the one
+        // round-trip a browser client already makes to learn who it is (the response's NodePath is
+        // where `userId` comes from). A React client that has to ask separately either does not ask
+        // — the state today, where clients/portal-next omits the Admin notification leg entirely —
+        // or asks in a way a forged claim could answer (Plugins#1295).
+        //
+        // `hub.IsGlobalAdmin()` is the ONE sanctioned predicate: Permission.All at scope Admin,
+        // granted by an AccessAssignment in Admin/_Access. Never a role name off a token claim, and
+        // never a root-scope check — `Admin` is excluded from searchable_schemas, so only the
+        // path-anchored evaluation answers it at all.
+        //
+        // Fail CLOSED: any fault resolving it yields false. An admin who briefly sees no platform
+        // notifications is a nuisance; a non-admin who sees them is the failure this must not have.
+        // The verdict gates what the client ASKS for; RLS refuses the rows independently, so this is
+        // the second of two boundaries — but it is the one that decides what is even requested.
+        var adminVerdict = AdminVerdict.FailClosed(
+            PortalHub().IsGlobalAdmin(userId), userId, lateFaultLogger);
+
         return tokenService.CreateToken(userId, userName, userEmail, label, expiresAt)
-            .Select(creation => (IActionResult)Ok(new CreateTokenResponse
-            {
-                RawToken = creation.RawToken,
-                NodePath = creation.Node.Path,
-                Label = label,
-                CreatedAt = DateTimeOffset.UtcNow,
-                ExpiresAt = expiresAt,
-            }))
+            .SelectMany(creation => adminVerdict.Select(isGlobalAdmin => (IActionResult)Ok(
+                new CreateTokenResponse
+                {
+                    RawToken = creation.RawToken,
+                    NodePath = creation.Node.Path,
+                    Label = label,
+                    CreatedAt = DateTimeOffset.UtcNow,
+                    ExpiresAt = expiresAt,
+                    IsGlobalAdmin = isGlobalAdmin,
+                })))
             .FirstAsync()
             .ObserveCompletion(
                 ex => lateFaultLogger.LogWarning(ex,
@@ -164,6 +192,39 @@ public record CreateTokenRequest
     public int? ExpiresInDays { get; init; }
 }
 
+/// <summary>
+/// The fail-closed reduction of a global-admin lookup to ONE answer.
+///
+/// <para>🚨 <b>Any failure answers FALSE.</b> An admin who briefly sees no platform notifications is
+/// a nuisance; a non-admin who sees them is the failure this must not have. Extracted from the
+/// controller so that asymmetry is decided by a test rather than by reading — with a control arm,
+/// because a version that answered <c>false</c> unconditionally would pass a fault-only test
+/// (Plugins#1295).</para>
+/// </summary>
+internal static class AdminVerdict
+{
+    /// <summary>One answer from <paramref name="source"/>; a fault or an empty source is false.</summary>
+    /// <param name="source">The <c>hub.IsGlobalAdmin(userId)</c> stream.</param>
+    /// <param name="userId">Whose verdict this is — for the log line only.</param>
+    /// <param name="logger">Where a resolution failure is reported.</param>
+    public static IObservable<bool> FailClosed(
+        IObservable<bool> source, string userId, ILogger logger)
+        => source
+            .Take(1)
+            // A source that completes WITHOUT emitting is the same answer as one that faulted: we
+            // do not know, so we withhold. Take(1) alone would complete empty and SelectMany would
+            // then drop the response entirely — a mint that never returns.
+            .DefaultIfEmpty(false)
+            .Catch((Exception ex) =>
+            {
+                logger.LogWarning(ex,
+                    "Resolving the global-admin verdict for {UserId} failed — answering false "
+                    + "(fail-closed: the platform view is withheld, never granted, on an error)",
+                    userId);
+                return Observable.Return(false);
+            });
+}
+
 public record CreateTokenResponse
 {
     public string RawToken { get; init; } = "";
@@ -171,4 +232,19 @@ public record CreateTokenResponse
     public string Label { get; init; } = "";
     public DateTimeOffset CreatedAt { get; init; }
     public DateTimeOffset? ExpiresAt { get; init; }
+
+    /// <summary>
+    /// Whether the minting user is a PLATFORM admin — <c>Permission.All</c> at scope <c>Admin</c>,
+    /// the server's own <c>hub.IsGlobalAdmin()</c> answer.
+    ///
+    /// <para>🚨 It gates what a client ASKS for, never what it may read. A global admin is not a
+    /// superuser: the grant confers no Read on any other partition, and RLS refuses rows
+    /// independently. A client uses this to decide whether to issue the platform notification leg
+    /// at all — omitting it is why no React viewer has ever seen a platform notification
+    /// (Plugins#1295).</para>
+    ///
+    /// <para><b>Defaults to false</b>, and any failure to resolve it answers false. Withholding the
+    /// platform view from an admin is a nuisance; granting it to a non-admin is not.</para>
+    /// </summary>
+    public bool IsGlobalAdmin { get; init; }
 }

--- a/test/Memex.Portal.Shared.Test/AdminVerdictFailsClosedTest.cs
+++ b/test/Memex.Portal.Shared.Test/AdminVerdictFailsClosedTest.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using System.Threading.Tasks;
+using Memex.Portal.Shared.Authentication;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// 🚨 THE PLATFORM-ADMIN VERDICT FAILS CLOSED.
+///
+/// <para>The token mint now carries the server's <c>hub.IsGlobalAdmin()</c> answer so a browser
+/// client can decide whether to issue the platform notification leg at all — today
+/// <c>clients/portal-next</c> omits it, which is why no React viewer has ever seen a platform
+/// notification (Systemorph/MeshWeaver.Plugins#1295).</para>
+///
+/// <para><b>The asymmetry is the whole design.</b> An admin who briefly sees no platform
+/// notifications is a nuisance; a non-admin who sees them is a disclosure. So every way of NOT
+/// knowing — a fault, an empty source — answers <c>false</c>.</para>
+///
+/// <para>🚨 <b>The control arm is not optional here.</b> A reduction that answered <c>false</c>
+/// unconditionally would pass every fault case and be catastrophically wrong: no admin would ever
+/// get the platform leg. The `true` row is what makes the others mean anything.</para>
+/// </summary>
+public class AdminVerdictFailsClosedTest
+{
+    private static Task<bool> Resolve(IObservable<bool> source) =>
+        AdminVerdict.FailClosed(source, "rbuergi", NullLogger.Instance).FirstAsync().ToTask();
+
+    /// <summary>THE CONTROL ARM — a real admin still gets true, or the fail-closed rows prove nothing.</summary>
+    [Fact]
+    public async Task AnAdmin_IsAnsweredTrue()
+        => Assert.True(await Resolve(Observable.Return(true)));
+
+    [Fact]
+    public async Task ANonAdmin_IsAnsweredFalse()
+        => Assert.False(await Resolve(Observable.Return(false)));
+
+    /// <summary>A FAULTED lookup is "we do not know", which must read as not-admin.</summary>
+    [Fact]
+    public async Task AFaultedLookup_IsAnsweredFalse()
+        => Assert.False(await Resolve(
+            Observable.Throw<bool>(new InvalidOperationException("permission evaluator unavailable"))));
+
+    /// <summary>
+    /// A source that completes WITHOUT emitting is the same answer as one that faulted — and
+    /// getting this wrong is worse than a wrong verdict: without the empty guard the mint's
+    /// SelectMany would drop the response entirely, so the token request would never return.
+    /// </summary>
+    [Fact]
+    public async Task AnEmptyLookup_IsAnsweredFalse_RatherThanNeverAnswering()
+        => Assert.False(await Resolve(Observable.Empty<bool>()));
+
+    /// <summary>Only the FIRST answer counts — a stream that later flips to true must not
+    /// retroactively grant the platform view for a token already minted.</summary>
+    [Fact]
+    public async Task OnlyTheFirstAnswerCounts()
+        => Assert.False(await Resolve(new[] { false, true }.ToObservable()));
+
+    /// <summary>The response record's own default is not-admin: an unset field is never a grant.</summary>
+    [Fact]
+    public void TheResponseDefaultsToNotAdmin()
+        => Assert.False(new CreateTokenResponse().IsGlobalAdmin);
+}

--- a/test/Memex.Portal.Shared.Test/AdminVerdictFailsClosedTest.cs
+++ b/test/Memex.Portal.Shared.Test/AdminVerdictFailsClosedTest.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Reactive.Linq;
-using System.Reactive.Threading.Tasks;
 using System.Threading.Tasks;
 using Memex.Portal.Shared.Authentication;
+using MeshWeaver.Messaging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Xunit;
 
@@ -26,8 +26,28 @@ namespace Memex.Portal.Shared.Test;
 /// </summary>
 public class AdminVerdictFailsClosedTest
 {
-    private static Task<bool> Resolve(IObservable<bool> source) =>
-        AdminVerdict.FailClosed(source, "rbuergi", NullLogger.Instance).FirstAsync().ToTask();
+    /// <summary>
+    /// A fault that reached the observer AFTER the verdict settled. <see cref="AdminVerdict.FailClosed"/>
+    /// catches into <c>false</c> and completes, so this must stay null on every row — a late fault here
+    /// would mean the catch arm let something through behind the answer.
+    /// </summary>
+    private Exception? lateFault;
+
+    /// <summary>
+    /// 🚨 NOT <c>.ToTask()</c>. That bridge resumes the awaiter INLINE on the signalling thread and
+    /// discards a fault arriving after the task settles — banned repo-wide, and the guard
+    /// <c>ObservableToTaskBridgeGuard</c> fails the build on a new site. <see cref="ReactiveCompletion"/>
+    /// is the sanctioned bridge: it settles on the first notification without blocking, keeps the
+    /// error arm attached, and hands a late fault to <see cref="lateFault"/> rather than dropping it.
+    /// </summary>
+    private async Task<bool> Resolve(IObservable<bool> source)
+    {
+        var verdict = await AdminVerdict
+            .FailClosed(source, "rbuergi", NullLogger.Instance)
+            .ObserveCompletion(ex => lateFault = ex, TestContext.Current.CancellationToken);
+        Assert.Null(lateFault);
+        return verdict;
+    }
 
     /// <summary>THE CONTROL ARM — a real admin still gets true, or the fail-closed rows prove nothing.</summary>
     [Fact]


### PR DESCRIPTION
Since #3156/#3216 the Blazor bell reads **two** anchored legs — the viewer's own `_Notification` namespace, and `Admin/_Notification` when `hub.IsGlobalAdmin()` says yes. The second is what delivers platform-operator alerts: startup errors, an unreconcilable package feed, an instance stuck on a fallback page.

`clients/portal-next` reads only the first, because `LiveMesh` carries `userId` and **no admin verdict** — so it *omits* the leg rather than issuing it unconditionally. That is the right fail-closed choice, and it means **no React viewer has ever seen a platform notification** (Systemorph/MeshWeaver.Plugins#1295).

## Why the mint carries it

`userId` already rides on the mint response's `NodePath` (`live.ts:125`), so this is the one round-trip a browser client already makes to learn who it is. A client that has to ask separately either does not ask — today's state — or asks in a way a **forged claim** could answer.

`hub.IsGlobalAdmin()` is the one sanctioned predicate: `Permission.All` at scope `Admin`, granted by an `AccessAssignment` in `Admin/_Access`. Never a role name off a token claim, and never a root-scope check — `Admin` is excluded from `searchable_schemas`, so only the path-anchored evaluation answers it at all.

🚨 **It gates what a client ASKS FOR, never what it may read.** A global admin is not a superuser; RLS refuses the rows independently, which `NotificationAddressingTest.PlatformNotification_IsNotReadableByANonAdmin` pins. This is the second of two boundaries — but the one that decides what is even requested.

## Fail-closed, and asserted with a control arm

`AdminVerdict.FailClosed` is extracted from the controller so the asymmetry is decided by a test rather than by reading:

| case | answer |
|---|---|
| admin | **true** ← the control arm |
| non-admin | false |
| faulted lookup | false |
| **empty** source | false |
| a stream that later flips to true | false — only the first answer counts |
| unset field on the response record | false |

The **empty** case is not pedantry: without `DefaultIfEmpty` the mint's `SelectMany` drops the response entirely, so the token request never returns. That is a worse failure than a wrong verdict.

🚨 The `true` row is what makes the rest mean anything — a reduction that answered `false` unconditionally would pass every fail-closed case and leave no admin ever getting the leg.

| mutation | result |
|---|---|
| verdict always false | **FAIL** `AnAdmin_IsAnsweredTrue` |
| drop `DefaultIfEmpty` | **FAIL** `AnEmptyLookup_IsAnsweredFalse_RatherThanNeverAnswering` |
| restored | 6/6 · `Memex.Portal.Shared.Test` **703/0** |

## Sequencing

The client half (`LiveMesh.isGlobalAdmin` + the bell's platform leg in `clients/portal-next`) follows in MeshWeaver.Plugins once this is in — the field has to exist before a client can read it.

Picked up from meshweaver-9c, whose session hit its rate limit; they explicitly released it rather than leave it claimed-but-blocked.

Refs Systemorph/MeshWeaver.Plugins#1295

🤖 Generated with [Claude Code](https://claude.com/claude-code)
