### PR TITLE
The superseded count reported flags, not assemblies — "2" for one name

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1013,7 +1013,12 @@ jobs:
           # Empty ⇒ no flags ⇒ byte-identical invocation to before this input existed.
           superseded=()
           for asm in ${SUPERSEDED//,/ }; do superseded+=(--superseded-image-assembly "$asm"); done
-          [ "${#superseded[@]}" -eq 0 ] || echo "superseding ${#superseded[@]} image assembl(y|ies) from the reference set: ${SUPERSEDED}"
+          # ${#superseded[@]} counts ARRAY ELEMENTS, and each assembly contributes TWO (the flag
+          # and its value) — reporting it as a count of assemblies said "2" for one name. Count the
+          # names instead, so the line states what was actually dropped.
+          superseded_n=0
+          for asm in ${SUPERSEDED//,/ }; do superseded_n=$((superseded_n+1)); done
+          [ "$superseded_n" -eq 0 ] || echo "superseding $superseded_n image assembl(y|ies) from the reference set: ${SUPERSEDED}"
           args=()
           for prj in "${projects[@]}"; do args+=("/repo/$prj"); done
           echo "global build: ${#projects[@]} container entr(y|ies) in ONE workspace — ${projects[*]}"


### PR DESCRIPTION
## The defect

`${#superseded[@]}` counts array **elements**, and each superseded assembly contributes **two** —
the flag `--superseded-image-assembly` and its value. So one assembly logs as two:

```
superseding 2 image assembl(y|ies) from the reference set: MeshWeaver.Blazor.Views
```

Observed on MeshWeaver.Plugins#1268's first green run. **The build is correct** — the flags are
built and passed properly, and the compile does exactly what it should. Only the narration is wrong.

## Why bother

This line is the **only** evidence in the log of what left the reference set. Someone reconciling a
`CS0436` — or checking whether a superseded entry has gone stale (#3223) — reads it and is told two
assemblies were dropped when one was, then goes looking for a second that does not exist. A count
that disagrees with the list beside it is worse than no count.

## The fix

Count the names, not the flags. Verified both ways under the same shell semantics the lane uses
(`${SUPERSEDED//,/ }` word-splitting):

```
one name    -> 1
"A,B C"     -> 3
```

`actionlint` clean.

## Provenance

Mine, from #3225 — the third defect from that change, after #3226 (a YAML insertion split
`always-modules:` from its `default:`) and #3234 (`SUPERSEDED` defined on a step that never read
it). Those two broke builds; this one only misreports. Recording the count here because the pattern
matters more than any of them individually: **all three were introduced by the same change and each
was found by a consumer rather than by its author's own verification.**

Pairs-with: none — narration only; no behaviour change.
No What's New — internal CI log text.
