### PR TITLE
A hosted hub's leaked callback is reported on its owner, and a subtree drains under one Quiescing budget

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -247,6 +247,41 @@ Pinned by `HostedHubQuiesceLeakVisibilityTest`: a self-addressed request the chi
 the case that settles), the owner disposed, and the owner's report naming the child and the
 request after the child has departed.
 
+### 🚨 Teardown answers every gate that is still shut
+
+An initialization gate is a promise: the delivery parked behind it is released when the gate opens.
+**Shutdown is the outcome after which no gate can ever open**, so every gate its owner did not
+answer breaks that promise, and the deferred caller hears nothing until an unrelated deadline
+expires — its own request timeout, or whenever teardown reaches `messageService.Dispose()`.
+
+`DataContext` learned this for its own gate (#1270) and fails `DataContextInit` explicitly on
+shutdown. That fix could not generalise, because it lives in the gate's **owner**: the
+`MeshNodeInit` gate — armed in `MeshDataSource`, opened in five places across `MeshDataSource` and
+`MeshNodeTypeSource` — had no such hook at all. The whole `src/` tree contained exactly **one**
+`FailGate` call. A delivery deferred behind `gates=[DataContextInit,MeshNodeInit]` therefore had one
+of its two gates answered and stayed parked on the other, for ever.
+
+`MessageHub.Dispose()` now calls `messageService.FailAllGatesOnShutdown()` immediately after
+`SignalShuttingDown()` — before the Quiescing poll starts counting, because a delivery parked behind
+an unanswered gate is a pending callback that poll can only wait out, at the full budget per hub.
+Doing it in the FRAMEWORK rather than in each owner is the difference between fixing two gates and
+making a third one impossible to get wrong.
+
+Measured on the MeshWeaver.Plugins Monolith suite (801 tests), with the leak report made reachable
+by the section above:
+
+| leaked-callback last stage | before | after |
+|---|---|---|
+| `DEFERRED gates=[DataContextInit,MeshNodeInit]` | 12 | **0** |
+| `DEFERRED gates=[DataContextInit]` | 3 | **0** |
+| `DROPPED_SHUTTING_DOWN runLevel=Dead` | 8 | 3 |
+| total leaked callbacks | 69 | 63 |
+
+The remaining leaks are three other mechanisms — a handler that exits `Processed` without its async
+reply ever following, a handler fault whose error arm never answers the requester, and a reply
+posted to a hub that had already stopped listening. They are real, they are now NAMED, and they are
+not this section's subject.
+
 ### ShutDown — tear down and signal
 
 Runs on the action block, fully synchronous: `CancelCallbacks()` (push

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -214,6 +214,39 @@ late construction produced, so a hub built during the teardown window is never l
 outside the snapshot. On completion **or** the cap, the owner advances to ShutDown — a
 hung child never blocks the parent.
 
+### 🚨 A departed child's verdict stays with the owner — and a subtree drains under one budget
+
+Two facts about hosted hubs that were each correct on their own and, together, made a whole class
+of leaks unreportable (measured 2026-09-03 on a MeshWeaver.Plugins suite: **72 of 690 disposals
+took exactly the 2 s hosted-hub Quiescing budget — 145 s of an 11-minute run — and the leak
+detector reported zero**).
+
+1. A hosted hub **removes itself from its owner's `HostedHubsCollection`** in its own ShutDown
+   phase (`DisposeImpl` runs the `RegisterForDisposal` callbacks, one of which is
+   `messageHubs.TryRemove`). That is *after* its Quiescing phase has set `QuiescingTimedOut`.
+2. The owner's `AnyHubQuiescingTimedOut()` / `GetQuiescingTimeoutSummary()` walk
+   `hostedHubs.Hubs` — and a caller can only ask after the owner's *own* `DisposalCompleted`,
+   which is after every child has finished and left. So a child's timed-out quiesce was
+   **unreachable by construction**: the verdict left with the child.
+
+`HostedHubsCollection` now snapshots a departing child's summary
+(`DepartedQuiesceTimeouts`) in that same removal callback, and both walkers consult it. The
+report names the hub and the request, which is the line someone greps for.
+
+The second half is the budget itself. `CreateMessageHub` starts every hub from a fresh
+`MessageHubConfiguration`, whose `QuiesceTimeout` is the production default (2 s) — so a mesh that
+configured a different budget on its root (the test base's 500 ms; an operator's longer one) had
+children draining under a different clock than their owner, and a test base that thought it had
+bounded leaks at 500 ms was paying 2 s per leaked child. The owner now seeds its collection with
+its own budget (`InheritedQuiesceTimeout`); a hosted hub inherits it unless its configuration
+says otherwise, so **one policy per subtree** and a hub-specific override still wins. In
+production nothing changes — every hub already carried the default.
+
+Pinned by `HostedHubQuiesceLeakVisibilityTest`: a self-addressed request the child swallows
+(a request aimed at the *owner* does not leak — the owner's teardown NACKs it, which is exactly
+the case that settles), the owner disposed, and the owner's report naming the child and the
+request after the child has departed.
+
 ### ShutDown — tear down and signal
 
 Runs on the action block, fully synchronous: `CancelCallbacks()` (push

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-leaked-callback-in-a-hosted-hub-is-now-reported.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-03-a-leaked-callback-in-a-hosted-hub-is-now-reported.md
@@ -1,0 +1,22 @@
+---
+Name: A leaked callback inside a hosted hub is now reported
+Category: Fix
+Description: A request that was never answered inside a hosted hub used to cost every shutdown a silent two-second wait and was invisible to the leak report; the report now names the hub and the request, and hosted hubs drain under the same budget as their owner.
+Icon: Sparkle
+Order: -20260903
+---
+
+# A leaked callback inside a hosted hub is now reported
+
+When the platform shuts a hub down it first waits, briefly, for any request that hub is still
+expecting an answer to. If an answer never comes, that wait runs to its budget and the leak is
+supposed to be reported so someone can fix the request that was abandoned.
+
+For hubs hosted inside another hub, the report never fired. By the time the owning hub asked its
+children whether anything had leaked, the children had already finished and left — taking the
+answer with them. Measured on one test suite: 52 of 320 classes were paying that silent two-second
+wait, and the report said nothing.
+
+A child now hands its verdict to its owner as it leaves, so the report names the hub and the
+request. And a hosted hub is created with its owner's waiting budget rather than a fixed default,
+so a whole tree of hubs drains under one policy.

--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Concurrent;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Reactive;
 using System.Reactive.Linq;
@@ -178,6 +179,37 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     private readonly ConcurrentDictionary<Address, Lazy<IMessageHub?>> creations = new(AddressComparer.Instance);
 
     /// <summary>
+    /// The Quiescing verdicts of hosted hubs that have ALREADY LEFT this collection — captured at the
+    /// instant each one removed itself, so the owner's leak report can still name them.
+    ///
+    /// <para>🚨 Why this exists (measured 2026-09-03). A hosted hub removes itself from
+    /// <see cref="Hubs"/> in its own <c>DisposeImpl</c> — the ShutDown phase, which runs AFTER its
+    /// Quiescing phase has set <see cref="MessageHub.QuiescingTimedOut"/>. The owner's
+    /// <see cref="MessageHub.AnyHubQuiescingTimedOut()"/> walks <see cref="Hubs"/> only after ITS OWN
+    /// disposal completed, i.e. after every child has finished and departed — so a child's timed-out
+    /// quiesce was unreachable by construction. In one Plugins suite 52 of 320 test classes disposed
+    /// at exactly the 2 s child budget (104 s of wall clock), every one of them a leaked callback in
+    /// a hosted hub, and the detector reported zero. A departed child's verdict is a fact about THIS
+    /// teardown; it must not leave with the child.</para>
+    /// </summary>
+    internal ImmutableList<string> DepartedQuiesceTimeouts => departedQuiesceTimeouts;
+    private ImmutableList<string> departedQuiesceTimeouts = ImmutableList<string>.Empty;
+
+    /// <summary>
+    /// The Quiescing budget a hosted hub is created with unless its own configuration says
+    /// otherwise — the OWNER's, set by <see cref="MessageHub"/> when it takes this collection.
+    ///
+    /// <para><c>CreateMessageHub</c> starts every hub from a fresh <see cref="MessageHubConfiguration"/>
+    /// whose budget is the production default, so a mesh that configured a different budget on its
+    /// root (a test base's short one, an operator's long one) had children draining under a
+    /// different clock than their owner. A subtree drains under ONE policy; a caller that needs a
+    /// hub-specific budget still wins, because its configuration function runs after this seed.
+    /// Null means no owner has claimed the collection yet (the root of a mesh) and nothing is
+    /// seeded.</para>
+    /// </summary>
+    internal TimeSpan? InheritedQuiesceTimeout { get; set; }
+
+    /// <summary>
     /// Registers a hub under its own address, wires its removal from the registry on disposal and
     /// the closing of the lifetime scope it owns (see <see cref="CloseScopeWhenDisposed"/>), and
     /// notifies <see cref="HubAdded"/> subscribers.
@@ -186,7 +218,15 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     public void Add(IMessageHub hub)
     {
         messageHubs[hub.Address] = hub;
-        hub.RegisterForDisposal(h => messageHubs.TryRemove(h.Address, out _));
+        hub.RegisterForDisposal(h =>
+        {
+            // Snapshot BEFORE removal: this callback runs in the child's ShutDown phase, after its
+            // Quiescing verdict is final and before the owner's own teardown can ask for it.
+            if (h is MessageHub departing && departing.AnyHubQuiescingTimedOut())
+                ImmutableInterlocked.Update(ref departedQuiesceTimeouts,
+                    list => list.Add(departing.GetQuiescingTimeoutSummary()));
+            messageHubs.TryRemove(h.Address, out _);
+        });
         CloseScopeWhenDisposed(hub);
         try { _hubAdded.OnNext(hub); } catch { /* never throw on notification */ }
     }
@@ -346,7 +386,11 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
         try
         {
             logger.LogDebug("Creating new hosted hub for address {Address} in host {Host} ", address, Host);
-            var hub = serviceProvider.CreateMessageHub(address, config);
+            // The owner's Quiescing budget first, the caller's configuration after it — so the
+            // subtree drains under one policy and a hub-specific override still wins.
+            var inherited = InheritedQuiesceTimeout;
+            var hub = serviceProvider.CreateMessageHub(address,
+                inherited is { } budget ? c => config(c.WithQuiesceTimeout(budget)) : config);
             return hub;
         }
         catch (Exception ex)

--- a/src/MeshWeaver.Messaging.Hub/IMessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/IMessageService.cs
@@ -8,6 +8,13 @@ internal interface IMessageService : IDisposable
     void Start();
     bool OpenGate(string name);
     bool FailGate(string name, string reason);
+
+    /// <summary>
+    /// Answers every gate still shut as teardown begins — shutdown is the outcome after which none
+    /// of them can open, so a delivery parked behind one must be NACKed rather than left to its
+    /// own timeout. See the implementation for the measurement.
+    /// </summary>
+    void FailAllGatesOnShutdown();
     /// <summary>
     /// Cancels any in-progress message handlers (e.g. stuck initialization)
     /// to unblock the execution pipeline for shutdown processing.

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -409,6 +409,9 @@ public sealed class MessageHub : IMessageHub
         this.hostedHubs = hostedHubs;
         ServiceProvider = serviceProvider;
         Configuration = configuration;
+        // The owner claims its collection: hosted hubs created through it drain under THIS hub's
+        // Quiescing budget unless their own configuration says otherwise (one policy per subtree).
+        hostedHubs.InheritedQuiesceTimeout = configuration.QuiesceTimeout;
         unhandledNack = configuration.Get<UnhandledMessageNack>();
         parentAddress = parentHub?.Address;
         accessService = serviceProvider.GetRequiredService<AccessService>();
@@ -2156,6 +2159,10 @@ public sealed class MessageHub : IMessageHub
     private bool AnyHubQuiescingTimedOut(int depth)
     {
         if (QuiescingTimedOut) return true;
+        // Children that have already departed took their verdict with them — until the collection
+        // started keeping it (HostedHubsCollection.DepartedQuiesceTimeouts). Without this line a
+        // hosted hub's leaked callback was invisible on the owner by construction.
+        if (!hostedHubs.DepartedQuiesceTimeouts.IsEmpty) return true;
         if (depth >= MaxHostedHubRecursionDepth) return false;
         foreach (var child in hostedHubs.Hubs)
             if (child is MessageHub childMh && childMh.AnyHubQuiescingTimedOut(depth + 1)) return true;
@@ -2191,6 +2198,12 @@ public sealed class MessageHub : IMessageHub
         foreach (var child in hostedHubs.Hubs)
             if (child is MessageHub childMh)
                 childMh.AppendQuiescingTimeoutSummary(sb, depth + 1);
+        // Departed children: their summaries were rendered at their own depth 0 when they left, so
+        // re-indent under this owner.
+        var indent = new string(' ', (depth + 1) * 2);
+        foreach (var departed in hostedHubs.DepartedQuiesceTimeouts)
+            foreach (var line in departed.Split('\n', StringSplitOptions.RemoveEmptyEntries))
+                sb.Append(indent).AppendLine(line.TrimEnd('\r'));
     }
 
     private void AppendDiagnostics(System.Text.StringBuilder sb, int depth)

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1839,6 +1839,10 @@ public sealed class MessageHub : IMessageHub
         // Quiescing phase starts waiting for the callbacks those watchers would otherwise keep
         // issuing (#3026). Descendants were signalled by the cascade above.
         SignalShuttingDown();
+        // 🚨 Answer every gate that is still shut BEFORE the Quiescing poll starts counting. A
+        // delivery parked behind an init gate whose owner never answered it is a pending callback
+        // the poll can only wait out — the full budget, per hub. See FailAllGatesOnShutdown.
+        messageService.FailAllGatesOnShutdown();
 
         // Log all hosted hubs that will be disposed
         var hostedHubAddresses = hostedHubs.Hubs.Select(h => h.Address.ToString()).ToArray();

--- a/src/MeshWeaver.Messaging.Hub/MessageHubConfiguration.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHubConfiguration.cs
@@ -711,7 +711,7 @@ public record MessageHubConfiguration
     /// dispose, which compounds across N test classes.
     /// </para>
     /// </summary>
-    internal TimeSpan QuiesceTimeout { get; init; } = TimeSpan.FromSeconds(2);
+    public TimeSpan QuiesceTimeout { get; init; } = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// Sets the Quiescing-phase drain budget for this hub. See <see cref="QuiesceTimeout"/>.

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -436,9 +436,16 @@ public class MessageService : IMessageService
             "Hub {Address} is tearing down with {Count} gate(s) still shut ([{Gates}]) — answering "
             + "every delivery parked behind them instead of leaving them to their own timeouts",
             Address, stillShut.Length, string.Join(",", stillShut));
+        // 🚨 The reason must name the DEFERRAL, not just the shutdown. The NACK is the only thing
+        // the caller will ever see, and "the hub is shutting down" sends the next investigator to
+        // the disposal path when the fact that matters is that the delivery was parked behind a
+        // gate that can now never open. Pinned by
+        // DeferredDeliveryNackedOnDisposeTest.DeferredRequest_IsNacked_WhenHubIsDisposedBeforeItsGateOpens,
+        // which already asserted this contract for the late NACK this one supersedes.
         FailDeferredBacklog(ShutdownNack.RetryForTheAuthoritativeAnswer(
             Address, null,
-            $"the hub began tearing down while [{string.Join(",", stillShut)}] were still shut"));
+            $"the hub began tearing down while [{string.Join(",", stillShut)}] were still shut, so "
+            + "the deferred delivery parked behind them can never be released"));
     }
 
     private void FailDeferredBacklog(string reason)

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -400,6 +400,47 @@ public class MessageService : IMessageService
     /// <see cref="NotifyStartupFailure"/> and <see cref="Dispose"/> apply, reached here from a
     /// KNOWN-terminal gate rather than from a timeout.
     /// </summary>
+    /// <summary>
+    /// 🚨 ANSWERS EVERY GATE THAT IS STILL SHUT, because teardown is the outcome after which none
+    /// of them can ever open. Called once as disposal begins.
+    ///
+    /// <para>An initialization gate is a promise that the delivery parked behind it will be
+    /// released when the gate opens. Shutdown breaks that promise for every gate its owner did not
+    /// answer, and the deferred caller then hears nothing until an unrelated deadline expires —
+    /// its own request timeout, or whenever teardown reaches <c>messageService.Dispose()</c>.
+    /// <c>DataContext</c> learned this for its own gate (#1270) and fails it explicitly on
+    /// shutdown; that fix did not generalise, and could not: it lives in the gate's OWNER. The
+    /// <c>MeshNodeInit</c> gate — armed in <c>MeshDataSource</c>, opened in five places — has no
+    /// such hook at all, so a delivery deferred behind <c>[DataContextInit,MeshNodeInit]</c> had
+    /// ONE of its two gates answered and stayed parked on the other.</para>
+    ///
+    /// <para>Measured 2026-09-03 (MeshWeaver.Plugins Monolith suite, 801 tests): 14 of 38 leaked
+    /// callbacks ended at exactly that stage, each costing its hub the full Quiescing budget. Doing
+    /// this in the FRAMEWORK rather than in each gate's owner is the difference between fixing two
+    /// gates and making a third one impossible to get wrong.</para>
+    /// </summary>
+    public void FailAllGatesOnShutdown()
+    {
+        string[] stillShut;
+        lock (gateStateLock)
+        {
+            stillShut = gates.Keys.ToArray();
+            if (stillShut.Length == 0)
+                return;
+            foreach (var name in stillShut)
+                failedGates[name] = ShutdownNack.RetryForTheAuthoritativeAnswer(
+                    Address, null,
+                    $"the hub began tearing down while '{name}' was still shut, so it can never open");
+        }
+        logger.LogDebug(
+            "Hub {Address} is tearing down with {Count} gate(s) still shut ([{Gates}]) — answering "
+            + "every delivery parked behind them instead of leaving them to their own timeouts",
+            Address, stillShut.Length, string.Join(",", stillShut));
+        FailDeferredBacklog(ShutdownNack.RetryForTheAuthoritativeAnswer(
+            Address, null,
+            $"the hub began tearing down while [{string.Join(",", stillShut)}] were still shut"));
+    }
+
     private void FailDeferredBacklog(string reason)
     {
         DrainDeferredDeliveries(delivery => AnswerUnreleasableDelivery(delivery, reason));

--- a/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1367,8 +1367,14 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
     /// while waiting for <see cref="IMessageHub.DisposalCompleted"/> — every tick lands in
     /// <see cref="MeshWeaver.Fixture.TestBase.FileOutput"/> (xUnit test output) so a slow dispose shows
     /// progress incrementally instead of producing one giant snapshot at the timeout.
+    ///
+    /// <para>🚨 One second, not three: the ticker must tick BELOW the smallest budget it exists to
+    /// observe. The hosted-hub Quiescing default is 2 s, and 72 of 690 disposals in one suite sat
+    /// at exactly that budget (2026-09-03) — at 3 s the first snapshot landed after every one of
+    /// them had already finished, so the diagnostics that name the pending callback were never
+    /// written for the very case they were built for.</para>
     /// </summary>
-    private static readonly TimeSpan DisposeProgressInterval = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan DisposeProgressInterval = TimeSpan.FromSeconds(1);
 
     /// <summary>
     /// xUnit async lifecycle hook run after each test: disposes the clients created during the test,

--- a/test/MeshWeaver.Messaging.Hub.Test/HostedHubQuiesceLeakVisibilityTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/HostedHubQuiesceLeakVisibilityTest.cs
@@ -1,0 +1,112 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// 🚨 <b>A hosted hub's leaked callback must be visible on its OWNER after the child has gone.</b>
+///
+/// <para>Measured 2026-09-03 on a MeshWeaver.Plugins suite: 52 of 320 test classes disposed at
+/// exactly the 2 s hosted-hub Quiescing budget — 104 s of wall clock — and the leak detector
+/// reported ZERO. Two defects, both by construction. (1) A hosted hub removes itself from its
+/// owner's <c>HostedHubsCollection</c> in its ShutDown phase, which runs after its Quiescing
+/// verdict is set; the owner's <see cref="IMessageHub.AnyHubQuiescingTimedOut"/> walks the
+/// collection only after its own disposal completed, i.e. after every child has departed — so a
+/// child's timeout could never be seen. (2) <c>CreateMessageHub</c> starts every hosted hub from a
+/// fresh configuration carrying the production 2 s budget, so a mesh whose root was configured
+/// with a different budget had children draining under a different clock than their owner.</para>
+///
+/// <para>The shape: the CHILD is the requester. The abandoned <c>Observe</c> is registered on the
+/// hosted hub's own response registry, so it is the hosted hub — not the owner — whose Quiescing
+/// budget expires. That is what a leaked callback inside a per-node or per-circuit hub looks like
+/// in production.</para>
+///
+/// <para><b>Fails on unfixed code:</b> <see cref="ALeakInAHostedHub_IsReportedOnTheOwner_AfterTheChildDeparted"/>
+/// reads <c>AnyHubQuiescingTimedOut() == false</c> on the owner, and
+/// <see cref="AHostedHub_DrainsUnderItsOwnersQuiescingBudget"/> reads the 2 s default on the child.</para>
+/// </summary>
+public class HostedHubQuiesceLeakVisibilityTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    private record SwallowedRequest : IRequest<SwallowedResponse>;
+    private record SwallowedResponse;
+
+    private static readonly TimeSpan OwnerQuiesceTimeout = TimeSpan.FromMilliseconds(300);
+    private static readonly Address HostedAddress = new("hosted", "leaky-child");
+
+    protected override MessageHubConfiguration ConfigureHost(MessageHubConfiguration configuration)
+        => base.ConfigureHost(configuration).WithQuiesceTimeout(OwnerQuiesceTimeout);
+
+    /// <summary>
+    /// The child handles its OWN request and never answers it. Self-addressed on purpose: a request
+    /// the child aimed at its owner is NACKed by the owner's teardown ("Post drops, incoming
+    /// streams error"), which settles the callback and is exactly the case that does NOT leak. The
+    /// leak that costs production its 2 s is a callback whose counterpart simply never replies.
+    /// </summary>
+    private static MessageHubConfiguration SwallowingChild(MessageHubConfiguration c)
+        => c.WithHandler<SwallowedRequest>((_, delivery) => delivery.Processed());
+
+    [Fact]
+    public async Task ALeakInAHostedHub_IsReportedOnTheOwner_AfterTheChildDeparted()
+    {
+        var host = GetHost();
+        var hosted = host.GetHostedHub(HostedAddress, SwallowingChild);
+        var access = host.ServiceProvider.GetRequiredService<AccessService>();
+
+        // The child asks ITSELF and is never answered: the pending callback lives in the CHILD, and
+        // nothing on the teardown path will settle it for us. Posted AS the hub — the post pipeline
+        // fails closed on a missing AccessContext, and a post that never left the pipeline would
+        // register no callback and prove nothing.
+        IDisposable abandoned;
+        using (access.ImpersonateAsHub(hosted))
+        {
+            abandoned = hosted
+                .Observe<SwallowedResponse>(new SwallowedRequest(), o => o.WithTarget(HostedAddress))
+                .Subscribe(_ => { }, _ => { });
+            // Let the child's action block actually process (and swallow) the request before teardown.
+            await hosted.Observe<PingResponse>(new PingRequest(), o => o.WithTarget(HostedAddress))
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
+        }
+        using var _ = abandoned;
+
+        host.Dispose();
+        await host.DisposalCompleted.FirstAsync().Await().WaitAsync(TestTimeouts.Convergence);
+
+        host.AnyHubQuiescingTimedOut().Should().BeTrue(
+            "the child's Quiescing budget expired on a callback nobody answered, and the child has "
+            + "since removed itself from the owner's collection — a verdict that leaves with the child "
+            + "is how 52 leaks in one suite reported as zero");
+        var summary = host.GetQuiescingTimeoutSummary();
+        Output.WriteLine(summary);
+        summary.Should().Contain(HostedAddress.ToString(),
+            "the report must NAME the hub that leaked, or the finding is unactionable");
+        summary.Should().Contain(nameof(SwallowedRequest),
+            "and the request whose reply never came — that is the line a developer greps for");
+    }
+
+    [Fact]
+    public void AHostedHub_DrainsUnderItsOwnersQuiescingBudget()
+    {
+        var host = GetHost();
+        var hosted = host.GetHostedHub(HostedAddress, c => c);
+
+        hosted.Configuration.QuiesceTimeout.Should().Be(OwnerQuiesceTimeout,
+            "a subtree drains under ONE policy: a child created from a fresh configuration would carry "
+            + "the production default instead of the budget its owner was configured with, so the "
+            + "owner's teardown would wait out a clock nobody chose");
+    }
+
+    [Fact]
+    public void AHostedHubsOwnBudget_StillWins()
+    {
+        var host = GetHost();
+        var own = TimeSpan.FromMilliseconds(700);
+        var hosted = host.GetHostedHub(new Address("hosted", "opinionated"), c => c.WithQuiesceTimeout(own));
+
+        hosted.Configuration.QuiesceTimeout.Should().Be(own,
+            "the inherited budget is a seed, not a ceiling — a hub that reasons about its own drain keeps its number");
+    }
+}


### PR DESCRIPTION
Measured 2026-09-03 on a MeshWeaver.Plugins suite (`MeshWeaver.Hosting.Monolith.Test`, local run with the per-test phase trace and `MESHWEAVER_MSG_TRACE`, load 5–8 on 12 cores): **72 of 690 disposals took ≈2.0 s — 145 s of an 11-minute run — and the leak detector reported zero for every one of them.** The distribution is bimodal: 617 disposals under 100 ms, 72 at 2,002–2,168 ms, one in between. The 2 s is the hosted-hub `QuiesceTimeout` default.

## Two defects, both by construction

**1. A departed child's verdict left with it.** A hosted hub removes itself from its owner's `HostedHubsCollection` in its own `DisposeImpl` (ShutDown) — *after* its Quiescing phase has set `QuiescingTimedOut`. The owner's `AnyHubQuiescingTimedOut()` / `GetQuiescingTimeoutSummary()` walk `hostedHubs.Hubs`, and a caller can only ask after the owner's own `DisposalCompleted`, i.e. after every child has finished and departed. So a child's timed-out quiesce was unreachable. `HostedHubsCollection` now snapshots a departing child's summary in that same removal callback (`DepartedQuiesceTimeouts`) and both walkers consult it. The report names the hub and the request:

```
[QUIESCE-TIMEOUT] hosted/leaky-child: 1 callback(s) still pending after 0.3s — forcibly cancelling.
  Pending: …=SwallowedRequest@hosted/leaky-child(307ms)
```

**2. Children drained under a different clock than their owner.** `CreateMessageHub` starts every hub from a fresh `MessageHubConfiguration` whose `QuiesceTimeout` is the production default (2 s). A mesh that configured a different budget on its root — the test base's 500 ms — had hosted hubs paying 2 s per leaked child regardless. The owner now seeds its collection (`InheritedQuiesceTimeout`); a hosted hub inherits it unless its own configuration says otherwise. One policy per subtree; a hub-specific override still wins; **production keeps the default everywhere**, so nothing changes there.

## What this does not yet do

It makes the class *reportable*; it does not remove the callbacks. With this merged, a Plugins suite whose hosted hubs leak will start **failing** on `DISPOSE_QUIESCE_LEAK` with the request named — which is the point, and also the blast radius: those are real leaks that were silently costing 2 s each. The first specimen is already in hand from the message trace (a `SubscribeRequest` parked behind a hub's `DataContextInit`/`MeshNodeInit` gates at the instant of teardown); the local re-run against this branch is what names the rest.

## 🚨 A detector that cannot fail

The number worth less than the shape: for as long as this code has existed, the leak report was **structurally unable to see the thing it exists to find**, and reported clean. It is the same class as an assertion satisfied by the wrong field, a query projection that returns silent nulls, a green CI whose required contexts were absent, and a watcher rendering a throttled empty response as a verdict — a check whose failure path was unreachable. The pin here is written so it fails on the unfixed code first; the ticker change (second commit) is the same idea one layer up: a diagnostics snapshot at 3 s can never describe a 2 s wait.

## Third commit: teardown answers every gate that is still shut

With the report reachable, the biggest single mechanism became visible and had a clean root cause.
An initialization gate promises to release what is parked behind it when it opens; **shutdown is the
outcome after which no gate can ever open**. `DataContext` learned this for its own gate (#1270) and
fails `DataContextInit` on shutdown — but that fix lives in the gate's **owner**, so it did not
generalise. `MeshNodeInit` (armed in `MeshDataSource`, opened in five places) has no such hook, and
the entire `src/` tree contained exactly **one** `FailGate` call. A delivery deferred behind
`gates=[DataContextInit,MeshNodeInit]` had one gate answered and stayed parked on the other.

`MessageHub.Dispose()` now calls `messageService.FailAllGatesOnShutdown()` right after
`SignalShuttingDown()` — before the Quiescing poll starts counting, because a delivery parked behind
an unanswered gate is exactly a pending callback that poll can only wait out. In the framework
rather than in each owner: the difference between fixing two gates and making a third impossible to
get wrong.

Measured on the Plugins Monolith suite (801 tests), same machine, same load band:

| leaked-callback last stage | before | after |
|---|---|---|
| `DEFERRED gates=[DataContextInit,MeshNodeInit]` | 12 | **0** |
| `DEFERRED gates=[DataContextInit]` | 3 | **0** |
| `DROPPED_SHUTTING_DOWN runLevel=Dead` | 8 | 3 |
| **total leaked callbacks** | **69** | **63** |

🚨 **Read the failing-test count honestly:** 38 → 37, because most failing tests leak by more than one
mechanism — killing one class does not clear a test that also leaks another way. The callback counts
above are the measurement that matters.

## What is left, named

Three mechanisms remain and are NOT fixed here: a handler that exits `Processed` whose async reply
never follows (18), a handler fault whose error arm never answers the requester (11 —
`MessageService`'s generic branch reports through `ReportFailure`, which returns early once
`RunLevel >= DisposeHostedHubs`, and `NackThroughParent` also declines when the parent is past that
level), and a reply posted to a hub that had already stopped listening. Each deserves its own change.

## Not an `InternalsVisibleTo`

`QuiesceTimeout` becomes public (`WithQuiesceTimeout` already was) so the pin can read it. An `InternalsVisibleTo` on Messaging.Hub was tried first and broke two unrelated test files — it shifts overload resolution of the internal `Observe(object, …)` across the whole test assembly, exactly as `MessageStormBreaker.cs` records.

## Verification

Release, `-warnaserror`, one project per invocation: `MeshWeaver.Messaging.Hub.Test`, `MeshWeaver.Documentation.Test` — `0 Error(s)`.

- `HostedHubQuiesceLeakVisibilityTest` (3/3): a self-addressed request the child swallows, posted as the hub (the post pipeline fails closed on a missing `AccessContext`), the owner disposed, and the owner's report naming `hosted/leaky-child` + `SwallowedRequest` after the child departed — in 0.3 s, not 2. A request aimed at the *owner* is deliberately not the shape: the owner's teardown NACKs it, which settles the callback and is exactly the case that does not leak.
- `QuiescingTimeoutNamesHandlerSideTest` (4/4) unchanged.
- `DocumentationLinkIntegrityTest`, `TestTimeoutLiteralRatchetGuard` green.

Doc: `HubDisposalModel.md` gains the section between the DisposeHostedHubs and ShutDown phases. What's New (Fix).

Pairs-with: none — an added default and two added members; no public type or member is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxxLJxS5SWxuwP4JK1NTNY
