### PR TITLE
docs: the release wave has ONE emitter — and which one depends on a pin

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/TheReleaseWave.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/TheReleaseWave.md
@@ -1,0 +1,118 @@
+---
+Name: The Release Wave — one emitter, and who resolves the digest
+Category: Documentation
+Description: How a publication becomes a repository_dispatch across the plugin fleet — the single emitter rule, the image/digest contract that puts resolution on the RECEIVER, and the transitional gap left by retiring the GitHub-to-GitHub job
+---
+
+A module is built against a platform **pin**, so when the platform (or an upstream catalog)
+publishes, every dependent repo must rebuild or its portals read `FrameworkDeclined` and adopt
+nothing. The mechanism that wakes them is the **release wave**: one `repository_dispatch` per
+subscribed repository.
+
+This page exists because the wave has been mis-diagnosed twice in one day, in opposite directions —
+once by blaming a receiver's pin, once by blaming an emitter that did not exist. Both mistakes are
+cheap to repeat, because **the evidence for "who sent this" is not in the repo that received it.**
+
+## 🚨 The wave has exactly ONE emitter — and which one it is depends on a PIN
+
+> Maintainer, 2026-09-03: *"None of the top-level repos should have any dependency to anyone else.
+> It must be event based: (1) memex issues an event that something has a new version; (2) GitHub
+> subscribes to this and triggers the build. Core publishes an event and finishes."*
+
+That directive **retired** the GitHub→GitHub emitter — the `dispatch-dependents` job in this repo's
+`node-repo-publish-bake.yml`. On `main` the input survives only as a `RETIRED 2026-09-03` stub that
+is *ignored*, so a caller pinned to an older lane still validates while it moves its pin.
+
+**And that is the trap.** A reusable workflow is consumed at a `@<sha>` pin, so retiring a job on
+`main` retires it for *nobody* until each caller moves. A repo pinned before the retirement still
+runs the old job, which still dispatches — a **zombie emitter**, live in a caller's `ci.yml` rather
+than anywhere you would grep for it.
+
+**So: never answer "where did this dispatch come from?" from `main`.** Read the emitting repo's
+pin, then read `node-repo-publish-bake.yml` *at that pin*:
+
+```bash
+grep -n 'node-repo-publish-bake.yml@' <repo>/.github/workflows/ci.yml
+git -C ~/code/MeshWeaver cat-file -p "<pin>:.github/workflows/node-repo-publish-bake.yml" \
+  | grep -n 'dispatch-dependents:'
+```
+
+A corollary worth stating because it has already cost a wrong issue: **an in-mesh node is not the
+emitter merely because no committed source explains the dispatch.** In-mesh `.cs` compiles at
+runtime and is invisible to `dotnet build` and to a `.cs` grep, which makes it a tempting suspect.
+Before accusing it, `get` the live node and diff it against `origin/main`. On 2026-09-03
+`Hosting/Deployment/Source/PlatformBuildInboxWatcher` (v7) matched the repo exactly and contained
+no wave emitter at all — the dispatches were the zombie job above.
+
+## The image/digest contract — the RECEIVER resolves
+
+The dispatch payload carries both forms, and they are not redundant:
+
+| field | what it is |
+|---|---|
+| `image` | the full tester-image reference the bake used — **authoritative** |
+| `platform_image` | the portal image this bake compiled against (MeshWeaver#3022) |
+| `digest` | a **convenience**: the part after `@`, and **empty when `image` was a tag** |
+
+```sh
+# A receiver's own gate wants the bare digest (its image-digest input); the bake wants
+# the full reference. Carry both — the digest is the part after '@' when the image was
+# resolved by digest, empty when it was a tag (then the receiver resolves it itself).
+digest=""; case "$IMAGE" in *@sha256:*) digest="${IMAGE#*@}" ;; esac
+```
+
+🚨 **An empty `digest` beside a present `image` is the contract WORKING, not a contract break.**
+The parenthesis — *"then the receiver resolves it itself"* — is the receiver's obligation, and a
+receiver that refuses instead throws away well-formed waves. MeshWeaver.Manufacturing did exactly
+that for ten consecutive red `main` runs on 2026-09-03 before its preflight was taught to resolve
+`client_payload.image` (Manufacturing#50).
+
+**Resolving is not the same as falling back to the pin, and the difference is the whole point.**
+The pin *caps* what the gates can see, so gating against it reports a green release-follow for a
+framework nobody checked. Resolve the wave's own image and fail LOUD when you cannot:
+
+```sh
+digest=$(docker manifest inspect -v "$WAVE_IMAGE" \
+  | jq -r 'if type == "array" then .[0] else . end | .Descriptor.digest // ""')
+```
+
+Not `imagetools inspect --format '{{.Manifest.Digest}}'` — that template reads a member an OCI
+manifest does not carry, so it yields nothing and every run takes the fail-loud branch.
+
+## The transitional gap (open as of 2026-09-03)
+
+The directive's end state is: the lane ends with **one signed POST** of the publication record to
+memex (`webhook-url` / `webhook-secret`), and **memex** emits `meshweaver-upstream-published`.
+
+The receiving half exists — memex's generic webhook inbox, and
+`Hosting/Deployment/Source/PlatformBuildInboxWatcher` draining it. The **emitting half does not**:
+`ParseBuild` accepts only `event: "platform-build"` and logs *"ignoring non-build event"* for
+anything else, then deletes it. `FrameworkReleaseBroadcaster.Broadcast` already takes the
+`eventType` and `payload` arguments a `bundle-publication` branch would need; nothing calls them.
+
+**Therefore the pins must move in this order**, and moving them early is worse than leaving them:
+
+1. Write the `bundle-publication` branch (parse the record, broadcast
+   `meshweaver-upstream-published` carrying `source`, `image`, `platform_image`, `digest`,
+   `identity`, `version`, `sha`), with a test pinning the **payload**, not just the log line.
+2. Provision `webhook-url` / `webhook-secret` on each publishing caller.
+3. Then move each caller's pin past the retirement.
+
+Move a pin before step 1 and the publication POSTs to an inbox that discards it: the zombie
+emitter stops, nothing replaces it, and **the wave dies silently** — every dependent falls back to
+its daily schedule poll, which is exactly the "absence of evidence read as evidence" failure the
+whole lane is built to refuse.
+
+## Reading a wave, in order
+
+1. **Who emitted it?** The receiver's run says `repository_dispatch` and an actor; it does not say
+   which repo. Find the caller whose `bake-source` matches `client_payload.source`, then read its
+   pin (above) — not core `main`.
+2. **Who subscribes?** The old job filtered on the dependent's own `ci.yml` declaring the source
+   under `upstream-sources:` / `upstream-seed:` — a line-anchored match, so a mention in a comment
+   does not subscribe a repo. The end-state answer is data in the mesh: a `Hosting/Deployment`
+   record's `pluginRepos[].isRegistrySource`. **Never a list in configuration** — every earlier
+   design kept a second copy of that graph and each copy was empty on the deploy that mattered
+   (MeshWeaver#2235, Memex#140).
+3. **What did it name?** `image` first, `digest` only as a shortcut, `platform_image` for the
+   portal to pair with. A wave that names no image at all is the only genuine contract break.


### PR DESCRIPTION
Conserves an investigation that cost two wrong diagnoses in one day, in opposite directions:
once blaming a receiver's pin, once blaming an in-mesh emitter that does not exist.

Both are cheap to repeat, because **the evidence for "who sent this dispatch" is not in the repo
that received it.**

## What the page pins down

**1. A retirement on `main` retires nothing until each caller moves its pin.**
`dispatch-dependents` is `RETIRED 2026-09-03` in `node-repo-publish-bake.yml`, ignored, kept only
so an older caller still validates. But a reusable workflow is consumed at `@<sha>` — so a repo
pinned before that commit still runs the old job and still dispatches. A **zombie emitter**, live
in a caller's `ci.yml` rather than anywhere you would grep. The page gives the two commands that
answer "who emitted this" correctly.

**2. `digest` is a convenience; the RECEIVER resolves.** The emitter's own comment is explicit —
*"empty when it was a tag (then the receiver resolves it itself)"*. An empty `digest` beside a
present `image` is the contract **working**. Refusing it cost MeshWeaver.Manufacturing ten
consecutive red `main` runs on 2026-09-03 (fixed in Manufacturing#50).

The page is careful about the distinction that makes this safe: **resolving the wave's own image
is not falling back to the pin.** The pin *caps* what the gates can see, so gating against it
reports a green release-follow for a framework nobody checked — forbidden. Resolving
`client_payload.image`, and failing loud when it cannot be resolved, gates against exactly what
the upstream sealed against.

**3. The end state is HALF built, so the pins must move in a fixed order.** memex's inbox and its
`PlatformBuildInboxWatcher` exist; the `bundle-publication` branch does not (`ParseBuild` accepts
only `platform-build` and *deletes* anything else), and `FrameworkReleaseBroadcaster.Broadcast`
already takes the `eventType`/`payload` arguments such a branch needs — with nothing calling them.

> Write the branch → provision `webhook-url`/`webhook-secret` → *then* move the pin.

Move a pin before step 1 and the zombie emitter stops with nothing replacing it: **the wave dies
silently** and every dependent falls back to its daily poll — the exact "absence of evidence read
as evidence" the lane exists to refuse.

## Also recorded: the anti-pattern behind mistake #2

An in-mesh node is not the emitter merely because no committed source explains the dispatch.
In-mesh `.cs` is invisible to `dotnet build` and to a `.cs` grep, which makes it a tempting
suspect. `get` the live node and diff it against `origin/main` first — on 2026-09-03
`Hosting/Deployment/Source/PlatformBuildInboxWatcher` (v7) matched the repo exactly and contained
no wave emitter at all.

## Verification

Docs only — no code paths touched. Full `MeshWeaver.Documentation.Test` suite green, **246/246**
(the whole suite, not only the guards that looked relevant).