### PR TITLE
A Graph:Storage section without a Type means NO storage, not "FileSystem"

### DIFF
--- a/memex/Memex.Portal.Shared/MemexConfiguration.cs
+++ b/memex/Memex.Portal.Shared/MemexConfiguration.cs
@@ -358,7 +358,19 @@ public static class MemexConfiguration
             // today is appsettings-configured and has no manifest, and this path must leave all of
             // them byte-identical — an additive mechanism that changed a configured instance's
             // storage would be a data-loss bug, not a feature.
-            var graphStorageConfig = configuration.GetSection("Graph:Storage").Get<GraphStorageConfig>();
+            // 🚨 The section is bound ONLY when the raw Graph:Storage:Type key actually names a
+            // backend. `GraphStorageConfig.Type` carries the initializer "FileSystem", so binding a
+            // section that exists but states no type hands back a working-looking file-system
+            // configuration — and the section legitimately exists for other reasons: the deployed
+            // image states Graph:Storage:UnanchoredQueryPolicy there so no chart or environment can
+            // forget it (the ci.7658 503 incident). Without this test, that one query-policy line
+            // would silently mean "storage is configured": MarkAwaitingSetup is never reached, the
+            // first-run wizard becomes unreachable, and a real instance is pointed at
+            // container-ephemeral disk — issue #435's shape, arriving from a file nobody edited.
+            var graphStorageConfig =
+                string.IsNullOrWhiteSpace(configuration["Graph:Storage:Type"])
+                    ? null
+                    : configuration.GetSection("Graph:Storage").Get<GraphStorageConfig>();
             // 🚨 COMPLETE, and with a real backend named (Copilot review). A manifest that exists
             // is not a manifest that ANSWERS: the wizard's own starting point is
             // State=AwaitingStorage with a pre-filled type, and an Unreadable one answers nothing

--- a/memex/Memex.Portal.Shared/Setup/SetupOnlyHost.cs
+++ b/memex/Memex.Portal.Shared/Setup/SetupOnlyHost.cs
@@ -39,20 +39,29 @@ public static class SetupOnlyHost
     /// <summary>
     /// Whether this instance has no storage and must therefore be set up.
     ///
-    /// <para>🚨 <b>An ABSENT <c>Graph:Storage</c> section, not an empty one</b> —
-    /// <c>GraphStorageConfig.Type</c> defaults to <c>FileSystem</c>, so a section that EXISTS but
-    /// says nothing binds to a working-looking file-system configuration and would boot straight
-    /// past setup onto container-ephemeral disk. A blank <c>Type</c> is treated as absent for the
-    /// same reason: an environment variable cannot be null, only empty.</para>
+    /// <para>🚨 <b>Decided on the RAW <c>Graph:Storage:Type</c> key, never on the bound record.</b>
+    /// <c>GraphStorageConfig.Type</c> carries the initializer <c>FileSystem</c>, so binding a
+    /// section that EXISTS but names no type yields a working-looking file-system configuration —
+    /// and that section legitimately exists for other reasons (the deployed image states
+    /// <c>UnanchoredQueryPolicy</c> there deliberately). Binding would read "configured" off a
+    /// query policy, put the instance on container-ephemeral disk, and make this wizard
+    /// unreachable. Blank counts as absent too: an environment variable cannot be null, only
+    /// empty.</para>
     /// </summary>
     /// <param name="configuration">The host's configuration, with the instance manifest already
     /// layered in (see <see cref="InstanceManifestConfigurationExtensions.AddInstanceManifest"/>).</param>
     public static bool IsAwaitingSetup(IConfiguration configuration)
     {
         ArgumentNullException.ThrowIfNull(configuration);
-        var storage = configuration.GetSection(InstanceManifestProjection.StorageSection)
-            .Get<GraphStorageConfig>();
-        return storage is null || string.IsNullOrWhiteSpace(storage.Type);
+        // 🚨 The RAW key, never the bound record. `GraphStorageConfig.Type` carries the initializer
+        // "FileSystem", so BINDING a section that exists but names no Type yields a working-looking
+        // file-system store — and the section legitimately exists for other reasons: the deployed
+        // image states Graph:Storage:UnanchoredQueryPolicy there so no chart or environment can
+        // forget it. Binding would therefore read "configured" off a section whose only content is
+        // a query policy, make the wizard unreachable again, and point a real instance at
+        // container-ephemeral disk. Absent and blank are both "no storage stated".
+        return string.IsNullOrWhiteSpace(
+            configuration[$"{InstanceManifestProjection.StorageSection}:Type"]);
     }
 
     /// <summary>

--- a/test/Memex.Portal.Shared.Test/StorageSectionWithoutTypeIsNotConfiguredTest.cs
+++ b/test/Memex.Portal.Shared.Test/StorageSectionWithoutTypeIsNotConfiguredTest.cs
@@ -1,0 +1,63 @@
+using Memex.Portal.Shared.Setup;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// A <c>Graph:Storage</c> section that exists but names no <c>Type</c> means NO STORAGE — it does
+/// not mean "file system".
+///
+/// <para>🚨 <b>Two changes that are each correct combine into a silent disaster without this.</b>
+/// The deployed image states <c>Graph:Storage:UnanchoredQueryPolicy</c> deliberately, so that no
+/// chart, ConfigMap or environment can forget it (the image ci.7658 incident, where every signed-in
+/// request answered 503). The same image deliberately states no <c>Graph:Storage:Type</c>, so the
+/// first-run setup wizard is reachable. The section therefore EXISTS while answering nothing about
+/// storage — and <c>GraphStorageConfig.Type</c> carries the initializer <c>FileSystem</c>, so
+/// anything that BINDS that section reads a working-looking file-system store.</para>
+///
+/// <para>The consequences of getting this wrong are both silent: the wizard becomes unreachable
+/// again, and a real instance is pointed at container-ephemeral disk — issue #435's shape, arriving
+/// from a file nobody edited. So both readers test the RAW key, and this pins that they do.</para>
+/// </summary>
+public class StorageSectionWithoutTypeIsNotConfiguredTest
+{
+    private static IConfiguration Config(params (string Key, string? Value)[] entries)
+        => new ConfigurationBuilder()
+            .AddInMemoryCollection(entries.ToDictionary(e => e.Key, e => e.Value))
+            .Build();
+
+    [Fact]
+    public void APolicyOnlySection_ReadsAsAwaitingSetup()
+    {
+        // Exactly the deployed image's shape after the two changes met.
+        var configuration = Config(("Graph:Storage:UnanchoredQueryPolicy", "ServeAndReport"));
+
+        Assert.True(SetupOnlyHost.IsAwaitingSetup(configuration),
+            "a section carrying only a query policy states no storage — binding it would yield "
+            + "Type=FileSystem from the record's initializer and boot a real instance onto "
+            + "container-ephemeral disk.");
+    }
+
+    [Fact]
+    public void ABlankType_ReadsAsAwaitingSetup()
+        // An environment variable cannot be null, only empty — "" is the deployed shape of unset,
+        // and it is exactly what the chart emits for a values file that states nothing.
+        => Assert.True(SetupOnlyHost.IsAwaitingSetup(
+            Config(("Graph:Storage:Type", ""), ("Graph:Storage:UnanchoredQueryPolicy", "ServeAndReport"))));
+
+    [Fact]
+    public void NoSectionAtAll_ReadsAsAwaitingSetup()
+        => Assert.True(SetupOnlyHost.IsAwaitingSetup(Config()));
+
+    [Fact]
+    public void ARealBackend_ReadsAsConfigured()
+    {
+        // The negative control: without it every assertion above would pass on a predicate that
+        // simply always answers true.
+        Assert.False(SetupOnlyHost.IsAwaitingSetup(
+            Config(("Graph:Storage:Type", "PostgreSql"),
+                   ("Graph:Storage:UnanchoredQueryPolicy", "ServeAndReport"))));
+        Assert.False(SetupOnlyHost.IsAwaitingSetup(Config(("Graph:Storage:Type", "Sqlite"))));
+    }
+}


### PR DESCRIPTION
**Two changes that are each correct combine into a silent disaster.** Found while resolving a merge
conflict, not by review — and it is the same pairing shape as the ci.7658 incident that prompted the
other half of it.

## The seam

- MeshWeaver.Plugins states `Graph:Storage:UnanchoredQueryPolicy` **in the deployed image**,
  deliberately, so that no chart, ConfigMap or environment can forget it. That is what stops image
  ci.7658 recurring, where every signed-in request answered 503 for twenty minutes.
- The same image deliberately states **no** `Graph:Storage:Type`, so the first-run setup wizard is
  reachable (MeshWeaver.Plugins#1284 — without that, the ConfigMap can omit the key and the portal
  still boots configured off the image).

So `Graph:Storage` now **exists while answering nothing about storage** — and
`GraphStorageConfig.Type` carries the initializer `"FileSystem"`. Anything that *binds* the section
reads a working-looking file-system store out of a lone query-policy line.

Both consequences are silent:

1. `MemexConfiguration` never reaches `MarkAwaitingSetup` ⇒ **the wizard is unreachable again**.
2. A real instance is configured onto **container-ephemeral disk** — issue #435's shape, arriving
   from a file nobody edited.

## The fix

Both readers test the **raw `Graph:Storage:Type` key** rather than the bound record —
`MemexConfiguration` (which decides `MarkAwaitingSetup`) and `SetupOnlyHost.IsAwaitingSetup`. Absent
and blank both mean "no storage stated"; an environment variable cannot be null, only empty, so `""`
is the deployed shape of unset.

## Verification

`StorageSectionWithoutTypeIsNotConfiguredTest` pins all four shapes — policy-only section, blank
type, no section, and **a real backend as the negative control**, without which the predicate could
simply always answer true and every other assertion would pass vacuously.

42/42 across the setup suites.

`Pairs-with: Systemorph/MeshWeaver.Plugins#1284 — the change that makes the image state the policy
without the type. This core PR should land FIRST: with it, the Plugins change is safe; without it,
the pairing is the failure described above.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
