### PR TITLE
fix(#3175): the SDK leg honours superseded-image-assemblies too

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1382,6 +1382,67 @@ jobs:
           n=${#dlls[@]}
           [ "$n" -gt 50 ] || { echo "::error::the image's /app yielded $n assemblies — not a platform image"; exit 1; }
           echo "platform refs: $n assemblies from ${IMAGE_NOTAG}@${DIGEST}"
+      # 🚨 THE SDK LEG NEEDS THE SUPERSEDE TOO — it did not have it, and that is a whole class of
+      # red (#3175 wave). `superseded-image-assemblies` reached ONLY the container leg, as
+      # `--superseded-image-assembly` on `build-project`. The SDK leg compiles with
+      # `-p:MeshWeaverRefs=$RUNNER_TEMP/platform-refs`, a raw `docker cp` of the image's /app, and
+      # nothing subtracted the stale copy from it. So a repository that moved a type OUT of an
+      # image-shipped assembly saw its container entries go green and its sdk entries fail CS0436 on
+      # the very same tree — measured on MeshWeaver.Plugins #1268, where the three collaboration
+      # views moved into MeshWeaver.Markdown.Collaboration: "Build the workspace (one global build)"
+      # passed while "Module bundle (MeshWeaver.Blazor.Chat)" failed, because Blazor.Chat reaches the
+      # moved sources through MeshWeaver.AI while the pinned image still defines them in
+      # MeshWeaver.Blazor.Views.
+      #
+      # 🚨 A COPY, NEVER AN IN-PLACE DELETE. `platform-refs` is restored AND SAVED under
+      # `platform-refs-<digest>`, a key that says nothing about superseding. Pruning it in place
+      # would let actions/cache store the pruned set under the unpruned key, and the next run that
+      # declares no supersede — any other repository sharing the digest — would silently compile
+      # against a reference set missing a real platform assembly, failing CS0246 naming innocent
+      # code. The copy keeps the cached directory a faithful image copy.
+      #
+      # The staleness check (an entry whose assembly no longer overlaps this repository's source)
+      # lives in the container leg's tool, which reads type tables this step cannot. It runs
+      # whenever the lane has container entries, which is the same wave that makes an entry
+      # necessary; an sdk-only selection is not the case that goes stale unnoticed.
+      - name: Drop superseded image assemblies from the SDK reference set
+        id: refs
+        if: inputs.platform-image-digest != ''
+        env:
+          SUPERSEDED: ${{ inputs.superseded-image-assemblies }}
+        run: |
+          set -euo pipefail
+          src="$RUNNER_TEMP/platform-refs"
+          # Empty ⇒ the reference set is the image's /app unchanged, and REFS keeps the exact value
+          # it had before this step existed. Byte-identical to before the input existed.
+          if [ -z "${SUPERSEDED// /}" ]; then
+            echo "refs=$src" >> "$GITHUB_OUTPUT"
+            echo "no superseded assemblies declared — SDK reference set is the image's /app unchanged"
+            exit 0
+          fi
+          [ -d "$src" ] || { echo "::error::platform-image-digest is set but $src does not exist — the reference set was never taken from the image."; exit 1; }
+          dst="$RUNNER_TEMP/platform-refs-effective"
+          rm -rf "$dst"
+          cp -a "$src" "$dst"
+          dropped=0
+          for asm in ${SUPERSEDED//,/ }; do
+            [ -n "$asm" ] || continue
+            if [ ! -f "$dst/$asm.dll" ]; then
+              echo "::error::superseded-image-assemblies names '$asm', but the pinned image ships no $asm.dll in /app. An entry that matches nothing cannot be protecting anything: correct the name, or remove it."
+              exit 1
+            fi
+            # The satellites go with it: a lingering .xml or .pdb for a dropped reference is at best
+            # noise and at worst a second opinion about what the assembly contained.
+            rm -f "$dst/$asm.dll" "$dst/$asm.xml" "$dst/$asm.pdb"
+            dropped=$((dropped + 1))
+            echo "superseded: dropped $asm.dll from the SDK reference set (this repository's source now defines types it still contains)"
+          done
+          before=$(find "$src" -maxdepth 1 -name '*.dll' | wc -l | tr -d ' ')
+          after=$(find "$dst" -maxdepth 1 -name '*.dll' | wc -l | tr -d ' ')
+          [ "$after" -eq "$((before - dropped))" ] || { echo "::error::pruned reference set holds $after assemblies; expected $((before - dropped)) (was $before, dropped $dropped)."; exit 1; }
+          echo "refs=$dst" >> "$GITHUB_OUTPUT"
+          echo "SDK reference set: $after assemblies ($before from the image, $dropped superseded)"
+
       # ══════════ THE COMPILER — the CONTAINER or the SDK, and the log says WHICH ══════════
       # 🚨 "we want to use memex build plugin and not dotnet build" (maintainer, 2026-08-31). A
       # module does not run against a source tree and it does not run against a feed: it is loaded
@@ -1437,7 +1498,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           ACR_USERNAME: ${{ secrets.acr-username }}
           ACR_PASSWORD: ${{ secrets.acr-password }}
-          REFS: ${{ inputs.platform-image-digest != '' && format('{0}/platform-refs', runner.temp) || '' }}
+          REFS: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.refs || '' }}
         run: |
           set -euo pipefail
           # The closure arguments are written HERE and read by the pack step, so the compiler that
@@ -1654,7 +1715,7 @@ jobs:
           # different things. When a platform image is pinned, `platform-refs` is a `docker cp` of
           # its /app, which the sdk build passes as `-p:MeshWeaverRefs=$REFS` and the container
           # build compiles inside; when none is, it is empty and the platform came from source.
-          REFS: ${{ inputs.platform-image-digest != '' && format('{0}/platform-refs', runner.temp) || '' }}
+          REFS: ${{ inputs.platform-image-digest != '' && steps.refs.outputs.refs || '' }}
         run: |
           set -euo pipefail
           # 🚨 The closure flags come from the COMPILER THAT RAN, written to a file by the step


### PR DESCRIPTION
## The gap

`superseded-image-assemblies` (#3225) reaches only the **container** leg of `node-repo-module-pack.yml`, as `--superseded-image-assembly` on `build-project`. The **SDK** leg compiles with `-p:MeshWeaverRefs=$RUNNER_TEMP/platform-refs` — a raw `docker cp` of the pinned image's `/app` — and nothing subtracted the stale copy from it.

So a repository that moves a type out of an image-shipped assembly sees its container entries go green and its sdk entries fail `CS0436` **on the same tree**.

Measured on MeshWeaver.Plugins #1268 (three collaboration views move into `MeshWeaver.Markdown.Collaboration`):

| leg | result |
|---|---|
| `Module bundles / Build the workspace (one global build)` | green — logs `superseding … MeshWeaver.Blazor.Views` |
| `Module bundles / Module bundle (MeshWeaver.Blazor.Chat)` | **CS0436** — `'CollaborativeMarkdownView' … conflicts with the imported type in 'MeshWeaver.Blazor.Views, Version=3.0.0.0'` |

`Blazor.Chat` reaches the moved sources through `MeshWeaver.AI → MeshWeaver.Markdown.Collaboration`, while the pinned image still defines them in `MeshWeaver.Blazor.Views`. #1268 already cuts the producing edge and declares the input at both call sites; there was simply nothing on the SDK side to honour it.

## Why this is urgent

This is the last red between the fleet and a sealed publication. Core's own **`Plugins: bake + seal the publication for this identity` has failed on every image-building CD run since 2026-09-03 18:34Z** on the two-producer guard (#3175) — the runs that report success in between are reconciles that skip build/promote/seal entirely. Consequence today: `3.0.0-rc9.ci.7724` is promoted but **unsealed**, and memex-cloud's `Admin/UpdatePolicy` holds with `heldIndeterminate: true` and ~38 bundles reporting *"no sealed content bake for framework identity … would recompile it at boot"*.

## The change

One step in the `pack` job, between the refs extraction and the compiler.

- **A copy, never an in-place delete.** `platform-refs` is restored *and saved* under `platform-refs-<digest>`, a key that says nothing about superseding. Pruning in place would let `actions/cache` store the pruned set under the unpruned key, and the next run declaring no supersede — any other repository sharing that digest — would compile against a reference set missing a real platform assembly and fail `CS0246` naming innocent code. The cached directory stays a faithful image copy.
- **An entry matching no assembly fails the step.** An entry protecting nothing is a caller mistake, and silence is how it survives to keep a real assembly out later.
- **Staleness stays where it can be measured** — the container leg's tool reads type tables a shell step cannot, and it runs in the same wave that makes an entry necessary.
- **Empty input ⇒ no copy**, and `REFS` keeps the exact value it had before this step existed.

Both `REFS` consumers (the build step and the pack step, which the file deliberately keeps identical so the identity anchor and the compiled-against set cannot diverge) now read the same effective directory.

## Verification

The step's script was extracted and run against a synthetic 62-assembly reference set — **18/18 assertions pass**: empty input leaves the path untouched and makes no copy; one and two comma-separated entries drop the `.dll` plus its `.xml`/`.pdb` siblings while every other assembly survives; **the source directory is never mutated**; the count postcondition holds; an entry matching nothing exits 1 naming it; a missing refs directory exits 1; and a rerun clears a stale effective directory.

Harness: `scratchpad/test-prune.sh` (not committed — it drives the step's own `run:` block extracted from the YAML, so it tests the shipped text rather than a copy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
