### PR TITLE
ci: run actionlint over every workflow — a structural defect must not land two repos away

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -1837,6 +1837,79 @@ jobs:
     - name: "Every job is capped at 45 minutes"
       run: python3 .github/scripts/check-workflow-timeouts.py --root .
 
+    # 🚨 THE GAP actionlint CLOSES (MeshWeaver#3228): every check above reads a workflow with
+    # `yaml.safe_load`, and **PyYAML accepts a duplicate mapping key and silently keeps the last
+    # one**. So a STRUCTURAL defect — the kind GitHub itself refuses — parses cleanly here, every
+    # assertion built on the parsed document passes, and the verification that "passed" could not
+    # have failed.
+    #
+    # What that cost, measured on 2026-09-03. #3225 inserted an input between the previous input's
+    # `required:` line and its `default:` line; the orphaned `default` attached to the NEW input,
+    # producing a duplicate `default` key in `node-repo-module-pack.yml`, and the input above
+    # silently lost its default. GitHub refuses the whole workflow. Because these are
+    # `workflow_call` lanes that five satellite repos pin, the break was invisible in core — core
+    # does not call them — and landed TWO REPOS AWAY as MeshWeaver.Plugins#1268 run 33777768374:
+    # `failure`, with ZERO jobs and ZERO check contexts. A `startup_failure` renders as an ordinary
+    # red and names nothing: no job to open, no log to read, no annotation on the commit.
+    # Attributing it took comparing job counts across two heads in two repos (29 jobs, then 0).
+    # actionlint names it in one line, at the source, on the PR that writes it:
+    #
+    #   node-repo-module-pack.yml:289:9: key "default" is duplicated in input of workflow_call
+    #   event. previously defined at line:288,col:9 [syntax-check]
+    #
+    # 🛡️ NO SKIP-TRAPDOOR (AGENTS.md → "A gate NEVER tests its own inputs"). The binary is an
+    # INPUT to this gate, so its acquisition may not be `continue-on-error:` and may not be
+    # conditional: a download failure fails the job RED naming the URL, rather than reducing the
+    # gate to the checks it happened to be able to run. The version is PINNED (never `latest`) and
+    # the tarball is checked against its published sha256 — an unverified binary is not evidence —
+    # and installation is proven by a POSITIVE signal: actionlint must RUN and print exactly the
+    # version pinned here. "The command returned" is not a success signal.
+    #
+    # ⚖️ `-shellcheck= -pyflakes=` disables actionlint's EMBEDDED shell/python linters, so this
+    # arrives about workflow STRUCTURE only. It is not a softening: `run:` blocks are already
+    # shellchecked by check-workflow-shell.py below, at severity `warning`, over a corpus with a
+    # ratchet allow-file — two tools linting the same shell with two different bars would put this
+    # repo in the position that gate exists to avoid. Enabling either integration later is a
+    # DELIBERATE follow-up (its own PR, triaging whatever backlog it surfaces), not a flag to flip
+    # in passing. Measured on this tree at the time of writing: zero findings across all 30
+    # workflows structurally, against 37 findings if shellcheck were left on — which is the
+    # measurement behind the flags, not a guess.
+    - name: "Install actionlint (pinned; a failed or unverified download fails this job RED)"
+      run: |
+        set -euo pipefail
+        ver=1.7.12
+        sha=8aca8db96f1b94770f1b0d72b6dddcb1ebb8123cb3712530b08cc387b349a3d8
+        url="https://github.com/rhysd/actionlint/releases/download/v${ver}/actionlint_${ver}_linux_amd64.tar.gz"
+        curl -fsSL --retry 3 --retry-delay 5 -o "${RUNNER_TEMP}/actionlint.tar.gz" "${url}" \
+          || { echo "::error::could not download actionlint ${ver} from ${url} — this gate has no evidence without it, so it fails rather than skipping"; exit 1; }
+        echo "${sha}  ${RUNNER_TEMP}/actionlint.tar.gz" | sha256sum -c - \
+          || { echo "::error::actionlint ${ver} tarball does not match its pinned sha256 (${sha}) — refusing to run an unverified binary"; exit 1; }
+        tar -xzf "${RUNNER_TEMP}/actionlint.tar.gz" -C "${RUNNER_TEMP}" actionlint \
+          || { echo "::error::actionlint ${ver} tarball did not contain an 'actionlint' binary"; exit 1; }
+        # The POSITIVE success signal: it runs, and it is the version pinned above.
+        installed=$("${RUNNER_TEMP}/actionlint" --version | head -1)
+        if [ "${installed}" != "${ver}" ]; then
+          echo "::error::actionlint reported version '${installed}' but this gate pinned '${ver}'"
+          exit 1
+        fi
+        echo "actionlint ${installed} installed and verified"
+    # The file list is ENUMERATED and asserted non-empty rather than passed as a bare glob. Two
+    # reasons, both the same rule: `actionlint` with no file arguments auto-discovers, and would
+    # exit 0 having checked nothing if discovery ever came up empty; and a `*.yml` glob silently
+    # excludes a future `.yaml` workflow (check-workflow-shell.py already scans both extensions).
+    - name: "Every workflow is structurally valid (actionlint)"
+      run: |
+        set -euo pipefail
+        workflows=()
+        while IFS= read -r f; do workflows+=("$f"); done \
+          < <(find .github/workflows -maxdepth 1 -type f \( -name '*.yml' -o -name '*.yaml' \) | sort)
+        if [ "${#workflows[@]}" -eq 0 ]; then
+          echo "::error::no workflow files found under .github/workflows — this gate would otherwise report green having checked nothing"
+          exit 1
+        fi
+        echo "actionlint ${#workflows[@]} workflow file(s)"
+        "${RUNNER_TEMP}/actionlint" -shellcheck= -pyflakes= -no-color -oneline "${workflows[@]}"
+
     # The merge-queue steward (merge-queue-steward.yml) decides whether a DEQUEUED pull request is
     # re-queued or left out; a wrong row in its table re-queues on nothing or rejects a flake. The
     # steward runs this same self-test before every real decision, but that lane only fires on a
@@ -2528,7 +2601,7 @@ jobs:
       # produced no verdict, and "no verdict" must never read as "passed".
       if: needs.workflow-shell.result != 'success'
       run: |
-        echo "::error::The 'CI's own shell' gate concluded '${{ needs.workflow-shell.result }}' — see that job. It shellchecks every workflow \`run:\` block, refuses a captured command substitution that swallows BOTH stderr and its exit status (the #2642 shape: a failed call becomes an empty answer that is then read as authoritative), refuses an az \`--query\` that throws on a null field, and EXECUTES main-cd's release-version recovery against a fixture. main-cd.yml is exercised by no other check on this PR."
+        echo "::error::The 'CI's own shell' gate concluded '${{ needs.workflow-shell.result }}' — see that job. It shellchecks every workflow \`run:\` block, refuses a captured command substitution that swallows BOTH stderr and its exit status (the #2642 shape: a failed call becomes an empty answer that is then read as authoritative), refuses an az \`--query\` that throws on a null field, runs actionlint over every workflow so a STRUCTURAL defect (#3228: a duplicate key PyYAML silently accepts and GitHub refuses) is named here instead of landing as a job-less \`startup_failure\` on a satellite that pins these lanes, and EXECUTES main-cd's release-version recovery against a fixture. main-cd.yml is exercised by no other check on this PR."
         exit 1
 
     # `!= 'success'` rather than `== 'failure'`, for the same reason as the gate above: a job

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -360,6 +360,42 @@ only one of them was an API change:
 core's tree, at a version it does not control."** Prose, package data, CI infrastructure and image
 timing all belong to it.
 
+### 🚨 A red with ZERO jobs and ZERO contexts is a `startup_failure` — the workflow file is invalid
+
+Every other red on this page names something: a job to open, a log to read, an annotation on the
+commit. **A `startup_failure` names nothing.** GitHub rejected the workflow file before it created a
+single job, so the run's job list is empty, it posts no check contexts, and the commit shows an
+ordinary red tick with nothing behind it. The run's `conclusion` is `failure` like any other; only
+`gh run view <id> --json jobs` distinguishes it, by answering `[]`.
+
+Measured 2026-09-03. MeshWeaver#3225 inserted an input into `node-repo-module-pack.yml` between the
+previous input's `required:` line and its `default:` line. The orphaned `default` attached to the
+**new** input — a duplicate `default` key — and the input above silently lost its default. GitHub
+refuses such a workflow outright. But these are `workflow_call` lanes that five satellite repos pin,
+so the break was invisible in core (core does not call them) and surfaced **two repos away**, as
+MeshWeaver.Plugins#1268 run `33777768374`: `failure`, zero jobs, zero contexts, on a change that
+repo did not make. Attributing it took comparing job counts across two heads in two repos — the
+prior head ran 29 jobs, this one ran 0 — and then linting the lane by hand.
+
+**The diagnostic, in order:**
+
+```bash
+gh run view <run-id> --repo Systemorph/<repo> --json conclusion,jobs --jq '{conclusion, jobs: (.jobs|length)}'
+# {"conclusion":"failure","jobs":0}   ⇒ startup_failure: the WORKFLOW FILE is invalid, not the code
+# then, in that repo's tree — actionlint takes FILES, not a directory:
+actionlint -shellcheck= -pyflakes= -oneline .github/workflows/*.yml   # names the defect at its line
+```
+
+🚨 **And the reason nothing caught it upstream: `yaml.safe_load` accepts a duplicate mapping key and
+silently keeps the last one.** #3225 validated the edited lane by parsing it with PyYAML and
+asserting the required inputs were unchanged; the parse succeeded, the spec read back correctly, and
+the assertion passed. **Any workflow validation built on a permissive YAML load is blind to this
+class by construction** — the same shape as every other gate on this page that passes on evidence it
+could not produce. Core's `CI's own shell` job now runs `actionlint` over every workflow for exactly
+this reason (MeshWeaver#3228), with the embedded shellcheck/pyflakes integrations disabled so the
+gate is about structure only; `check-workflow-timeouts.py` and `check-workflow-shell.py` both stay
+green on the defect, which is the measurement that says the new check is not redundant.
+
 ### A verdict about an unpinned checkout is a function of wall-clock time
 
 The cross-repo gates check core out with **no `ref:`**. Two people therefore measured the same


### PR DESCRIPTION
Closes #3228.

## The gap

Nothing ran `actionlint`, and **every existing workflow check reads a workflow with `yaml.safe_load` — PyYAML accepts a duplicate mapping key and silently keeps the last one.** So a *structural* defect, the kind GitHub itself refuses, parsed cleanly here, the input's spec read back correctly, and every assertion built on the parsed document passed. The verification that "passed" could not have failed.

#3225 inserted an input between the previous input's `required:` line and its `default:` line. The orphaned `default` attached to the **new** input — a duplicate `default` key in `node-repo-module-pack.yml` — and the input above silently lost its default. Because these are `workflow_call` lanes five satellite repos pin, the break was invisible in core (core does not call them) and landed **two repos away** as MeshWeaver.Plugins#1268 run `33777768374`: `failure`, **zero jobs, zero check contexts**. A `startup_failure` renders as an ordinary red and names nothing — no job to open, no log to read, no annotation on the commit.

## What this adds

`actionlint` in the **existing** `CI's own shell` job (`workflow-shell`), which is already a `needs:` of `Consolidate test results` with an explicit fail step — so the verdict propagates to the required check with no new wiring.

- **Pinned at `v1.7.12`**, never `latest`, and the tarball is verified against its published sha256. An unverified binary is not evidence.
- **Installation is proven by a positive signal**: actionlint must *run* and print exactly the pinned version. "The command returned" is not a success signal.
- **No skip-trapdoor** (AGENTS.md → *"A gate NEVER tests its own inputs"*): no `continue-on-error:` on the acquisition step, no input-shaped `if:`. A failed download or a checksum mismatch fails the job **RED**, naming the URL and the expected digest.
- **The file list is enumerated with `find` and asserted non-empty** — `actionlint` with no file arguments auto-discovers and would exit 0 having checked nothing if discovery ever came up empty; the assertion also covers a future `.yaml` workflow, which a bare `*.yml` glob would silently skip.
- **`-shellcheck= -pyflakes=`** disables actionlint's embedded linters, so this arrives about workflow **structure** only. Not a softening: `run:` blocks are already shellchecked by `check-workflow-shell.py` at severity `warning` over a ratcheted allow-file, and two tools linting the same shell at two different bars would put this repo in the position that gate exists to avoid. Enabling either integration is a deliberate follow-up with its own PR and its own triage.

No new job, so no new `timeout-minutes` — the host job's cap of 10 min is unchanged, and `check-workflow-timeouts.py --root .` is green (66 jobs checked, 0 violations).

## Findings on the clean repo

**Zero structural findings across all 30 workflows.** So this arrives green rather than with a backlog. For contrast, with the embedded shellcheck integration left enabled the same tree reports **37 findings**, all `[shellcheck]` — that measurement, not a guess, is what is behind the flags.

## Proof the gate can fail

`.github/workflows/node-repo-module-pack.yml` was temporarily given **#3225's exact shape** — an orphaned `default:` line left on the following input — and the *shipped* steps were executed against it locally. The deliberate break is **not** in this diff.

```
===== STEP 1: Install actionlint (pinned) =====
actionlint.tar.gz: OK
actionlint 1.7.12 installed and verified
===== STEP 2: Every workflow is structurally valid (actionlint) =====
actionlint 30 workflow file(s)
.github/workflows/node-repo-module-pack.yml:305:9: key "default" is duplicated in input of workflow_call event. previously defined at line:294,col:9 [syntax-check]
SHIPPED-STEPS EXIT=1
```

On that same injected defect the checks that already exist both report green — which is the measurement that says this one is not redundant:

```
actionlint                  EXIT=1
check-workflow-timeouts.py  EXIT=0   (blind to this defect)
check-workflow-shell.py     EXIT=0   (blind to this defect)
```

And PyYAML, the parser every existing check is built on, does not merely tolerate it — it reports the *wrong answer* with no error:

```
PyYAML safe_load: parsed with NO error
platform-image spec = {'default': '', 'description': …, 'type': 'string', 'required': False}
```

Both **no-evidence** paths were executed too, and each fails red naming what is missing:

```
curl: (56) The requested URL returned error: 404
::error::could not download actionlint 1.7.12 from … — this gate has no evidence without it, so it fails rather than skipping
BAD-URL EXIT=1

actionlint.tar.gz: FAILED  /  shasum: WARNING: 1 computed checksum did NOT match
::error::actionlint 1.7.12 tarball does not match its pinned sha256 (…) — refusing to run an unverified binary
BAD-SHA EXIT=1
```

## Work product conserved

The durable finding is documented in [Reading CI Signals](https://github.com/Systemorph/MeshWeaver/blob/fix/3228-actionlint-runs/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md) as a new section — *"A red with ZERO jobs and ZERO contexts is a `startup_failure` — the workflow file is invalid"* — with the diagnostic (`gh run view --json conclusion,jobs` answering `jobs: 0`) and the `yaml.safe_load` blind spot. Nothing in the doc tree or the skills named `startup_failure` before this; it is the one red that names nothing, and it took comparing job counts across two heads in two repos to attribute.

## Not included

- **What's New entry:** deliberately skipped — developer-facing CI only, no user-visible change.
- **Rolling actionlint into `node-repo-validate.yml`** so satellites lint their own workflows: a real follow-up, but it would arrive red on whatever backlog each satellite carries and cannot be verified from here. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhT5AXByEKo2fRQtWH2wCW
