### PR TITLE
fix(#3249): a code cell that cannot prove it is current no longer claims to be

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
@@ -118,6 +118,27 @@ Each call to `ExecuteScriptRequest` creates a **new** Activity node in the **use
 
 Historical runs accumulate as siblings under `{partitionRoot}/_Activity/*`, and the Code node's `LastExecutedAt` field is stamped on each run. A **Run** button rendered on Code views (visible when the caller has `Permission.Execute`) wires this exact request.
 
+#### What a cell may claim about its own output — the currency rule
+
+The stamp writes four fields together — `LastExecutedAt`, `LastExecutedBy`, `LastActivityPath` and `LastExecutedCodeHash` — and the last of them is the *proof* the other three lack: the `CodeFingerprint` of what that run actually submitted. A view re-computes the fingerprint from the node's current `Code`/`Language` and compares, which is how a cell knows the output pane below it belongs to source the reader has since edited.
+
+🚨 **The stamp is a write, and a write can fail.** It is dispatched fire-and-forget after the run has already been acknowledged (the Run click must never be silent), so a failure reaches a log and nothing else. That leaves a node that ran while recording only part of what it ran — and a boolean "is it stale?" has nowhere honest to put that. Answering *not stale* asserts a currency nothing substantiates: **a wrong claim, not a missing one.**
+
+So the verdict is not a boolean. `CodeConfiguration.OutputCurrency()` (`MeshWeaver.Mesh.Contract`) is the one rule every surface must use, and it fails **closed**:
+
+| State | When | What the cell may show |
+|---|---|---|
+| `NeverRun` | no run recorded at all — no timestamp, no activity path, no runner | nothing; a cell nobody has run has no output to be wrong about |
+| `Current` | a run is recorded **and** its fingerprint reproduces from the code on screen | "up to date" — the only state that may say so |
+| `Stale` | a run is recorded, its fingerprint was recorded, and the code has moved since | "code changed — re-run" |
+| `Unverified` | a run is recorded but **its fingerprint is not** | "output unverified — re-run to be sure" |
+
+`Unverified` is the fail-closed state, and it is deliberately neither of the two it sits between. It is not `Current`, because nothing proves the output belongs to the code above it. It is not `Stale` either: every node last executed by a build that predates the fingerprint field would light up amber at once, which trains readers to ignore the indicator — the failure mode the fingerprint's own normalization rules exist to avoid.
+
+"A run is recorded" is deliberately generous — *any* of the three run fields present, not `LastExecutedAt` specifically — so a stamp that landed only in part cannot fall back into `NeverRun` and go silent on a cell that ran.
+
+**The residual, stated rather than hidden:** a cell whose *very first* run failed to stamp anything at all records nothing, and is therefore indistinguishable from a cell nobody has run. No rule over the node's content can recover that; making it observable needs the run's failure to be written somewhere — see [issue #3249](https://github.com/Systemorph/MeshWeaver/issues/3249).
+
 ### 2. From application code — `SubmitCodeRequest` directly
 
 For one-off submissions — interactive markdown cells, REPL-style flows — where you already own an Activity hub address:

--- a/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
@@ -128,14 +128,16 @@ So the verdict is not a boolean. `CodeConfiguration.OutputCurrency()` (`MeshWeav
 
 | State | When | What the cell may show |
 |---|---|---|
-| `NeverRun` | no run recorded at all — no timestamp, no activity path, no runner | nothing; a cell nobody has run has no output to be wrong about |
+| `NeverRun` | no run recorded at all — no fingerprint, no timestamp, no activity path, no runner | nothing; a cell nobody has run has no output to be wrong about |
 | `Current` | a run is recorded **and** its fingerprint reproduces from the code on screen | "up to date" — the only state that may say so |
 | `Stale` | a run is recorded, its fingerprint was recorded, and the code has moved since | "code changed — re-run" |
 | `Unverified` | a run is recorded but **its fingerprint is not** | "output unverified — re-run to be sure" |
 
 `Unverified` is the fail-closed state, and it is deliberately neither of the two it sits between. It is not `Current`, because nothing proves the output belongs to the code above it. It is not `Stale` either: every node last executed by a build that predates the fingerprint field would light up amber at once, which trains readers to ignore the indicator — the failure mode the fingerprint's own normalization rules exist to avoid.
 
-"A run is recorded" is deliberately generous — *any* of the three run fields present, not `LastExecutedAt` specifically — so a stamp that landed only in part cannot fall back into `NeverRun` and go silent on a cell that ran.
+"A run is recorded" is deliberately generous — *any* of the four stamped fields present, not `LastExecutedAt` specifically — so a stamp that landed only in part cannot fall back into `NeverRun` and go silent on a cell that ran.
+
+The **fingerprint is tested first**, before the other three. It is both evidence of a run and the only field that can decide currency, so a node carrying the hash and nothing else is fully determinable; checking the run markers first would answer `NeverRun` there and silence a verdict we can actually substantiate — the same fail-open shape, mirrored.
 
 **The residual, stated rather than hidden:** a cell whose *very first* run failed to stamp anything at all records nothing, and is therefore indistinguishable from a cell nobody has run. No rule over the node's content can recover that; making it observable needs the run's failure to be written somewhere — see [issue #3249](https://github.com/Systemorph/MeshWeaver/issues/3249).
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-cell-that-cannot-prove-it-is-current-says-so.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-cell-that-cannot-prove-it-is-current-says-so.md
@@ -1,0 +1,30 @@
+---
+Name: A code cell that cannot prove it is current now says so
+Category: Fix
+Description: When a run was recorded but what it ran was not, a code cell no longer shows its output as up to date — it says the output is unverified, instead of quietly vouching for a result it cannot account for.
+Icon: Sparkle
+Order: -20260904
+---
+
+# A code cell that cannot prove it is current now says so
+
+Every time you press **Run** on a code cell, the platform records the run on the cell — when it
+happened, who started it, and a fingerprint of the exact code that was submitted. That fingerprint
+is what lets the cell tell you *"code changed — re-run"*: it compares the fingerprint of the run
+against the code you are looking at now.
+
+Recording that is a write like any other, and a write can fail. When it did, the cell was left
+saying it had run while saying nothing about **what** it had run — and the indicator read that as
+"nothing to worry about". The output pane showed a result, the toolbar showed a plain Run button,
+and there was no way for you to tell that the two might not belong together. A missing warning is
+inconvenient; a cell vouching for output it cannot account for is worse, because you believe it.
+
+A cell now has three honest things to say instead of two. If it never ran, it stays quiet — there
+is no output to be wrong about. If it ran and recorded what it ran, it tells you whether the code
+has moved since, exactly as before. And if it ran but the record is incomplete, it now says the
+output is **unverified** and invites you to re-run, rather than presenting it as current.
+
+Older cells — those last executed before the fingerprint existed — fall into that third case too.
+They are marked unverified rather than stale on purpose: telling you a cell is definitely out of
+date when nobody knows would make the warning worth ignoring, and the warning is only useful while
+you still believe it.

--- a/src/MeshWeaver.Mesh.Contract/CodeConfiguration.cs
+++ b/src/MeshWeaver.Mesh.Contract/CodeConfiguration.cs
@@ -47,9 +47,14 @@ public record CodeConfiguration
     /// content and compares: a mismatch means the output pane below is showing the result of code the
     /// reader is no longer looking at, and the cell renders a "code changed — re-run" state.
     ///
-    /// <para><c>null</c> until the first run — and also on nodes last executed by a build that predates
-    /// this field, which is why an absent hash reads as "unknown", never as "stale". Claiming staleness
-    /// we cannot prove would light up every legacy node at once.</para>
+    /// <para><c>null</c> until the first run — and also whenever the last-execution stamp landed only
+    /// in part (a node last executed by a build that predates this field, or a merge patch written
+    /// through a narrower shape). 🚨 An absent hash therefore reads as "unknown", which is neither
+    /// "stale" nor "up to date": claiming staleness we cannot prove would light up every legacy node
+    /// at once, and claiming currency we cannot prove is the WRONG claim the whole fingerprint exists
+    /// to avoid. Do not read this field directly to decide what a cell shows —
+    /// <see cref="CodeOutputCurrencyExtensions.OutputCurrency"/> is the one rule, and it fails
+    /// closed on exactly this case (<see cref="CodeOutputCurrency.Unverified"/>).</para>
     /// </summary>
     public string? LastExecutedCodeHash { get; init; }
 

--- a/src/MeshWeaver.Mesh.Contract/CodeFingerprint.cs
+++ b/src/MeshWeaver.Mesh.Contract/CodeFingerprint.cs
@@ -9,6 +9,11 @@ namespace MeshWeaver.Mesh;
 /// Stamped onto <see cref="CodeConfiguration.LastExecutedCodeHash"/> at submit time and re-computed
 /// from the node's current content at render time; a mismatch means the visible output belongs to
 /// code the reader is no longer looking at.
+///
+/// <para>🚨 The comparison is one INPUT to that question, not the answer: a cell can also carry no
+/// fingerprint at all, which is neither a match nor a mismatch. Ask
+/// <see cref="CodeOutputCurrencyExtensions.OutputCurrency"/> instead of comparing here — it is the
+/// one rule, and it fails closed on the unprovable case.</para>
 /// </summary>
 /// <remarks>
 /// 🚨 Cryptographic, deliberately — NOT <c>string.GetHashCode()</c>. String hash codes are randomized

--- a/src/MeshWeaver.Mesh.Contract/CodeOutputCurrency.cs
+++ b/src/MeshWeaver.Mesh.Contract/CodeOutputCurrency.cs
@@ -65,14 +65,20 @@ public static class CodeOutputCurrencyExtensions
     /// it. Anything less is <see cref="CodeOutputCurrency.Unverified"/>, never
     /// <see cref="CodeOutputCurrency.Current"/>.</para>
     ///
-    /// <para><b>Why "a run is recorded" is deliberately generous.</b> The last-execution stamp
-    /// writes <see cref="CodeConfiguration.LastExecutedAt"/>,
-    /// <see cref="CodeConfiguration.LastExecutedBy"/>,
+    /// <para><b>Why every field is treated as evidence of a run.</b> The last-execution stamp writes
+    /// <see cref="CodeConfiguration.LastExecutedAt"/>, <see cref="CodeConfiguration.LastExecutedBy"/>,
     /// <see cref="CodeConfiguration.LastActivityPath"/> and
-    /// <see cref="CodeConfiguration.LastExecutedCodeHash"/> together, and any of them arriving
-    /// without the hash means a run happened whose source we did not record. Requiring
-    /// <c>LastExecutedAt</c> specifically would let a partial stamp that dropped only the timestamp
-    /// fall back into <see cref="CodeOutputCurrency.NeverRun"/> — silence, on a cell that ran.</para>
+    /// <see cref="CodeConfiguration.LastExecutedCodeHash"/> together, so ANY of them present means a
+    /// run happened. Requiring <c>LastExecutedAt</c> specifically would let a partial stamp that
+    /// dropped only the timestamp fall back into <see cref="CodeOutputCurrency.NeverRun"/> —
+    /// silence, on a cell that ran.</para>
+    ///
+    /// <para><b>And why the fingerprint is tested FIRST.</b> It is both evidence of a run and the
+    /// only field that can decide currency, so a node carrying the hash and nothing else is fully
+    /// determinable. Checking the other three first would answer
+    /// <see cref="CodeOutputCurrency.NeverRun"/> there and silence a verdict we can actually
+    /// substantiate — the same fail-open shape as the defect this rule exists to remove, mirrored.
+    /// (Found by review on the PR that introduced this rule.)</para>
     ///
     /// <para><b>And why an absent run is silent.</b> <see cref="CodeOutputCurrency.NeverRun"/> is
     /// not a weaker <see cref="CodeOutputCurrency.Unverified"/>: a cell nobody has run has no
@@ -86,20 +92,25 @@ public static class CodeOutputCurrencyExtensions
         if (code is null)
             return CodeOutputCurrency.NeverRun;
 
+        // The fingerprint is BOTH evidence that a run happened and the only field that can decide
+        // currency, so whenever it is present the verdict is the comparison — whatever else the
+        // stamp failed to land. Testing the run markers first would answer NeverRun for a node
+        // carrying only the hash and silence an indicator that is fully determinable: the same
+        // fail-open shape, mirrored.
+        if (!string.IsNullOrEmpty(code.LastExecutedCodeHash))
+            return CodeFingerprint.Of(code.Code, code.Language) == code.LastExecutedCodeHash
+                ? CodeOutputCurrency.Current
+                : CodeOutputCurrency.Stale;
+
+        // No fingerprint: nothing here can prove what ran. If anything else says a run happened,
+        // fail CLOSED rather than claim currency; otherwise the cell genuinely has nothing to show.
         var ranAtLeastOnce = code.LastExecutedAt is not null
                              || !string.IsNullOrEmpty(code.LastActivityPath)
                              || !string.IsNullOrEmpty(code.LastExecutedBy);
 
-        if (!ranAtLeastOnce)
-            return CodeOutputCurrency.NeverRun;
-
-        // A run without its fingerprint proves nothing about what it ran. Fail CLOSED.
-        if (string.IsNullOrEmpty(code.LastExecutedCodeHash))
-            return CodeOutputCurrency.Unverified;
-
-        return CodeFingerprint.Of(code.Code, code.Language) == code.LastExecutedCodeHash
-            ? CodeOutputCurrency.Current
-            : CodeOutputCurrency.Stale;
+        return ranAtLeastOnce
+            ? CodeOutputCurrency.Unverified
+            : CodeOutputCurrency.NeverRun;
     }
 
     /// <summary>

--- a/src/MeshWeaver.Mesh.Contract/CodeOutputCurrency.cs
+++ b/src/MeshWeaver.Mesh.Contract/CodeOutputCurrency.cs
@@ -1,0 +1,116 @@
+namespace MeshWeaver.Mesh;
+
+/// <summary>
+/// What an executable cell can HONESTLY say about the relationship between the output it is
+/// showing and the code the reader is looking at.
+///
+/// <para>Four states, not two, because the honest answer to "is this output out of date?" is
+/// sometimes <em>I cannot tell</em> — and collapsing that onto "no" is a claim, not an absence of
+/// one. See <see cref="CodeOutputCurrencyExtensions.OutputCurrency"/>.</para>
+/// </summary>
+public enum CodeOutputCurrency
+{
+    /// <summary>
+    /// The cell records no run at all. There is no output claim to be current or stale about, so
+    /// the cell says nothing — a cell nobody has pressed Run on must not carry a warning.
+    /// </summary>
+    NeverRun,
+
+    /// <summary>
+    /// The cell PROVES its output belongs to the code on screen: it recorded a run, recorded the
+    /// fingerprint of what that run submitted, and that fingerprint matches the current source.
+    /// This is the only state that may be rendered as "up to date".
+    /// </summary>
+    Current,
+
+    /// <summary>
+    /// The cell proves the opposite: it recorded the fingerprint of its run, and the code has moved
+    /// since. The visible output belongs to source the reader is no longer looking at — re-run.
+    /// </summary>
+    Stale,
+
+    /// <summary>
+    /// A run is recorded but its fingerprint is NOT — so the cell can neither prove nor disprove
+    /// that the visible output belongs to the code on screen.
+    ///
+    /// <para>🚨 This is the fail-CLOSED state and the reason the verdict is not a <c>bool</c>. It
+    /// arises whenever the last-execution stamp landed only in part: a node last executed by a build
+    /// that predates <see cref="CodeConfiguration.LastExecutedCodeHash"/>, a merge patch written
+    /// through a narrower shape, or any write that recorded the run without recording what it ran.
+    /// Answering "not stale" here would assert a currency nothing substantiates — a WRONG claim
+    /// rather than a missing one. Answering <see cref="Stale"/> would be equally dishonest (and
+    /// would light every legacy node amber at once), so it gets its own state: say that the output
+    /// is unverified, and let the reader decide whether to re-run.</para>
+    /// </summary>
+    Unverified,
+}
+
+/// <summary>
+/// The single, fail-closed rule for "may this cell be shown as up to date?".
+///
+/// <para>The rule lives beside the field it interprets — <see cref="CodeConfiguration"/> and
+/// <see cref="CodeFingerprint"/> are both here — rather than in whichever view happens to render a
+/// cell, so every surface (the notebook toolbar, an agent reading a node, a future client) answers
+/// the question the same way and inherits the fail-closed behaviour rather than re-deriving it.</para>
+/// </summary>
+public static class CodeOutputCurrencyExtensions
+{
+    /// <summary>
+    /// What <paramref name="code"/> can honestly say about its own output.
+    ///
+    /// <para><b>The rule.</b> A cell may be shown as up to date only when it can PROVE it:
+    /// it records a run, it records the <see cref="CodeFingerprint"/> of what that run submitted,
+    /// and re-computing the fingerprint from the node's current
+    /// <see cref="CodeConfiguration.Code"/> / <see cref="CodeConfiguration.Language"/> reproduces
+    /// it. Anything less is <see cref="CodeOutputCurrency.Unverified"/>, never
+    /// <see cref="CodeOutputCurrency.Current"/>.</para>
+    ///
+    /// <para><b>Why "a run is recorded" is deliberately generous.</b> The last-execution stamp
+    /// writes <see cref="CodeConfiguration.LastExecutedAt"/>,
+    /// <see cref="CodeConfiguration.LastExecutedBy"/>,
+    /// <see cref="CodeConfiguration.LastActivityPath"/> and
+    /// <see cref="CodeConfiguration.LastExecutedCodeHash"/> together, and any of them arriving
+    /// without the hash means a run happened whose source we did not record. Requiring
+    /// <c>LastExecutedAt</c> specifically would let a partial stamp that dropped only the timestamp
+    /// fall back into <see cref="CodeOutputCurrency.NeverRun"/> — silence, on a cell that ran.</para>
+    ///
+    /// <para><b>And why an absent run is silent.</b> <see cref="CodeOutputCurrency.NeverRun"/> is
+    /// not a weaker <see cref="CodeOutputCurrency.Unverified"/>: a cell nobody has run has no
+    /// output to be wrong about, and warning there would cry wolf on every unrun cell in the
+    /// mesh.</para>
+    /// </summary>
+    /// <param name="code">The cell's configuration; <c>null</c> reads as
+    /// <see cref="CodeOutputCurrency.NeverRun"/> (there is no cell to judge).</param>
+    public static CodeOutputCurrency OutputCurrency(this CodeConfiguration? code)
+    {
+        if (code is null)
+            return CodeOutputCurrency.NeverRun;
+
+        var ranAtLeastOnce = code.LastExecutedAt is not null
+                             || !string.IsNullOrEmpty(code.LastActivityPath)
+                             || !string.IsNullOrEmpty(code.LastExecutedBy);
+
+        if (!ranAtLeastOnce)
+            return CodeOutputCurrency.NeverRun;
+
+        // A run without its fingerprint proves nothing about what it ran. Fail CLOSED.
+        if (string.IsNullOrEmpty(code.LastExecutedCodeHash))
+            return CodeOutputCurrency.Unverified;
+
+        return CodeFingerprint.Of(code.Code, code.Language) == code.LastExecutedCodeHash
+            ? CodeOutputCurrency.Current
+            : CodeOutputCurrency.Stale;
+    }
+
+    /// <summary>
+    /// Whether the cell may be rendered as "up to date" — true for
+    /// <see cref="CodeOutputCurrency.Current"/> alone.
+    ///
+    /// <para>The predicate a view wants when it has one boolean to spend, written so that the
+    /// unprovable cases fall on the safe side by construction: a caller cannot get the fail-closed
+    /// behaviour wrong by forgetting to list a state.</para>
+    /// </summary>
+    /// <param name="code">The cell's configuration.</param>
+    public static bool ProvesOutputIsCurrent(this CodeConfiguration? code) =>
+        code.OutputCurrency() is CodeOutputCurrency.Current;
+}

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -15,6 +15,8 @@
   "common.run": "Ausführen",
   "common.stop": "Stoppen",
   "code.staleCell": "Code geändert — erneut ausführen",
+  "code.unverifiedCell": "Ausgabe nicht bestätigt",
+  "code.unverifiedCellHint": "Dieser Lauf wurde nicht vollständig erfasst — ob die Ausgabe zum Code oben gehört, lässt sich nicht feststellen. Zur Sicherheit erneut ausführen",
   "code.runCell": "Diesen Codeblock ausführen",
   "code.rerunCell": "Der Code hat sich seit dieser Ausgabe geändert — erneut ausführen",
   "code.kernelUnavailable": "Der interaktive Kernel ist hier nicht verfügbar",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -15,6 +15,8 @@
   "common.run": "Run",
   "common.stop": "Stop",
   "code.staleCell": "Code changed — re-run",
+  "code.unverifiedCell": "Output unverified",
+  "code.unverifiedCellHint": "This run was not fully recorded, so whether the output belongs to the code above cannot be established — re-run to be sure",
   "code.runCell": "Run this code block",
   "code.rerunCell": "The code changed since this output was produced — run it again",
   "code.kernelUnavailable": "Interactive kernel is not available here",

--- a/test/MeshWeaver.Graph.Test/CodeCellCurrencyThroughTheMeshTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeCellCurrencyThroughTheMeshTest.cs
@@ -1,0 +1,152 @@
+using System;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// #3249, through a real mesh: the state a swallowed last-execution stamp leaves in STORAGE must
+/// not read back as "up to date".
+///
+/// <para><see cref="CodeOutputCurrencyTest"/> pins the rule as a pure function. This class pins the
+/// two things a pure function cannot: that the state actually survives the write/serialize/read
+/// round trip as the rule expects (a hash absent on the wire is an ABSENT member, not an empty
+/// string, and the run markers around it must still arrive), and that a genuine run through
+/// <c>CodeNodeType</c>'s own dispatch does reach <see cref="CodeOutputCurrency.Current"/> — a
+/// fail-closed rule that never says "current" would be no better than the fail-open one it
+/// replaced.</para>
+///
+/// <para>Every read is <c>GetMeshNodeStream(path)</c> — the authoritative, live single-node read —
+/// never a query, and every wait is on the condition itself.</para>
+/// </summary>
+public class CodeCellCurrencyThroughTheMeshTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private const string Source = "1 + 1";
+
+    private static TimeSpan Bound => TestTimeouts.Convergence;
+
+    /// <summary>
+    /// The defect's own shape: the node records a run — timestamp, runner, activity pointer — and
+    /// records nothing about WHAT it ran, because the write that would have carried the fingerprint
+    /// did not land. Read back off the node stream, that cell must not claim to be current.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ARunTheNodeDidNotRecord_IsNotReadBackAsUpToDate()
+    {
+        var path = await CreateCell(new CodeConfiguration
+        {
+            Code = Source,
+            IsExecutable = true,
+            // It ran …
+            LastExecutedAt = DateTimeOffset.UtcNow,
+            LastExecutedBy = "rbuergi",
+            LastActivityPath = $"{TestPartition}/_Activity/{Guid.NewGuid():N}",
+            // … and the stamp's proof of WHAT it ran never arrived.
+            LastExecutedCodeHash = null,
+        });
+
+        var cell = await ReadCell(path, c => c is { Code: Source });
+
+        cell.LastExecutedCodeHash.Should().BeNull(
+            "the round trip must preserve the state under test — if storage had invented a hash "
+            + "there would be nothing here to fail closed about");
+        cell.ProvesOutputIsCurrent().Should().BeFalse(
+            "the cell records that it ran but not what it ran, so it cannot substantiate 'up to "
+            + "date' — and asserting it anyway is a wrong claim, not a missing one (#3249)");
+        cell.OutputCurrency().Should().Be(CodeOutputCurrency.Unverified,
+            "the honest verdict is 'unverified': neither Current (nothing proves it) nor Stale "
+            + "(which would light up every node stamped before the fingerprint existed)");
+    }
+
+    /// <summary>
+    /// The control arm, end to end: a run dispatched through <c>ExecuteScriptRequest</c> stamps the
+    /// fingerprint, so the cell reads as <see cref="CodeOutputCurrency.Current"/> — and moving the
+    /// code underneath that recorded run flips it to <see cref="CodeOutputCurrency.Stale"/>. Without
+    /// this, "fails closed" could be satisfied by a rule that simply never says anything is current.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ARunTheNodeDidRecord_ReadsAsCurrent_AndGoesStaleWhenTheCodeMoves()
+    {
+        var path = await CreateCell(new CodeConfiguration { Code = Source, IsExecutable = true });
+
+        var dispatch = await RequestHub
+            .Observe<ExecuteScriptResponse>(new ExecuteScriptRequest(), o => o.WithTarget(new Address(path)))
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await();
+        dispatch.Message.Success.Should().BeTrue(
+            "the dispatch must be accepted before its stamp can be asserted on");
+
+        var ran = await ReadCell(path, c => c is { LastExecutedCodeHash: not null and not "" });
+        ran.OutputCurrency().Should().Be(CodeOutputCurrency.Current,
+            "the stamp recorded the fingerprint of what the run submitted and the code has not "
+            + "moved since — the one state a cell may render as up to date");
+
+        // Move the code under the recorded run — the ordinary way a cell goes stale.
+        var options = Mesh.JsonSerializerOptions;
+        var workspace = Mesh.GetWorkspace();
+        await workspace.GetMeshNodeStream(path)
+            .Update(current => current with
+            {
+                Content = (current.ContentAs<CodeConfiguration>(options) ?? new CodeConfiguration())
+                    with { Code = "2 + 2" },
+            })
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await();
+
+        var edited = await ReadCell(path,
+            c => c is { Code: "2 + 2", LastExecutedCodeHash: not null and not "" });
+        edited.OutputCurrency().Should().Be(CodeOutputCurrency.Stale,
+            "the visible output belongs to source the reader is no longer looking at");
+    }
+
+    // ── helpers ──
+
+    private async Task<string> CreateCell(CodeConfiguration content)
+    {
+        var id = $"cell{Guid.NewGuid():N}"[..12];
+        var path = $"{TestPartition}/{id}";
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        await access
+            .RunAsSystem(() => mesh.CreateNode(MeshNode.FromPath(path) with
+            {
+                NodeType = CodeNodeType.NodeType,
+                Name = id,
+                State = MeshNodeState.Active,
+                Content = content,
+            }))
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await();
+        return path;
+    }
+
+    /// <summary>
+    /// Reads the cell's content off the authoritative single-node stream, waiting on the CONDITION
+    /// rather than on the clock. 🚨 <c>ContentAs</c>, never <c>is CodeConfiguration</c>: content
+    /// that crossed a hub boundary can arrive as untyped JSON, and the cast would yield a silent
+    /// null that reads exactly like "the node has no code".
+    /// </summary>
+    private async Task<CodeConfiguration> ReadCell(string path, Func<CodeConfiguration?, bool> until)
+    {
+        var options = Mesh.JsonSerializerOptions;
+        return (await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(node => node is not null)
+            .Select(node => node.ContentAs<CodeConfiguration>(options))
+            .Where(until)
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await())!;
+    }
+}

--- a/test/MeshWeaver.Graph.Test/CodeOutputCurrencyTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeOutputCurrencyTest.cs
@@ -153,6 +153,32 @@ public class CodeOutputCurrencyTest
     }
 
     /// <summary>
+    /// 🚨 The MIRROR hole, found by review on this PR's first push: a node carrying the fingerprint
+    /// and none of the three run markers. The verdict there is fully determinable — the hash is
+    /// right in front of us — so answering <see cref="CodeOutputCurrency.NeverRun"/> would silence
+    /// an indicator we can actually substantiate. That is the same fail-open shape as the defect
+    /// this rule exists to remove, and it is why the fingerprint is tested FIRST.
+    /// </summary>
+    [Theory]
+    [InlineData(Source, CodeOutputCurrency.Current)]
+    [InlineData(Source + "\n// edited", CodeOutputCurrency.Stale)]
+    public void AFingerprintWithNoRunMarkers_IsStillDecided_NotSilenced(
+        string currentCode, CodeOutputCurrency expected)
+    {
+        var cell = new CodeConfiguration
+        {
+            Code = currentCode,
+            // No LastExecutedAt, no LastActivityPath, no LastExecutedBy — only the proof itself.
+            LastExecutedCodeHash = FingerprintOf(Source),
+        };
+
+        cell.OutputCurrency().Should().Be(expected,
+            "the fingerprint is both evidence that a run happened and the only field that can "
+            + "decide currency, so a node carrying it alone is decidable — reading it as NeverRun "
+            + "would silence a verdict we can substantiate");
+    }
+
+    /// <summary>
     /// The other half of fail-closed: the rule must not be closed so hard that it never says
     /// <see cref="CodeOutputCurrency.Current"/>. An indicator that always warns is an indicator
     /// nobody reads, which is the same failure as one that never warns.

--- a/test/MeshWeaver.Graph.Test/CodeOutputCurrencyTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeOutputCurrencyTest.cs
@@ -1,0 +1,175 @@
+using System;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// #3249 — the stale-cell indicator must fail CLOSED.
+///
+/// <para><b>The defect.</b> After dispatching a run, <c>CodeNodeType</c> stamps
+/// <c>Last{ExecutedAt,ExecutedBy,ActivityPath,ExecutedCodeHash}</c> onto the Code node
+/// fire-and-forget; both of its failure paths only log, and the dispatch acknowledgement has
+/// already been posted by then. So a node can record that it RAN while recording nothing about
+/// WHAT it ran. The indicator's rule was a boolean — <c>LastExecutedAt is not null &amp;&amp;
+/// hash is not null/"" &amp;&amp; fingerprint(current) != hash</c> — which answers <c>false</c>
+/// ("not stale", i.e. up to date) for exactly that state. That is a WRONG claim, not a missing
+/// one: the cell asserts a currency nothing substantiates.</para>
+///
+/// <para><b>The rule these cases pin.</b>
+/// <see cref="CodeOutputCurrencyExtensions.OutputCurrency"/> answers four states, not two, and only
+/// <see cref="CodeOutputCurrency.Current"/> may be rendered as up to date. A run without its
+/// fingerprint is <see cref="CodeOutputCurrency.Unverified"/> — deliberately neither
+/// <c>Current</c> (nothing proves it) nor <see cref="CodeOutputCurrency.Stale"/> (every node last
+/// executed by a build predating the fingerprint field would light up amber at once, which trains
+/// readers to ignore the indicator).</para>
+///
+/// <para>🚨 Pure and hub-free on purpose — the rule is a pure function of node content, and
+/// deriving this class from a mesh test base would boot a mesh per case for nothing. The
+/// round trip through a REAL mesh (the shape a swallowed stamp actually leaves in storage) is
+/// <see cref="CodeCellCurrencyThroughTheMeshTest"/>.</para>
+/// </summary>
+public class CodeOutputCurrencyTest
+{
+    private const string Source = "var x = 1;\nx + 41";
+
+    private static string FingerprintOf(string? code, string? language = null) =>
+        CodeFingerprint.Of(code, language);
+
+    /// <summary>
+    /// The verdict the PRE-FIX predicate gave — kept verbatim so these cases cannot go vacuous.
+    /// A test asserting only the new answer would pass just as happily if the state it names had
+    /// never been mishandled; this is the control arm that says it was.
+    /// </summary>
+    private static bool PreFixIsOutputStale(CodeConfiguration? code) =>
+        code is { LastExecutedAt: not null, LastExecutedCodeHash: not null and not "" }
+        && CodeFingerprint.Of(code.Code, code.Language) != code.LastExecutedCodeHash;
+
+    [Fact]
+    public void ACellNobodyHasRun_SaysNothing()
+    {
+        var cell = new CodeConfiguration { Code = Source, IsExecutable = true };
+
+        cell.OutputCurrency().Should().Be(CodeOutputCurrency.NeverRun,
+            "a cell with no run recorded has no output to be wrong about — warning here would cry "
+            + "wolf on every unrun cell in the mesh");
+        cell.ProvesOutputIsCurrent().Should().BeFalse(
+            "'nothing has run' is not 'the output is up to date' either — there is no output");
+    }
+
+    [Fact]
+    public void ANullConfiguration_IsNeverRun()
+    {
+        ((CodeConfiguration?)null).OutputCurrency().Should().Be(CodeOutputCurrency.NeverRun,
+            "there is no cell to judge, and a missing cell must not render a warning");
+    }
+
+    [Fact]
+    public void ARecordedRunOfTheCodeOnScreen_IsCurrent()
+    {
+        var cell = new CodeConfiguration
+        {
+            Code = Source,
+            LastExecutedAt = DateTimeOffset.UtcNow,
+            LastExecutedCodeHash = FingerprintOf(Source),
+        };
+
+        cell.OutputCurrency().Should().Be(CodeOutputCurrency.Current,
+            "the run recorded the fingerprint of what it submitted and the code has not moved — "
+            + "this is the one state that may be shown as up to date");
+        cell.ProvesOutputIsCurrent().Should().BeTrue();
+    }
+
+    [Fact]
+    public void CodeEditedSinceTheRecordedRun_IsStale()
+    {
+        var cell = new CodeConfiguration
+        {
+            Code = Source + "\n// edited",
+            LastExecutedAt = DateTimeOffset.UtcNow,
+            LastExecutedCodeHash = FingerprintOf(Source),
+        };
+
+        cell.OutputCurrency().Should().Be(CodeOutputCurrency.Stale,
+            "the output pane is showing the result of source the reader is no longer looking at");
+        cell.ProvesOutputIsCurrent().Should().BeFalse();
+    }
+
+    [Fact]
+    public void LanguageSwitchedSinceTheRecordedRun_IsStale()
+    {
+        var cell = new CodeConfiguration
+        {
+            Code = Source,
+            Language = "python",
+            LastExecutedAt = DateTimeOffset.UtcNow,
+            LastExecutedCodeHash = FingerprintOf(Source, "csharp"),
+        };
+
+        cell.OutputCurrency().Should().Be(CodeOutputCurrency.Stale,
+            "the language decides WHERE the code runs, so switching it invalidates the output as "
+            + "surely as editing a line");
+    }
+
+    /// <summary>
+    /// 🚨 The fail-closed case, over every marker that says "a run happened" and both shapes of a
+    /// missing fingerprint. Each row is a state a partial stamp can actually leave behind.
+    /// </summary>
+    [Theory]
+    // The whole stamp landed except the hash (a build predating the field; a narrowing merge patch).
+    [InlineData(true, false, false, null)]
+    [InlineData(true, false, false, "")]
+    // Only the activity pointer survived — the field the output pane keys on.
+    [InlineData(false, true, false, null)]
+    // Only the runner survived.
+    [InlineData(false, false, true, null)]
+    // Everything that says "it ran" is there; only the proof of WHAT ran is missing.
+    [InlineData(true, true, true, null)]
+    [InlineData(true, true, true, "")]
+    public void ARunWhoseFingerprintWasNotRecorded_IsNeverReportedAsUpToDate(
+        bool at, bool activityPath, bool by, string? hash)
+    {
+        var cell = new CodeConfiguration
+        {
+            Code = Source,
+            LastExecutedAt = at ? DateTimeOffset.UtcNow : null,
+            LastActivityPath = activityPath ? "rbuergi/_Activity/abc" : null,
+            LastExecutedBy = by ? "rbuergi" : null,
+            LastExecutedCodeHash = hash,
+        };
+
+        cell.ProvesOutputIsCurrent().Should().BeFalse(
+            "the node records that it RAN but not WHAT it ran, so nothing here substantiates "
+            + "'up to date' — a cell that cannot prove it is current must not claim to be (#3249)");
+        cell.OutputCurrency().Should().Be(CodeOutputCurrency.Unverified,
+            "the honest answer is 'I cannot tell', which is its own state: calling it Stale would "
+            + "light up every node last executed before the fingerprint existed");
+
+        // The control arm. The pre-fix predicate answered "not stale" for precisely this row —
+        // which the toolbar rendered as a plain Run button on a cell showing unaccountable output.
+        PreFixIsOutputStale(cell).Should().BeFalse(
+            "this row IS the state the old boolean got wrong — if it ever starts reporting true "
+            + "here, the cases above have stopped discriminating and need rewriting");
+    }
+
+    /// <summary>
+    /// The other half of fail-closed: the rule must not be closed so hard that it never says
+    /// <see cref="CodeOutputCurrency.Current"/>. An indicator that always warns is an indicator
+    /// nobody reads, which is the same failure as one that never warns.
+    /// </summary>
+    [Fact]
+    public void TheRuleStillReachesCurrent_SoTheWarningKeepsItsMeaning()
+    {
+        var ran = new CodeConfiguration
+        {
+            Code = Source,
+            Language = "csharp",
+            LastExecutedAt = DateTimeOffset.UtcNow,
+            LastExecutedBy = "rbuergi",
+            LastActivityPath = "rbuergi/_Activity/abc",
+            LastExecutedCodeHash = FingerprintOf(Source, "csharp"),
+        };
+
+        ran.OutputCurrency().Should().Be(CodeOutputCurrency.Current);
+    }
+}


### PR DESCRIPTION
## What this is

Issue #3249 lists three candidate shapes for the swallowed last-execution stamp and says (3) "is
separable and could land alone". **This is (3), and only (3): the stale-cell indicator now fails
CLOSED.** Options 1 and 2 are deliberately not here — see *What is not in this PR*.

## The defect

`CodeNodeType` stamps `Last{ExecutedAt,ExecutedBy,ActivityPath,ExecutedCodeHash}` onto the Code node
fire-and-forget after dispatching a run; both failure paths only log, and
`ExecuteScriptResponse { Success = true }` has already been posted by the time either could fire. So
a node can record that it **ran** while recording nothing about **what** it ran.

The indicator's rule was a boolean:

```csharp
code is { LastExecutedAt: not null, LastExecutedCodeHash: not null and not "" }
&& CodeFingerprint.Of(code.Code, code.Language) != code.LastExecutedCodeHash;
```

`false` for that state — "not stale", i.e. **up to date**. The cell asserts a currency nothing
substantiates: a wrong claim, not a missing one.

## Why this is the root cause, not a band-aid

The rule's contract was *"not stale unless proven stale"*. Nothing about making the stamp write more
reliable would make that contract honest — a node read from storage by any surface, at any later
time, can be in a state where currency is unknowable (a build predating the fingerprint field, a
merge patch written through a narrower shape). The fix changes the contract to **"not current unless
proven current"**, which is where the wrong claim actually comes from.

Nor does it hide the write's failure. The residual is written down rather than papered over — see
*What is not in this PR*.

## The three states, made honest about each

| Node state | Verdict | What the cell shows |
|---|---|---|
| never run — no timestamp, no activity path, no runner | `NeverRun` | **nothing.** A cell nobody has run has no output to be wrong about; warning here would cry wolf on every unrun cell in the mesh |
| ran **and** recorded its fingerprint | `Current` / `Stale` | as before — "up to date", or "code changed — re-run" |
| ran but the fingerprint was **not** recorded | `Unverified` | "output unverified — re-run to be sure" |

`Unverified` is deliberately neither neighbour. Not `Current`, because nothing proves it. **Not
`Stale` either** — every node last executed before the fingerprint field existed would light up amber
at once, and a warning nobody believes is the same failure as no warning at all. That is why the
verdict is a four-state enum and not a `bool`: collapsing "I cannot tell" onto "no" *is* a claim.

"A run is recorded" accepts **any** of the three run markers, not `LastExecutedAt` specifically, so a
stamp that landed only in part cannot fall back into `NeverRun` and go silent on a cell that ran.

The rule lives in `MeshWeaver.Mesh.Contract` beside the field it interprets — `CodeConfiguration` and
`CodeFingerprint` are both there — rather than in whichever view happens to render a cell, so every
surface inherits the fail-closed behaviour instead of re-deriving it.

## What is not in this PR

Option 1 (a persisted `LastStampFailedAt`) and option 2 (raise the log level and ticket it) are
**not** implemented. The issue is explicit that the response cannot report the stamp failure without
undoing Plugins#1266 — a Run click is acknowledged immediately and is never silent — and that
picking a shape silently would be the wrong kind of decisiveness. That design tension is the
maintainer's call, so `Refs #3249` rather than `Closes`, and I have left a comment on the issue
recording exactly what landed and what remains.

**The residual, stated rather than hidden:** a cell whose *very first* run stamps nothing at all
records nothing, so it is indistinguishable from a cell nobody has run. No rule over node content can
recover that — making it observable is precisely what options 1 and 2 are for. It is written into
`Doc/Architecture/ScriptExecution` so the next reader finds it there, not only in a terminal.

## Tests

`test/MeshWeaver.Graph.Test/CodeOutputCurrencyTest.cs` — the pure state table, including a `[Theory]`
over every partial-stamp shape, and a **control arm** that pins the pre-fix predicate's answer for
those rows so the cases cannot go vacuous.

`test/MeshWeaver.Graph.Test/CodeCellCurrencyThroughTheMeshTest.cs` — the same states round-tripped
through a real `MonolithMeshTestBase` mesh and read back off `GetMeshNodeStream(path)` (never a
query), waiting on the condition and never on the clock; plus a genuine `ExecuteScriptRequest`
dispatch proving the rule still **reaches** `Current`, because a fail-closed rule that never says
"current" would be no better than the fail-open one it replaces.

Measured both ways, `-c Release`:

| | pure cases | mesh cases |
|---|---|---|
| with the fix | 14/14 pass | 2/2 pass |
| fail-open semantics restored (`Unverified` → `Current`) | **6 fail** | **1 fails** |
| pre-review ordering restored (run markers tested before the fingerprint) | **2 fail** | 2/2 pass |

The failing rows are exactly the unrecorded-fingerprint ones; the `Current`/`Stale` control cases
pass either way, which is what makes the six meaningful.

**The Copilot review found the mirrored hole and it is fixed** (`e291c8a`): the first push asked "did
a run happen?" off the three run markers and answered `NeverRun` when none was set — *including when
the fingerprint WAS set*. A node carrying only the hash is fully decidable, so that silenced a
verdict we can substantiate: fail-open, pointing the other way. The fingerprint is now tested
**first**, because it is both evidence of a run and the only field that can decide currency; the run
markers are consulted only in its absence, and there they still fail closed to `Unverified`. That
row of the table above is the measurement.

Also green locally: `LocalizationTest` (58), `MeshWeaver.Documentation.Test` (250), the full
`MeshWeaver.Graph.Test` suite, and `dotnet build -c Release -warnaserror` on
`MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph`, `MeshWeaver.Messaging.Hub`,
`MeshWeaver.Documentation` and the three touched test projects — `0 Error(s)`, `0 Warning(s)` each.

## i18n

Two new keys in **both** `strings.en.json` and `strings.de.json`: `code.unverifiedCell` and
`code.unverifiedCellHint`. 🚨 **A mirror PR is needed in `MeshWeaver.Plugins`
(`clients/react/src/i18n/`)** — core is the source of truth and merges first. That mirror pins a core
commit (`catalog-source.json` → `ref: e7f1d699…`), so its drift guard does not go red on this merge;
the pin moves with the mirror PR.

## Cross-repo

No public top-level type or member is **removed** — this PR only adds (`CodeOutputCurrency`,
`CodeOutputCurrencyExtensions`) and edits doc comments — so the `Cross-repo pair (public surface)`
gate does not apply and there is no `Pairs-with:` line. (Measured: that check is already green here,
as is `Public surface (binary compatibility)`.) It does change the public declaration set, so
AGENTS.md says `Dependent suites (MeshWeaver.Plugins)` runs — **it does not, and no such job exists
in `.github/workflows/`** (grepped for the name and for `dependent` / `declaration set`; nothing).
Reporting it rather than folding a CI change into this PR: the prose asserts a guard that is not
wired, which is its own issue.

The toolbar that renders the state is `CodeViews.IsOutputStale` in **MeshWeaver.Plugins**, and it
adopts `OutputCurrency()` in a follow-up PR there. 🚨 **That PR cannot open green today.** Plugins
compiles core at `MW_PLATFORM_REF`, which is a **pin of the sealed set** (`check-platform-pins.py`),
not a moving `main` — so a Plugins PR using an API added here stays red until that pin moves to a
core sha containing this merge, and moving the pin set is a gated fleet operation this change
deliberately does not do unilaterally. Until then the rule ships unused by the toolbar, which changes
nothing for the worse: the existing predicate is left exactly as it is.

## What's New

`Category: Fix` — a user can notice a cell that wrongly claims to be up to date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhT5AXByEKo2fRQtWH2wCW

