### PR TITLE
fix: a hosted-hub creation that races pod teardown is not a fault (#3243)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/LogWatchTriage.md
@@ -386,13 +386,14 @@ to the triage thread that wrote it.
 
 Everything red becomes a ticket, so **the level a call site chooses is a ticketing decision**, not a
 verbosity knob (AGENTS.md: never edit a level to dial a debugging session up or down; fix it
-permanently, with the reason, or leave it). Two outcomes are routinely mistaken for faults, and both
-produced steady ticket streams:
+permanently, with the reason, or leave it). Three outcomes are routinely mistaken for faults, and
+each produced a steady ticket stream:
 
 | Outcome | Why it is not a fault | Where |
 |---|---|---|
 | **Cooperative cancellation** — the caller went away, a partition cleanup cascaded, the host is shutting down, the I/O pool drained | Nothing failed and nothing was written. `MeshWeaver.Mesh.CreateNode` logged 491 of these in three days (#2152); `MeshWeaver.Mesh.MeshNode` logged `[DeleteNode] unexpected … partial-deleted=0` (#2182) — a counter that says the node was never touched. | `CancellationClassifier.IsCooperativeCancellation` |
 | **A client that disconnected mid-stream** | gRPC finalises the request and answers the next write with `InvalidOperationException("Can't write the message because the request is complete.")`; the client is already gone (#2138 / #2139). | `MeshGrpcService.WritePumpAsync` |
+| **Hosted-hub creation that raced pod teardown** | A hub activates while its pod is stopping and the Autofac scope dies UNDER the build (`LifetimeScope.ThrowDisposedException`). Nothing failed, nothing was written, and the next access re-activates the node on a live host (#3243). | `HostedHubsCollection.CreateHub` → `HostedHubOutcome.HostShuttingDown` |
 
 🚨 **The rule is narrow on purpose, and the exceptions to it are the point:**
 
@@ -410,8 +411,20 @@ produced steady ticket streams:
   licence to swallow an outcome.
 - **The exception still rides along.** The benign line is `LogDebug(ex, …)`, and it states the token
   state that made it benign rather than asserting it (`CancellationClassifier.Describe`).
+- **A caller cannot classify what it cannot see, so the condition TRAVELS.** `GetHostedHub` answered
+  `null` for a shutdown and for a configuration that threw alike, so `MessageHubGrain` logged one
+  fail-level sentence listing both and committing to neither — a message that was *honest about its
+  own ignorance* and ticketed a pod rollout every time. `HostedHubResult` carries the outcome from
+  the collection that owns the container to the grain that writes the line (#3243); re-deriving it
+  at the caller would have been a guess.
+- **And the benign verdict is MEASURED.** An `ObjectDisposedException` out of hub construction is
+  only a shutdown if the container really is gone, so the container is asked — directly — whether it
+  can still resolve. A live scope that threw that type for its own reasons still reads as a fault,
+  and a probe that cannot answer leaves the outcome LOUD.
 
-`CancellationIsNotAFaultTest` pins both directions, including the timeout impostor.
+`CancellationIsNotAFaultTest` pins the cancellation directions, including the timeout impostor;
+`HubCreationDuringTeardownIsNotAFaultTest` and `HubConstructionOutcomeReportingTest` pin the
+hub-creation ones, including the configuration-throw that must stay red.
 
 ## What this is not
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-pod-shutting-down-is-no-longer-an-error.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-pod-shutting-down-is-no-longer-an-error.md
@@ -1,0 +1,69 @@
+---
+Name: A pod shutting down is no longer reported as an error
+Category: Fix
+Description: Hosted-hub creation answered null for two conditions that are nothing alike — a host going down, and a hub configuration that threw — and the Orleans grain reported both at fail level. Every pod rollout opened a ticket for a race in which nothing failed. The condition is now named where it is known.
+Icon: Bug
+Order: -20260904
+---
+
+# A pod shutting down is no longer reported as an error
+
+Every red line a portal writes becomes an incident, and every distinct incident becomes a GitHub
+issue. That is what makes red mean something — and it is why a line that is red *by accident* is
+expensive: it costs a ticket, a triage round, and a little of the credibility of every other red
+line on the page.
+
+One of those lines fired on **every pod rollout**:
+
+> `fail:` … *Hub construction returned no hub for `Admin/PlatformVersion` (NodeType: Markdown).
+> Either the hub configuration threw — see the 'Failed to create hosted hub' entry logged
+> immediately before this one, which carries the real exception — or hosted-hub creation is frozen
+> because this host (or an ancestor) is disposing.*
+
+Read it again: the message **names both possibilities and commits to neither**. That was not sloppy
+writing. The grain genuinely could not tell — `GetHostedHub` answers `null` for both, and a null
+carries no reason. So the sentence listed what it might have been and logged the whole thing red,
+because one of the two really is a defect.
+
+The one that kept happening was the other one. A node hub activates, the pod it lives on is
+stopping, and the container the hub would be built from is torn down *underneath* the construction:
+Autofac answers every resolution with `ObjectDisposedException`. Nothing failed. Nothing was
+written. The next request re-activates the node on a live host — which is precisely what the design
+intends, and the message even said so, in the half nobody could confirm.
+
+## The reason now travels with the answer
+
+Hosted-hub lookup returns the outcome alongside the hub: **available**, **absent**, **the host is
+shutting down**, or **construction faulted**. The collection that owns the container is the one
+place that can tell those apart, so that is where the classification is made — not guessed at by a
+caller two layers away that cannot see a container at all.
+
+And the shutdown case is *measured*, not assumed. When construction dies on an
+`ObjectDisposedException`, the container is asked directly whether it can still resolve anything. A
+live container that happens to throw that exception for its own reasons still reads as a fault; only
+a container that is genuinely gone reads as a shutdown. If the check itself cannot answer, the
+outcome stays loud — the conservative direction, by construction.
+
+## What each condition now looks like
+
+A host going down is stated as what it is, at debug level, with the evidence that made it benign:
+
+> *Hub construction for `Admin/PlatformVersion` (NodeType: Markdown) was refused because this host
+> (or an ancestor) is shutting down — an expected teardown race, not a fault. Nothing failed and
+> nothing was written; the next access re-activates this node on a live host.*
+
+A configuration that threw stays exactly as loud as before, and still points at the entry carrying
+the real stack:
+
+> `fail:` … *Hub construction FAILED for … the hub configuration threw. See the 'Failed to create
+> hosted hub' entry logged immediately before this one, which carries the real exception and its
+> stack.*
+
+Downgrading a level is never licence to swallow an outcome, so both branches still do everything
+they did: the failure cause is recorded for the caller, parked deliveries fail fast instead of
+hanging, and the grain deactivates so the next access retries from scratch. An *unclassified*
+outcome — one nothing has claimed — stays at fail level too. Only a **known** shutdown is quiet.
+
+This is the same distinction `CancellationClassifier` already draws for cooperative cancellation: a
+caller that went away, a pool that drained, a host that stopped. The level a call site picks is a
+ticketing decision, not a verbosity knob.

--- a/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
+++ b/src/MeshWeaver.Hosting.Orleans/MessageHubGrain.cs
@@ -545,7 +545,14 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
             // the ACTUAL exception sat in a separate log entry milliseconds earlier. The Monolith
             // twin has always been null-safe here (MonolithRoutingService: `createdHub?.Register…`);
             // this is the same treatment plus a message that says which of the three it was.
-            var hub = meshHub.GetHostedHub(address, config =>
+            //
+            // 🚨 And the three are ASKED FOR, not guessed at (#3243). TryGetHostedHub carries the
+            // condition out of HostedHubsCollection, where it is known, so the two that matter can
+            // be reported honestly: a host going down is a teardown race at Debug, a configuration
+            // that threw stays at fail level with its exception. The previous single fail-level
+            // line named both possibilities and committed to neither, so every pod rollout
+            // fingerprinted and ticketed an expected shutdown.
+            var creation = meshHub.TryGetHostedHub(address, config =>
             {
                 config = config.WithOwnNodeStream(ownNodeStream);
                 return node.HubConfiguration!(config)
@@ -575,16 +582,27 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
                             this.GetPrimaryKeyString());
                         TryDeactivateOnIdle();
                     }));
-            });
+            }, HostedHubCreation.Always);
 
+            var hub = creation.Hub;
             if (hub is null)
             {
                 // Not a defect in THIS method — the cause is already logged with its stack by
                 // HostedHubsCollection. Report the fact in terms a caller can act on, and keep the
                 // retry-on-next-access semantics the rest of this method has: the next delivery
                 // re-runs resolution and hub construction from scratch.
-                var reason = HubConstructionFailureReason(node);
-                logger.LogError("[ACTIVATE] Grain {StreamId}: {Reason}", streamId, reason);
+                //
+                // 🚨 The LEVEL is a ticketing decision, not a verbosity knob (#3243, and the same
+                // rule CancellationClassifier follows for #2152/#2182). A host going down is an
+                // expected teardown race — nothing failed, nothing was written — so it goes to
+                // Debug WITH the evidence; anything else stays at fail level WITH the exception.
+                // Downgrading the level is not licence to swallow the outcome: both branches still
+                // record the cause, still fail parked deliveries, and still deactivate for retry.
+                var reason = HubConstructionFailureReason(node, creation.Outcome);
+                logger.Log(
+                    HubConstructionFailureLevel(creation.Outcome),
+                    creation.Error,
+                    "[ACTIVATE] Grain {StreamId}: {Reason}", streamId, reason);
                 activationFailures?.Record(streamId, reason);
                 _hubReadyRaw.OnError(new InvalidOperationException(reason));
                 TryDeactivateOnIdle();
@@ -626,14 +644,55 @@ public class MessageHubGrain(ILogger<MessageHubGrain> logger, IMessageHub meshHu
     /// that the REAL exception had already been logged with its stack a moment earlier. Naming the
     /// node, its type, and where the real cause is written is the whole difference between an
     /// unactionable alert and a diagnosis.</para>
+    ///
+    /// <para>🚨 <b>And it now says WHICH condition it was</b> (#3243). The single sentence below
+    /// used to list both possibilities and commit to neither, because the grain genuinely could not
+    /// tell them apart — <c>GetHostedHub</c> answered null for both. It reported both at fail
+    /// level, so every pod rollout fingerprinted and ticketed a teardown race the message itself
+    /// anticipated (incident e2028eb86d6a85a6 and its sibling 8bd7c9c44c12e40b, recurring across
+    /// four deployments since mid-August). <see cref="HostedHubOutcome"/> carries the condition out
+    /// of <c>HostedHubsCollection</c>, where it is known, so each one is now reported as what it
+    /// is.</para>
     /// </summary>
     /// <param name="node">The node whose hub could not be constructed.</param>
+    /// <param name="outcome">Which condition produced the missing hub.</param>
     /// <returns>The failure reason.</returns>
-    internal static string HubConstructionFailureReason(MeshNode node) =>
-        $"Hub construction returned no hub for {node.Path} (NodeType: {node.NodeType ?? "(null)"}). "
-        + "Either the hub configuration threw — see the 'Failed to create hosted hub' entry logged "
-        + "immediately before this one, which carries the real exception — or hosted-hub creation is "
-        + "frozen because this host (or an ancestor) is disposing.";
+    internal static string HubConstructionFailureReason(MeshNode node, HostedHubOutcome outcome) =>
+        outcome switch
+        {
+            HostedHubOutcome.HostShuttingDown =>
+                $"Hub construction for {node.Path} (NodeType: {node.NodeType ?? "(null)"}) was refused "
+                + "because this host (or an ancestor) is shutting down — an expected teardown race, "
+                + "not a fault. Nothing failed and nothing was written; the next access re-activates "
+                + "this node on a live host.",
+            HostedHubOutcome.ConstructionFaulted =>
+                $"Hub construction FAILED for {node.Path} (NodeType: {node.NodeType ?? "(null)"}): the "
+                + "hub configuration threw. See the 'Failed to create hosted hub' entry logged "
+                + "immediately before this one, which carries the real exception and its stack.",
+            _ =>
+                $"Hub construction returned no hub for {node.Path} (NodeType: {node.NodeType ?? "(null)"}). "
+                + "Either the hub configuration threw — see the 'Failed to create hosted hub' entry logged "
+                + "immediately before this one, which carries the real exception — or hosted-hub creation is "
+                + "frozen because this host (or an ancestor) is disposing.",
+        };
+
+    /// <summary>
+    /// The level the missing-hub line is logged at — a TICKETING decision, not a verbosity knob
+    /// (#3243). Everything a portal reports as red becomes an incident and a GitHub issue
+    /// (<c>Doc/Architecture/LogWatchTriage</c>), so a shutdown race logged at <c>fail:</c> is
+    /// indistinguishable from a hub whose configuration is broken. Only
+    /// <see cref="HostedHubOutcome.HostShuttingDown"/> is benign; everything else — including
+    /// <see cref="HostedHubOutcome.Unclassified"/>, which is an unknown and not a shutdown — stays
+    /// at <see cref="LogLevel.Error"/>.
+    ///
+    /// <para>Pure and <c>internal static</c> for the same reason as
+    /// <see cref="HubConstructionFailureReason"/>: the classification IS the fix, so it is pinned
+    /// by a test rather than by reading the call site.</para>
+    /// </summary>
+    /// <param name="outcome">Which condition produced the missing hub.</param>
+    /// <returns>The log level to report it at.</returns>
+    internal static LogLevel HubConstructionFailureLevel(HostedHubOutcome outcome) =>
+        outcome == HostedHubOutcome.HostShuttingDown ? LogLevel.Debug : LogLevel.Error;
 
     /// <summary>
     /// Composes the per-emission "enrich with HubConfiguration" step as an

--- a/src/MeshWeaver.Messaging.Hub/HostedHubResult.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubResult.cs
@@ -1,0 +1,80 @@
+namespace MeshWeaver.Messaging;
+
+/// <summary>
+/// Why a hosted-hub lookup produced — or did not produce — a hub.
+///
+/// <para>🚨 <b>Why this exists</b> (Systemorph/MeshWeaver#3243). <c>GetHostedHub</c> answers
+/// <c>null</c> for conditions that are not remotely alike, and every caller that only sees the
+/// null has to GUESS which one it was. Two of them matter and they belong at opposite log levels:
+/// a host that is going down (<see cref="HostShuttingDown"/>) is a teardown race nothing can or
+/// should prevent, while a configuration that threw (<see cref="ConstructionFaulted"/>) is a
+/// defect somebody must look at. <c>MessageHubGrain</c> reported BOTH at <c>fail:</c> with a
+/// sentence that listed the two possibilities and committed to neither — so every pod rollout
+/// fingerprinted and ticketed an expected shutdown race. Naming the condition where it is KNOWN
+/// beats re-deriving it at the caller, which cannot see the container at all.</para>
+///
+/// <para>This is the same distinction <c>CancellationClassifier</c> draws for cooperative
+/// cancellation (issues #2152 / #2182): the level a call site chooses is a ticketing decision,
+/// not a verbosity knob, and downgrading one is never licence to swallow the outcome — the
+/// caller is still answered, and answered accurately.</para>
+/// </summary>
+public enum HostedHubOutcome
+{
+    /// <summary>
+    /// The outcome was not classified — the <see cref="IMessageHub"/> implementation does not
+    /// implement <see cref="IMessageHub.TryGetHostedHub"/> and only returned a null hub. Zero so
+    /// that <c>default(HostedHubResult)</c> is coherent (no hub, no claim about why). Callers
+    /// must treat this as "unknown", never as an expected shutdown.
+    /// </summary>
+    Unclassified = 0,
+
+    /// <summary>A hub is available — either already registered, or newly constructed.</summary>
+    Available,
+
+    /// <summary>
+    /// No hub exists at that address and none was requested
+    /// (<see cref="HostedHubCreation.Never"/>) — a pure read miss, the routing hot path's
+    /// ordinary answer.
+    /// </summary>
+    Absent,
+
+    /// <summary>
+    /// Creation was refused, or could not run, because this host — or an ancestor — is shutting
+    /// down. Either the collection's creation freeze had already flipped, or the container the
+    /// hub would have been built from is disposed. An EXPECTED teardown race: nothing failed,
+    /// nothing was written, and the next access re-activates on a live host.
+    /// </summary>
+    HostShuttingDown,
+
+    /// <summary>
+    /// Hub construction ran and FAULTED — the configuration lambda, a synchronous buildup action,
+    /// or the container threw while the host was live. <see cref="HostedHubResult.Error"/>
+    /// carries the exception, which <c>HostedHubsCollection</c> has already logged with its
+    /// stack. A real defect; stays at fail level.
+    /// </summary>
+    ConstructionFaulted,
+}
+
+/// <summary>
+/// The answer to a hosted-hub lookup: the hub when there is one, plus WHY when there is not.
+/// </summary>
+/// <param name="Hub">The hosted hub, or null when none was produced.</param>
+/// <param name="Outcome">Which condition produced this answer.</param>
+/// <param name="Error">
+/// The exception behind the outcome, when there was one — set for
+/// <see cref="HostedHubOutcome.ConstructionFaulted"/>, and for the
+/// <see cref="HostedHubOutcome.HostShuttingDown"/> case that surfaced as an
+/// <see cref="ObjectDisposedException"/> off a disposed container. Null otherwise. It rides along
+/// so a caller's log line can carry the real cause instead of asserting one.
+/// </param>
+public readonly record struct HostedHubResult(
+    IMessageHub? Hub,
+    HostedHubOutcome Outcome,
+    Exception? Error)
+{
+    /// <summary>
+    /// True when the lookup produced no hub because the host is going down — the one outcome a
+    /// caller must NOT report as a fault.
+    /// </summary>
+    public bool IsShutdownRace => Outcome == HostedHubOutcome.HostShuttingDown;
+}

--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -82,9 +82,22 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     /// <param name="create">Whether to create the hub when absent, or only read.</param>
     /// <returns>The existing or newly created hub, or null if absent (read-only), refused during disposal, or construction failed.</returns>
     public IMessageHub? GetHub(Address address, Func<MessageHubConfiguration, MessageHubConfiguration> config, HostedHubCreation create)
+        => GetHubWithOutcome(address, config, create).Hub;
+
+    /// <summary>
+    /// <see cref="GetHub"/> plus the REASON — see <see cref="HostedHubOutcome"/>. Same work, same
+    /// single-flight, same logging; the only difference is that a caller handed a null hub is also
+    /// told which condition produced it, instead of having to guess between an expected teardown
+    /// race and a configuration that threw (Systemorph/MeshWeaver#3243).
+    /// </summary>
+    /// <param name="address">Address of the hosted hub to find or create.</param>
+    /// <param name="config">Configuration transform applied when a new hub is constructed.</param>
+    /// <param name="create">Whether to create the hub when absent, or only read.</param>
+    /// <returns>The hub (when there is one) and the outcome that produced this answer.</returns>
+    public HostedHubResult GetHubWithOutcome(Address address, Func<MessageHubConfiguration, MessageHubConfiguration> config, HostedHubCreation create)
     {
         if (messageHubs.TryGetValue(address, out var hub))
-            return hub;
+            return new HostedHubResult(hub, HostedHubOutcome.Available, null);
 
         // 🚨 Never-create lookups are PURE READS and must not touch any lock:
         // RouteStreamMessage probes this per stream message per parent-chain
@@ -98,12 +111,12 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
         // burning an Orleans grain turn for minutes (the AgenticPension space
         // "wedge": queue backing up behind a multi-minute drain turn).
         if (create != HostedHubCreation.Always)
-            return null;
+            return new HostedHubResult(null, HostedHubOutcome.Absent, null);
 
         if (IsDisposing)
         {
             logger.LogWarning("Rejecting hosted hub creation for address {Address} in Host {Host} during disposal - collection is disposing", address, Host);
-            return null;
+            return new HostedHubResult(null, HostedHubOutcome.HostShuttingDown, null);
         }
 
         // Per-address single-flight; CONSTRUCTION RUNS OUTSIDE ANY GLOBAL LOCK.
@@ -111,22 +124,22 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
         // blocks only on that address); creators of different addresses never
         // contend. The factory re-checks messageHubs so a creator racing the
         // post-construction cleanup below cannot build a duplicate hub.
-        var lazy = creations.GetOrAdd(address, a => new Lazy<IMessageHub?>(() =>
+        var lazy = creations.GetOrAdd(address, a => new Lazy<HostedHubResult>(() =>
         {
             if (messageHubs.TryGetValue(a, out var existing))
-                return existing;
+                return new HostedHubResult(existing, HostedHubOutcome.Available, null);
             if (IsDisposing)
             {
                 logger.LogWarning("Rejecting hosted hub creation for address {Address} in Host {Host} during disposal - collection is disposing", a, Host);
-                return null;
+                return new HostedHubResult(null, HostedHubOutcome.HostShuttingDown, null);
             }
-            var newHub = CreateHub(a, config);
-            if (newHub != null)
+            var created = CreateHub(a, config);
+            if (created.Hub is not null)
             {
-                messageHubs[a] = newHub;
-                try { _hubAdded.OnNext(newHub); } catch { /* never throw on notification */ }
+                messageHubs[a] = created.Hub;
+                try { _hubAdded.OnNext(created.Hub); } catch { /* never throw on notification */ }
             }
-            return newHub;
+            return created;
         }, LazyThreadSafetyMode.ExecutionAndPublication));
 
         // 🚨 In-flight construction is TRACKED so disposal can FINISH it instead of racing it.
@@ -175,7 +188,7 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     /// live only for the duration of one construction; <see cref="messageHubs"/>
     /// remains the steady-state registry.
     /// </summary>
-    private readonly ConcurrentDictionary<Address, Lazy<IMessageHub?>> creations = new(AddressComparer.Instance);
+    private readonly ConcurrentDictionary<Address, Lazy<HostedHubResult>> creations = new(AddressComparer.Instance);
 
     /// <summary>
     /// Registers a hub under its own address, wires its removal from the registry on disposal and
@@ -335,26 +348,86 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
         }
     }
 
-    private IMessageHub? CreateHub(Address address, Func<MessageHubConfiguration, MessageHubConfiguration> config)
+    private HostedHubResult CreateHub(Address address, Func<MessageHubConfiguration, MessageHubConfiguration> config)
     {
         if (IsDisposing)
         {
             logger.LogWarning("Preventing hub creation for address {Address} in host {Host} - collection is disposing", address, Host);
-            return null;
+            return new HostedHubResult(null, HostedHubOutcome.HostShuttingDown, null);
         }
 
         try
         {
             logger.LogDebug("Creating new hosted hub for address {Address} in host {Host} ", address, Host);
             var hub = serviceProvider.CreateMessageHub(address, config);
-            return hub;
+            return new HostedHubResult(hub, HostedHubOutcome.Available, null);
+        }
+        catch (ObjectDisposedException ex) when (IsHostContainerDisposed())
+        {
+            // 🚨 A TEARDOWN RACE, not a fault (Systemorph/MeshWeaver#3243). The creation passed
+            // IsDisposing — the freeze had not reached this collection — and then the container
+            // itself died under the build: the generic host stops, the root provider goes down,
+            // and Autofac answers every resolution with ObjectDisposedException
+            // (LifetimeScope.ThrowDisposedException). Nothing failed and nothing was written; the
+            // next access re-activates on a live host. Reported as fail: it is indistinguishable
+            // from a configuration that genuinely threw on the same line, so every pod rollout
+            // fingerprinted and ticketed a shutdown (incident e2028eb86d6a85a6 and its sibling).
+            //
+            // The filter is the CLASSIFICATION, and it is a measurement, not an assumption: a
+            // disposed container is asked, directly, whether it can still resolve. Should the
+            // probe itself throw, the CLR treats the filter as false and this falls through to the
+            // LOUD branch below — the conservative direction, by construction.
+            logger.LogDebug(ex,
+                "Hosted hub creation for address {Address} in host {Host} lost a race with teardown: "
+                + "the container it builds from is already disposed ({Evidence}), so this host is "
+                + "going down. Nothing failed and nothing was written — the next access re-activates "
+                + "on a live host.",
+                address, Host, DescribeDisposedContainer(ex));
+            return new HostedHubResult(null, HostedHubOutcome.HostShuttingDown, ex);
         }
         catch (Exception ex)
         {
             logger.LogError(ex, "Failed to create hosted hub for address {Address}", address);
-            return null;
+            return new HostedHubResult(null, HostedHubOutcome.ConstructionFaulted, ex);
         }
     }
+
+    /// <summary>
+    /// Asks the container this collection builds hubs from whether it is still alive — the honest
+    /// discriminator between an expected teardown race and a hub configuration that faulted while
+    /// the host was up. A live Autofac scope answers a plain resolution; a disposed one throws
+    /// <see cref="ObjectDisposedException"/> from <c>LifetimeScope.ThrowDisposedException</c>,
+    /// which is the exact frame the production incident carried.
+    ///
+    /// <para>Only ever called on the failure path, so the hot creation path pays nothing for it.
+    /// <see cref="ILoggerFactory"/> is a service the container is KNOWN to hold — this collection's
+    /// own logger came from it — so a live scope cannot answer this with a miss.</para>
+    /// </summary>
+    /// <returns>True when the container is disposed.</returns>
+    private bool IsHostContainerDisposed()
+    {
+        try
+        {
+            _ = serviceProvider.GetService(typeof(ILoggerFactory));
+            return false;
+        }
+        catch (ObjectDisposedException)
+        {
+            return true;
+        }
+    }
+
+    /// <summary>
+    /// The evidence line for a benign teardown race — what the container actually said, so the
+    /// Debug line STATES why it was judged benign instead of asserting it (the same contract as
+    /// <c>CancellationClassifier.Describe</c>).
+    /// </summary>
+    /// <param name="exception">The exception hub construction raised.</param>
+    /// <returns>A short, log-safe description.</returns>
+    private static string DescribeDisposedContainer(ObjectDisposedException exception) =>
+        string.IsNullOrEmpty(exception.ObjectName)
+            ? $"{exception.GetType().Name}; a plain service resolution against it throws too"
+            : $"{exception.GetType().Name} on {exception.ObjectName}; a plain service resolution against it throws too";
 
     private readonly object locker = new();
     private bool IsDisposing => disposalStarted || creationClosed;

--- a/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/IMessageHub.cs
@@ -154,6 +154,30 @@ public interface IMessageHub : IMessageHandlerRegistry, IDisposable
     /// </summary>
     IMessageHub? GetHostedHub(Address address, Func<MessageHubConfiguration, MessageHubConfiguration> config, HostedHubCreation create);
 
+    /// <summary>
+    /// <see cref="GetHostedHub(Address, Func{MessageHubConfiguration, MessageHubConfiguration}, HostedHubCreation)"/>
+    /// plus the REASON — see <see cref="HostedHubOutcome"/>.
+    ///
+    /// <para>🚨 <b>Use this wherever a null hub gets LOGGED</b> (Systemorph/MeshWeaver#3243). The
+    /// plain overload answers null for conditions that belong at opposite log levels — a host that
+    /// is going down, and a configuration that threw — and a caller holding only the null cannot
+    /// tell them apart, so it either tickets every shutdown race or hides real faults. This
+    /// overload carries the condition from where it is KNOWN (the hub that owns the container) to
+    /// where the decision is made.</para>
+    ///
+    /// <para>Default-implemented so an <see cref="IMessageHub"/> that predates the distinction
+    /// keeps compiling: it reports <see cref="HostedHubOutcome.Unclassified"/>, which callers must
+    /// treat as unknown — never as an expected shutdown.</para>
+    /// </summary>
+    /// <param name="address">The address of the hosted hub.</param>
+    /// <param name="config">Transform applied to the hosted hub's configuration when it is created.</param>
+    /// <param name="create">Whether to create the hub if it does not yet exist.</param>
+    /// <returns>The hub (when there is one) and the outcome that produced this answer.</returns>
+    HostedHubResult TryGetHostedHub(Address address, Func<MessageHubConfiguration, MessageHubConfiguration> config, HostedHubCreation create)
+        => GetHostedHub(address, config, create) is { } hub
+            ? new HostedHubResult(hub, HostedHubOutcome.Available, null)
+            : new HostedHubResult(null, HostedHubOutcome.Unclassified, null);
+
     // Disposal at the hub level is reactive but never a Task — nothing here is async
     // in the await sense. The first two overloads couple a SYNCHRONOUS cleanup to the
     // hub's lifetime (held in a CompositeDisposable, disposed during ShutDown).

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1526,12 +1526,27 @@ public sealed class MessageHub : IMessageHub
         Address address,
         Func<MessageHubConfiguration, MessageHubConfiguration> config,
         HostedHubCreation create
+    ) => TryGetHostedHub(address, config, create).Hub;
+
+    /// <summary>
+    /// <see cref="GetHostedHub(Address, Func{MessageHubConfiguration, MessageHubConfiguration}, HostedHubCreation)"/>
+    /// plus the reason a null hub came back — see <see cref="HostedHubOutcome"/>. Same work and
+    /// same logging; this overload just does not throw the classification away
+    /// (Systemorph/MeshWeaver#3243).
+    /// </summary>
+    /// <param name="address">The address of the hosted hub.</param>
+    /// <param name="config">Transform applied to the hosted hub's configuration when it is created.</param>
+    /// <param name="create">Whether to create the hub if it does not yet exist.</param>
+    /// <returns>The hub (when there is one) and the outcome that produced this answer.</returns>
+    public HostedHubResult TryGetHostedHub(
+        Address address,
+        Func<MessageHubConfiguration, MessageHubConfiguration> config,
+        HostedHubCreation create
     )
     {
         if (create != HostedHubCreation.Never && !messageProcessingStarted)
             ReportHubConstructionDuringBuild(address);
-        var messageHub = hostedHubs.GetHub(address, config, create);
-        return messageHub;
+        return hostedHubs.GetHubWithOutcome(address, config, create);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Hosting.Orleans.Test/HubConstructionFailureReasonTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/HubConstructionFailureReasonTest.cs
@@ -1,4 +1,5 @@
 using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
 using Xunit;
 
 namespace MeshWeaver.Hosting.Orleans.Test;
@@ -25,6 +26,11 @@ namespace MeshWeaver.Hosting.Orleans.Test;
 /// <para>Deleting the <c>!</c> is what makes the null check compiler-enforced under this repo's
 /// nullable + warnings-as-errors settings; this test pins the other half — that the message a
 /// caller receives is a diagnosis rather than a null dereference.</para>
+///
+/// <para>🚨 <b>#3243 sharpened it.</b> The reason no longer LISTS the reachable causes, it NAMES
+/// the one that happened — <see cref="HostedHubOutcome"/> carries the condition out of
+/// <c>HostedHubsCollection</c>, where it is known. Which one it was also decides the log LEVEL;
+/// that half is pinned by <see cref="HubConstructionOutcomeReportingTest"/>.</para>
 /// </summary>
 public class HubConstructionFailureReasonTest
 {
@@ -36,7 +42,8 @@ public class HubConstructionFailureReasonTest
     public void TheReason_NamesTheNodeAndItsType()
     {
         var reason = MessageHubGrain.HubConstructionFailureReason(
-            new MeshNode("AdvancedBusinessRules") { NodeType = "Store/Plugin" });
+            new MeshNode("AdvancedBusinessRules") { NodeType = "Store/Plugin" },
+            HostedHubOutcome.ConstructionFaulted);
 
         reason.Should().Contain("AdvancedBusinessRules").And.Contain("Store/Plugin");
         reason.Should().NotContain("Object reference not set",
@@ -53,13 +60,22 @@ public class HubConstructionFailureReasonTest
     public void TheReason_PointsAtTheLogEntryCarryingTheRealException()
     {
         var reason = MessageHubGrain.HubConstructionFailureReason(
-            new MeshNode("AdvancedBusinessRules") { NodeType = "Store/Plugin" });
+            new MeshNode("AdvancedBusinessRules") { NodeType = "Store/Plugin" },
+            HostedHubOutcome.ConstructionFaulted);
 
         reason.Should().Contain("Failed to create hosted hub",
             "that is the verbatim HostedHubsCollection log entry that carries the actual stack");
-        reason.Should().Contain("disposing",
-            "the other reachable cause is a frozen/ disposing hub collection — a reader must be able "
-            + "to tell a broken configuration from a pod that is going away");
+
+        // 🚨 #3243: the reader no longer has to tell the two apart from one sentence — the two
+        // conditions produce two DIFFERENT sentences, and only one of them mentions a shutdown.
+        var shuttingDown = MessageHubGrain.HubConstructionFailureReason(
+            new MeshNode("AdvancedBusinessRules") { NodeType = "Store/Plugin" },
+            HostedHubOutcome.HostShuttingDown);
+
+        shuttingDown.Should().Contain("shutting down",
+            "a reader must be able to tell a broken configuration from a pod that is going away");
+        shuttingDown.Should().NotBe(reason,
+            "reporting both conditions with one sentence is exactly what #3243 removed");
     }
 
     /// <summary>
@@ -69,7 +85,8 @@ public class HubConstructionFailureReasonTest
     [Fact(Timeout = 30000)]
     public void AnUntypedNode_StillReadsAsASentence()
     {
-        var reason = MessageHubGrain.HubConstructionFailureReason(new MeshNode("Orphan"));
+        var reason = MessageHubGrain.HubConstructionFailureReason(
+            new MeshNode("Orphan"), HostedHubOutcome.ConstructionFaulted);
 
         reason.Should().Contain("Orphan").And.Contain("(null)");
     }

--- a/test/MeshWeaver.Hosting.Orleans.Test/HubConstructionOutcomeReportingTest.cs
+++ b/test/MeshWeaver.Hosting.Orleans.Test/HubConstructionOutcomeReportingTest.cs
@@ -1,0 +1,77 @@
+using MeshWeaver.Mesh;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Orleans.Test;
+
+/// <summary>
+/// Pins how <see cref="MessageHubGrain"/> REPORTS a missing hub (Systemorph/MeshWeaver#3243).
+///
+/// <para>The defect: the grain could not tell an expected teardown race from a hub configuration
+/// that threw — <c>GetHostedHub</c> answered null for both — so it logged one fail-level line that
+/// named both possibilities and committed to neither. The level a call site chooses is a TICKETING
+/// decision (<c>Doc/Architecture/LogWatchTriage</c>: everything red becomes an incident and an
+/// issue), so every pod rollout fingerprinted and ticketed a shutdown the message itself
+/// anticipated — incident <c>e2028eb86d6a85a6</c> and its sibling <c>8bd7c9c44c12e40b</c>.</para>
+///
+/// <para>Both halves are pure functions on purpose — the classification IS the fix, so it is
+/// pinned here rather than inferred from reading the call site, and no cluster is needed
+/// (same shape as <c>MessageHubGrainActivationSourceTest</c>).</para>
+/// </summary>
+public class HubConstructionOutcomeReportingTest
+{
+    private static MeshNode Node() => new("Admin/PlatformVersion") { NodeType = "Markdown" };
+
+    /// <summary>
+    /// The expected shutdown race: benign, so it must not reach <c>fail:</c> — and it must SAY it
+    /// is a shutdown rather than listing possibilities.
+    /// </summary>
+    [Fact]
+    public void HostShuttingDown_IsNotReportedAsAFault()
+    {
+        MessageHubGrain.HubConstructionFailureLevel(HostedHubOutcome.HostShuttingDown)
+            .Should().Be(LogLevel.Debug,
+                "a teardown race is expected: nothing failed, nothing was written, and the next "
+                + "access re-activates on a live host — logging it red tickets every pod rollout");
+
+        var reason = MessageHubGrain.HubConstructionFailureReason(Node(), HostedHubOutcome.HostShuttingDown);
+
+        reason.Should().Contain("Admin/PlatformVersion").And.Contain("Markdown",
+            "the caller is still answered, and answered accurately");
+        reason.Should().Contain("shutting down");
+        reason.Should().NotContain("Either the hub configuration threw",
+            "the whole defect was a sentence that named both conditions and committed to neither");
+    }
+
+    /// <summary>
+    /// The real fault: stays loud, and keeps pointing at the entry that carries the stack.
+    /// Downgrading THIS would hide a broken NodeType.
+    /// </summary>
+    [Fact]
+    public void ConfigurationThatThrows_StaysAtFailLevel()
+    {
+        MessageHubGrain.HubConstructionFailureLevel(HostedHubOutcome.ConstructionFaulted)
+            .Should().Be(LogLevel.Error, "a configuration that threw is a defect someone must fix");
+
+        var reason = MessageHubGrain.HubConstructionFailureReason(Node(), HostedHubOutcome.ConstructionFaulted);
+
+        reason.Should().Contain("Admin/PlatformVersion").And.Contain("Markdown");
+        reason.Should().Contain("Failed to create hosted hub",
+            "the real exception is logged there, and the reader must be sent to it");
+        reason.Should().NotContain("expected teardown race");
+    }
+
+    /// <summary>
+    /// An unclassified answer is an UNKNOWN, not a shutdown — the one way this fix could silently
+    /// become a mute button is by treating "no classification" as benign.
+    /// </summary>
+    [Theory]
+    [InlineData(HostedHubOutcome.Unclassified)]
+    [InlineData(HostedHubOutcome.Available)]
+    [InlineData(HostedHubOutcome.Absent)]
+    public void EverythingElse_StaysAtFailLevel(HostedHubOutcome outcome)
+        => MessageHubGrain.HubConstructionFailureLevel(outcome)
+            .Should().Be(LogLevel.Error,
+                "only a KNOWN shutdown is benign; an unknown must never be quietly downgraded");
+}

--- a/test/MeshWeaver.Messaging.Hub.Test/HubCreationDuringTeardownIsNotAFaultTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/HubCreationDuringTeardownIsNotAFaultTest.cs
@@ -1,0 +1,117 @@
+using System;
+using MeshWeaver.Fixture;
+using MeshWeaver.ServiceProvider;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace MeshWeaver.Messaging.Hub.Test;
+
+/// <summary>
+/// Pins the distinction hosted-hub creation used to throw away (Systemorph/MeshWeaver#3243): a
+/// null hub can mean the HOST IS GOING DOWN or that the HUB CONFIGURATION THREW, and those belong
+/// at opposite log levels because everything a portal reports as red becomes an incident and a
+/// GitHub issue (<c>Doc/Architecture/LogWatchTriage</c>).
+///
+/// <para>The production shape (incident <c>e2028eb86d6a85a6</c> plus its sibling
+/// <c>8bd7c9c44c12e40b</c>, recurring across four deployments since mid-August): a
+/// <c>MessageHubGrain</c> activated while its pod was stopping, the creation passed the collection's
+/// <c>IsDisposing</c> check, and the Autofac scope then died UNDER the build —
+/// <c>LifetimeScope.ThrowDisposedException</c>. <c>CreateHub</c> logged that as
+/// <c>Failed to create hosted hub</c> at fail level and returned null; the grain, unable to tell
+/// which of the two conditions it was, logged its own fail-level line naming BOTH. Two tickets per
+/// pod rollout for a race nothing failed in.</para>
+///
+/// <para>All three cases below run against a REAL Autofac container built by the framework's own
+/// <c>SetupModules</c> — the same call <c>MessageHubConfiguration.CreateServiceProvider</c> makes —
+/// so the disposed-container case reproduces the incident's exact frame rather than simulating it.
+/// No mocks: <see cref="HostedHubsCollection"/> is exercised through its own public surface.</para>
+/// </summary>
+public class HubCreationDuringTeardownIsNotAFaultTest(ITestOutputHelper output) : HubTestBase(output)
+{
+    /// <summary>
+    /// A configuration that faults while the host is fully alive — the condition that MUST stay
+    /// loud. Reported as a shutdown it would hide a broken NodeType behind a Debug line.
+    /// </summary>
+    [Fact]
+    public void ConfigurationThatThrows_IsReportedAsAFault_WithTheRealException()
+    {
+        var host = GetClient().ServiceProvider.CreateMessageHub(
+            new Address("outcome-host", "faulted"),
+            c => c.WithPostingIdentity(PostingIdentity.System));
+
+        var boom = new InvalidOperationException("the NodeType's configuration lambda blew up");
+
+        var result = host.TryGetHostedHub(
+            new Address("outcome-child", "faulted"),
+            _ => throw boom,
+            HostedHubCreation.Always);
+
+        result.Hub.Should().BeNull("the configuration threw, so no hub was produced");
+        result.Outcome.Should().Be(HostedHubOutcome.ConstructionFaulted,
+            "a configuration that throws while the host is live is a defect someone must look at");
+        result.IsShutdownRace.Should().BeFalse("nothing here is a teardown race");
+        result.Error.Should().BeSameAs(boom, "the caller's log line must carry the REAL cause, not a guess");
+
+        host.Dispose();
+    }
+
+    /// <summary>
+    /// The freeze half of the shutdown case: the collection already knows it is disposing, so
+    /// creation is refused before it starts. No exception exists, and none is needed.
+    /// </summary>
+    [Fact]
+    public void CreationRefusedByTheDisposalFreeze_IsReportedAsAShutdown()
+    {
+        var host = GetClient().ServiceProvider.CreateMessageHub(
+            new Address("outcome-host", "frozen"),
+            c => c.WithPostingIdentity(PostingIdentity.System));
+
+        // Dispose freezes hosted-hub creation SYNCHRONOUSLY across the subtree
+        // (TeardownHubCreationFreezeTest pins that); this asserts what the refusal is CALLED.
+        host.Dispose();
+
+        var result = host.TryGetHostedHub(
+            new Address("outcome-child", "frozen"),
+            c => c,
+            HostedHubCreation.Always);
+
+        result.Hub.Should().BeNull("a disposing host refuses new hosted hubs");
+        result.Outcome.Should().Be(HostedHubOutcome.HostShuttingDown,
+            "a refusal by the teardown freeze is an expected shutdown, never a hub-construction fault");
+        result.IsShutdownRace.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// 🚨 The incident itself: the container dies UNDER a creation that had already passed the
+    /// freeze check. Before the fix this was indistinguishable from
+    /// <see cref="ConfigurationThatThrows_IsReportedAsAFault_WithTheRealException"/> — same null,
+    /// same fail-level line — which is exactly why an expected pod rollout opened a ticket.
+    /// </summary>
+    [Fact]
+    public void ContainerDisposedUnderALiveCollection_IsReportedAsAShutdown_NotAFault()
+    {
+        // A real child lifetime scope of the fixture's container — the same construction
+        // MessageHubConfiguration.CreateServiceProvider performs for every hosted hub.
+        var scope = new ServiceCollection().SetupModules(GetClient().ServiceProvider);
+
+        // Built while the scope is ALIVE (its ctor resolves this collection's logger from it), so
+        // the collection's own freeze flags stay false — nothing told it a shutdown is happening.
+        var hubs = new HostedHubsCollection(scope, new Address("outcome-host", "disposed-container"));
+
+        // The pod stops: the container goes down without the collection ever being disposed.
+        ((IDisposable)scope).Dispose();
+
+        var result = hubs.GetHubWithOutcome(
+            new Address("outcome-child", "disposed-container"),
+            c => c,
+            HostedHubCreation.Always);
+
+        result.Hub.Should().BeNull("hub construction cannot run against a disposed container");
+        result.Outcome.Should().Be(HostedHubOutcome.HostShuttingDown,
+            "a container that answers every resolution with ObjectDisposedException IS a host going "
+            + "down — reporting it as a construction fault tickets every pod rollout (#3243)");
+        result.IsShutdownRace.Should().BeTrue();
+        result.Error.Should().BeOfType<ObjectDisposedException>(
+            "the evidence rides along: downgrading the level is not licence to swallow the outcome");
+    }
+}


### PR DESCRIPTION
Closes #3243

## The defect

`MessageHubGrain` logged `[ACTIVATE] … Hub construction returned no hub` at **fail level** for *both* conditions that produce a null hub, and the message text listed the two and committed to neither:

> Either the hub configuration threw — see the 'Failed to create hosted hub' entry logged immediately before this one … — or hosted-hub creation is frozen because this host (or an ancestor) is disposing.

The vagueness was honest. `GetHostedHub` answers `null` for both and a null carries no reason, so the grain genuinely could not tell them apart. But **the level a call site chooses is a ticketing decision, not a verbosity knob** — every red line a portal writes becomes an incident and a GitHub issue (`Doc/Architecture/LogWatchTriage`). So the condition that happens on *every pod rollout* opened a ticket for a race in which nothing failed and nothing was written: incident `e2028eb86d6a85a6` and its sibling `8bd7c9c44c12e40b`, recurring across four deployments since mid-August.

This is not a log-level dial. It is a real cost/value distinction between two conditions that were previously indistinguishable, and **both remain fully reported** — only the one that is not a fault stops being red.

## The reason now travels with the answer

- `HostedHubsCollection.GetHubWithOutcome` returns a `HostedHubResult`: the hub, a `HostedHubOutcome` (`Available` / `Absent` / `HostShuttingDown` / `ConstructionFaulted`), and the exception behind it.
- `IMessageHub.TryGetHostedHub` carries it to the caller. **Default-implemented**, so any other `IMessageHub` implementation keeps compiling and reports `Unclassified`.
- The classification is made in the one place that can see the container, instead of being re-derived two layers away by a caller that cannot.

## The shutdown verdict is MEASURED, not assumed

The production shape is *not* the creation freeze: the creation passed `IsDisposing`, and the Autofac scope then died **under** the build (`LifetimeScope.ThrowDisposedException`). So an `ObjectDisposedException` out of hub construction is classified by **asking the container whether it can still resolve anything**. A live scope that threw that type for its own reasons still reads as a fault; and if the probe itself cannot answer, the CLR treats the exception filter as false and the outcome stays **loud** — the conservative direction, by construction.

Downgrading a level is not licence to swallow an outcome. Both branches still record the activation failure for the caller, still fail parked deliveries through `_hubReadyRaw.OnError`, and still `DeactivateOnIdle` for retry-on-next-access. `Unclassified` stays at fail level too — only a **known** shutdown is quiet.

## Tests, and the negative control

`HubCreationDuringTeardownIsNotAFaultTest` (new) runs all three conditions against a **real Autofac container** built by the framework's own `SetupModules` — no mocks, no hand-rolled gates, no async:

| Case | Expected |
|---|---|
| Configuration throws while the host is live | `ConstructionFaulted`, `Error` is the thrown exception |
| Creation refused by the disposal freeze | `HostShuttingDown`, no exception |
| Container disposed under a live (unfrozen) collection — **the incident** | `HostShuttingDown`, `Error` is the `ObjectDisposedException` |

**Verified it fails without the fix.** With the classification disabled the third case fails with

```
Expected value to be HostShuttingDown because a container that answers every resolution with
ObjectDisposedException IS a host going down …, but found ConstructionFaulted.
```

over the verbatim production stack — `Autofac.Core.Lifetime.LifetimeScope.ThrowDisposedException()` → `MessageHubConfiguration..ctor` → `CreateMessageHub` → `HostedHubsCollection.CreateHub`, preceded by the companion `[Error] Failed to create hosted hub for address …` line from the sibling incident.

`HubConstructionOutcomeReportingTest` (new) pins the level and the wording per outcome, including that an unclassified answer is never quietly downgraded. `HubConstructionFailureReasonTest` (#1693) is carried forward onto the new signature.

## Verification

- `dotnet build -c Release -warnaserror`, one project per invocation, `0 Error(s)` on: `MeshWeaver.Messaging.Hub`, `MeshWeaver.Hosting.Orleans`, `MeshWeaver.Documentation`, `MeshWeaver.Mesh.Operations`, `MeshWeaver.PluginCatalog`, `MeshWeaver.Hosting.AspNetCore`, `MeshWeaver.Compiler.Pipeline`, and the three touched test projects.
- `MeshWeaver.Messaging.Hub.Test`: full suite green (365 tests).
- `MeshWeaver.Hosting.Orleans.Test` `~HubConstruction`: 8/8 green.
- `MeshWeaver.Documentation.Test` `~WhatsNew` / `~DocumentationLinkIntegrity`: green.

## Docs

`Doc/Architecture/LogWatchTriage` gains the third "not a fault" row and the two rules this case adds: **the condition must travel** (a caller cannot classify what it cannot see), and **the benign verdict must be measured**. What's New entry: *A pod shutting down is no longer reported as an error* (`Category: Fix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhT5AXByEKo2fRQtWH2wCW
