### PR TITLE
docs(deploy): re-measure chart drift 2026-09-04 and split CLUSTER-ONLY by helm ownership

### DIFF
--- a/.github/workflows/chart-drift.yml
+++ b/.github/workflows/chart-drift.yml
@@ -86,11 +86,27 @@ name: Chart Drift
 # read: "ConfigMap Authentication__Microsoft__ClientId is still `CHANGE_ME_aad_application_client_id`
 # in the chart, so a `helm upgrade` today would overwrite working auth with the placeholder." Both
 # halves are false and each was falsifiable from the day it was written:
-#   * NO run has EVER reported an `Authentication__` finding (2026-08-26, 09-02, 09-03). Every
-#     environment sets a real client id in its own overlay, which is layered over the chart default,
-#     so nothing renders the placeholder in the first place.
+#   * `Authentication__Microsoft__ClientId` is COMPARED and it AGREES. Verified 2026-09-04 on the
+#     live ConfigMaps: both namespaces carry a 36-character GUID, not the 35-character placeholder,
+#     and each overlay states its own real client id, which layers over the chart default — so
+#     nothing renders the placeholder in the first place. The claim is "compared and equal", not
+#     "not compared": the same run emitted four `DIFFERS ConfigMap` findings, so the comparison
+#     could have failed on this key and did not.
 #   * A `helm upgrade` does not overwrite a live value with a rendered one anyway — measured, see
 #     check-chart-drift.sh's header. The whole "a deploy would destroy this" model was wrong.
+#
+# 🚨 AND THE CORRECTION ITSELF WENT STALE IN ONE DAY. This paragraph used to say "NO run has EVER
+# reported an `Authentication__` finding (2026-08-26, 09-02, 09-03)". The 2026-09-04 run reports
+# FIVE — `CLUSTER-ONLY ConfigMap Authentication__DevAdminUsers` and `Authentication__Google__ClientId`
+# on both namespaces, plus `Authentication__LinkedIn__ClientId` on memex. Nothing drifted: the
+# first-run-setup change made those keys conditional (`if`) where they had been emitted
+# unconditionally with `| default ""`, so the render stopped carrying a key the live ConfigMap still
+# holds at zero length. Measured cause, not a hypothesis: the live ConfigMaps have not been written
+# since 2026-08-30 (memex) / 2026-08-29 (memex-cloud) — `managedFields`, and helm revisions 28/21.
+# The finding is real and correctly classified; the value being empty is what makes it harmless.
+# A "no run has ever" clause in a gate's header is a standing claim about future runs, so it dates
+# the moment the chart changes — prefer the mechanism to the tally.
+#
 # Left in place as a correction rather than deleted: this file's own warning is what #2355 was
 # triaged against for a week, and an un-measured hazard in a gate's header propagates as fact.
 

--- a/deploy/aks/scripts/check-chart-drift.sh
+++ b/deploy/aks/scripts/check-chart-drift.sh
@@ -89,7 +89,9 @@
 #                  the values files and the ConfigMap is reading a value no pod uses. This is the
 #                  #2235 shape: the ConfigMap said Hosting/PlatformBuilds, the pod ran
 #                  Store/Payments, every signal was green and the endpoint 404'd for 11 days.
-#   CLUSTER-ONLY   live, not rendered   → survives a deploy, but exists in NO committed source, so
+#   CLUSTER-ONLY   live, not rendered   → survives a deploy UNLESS the release manifest still owns the
+#                  key (a chart RETIREMENT — then the merge deletes it; check `helm get manifest`),
+#                  and it exists in NO committed source, so
 #                  it is lost the moment the namespace is rebuilt or restored from the chart, and
 #                  it is invisible to review. Fleet rule: nothing may live only on the cluster.
 #   CHART-ONLY     rendered, not live   → described but never applied; nobody is getting it

--- a/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
@@ -53,6 +53,11 @@ them"* — that inventory was right and the detector's legend was wrong.
 > urgency the old legend created was false, *and* the reassurance "it will sort itself out on the
 > next deploy" is equally false. Drift is only ever cleared deliberately.
 
+One exception, and it follows from the same mechanism rather than qualifying it: a key the LAST
+deploy rendered and the CURRENT chart does not is in the release's own manifest, so helm owned it
+and the merge deletes it. That is not a cluster-only setting surviving; it is a chart retirement
+landing. The discriminator, and today's count, are under *"`CLUSTER-ONLY` splits in two"* below.
+
 ## The hazard that is real, and was invisible
 
 An inline `env:` entry **overrides `envFrom`**. So an inline entry whose name matches a key the
@@ -80,7 +85,7 @@ owned.
 |---|---|---|
 | `COLLIDES` | inline `env:` + a ConfigMap key differing **only in case** | **already**, at random, every pod start |
 | `SHADOWS` | inline `env:` + the **same** key from **any** envFrom source | **already** — the shadowed value is dead |
-| `CLUSTER-ONLY` | live, in no committed source | on a rebuild or restore, and at every review |
+| `CLUSTER-ONLY` | live, in no committed source | on a rebuild or restore, and at every review — **unless the release manifest still owns the key**, when the next upgrade deletes it |
 | `CHART-ONLY` | rendered, never applied | nobody is getting it today |
 | `DIFFERS` | both sides, values disagree | never resolves itself; needs a decision — except an `inline env`, which helm owns and an upgrade resets |
 
@@ -187,29 +192,83 @@ Findings are printed worst-first and the summary counts each class. Rank the wor
 `Systemorph/Memex#148` (*nothing may live only on the cluster* — every value belongs on the
 `Hosting/Deployment` record, rendered by the chart); `DIFFERS` is a decision, not a deploy.
 
-## The backlog, classified — run 33755512452, 2026-09-03
+## `CLUSTER-ONLY` splits in two, and only one half survives a deploy
 
-"91 divergences" is not a worklist. **76 today** (`memex` 32 across 188 compared fields,
-`memex-cloud` 44 across 204), and they are seven groups, not seventy-six decisions. Counts are from
-the run's own log; no cluster was touched to produce them.
+"A `helm upgrade` does not delete cluster-only settings" is the measured rule, and it is right about
+the *mechanism* — helm removes only what it **previously owned**. But a key can be cluster-only
+*today* precisely **because the chart stopped rendering a key the last deploy did render**, and that
+key IS in the release's own manifest. The three-way merge then deletes it, correctly.
+
+So the class has two mechanically distinguishable halves, and the discriminator is one command —
+`helm get manifest <release> -n <ns>`, the `original` side of the merge:
+
+| sub-class | test | next `helm upgrade` |
+|---|---|---|
+| **owned-but-retired** | the key IS in `helm get manifest` | **deletes it** — helm owned it |
+| **never-owned** | the key is NOT in `helm get manifest` | **leaves it** — the migration backlog |
+
+Measured 2026-09-04 over all 36 `CLUSTER-ONLY` findings: **13 owned-but-retired** (`memex` 7,
+`memex-cloud` 6) and **23 never-owned** (`memex` 12, `memex-cloud` 11). Every one of the 13 is
+zero-length live, so all thirteen deletions are no-ops — but that is a property of *these* keys on
+*this* day, not of the sub-class. `Systemorph/Memex#152` asked for exactly this check in the
+opposite direction ("a key that is live and rendered by neither chart nor overlay is about to be
+deleted, which is information no current gate reports"); the manifest probe above is that check, and
+running it before a deploy is what turns a silent deletion into a reviewed one.
+
+🚨 **And read the VALUE, not the key name, before calling such a deletion harmless.**
+`FrameworkBroadcast__Subscribers__0..3` was reported here on 2026-09-03 as "the live keys feed
+nothing", and separately as a subscriber list that a deploy would take "from 4 to 0". Both readings
+assumed a value. Measured on 2026-09-04 by three methods — live ConfigMap `jsonpath`, live ConfigMap
+YAML, and the deployed release manifest — **all four slots are `""` on BOTH namespaces**, and the
+deployed release (`helm get values`) sets no value for any of them. The release wave has been
+resolving to an empty subscriber set on both portals all along; the pending deletion removes four
+empty strings and changes nothing. The hazard is real and already realised, which is a different
+piece of work from the one "a deploy will break it" describes.
+
+## The backlog, classified — run 33843264982, 2026-09-04
+
+"91 divergences" is not a worklist. **81 today** (`memex` 35 across 188 compared fields,
+`memex-cloud` 46 across 204), and they are seven groups, not eighty-one decisions. Counts are from
+the run's own log; the owned/never-owned split and the value probes are read-only cluster reads.
 
 | # | group | count | what it is | what clears it |
 |---|---|---|---|---|
-| 1 | **Disagreeing `SHADOWS`** | **8** | the pod runs a value the ConfigMap contradicts — `PreWarm__BatchBake`/`PrebuiltBundleRoot` (both), `PluginCatalog__RegistryUrl` (both), `PreWarm__GateReadiness` + `Features__Ai__Providers__AzureOpenAI` (memex) | chart value first, **then** delete the inline entry |
+| 1 | **Disagreeing `SHADOWS`** | **8** | the pod runs a value the ConfigMap contradicts — `PreWarm__BatchBake`/`PrebuiltBundleRoot` and `PluginCatalog__RegistryUrl` (both namespaces), `PreWarm__GateReadiness` + `Features__Ai__Providers__AzureOpenAI` (memex) | chart value first, **then** delete the inline entry |
 | 2 | **The registry credential** | **2** | `PluginCatalog__RegistryToken`: on memex a `SHADOWS` over `secret/memex-portal-secrets` whose two values differ; on memex-cloud the inline entry is the ONLY copy | MeshWeaver#3201 — establish the live token, vault it, delete inline, rotate |
 | 3 | **Agreeing `SHADOWS`** | **29** | not wrong today; the ConfigMap is simply not what the pod reads, so the next chart change to any of them silently fails — Kestrel endpoints, `PluginCatalog__Sources__*`, `WebhookInbox__Targets__0` | same two steps, no urgency |
-| 4 | **Chart-retired, inert** | **8** | `FrameworkBroadcast__Subscribers__0..3` on both namespaces. The chart stopped rendering these on 2026-09-03 — the subscriber set is mesh data now — so the live keys feed nothing | delete the keys; drop them from the memex-cloud overlay, which still sets them |
-| 5 | **Cluster-only, now expressible** | **22** | live-edited settings the chart had no key for until MeshWeaver#3199 — AI providers, `LogWatch__*`, `Speech__*`, `Commerce__BaseUrl`, `Features__Ai__Clis__*`, `Portal__ReactAppUrl` | put them on the `Hosting/Deployment` record — `Systemorph/Memex#148` |
+| 4 | **Chart-retired, helm-owned** | **13** | `FrameworkBroadcast__Subscribers__0..3` (both) plus `Authentication__DevAdminUsers`/`__Google__ClientId` (both) and `__LinkedIn__ClientId` (memex). All 13 are in the release manifest and zero-length live | the next `helm upgrade` deletes them; verify each is still empty first |
+| 5 | **Cluster-only, never owned** | **22** | live-edited settings the chart had no key for until MeshWeaver#3199 — AI providers, `LogWatch__*`, `Speech__*`, `Commerce__BaseUrl`, `Features__Ai__Clis__*`, `Portal__ReactAppUrl` | put them on the `Hosting/Deployment` record — `Systemorph/Memex#148` |
 | 6 | **Committed, never deployed** | **5** | memex-cloud's overlay carries `PreWarm__{BatchBake,BuildProtocol,DynamicTypes,GateReadiness}: "true"` and `probes.startup.failureThreshold: 1080`; live runs the shipped defaults | a deploy, not a cleanup — this is `deploy-drift`'s class surfacing here |
 | 7 | **Ruled inert** | **2** | the memex liveness/readiness `initialDelaySeconds` — see above; the chart is authoritative | nothing; do not "fix" it |
 
-Zero `COLLIDES` and zero `CHART-ONLY`. The `EMAIL__*` collisions that crashed memex at boot on
-2026-08-30, and the four blanked `ModelTier__*`, are gone from both namespaces.
+Zero `COLLIDES` and zero `CHART-ONLY`, for the ninth consecutive run. The `EMAIL__*` collisions that
+crashed memex at boot on 2026-08-30, and the four blanked `ModelTier__*`, are gone from both
+namespaces.
 
-**Groups 1–5 all need a Deployment-spec edit, and that is blocked**: MeshWeaver#3207 — the portal
-image is ahead of its schema, so any pod-template change spawns a ReplicaSet that lands on
-`DbVersionGate` and crash-loops, and both portals are pinned under a freeze. The classification is
-the deliverable until the schema is current; nothing here is urgent enough to lift a freeze for.
+**76 → 81 in a day, and nothing drifted.** The five new findings are the `Authentication__*` keys in
+group 4: the first-run-setup change made them conditional where they had been emitted unconditionally
+with `| default ""`, so the render stopped carrying a key the cluster still holds. The live
+ConfigMaps have not been written since 2026-08-30 / 2026-08-29 (`managedFields`; helm revisions 28
+and 21). **A count that moves is not automatically drift** — check the chart's own history before
+reading a rise as a regression.
+
+**Group 6 carries the one coupled hazard on the list.** `PreWarm__GateReadiness` reaches the pod
+through an inline `env:` that shadows the ConfigMap, so a `helm upgrade` of `memex-cloud` would raise
+`probes.startup.failureThreshold` to 1080 — a pod-template field helm owns — while the gate it is
+paired with stays off, because the inline entry still wins. `progressDeadlineSeconds` is derived as
+`periodSeconds × failureThreshold + 600`, so a genuinely failed rollout would take **3 h 10 m** to be
+declared failed instead of ~16 minutes. Deleting the inline entry and deploying are one change, not
+two.
+
+## What is NOT in these 81
+
+The checker compares `memex-portal-config`, `memex-portal-deployment`, the PodDisruptionBudget and
+the ScaledObject. Every other object in these namespaces is outside its scope, and two of them are
+drifted right now: `portal-next-deployment` (both namespaces — `kubectl-client-side-apply` 2026-07-05
+then `kubectl set` 2026-08-07, no helm annotations, 0/1 ready on an image tag ACR does not have;
+`Systemorph/Memex#172`) and the `k8s-dashboard`/`memex-website`/`whisper-swiss-german` workloads. A
+green Chart Drift would say nothing about any of them, which is worth knowing before this report is
+read as "the namespace matches the chart".
 
 See also [DeploymentAKS.md](/Doc/Architecture/DeploymentAKS) and
 [Deployment.md](/Doc/Architecture/Deployment).

--- a/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
@@ -241,9 +241,10 @@ the run's own log; the owned/never-owned split and the value probes are read-onl
 | 6 | **Committed, never deployed** | **5** | memex-cloud's overlay carries `PreWarm__{BatchBake,BuildProtocol,DynamicTypes,GateReadiness}: "true"` and `probes.startup.failureThreshold: 1080`; live runs the shipped defaults | a deploy, not a cleanup — this is `deploy-drift`'s class surfacing here |
 | 7 | **Ruled inert** | **2** | the memex liveness/readiness `initialDelaySeconds` — see above; the chart is authoritative | nothing; do not "fix" it |
 
-Zero `COLLIDES` and zero `CHART-ONLY`, for the ninth consecutive run. The `EMAIL__*` collisions that
-crashed memex at boot on 2026-08-30, and the four blanked `ModelTier__*`, are gone from both
-namespaces.
+Zero `COLLIDES` and zero `CHART-ONLY` — as on 2026-09-03, which is the only other run since #3168
+introduced those two classes, so "consecutive" is a two-run claim and nothing more. The `EMAIL__*`
+collisions that crashed memex at boot on 2026-08-30, and the four blanked `ModelTier__*`, are gone
+from both namespaces.
 
 **76 → 81 in a day, and nothing drifted.** The five new findings are the `Authentication__*` keys in
 group 4: the first-run-setup change made them conditional where they had been emitted unconditionally


### PR DESCRIPTION
Re-measures the Chart Drift backlog on **2026-09-04** and records what the measurement changes.
Documentation and comments only — **no chart template, no values file, no workflow step; nothing
production runs is affected.** Refs #2355 (no closing keyword: the config work closes it, not this).

## Why now

`Doc/Architecture/ChartDriftSemantics` classified the **09-03** run (76 findings) and said every
actionable group was blocked by #3207. #3207 **closed at 05:59Z today**, and the run I dispatched on
`main` this morning
([33843264982](https://github.com/Systemorph/MeshWeaver/actions/runs/33843264982)) reports **81**:

| namespace | compared | divergences | COLLIDES | SHADOWS | CLUSTER-ONLY | CHART-ONLY | DIFFERS |
|---|---:|---:|---:|---:|---:|---:|---:|
| `memex` | 188 | 35 | 0 | 14 | 19 | 0 | 2 |
| `memex-cloud` | 204 | 46 | 0 | 24 | 17 | 0 | 5 |

## What the re-measurement establishes

**1 · `CLUSTER-ONLY` splits in two, and the discriminator is one command.** *"A `helm upgrade` does
not delete cluster-only settings"* is right about the mechanism — helm removes only what it
**previously owned**. But a key can be cluster-only *because the chart retired a key the last deploy
rendered*, and that key **is** in the release manifest, so the merge deletes it. `helm get manifest`
is the test. Measured over all 36: **13 owned-but-retired** (`memex` 7, `memex-cloud` 6) and **23
never-owned**. `Systemorph/Memex#152` asked for exactly this check ("a key live and rendered by
neither chart nor overlay is about to be deleted, which is information no current gate reports") —
this quantifies it.

**2 · 🚨 The eight `FrameworkBroadcast__Subscribers` slots are `""` on BOTH namespaces.** Verified
three ways — live ConfigMap `jsonpath` (len=0 ×8), live ConfigMap YAML, the deployed release manifest
— plus `helm get values`, which sets **no value** for any of them. This page called them
"chart-retired, inert"; `Systemorph/Memex#152` read them as *functional today* and a deploy as taking
the subscriber list *"from 4 to 0"*. **It is already 0.** The pending deletion removes four empty
strings; the quiet release wave is a live condition, not a deploy hazard. The deployed manifest's own
comment agrees: *"the broadcast resolved to an EMPTY set."*

**3 · 76 → 81 is not drift.** The five new findings are the `Authentication__*` keys the
first-run-setup change made conditional (`if`) where they had been unconditional with `| default ""`
— so the *render* stopped carrying a key the cluster still holds, at **zero length**. The live
ConfigMaps have not been written since 2026-08-30 / 2026-08-29 (`managedFields`; helm revisions 28
and 21). A count that rises is not automatically a regression.

**4 · The one coupled hazard on the list.** A `helm upgrade` of `memex-cloud` would raise
`probes.startup.failureThreshold` to 1080 — a pod-template field helm owns, so it lands — while the
`PreWarm__GateReadiness` it is paired with stays **off**, because an inline `env:` shadows the
ConfigMap. `progressDeadlineSeconds` is `periodSeconds × failureThreshold + 600`, so a genuinely
failed rollout would be declared failed after **3 h 10 m** instead of ~16 minutes, with no gate in
exchange. The inline entry must go in the **same** change as the deploy.

## The header claim that went false in a day

`chart-drift.yml` said *"NO run has EVER reported an `Authentication__` finding (2026-08-26, 09-02,
09-03)"*. **Five today.** Replaced with the mechanism, and with what is actually verified:
`Authentication__Microsoft__ClientId` is **compared and equal** — both live ConfigMaps carry a
36-character GUID (not the 35-character `CHANGE_ME_…` placeholder) and both overlays state a real
client id. That is not a vacuous pass: the same run emitted four `DIFFERS ConfigMap` findings, so the
comparator was live on that object and could have failed on this key.

A *"no run has ever"* clause in a gate's header is a standing claim about future runs, so it dates
the moment the chart changes. Prefer the mechanism to the tally.

`check-chart-drift.sh`'s `CLUSTER-ONLY` legend no longer claims such a key always survives a deploy.

## Method

Dispatched the gate on `main` rather than reading a prior number, then cross-checked every
load-bearing claim on the live cluster **read-only** through `az aks command invoke` — probes,
ConfigMap key presence and value **lengths**, `managedFields`, `helm history`, `helm get manifest`,
`helm get values`, the Deployment inventory — plus `az acr repository show-tags`. **No cluster object
was mutated, and no secret value was read, printed or stored.**

## Verified

- `dotnet build test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj -c Release -warnaserror` → **0 Warning(s), 0 Error(s)**; the built `MeshWeaver.Documentation.dll` carries the edited page (checked, not assumed).
- `DocumentationLinkIntegrityTest` + `WhatsNewEntryIntegrityTest` → **2 passed**, `.trx` written.
- `python3 yaml.safe_load(chart-drift.yml)` → OK, 3 jobs. `bash -n check-chart-drift.sh` → OK, and `--help` still renders the legend.

**No What's New entry:** pure-internal (a CI gate header and an operations doc), no user-visible
effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhT5AXByEKo2fRQtWH2wCW
