### PR TITLE
fix(#3264): "no history for this node" and "this portal keeps none" are different answers

### DIFF
--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-restoring-a-version-says-when-there-is-nothing-to-restore-from.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-restoring-a-version-says-when-there-is-nothing-to-restore-from.md
@@ -1,0 +1,30 @@
+---
+Name: Restoring a version says when there is nothing to restore from
+Category: Fix
+Description: Rolling back a node or undoing an activity reported "version not found" on portals that keep no version history at all — a data-shaped answer to a configuration fact. It now says plainly that history is not retained on this deployment, so you know the difference between a node that has no earlier version and a portal that records none.
+Icon: History
+Order: -20260904
+---
+
+# Restoring a version says when there is nothing to restore from
+
+Every node counts up a version number as you edit it. On some portals those earlier versions are
+kept; on others nothing is recorded behind the counter at all.
+
+Until now you could not tell which kind of portal you were on. Asking to roll a node back, or to
+undo an activity, answered **"version not found"** either way — the same message you would get for
+a node that genuinely had no earlier version. So a portal that had never recorded a single version
+looked exactly like a node you happened to be unlucky with, and the natural next step — try a
+different version, try a different node — could never work.
+
+Those surfaces now answer honestly. When the portal retains no history, restoring says so:
+
+> Version history is not retained on this deployment, so there is nothing to restore from. This is
+> a configuration fact, not a property of this node.
+
+Nothing about which portals keep history has changed, and nothing you could restore before has
+become unavailable. What changed is that a portal no longer reports a settings fact as though it
+were something about your document.
+
+If you are looking at a node whose version number is high and whose history is empty, that is this
+case, and the message will now tell you.

--- a/src/MeshWeaver.Graph/VersionLayoutArea.cs
+++ b/src/MeshWeaver.Graph/VersionLayoutArea.cs
@@ -60,11 +60,20 @@ public static class VersionLayoutArea
         IMessageHub hub,
         IMessageDelivery<RollbackNodeRequest> request)
     {
+        // 🚨 Ask whether history is RETAINED, not whether the service resolved. The null check
+        // alone was unreachable: `NoOpVersionQuery` is registered unconditionally
+        // (`PersistenceExtensions`, TryAddSingleton), so this service is never null on any
+        // deployment — and on every DATABASE-backed one it is the no-op, which answers "no
+        // version found" to a question it never records an answer to. So this honest refusal
+        // existed and could not fire, and the caller was told a data-shaped miss about a
+        // configuration fact (MeshWeaver#3264).
         var versionQuery = hub.ServiceProvider.GetService<IVersionQuery>();
-        if (versionQuery == null)
+        if (versionQuery is null or { RetainsHistory: false })
         {
             hub.Post(new DataChangeResponse(hub.Version,
-                new ActivityLog("Rollback").Fail("Version history not available")),
+                new ActivityLog("Rollback").Fail(
+                    "Version history is not retained on this deployment, so there is nothing to "
+                    + "restore from. This is a configuration fact, not a property of this node.")),
                 o => o.ResponseFor(request));
             return request.Processed();
         }
@@ -127,11 +136,20 @@ public static class VersionLayoutArea
         IMessageHub hub,
         IMessageDelivery<UndoActivityRequest> request)
     {
+        // 🚨 Ask whether history is RETAINED, not whether the service resolved. The null check
+        // alone was unreachable: `NoOpVersionQuery` is registered unconditionally
+        // (`PersistenceExtensions`, TryAddSingleton), so this service is never null on any
+        // deployment — and on every DATABASE-backed one it is the no-op, which answers "no
+        // version found" to a question it never records an answer to. So this honest refusal
+        // existed and could not fire, and the caller was told a data-shaped miss about a
+        // configuration fact (MeshWeaver#3264).
         var versionQuery = hub.ServiceProvider.GetService<IVersionQuery>();
-        if (versionQuery == null)
+        if (versionQuery is null or { RetainsHistory: false })
         {
             hub.Post(new DataChangeResponse(hub.Version,
-                new ActivityLog("Undo").Fail("Version history not available")),
+                new ActivityLog("Undo").Fail(
+                    "Version history is not retained on this deployment, so there is nothing to "
+                    + "restore from. This is a configuration fact, not a property of this node.")),
                 o => o.ResponseFor(request));
             return request.Processed();
         }

--- a/src/MeshWeaver.Hosting/Persistence/RoutingVersionQuery.cs
+++ b/src/MeshWeaver.Hosting/Persistence/RoutingVersionQuery.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Reactive.Linq;
 using System.Text.Json;
 using MeshWeaver.Mesh;
@@ -27,6 +28,13 @@ public class RoutingVersionQuery : IVersionQuery
         _queries[partition] = query;
     }
 
+    /// <inheritdoc />
+    /// <remarks>True when ANY registered partition provider retains history. The routing layer
+    /// cannot answer per-path here (the surfaces that ask are reporting a deployment-level
+    /// capability, not a per-node one), and "some partition records history" is the honest
+    /// answer to "are these surfaces functional at all".</remarks>
+    public bool RetainsHistory => _queries.Values.Any(q => q.RetainsHistory);
+
     private IVersionQuery? GetQuery(string path)
     {
         var segment = PathPartition.GetFirstSegment(path);
@@ -54,9 +62,21 @@ public class RoutingVersionQuery : IVersionQuery
 /// <summary>
 /// No-op implementation of <see cref="IVersionQuery"/> for environments
 /// without version history support.
+///
+/// <para>🚨 This is what EVERY database-backed deployment resolves — `PersistenceExtensions`
+/// only ever hands out a real store for a <c>FileSystemStorageAdapter</c>, so PostgreSQL, Cosmos,
+/// Sqlite and Snowflake all land here and retain nothing (MeshWeaver#3264). It answers
+/// <see cref="RetainsHistory"/> = <c>false</c> so a caller can say WHICH of the two facts it is
+/// looking at, rather than reporting "no history for this node" about a deployment that records
+/// none for any node.</para>
 /// </summary>
 public class NoOpVersionQuery : IVersionQuery
 {
+    /// <inheritdoc />
+    /// <remarks>Nothing is ever written here, so an empty answer is a property of the
+    /// deployment, not of the node.</remarks>
+    public bool RetainsHistory => false;
+
     /// <inheritdoc />
     public IObservable<MeshNodeVersion> GetVersions(string path)
         => Observable.Empty<MeshNodeVersion>();

--- a/src/MeshWeaver.Mesh.Contract/Services/IVersionQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IVersionQuery.cs
@@ -21,11 +21,31 @@ public record MeshNodeVersion(
 /// inside hub-reachable code without bridging to a Task. See
 /// <c>Doc/Architecture/AsynchronousCalls.md</c> ("Return type MUST be IObservable&lt;T&gt;").
 ///
-/// <para>Implementations: <c>FileSystemVersionStore</c>, <c>PostgreSqlVersionQuery</c>,
-/// <c>RoutingVersionQuery</c>, <c>NoOpVersionQuery</c>.</para>
+/// <para>Implementations: <c>FileSystemVersionStore</c>, <c>RoutingVersionQuery</c>,
+/// <c>NoOpVersionQuery</c>. 🚨 There is deliberately NO database implementation — this doc
+/// named a <c>PostgreSqlVersionQuery</c> for months and no such type has ever existed
+/// (MeshWeaver#3264). Every database-backed deployment therefore resolves
+/// <c>NoOpVersionQuery</c> and retains no history at all.</para>
 /// </summary>
 public interface IVersionQuery
 {
+    /// <summary>
+    /// Whether this deployment RETAINS history — i.e. whether an empty answer from
+    /// <see cref="GetVersions"/> means "this node has none" or "nothing is ever recorded here".
+    ///
+    /// <para>🚨 Those are different facts and callers were unable to tell them apart. The
+    /// surfaces built on history — Versions, VersionDiff, RestoreVersion, RestoreFromPointInTime —
+    /// each carry an honest "version history not available" branch, and every one of them was
+    /// UNREACHABLE: they guard on <c>GetService&lt;IVersionQuery&gt;() == null</c>, but
+    /// <c>NoOpVersionQuery</c> is registered unconditionally (<c>TryAddSingleton</c>), so the
+    /// service is never null and the no-op's empty answer was reported as a data-shaped miss
+    /// (MeshWeaver#3264). Ask this instead of null-checking the service.</para>
+    ///
+    /// <para>Defaults to <c>true</c>: an implementation that stores versions need not opt in,
+    /// and a third-party implementation is not silently declared history-less.</para>
+    /// </summary>
+    bool RetainsHistory => true;
+
     /// <summary>
     /// Streams every version summary for a node, ordered by version descending
     /// (newest first). Cold observable — completes after the last version is
@@ -54,8 +74,8 @@ public interface IVersionQuery
     /// pre-save Version writes the new content into an OLDER version's
     /// snapshot, overwriting history).
     /// <para>Default implementation is a no-op observable (single emission of
-    /// the input + completion); overridden by <c>FileSystemVersionStore</c>
-    /// and <c>PostgreSqlVersionQuery</c>.</para>
+    /// the input + completion); overridden by <c>FileSystemVersionStore</c>. No database
+    /// backend overrides it — see the note on <see cref="RetainsHistory"/>.</para>
     /// </summary>
     IObservable<MeshNode> WriteVersion(MeshNode node, JsonSerializerOptions options)
         => System.Reactive.Linq.Observable.Return(node);

--- a/test/MeshWeaver.Hosting.Test/VersionRetentionIsAStatedCapabilityTest.cs
+++ b/test/MeshWeaver.Hosting.Test/VersionRetentionIsAStatedCapabilityTest.cs
@@ -1,0 +1,134 @@
+using System.Reactive.Linq;
+using System.Text.Json;
+using MeshWeaver.Hosting.Persistence;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// MeshWeaver#3264 — <b>"this node has no history" and "this deployment records none" are different
+/// facts, and nothing could tell them apart.</b>
+///
+/// <para>Version history is implemented generically: <c>VersionWritingStorageAdapter</c> decorates
+/// every <see cref="IStorageAdapter"/> so each write chains a snapshot through
+/// <see cref="IVersionQuery.WriteVersion"/>. But it no-ops when no <see cref="IVersionQuery"/> is
+/// registered, and <c>PersistenceExtensions</c> only ever hands out a real store for a
+/// <c>FileSystemStorageAdapter</c> — every database backend (PostgreSQL, Cosmos, Sqlite, Snowflake)
+/// resolves <see cref="NoOpVersionQuery"/>. Measured on the production portal: a node at version
+/// 1172 with `GetVersions` answering "no version history found", on every node type, in every
+/// space. Nothing was lost; nothing was ever written.</para>
+///
+/// <para>🚨 <b>The defect this pins is the REPORTING, not the missing store.</b> The surfaces built
+/// on history each carry an honest refusal — <c>"Version history not available"</c> — and every one
+/// of them was UNREACHABLE, because they guard on <c>GetService&lt;IVersionQuery&gt;() == null</c>
+/// while <see cref="NoOpVersionQuery"/> is registered unconditionally (<c>TryAddSingleton</c>). So
+/// the service is never null, the honest branch never fires, and the no-op's empty answer is
+/// reported as a data-shaped miss about a configuration fact. That is a fail-closed fallback
+/// forging a correct-looking bug: the caller is told something false in a shape that looks like
+/// data.</para>
+///
+/// <para>The cure is that retention is a STATED capability (<see cref="IVersionQuery.RetainsHistory"/>)
+/// rather than something a caller infers from an empty result.</para>
+/// </summary>
+public class VersionRetentionIsAStatedCapabilityTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+
+    /// <summary>A store that genuinely retains — the shape <c>FileSystemVersionStore</c> has, and the
+    /// shape a database implementation would have. Present so the assertions below cannot pass by
+    /// answering <c>false</c> everywhere.</summary>
+    private sealed class RetainingVersionQuery : IVersionQuery
+    {
+        public IObservable<MeshNodeVersion> GetVersions(string path)
+            => Observable.Return(new MeshNodeVersion(path, 1, DateTimeOffset.UnixEpoch, null, null, null));
+
+        public IObservable<MeshNode?> GetVersion(string path, long version, JsonSerializerOptions options)
+            => Observable.Return<MeshNode?>(MeshNode.FromPath(path));
+
+        public IObservable<MeshNode?> GetVersionBefore(string path, long beforeVersion, JsonSerializerOptions options)
+            => Observable.Return<MeshNode?>(MeshNode.FromPath(path));
+    }
+
+    /// <summary>🚨 The anti-vacuity anchor. An implementation that stores versions must NOT have to
+    /// opt in — otherwise every third-party implementation is silently declared history-less, and
+    /// these tests would pass with <c>RetainsHistory</c> hard-wired to <c>false</c>.</summary>
+    [Fact]
+    public void AnImplementationThatStores_RetainsHistoryByDefault()
+    {
+        // Held as IVersionQuery deliberately: RetainsHistory is a DEFAULT INTERFACE MEMBER, so it
+        // is reachable only through the interface — which is exactly how every caller holds it
+        // (resolved from DI as IVersionQuery). An implementation opts OUT by overriding; it never
+        // has to opt in.
+        IVersionQuery retaining = new RetainingVersionQuery();
+
+        Assert.True(retaining.RetainsHistory,
+            "the interface default must be true: a store that records history should not need to "
+            + "declare it, and a test suite that only ever sees false proves nothing");
+    }
+
+    /// <summary>The production condition on every database-backed deployment.</summary>
+    [Fact]
+    public void TheNoOp_SaysItRetainsNothing()
+        => Assert.False(((IVersionQuery)new NoOpVersionQuery()).RetainsHistory,
+            "NoOpVersionQuery is what PostgreSQL / Cosmos / Sqlite / Snowflake all resolve; its "
+            + "empty answer is a property of the deployment, not of the node");
+
+    /// <summary>🚨 The behaviour the old code could not express: the no-op answers "not found" in
+    /// exactly the same shape a real store answers for a node that genuinely has no history. The
+    /// two are indistinguishable from the RESULT, which is why the capability has to be asked.</summary>
+    [Fact]
+    public void TheNoOpsEmptyAnswer_IsShapedLikeAGenuineMiss()
+    {
+        var noOp = new NoOpVersionQuery();
+
+        // 🚨 Subscribe, never a blocking bridge. These observables complete synchronously on
+        // Subscribe, so the captures below are deterministic — and `.Wait()` / `.ToEnumerable()`
+        // would trip the blocking-bridge ratchet while measuring nothing extra.
+        var versions = 0;
+        var listed = false;
+        noOp.GetVersions("Any/Path").Subscribe(_ => versions++, () => listed = true);
+        Assert.True(listed, "the no-op must COMPLETE, not hang — a caller composes on completion");
+        Assert.Equal(0, versions);
+
+        MeshNode? atVersion = null;
+        var gotAtVersion = false;
+        noOp.GetVersion("Any/Path", 1171, Options)
+            .Subscribe(v => { atVersion = v; gotAtVersion = true; });
+        Assert.True(gotAtVersion);
+        Assert.Null(atVersion);
+
+        MeshNode? before = null;
+        var gotBefore = false;
+        noOp.GetVersionBefore("Any/Path", 1172, Options)
+            .Subscribe(v => { before = v; gotBefore = true; });
+        Assert.True(gotBefore);
+        Assert.Null(before);
+
+        // …and that is precisely why a caller must not infer from it: a real store answers the
+        // same three shapes for a node that genuinely has no history.
+        Assert.False(((IVersionQuery)noOp).RetainsHistory);
+    }
+
+    /// <summary>Routing with nothing registered retains nothing — the empty-mesh case must not
+    /// claim a capability it cannot deliver.</summary>
+    [Fact]
+    public void Routing_WithNoProviders_RetainsNothing()
+        => Assert.False(((IVersionQuery)new RoutingVersionQuery()).RetainsHistory);
+
+    /// <summary>Routing reports the capability of what is actually registered, so a deployment that
+    /// retains for one partition is not reported as history-less.</summary>
+    [Fact]
+    public void Routing_ReportsWhatIsRegistered()
+    {
+        var routing = new RoutingVersionQuery();
+        var asQuery = (IVersionQuery)routing;
+
+        routing.Register("NoHistory", new NoOpVersionQuery());
+        Assert.False(asQuery.RetainsHistory);
+
+        routing.Register("Doc", new RetainingVersionQuery());
+        Assert.True(asQuery.RetainsHistory);
+    }
+}


### PR DESCRIPTION
## What this is

**Not the missing Postgres store.** This lands the half of #3264 that makes the other half legible — and it is a distinct defect, not a consolation prize.

## The defect

Version history *is* implemented, generically: `VersionWritingStorageAdapter` decorates every `IStorageAdapter` so each write chains a snapshot through `IVersionQuery.WriteVersion`. It no-ops when no `IVersionQuery` is registered — and `PersistenceExtensions` only ever hands out a real store for a `FileSystemStorageAdapter`:

```csharp
services.TryAddSingleton<IVersionQuery>(sp =>
{
    var inner = sp.GetKeyedService<IStorageAdapter>(InnerStorageAdapterKey) ?? sp.GetService<IStorageAdapter>();
    if (inner is FileSystemStorageAdapter fsAdapter)
        return new FileSystemVersionStore(fsAdapter.BaseDirectory, sp.GetRequiredIoPoolRegistry());
    return new NoOpVersionQuery();
});
```

So PostgreSQL, Cosmos, Sqlite and Snowflake all resolve `NoOpVersionQuery`. That is why a production node at version **1172** answers *"no version history found"*, on every node type, in every space: **nothing was lost; nothing was ever written.**

## 🚨 The part this PR fixes: the honest refusal existed and was UNREACHABLE

Every surface built on history already carries the right message — `"Version history not available"` — behind this guard:

```csharp
var versionQuery = hub.ServiceProvider.GetService<IVersionQuery>();
if (versionQuery == null) { …Fail("Version history not available")… }
```

`NoOpVersionQuery` is registered **unconditionally** (`TryAddSingleton`), so that service is **never null on any deployment**. The branch could not fire. The no-op's empty answer was therefore reported as a data-shaped miss — *"version 1171 not found"* — about what is actually a configuration fact.

That is the fail-closed-fallback shape: the caller is told something false, in a shape that looks like data, and the natural next step (try another version, try another node) can never work.

## The change

Retention becomes a **stated capability** instead of something inferred from an empty result:

| | `RetainsHistory` |
|---|---|
| `IVersionQuery` (default) | **`true`** — a store that records history does not opt in, and a third-party implementation is not silently declared history-less |
| `NoOpVersionQuery` | `false` |
| `RoutingVersionQuery` | `true` iff some registered partition retains |

`HandleRollbackNodeRequest` and `HandleUndoActivityRequest` now ask that instead of null-checking the service, so their existing refusal is reachable and names which fact it is reporting.

**Also corrects the contract's own documentation.** `IVersionQuery`'s XML doc listed a `PostgreSqlVersionQuery` among its implementations and said `WriteVersion` is *"overridden by `FileSystemVersionStore` and `PostgreSqlVersionQuery`"*. **No such type has ever existed anywhere in the repository** (`grep -rn 'class PostgreSqlVersionQuery' .` → nothing). The doc asserted a database implementation that was never written, which is a fair part of why this went unnoticed for so long.

## Verification

- Release + `-warnaserror`: `0 Warning(s) 0 Error(s)` on `MeshWeaver.Graph` and `MeshWeaver.Hosting.Test`.
- New suite **5/5**; full `MeshWeaver.Hosting.Test` **336/336**.
- 🚨 **The guard was made to fail on purpose.** With `NoOpVersionQuery`'s opt-out reverted, **3 of 5 fail** — `TheNoOp_SaysItRetainsNothing`, `Routing_ReportsWhatIsRegistered`, `TheNoOpsEmptyAnswer_IsShapedLikeAGenuineMiss` — while **both anti-vacuity anchors still pass** (`AnImplementationThatStores_RetainsHistoryByDefault`, `Routing_WithNoProviders_RetainsNothing`). So the suite discriminates rather than merely agreeing, and it would fail if `RetainsHistory` were hard-wired either way.
- Worth recording, since it nearly fooled me: my first falsification run reported **5 passed with the fix reverted** — because the revert broke a doc `cref`, the build failed, and `--no-build` then ran the *stale* binary. `TEST_EXIT=0` over `BUILD=1`. The re-run above is against a build that actually succeeded.

## Deliberately not here

- **The Postgres store.** That is the substance of #3264 and needs a retention policy decided with it — `VersionWritingStorageAdapter` snapshots on *every* write, and a node at version 3589 shows what row-per-write would cost. Priced, not assumed, before it is built.
- **Localizing the two refusal strings.** They stay plain English `ActivityLog` messages on purpose: `LogMessage` is a persisted rendered surface with no key and no render-time resolution hook, and the seam for that is #3236, currently in flight. Localizing these two here would collide with it.

`Refs #3264` rather than `Closes` — the issue stays open for the store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhT5AXByEKo2fRQtWH2wCW
