### PR TITLE
fix(deploy): a credential shadow can be two PRINCIPALS, and the checker may not narrate provenance

### DIFF
--- a/deploy/aks/scripts/chart-drift-compare.py
+++ b/deploy/aks/scripts/chart-drift-compare.py
@@ -198,13 +198,24 @@ for n in sorted(d_env | l_env):
                 f"a COIN TOSS PER POD START. Delete the inline entry (`kubectl set env deploy/… "
                 f"{n}-`); adding it to the chart does NOT remove the collision")
     elif external_only:
+        # 🚨 "Which value is live?" is the wrong question for a CREDENTIAL, and this message used
+        # to ask only that — while also asserting a Key Vault provenance this script cannot see.
+        # Measured on memex 2026-09-04 (MeshWeaver#3201): the shadowed side was NOT a stale copy of
+        # the same secret. Both sides were VALID registry instance keys, of DIFFERENT registered
+        # instances, with different entitlements — so the cleanup everyone reaches for first would
+        # have re-identified the portal, not merely changed a value. A name is all this script
+        # reads; it must not imply the two sides are the same credential, nor say where either came
+        # from.
         finding("SHADOWS", f"inline env {n}",
                 f"{origin} supplies '{n}' through envFrom, and an inline env OVERRIDES envFrom — so "
                 f"this entry wins and THAT source's value is dead. Whether the two agree is NOT "
-                f"checked here (only key names are read from that source) and must not be assumed: "
-                f"on memex they differed, leaving the pod on a plaintext copy while the Key Vault "
-                f"credential went unused (MeshWeaver#3201). Establish which value is the live one "
-                f"FIRST, then put it in that source and delete the inline entry")
+                f"checked here (only key names are read from that source) and must not be assumed — "
+                f"and for a CREDENTIAL they may not even be the same secret: on memex both sides "
+                f"were valid keys of DIFFERENT registered instances, so deleting the inline entry "
+                f"would have changed which principal the deployment authenticates as, and silently "
+                f"widened what it was entitled to (MeshWeaver#3201, measured 2026-09-04). Establish "
+                f"what EACH side IS — its value, and for a credential the identity it authenticates "
+                f"as — FIRST, then put the intended one in that source and delete the inline entry")
     else:
         in_chart = n in d_data
         # An entry sourced with valueFrom (secretKeyRef/fieldRef) carries no literal to compare —

--- a/deploy/aks/scripts/check-chart-drift.sh
+++ b/deploy/aks/scripts/check-chart-drift.sh
@@ -255,9 +255,16 @@ done
 # ---------------------------------------------------------------------------
 # Every key an envFrom source supplies reaches the portal exactly like a memex-portal-config key —
 # so an inline env of the same name shadows it just as silently. memex proves it is not theoretical:
-# the Key-Vault-provisioned PluginCatalog__RegistryToken sits under an inline entry carrying a
-# DIFFERENT token, so the managed credential is dead and the pod authenticates with a plaintext
-# copy (MeshWeaver#3201). Reading only the names is enough to see that, and is all we read.
+# PluginCatalog__RegistryToken sits in secret/memex-portal-secrets AND as an inline entry carrying a
+# DIFFERENT value, so the secret's copy is dead and the pod authenticates with a plaintext one
+# (MeshWeaver#3201). Reading only the names is enough to see that, and is all we read.
+#
+# 🚨 And reading only the names is also all we may CLAIM. Re-measured 2026-09-04, the two sides were
+# not one credential in two places: they were valid instance keys of DIFFERENT registered instances,
+# and the secret's copy was never Key Vault-provisioned at all (that namespace's CSI-backed secret is
+# memex-kv-secrets, which does not carry this key, and the vault holds no such entry). A name-only
+# checker cannot see provenance or identity — so it reports the shadow and says the two are unknown,
+# rather than narrating a story about where either side came from.
 #
 # 🚨 BOTH source kinds, not just Secrets. `.Values.extraEnvFrom` takes verbatim EnvFromSource
 # objects and the chart documents `{configMapRef: {name: …}}` as one of the two shapes, so

--- a/deploy/aks/scripts/test-chart-drift-compare.sh
+++ b/deploy/aks/scripts/test-chart-drift-compare.sh
@@ -101,6 +101,33 @@ else
   echo "  ok   a secret-backed shadow states no value verdict"
 fi
 
+# ...nor a PROVENANCE. Reading a key NAME says nothing about where that key's value came from. The
+# message asserted "the Key Vault credential went unused" until 2026-09-04, when re-measuring memex
+# showed the shadowed secret was helm-rendered, that its namespace's CSI-backed secret does not carry
+# the key, and that the vault holds no such entry at all. A checker that narrates an unmeasured
+# provenance teaches its reader a wrong fix.
+if echo "$out" | grep -A1 'SHADOWS *inline env PluginCatalog__RegistryToken' | grep -qi 'key vault'; then
+  echo "::error::the secret-backed shadow claims a Key Vault provenance. Only the key NAME is read"
+  echo "         from that source — where its value came from is not observable here."
+  fail=1
+else
+  echo "  ok   a secret-backed shadow claims no provenance"
+fi
+
+# ...and it MUST warn that a credential shadow can be two PRINCIPALS, not two values of one setting.
+# On memex both sides were valid registry instance keys of DIFFERENT registered instances, so the
+# reflex cleanup would have re-identified the portal and widened its entitlement. "Establish which
+# value is live" is not sufficient advice for a credential, and that is the whole lesson of #3201.
+if echo "$out" | grep -A1 'SHADOWS *inline env PluginCatalog__RegistryToken' \
+     | grep -q 'DIFFERENT registered instances'; then
+  echo "  ok   a secret-backed shadow warns the two sides may be different principals"
+else
+  echo "::error::the secret-backed shadow does not warn that the two sides may be different"
+  echo "         PRINCIPALS. Deleting the inline entry can re-identify the deployment, not merely"
+  echo "         change a value — see MeshWeaver#3201."
+  fail=1
+fi
+
 # A SHADOWS whose two values disagree must SAY so — that verdict is the whole point of the class.
 if echo "$out" | grep -A1 'SHADOWS *inline env PreWarm__GateReadiness' | grep -q 'THE TWO DISAGREE'; then
   echo "  ok   disagreeing SHADOWS is called out as such"

--- a/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChartDriftSemantics.md
@@ -93,15 +93,76 @@ names of **every** envFrom source, not just the secrets. Enumerating one kind an
 would have left exactly the blind spot MeshWeaver#3201 exposed, one source-kind over: a checker that
 can see half of the class it is named for reports "clean" for a reason its reader cannot guess.
 
-A shadowed secret is the worst version of this: the credential the platform provisioned through Key
-Vault is inert, and the value actually in use sits in plaintext on the Deployment spec, in no
-committed source, readable by anything that can `get deploy`.
+A shadowed secret is the worst version of this: the shadowed copy is inert, and the value actually
+in use sits in plaintext on the Deployment spec, in no committed source, readable by anything that
+can `get deploy`.
 
 That is live on `memex` today (MeshWeaver#3201): `PluginCatalog__RegistryToken` exists both in
 `secret/memex-portal-secrets` and as an inline entry, and **the two values differ** — so the portal
-authenticates to the plugin registry with the plaintext copy while the managed credential goes
-unused. It also means the obvious cleanup is wrong: deleting the inline entry does not restore the
-status quo, it switches the portal onto a different token.
+authenticates to the plugin registry with the plaintext copy while the secret's copy goes unused. It
+also means the obvious cleanup is wrong: deleting the inline entry does not restore the status quo.
+
+### A credential shadow can be two PRINCIPALS, not two values
+
+Re-measured on the live cluster 2026-09-04, that case was worse than "two values of one setting",
+and in a way the checker cannot see — which is why the conclusion belongs here rather than in its
+output:
+
+- **Both sides are valid.** The live inline key and the shadowed copy each authenticate to
+  `https://memex.meshweaver.cloud/api/plugins` — verified out of band from inside the cluster, with
+  an anonymous call and a syntactically-valid bogus key as the two controls (both `401`).
+- **They are different registered instances.** Hashing each credential *inside the cluster* and
+  comparing against the `MeshWeaverInstance.keyHash` the registry stores identifies the inline key
+  as instance `memex` — the portal's own identity, and the correct one. The shadowed copy matches
+  no enumerable instance, and its catalog projection is `Plugins/*` **plus** `Crm/*`, a strict
+  superset of what instance `memex` is granted.
+- **So the reflex cleanup re-identifies the deployment.** Deleting the inline entry would not have
+  "switched onto an unverified token"; it would have made the portal authenticate as a *different
+  instance*, silently widening what it may pull from 44 packages to 45.
+- **There was never a Key Vault copy.** `secret/memex-portal-secrets` is helm-rendered
+  (`app.kubernetes.io/managed-by=Helm`), not CSI-provisioned. The CSI-backed secrets in those
+  namespaces are `memex-kv-secrets` and `memexcloud-portal-ai-secrets`, neither of which carries
+  this key, and the `Systemorph` vault holds no `PluginCatalog-RegistryToken` entry for either
+  portal. `deployments/aks/secretproviderclass.reference.yaml` in `Systemorph/Memex` already
+  templates that wiring; it was never applied to either live SecretProviderClass.
+
+The generalisable rule: **for a credential, "which value is live?" is not the whole question — "which
+identity does each side authenticate as?" is.** A name-only checker can report the shadow and must
+say the two sides are unknown; it cannot say they are the same credential, and it must not narrate a
+provenance it never observed. The comparator asserted a Key Vault origin here until 2026-09-04, and
+the self-test now fails if that claim returns.
+
+Neither namespace sets `PluginCatalog__InstanceId` and neither carries a `PluginCatalog__BootstrapKey`,
+so nothing self-registers: **the token IS the identity**. memex's own ConfigMap asks for
+`PluginCatalog__InstallByDefault__0=Plugins/*`, which is exactly instance `memex`'s grant and not the
+shadowed copy's — the configuration and the live key agree, and only the shadowed copy is the odd one
+out.
+
+### Clearing it, and what a rotation does NOT need
+
+The order is forced by the fact that the live key is the correct one:
+
+1. **Vault the LIVE key of each portal** — `memex-PluginCatalog-RegistryToken` and
+   `memexcloud-PluginCatalog-RegistryToken` in the `Systemorph` vault, then add the object plus its
+   `secretObjects.data` mapping to the namespace's SecretProviderClass (`memex-kv`,
+   `memexcloud-portal-ai-secrets`). Additive and inert: those CSI secrets sit *after*
+   `memex-portal-secrets` in `envFrom`, and the inline entry outranks both until it is deleted.
+2. **Drop the foreign copy from the source that renders it.** `secret/memex-portal-secrets` is
+   helm-rendered, so deleting the live Secret key alone is undone by the next `helm upgrade` — the
+   env's (uncommitted) values file must stop setting `secrets.memex_portal.PluginCatalog__RegistryToken`.
+3. **Then delete the inline `env:` entries** — a Deployment-spec edit, so a rollout on both portals.
+4. **Then rotate**, because both live keys sat in plaintext in a spec readable by anything that can
+   `get deploy`.
+
+🚨 **Rotating an instance key needs no re-granting.** `PluginGrant` nodes are keyed by
+`instanceId` (`Admin/_PluginGrant/memex`, `…/memex-cloud`), and re-issuing a key replaces
+`MeshWeaverInstance.KeyHash` on the *same* instance record — so entitlement, plan and install history
+survive untouched. What must be updated is every **holder of the key value**, and measured on
+2026-09-04 that is a short list: the Key Vault entry from step 1, and nothing else. No GitHub Actions
+secret in `Systemorph/MeshWeaver` or the org holds either portal's instance key (the `ci-*` instances
+used by node repos are separate records with separate keys), and `Plugins__Registry__PublishToken` is
+a different credential entirely. **Re-registering a new instance instead of re-issuing the key is the
+move that would need re-granting** — and would lose the install history keyed to the old id.
 
 The checker reads only the KEY NAMES of every envFrom source other than `memex-portal-config`,
 projected inside the cluster — a drift checker must not become the thing that copies the credentials
@@ -196,7 +257,7 @@ the run's own log; no cluster was touched to produce them.
 | # | group | count | what it is | what clears it |
 |---|---|---|---|---|
 | 1 | **Disagreeing `SHADOWS`** | **8** | the pod runs a value the ConfigMap contradicts — `PreWarm__BatchBake`/`PrebuiltBundleRoot` (both), `PluginCatalog__RegistryUrl` (both), `PreWarm__GateReadiness` + `Features__Ai__Providers__AzureOpenAI` (memex) | chart value first, **then** delete the inline entry |
-| 2 | **The registry credential** | **2** | `PluginCatalog__RegistryToken`: on memex a `SHADOWS` over `secret/memex-portal-secrets` whose two values differ; on memex-cloud the inline entry is the ONLY copy | MeshWeaver#3201 — establish the live token, vault it, delete inline, rotate |
+| 2 | **The registry credential** | **2** | `PluginCatalog__RegistryToken`: on memex a `SHADOWS` over `secret/memex-portal-secrets` whose two values differ **and belong to different registered instances**; on memex-cloud the inline entry is the ONLY copy, and neither portal has a Key Vault entry at all | MeshWeaver#3201 — the live inline key is the CORRECT one for each portal (hash-confirmed); vault *it*, then delete inline, then rotate. Never adopt the shadowed copy |
 | 3 | **Agreeing `SHADOWS`** | **29** | not wrong today; the ConfigMap is simply not what the pod reads, so the next chart change to any of them silently fails — Kestrel endpoints, `PluginCatalog__Sources__*`, `WebhookInbox__Targets__0` | same two steps, no urgency |
 | 4 | **Chart-retired, inert** | **8** | `FrameworkBroadcast__Subscribers__0..3` on both namespaces. The chart stopped rendering these on 2026-09-03 — the subscriber set is mesh data now — so the live keys feed nothing | delete the keys; drop them from the memex-cloud overlay, which still sets them |
 | 5 | **Cluster-only, now expressible** | **22** | live-edited settings the chart had no key for until MeshWeaver#3199 — AI providers, `LogWatch__*`, `Speech__*`, `Commerce__BaseUrl`, `Features__Ai__Clis__*`, `Portal__ReactAppUrl` | put them on the `Hosting/Deployment` record — `Systemorph/Memex#148` |


### PR DESCRIPTION
Re-measured the #3201 shadow on the live cluster today (2026-09-04). The shadow reproduces exactly as filed — and two things the drift comparator tells its reader about it are **false**, one of which makes the obvious cleanup dangerous rather than merely risky.

## 1. The checker asserted a provenance it cannot observe

The `SHADOWS` message said *"the Key Vault credential went unused"*. Measured:

| | measured 2026-09-04 |
|---|---|
| `secret/memex-portal-secrets` | **helm-rendered** (`app.kubernetes.io/managed-by=Helm`, `meta.helm.sh/release-name=memex`) — not CSI |
| CSI-backed secrets in those namespaces | `memex-kv-secrets`, `memexcloud-portal-ai-secrets` — **neither carries this key** |
| `Systemorph` Key Vault | holds **no** `PluginCatalog-RegistryToken` for either portal (only the unrelated `Plugins-Registry-PublishToken` pair) |

So there is no dead Key Vault credential; there is no Key Vault credential. A checker that reads only key *names* cannot see where a value came from, and narrating one teaches a wrong fix.

## 2. "Which value is live?" is not the whole question for a credential

Both sides are **valid**, verified out of band from inside the cluster against `https://memex.meshweaver.cloud/api/plugins`, with two controls that both returned `401` (an anonymous call, and a syntactically-valid bogus `mwi_` key — the registry logged both rejections):

| credential | HTTP | catalog |
|---|---|---|
| `memex` inline (live) | 200 | 44 packages, source `Plugins` |
| `memex-cloud` inline (live, only copy) | 200 | 45 packages |
| `memex` shadowed copy | **200** | **45 packages — `Plugins` + `Crm`** |

Hashing each credential *inside the cluster* and comparing against the `MeshWeaverInstance.keyHash` the registry stores identifies the inline keys as instances **`memex`** and **`memex-cloud`** — each portal's own, correct identity. (Both matched their published hash exactly, which is the positive control for the method.) The shadowed copy matches **none** of the 22 enumerable instance records, and its grant projection is a strict superset.

**So deleting the inline entry would not have "switched onto an unverified token" — it would have re-identified the deployment**, making memex authenticate as a different registered instance and silently widening its entitlement from 44 packages to 45. Corroboration: neither namespace sets `PluginCatalog__InstanceId` or a bootstrap key, so the token *is* the identity; and memex's own ConfigMap asks for `PluginCatalog__InstallByDefault__0=Plugins/*`, which is instance `memex`'s grant and not the shadowed copy's.

## What changed

- `chart-drift-compare.py` — the external-only `SHADOWS` message states no provenance, and warns the two sides may be different **principals**, not two values of one setting.
- `check-chart-drift.sh` — the same correction in the collector's rationale.
- `test-chart-drift-compare.sh` — **two new assertions** pinning both corrections.
- `ChartDriftSemantics.md` — the measurement, the forced remediation order, and the re-grant finding.

## Proof it can fail

The envFrom-Secret coverage itself landed in #3204; this verifies it and extends its guidance. Every assertion was mutated to confirm it is not vacuous:

| mutation | result |
|---|---|
| comparator ignores envFrom-source keys (`ext_by_lower = {}`) — the pre-#3204 detector | **red**: `PluginCatalog__RegistryToken`, `Speech__ApiKey`, `Commerce__BaseUrl` all lose their class |
| collector supplies an empty key file | `PluginCatalog__RegistryToken` demotes `SHADOWS` → **`CLUSTER-ONLY`**, sorted in among the harmless ones — exactly the blind spot #3201 reported |
| reinstate the Key Vault phrasing | **red** on the new provenance assertion, and only that one |
| drop the different-principals warning | **red** on the new principals assertion, and only that one |
| unmutated | green, exit 0 |

## Re-grant scope (the question #3201's comment asked)

🚨 **Rotating an instance key needs no re-granting.** `PluginGrant` is keyed by `instanceId`, and re-issuing replaces `KeyHash` on the *same* record — entitlement, plan and install history survive. The only holder to update is the Key Vault entry. No GitHub Actions secret in this repo or the org holds either portal's instance key, and `Plugins__Registry__PublishToken` is a different credential. **Re-registering a new instance** is the move that would need re-granting, and would lose the install history.

## Verification

`test-chart-drift-compare.sh` ✅ · `check-chart-invariants.sh` ✅ (3/3) · `check-values-are-read.sh` ✅ (111/111) · `DocumentationLinkIntegrityTest` ✅ · `dotnet build -c Release -warnaserror` on `MeshWeaver.Documentation.Test` → **0 Warning(s), 0 Error(s)**.

No What's New entry: this is an operator-facing deploy checker, matching the precedent of #3168 and #3204.

🚨 **No token value was read out, printed, logged or stored at any point.** Only key names, byte lengths, HTTP status codes, package-id sets, and equality/identity verdicts computed inside the cluster left the cluster.

Refs #3201, #3204, #3168

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HhT5AXByEKo2fRQtWH2wCW
