### PR TITLE
docs(#890): the first Plugins occurrence, and the onset claim is falsified

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -749,10 +749,12 @@ identically over 6 m 15 s and **none** succeeded — while every compile that ne
 kept returning correct `CS####` codes. **Replicated in the other repository** on MeshWeaver.Plugins
 run [`33760859754`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/33760859754) shard
 3 (2026-09-03, a `push` to `main`): **39 of 39** compile faults over 13 m 21 s were the same NRE,
-**zero** were a `CompilationException`, and `BrokenNodeTypeAccessTest` — which asserts that a
-deliberately non-compiling NodeType answers a terminal error — **passed at +13 min**, with
-`CS1040`/`CS0246`/`CS0103` still correct. Two repos, two harnesses, two shard layouts, same split:
-parse and bind healthy, emit 100 % dead, no recovery.
+**zero** were a `CompilationException`. Two separate facts pin the other half there: correct
+`CS0103`/`CS1591` diagnostics were still being produced at **+7 m 32 s** (13:41:55, on
+`type/RedriveRecovers…`'s deliberately broken source), and `BrokenNodeTypeAccessTest` — which
+asserts that a non-compiling NodeType answers a terminal error rather than silence — **passed at
++13 min**. Two repos, two harnesses, two shard layouts, same split: parse and bind healthy, emit
+100 % dead, no recovery.
 
 A one-off zeroed word cannot produce a 100 % failure rate over freshly allocated symbols; a
 **tier-1 / dynamic-PGO miscompilation** of one method can, and also explains the fixed frame and the

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -613,6 +613,18 @@ managed assemblies** it loads, none comes from a project that sets `AllowUnsafeB
 in the repo is `memex/Memex.Client`, which this process never loads. So `unsafe` is not merely absent
 from the sources on the stack — it could not have compiled into anything in the process.
 
+**Re-established fleet-wide on 2026-09-04, from the sources rather than from one dump**, because the
+same branch has to stay closed for #890 and its hosts live in the other repository now:
+`git grep AllowUnsafeBlocks` over every tracked `*.csproj`/`*.props` returns **zero** in
+`Systemorph/MeshWeaver` and **zero** in `Systemorph/MeshWeaver.Plugins` — so no assembly either repo
+builds can contain `unsafe` code at all. The control: the same pattern *does* match where the setting
+exists (`memex/Memex.Client` and `MeshWeaver.BusinessRules.Generator` in older checkouts), so the
+zero is a measurement and not a broken grep. The only span-level memory operations in either `src/`
+tree are one read-only `MemoryMarshal.AsBytes` (`PatchStringSplice.cs`) and one fixed-size
+`stackalloc byte[64]` (`OciDigest.cs`) — neither can write out of bounds. **MeshWeaver code cannot
+scribble on the heap directly; if the heap is being corrupted, the writer is the runtime or a native
+module the runtime loads.**
+
 ### 2026-09-03: sighting #9 — a FOURTH frame (`background_mark_simple1`), and the CI gate named the wrong cause
 
 `MeshWeaver.Futu-49849.dmp` (MeshWeaver.Plugins run
@@ -734,12 +746,30 @@ What #890 *can* contribute that a dump cannot is a measurement #613 has no way t
 crashed process has no "after": **the fault is total and permanent.** On run `33322993649` shard 1,
 after the first throw at 16:42:42.375, **7 of 7** compiles that reached the metadata writer failed
 identically over 6 m 15 s and **none** succeeded — while every compile that needed only diagnostics
-kept returning correct `CS####` codes. A one-off zeroed word cannot produce a 100 % failure rate over
-freshly allocated symbols; a **tier-1 / dynamic-PGO miscompilation** of one method can, and also
-explains the fixed frame, the load dependence and the onset ~80 s into a compile-heavy assembly.
-So the cheap next measurement for BOTH issues is the half of the advice that *is* followable:
-re-run with `DOTNET_TieredCompilation=0` (or `DOTNET_TieredPGO=0`, the sharper probe). See
-[NodeTypeCompilation → When the PROCESS cannot emit](/Doc/Architecture/NodeTypeCompilation).
+kept returning correct `CS####` codes. **Replicated in the other repository** on MeshWeaver.Plugins
+run [`33760859754`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/33760859754) shard
+3 (2026-09-03, a `push` to `main`): **39 of 39** compile faults over 13 m 21 s were the same NRE,
+**zero** were a `CompilationException`, and `BrokenNodeTypeAccessTest` — which asserts that a
+deliberately non-compiling NodeType answers a terminal error — **passed at +13 min**, with
+`CS1040`/`CS0246`/`CS0103` still correct. Two repos, two harnesses, two shard layouts, same split:
+parse and bind healthy, emit 100 % dead, no recovery.
+
+A one-off zeroed word cannot produce a 100 % failure rate over freshly allocated symbols; a
+**tier-1 / dynamic-PGO miscompilation** of one method can, and also explains the fixed frame and the
+load dependence.
+
+> 🚨 **Do not lean on "onset ~80 s into a compile-heavy assembly" — it is not a stable threshold.**
+> Measured onsets: `33322993649` (core) 130 s in, after **199** `TEST START`s; `33760859754`
+> (Plugins) **33 s** in, after **12**, on the first compile of that class, with `alc=1`, `asm=138`,
+> `gc2=4`, RSS 548 MiB — i.e. an unremarkable, barely-warm process. A warm-up threshold is what a
+> tier-1 promotion argument *predicts*; a 4× spread in wall time and a 16× spread in test count do
+> not refute it (promotion is call-count driven and the call counts are unmeasured) but they are
+> not evidence for it either. **The tiering hypothesis is still UNTESTED**, and the cheap next
+> measurement for BOTH issues is the half of the canary's advice that *is* followable: re-run with
+> `DOTNET_TieredCompilation=0` (or `DOTNET_TieredPGO=0`, the sharper probe). Design it split-arm —
+> at the measured ~1 % per run a single-arm clean result means nothing.
+
+See [NodeTypeCompilation → When the PROCESS cannot emit](/Doc/Architecture/NodeTypeCompilation).
 
 ## Related
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -803,6 +803,24 @@ and bind were healthy and only the **emit** was dead. That split is the fastest 
 in a log: correct `CS####` for broken source, `NullReferenceException` for source that should
 succeed.
 
+**Replicated independently in MeshWeaver.Plugins** — run
+[`33760859754`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/33760859754) shard 3,
+2026-09-03, a `push` to `main`, `MeshWeaver.Hosting.Monolith.Test`. Onset **13:34:23.568**, 1.3 s
+into `CodeEditRecompileTest.CodeEdit_ExplicitRelease_IsUpToDate_RecompilesOnSourceChange` and 33 s
+into the process; it is the **first** `NullReferenceException` in the whole trace, so it is not
+downstream of an earlier fault. Then **39 of 39** compile faults over the next 13 m 21 s were that
+same NRE with `canary=BELOW-ROSLYN` — **zero** `CompilationException` — across 12 unrelated node
+paths and partitions, and `BrokenNodeTypeAccessTest` still **passed** at +13 min with correct
+`CS####` diagnostics. Memory was flat (managed 147 MiB / RSS 961 MiB) through the final wedge, and
+the ten test hosts that ran after it **on the same runner were clean**, so the condition is
+process-scoped, not machine-scoped. Two repos, two harnesses, two shard layouts, one shape.
+
+🚨 **Onset is not a warm-up threshold.** Core's occurrence fired 130 s and 199 `TEST START`s into the
+host; this one fired at 33 s and 12, with `alc=1`, `asm=138`, `gc2=4` — no ALC churn, no memory
+pressure, and the two ALC-heavy suites (`NodeTypeRecompileAlcLeakTest`,
+`NodeAlcUnloadTeardownOrderingTest`) ran **after** the onset, not before it. Any hypothesis that
+needs a precursor workload has to explain that.
+
 **It is not a MeshWeaver defect and no compile-side change fixes it.** `EmitPipeline`'s canary
 answers that at the first throw, in two legs: re-emit a trivial, freshly parsed, known-good
 compilation against the same references, then — if that fails too — against an image-backed CoreLib
@@ -849,7 +867,9 @@ Two readings that look right and are not:
 
 > 🚨 **The core dump the canary asks for cannot be captured this way.** `DOTNET_DbgEnableMiniDump`
 > fires on a *signal*, and this process never crashes — it throws a managed exception and keeps
-> running until CI's 8-minute cap kills it (`exit=124`, no dump). That is why three weeks of
+> running until CI's per-suite wall-clock cap kills it (`exit=124`, no dump): 8 minutes on core's
+> shards, **15 minutes** on MeshWeaver.Plugins' `Portal hosts` shards, so the cap is a property of
+> the harness and not a fingerprint to grep for. That is why weeks of
 > "capture a core dump" produced none. Its SIGSEGV twin,
 > [#613](https://github.com/Systemorph/MeshWeaver/issues/613), *does* dump — see
 > [Debugging Native Crashes](/Doc/Architecture/DebuggingNativeCrashes) for the invariant the two share (a single

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -864,6 +864,16 @@ Two readings that look right and are not:
   written. The retry's own error is the `NullReferenceException`. Compare timestamps, not adjacency.
 - **"That one is just a slow shard."** `ReleaseRequestWatcherHighWaterTest`'s compile threw **174 ms**
   after `TEST START`; the 50 s wait that followed was waiting for an `Ok` that could never arrive.
+- 🚨 **"It's a compile suite and it hit the cap, so it's this."** The 2026-08-13 sweep found that
+  `exit=124` on `MeshWeaver.Hosting.Monolith.Test` was *almost entirely* this defect. **That has
+  stopped being true.** Measured 2026-09-03→04 on MeshWeaver.Plugins: **3** such timeouts in 122
+  runs, of which **1** carries the signature and **2 carry none** — read on the authoritative sink
+  (467 and 560 `[FAULT]` records each, zero `canary=`), so the nulls are not the job log's
+  failing-tests-only blind spot. Both nulls wedged **inside one compile test that never ended** (one
+  unclosed `TEST_START` for the whole 15-minute cap, `methodTimeout` never firing) — a hang, not
+  this defect's fast many-failure cascade, and both were in this issue's own blame set
+  (`NodeTypeReleaseGateTest`, `CodeEditRecompileTest`). **Discriminate on the verdict, never on the
+  suite name plus the exit code**; folding a live wedge into a known-upstream defect hides it.
 
 > 🚨 **The core dump the canary asks for cannot be captured this way.** `DOTNET_DbgEnableMiniDump`
 > fires on a *signal*, and this process never crashes — it throws a managed exception and keeps

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -810,8 +810,10 @@ into `CodeEditRecompileTest.CodeEdit_ExplicitRelease_IsUpToDate_RecompilesOnSour
 into the process; it is the **first** `NullReferenceException` in the whole trace, so it is not
 downstream of an earlier fault. Then **39 of 39** compile faults over the next 13 m 21 s were that
 same NRE with `canary=BELOW-ROSLYN` — **zero** `CompilationException` — across 12 unrelated node
-paths and partitions, and `BrokenNodeTypeAccessTest` still **passed** at +13 min with correct
-`CS####` diagnostics. Memory was flat (managed 147 MiB / RSS 961 MiB) through the final wedge, and
+paths and partitions. Parse and bind stayed healthy throughout, on two independent readings:
+correct `CS0103`/`CS1591` diagnostics were still returned at **13:41:55, +7 m 32 s** after onset,
+and `BrokenNodeTypeAccessTest` **passed at +13 min**.
+Memory was flat (managed 147 MiB / RSS 961 MiB) through the final wedge, and
 the ten test hosts that ran after it **on the same runner were clean**, so the condition is
 process-scoped, not machine-scoped. Two repos, two harnesses, two shard layouts, one shape.
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -428,9 +428,12 @@ the 11 occurrences fired inside one of those two suites. The last one is 2 h 35 
 Be precise about what left, because "the suite moved" and "the repo is now immune" are different
 claims. Core still emits NodeType assemblies in `Compiler.Pipeline.Test` and `Graph.Test` — but those
 run in **9 s** and **100 s**, against the **13 m 38 s** of compile-heavy integration work that walked
-out, and the onset in every measured occurrence was ~2 minutes into such an assembly. What the
-removal took was not the possibility, it was **the exposure that made the rate measurable** — which
-is enough to make a post-removal null uninformative either way.
+out. What the removal took was not the possibility, it was **the exposure that made the rate
+measurable** — which is enough to make a post-removal null uninformative either way. (An earlier
+version of this paragraph justified that with *"the onset in every measured occurrence was ~2 minutes
+into such an assembly"*. **That is now falsified** — the 2026-09-03 Plugins occurrence fired **33 s**
+in — so the argument rests on suite RUNTIME, which is what the 9 s / 100 s vs 13 m 38 s comparison
+actually measures, not on a warm-up threshold.)
 
 **The rule:** before believing a null, ask *"does the code that produces this signal still run in
 this repository, in this window?"* Confirm it positively — name a run and the suite verdict line it
@@ -452,6 +455,33 @@ suffix) therefore returns a clean, fast, entirely vacuous zero. **Grep the signa
 packaging around it**, and prove the sink is alive in the target repo with a positive control before
 reporting the null (17 of 43 Plugins trace artifacts carried real `Compile failure for …` records,
 which is what made that null worth stating).
+
+#### Two sinks per repo, and only one of them is complete
+
+**Read both, and know which is authoritative.** A post-hoc `dotnet test` job log carries only the
+output of tests that **FAILED** — and the fault you are hunting is often captured by a test that
+*passed*. In the calibrated core occurrence the very first canary record is printed under
+`CreateLayoutAreaIntegrationTest.CreateArea_WithoutTypeParam_ShowsTypeSelection`, which is **not** one
+of that shard's five failures: on a `dotnet test`-driven harness that record would never have reached
+the job log at all. The complete sink is the phase trace — `_meshweaver-test-trace.log` inside
+`teardown-stragglers-<run>-<attempt>-shard<N>` — which takes an unconditional `[FAULT]` record for
+every `ILogger` call carrying an exception at Warning or worse, whatever test was running and whether
+or not it failed. (It is collected only when a suite failed, which is why it covers this defect: the
+poisoned process always reds its suite.)
+
+**Measured 2026-09-04 over 2026-09-03T06:04Z → 2026-09-04T06:34Z**: 122 non-cancelled
+`Plugin Catalog CI` runs, all 58 non-success `Portal hosts (shard N)` job logs fetched (0
+unfetchable, 50 of them running the exposure suite) plus 57 trace-log artifacts carrying 13,460
+`[FAULT]` records — **one occurrence**, run `33760859754` shard 3, on `main`, and it surfaced in
+**both** sinks (56 `canary=BELOW-ROSLYN` and 20 `PROCESS CANNOT EMIT` in the job log; 119 signature
+lines and 39 `Compile failure for …` records in the trace). That closes the blind spot the previous
+sweep recorded as open — *"I have not proved the canary's log line reaches job-log stdout in a
+Plugins shard"* — with a real occurrence rather than an argument.
+
+**Calibrate before believing a null.** The four patterns above, run over the known core occurrence
+(job `99288463497`), return **77** signature lines and **38** `canary=BELOW-ROSLYN` — the counts that
+occurrence's own report published. A detector that cannot reproduce those numbers is not entitled to
+report a zero.
 
 ### A grep hit is not a binder
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReadingCiSignals.md
@@ -483,6 +483,15 @@ Plugins shard"* — with a real occurrence rather than an argument.
 occurrence's own report published. A detector that cannot reproduce those numbers is not entitled to
 report a zero.
 
+🚨 **And know which questions the sinks cannot answer.** *Neither* Plugins sink carries a compile
+**success**: `Compile success for …` is `LogInformation`, so the trace log (faults only) never sees
+it and the post-hoc job log never sees it either unless the test that logged it failed. Core's live
+`[OUTPUT]` stream does carry it — which is why the "**none** succeeded" half of the
+[total-and-permanent measurement](/Doc/Architecture/NodeTypeCompilation) is stated for the core
+occurrence and **not** for the Plugins one. Asserting it there would be inferring an absence from a
+sink that never records the presence. Before writing "and X never happened", check that the sink you
+read would have shown X happening.
+
 ### A grep hit is not a binder
 
 Twice in one day, prose was mistaken for the thing it described. A quoted phrase in a `//` comment


### PR DESCRIPTION
## What this is

An investigation write-up for [#890](https://github.com/Systemorph/MeshWeaver/issues/890), conserved into the doc tree instead of into a comment thread. **Docs only — no behaviour change, no claim about the mechanism.**

#890's throw site has been named since 2026-08-12 (`NamedTypeSymbol.…get_ContainingTypeDefinition` under `Cci.MetadataWriter.GetConsolidatedTypeParameters`) and its `BELOW-ROSLYN` verdict has been earned since #2663's image-backed control. What was still open were the thread's own two follow-ups after the exposure suites moved to MeshWeaver.Plugins on 2026-09-01: another window of comparable exposure, and a positive control that the canary's line actually reaches a Plugins sink.

## The measurement behind the change

Window `2026-09-03T06:04:06Z → 2026-09-04T06:34:14Z`, continuing exactly where the previous sweep ended (no overlap).

| | MeshWeaver.Plugins (`ci.yml`) | core (`dotnet-test.yml`) |
|---|---|---|
| non-cancelled runs in window | **122** | 249 |
| shard jobs | 484 `Portal hosts (shard N)` | 1,035 `Run tests (shard N)` |
| non-success shard logs fetched / unfetchable | **58 / 0** | 27 / 0 |
| of those, running the exposure suite | **50** | — |
| trace-log artifacts read | **57** (13,460 `[FAULT]` records) | — |
| **occurrences** | **1** | 0 (uninformative — the exposure left core on 09-01) |

**Detector calibrated before any null was believed**: the four patterns over the known core occurrence (job `99288463497`) return **77 signature lines / 38 `canary=BELOW-ROSLYN`**, the counts that occurrence's own report published.

The occurrence is MeshWeaver.Plugins run [`33760859754`](https://github.com/Systemorph/MeshWeaver.Plugins/actions/runs/33760859754) `Portal hosts (shard 3)` — a **`push` to `main`**, other three shards green.

## What the pages now say that they did not

- **A replication of "total and permanent"** in a second repo, harness and shard layout: 39/39 emit-reaching compiles NRE'd over 13 m 21 s with zero `CompilationException` and no success, while parse and bind stayed correct (`BrokenNodeTypeAccessTest` passed at **+13 min** with real `CS####`). Process-scoped: the ten hosts that ran after it on the same runner were clean.
- 🚨 **A falsified claim.** *"the onset ~80 s / ~2 minutes into a compile-heavy assembly"* appeared in two pages and was the timing evidence for the tier-1-miscompilation argument. Measured onsets are **130 s / 199 tests** (core) and **33 s / 12 tests** (Plugins) — the latter at `alc=1 asm=138 gc2=4`, RSS 548 MiB. Both pages now say the tiering hypothesis is **untested**, and `ReadingCiSignals`' exposure argument is re-grounded on suite *runtime*, which is what its own 9 s / 100 s vs 13 m 38 s comparison actually measures.
- **ALC churn is not a precursor** — the two ALC-heavy suites ran *after* the onset.
- **Two sinks per repo, and only one is complete.** A `dotnet test` job log carries only the output of tests that **FAILED**; in the calibrated core occurrence the first canary record was printed under a test that **passed**. `_meshweaver-test-trace.log` in the `teardown-stragglers-*` artifact is the authoritative sink. Recorded with the reproduction recipe.
- **`AllowUnsafeBlocks` re-established fleet-wide from the sources**, not from one dump: zero in every tracked `*.csproj`/`*.props` of **both** repos, with the control stated (the pattern matches where the setting exists). MeshWeaver code cannot corrupt the heap directly.
- The `exit=124` cap is **8 min on core, 15 min on Plugins** — a harness property, not a fingerprint to grep for.

- 🚨 **A correction to a load-bearing claim in the thread.** The 2026-08-13 sweep read `MeshWeaver.Hosting.Monolith.Test` timeouts as *"almost entirely one defect"*. In this window **3** such timeouts occurred and only **1** carries the signature; the other two carry **none on the authoritative sink** (467 and 560 `[FAULT]` records, zero `canary=`) and each wedged inside a **single compile test that never ended** — a hang, not this cascade. Both are in #890's own blame set, which is what makes folding them in tempting and wrong.

## Verification

- `dotnet build test/MeshWeaver.Documentation.Test/… -c Release -warnaserror` → `0 Warning(s), 0 Error(s)`.
- `MeshWeaver.Documentation.Test` in full: **250 passed, 0 failed**.
- 🚨 **`DocumentationLinkIntegrityTest` proved non-vacuous on this diff**: a deliberate `/Doc/Architecture/ThisPageDoesNotExist890` link appended to the edited page turned it **red**, naming that page and that link; removing it turned it green again. The guard demonstrably sees these files.

## Not included

- **No What's New entry** — internal engineering-triage documentation with no user-visible effect.
- **No fix for the NRE.** It is below Roslyn; nothing here touches it.
- One separately-named, still-open defect is reported on the issue rather than fixed here, because it lives in the other repo's verdict machinery: the shard's `exit=124` remedy tells the reader to *"find the wedged test"* while the same log carries 20 copies of `PROCESS CANNOT EMIT (#890)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
