### PR TITLE
chart: render the model-credit rate-feed keys, or the arming knob never reaches a pod

### DIFF
--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -159,6 +159,31 @@ data:
   Notifications__Retention__Enabled: "{{ .Values.config.memex_portal.Notifications__Retention__Enabled | default "true" }}"
   Notifications__Retention__MaxAge: "{{ .Values.config.memex_portal.Notifications__Retention__MaxAge | default "90.00:00:00" }}"
   Notifications__Retention__MaxDeletionsPerRun: "{{ .Values.config.memex_portal.Notifications__Retention__MaxDeletionsPerRun | default "200" }}"
+  {{- /* The model-credit FX rate feed (MeshWeaver.Plugins, AI/ModelCreditRateFeed). A daily
+         download that keeps Admin/ModelCredit/_Rate-{FROM}-{TO} current from a published reference
+         feed, so the credit meter can fold a USD-priced round against a CHF allowance.
+
+         🚨 THESE KEYS MUST EXIST HERE OR THEY ARE SILENTLY DROPPED. This ConfigMap names every key
+         explicitly and the Deployment's only env path is envFrom, so a values file that sets a key
+         this template does not render produces NOTHING — the Memex#53 shape. That failure is
+         especially bad for this feature: the operator sets Enabled=true, the key never reaches a
+         pod, the feed reads "absent" and stays disarmed, and the knob LOOKS set. Which is exactly
+         the class of silence the feed's own configuration reader was written to refuse.
+
+         DISARMED by default, and unlike notification retention that is deliberate: a wrong answer
+         there deletes a three-month-old pointer, a wrong answer here writes a NUMBER THE PLATFORM
+         BILLS AGAINST — at a margin (Stripe's currency-conversion fee) nobody has verified for this
+         account. So no Helm `default` arms it, and the empty string these render while unset is
+         what the reader treats as absent.
+
+         🚨 An EMPTY value means absent; a value an operator TYPED but that is not a value makes the
+         service REFUSE TO ARM and log which key and which value. "Margin: 0,015" is not 0.015. */}}
+  ModelCredit__RateFeed__Enabled: "{{ .Values.config.memex_portal.ModelCredit__RateFeed__Enabled | default "" }}"
+  ModelCredit__RateFeed__Margin: "{{ .Values.config.memex_portal.ModelCredit__RateFeed__Margin | default "" }}"
+  ModelCredit__RateFeed__Pairs: "{{ .Values.config.memex_portal.ModelCredit__RateFeed__Pairs | default "" }}"
+  ModelCredit__RateFeed__Url: "{{ .Values.config.memex_portal.ModelCredit__RateFeed__Url | default "" }}"
+  ModelCredit__RateFeed__IntervalHours: "{{ .Values.config.memex_portal.ModelCredit__RateFeed__IntervalHours | default "" }}"
+  ModelCredit__RateFeed__InitialDelaySeconds: "{{ .Values.config.memex_portal.ModelCredit__RateFeed__InitialDelaySeconds | default "" }}"
   {{- /* Commit-pinned source replica (GitModuleReplica). Point Root at a DEDICATED persistent mount —
          see .Values.persistence for the volume. Empty means "unset": the option then falls back to a
          temp subdir, which on a pod is ephemeral and re-clones the repo on every restart. This key


### PR DESCRIPTION
## The arming knob has to be able to reach a pod

`MeshWeaver.Plugins#1323` adds a **daily FX download** that keeps
`Admin/ModelCredit/_Rate-{FROM}-{TO}` current from the ECB's `eurofxref-daily` feed, so the
model-credit meter can fold a USD-priced round against a CHF allowance. It ships **disarmed**: an
operator sets `ModelCredit:RateFeed:Enabled` and chooses the margin at the same moment, because the
number is billed against.

On AKS that setting **cannot reach a pod today**, and it would fail silently.

This ConfigMap names every key **explicitly**, and the Deployment's only env path is `envFrom` — so
a values file that sets a key this template does not render produces **nothing**. This file's own
comments already record the incident (Memex#53: the key *"kept vanishing"*, set in three AKS values
files, none of which could reach a container). For this feature that is the worst available failure:
the operator sets `Enabled=true`, the key never arrives, the feed reads *absent*, stays disarmed —
and the knob **looks set**. Which is precisely the class of silence the feed's own configuration
reader was written to refuse.

## What this does

Six keys, rendered beside `Notifications__Retention__*` and following its shape, all defaulting to
`""`:

```
ModelCredit__RateFeed__Enabled / Margin / Pairs / Url / IntervalHours / InitialDelaySeconds
```

🚨 **Deliberately no Helm `default` that arms anything** — the opposite of the retention block
directly above it, and the asymmetry is the point. That pass arms itself because a wrong answer
deletes a three-month-old pointer to a node that still exists. Here a wrong answer writes **a number
the platform bills against**, at a Stripe currency-conversion margin **nobody has verified for this
account**. Arming it stays the operator's act.

`""` is what the reader treats as **absent**, so a values file predating these keys renders exactly
what an un-rendered key meant: **no deployment changes behaviour from this PR.** And a value an
operator *typed* that is not a value (`Margin: "0,015"` — a decimal comma) makes the service refuse
to arm and log which key and which value, rather than falling back to a default and writing a rate
nobody chose.

## Verification

- `helm template memex deploy/helm -f deploy/helm/values.yaml` → all six render as `""`.
- `--set config.memex_portal.ModelCredit__RateFeed__Enabled=true --set …Margin=0.015` → both render
  through with their values.
- `deploy/aks/scripts/test-chart-drift-compare.sh` → *"all classification assertions passed"*. A key
  the chart renders but the live ConfigMap does not yet carry is a case the comparator already
  handles explicitly (*"fall back to the render when the key is rendered but not (yet) live"*), so
  this adds no drift finding.

`Pairs-with: Systemorph/MeshWeaver.Plugins#1323` — and it is order-independent: the rendered empty
strings are inert on a portal whose image predates the feed, and the feed is disarmed on a portal
whose chart predates these keys. Neither half can break the other.

Design and operating instructions: `AI/ModelCreditRateFeed` in MeshWeaver.Plugins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
