### PR TITLE
ci: the Plugins bake composes every module its content binds

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2164,11 +2164,33 @@ jobs:
       content-repository: Systemorph/MeshWeaver.Plugins
       content-ref: ${{ needs.gate.outputs.plugins_sha }}
       platform-ref: ${{ needs.gate.outputs.sha }}
-      # The compose set the bake needs (the same two Plugins' own ci.yml passes as
-      # module-artifacts); the rest of the catalog is content, baked below.
+      # The compose set the bake needs — the same set Plugins' own ci.yml passes as
+      # module-artifacts; the rest of the catalog is content, baked below.
+      #
+      # 🚨 THE SET IS "EVERY MODULE THE CONTENT BINDS", not "the two we started with". The bake
+      # lane states the rule in its own input description: *"a repo whose NodeType source binds a
+      # module's types names that module here or in registry-modules, or its bake fails
+      # CS0103/CS0246 on every wave."* It listed two while the Plugins content binds four:
+      #   • MeshWeaver.Maps — the AppleMaps / GoogleMaps / OpenStreetMap galleries and
+      #     Cornerstone/Pricing bind it. It stopped being image-shipped in MeshWeaver#2941 and now
+      #     reaches a mesh only as a module bundle (its lines left MeshWeaver.Plugins'
+      #     src/platform-shipped.txt), so /app supplies nothing for those four to bind.
+      #   • MeshWeaver.Payments.Stripe — the Stripe protocol left Store/Order/Source for its own
+      #     module (MeshWeaver.Plugins#…), so Store/Order binds it, and Store/Catalog, Store/Plugin
+      #     and Store/Maintenance do too through shared=@Store/Order/Source.
+      # Neither gap was OBSERVED as a red compile: this job's bake has been dying earlier, on the
+      # MeshWeaver.Markdown.Collaboration one-producer FATAL (Plugins#1262/#1268), which masks
+      # everything downstream of it. Naming the modules the content binds is right independently of
+      # when that clears.
+      #
+      # 🚨 registry-modules is NOT the alternative here: composing the registry's own bytes would
+      # avoid rebuilding these for the seal, but this repo holds no registry credential
+      # (Doc/Architecture/ModuleBuildArchitecture → "What the gate still cannot see").
       modules: >-
         [{"package": "AI", "module": "MeshWeaver.AI", "project": "src/MeshWeaver.AI/MeshWeaver.AI.csproj"},
-         {"package": "Essentials", "module": "MeshWeaver.Markdown.Collaboration", "project": "src/MeshWeaver.Markdown.Collaboration/MeshWeaver.Markdown.Collaboration.csproj"}]
+         {"package": "Essentials", "module": "MeshWeaver.Markdown.Collaboration", "project": "src/MeshWeaver.Markdown.Collaboration/MeshWeaver.Markdown.Collaboration.csproj"},
+         {"package": "Maps", "module": "MeshWeaver.Maps", "project": "src/MeshWeaver.Maps/MeshWeaver.Maps.csproj"},
+         {"package": "Stripe", "module": "MeshWeaver.Payments.Stripe", "project": "src/MeshWeaver.Payments.Stripe/MeshWeaver.Payments.Stripe.csproj"}]
       # Registry module PACKAGES are content-versioned and published by Plugins' own lane when a
       # package changes; a platform release changes no package content. The bundles packed here
       # are the bake's inputs (artifacts), nothing more.
@@ -2248,7 +2270,7 @@ jobs:
       content-repository: Systemorph/MeshWeaver.Plugins
       content-ref: ${{ needs.gate.outputs.plugins_sha }}
       bake-source: plugins
-      module-artifacts: module-bundle-MeshWeaver.{AI,Markdown.Collaboration}
+      module-artifacts: module-bundle-MeshWeaver.{AI,Markdown.Collaboration,Maps,Payments.Stripe}
       test-image: meshweaver.azurecr.io/mw-plugin-test:${{ needs.plugin-test-image.outputs.version }}
       image-digest: ${{ needs.plugins-bake-image.outputs.digest }}
       # 🚨 The PORTAL of this run's promoted set (MeshWeaver#3022): the tester EXECUTES the bake,


### PR DESCRIPTION
> **Ordering satisfied.** Systemorph/MeshWeaver.Plugins#1325 is MERGED, so
> `src/MeshWeaver.Payments.Stripe/` now exists at the `plugins_sha` this job checks out.
> This is the second half, landing in dependency order.

`node-repo-publish-bake.yml` states the rule in its own `module-artifacts` description:

> *a repo whose NodeType source binds a module's types names that module here or in
> `registry-modules`, or its bake fails CS0103/CS0246 on every wave.*

`plugins-modules` names **two**. The Plugins content binds **four**:

| module | what binds it | why `/app` cannot supply it |
|---|---|---|
| `MeshWeaver.AI` | Skill/Agent NodeTypes, and five packages' sources | already composed ✅ |
| `MeshWeaver.Markdown.Collaboration` | `Collaboration/Review` | already composed ✅ |
| **`MeshWeaver.Maps`** | the AppleMaps / GoogleMaps / OpenStreetMap galleries and `Cornerstone/Pricing` | it stopped being image-shipped in #2941; its lines left `MeshWeaver.Plugins/src/platform-shipped.txt` and it now reaches a mesh only as a module bundle |
| **`MeshWeaver.Payments.Stripe`** | `Store/Order`, and `Store/Catalog` / `Store/Plugin` / `Store/Maintenance` through `shared=@Store/Order/Source` | new module (Plugins#1325) — the Stripe protocol left `Store/Order/Source` |

## 🚨 Neither gap has been OBSERVED, and the PR says so

This job has been dying **earlier**, on the `MeshWeaver.Markdown.Collaboration` one-producer FATAL
(Plugins#1262 / #1268, both open) — measured on run 33853637332:

```
bake: module MeshWeaver.AI mvid=9b61138e… — composed into the reference set
bake: module MeshWeaver.Markdown.Collaboration mvid=192e2f28… — composed into the reference set
compile: FATAL — module(s) MeshWeaver.Markdown.Collaboration are composed with --module AND
         shipped by the platform host at '/app' — two builds of one assembly name in one bake…
```

The FATAL precedes the NodeType compiles, so it masks whatever those would have said about Maps.
This change is therefore stated as **inference from the lane's own contract plus
`platform-shipped.txt`'s measurement**, not as a measured red. Naming the modules the content binds
is right independently of when the FATAL clears — and once it does, this is what stops the next
failure from being four map galleries and four Store types reporting CS0234/CS0246 against *content*.

## Why not `registry-modules:`

It would compose the registry's own bytes and avoid rebuilding these for the seal — closing the
"second producer in time" row rather than widening it. It is not available here: this repo holds no
registry credential, which `Doc/Architecture/ModuleBuildArchitecture` → *What the gate still cannot
see* records as the reason that row stays open.

## Cost

Two more SDK module packs per publishing CD run, both small libraries. `plugins-bake`'s
`module-artifacts` glob is widened to match, so the artifacts are actually composed — adding matrix
entries alone would pack bundles nobody reads.

No behaviour outside `plugins-modules` / `plugins-bake` changes. YAML re-parsed after the edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
