### PR TITLE
Teardown lets accepted work finish and names what it had to stop — no forced teardown

### DIFF
--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -937,16 +937,24 @@ public static class DataExtensions
     /// <c>MessageService.PostImplGeneric</c> stamps <c>POST_REFUSED_SHUTTING_DOWN</c> and returns
     /// exactly that when the owner AND its parent are past <c>DisposeHostedHubs</c>, and its own
     /// comment says "This site does NOT answer the sender itself".</para>
-    /// <para>🚨 <b>Except when the caller is ARMED on the late watch</b> (<paramref name="isArmed"/>):
-    /// the caller's <c>Observe</c> callback has then already expired and handed its wait to the
-    /// registry, so a post can only reach it the long way round — routed through the parent to the
-    /// cache hub, whose handler dispatches into the same registry. On a whole-mesh teardown that
-    /// route closes asynchronously: the owner's <c>Post</c> ACCEPTS the response (its own run level
-    /// is still open) and the PARENT's routing then drops it ("cannot route … its parent hub is
-    /// shutting down (RunLevel=DisposeHostedHubs)"), which this seam cannot see — measured on a
+    /// <para>🚨 <b>While the owner is SHUTTING DOWN, the accepted post is not proof of delivery</b>
+    /// (<paramref name="ownerIsShuttingDown"/>). The owner's <c>Post</c> is accepted — its own run
+    /// level is still open, so <c>PostImplGeneric</c> does not refuse — and the PARENT's routing
+    /// then drops it one turn later ("cannot route … its parent hub is shutting down
+    /// (RunLevel=DisposeHostedHubs)"), asynchronously, where this seam cannot see it. Measured on a
     /// 2-core runner as the merge's own ack never reaching the armed watch
-    /// (NackReachesTheWaiterDuringTeardownTest, run 33861078925). An armed caller is served through
-    /// the sink FIRST; the transport for writes whose callback is still pending is unchanged.</para>
+    /// (NackReachesTheWaiterDuringTeardownTest, run 33861078925). So during teardown the armed sink
+    /// is served TOO, right after the post. the registry's dispatch removes
+    /// the entry before it calls back, and the posted response — if it survives the route — reaches
+    /// the same registry through the cache hub's handler, so the caller is answered exactly once
+    /// whichever arrives first.</para>
+    ///
+    /// <para>🚨 It is <b>only</b> during teardown. A late watch is armed for EVERY patch at post
+    /// time, not just an expired one, so serving the sink whenever it is armed would move every
+    /// ordinary ack off its designed transport — and forward of it, because the sink dispatches
+    /// synchronously on the owner's turn while the posted response arrives after the state change it
+    /// acknowledges. Measured: that reordering reddened <c>ComboGateRollTest</c> under load (run
+    /// 33863349195) — the caller's write completed before the change it wrote was readable.</para>
     /// </summary>
     /// <returns><c>true</c> when the post was accepted or the sink found an armed caller.</returns>
     internal static bool RoutePatchVerdict(
@@ -954,14 +962,17 @@ public static class DataExtensions
         string requestId,
         Func<PatchDataResponse, IMessageDelivery?> post,
         Func<string, PatchDataResponse, bool>? dispatchLate,
-        Func<string, bool>? isArmed = null)
+        Func<bool>? ownerIsShuttingDown = null)
     {
-        if (dispatchLate is not null && isArmed is not null && isArmed(requestId)
-            && dispatchLate(requestId, response))
-            return true;
         var delivery = post(response);
         if (delivery is not null && delivery.State != MessageDeliveryState.Failed)
+        {
+            // Accepted — and that is the whole answer on the live path. In teardown it is not:
+            // the parent drops the response after this returns, so serve the armed sink as well.
+            if (ownerIsShuttingDown?.Invoke() == true && dispatchLate is not null)
+                dispatchLate(requestId, response);
             return true;
+        }
         return dispatchLate is not null && dispatchLate(requestId, response);
     }
 
@@ -1034,7 +1045,7 @@ public static class DataExtensions
                 request.Id,
                 resp => hub.Post(resp, o => o.ResponseFor(request)),
                 lateVerdicts is null ? null : lateVerdicts.Dispatch,
-                lateVerdicts is null ? null : lateVerdicts.IsAdmissible))
+                () => hub.IsShuttingDown))
             return;
 
         logger?.LogWarning(

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -937,14 +937,28 @@ public static class DataExtensions
     /// <c>MessageService.PostImplGeneric</c> stamps <c>POST_REFUSED_SHUTTING_DOWN</c> and returns
     /// exactly that when the owner AND its parent are past <c>DisposeHostedHubs</c>, and its own
     /// comment says "This site does NOT answer the sender itself".</para>
+    /// <para>🚨 <b>Except when the caller is ARMED on the late watch</b> (<paramref name="isArmed"/>):
+    /// the caller's <c>Observe</c> callback has then already expired and handed its wait to the
+    /// registry, so a post can only reach it the long way round — routed through the parent to the
+    /// cache hub, whose handler dispatches into the same registry. On a whole-mesh teardown that
+    /// route closes asynchronously: the owner's <c>Post</c> ACCEPTS the response (its own run level
+    /// is still open) and the PARENT's routing then drops it ("cannot route … its parent hub is
+    /// shutting down (RunLevel=DisposeHostedHubs)"), which this seam cannot see — measured on a
+    /// 2-core runner as the merge's own ack never reaching the armed watch
+    /// (NackReachesTheWaiterDuringTeardownTest, run 33861078925). An armed caller is served through
+    /// the sink FIRST; the transport for writes whose callback is still pending is unchanged.</para>
     /// </summary>
     /// <returns><c>true</c> when the post was accepted or the sink found an armed caller.</returns>
     internal static bool RoutePatchVerdict(
         PatchDataResponse response,
         string requestId,
         Func<PatchDataResponse, IMessageDelivery?> post,
-        Func<string, PatchDataResponse, bool>? dispatchLate)
+        Func<string, PatchDataResponse, bool>? dispatchLate,
+        Func<string, bool>? isArmed = null)
     {
+        if (dispatchLate is not null && isArmed is not null && isArmed(requestId)
+            && dispatchLate(requestId, response))
+            return true;
         var delivery = post(response);
         if (delivery is not null && delivery.State != MessageDeliveryState.Failed)
             return true;
@@ -1019,7 +1033,8 @@ public static class DataExtensions
                 response,
                 request.Id,
                 resp => hub.Post(resp, o => o.ResponseFor(request)),
-                lateVerdicts is null ? null : lateVerdicts.Dispatch))
+                lateVerdicts is null ? null : lateVerdicts.Dispatch,
+                lateVerdicts is null ? null : lateVerdicts.IsAdmissible))
             return;
 
         logger?.LogWarning(

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -1063,8 +1063,9 @@ public static class DataExtensions
         // from inside the disposal action below. MessageHub's own ShutDown phase states the rule
         // ("Never call DI from a disposal path") because a hub's lifetime scope, or an ancestor of
         // it, can already be closed by the time disposal actions run: HostedHubsCollection closes a
-        // hosted hub's scope on DisposalCompleted, and the watchdog's out-of-band
-        // ForceTeardownAfterWatchdog runs hostedHubs.Dispose() BEFORE DisposeImpl(). A resolve then
+        // hosted hub's scope on DisposalCompleted, so an ancestor's scope can be closed by the time
+        // a late registrant runs — and the ShutDown phase runs DisposeImpl() AFTER the hosted hubs
+        // have gone (their scopes with them). A resolve then
         // throws ObjectDisposedException ("Instances cannot be resolved … from this LifetimeScope"),
         // and the verdict is then never dispatched — so the writer burns the full 31 s
         // WriteVerdictBound and reports OwnerUnreachable, the exact acked-write-loss this

--- a/src/MeshWeaver.Data/DataExtensions.cs
+++ b/src/MeshWeaver.Data/DataExtensions.cs
@@ -937,42 +937,33 @@ public static class DataExtensions
     /// <c>MessageService.PostImplGeneric</c> stamps <c>POST_REFUSED_SHUTTING_DOWN</c> and returns
     /// exactly that when the owner AND its parent are past <c>DisposeHostedHubs</c>, and its own
     /// comment says "This site does NOT answer the sender itself".</para>
-    /// <para>🚨 <b>While the owner is SHUTTING DOWN, the accepted post is not proof of delivery</b>
-    /// (<paramref name="ownerIsShuttingDown"/>). The owner's <c>Post</c> is accepted — its own run
-    /// level is still open, so <c>PostImplGeneric</c> does not refuse — and the PARENT's routing
-    /// then drops it one turn later ("cannot route … its parent hub is shutting down
-    /// (RunLevel=DisposeHostedHubs)"), asynchronously, where this seam cannot see it. Measured on a
-    /// 2-core runner as the merge's own ack never reaching the armed watch
-    /// (NackReachesTheWaiterDuringTeardownTest, run 33861078925). So during teardown the armed sink
-    /// is served TOO, right after the post. the registry's dispatch removes
-    /// the entry before it calls back, and the posted response — if it survives the route — reaches
-    /// the same registry through the cache hub's handler, so the caller is answered exactly once
-    /// whichever arrives first.</para>
+    /// <para>🚨 <b>Do not serve the armed sink alongside an accepted post.</b> It was tried twice
+    /// here, to close a teardown hole — the owner's <c>Post</c> is accepted (its own run level is
+    /// still open, so <c>PostImplGeneric</c> does not refuse) and the PARENT's routing then drops it
+    /// a turn later, asynchronously, where this seam cannot see it. Both attempts reddened LIVE
+    /// tests, because a late watch is armed for EVERY patch at post time, not just an expired one:
+    /// serving it dispatches the ack synchronously on the OWNER's turn, ahead of the state change
+    /// the ack is about, so the caller's write completes before what it wrote is readable. Measured
+    /// — dispatch-first reddened <c>ComboGateRollTest</c> (run 33863349195) and, gated on
+    /// <c>IsShuttingDown</c>, <c>ImportTypeBeforeInstanceTest</c> (run 33865385033), which recycles
+    /// node hubs throughout its import and so meets that gate on the live path.</para>
     ///
-    /// <para>🚨 It is <b>only</b> during teardown. A late watch is armed for EVERY patch at post
-    /// time, not just an expired one, so serving the sink whenever it is armed would move every
-    /// ordinary ack off its designed transport — and forward of it, because the sink dispatches
-    /// synchronously on the owner's turn while the posted response arrives after the state change it
-    /// acknowledges. Measured: that reordering reddened <c>ComboGateRollTest</c> under load (run
-    /// 33863349195) — the caller's write completed before the change it wrote was readable.</para>
+    /// <para>The teardown hole is real and belongs one layer down: a correlated reply that
+    /// <c>HierarchicalRouting</c> cannot forward is DROPPED with nobody told, and the process still
+    /// holds the registry that could take it. Answering it here cannot be right — this seam is
+    /// called before routing has run. The owner's <c>ShutDown</c>-phase NACK
+    /// (<c>RegisterOwnerDisposingNack</c>) is the designed answer for that case.</para>
     /// </summary>
     /// <returns><c>true</c> when the post was accepted or the sink found an armed caller.</returns>
     internal static bool RoutePatchVerdict(
         PatchDataResponse response,
         string requestId,
         Func<PatchDataResponse, IMessageDelivery?> post,
-        Func<string, PatchDataResponse, bool>? dispatchLate,
-        Func<bool>? ownerIsShuttingDown = null)
+        Func<string, PatchDataResponse, bool>? dispatchLate)
     {
         var delivery = post(response);
         if (delivery is not null && delivery.State != MessageDeliveryState.Failed)
-        {
-            // Accepted — and that is the whole answer on the live path. In teardown it is not:
-            // the parent drops the response after this returns, so serve the armed sink as well.
-            if (ownerIsShuttingDown?.Invoke() == true && dispatchLate is not null)
-                dispatchLate(requestId, response);
             return true;
-        }
         return dispatchLate is not null && dispatchLate(requestId, response);
     }
 
@@ -1044,8 +1035,7 @@ public static class DataExtensions
                 response,
                 request.Id,
                 resp => hub.Post(resp, o => o.ResponseFor(request)),
-                lateVerdicts is null ? null : lateVerdicts.Dispatch,
-                () => hub.IsShuttingDown))
+                lateVerdicts is null ? null : lateVerdicts.Dispatch))
             return;
 
         logger?.LogWarning(

--- a/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
+++ b/src/MeshWeaver.Data/Serialization/JsonSynchronizationStream.cs
@@ -926,10 +926,10 @@ public static class JsonSynchronizationStream
             // disposing — the re-ask proceeds at once, exactly as before.
             //
             // No .Timeout here, deliberately: this join must not out-run the answer it joins
-            // (#1317). MessageHub.Dispose arms a disposal watchdog that force-tears-down and
-            // signals DisposalCompleted as its last act, so the leg is already guaranteed
-            // terminal; the caller's own budget (UpdateRemote's initial-state wait) is the
-            // deadline that belongs to the caller.
+            // (#1317). The owner signals DisposalCompleted as the last act of its teardown once
+            // its accepted work has drained, so the leg answers from a terminal state; the
+            // caller's own budget (UpdateRemote's initial-state wait) is the deadline that belongs
+            // to the caller.
             IObservable<Unit> OwnerTeardownSettled()
             {
                 var live = LocalInstanceOf(owner);

--- a/src/MeshWeaver.Data/Workspace.cs
+++ b/src/MeshWeaver.Data/Workspace.cs
@@ -214,8 +214,9 @@ public class Workspace : IWorkspace
         }
 
         // Event-driven, not timed: DisposalCompleted is a ReplaySubject(1) that the hub signals as
-        // the last act of its teardown (the disposal watchdog force-completes it if the phased path
-        // ever wedges), so this leg is already guaranteed terminal and needs no deadline of its own.
+        // the last act of its teardown, so this leg is terminal once the hub's accepted work has
+        // drained and needs no deadline of its own; a teardown that never finishes is reported by
+        // the hub's stall detector and bounded by the caller's teardown budget, not here.
         Hub.DisposalCompleted
             .Take(1)
             .Subscribe(

--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlledIoPooling.md
@@ -416,12 +416,20 @@ So the mesh teardown awaits **all three**, in order, before the scope is dispose
 1. `IMessageHub.DisposalCompleted` — action blocks + message round-trips. (Resources enqueue their
    async cleanup onto the `AsyncDisposeQueue` during this synchronous-`Dispose()` phase — `Dispose()`
    must never block, so async cleanup is *queued*, not run inline.)
-2. `IoPoolRegistry.DrainAll()` — offloaded ThreadPool I/O. **CANCEL + JOIN, not wait.** 🚨 Do *not*
-   use the wait-only `WhenDrained(timeout)` here: a live change-feed leaf never completes on its own,
-   so a polled wait times out and lets the scope dispose *while the leaf is still running* — its
-   ThreadPool thread then dereferences a collectible node ALC's freed metadata after unload, a
-   native use-after-unload **SIGSEGV**. `DrainAll()` cancels every leaf so it stops, then joins, and
-   returns the count it had to leak.
+2. `IoPoolRegistry.DrainAll()` — offloaded ThreadPool I/O. **GRACE, then CANCEL + JOIN — never wait
+   alone, never cancel first.** The drain first lets every in-flight leaf finish on its own: it
+   re-acquires the gate permits one at a time, each under `IoPoolOptions.DrainGrace` (8 s), so every
+   completion restarts the clock and a leaf that is going to finish is never cancelled (a write that
+   would have landed in 50 ms lands). Only a leaf that outlives a whole grace with the pool making
+   no further progress is *wedged*: its call site is captured, and then the pool cancels. 🚨 Do *not*
+   use the wait-only `WhenDrained(timeout)` in place of that cancel: a live change-feed leaf never
+   completes on its own, so a polled wait times out and lets the scope dispose *while the leaf is
+   still running* — its ThreadPool thread then dereferences a collectible node ALC's freed metadata
+   after unload, a native use-after-unload **SIGSEGV**. `DrainAll()` cancels so the stream leaves and
+   the wedged leaves stop, then joins, and returns the count it had to leak — and, separately, the
+   leaves it had to cancel (`IoPool.LeavesCancelledAfterGrace` / `CancelledLeafSites`), which the
+   teardown logs at **Error** because that work did not finish
+   ([Teardown Layers](/Doc/Architecture/TeardownLayers)).
    🚨 **The cancel runs on its own thread, never on the joining one.**
    `CancellationTokenSource.Cancel()` executes every registered callback *synchronously on the
    caller*, and this token's callbacks are not bookkeeping: `SubscribeThroughPool` registers one per

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingDisposalAndLeaks.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingDisposalAndLeaks.md
@@ -180,8 +180,10 @@ root.
 - **A reply that lands at `runLevel=Quiescing`** was gated on teardown work — look
   for a debounced/flushed/timer-driven dependency, not a wedged handler.
 - **Disposed ≠ unrooted.** Use the ClrMD probe; the *root kind* names the bug.
-- **A watchdog that force-completes disposal is a smell** — it usually masks a
-  non-quiescing cascade and can itself leak via its `Task.Delay` timer. Keep it
-  *cancellable* so it never pins the hub it is guarding.
+- **There is no watchdog that force-completes disposal any more — a stall is REPORTED.**
+  `DISPOSAL DEADLOCK DETECTED` / `[DISPOSE-WEDGE]` at Error names the hub, the turn on the
+  block and its age, and attaches the recursive snapshot; the hub stays pending until the
+  turn returns. Read the snapshot for the wedged child or the blocking registrant; never
+  reach for a force ([Teardown Layers](/Doc/Architecture/TeardownLayers)).
 - **Never bump a timeout to "fix" a bulk-only hang.** It's a leak or a flush/
   thread-pool dependency; the timeout is the messenger.

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -30,6 +30,8 @@ Tags:
 >
 > For *debugging* a disposal that hangs or leaks, see
 > [Debugging Disposal, Storms and Leaks](/Doc/Architecture/DebuggingDisposalAndLeaks).
+> For the policy the phases implement — accepted work finishes, wedged work is reported
+> and cancelled, nothing is forced — see [Teardown Layers](/Doc/Architecture/TeardownLayers).
 > This page is the **model** — how shutdown is built and how to add to it.
 
 ---
@@ -223,37 +225,56 @@ registered sync dispose actions), `messageService.Dispose()` (**sync** —
 `RunLevel = Dead`. The disposal-phase subscriptions are disposed in the `finally`
 (each has already self-completed).
 
-### The watchdog — `Observable.Timer`, and it tears down for real
+### The stall detector — `Observable.Timer`, and it reports instead of tearing down
 
-A safety net runs the teardown if the state machine ever wedges. It is a reactive
-timer that **cancels itself the instant disposal completes**:
+A reactive timer watches the teardown and **cancels itself the instant disposal
+completes**. It measures a **stall**, not a duration: it is re-armed by every
+`RunLevel` transition anywhere in the hosted subtree, so a slow nested teardown never
+trips it (#1701), and it fires every `DisposalWatchdogTimeout` (8 s) that goes by with
+no such signal:
 
 ```csharp
-watchdogSubscription = Observable
-    .Timer(DisposalWatchdogTimeout)            // 8 s, default scheduler (off action block)
-    .TakeUntil(disposalCompleted)              // cancel the moment disposal finishes
-    .Subscribe(
-        _ => { if (!DisposalSignalled) ForceTeardownAfterWatchdog(); },
-        _ => { });                             // a faulted disposalCompleted needs no watchdog
+watchdogSubscription = DisposalProgress
+    .StartWith($"{Address} Dispose() called")
+    .Select(reason => Observable.Timer(DisposalWatchdogTimeout, DisposalWatchdogTimeout).Select(_ => reason))
+    .Switch()                                   // re-arm on every progress signal in the subtree
+    .TakeUntil(disposalCompleted)               // stop the moment disposal finishes
+    .ObserveOn(DefaultScheduler.Instance)       // never on the progress path (lock-order inversion)
+    .Subscribe(OnDisposalStall, _ => { });
 ```
 
-Two things matter here, and both were once wrong:
+`OnDisposalStall` reaches one of five verdicts and **performs no teardown** — see
+[Teardown Layers](/Doc/Architecture/TeardownLayers) for the table. In short: a pump that
+keeps completing turns is *busy* (Information; accepted work is draining ahead of the
+`ShutdownRequest`, which queues FIFO behind it); a turn that has held the block for a
+whole budget is handed its cancellation token once and reported at **Error** by name;
+one that ignores that is reported again every budget; a `ShutdownRequest` that is itself
+on the block means a registered cleanup is blocking inside `DisposeImpl` (reported, not
+cancelled — it runs with `CancellationToken.None`); and no turn at all means the stall
+is in a child or a join, which the recursive diagnostics name.
 
-- **It force-*tears down*, it does not merely signal.** `ForceTeardownAfterWatchdog`
-  flips `RunLevel` to `ShutDown` first (so heartbeats and hosted-hub creation stop
-  feeding the storm), then runs the SAME teardown the phases would have —
-  `hostedHubs.Dispose()`, `CancelCallbacks()`, `DisposeImpl()`,
-  `messageService.Dispose()` — each in its own `try/catch`, then sets `Dead` and
-  signals. The predecessor only **signalled** completion here: the caller unblocked
-  and every child leaked, which is how one dead Blazor circuit's portal hub kept
-  ~7k sync-stream hubs alive heartbeating at ~1.2 cores forever (the 2026-07-01
-  zombie portal-hub storm).
+Two things about its history matter, because both were once wrong the other way:
+
+- **It no longer tears anything down out of band.** The predecessor ran
+  `hostedHubs.Dispose()`, `CancelCallbacks()`, `DisposeImpl()` and
+  `messageService.Dispose()` from the timer thread and signalled `Dead` while the
+  wedged turn was still executing. A parent then advanced against a subtree that was
+  mid-flight; production (`memex-cloud`, 2026-08-29 → 09-03) showed it firing dozens of
+  times per shutdown and on pods that were not shutting down. Its own predecessor
+  merely **signalled** completion and leaked every child (the 2026-07-01 zombie
+  portal-hub storm). Now a hub either finishes its phases or stays *pending* and says
+  why; the bound that ends a wedged teardown is the caller's, and it reports the
+  snapshot rather than forcing.
 - **`TakeUntil(disposalCompleted)` is what fixed the TimerQueue leak.** The old
   uncancelled `Task.Delay(25 s)` rooted the entire hub graph (cache, data sources,
   action block, subscriptions) for 25 s after *every* dispose, even a fast one. The
-  reactive timer releases its scheduler entry as soon as the subject fires. (The
-  current budget is `DisposalWatchdogTimeout` = **8 s**; the 25 s figure is the
-  deleted `Task.Delay`, not today's bound.)
+  reactive timer releases its scheduler entry as soon as the subject fires.
+
+`Dispose()` also **no longer cancels the in-flight turn on entry**. Work the hub accepted
+before teardown began runs to completion; cancellation is the stall verdict above, never
+a reflex. The one exception is a hub still in `Starting`: its `InitializeHubRequest` is
+its own bring-up, not accepted work, and is cancelled at once so a hung initialization
+cannot hold its ancestry pending for a whole stall budget.
 
 ---
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/HubDisposalModel.md
@@ -171,7 +171,13 @@ quiescingSubscription = drained
 > trips (the gap is always 50 ms, never 2 s). The deadline must be a **separate
 > total-duration `Observable.Timer`**, raced against the drain signal with `Amb`.
 
-If the budget elapses with callbacks still pending, the hub sets the sticky
+If the budget elapses with callbacks still pending, the hub first asks whether any of
+them is **owed by a sibling hub in this mesh that is itself shutting down** — resolved at
+the mesh root like `HierarchicalRouting` does — and if so **re-arms the budget** rather
+than cancelling (`[QUIESCE-WAIT]`): that sibling answers every delivery it accepted before
+it leaves the registry, so the wait ends by construction (a cycle breaker,
+`MaxQuiesceRearms`, covers two hubs holding each other's deferred requests; see
+[Teardown Layers](/Doc/Architecture/TeardownLayers)). Otherwise the hub sets the sticky
 `QuiescingTimedOut` flag, records `QuiescingTimeoutDetail` and force-cancels them.
 **Tests treat `AnyHubQuiescingTimedOut()` as a dispose failure** — a leaked `Observe`
 subscription that never got its reply is a real bug, not a teardown oddity. Either

--- a/src/MeshWeaver.Documentation/Data/Architecture/MeshLifecycle.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/MeshLifecycle.md
@@ -1,7 +1,7 @@
 ---
 Name: Mesh Lifecycle — Build Up & Tear Down
 Category: Architecture
-Description: The exact, symmetric order for standing a mesh up and taking it down — including the activity quiesce and the three-phase drain (DisposalCompleted + IoPool cancel-and-join + async dispose queue) that every teardown MUST complete before the service scope dies. Applies to tests, the Orleans silo, and host shutdown.
+Description: The exact, symmetric order for standing a mesh up and taking it down — including the activity quiesce (progress-based; a stalled run is cancelled and named) and the three-phase drain (DisposalCompleted + IoPool grace-then-cancel join + async dispose queue) that every teardown MUST complete before the service scope dies. Applies to tests, the Orleans silo, and host shutdown.
 Icon: ArrowSync
 ---
 
@@ -60,7 +60,7 @@ scope is disposed:
 | # | In-flight work | Drained by | Why it's separate |
 |---|---|---|---|
 | 1 | Hub **action blocks** + in-flight **message round-trips** (`hub.Observe`, `GetMeshNode`, …) | `IMessageHub.DisposalCompleted` | Runs on the hub's single-threaded action block; the disposal state machine waits for the response subjects to drain. |
-| 2 | **Offloaded I/O** — anything sent through `IIoPool` (DB, blob, HTTP, compile) | `IoPoolRegistry.DrainAll()` — **cancel + join**, synchronous, returns the count of leaves that did not stop | Runs on the **ThreadPool**, independent of the action block. `DisposalCompleted` does **not** know about it. |
+| 2 | **Offloaded I/O** — anything sent through `IIoPool` (DB, blob, HTTP, compile) | `IoPoolRegistry.DrainAll()` — **grace, then cancel, then join**, synchronous; returns the count of leaves that did not stop and names the ones it had to cancel | Runs on the **ThreadPool**, independent of the action block. `DisposalCompleted` does **not** know about it. |
 | 3 | **Async cleanup** a resource cannot finish inside its synchronous `Dispose()` (flush a write queue, await a stream) | `AsyncDisposeQueue.DrainAsync(quiesce)` | `Dispose()` may not block; resources `Enqueue` their async cleanup onto the queue and a TPL `ActionBlock` drains it. |
 
 The async dispose queue is the key to phase 3: **`Dispose()` is synchronous and must
@@ -79,10 +79,14 @@ drains it in the background; tear-down gives it a bounded quiesce budget to fini
 There is also a **phase 0** that is easy to miss: an in-flight *activity* falls through all
 three phases above — its trigger returned as soon as the activity existed, its command runs
 off-turn so it holds no grain turn, and the subscribe-window pool permit is long released, so
-`DrainAll()` joins nothing. So teardown **waits for `ActivityTracker.WhenIdle` first**, before
-anything is disposed: those runs still write their terminal `ActivityLog` status through hubs
-that must still be alive. (Measured before this existed: a 5 s activity, and teardown returned
-after 2028 ms with the command still running.)
+`DrainAll()` joins nothing. So teardown **quiesces the activities first**, before anything is
+disposed — `ActivityTracker.Quiesce(ActivityStallBudget)`: a run that keeps reporting progress
+(every `ctx.Log` line) is waited for; one that has made no progress for the stall budget (8 s) is
+cancelled once, through the same token a user's cancel would trip, and named on the report; one
+that ignores that is named as abandoned a budget later so the teardown can proceed. Those runs
+still write their terminal `ActivityLog` status through hubs that must still be alive. (Measured
+before any of this existed: a 5 s activity, and teardown returned after 2028 ms with the command
+still running.) Policy and evidence: [Teardown Layers](/Doc/Architecture/TeardownLayers).
 
 The canonical helper does all of it:
 
@@ -98,20 +102,25 @@ await ((IAsyncDisposable)mesh.ServiceProvider).DisposeAsync();
 1. captures the `IoPoolRegistry`, `AsyncDisposeQueue`, `ActivityTracker` and
    `MeshTeardownSignal` **while the scope is still alive** (never resolve DI once disposal has
    begun — see the note in `MessageHub`'s ShutDown `finally`),
-2. waits (bounded) on `ActivityTracker.WhenIdle` — phase 0,
+2. runs `ActivityTracker.Quiesce` (bounded by the caller's timeout) — phase 0 — and logs every
+   run it had to cancel or abandon at **Error**,
 3. calls `mesh.Dispose()` (resources enqueue their async cleanup during this reactive disposal),
 4. awaits `DisposalCompleted` (phase 1),
 5. calls `IoPoolRegistry.DrainAll()` (phase 2), then
 6. awaits `AsyncDisposeQueue.DrainAsync(timeout)` (phase 3), and finally
 7. fires `MeshTeardownSignal` with the `TeardownReport`.
 
-> 🚨 **Phase 2 CANCELS, it does not merely wait.** The predecessor was the wait-only, polled
-> `WhenDrained(timeout)`, which **still exists on `IoPoolRegistry`** — it is simply the wrong
-> primitive here, so do not reach for it in a teardown path. A live change-feed leaf never completes on its
-> own, so a wait-without-cancel timed out and let the scope dispose *while the leaf still ran*;
+> 🚨 **Phase 2 gives a GRACE, then CANCELS, then joins — it never merely waits.** `DrainAll()`
+> first lets every in-flight leaf finish on its own: it re-acquires the gate permits one at a
+> time under `IoPoolOptions.DrainGrace` (8 s per completion — a stall bound, so a burst of short
+> writes drains in as many completions), names the leaves that outlived it, and only then
+> cancels. The cancel is still required: a live change-feed leaf never completes on its own, and
+> the wait-only, polled `WhenDrained(timeout)` — which **still exists on `IoPoolRegistry`** and
+> is the wrong primitive here — timed out and let the scope dispose *while the leaf still ran*;
 > its ThreadPool thread then dereferenced a collectible node ALC's freed metadata after unload
-> → a native use-after-unload SIGSEGV. `DrainAll()` cancels every leaf so it stops, then joins,
-> and returns how many did not.
+> → a native use-after-unload SIGSEGV. After the cancel `DrainAll()` joins, and returns how many
+> leaves did not unwind. A leaf it had to cancel after the grace is a unit of work that did not
+> finish — reported at **Error** with its call site (`TeardownReport.CancelledIoByPool`).
 
 `TeardownAsync` returns a **`TeardownReport`** (leaked I/O leaves + whether the async dispose
 queue drained clean). **Surface a dirty report** — fail the test class, error-log the shutdown.

--- a/src/MeshWeaver.Documentation/Data/Architecture/TeardownLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/TeardownLayers.md
@@ -148,6 +148,27 @@ forces: `MonolithMeshTestBase.DisposeTimeout` (30 s) fails the class with the sn
 host proceed to `HostOptions.ShutdownTimeout` (90 s); Kubernetes ends the process at its grace
 ceiling. At no point does a hub say it has finished when it has not.
 
+### Quiescing waits for a reply a shutting-down sibling still owes
+
+The Quiescing phase gives a hub's pending `Observe` callbacks `QuiesceTimeout` (2 s, 0.5 s in
+the test base) to drain, then cancels them and records a leak. Measured with #3261's departed-child
+detector, every callback that cancel hit in a whole-mesh teardown was a request to a **sibling hub
+that was itself disposing** — `CreateOrUpdateNodeRequest@portal/nodeops-*` from a type hub,
+`SubscribeRequest@…` and `PatchDataRequest@Plugins/_Policy` from a `cache/*` hub — and production
+shows the identical `[QUIESCE-TIMEOUT] … CreateNodeRequest@portal/nodeops-*` at 2 s. Those replies
+were on their way: a disposing hub answers every delivery it accepted before it leaves its owner's
+registry (served ahead of its own `ShutdownRequest`, or NACKed `ShuttingDown` by its
+`messageService.Dispose()`). Cancelling them discarded accepted work and reported a leak that was
+not one.
+
+So on expiry the phase now asks, per pending callback, whether its target resolves — at the mesh
+root, the way `HierarchicalRouting` resolves it — to a hub that `IsShuttingDown` and has not
+signalled `Dead`. If any does, the budget is **re-armed** (`[QUIESCE-WAIT]`, Information) instead
+of cancelled; the wait ends by construction when the reply lands or the sibling has gone. A cycle
+breaker (`MaxQuiesceRearms`, 20) covers two hubs each holding a deferred request of the other's:
+past it the callbacks are cancelled as before and the case is logged at **Error** (`[QUIESCE-CUT]`,
+7315). The stall detector treats a Quiescing hub with owed replies as *busy*.
+
 ### What a hub still discards, and why that is an Error too
 
 Two things a disposing hub cannot carry across: deliveries **deferred** behind an initialization

--- a/src/MeshWeaver.Documentation/Data/Architecture/TeardownLayers.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/TeardownLayers.md
@@ -1,0 +1,215 @@
+---
+NodeType: Markdown
+Name: "Teardown Layers — work finishes, nothing is forced"
+Abstract: "The mesh tears down in two layers: the APPLICATION layer (activities, pooled I/O, handler turns) is drained first and given the chance to finish its job; the INFRASTRUCTURE layer (hubs, action blocks, scopes) goes down behind it. Nothing is cancelled on entry and nothing is torn down out of band: a unit of work that stops making progress is detected by a stall budget, cancelled once cooperatively, and reported at Error with everything a reproduction needs. Why the forced teardown was removed, what the five stall verdicts are, and what production measured."
+Icon: "<svg viewBox='0 0 24 24' xmlns='http://www.w3.org/2000/svg'><rect width='24' height='24' rx='4' fill='#00695c'/><path d='M5 8h14M5 12h10M5 16h6' fill='none' stroke='white' stroke-width='1.8' stroke-linecap='round'/></svg>"
+Thumbnail: "images/DataMesh.svg"
+Authors:
+  - "Roland Buergi"
+Tags:
+  - "Architecture"
+  - "Disposal"
+  - "Lifecycle"
+  - "Operations"
+---
+
+# Teardown Layers — work finishes, nothing is forced
+
+> **The rule.** A teardown lets the work the mesh has accepted **finish its job**, and it never
+> pretends to be done while that work is running. Two layers go down in order: the
+> **application layer** — activities, pooled I/O, handler turns — is drained first; the
+> **infrastructure layer** — hubs, action blocks, scopes — goes down behind it. Nothing is
+> cancelled on entry. A unit of work that has **stopped making progress** for one stall budget is
+> *wedged*: it is cancelled once, cooperatively, and reported at **Error** by name with the
+> evidence a reproduction needs. A unit that ignores that is reported again and left behind so
+> the process can exit — but the hub that owns it stays honestly *pending*, it never signals a
+> completion that is not true. **Forced teardown does not exist.**
+>
+> The hub-level mechanics are in [Hub Disposal Model](/Doc/Architecture/HubDisposalModel); the
+> mesh-level order in [Mesh Lifecycle](/Doc/Architecture/MeshLifecycle); the pool drain in
+> [Controlled I/O Pooling](/Doc/Architecture/ControlledIoPooling). This page is the policy those
+> three implement, and the evidence that fixed it (maintainer directive, 2026-09-04).
+
+---
+
+## Why forced teardown was removed
+
+Until 2026-09-04 every hub armed an 8 s watchdog on `Dispose()`. When the disposal state machine
+made no progress for 8 s the watchdog ran the teardown **itself, from its timer thread**: hosted
+hubs disposed, callbacks cancelled, registered cleanups run, message service stopped, `Dead`
+signalled — while the turn that had wedged the hub was still executing on the action block. Two
+things were true of that design and both were measured:
+
+- **It lied about completion.** A parent whose child was force-torn-down advanced to its own
+  `ShutDown` phase against a subtree that was mid-flight. In `MeshWeaver.Graph.Test`, the
+  `OwnerDisposing` NACK for a patch in flight at teardown could only be minted **after** the force
+  had fired, so the waiting caller's whole budget was "the watchdog plus two seconds" — and a
+  loaded CI shard lost those two seconds (run 33847949620).
+- **It ran in production dozens of times per shutdown, and while serving.** Loki on `memex-cloud`
+  (2026-08-29 → 09-03) shows `DISPOSAL DEADLOCK DETECTED: Hub sync/… (last progress: sync/… →
+  ShutDown). RunLevel=ShutDown` followed by `[FORCE-TEARDOWN] … out-of-band teardown complete
+  after 22706ms`, on sync-stream hubs and on the node hubs above them (`AgenticBusiness/Handbook`,
+  `app/Northwind`, `rbuergi/OpenStreetMap/Examples`), including at 16:24 on a pod that was not
+  shutting down at all. Each of those was a hub reported disposed with work still holding it.
+
+The replacement is a **stall detector** that observes and reports. It keeps everything the
+watchdog got right — it measures a stall, re-armed on every `RunLevel` transition anywhere in the
+subtree, so a slow nested teardown never trips it (#1701) — and it stops doing the one thing that
+was wrong: it performs no teardown. See the five verdicts below.
+
+---
+
+## Layer 1 — the application layer drains first
+
+| Work | Where it is tracked | Progress signal | Grace | Kill |
+|---|---|---|---|---|
+| **Activities** (`RunActivity`) | `ActivityTracker` — one `ActivityRunHandle` per run, labelled with its activity path | `handle.Progress()` on every `ctx.Log(...)` line the run appends | `ActivityStallBudget` (8 s) of **no progress** | the run's cancellation token — the same one a user's cancel request trips |
+| **Pooled I/O leaves** (`IIoPool.Invoke/InvokeStream/InvokeBlocking`) | the pool's gate permits and blocking-idle event | a leaf completing (a permit released) | `IoPoolOptions.DrainGrace` (8 s) of **no completion** | `_poolCts` — the pool token linked into every leaf |
+| **Handler turns** | the hub's action block (`MessageService`) | a turn completing (`TurnsCompleted`) or a `RunLevel` transition | `DisposalWatchdogTimeout` (8 s) of **no progress** | `CancelExecution()` — the token the handler was given |
+
+The same number everywhere is deliberate: "no progress for 8 s" means the same thing at every
+layer, and every grace is a **stall** bound, not a duration. A burst of ten short writes drains in
+ten completions, a run that logs a line every second is waited for as long as the caller's outer
+budget allows, a backlog of 800 accepted turns drains in 800 turns.
+
+### Activities: `Quiesce`, not `WhenIdle`
+
+`MeshTeardownExtensions.TeardownAsync` (production) and `MonolithMeshTestBase.DisposeAsync`
+(tests) both start with `ActivityTracker.Quiesce(ActivityStallBudget)`:
+
+```
+idle?            → done at once, Clean
+run progressing  → wait (the caller's timeout is the only outer bound)
+run stalled      → RequestCancel() once   → listed in report.Cancelled  → Error
+run ignores it   → after one more budget  → listed in report.Abandoned  → Error, and the quiesce
+                                             no longer waits on it
+```
+
+`ActivityRunner` registers each run with `TrackRun(activityPath, () => cts.Cancel())` and calls
+`Progress()` from the `ActivityContext.Log` seam, so a run that is writing its log is provably
+alive. A run cancelled this way finishes `Cancelled` with the message *"Cancelled by teardown: the
+run made no progress while the mesh was shutting down"* and the runner logs it at **Error** — it
+is not the ordinary user-cancel outcome, it is a run that did not finish its job.
+
+### Pooled I/O: grace, then cancel, then join
+
+`IoPool.Drain()` used to cancel first and join second, so every in-flight write at teardown was
+aborted the instant the mesh decided to go down. It now:
+
+1. **Joins under the grace** — re-acquires the gate's permits one at a time, waiting up to one
+   `DrainGrace` for *each*; every acquisition is a leaf that finished (or a free permit), and the
+   clock restarts. Blocking leaves are waited for on their idle event under the same grace.
+2. **Names what did not finish** — the permits it could not re-acquire are wedged leaves; their
+   call sites are captured **now**, before the cancel erases them (`CancelledLeafSites`).
+3. **Cancels** — which is also what ends the long-lived pooled *subscriptions* (change feeds hold
+   no permit past their subscribe and have no job to finish; ending them is not a kill).
+4. **Joins under the drain budget** as before, and reports the residual as before.
+
+`IoPoolRegistry.DrainAll(out residual, out cancelledAfterGrace)` carries both lists; the teardown
+report exposes them as `CancelledIoLeaves` / `CancelledIoByPool` and logs each at **Error**.
+
+### Handler turns: accepted work drains ahead of the shutdown
+
+`MessageHub.Dispose()` no longer calls `CancelExecution()` on entry. The `ShutdownRequest` that
+starts the phases queues FIFO behind whatever the hub had already accepted, and the pump drains it.
+A turn that returns on its own is never cancelled.
+
+The one exception is a hub that never finished **starting**: its `InitializeHubRequest` is the
+hub's own bring-up, not work anyone handed it — intake is gated behind it, so no accepted turn
+can depend on its result — and a bring-up still running when the owner tears down produces
+nothing the owner will keep. That turn is cancelled on entry, so a hung initialization releases
+the block at once instead of holding its whole ancestry pending for a stall budget; whatever was
+parked behind its gates is answered `ShuttingDown` and reported (`[DISPOSE-DISCARD]`).
+
+---
+
+## Layer 2 — the hub goes down behind its work: the five stall verdicts
+
+`MessageHub.OnDisposalStall` runs every `DisposalWatchdogTimeout` (8 s) during which nothing in the
+subtree changed `RunLevel`. It reads the pump's completed-turn counter and the executing turn, and
+reaches exactly one of these:
+
+| Verdict | Condition | Action | Level / event |
+|---|---|---|---|
+| **busy** | turns completed since the last look | none — keep waiting | Information `[DISPOSE-BUSY]` |
+| **wedged turn, first strike** | a turn has held the block for the whole budget | `CancelExecution()` once | **Error** `[DISPOSE-WEDGE]` (7311) |
+| **wedged turn, ignores cancellation** | same turn, another budget later | none — report again every budget | **Error** `DISPOSAL DEADLOCK DETECTED` (7312) |
+| **ShutDown phase blocked** | the executing turn *is* the `ShutdownRequest` | none — it runs with `CancellationToken.None`; the finding is the registrant that blocks inside `DisposeImpl` / `messageService.Dispose` | **Error** (7314) |
+| **stalled below** | no turn executing, no progress | none — the stall is in a child or a join; the diagnostics name it | **Error** (7313) |
+
+Every Error carries the hub address, the message type and its age, the queue depth, the last
+progress signal, the `RunLevel`, and the **recursive disposal snapshot** (every hosted hub's
+`RunLevel`, queue depths, executing turn, pending callbacks). That is the reproduction: which hub,
+which message, how long, what it was waiting on.
+
+**The bound that ends a wedged teardown belongs to the caller**, and it reports rather than
+forces: `MonolithMeshTestBase.DisposeTimeout` (30 s) fails the class with the snapshot;
+`MeshTeardownHostedService.TeardownTimeout` (30 s) logs an **Error** with the snapshot and lets the
+host proceed to `HostOptions.ShutdownTimeout` (90 s); Kubernetes ends the process at its grace
+ceiling. At no point does a hub say it has finished when it has not.
+
+### What a hub still discards, and why that is an Error too
+
+Two things a disposing hub cannot carry across: deliveries **deferred** behind an initialization
+gate that never opened, and turns still **queued** when `messageService.Dispose()` stops the pump.
+Both were accepted; neither ran. The first is answered `ShuttingDown` (transient, so the sender
+retries against the fresh activation — the #2176 hang was the silent version); both are logged at
+**Error** (`[DISPOSE-DISCARD]`, events 7301/7302) with the message type, id, sender, the gates it
+sat behind and the run level. A hub that disposes with its gates still shut is the defect those
+lines point at.
+
+---
+
+## Errors become issues — in production
+
+Every kill and every discard above is an **Error**, and every Error carries an `EventId`. The
+red-log pipeline ([Log watch and triage](/Doc/Architecture/LogWatchTriage)) keys an incident on
+*category + event id + exception + top frame* and never on prose, so each verdict shape files as
+**one** issue however many hubs reach it, and the prose is free to carry every address, message
+type and snapshot a reproduction needs. Triage checks for an existing issue before it files.
+
+That pipeline runs only against production Loki. In a test run the same lines land in the test
+output and in the per-test trace (`DISPOSE_WEDGED_WORK`, `DISPOSE_ACTIVITIES_QUIESCED`), and the
+test base **does not fail the class** on killed work — the dirty-teardown and quiesce-leak gates
+keep their existing verdicts, and a killed run is logged where the test author will see it.
+
+---
+
+## What production measured (Loki, memex / memex-cloud, 2026-08-28 → 09-04)
+
+The maintainer's report was *"blocked rolls — disposal seems to be keeping something"*. Two
+different things were keeping pods, at two different scales:
+
+- **28 minutes, pod level — not disposal.** `terminationGracePeriodSeconds` is 1800 s and the
+  `preStop` hook polls `/drain` until no Blazor circuit is open. In every captured case one real
+  signed-in user's tab stayed pinned to the terminating pod, the count sat flat (`1→1`), and preStop
+  gave up at 1680 s (`Drain: GIVING UP after 00:28:02 — 1 circuit(s) are STILL OPEN`). Fifteen
+  such pods in the window. A Terminating pod keeps its 4 CPU / 8 GiB reservation, the HPA fills
+  the remaining slots, and `maxSurge=1` then has no slot for the surge pod — measured on 09-03
+  17:14, 6 m 39 s `Pending` until a manual kill freed one. That is a scheduling question
+  ([Deployment on AKS](/Doc/Architecture/DeploymentAKS)), not a teardown one.
+- **55–61 seconds, process level — disposal, bounded.** After SIGTERM the slow shutdowns were
+  `RoutingQuiescence` spending its 30 s on route legs that never landed (3 to 17 of them),
+  `IoPoolSiloTeardown` spending its 30 s on a leaf ignoring cancellation, and the sync-stream hubs
+  and their node hubs being force-torn-down after 8–23 s. Those are the defects this page's
+  verdicts now name individually — and the reason the force was removed: a hub that reported
+  itself disposed at 8 s while its work ran on is exactly "keeping something".
+
+One more finding for the operator: `MeshWeaver` logs at `Warning` in the production
+`appsettings.json`, so the Information-level teardown narrative (`Drain: TERMINATION BEGUN`,
+`MeshTeardownHostedService … drained cleanly`, `IoPoolSiloTeardown: pooled I/O joined`) is
+invisible in Loki. Every verdict on this page is therefore an **Error** — not to be loud, but so
+that it exists in the one log level that ships.
+
+---
+
+## Rules for adding teardown work
+
+- **A unit of work reports its own progress.** Never invent a heartbeat for it; if it has no
+  observable step, it has no claim to be waited for beyond one budget.
+- **Cancel is a verdict, never a reflex.** Nothing on the teardown path cancels on entry.
+- **Never tear down around a running turn.** If a hub cannot finish, it stays pending and says so.
+- **Kills and discards are Errors with event ids and the snapshot attached.** A Warning does not
+  ship, and a line without the address, the message type and the age cannot be reproduced.
+- **The outer bound reports; it does not force.** Tests fail with the snapshot; the host logs it
+  and exits on its own timeout.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-shutdown-lets-work-finish-and-names-what-it-had-to-stop.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-shutdown-lets-work-finish-and-names-what-it-had-to-stop.md
@@ -1,0 +1,39 @@
+---
+Name: Shutdown lets work finish, and names what it had to stop
+Category: Fix
+Description: A portal going down no longer cuts off the work it had already accepted. Running activities, in-flight reads and writes, and handlers mid-turn are given the chance to finish; only something that has stopped making progress for eight seconds is stopped, and when that happens the log says which one, with enough detail to find out why. The forced teardown that used to declare a hub finished while its work was still running is gone.
+Icon: ArrowSync
+Order: -20260904
+---
+
+# Shutdown lets work finish, and names what it had to stop
+
+When a portal restarts — a deploy, a scale-down, a recycle of one node — everything it was doing
+has to come to an end. Until now it did that impatiently. The moment a hub began shutting down it
+cancelled whatever it was running, cancelled every read or write still in flight on the I/O pools,
+and if the shutdown made no progress for eight seconds it tore the hub down from the outside and
+declared it finished — with the work that had wedged it still running underneath.
+
+Measured on the production portals, that last step fired dozens of times per shutdown, and
+sometimes on a portal that was not shutting down at all. Each time, a hub reported itself gone
+while it was still holding something.
+
+## What changes
+
+**Accepted work is drained, not cut off.** A handler in the middle of a merge finishes the merge.
+A queue of messages the hub had already accepted is processed before the shutdown takes its turn.
+A write that would have landed in fifty milliseconds lands. A running activity keeps running for
+as long as it keeps reporting progress.
+
+**Only what has stopped is stopped.** Something that has made no progress for eight seconds — an
+activity that has not logged a line, an I/O operation that has not completed, a handler that has
+not returned — is cancelled once, cooperatively. If it ignores that, it is reported again and the
+shutdown proceeds around it at the host's own deadline, but the hub that owns it never claims to
+have finished.
+
+**Every stop is named.** Each cancellation and each message a hub had to discard is logged as an
+error carrying the hub, the message or activity, how long it had been stuck, and a snapshot of
+what it was waiting on. On production portals those errors are what the log triage turns into
+issues, so a wedge is a ticket with a reproduction attached rather than a line nobody reads.
+
+Nothing about a healthy shutdown changes: a hub with nothing in flight goes down as fast as before.

--- a/src/MeshWeaver.GitSync/ActivityRunner.cs
+++ b/src/MeshWeaver.GitSync/ActivityRunner.cs
@@ -149,14 +149,26 @@ public static class ActivityRunner
             var scopeIdentity = owner ?? ContextOf(created.LastModifiedBy);
             IObservable<string> Run()
             {
+                var cts = new CancellationTokenSource();
                 // Register the run as in flight for the WHOLE of its life, released in the
                 // Finally below — i.e. at TERMINAL (succeeded / failed / cancelled), not when
                 // it was merely dispatched. Teardown quiesces on this: it stops starting new
                 // work and waits for what is running, instead of walking away from it while
                 // the command still executes against a tearing-down mesh.
-                var runRegistration = hub.ServiceProvider.GetService<ActivityTracker>()?.Track();
-
-                var cts = new CancellationTokenSource();
+                //
+                // The registration carries the run's NAME and its cooperative KILL (the same token
+                // a user's cancel request trips), and the run reports progress on every log line
+                // it appends — so a teardown can let a working run finish and cancel only one that
+                // has stopped moving. `killedByTeardown` is what turns that cancel into an ERROR
+                // in the terminal log below rather than the ordinary "cancelled" outcome.
+                var killedByTeardown = 0;
+                var runRegistration = hub.ServiceProvider.GetService<ActivityTracker>()?.TrackRun(
+                    activityPath,
+                    () =>
+                    {
+                        Interlocked.Exchange(ref killedByTeardown, 1);
+                        try { cts.Cancel(); } catch { /* already disposed */ }
+                    });
                 // Cancel watcher: RequestedStatus = Cancelled trips the command's token
                 // (Activity Control Plane). Subscribed for the life of the run; disposed on
                 // completion.
@@ -203,7 +215,13 @@ public static class ActivityRunner
                             activityPath));
 
                 var ctx = new ActivityContext(activityPath, cts.Token,
-                    (msg, level) => Append(workspace, accessService, owner, activityPath, msg, level, logger));
+                    (msg, level) =>
+                    {
+                        // Every appended line is the run saying "still working" — the quiesce's
+                        // notion of progress is exactly this, never a heartbeat.
+                        runRegistration?.Progress();
+                        Append(workspace, accessService, owner, activityPath, msg, level, logger);
+                    });
 
                 // Run the command; on terminal, write the final Status + dispose watcher/cts.
                 return command(ctx)
@@ -213,11 +231,26 @@ public static class ActivityRunner
                     .Catch<Unit, Exception>(ex =>
                     {
                         var cancelled = ex is OperationCanceledException || cts.IsCancellationRequested;
-                        logger?.LogWarning(ex, "Activity {Path} {Outcome}", activityPath,
-                            cancelled ? "cancelled" : "failed");
+                        if (cancelled && Volatile.Read(ref killedByTeardown) != 0)
+                            // 🚨 An ERROR, not the ordinary cancelled outcome: the run did not finish
+                            // its job — teardown found it making no progress and had to kill it.
+                            // That is a defect in whatever the run was waiting on, and an Error is
+                            // what the red-log pipeline files as an issue.
+                            logger?.LogError(ex,
+                                "Activity {Path} was CANCELLED BY TEARDOWN: it made no progress for the "
+                                + "stall budget while the mesh was quiescing, so its work did not finish. "
+                                + "Find what it was waiting on; a run that reports progress is never cancelled.",
+                                activityPath);
+                        else
+                            logger?.LogWarning(ex, "Activity {Path} {Outcome}", activityPath,
+                                cancelled ? "cancelled" : "failed");
                         return Finish(workspace, accessService, owner, activityPath,
                             cancelled ? ActivityStatus.Cancelled : ActivityStatus.Failed,
-                            cancelled ? "Cancelled." : ex.Message, logger);
+                            cancelled
+                                ? (Volatile.Read(ref killedByTeardown) != 0
+                                    ? "Cancelled by teardown: the run made no progress while the mesh was shutting down."
+                                    : "Cancelled.")
+                                : ex.Message, logger);
                     })
                     .Finally(() =>
                     {

--- a/src/MeshWeaver.Hosting/MeshTeardownHostedService.cs
+++ b/src/MeshWeaver.Hosting/MeshTeardownHostedService.cs
@@ -101,9 +101,21 @@ public sealed class MeshTeardownHostedService(
         catch (Exception ex)
         {
             // Never let a teardown drain failure escape into host shutdown — log and continue so the
-            // host still exits. A genuine leak surfaces via AnyHubQuiescingTimedOut / IoPool in-flight.
-            logger.LogWarning(ex,
-                "MeshTeardownHostedService: mesh drain did not complete cleanly within {Timeout}", TeardownTimeout);
+            // host still exits. But it is an ERROR, with the evidence attached: a mesh that did not
+            // finish draining inside its budget is holding work it has not finished (the process
+            // is about to exit over it), and the red-log pipeline files an Error as an issue. The
+            // recursive disposal snapshot names the hub, the phase, the executing turn and the
+            // pending callbacks — what a reproduction has to start from. (Was a Warning with no
+            // diagnostics; measured on memex/memex-cloud the 55–61 s shutdowns carried nothing
+            // that said WHICH hub was still going down.)
+            string diagnostics;
+            try { diagnostics = mesh.GetDisposalDiagnostics(); }
+            catch (Exception diagEx) { diagnostics = $"(disposal diagnostics unavailable: {diagEx.GetType().Name}: {diagEx.Message})"; }
+            logger.LogError(ex,
+                "MeshTeardownHostedService: mesh {Address} did not finish draining within {Timeout} — the host "
+                + "proceeds to dispose its container over work that has not finished. Find what is still going "
+                + "down; do not widen the budget.\n{Diagnostics}",
+                mesh.Address, TeardownTimeout, diagnostics);
         }
     }
 }

--- a/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
@@ -119,15 +119,27 @@ public sealed class ActivityTracker : IDisposable
     {
         var handle = new ActivityRunHandle(this, Interlocked.Increment(ref ticketSeq), label, cancel);
         runs[handle.Ticket] = handle;
-        deltas.OnNext(1);
+        Emit(1);
         return handle;
     }
 
     internal void Complete(ActivityRunHandle handle)
     {
         if (runs.TryRemove(handle.Ticket, out _))
-            deltas.OnNext(-1);
+            Emit(-1);
     }
+
+    // 🚨 Every delta is QUEUED onto the tracker's own event loop before it reaches the subject, so
+    // OnNext is only ever called from that one thread — the Rx grammar's serialisation, without a
+    // lock. Runs start and finish on arbitrary threads (pool leaves, response hops); calling the
+    // subject from them directly would interleave two OnNexts, which Subject<T> does not guard.
+    private void Emit(int delta) =>
+        scheduler.Schedule(delta, (_, d) =>
+        {
+            try { deltas.OnNext(d); }
+            catch (ObjectDisposedException) { /* the tracker died with its mesh; nothing to count */ }
+            return Disposable.Empty;
+        });
 
     /// <summary>
     /// Waits for the in-flight runs to finish, cancelling any that stop making progress, and

--- a/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
@@ -1,3 +1,6 @@
+using System.Collections.Concurrent;
+using System.Collections.Immutable;
+using System.Diagnostics;
 using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Linq;
@@ -8,7 +11,8 @@ namespace MeshWeaver.Mesh;
 
 /// <summary>
 /// Counts the activity runs currently in flight on this mesh, so teardown can QUIESCE — stop
-/// starting new work, let what is running finish, and only then tear down.
+/// starting new work, let what is running finish, and only then tear down — and so it can tell a
+/// run that is still WORKING from one that has WEDGED.
 ///
 /// <para><b>Why the existing drains do not cover this.</b> Mesh teardown already has three phases
 /// (<c>DisposalCompleted</c> → <c>IoPoolRegistry.DrainAll()</c> → <c>AsyncDisposeQueue</c>), but an
@@ -29,14 +33,19 @@ namespace MeshWeaver.Mesh;
 /// torn-down container — and when it touches a collectible ALC's metadata after unload, the process
 /// dies on a bare signal with no managed exception (FutuRe.Test exit=139, ~1 run in 5).</para>
 ///
-/// <para><b>Quiesce, do not cancel.</b> The run is allowed to finish and emit its terminal
-/// ActivityLog status; teardown waits for that. Cancelling would abort work the caller believes is
-/// running and would leave the activity in a non-terminal state.</para>
+/// <para><b>Quiesce; cancel only what has stopped.</b> A run that is making progress is allowed to
+/// finish and emit its terminal ActivityLog status, however long that takes within the caller's
+/// budget; teardown waits for it. A run that has made NO progress for a whole stall budget is
+/// wedged: it is handed its cancellation (the one cooperative kill an activity has — the same
+/// token a user's cancel request trips), reported by name, and if it ignores that too it is
+/// reported again as abandoned so teardown can proceed without pretending the run finished.
+/// "Progress" is what the run itself reports through <see cref="ActivityRunHandle.Progress"/> —
+/// every appended log line, every status write — never a heartbeat the tracker invents.</para>
 ///
 /// <para><b>Must not deadlock.</b> The wait belongs to the teardown CALLER, never to a hub action
 /// block: a running activity's own Append/Finish writes go back through the hubs, so blocking a hub
-/// turn on this would block the very work it waits for. It is also bounded — a run that never
-/// settles must surface as a timeout, not hang teardown forever.</para>
+/// turn on this would block the very work it waits for. It is also bounded by the caller — a run
+/// that never settles must surface as a timeout, not hang teardown forever.</para>
 ///
 /// <para>Instance state owned by the mesh (never <c>static</c>): the counter dies with the mesh
 /// rather than bleeding into the next test — see <c>Doc/Architecture/NoStaticState</c>.</para>
@@ -54,6 +63,10 @@ public sealed class ActivityTracker : IDisposable
     private readonly EventLoopScheduler scheduler = new();
     private readonly IConnectableObservable<int> counts;
     private readonly IDisposable connection;
+    // The live runs, keyed by ticket, so a quiesce can look at EACH one's progress rather than at
+    // an anonymous count. Instance field on the mesh-scoped singleton — never static.
+    private readonly ConcurrentDictionary<long, ActivityRunHandle> runs = new();
+    private long ticketSeq;
 
     /// <summary>Initializes a new instance of the <see cref="ActivityTracker"/> class.</summary>
     public ActivityTracker()
@@ -80,15 +93,137 @@ public sealed class ActivityTracker : IDisposable
     public IObservable<Unit> WhenIdle =>
         counts.Where(running => running == 0).Take(1).Select(_ => Unit.Default);
 
+    /// <summary>The runs currently in flight — a snapshot, most recently started last.</summary>
+    public IReadOnlyList<ActivityRunHandle> InFlight =>
+        runs.OrderBy(kvp => kvp.Key).Select(kvp => kvp.Value).ToImmutableList();
+
     /// <summary>
     /// Registers one run as in flight. Dispose the returned handle when the run reaches a TERMINAL
     /// state (succeeded or failed) — not when it was merely dispatched. A double dispose does not
     /// double-decrement.
     /// </summary>
-    public IDisposable Track()
+    public IDisposable Track() => TrackRun("(unlabelled run)", cancel: null);
+
+    /// <summary>
+    /// <see cref="Track"/>, with the two things a quiesce needs to treat the run as WORK rather
+    /// than as a count: a <paramref name="label"/> to name it in a report, and the
+    /// <paramref name="cancel"/> that is its cooperative kill (trip the same token a user's
+    /// cancel request would). The run reports its own progress through
+    /// <see cref="ActivityRunHandle.Progress"/>; a run that never does is treated as stalled from
+    /// the moment the quiesce begins looking.
+    /// </summary>
+    /// <param name="label">Names the run — its activity path, typically.</param>
+    /// <param name="cancel">Requests the run stop; <c>null</c> when it has no cancellation.</param>
+    /// <returns>The handle; dispose it when the run is terminal.</returns>
+    public ActivityRunHandle TrackRun(string label, Action? cancel)
     {
+        var handle = new ActivityRunHandle(this, Interlocked.Increment(ref ticketSeq), label, cancel);
+        runs[handle.Ticket] = handle;
         deltas.OnNext(1);
-        return Disposable.Create(() => deltas.OnNext(-1));
+        return handle;
+    }
+
+    internal void Complete(ActivityRunHandle handle)
+    {
+        if (runs.TryRemove(handle.Ticket, out _))
+            deltas.OnNext(-1);
+    }
+
+    /// <summary>
+    /// Waits for the in-flight runs to finish, cancelling any that stop making progress, and
+    /// reports what it had to do. Completes with the report when every run has either finished or
+    /// been abandoned — never faults. Emits at once on an idle mesh.
+    ///
+    /// <para>The <paramref name="stallBudget"/> is a STALL bound, not a duration: a run that keeps
+    /// reporting progress is waited for indefinitely (the caller bounds the whole wait with its own
+    /// token). A run with no progress for one budget is cancelled and listed in
+    /// <see cref="ActivityQuiesceReport.Cancelled"/>; one that then shows no progress for another
+    /// budget is listed in <see cref="ActivityQuiesceReport.Abandoned"/> and no longer holds the
+    /// quiesce open — it ignored its cancellation, and that is a defect in the run.</para>
+    /// </summary>
+    /// <param name="stallBudget">How long a run may go without reporting progress before it is
+    /// treated as wedged.</param>
+    /// <returns>A single-emission observable carrying the report.</returns>
+    public IObservable<ActivityQuiesceReport> Quiesce(TimeSpan stallBudget)
+    {
+        if (stallBudget <= TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(stallBudget));
+
+        return Observable.Create<ActivityQuiesceReport>(observer =>
+        {
+            var cancelled = ImmutableList<string>.Empty;
+            var abandoned = ImmutableList<string>.Empty;
+            var done = 0;
+
+            void Finish()
+            {
+                if (Interlocked.Exchange(ref done, 1) != 0)
+                    return;
+                observer.OnNext(new ActivityQuiesceReport(cancelled, abandoned));
+                observer.OnCompleted();
+            }
+
+            // Every verdict runs on the tracker's own event loop, so the two lists above are only
+            // ever touched from one thread and the poll cannot overlap itself.
+            // One-shot: a fault on the count stream ends the quiesce with what it has — the
+            // report is still the truthful answer, and a fault here must never leave the
+            // teardown waiting on a signal that will not come.
+            var idle = counts.Where(running => running == 0).Take(1)
+                .ObserveOn(scheduler)
+                .Subscribe(_ => Finish(), _ => Finish());
+
+            var period = TimeSpan.FromMilliseconds(Math.Max(20, stallBudget.TotalMilliseconds / 4));
+            // Long-lived: a fault INSIDE a verdict is handled in onNext (the quiesce ends with the
+            // report it has rather than stopping silently), and the onError arm covers the
+            // interval itself faulting.
+            var poll = Observable.Interval(period, scheduler).Subscribe(_ =>
+            {
+                try
+                {
+                    if (Volatile.Read(ref done) != 0)
+                        return;
+                    var live = runs.Values.ToArray();
+                    if (live.Length == 0)
+                    {
+                        Finish();
+                        return;
+                    }
+                    var holding = 0;
+                    foreach (var run in live)
+                    {
+                        if (run.Abandoned)
+                            continue;
+                        if (!run.CancelRequested)
+                        {
+                            if (run.SinceLastProgress < stallBudget)
+                            {
+                                holding++;
+                                continue;
+                            }
+                            run.RequestCancel();
+                            cancelled = cancelled.Add(run.Label);
+                            holding++;
+                            continue;
+                        }
+                        if (run.SinceCancelRequested < stallBudget)
+                        {
+                            holding++;
+                            continue;
+                        }
+                        run.MarkAbandoned();
+                        abandoned = abandoned.Add(run.Label);
+                    }
+                    if (holding == 0)
+                        Finish();
+                }
+                catch
+                {
+                    Finish();
+                }
+            }, _ => Finish());
+
+            return new CompositeDisposable(idle, poll);
+        });
     }
 
     /// <inheritdoc />
@@ -98,4 +233,99 @@ public sealed class ActivityTracker : IDisposable
         deltas.Dispose();
         scheduler.Dispose();
     }
+}
+
+/// <summary>
+/// One in-flight activity run as the tracker sees it: what it is called, when it last reported
+/// progress, and how to ask it to stop. Handed out by <see cref="ActivityTracker.TrackRun"/>;
+/// disposed by the run when it reaches a terminal state.
+/// </summary>
+public sealed class ActivityRunHandle : IDisposable
+{
+    private readonly ActivityTracker owner;
+    private readonly Action? cancel;
+    private long lastProgressTicks;
+    private long cancelRequestedTicks;
+    private int cancelRequested;
+    private int abandoned;
+    private int disposed;
+
+    internal ActivityRunHandle(ActivityTracker owner, long ticket, string label, Action? cancel)
+    {
+        this.owner = owner;
+        this.cancel = cancel;
+        Ticket = ticket;
+        Label = label;
+        lastProgressTicks = Stopwatch.GetTimestamp();
+    }
+
+    internal long Ticket { get; }
+
+    /// <summary>Names the run — its activity path, typically.</summary>
+    public string Label { get; }
+
+    /// <summary>How long since the run last reported <see cref="Progress"/> (or started).</summary>
+    public TimeSpan SinceLastProgress =>
+        Stopwatch.GetElapsedTime(Volatile.Read(ref lastProgressTicks));
+
+    /// <summary>Whether a quiesce has asked this run to stop.</summary>
+    public bool CancelRequested => Volatile.Read(ref cancelRequested) != 0;
+
+    /// <summary>Whether a quiesce gave up waiting on this run after it ignored its cancellation.</summary>
+    public bool Abandoned => Volatile.Read(ref abandoned) != 0;
+
+    internal TimeSpan SinceCancelRequested =>
+        Stopwatch.GetElapsedTime(Volatile.Read(ref cancelRequestedTicks));
+
+    /// <summary>
+    /// The run reports that it is still working. Call it from every observable step — an appended
+    /// log line, a status write, a completed sub-operation. A quiesce treats the time since the
+    /// last call as the run's stall.
+    /// </summary>
+    public void Progress() => Volatile.Write(ref lastProgressTicks, Stopwatch.GetTimestamp());
+
+    internal void RequestCancel()
+    {
+        if (Interlocked.Exchange(ref cancelRequested, 1) != 0)
+            return;
+        Volatile.Write(ref cancelRequestedTicks, Stopwatch.GetTimestamp());
+        try { cancel?.Invoke(); }
+        catch
+        {
+            // A cancel that throws is the run's problem to report; the quiesce still counts the
+            // request as made and moves on to the abandon verdict on the next budget.
+        }
+    }
+
+    internal void MarkAbandoned() => Interlocked.Exchange(ref abandoned, 1);
+
+    /// <summary>Marks the run terminal. Idempotent.</summary>
+    public void Dispose()
+    {
+        if (Interlocked.Exchange(ref disposed, 1) != 0)
+            return;
+        owner.Complete(this);
+    }
+}
+
+/// <summary>
+/// What an <see cref="ActivityTracker.Quiesce"/> had to do to reach idle. Empty lists mean every
+/// run finished on its own; a name in <see cref="Cancelled"/> is a run that stopped making progress
+/// and was told to stop; a name in <see cref="Abandoned"/> is one that ignored that too.
+/// </summary>
+/// <param name="Cancelled">Runs the quiesce cancelled for making no progress.</param>
+/// <param name="Abandoned">Runs that ignored their cancellation and were left behind.</param>
+public sealed record ActivityQuiesceReport(IReadOnlyList<string> Cancelled, IReadOnlyList<string> Abandoned)
+{
+    /// <summary>True when no run had to be cancelled or abandoned.</summary>
+    public bool Clean => Cancelled.Count == 0 && Abandoned.Count == 0;
+
+    /// <inheritdoc />
+    public override string ToString() =>
+        Clean
+            ? "every activity finished on its own"
+            : $"cancelled {Cancelled.Count} stalled activit{(Cancelled.Count == 1 ? "y" : "ies")}"
+              + (Cancelled.Count == 0 ? string.Empty : $" [{string.Join(" | ", Cancelled)}]")
+              + $", abandoned {Abandoned.Count}"
+              + (Abandoned.Count == 0 ? string.Empty : $" [{string.Join(" | ", Abandoned)}]");
 }

--- a/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
+++ b/src/MeshWeaver.Mesh.Contract/ActivityTracker.cs
@@ -177,10 +177,21 @@ public sealed class ActivityTracker : IDisposable
 
             // Every verdict runs on the tracker's own event loop, so the two lists above are only
             // ever touched from one thread and the poll cannot overlap itself.
+            // 🚨 Idle is decided on the RUN REGISTRY, never on the replayed count alone. A delta
+            // reaches the count stream through the event loop, so a quiesce that subscribes right
+            // after TrackRun() can replay a count of zero while `runs` already holds the run —
+            // measured on a 2-core CI runner as a report that never looked at the run it was
+            // asked to wait for. The registry is written synchronously by TrackRun/Complete, so
+            // it is the fact; the count is the wake-up.
+            if (runs.IsEmpty)
+            {
+                Finish();
+                return Disposable.Empty;
+            }
             // One-shot: a fault on the count stream ends the quiesce with what it has — the
             // report is still the truthful answer, and a fault here must never leave the
             // teardown waiting on a signal that will not come.
-            var idle = counts.Where(running => running == 0).Take(1)
+            var idle = counts.Where(running => running == 0 && runs.IsEmpty).Take(1)
                 .ObserveOn(scheduler)
                 .Subscribe(_ => Finish(), _ => Finish());
 

--- a/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshNodeStreamExtensions.cs
@@ -2829,8 +2829,8 @@ public static class MeshNodeStreamExtensions
             // number of times. ErrorType.ShuttingDown's own contract (Events.cs) is "retry-worthy,
             // never terminal … the sender must read this as 'ask again', not 'gone'" — and the
             // previous one-immediate-re-probe cap violated it under any recycle longer than a few
-            // milliseconds: a package-root hub whose dispose wedges for the 8s force-teardown
-            // watchdog window (MeshWeaver#1701) NACKed BOTH probes within ~1s, and a 15s-budget
+            // milliseconds: a package-root hub whose dispose sat behind accepted work for the
+            // 8s stall-detector window (MeshWeaver#1701) NACKed BOTH probes within ~1s, and a 15s-budget
             // compile-path read settled terminally failed with 14s of its budget unused — every
             // NodeType compile reading the root in that window went CompilationStatus=Error and
             // the satellite gate reported phantom, module-varying "compile failures". The first
@@ -3116,7 +3116,7 @@ public static class MeshNodeStreamExtensions
                                 // live-stream path, where "is shutting down" is classified transient for this
                                 // same reason. The first NACK re-probes immediately (zero latency for the
                                 // sub-second recycle); later NACKs ride the pacing timer so a wedged dispose
-                                // (the 8s force-teardown window, MeshWeaver#1701) is polled, not hammered.
+                                // (the 8s stall-detector window, MeshWeaver#1701) is polled, not hammered.
                                 if (ex is DeliveryFailureException { Failure.ErrorType: ErrorType.ShuttingDown })
                                 {
                                     lastRecyclingNack = ex;
@@ -3200,8 +3200,8 @@ public static class MeshNodeStreamExtensions
     /// <summary>
     /// How long a recycling (ShuttingDown-NACKing) address rests between re-probes after the
     /// first immediate one. Short enough that a read resumes well within a normal read budget
-    /// once the address reactivates; long enough that a wedged dispose (the 8s force-teardown
-    /// watchdog window) is polled a handful of times, not hammered. The caller's own budget —
+    /// once the address reactivates; long enough that a slow dispose (the 8s stall-detector
+    /// window) is polled a handful of times, not hammered. The caller's own budget —
     /// never this constant — bounds the loop.
     /// </summary>
     private static readonly TimeSpan RecyclingReProbePace = TimeSpan.FromMilliseconds(500);

--- a/src/MeshWeaver.Mesh.Contract/MeshTeardownExtensions.cs
+++ b/src/MeshWeaver.Mesh.Contract/MeshTeardownExtensions.cs
@@ -81,26 +81,51 @@ public static class MeshTeardownExtensions
         // ObserveCompletion completes with RunContinuationsAsynchronously (no hub thread carries
         // us onward), cancelling the WAIT leaves the observation attached (a late fault is still
         // reported), and the expiry is DATA now (ActivitiesQuiesced on the report), not a silence.
+        //
+        // 🚨 LET THE WORK FINISH; KILL ONLY WHAT HAS STOPPED. `Quiesce` waits for every run that is
+        // reporting progress, however long that takes inside `timeout`, and cancels only a run that
+        // has made no progress for ActivityStallBudget — then abandons one that ignores even that.
+        // Both are reported at ERROR (the red-log pipeline files an issue), with the activity path:
+        // a run teardown had to kill did not finish its job, and that is a defect to find, never a
+        // teardown detail to tolerate.
         var activitiesQuiesced = true;
+        ActivityQuiesceReport quiesce = new([], []);
         if (activities is not null)
         {
             using var quiesceBudget = new CancellationTokenSource(timeout);
             try
             {
-                await activities.WhenIdle.ObserveCompletion(
+                quiesce = await activities.Quiesce(ActivityStallBudget).ObserveCompletion(
                     ex => logger?.LogError(ex,
                         "Mesh {Address}: the activity quiesce signal faulted AFTER teardown stopped "
                         + "waiting on it. Reported rather than orphaned; investigate the activity that "
                         + "faulted on its way to idle.", mesh.Address),
-                    quiesceBudget.Token).ConfigureAwait(false);
+                    quiesceBudget.Token).ConfigureAwait(false) ?? quiesce;
+                foreach (var path in quiesce.Cancelled)
+                    logger?.LogError(ActivityCancelledByTeardown,
+                        "Mesh {Address}: activity {ActivityPath} made no progress for {StallBudget} while the "
+                        + "mesh was quiescing and was CANCELLED — its work did not finish. Find what it was "
+                        + "waiting on; a run that reports progress is never cancelled.",
+                        mesh.Address, path, ActivityStallBudget);
+                foreach (var path in quiesce.Abandoned)
+                    logger?.LogError(ActivityAbandonedByTeardown,
+                        "Mesh {Address}: activity {ActivityPath} ignored the cancellation teardown handed it "
+                        + "for another {StallBudget} and was ABANDONED — teardown proceeds over a run that "
+                        + "observes neither progress nor cancellation. That run is the defect.",
+                        mesh.Address, path, ActivityStallBudget);
             }
             catch (OperationCanceledException)
             {
                 activitiesQuiesced = false;
-                logger?.LogError(
+                var inFlight = activities.InFlight;
+                logger?.LogError(ActivitiesDidNotQuiesce,
                     "Mesh {Address}: activities did not reach idle within {Timeout} — teardown is "
-                    + "proceeding over a run that is still writing. Find the activity that will not "
-                    + "settle; do not widen the budget.", mesh.Address, timeout);
+                    + "proceeding over {Count} run(s) still in flight: [{Runs}]. A run still working at "
+                    + "the host's teardown bound is reported, not killed; find why it takes this long.",
+                    mesh.Address, timeout, inFlight.Count,
+                    string.Join(" | ", inFlight.Select(r =>
+                        $"{r.Label} (last progress {r.SinceLastProgress.TotalSeconds:F1}s ago"
+                        + $"{(r.CancelRequested ? ", cancel requested" : string.Empty)})")));
             }
         }
 
@@ -109,10 +134,27 @@ public static class MeshTeardownExtensions
         // Hand the PRE-DISPOSE logger down: DrainAsync runs after mesh.Dispose(), where resolving
         // one is exactly the "never resolve DI once disposal has begun" mistake this method's own
         // header warns about. (Copilot review, #2527.)
-        return await DrainAsync(
-            mesh, ioPools, asyncDisposeQueue, timeout, teardownSignal, activitiesQuiesced, logger)
+        var report = await DrainAsync(
+            mesh, ioPools, asyncDisposeQueue, timeout, teardownSignal, activitiesQuiesced, logger,
+            quiesce)
             .ConfigureAwait(false);
+        return report;
     }
+
+    /// <summary>
+    /// How long an activity may go without reporting progress during the pre-dispose quiesce
+    /// before it is cancelled. A STALL budget, not a duration: a run that keeps logging is waited
+    /// for up to the caller's whole teardown timeout. Matches the hub disposal stall budget and the
+    /// I/O pool drain grace, so "no progress" means the same thing at every layer.
+    /// </summary>
+    public static readonly TimeSpan ActivityStallBudget = TimeSpan.FromSeconds(8);
+
+    // Event ids so the red-log triage keys each shape on the log SITE (it ignores prose) — one
+    // issue per shape, the prose free to carry the activity paths a reproduction needs.
+    internal static readonly EventId ActivityCancelledByTeardown = new(7321, nameof(ActivityCancelledByTeardown));
+    internal static readonly EventId ActivityAbandonedByTeardown = new(7322, nameof(ActivityAbandonedByTeardown));
+    internal static readonly EventId ActivitiesDidNotQuiesce = new(7323, nameof(ActivitiesDidNotQuiesce));
+    internal static readonly EventId IoLeavesCancelledAfterGrace = new(7324, nameof(IoLeavesCancelledAfterGrace));
 
     /// <summary>
     /// The wait half of <see cref="TeardownAsync"/>, exposed for callers that
@@ -153,7 +195,8 @@ public static class MeshTeardownExtensions
             // No pre-dispose capture to inherit: this overload is entered AFTER the caller drove
             // Dispose() itself, so TeardownLogger's defensive resolve is the best available and a
             // dead scope degrades to "no logger" rather than throwing out of teardown.
-            logger: TeardownLogger(mesh));
+            logger: TeardownLogger(mesh),
+            quiesce: new ActivityQuiesceReport([], []));
 
     // 🚨 The public signature above is UNCHANGED on purpose. Threading the quiesce outcome through
     // as an extra optional parameter would have been source-compatible and BINARY-BREAKING — a
@@ -163,7 +206,7 @@ public static class MeshTeardownExtensions
     private static async Task<TeardownReport> DrainAsync(
         IMessageHub mesh, IoPoolRegistry? ioPools, AsyncDisposeQueue? asyncDisposeQueue,
         TimeSpan timeout, MeshTeardownSignal? teardownSignal, bool activitiesQuiesced,
-        ILogger? logger)
+        ILogger? logger, ActivityQuiesceReport quiesce)
     {
         // (1) Action blocks + message round-trips.
         //
@@ -200,9 +243,13 @@ public static class MeshTeardownExtensions
             {
                 // Preserve the shape callers already branch on: HubTestBase and MonolithMeshTestBase
                 // both treat a TimeoutException here as HANG DETECTED and dump hub diagnostics.
+                string diagnostics;
+                try { diagnostics = mesh.GetDisposalDiagnostics(); }
+                catch (Exception diagEx) { diagnostics = $"(disposal diagnostics unavailable: {diagEx.GetType().Name}: {diagEx.Message})"; }
                 throw new TimeoutException(
                     $"Mesh {mesh.Address}: disposal did not complete within {timeout}. "
-                    + "Something on the action block is not finishing — find it; do not widen the budget.");
+                    + "Something on the action block is not finishing — find it; do not widen the budget."
+                    + Environment.NewLine + diagnostics);
             }
             catch (Exception ex)
             {
@@ -221,8 +268,21 @@ public static class MeshTeardownExtensions
         //     leaf still runs → its ThreadPool thread dereferences a collectible node ALC's freed
         //     metadata after unload → native use-after-unload SIGSEGV. DrainAll() cancels every leaf
         //     so it stops, then joins — no ToTask, no wait-without-cancel.
+        //
+        //     🚨 The drain gives every leaf a GRACE to finish on its own before it cancels anything
+        //     (IoPool.Drain): only a leaf that outlives the grace with its pool making no further
+        //     progress is cancelled — and that is a KILL, reported at Error with the leaf's site,
+        //     because the work it was doing did not finish.
         IReadOnlyList<IoPoolRegistry.PoolResidual> residualByPool = [];
-        var leakedIoLeaves = ioPools is null ? 0 : ioPools.DrainAll(out residualByPool);
+        IReadOnlyList<IoPoolRegistry.PoolResidual> cancelledByPool = [];
+        var leakedIoLeaves = ioPools is null ? 0 : ioPools.DrainAll(out residualByPool, out cancelledByPool);
+        var cancelledIoLeaves = cancelledByPool.Sum(p => p.Residual);
+        if (cancelledIoLeaves > 0)
+            logger?.LogError(IoLeavesCancelledAfterGrace,
+                "Mesh {Address}: the I/O drain had to CANCEL {Count} pooled leaf(es) that made no progress "
+                + "within the drain grace — that work did not finish: [{Leaves}]. Find why each stalled; "
+                + "a leaf that completes is never cancelled.",
+                mesh.Address, cancelledIoLeaves, string.Join(", ", cancelledByPool));
 
         // (3) After all the sync stuff is disposed (and everyone has enqueued their
         //     async cleanup), quiesce the async dispose queue before the scope closes.
@@ -237,7 +297,11 @@ public static class MeshTeardownExtensions
         {
             ResidualByPool = residualByPool,
             DisposalFault = disposalFault,
-            ActivitiesQuiesced = activitiesQuiesced
+            ActivitiesQuiesced = activitiesQuiesced,
+            CancelledActivities = quiesce.Cancelled,
+            AbandonedActivities = quiesce.Abandoned,
+            CancelledIoLeaves = cancelledIoLeaves,
+            CancelledIoByPool = cancelledByPool,
         };
         teardownSignal?.SignalCompleted(report);
         return report;

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -55,6 +55,12 @@ public sealed class IoPool : IIoPool, IDisposable
     private int _gateUsers;
 
     private volatile bool _disposed;
+    // 🚨 Drain is TERMINAL from its FIRST line, not from the cancel that comes after the grace.
+    // A leaf issued once the drain has begun is refused outright (Cancelled<T>(), exactly like a
+    // leaf issued after disposal); only work admitted BEFORE the drain gets the grace. Without
+    // this a producer that issues one leaf per completion keeps the admission count moving and
+    // the grace open indefinitely (Copilot review, #3291).
+    private volatile bool _draining;
     // Idempotence for Dispose. A plain `if (_disposed) return` cannot serve: _disposed is now set
     // AFTER the join (so Drain's own guard does not short-circuit it), which leaves a window where
     // two callers would both drain and both dispose the gate.
@@ -316,7 +322,7 @@ public sealed class IoPool : IIoPool, IDisposable
     /// <param name="io">The cancellable async work to run once the gate grants a slot.</param>
     /// <returns>A cold observable that, on subscribe, runs the work and emits its single result.</returns>
     public IObservable<T> Invoke<T>(Func<CancellationToken, Task<T>> io)
-        => _disposed ? Cancelled<T>() : InvokeCore(io);
+        => (_disposed || _draining) ? Cancelled<T>() : InvokeCore(io);
 
     private IObservable<T> InvokeCore<T>(Func<CancellationToken, Task<T>> io)
         // SubscribeOn moves the whole subscribe — including the gate wait and the
@@ -394,7 +400,7 @@ public sealed class IoPool : IIoPool, IDisposable
     /// <param name="source">The cancellable async sequence to enumerate once the gate grants a slot.</param>
     /// <returns>A cold observable that, on subscribe, enumerates the source and emits each element.</returns>
     public IObservable<T> InvokeStream<T>(Func<CancellationToken, IAsyncEnumerable<T>> source)
-        => _disposed ? Cancelled<T>() : InvokeStreamCore(source);
+        => (_disposed || _draining) ? Cancelled<T>() : InvokeStreamCore(source);
 
     private IObservable<T> InvokeStreamCore<T>(Func<CancellationToken, IAsyncEnumerable<T>> source)
         => Observable.Create<T>(async (observer, subscriberCt) =>
@@ -434,7 +440,7 @@ public sealed class IoPool : IIoPool, IDisposable
     /// <param name="work">The cancellable blocking work to run once the scheduler grants a slot.</param>
     /// <returns>A cold observable that, on subscribe, runs the work and emits its single result; unsubscribing cancels it.</returns>
     public IObservable<T> InvokeBlocking<T>(Func<CancellationToken, T> work)
-        => _disposed ? Cancelled<T>() : InvokeBlockingCore(work);
+        => (_disposed || _draining) ? Cancelled<T>() : InvokeBlockingCore(work);
 
     private IObservable<T> InvokeBlockingCore<T>(Func<CancellationToken, T> work)
         => Observable.Create<T>(observer =>
@@ -546,7 +552,7 @@ public sealed class IoPool : IIoPool, IDisposable
 
     /// <inheritdoc />
     public IObservable<T> SubscribeThroughPool<T>(IObservable<T> source) =>
-        _disposed ? Cancelled<T>() : SubscribeThroughPoolCore(source);
+        (_disposed || _draining) ? Cancelled<T>() : SubscribeThroughPoolCore(source);
 
     private IObservable<T> SubscribeThroughPoolCore<T>(IObservable<T> source) =>
         Observable.Create<T>(observer =>
@@ -737,6 +743,8 @@ public sealed class IoPool : IIoPool, IDisposable
         // the flag gave (disposal cancels and reports its own residual through Disposed) — only now
         // it is a claim rather than a guess.
         if (!TryEnterGateRegion()) return 0;
+        // Terminal from here: nothing issued after this line is admitted (see _draining).
+        _draining = true;
         try
         {
             // 🚨 GRACE FIRST — let the work finish its job. Nothing is cancelled until the pool has

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPool.cs
@@ -92,6 +92,18 @@ public sealed class IoPool : IIoPool, IDisposable
     private readonly TimeSpan _drainTimeout;
 
     /// <summary>
+    /// The GRACE <see cref="Drain"/> gives in-flight work before it cancels anything: how long the
+    /// pool waits for the NEXT leaf to finish on its own. A leaf that is making progress is never
+    /// cancelled — every completion restarts the clock, so a burst of ten short writes drains in
+    /// ten completions, not one budget. A leaf that has not completed within one grace with the
+    /// pool otherwise idle is WEDGED: it is then cancelled, joined under <see cref="DefaultDrainTimeout"/>,
+    /// and named in <see cref="CancelledLeafSites"/>. Matches the hub's disposal stall budget so
+    /// "no progress" means the same thing on both sides of the I/O boundary.
+    /// </summary>
+    internal static readonly TimeSpan DefaultDrainGrace = TimeSpan.FromSeconds(8);
+    private readonly TimeSpan _drainGrace;
+
+    /// <summary>
     /// Creates a pool whose async gate and sync-blocking scheduler are both capped at
     /// <paramref name="maxConcurrency"/>.
     /// </summary>
@@ -109,13 +121,28 @@ public sealed class IoPool : IIoPool, IDisposable
     /// that has to let the budget EXPIRE (the only way to observe a residual) can do so in
     /// milliseconds instead of spending 30 s of shard time per join.
     /// </param>
-    public IoPool(int maxConcurrency, TimeSpan drainTimeout)
+    public IoPool(int maxConcurrency, TimeSpan drainTimeout) : this(maxConcurrency, drainTimeout, DefaultDrainGrace) { }
+
+    /// <summary>
+    /// As <see cref="IoPool(int, TimeSpan)"/>, with an explicit drain grace.
+    /// </summary>
+    /// <param name="maxConcurrency">Maximum number of operations allowed to run concurrently; must be at least 1.</param>
+    /// <param name="drainTimeout">How long <see cref="Drain"/> waits at each of its joins AFTER cancelling.</param>
+    /// <param name="drainGrace">
+    /// How long <see cref="Drain"/> waits for the next in-flight leaf to finish on its own BEFORE
+    /// cancelling — see <see cref="DefaultDrainGrace"/>. 🚨 Production uses the default; this
+    /// overload exists so a test whose leaf can only end by cancellation need not spend the grace.
+    /// </param>
+    public IoPool(int maxConcurrency, TimeSpan drainTimeout, TimeSpan drainGrace)
     {
         if (maxConcurrency < 1)
             throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
         if (drainTimeout <= TimeSpan.Zero)
             throw new ArgumentOutOfRangeException(nameof(drainTimeout));
+        if (drainGrace < TimeSpan.Zero)
+            throw new ArgumentOutOfRangeException(nameof(drainGrace));
         _drainTimeout = drainTimeout;
+        _drainGrace = drainGrace;
         _maxConcurrency = maxConcurrency;
         _gate = new SemaphoreSlim(maxConcurrency, maxConcurrency);
         _blockingFactory = new TaskFactory(
@@ -264,6 +291,23 @@ public sealed class IoPool : IIoPool, IDisposable
     // Set by Drain() when its cancel join expires; read by PendingLeafSites, which the registry
     // consults right after Drain() returns. Never cleared — Drain is terminal.
     private volatile bool _cancelJoinExpired;
+
+    // What Drain()'s GRACE could not wait out: the leaves that were still running when the pool
+    // stopped making progress and had to be cancelled. Distinct from the residual (leaves that
+    // ignored even the cancel): these unwound, but only because they were killed — each one is a
+    // unit of work that did not finish its job, and the report names it so the owner can see why.
+    private int _leavesCancelledAfterGrace;
+    private volatile IReadOnlyList<string> _cancelledLeafSites = [];
+
+    /// <summary>
+    /// Leaves <see cref="Drain"/> had to CANCEL because they outlived the grace with the pool making
+    /// no further progress — the wedged work the drain killed, as opposed to the residual it could
+    /// not even kill. Zero when every leaf finished on its own.
+    /// </summary>
+    public int LeavesCancelledAfterGrace => Volatile.Read(ref _leavesCancelledAfterGrace);
+
+    /// <summary>The call sites of the leaves counted by <see cref="LeavesCancelledAfterGrace"/>.</summary>
+    public IReadOnlyList<string> CancelledLeafSites => _cancelledLeafSites;
 
     /// <summary>
     /// Runs an async I/O leaf off the calling scheduler under the pool's concurrency gate.
@@ -658,8 +702,9 @@ public sealed class IoPool : IIoPool, IDisposable
         });
 
     /// <summary>
-    /// Cancels every in-flight leaf and JOINS — blocks until they have all unwound — WITHOUT
-    /// disposing the pool. Called before a collectible node <c>AssemblyLoadContext</c> is unloaded
+    /// Lets every in-flight leaf FINISH (the grace — see <see cref="DefaultDrainGrace"/>), then
+    /// cancels whatever stopped making progress and JOINS — blocks until everything has unwound —
+    /// WITHOUT disposing the pool. Called before a collectible node <c>AssemblyLoadContext</c> is unloaded
     /// so no pool thread is still executing (or about to dereference) that ALC's compiled types
     /// when it is torn down (the teardown use-after-unload SIGSEGV). TERMINAL — it cancels the
     /// pool token, so any leaf issued after Drain is cancelled immediately; idempotent (a second
@@ -694,6 +739,46 @@ public sealed class IoPool : IIoPool, IDisposable
         if (!TryEnterGateRegion()) return 0;
         try
         {
+            // 🚨 GRACE FIRST — let the work finish its job. Nothing is cancelled until the pool has
+            // provably stopped making progress. "Work" is every caller admitted to the pool —
+            // running leaves, leaves still QUEUED on the gate, blocking leaves on their scheduler —
+            // which is exactly what the admission counter (_gateUsers) counts, minus this drain's own
+            // region. The wait is progress-based: every time that count drops (a leaf finished, or a
+            // queued one ran and finished) the clock restarts, so a burst of short leaves drains in as
+            // many completions however long that takes in total. Only when a whole grace passes with
+            // NOTHING finishing is what remains wedged — and only then does the cancel below run.
+            //
+            // Not the gate itself: re-acquiring permits here would compete with the queued leaves for
+            // them and steal their turn, then cancel them at the gate — accepted work discarded, which
+            // is the very thing the grace exists to prevent. A change-feed subscription holds neither
+            // a permit nor a region past its subscribe, so it never holds the grace open; the cancel
+            // is what ends it, as it always was — a stream has no job to finish.
+            //
+            // The predecessor cancelled FIRST and joined second, so every in-flight write, read or
+            // compile at teardown was aborted the instant the mesh decided to go down — a flush that
+            // would have landed in 50 ms thrown away and its row handed to the sampler. The grace
+            // costs nothing on an idle pool and one completion's worth on a busy one.
+            var lastSeen = Volatile.Read(ref _gateUsers) - 1;
+            while (lastSeen > 0)
+            {
+                var seen = lastSeen;
+                var progressed = SpinWait.SpinUntil(
+                    () => Volatile.Read(ref _gateUsers) - 1 < seen,
+                    _drainGrace);
+                if (!progressed)
+                    break; // a whole grace with nothing finishing: what remains is wedged
+                lastSeen = Volatile.Read(ref _gateUsers) - 1;
+            }
+            var wedged = Math.Max(0, Volatile.Read(ref _gateUsers) - 1);
+            if (wedged > 0)
+            {
+                // Name them NOW, while they are provably the ones still in flight: after the
+                // cancel a leaf that observed its token has unwound and left no trace. A queued
+                // leaf has entered no site yet, so the list can be shorter than the count.
+                _cancelledLeafSites = PendingLeafSites;
+                Interlocked.Exchange(ref _leavesCancelledAfterGrace, wedged);
+            }
+
             // 🚨 NOT `_poolCts.Cancel()` on this thread — see StartCancelOffCallerThread. The
             // callbacks this token carries run the pooled subscriptions' whole DOWNSTREAM teardown,
             // and this thread is the mesh-teardown thread.

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolOptions.cs
@@ -146,6 +146,17 @@ public sealed record IoPoolOptions
     public TimeSpan DrainTimeout { get; init; } = IoPool.DefaultDrainTimeout;
 
     /// <summary>
+    /// How long <see cref="IoPool.Drain"/> waits for the NEXT in-flight leaf to finish on its own
+    /// before it cancels anything — the grace that lets accepted work finish its job at teardown.
+    /// Every completion restarts it; a leaf that outlives one grace with nothing else finishing is
+    /// wedged and is cancelled. See <see cref="IoPool.DefaultDrainGrace"/>.
+    ///
+    /// <para>🚨 Leave this at the default in production. It is settable so a TEST whose leaf can
+    /// only end by cancellation need not spend the grace on every drain.</para>
+    /// </summary>
+    public TimeSpan DrainGrace { get; init; } = IoPool.DefaultDrainGrace;
+
+    /// <summary>
     /// Concurrent file-system ops. These are async leaves (the thread is released
     /// during the await), so a generous cap avoids bottlenecking the many concurrent
     /// data-path reads/writes a busy mesh issues, while still preventing pathological

--- a/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/IoPoolRegistry.cs
@@ -64,7 +64,7 @@ public sealed class IoPoolRegistry : IDisposable
         if (Volatile.Read(ref _disposing) != 0)
             return _refused.Value;
 
-        var pool = _pools.GetOrAdd(name, n => new IoPool(_options.MaxConcurrencyFor(n), _options.DrainTimeout));
+        var pool = _pools.GetOrAdd(name, n => new IoPool(_options.MaxConcurrencyFor(n), _options.DrainTimeout, _options.DrainGrace));
 
         // Re-check: disposal may have begun between the check above and the add, in which case our
         // pool went in after the snapshot was taken. Pull it back out and refuse — losing a pool
@@ -155,10 +155,22 @@ public sealed class IoPoolRegistry : IDisposable
     /// <param name="byPool">
     /// One entry per pool that did NOT fully unwind, in drain order. Empty on a clean drain.
     /// </param>
-    public int DrainAll(out IReadOnlyList<PoolResidual> byPool)
+    public int DrainAll(out IReadOnlyList<PoolResidual> byPool) => DrainAll(out byPool, out _);
+
+    /// <summary>
+    /// <see cref="DrainAll(out IReadOnlyList{PoolResidual})"/>, also handing back the leaves each pool
+    /// had to CANCEL because they outlived the drain grace with the pool making no further progress
+    /// (<see cref="IoPool.LeavesCancelledAfterGrace"/>). Those leaves unwound — they are not a
+    /// residual — but each is a unit of work that did not finish its job; the teardown report names
+    /// them so a wedged write, read or compile is a visible finding rather than a silent kill.
+    /// </summary>
+    /// <param name="byPool">One entry per pool that did NOT fully unwind, in drain order.</param>
+    /// <param name="cancelledByPool">One entry per pool that had to cancel a wedged leaf, in drain order.</param>
+    public int DrainAll(out IReadOnlyList<PoolResidual> byPool, out IReadOnlyList<PoolResidual> cancelledByPool)
     {
         var leaked = 0;
         var residuals = new List<PoolResidual>();
+        var cancelled = new List<PoolResidual>();
         foreach (var kvp in _pools)
         {
             // Read the sites BEFORE the drain returns nothing to name: Drain() joins, so by the
@@ -166,6 +178,18 @@ public sealed class IoPoolRegistry : IDisposable
             // registered — but a leaf that unwinds during the join must not be reported, so this
             // is read after Drain and reflects what is genuinely still running.
             var residual = kvp.Value.Drain();
+            var wedged = kvp.Value.LeavesCancelledAfterGrace;
+            if (wedged != 0)
+            {
+                cancelled.Add(new PoolResidual(kvp.Key, wedged) { Sites = kvp.Value.CancelledLeafSites });
+                _logger?.LogWarning(
+                    "IoPoolDrain: pool '{PoolName}' had to CANCEL {Wedged} leaf(es) that made no progress "
+                    + "within the {Grace} drain grace — that work did not finish its job. Find why it stalled; "
+                    + "do not widen the grace. Cancelled: {Sites}", kvp.Key, wedged, _options.DrainGrace,
+                    kvp.Value.CancelledLeafSites.Count == 0
+                        ? "(no site captured)"
+                        : string.Join(" | ", kvp.Value.CancelledLeafSites));
+            }
             if (residual != 0)
                 residuals.Add(new PoolResidual(kvp.Key, residual) { Sites = kvp.Value.PendingLeafSites });
             if (residual != 0)
@@ -185,6 +209,7 @@ public sealed class IoPoolRegistry : IDisposable
             leaked += residual;
         }
         byPool = residuals;
+        cancelledByPool = cancelled;
         return leaked;
     }
 

--- a/src/MeshWeaver.Mesh.Contract/Threading/MeshTeardownSignal.cs
+++ b/src/MeshWeaver.Mesh.Contract/Threading/MeshTeardownSignal.cs
@@ -51,6 +51,41 @@ public sealed record TeardownReport(int LeakedIoLeaves, bool AsyncDisposeClean)
     /// </summary>
     public bool ActivitiesQuiesced { get; init; } = true;
 
+    /// <summary>
+    /// Activities the pre-dispose quiesce had to CANCEL because they stopped reporting progress
+    /// (see <c>ActivityTracker.Quiesce</c>). Each is a run that did not finish its job — the
+    /// teardown killed it — and is logged at Error by the orchestrator. Empty when every run
+    /// finished on its own.
+    /// </summary>
+    public IReadOnlyList<string> CancelledActivities { get; init; } = [];
+
+    /// <summary>
+    /// Activities that ignored the cancellation the quiesce handed them and were left behind so
+    /// teardown could proceed. A run listed here is a defect in that run: it observes neither
+    /// progress nor cancellation.
+    /// </summary>
+    public IReadOnlyList<string> AbandonedActivities { get; init; } = [];
+
+    /// <summary>
+    /// Pooled I/O leaves the drain had to CANCEL because they outlived the drain grace with their
+    /// pool making no further progress (<c>IoPool.LeavesCancelledAfterGrace</c>). They unwound —
+    /// they are not in <see cref="LeakedIoLeaves"/> — but each is a unit of work that did not
+    /// finish, and the drain names it per pool in <see cref="CancelledIoByPool"/>.
+    /// </summary>
+    public int CancelledIoLeaves { get; init; }
+
+    /// <summary>Per-pool detail for <see cref="CancelledIoLeaves"/>; empty when nothing was cancelled.</summary>
+    public IReadOnlyList<IoPoolRegistry.PoolResidual> CancelledIoByPool { get; init; } = [];
+
+    /// <summary>
+    /// True when the teardown had to KILL something to get here — an activity cancelled or
+    /// abandoned, a pooled leaf cancelled after the grace. The scope may still be safe to dispose
+    /// (<see cref="Clean"/> answers that); this answers whether every unit of work finished its
+    /// job, which is the contract teardown is held to. A consumer surfaces it like a dirty report.
+    /// </summary>
+    public bool WorkWasKilled =>
+        CancelledActivities.Count > 0 || AbandonedActivities.Count > 0 || CancelledIoLeaves > 0;
+
     /// <summary>True iff nothing survived teardown — the scope may be disposed and node ALCs
     /// unloaded with no thread still executing their code.</summary>
     public bool Clean => LeakedIoLeaves == 0 && AsyncDisposeClean;
@@ -61,6 +96,12 @@ public sealed record TeardownReport(int LeakedIoLeaves, bool AsyncDisposeClean)
         var notes = string.Empty;
         if (!ActivitiesQuiesced)
             notes += "; activities did NOT quiesce within budget";
+        if (CancelledActivities.Count > 0)
+            notes += $"; {CancelledActivities.Count} activit{(CancelledActivities.Count == 1 ? "y" : "ies")} CANCELLED for making no progress [{string.Join(" | ", CancelledActivities)}]";
+        if (AbandonedActivities.Count > 0)
+            notes += $"; {AbandonedActivities.Count} activit{(AbandonedActivities.Count == 1 ? "y" : "ies")} ABANDONED after ignoring cancellation [{string.Join(" | ", AbandonedActivities)}]";
+        if (CancelledIoLeaves > 0)
+            notes += $"; {CancelledIoLeaves} pooled I/O leaf(s) CANCELLED after the drain grace [{string.Join(", ", CancelledIoByPool)}]";
         if (DisposalFault is not null)
             notes += $"; disposal FAULTED: {DisposalFault.GetType().Name}: {DisposalFault.Message}";
         return (Clean

--- a/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
+++ b/src/MeshWeaver.Messaging.Hub/HostedHubsCollection.cs
@@ -47,13 +47,14 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     /// <para>🚨 This is what stops an owner OUT-RUNNING the mechanism that answers it (#1701).
     /// The owner's disposal watchdog is armed at the owner's own <c>Dispose()</c>; a child's is
     /// armed strictly later, in the owner's <c>DisposeHostedHubs</c> phase — so with a fixed
-    /// DURATION watchdog the owner ALWAYS expires first, reports
-    /// <c>DISPOSAL DEADLOCK DETECTED … RunLevel=DisposeHostedHubs</c>, and force-tears-down a
-    /// subtree that was merely still working. That is the same inversion #1317 removed one level
-    /// down (<see cref="DisposeHubsReactive"/>'s flat 5 s cap), left in place one level up. Feeding
+    /// DURATION watchdog the owner ALWAYS expires first and reports
+    /// <c>DISPOSAL DEADLOCK DETECTED … RunLevel=DisposeHostedHubs</c> about a subtree that was
+    /// merely still working. That is the same inversion #1317 removed one level down
+    /// (<see cref="DisposeHubsReactive"/>'s flat 5 s cap), left in place one level up. Feeding
     /// subtree progress back to the owner turns its watchdog into a STALL detector: a healthy
     /// nested teardown keeps re-arming it, and a genuinely wedged one still trips — the difference
-    /// being that the message is then TRUE.</para>
+    /// being that the message is then TRUE. (The watchdog reports and cancels the wedged turn; it
+    /// no longer tears anything down out of band — see <c>MessageHub.OnDisposalStall</c>.)</para>
     ///
     /// <para>Depth-capped like the diagnostics walk, and every child's stream is Catch-guarded:
     /// a progress signal must never fault the teardown it is reporting on.</para>
@@ -514,11 +515,11 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     ///
     /// <para>🚨 <b>This is a JOIN, and a join must not out-run the answers it is joining — so it
     /// carries no deadline of its own</b> (issue #1317). It used to cap the whole wait at a flat
-    /// <c>Timeout(5s)</c>. Every leg it waits on is already bounded, and bounded LONGER: each child
-    /// is a <see cref="MessageHub"/>, whose <c>Dispose</c> arms a disposal watchdog (8 s) that
-    /// force-tears-down and signals <c>DisposalCompleted</c> as its last act — so a child's answer
-    /// is guaranteed terminal, just not inside 5 s. The cap therefore expired 3 s BEFORE the
-    /// mechanism that produces a clean answer, in precisely the wedged case it was written for.
+    /// <c>Timeout(5s)</c>. Every leg it waits on answers from its own terminal state: each child
+    /// is a <see cref="MessageHub"/>, whose disposal signals <c>DisposalCompleted</c> as its last
+    /// act once the work it accepted has drained — so a child's answer is guaranteed to come, just
+    /// not inside 5 s. The cap therefore expired BEFORE the mechanism that produces a clean answer,
+    /// in precisely the busy case it was written for.
     /// Nesting made it fire with nothing wedged at all: a child's own disposal is its quiesce
     /// budget (2 s by default) plus its own hosted-subtree join, so a busy two-level tree exceeds a
     /// flat 5 s while every individual step stays inside its own budget.</para>
@@ -528,9 +529,10 @@ public class HostedHubsCollection(IServiceProvider serviceProvider, Address addr
     /// services from it. That is the post-teardown straggler class described throughout this file
     /// (#613), i.e. the cap was manufacturing the very leak the rest of the file works to prevent,
     /// and it silently voided the in-flight-construction contract asserted below. Removing it does
-    /// not remove a bound: the owning hub keeps its OWN disposal watchdog over this whole phase,
-    /// which is where a "the shutdown path wedged" deadline belongs, and which force-tears-down
-    /// rather than merely giving up.</para>
+    /// not remove a report: the owning hub keeps its OWN disposal stall detector over this whole
+    /// phase, which names the child that stopped moving; the bound that ENDS a wedged teardown is
+    /// the caller's (the test base's dispose deadline, the host's teardown budget), and it reports
+    /// a hang with those diagnostics rather than a completion that is not true.</para>
     /// </summary>
     private void DisposeHubsReactive()
     {

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1790,7 +1790,7 @@ public sealed class MessageHub : IMessageHub
     /// The STALL budget of the disposal watchdog: how long the subtree may make no
     /// <see cref="RunLevel"/> progress before the watchdog looks at what is holding the
     /// teardown. It is not a duration cap and it forces nothing — see
-    /// <see cref="OnDisposalStall"/> for the three verdicts it can reach.
+    /// <see cref="OnDisposalStall"/> for the five verdicts it can reach.
     /// </summary>
     internal static readonly TimeSpan DisposalWatchdogTimeout = TimeSpan.FromSeconds(8);
     // Stall-detector state (see OnDisposalStall). `stallTurnsSeen` is the pump's completed-turn
@@ -1955,7 +1955,7 @@ public sealed class MessageHub : IMessageHub
         // teardown now SAYS SO, names the turn, cancels it once (cooperatively), and stays
         // Pending: the outer bounds — the test base's dispose deadline, the host's teardown
         // budget — report a hang with these diagnostics attached instead of a lie about
-        // completion. See OnDisposalStall for the three verdicts.
+        // completion. See OnDisposalStall for the five verdicts.
         watchdogSubscription = DisposalProgress
             .StartWith($"{Address} Dispose() called")
             .Select(reason => Observable.Timer(DisposalWatchdogTimeout, DisposalWatchdogTimeout).Select(_ => reason))

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -438,7 +438,7 @@ public sealed class MessageHub : IMessageHub
         Register<PingRequest>(HandlePingRequest);
         // HandleInitialize already returns IObservable (buildup composed via Observable.Concat,
         // no await) — register it directly now that the rule chain is reactive.
-        Register<InitializeHubRequest>((request, ct) => HandleInitialize(request));
+        Register<InitializeHubRequest>(HandleInitialize);
         lock (messageHandlerRegistrationLock)
         {
             foreach (var messageHandler in configuration.MessageHandlers)
@@ -483,7 +483,8 @@ public sealed class MessageHub : IMessageHub
     /// <c>Doc/Architecture/HubInitializationFailure.md</c>.</para>
     /// Bridged to the Task-based rule chain at the <c>Register</c> edge.
     /// </remarks>
-    private IObservable<IMessageDelivery> HandleInitialize(IMessageDelivery<InitializeHubRequest> request)
+    private IObservable<IMessageDelivery> HandleInitialize(
+        IMessageDelivery<InitializeHubRequest> request, CancellationToken ct)
     {
         logger.LogDebug("Message hub {address} initializing via InitializeHubRequest", Address);
 
@@ -506,6 +507,19 @@ public sealed class MessageHub : IMessageHub
         // run (MeshWeaver CD 33619142646) — a Warning each time, and the one test that asserts a
         // fault-free probe teardown (ProbeHubCostTest) red whenever the late creation landed in its
         // window. Pinned by InitializationStopsAtTeardownStartTest.
+        // 🚨 The bring-up OBSERVES its cancellation. `ct` is the execution token Dispose() cancels
+        // for a hub that never reached Started (see Dispose): a BuildupAction parked on a source
+        // that never emits — a data source's initial load that never answers, a NodeType that never
+        // compiles — used to hold this turn for the whole StartupTimeout (120 s) with the
+        // ShutdownRequest queued behind it, so an owner disposing such a child waited on it too.
+        // Racing the buildup against the token ends the turn the moment the hub is told to go
+        // down: the cancellation errors into the Catch below, whose shutdown arm records no
+        // failure. A ShutdownRequest runs with CancellationToken.None; every other turn's token is
+        // the stall detector's, so nothing else changes here.
+        var cancelled = Observable.Create<IList<Unit>>(observer =>
+            ct.Register(() => observer.OnError(new OperationCanceledException(
+                $"Hub {Address} was told to shut down before its initialization completed", ct))));
+
         var skipLogged = false;
         return Observable
             .Concat(actions.Select(a => Observable.Defer(() =>
@@ -522,6 +536,7 @@ public sealed class MessageHub : IMessageHub
                 return Observable.Empty<Unit>();
             })))
             .ToList()
+            .Amb(cancelled)
             // 🚫 Liveness bound. A BuildupAction that HANGS — never emits and never completes (a
             // dependency that never initialises, a stuck NodeType compile, a subscribe that never
             // fires) — leaves the Concat incomplete, so the gate never opens and EVERY message defers
@@ -1771,7 +1786,26 @@ public sealed class MessageHub : IMessageHub
     private IDisposable? watchdogSubscription;
     private IDisposable? quiescingSubscription;
     private IDisposable? hostedHubsDisposalSubscription;
-    private static readonly TimeSpan DisposalWatchdogTimeout = TimeSpan.FromSeconds(8);
+    /// <summary>
+    /// The STALL budget of the disposal watchdog: how long the subtree may make no
+    /// <see cref="RunLevel"/> progress before the watchdog looks at what is holding the
+    /// teardown. It is not a duration cap and it forces nothing — see
+    /// <see cref="OnDisposalStall"/> for the three verdicts it can reach.
+    /// </summary>
+    internal static readonly TimeSpan DisposalWatchdogTimeout = TimeSpan.FromSeconds(8);
+    // Stall-detector state (see OnDisposalStall). `stallTurnsSeen` is the pump's completed-turn
+    // count at the last stall verdict; `wedgedTurnCancelled` records that the in-flight turn has
+    // already been handed its cancellation, so the next stall verdict on the same turn is the
+    // Error that names a handler ignoring cancellation, not a second cancel.
+    private long stallTurnsSeen = -1;
+    private bool wedgedTurnCancelled;
+    // Event ids for the stall verdicts: the red-log triage keys an incident on the log SITE and
+    // deliberately ignores prose, so each verdict shape files as ONE issue however many hubs
+    // reach it, and the prose is free to carry every detail a reproduction needs.
+    internal static readonly EventId DisposalWedgedTurnCancelled = new(7311, nameof(DisposalWedgedTurnCancelled));
+    internal static readonly EventId DisposalWedgedTurnIgnoresCancellation = new(7312, nameof(DisposalWedgedTurnIgnoresCancellation));
+    internal static readonly EventId DisposalStalledBelowThisHub = new(7313, nameof(DisposalStalledBelowThisHub));
+    internal static readonly EventId DisposalShutDownPhaseBlocked = new(7314, nameof(DisposalShutDownPhaseBlocked));
     private readonly Stopwatch disposalStopwatch = new();
 
     private bool DisposalSignalled => Volatile.Read(ref disposalSignalled) != 0;
@@ -1798,10 +1832,12 @@ public sealed class MessageHub : IMessageHub
     private readonly Lock locker = new();
 
     /// <summary>
-    /// Begins the hub's reactive, phased teardown (idempotent). Cancels any in-flight handler, posts
+    /// Begins the hub's reactive, phased teardown (idempotent). Freezes hosted-hub creation, posts
     /// the Quiescing shutdown request that drives the Quiescing → DisposeHostedHubs → ShutDown state
-    /// machine, and arms a watchdog that force-completes disposal if that path ever wedges. Returns
-    /// immediately; observe <see cref="DisposalCompleted"/> for completion.
+    /// machine behind whatever work the hub has already accepted, and arms a stall detector that
+    /// reports — and cooperatively cancels — a turn that stops the path from advancing. Nothing is
+    /// forced: a hub that cannot finish stays pending and says why. Returns immediately; observe
+    /// <see cref="DisposalCompleted"/> for completion.
     /// </summary>
     /// <summary>
     /// Freezes creation of NEW hosted hubs beneath this hub, cascading through the
@@ -1864,17 +1900,36 @@ public sealed class MessageHub : IMessageHub
             logger.LogDebug("Hub {address} has no hosted hubs to dispose", Address);
         }
 
-        // Cancel any in-progress message handlers (e.g. stuck initialization) to free the
-        // execution block so that the ShutdownRequest can be processed immediately.
-        // ShutdownRequest uses CancellationToken.None so it won't be affected.
-        messageService.CancelExecution();
+        // The stall detector's baseline: how many turns the pump had completed when the teardown
+        // began. Its first verdict compares against THIS, so a pump that drained 500 accepted turns
+        // in the first budget reads as busy rather than as a wedge with no history.
+        stallTurnsSeen = (messageService as MessageService)?.TurnsCompleted ?? -1;
+
+        // 🚨 The in-flight turn is NOT cancelled here. Work this hub accepted before teardown began
+        // runs to completion — a merge that is half-way through, a handler awaiting pooled I/O.
+        // The ShutdownRequest posted below queues behind it FIFO, so the shutdown proceeds the
+        // moment the turn returns. This used to call messageService.CancelExecution() on entry,
+        // which aborted whatever the hub was doing at the instant an ancestor decided to tear
+        // down — a cooperative handler then unwound with its work undone. Cancellation is now a
+        // VERDICT the stall detector reaches after the turn has provably stopped making progress
+        // (see OnDisposalStall), never a reflex.
+        //
+        // The ONE exception is a hub that never finished STARTING. Its InitializeHubRequest is
+        // the hub's own bring-up, not work anyone handed it — intake is gated behind it, so no
+        // accepted turn can be waiting on its result — and a bring-up that is still running when
+        // the owner tears down produces nothing the owner will keep. Cancelling it now is what
+        // lets a hung initialization (a data source that never answers, a NodeType that never
+        // compiles) release the block at once instead of holding its whole ancestry pending for
+        // a stall budget. Anything parked behind its gates is answered ShuttingDown and reported
+        // by messageService.Dispose (DISPOSE-DISCARD).
+        if (RunLevel < MessageHubRunLevel.Started)
+            messageService.CancelExecution();
 
         logger.LogDebug("POSTING initial ShutdownRequest for hub {Address} with Version={Version} (disposal preparation took {elapsed}ms)",
             Address, Version, totalStopwatch.ElapsedMilliseconds);
         Post(new ShutdownRequest(MessageHubRunLevel.Quiescing, Version));
 
-        // Safety net: if the reactive shutdown path ever wedges, force-complete disposal after
-        // a timeout so callers (tests, grain deactivation) don't hang forever.
+        // The disposal STALL DETECTOR. It watches the teardown; it never performs it.
         //
         // 🚨 Reactive, NOT a Task.Delay. `Observable.Timer` schedules on the DefaultScheduler
         // (OFF the action block), and `TakeUntil(disposalCompleted)` cancels the timer the
@@ -1886,47 +1941,157 @@ public sealed class MessageHub : IMessageHub
         // 🚨 It measures a STALL, not a DURATION (#1701). A fixed-duration watchdog on an owner
         // OUT-RUNS the very mechanism that answers it: the owner arms at its own Dispose(), a
         // child arms strictly later — in the owner's DisposeHostedHubs phase — for the same 8 s.
-        // So whenever a child needs its own watchdog to produce an answer, the OWNER's expires
-        // first and reports "DISPOSAL DEADLOCK DETECTED … RunLevel=DisposeHostedHubs" about a
-        // subtree that was working correctly, then force-tears it down mid-flight. That is the
-        // #1317 inversion ("a join must not out-run the answers it is joining") left in place one
-        // level up, and it is why #1701's captures show TWO force-teardown pairs of which only the
-        // inner one carries information.
-        //
         // Switch() over the progress stream re-arms the timer on every sign of life anywhere in
         // the subtree, so a healthy nested teardown never trips however deep it is, and a hub that
-        // genuinely stops moving still trips 8 s later — with the message finally TRUE: no
-        // progress, rather than "not finished yet".
+        // genuinely stops moving is looked at 8 s later — and again every 8 s while it stays
+        // still, because the periodic Timer keeps ticking until progress resumes or disposal ends.
+        //
+        // 🚨 It FORCES NOTHING. The predecessor ran an out-of-band teardown from this thread —
+        // hosted hubs, callbacks, dispose actions, message service — while the wedged turn was
+        // still executing, then signalled Dead. Measured, that produced a hub that reported itself
+        // disposed while its children were mid-flight, a NACK minted only after the 8 s force had
+        // fired (the waiter's whole budget spent on a verdict that existed), and in production a
+        // pod whose "completed" teardown was still holding work. A hub that cannot finish its
+        // teardown now SAYS SO, names the turn, cancels it once (cooperatively), and stays
+        // Pending: the outer bounds — the test base's dispose deadline, the host's teardown
+        // budget — report a hang with these diagnostics attached instead of a lie about
+        // completion. See OnDisposalStall for the three verdicts.
         watchdogSubscription = DisposalProgress
             .StartWith($"{Address} Dispose() called")
-            .Select(reason => Observable.Timer(DisposalWatchdogTimeout).Select(_ => reason))
+            .Select(reason => Observable.Timer(DisposalWatchdogTimeout, DisposalWatchdogTimeout).Select(_ => reason))
             .Switch()
             .TakeUntil(disposalCompleted)
-            .Take(1)
             // 🚨 OFF the progress path. Switch serialises its downstream delivery under its own
             // gate, and a progress signal originates INSIDE the emitting hub's `locker` (the
-            // RunLevel setter runs under it in HandleShutdownCore). Running the force-teardown
-            // inline would therefore hold Switch's gate while taking a child's `locker`, while
-            // that child holds its `locker` and wants Switch's gate — a lock-order inversion that
+            // RunLevel setter runs under it in HandleShutdownCore). Running the verdict inline
+            // would therefore hold Switch's gate while taking a child's `locker`, while that
+            // child holds its `locker` and wants Switch's gate — a lock-order inversion that
             // wedges the child's action block on its own ShutdownRequest (measured: the child
             // sitting at Executing(ShutdownRequest, 8000ms) with deliveryActionCompleted=False).
-            // The pre-Switch watchdog ran on the bare timer thread; this restores that isolation.
             .ObserveOn(System.Reactive.Concurrency.DefaultScheduler.Instance)
             .Subscribe(
-                lastProgress =>
-                {
-                    if (DisposalSignalled)
-                        return;
-                    logger.LogError(
-                        "DISPOSAL DEADLOCK DETECTED: Hub {Address} made no teardown progress for {Timeout} " +
-                        "(last progress: {LastProgress}). RunLevel={RunLevel}. Forcing out-of-band teardown " +
-                        "so children/subscriptions cannot leak.\n{Diagnostics}",
-                        Address, DisposalWatchdogTimeout, lastProgress, RunLevel, DescribeWedge());
-                    ForceTeardownAfterWatchdog();
-                },
+                OnDisposalStall,
                 // disposalCompleted faulting (SignalDisposalFaulted) propagates through TakeUntil;
                 // the watchdog is no longer needed — swallow so it isn't an unobserved error.
                 _ => { });
+    }
+
+    /// <summary>
+    /// One stall verdict: the subtree has made no <see cref="RunLevel"/> progress for
+    /// <see cref="DisposalWatchdogTimeout"/>. Reached every budget while the stall persists.
+    ///
+    /// <para><b>Busy is not wedged.</b> The RunLevel only moves when a ShutdownRequest is
+    /// processed, and that request queues FIFO behind whatever this hub had already accepted. A
+    /// pump that keeps completing turns is draining accepted work ahead of its shutdown — the
+    /// designed behaviour, reported at Information and left alone.</para>
+    ///
+    /// <para><b>A wedged turn is cancelled once, then named.</b> A turn that has held the block
+    /// for a whole budget without a single completion is handed its cancellation token — the one
+    /// cooperative kill the actor model has. A handler that observes it returns and the shutdown
+    /// proceeds. One that does not is reported at Error on every following budget, with the
+    /// message type and its age, as the defect it is. Nothing is torn down around it.</para>
+    ///
+    /// <para><b>No turn, no progress</b> means the stall is below this hub — a hosted hub that is
+    /// itself wedged, or a join still waiting on one. The recursive diagnostics say which; that
+    /// child's own detector carries the turn-level verdict.</para>
+    /// </summary>
+    /// <param name="lastProgress">The last progress signal seen before the stall.</param>
+    private void OnDisposalStall(string lastProgress)
+    {
+        if (DisposalSignalled)
+            return;
+
+        var pump = messageService as MessageService;
+        var turns = pump?.TurnsCompleted ?? -1;
+        var snapshot = pump?.GetQueueSnapshot();
+
+        if (pump is not null && turns != stallTurnsSeen)
+        {
+            var completed = turns - stallTurnsSeen;
+            stallTurnsSeen = turns;
+            // Turns are completing: the pump is busy, not wedged. A new turn means the previous
+            // one returned, so a cancellation issued for it is spent — start the next one clean.
+            wedgedTurnCancelled = false;
+            TryLog(LogLevel.Information,
+                "[DISPOSE-BUSY] {Address}: no phase transition for {Timeout}, but the pump completed "
+                + "{Turns} turn(s) in that window (queue depth {Depth}) — accepted work is draining ahead "
+                + "of the shutdown request. Not a wedge; waiting.",
+                Address, DisposalWatchdogTimeout, completed, snapshot?.Buffer ?? -1);
+            return;
+        }
+        stallTurnsSeen = turns;
+
+        if (snapshot?.CurrentMessage is { } young
+            && snapshot.Value.CurrentMessageElapsedMs < DisposalWatchdogTimeout.TotalMilliseconds)
+        {
+            // A turn younger than the budget started AFTER the last look — the pump is moving even
+            // if the counter has not caught up with this verdict; nothing here is wedged yet.
+            TryLog(LogLevel.Information,
+                "[DISPOSE-BUSY] {Address}: no phase transition for {Timeout}, but the turn on the block "
+                + "({MessageType}) is only {ElapsedMs}ms old — the pump is moving; waiting.",
+                Address, DisposalWatchdogTimeout, young, snapshot.Value.CurrentMessageElapsedMs);
+            return;
+        }
+
+        if (snapshot?.CurrentMessage is { } current)
+        {
+            if (current == nameof(ShutdownRequest))
+            {
+                // The turn on the block IS the shutdown phase itself. Its handler runs the
+                // registered cleanups synchronously (DisposeImpl → disposables.Dispose, then
+                // messageService.Dispose), so a ShutdownRequest that has held the block for a
+                // whole budget is a registrant that blocks — a subscription's Dispose waiting on
+                // a lock, a stream teardown joining something that needs this very turn. It runs
+                // with CancellationToken.None by design, so there is nothing to cancel; the
+                // finding is the blocking registrant, and the snapshot names the phase it is in.
+                // Measured in production (memex-cloud, 2026-08-29 → 09-03): sync/* hubs reported
+                // `(last progress: sync/… → ShutDown). RunLevel=ShutDown` dozens of times per
+                // shutdown, and the predecessor then tore them down out of band after 8–23 s.
+                logger.LogError(DisposalShutDownPhaseBlocked,
+                    "DISPOSAL DEADLOCK DETECTED: Hub {Address} made no teardown progress for {Timeout} "
+                    + "(last progress: {LastProgress}). RunLevel={RunLevel}. The ShutDown phase itself has "
+                    + "held the action block for {ElapsedMs}ms — a registered cleanup is BLOCKING inside "
+                    + "DisposeImpl or messageService.Dispose (a Dispose waiting on a lock, a teardown "
+                    + "joining a turn it is itself occupying). Disposal is NOT forced; find the registrant.\n{Diagnostics}",
+                    Address, DisposalWatchdogTimeout, lastProgress, RunLevel,
+                    snapshot.Value.CurrentMessageElapsedMs, DescribeWedge());
+                return;
+            }
+            if (!wedgedTurnCancelled)
+            {
+                wedgedTurnCancelled = true;
+                // 🚨 An ERROR, not a warning: having to cancel a turn means the hub did not finish
+                // the work it accepted, and the red-log pipeline files an Error as an issue. The
+                // line carries what a reproduction needs — the hub, the message type, how long it
+                // has held the block, the queue behind it and the recursive disposal snapshot.
+                logger.LogError(DisposalWedgedTurnCancelled,
+                    "[DISPOSE-WEDGE] Hub {Address}: the turn {MessageType} has held the action block for "
+                    + "{ElapsedMs}ms with no progress (last progress: {LastProgress}); RunLevel={RunLevel}, "
+                    + "queue depth {Depth}, {Turns} turn(s) completed since Dispose(). Cancelling its token so a "
+                    + "cooperative handler returns and the shutdown behind it can proceed — the work of that "
+                    + "turn did NOT finish. Find what it was waiting on; a turn that returns is never cancelled.\n{Diagnostics}",
+                    Address, current, snapshot.Value.CurrentMessageElapsedMs, lastProgress, RunLevel,
+                    snapshot.Value.Buffer, turns, DescribeWedge());
+                messageService.CancelExecution();
+                return;
+            }
+            logger.LogError(DisposalWedgedTurnIgnoresCancellation,
+                "DISPOSAL DEADLOCK DETECTED: Hub {Address} made no teardown progress for {Timeout} "
+                + "(last progress: {LastProgress}). RunLevel={RunLevel}. The turn {MessageType} "
+                + "({ElapsedMs}ms, queue depth {Depth}) was handed its cancellation and is still running — a "
+                + "handler that ignores cancellation is a defect in that handler. Disposal is NOT forced: it "
+                + "stays pending until the turn returns, and the outer teardown bound reports this hang.\n{Diagnostics}",
+                Address, DisposalWatchdogTimeout, lastProgress, RunLevel, current,
+                snapshot.Value.CurrentMessageElapsedMs, snapshot.Value.Buffer, DescribeWedge());
+            return;
+        }
+
+        logger.LogError(DisposalStalledBelowThisHub,
+            "DISPOSAL DEADLOCK DETECTED: Hub {Address} made no teardown progress for {Timeout} "
+            + "(last progress: {LastProgress}). RunLevel={RunLevel}, queue depth {Depth}. No turn is "
+            + "executing on this hub, so the stall is in a hosted hub or a join it is waiting on — the "
+            + "diagnostics below name it. Disposal is NOT forced.\n{Diagnostics}",
+            Address, DisposalWatchdogTimeout, lastProgress, RunLevel, snapshot?.Buffer ?? -1, DescribeWedge());
     }
 
     /// <summary>
@@ -1958,67 +2123,6 @@ public sealed class MessageHub : IMessageHub
         {
             return $"(disposal diagnostics unavailable: {e.GetType().Name}: {e.Message})";
         }
-    }
-
-    /// <summary>
-    /// Last-resort teardown when the phased shutdown state machine never ran: the posted
-    /// ShutdownRequest is starved behind a message flood (or a handler wedged the action
-    /// block), so Quiescing → DisposeHostedHubs → ShutDown can never advance. Runs the SAME
-    /// teardown those phases would have run — hosted hubs, pending callbacks, dispose
-    /// actions/subscriptions, message service — from the watchdog thread. Every step is
-    /// idempotent, so a rare race with a slow-but-alive phased disposal is harmless.
-    ///
-    /// 🚨 The predecessor only SIGNALLED completion here (unblocking the caller) and leaked
-    /// every child: a dead Blazor circuit's portal hub kept 7k sync-stream hubs alive,
-    /// heartbeating and fanning out DataChangedEvents at ~1.2 cores FOREVER — no
-    /// UnsubscribeRequest ever reached the owner nodes because the client streams were never
-    /// disposed (the 2026-07-01 zombie portal-hub storm; the memory-climbing wedge class).
-    /// </summary>
-    private void ForceTeardownAfterWatchdog()
-    {
-        // Past-Started guards (heartbeat self-dispose, hosted-hub creation refusal) key off
-        // RunLevel — flip it first so periodic emitters stop feeding the storm.
-        lock (locker)
-        {
-            RunLevel = MessageHubRunLevel.ShutDown;
-        }
-        try { hostedHubs.Dispose(); }
-        catch (Exception e)
-        {
-            TryLog(LogLevel.Warning, "[FORCE-TEARDOWN] {Address}: hostedHubs.Dispose faulted: {Type}: {Message}",
-                Address, e.GetType().Name, e.Message);
-        }
-        try { CancelCallbacks(); }
-        catch (Exception e)
-        {
-            TryLog(LogLevel.Warning, "[FORCE-TEARDOWN] {Address}: CancelCallbacks faulted: {Type}: {Message}",
-                Address, e.GetType().Name, e.Message);
-        }
-        try { DisposeImpl(); }
-        catch (Exception e)
-        {
-            TryLog(LogLevel.Warning, "[FORCE-TEARDOWN] {Address}: DisposeImpl faulted: {Type}: {Message}",
-                Address, e.GetType().Name, e.Message);
-        }
-        // Stops intake AND the drain pump — the starved queue can no longer burn CPU.
-        try { messageService.Dispose(); }
-        catch (Exception e)
-        {
-            TryLog(LogLevel.Warning, "[FORCE-TEARDOWN] {Address}: messageService.Dispose faulted: {Type}: {Message}",
-                Address, e.GetType().Name, e.Message);
-        }
-        // Dead BEFORE signalling — callers awaiting DisposalCompleted must observe the
-        // terminal state, never a mid-teardown snapshot.
-        lock (locker)
-        {
-            RunLevel = MessageHubRunLevel.Dead;
-        }
-        SignalDisposalCompleted();
-        disposalStopwatch.Stop();
-        quiescingSubscription?.Dispose();
-        hostedHubsDisposalSubscription?.Dispose();
-        TryLog(LogLevel.Warning, "[FORCE-TEARDOWN] {Address}: out-of-band teardown complete after {Elapsed}ms",
-            Address, disposalStopwatch.ElapsedMilliseconds);
     }
 
     private void DisposeImpl()
@@ -2378,9 +2482,9 @@ public sealed class MessageHub : IMessageHub
                 // no `await hostedHubs.Disposal`, no Task.Run. Each child hub completes its own
                 // reactive disposal and the collection completes once all have. On completion
                 // OR error, advance to ShutDown. The collection carries NO deadline of its own
-                // (#1317) — this hub's DisposalWatchdogTimeout is the single backstop over the
-                // whole phase, and unlike a give-up it force-tears-down rather than abandoning
-                // children mid-disposal.
+                // (#1317) — this hub's stall detector (OnDisposalStall) watches the whole phase
+                // and names a child that stops moving; nothing here gives up on a child or tears
+                // it down mid-disposal.
                 hostedHubs.Dispose();
                 var hostedSw = disposeHostedHubsStopwatch;
                 hostedHubsDisposalSubscription = hostedHubs.DisposalCompleted
@@ -2439,8 +2543,8 @@ public sealed class MessageHub : IMessageHub
                     // takes. What it costs when NOBODY closes it is in that method's remarks.
 
                     // Dead BEFORE signalling — callers awaiting DisposalCompleted must observe the
-                    // terminal state, never a mid-teardown ShutDown snapshot. The force-teardown
-                    // path already orders it this way; here Dead was only set in the FINALLY, so a
+                    // terminal state, never a mid-teardown ShutDown snapshot. Dead used to be set
+                    // only in the FINALLY here, so a
                     // StopAsync waiter woken by the signal could finish its (fast) IoPool +
                     // AsyncDisposeQueue drains and read RunLevel == ShutDown — the flaky
                     // MeshHostBuilderTeardownOrderingTest failure on loaded CI shards. The finally

--- a/src/MeshWeaver.Messaging.Hub/MessageHub.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageHub.cs
@@ -1806,6 +1806,7 @@ public sealed class MessageHub : IMessageHub
     internal static readonly EventId DisposalWedgedTurnIgnoresCancellation = new(7312, nameof(DisposalWedgedTurnIgnoresCancellation));
     internal static readonly EventId DisposalStalledBelowThisHub = new(7313, nameof(DisposalStalledBelowThisHub));
     internal static readonly EventId DisposalShutDownPhaseBlocked = new(7314, nameof(DisposalShutDownPhaseBlocked));
+    internal static readonly EventId DisposalQuiesceWaitCutOff = new(7315, nameof(DisposalQuiesceWaitCutOff));
     private readonly Stopwatch disposalStopwatch = new();
 
     private bool DisposalSignalled => Volatile.Read(ref disposalSignalled) != 0;
@@ -2084,6 +2085,20 @@ public sealed class MessageHub : IMessageHub
                 Address, DisposalWatchdogTimeout, lastProgress, RunLevel, current,
                 snapshot.Value.CurrentMessageElapsedMs, snapshot.Value.Buffer, DescribeWedge());
             return;
+        }
+
+        if (RunLevel == MessageHubRunLevel.Quiescing)
+        {
+            var owed = SnapshotPendingCallbacks()
+                .Where(c => AReplyIsOwedByAShuttingDownLocalHub(c.Target)).ToArray();
+            if (owed.Length > 0)
+            {
+                TryLog(LogLevel.Information,
+                    "[DISPOSE-BUSY] {Address}: quiescing — {Count} reply(ies) still owed by shutting-down hub(s) "
+                    + "in this mesh ({Pending}); their own teardown answers them. Waiting.",
+                    Address, owed.Length, FormatPendingCallbacks(owed));
+                return;
+            }
         }
 
         logger.LogError(DisposalStalledBelowThisHub,
@@ -2443,21 +2458,7 @@ public sealed class MessageHub : IMessageHub
                 // separate total-duration timer.) The result funnels into OnQuiesceComplete,
                 // which posts DisposeHostedHubs. No Task.Delay, no await — the handler returns
                 // immediately and the action block stays free.
-                var quiesceSw = Stopwatch.StartNew();
-                var drained = Observable
-                    .Interval(QuiescePollInterval)
-                    .StartWith(-1L)
-                    .Select(_ => { lock (responseSubjects) return responseSubjects.Count == 0; })
-                    .Where(empty => empty)
-                    .Take(1)
-                    .Select(_ => true);
-                var quiesceDeadline = Observable.Timer(QuiesceTimeout).Select(_ => false);
-                quiescingSubscription = drained
-                    .Amb(quiesceDeadline)
-                    .Take(1)
-                    .Subscribe(
-                        drainedOk => OnQuiesceComplete(drainedOk, quiesceSw, initialPendingSnapshot),
-                        _ => OnQuiesceComplete(drainedOk: false, quiesceSw, initialPendingSnapshot));
+                StartQuiesceWait(Stopwatch.StartNew(), initialPendingSnapshot);
                 break;
             case MessageHubRunLevel.DisposeHostedHubs:
                 var disposeHostedHubsStopwatch = Stopwatch.StartNew();
@@ -2611,6 +2612,92 @@ public sealed class MessageHub : IMessageHub
     internal bool OwnsServiceProvider => Configuration.OwnsServiceProvider;
 
     /// <summary>
+    /// One Quiescing wait: the reactive drain poll raced against one <see cref="QuiesceTimeout"/>
+    /// deadline, funnelled into <see cref="OnQuiesceComplete"/>. Called once from the Quiescing
+    /// phase and again by <see cref="OnQuiesceComplete"/> when the budget expired on replies that a
+    /// shutting-down sibling still owes (see <see cref="AReplyIsOwedByAShuttingDownLocalHub"/>).
+    /// </summary>
+    private void StartQuiesceWait(
+        Stopwatch quiesceSw,
+        (string MessageId, string RequestType, Address? Target, long AgeMs, string? DiagnosticKey)[]
+            initialPendingSnapshot)
+    {
+        var drained = Observable
+            .Interval(QuiescePollInterval)
+            .StartWith(-1L)
+            .Select(_ => { lock (responseSubjects) return responseSubjects.Count == 0; })
+            .Where(empty => empty)
+            .Take(1)
+            .Select(_ => true);
+        var quiesceDeadline = Observable.Timer(QuiesceTimeout).Select(_ => false);
+        quiescingSubscription = drained
+            .Amb(quiesceDeadline)
+            .Take(1)
+            .Subscribe(
+                drainedOk => OnQuiesceComplete(drainedOk, quiesceSw, initialPendingSnapshot),
+                _ => OnQuiesceComplete(drainedOk: false, quiesceSw, initialPendingSnapshot));
+    }
+
+    /// <summary>
+    /// How many times the Quiescing budget may be re-armed on replies a shutting-down sibling still
+    /// owes before the wait is cut and the callbacks cancelled. The wait normally ends by
+    /// construction — the sibling answers or leaves the registry — so this is the cycle breaker
+    /// for two hubs each holding a deferred request of the other's, never a duration to tune.
+    /// </summary>
+    private const int MaxQuiesceRearms = 20;
+    private int quiesceRearms;
+
+    /// <summary>
+    /// True when a pending reply for <paramref name="target"/> is guaranteed to arrive from a hub in
+    /// THIS mesh that is itself shutting down. Such a hub answers every delivery it accepted before
+    /// it signals Dead and leaves its owner's registry: served ahead of its own ShutdownRequest, or
+    /// NACKed <c>ShuttingDown</c> by its <c>messageService.Dispose()</c> (DISPOSE-DISCARD). A
+    /// Quiescing hub therefore WAITS for that reply instead of cancelling its callback on a
+    /// duration — the wait ends by construction when the sibling has answered or gone.
+    ///
+    /// <para>Measured on the #3261 detector: every callback the 0.5 s test budget cancelled was a
+    /// request to a sibling disposing concurrently — <c>CreateOrUpdateNodeRequest@portal/nodeops-*</c>,
+    /// <c>SubscribeRequest@cache/*</c> — whose answer was on its way; production shows the same
+    /// <c>[QUIESCE-TIMEOUT] … CreateNodeRequest@portal/nodeops-*</c> at 2 s. Cancelling those was
+    /// discarding accepted work and reporting a leak that was not one.</para>
+    ///
+    /// <para>Resolution mirrors <c>HierarchicalRouting</c> at the root: the address's host chain is
+    /// climbed and the top-level hub is looked up (never created), then shorter prefixes for a hub
+    /// hosting a sub-path. Only hubs directly under the mesh root are recognised; anything else
+    /// — a remote address, a nested hub, a live hub that is not disposing — keeps today's budget.</para>
+    /// </summary>
+    private bool AReplyIsOwedByAShuttingDownLocalHub(Address? target)
+    {
+        if (target is null)
+            return false;
+        try
+        {
+            IMessageHub root = this;
+            while ((root as MessageHub)?.messageService is MessageService ms && ms.ParentHub is { } parent)
+                root = parent;
+            if (ReferenceEquals(root, this))
+                return false;
+            var top = target;
+            while (top.Host is not null)
+                top = top.Host;
+            var segments = top.Segments;
+            for (var k = segments.Length; k >= 1; k--)
+            {
+                var candidate = k == segments.Length ? top : new Address(segments[..k]);
+                if (root.GetHostedHub(candidate, HostedHubCreation.Never) is not MessageHub sibling
+                    || ReferenceEquals(sibling, this))
+                    continue;
+                return sibling.IsShuttingDown && !sibling.DisposalSignalled;
+            }
+        }
+        catch (ObjectDisposedException)
+        {
+            // The registry or a scope is already gone — nothing there will answer.
+        }
+        return false;
+    }
+
+    /// <summary>
     /// Terminal step of the reactive Quiescing poll (see the Quiescing branch of
     /// <see cref="HandleShutdownCore"/>). Runs on the poll's scheduler thread when the
     /// response subjects drain (<paramref name="drainedOk"/> = true) or the
@@ -2624,6 +2711,7 @@ public sealed class MessageHub : IMessageHub
         (string MessageId, string RequestType, Address? Target, long AgeMs, string? DiagnosticKey)[]
             initialPendingSnapshot)
     {
+        var advance = true;
         try
         {
             if (drainedOk)
@@ -2635,6 +2723,32 @@ public sealed class MessageHub : IMessageHub
             else
             {
                 var stuck = SnapshotPendingCallbacks();
+                var owed = stuck.Where(c => AReplyIsOwedByAShuttingDownLocalHub(c.Target)).ToArray();
+                if (owed.Length > 0 && quiesceRearms < MaxQuiesceRearms)
+                {
+                    // Accepted work, still being answered: the sibling that owes each reply is in
+                    // this mesh and shutting down, so it WILL answer before it goes. Re-arm the
+                    // budget instead of cancelling — the wait ends when the reply lands or the
+                    // sibling has left the registry, whichever comes first.
+                    quiesceRearms++;
+                    TryLog(LogLevel.Information,
+                        "[QUIESCE-WAIT] {Address}: {Count} callback(s) still pending after {Elapsed}ms are owed by "
+                        + "hub(s) in this mesh that are themselves shutting down and answer before they go — "
+                        + "waiting (re-arm {Rearm}/{Max}), not cancelling: {Pending}",
+                        Address, owed.Length, quiesceSw.ElapsedMilliseconds, quiesceRearms, MaxQuiesceRearms,
+                        FormatPendingCallbacks(owed));
+                    advance = false;
+                    quiescingSubscription?.Dispose();
+                    StartQuiesceWait(quiesceSw, initialPendingSnapshot);
+                    return;
+                }
+                if (owed.Length > 0)
+                    logger.LogError(DisposalQuiesceWaitCutOff,
+                        "[QUIESCE-CUT] Hub {Address}: {Count} reply(ies) owed by shutting-down hub(s) in this mesh "
+                        + "never arrived across {Rearms} re-armed budgets ({Elapsed}ms) — most likely each side is "
+                        + "holding a deferred request of the other's. Cancelling them now; the sender is answered "
+                        + "with a disposal failure. Pending: {Pending}",
+                        Address, owed.Length, quiesceRearms, quiesceSw.ElapsedMilliseconds, FormatPendingCallbacks(owed));
                 var detail = FormatPendingCallbacks(stuck);
                 // 🚨 The HANDLER side (issue #981). The line above is caller-only — it says a
                 // request was posted and never answered. This one says what happened to the
@@ -2684,10 +2798,12 @@ public sealed class MessageHub : IMessageHub
         }
         finally
         {
-            // Advance to DisposeHostedHubs. Registered subscriptions are disposed
+            // Advance to DisposeHostedHubs — unless the budget was re-armed on replies a
+            // shutting-down sibling still owes. Registered subscriptions are disposed
             // synchronously later, in the ShutDown phase (DisposeImpl →
             // disposables.Dispose) — there is no async dispose-action drain to await.
-            Post(new ShutdownRequest(MessageHubRunLevel.DisposeHostedHubs, Version));
+            if (advance)
+                Post(new ShutdownRequest(MessageHubRunLevel.DisposeHostedHubs, Version));
         }
     }
 

--- a/src/MeshWeaver.Messaging.Hub/MessageService.cs
+++ b/src/MeshWeaver.Messaging.Hub/MessageService.cs
@@ -49,6 +49,13 @@ internal static class MessageTrace
 /// </summary>
 public class MessageService : IMessageService
 {
+    /// <summary>
+    /// Event ids for the shutdown-time discards, so the red-log triage keys the incident on the log
+    /// SITE (it deliberately ignores prose): one issue per discard shape, however many hubs hit it.
+    /// </summary>
+    internal static readonly EventId DisposalDiscardedDeferredDelivery = new(7301, nameof(DisposalDiscardedDeferredDelivery));
+    internal static readonly EventId DisposalDiscardedQueuedDelivery = new(7302, nameof(DisposalDiscardedQueuedDelivery));
+
     private readonly ILogger<MessageService> logger;
     private readonly IMessageHub hub;
 
@@ -738,6 +745,18 @@ public class MessageService : IMessageService
     // invocation in ScheduleExecution. Null means the action block is idle.
     private volatile string? currentlyExecutingMessageType;
     private long currentlyExecutingStartedTicks;
+    // Turns the pump has finished since this service was built. The disposal stall detector reads
+    // it to tell a BUSY pump (accepted work still draining ahead of the shutdown request) from a
+    // WEDGED one (a single turn that never returns): the two produce the same RunLevel and the same
+    // queue depths, and only this counter separates them.
+    private long turnsCompleted;
+
+    /// <summary>
+    /// Number of handler turns the pump has completed so far. Monotonic; read by the hub's
+    /// disposal stall detector to distinguish a pump that is draining accepted work from one whose
+    /// current turn never returns.
+    /// </summary>
+    internal long TurnsCompleted => Interlocked.Read(ref turnsCompleted);
 
     /// <summary>
     /// Snapshot counts of the dataflow buffers — used by
@@ -1684,6 +1703,7 @@ public class MessageService : IMessageService
                 // Clear the currently-executing tracker — the turn is now idle.
                 currentlyExecutingMessageType = null;
                 Interlocked.Exchange(ref currentlyExecutingStartedTicks, 0);
+                Interlocked.Increment(ref turnsCompleted);
                 if (delivery.Message is not ExecutionRequest && logger.IsEnabled(LogLevel.Debug))
                     logger.LogDebug("Finished processing {Delivery} in {Address} after {Duration}ms",
                         delivery.Id, Address, executionStopwatch.ElapsedMilliseconds);
@@ -1969,9 +1989,9 @@ public class MessageService : IMessageService
     /// </summary>
     public void Dispose()
     {
-        // 🚨 IDEMPOTENT — a second call must be a no-op, not a second teardown. MessageHub reaches
-        // here from TWO places: the ShutDown phase of HandleShutdownCore and the watchdog's
-        // force-teardown, which can both run for one hub. The second pass re-cancelled an already
+        // 🚨 IDEMPOTENT — a second call must be a no-op, not a second teardown. MessageHub reached
+        // here from TWO places (the ShutDown phase of HandleShutdownCore and, historically, the
+        // watchdog's out-of-band teardown), and both could run for one hub. The second pass re-cancelled an already
         // disposed hangDetectionCts and re-disposed the storm breaker; both throw
         // ObjectDisposedException and were only invisible because they sit inside catch-and-log
         // blocks — i.e. the .NET IDisposable contract was being met by a swallow.
@@ -2032,17 +2052,46 @@ public class MessageService : IMessageService
         // timeout continuation (or a gate drain) dispose the same CancellationTokenSource
         // concurrently, and this Cancel() then threw ObjectDisposedException out of Dispose itself
         // — logged as "Error during shutdown of hub …" (issue #2176).
+        // 🚨 An ERROR for every delivery this discards. A message that was ACCEPTED and is now
+        // thrown away — answered with a transient NACK at best — is work the hub did not finish:
+        // exactly the "we could not drain the queue" the teardown contract forbids, and the
+        // red-log pipeline files an Error as an issue. The line carries what a reader needs to
+        // reproduce it: the hub, the message type and id, its sender, the gates it was parked
+        // behind and this hub's run level.
+        var discarded = 0;
         DrainDeferredDeliveries(delivery =>
+        {
+            discarded++;
+            logger.LogError(DisposalDiscardedDeferredDelivery,
+                "[DISPOSE-DISCARD] Hub {Address} is disposing with {MessageType} (id={MessageId}, from {Sender}) "
+                + "still deferred behind its initialization gates [{Gates}] — the message is NOT processed; "
+                + "the sender is answered ShuttingDown. RunLevel={RunLevel}. Accepted work must be drained "
+                + "before a hub goes down; find why this hub disposed with its gates still shut.",
+                Address, delivery.Message.GetType().Name, delivery.Id, delivery.Sender,
+                string.Join(",", gates.Keys), hub.RunLevel);
             NackThroughParent(delivery,
                 $"Hub {Address} was disposed while {delivery.Message.GetType().Name} "
                 + $"(id={delivery.Id}) was still deferred behind its initialization gates "
                 + $"[{string.Join(",", gates.Keys)}] — the message was never processed. The address "
-                + "may reactivate (recycle / restart); retry to get the authoritative answer."));
+                + "may reactivate (recycle / restart); retry to get the authoritative answer.");
+        });
 
         // No buffers to Complete — ScheduleNotify drops post-shutdown messages and the
         // pump drains whatever is already queued.
         logger.LogDebug("[DISPOSE-TRACE] {address}: turn queues (mainCount={bufferCount}, deferredCount={deferredCount})",
             Address, mainQueue.Count, deferredQueue.Count);
+        // The ShutDown request is FIFO behind everything accepted before it, so by the time this
+        // runs the main queue holds only what arrived in the shutdown window and is about to be
+        // left unprocessed once the pump stops. Anything at all here is the same discard as above.
+        int leftBehind;
+        lock (turnGate) leftBehind = mainQueue.Count;
+        if (leftBehind > 0)
+            logger.LogError(DisposalDiscardedQueuedDelivery,
+                "[DISPOSE-DISCARD] Hub {Address} is disposing with {Count} turn(s) still queued and "
+                + "unprocessed (the pump stops with this call). RunLevel={RunLevel}; {Discarded} deferred "
+                + "delivery(ies) already answered ShuttingDown; last turn executing: {Executing}. Accepted work "
+                + "must be drained before a hub goes down — find what posted into the shutdown window.",
+                Address, leftBehind, hub.RunLevel, discarded, currentlyExecutingMessageType ?? "(idle)");
 
         // Don't wait on deliveryAction.Completion. Handler execution now runs INLINE
         // on this same block (executionBuffer/executionBlock were collapsed away), so

--- a/test/MeshWeaver.Data.Test/PatchVerdictRoutingTest.cs
+++ b/test/MeshWeaver.Data.Test/PatchVerdictRoutingTest.cs
@@ -107,49 +107,31 @@ public class PatchVerdictRoutingTest
     }
 
     /// <summary>
-    /// 🚨 During TEARDOWN an accepted post is not proof of delivery: the owner accepts it (its own
-    /// run level is still open) and the parent's routing drops it a turn later, where
-    /// <c>RoutePatchVerdict</c> cannot see it. So the armed sink is served too. The registry removes
-    /// the entry before it calls back and the posted response reaches the same registry through the
-    /// cache hub, so the caller is answered exactly once whichever arrives first.
+    /// 🚨 <b>The regression that must not come back.</b> Serving the armed sink ALONGSIDE an
+    /// accepted post — to close the teardown hole where the parent drops the response after this
+    /// returns — was tried twice and reddened live tests both times. A late watch is armed for
+    /// EVERY patch at post time, not just an expired one, so the sink dispatches the ack
+    /// synchronously on the OWNER's turn, ahead of the state change it acknowledges: the caller's
+    /// write completes before what it wrote is readable. Dispatch-first reddened
+    /// <c>ComboGateRollTest</c> (run 33863349195); gated on <c>IsShuttingDown</c> it reddened
+    /// <c>ImportTypeBeforeInstanceTest</c> (run 33865385033), which recycles node hubs throughout
+    /// its import and so meets that gate on the live path. This test is the guard: with a sink
+    /// present and armed, an accepted post must leave it untouched.
     /// </summary>
     [Fact]
-    public void AnAcceptedPost_WhileTheOwnerIsShuttingDown_AlsoServesTheSink()
-    {
-        var dispatched = new List<string>();
-
-        var routed = DataExtensions.RoutePatchVerdict(
-            Verdict, RequestId,
-            _ => Delivered(MessageDeliveryState.Submitted),
-            (id, _) => { dispatched.Add(id); return true; },
-            () => true);
-
-        routed.Should().BeTrue();
-        dispatched.Should().ContainSingle(
-            "the parent drops the accepted response after this returns — the sink is the only "
-            + "route left, and it is single-shot so it cannot double-answer");
-    }
-
-    /// <summary>
-    /// 🚨 …and ONLY during teardown. A late watch is armed for every patch at post time, not just
-    /// an expired one, so serving the sink whenever it is armed moves every ordinary ack off its
-    /// designed transport — and FORWARD of the state it acknowledges, because the sink dispatches
-    /// synchronously on the owner's turn. Measured: that reordering reddened ComboGateRollTest
-    /// under load (run 33863349195) — the write completed before what it wrote was readable.
-    /// </summary>
-    [Fact]
-    public void AnAcceptedPost_WhileTheOwnerIsLive_LeavesTheSinkAlone()
+    public void AnAcceptedPost_NeverAlsoServesTheSink_EvenWithOneArmed()
     {
         var dispatched = 0;
 
         var routed = DataExtensions.RoutePatchVerdict(
             Verdict, RequestId,
             _ => Delivered(MessageDeliveryState.Submitted),
-            (_, _) => { dispatched++; return true; },
-            () => false);
+            (_, _) => { dispatched++; return true; });
 
         routed.Should().BeTrue();
-        dispatched.Should().Be(0, "the live path keeps the post as its only transport");
+        dispatched.Should().Be(0,
+            "the post is the live path's only transport — a second, earlier answer through the "
+            + "sink reorders the ack ahead of the state it acknowledges");
     }
 
     /// <summary>No sink registered at all (a minimal fixture) degrades the same way — no throw.</summary>

--- a/test/MeshWeaver.Data.Test/PatchVerdictRoutingTest.cs
+++ b/test/MeshWeaver.Data.Test/PatchVerdictRoutingTest.cs
@@ -106,6 +106,52 @@ public class PatchVerdictRoutingTest
             .Should().BeFalse();
     }
 
+    /// <summary>
+    /// 🚨 During TEARDOWN an accepted post is not proof of delivery: the owner accepts it (its own
+    /// run level is still open) and the parent's routing drops it a turn later, where
+    /// <c>RoutePatchVerdict</c> cannot see it. So the armed sink is served too. The registry removes
+    /// the entry before it calls back and the posted response reaches the same registry through the
+    /// cache hub, so the caller is answered exactly once whichever arrives first.
+    /// </summary>
+    [Fact]
+    public void AnAcceptedPost_WhileTheOwnerIsShuttingDown_AlsoServesTheSink()
+    {
+        var dispatched = new List<string>();
+
+        var routed = DataExtensions.RoutePatchVerdict(
+            Verdict, RequestId,
+            _ => Delivered(MessageDeliveryState.Submitted),
+            (id, _) => { dispatched.Add(id); return true; },
+            () => true);
+
+        routed.Should().BeTrue();
+        dispatched.Should().ContainSingle(
+            "the parent drops the accepted response after this returns — the sink is the only "
+            + "route left, and it is single-shot so it cannot double-answer");
+    }
+
+    /// <summary>
+    /// 🚨 …and ONLY during teardown. A late watch is armed for every patch at post time, not just
+    /// an expired one, so serving the sink whenever it is armed moves every ordinary ack off its
+    /// designed transport — and FORWARD of the state it acknowledges, because the sink dispatches
+    /// synchronously on the owner's turn. Measured: that reordering reddened ComboGateRollTest
+    /// under load (run 33863349195) — the write completed before what it wrote was readable.
+    /// </summary>
+    [Fact]
+    public void AnAcceptedPost_WhileTheOwnerIsLive_LeavesTheSinkAlone()
+    {
+        var dispatched = 0;
+
+        var routed = DataExtensions.RoutePatchVerdict(
+            Verdict, RequestId,
+            _ => Delivered(MessageDeliveryState.Submitted),
+            (_, _) => { dispatched++; return true; },
+            () => false);
+
+        routed.Should().BeTrue();
+        dispatched.Should().Be(0, "the live path keeps the post as its only transport");
+    }
+
     /// <summary>No sink registered at all (a minimal fixture) degrades the same way — no throw.</summary>
     [Fact]
     public void RefusedPost_WithNoSinkRegistered_ReportsThatNoRouteTookIt()

--- a/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
@@ -34,10 +34,16 @@ namespace MeshWeaver.Graph.Test;
 /// activation (bounded re-enqueue budget, re-diffed against the freshest state).</para>
 ///
 /// <para>The scripted interleaving: park the owner's merge turn behind a gated no-op turn
-/// (so no response can arrive inside the 2s window), THEN dispose the owner — the disposal
-/// NACK is necessarily LATE. The write must still reach durable storage via the re-enqueue.
-/// Without Part 2 the late NACK is dropped and the storage poll times out at the pre-write
-/// state.</para>
+/// (so no response can arrive inside the 2s window), THEN dispose the owner — whatever verdict
+/// the owner produces is necessarily LATE, and the write must still reach durable storage and
+/// the caller must still see it as its own success. Since the teardown lets accepted work finish
+/// (Doc/Architecture/TeardownLayers), the parked turn releases itself when the owner starts
+/// shutting down and the queued merge then RUNS — so the late verdict here is normally the
+/// commit's own ack, dispatched to the armed watch; the OwnerDisposing NACK and its re-enqueue
+/// remain the safety net for a merge the owner could not run at all (a post refused by an
+/// already-closing sync hub, a store that completes before the echo). Both paths end in the same
+/// ground truth this test asserts. Without the late watch either verdict is dropped and the
+/// storage poll times out at the pre-write state.</para>
 ///
 /// <para>🚨 Since #2661 the caller is NOT completed at the 2 s bound — a bound expiring is not
 /// a commit, so the write's terminal is the owner's verdict wherever it arrives. Here that
@@ -76,13 +82,21 @@ public class LateNackReenqueueTest(ITestOutputHelper output) : MonolithMeshTestB
         // 🚨 No hand-woven gate. The turn → test signal is an AsyncSubject the parked turn
         // completes; the release travels back INTO that deliberately parked executor turn, so it
         // is a volatile flag polled under a bounded SpinUntil and written in the `finally` below.
+        // The parked turn ALSO observes the owner's shutdown: accepted work finishes its job when
+        // the owner goes down, it does not sit on the block waiting to be killed. The owner's
+        // teardown no longer force-tears a parked sync hub down (Doc/Architecture/TeardownLayers),
+        // so a turn blind to the shutdown would hold the owner at DisposeHostedHubs — honestly
+        // pending — until the test's own `finally`, and the caller would burn its verdict budget.
         var gateEntered = new AsyncSubject<Unit>();
         var releaseGate = 0;
+        var owner = nodeHub!;
         primary.Update((Func<EntityStore?, ChangeItem<EntityStore>?>)(_ =>
         {
             gateEntered.OnNext(Unit.Default);
             gateEntered.OnCompleted();
-            SpinWait.SpinUntil(() => Volatile.Read(ref releaseGate) == 1, TimeSpan.FromSeconds(60));
+            SpinWait.SpinUntil(
+                () => Volatile.Read(ref releaseGate) == 1 || owner.IsShuttingDown,
+                TimeSpan.FromSeconds(60));
             return null;
         }), _ => { });
         try

--- a/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
+++ b/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
@@ -10,8 +10,10 @@ using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Xunit;
 using MeshWeaver.Fixture;
+using System.Collections.Concurrent;
 
 // Core twin of MeshWeaver.Plugins/src/MeshWeaver.Hosting.Monolith.Test/NackReachesTheWaiterDuringTeardownTest.cs (ported 2026-09-02):
 // core's own CI cannot run the Plugins-hosted suite, so the 2026-09-02 regression of the owner-disposing
@@ -55,10 +57,27 @@ namespace MeshWeaver.Graph.Test;
 /// to zero is precisely "the owner's verdict reached the waiter", the step that used to be skipped.
 /// With the defect present the post is never made, nothing dispatches, and the entry simply sits
 /// armed until it expires 30 s later.</para>
+///
+/// <para><b>Why the parked merge turn releases itself when the owner starts shutting down.</b>
+/// The first shape of this test parked the owner's merge executor until the test's own
+/// <c>finally</c> — a turn blind to the shutdown, held for the whole assertion window. The verdict
+/// then reached the waiter only after the disposal watchdog had force-torn the parked sync hub down
+/// at 8 s, which made the 10 s assertion "the watchdog plus two seconds" — and a loaded CI shard
+/// lost those two seconds (run 33847949620). That force-teardown no longer exists: a hub whose turn
+/// is parked stays honestly pending and reports the turn (<c>DisposalStallWatchdogTest</c>). So the
+/// parked turn here is what accepted work is supposed to be — it observes the owner's
+/// <c>IsShuttingDown</c> and finishes its job — and the assertion bound is now well inside the
+/// 8 s stall budget, which is also what proves no watchdog took part.</para>
 /// </summary>
 public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
     : MonolithMeshTestBase(output)
 {
+    private readonly StallVerdictCapture verdicts = new();
+
+    protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
+        => base.ConfigureMesh(builder)
+            .ConfigureServices(services => services.AddSingleton<ILoggerProvider>(verdicts));
+
     [Fact]
     public async Task OwnerDisposingUnderMeshTeardown_StillAnswersTheWaitingCaller()
     {
@@ -86,17 +105,22 @@ public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
         //
         // 🚨 No hand-woven gate: the turn → test signal is an AsyncSubject the parked turn
         // completes; the release travels back INTO the deliberately parked turn, so it is a
-        // volatile flag polled under a bounded SpinUntil and written in the `finally`.
+        // volatile flag polled under a bounded SpinUntil and written in the `finally`. The turn
+        // ALSO observes the owner's shutdown (see the class remarks): accepted work finishes its
+        // job when the mesh goes down, it does not sit on the block waiting to be killed.
         var primary = nodeHub!.GetWorkspace().DataContext
             .GetDataSourceForType(typeof(MeshNode))!
             .GetStreamForPartition(null)!;
         var gateEntered = new AsyncSubject<Unit>();
         var releaseGate = 0;
+        var owner = nodeHub!;
         primary.Update((Func<EntityStore?, ChangeItem<EntityStore>?>)(_ =>
         {
             gateEntered.OnNext(Unit.Default);
             gateEntered.OnCompleted();
-            SpinWait.SpinUntil(() => Volatile.Read(ref releaseGate) == 1, TimeSpan.FromSeconds(60));
+            SpinWait.SpinUntil(
+                () => Volatile.Read(ref releaseGate) == 1 || owner.IsShuttingDown,
+                TimeSpan.FromSeconds(60));
             return null;
         }), _ => { });
         try
@@ -132,10 +156,12 @@ public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
             // ArmedCount returning to zero is the observable fact "the owner's verdict reached the
             // waiter". The bound is deliberately far below LateResponseWatchBound (30 s), because
             // an entry that merely EXPIRES would also end at zero — waiting that long is
-            // indistinguishable from the defect, so a generous bound would pass on it.
+            // indistinguishable from the defect, so a generous bound would pass on it. It is ALSO
+            // below the 8 s disposal stall budget: the verdict has to come from the ordinary
+            // teardown, never from a stall verdict on a parked hub.
             await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
                 .Where(_ => registry.ArmedCount == 0)
-                .FirstAsync().Timeout(10.Seconds()).Await(ct);
+                .FirstAsync().Timeout(6.Seconds()).Await(ct);
 
             registry.ArmedCount.Should().Be(0,
                 "the owner minted an OwnerDisposing NACK for this patch, and a caller was armed and "
@@ -150,11 +176,43 @@ public class NackReachesTheWaiterDuringTeardownTest(ITestOutputHelper output)
             Output.WriteLine(
                 $"[caller] terminal={(callerTerminal is null ? "<null>" : callerTerminal.Name)} "
                 + $"error={(callerError is null ? "<null>" : callerError.GetType().Name)}");
+
+            // No hub was reported wedged and nothing was cancelled or torn down out of band: the
+            // verdict travelled the ordinary teardown. A stall verdict here would mean the parked
+            // turn did not observe the shutdown — the shape this test no longer relies on.
+            foreach (var verdict in verdicts.Entries)
+                Output.WriteLine(verdict);
+            verdicts.Entries.Should().BeEmpty(
+                "the waiter must be answered by the ordinary teardown, not by a stall verdict on a parked hub");
         }
         finally
         {
             // In a `finally` so a failing assertion above cannot strand the parked executor turn.
             Volatile.Write(ref releaseGate, 1);
+        }
+    }
+
+    /// <summary>Captures the Error-level disposal stall verdicts (both shapes).</summary>
+    private sealed class StallVerdictCapture : ILoggerProvider
+    {
+        public ConcurrentQueue<string> Entries { get; } = new();
+        public ILogger CreateLogger(string categoryName) => new Capturing(Entries);
+        public void Dispose() { }
+
+        private sealed class Capturing(ConcurrentQueue<string> sink) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (logLevel < LogLevel.Error)
+                    return;
+                var message = formatter(state, exception);
+                if (message.Contains("DISPOSAL DEADLOCK DETECTED", StringComparison.Ordinal)
+                    || message.Contains("[DISPOSE-WEDGE]", StringComparison.Ordinal))
+                    sink.Enqueue(message);
+            }
         }
     }
 }

--- a/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
+++ b/test/MeshWeaver.Hosting.Monolith.TestBase/MonolithMeshTestBase.cs
@@ -1492,6 +1492,34 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             }
             TestPhaseTrace(testName, "DISPOSE_HOSTED_SERVICES_STOPPED", sw.ElapsedMilliseconds);
 
+            // Phase 0 — QUIESCE ACTIVITIES before anything is disposed, exactly as the production
+            // TeardownAsync does: a run that is reporting progress is waited for; one that has made
+            // no progress for the stall budget is cancelled; one that ignores that is abandoned.
+            // Both kills are recorded on the report below and FAIL the class — a run teardown had
+            // to kill did not finish its job, and that is a defect in the test's arrangement or in
+            // the run, never a teardown detail to tolerate.
+            var activityQuiesce = new ActivityQuiesceReport([], []);
+            var activitiesQuiesced = true;
+            if (Mesh.ServiceProvider.GetService<ActivityTracker>() is { } activities)
+            {
+                using var quiesceCts = new CancellationTokenSource(DisposeTimeout);
+                try
+                {
+                    activityQuiesce = await activities.Quiesce(MeshTeardownExtensions.ActivityStallBudget)
+                        .ObserveCompletion(
+                            ex => FileOutput.WriteLine($"[DISPOSE] {testName}: activity quiesce faulted late: {ex}"),
+                            quiesceCts.Token) ?? activityQuiesce;
+                }
+                catch (OperationCanceledException)
+                {
+                    activitiesQuiesced = false;
+                    TestPhaseTrace(testName, "DISPOSE_ACTIVITIES_STILL_RUNNING", sw.ElapsedMilliseconds,
+                        string.Join(" | ", activities.InFlight.Select(r =>
+                            $"{r.Label} (last progress {r.SinceLastProgress.TotalSeconds:F1}s ago)")));
+                }
+            }
+            TestPhaseTrace(testName, "DISPOSE_ACTIVITIES_QUIESCED", sw.ElapsedMilliseconds, activityQuiesce.ToString());
+
             FileOutput.WriteLine($"[DISPOSE] {testName}: Mesh.Dispose() invoking on {Mesh.Address}");
             // Capture the mesh-scoped teardown services BEFORE disposal — once Dispose()
             // begins, resolving DI races the scope teardown. We drain them after
@@ -1531,10 +1559,13 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // residual reads as an anonymous "1" — which is how #2578 and #2616 both ended with
             // nothing to act on. (Query=1 and Compile=1 are different bugs.)
             IReadOnlyList<IoPoolRegistry.PoolResidual> residualByPool = [];
-            var leakedIoLeaves = ioPools is null ? 0 : ioPools.DrainAll(out residualByPool);
+            IReadOnlyList<IoPoolRegistry.PoolResidual> cancelledByPool = [];
+            var leakedIoLeaves = ioPools is null ? 0 : ioPools.DrainAll(out residualByPool, out cancelledByPool);
+            var cancelledIoLeaves = cancelledByPool.Sum(p => p.Residual);
             TestPhaseTrace(testName, "DISPOSE_IOPOOL_DRAIN_DONE", sw.ElapsedMilliseconds,
                 $"leakedIoLeaves={leakedIoLeaves}"
-                + (residualByPool.Count > 0 ? $" pools=[{string.Join(", ", residualByPool)}]" : ""));
+                + (residualByPool.Count > 0 ? $" pools=[{string.Join(", ", residualByPool)}]" : "")
+                + (cancelledIoLeaves > 0 ? $" cancelledAfterGrace=[{string.Join(", ", cancelledByPool)}]" : ""));
             // After all the sync stuff is disposed (and everyone has enqueued their async
             // cleanup), quiesce the async dispose queue before the scope closes below.
             var asyncDisposeClean = asyncDisposeQueue is null
@@ -1545,7 +1576,15 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
             // The terminal signal — DISPOSE_DONE is only true when this report is CLEAN. Fire it
             // before the scope disposes below so any subscriber ordering on "all is done" (ALC
             // unload hooks, diagnostics) observes the truthful terminal state, dirty or not.
-            var teardownReport = new TeardownReport(leakedIoLeaves, asyncDisposeClean);
+            var teardownReport = new TeardownReport(leakedIoLeaves, asyncDisposeClean)
+            {
+                ResidualByPool = residualByPool,
+                ActivitiesQuiesced = activitiesQuiesced,
+                CancelledActivities = activityQuiesce.Cancelled,
+                AbandonedActivities = activityQuiesce.Abandoned,
+                CancelledIoLeaves = cancelledIoLeaves,
+                CancelledIoByPool = cancelledByPool,
+            };
             teardownSignal?.SignalCompleted(teardownReport);
             FileOutput.WriteLine($"[DISPOSE] {testName}: Mesh.Disposal completed in {sw.ElapsedMilliseconds}ms — {teardownReport}");
             TestPhaseTrace(testName, "DISPOSE_DONE", sw.ElapsedMilliseconds, teardownReport.ToString());
@@ -1564,6 +1603,21 @@ public abstract class MonolithMeshTestBase : Fixture.TestBase
                     "A pooled I/O leaf or async cleanup ignored its cancellation token; the service " +
                     "scope (and any collectible node ALC) is about to be torn down over live code — " +
                     "the use-after-unload SIGSEGV. Fix the leaf that will not cancel; do not widen the drain budget.");
+            }
+
+            // Work the teardown had to KILL is LOGGED here, not failed: a cancelled activity or a
+            // pooled leaf cancelled after the drain grace unwound, so the scope is safe, and the
+            // src-side Error lines (the ones production's red-log triage files as issues) have
+            // already named the run or leaf. In a test that is the whole signal — the trace and the
+            // output carry it — and turning it into a class failure would take the suite down for
+            // a wedge the test under it never asserted on. (Maintainer, 2026-09-04: "in testing we
+            // must have some way to just log out".)
+            if (teardownReport.WorkWasKilled)
+            {
+                TestPhaseTrace(testName, "DISPOSE_WEDGED_WORK", sw.ElapsedMilliseconds, teardownReport.ToString());
+                FileOutput.WriteLine(
+                    $"[DISPOSE] {testName}: teardown had to KILL work that made no progress — {teardownReport}. "
+                    + "A run or pooled leaf that reports progress is never cancelled; find what it was waiting on.");
             }
 
             // Fail the test class' dispose if any hub hit Quiescing timeout. A leaked

--- a/test/MeshWeaver.Hosting.Test/ActivityTrackerQuiesceTest.cs
+++ b/test/MeshWeaver.Hosting.Test/ActivityTrackerQuiesceTest.cs
@@ -1,0 +1,134 @@
+using System;
+using System.Diagnostics;
+using System.Reactive.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Hosting.Test;
+
+/// <summary>
+/// The activity quiesce — the phase-0 of mesh teardown — lets a run that is WORKING finish,
+/// cancels only a run that has stopped reporting progress, and abandons one that ignores even
+/// that. Each verdict is DATA on the report, so a teardown can say what it had to do rather than
+/// pretend the run finished. Progress is what the run reports itself (every appended log line);
+/// the tracker never invents a heartbeat.
+/// </summary>
+public class ActivityTrackerQuiesceTest
+{
+    private static readonly TimeSpan Stall = TimeSpan.FromMilliseconds(400);
+
+    [Fact]
+    public async Task AnIdleMesh_QuiescesAtOnce_AndClean()
+    {
+        using var tracker = new ActivityTracker();
+        var sw = Stopwatch.StartNew();
+        var report = await tracker.Quiesce(Stall).FirstAsync().Timeout(TimeSpan.FromSeconds(5))
+            .Await(TestContext.Current.CancellationToken);
+        report.Clean.Should().BeTrue();
+        sw.Elapsed.Should().BeLessThan(Stall, "an idle mesh must not wait a stall budget to learn it is idle");
+    }
+
+    /// <summary>
+    /// A run that keeps reporting progress is waited for — well past one stall budget — and is
+    /// never cancelled. This is the contract that lets accepted work finish its job.
+    /// </summary>
+    [Fact]
+    public async Task AProgressingRun_IsWaitedFor_AndNeverCancelled()
+    {
+        using var tracker = new ActivityTracker();
+        var cancelRequested = 0;
+        var handle = tracker.TrackRun("progressing", () => Interlocked.Exchange(ref cancelRequested, 1));
+
+        // The run: reports progress every 100 ms for three stall budgets, then finishes.
+        var runLength = TimeSpan.FromMilliseconds(Stall.TotalMilliseconds * 3);
+        var run = Observable.Interval(TimeSpan.FromMilliseconds(100))
+            .TakeUntil(Observable.Timer(runLength))
+            .Do(_ => handle.Progress())
+            .Finally(handle.Dispose)
+            .Subscribe();
+
+        var sw = Stopwatch.StartNew();
+        var report = await tracker.Quiesce(Stall).FirstAsync().Timeout(TimeSpan.FromSeconds(15))
+            .Await(TestContext.Current.CancellationToken);
+        sw.Stop();
+        run.Dispose();
+
+        report.Clean.Should().BeTrue(report.ToString());
+        Volatile.Read(ref cancelRequested).Should().Be(0, "a run that reports progress is never cancelled");
+        sw.Elapsed.Should().BeGreaterThan(Stall + Stall,
+            "the quiesce must have waited well past one stall budget for a run that kept working");
+    }
+
+    /// <summary>
+    /// A run that stops reporting progress is CANCELLED after one stall budget. Here the run
+    /// honours the cancel by finishing, so the quiesce completes clean of abandonments but names
+    /// the run it had to kill.
+    /// </summary>
+    [Fact]
+    public async Task AStalledRun_IsCancelledAfterOneStallBudget_AndNamed()
+    {
+        using var tracker = new ActivityTracker();
+        ActivityRunHandle? handle = null;
+        handle = tracker.TrackRun("stalled", () => handle!.Dispose()); // observes the cancel by finishing
+
+        var sw = Stopwatch.StartNew();
+        var report = await tracker.Quiesce(Stall).FirstAsync().Timeout(TimeSpan.FromSeconds(15))
+            .Await(TestContext.Current.CancellationToken);
+        sw.Stop();
+
+        report.Cancelled.Should().ContainSingle().Which.Should().Be("stalled");
+        report.Abandoned.Should().BeEmpty();
+        report.Clean.Should().BeFalse("a kill is a finding, not a clean quiesce");
+        sw.Elapsed.Should().BeGreaterThanOrEqualTo(Stall,
+            "the cancel is a verdict reached after a whole stall budget of no progress, never a reflex");
+        handle.CancelRequested.Should().BeTrue();
+    }
+
+    /// <summary>
+    /// A run that ignores its cancellation is ABANDONED after a second stall budget, so the
+    /// quiesce (and the teardown behind it) can proceed — and the report says so by name instead
+    /// of pretending the run finished.
+    /// </summary>
+    [Fact]
+    public async Task ARunThatIgnoresCancellation_IsAbandonedAfterASecondBudget()
+    {
+        using var tracker = new ActivityTracker();
+        var cancelRequested = 0;
+        var handle = tracker.TrackRun("blind", () => Interlocked.Exchange(ref cancelRequested, 1));
+        try
+        {
+            var sw = Stopwatch.StartNew();
+            var report = await tracker.Quiesce(Stall).FirstAsync().Timeout(TimeSpan.FromSeconds(15))
+                .Await(TestContext.Current.CancellationToken);
+            sw.Stop();
+
+            Volatile.Read(ref cancelRequested).Should().Be(1, "the run was handed its cancellation first");
+            report.Cancelled.Should().ContainSingle().Which.Should().Be("blind");
+            report.Abandoned.Should().ContainSingle().Which.Should().Be("blind");
+            sw.Elapsed.Should().BeGreaterThanOrEqualTo(Stall + Stall,
+                "one budget to cancel, another to conclude the run ignores it");
+            handle.Abandoned.Should().BeTrue();
+        }
+        finally
+        {
+            handle.Dispose();
+        }
+    }
+
+    /// <summary>The counting surface is unchanged: Track() still counts, WhenIdle still fires.</summary>
+    [Fact]
+    public async Task Track_StillCounts_AndWhenIdleFiresOnRelease()
+    {
+        using var tracker = new ActivityTracker();
+        var registration = tracker.Track();
+        var idle = tracker.WhenIdle.FirstAsync().Timeout(TimeSpan.FromSeconds(5)).Await(TestContext.Current.CancellationToken);
+        await Task.Yield();
+        idle.IsCompleted.Should().BeFalse("a tracked run holds idle open");
+        registration.Dispose();
+        await idle;
+        tracker.InFlight.Should().BeEmpty();
+    }
+}

--- a/test/MeshWeaver.Hosting.Test/IoPoolResidualNamesItsPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolResidualNamesItsPoolTest.cs
@@ -52,7 +52,7 @@ public class IoPoolResidualNamesItsPoolTest
         // A millisecond budget: the SAME code path through the SAME DrainAll, three orders of
         // magnitude less waiting. The subject is the residual naming its pool, not the 30 s value.
         using var registry = new IoPoolRegistry(
-            new IoPoolOptions { DrainTimeout = TimeSpan.FromMilliseconds(250) });
+            new IoPoolOptions { DrainTimeout = TimeSpan.FromMilliseconds(250), DrainGrace = TimeSpan.FromMilliseconds(100) });
         var pool = registry.Get(IoPoolNames.Query);
 
         // 🚨 NO HAND-WOVEN GATE AND NO BLOCKING BRIDGE. The first version of this used
@@ -110,6 +110,12 @@ public class IoPoolResidualNamesItsPoolTest
     /// cannot quietly change the teardown contract (#2578/#2616 both turn on 30 s being the
     /// window in which a leaf must unwind).
     /// </summary>
+    [Fact]
+    public void TheDefaultDrainGrace_IsTheProductionContract()
+        => new IoPoolOptions().DrainGrace.Should().Be(TimeSpan.FromSeconds(8),
+            "the grace a leaf gets to finish on its own before teardown cancels it matches the hub "
+            + "disposal stall budget, so 'no progress' means the same thing at every layer");
+
     [Fact]
     public void TheDefaultDrainBudget_IsTheProductionContract()
         => new IoPoolOptions().DrainTimeout.Should().Be(TimeSpan.FromSeconds(30),

--- a/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
+++ b/test/MeshWeaver.Hosting.Test/IoPoolTest.cs
@@ -31,6 +31,89 @@ public class IoPoolTest
 {
     private static readonly TimeSpan Timeout5 = TimeSpan.FromSeconds(5);
     private static readonly TimeSpan Timeout10 = TimeSpan.FromSeconds(10);
+    /// <summary>A drain grace for tests whose leaf can only end by cancellation.</summary>
+    private static readonly TimeSpan ShortGrace = TimeSpan.FromMilliseconds(200);
+
+    /// <summary>
+    /// 🚨 The grace: a leaf that is going to finish is NOT cancelled. The drain waits for it,
+    /// joins it, and reports nothing — the write it was doing landed. The predecessor cancelled
+    /// first and joined second, so every in-flight write at teardown was aborted the instant the
+    /// mesh decided to go down.
+    /// </summary>
+    [Fact]
+    public async Task Drain_letsALeafThatFinishesWithinTheGrace_Complete_WithoutCancellingIt()
+    {
+        using var pool = new IoPool(2, IoPool.DefaultDrainTimeout, TimeSpan.FromSeconds(3));
+        var entered = new AsyncSubject<Unit>();
+        var cancelled = false;
+        var completed = false;
+
+        pool.Invoke(async ct =>
+        {
+            entered.OnNext(Unit.Default);
+            entered.OnCompleted();
+            try { await Task.Delay(400, ct); }
+            catch (OperationCanceledException) { cancelled = true; throw; }
+            completed = true;
+            return 0;
+        }).Subscribe(_ => { }, _ => { });
+
+        await entered.Should().Within(Timeout5).Emit();
+        pool.CurrentInFlight.Should().Be(1);
+
+        var residual = pool.Drain();
+
+        residual.Should().Be(0);
+        completed.Should().BeTrue("the leaf finished on its own inside the grace");
+        cancelled.Should().BeFalse("a leaf that finishes is never cancelled — its work landed");
+        pool.LeavesCancelledAfterGrace.Should().Be(0);
+        pool.CancelledLeafSites.Should().BeEmpty();
+        pool.CurrentInFlight.Should().Be(0);
+    }
+
+    /// <summary>
+    /// The grace is a STALL bound, not a duration: every completion restarts it. Three leaves on a
+    /// pool of one run back to back for longer than one grace in total, and none is cancelled,
+    /// because each finished within one grace of the previous one.
+    /// </summary>
+    [Fact]
+    public async Task Drain_restartsTheGraceOnEveryCompletion_SoABurstOfShortLeavesIsNeverCancelled()
+    {
+        var grace = TimeSpan.FromMilliseconds(500);
+        using var pool = new IoPool(1, IoPool.DefaultDrainTimeout, grace);
+        // Completed by WHICHEVER leaf the pool admits first — the ThreadPool decides the order, not
+        // the order of subscription, so "the first leaf" is the first one running, never leaf 0.
+        var firstAdmitted = new AsyncSubject<Unit>();
+        var cancelledLeaves = 0;
+        var completedLeaves = 0;
+
+        for (var i = 0; i < 3; i++)
+        {
+            pool.Invoke(async ct =>
+            {
+                firstAdmitted.OnNext(Unit.Default);
+                firstAdmitted.OnCompleted();
+                try { await Task.Delay(300, ct); }
+                catch (OperationCanceledException) { Interlocked.Increment(ref cancelledLeaves); throw; }
+                Interlocked.Increment(ref completedLeaves);
+                return 0;
+            }).Subscribe(_ => { }, _ => { });
+        }
+
+        await firstAdmitted.Should().Within(Timeout5).Emit();
+        var sw = Stopwatch.StartNew();
+        var residual = pool.Drain();
+        sw.Stop();
+
+        residual.Should().Be(0);
+        Volatile.Read(ref completedLeaves).Should().Be(3, "every leaf finished on its own");
+        Volatile.Read(ref cancelledLeaves).Should().Be(0,
+            "the drain waited ~900 ms across three completions on a 500 ms grace — the clock restarts "
+            + "on every completion, so work that keeps finishing is never cancelled");
+        pool.LeavesCancelledAfterGrace.Should().Be(0);
+        sw.Elapsed.Should().BeGreaterThan(grace,
+            "the total wait must exceed one grace, or this test never exercised the restart");
+    }
 
     // 🚨 PIN for the endemic teardown SIGSEGV (Hosting.Monolith.Test exit=139). Root cause: a
     // MeshQuery straggler whose SUBSCRIBE (initial emission → route → CreateHub → Autofac
@@ -594,7 +677,10 @@ public class IoPoolTest
     [Fact]
     public async Task Drain_cancels_in_flight_leaves_and_joins_synchronously()
     {
-        using var pool = new IoPool(2);
+        // A leaf that can only end by cancellation is WEDGED by definition, so this test spends the
+        // grace deliberately short: the subject is the cancel + join, not the wait for a completion
+        // that will never come.
+        using var pool = new IoPool(2, IoPool.DefaultDrainTimeout, ShortGrace);
         var entered = new AsyncSubject<Unit>();
         var cancelled = false;
 
@@ -610,11 +696,15 @@ public class IoPoolTest
         await entered.Should().Within(Timeout5).Emit();
         pool.CurrentInFlight.Should().Be(1);
 
-        pool.Drain(); // cancel the leaf + JOIN — returns only once it has unwound
+        pool.Drain(); // grace expires (no progress) → cancel the leaf + JOIN — returns only once it has unwound
 
         pool.CurrentInFlight.Should().Be(0,
             "Drain joins synchronously — no spin: when it returns every in-flight leaf has unwound");
         cancelled.Should().BeTrue("Drain cancels in-flight leaves so a never-completing one actually stops");
+        pool.LeavesCancelledAfterGrace.Should().Be(1,
+            "the leaf outlived the grace with the pool making no progress — the drain must SAY it killed it");
+        string.Join(" | ", pool.CancelledLeafSites).Should().Contain(nameof(Drain_cancels_in_flight_leaves_and_joins_synchronously),
+            "the killed leaf is named by its site, so the report points at the work that did not finish");
 
         // Drain is TERMINAL (it cancels the pool token) — new work issued after Drain is
         // cancelled immediately; there is no in-flight leaf left to reference an unloading ALC.
@@ -650,7 +740,9 @@ public class IoPoolTest
     [Fact(Timeout = 30_000)]
     public async Task Drain_terminates_a_SubscribeThroughPool_leg_it_cancels()
     {
-        using var pool = new IoPool(1);
+        // Leg A holds the only permit inside a subscribe that never returns on its own — wedged by
+        // construction — so the grace is spent short; the subject is what the cancel does to leg B.
+        using var pool = new IoPool(1, IoPool.DefaultDrainTimeout, ShortGrace);
         var legAEntered = new AsyncSubject<Unit>();
         var releaseLegA = 0;
         // Whether leg A was RELEASED rather than timing out. If the wait ever timed out, leg A would

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalDeadlockDiagnosticsTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalDeadlockDiagnosticsTest.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
@@ -13,28 +15,12 @@ using Xunit;
 namespace MeshWeaver.Messaging.Hub.Test;
 
 /// <summary>
-/// #1701 — the disposal-deadlock error must carry the EVIDENCE, not just the phase.
-///
-/// <para><b>What was wrong.</b> When the watchdog fires, the log said only
-/// <c>"Hub &lt;X&gt; did not complete shutdown within 00:00:08. RunLevel=DisposeHostedHubs"</c>.
-/// <c>RunLevel=DisposeHostedHubs</c> means "a hosted child has not answered yet" and NOTHING
-/// about which child or why — and at least four different mechanisms produce it: a child whose
-/// pump is starved behind a FIFO backlog, a child frozen on one non-terminating turn, an
-/// in-flight hosted-hub construction the join is (correctly) waiting out, and a child that simply
-/// answers on its OWN watchdog — which is armed one quiesce budget LATER than the parent's and
-/// therefore structurally cannot answer before it. #1701 sat on "the compile-pool children are
-/// the prime suspects" for months because the log could not tell those apart.</para>
-///
-/// <para><b>What is pinned.</b> The error now carries the recursive disposal snapshot: the wedged
-/// hub's queue depths and — decisive — the message currently occupying its action block, by name
-/// and elapsed. Those two numbers are what discriminate "starved behind a backlog"
-/// (<c>buffer</c> large, <c>Executing</c> a few ms) from "frozen on one turn" (<c>buffer</c>
-/// small, <c>Executing</c> thousands of ms) from "waiting on a child" (this hub idle, a CHILD
-/// line carrying the backlog).</para>
-///
-/// <para>The wedge itself is the harness <c>MessageHubTest.Dispose_WhenActionBlockWedged_…</c>
-/// already uses — a genuine FIFO backlog of slow turns that the phased <c>ShutdownRequest</c>
-/// cannot jump — so this test asserts on a REAL watchdog trip, never a simulated one.</para>
+/// The stall verdict must carry the evidence that turns it into a diagnosis: the recursive
+/// disposal snapshot — queue depths, the message occupying the action block and its age, the
+/// pending callbacks (#1701). Without it the log names a phase and nothing else, and a backlog,
+/// a frozen turn, an in-flight construction and a child answering on its own budget all read
+/// alike. The verdict is also what production's red-log triage files as an issue, so it is what a
+/// reproduction has to start from.
 /// </summary>
 public class DisposalDeadlockDiagnosticsTest : HubTestBase
 {
@@ -49,47 +35,55 @@ public class DisposalDeadlockDiagnosticsTest : HubTestBase
     private record WedgeEvent;
 
     [Fact(Timeout = 120_000)]
-    public async Task DisposalDeadlock_NamesTheMessageHoldingTheActionBlock()
+    public async Task DisposalStallVerdict_NamesTheMessageHoldingTheActionBlock_WithQueueDepths()
     {
-        var wedgeTurns = 0;
-        // Same starvation recipe as MessageHubTest's zombie-hub regression: a queue backlog of
-        // slow turns, sized under the storm breaker's trip threshold (a tripped flood is dropped
-        // at ingestion and never builds a backlog) and long enough to outlast the 8 s watchdog.
+        var entered = new AsyncSubject<Unit>();
+        var release = 0;
+        // A turn that holds the block and is blind to cancellation — the shape whose verdict has
+        // to be read off the log alone, because nothing else about it ever terminates.
         var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "diagnostics"), c => c
             .WithPostingIdentity(PostingIdentity.System)
             .WithHandler<WedgeEvent>((_, d) =>
             {
-                Interlocked.Increment(ref wedgeTurns);
-                Thread.Sleep(15);
+                entered.OnNext(Unit.Default);
+                entered.OnCompleted();
+                SpinWait.SpinUntil(() => Volatile.Read(ref release) == 1, TimeSpan.FromSeconds(60));
                 return d.Processed();
             }), HostedHubCreation.Always)!;
 
-        for (var i = 0; i < 800; i++)
+        try
+        {
             victim.Post(new WedgeEvent(), o => o.WithTarget(victim.Address));
-        // Let the first turn start so the backlog is genuinely queued when Dispose posts.
-        await Task.Delay(100, TestContext.Current.CancellationToken);
+            await entered.Should().Within(10.Seconds()).Emit("the turn must hold the block before we dispose");
 
-        victim.Dispose();
-        await victim.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(30.Seconds());
+            victim.Dispose();
 
-        var deadlock = _capture.Entries.FirstOrDefault(e => e.Contains("DISPOSAL DEADLOCK DETECTED"));
-        deadlock.Should().NotBeNull(
-            "the backlog must starve the phased shutdown so the watchdog is what completes disposal "
-            + $"(wedge turns processed: {Volatile.Read(ref wedgeTurns)})");
-        Output.WriteLine(deadlock!);
+            var verdict = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+                .Where(_ => !_capture.Entries.IsEmpty)
+                .Select(_ => _capture.Entries.First())
+                .FirstAsync()
+                .Timeout(TimeSpan.FromSeconds(25))
+                .Await(TestContext.Current.CancellationToken);
+            Output.WriteLine(verdict);
 
-        deadlock!.Should().Contain("Queue(buffer=",
-            "the deadlock report must carry the wedged hub's queue depths — a backlog and a frozen "
-            + "turn produce the same RunLevel and are told apart by nothing else");
-        deadlock.Should().Contain(nameof(WedgeEvent),
-            "the deadlock report must NAME the message occupying the action block; without it the "
-            + "log identifies a phase and leaves the culprit to guesswork (#1701)");
+            verdict.Should().Contain("Queue(buffer=",
+                "the verdict must carry the wedged hub's queue depths — a backlog and a frozen "
+                + "turn produce the same RunLevel and are told apart by nothing else");
+            verdict.Should().Contain(nameof(WedgeEvent),
+                "the verdict must NAME the message occupying the action block; without it the "
+                + "log identifies a phase and leaves the culprit to guesswork (#1701)");
+            verdict.Should().Contain("Executing(",
+                "the verdict must carry how long the turn has held the block");
+            verdict.Should().Contain(victim.Address.ToString(),
+                "the verdict must name the hub, so a reproduction knows where to look");
+        }
+        finally
+        {
+            Volatile.Write(ref release, 1);
+        }
+        await victim.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(TestTimeouts.Convergence);
     }
 
-    /// <summary>
-    /// Keeps only the disposal-deadlock lines — the provider is attached to every category, so
-    /// storing everything would make the capture the test's dominant cost.
-    /// </summary>
     private sealed class DeadlockLogCapture : ILoggerProvider
     {
         public ConcurrentQueue<string> Entries { get; } = new();
@@ -100,14 +94,14 @@ public class DisposalDeadlockDiagnosticsTest : HubTestBase
         {
             public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
             public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
-
             public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
                 Exception? exception, Func<TState, Exception?, string> formatter)
             {
                 if (logLevel < LogLevel.Error)
                     return;
                 var message = formatter(state, exception);
-                if (message.Contains("DISPOSAL DEADLOCK DETECTED", StringComparison.Ordinal))
+                if (message.Contains("DISPOSAL DEADLOCK DETECTED", StringComparison.Ordinal)
+                    || message.Contains("[DISPOSE-WEDGE]", StringComparison.Ordinal))
                     sink.Enqueue(message);
             }
         }

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalRaceNackTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalRaceNackTest.cs
@@ -30,9 +30,13 @@ namespace MeshWeaver.Messaging.Hub.Test;
 /// reaching <c>LayoutAreaHost</c> in the recycle window faults with <c>HubDisposingException</c>,
 /// and the sender still hears nothing.</para>
 ///
-/// <para><b>The contract pinned here.</b> Both outcomes must NACK through the PARENT hub with the
-/// TRANSIENT <see cref="ErrorType.ShuttingDown"/> — through the parent because the disposing hub's
-/// own <c>Post</c> re-enters <c>ReportFailure</c>'s "don't post during shutdown" gate
+/// <para><b>The contract pinned here.</b> A delivery the hub accepted is never abandoned in
+/// silence. Since the teardown lets accepted work finish (Doc/Architecture/TeardownLayers) the
+/// ShutdownRequest queues FIFO behind it, so door one is now SERVED — the queued request runs and
+/// is answered before the hub goes down. Door two — a handler that cannot complete because the
+/// hub is tearing down — must still NACK through the PARENT hub with the TRANSIENT
+/// <see cref="ErrorType.ShuttingDown"/>: through the parent because the disposing hub's own
+/// <c>Post</c> re-enters <c>ReportFailure</c>'s "don't post during shutdown" gate
 /// (<c>RunLevel &gt;= DisposeHostedHubs</c>) and is dropped, which is precisely how the disposal
 /// branch's NACK went missing while looking correct in the source.</para>
 /// </summary>
@@ -51,12 +55,14 @@ public class DisposalRaceNackTest(ITestOutputHelper output) : HubTestBase(output
     private static readonly Address FaultingAddress = new("disposal-race-fault", "1");
 
     /// <summary>
-    /// Door one: the delivery reaches <c>HandleMessage</c> with the hub already past
-    /// <c>ShutDown</c>, so no handler is entered at all (<c>NOT_PROCESSED_DISPOSING</c>). It used
-    /// to be returned unchanged — abandoned without a word to the sender.
+    /// Door one: the delivery was accepted into the main queue behind a stalled turn, and the hub
+    /// is disposed before its turn runs. It used to reach <c>HandleMessage</c> after the watchdog
+    /// had forced the hub past <c>ShutDown</c> and be returned unchanged — abandoned without a
+    /// word to the sender (<c>NOT_PROCESSED_DISPOSING</c>). Now the shutdown waits its turn behind
+    /// the accepted work: the request RUNS and is ANSWERED, and only then does the hub go down.
     /// </summary>
     [Fact(Timeout = 120_000)]
-    public async Task AcceptedRequest_IsNacked_WhenTheHubGoesDownBeforeItsTurnRuns()
+    public async Task AcceptedRequest_IsServed_WhenTheHubGoesDownBeforeItsTurnRuns()
         => await RunRace(VictimAddress, faulting: false);
 
     /// <summary>
@@ -82,16 +88,17 @@ public class DisposalRaceNackTest(ITestOutputHelper output) : HubTestBase(output
         var host = GetHost();
         var victim = host.GetHostedHub(victimAddress, c => c
             .WithTypes(typeof(RaceRequest), typeof(FaultingRequest), typeof(RaceResponse), typeof(Blocker))
-            // Deliberately ignores cancellation: keeps the victim's single-threaded action block
-            // busy so the ShutdownRequest posted by Dispose() cannot be processed. Disposal then
-            // completes out of band (the disposal watchdog), which is what lets RunLevel advance
-            // while our request is still sitting in the main queue — the production interleaving,
-            // made deterministic.
-            .WithHandler<Blocker>((_, d) =>
+            // Keeps the victim's single-threaded action block busy so the ShutdownRequest posted
+            // by Dispose() queues behind it — and behind our request. The turn observes the hub's
+            // own shutdown signal as accepted work should, so nothing here depends on a watchdog:
+            // the teardown never forces a hub past a running turn (Doc/Architecture/TeardownLayers).
+            .WithHandler<Blocker>((h, d) =>
             {
                 handlerEntered.OnNext(Unit.Default);
                 handlerEntered.OnCompleted();
-                SpinWait.SpinUntil(() => Volatile.Read(ref releaseHandler) == 1, TimeSpan.FromSeconds(60));
+                SpinWait.SpinUntil(
+                    () => Volatile.Read(ref releaseHandler) == 1 || h.IsShuttingDown,
+                    TimeSpan.FromSeconds(60));
                 return d.Processed();
             })
             // Both handlers WOULD answer / would be entered, so a pass can only come from the
@@ -120,20 +127,28 @@ public class DisposalRaceNackTest(ITestOutputHelper output) : HubTestBase(output
                 .FirstAsync()
                 .Await(TestContext.Current.CancellationToken);
 
-            // 3. Dispose. The phase machine is starved behind the stall, so the disposal watchdog
-            //    tears the hub down out of band and RunLevel reaches Dead with our request still
-            //    queued. Polls the public RunLevel rather than sleeping a fixed budget.
+            // 3. Dispose. The blocker observes the shutdown and returns; the queue behind it —
+            //    our request, then the ShutdownRequest — runs in order.
             victim!.Dispose();
-            await WaitUntil(() => victim.RunLevel >= MessageHubRunLevel.ShutDown,
-                "the victim must reach ShutDown while the request is still queued");
-            Output.WriteLine($"victim RunLevel at release: {victim.RunLevel}");
 
-            // 4. Let the turn loop reach our request.
-            Volatile.Write(ref releaseHandler, 1);
+            if (!faulting)
+            {
+                // Door one: the accepted request is SERVED before the hub goes down. A force-torn
+                // hub used to abandon it (NOT_PROCESSED_DISPOSING, no NACK); a silently-dropped
+                // one would leave this task pending for the [Fact] timeout with no explanation —
+                // exactly the production symptom (an install that spins for 60 s).
+                var served = await response;
+                served.Should().NotBeNull("the request was accepted, so it runs and is answered "
+                    + "before the hub goes down — the shutdown waits its turn behind accepted work");
+                await victim.DisposalCompleted.FirstOrDefaultAsync().Await()
+                    .WaitAsync(TestTimeouts.Convergence);
+                victim.RunLevel.Should().Be(MessageHubRunLevel.Dead);
+                return;
+            }
 
-            // WITHOUT the fix this task never completes and the [Fact] timeout fires with no
-            // explanation — exactly the production symptom (an install that spins for 60 s, a
-            // page that never renders).
+            // Door two: the handler throws HubDisposingException — it cannot complete because
+            // the hub is tearing down. WITHOUT the fix this task never completes and the [Fact]
+            // timeout fires with no explanation.
             var failure = await Assert.ThrowsAsync<DeliveryFailureException>(() => response);
             failure.Failure.Should().NotBeNull();
             Output.WriteLine(
@@ -164,17 +179,5 @@ public class DisposalRaceNackTest(ITestOutputHelper output) : HubTestBase(output
         {
             Volatile.Write(ref releaseHandler, 1);
         }
-    }
-
-    private static async Task WaitUntil(Func<bool> condition, string because)
-    {
-        for (var i = 0; i < 400; i++)
-        {
-            if (condition())
-                return;
-            await Task.Delay(50);
-        }
-
-        Assert.Fail($"Timed out waiting: {because}");
     }
 }

--- a/test/MeshWeaver.Messaging.Hub.Test/DisposalStallWatchdogTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/DisposalStallWatchdogTest.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Concurrent;
 using System.Linq;
+using System.Reactive;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using System.Threading;
 using System.Threading.Tasks;
 using MeshWeaver.Fixture;
@@ -13,29 +15,26 @@ using Xunit;
 namespace MeshWeaver.Messaging.Hub.Test;
 
 /// <summary>
-/// 🚨 #1701 — <b>an owner must not out-run the mechanism that answers it.</b>
+/// The disposal STALL DETECTOR — what it reports, what it does, and what it never does.
 ///
-/// <para><b>The inversion.</b> The disposal watchdog is armed per hub, at that hub's OWN
-/// <c>Dispose()</c>, for a flat 8 s at every depth. A child's <c>Dispose()</c> is NOT called at the
+/// <para><b>#1701 — an owner must not out-run the mechanism that answers it.</b> The detector is
+/// armed per hub at that hub's own <c>Dispose()</c>. A child's <c>Dispose()</c> is NOT called at the
 /// parent's t=0 — it is called in the parent's <c>DisposeHostedHubs</c> phase, i.e. strictly AFTER
-/// the parent's quiesce budget. So a child's watchdog is armed strictly later than its parent's, for
-/// the same duration: whenever a child needs its own watchdog to produce an answer, the PARENT's
-/// always expires first. The parent then logs
-/// <c>DISPOSAL DEADLOCK DETECTED … RunLevel=DisposeHostedHubs</c> and force-tears-down a subtree that
-/// was working correctly.</para>
+/// the parent's quiesce budget. So a fixed-DURATION watchdog on the parent always expires first and
+/// reports a subtree that is merely still working. The detector therefore measures a STALL: it
+/// re-arms on every disposal-progress signal from anywhere in the subtree (each hub's
+/// <c>RunLevel</c> transitions, recursively — never a heartbeat, so quiet means genuinely stopped).</para>
 ///
-/// <para>That is exactly the defect #1317 fixed one level down — <c>DisposeHubsReactive</c>'s flat
-/// 5 s cap, removed with the note that <i>"a child's answer is guaranteed terminal, just not inside
-/// 5 s"</i> — left in place one level up, between an owner's watchdog and its children's. It is why
-/// #1701's captures show TWO <c>[FORCE-TEARDOWN]</c> pairs of which only the inner one carries
-/// information, and it is a real production cost: the 8 s force-teardown is inside the recycle window
-/// that clients must ride out (#1996 measured recovery at 10.06 s against a 7.75 s retry budget).</para>
-///
-/// <para><b>The fix is a shape, not a bound.</b> The watchdog measures a STALL instead of a
-/// DURATION: it re-arms on every disposal-progress signal from anywhere in the subtree (each hub's
-/// <c>RunLevel</c> transitions, recursively — never a heartbeat, so quiet means genuinely stopped).
-/// A healthy nested teardown keeps it re-armed however deep it is; a hub that stops moving still
-/// trips 8 s later, with the message finally TRUE.</para>
+/// <para><b>It forces nothing.</b> Its predecessor ran an out-of-band teardown from the watchdog
+/// thread while the wedged turn was still executing and then signalled Dead — a hub that reported
+/// itself disposed with its children mid-flight, and in production a pod whose "completed" teardown
+/// was still holding work. Now a stall has five verdicts (<c>MessageHub.OnDisposalStall</c>), none of
+/// which tears anything down: a pump that keeps completing turns is BUSY (Information, keep waiting);
+/// a turn holding the block with no progress is CANCELLED once, cooperatively, and reported at Error
+/// by name; a turn that ignores that is reported again, every budget, as the defect it is; a
+/// ShutDown phase that is itself blocked names the registrant; and a stall with no turn executing is
+/// in a child or a join the diagnostics name — while disposal stays honestly pending until the work
+/// returns. The bound that ENDS a wedged teardown is the caller's.</para>
 /// </summary>
 public class DisposalStallWatchdogTest : HubTestBase
 {
@@ -50,23 +49,23 @@ public class DisposalStallWatchdogTest : HubTestBase
     /// stays pending and that hub's Quiescing phase burns its whole budget.</summary>
     private record NeverAnswered;
 
-    /// <summary>Slow turns, queued deep enough to starve the phased shutdown — a genuine wedge.</summary>
+    /// <summary>A turn that parks the action block until the test releases it.</summary>
     private record WedgeEvent;
 
-    /// <summary>Per level: long enough that the whole chain outlasts the 8 s watchdog, short
+    /// <summary>Per level: long enough that the whole chain outlasts the 8 s stall window, short
     /// enough that no single gap between progress signals reaches it.</summary>
     private static readonly TimeSpan PerLevelQuiesce = TimeSpan.FromSeconds(3);
     private const int ChainDepth = 4;   // 4 × 3 s ≈ 12 s > 8 s, in 3 s steps
 
     /// <summary>
-    /// A nested teardown that legitimately takes LONGER than the watchdog window, while every
+    /// A nested teardown that legitimately takes LONGER than the stall window, while every
     /// individual step stays well inside it. Four hosted hubs, each holding one unanswered callback
     /// so its Quiescing phase runs its full 3 s budget: the chain needs ~12 s end to end, in 3 s
     /// steps, and nothing is wedged at any point.
     ///
-    /// <para><b>Non-vacuity.</b> On <c>origin/main</c> the root's fixed 8 s timer expires at t=8 —
-    /// four seconds before the subtree it is waiting on could possibly have finished — and logs
-    /// <c>DISPOSAL DEADLOCK DETECTED</c>, force-tearing down a healthy teardown mid-flight.</para>
+    /// <para><b>Non-vacuity.</b> A fixed 8 s timer on the root expires at t=8 — four seconds before
+    /// the subtree it is waiting on could possibly have finished — and reports
+    /// <c>DISPOSAL DEADLOCK DETECTED</c> about a healthy teardown.</para>
     /// </summary>
     [Fact(Timeout = 180_000)]
     public async Task NestedTeardownSlowerThanTheWindow_DoesNotTripTheWatchdog()
@@ -79,71 +78,202 @@ public class DisposalStallWatchdogTest : HubTestBase
         await root.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(120.Seconds());
         var elapsed = DateTime.UtcNow - started;
 
-        // The premise of the test, asserted rather than assumed: the teardown really did outlast
-        // the watchdog window. If it did not, "no deadlock was logged" would prove nothing.
         elapsed.Should().BeGreaterThan(TimeSpan.FromSeconds(9),
-            "the chain must genuinely take longer than the 8 s watchdog window, or this test is vacuous "
+            "the chain must genuinely take longer than the 8 s stall window, or this test is vacuous "
             + $"(actual {elapsed.TotalSeconds:F1}s over {ChainDepth} levels of {PerLevelQuiesce.TotalSeconds}s)");
 
         foreach (var entry in capture.Entries)
             Output.WriteLine(entry);
-
         capture.Entries.Should().BeEmpty(
             "nothing was wedged — every level advanced through its phases within 3 s of the last. "
-            + "A watchdog that fires here is measuring DURATION, and it out-runs the very mechanism "
-            + "that answers it: a child's watchdog is armed one quiesce budget later than its "
+            + "A detector that fires here is measuring DURATION, and it out-runs the very mechanism "
+            + "that answers it: a child's detector is armed one quiesce budget later than its "
             + $"parent's, for the same 8 s. Elapsed {elapsed.TotalSeconds:F1}s.");
     }
 
     /// <summary>
-    /// The safety half: a hub that genuinely stops moving must STILL trip. Re-arming on progress
-    /// must not be a way of switching the backstop off — a stall watchdog that never fires is just
-    /// a deleted watchdog.
-    ///
-    /// <para>Same wedge recipe as <c>DisposalDeadlockDiagnosticsTest</c>: a FIFO backlog of slow
-    /// turns that the phased <c>ShutdownRequest</c> cannot jump. The hub emits no phase transition
-    /// while starved, so there is no progress to re-arm on — and the report still names the message
-    /// holding the action block.</para>
+    /// A turn that holds the block but OBSERVES its cancellation token. After one stall budget the
+    /// detector reports it at Error — naming the message and the hub — and hands it the cancel; the
+    /// handler returns, and disposal completes through the ordinary phases. Nothing is forced.
     /// </summary>
     [Fact(Timeout = 120_000)]
-    public async Task GenuinelyWedgedHub_StillTripsTheWatchdog()
+    public async Task ACooperativeWedgedTurn_IsReportedAndCancelled_ThenDisposalCompletes()
     {
-        var wedgeTurns = 0;
-        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "stall-watchdog"), c => c
+        var entered = new AsyncSubject<Unit>();
+        var release = 0;
+        var cancellationObserved = 0;
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "stall-cooperative"), c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithHandler<WedgeEvent>((_, d, ct) =>
+            {
+                entered.OnNext(Unit.Default);
+                entered.OnCompleted();
+                SpinWait.SpinUntil(
+                    () => Volatile.Read(ref release) == 1 || ct.IsCancellationRequested,
+                    TimeSpan.FromSeconds(60));
+                if (ct.IsCancellationRequested)
+                    Interlocked.Exchange(ref cancellationObserved, 1);
+                return Task.FromResult(d.Processed());
+            }), HostedHubCreation.Always)!;
+
+        try
+        {
+            victim.Post(new WedgeEvent(), o => o.WithTarget(victim.Address));
+            await entered.Should().Within(10.Seconds()).Emit("the turn must hold the block before we dispose");
+
+            victim.Dispose();
+
+            var verdict = await FirstVerdict(TimeSpan.FromSeconds(25));
+            Output.WriteLine(verdict);
+            verdict.Should().Contain("[DISPOSE-WEDGE]",
+                "the first verdict on a turn holding the block is the cooperative cancel, reported at Error");
+            verdict.Should().Contain(nameof(WedgeEvent),
+                "the report must NAME the message occupying the action block (#1701's diagnostic half)");
+            verdict.Should().Contain("Queue(buffer=",
+                "the report carries the recursive disposal snapshot — queue depths, the executing turn, "
+                + "pending callbacks — so a reader can reproduce it from the log alone");
+
+            await victim.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(TestTimeouts.Convergence);
+            Volatile.Read(ref cancellationObserved).Should().Be(1,
+                "the turn returned because it observed the cancellation the detector handed it");
+            victim.RunLevel.Should().Be(MessageHubRunLevel.Dead);
+        }
+        finally
+        {
+            Volatile.Write(ref release, 1);
+        }
+    }
+
+    /// <summary>
+    /// A turn that ignores its cancellation. The detector cancels once (Error), then reports the
+    /// turn again a budget later as one that ignores cancellation (Error, <c>DISPOSAL DEADLOCK
+    /// DETECTED</c>) — and disposal stays PENDING the whole time: nothing is torn down around a
+    /// running turn, and <c>DisposalCompleted</c> is not signalled until the turn actually returns.
+    /// Releasing the turn then completes disposal through the ordinary phases, children and
+    /// disposables included.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ATurnThatIgnoresCancellation_IsReportedEveryBudget_AndDisposalWaitsForIt()
+    {
+        var entered = new AsyncSubject<Unit>();
+        var childDisposed = new AsyncSubject<Unit>();
+        var ownDisposed = new AsyncSubject<Unit>();
+        var release = 0;
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "stall-uncooperative"), c => c
             .WithPostingIdentity(PostingIdentity.System)
             .WithHandler<WedgeEvent>((_, d) =>
             {
-                Interlocked.Increment(ref wedgeTurns);
+                entered.OnNext(Unit.Default);
+                entered.OnCompleted();
+                // Deliberately blind to cancellation: the shape of a handler that blocks on
+                // something it never checks.
+                SpinWait.SpinUntil(() => Volatile.Read(ref release) == 1, TimeSpan.FromSeconds(90));
+                return d.Processed();
+            }), HostedHubCreation.Always)!;
+        victim.RegisterForDisposal(System.Reactive.Disposables.Disposable.Create(() =>
+        {
+            ownDisposed.OnNext(Unit.Default);
+            ownDisposed.OnCompleted();
+        }));
+        var child = victim.GetHostedHub(new Address("child", "1"),
+            cc => cc.WithPostingIdentity(PostingIdentity.System), HostedHubCreation.Always)!;
+        child.RegisterForDisposal(System.Reactive.Disposables.Disposable.Create(() =>
+        {
+            childDisposed.OnNext(Unit.Default);
+            childDisposed.OnCompleted();
+        }));
+
+        try
+        {
+            victim.Post(new WedgeEvent(), o => o.WithTarget(victim.Address));
+            await entered.Should().Within(10.Seconds()).Emit("the turn must hold the block before we dispose");
+
+            var completed = victim.DisposalCompleted.FirstOrDefaultAsync().Await();
+            victim.Dispose();
+
+            // Two budgets of no progress: the cancel verdict, then the ignores-cancellation verdict.
+            var second = await NthVerdict(2, TimeSpan.FromSeconds(40));
+            foreach (var entry in capture.Entries)
+                Output.WriteLine(entry);
+            capture.Entries.First().Should().Contain("[DISPOSE-WEDGE]");
+            second.Should().Contain("DISPOSAL DEADLOCK DETECTED",
+                "a turn that ignores the cancel is reported again, every budget, as the defect it is");
+            second.Should().Contain("ignores cancellation");
+            second.Should().Contain(nameof(WedgeEvent));
+
+            // Sanctioned negative wait: the finding IS that disposal has NOT completed — nothing was
+            // torn down around the running turn, so there is no positive signal to filter for.
+            var winner = await Task.WhenAny(completed, Task.Delay(TimeSpan.FromSeconds(2)));
+            winner.Should().NotBe(completed,
+                "disposal must stay PENDING while the turn runs: a hub that has not finished must not "
+                + "say it has — the predecessor force-tore the subtree down here and signalled Dead");
+            ownDisposed.IsCompleted.Should().BeFalse("nothing is torn down around a running turn");
+            childDisposed.IsCompleted.Should().BeFalse("nothing is torn down around a running turn");
+
+            // The work finishes; the ordinary phases run to the end.
+            Volatile.Write(ref release, 1);
+            await completed.WaitAsync(TestTimeouts.Convergence);
+            await ownDisposed.Should().Within(5.Seconds()).Emit("ShutDown disposes the hub's own registrations");
+            await childDisposed.Should().Within(5.Seconds()).Emit("DisposeHostedHubs disposes the children");
+            victim.RunLevel.Should().Be(MessageHubRunLevel.Dead);
+        }
+        finally
+        {
+            Volatile.Write(ref release, 1);
+        }
+    }
+
+    /// <summary>
+    /// A backlog of accepted work ahead of the ShutdownRequest is not a wedge: turns keep
+    /// completing, the detector reads the pump as busy, reports nothing at Error, and the
+    /// shutdown proceeds once the backlog is through. Pinned here beside the wedge cases because
+    /// the two produce the SAME RunLevel and the same queue depths — only the completed-turn count
+    /// tells them apart, and a detector that cannot tell them apart force-tore the busy case down.
+    /// </summary>
+    [Fact(Timeout = 120_000)]
+    public async Task ABacklogOfAcceptedWork_IsBusyNotWedged_AndDrains()
+    {
+        var turns = 0;
+        var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "stall-busy"), c => c
+            .WithPostingIdentity(PostingIdentity.System)
+            .WithHandler<WedgeEvent>((_, d) =>
+            {
+                Interlocked.Increment(ref turns);
                 Thread.Sleep(15);
                 return d.Processed();
             }), HostedHubCreation.Always)!;
-
         for (var i = 0; i < 800; i++)
             victim.Post(new WedgeEvent(), o => o.WithTarget(victim.Address));
         await Task.Delay(100, TestContext.Current.CancellationToken);
 
+        var started = DateTime.UtcNow;
         victim.Dispose();
         await victim.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(60.Seconds());
+        var elapsed = DateTime.UtcNow - started;
 
-        var deadlock = capture.Entries.FirstOrDefault();
-        deadlock.Should().NotBeNull(
-            "a hub whose pump is starved emits no phase transition, so there is no progress to re-arm "
-            + "on and the watchdog must still fire "
-            + $"(wedge turns processed: {Volatile.Read(ref wedgeTurns)})");
-        Output.WriteLine(deadlock!);
-
-        deadlock!.Should().Contain("made no teardown progress",
-            "the message must now say what is actually true — no progress — rather than conflating "
-            + "'slow but progressing' with 'wedged'");
-        deadlock.Should().Contain(nameof(WedgeEvent),
-            "the report must still NAME the message occupying the action block (#1701's diagnostic half)");
+        elapsed.Should().BeGreaterThan(TimeSpan.FromSeconds(7),
+            $"the backlog must outlast the stall window so the detector provably looked at this hub "
+            + $"(turns processed: {Volatile.Read(ref turns)})");
+        Volatile.Read(ref turns).Should().Be(800, "every accepted turn ran before the shutdown");
+        foreach (var entry in capture.Entries)
+            Output.WriteLine(entry);
+        capture.Entries.Should().BeEmpty(
+            "a pump that keeps completing turns is BUSY, not wedged — nothing to report at Error");
     }
 
-    /// <summary>
-    /// Builds <see cref="ChainDepth"/> nested hosted hubs, each with a long Quiescing budget it
-    /// will actually burn: one unanswered self-request per hub keeps its <c>responseSubjects</c>
-    /// non-empty, so the Quiescing drain runs to its deadline instead of completing early.
-    /// </summary>
+    private async Task<string> FirstVerdict(TimeSpan within) => await NthVerdict(1, within);
+
+    private async Task<string> NthVerdict(int n, TimeSpan within)
+    {
+        var verdict = await Observable.Interval(TimeSpan.FromMilliseconds(100)).StartWith(0L)
+            .Where(_ => capture.Entries.Count >= n)
+            .Select(_ => capture.Entries.ElementAt(n - 1))
+            .FirstAsync()
+            .Timeout(within)
+            .Await(TestContext.Current.CancellationToken);
+        return verdict;
+    }
+
     private MessageHub[] BuildQuiesceChain()
     {
         var chain = new MessageHub[ChainDepth];
@@ -154,20 +284,16 @@ public class DisposalStallWatchdogTest : HubTestBase
                 new Address("chain", $"level{level}"),
                 c => c.WithPostingIdentity(PostingIdentity.System)
                       .WithQuiesceTimeout(PerLevelQuiesce)
-                      // Handled, never answered: the observing callback below stays pending.
                       .WithHandler<NeverAnswered>((_, d) => d.Processed()),
                 HostedHubCreation.Always)!;
-
-            // One pending callback is enough — Quiescing polls for responseSubjects to EMPTY.
             hub.Observe(new NeverAnswered(), o => o.WithTarget(hub.Address)).Subscribe(_ => { }, _ => { });
-
             chain[level] = hub;
             parent = hub;
         }
         return chain;
     }
 
-    /// <summary>Keeps only the disposal-deadlock lines (the provider sees every category).</summary>
+    /// <summary>Captures every Error-level stall verdict — both the cancel and the deadlock shapes.</summary>
     private sealed class DeadlockLogCapture : ILoggerProvider
     {
         public ConcurrentQueue<string> Entries { get; } = new();
@@ -178,14 +304,14 @@ public class DisposalStallWatchdogTest : HubTestBase
         {
             public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
             public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Error;
-
             public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
                 Exception? exception, Func<TState, Exception?, string> formatter)
             {
                 if (logLevel < LogLevel.Error)
                     return;
                 var message = formatter(state, exception);
-                if (message.Contains("DISPOSAL DEADLOCK DETECTED", StringComparison.Ordinal))
+                if (message.Contains("DISPOSAL DEADLOCK DETECTED", StringComparison.Ordinal)
+                    || message.Contains("[DISPOSE-WEDGE]", StringComparison.Ordinal))
                     sink.Enqueue(message);
             }
         }

--- a/test/MeshWeaver.Messaging.Hub.Test/HostedHubDisposalJoinTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/HostedHubDisposalJoinTest.cs
@@ -13,11 +13,11 @@ namespace MeshWeaver.Messaging.Hub.Test;
 /// #1317 — <c>HostedHubsCollection</c> must JOIN its children's disposal, not pre-empt it.
 ///
 /// <para><b>The inversion.</b> The collection capped its wait at a flat 5 s literal. What it was
-/// waiting on is bounded elsewhere and bounded LONGER: every hosted hub is a <c>MessageHub</c>, and
-/// <c>MessageHub.Dispose</c> arms a <c>DisposalWatchdogTimeout</c> (8 s) that force-tears-down and
-/// signals <c>DisposalCompleted</c> — so a child's answer is guaranteed terminal, just not within
-/// 5 s. The cap therefore fired 3 s BEFORE the mechanism that would have produced a clean answer,
-/// in exactly the wedged case it was written for. Nesting makes it worse without any wedge at all:
+/// waiting on answers from its own terminal state: every hosted hub is a <c>MessageHub</c>, and it
+/// signals <c>DisposalCompleted</c> as the last act of its own phased teardown once the work it
+/// accepted has drained — so a child's answer is guaranteed to come, just not within 5 s. The cap
+/// therefore fired BEFORE the mechanism that would have produced a clean answer, in exactly the
+/// busy case it was written for. Nesting makes it worse without any wedge at all:
 /// a child's own disposal is quiesce (2 s default) plus its own hosted-subtree wait, so a
 /// legitimately busy two-level tree exceeds a flat 5 s while every individual step is inside its
 /// own budget.</para>
@@ -36,10 +36,10 @@ namespace MeshWeaver.Messaging.Hub.Test;
 public class HostedHubDisposalJoinTest(ITestOutputHelper output) : HubTestBase(output)
 {
     /// <summary>
-    /// Sits between the removed 5 s cap and <c>MessageHub</c>'s 8 s disposal watchdog — the only
+    /// Sits between the removed 5 s cap and <c>MessageHub</c>'s 8 s disposal stall budget — the only
     /// band in which the two bounds disagree, which is precisely the defect's footprint. Long
     /// enough that the cap has certainly fired (it is a fixed timer, so this margin does not
-    /// shrink under CI load), short enough that the owner's watchdog has certainly not.
+    /// shrink under CI load), short enough that the owner's stall detector has certainly not looked.
     /// </summary>
     private static readonly TimeSpan PastTheOldCap = TimeSpan.FromSeconds(6.5);
 
@@ -88,9 +88,9 @@ public class HostedHubDisposalJoinTest(ITestOutputHelper output) : HubTestBase(o
             winner.Should().NotBe(disposalCompleted,
                 "the owner declared its hosted hubs disposed while a construction it started was "
                 + "still running — so it went on to tear down the container underneath that Build. "
-                + "A join must not out-run the answers it is joining: the child's completion is "
-                + "already guaranteed terminal by MessageHub's own disposal watchdog, and a second, "
-                + "SHORTER budget layered above it can only ever pre-empt that guarantee");
+                + "A join must not out-run the answers it is joining: the child's completion comes "
+                + "from its own teardown once the work it started has finished, and a second, "
+                + "SHORTER budget layered above it can only ever pre-empt that");
 
             Volatile.Write(ref releaseConstruction, 1);
 

--- a/test/MeshWeaver.Messaging.Hub.Test/MessageHubTest.cs
+++ b/test/MeshWeaver.Messaging.Hub.Test/MessageHubTest.cs
@@ -181,25 +181,27 @@ public class MessageHubTest(ITestOutputHelper output) : HubTestBase(output)
     record WedgeEvent;
 
     /// <summary>
-    /// Regression for the ZOMBIE-HUB leak (2026-07-01, the dead-circuit portal-hub storm).
-    /// When the action block is wedged (here: a handler blocking on an event that ignores
-    /// cancellation — in prod: a ShutdownRequest starved behind a DataChangedEvent flood),
-    /// the phased Quiescing → DisposeHostedHubs → ShutDown machine never runs. The disposal
-    /// watchdog used to merely SIGNAL completion — the caller unblocked, but every child
-    /// leaked: hosted sync-stream hubs kept heartbeating and fanning out stream traffic
-    /// forever (7k zombie sync hubs at ~1.2 cores on the e2e portal). The watchdog must run
-    /// the REAL teardown: hosted hubs disposed, registered disposables disposed, message
-    /// service stopped.
+    /// The BACKLOG case: accepted work queued ahead of the ShutdownRequest is DRAINED, never
+    /// discarded and never jumped. The phased Quiescing → DisposeHostedHubs → ShutDown machine
+    /// waits its turn behind every message the hub had already accepted; the stall detector reads
+    /// the pump as busy (turns keep completing) and reports nothing; and disposal completes by the
+    /// ordinary phases once the backlog is through — hosted hubs and registered disposables torn
+    /// down by ShutDown, not out of band.
+    ///
+    /// <para>History: the 2026-07-01 zombie-hub storm was a watchdog that merely SIGNALLED
+    /// completion and leaked every child; its successor force-tore the hub down at 8 s while
+    /// hundreds of accepted turns were still queued — the work thrown away, and a hub reported
+    /// disposed while its subtree was mid-flight. Neither is acceptable: a queue of accepted work
+    /// is not a wedge, and a hub that has not finished must not say it has.</para>
     /// </summary>
-    [Fact]
-    public async Task Dispose_WhenActionBlockWedged_WatchdogTearsDownChildrenAndDisposables()
+    [Fact(Timeout = 60_000)]
+    public async Task Dispose_WhenAcceptedWorkIsQueued_DrainsItBeforeShuttingDown()
     {
-        // Starve the block the way prod does: a QUEUE BACKLOG of slow messages the
-        // ShutdownRequest cannot jump. CancelExecution only cancels the IN-FLIGHT handler —
-        // it does not clear the queue. Sized under the storm breaker's trip threshold
-        // (2000 identical/1s window — a tripped flood is DROPPED at ingestion and never
-        // builds a backlog): 800 turns × 15ms ≈ 12s of queue ahead of the phased
-        // Quiescing request, well past the 8s watchdog.
+        // A QUEUE BACKLOG of slow messages ahead of the ShutdownRequest, sized under the storm
+        // breaker's trip threshold (2000 identical/1s window — a tripped flood is DROPPED at
+        // ingestion and never builds a backlog): 800 turns × 15ms ≈ 12s of queue ahead of the
+        // phased Quiescing request, well past the 8s stall window — so the detector provably
+        // LOOKS at this hub and must read it as busy, not wedged.
         var wedgeTurns = 0;
         var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "wedged"), c => c
             // Plumbing fixture with no user → posts as infrastructure (System), per the
@@ -225,24 +227,29 @@ public class MessageHubTest(ITestOutputHelper output) : HubTestBase(output)
         var disposeSw = System.Diagnostics.Stopwatch.StartNew();
         victim.Dispose();
 
-        // The phased path is starved; only the watchdog (8s) can complete this.
-        await victim.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(20.Seconds());
+        // The phased path queues behind the backlog; disposal completes once it has drained.
+        await victim.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(45.Seconds());
         disposeSw.Stop();
 
-        // Sanity: this repro must actually exercise the starved path, not a fast phased dispose.
+        // Sanity: the backlog must genuinely outlast the stall window, or the detector never looked.
         disposeSw.Elapsed.Should().BeGreaterThan(TimeSpan.FromSeconds(7),
-            $"the backlog must starve the phased shutdown so the watchdog is what completes disposal "
-            + $"(wedge turns processed: {Volatile.Read(ref wedgeTurns)})");
+            $"the backlog must outlast the 8 s stall window so the detector provably read this hub "
+            + $"as busy rather than wedged (wedge turns processed: {Volatile.Read(ref wedgeTurns)})");
 
-        // The watchdog must have TORN DOWN, not just signalled:
+        // Every accepted turn RAN — the shutdown waited its turn behind them.
+        Volatile.Read(ref wedgeTurns).Should().Be(800,
+            "accepted work is drained before the hub shuts down; a force-teardown at 8 s used to "
+            + "throw the rest of the queue away");
+
+        // …and the ordinary phases did the teardown:
         registeredDisposableDisposed.Should().BeTrue(
-            "the watchdog force-teardown must dispose registered disposables (heartbeats, sync streams) — " +
-            "signalling without teardown leaks them forever (the zombie portal-hub storm)");
+            "the ShutDown phase disposes registered disposables (heartbeats, sync streams) — " +
+            "leaving them leaks them forever (the zombie portal-hub storm)");
         child!.IsDisposing.Should().BeTrue(
-            "the watchdog force-teardown must dispose hosted child hubs — leaked children keep " +
+            "the DisposeHostedHubs phase disposes hosted child hubs — leaked children keep " +
             "heartbeating/fanning out stream traffic forever");
         victim.RunLevel.Should().Be(MessageHubRunLevel.Dead,
-            "a force-torn hub must be terminally dead, not a Started zombie");
+            "a hub whose teardown completed is terminally dead, not a Started zombie");
     }
 
     record StormFloodEvent(int Seq);
@@ -394,39 +401,45 @@ public class MessageHubTest(ITestOutputHelper output) : HubTestBase(output)
     }
 
     /// <summary>
-    /// The portal-wedge root cause (memory <c>wedge-reproduced-local-k3s-e2e-portal</c>): the reactive
-    /// disposal state machine (Quiescing → DisposeHostedHubs → ShutDown) runs <c>DisposeImpl</c> and
-    /// <c>hostedHubs.Dispose()</c> ONLY in its final phases. If the action block is wedged, the posted
-    /// <c>ShutdownRequest</c> is starved (RunLevel stays Started), the state machine never advances, and
-    /// the 8s watchdog used to only signal completion — unblocking the caller while LEAKING every hosted
-    /// sync-stream hub and its <c>Observable.Interval</c> keep-alive heartbeat. Those orphaned heartbeats
-    /// accumulate run-over-run until the portal pegs CPU and <c>/healthz</c> times out. This pins the fix:
-    /// when the watchdog fires it must actually tear the children + subscriptions down. RED before the
-    /// fix (both probes leak → time out); GREEN after.
+    /// The WEDGED-TURN case (memory <c>wedge-reproduced-local-k3s-e2e-portal</c>): a handler holds
+    /// the single turn thread, so the posted <c>ShutdownRequest</c> cannot run and the phased
+    /// Quiescing → DisposeHostedHubs → ShutDown machine cannot advance. The stall detector notices
+    /// after one 8 s budget of no progress, hands the turn its cancellation token — the one
+    /// cooperative kill the actor model has — and a handler that observes it returns; the phases
+    /// then run and tear the children and registered disposables down in the ordinary order.
+    ///
+    /// <para>What is NOT done: nothing is torn down around the running turn. The 2026-07-01
+    /// storm was a watchdog that only signalled (every hosted sync-stream hub and its keep-alive
+    /// heartbeat leaked, ~1.2 cores forever); its successor force-tore the hub down from the
+    /// watchdog thread while the turn still ran. Both lied about completion. Now the hub either
+    /// finishes or says it cannot — see <c>DisposalStallWatchdogTest</c> for the non-cooperative
+    /// half, where disposal stays pending and the turn is reported by name.</para>
     /// </summary>
-    // Companion to Dispose_WhenActionBlockWedged_… (which starves shutdown via a message-FLOOD
-    // backlog): this wedges the turn thread with a BLOCKED handler. Both wedge modes are named in
-    // ForceTeardownAfterWatchdog's contract, so both stay covered after the main-merge de-dup.
-    [Fact]
-    public async Task Dispose_WhenHandlerBlocksTheTurn_WatchdogTearsDownChildrenAndDisposables()
+    [Fact(Timeout = 60_000)]
+    public async Task Dispose_WhenAHandlerHoldsTheTurn_TheStallDetectorCancelsItAndThePhasesFinish()
     {
         // 🚨 No hand-woven gate — see ManyDistinctMissingSubscribes_DoNotWedge above for why the
         // two directions get different shapes: producer → test is an AsyncSubject, test → parked
-        // turn is a volatile flag polled under a bounded SpinUntil.
+        // turn is a volatile flag polled under a bounded SpinUntil. The parked turn ALSO polls its
+        // cancellation token: that is what makes it a cooperative handler.
         var blockHandlerEntered = new AsyncSubject<Unit>();
         var ownDisposed = new AsyncSubject<Unit>();
         var childDisposed = new AsyncSubject<Unit>();
         var releaseBlock = 0;
-
+        var cancellationObserved = 0;
         var victim = (MessageHub)Mesh.GetHostedHub(new Address("victim", "wedged-dispose"), c => c
             .WithPostingIdentity(PostingIdentity.System)
-            .WithHandler<BlockTurnRequest>((_, d) =>
+            .WithHandler<BlockTurnRequest>((_, d, ct) =>
             {
                 blockHandlerEntered.OnNext(Unit.Default);
                 blockHandlerEntered.OnCompleted();
-                // hold the single turn thread → starve ShutdownRequest
-                SpinWait.SpinUntil(() => Volatile.Read(ref releaseBlock) == 1, TimeSpan.FromSeconds(30));
-                return d.Processed();
+                // hold the single turn thread → the ShutdownRequest queues behind this turn
+                SpinWait.SpinUntil(
+                    () => Volatile.Read(ref releaseBlock) == 1 || ct.IsCancellationRequested,
+                    TimeSpan.FromSeconds(30));
+                if (ct.IsCancellationRequested)
+                    Interlocked.Exchange(ref cancellationObserved, 1);
+                return Task.FromResult(d.Processed());
             }));
 
         // Stands in for a sync-stream subscription that DisposeImpl tears down.
@@ -446,19 +459,29 @@ public class MessageHubTest(ITestOutputHelper output) : HubTestBase(output)
 
         try
         {
-            // 1) Wedge the victim's action block so its ShutdownRequest can never get a turn.
+            // 1) Park the victim's action block so its ShutdownRequest queues behind the turn.
             victim.Post(new BlockTurnRequest(), o => o.WithTarget(victim.Address));
             await blockHandlerEntered.Should().Within(10.Seconds())
                 .Emit("the block handler must occupy the turn thread before we dispose");
-
-            // 2) Dispose — the state machine is starved; only the 8s watchdog can complete it.
+            // 2) Dispose — the phased machine cannot advance until the turn returns.
+            var disposeSw = System.Diagnostics.Stopwatch.StartNew();
             victim.Dispose();
+            // 3) After one stall budget the detector cancels the turn; the handler returns; the
+            //    ordinary phases run: DisposeImpl (own disposables) and DisposeHostedHubs (children).
+            await ownDisposed.Should().Within(25.Seconds())
+                .Emit("once the cancelled turn returns, the ShutDown phase runs DisposeImpl — the hub's own subscriptions must not leak");
+            await childDisposed.Should().Within(25.Seconds())
+                .Emit("once the cancelled turn returns, the DisposeHostedHubs phase disposes hosted hubs — their keep-alive heartbeats must not leak");
+            await victim.DisposalCompleted.FirstOrDefaultAsync().Await().WaitAsync(25.Seconds());
+            disposeSw.Stop();
 
-            // 3) The watchdog (8s) must force the real teardown, not just signal completion.
-            await ownDisposed.Should().Within(20.Seconds())
-                .Emit("the watchdog must run DisposeImpl so the hub's own subscriptions don't leak when disposal wedges");
-            await childDisposed.Should().Within(20.Seconds())
-                .Emit("the watchdog must dispose hosted hubs so their keep-alive heartbeats don't leak forever");
+            Volatile.Read(ref cancellationObserved).Should().Be(1,
+                "the turn ended because the stall detector handed it its cancellation token — not because "
+                + "the test released it, and not because anything was torn down around it");
+            disposeSw.Elapsed.Should().BeGreaterThan(TimeSpan.FromSeconds(7),
+                "the cancel is a stall VERDICT reached after a whole budget of no progress, never a reflex "
+                + "at Dispose(): a turn that returns on its own is never cancelled");
+            victim.RunLevel.Should().Be(MessageHubRunLevel.Dead);
         }
         finally
         {


### PR DESCRIPTION
## Why

The red runs in the last 130 (`MeshWeaver Build and Test`) split into two families. Five were the `AGENTS.md shared rule blocks` gate — a satellite added the `rest-not-graphql` block before core's manifest declared it — cured by #3287. The rest are teardown-shaped flakes: `NackReachesTheWaiterDuringTeardownTest` (run 33847949620, docs-only PR #3286), `PodHubTransportTest.CrossSiloNack…` (merge-queue run for the docs-only #3285), and their earlier sibling `LateNackReenqueueTest`.

The mechanism, from the passing trace beside the failing one: the owner's merge turn is parked, the sync hub cannot process its `ShutdownRequest`, and after **8 s the disposal watchdog force-tore the sync hub down from its timer thread**; only then could the owner reach `ShutDown` and mint the verdict the waiter was armed for — 3 ms later locally, but the assertion window was 10 s, i.e. "the watchdog plus two seconds", and a loaded CI shard lost those two seconds.

Production shows the same instrument doing worse: Loki on `memex-cloud` (2026-08-29 → 09-03) has `DISPOSAL DEADLOCK DETECTED: Hub sync/… RunLevel=ShutDown` → `[FORCE-TEARDOWN] … out-of-band teardown complete after 22706ms` dozens of times per shutdown, on sync hubs and the node hubs above them, and once on a pod that was not shutting down. A hub that reports itself disposed while its work is still running is exactly "disposal seems to be keeping something".

Maintainer directives this implements (2026-09-04): let accepted work — activities, pooled I/O, handler turns — finish its job; never cancel on entry; **no forced teardown, not in prod and not in tests**; detect a wedge as *no progress for a budget*, cancel it once cooperatively, and log every such kill or discard at **Error** with enough detail to reproduce, so the red-log triage files it as an issue (prod only; tests just log).

## What changes

**Hub (`MessageHub` / `MessageService`)**
- `Dispose()` no longer calls `CancelExecution()`; the `ShutdownRequest` queues FIFO behind accepted work and the pump drains it.
- The watchdog is now a **stall detector** (`OnDisposalStall`): re-armed on every subtree `RunLevel` transition (unchanged), fires every 8 s of no progress, and reaches one of five verdicts — *busy* (turns completing, Information), *wedged turn* (cancel once, **Error** 7311 with the turn, its age, queue depth and the recursive snapshot), *ignores cancellation* (**Error** 7312 every budget, disposal stays pending), *ShutDown phase blocked* (**Error** 7314 — a registrant blocking inside `DisposeImpl`; the exact shape Loki showed), *stalled below* (**Error** 7313). `ForceTeardownAfterWatchdog` is deleted.
- Shutdown-time discards are **Errors** with event ids: a delivery still deferred behind an init gate (7301) and turns still queued when the pump stops (7302), with message type/id/sender/gates/run level.

**I/O pools (`IoPool` / `IoPoolRegistry` / `IoPoolOptions`)**
- `Drain()` gives a **grace before it cancels**: waits on the admission count with `DrainGrace` (8 s) restarted on every completion, so leaves that finish are never cancelled and a burst drains in as many completions; only what outlives a whole grace is named (`CancelledLeafSites`) and cancelled, then joined under the drain budget as before. New `DrainAll(out residual, out cancelledAfterGrace)`; the old overloads stay.

**Activities (`ActivityTracker` / `ActivityRunner`)**
- `TrackRun(label, cancel)` + `ActivityRunHandle.Progress()` (called from every `ctx.Log` line). `Quiesce(stallBudget)` waits for progressing runs, cancels a run with no progress for one budget (**Error** 7321), abandons one that ignores it a budget later (**Error** 7322). `Track()` is unchanged.

**Orchestration**
- `MeshTeardownExtensions.TeardownAsync` uses `Quiesce`; `TeardownReport` gains `CancelledActivities`, `AbandonedActivities`, `CancelledIoLeaves`, `CancelledIoByPool`, `WorkWasKilled` (additive; `Clean` unchanged). The 30 s hang bound in `TeardownAsync` and `MeshTeardownHostedService` now carries the recursive disposal snapshot, at **Error**.
- `MonolithMeshTestBase` runs the same phase 0, traces `DISPOSE_WEDGED_WORK`, and does **not** fail the class on killed work (maintainer: in tests, log).

**Tests** — the force-dependent tests are rewritten to the new contract: a cooperative wedged turn is cancelled at the stall budget and the phases finish; a non-cooperative one keeps disposal pending, is reported every budget, and completes when released with nothing forced; a backlog is busy, not wedged, and all 800 accepted turns run; the pool grace lets a finishing leaf finish and restarts per completion; the activity quiesce's four verdicts. `NackReachesTheWaiterDuringTeardownTest` and `LateNackReenqueueTest` park a turn that **observes the owner's shutdown** and assert the verdict inside 6 s with no stall verdict logged. `DisposalRaceNackTest` door one now asserts the accepted request is *served* before the hub goes down.

**Docs** — new `Doc/Architecture/TeardownLayers` (policy, verdict table, the Loki findings incl. the 28-minute preStop/live-circuit cause of the blocked rolls, which is a scheduling matter, not disposal); `HubDisposalModel`, `MeshLifecycle`, `ControlledIoPooling`, `DebuggingDisposalAndLeaks` updated; What's New entry (Fix).

## Verification

Built every touched project with `-c Release -warnaserror`. Ran locally in Release: the teardown classes in `MeshWeaver.Messaging.Hub.Test`, `MeshWeaver.Hosting.Test`, `MeshWeaver.Graph.Test`; then the full projects `Messaging.Hub.Test`, `Hosting.Test`, `Graph.Test`, `Data.Test`, `Layout.Test`, `Documentation.Test` (link integrity) and `Hosting.Orleans.Test` under `DOTNET_PROCESSOR_COUNT=4` — results in the PR conversation below. `NackReachesTheWaiterDuringTeardownTest` now completes in well under the 8 s stall budget and logs no stall verdict.

Pairs-with: none — no public type or member is removed; every surface change is additive. The two Plugins twins of the parked-turn tests (`MeshWeaver.Hosting.Monolith.Test/{NackReachesTheWaiterDuringTeardownTest,LateNackReenqueueTest}.cs`) are updated in a Plugins PR (behaviour change behind an unchanged signature, shape 7); the change there is backward compatible with the current pin. `OwnerDisposalNackTest` there needs no change — its NACK is minted when the owner's stream ends at the shutdown signal, never by the force.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HiucTsjSiMxEUxYM9ou688
