### PR TITLE
docs: correct what #3288 falsified — a delegated component's box, and "no database version query"

### DIFF
--- a/src/MeshWeaver.Documentation/Data/GUI/BlazorCustomControls.md
+++ b/src/MeshWeaver.Documentation/Data/GUI/BlazorCustomControls.md
@@ -127,6 +127,16 @@ Each of these is invisible when it bites, which is why they are listed rather th
   runtime-contributed view must carry no CSS/JS of its own — inline what it needs, or ship it as a
   compiled pack. (A pack can self-load its script on first render and gate rendering on it, as
   `RadzenChartView` does with `AssetsReady`.)
+- **A third-party component's root element is not yours to style — unless you ship the rule.** A
+  view that delegates to a component library renders *its* markup, and that markup may carry no
+  `style` attribute at all: BlazorMonaco, for one, emits its editor host as
+  `<div id="…" class="@CssClass">` and nothing else. Wrapping it in a sized `<div>` does not help —
+  `height` does not inherit and a block child does not stretch — so the component's own root
+  collapses to zero pixels and the control renders as an empty gap: no exception, no console
+  warning, no failed request, just nothing on screen. Name a class, ship a `::deep` rule for it in
+  the view's `.razor.css`, and check the rendered box, not the emitted markup. This is what made a
+  node's version comparison invisible for months (MeshWeaver#3288); the guard that now pins it is
+  `MonacoEditorContainerSizingGuard`, beside the views in MeshWeaver.Plugins.
 - **A recompile mints a new type.** Every NodeType rebuild loads into a fresh collectible
   `AssemblyLoadContext`, so "the same" view class is a different CLR type per build. Portal
   contributions are keyed by owner and **replace** on re-registration for exactly this reason;

--- a/src/MeshWeaver.Graph/VersionLayoutArea.cs
+++ b/src/MeshWeaver.Graph/VersionLayoutArea.cs
@@ -63,10 +63,13 @@ public static class VersionLayoutArea
         // 🚨 Ask whether history is RETAINED, not whether the service resolved. The null check
         // alone was unreachable: `NoOpVersionQuery` is registered unconditionally
         // (`PersistenceExtensions`, TryAddSingleton), so this service is never null on any
-        // deployment — and on every DATABASE-backed one it is the no-op, which answers "no
-        // version found" to a question it never records an answer to. So this honest refusal
-        // existed and could not fire, and the caller was told a data-shaped miss about a
-        // configuration fact (MeshWeaver#3264).
+        // deployment — and where the no-op is what wins (a backend that registers no
+        // IVersionQuery of its own), it answers "no version found" to a question it never
+        // records an answer to. So this honest refusal existed and could not fire, and the
+        // caller was told a data-shaped miss about a configuration fact (MeshWeaver#3264).
+        // 🚨 NOT every database deployment is that case, whatever this comment used to say:
+        // Postgres, Cosmos and Snowflake each register a real IVersionQuery from
+        // MeshWeaver.Plugins and DO retain history — see the remarks on IVersionQuery.
         var versionQuery = hub.ServiceProvider.GetService<IVersionQuery>();
         if (versionQuery is null or { RetainsHistory: false })
         {
@@ -139,10 +142,13 @@ public static class VersionLayoutArea
         // 🚨 Ask whether history is RETAINED, not whether the service resolved. The null check
         // alone was unreachable: `NoOpVersionQuery` is registered unconditionally
         // (`PersistenceExtensions`, TryAddSingleton), so this service is never null on any
-        // deployment — and on every DATABASE-backed one it is the no-op, which answers "no
-        // version found" to a question it never records an answer to. So this honest refusal
-        // existed and could not fire, and the caller was told a data-shaped miss about a
-        // configuration fact (MeshWeaver#3264).
+        // deployment — and where the no-op is what wins (a backend that registers no
+        // IVersionQuery of its own), it answers "no version found" to a question it never
+        // records an answer to. So this honest refusal existed and could not fire, and the
+        // caller was told a data-shaped miss about a configuration fact (MeshWeaver#3264).
+        // 🚨 NOT every database deployment is that case, whatever this comment used to say:
+        // Postgres, Cosmos and Snowflake each register a real IVersionQuery from
+        // MeshWeaver.Plugins and DO retain history — see the remarks on IVersionQuery.
         var versionQuery = hub.ServiceProvider.GetService<IVersionQuery>();
         if (versionQuery is null or { RetainsHistory: false })
         {

--- a/src/MeshWeaver.Layout/DiffEditorControl.cs
+++ b/src/MeshWeaver.Layout/DiffEditorControl.cs
@@ -2,6 +2,15 @@ namespace MeshWeaver.Layout;
 
 /// <summary>
 /// A control that wraps the Monaco diff editor for side-by-side comparison.
+///
+/// <para>🚨 <see cref="Height"/> sizes the view's HOST box, and that is not the same thing as sizing
+/// the editor. The renderer delegates to BlazorMonaco, which emits its editor container as
+/// <c>&lt;div id="…" class="…"&gt;</c> with no style attribute — so the container needs a stylesheet
+/// rule of its own, or it collapses to zero pixels inside a perfectly correct 600px host and the
+/// comparison is invisible with no error anywhere. That is MeshWeaver#3288, and the guard that pins
+/// it is <c>MonacoEditorContainerSizingGuard</c> beside the view in MeshWeaver.Plugins. A renderer
+/// added for this control elsewhere (React, MAUI) inherits the same obligation: give the editor's
+/// own element a box.</para>
 /// </summary>
 public record DiffEditorControl() : UiControl<DiffEditorControl>(ModuleSetup.ModuleName, ModuleSetup.ApiVersion)
 {

--- a/src/MeshWeaver.Mesh.Contract/Services/IVersionQuery.cs
+++ b/src/MeshWeaver.Mesh.Contract/Services/IVersionQuery.cs
@@ -21,11 +21,21 @@ public record MeshNodeVersion(
 /// inside hub-reachable code without bridging to a Task. See
 /// <c>Doc/Architecture/AsynchronousCalls.md</c> ("Return type MUST be IObservable&lt;T&gt;").
 ///
-/// <para>Implementations: <c>FileSystemVersionStore</c>, <c>RoutingVersionQuery</c>,
-/// <c>NoOpVersionQuery</c>. 🚨 There is deliberately NO database implementation — this doc
-/// named a <c>PostgreSqlVersionQuery</c> for months and no such type has ever existed
-/// (MeshWeaver#3264). Every database-backed deployment therefore resolves
-/// <c>NoOpVersionQuery</c> and retains no history at all.</para>
+/// <para>Implementations in THIS repository: <c>FileSystemVersionStore</c>,
+/// <c>RoutingVersionQuery</c>, <c>NoOpVersionQuery</c> — the last of which is registered
+/// unconditionally (<c>TryAddSingleton</c>), so this service is never null and a null check can
+/// never stand in for "is there history here". Ask <see cref="RetainsHistory"/> instead.</para>
+///
+/// <para>🚨 <b>"There is no database implementation" is FALSE, and this doc said it.</b> It was
+/// written when MeshWeaver#3264 searched core alone — but the storage backends had already left
+/// for MeshWeaver.Plugins, and every one of them implements this interface AND overrides
+/// <see cref="WriteVersion"/>: <c>PostgreSqlVersionQuery</c> and
+/// <c>PostgreSqlPartitionedVersionQuery</c> (both registered by <c>PostgreSqlExtensions</c> with a
+/// plain <c>AddSingleton</c> that deliberately precedes — and therefore beats — the no-op's
+/// <c>TryAdd</c>), <c>CosmosVersionQuery</c> and <c>SnowflakeVersionQuery</c>. Measured 2026-09-04
+/// against memex.meshweaver.cloud, a Postgres deployment: 32 recorded versions on one node. A
+/// grep that stops at this repository's boundary answers a question about core, never about a
+/// deployment (MeshWeaver#3288).</para>
 /// </summary>
 public interface IVersionQuery
 {
@@ -74,8 +84,9 @@ public interface IVersionQuery
     /// pre-save Version writes the new content into an OLDER version's
     /// snapshot, overwriting history).
     /// <para>Default implementation is a no-op observable (single emission of
-    /// the input + completion); overridden by <c>FileSystemVersionStore</c>. No database
-    /// backend overrides it — see the note on <see cref="RetainsHistory"/>.</para>
+    /// the input + completion); overridden by <c>FileSystemVersionStore</c> here, and by every
+    /// database backend in MeshWeaver.Plugins (Postgres, Cosmos, Snowflake) — the claim that none
+    /// of them did was the same core-only grep corrected in the interface remarks above.</para>
     /// </summary>
     IObservable<MeshNode> WriteVersion(MeshNode node, JsonSerializerOptions options)
         => System.Reactive.Linq.Observable.Return(node);


### PR DESCRIPTION
The core half of Systemorph/MeshWeaver#3288. **The fix itself is [Systemorph/MeshWeaver.Plugins#1335](https://github.com/Systemorph/MeshWeaver.Plugins/pull/1335)** — `DiffEditorView` lives in that repo — so this PR carries no behaviour change at all, only the two statements this repo makes that the investigation disproved. It deliberately does **not** say `Closes #3288`: the issue is closed against the Plugins PR, with the measurement.

## 1. A delegated component's root element

`DiffEditorControl` renders through BlazorMonaco, which emits its editor host as `<div id="…" class="@CssClass">` and writes **no `style` attribute** (verified against the shipped 3.5 assembly). Wrapping it in a sized `<div>` does not help — `height` does not inherit and a block child does not stretch — so the component's own root collapsed to zero pixels and the version comparison rendered as an empty 600px gap: no exception, no console warning, no failed request.

Measured in a headless browser on the exact DOM the view emits, against the **real served** stylesheet bundles:

| stylesheet under test | host box | Monaco container | panes |
|---|---|---|---|
| memex.meshweaver.cloud, live | 1280×600 | 1280×**0** | 625×**0** |
| a portal built from Plugins#1335 | 1280×600 | 1280×600 | 625×600 |

Recorded in two places a future author actually reads: the "invisible when it bites" list in `Doc/GUI/BlazorCustomControls.md`, and `DiffEditorControl`'s own XML doc — so a renderer added for this control elsewhere (React, MAUI) inherits the obligation rather than rediscovering it.

## 2. "There is deliberately NO database implementation"

`IVersionQuery`'s remarks said that, and concluded *"every database-backed deployment therefore resolves `NoOpVersionQuery` and retains no history at all"*; `VersionLayoutArea` repeated it in two comment blocks. It is false, and it is the premise this investigation started from.

MeshWeaver#3264 searched core alone — but the storage backends had already moved to MeshWeaver.Plugins (`69a37b7e`), and **every one of them implements `IVersionQuery` and overrides `WriteVersion`**:

- `PostgreSqlVersionQuery` — the very type the doc said "has never existed" (`PostgreSqlExtensions.cs:187,232`)
- `PostgreSqlPartitionedVersionQuery` (`:405,:517`)
- `CosmosVersionQuery`, `SnowflakeVersionQuery`

All four register with a plain `AddSingleton<IVersionQuery>` placed **before** `AddPartitionedCoreAndWrapperServices`, precisely so the no-op's `TryAdd` no-ops.

Measured 2026-09-04 against memex.meshweaver.cloud, a Postgres deployment: the node #3288 reports carries **32 recorded versions** (1, 3, 4, 29, 33–60), and both endpoints of its `from=3&to=4` read back with full content. History is retained there.

**No code changes.** `versionQuery is null or { RetainsHistory: false }` is correct either way — #3278's guard stands. Only the reasoning attached to it was wrong, and that kind of wrong sends the next session hunting a data-shaped miss that is not there. (Related, and *not* fixed here: the Versions/VersionDiff views in Plugins still guard on `versionQuery == null` rather than `RetainsHistory`, so #3278's honest message never reaches them. Filed separately.)

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation: `MeshWeaver.Layout`, `MeshWeaver.Mesh.Contract`, `MeshWeaver.Graph`, `MeshWeaver.Documentation`, `MeshWeaver.Documentation.Test` — all `0 Warning(s) / 0 Error(s)`. `DocumentationLinkIntegrityTest` passes (a doc page changed).

No public type or member is removed, so the cross-repo pair gate does not apply. No new localization keys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
