### PR TITLE
CD: a source-built platform states its identity as the COMMIT — CD has been red since 09:31Z

### DIFF
--- a/.github/scripts/module-build-key.py
+++ b/.github/scripts/module-build-key.py
@@ -73,7 +73,15 @@ from pathlib import Path
 # genuinely differ — and a REUSED pre-#3211 bundle would be refused at the publish step, which is the
 # right verdict for those bytes and the wrong thing to spend a run discovering. One rebuild wave, and
 # every recorded key afterwards attests bytes that state what they were built against.
-RECIPE_VERSION = "2"
+# "2" → "3": when the platform is built from SOURCE the identity is now STATED as the commit
+# (`--framework-mvid g<sha>`), not read off a copy of MeshWeaver.Compiler.dll in the module's own
+# publish output. Recipe 2 recorded a per-MODULE value there — the module's own rebuild of the
+# platform carries its own `-p:Version`, which the assembly attributes take into the MVID: measured
+# in ONE run (33867996265) AI packed fc70b6e19be34b65983eb5fa15ce5243 and Markdown.Collaboration
+# 0a96ab4c9eb744558431b2a018dc4699 for the same platform commit, and neither could ever match a
+# portal image, which stamps `g<sha>`. Bundles recorded under recipe 2 therefore attest an identity
+# no consumer can use; they must be repacked, not reused.
+RECIPE_VERSION = "3"
 
 # Repo-level files that change what EVERY project compiles or tests. Presence and content both
 # count; a file the repo does not have hashes as null so adding it later changes the key.

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1739,18 +1739,55 @@ jobs:
           #     publish output. Measured green on CD run 33779812466:
           #     "built-against MVID ce81fd4e3f5146c7a6ebaa6dc72da3f2".
           #
-          # Both arms end in a RED with no anchor — neither is a quiet fallback, and the packer
-          # refuses again behind them, so a bundle whose identity is a guess cannot exist.
+          # 🚨 …and the SOURCE arm above is wrong in two ways that only showed once core CD composed
+          # more than two modules (#3290, 2026-09-04). Reading the anchor out of the MODULE's own
+          # publish output makes the identity a property of the MODULE, not of the platform:
+          #
+          #   * a module whose reference chain never reaches MeshWeaver.Compiler simply has no copy.
+          #     Only MeshWeaver.Graph and MeshWeaver.Compiler.Pipeline reference it, so AI and
+          #     Markdown.Collaboration (→ Graph) carry one while Maps (→ Layout) and
+          #     Payments.Stripe (→ Mesh.Contract) do not — CD run 33867996265 died there, and every
+          #     run since 7751 with it;
+          #   * and where a copy DOES exist it is the module's OWN rebuild of the platform, made
+          #     with that module's `-p:Version=$VERSION`, which the assembly attributes carry into
+          #     the MVID. Measured in ONE run (33867996265, core 7d644de95): AI recorded
+          #     frameworkMvid fc70b6e19be34b65983eb5fa15ce5243 and Markdown.Collaboration recorded
+          #     0a96ab4c9eb744558431b2a018dc4699 — two identities for one platform commit.
+          #
+          # Neither value could ever match a consumer either: a portal image is built with
+          # `-p:CIRun=true` on GitHub Actions (main-cd.yml), so its MeshWeaver.Compiler carries the
+          # STAMPED commit identity `g<sha>` (Directory.Build.props → AddCommitHashMetadata, #1660
+          # WS3), never an MVID. So the field #3154 compares on every update decision was being
+          # filled with a token that is unstable across modules and unmatchable by design.
+          #
+          # When the platform is SOURCE, its identity is the COMMIT — state it, exactly as the image
+          # build stamps it, rather than reading a per-module copy. `--framework-mvid` is the
+          # packer's own flag for "the platform's own reading", and `g<sha>` is one of the three
+          # tokens it documents (s<hash>, g<sha>, 32-hex MVID). The IMAGE arm is unchanged: there
+          # the anchor really is in the extracted /app, and reading it is the platform's own reading.
+          #
+          # Both arms still end in a RED with nothing to state — neither is a quiet fallback, and
+          # the packer refuses again behind them, so a bundle whose identity is a guess cannot exist.
+          identity=()
           if [ -n "$REFS" ]; then
             anchor="$REFS/MeshWeaver.Compiler.dll"
-            where="the pinned platform image's extracted /app"
+            if [ ! -f "$anchor" ]; then
+              echo "::error::no identity anchor for $MODULE — expected MeshWeaver.Compiler.dll at '$anchor', i.e. in the pinned platform image's extracted /app. Every bundle must state the framework build its bytes were compiled against (#3211): a consumer compares it against what it has landed, and an unstated one makes every reconcile answer 'up to date, identity could not be checked' forever. Nothing here may guess it, so the pack stops."
+              exit 1
+            fi
+            identity=(--graph-dll "$anchor")
+            echo "identity anchor: $anchor (the pinned platform image's /app)"
           else
-            anchor="$PACKDIR/MeshWeaver.Compiler.dll"
-            where="the module's own build output (no platform image is pinned, so the platform was built from source)"
-          fi
-          if [ ! -f "$anchor" ]; then
-            echo "::error::no identity anchor for $MODULE — expected MeshWeaver.Compiler.dll at '$anchor', i.e. in $where. Every bundle must state the framework build its bytes were compiled against (#3211): a consumer compares it against what it has landed, and an unstated one makes every reconcile answer 'up to date, identity could not be checked' forever. Nothing here may guess it, so the pack stops."
-            exit 1
+            sha="$(git -C "$GITHUB_WORKSPACE/meshweaver" rev-parse HEAD 2>/dev/null || true)"
+            case "$sha" in
+              [0-9a-f]*) ;;
+              *)
+                echo "::error::no identity for $MODULE — the platform was built from SOURCE (no image is pinned), so its identity is the commit it was built from, and 'git rev-parse HEAD' in '$GITHUB_WORKSPACE/meshweaver' produced '$sha'. Every bundle must state the framework build its bytes were compiled against (#3211). Nothing here may guess it, so the pack stops."
+                exit 1
+                ;;
+            esac
+            identity=(--framework-mvid "g$sha")
+            echo "identity: g$sha (the platform was built from source at that commit — the same token its image build stamps)"
           fi
           echo "packing $MODULE from $PACKDIR (compiler: $COMPILER); closure flags: ${closure[*]:-<none>}"
           dotnet "$RUNNER_TEMP/pack-tool/MeshWeaver.Plugin.Build.dll" \
@@ -1760,7 +1797,7 @@ jobs:
             --plugin "$PACKAGE" \
             --package-version "$VERSION" \
             --min-mesh-version "$FLOOR" \
-            --graph-dll "$anchor" \
+            "${identity[@]}" \
             --own-platform "$(bash "$GITHUB_WORKSPACE/meshweaver/.github/scripts/module-owned-platform.sh" "$GITHUB_WORKSPACE/src")" \
             --out "$RUNNER_TEMP/bundles"
 

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1778,11 +1778,17 @@ jobs:
             identity=(--graph-dll "$anchor")
             echo "identity anchor: $anchor (the pinned platform image's /app)"
           else
-            sha="$(git -C "$GITHUB_WORKSPACE/meshweaver" rev-parse HEAD 2>/dev/null || true)"
+            # No `|| true`: a git that cannot answer must SAY so — its stderr is the diagnosis,
+            # and swallowing the status would turn "the checkout is not there" into an empty
+            # identity, which is the shape this whole block exists to refuse.
+            if ! sha="$(git -C "$GITHUB_WORKSPACE/meshweaver" rev-parse HEAD)"; then
+              echo "::error::no identity for $MODULE — the platform was built from SOURCE (no image is pinned), so its identity is the commit it was built from, and 'git rev-parse HEAD' in '$GITHUB_WORKSPACE/meshweaver' failed (its error is above). Every bundle must state the framework build its bytes were compiled against (#3211). Nothing here may guess it, so the pack stops."
+              exit 1
+            fi
             case "$sha" in
               [0-9a-f]*) ;;
               *)
-                echo "::error::no identity for $MODULE — the platform was built from SOURCE (no image is pinned), so its identity is the commit it was built from, and 'git rev-parse HEAD' in '$GITHUB_WORKSPACE/meshweaver' produced '$sha'. Every bundle must state the framework build its bytes were compiled against (#3211). Nothing here may guess it, so the pack stops."
+                echo "::error::no identity for $MODULE — 'git rev-parse HEAD' in '$GITHUB_WORKSPACE/meshweaver' produced '$sha', which is not a commit sha. The platform was built from SOURCE, so its identity is that commit (#3211). Nothing here may guess it, so the pack stops."
                 exit 1
                 ;;
             esac

--- a/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
@@ -41,21 +41,38 @@ public class ModuleIdentityPublishGuard
     {
         var pack = JobBody("pack");
 
-        // The anchor is the SAME reference set the build bound against, and WHERE that is moves
-        // with the platform: the pinned image's extracted /app when one is pinned (`platform-refs`
-        // — which the sdk build passes as MeshWeaverRefs and the container build compiles inside),
-        // the module's own output when the platform was built from source. It is never a second
-        // opinion, and never left to the packer's default probe, which is exactly the probe that
-        // found nothing on all 34 of the fleet's bundles.
+        // WHERE the identity comes from moves with the platform, and so does HOW it is obtained.
+        //
+        //  * platform pinned as an IMAGE — the anchor really is a file, in the extracted /app
+        //    (`platform-refs`, which the sdk build passes as MeshWeaverRefs and the container build
+        //    compiles inside). Read it; never leave it to the packer's default probe, which is
+        //    exactly the probe that found nothing on all 34 of the fleet's bundles.
+        //  * platform built from SOURCE — the identity is the COMMIT, stated. Reading it off the
+        //    module's own publish output made it a property of the MODULE: a module whose reference
+        //    chain never reaches MeshWeaver.Compiler has no copy at all (Maps, Payments.Stripe — CD
+        //    run 33867996265, and every run since 7751), and where a copy exists it is that
+        //    module's own rebuild of the platform carrying its own `-p:Version`, which the assembly
+        //    attributes take into the MVID. One run recorded TWO identities for one platform commit
+        //    (AI fc70b6e1…, Markdown.Collaboration 0a96ab4c…) — and neither could ever match a
+        //    consumer, because a portal image is built `-p:CIRun=true` on GitHub Actions and its
+        //    MeshWeaver.Compiler therefore carries the stamped `g<sha>` (#1660 WS3), never an MVID.
         Assert.Contains("anchor=\"$REFS/MeshWeaver.Compiler.dll\"", pack, StringComparison.Ordinal);
-        Assert.Contains("anchor=\"$PACKDIR/MeshWeaver.Compiler.dll\"", pack, StringComparison.Ordinal);
-        Assert.Contains("--graph-dll \"$anchor\"", pack, StringComparison.Ordinal);
+        Assert.Contains("identity=(--graph-dll \"$anchor\")", pack, StringComparison.Ordinal);
+        Assert.Contains("identity=(--framework-mvid \"g$sha\")", pack, StringComparison.Ordinal);
+        Assert.Contains("\"${identity[@]}\"", pack, StringComparison.Ordinal);
 
-        // 🚨 BOTH arms end RED when there is no anchor — the branch picks WHERE to look, never
-        // whether to check. A bundle whose identity is a guess is worse than a pack that stops.
+        // 🚨 The source arm must NOT go back to reading the anchor out of the module's own output —
+        // that is the per-module identity this guard now exists to keep from returning.
+        Assert.DoesNotContain("anchor=\"$PACKDIR/MeshWeaver.Compiler.dll\"", pack, StringComparison.Ordinal);
+
+        // 🚨 BOTH arms end RED when there is nothing to state — the branch picks WHERE the identity
+        // comes from, never whether to have one. A bundle whose identity is a guess is worse than a
+        // pack that stops.
         Assert.Contains("if [ ! -f \"$anchor\" ]; then", pack, StringComparison.Ordinal);
         Assert.Contains("::error::no identity anchor for $MODULE", pack, StringComparison.Ordinal);
+        Assert.Contains("::error::no identity for $MODULE", pack, StringComparison.Ordinal);
         Assert.DoesNotContain("--graph-dll \"${anchor:-", pack, StringComparison.Ordinal);
+        Assert.DoesNotContain("--framework-mvid \"g${sha:-", pack, StringComparison.Ordinal);
     }
 
     [Fact]
@@ -108,7 +125,12 @@ public class ModuleIdentityPublishGuard
         var key = File.ReadAllText(Path.Combine(FindRepoRoot(), KeyScript));
         var recipe = Regex.Match(key, @"^RECIPE_VERSION = ""(?<v>[^""]+)""", RegexOptions.Multiline);
         Assert.True(recipe.Success, $"{KeyScript} must declare RECIPE_VERSION");
+        // Every byte-changing lane edit moves it: "1" → "2" was #3211 (the manifest gained
+        // frameworkMvid at all); "2" → "3" is the source arm stating the commit, so the recorded
+        // value differs for the SAME source and a reused recipe-2 bundle attests an identity no
+        // consumer can match.
         Assert.NotEqual("1", recipe.Groups["v"].Value);
+        Assert.NotEqual("2", recipe.Groups["v"].Value);
     }
 
     private static string JobBody(string job)


### PR DESCRIPTION
## Why

**Core CD has not concluded green since 09:31Z today.** Every run from 7751 on dies in the same place:

```
##[error]no identity anchor for MeshWeaver.Maps — expected MeshWeaver.Compiler.dll at
'…/src/MeshWeaver.Maps/bin/Release/net10.0/publish/MeshWeaver.Compiler.dll', i.e. in the
module's own build output (no platform image is pinned, so the platform was built from source).
```

#3290 made the Plugins bake compose **every** module its content binds — four instead of two — and that exposed two defects in the *source* arm of the identity anchor. Both make `frameworkMvid`, the field #3154 compares on every consumer's update decision, useless:

1. **A module that never references `MeshWeaver.Compiler` has no copy of it.** Only `MeshWeaver.Graph` and `MeshWeaver.Compiler.Pipeline` reference it, so `AI` and `Markdown.Collaboration` (→ Graph) carry one while `Maps` (→ Layout) and `Payments.Stripe` (→ Mesh.Contract) do not. Nothing about a module's own reference graph should decide whether the *platform* can state its identity.

2. **Where a copy does exist it is a per-MODULE value.** The source arm rebuilds the platform ProjectReferences with that module's `-p:Version=$VERSION`, and the assembly attributes take it into the MVID. Measured in **one** run (33867996265, core `7d644de95`):

   | module | recorded `frameworkMvid` |
   |---|---|
   | `MeshWeaver.AI` | `fc70b6e19be34b65983eb5fa15ce5243` |
   | `MeshWeaver.Markdown.Collaboration` | `0a96ab4c9eb744558431b2a018dc4699` |

   Two identities, one platform commit, one run.

And **neither value could ever match a consumer.** A portal image is built with `-p:CIRun=true` on GitHub Actions, so its `MeshWeaver.Compiler` carries the *stamped* commit identity `g<sha>` (`Directory.Build.props` → `AddCommitHashMetadata`, #1660 WS3) — never an MVID. So the comparison had nothing it could match, in every source-built bundle the fleet has published.

## What changes

The source arm **states** the identity instead of reading it off an incidental copy:

```bash
sha="$(git -C "$GITHUB_WORKSPACE/meshweaver" rev-parse HEAD)"
identity=(--framework-mvid "g$sha")
```

`--framework-mvid` is the packer's own flag for "the platform's own reading", and `g<sha>` is one of the three tokens it documents (`s<hash>`, `g<sha>`, 32-hex MVID). The **image arm is untouched** — there the anchor really is a file in the extracted `/app`, and reading it *is* the platform's own reading.

Both arms still end **RED** with nothing to state: the branch picks where the identity comes from, never whether to have one. The source arm's refusal is new (`::error::no identity for $MODULE …`) and fires when `git rev-parse` cannot answer.

## Guards moved with the subject

- **`ModuleIdentityPublishGuard`** pins both arms by shape, asserts the source arm does **not** go back to `$PACKDIR/MeshWeaver.Compiler.dll`, and requires a RED on each. Without the update it would have kept asserting the old shape — a guard passing on prose nobody executes.
- **`module-build-key.py` `RECIPE_VERSION` 2 → 3.** The bytes for the same source genuinely differ now, and a reused recipe-2 bundle attests an identity no consumer can match — those must be repacked, not reused. (This is the lever the script documents for exactly this, and the guard asserts it moved.)

## Verification

```
MeshWeaver.Documentation.Test          257/257 (Release, the governance-guard suite)
module-build-key.py --self-test        36 cases green
python3 -c "yaml.safe_load(node-repo-module-pack.yml)"   parses
```

The other CD failure — `Plugins: bake + seal`, the #3175 double producer — was fixed independently by MeshWeaver.Plugins#1268, which merged a few minutes ago. With both in, CD's remaining legs have nothing known blocking them.

Pairs-with: none — CI lane + guard + script; no public surface changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
