### PR TITLE
Fix #3265: order the compile settle wait against the dispatch

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeContractHandler.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using System.Text.Json;
 using MeshWeaver.Data;
 using MeshWeaver.Graph;
 using MeshWeaver.Mesh;
@@ -65,15 +66,20 @@ internal static class NodeTypeContractHandler
         // the single-flight lock, the watcher is the only Roslyn driver for a
         // triggered compile.
         //
-        // AwaitCompilationSettled then holds the read until the dispatched compile
+        // SettledAtOrAfter then holds the read until the dispatched compile
         // finishes: a naive Take(1) would hand the requester the previous
         // release's AssemblyLocation while V2 is mid-compile, and every fresh
         // instance hub activated in that gap would render the stale layout.
+        //
+        // 🚨 …and it is ORDERED AGAINST THE DISPATCH (#3265). Waiting on a freshly
+        // subscribed stream let the settle question be answered by the PRE-dispatch
+        // snapshot — status still null, which IsCompilationSettled accepts — so the
+        // gate above was decorative and the inline compile ran anyway. See
+        // SettledAtOrAfter for the measurement and why the predicate is not the bug.
         var workspace = hub.GetWorkspace();
         EnsureCompileDispatched(hub, workspace)
-            .SelectMany(_ => workspace.GetMeshNodeStream()
-                .AwaitCompilationSettled(hub.JsonSerializerOptions)
-                .Take(1))
+            .SelectMany(dispatched => SettledAtOrAfter(
+                workspace.GetMeshNodeStream(), dispatched, hub.JsonSerializerOptions))
             .Timeout(SettleBudget)
             .SelectMany(node =>
             {
@@ -380,6 +386,60 @@ internal static class NodeTypeContractHandler
                 }))
             .Take(1);
     }
+
+    /// <summary>
+    /// 🚨 The settle wait, ORDERED AGAINST THE DISPATCH — the second half of the
+    /// single-compile-driver gate, and the half whose absence made the first half
+    /// decorative.
+    ///
+    /// <para><b>The defect (#3265).</b> <see cref="EnsureCompileDispatched"/> commits the
+    /// <see cref="CompilationStatus.Pending"/> flip and emits the COMMITTED node, and the caller
+    /// then subscribed a FRESH <c>GetMeshNodeStream()</c> to wait for that compile to settle. A
+    /// new subscriber's initial replay is not guaranteed to carry the owner's latest commit — the
+    /// reduced own-node pipeline seeds it from a source that can lag a write the same hub has
+    /// already applied (the same lag <c>UpdateOwn</c>'s echo detection documents: "the
+    /// subscription's initial replay could be delivered AFTER the write applied"). So the wait
+    /// could be handed the PRE-DISPATCH snapshot, whose <c>CompilationStatus</c> is still
+    /// <c>null</c> — and <see cref="NodeTypeBuildState.IsCompilationSettled"/> answers TRUE for
+    /// null, because for a static-only type or one with a usable build "never compiled" is a
+    /// settled answer. <c>Take(1)</c> took it, the handler fell through to
+    /// <see cref="IMeshNodeCompilationService.CompileAndGetConfigurations"/>, and a SECOND Roslyn
+    /// run went off beside the watcher's — precisely what the header comment of
+    /// <see cref="Handle"/> says must never happen.
+    ///
+    /// Measured on 2026-09-04 (monolith, <c>DOTNET_PROCESSOR_COUNT=2</c>, 8/8 runs): dispatch
+    /// committed v3=Pending, the settle wait was handed v1 with a null status, both compiles ran,
+    /// and TWO terminal success writes landed 16 ms apart — this handler's (store key v1, no
+    /// release) publishing <c>Status=Ok</c> first, then <c>RunCompile</c>'s (store key v4, with the
+    /// release). Two DLLs under two store keys for one type, whichever write-back lands last
+    /// deciding which the record names (#1368's family), and a ~16 ms window in which
+    /// <c>Status=Ok</c> is published but the pipeline has not written its last word — so a
+    /// concurrent writer to the node loses its field to the tail (the reported symptom).</para>
+    ///
+    /// <para><b>The rule.</b> A state OLDER than the dispatch cannot answer a question about the
+    /// dispatch. Gate on the version <see cref="EnsureCompileDispatched"/> reached — strictly the
+    /// same discipline as <c>UpdateOwn</c>'s echo detection, which is "WRITE-IDENTITY-based, never
+    /// emission-count-based": accept only a state of the node at-or-past the stamp this caller
+    /// established. A no-op dispatch (already Pending/Compiling/Ok/Error, a usable build, a
+    /// static-only type) emits the authoritative current node from inside the action block, so the
+    /// gate is satisfied by that same version and the wait answers immediately, as before.</para>
+    ///
+    /// <para>🚨 NOT fixed by making <see cref="NodeTypeBuildState.IsCompilationSettled"/> refuse a
+    /// null status: null is a legitimate settled answer for the two kinds of type
+    /// <see cref="EnsureCompileDispatched"/> deliberately leaves alone, and refusing it would hang
+    /// their resolve for the whole <see cref="SettleBudget"/>. The predicate was never wrong — it
+    /// was asked about a state the dispatch had already superseded.</para>
+    /// </summary>
+    /// <param name="ownStream">The per-NodeType hub's own MeshNode stream.</param>
+    /// <param name="dispatched">What <see cref="EnsureCompileDispatched"/> committed (or, on a
+    /// no-op, the authoritative unchanged node) — its <see cref="MeshNode.Version"/> is the floor.</param>
+    /// <param name="options">The hub's serializer options, for the tolerant content read.</param>
+    internal static IObservable<MeshNode> SettledAtOrAfter(
+        IObservable<MeshNode> ownStream, MeshNode dispatched, JsonSerializerOptions options)
+        => ownStream
+            .Where(node => node is not null && node.Version >= dispatched.Version)
+            .AwaitCompilationSettled(options)
+            .Take(1);
 
     /// <summary>
     /// Reads the persisted compile activity (when available) and overlays its

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -136,6 +136,49 @@ This is what makes a NodeType "just work" the first time an instance is created,
 after a `Source/*.cs` edit, or after a framework redeploy — no operator action
 required.
 
+### 🚨 ONE driver runs Roslyn — a resolve request joins the queue, it never starts a second compile
+
+`GetCompilationPathRequest` (`NodeTypeContractHandler`) is how an activating instance hub, a
+cross-process probe or a bake consumer asks "where are this type's bytes?". It must **never** run
+Roslyn beside the watcher's compile. Two concurrent compiles on one NodeType produce two assemblies
+under two `IAssemblyStore` keys, each terminal write-back names its own, and whichever lands second
+decides what the record says — the loser's bytes are addressed by nothing, activation resolves a
+store key with no content, and the instance silently falls back to the default configuration
+(issue #1368).
+
+The handler therefore does not compile. It **dispatches** — `EnsureCompileDispatched` makes one
+status-guarded flip to `Pending`, which the watcher turns into the one activity compile — and then
+**waits** for that compile to settle before hydrating the answer. The status field is the
+single-flight lock.
+
+> 🚨 **The wait must be ORDERED AGAINST THE DISPATCH.** `CompilationStatus == null` reads as
+> *settled*, and correctly so: for a static-only type, or one that already has a usable build,
+> "never compiled" is a final answer and `EnsureCompileDispatched` deliberately leaves those alone.
+> But a subscriber that attaches to the own-node stream *after* the dispatch is not guaranteed to be
+> replayed the dispatch's commit — the reduced own-node pipeline seeds a new subscriber from a
+> source that can lag a write the same hub has already applied. So the settle question could be
+> answered by the **pre-dispatch snapshot**, whose status is still null, and the handler would
+> compile inline anyway (issue #3265).
+>
+> The remedy is the same one `MeshNodeStreamHandle.UpdateOwn` uses for its own echo detection, and
+> for the same reason: **accept only a state of the node at-or-past the version this caller
+> established** — `NodeTypeContractHandler.SettledAtOrAfter`, gated on the version
+> `EnsureCompileDispatched` reached. Never make the predicate stricter instead: refusing a null
+> status would hold every static-only and already-built type for the whole 60 s settle budget.
+
+Measured while this was broken (monolith, `DOTNET_PROCESSOR_COUNT=2`, 8 runs of 8): the dispatch
+committed `v3 = Pending`, the settle wait was handed `v1` with a null status, two Roslyn runs went
+off, and **two terminal success writes landed 16 ms apart** — the handler's first (store key `v1`,
+no release path), publishing `CompilationStatus = Ok`; `RunCompile`'s second (store key `v4`, with
+the release), re-stamping `CompiledFrameworkVersion`, `LastCompiledVersion` and the assembly
+coordinates.
+
+That second write is why **`Status = Ok` alone is not a completion signal** for anything that
+intends to *write* to the node. With one driver there is exactly one terminal write and `Ok` is the
+last word; with two, the first `Ok` opens a window in which a concurrent writer's field is
+overwritten by the tail. Readers are safe either way (both writes describe a real build); writers
+must not treat the first `Ok` as "the pipeline is finished".
+
 ### Explicit — Create Release
 
 **The one entry point is `hub.RequestNodeTypeRelease(nodeTypePath, …)`** (`MeshWeaver.Graph/NodeTypeReleaseExtensions.cs`) — GUI, agents, and tests all call it. It writes the trigger onto the NodeType node via `stream.Update`: `RequestedReleaseAt` (a timestamp, so repeated requests are distinct), plus `RequestedReleaseForce` to bypass the "sources match the last compile" short-circuit and `RequestedReleaseBy` to attribute the release to the caller. The per-NodeType release watcher dispatches only while `RequestedReleaseAt > LastReleaseRequestHandledAt` — an idempotent CAS — and lands on the same `RunCompile`.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-type-is-only-ever-built-once-at-a-time.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-type-is-only-ever-built-once-at-a-time.md
@@ -1,0 +1,44 @@
+---
+Name: A type is only ever built once at a time
+Category: Fix
+Description: Opening a page of a type that was compiling could quietly start a second build of the same type. Two builds finished seconds apart, each recorded where its own copy went, and whichever finished last won — so the page could open against bytes nothing pointed at any more and fall back to the generic view. A request to use a type now waits for the build that is already running instead of starting its own.
+Icon: Bug
+Order: -20260904
+---
+
+# A type is only ever built once at a time
+
+A dynamic type — one whose behaviour is C# stored in the mesh — is compiled on demand, the first
+time something needs it. Two things can ask at the same moment: the type's own hub, which starts a
+build as soon as it notices there isn't one, and whatever needed the type right now — a page
+opening, another pod probing, a package being installed.
+
+Only one of them is supposed to run the compiler. The other is supposed to wait.
+
+## What was going wrong
+
+The waiter could miss the start of the build it was meant to wait for, decide nothing was running,
+and compile the type itself. Both builds then finished — seconds apart, sometimes milliseconds —
+and each wrote down where it had put its assembly. The second one to finish overwrote the first.
+
+Most of the time that is merely wasteful: two compilations, two copies of the same assembly kept
+on disk, two sets of change notifications sent to everything watching the type. But when the
+record ended up naming the copy that the *other* build produced, anything opening an instance of
+that type looked for bytes that were no longer addressed by anything, found nothing, and rendered
+the fallback view — a page with none of the type's own areas on it, and nothing in the log to say
+why.
+
+There was a second, subtler consequence. A type reports `Ok` when its build finishes, and that is
+the signal everything else waits on. With two builds running, the first `Ok` was not the end of the
+story: a further write followed a few milliseconds later. Anything that reacted to that first `Ok`
+by writing to the type — recording a decision, marking a version, stamping which framework build it
+belongs to — had its write silently replaced by the tail of the second build.
+
+## What changes
+
+A request to use a type now waits for the build that is already in flight, and can no longer be
+fooled by a snapshot of the type taken before that build started. One build runs; one assembly is
+produced; one record is written; `Ok` means finished.
+
+Nothing changes for a type that needs no build at all — one whose behaviour ships with the
+platform, or one that already has a usable assembly. Those answer immediately, as before.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/SettleWaitIsOrderedAgainstTheDispatchTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/SettleWaitIsOrderedAgainstTheDispatchTest.cs
@@ -1,0 +1,134 @@
+using System.Reactive.Subjects;
+using System.Text.Json;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// 🔴 <b>The ordering pin for issue #3265 — "a state older than the dispatch cannot answer a
+/// question about the dispatch".</b>
+///
+/// <para><b>The defect.</b> <c>NodeTypeContractHandler</c> guards against running a second Roslyn
+/// compile beside the watcher's by DISPATCHING one (<c>EnsureCompileDispatched</c> flips
+/// <see cref="CompilationStatus.Pending"/>) and then WAITING for it to settle. The wait subscribed
+/// a freshly derived own-node stream, and a new subscriber's initial replay is not guaranteed to
+/// carry the owner's latest commit — the reduced own-node pipeline seeds it from a source that can
+/// lag a write the same hub has already applied. So the wait was handed the PRE-dispatch snapshot,
+/// whose <see cref="NodeTypeDefinition.CompilationStatus"/> is still <c>null</c>, and
+/// <see cref="NodeTypeBuildState.IsCompilationSettled"/> answers TRUE for null — because for a
+/// static-only type, or one that already has a usable build, "never compiled" IS a settled answer.
+/// <c>Take(1)</c> took it and the handler compiled inline anyway.</para>
+///
+/// <para><b>What that cost.</b> Measured on 2026-09-04 (monolith,
+/// <c>DOTNET_PROCESSOR_COUNT=2</c>, 8 runs out of 8): the dispatch committed v3=Pending, the settle
+/// wait was handed v1 with a null status, and TWO Roslyn compiles ran for one NodeType — uploading
+/// two assemblies under two store keys. Both then wrote a TERMINAL SUCCESS, 16 ms apart: this
+/// handler's first (publishing <c>Status=Ok</c>), <c>RunCompile</c>'s second (re-stamping
+/// <see cref="NodeTypeDefinition.CompiledFrameworkVersion"/>,
+/// <see cref="NodeTypeDefinition.LastCompiledVersion"/> and the assembly coordinates). So
+/// <c>Status=Ok</c> was published while the pipeline still had a write to make, and anything that
+/// stamped the node in that window was clobbered by the tail.</para>
+///
+/// <para>🚨 <b>The rejected fix</b> is pinned here too: making
+/// <see cref="NodeTypeBuildState.IsCompilationSettled"/> refuse a null status would look like it
+/// closes the hole and would instead hang every type the dispatch deliberately leaves alone. The
+/// predicate was never wrong — it was asked about a state the dispatch had already superseded.</para>
+/// </summary>
+public class SettleWaitIsOrderedAgainstTheDispatchTest
+{
+    private static readonly JsonSerializerOptions Options = new();
+
+    private static MeshNode NodeAt(long version, CompilationStatus? status) =>
+        new("T", "type")
+        {
+            NodeType = MeshNode.NodeTypePath,
+            Version = version,
+            Content = new NodeTypeDefinition
+            {
+                Configuration = "config => config",
+                CompilationStatus = status,
+            },
+        };
+
+    /// <summary>
+    /// The replay that predates the dispatch must not be able to answer. Pushed synchronously
+    /// through a <see cref="Subject{T}"/> so the assertion sits between the two emissions and can
+    /// only pass for the right reason.
+    /// </summary>
+    [Fact]
+    public void APreDispatchSnapshotCannotSettleTheDispatchedCompile()
+    {
+        // What EnsureCompileDispatched committed: the Pending flip, at version 3.
+        var dispatched = NodeAt(3, CompilationStatus.Pending);
+
+        var ownStream = new Subject<MeshNode>();
+        MeshNode? settled = null;
+        using var subscription = NodeTypeContractHandler
+            .SettledAtOrAfter(ownStream, dispatched, Options)
+            .Subscribe(node => settled = node);
+
+        // The lagging initial replay: the node as it was BEFORE the dispatch, never compiled, so
+        // CompilationStatus is null — which IsCompilationSettled accepts as settled.
+        ownStream.OnNext(NodeAt(1, status: null));
+
+        settled.Should().BeNull(
+            "a snapshot from BEFORE the dispatch cannot answer whether the dispatched compile has "
+            + "settled — accepting it is what let this handler run a second Roslyn compile beside "
+            + "the watcher's and publish Status=Ok while the pipeline still had its terminal write "
+            + "to make (#3265)");
+
+        // The states the dispatch actually produced, arriving late.
+        ownStream.OnNext(NodeAt(4, CompilationStatus.Compiling));
+        settled.Should().BeNull("Compiling is not settled");
+
+        ownStream.OnNext(NodeAt(5, CompilationStatus.Ok));
+        settled.Should().NotBeNull("the dispatched compile reached a terminal state");
+        settled!.Version.Should().Be(5,
+            "the wait must answer with the state the DISPATCHED compile reached, never with the "
+            + "one it superseded");
+    }
+
+    /// <summary>
+    /// The no-op dispatch — an already-Ok type, a static-only type, one with a usable build —
+    /// emits the authoritative unchanged node, so the gate is satisfied at that same version and
+    /// the wait answers immediately. A gate written as strictly-greater would have stalled every
+    /// one of these for the whole settle budget.
+    /// </summary>
+    [Fact]
+    public void ANoOpDispatchIsAnsweredByItsOwnVersion()
+    {
+        var dispatched = NodeAt(7, CompilationStatus.Ok);
+
+        var ownStream = new Subject<MeshNode>();
+        MeshNode? settled = null;
+        using var subscription = NodeTypeContractHandler
+            .SettledAtOrAfter(ownStream, dispatched, Options)
+            .Subscribe(node => settled = node);
+
+        ownStream.OnNext(NodeAt(7, CompilationStatus.Ok));
+
+        settled.Should().NotBeNull(
+            "EnsureCompileDispatched returns the node UNCHANGED for a type it must not touch, so "
+            + "the floor is that node's own version — a strictly-greater gate would hold every "
+            + "static-only and already-built type for the whole 60 s settle budget");
+        settled!.Version.Should().Be(7);
+    }
+
+    /// <summary>
+    /// 🚨 The rejected alternative, pinned so it stays rejected: a null
+    /// <see cref="NodeTypeDefinition.CompilationStatus"/> IS settled. That is not the bug, and
+    /// "fixing" it here trades a race for a hang.
+    /// </summary>
+    [Fact]
+    public void ANullCompilationStatusStaysSettled()
+    {
+        NodeAt(1, status: null).IsCompilationSettled(Options).Should().BeTrue(
+            "for a static-only NodeType, or one whose usable build the dispatch deliberately left "
+            + "alone, 'never compiled' is a settled answer — refusing it would hold their resolve "
+            + "for the whole settle budget. The ordering gate, not the predicate, is what keeps a "
+            + "stale null out of the dispatched compile's answer (#3265)");
+    }
+}


### PR DESCRIPTION
Closes #3265.

## The issue's premise is right; its proposed fix is not

`CompiledFrameworkVersion` is already set in the same `with { … }` expression as
`CompilationStatus = Ok` — in **both** writers (`ApplyCompileSuccess`,
`ApplyResolvedSuccess`). Folding it in changes nothing. What the trace actually
shows is **two producers of the terminal success write**, and the fix is to remove
the second one.

## Root cause (measured, not inferred)

`NodeTypeContractHandler` must never run Roslyn beside the watcher's compile. That
is what `EnsureCompileDispatched` (one status-guarded flip to `Pending`) plus a
settle wait exist for. But the wait subscribed a **freshly derived** own-node
stream, and a new subscriber's initial replay is not guaranteed to carry the
owner's latest commit — the reduced own-node pipeline seeds it from a source that
can lag a write the same hub has already applied.

So the settle question was answered by the **pre-dispatch snapshot**, whose
`CompilationStatus` is still `null`. `IsCompilationSettled` accepts `null` — and
correctly so: for a static-only type, or one that already has a usable build,
"never compiled" is a settled answer. `Take(1)` took it and the handler compiled
inline anyway.

Instrumented run (monolith, `DOTNET_PROCESSOR_COUNT=2`, **8 runs out of 8**):

```
[DISPATCHED]           type/StaleArea… v=3 status=Pending   ← the dispatch committed
[SETTLE-CANDIDATE]     type/StaleArea… v=1 status=          ← a snapshot from BEFORE it
[SETTLED]              type/StaleArea… v=1 status=          ← null reads as settled
[INLINE-COMPILE]       type/StaleArea… v=1 rel='' coll='' path=''
[SETTLE-CANDIDATE]     type/StaleArea… v=2 status=Pending   ← the real states, too late
[SETTLE-CANDIDATE]     type/StaleArea… v=3 status=Pending
[CONTRACT-WRITEBACK]   currV=5 fresh=True respVer=1         ← producer A, publishes Status=Ok
[RUNCOMPILE-WRITEBACK] currV=6 resultVer=4 rel='…/Release/…' ← producer B, 16 ms later
```

Two Roslyn runs, **two assemblies under two `IAssemblyStore` keys**, two terminal
success writes 16 ms apart:

```
v=6 Status=Ok fv='cb5b…' lcv=1 rel=''            ← the handler's inline compile
v=7 Status=Ok fv='cb5b…' lcv=4 rel='…/Release/…' ← RunCompile, 16 ms later
v=8 Status=Ok fv='STALE-…'                       ← a concurrent writer's stamp
```

That 16 ms window is the reported symptom: `Status=Ok` is published while the
pipeline still has a write to make, so anything that stamps the node on seeing
`Ok` is overwritten by the tail. The worse consequence is #1368's family —
whichever write-back lands last decides which store key the record names, and the
loser's bytes are addressed by nothing, so activation falls back to the default
configuration.

## The fix

`SettledAtOrAfter` gates the settle wait on the version `EnsureCompileDispatched`
reached: **a state older than the dispatch cannot answer a question about the
dispatch.** Same write-identity discipline `MeshNodeStreamHandle.UpdateOwn`'s echo
detection already uses, for the same reason. A no-op dispatch (static-only,
already built, already Pending/Ok) emits the authoritative current node, so the
gate is satisfied at that same version and those resolves answer immediately, as
before.

### Alternatives rejected

- **Make `IsCompilationSettled` refuse a null status.** It would hold every
  static-only and already-built type for the whole 60 s settle budget. The
  predicate was never wrong — it was asked about a state the dispatch had already
  superseded. Pinned as a test so it stays rejected.
- **The issue's proposal** (fold `CompiledFrameworkVersion` into the `Status=Ok`
  patch). Already true in both writers; leaves the second producer in place.
- **A completion seam the pipeline writes last.** It would paper over a duplicate
  compile and a duplicate assembly upload rather than remove them.

## Guard — mutation-proved

`test/MeshWeaver.Compiler.Pipeline.Test/SettleWaitIsOrderedAgainstTheDispatchTest.cs`.
With the version gate removed on purpose, it goes red naming the defect:

```
MeshWeaver.Graph.Test.SettleWaitIsOrderedAgainstTheDispatchTest
  .APreDispatchSnapshotCannotSettleTheDispatchedCompile [FAIL]
  Expected value to be <null> because a snapshot from BEFORE the dispatch cannot
  answer whether the dispatched compile has settled — accepting it is what let
  this handler run a second Roslyn compile beside the watcher's and publish
  Status=Ok while the pipeline still had its terminal write to make (#3265),
  but found MeshNode { … Version = 1, … CompilationStatus = , … }
```

Restored, green again.

## Verification

| | result |
|---|---|
| `MeshWeaver.Compiler.Pipeline.Test` (Release) | `Passed! 604/604` |
| `MeshWeaver.Graph.Test` (Release) | `Passed! 1324/1324` |
| `MeshWeaver.Documentation.Test` (Release) | `Passed! 257/257` |
| Plugins `MeshWeaver.Hosting.Monolith.Test`, compile filter, against this core | `Passed! 91/91` |
| The detector, 8 constrained-CPU runs | 4 terminal-success emissions per run → **3**, zero `lastCompiledVersion=1` duplicates |

All touched projects build `-c Release -warnaserror` with `0 Error(s)`,
`0 Warning(s)`.

## Work product

`Doc/Architecture/NodeTypeCompilation` gains **"ONE driver runs Roslyn — a resolve
request joins the queue, it never starts a second compile"**: the invariant, why
the wait must be ordered against the dispatch, the measurement, and why
`Status = Ok` alone is not a completion signal for a *writer*.

Pairs-with: none — the diff removes no public type and no public member (it adds
one `internal` method to an `internal` static class).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
