### PR TITLE
Report a swallowed last-execution stamp instead of losing it (#3249)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
@@ -139,7 +139,29 @@ So the verdict is not a boolean. `CodeConfiguration.OutputCurrency()` (`MeshWeav
 
 The **fingerprint is tested first**, before the other three. It is both evidence of a run and the only field that can decide currency, so a node carrying the hash and nothing else is fully determinable; checking the run markers first would answer `NeverRun` there and silence a verdict we can actually substantiate — the same fail-open shape, mirrored.
 
-**The residual, stated rather than hidden:** a cell whose *very first* run failed to stamp anything at all records nothing, and is therefore indistinguishable from a cell nobody has run. No rule over the node's content can recover that; making it observable needs the run's failure to be written somewhere — see [issue #3249](https://github.com/Systemorph/MeshWeaver/issues/3249).
+**The residual, stated rather than hidden:** a cell whose *very first* run failed to stamp anything at all records nothing, and is therefore indistinguishable from a cell nobody has run. No rule over the node's content can recover that. What happens instead is below.
+
+#### When the stamp does not land
+
+The stamp is one write to one node. It lands whole or not at all — there is no partial outcome to read a warning out of — so a cell whose stamp failed reads exactly as `NeverRun`. Recovering that on the cell is **not possible from the dispatching hub**, and the reasons are worth writing down because all three candidate shapes look plausible until you follow them:
+
+| Candidate | Why not |
+|---|---|
+| Put a `LastStampFailedAt` marker on the cell | It records the failure of a node write **by performing another node write to the same node through the same handle**. In every failure mode that actually occurs — the workspace not ready, the partition write refused, the content unreadable — the second write fails for the reason the first one did. Recovery in the same failure domain is not recovery. |
+| Append the failure to the run's Activity | The Activity *is* a different failure domain, and it is where `FailActivity` already writes. But for the in-process C# path the activity's transcript has a **single writer that re-asserts it wholesale**: `ActivityLogLogger.PublishSnapshotLocked` writes `Messages`, `MessageCount`, `MaxSeverity`, `Status` and `End` from its own private list on every flush and on `Complete`. An append issued from the dispatcher — which runs immediately after the submit, i.e. before the kernel has published anything — is overwritten by the next snapshot. Worse if it survived: an `Error`-level line rolls `MaxSeverity` up, and a terminal write that folds severity would report a **successful run as failed**. |
+| Have `ExecuteScriptResponse` carry the verdict | The response is posted before the stamp resolves. Waiting for it undoes MeshWeaver.Plugins#1266, whose whole point is that a Run click is acknowledged immediately and never silently. A stamp write that stalls would then hold the acknowledgement of a run that is already executing. |
+
+So the failure is **reported, not recovered**: `CodeNodeType.ReportStampNotRecorded` logs one line at **`Error`**, under event id `3249`, naming the cell, the activity and the fact that the run itself succeeded.
+
+Two things make that an honest answer rather than a shrug.
+
+**The run's durable record is not lost.** The Activity node was created *before* the dispatch and it carries the originating cell on `ActivityLog.HubPath`. A failed stamp loses the cell's **pointer** to its run, not the run. A listing over `_Activity` can still find it.
+
+**Every way the stamp can fail now reaches that one line.** It previously had two log calls and a third path with none: the update lambda tested `curr.Content is CodeConfiguration`, so content arriving as untyped JSON — the polymorphic converter degrading an unresolvable `$type`, the as-written `JsonObject` DOM, a same-named record from another collectible assembly — simply did not match, the write short-circuited as a no-op, and the stamp vanished with no exception and no log at all. The stamp now goes through the typed `Update<CodeConfiguration>` overload, which **refuses to write** unreadable content and faults with the runtime type and a JSON excerpt instead of silently writing a default-valued record over the cell.
+
+`Error` rather than `Warning` is deliberate and costs nothing extra: both levels ship to Loki and the path is exceptional, so the only thing that changes is that it trips error-rate alerting. That is the right classification — nothing retries the write, the loss is permanent, and the visible consequence is a cell that tells a human it has never run. "Degraded but self-correcting" is what `Warning` claims, and none of it holds here.
+
+What is still **not** covered: a viewer looking at a cell after a reload cannot tell `NeverRun` from "ran, not recorded". Closing that needs a surface that finds a cell's runs by `ActivityLog.HubPath` rather than by the stamp — a client-side concern, not a dispatch one. See [issue #3249](https://github.com/Systemorph/MeshWeaver/issues/3249).
 
 ### 2. From application code — `SubmitCodeRequest` directly
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
@@ -161,7 +161,7 @@ Two things make that an honest answer rather than a shrug.
 
 `Error` rather than `Warning` is deliberate and costs nothing extra: both levels ship to Loki and the path is exceptional, so the only thing that changes is that it trips error-rate alerting. That is the right classification — nothing retries the write, the loss is permanent, and the visible consequence is a cell that tells a human it has never run. "Degraded but self-correcting" is what `Warning` claims, and none of it holds here.
 
-What is still **not** covered: a viewer looking at a cell after a reload cannot tell `NeverRun` from "ran, not recorded". Closing that needs a surface that finds a cell's runs by `ActivityLog.HubPath` rather than by the stamp — a client-side concern, not a dispatch one. See [issue #3249](https://github.com/Systemorph/MeshWeaver/issues/3249).
+What is still **not** covered: a viewer looking at a cell after a reload cannot tell `NeverRun` from "ran, not recorded". Closing that needs a surface that finds a cell's runs by `ActivityLog.HubPath` rather than by the stamp — a read that does not depend on the stamp, not another write. See [issue #3301](https://github.com/Systemorph/MeshWeaver/issues/3301).
 
 ### 2. From application code — `SubmitCodeRequest` directly
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-cell-that-ran-no-longer-forgets-it-silently.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-cell-that-ran-no-longer-forgets-it-silently.md
@@ -1,0 +1,39 @@
+---
+Name: A cell that ran no longer forgets it silently
+Category: Fix
+Description: Running a code cell records when it ran, who ran it, and which run produced the output on screen. That record could quietly fail to save — leaving a cell that had just executed still reading as never run, with nothing anywhere saying so. It now saves in a case where it used to vanish, and when it genuinely cannot, that is reported instead of swallowed.
+Icon: Bug
+Order: -20260904
+---
+
+# A cell that ran no longer forgets it silently
+
+Press **Run** on a code cell and two separate things are written. The run itself goes to its own
+activity — the transcript you watch scroll past in the output pane. Separately, a short note is
+written back onto the cell: *when* it last ran, *who* ran it, *which* activity holds the output, and
+a fingerprint of the exact code that was submitted. That note is what lets the cell say "Last
+executed 10 minutes ago" on your next visit, and what lets it warn you when you have edited the code
+since the output below it was produced.
+
+The note is a separate save, and a save can fail. When it did, nothing said so. The cell went back
+to reading as though it had never been run at all — indistinguishable from a cell nobody has ever
+touched — and the only trace was a low-priority line in the server log that no alert was watching.
+
+Two things change.
+
+**One case that used to lose the note now keeps it.** Depending on how a cell's content arrived at
+the server, the save could quietly decide there was nothing to write and report success anyway.
+Nothing was saved, nothing failed, and nothing was logged — the run had happened and the cell simply
+did not know. That path no longer exists: the save either writes the note or reports that it could
+not, and it can no longer overwrite a cell with a blank one while trying.
+
+**When the note genuinely cannot be saved, that is now an alertable fault.** It is recorded once, at
+error level, naming the cell, naming where the run's transcript actually is, and stating plainly
+that the run itself succeeded — so nobody goes hunting a script failure that never happened.
+
+Nothing about running cells has changed, and no output that used to appear has moved. What changed
+is that "this cell has never been run" is now a statement the cell has actually earned.
+
+One thing is still open: opening a cell after a page reload, you cannot tell "never run" apart from
+"ran, and the note did not save". The run is not lost — its activity records which cell produced it
+— but the cell has no pointer back to it. Reconnecting the two is tracked separately.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-cell-that-ran-no-longer-forgets-it-silently.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-cell-that-ran-no-longer-forgets-it-silently.md
@@ -37,3 +37,6 @@ is that "this cell has never been run" is now a statement the cell has actually 
 One thing is still open: opening a cell after a page reload, you cannot tell "never run" apart from
 "ran, and the note did not save". The run is not lost — its activity records which cell produced it
 — but the cell has no pointer back to it. Reconnecting the two is tracked separately.
+
+If you have ever pressed Run on a cell and come back to find it claiming it had never been run,
+that is what this was.

--- a/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
@@ -374,53 +374,13 @@ public static class CodeNodeType
                                 hub.Post(submit, o => o.WithTarget(submitTarget));
                             }
 
-                            // Stamp Last{ExecutedAt,ExecutedBy,ActivityPath} onto
+                            // Stamp Last{ExecutedAt,ExecutedBy,ActivityPath,ExecutedCodeHash} onto
                             // the Code MeshNode so the Content area can show
                             // "Last executed: <when> by <who>" and embed the last
                             // activity's Progress area for the Output pane —
                             // without separately querying activity children.
-                            try
-                            {
-                                var workspace = hub.GetWorkspace();
-                                var stampLogger = logger;
-                                // .Subscribe is mandatory: Update is Observable.Create —
-                                // the partition write only runs on Subscribe. Discarding
-                                // the observable silently drops the stamp.
-                                workspace.GetMeshNodeStream().Update(curr =>
-                                    curr.Content is CodeConfiguration cfg
-                                        ? curr with
-                                        {
-                                            Content = cfg with
-                                            {
-                                                LastExecutedAt = DateTimeOffset.UtcNow,
-                                                LastExecutedBy = viewerHome,
-                                                LastActivityPath = activityPath,
-                                                // Fingerprint what was ACTUALLY submitted (submit.Code /
-                                                // submit.Language), not `cfg` — the two agree today, but
-                                                // stamping the node's current content would silently
-                                                // record "up to date" for a run of something else the
-                                                // moment any future path submits a transformed source.
-                                                LastExecutedCodeHash =
-                                                    CodeFingerprint.Of(submit.Code, submit.Language)
-                                            }
-                                        }
-                                        : curr)
-                                    .Subscribe(
-                                        _ => { },
-                                        ex => stampLogger?.LogWarning(ex,
-                                            "CodeNodeType: stamp UpdateMeshNode failed for {Hub}",
-                                            hub.Address));
-                            }
-                            catch (Exception stampEx)
-                            {
-                                // The workspace might not be ready (cold-start race) — the
-                                // missing stamp is a UI nicety, not a correctness invariant,
-                                // and the Activity log IS written. But a bare `catch {}` here
-                                // hid whatever went wrong; name it, with type + stack.
-                                logger?.LogWarning(stampEx,
-                                    "CodeNodeType: could not stamp last-execution fields on {Hub} "
-                                    + "(run {Activity} is unaffected)", hub.Address, activityPath);
-                            }
+                            StampLastExecution(
+                                hub, logger, activityPath, viewerHome, submit.Code, submit.Language);
 
                             hub.Post(
                                 new ExecuteScriptResponse
@@ -446,6 +406,135 @@ public static class CodeNodeType
             readError => FaultDispatch(readError, "Could not read the Code node to execute"));
         return request.Processed();
     }
+
+    /// <summary>
+    /// The ONE event id an operator can alert on for "a run happened and the cell does not know it".
+    /// 3249 is the issue that made this observable; keeping the number means a Loki/Grafana rule
+    /// written against it survives every future edit to the message text.
+    /// </summary>
+    internal static readonly EventId LastExecutionStampNotRecorded =
+        new(3249, nameof(LastExecutionStampNotRecorded));
+
+    /// <summary>
+    /// The last-execution stamp, as a cold write — subscribe to run it.
+    ///
+    /// <para>🚨 <b>Typed <c>Update&lt;CodeConfiguration&gt;</c>, never <c>curr.Content is CodeConfiguration</c>.</b>
+    /// The type test is the trap-door AGENTS.md rules out, and here it was the WORST of the stamp's
+    /// failure paths: content that arrives as untyped JSON (the polymorphic converter degrading an
+    /// unresolvable <c>$type</c>, the as-written <c>JsonObject</c> DOM, a same-named record from
+    /// another collectible assembly) does not match, the lambda returns <c>curr</c>, <c>Update</c>
+    /// short-circuits the no-op — and the stamp is dropped with <b>no exception and no log at all</b>.
+    /// The two paths the issue names at least logged. The typed overload turns that silence into a
+    /// terminal: it refuses to write and faults with a <c>MeshNodeStreamException</c> naming the
+    /// runtime type and a JSON excerpt, which lands in the same sink as every other failure.</para>
+    ///
+    /// <para>It cannot write defaults over real content either — that is the overload's contract:
+    /// unconvertible content FAILS the write rather than materialising a blank record
+    /// (<c>MeshNodeStreamHandle.ResolveContent</c>), so recovering the degraded case costs nothing
+    /// in the case where the node genuinely is not a cell.</para>
+    /// </summary>
+    /// <param name="stream">Handle to the Code node — the dispatching hub's OWN node.</param>
+    /// <param name="activityPath">Path of the Activity node this run writes its transcript to.</param>
+    /// <param name="executedBy">The viewer who triggered the run, if known.</param>
+    /// <param name="code">The source that was ACTUALLY submitted.</param>
+    /// <param name="language">The language it was submitted as.</param>
+    // internal, not private: CodeNodeStampFailureTest drives this directly. A stamp failure cannot
+    // be provoked through the dispatch — the handler refuses to dispatch at all unless the node
+    // reads as an executable CodeConfiguration — so the seam is the only place the contract is
+    // assertable.
+    internal static IObservable<MeshNode> LastExecutionStamp(
+        MeshNodeStreamHandle stream,
+        string activityPath,
+        string? executedBy,
+        string? code,
+        string? language)
+        => stream.Update<CodeConfiguration>(cfg => cfg with
+        {
+            LastExecutedAt = DateTimeOffset.UtcNow,
+            LastExecutedBy = executedBy,
+            LastActivityPath = activityPath,
+            // Fingerprint what was ACTUALLY submitted (submit.Code / submit.Language), not `cfg` —
+            // the two agree today, but stamping the node's current content would silently record
+            // "up to date" for a run of something else the moment any future path submits a
+            // transformed source.
+            LastExecutedCodeHash = CodeFingerprint.Of(code, language),
+        });
+
+    /// <summary>
+    /// Runs the stamp and reports it when it does not land. Fire-and-forget by DESIGN: the run has
+    /// already been dispatched and the caller has already been acknowledged
+    /// (MeshWeaver.Plugins#1266 — a Run click is never silent), so this must not gate anything.
+    ///
+    /// <para>🚨 <b>Every way this can fail ends in <see cref="ReportStampNotRecorded"/>.</b> The
+    /// synchronous throw (no workspace yet — the cold-start race), the write's <c>OnError</c> (a
+    /// refused/failed partition write), and content that cannot be read as a
+    /// <see cref="CodeConfiguration"/> at all all arrive at one sink. Two copies of a log call is
+    /// how the third path came to have none.</para>
+    ///
+    /// <para><b>Why the failure is reported and not recovered</b> — the decision is written up in
+    /// <c>Doc/Architecture/ScriptExecution</c> → "When the stamp does not land". In short: every
+    /// scheme that puts a marker on the CELL is a second write to the node whose first write just
+    /// failed, i.e. recovery in the same failure domain; the Activity is a different domain but its
+    /// message list is re-asserted wholesale by <c>ActivityLogLogger</c>, so an append from here is
+    /// clobbered by the next snapshot; and making the response carry the verdict means waiting for
+    /// the stamp before acknowledging the click. The run's own durable record — the Activity node,
+    /// which carries the cell's path on <c>ActivityLog.HubPath</c> — is NOT lost when the stamp
+    /// fails. What is lost is the cell's pointer to it, and this line is where that fact lives.</para>
+    /// </summary>
+    private static void StampLastExecution(
+        IMessageHub hub,
+        ILogger? logger,
+        string activityPath,
+        string? executedBy,
+        string? code,
+        string? language)
+    {
+        try
+        {
+            // .Subscribe is mandatory: Update is Observable.Create — the partition write only runs
+            // on Subscribe. Discarding the observable silently drops the stamp.
+            LastExecutionStamp(
+                    hub.GetWorkspace().GetMeshNodeStream(), activityPath, executedBy, code, language)
+                .Subscribe(
+                    _ => { },
+                    ex => ReportStampNotRecorded(logger, hub.Address, activityPath, ex));
+        }
+        catch (Exception ex)
+        {
+            // Thrown before the write could even be composed — the workspace is not ready
+            // (cold-start race), or its MeshNode reducer/data source is absent.
+            ReportStampNotRecorded(logger, hub.Address, activityPath, ex);
+        }
+    }
+
+    /// <summary>
+    /// The ONE sink for a stamp that did not land, and — deliberately — the only place in the
+    /// system where that fact exists.
+    ///
+    /// <para>🚨 <b>Error, not Warning, and the trade-off stated rather than assumed.</b> Both levels
+    /// ship to Loki, so the storage cost is identical and the path is exceptional (the happy path
+    /// logs nothing at all) — what changes is that this now trips error-rate alerting. That is the
+    /// correct classification: the write is not retried by anything, the loss is permanent, and the
+    /// consequence is a cell that will report itself to a human as never run. "Degraded but
+    /// self-correcting" is what Warning claims, and none of it is true here.</para>
+    ///
+    /// <para>Operator-facing, therefore NOT localized — nothing here reaches a screen.</para>
+    /// </summary>
+    /// <param name="logger">The dispatch logger; a null logger degrades to no report, as everywhere.</param>
+    /// <param name="hubAddress">The Code node whose record was lost.</param>
+    /// <param name="activityPath">Where the run's transcript actually is.</param>
+    /// <param name="exception">What went wrong — type and stack, never just <c>.Message</c>.</param>
+    internal static void ReportStampNotRecorded(
+        ILogger? logger, Address hubAddress, string activityPath, Exception exception) =>
+        logger?.LogError(
+            LastExecutionStampNotRecorded, exception,
+            "CodeNodeType: the last-execution stamp for {Hub} did NOT land. The run itself is "
+            + "unaffected and its transcript is at {Activity} (which records this cell on "
+            + "ActivityLog.HubPath) — what is lost is the cell's own record of it, permanently: "
+            + "nothing retries this write, so the cell reads as never run and cannot prove its "
+            + "output is current until a later run stamps it. This line is the only place that "
+            + "fact exists — see Doc/Architecture/ScriptExecution.",
+            hubAddress, activityPath);
 
     /// <summary>
     /// Reconcile a foreign-language run's ActivityLog to a terminal <see cref="ActivityStatus.Failed"/>

--- a/test/MeshWeaver.Graph.Test/CodeNodeStampFailureTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeNodeStampFailureTest.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Concurrent;
+using System.Linq;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Data;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Hosting.Monolith.TestBase;
+using MeshWeaver.Mesh;
+using MeshWeaver.Mesh.Services;
+using MeshWeaver.Messaging;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// #3249, the remainder: a last-execution stamp that does not land must SAY SO.
+///
+/// <para><see cref="CodeCellCurrencyThroughTheMeshTest"/> pins what a cell may claim once the stamp
+/// has (or has not) landed. This class pins the write itself — that it terminates with a verdict
+/// instead of a silent no-op, and that the verdict reaches an operator as one alertable line which
+/// does not misreport the run as failed.</para>
+///
+/// <para>🚨 <b>Why the seam and not the dispatch.</b> A stamp failure cannot be provoked through
+/// <c>ExecuteScriptRequest</c>: the handler refuses to dispatch at all unless the node already
+/// reads as an executable <see cref="CodeConfiguration"/>, so by the time the stamp runs the only
+/// remaining failure modes are infrastructural ones a test cannot induce from outside. The seam is
+/// therefore the only place the contract is assertable — and the happy-path wiring (handler →
+/// seam) is already covered end to end by
+/// <c>CodeCellCurrencyThroughTheMeshTest.ARunTheNodeDidRecord_ReadsAsCurrent_AndGoesStaleWhenTheCodeMoves</c>,
+/// which would fail if the dispatch stopped calling it.</para>
+/// </summary>
+public class CodeNodeStampFailureTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
+{
+    private static TimeSpan Bound => TestTimeouts.Convergence;
+
+    private const string Source = "1 + 1";
+
+    /// <summary>
+    /// The defect the issue's fourth failure path describes, and the only one that produced NO
+    /// signal whatsoever: the stamp's update lambda tested <c>curr.Content is CodeConfiguration</c>,
+    /// so a node whose content it cannot read simply did not match — <c>Update</c> short-circuited
+    /// the no-op, the observable COMPLETED as though the write had happened, and the stamp was gone
+    /// with no exception and no log. Nothing downstream could distinguish that from success.
+    ///
+    /// <para>Content that is absent is the deterministic instance of that class (no serializer, no
+    /// type registry, no timing involved); untyped JSON and a same-named record from another
+    /// collectible assembly are the others, and the typed overload refuses all three the same way.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task AStampThatCannotLand_Faults_InsteadOfCompletingAsThoughItHad()
+    {
+        // A node the stamp CANNOT write: there is no CodeConfiguration on it to carry the fields.
+        var path = await CreateNode(content: null);
+
+        var outcome = await CodeNodeType
+            .LastExecutionStamp(
+                Mesh.GetWorkspace().GetMeshNodeStream(path),
+                $"{TestPartition}/_Activity/{Guid.NewGuid():N}",
+                executedBy: "rbuergi",
+                code: Source,
+                language: "csharp")
+            // Materialize so BOTH terminals are observable: the old shape completed with a value,
+            // the fixed one faults, and asserting on the exception alone could not tell the
+            // difference between "it faulted" and "the test never got that far".
+            .Materialize()
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await();
+
+        outcome.Kind.Should().Be(System.Reactive.NotificationKind.OnError,
+            "a stamp that cannot land must terminate with a VERDICT — completing as though it had "
+            + "written is what made this failure path invisible to every caller and every log "
+            + "(#3249). Observed: {0}", Describe(outcome));
+
+        outcome.Exception!.Message.Should().Contain(nameof(CodeConfiguration),
+            "the verdict has to name what could not be read, or an operator holding it still "
+            + "cannot tell a stamp failure from any other write failure");
+        outcome.Exception!.Message.Should().Contain("NOT applied",
+            "and it has to say the write did not happen — a diagnosis that leaves that open "
+            + "invites exactly the 'maybe it partially landed' guessing the currency rule exists "
+            + "to remove");
+    }
+
+    /// <summary>
+    /// The control arm. Without it, "a stamp that cannot land faults" would be satisfied by a seam
+    /// that faults unconditionally — a guard that cannot pass proves as little as one that cannot
+    /// fail. A cell the stamp CAN write must come back carrying all four fields, including the
+    /// fingerprint of what was submitted.
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task AStampThatCanLand_WritesAllFourFields()
+    {
+        var path = await CreateNode(new CodeConfiguration { Code = Source, IsExecutable = true });
+        var activityPath = $"{TestPartition}/_Activity/{Guid.NewGuid():N}";
+
+        await CodeNodeType
+            .LastExecutionStamp(
+                Mesh.GetWorkspace().GetMeshNodeStream(path),
+                activityPath,
+                executedBy: "rbuergi",
+                code: Source,
+                language: "csharp")
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await();
+
+        var stamped = await ReadCell(path, c => c is { LastExecutedCodeHash: not null and not "" });
+
+        stamped.LastActivityPath.Should().Be(activityPath,
+            "the cell's pointer to its run is the whole reason the stamp exists");
+        stamped.LastExecutedBy.Should().Be("rbuergi");
+        stamped.LastExecutedAt.Should().NotBeNull();
+        stamped.LastExecutedCodeHash.Should().Be(CodeFingerprint.Of(Source, "csharp"),
+            "the fingerprint records what the run SUBMITTED, which is what lets the cell prove "
+            + "its output belongs to the code on screen");
+        stamped.OutputCurrency().Should().Be(CodeOutputCurrency.Current,
+            "a stamp that landed whole leaves the one state a cell may render as up to date");
+    }
+
+    /// <summary>
+    /// The report itself. A swallowed stamp is a PERMANENT loss that nothing retries, and its
+    /// visible consequence is a cell telling a human it has never run — so it is an Error, not the
+    /// Warning it used to be (both ship to Loki, so the level buys alerting, not volume).
+    ///
+    /// <para>And it must not read as a failed RUN. The run succeeded; only its record did not land,
+    /// and the transcript is still at the activity path. A line that blurs the two sends an
+    /// operator hunting a script failure that never happened.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public void TheReport_IsOneErrorThatDoesNotBlameTheRun()
+    {
+        var recorder = new RecordingLoggerProvider();
+        var cell = new Address("rbuergi", "daily-rollup");
+        const string ActivityPath = "rbuergi/_Activity/deadbeef";
+
+        CodeNodeType.ReportStampNotRecorded(
+            recorder.CreateLogger("MeshWeaver.Graph.CodeNodeType"),
+            cell,
+            ActivityPath,
+            new InvalidOperationException("the partition write was refused"));
+
+        var record = recorder.Records.Should().ContainSingle(
+            "one swallowed stamp must produce exactly ONE alertable line — the shape this replaced "
+            + "had a copy of the log call per failure path, which is how the third path came to "
+            + "have none").Subject;
+
+        record.Level.Should().Be(LogLevel.Error,
+            "nothing retries this write, the loss is permanent, and the user-visible consequence "
+            + "is a cell that reports itself as never run — none of which is the 'degraded but "
+            + "self-correcting' that Warning claims");
+        record.EventId.Id.Should().Be(3249,
+            "a stable event id is what an operator alerts on; the message text is free to change");
+        record.Error.Should().BeOfType<InvalidOperationException>(
+            "the cause travels with type and stack, never reduced to its .Message");
+        record.Message.Should().Contain(cell.ToString()).And.Contain(ActivityPath,
+            "the line has to name the cell whose record was lost AND where the run's transcript "
+            + "actually is, or it cannot be acted on");
+        record.Message.Should().Contain("run itself is unaffected",
+            "the run SUCCEEDED — a line that reads as a failed run sends an operator hunting a "
+            + "script failure that never happened (#3249)");
+    }
+
+    // ── helpers ──
+
+    private async Task<string> CreateNode(object? content)
+    {
+        var id = $"cell{Guid.NewGuid():N}"[..12];
+        var path = $"{TestPartition}/{id}";
+        var mesh = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var access = Mesh.ServiceProvider.GetRequiredService<AccessService>();
+        await access
+            .RunAsSystem(() => mesh.CreateNode(MeshNode.FromPath(path) with
+            {
+                NodeType = CodeNodeType.NodeType,
+                Name = id,
+                State = MeshNodeState.Active,
+                Content = content,
+            }))
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await();
+        return path;
+    }
+
+    /// <summary>
+    /// Reads the cell off the authoritative single-node stream, waiting on the CONDITION rather
+    /// than the clock. 🚨 <c>ContentAs</c>, never <c>is CodeConfiguration</c>.
+    /// </summary>
+    private async Task<CodeConfiguration> ReadCell(string path, Func<CodeConfiguration?, bool> until)
+    {
+        var options = Mesh.JsonSerializerOptions;
+        return (await Mesh.GetWorkspace().GetMeshNodeStream(path)
+            .Where(node => node is not null)
+            .Select(node => node.ContentAs<CodeConfiguration>(options))
+            .Where(until)
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await())!;
+    }
+
+    private static string Describe(System.Reactive.Notification<MeshNode> outcome)
+        => outcome.Kind switch
+        {
+            System.Reactive.NotificationKind.OnNext =>
+                $"OnNext({outcome.Value.Path}) — the write reported success",
+            System.Reactive.NotificationKind.OnCompleted => "OnCompleted with no value",
+            _ => $"OnError({outcome.Exception?.GetType().Name})",
+        };
+
+    /// <summary>
+    /// Instance-scoped log sink — no static state, per the house rule. Records the structured
+    /// facts an assertion needs (level, event id, exception) rather than only the formatted prose.
+    /// </summary>
+    private sealed class RecordingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<LogRecord> records = new();
+
+        public IReadOnlyList<LogRecord> Records => records.ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new Recorder(categoryName, records);
+
+        public void Dispose() { }
+
+        internal sealed record LogRecord(
+            LogLevel Level, EventId EventId, string Category, string Message, Exception? Error);
+
+        private sealed class Recorder(string category, ConcurrentQueue<LogRecord> sink) : ILogger
+        {
+            public IDisposable BeginScope<TState>(TState state) where TState : notnull
+                => Disposable.Empty;
+
+            public bool IsEnabled(LogLevel logLevel) => logLevel >= LogLevel.Warning;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state,
+                Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                if (!IsEnabled(logLevel)) return;
+                sink.Enqueue(new LogRecord(
+                    logLevel, eventId, category, formatter(state, exception), exception));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Finishes #3249. Option (3) landed in #3270; this is the remainder — *"nothing anywhere can
distinguish 'this cell has never been run' from 'it ran and we failed to record it'."*

The maintainer authorised deciding rather than asking, so the decision is argued here rather than
assumed — including the part where I think the issue's own option (1) is unsound.

## What was actually wrong

The stamp had **three** failure paths, not the two the issue quotes, and the third was the only one
with no signal at all:

```csharp
workspace.GetMeshNodeStream().Update(curr =>
    curr.Content is CodeConfiguration cfg ? curr with { … } : curr)
```

`curr.Content is CodeConfiguration` is the trap-door AGENTS.md rules out. Content arriving as
untyped JSON — the polymorphic converter degrading an unresolvable `$type`, the as-written
`JsonObject` DOM, a same-named record from another collectible assembly — does not match, so the
lambda returns `curr`, `UpdateOwn` short-circuits it as a no-op (`EmitOnce(current)`), and the
observable **completes with a value**. From every caller's point of view the write succeeded. No
exception, no log, nothing to grep. The two paths the issue names at least logged.

## What lands

**1. The silence is gone.** The stamp goes through the typed `Update<CodeConfiguration>` overload,
whose documented contract is exactly this case: *"Unconvertible content FAILS THE WRITE — it never
writes a default."* It refuses to write and faults with `MeshNodeStreamException` carrying the
runtime type and a JSON excerpt. That also removes the risk the previous reviewer named for
`ContentAs` — it cannot write a default-valued record over real content, because it does not write
at all.

**2. One sink.** The synchronous throw, the write's `OnError`, and unreadable content all arrive at
`ReportStampNotRecorded`. Two copies of a log call is how the third path came to have none.

**3. `Error`, not `Warning` — with the cost stated.** Both levels ship to Loki and this path is
exceptional (the happy path logs nothing), so the storage cost is **identical**; what the level buys
is error-rate alerting. That is the right classification: nothing retries the write, the loss is
permanent, and the visible consequence is a cell reporting itself to a human as never run.
"Degraded but self-correcting" is what `Warning` claims and none of it holds. Stable event id
`3249` so an alert rule survives edits to the text, and the line says explicitly that the **run**
succeeded — a line reading as a failed run sends an operator hunting a script failure that never
happened.

## What I deliberately did NOT do, and why

Written up in `Doc/Architecture/ScriptExecution` → **"When the stamp does not land"**, not only here.

| Option | Verdict |
|---|---|
| **(1) `LastStampFailedAt` on the cell** | **Unsound.** It records the failure of a node write by performing another node write to the same node through the same handle. In every failure mode named — workspace not ready, partition write refused, content unreadable — the second write fails for the reason the first did. Recovery in the same failure domain. |
| **Append the failure to the run's Activity** | **Unsound, and I had to read the code to find out.** The Activity genuinely is a different failure domain, and `FailActivity` already writes there — but for the in-process C# path `ActivityLogLogger.PublishSnapshotLocked` re-asserts `Messages` / `MessageCount` / `MaxSeverity` / `SegmentCount` / `Status` / `End` **wholesale from its own private list** on every 100 ms flush and on `Complete`. The stamp runs immediately after the submit, i.e. before the kernel has published anything, so an append from here is overwritten by the next snapshot. And had it survived it would be worse: an `Error` line rolls `MaxSeverity` up, and `GetFinalStatus()` maps `Error → Failed` / `Warning → Warning`, so a terminal write that folds severity would report a **successful run as failed** — exactly the thing the brief says must not happen. Post-terminal appends are safe but unreachable without racing. |
| **(2) Operator-facing Error** | **Taken.** It is the only channel that works in *every* failure mode, because the logger is not the mesh. |
| **Response carries the verdict** | Would mean waiting for the stamp before acknowledging the click — undoes MeshWeaver.Plugins#1266. (The synchronous `catch` does resolve before the `Post`, but relying on that ordering would make the report timing-dependent: present for the cold-start race, absent for an async write failure. A non-deterministic signal is not a signal.) |

## One correction to the issue's framing

*"nothing anywhere can distinguish"* is slightly too strong, and the difference matters for how bad
this is. The **Activity node is created before the dispatch** and carries the originating cell on
`ActivityLog.HubPath`. A failed stamp loses the cell's **pointer** to its run, not the run. The
durable record survives; it is just no longer reachable from the cell without a listing.

## What still remains after this

A viewer looking at a cell after a page reload still cannot tell `NeverRun` from "ran, not
recorded". That half is not another write — it is a **read that does not depend on the stamp**: a
listing over `_Activity` filtered on `ActivityLog.HubPath`, which is already stamped onto every
activity at creation. Filed as **#3301** with the shape and its cost, and both the doc and the
What's New entry point there rather than at an issue this change set closes.

So #3249 itself is done: its option (3) landed in #3270, its option (2) lands here, and its option
(1) is rejected with an argument rather than left hanging. I intend to close it on merge and point
it at #3301 — reopening is one click if you read the split differently.

## Verification

`CodeNodeStampFailureTest` (3 tests, `MonolithMeshTestBase`):
- the fault-instead-of-silence contract, asserted through `Materialize()` so *both* terminals are
  observable — asserting on the exception alone cannot tell "it faulted" from "the test never got
  there";
- a **control arm** proving the stamp still lands and still reaches `CodeOutputCurrency.Current`, so
  the guard is not satisfied by a seam that always errors;
- the report's level, event id, cause type and wording.

**Mutation-proved.** Restoring the `is CodeConfiguration` shape and the `LogWarning`, rebuilding and
re-running:

```
Failed  AStampThatCannotLand_Faults_InsteadOfCompletingAsThoughItHad [596 ms]
  Expected value to be OnError because a stamp that cannot land must terminate with a VERDICT —
  completing as though it had written is what made this failure path invisible to every caller and
  every log (#3249). Observed: OnNext(TestData/cell398dfe5c) — the write reported success,
  but found OnNext.

Failed  TheReport_IsOneErrorThatDoesNotBlameTheRun [133 ms]
  Expected value to be Error because nothing retries this write, the loss is permanent, and the
  user-visible consequence is a cell that reports itself as never run — none of which is the
  'degraded but self-correcting' that Warning claims, but found Warning.

Failed!  - Failed: 2, Passed: 1, Skipped: 0, Total: 3
```

The control arm passed under the mutation, which is the point: the tests discriminate rather than
blanket-fail. Restored → `Passed! - Failed: 0, Passed: 19` (the new class plus
`CodeCellCurrencyThroughTheMeshTest` and `CodeOutputCurrencyTest`).

`dotnet build -c Release -warnaserror`, one project per invocation, all `0 Warning(s) / 0 Error(s)`:
`MeshWeaver.Graph` (11.9 s) · `MeshWeaver.Documentation` (5.0 s) · `MeshWeaver.Graph.Test` (7.6 s) ·
`MeshWeaver.Documentation.Test` (4.8 s). `DocumentationLinkIntegrityTest` and
`WhatsNewEntryIntegrityTest` pass.

## Notes

- **No i18n keys.** Nothing here reaches a screen — the one string added is an operator-facing log
  line, which AGENTS.md explicitly does not translate.
- **No public surface removed** (`git diff | grep '^-' | grep public` is empty); the three new
  members are `internal`, covered by the existing `InternalsVisibleTo MeshWeaver.Graph.Test`. So the
  `Cross-repo pair (public surface)` gate does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
