### PR TITLE
test(Cascade): observe the overlap instead of timing it — the parallelism assertion measured the runner

### DIFF
--- a/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/CascadeTest.cs
@@ -149,19 +149,43 @@ public class CascadeTest
             (_, _) =>
             {
                 var now = Interlocked.Increment(ref inFlight);
-                int seen;
-                do
+                try
                 {
-                    seen = Volatile.Read(ref peak);
-                } while (now > seen && Interlocked.CompareExchange(ref peak, now, seen) != seen);
-                Thread.Sleep(80);
-                Interlocked.Decrement(ref inFlight);
-                return (0, true);
+                    int seen;
+                    do
+                    {
+                        seen = Volatile.Read(ref peak);
+                    } while (now > seen && Interlocked.CompareExchange(ref peak, now, seen) != seen);
+                    // 🚨 OBSERVE the overlap; do not infer it from a sleep. This body used to
+                    // `Thread.Sleep(80)` and trust that two of the three slots would land inside it
+                    // at once. On a starved runner they need not: the scheduler can admit, run and
+                    // release one node before the next is dispatched, `peak` stays 1, and
+                    // "nodes with no edge between them run at the same time" fails having measured
+                    // the RUNNER's load rather than the cascade's parallelism (core CI run
+                    // 33878671896, shard 3 — green on three sibling PRs and on main's previous
+                    // three runs, and 10/10 locally, i.e. exactly the load-sensitivity signature).
+                    //
+                    // Now the first node in waits until a SECOND is inside with it. If the cascade
+                    // really does admit more than one, both see it immediately and neither waits;
+                    // if it serialises, the wait expires and the assertion below fails for the
+                    // reason it is written for. The bound is per node and generous, so a genuinely
+                    // serial scheduler costs the test a few seconds rather than hanging it.
+                    SpinWait.SpinUntil(() => Volatile.Read(ref inFlight) > 1, TimeSpan.FromSeconds(2));
+                    return (0, true);
+                }
+                finally
+                {
+                    // In the finally so a body that throws cannot strand the count and turn this
+                    // into a different, harder question.
+                    Interlocked.Decrement(ref inFlight);
+                }
             },
             maxParallel: slots).Await(TestContext.Current.CancellationToken);
 
         Assert.Equal(nodes, results.Length); Assert.All(results, r => Assert.True(r.IsGreen));
-        Assert.True(peak > 1, "nodes with no edge between them run at the same time");
+        Assert.True(peak > 1,
+            "nodes with no edge between them run at the same time — each body waits (bounded) for a "
+            + "second node to join it, so this fails only when the cascade actually serialises");
         Assert.True(peak <= slots, $"peak {peak} exceeded the slot cap {slots}");
         Assert.Contains(results, r => r.Queued > TimeSpan.Zero); // six nodes on three slots: somebody waited
     }


### PR DESCRIPTION
## Why

`CascadeTest.IndependentNodesRunInParallel_BoundedByTheSlotCount` failed core CI run **33878671896** (shard 3) on:

```
nodes with no edge between them run at the same time
```

It is a **load-sensitive assertion**, and the base rate says so rather than my reading it that way: `Run tests (shard 3)` was **green on three sibling PRs** (#3297, #3299, #3300) and on **main's previous three runs**, and the class is **10/10 locally**. A failure that appears only under contention, on one run, in a test whose subject is timing, is the signature of the test measuring the runner.

## The mechanism

The test runs six nodes on three slots and puts `Thread.Sleep(80)` in each body, trusting that two of them will be inside the sleep at the same moment so the `peak` counter exceeds 1. Nothing enforces that. On a starved runner the scheduler can admit, run and release one node before the next is dispatched — `peak` stays 1 and the assertion fires, having established nothing about the cascade.

## What changes

The overlap is **observed** rather than timed. Each body waits, bounded, for a second node to join it:

```csharp
SpinWait.SpinUntil(() => Volatile.Read(ref inFlight) > 1, TimeSpan.FromSeconds(2));
```

- If the cascade admits more than one — the property under test — both nodes see it immediately and neither waits. The green path costs nothing extra.
- If it genuinely serialises, the wait expires and the assertion fails **for the reason it is written for**, in a couple of seconds rather than hanging.
- The `inFlight` decrement moves into a `finally`, so a throwing body cannot strand the count and turn a clear failure into a harder question.

No hand-woven gate: a volatile counter polled under a bounded `SpinWait.SpinUntil` is the shape AGENTS.md sanctions for a release into a worker the test parks.

## Verification

`MeshWeaver.PluginTester.Test` `CascadeTest` **10/10** in Release at `DOTNET_PROCESSOR_COUNT=2` — 2 s, versus 485 ms before, which is the cost of proving the overlap instead of assuming it.

Pairs-with: none — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
