### PR TITLE
fix(#3176): the identity anchor must not carry the module's version — #3293's cure leaves one identity per module

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -761,6 +761,9 @@ jobs:
       - name: Publish the module-pack tool (once for every pack job)
         if: steps.tool-cache.outputs.cache-hit != 'true'
         run: dotnet publish meshweaver/src/MeshWeaver.Plugin.Build/MeshWeaver.Plugin.Build.csproj -c Release -o "$RUNNER_TEMP/pack-tool"
+      # Lane-scoped like every other artifact this workflow drops: two calls in one run publish
+      # the tool from their OWN platform pin, and a run-wide name lets one call's pack jobs pack
+      # with the other call's builder.
       - name: Hand the tool to the matrix
         uses: actions/upload-artifact@v7
         with:
@@ -1765,13 +1768,17 @@ jobs:
             # this "the assembly publish would have copied" — but that is the one global property
             # that must NOT reach here, because $VERSION is the MODULE's package version and the
             # identity must be the PLATFORM's. MSBuild writes Version into the assembly's version
-            # attributes, so it lands in the metadata the MVID is computed over: measured locally,
-            # one project published twice changing nothing else, 914d015cd9c04427be1f1f9e9eca0f1e
-            # (no override) vs 9b9fa23435b44398ae91244d3ddd02e8 (-p:Version=1.3.18). With it, each
-            # matrix job builds its OWN compiler and the run states one identity PER MODULE — seen
-            # on run 33874892203, where the identity still came from the module's output: AI stated
-            # be27d0fb9ad54ae6a862bfa7aeb97c9b while Markdown.Collaboration stated
-            # d756b82e09804a11b0ea44d26233af6c for the same platform and the same commit. A
+            # attributes, so it lands in the metadata the MVID is computed over. Measured on THIS
+            # command, with the two package versions core CD packs, plus a control:
+            #     -p:Version=1.3.18 (AI)         -> 34337c31960d47f5b5251d32ef923fc6
+            #     -p:Version=1.0.24 (Essentials) -> 7c1c4f70de084da78659e6bda495e1c5
+            #     no override, run A             -> 71cc81badb364c5d8558ac5e7db6a44e
+            #     no override, run B             -> 71cc81badb364c5d8558ac5e7db6a44e   (identical)
+            # With it, each matrix job builds its OWN compiler and the run states one identity PER
+            # MODULE — already seen in the field on run 33874892203, by the earlier route to the
+            # same pollution: AI stated be27d0fb9ad54ae6a862bfa7aeb97c9b while
+            # Markdown.Collaboration stated d756b82e09804a11b0ea44d26233af6c for the same platform
+            # and the same commit. A
             # per-module identity names no platform build a consumer can have landed, so #3154's
             # (version, identity) comparison gets a value that means nothing — GREEN, and useless.
             # Without it every job builds byte-identical bytes from one commit, so the whole run

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -761,6 +761,25 @@ jobs:
       - name: Publish the module-pack tool (once for every pack job)
         if: steps.tool-cache.outputs.cache-hit != 'true'
         run: dotnet publish meshweaver/src/MeshWeaver.Plugin.Build/MeshWeaver.Plugin.Build.csproj -c Release -o "$RUNNER_TEMP/pack-tool"
+      # 🚨 NO `if:` — this must hold on a CACHE HIT too. The tool artifact is also the SOURCE-ARM
+      # IDENTITY ANCHOR (#3176): it is published out of the `meshweaver` checkout at `platform-ref`
+      # with no module version override, and it ProjectReferences MeshWeaver.Graph →
+      # MeshWeaver.Compiler, so its output carries the platform's own identity assembly and every
+      # pack job reads the SAME bytes. That is a load-bearing side effect of a reference graph this
+      # workflow does not own, so it is asserted rather than assumed — if MeshWeaver.Plugin.Build
+      # ever stops reaching MeshWeaver.Compiler, this fails here, naming the anchor, instead of
+      # surfacing later as a per-module "no identity anchor" on whichever modules happen to reach it.
+      # Guarding it behind the cache-miss condition would let a warm cache restore a tool without the
+      # anchor and skip the check that would have caught it — a gate that tests its own input.
+      - name: The tool output carries the platform identity anchor
+        run: |
+          set -euo pipefail
+          anchor="$RUNNER_TEMP/pack-tool/MeshWeaver.Compiler.dll"
+          [ -f "$anchor" ] || {
+            echo "::error::the module-pack tool published no MeshWeaver.Compiler.dll at '$anchor', so the source-built arm has no identity anchor to name (#3176). It is there because MeshWeaver.Plugin.Build references MeshWeaver.Graph, which references MeshWeaver.Compiler; if that path was cut, publish the identity assembly alongside the tool rather than letting the pack fall back to a module-local copy — a module's own output carries it only by accident and rebuilds it under the module's -p:Version."
+            exit 1
+          }
+          echo "identity anchor: $anchor ($(wc -c < "$anchor" | tr -d ' ') bytes) — one platform identity for every module this run packs"
       # Lane-scoped like every other artifact this workflow drops: two calls in one run publish
       # the tool from their OWN platform pin, and a run-wide name lets one call's pack jobs pack
       # with the other call's builder.
@@ -1734,19 +1753,42 @@ jobs:
           #     passes as MeshWeaverRefs and the container build compiles inside) — the anchor is in
           #     there, and the module's own output deliberately carries no platform assembly. This
           #     is every satellite call, and it is the case the packer's default probe cannot see.
-          #   * platform built from SOURCE (`REFS` empty — core's own main-cd call) — the platform
-          #     ProjectReferences are real, so MeshWeaver.Compiler.dll IS beside the module in the
-          #     publish output. Measured green on CD run 33779812466:
-          #     "built-against MVID ce81fd4e3f5146c7a6ebaa6dc72da3f2".
+          #   * platform built from SOURCE (`REFS` empty — core's own main-cd call) — the anchor is
+          #     the PACK TOOL's publish output. The tool is published ONCE per `platform-ref`, in
+          #     `prepare`, out of the `meshweaver` checkout and with NO module version override, and
+          #     it ProjectReferences MeshWeaver.Graph → MeshWeaver.Compiler, so its output carries
+          #     the platform's own identity assembly. Every pack job downloads that one artifact,
+          #     so every bundle of a run states ONE identity.
+          #
+          # 🚨 IT USED TO READ `$PACKDIR/MeshWeaver.Compiler.dll` — the MODULE's own publish output —
+          # and that was wrong in BOTH directions (#3176):
+          #   * ABSENT. A module's output carries the identity assembly only if its reference closure
+          #     reaches it, and in core only MeshWeaver.Graph and MeshWeaver.Compiler.Pipeline do.
+          #     MeshWeaver.Maps (→ MeshWeaver.Layout) and MeshWeaver.Payments.Stripe
+          #     (→ MeshWeaver.Mesh.Contract) do not, so both packed RED — "no identity anchor" — on
+          #     EVERY core CD run of 2026-09-04 (33867513503, 33873443795, 33873909869, 33874892203),
+          #     skipping `Plugins: bake + seal` and stopping the fleet's module publication. They
+          #     became visible the moment Plugins#1268 cleared the one-producer FATAL that had been
+          #     masking everything downstream of it.
+          #   * WRONG WHERE PRESENT. That copy is REBUILT inside the module's own build, which passes
+          #     -p:Version=<the module's package version>; the property flows to every transitively
+          #     built platform project and moves the identity assembly's MVID. Run 33874892203: one
+          #     platform, one commit, two green bundles, TWO identities — MeshWeaver.AI stated
+          #     be27d0fb9ad54ae6a862bfa7aeb97c9b, MeshWeaver.Markdown.Collaboration stated
+          #     d756b82e09804a11b0ea44d26233af6c. Reproduced locally by publishing one project twice
+          #     changing nothing but -p:Version (914d015c… → 9b9fa234…). A per-module identity names
+          #     no platform build any consumer can have landed, so #3154's (version, identity)
+          #     comparison had a value that means nothing — the failure mode #3211 exists to close.
           #
           # Both arms end in a RED with no anchor — neither is a quiet fallback, and the packer
-          # refuses again behind them, so a bundle whose identity is a guess cannot exist.
+          # refuses again behind them (including a module-local anchor, refused by name), so a
+          # bundle whose identity is a guess cannot exist.
           if [ -n "$REFS" ]; then
             anchor="$REFS/MeshWeaver.Compiler.dll"
             where="the pinned platform image's extracted /app"
           else
-            anchor="$PACKDIR/MeshWeaver.Compiler.dll"
-            where="the module's own build output (no platform image is pinned, so the platform was built from source)"
+            anchor="$RUNNER_TEMP/pack-tool/MeshWeaver.Compiler.dll"
+            where="the platform build the module-pack tool was published from (no platform image is pinned, so the platform was built from source at platform-ref)"
           fi
           if [ ! -f "$anchor" ]; then
             echo "::error::no identity anchor for $MODULE — expected MeshWeaver.Compiler.dll at '$anchor', i.e. in $where. Every bundle must state the framework build its bytes were compiled against (#3211): a consumer compares it against what it has landed, and an unstated one makes every reconcile answer 'up to date, identity could not be checked' forever. Nothing here may guess it, so the pack stops."

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleIdentityAnchor.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleIdentityAnchor.md
@@ -196,6 +196,23 @@ writing down: a satellite pins the LANE (`uses: …@<sha>`) and `platform-ref` S
 purpose, so a lane edit alone does NOT move a satellite's key. That is safe here only because this
 edit cannot change what the image arm packs; a future edit to the image arm would need the bump.
 
+## The guards are CONFIG-level — what still cannot fail
+
+Worth stating plainly, because it is the same class of gap this page documents. Both guards assert
+the lane's *text* or the anchor's *location*; **neither can see the outcome fail.** A different
+mechanism that reintroduces a per-module identity — another per-module property reaching that command
+line, a future arm deriving the anchor a third way, a caller passing `--framework-mvid` per module —
+would leave every guard here green, and the failure is silent: the bundle packs, the manifest carries
+a well-formed 32-hex value, and every non-blank assertion passes.
+
+The check that would catch it is one assertion at the only place that sees the whole wave: **every
+bundle a run packs states the SAME identity**, which is true by definition — the identity names the
+platform build, and a run has one platform. The receipt `verify` already collects would carry the
+value, and `All selected bundles built` would refuse a lane whose bundles disagree. That is
+[#3310](https://github.com/Systemorph/MeshWeaver/issues/3310); it is not folded in here because it
+changes the receipt schema and the shared `node-repo-pack-verify.py`, which every satellite consumes
+at its own pin — and an absent field there must not read as "agrees".
+
 ## Still open, deliberately not changed here
 
 On the source arm the anchor states a raw MVID, because the anchor build passes no `-p:CIRun=true`

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleIdentityAnchor.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleIdentityAnchor.md
@@ -1,0 +1,176 @@
+---
+Name: The Module Identity Anchor
+Category: Architecture
+Description: A module bundle states the framework build its bytes were compiled against. That identity belongs to the PLATFORM, so it may never be read out of the module's own build output — where it is present only by accident and, when present, is a rebuild carrying the module's own version. The two failure shapes that produced, and where the anchor comes from on each lane.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="5" r="3"/><line x1="12" y1="22" x2="12" y2="8"/><path d="M5 12H2a10 10 0 0 0 20 0h-3"/></svg>
+---
+
+# The Module Identity Anchor
+
+**Every module bundle states the framework build its bytes were compiled against, and that value is
+a property of the PLATFORM — one value for every module packed in a run. It is read off an
+*identity anchor*: a copy of `MeshWeaver.Compiler.dll`, the assembly `FrameworkIdentity` is anchored
+on. The anchor is the platform's copy, never the module's own build output.**
+
+The rule reads as pedantry until you see what happens when it is broken, because the module's own
+output *sometimes* contains a copy of that assembly — and it is the wrong one, in two different
+ways at once.
+
+## Why the bundle states an identity at all
+
+MeshWeaver#3154 made the identity an INPUT TO A DECISION on every installation. A module's version
+encodes CONTENT only, so a rebuild of unchanged source against a NEW platform republishes under the
+SAME version; without the identity a consumer cannot tell that rebuild from a no-op, and
+`ModuleUpdateDecision.Decide` answers `SkipUpToDate` forever. MeshWeaver#3211 therefore made the
+field mandatory at the producer: a bundle that cannot say what it was built against is not written
+at all. `ModulePackCommand` takes it as `--framework-mvid <identity>` or reads it itself from
+`--graph-dll <path to MeshWeaver.Compiler.dll>`.
+
+So the whole mechanism turns on the anchor naming the right assembly. Naming the wrong one does not
+fail — it produces a bundle that states an identity confidently, and no consumer can ever match it.
+
+## Where the anchor is, per lane
+
+`node-repo-module-pack.yml` picks the anchor with the SAME expression the build used, so the anchor
+and the reference set the bytes were compiled against cannot be two different things:
+
+| the platform is… | the anchor is… | who runs this |
+|---|---|---|
+| a pinned IMAGE (`platform-image-digest` set) | `$REFS/MeshWeaver.Compiler.dll` — the `docker cp` of the image's `/app`, which the sdk build passes as `MeshWeaverRefs` and the container build compiles inside | every satellite call |
+| built from SOURCE (`REFS` empty) | `$RUNNER_TEMP/pack-tool/MeshWeaver.Compiler.dll` — the module-pack tool's publish output | core's own `main-cd` call |
+
+The second row is the one this page exists for. The pack tool is published ONCE per `platform-ref`,
+in the `prepare` job, out of the `meshweaver` checkout and with **no module version override**; it
+`ProjectReference`s `MeshWeaver.Graph` → `MeshWeaver.Compiler`, so its output carries the platform's
+own identity assembly. Every pack job downloads that one artifact, so every bundle of a run reads
+the SAME bytes.
+
+That is a load-bearing side effect of a reference graph the lane does not own, so `prepare` asserts
+it rather than assuming it — and asserts it **unconditionally**, because the tool is restored from a
+cache keyed on `platform-ref`. A check guarded by the cache-miss condition would let a warm cache
+restore a tool without the anchor and skip the very check that would have caught it.
+
+## What reading the module's own output actually did
+
+Until MeshWeaver#3176 the source arm read `$PACKDIR/MeshWeaver.Compiler.dll` — the directory being
+packed. The comment beside it asserted the premise plainly: *"the platform ProjectReferences are
+real, so MeshWeaver.Compiler.dll IS beside the module in the publish output."* That premise is false
+in general, and it fails in two opposite directions.
+
+### Shape 1 — ABSENT, and it stops the fleet
+
+A module's publish output carries the identity assembly only if the module's own reference closure
+reaches it. In core, `MeshWeaver.Compiler` is referenced by exactly two projects:
+
+```
+$ grep -rl "MeshWeaver.Compiler.csproj" src/ --include='*.csproj'
+src/MeshWeaver.Compiler.Pipeline/MeshWeaver.Compiler.Pipeline.csproj
+src/MeshWeaver.Graph/MeshWeaver.Graph.csproj
+```
+
+So whether the anchor exists at all is an accident of what a module imports:
+
+| module | its platform references | reaches `MeshWeaver.Compiler`? | packed |
+|---|---|---|---|
+| `MeshWeaver.AI` | `MeshWeaver.Graph`, `MeshWeaver.Hosting`, … | ✅ | green |
+| `MeshWeaver.Markdown.Collaboration` | `MeshWeaver.Graph`, `MeshWeaver.Blazor` | ✅ | green |
+| `MeshWeaver.Maps` | `MeshWeaver.Layout` only | ❌ | **RED** |
+| `MeshWeaver.Payments.Stripe` | `MeshWeaver.Mesh.Contract` only | ❌ | **RED** |
+
+Confirmed by publishing `MeshWeaver.Layout` — Maps' only platform reference — on its own: 43 files
+in the publish output, no `MeshWeaver.Compiler.dll`.
+
+The two red modules produced, on every core CD run of 2026-09-04
+(`33867513503`, `33873443795`, `33873909869`, `33874892203`):
+
+```
+##[error]no identity anchor for MeshWeaver.Maps — expected MeshWeaver.Compiler.dll at
+'…/src/MeshWeaver.Maps/bin/Release/net10.0/publish/MeshWeaver.Compiler.dll', i.e. in the module's
+own build output (no platform image is pinned, so the platform was built from source). …
+```
+
+`All selected bundles built` went red, `Plugins: bake + seal the publication for this identity` was
+**skipped**, and no module was published for the fleet. Note what this is NOT: the image half of CD
+was green throughout — `Promote: tag the full set` and `Verify every image shipped` both passed, and
+the heal ledger recorded a complete image set for every one of those commits. Only the module half
+stopped.
+
+**Why it appeared exactly then.** Maps and Payments.Stripe had just been added to the compose set,
+because the Plugins content binds them and a bake without them fails `CS0246`. Before that, the set
+was AI + Markdown.Collaboration — the two modules that happen to reach the compiler — so the defect
+had no way to show. It was additionally masked: every run had been dying earlier, on the
+`MeshWeaver.Markdown.Collaboration` one-producer FATAL. When MeshWeaver.Plugins#1268 cleared that
+mask at 12:48Z, this became the visible blocker within one run.
+
+### Shape 2 — PRESENT and WRONG, silently
+
+The worse half. Where the closure does reach the compiler, the copy beside the module was **rebuilt
+inside that module's own build**, which passes `-p:Version=<the module's package version>`. MSBuild
+flows that property to every transitively built project, so the platform's identity assembly is
+rebuilt under the module's version and its MVID moves with it.
+
+The result is visible in a single run. Core CD `33874892203` — one platform, one commit, two green
+bundles, **two identities**:
+
+```
+packed MeshWeaver.Plugin.AI.1.3.18.module.nupkg          … built against framework be27d0fb9ad54ae6a862bfa7aeb97c9b
+packed MeshWeaver.Plugin.Essentials.1.0.24.module.nupkg  … built against framework d756b82e09804a11b0ea44d26233af6c
+```
+
+Reproduced locally, changing nothing but the version property:
+
+```
+$ dotnet publish src/MeshWeaver.Plugin.Build/… -c Release                   -o tool-A
+$ dotnet publish src/MeshWeaver.Plugin.Build/… -c Release -p:Version=1.3.18 -o tool-B
+914d015cd9c04427be1f1f9e9eca0f1e  tool-A/MeshWeaver.Compiler.dll
+9b9fa23435b44398ae91244d3ddd02e8  tool-B/MeshWeaver.Compiler.dll
+```
+
+A per-module identity names no platform build any consumer can have landed. `ModuleUpdateDecision`
+then compares `(version, identity)` against a value that means nothing — which is precisely the
+blind spot #3211 was built to close, reopened one layer down. And unlike shape 1 it is GREEN: the
+bundle packs, the manifest carries a well-formed 32-hex identity, and every downstream assertion
+that the field is non-blank passes.
+
+## The guards
+
+Two, at different altitudes, because the config check and the behaviour check fail for different
+reasons.
+
+**In the packer** (`ModulePackCommand`, behavioural): an anchor that resolves inside the module
+directory being packed is refused by name — `exit 2`, nothing written — whether it was passed as
+`--graph-dll` or found by the default probe. The default-probe arm is the one that matters: without
+it the probe reads a module-local copy and the bundle packs green, which is how two identities for
+one platform reached a CD run unnoticed. `ModulePackCommandTest` covers both arms, and the fixture
+copies a REAL assembly into place so the refusal cannot pass for "the file was not readable".
+
+**In the lane guard** (`ModuleIdentityPublishGuard`): the pack step must name
+`$RUNNER_TEMP/pack-tool/MeshWeaver.Compiler.dll` on the source arm and must NOT name
+`$PACKDIR/MeshWeaver.Compiler.dll`; and `prepare` must carry the anchor assertion with no `if:` and
+no `continue-on-error`.
+
+## The rule
+
+**An identity is a property of the thing it identifies.** The framework identity belongs to the
+framework build, so it is read from something the framework build owns — the pinned image's `/app`,
+or a platform publish made once per run. The moment it is read from a per-module directory it
+becomes a per-module value, and a per-module value for a platform-wide property is wrong even when
+it is present, well-formed and green.
+
+## Still open, deliberately not changed here
+
+On the source arm the anchor states a raw MVID, because the pack tool is published without
+`-p:CIRun=true` and `FrameworkBuildIdentity.Resolve` falls back to the content identity when there
+is no `MeshWeaverFrameworkIdentity` stamp. The portal image for the same commit IS built with
+`-p:CIRun=true` (`main-cd.yml`), so it carries the `g<sha>` commit stamp. Making the two agree is a
+separate change with fleet-visible consequences — it changes the SHAPE of the identity core's own
+bundles state — and it is not required to make the anchor correct, which is what this page is about.
+Before #3176 the source arm already stated raw MVIDs and CD sealed green on them
+(run `33779812466`), so the shape is not what was blocking delivery.
+
+## Related
+
+- [Module Build Architecture](/Doc/Architecture/ModuleBuildArchitecture) — the one build shape every repo follows.
+- [Module Versioning](/Doc/Architecture/ModuleVersioning) — what you author versus what the build derives.
+- [Continuous Delivery Contract](/Doc/Architecture/ContinuousDeliveryContract) — what a CD run promises to publish.
+- [CI Content Bake](/Doc/Architecture/CiContentBake) — the surface manifest and the framework identity it carries.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleIdentityAnchor.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleIdentityAnchor.md
@@ -157,6 +157,25 @@ or a platform publish made once per run. The moment it is read from a per-module
 becomes a per-module value, and a per-module value for a platform-wide property is wrong even when
 it is present, well-formed and green.
 
+## Why the ledger's `RECIPE_VERSION` did NOT move with this
+
+`module-build-key.py` documents the rule as *"bump on a byte-changing lane edit"*, and #3211 bumped
+it to `"2"` when it ADDED `frameworkMvid` to the manifest. This change moves that field's VALUE on
+the source arm, so the question is fair — and the answer is that the key already covers it, on both
+arms, without a bump:
+
+- **Source arm (the only arm whose bytes change).** The key includes `platformRef`, and on core's
+  `main-cd` call `platform-ref` IS the commit being built. Any run after this change carries a
+  `platformRef` no pre-change run had, so its key differs and no pre-change bundle can be reused.
+- **Image arm.** Untouched — satellites read the anchor from the pinned image's `/app` exactly as
+  before, so their bundles' identity does not change and there is nothing to invalidate.
+
+A bump would therefore invalidate every cached bundle in the fleet — a full rebuild wave in every
+repo — to protect against a reuse that cannot happen. Note the asymmetry that makes this worth
+writing down: a satellite pins the LANE (`uses: …@<sha>`) and `platform-ref` SEPARATELY and on
+purpose, so a lane edit alone does NOT move a satellite's key. That is safe here only because this
+edit cannot change what the image arm packs; a future edit to the image arm would need the bump.
+
 ## Still open, deliberately not changed here
 
 On the source arm the anchor states a raw MVID, because the pack tool is published without

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-module-updates-reach-you-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-module-updates-reach-you-again.md
@@ -1,0 +1,47 @@
+---
+Name: Module updates reach your portal again
+Category: Fix
+Description: Plugin modules stopped being published for the fleet — two of them could not be built at all, and the ones that were built each claimed to have been compiled against a different platform, so no portal could tell an update from something it already had. Modules are published again, and every module from one release now states the same platform build.
+Icon: Box
+Order: -20260904
+---
+
+# Module updates reach your portal again
+
+Plugins reach your portal as **modules** — self-contained bundles the portal downloads and loads,
+separately from the portal image itself. Every bundle records which build of the platform it was
+compiled against, and your portal uses that record to answer one question: *is this bundle actually
+newer than what I already have?*
+
+A module's version number alone cannot answer it. The same source rebuilt against a newer platform
+republishes under the same version, so without the platform record your portal would see "same
+version" and skip an update it needed.
+
+## What was broken
+
+Two things, and they had the same cause: the record was being read from the wrong place — from the
+module's own build output, instead of from the platform.
+
+**Two modules could not be published at all.** Maps and the Stripe payments module do not happen to
+include the platform component that record is read from, so publishing them stopped with an error.
+Because module publication is all-or-nothing, that stopped publication of *every* module. No plugin
+update reached any portal on that path.
+
+**The modules that did publish disagreed with each other.** Where the component was present, it had
+been rebuilt as part of that module, stamped with that module's own version number — so each bundle
+recorded a different platform build, even though they were all built from one platform, in one
+release. A record that names a platform build no portal has ever run is a record no portal can match,
+so those bundles could not be recognised as updates either.
+
+Neither symptom looked like a problem from the outside. Portal images kept publishing normally
+throughout, and the bundles that did get built looked perfectly well-formed.
+
+## What changes
+
+The platform record is now taken from the platform, once per release, and every module built in that
+release states the same value. Two checks keep it that way: the packaging tool refuses outright to
+read the record from a module's own output, and the release pipeline confirms it has the platform's
+copy before any module is built.
+
+For you this means plugin updates flow again, and a portal deciding whether to take one is comparing
+against something real.

--- a/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
+++ b/src/MeshWeaver.Plugin.Build/ModulePackCommand.cs
@@ -302,16 +302,62 @@ public static class ModulePackCommand
         // be healed downstream. So the blind spot is closed where it is created — a bundle that
         // cannot say what it was built against is not written at all.
         //
-        // Two ways to state it, because the anchor is not always beside the module: on the
-        // container / MeshWeaverRefs lanes the platform IS the image, so MeshWeaver.Compiler.dll
-        // lives in the extracted /app rather than in the module's output (measured on every one of
-        // MeshWeaver.Plugins' 34 bundles, 2026-09-03: "built-against MVID (unrecorded)", both the
-        // sdk and the container path). ReadIdentity (not ReadMvid) so a CI-built anchor records its
-        // stamped commit identity — the value the runtime actually compares (#1660 WS3).
+        // Two ways to state it, and the anchor is NEVER the module's own output: on the container /
+        // MeshWeaverRefs lanes the platform IS the image, so MeshWeaver.Compiler.dll lives in the
+        // extracted /app (measured on every one of MeshWeaver.Plugins' 34 bundles, 2026-09-03:
+        // "built-against MVID (unrecorded)", both the sdk and the container path); where the
+        // platform is built from source it is the platform build the pack tool was published from.
+        // The guard below refuses a module-local anchor outright — see #3176 for why a copy beside
+        // the module is both optional and wrong. ReadIdentity (not ReadMvid) so a CI-built anchor
+        // records its stamped commit identity — the value the runtime actually compares (#1660 WS3).
         graphDll ??= Path.Combine(moduleDirectory, FrameworkIdentity.IdentityAssembly + ".dll");
         var frameworkMvid = statedFrameworkMvid;
         if (string.IsNullOrWhiteSpace(frameworkMvid) && File.Exists(graphDll))
+        {
+            // 🚨 THE ANCHOR IS A PROPERTY OF THE PLATFORM, NEVER OF THE MODULE'S OWN OUTPUT (#3176).
+            // A copy of MeshWeaver.Compiler.dll sitting in the directory being packed is there for
+            // one of two reasons, and BOTH make it the wrong assembly to read:
+            //
+            //   * the module's reference closure happens to reach it — in core it is reachable only
+            //     through MeshWeaver.Graph or MeshWeaver.Compiler.Pipeline, so whether the anchor
+            //     exists at all is an accident of what the module imports. MeshWeaver.AI and
+            //     MeshWeaver.Markdown.Collaboration reach it; MeshWeaver.Maps (→ MeshWeaver.Layout)
+            //     and MeshWeaver.Payments.Stripe (→ MeshWeaver.Mesh.Contract) do not, and packed RED
+            //     on every core CD run of 2026-09-04 while the other two packed green.
+            //   * and where it IS reached, it was REBUILT inside that module's own build, which
+            //     carries -p:Version=<the module's package version>. That version flows to every
+            //     transitively built platform project, so the identity assembly's MVID changes with
+            //     it: measured on run 33874892203, one platform, one commit, two bundles, two
+            //     identities — MeshWeaver.AI stated be27d0fb9ad54ae6a862bfa7aeb97c9b and
+            //     MeshWeaver.Markdown.Collaboration stated d756b82e09804a11b0ea44d26233af6c.
+            //
+            // Reproduced locally: publishing one project twice, changing nothing but -p:Version,
+            // moves MeshWeaver.Compiler.dll's MVID (914d015c… → 9b9fa234…). So a module-local anchor
+            // states an identity that names no platform build any consumer can ever have landed —
+            // #3154's (version, identity) comparison against a value that means nothing. Refused
+            // where it is created; the caller names the platform's own copy instead.
+            var anchorDirectory = Path.GetDirectoryName(Path.GetFullPath(graphDll));
+            if (anchorDirectory is not null
+                && string.Equals(
+                    Path.TrimEndingDirectorySeparator(anchorDirectory),
+                    Path.TrimEndingDirectorySeparator(Path.GetFullPath(moduleDirectory)),
+                    OperatingSystem.IsLinux() ? StringComparison.Ordinal : StringComparison.OrdinalIgnoreCase))
+            {
+                Console.Error.WriteLine(
+                    $"error: the identity anchor '{graphDll}' is inside the module directory being "
+                    + "packed, so it is the module's OWN build output rather than the platform's. "
+                    + "The framework identity is a property of the platform build — one value for "
+                    + "every module packed against it — but a copy beside the module exists only "
+                    + "when that module's reference closure happens to reach "
+                    + $"{FrameworkIdentity.IdentityAssembly}, and when it does it was rebuilt under "
+                    + "that module's -p:Version, which changes its MVID. Either way the bundle would "
+                    + "state an identity no consumer can match (#3176). Name the platform's own copy "
+                    + $"with --graph-dll (the pinned image's extracted /app, or the platform build the "
+                    + "pack tool was published from), or state it directly with --framework-mvid.");
+                return 2;
+            }
             frameworkMvid = FrameworkIdentity.ReadIdentity(graphDll);
+        }
         if (string.IsNullOrWhiteSpace(frameworkMvid))
         {
             Console.Error.WriteLine(

--- a/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
@@ -44,12 +44,22 @@ public class ModuleIdentityPublishGuard
         // The anchor is the SAME reference set the build bound against, and WHERE that is moves
         // with the platform: the pinned image's extracted /app when one is pinned (`platform-refs`
         // — which the sdk build passes as MeshWeaverRefs and the container build compiles inside),
-        // the module's own output when the platform was built from source. It is never a second
-        // opinion, and never left to the packer's default probe, which is exactly the probe that
-        // found nothing on all 34 of the fleet's bundles.
+        // the PACK TOOL's publish output when the platform was built from source. It is never a
+        // second opinion, and never left to the packer's default probe, which is exactly the probe
+        // that found nothing on all 34 of the fleet's bundles.
         Assert.Contains("anchor=\"$REFS/MeshWeaver.Compiler.dll\"", pack, StringComparison.Ordinal);
-        Assert.Contains("anchor=\"$PACKDIR/MeshWeaver.Compiler.dll\"", pack, StringComparison.Ordinal);
+        Assert.Contains(
+            "anchor=\"$RUNNER_TEMP/pack-tool/MeshWeaver.Compiler.dll\"", pack, StringComparison.Ordinal);
         Assert.Contains("--graph-dll \"$anchor\"", pack, StringComparison.Ordinal);
+
+        // 🚨 #3176 — NEVER the module's own publish output. `$PACKDIR` is the directory being
+        // packed, and a MeshWeaver.Compiler.dll in there is either absent (the module's closure does
+        // not reach it: MeshWeaver.Maps and MeshWeaver.Payments.Stripe packed RED on every core CD
+        // run of 2026-09-04) or a rebuild under that module's -p:Version (so one platform produced
+        // two identities in run 33874892203). The identity is a property of the PLATFORM, so it may
+        // not be read out of a per-module directory.
+        Assert.DoesNotContain(
+            "anchor=\"$PACKDIR/MeshWeaver.Compiler.dll\"", pack, StringComparison.Ordinal);
 
         // 🚨 BOTH arms end RED when there is no anchor — the branch picks WHERE to look, never
         // whether to check. A bundle whose identity is a guess is worse than a pack that stops.
@@ -94,6 +104,37 @@ public class ModuleIdentityPublishGuard
 
         // An unreadable manifest is a refusal too — "could not check" must never render as "checked".
         Assert.Contains("refusing to publish bytes whose manifest this lane could not check", pack, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 #3176 — the source-built arm's anchor is the pack tool's publish output, which carries
+    /// MeshWeaver.Compiler.dll only because MeshWeaver.Plugin.Build references MeshWeaver.Graph.
+    /// That is a load-bearing property of a reference graph this lane does not own, so `prepare`
+    /// ASSERTS it — and asserts it UNCONDITIONALLY, because the tool is restored from a cache keyed
+    /// on `platform-ref`: a check guarded by the cache-miss condition would let a warm cache restore
+    /// a tool without the anchor and skip the very check that would have caught it. That is a gate
+    /// testing its own input, and GitHub paints the skip the same colour as a pass.
+    /// </summary>
+    [Fact]
+    public void ThePrepareJob_AssertsTheAnchorInTheToolOutput_OnACacheHitToo()
+    {
+        var prepare = JobBody("prepare");
+
+        var stepIndex = prepare.IndexOf(
+            "- name: The tool output carries the platform identity anchor", StringComparison.Ordinal);
+        Assert.True(stepIndex >= 0,
+            "prepare must assert that the published module-pack tool carries MeshWeaver.Compiler.dll "
+            + "— the source-built arm names it as the identity anchor");
+
+        // Everything from that step's `- name:` up to the next step at the same indentation.
+        var rest = prepare[stepIndex..];
+        var next = rest.IndexOf("\n      - name:", StringComparison.Ordinal);
+        var step = next >= 0 ? rest[..next] : rest;
+
+        Assert.Contains("$RUNNER_TEMP/pack-tool/MeshWeaver.Compiler.dll", step, StringComparison.Ordinal);
+        Assert.Contains("::error::the module-pack tool published no MeshWeaver.Compiler.dll", step, StringComparison.Ordinal);
+        Assert.DoesNotContain("if:", step);
+        Assert.DoesNotContain("continue-on-error", step);
     }
 
     /// <summary>

--- a/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
+++ b/test/MeshWeaver.Graph.Test/ModulePackCommandTest.cs
@@ -156,6 +156,81 @@ public class ModulePackCommandTest : IDisposable
         Assert.Equal(expected, manifest!.FrameworkMvid);
     }
 
+    /// <summary>
+    /// 🚨 #3176 — the anchor is a property of the PLATFORM, so an anchor inside the module directory
+    /// being packed is refused, even though it is a real, readable PE.
+    ///
+    /// <para><b>Why a module-local anchor is never right.</b> A copy of
+    /// <c>MeshWeaver.Compiler.dll</c> beside the module exists only when that module's reference
+    /// closure happens to reach it — in core only through <c>MeshWeaver.Graph</c> or
+    /// <c>MeshWeaver.Compiler.Pipeline</c> — so the anchor's very EXISTENCE is an accident of what
+    /// the module imports. Measured on core CD run 33874892203: <c>MeshWeaver.AI</c> and
+    /// <c>MeshWeaver.Markdown.Collaboration</c> reach it and packed green; <c>MeshWeaver.Maps</c>
+    /// (→ <c>MeshWeaver.Layout</c>) and <c>MeshWeaver.Payments.Stripe</c>
+    /// (→ <c>MeshWeaver.Mesh.Contract</c>) do not and packed RED, skipping the seal.</para>
+    ///
+    /// <para>And where it IS reached it is a REBUILD carrying that module's
+    /// <c>-p:Version</c>, which moves its MVID — so the same run's two green bundles stated two
+    /// different framework identities (<c>be27d0fb…</c> vs <c>d756b82e…</c>) for one platform. Either
+    /// way the bundle states an identity no consumer can ever match, which is exactly the blind spot
+    /// #3211 closed at the producer and #3154 depends on.</para>
+    /// </summary>
+    [Fact]
+    public void AnAnchorInsideTheModuleDirectory_IsRefused_AndWritesNothing()
+    {
+        // A REAL assembly, so this cannot pass for "the file was not readable" — the refusal is
+        // about WHERE the anchor is, not whether it parses. Copied beside the module exactly as a
+        // publish of a module whose closure reaches the identity assembly would leave it.
+        var moduleDirectory = Path.Combine(root, "closure");
+        var moduleLocalAnchor =
+            Path.Combine(moduleDirectory, FrameworkIdentity.IdentityAssembly + ".dll");
+        File.Copy(typeof(ModulePackCommand).Assembly.Location, moduleLocalAnchor);
+        Assert.False(string.IsNullOrWhiteSpace(FrameworkIdentity.ReadIdentity(moduleLocalAnchor)),
+            "the fixture's anchor must be a readable PE, or this test would pass for the wrong reason");
+
+        var outDir = Path.Combine(root, "out-module-local-anchor");
+        var exit = ModulePackCommand.Run(
+        [
+            moduleDirectory,
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.7.0",
+            "--graph-dll", moduleLocalAnchor,
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(2, exit);
+        Assert.False(Directory.Exists(outDir),
+            "a bundle whose identity was read off the module's own output must not exist at all — "
+            + "the identity it would state names no platform build a consumer can have landed");
+    }
+
+    /// <summary>The same refusal when the anchor is not named at all and the packer's DEFAULT probe
+    /// finds a module-local copy. This is the silent arm: without the guard the probe reads it and
+    /// the bundle packs GREEN stating a per-module identity, which is how two identities for one
+    /// platform reached a CD run unnoticed.</summary>
+    [Fact]
+    public void TheDefaultProbe_FindingAModuleLocalAnchor_IsRefused_RatherThanReadingIt()
+    {
+        var moduleDirectory = Path.Combine(root, "closure");
+        File.Copy(
+            typeof(ModulePackCommand).Assembly.Location,
+            Path.Combine(moduleDirectory, FrameworkIdentity.IdentityAssembly + ".dll"));
+
+        var outDir = Path.Combine(root, "out-default-probe-anchor");
+        var exit = ModulePackCommand.Run(
+        [
+            moduleDirectory,
+            "--module-name", "Widget",
+            "--plugin", "WidgetPkg",
+            "--package-version", "1.7.0",
+            "--out", outDir,
+        ]);
+
+        Assert.Equal(2, exit);
+        Assert.False(Directory.Exists(outDir));
+    }
+
     [Fact]
     public void APackedModuleBundle_RoundTripsThroughTheReader()
     {


### PR DESCRIPTION
> **Rescoped after #3293 merged at 14:02Z, mid-review.** That PR fixed the same defect's FIRST half —
> the anchor is now BUILT from the pinned platform source instead of scavenged out of `$PACKDIR`.
> Its design is kept here in full. What it left is the **silent** half, below.

## What #3293 fixed, and what it left

The identity anchor was read from `$PACKDIR`, the module's own publish output. That was wrong in two
opposite directions. #3293 named the first and cured it; the second survives its fix and is **green**.

| shape | symptom | status |
|---|---|---|
| **ABSENT** — a module's output carries `MeshWeaver.Compiler.dll` only if its reference graph reaches it (`MeshWeaver.Maps` → `MeshWeaver.Layout`, `MeshWeaver.Payments.Stripe` → `MeshWeaver.Mesh.Contract` do not) | `no identity anchor`, pack RED, `bake + seal` **skipped**, no module published | ✅ fixed by #3293 |
| **PRESENT AND WRONG** — the anchor is built under the MODULE's `-p:Version`, so its MVID moves per module | packs **GREEN** stating an identity no consumer can match | ⛔ **this PR** |

## The measurement

#3293's anchor build passes `-p:Version="$VERSION"` deliberately, reasoning that matching the module
build's global properties makes it *"the assembly publish would have copied"*. But `$VERSION` is the
**module's package version**, and MSBuild writes it into the assembly's version attributes — part of
the metadata the MVID is computed over.

Run **on #3293's own command**, changing nothing but that property, with a positive control:

```
$ dotnet build src/MeshWeaver.Compiler/MeshWeaver.Compiler.csproj -c Release -warnaserror \
    -p:MeshWeaverRoot=<root> [-p:Version=<v>]

-p:Version=1.3.18   (AI)          → 34337c31960d47f5b5251d32ef923fc6
-p:Version=1.0.24   (Essentials)  → 7c1c4f70de084da78659e6bda495e1c5
no override, run A                → 71cc81badb364c5d8558ac5e7db6a44e
no override, run B                → 71cc81badb364c5d8558ac5e7db6a44e   ← identical
```

Those are the two package versions core CD actually packs. **The control is the point:** without the
property, two independent builds of one commit are byte-identical, so removing it does not merely
change the value — it makes every matrix job in a run agree, which is the property the field needs
and never had.

Already observed in the field before #3293, by the earlier route to the same pollution — run
`33874892203`, one platform, one commit, two green bundles, two identities:

```
MeshWeaver.Plugin.AI.1.3.18          … built against framework be27d0fb9ad54ae6a862bfa7aeb97c9b
MeshWeaver.Plugin.Essentials.1.0.24  … built against framework d756b82e09804a11b0ea44d26233af6c
```

#3154 compares `(version, identity)` on every installation. A per-module identity names no platform
build a consumer can have landed, so the comparison gets a value that means nothing — the blind spot
#3211 closed at the producer, reopened one layer down, and with four compose entries it would now be
four identities instead of two.

## The change

1. **Drop `-p:Version="$VERSION"` from the anchor build.** Everything else of #3293's is kept.
2. **Guard it** — `ModuleIdentityPublishGuard` reads the text between the `dotnet build` and the
   `anchor=` that consumes it and asserts no `-p:Version` reaches that command line.
3. **A behavioural guard #3293 has no equivalent of** — `ModulePackCommand` refuses an anchor that
   resolves inside the module directory, whether passed as `--graph-dll` or found by the default
   probe. #3293's guard is a lane-shape assertion; this one holds for every caller of the packer,
   including satellites and anyone running the tool by hand.
4. Doc + What's New.

Dropped from the first revision of this PR in favour of #3293's approach: the pack-tool anchor and
the `prepare`-job assertion.

## Guards — all mutation-proven

Restoring #3293's exact `-p:Version` line:

```
ModuleIdentityPublishGuard.ThePackStep_NamesTheIdentityAnchor_AndFailsRedWhenThereIsNone [FAIL]
   Assert.DoesNotContain() Failure: Sub-string found
   String: ···"hweaver" \\\n              -p:Version="$VERSION"\n   "···
   Found:  "-p:Version"
Failed!  - Failed: 1, Passed: 3, Total: 4
```

Removing the packer guard:

```
ModulePackCommandTest.TheDefaultProbe_FindingAModuleLocalAnchor_IsRefused_RatherThanReadingIt [FAIL]
ModulePackCommandTest.AnAnchorInsideTheModuleDirectory_IsRefused_AndWritesNothing [FAIL]
Failed!  - Failed: 2, Passed: 13, Total: 15
```

The default-probe arm is the one that matters — without the guard the packer reads the module-local
copy and packs GREEN.

Reverting the containment check to directory equality (Copilot's review finding, fixed in `264cad3`):

```
ModulePackCommandTest.AnAnchorNestedDeeperInsideTheModuleTree_IsAlsoRefused [FAIL]
Failed!  - Failed: 1, Passed: 16, Total: 17
```

`AnAnchorInASiblingDirectoryWithAPrefixName_IsAccepted` is the negative control for that one — the
trailing separator is what stops `…/closure-refs` reading as inside `…/closure`.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation — all `0 Error(s)`, `0 Warning(s)`:
`MeshWeaver.Plugin.Build`, `MeshWeaver.Documentation`, `MeshWeaver.Graph.Test`,
`MeshWeaver.Documentation.Test`.

```
ModulePackCommandTest        Passed! - Failed: 0, Passed: 17
ModuleIdentityPublishGuard   Passed! - Failed: 0, Passed:  4
DocumentationLinkIntegrity   Passed! - Failed: 0, Passed:  1
check-workflow-timeouts      66 job(s) checked, 0 violation(s), cap=45 min
check-workflow-shell         0 live finding(s)
```

## Scope

- **Satellites unaffected.** They pin this lane by sha and use the image arm, which neither #3293 nor
  this PR touches.
- **No `RECIPE_VERSION` bump**, same as #3293: the ledger key includes `platformRef`, which IS the
  commit on core's `main-cd` call, so no pre-change bundle can be reused on the source arm; the image
  arm's bytes do not change. Reasoning recorded in the doc so the next reader does not have to
  re-derive it.
- **Deliberately NOT changed:** the source arm states a raw MVID (no `-p:CIRun=true`, so no `g<sha>`
  stamp) while the portal image for the same commit is built with one. Making the two agree changes
  the SHAPE of the identity and is a separate, fleet-visible call; it is not required for the anchor
  to be correct, and CD sealed green on raw MVIDs before any of this (run `33779812466`). Recorded
  under "Still open, deliberately not changed here".

Finding committed as `Doc/Architecture/ModuleIdentityAnchor` — both shapes, both cures, and the
control that shows the second one works. What's New entry `Category: Fix`.

Refs #3176, #3240, #2543, #3293, #3211, #3154, Systemorph/MeshWeaver.Plugins#1268.

Pairs-with: none — the diff removes no public type and no public member from `src/`; the only
deletions in `src/` are comment lines in `ModulePackCommand.cs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
