### PR TITLE
fix(#3244): one producer in TIME — the download serves the module its own assemblies record

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -1077,6 +1077,12 @@ public static class PluginBundleEndpoints
         var ledger = Ledger(http);
         // Resolved NOW — see Index: the request scope is gone by the time a late fault lands.
         var lateFaultLogger = Log(http);
+        // The published bundle root this registry mounts (#3244) — read here, in the request scope,
+        // for the same reason the logger is. Null on a deployment that consumes no CI bakes, which
+        // leaves the module section exactly as it was before this existed.
+        var publishedRoot =
+            http.RequestServices.GetService<IConfiguration>()
+                ?[PublishedBundleCatalogue.PublishedRootConfigKey];
         return Servable(rootHub, anchorService, ct)
             .SelectMany(state =>
             {
@@ -1102,7 +1108,7 @@ public static class PluginBundleEndpoints
                 ledger?.Record(decision);
 
                 if (asked is not null && decision.Serves)
-                    return Assemble(rootHub, asked, identity, architecture);
+                    return Assemble(rootHub, asked, identity, architecture, publishedRoot);
 
                 // The refusal is uniform on the wire; the LOG is where it is diagnosable, naming
                 // which instance asked, what the entitlement answer actually was, and whether this
@@ -1150,7 +1156,8 @@ public static class PluginBundleEndpoints
     /// nothing and is COUNTED as a miss.</para>
     /// </summary>
     private static IObservable<IResult> Assemble(
-        IMessageHub rootHub, BundleEntry package, string identity, string architecture)
+        IMessageHub rootHub, BundleEntry package, string identity, string architecture,
+        string? publishedRoot)
     {
         var meshService = rootHub.ServiceProvider.GetRequiredService<IMeshService>();
         var store = rootHub.ServiceProvider.GetService<IAssemblyStore>() ?? NullAssemblyStore.Instance;
@@ -1207,10 +1214,27 @@ public static class PluginBundleEndpoints
                         package.PluginId, misses.Count, identity, architecture,
                         string.Join(" | ", misses.Take(MissesReported)));
 
-                return assemblies.SelectMany(found => ModuleFiles(rootHub, package)
-                    .Select(module =>
-                        BuildResult(package, found, module.Files, module.Assets,
-                            identity, architecture, misses)));
+                return assemblies.SelectMany(found =>
+                {
+                    // What the bytes THIS archive is about to carry were compiled against — the
+                    // evidence that decides which build of the module goes with them (#3244).
+                    // 🚨 The SAME filter BuildResult writes by: a type whose assembly could not be
+                    // located contributes no bytes, so its record must not vote on which module
+                    // rides beside bytes that are not there.
+                    var recorded = ServedModuleBytes.RecordedFor(
+                        found.Where(a => a.Path is not null).Select(a => a.Dependencies),
+                        package.Module ?? "");
+                    return ModuleFiles(rootHub, package, recorded, publishedRoot, identity)
+                        .Select(module =>
+                        {
+                            IReadOnlyList<string> reported = module.Divergence is null
+                                ? misses
+                                : misses.Append(
+                                        $"module '{package.Module}': {module.Divergence}")
+                                    .ToArray();
+                            return BuildResult(package, found, module, identity, architecture, reported);
+                        });
+                });
             });
     }
 
@@ -1289,14 +1313,14 @@ public static class PluginBundleEndpoints
     /// serve — the bundle then simply has no module section, which a consumer reads as "nothing
     /// to land".
     /// </summary>
-    private static IObservable<(IReadOnlyList<string> Files,
-        IReadOnlyList<(string RelativePath, string FullPath)> Assets)> ModuleFiles(
-        IMessageHub rootHub, BundleEntry package)
+    private static IObservable<ServedModule> ModuleFiles(
+        IMessageHub rootHub, BundleEntry package, RecordedModuleId recorded,
+        string? publishedRoot, string identity)
     {
         var landing = rootHub.ServiceProvider.GetService<ModuleLandingService>();
         if (landing is null || string.IsNullOrWhiteSpace(package.Module))
-            return Observable.Return<(IReadOnlyList<string> Files,
-                IReadOnlyList<(string RelativePath, string FullPath)> Assets)>(([], []));
+            return Observable.Return(
+                new ServedModule([], [], "no module section", null));
 
         var logger = rootHub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger(typeof(PluginBundleEndpoints));
@@ -1310,7 +1334,25 @@ public static class PluginBundleEndpoints
                     logger?.LogInformation(
                         "Plugin bundles: {Plugin} declares module '{Module}' but it is not served: {Reason}",
                         package.PluginId, package.Module, decline);
-                return (Files: files, Assets: assets);
+
+                // 🚨 ONE PRODUCER IN TIME (#3244). The shelf is content-versioned and identity-blind
+                // — it serves whatever the module's own lane published last — while the assemblies
+                // above are resolved for the CALLER's identity and record exactly which build of
+                // this module they were compiled against. Hand over the bytes they record, which is
+                // the shelf whenever the shelf IS that build and otherwise the module bundle the
+                // publication sealed for this identity.
+                var served = ServedModuleBytes.Resolve(
+                    package.Module, package.PluginId, files, assets, recorded,
+                    publishedRoot, identity, logger);
+                if (served.Divergence is not null)
+                    logger?.LogWarning(
+                        "Plugin bundles: {Plugin} on framework {Identity} — {Divergence}",
+                        package.PluginId, identity, served.Divergence);
+                else if (files.Count > 0 && recorded.Mvid is not null)
+                    logger?.LogInformation(
+                        "Plugin bundles: {Plugin} serves module '{Module}' {Mvid} from {Provenance}",
+                        package.PluginId, package.Module, recorded.Mvid, served.Provenance);
+                return served;
             });
     }
 
@@ -1337,12 +1379,13 @@ public static class PluginBundleEndpoints
     private static IResult BuildResult(
         BundleEntry package,
         IReadOnlyList<(string NodePath, string? Path, IReadOnlyDictionary<string, string>? Dependencies)> assemblies,
-        IReadOnlyList<string> moduleFiles,
-        IReadOnlyList<(string RelativePath, string FullPath)> moduleAssets,
+        ServedModule module,
         string identity,
         string architecture,
         IReadOnlyList<string> misses)
     {
+        var moduleFiles = module.Files;
+        var moduleAssets = module.Assets;
         var entries = new List<NuGetPackageWriter.Entry>();
         var assemblyRecords = new List<object>();
 
@@ -1366,8 +1409,7 @@ public static class PluginBundleEndpoints
         {
             var local = moduleFile;
             entries.Add(new NuGetPackageWriter.Entry(
-                NuGetPackageWriter.ModuleEntryPathFor(Path.GetFileName(local)),
-                () => File.OpenRead(local)));
+                NuGetPackageWriter.ModuleEntryPathFor(local.FileName), local.Open));
         }
 
         // The module's STATIC WEB ASSETS ride under their own folder, keeping the relative path a
@@ -1375,12 +1417,11 @@ public static class PluginBundleEndpoints
         // defect the publish path was just fixed for (#2221): the shelf would hold a complete pack
         // and hand consumers an assemblies-only bundle, so every downstream portal renders
         // unstyled while the registry's own copy looks fine.
-        foreach (var (relativePath, fullPath) in moduleAssets)
+        foreach (var moduleAsset in moduleAssets)
         {
-            var local = fullPath;
+            var local = moduleAsset;
             entries.Add(new NuGetPackageWriter.Entry(
-                NuGetPackageWriter.ModuleAssetEntryPathFor(relativePath),
-                () => File.OpenRead(local)));
+                NuGetPackageWriter.ModuleAssetEntryPathFor(local.RelativePath), local.Open));
         }
 
         var manifest = new PackagingManifest(
@@ -1416,7 +1457,7 @@ public static class PluginBundleEndpoints
                     : new
                     {
                         assemblyName = package.Module,
-                        assemblies = moduleFiles.Select(Path.GetFileName).ToArray(),
+                        assemblies = moduleFiles.Select(f => f.FileName).ToArray(),
                         minMeshVersion = package.MinMeshVersion,
                         // Declared, never inferred from the archive — BundleReader.ReadModuleAssets
                         // reads THIS list and treats a declared-but-absent entry as an incomplete
@@ -1424,6 +1465,13 @@ public static class PluginBundleEndpoints
                         staticAssets = moduleAssets.Count == 0
                             ? null
                             : moduleAssets.Select(a => a.RelativePath).ToArray(),
+                        // 🚨 Where these bytes came from, and — when the registry could not supply
+                        // the build this bundle's own assemblies record — what disagreed (#3244).
+                        // On the wire, not merely in a log, for the same reason `misses` is: a
+                        // consumer that will decline every NodeType binding this module must be
+                        // able to say WHY without correlating against the registry's logs.
+                        provenance = module.Provenance,
+                        divergence = module.Divergence,
                     },
             },
             new JsonSerializerOptions

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -496,11 +496,11 @@ project; a module is landed from the registry and composed into bakes, nowhere e
 The second row is a **second producer in time**: core CD's `plugins-modules` rebuilds
 `MeshWeaver.Markdown.Collaboration` per platform release to feed the Plugins seal (mvid A), while
 the registry's package endpoint serves the Plugins lane's last content-versioned publication (mvid
-B) — the bytes a portal actually installs. This row is NOT closed by this change (core holds no
-registry credential, so its bake cannot compose the registry's bytes); what changed is that the
-availability gate now sees it (below) instead of rolling onto it.
+B) — the bytes a portal actually installs. The availability gate saw it from #3242 on instead of
+rolling onto it; **the serve side now resolves it** (#3244, below), so the two producers can no
+longer disagree in the archive a consumer installs.
 
-### The two controls
+### The three controls
 
 1. **The bake refuses a double by name** (`BakeHost.ShippedByHostProblem`, run by `compile` /
    `--bake-output` under both `--app` and in-process). A module composed with `--module` whose
@@ -533,17 +533,63 @@ availability gate now sees it (below) instead of rolling onto it.
    the identity's module IS. Full reasoning and the measurement:
    [Module-Owned Siblings Ride](../ModuleOwnedSiblingsRide).
 
+### The third control: the download serves the module its own assemblies record (#3244)
+
+The set check above compares two halves of ONE publication — the sealed bundles' dependency records
+against the sealed module set — and passes when they agree. The instance runs neither: it installs
+what `/api/plugins/bundles/<pkg>/<version>` hands it, and that route was **asymmetric**. Its NodeType
+assemblies resolve through each type's `Release` node for exactly the CALLER's framework identity
+(#1751); its module section came off the registry's own `modules/` shelf, which is content-versioned
+(Plugins #931) and identity-blind — whatever the module's own lane published last, under a version
+that does not move when a rebuild changes the bytes. One archive, two producers, and the consumer's
+boot seeder declining every NodeType in it.
+
+**The rule is evidence, not a preference order.** The assemblies about to be written into the archive
+carry, per NodeType, the id they were compiled against; for an installed module that id is `mvid:` +
+its raw MVID. So the archive *states* which build it needs, and `ServedModuleBytes.Resolve` hands over
+the bytes that ARE that build:
+
+| the served assemblies record | what is served |
+|---|---|
+| nothing for this module | the shelf, unchanged — nothing binds it, so nothing constrains it |
+| the build the shelf holds | the shelf (one PE header read; the healthy path costs nothing more) |
+| a build a publication sealed for this identity carries | **those** bytes, off `<root>/<identity>/<source>/modules/<bundle>` |
+| a build nobody holds | the shelf, plus a `divergence` in the manifest's module section and a warning naming both MVIDs |
+| two builds, disagreeing among themselves | the shelf, plus the named disagreement — no single module can satisfy them |
+
+Three properties are load-bearing:
+
+- **Server-side, not client-side.** The other shape — an instance fetching its module bytes from the
+  `prebuilt/{identity}/{source}/modules` route directly — needs a whole-source grant (`<source>/*`)
+  on every installation, and a whole-source grant deliberately bypasses plan tiering (*"a sealed
+  publication carries every plan's bundles"*). Deciding at the registry needs no new grant, no new
+  credential and no client change, so the fleet converges on a registry roll rather than on every
+  install updating.
+- **It is right where a preference order is wrong.** A registry that COMPILED its own NodeTypes
+  records its own live module, and the shelf is then the correct answer. "Prefer the seal" would
+  serve the wrong bytes there; "serve what is recorded" cannot.
+- **The unsatisfiable case is NAMED, not hidden.** When no producer holds the recorded build the bytes
+  are unchanged — the registry cannot conjure a build it does not have — but the archive says so, so
+  "this lane cannot be satisfied" stops being a fact only a consumer's per-type decline could reveal.
+
 ### What the gate still cannot see
 
-The registry's package endpoint (`/api/plugins/bundles/<pkg>/<version>`) is content-versioned
-(Plugins #931): an instance that installed a module from it holds whatever that lane published last,
-and a platform release that rebuilds the module for the seal produces a *consistent* sealed set whose
-module MVID differs from the instance's landed one. The set check passes; the instance still
-declines. Closing that needs ONE producer in time as well — either the seal composes the registry's
-bytes for the root source (`registry-modules` in core CD, which needs a registry credential core
-does not hold today), or the instance adopts module bytes for its identity from the sealed
-publication it already adopts bundles from. Until one of those lands, `ShippedPrebuiltBundles`'
-`dependency record mismatch … live is mvid:` line on a portal is that gap, not a new defect.
+The instance's *already-landed* module is still outside every check here, because nothing above runs
+until the instance decides to DOWNLOAD. `ModuleUpdateDecision` takes that decision from the index's
+advertised **framework** identity against the landed entry's (Plugins#931/#723), never from the
+module MVID — so the re-land happens on the module's next republish (a platform release triggers the
+owning repo's lane, which is exactly when the two builds diverge, so the ordinary path does converge),
+and NOT when a seal for the running identity appears while the shelf sits still. A portal in that
+window keeps the build it has, and `ShippedPrebuiltBundles`' `dependency record mismatch … live is
+mvid:` line is that residue rather than a new defect.
+
+The remaining structural half is core CD's, and it is a credential decision rather than a code one:
+`plugins-modules` REBUILDS the modules it composes instead of taking `registry-modules`, because core
+holds no registry credential (`MW_REGISTRY_KEY` is validated in `node-repo-publish-bake.yml` as the
+*caller's* secret and is not among core's own). Composing the registry's bytes would make the
+publication and the shelf one producer at the source, which is strictly better than resolving them at
+serve time — but it needs that credential provisioned, and the resolution above is correct with or
+without it.
 
 ### Moving a type OUT of an image-shipped assembly into a module (the shadow set's blind spot)
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-an-install-gets-the-module-its-own-code-was-built-against.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-an-install-gets-the-module-its-own-code-was-built-against.md
@@ -1,0 +1,30 @@
+---
+Name: An install gets the module its own code was built against
+Category: Fix
+Description: A plugin download could carry compiled types built against one build of a shared module beside a different build of that module, so the portal that installed it declined every one of those types and rendered the plugin's pages empty. The download now hands over the build its own code records.
+Icon: LinkMultiple
+Order: -20260904
+---
+
+# An install gets the module its own code was built against
+
+Installing or updating a plugin fetches one archive: the plugin's compiled types, plus the compiled
+module they depend on. The two halves came from two different places. The types were resolved for
+exactly the platform build the installing portal runs. The module was whatever the module's own
+release published last — a version number that does not move when a rebuild changes the bytes.
+
+Most of the time those agree. When they did not, nothing failed loudly: the download succeeded, the
+archive was well formed, the module landed, and then the portal declined every compiled type in the
+package — *"dependency record mismatch — built against …, live is …"* — and quietly recompiled them
+itself, or, on a deployment that does not compile plugin content, served the plugin's pages empty.
+That is what memex.meshweaver.cloud did to one plugin's four packages on 2026-09-03, with no change
+in any repository to point at.
+
+The archive already knew the answer. Every compiled type in it records which build of the module it
+was compiled against, so the download now hands over **that** build: the registry's own copy when the
+registry's copy is it, and otherwise the module bundle sealed for the installing portal's platform
+alongside the types themselves. Nothing else changes — a package whose types bind no module, and the
+ordinary case where the two already agree, take exactly the path they took before.
+
+When no available build matches, the download says so in the package manifest, naming both builds,
+instead of leaving it to be discovered as a decline in the installing portal's log hours later.

--- a/src/MeshWeaver.PluginCatalog/ServedModuleBytes.cs
+++ b/src/MeshWeaver.PluginCatalog/ServedModuleBytes.cs
@@ -1,0 +1,369 @@
+using System.Collections.Immutable;
+using System.IO;
+using System.IO.Compression;
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+using MeshWeaver.Compiler;
+using MeshWeaver.Plugin.Packaging;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.PluginCatalog;
+
+/// <summary>
+/// WHICH BUILD of a package's compiled module the registry hands a consumer — the "one producer in
+/// TIME" decision (#3244).
+///
+/// <para>🚨 <b>The asymmetry this closes.</b> A bundle download resolves its NodeType assemblies
+/// through each type's <c>Release</c> node for exactly the CALLER's framework identity (#1751), and
+/// resolved the module section from the registry's own <c>modules/</c> shelf for nobody's — the
+/// shelf holds whatever the module's OWN lane published last, under a content version that does not
+/// move when a rebuild changes the bytes (MeshWeaver.Plugins#931). So one archive could carry
+/// assemblies sealed against <c>mvid:A</c> beside a module whose bytes are <c>mvid:B</c>, and the
+/// consumer's boot seeder rightly declined every one of them — <i>"dependency record mismatch —
+/// built against mvid:…, live is mvid:…"</i> — while every set-level check passed, because
+/// <see cref="ReleaseAvailability"/> compares the SEALED module set and the instance runs the
+/// SHELF's. Two internally-consistent producers, disagreeing across time.</para>
+///
+/// <para><b>The rule is evidence, not a preference order.</b> The assemblies being served carry, per
+/// NodeType, the id they were compiled against (<see cref="CompiledDependencies"/>); for an
+/// installed module that id is <c>mvid:</c> + the module's raw MVID. So the archive states which
+/// build it needs, and this picks the bytes that ARE that build: the shelf when the shelf is it
+/// (the healthy case, and no extra read beyond one PE header), otherwise the module bundle the
+/// SEALED publication for the caller's identity composed — the exact bytes those assemblies were
+/// built against (MeshWeaver#2698/#2707), which the registry already mounts and already serves at
+/// <c>…/prebuilt/{identity}/{source}/modules/{bundle}</c>.</para>
+///
+/// <para>🚨 <b>Why the decision lives on the SERVER.</b> The alternative — the instance fetching its
+/// module bytes from the prebuilt route directly — needs a whole-source grant
+/// (<c>&lt;source&gt;/*</c>) on every installation, and a whole-source grant deliberately bypasses
+/// plan tiering: <i>"a sealed publication carries every plan's bundles, so a plan-scoped
+/// <c>&lt;source&gt;/*@pro</c> … must never fetch the publication whole"</i>. Deciding here needs no
+/// new grant, no new credential and no client change, so the whole fleet converges the moment the
+/// registry rolls — and it is right in the case a preference order gets wrong, a registry that
+/// COMPILED its own NodeTypes (its records then name its own live module, and the shelf is the
+/// correct answer).</para>
+///
+/// <para><b>What is deliberately unchanged.</b> When nothing being served records an id for the
+/// module, when the shelf already IS the recorded build, or when no sealed publication for the
+/// caller's identity carries a matching build, the shelf's bytes are served exactly as before.
+/// The last of those three is not a silent fallback: it carries a
+/// <see cref="ServedModule.Divergence"/> naming both builds, which the caller reports as a MISS on
+/// the wire and in the log, so "the registry cannot satisfy this lane" stops being a fact only the
+/// consumer's decline could reveal.</para>
+/// </summary>
+public static class ServedModuleBytes
+{
+    /// <summary>The seal's own naming for a package's module bundle, mirrored from
+    /// <c>.github/scripts/compose-sealed-modules.sh</c> (<c>&lt;lower(package)&gt;.module.nupkg</c>)
+    /// — the first candidate tried, before the identity's module index is scanned.</summary>
+    public static string BundleNameFor(string packageId) =>
+        packageId.ToLowerInvariant() + ".module.nupkg";
+
+    /// <summary>
+    /// The build the assemblies in this bundle say they need for one module: the single
+    /// <c>mvid:</c> id their dependency records agree on, or a named
+    /// <see cref="RecordedModuleId.Disagreement"/> when they do not.
+    /// </summary>
+    /// <param name="dependencyRecords">Each served assembly's <c>CompiledDependencies</c> record
+    /// (null entries — an assembly recorded before records existed — simply contribute nothing).</param>
+    /// <param name="moduleName">The module's entry-assembly simple name.</param>
+    public static RecordedModuleId RecordedFor(
+        IEnumerable<IReadOnlyDictionary<string, string>?> dependencyRecords, string moduleName)
+    {
+        if (string.IsNullOrWhiteSpace(moduleName))
+            return new RecordedModuleId(null, null);
+
+        var found = ImmutableHashSet<string>.Empty;
+        foreach (var record in dependencyRecords)
+        {
+            if (record is null
+                || !record.TryGetValue(moduleName, out var id)
+                || !id.StartsWith(CompiledDependencies.MvidScheme, StringComparison.Ordinal))
+                continue;
+            found = found.Add(id);
+        }
+
+        return found.Count switch
+        {
+            0 => new RecordedModuleId(null, null),
+            1 => new RecordedModuleId(found.Single(), null),
+            // Two builds recorded INSIDE one bundle: no module choice can satisfy both, so this is
+            // named rather than resolved — picking either would decline the other's NodeTypes.
+            _ => new RecordedModuleId(
+                null,
+                $"the assemblies in this bundle were built against {found.Count} different builds of "
+                + $"'{moduleName}' ({string.Join(", ", found.OrderBy(x => x, StringComparer.Ordinal))}) "
+                + "— no single module can satisfy them"),
+        };
+    }
+
+    /// <summary>
+    /// The module bytes to serve, and where they came from.
+    /// </summary>
+    /// <param name="moduleName">The module's entry-assembly simple name.</param>
+    /// <param name="packageId">The package whose bundle is being assembled — names the seal's
+    /// module bundle (<see cref="BundleNameFor"/>).</param>
+    /// <param name="shelfFiles">The registry's own closure paths for the module, entry DLL first
+    /// (<see cref="ModuleBundleSource.Collect"/>). Empty means there is nothing to serve.</param>
+    /// <param name="shelfAssets">The shelf's static web assets, module-relative path and full path.</param>
+    /// <param name="recorded">What the served assemblies record for this module
+    /// (<see cref="RecordedFor"/>).</param>
+    /// <param name="publishedRoot">The published bundle root
+    /// (<see cref="PublishedBundleCatalogue.PublishedRootConfigKey"/>), or null when this deployment
+    /// consumes no CI bakes — then only the shelf exists.</param>
+    /// <param name="identity">The CALLER's framework build identity.</param>
+    /// <param name="logger">Diagnostics.</param>
+    public static ServedModule Resolve(
+        string? moduleName,
+        string packageId,
+        IReadOnlyList<string> shelfFiles,
+        IReadOnlyList<(string RelativePath, string FullPath)> shelfAssets,
+        RecordedModuleId recorded,
+        string? publishedRoot,
+        string? identity,
+        ILogger? logger = null)
+    {
+        var shelf = FromShelf(shelfFiles, shelfAssets);
+
+        // Nothing to serve, or nothing that binds it: byte-for-byte the pre-#3244 answer.
+        if (string.IsNullOrWhiteSpace(moduleName) || shelf.Files.Count == 0)
+            return shelf;
+        if (recorded.Disagreement is not null)
+            return shelf with { Divergence = recorded.Disagreement };
+        if (recorded.Mvid is null)
+            return shelf;
+
+        var shelfMvid = ShelfMvid(shelfFiles, moduleName!, logger);
+        if (string.Equals(shelfMvid, recorded.Mvid, StringComparison.Ordinal))
+            return shelf;
+
+        // The shelf is NOT the build these assemblies were compiled against. The sealed publication
+        // for this identity is, by construction — it is what the bake composed with `--module`.
+        foreach (var candidate in SealedCandidates(publishedRoot, identity, packageId, logger))
+        {
+            if (!string.Equals(candidate.Mvid, recorded.Mvid, StringComparison.Ordinal))
+                continue;
+            if (FromSealed(candidate, moduleName!, logger) is { } served)
+                return served;
+        }
+
+        return shelf with
+        {
+            Divergence =
+                $"the assemblies served here were built against module '{moduleName}' {recorded.Mvid}, "
+                + $"but this registry's shelf holds {shelfMvid ?? "a build whose MVID could not be read"} "
+                + $"and no publication sealed for framework identity '{identity}' carries a matching "
+                + "build — the consumer will decline every NodeType binding it (dependency record "
+                + "mismatch). Republish the package's module bundle for this identity, or rebake it "
+                + "against the module the registry serves",
+        };
+    }
+
+    private static ServedModule FromShelf(
+        IReadOnlyList<string> files,
+        IReadOnlyList<(string RelativePath, string FullPath)> assets) =>
+        new(
+            files.Select(path =>
+                    new ServedModuleFile(Path.GetFileName(path), () => File.OpenRead(path)))
+                .ToArray(),
+            assets.Select(asset =>
+                    new ServedModuleAsset(asset.RelativePath, () => File.OpenRead(asset.FullPath)))
+                .ToArray(),
+            "this registry's own modules/ shelf",
+            null);
+
+    /// <summary>
+    /// One sealed module bundle inflated into a servable module: its <c>meshweaver/modules/</c>
+    /// entries and its <c>meshweaver/moduleassets/</c> tree, read from the ARCHIVE rather than from
+    /// the manifest's claim — what lands is what the bundle contains (the #3221 rule). Null when the
+    /// archive turns out not to carry the entry after all, which is a reason to keep looking rather
+    /// than to fail the download.
+    /// </summary>
+    private static ServedModule? FromSealed(SealedModuleCandidate candidate, string moduleName, ILogger? logger)
+    {
+        try
+        {
+            var bytes = File.ReadAllBytes(candidate.Path);
+            using var buffer = new MemoryStream(bytes, writable: false);
+            using var archive = new ZipArchive(buffer, ZipArchiveMode.Read);
+
+            var files = new List<ServedModuleFile>();
+            var entryName = moduleName + ".dll";
+            foreach (var entry in archive.Entries
+                         .Where(e => e.FullName.StartsWith(
+                             NuGetPackageWriter.ModuleFolder + "/", StringComparison.Ordinal))
+                         .Where(e => !e.FullName[(NuGetPackageWriter.ModuleFolder.Length + 1)..].Contains('/'))
+                         .OrderBy(e => e.FullName, StringComparer.Ordinal))
+            {
+                var name = entry.FullName[(NuGetPackageWriter.ModuleFolder.Length + 1)..];
+                if (name.Length == 0)
+                    continue;
+                var content = Inflate(entry);
+                // Entry DLL FIRST, the order ModuleBundleSource.Collect guarantees and the consumer's
+                // landing relies on.
+                if (string.Equals(name, entryName, StringComparison.OrdinalIgnoreCase))
+                    files.Insert(0, new ServedModuleFile(name, () => new MemoryStream(content, writable: false)));
+                else
+                    files.Add(new ServedModuleFile(name, () => new MemoryStream(content, writable: false)));
+            }
+
+            if (files.Count == 0
+                || !string.Equals(files[0].FileName, entryName, StringComparison.OrdinalIgnoreCase))
+                return null;
+
+            var assetPrefix = NuGetPackageWriter.ModuleAssetFolder + "/";
+            var assets = archive.Entries
+                .Where(e => e.FullName.StartsWith(assetPrefix, StringComparison.Ordinal))
+                .Where(e => e.FullName.Length > assetPrefix.Length)
+                .OrderBy(e => e.FullName, StringComparer.Ordinal)
+                .Select(e =>
+                {
+                    var content = Inflate(e);
+                    return new ServedModuleAsset(
+                        e.FullName[assetPrefix.Length..],
+                        () => new MemoryStream(content, writable: false));
+                })
+                .ToArray();
+
+            return new ServedModule(
+                files,
+                assets,
+                $"the publication sealed for framework identity '{candidate.Identity}' by source "
+                + $"'{candidate.Source}' ({candidate.BundleName})",
+                null);
+        }
+        catch (Exception ex) when (ex is IOException or InvalidDataException or BadImageFormatException)
+        {
+            logger?.LogWarning(ex,
+                "Served module bytes: sealed module bundle {Path} is unreadable — it cannot supply "
+                + "'{Module}'", candidate.Path, moduleName);
+            return null;
+        }
+    }
+
+    private static byte[] Inflate(ZipArchiveEntry entry)
+    {
+        using var source = entry.Open();
+        using var target = new MemoryStream();
+        source.CopyTo(target);
+        return target.ToArray();
+    }
+
+    /// <summary>
+    /// The sealed module bundles under one identity that could carry <paramref name="packageId"/>'s
+    /// module, cheapest first: the lane's own name (<see cref="BundleNameFor"/>) in each complete
+    /// source, then every other bundle those sources sealed.
+    ///
+    /// <para>🚨 The broad scan runs ONLY when the shelf already disagreed — the healthy download
+    /// never reaches here, so the O(sealed bundles) PE reads are the cost of a divergence, not of a
+    /// serve. It exists because the naming convention is a contract of the pack lane, and a control
+    /// that can only see the conventionally-named bundle would report "no matching build" for a
+    /// package whose module the seal carries under another name.</para>
+    /// </summary>
+    private static IEnumerable<SealedModuleCandidate> SealedCandidates(
+        string? publishedRoot, string? identity, string packageId, ILogger? logger)
+    {
+        if (string.IsNullOrWhiteSpace(publishedRoot) || string.IsNullOrWhiteSpace(identity))
+            yield break;
+        var identityDirectory = Path.Combine(publishedRoot, identity);
+        if (!Directory.Exists(identityDirectory))
+            yield break;
+
+        var preferred = BundleNameFor(packageId);
+        var sources = new List<(string Directory, string Source, IReadOnlyList<string> Modules)>();
+        foreach (var sourceDirectory in Directory.EnumerateDirectories(identityDirectory)
+                     .OrderBy(d => d, StringComparer.Ordinal))
+        {
+            var reading = PublishedBundleCatalogue.SealedModulesOf(sourceDirectory, logger);
+            if (reading.Modules is { Count: > 0 })
+                sources.Add((sourceDirectory, Path.GetFileName(sourceDirectory)!, reading.Modules));
+        }
+
+        foreach (var pass in new[] { true, false })
+            foreach (var (directory, source, modules) in sources)
+                foreach (var bundle in modules)
+                {
+                    var isPreferred = string.Equals(bundle, preferred, StringComparison.OrdinalIgnoreCase);
+                    if (isPreferred != pass)
+                        continue;
+                    var path = Path.Combine(
+                        directory, PublishedBundleCatalogue.ModulesDirectoryName, bundle);
+                    string? mvid;
+                    try
+                    {
+                        mvid = PublishedBundleCatalogue.SealedModuleAssembliesOf(path)
+                            .FirstOrDefault(a => a.IsEntry).Mvid;
+                    }
+                    catch (Exception ex) when (ex is IOException or InvalidDataException
+                                                   or BadImageFormatException or InvalidOperationException)
+                    {
+                        logger?.LogWarning(ex,
+                            "Served module bytes: sealed module bundle {Path} could not be read for its "
+                            + "entry MVID — it cannot be offered as a match", path);
+                        continue;
+                    }
+                    if (mvid is not null)
+                        yield return new SealedModuleCandidate(identity!, source, bundle, path, mvid);
+                }
+    }
+
+    /// <summary>The MVID of the shelf's entry assembly, in the dependency-record spelling, or null
+    /// when it cannot be read (a truncated volume, bytes that are not a PE) — read as "unknown",
+    /// never as "matches".</summary>
+    private static string? ShelfMvid(IReadOnlyList<string> shelfFiles, string moduleName, ILogger? logger)
+    {
+        var entry = shelfFiles.FirstOrDefault(f =>
+            string.Equals(Path.GetFileName(f), moduleName + ".dll", StringComparison.OrdinalIgnoreCase));
+        if (entry is null)
+            return null;
+        try
+        {
+            using var stream = File.OpenRead(entry);
+            using var pe = new PEReader(stream);
+            var metadata = pe.GetMetadataReader();
+            return CompiledDependencies.MvidScheme
+                   + metadata.GetGuid(metadata.GetModuleDefinition().Mvid).ToString("N");
+        }
+        catch (Exception ex) when (ex is IOException or BadImageFormatException or InvalidOperationException)
+        {
+            logger?.LogWarning(ex,
+                "Served module bytes: the shelf's '{Module}' at {Path} could not be read for its MVID",
+                moduleName, entry);
+            return null;
+        }
+    }
+
+    private readonly record struct SealedModuleCandidate(
+        string Identity, string Source, string BundleName, string Path, string Mvid);
+}
+
+/// <summary>What the assemblies of one bundle record for a module: the single build they agree on,
+/// or the reason they do not.</summary>
+/// <param name="Mvid">The <c>mvid:</c> id every record naming the module agrees on, or null when
+/// none names it (nothing binds it) or they disagree.</param>
+/// <param name="Disagreement">Why no single build can satisfy them, or null.</param>
+public readonly record struct RecordedModuleId(string? Mvid, string? Disagreement);
+
+/// <summary>One file of a module bundle's closure, and how to open it — a path on the shelf, an
+/// inflated archive entry from a sealed publication.</summary>
+public sealed record ServedModuleFile(string FileName, Func<Stream> Open);
+
+/// <summary>One static web asset of a module, keeping the module-relative path a component's
+/// <c>_content/&lt;pack&gt;/…</c> URL asks for.</summary>
+public sealed record ServedModuleAsset(string RelativePath, Func<Stream> Open);
+
+/// <summary>
+/// The module bytes a bundle download carries, where they came from, and — when the registry could
+/// not supply the build the bundle's own assemblies record — what disagreed.
+/// </summary>
+/// <param name="Files">The closure, entry DLL first.</param>
+/// <param name="Assets">The module's static web assets.</param>
+/// <param name="Provenance">Human-readable origin, for the log line and the manifest.</param>
+/// <param name="Divergence">Null when these bytes ARE the recorded build (or nothing recorded one);
+/// otherwise the named reason the consumer will decline, reported as a miss rather than discovered
+/// downstream.</param>
+public sealed record ServedModule(
+    IReadOnlyList<ServedModuleFile> Files,
+    IReadOnlyList<ServedModuleAsset> Assets,
+    string Provenance,
+    string? Divergence);

--- a/test/Memex.Portal.Shared.Test/ServedModuleBytesTest.cs
+++ b/test/Memex.Portal.Shared.Test/ServedModuleBytesTest.cs
@@ -51,6 +51,11 @@ public class ServedModuleBytesTest : IDisposable
     private static string MvidOf(System.Reflection.Assembly assembly) =>
         CompiledDependencies.MvidScheme + assembly.ManifestModule.ModuleVersionId.ToString("N");
 
+    private static readonly byte[] AssetBytes = Encoding.UTF8.GetBytes(".mw-widget{color:#bada55}");
+
+    private static readonly byte[] NestedAssetBytes =
+        Encoding.UTF8.GetBytes("export function init(){ return 'mw-widget'; }");
+
     private readonly string root =
         Path.Combine(Path.GetTempPath(), "mw-served-module-" + Guid.NewGuid().ToString("N"));
 
@@ -83,6 +88,38 @@ public class ServedModuleBytesTest : IDisposable
         Assert.Equal(SealedBytes, Read(served.Files[0]));
         Assert.Contains(Source, served.Provenance, StringComparison.Ordinal);
         Assert.Contains(Identity, served.Provenance, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 The sealed build's STATIC WEB ASSETS ride with it. Switching which producer supplies the
+    /// module must not re-create #2221: a view pack whose <c>wwwroot</c> is dropped lands, loads and
+    /// renders unstyled with nothing in any log, and the seal's bundle carries its assets under
+    /// <c>meshweaver/moduleassets/</c> exactly as the pack lane wrote them
+    /// (<c>ModulePackCommand</c>). Asserted byte-exact, and by RELATIVE path — a component asks for
+    /// <c>_content/&lt;pack&gt;/Components/x.razor.js</c>, so a flattened asset 404s like a missing one.
+    /// </summary>
+    [Fact]
+    public void TheSealedBuildsStaticAssetsRideWithIt()
+    {
+        var shelf = Shelf(ShelfBytes);
+        PublishedRoot(
+            bundleName: ServedModuleBytes.BundleNameFor(Package),
+            moduleBytes: SealedBytes,
+            assets: [("wwwroot/MeshWeaver.Widget.styles.css", AssetBytes),
+                     ("wwwroot/Components/Widget.razor.js", NestedAssetBytes)]);
+
+        var served = ServedModuleBytes.Resolve(
+            Module, Package, shelf.Files, shelf.Assets,
+            new RecordedModuleId(SealedMvid, null),
+            PublishedRootPath, Identity);
+
+        Assert.Null(served.Divergence);
+        Assert.Equal(SealedBytes, Read(served.Files[0]));
+        Assert.Equal(
+            ["wwwroot/Components/Widget.razor.js", "wwwroot/MeshWeaver.Widget.styles.css"],
+            served.Assets.Select(a => a.RelativePath).ToArray());
+        Assert.Equal(NestedAssetBytes, ReadAsset(served.Assets[0]));
+        Assert.Equal(AssetBytes, ReadAsset(served.Assets[1]));
     }
 
     /// <summary>
@@ -261,17 +298,23 @@ public class ServedModuleBytesTest : IDisposable
 
     /// <summary>A SEALED publication for <see cref="Identity"/> whose module set carries one bundle
     /// declaring <see cref="Module"/> at the given build.</summary>
-    private void PublishedRoot(string bundleName, byte[] moduleBytes)
+    private void PublishedRoot(
+        string bundleName, byte[] moduleBytes,
+        IReadOnlyList<(string RelativePath, byte[] Bytes)>? assets = null)
     {
         var source = Path.Combine(PublishedRootPath, Identity, Source);
         var modules = Path.Combine(source, PublishedBundleCatalogue.ModulesDirectoryName);
         Directory.CreateDirectory(modules);
 
-        WriteZip(
-            Path.Combine(modules, bundleName),
+        var entries = new List<(string Entry, byte[] Bytes)>
+        {
             (NuGetPackageWriter.ManifestEntry,
                 Encoding.UTF8.GetBytes($$$"""{"plugin":"{{{Package}}}","module":{"assemblyName":"{{{Module}}}"}}""")),
-            ($"{NuGetPackageWriter.ModuleFolder}/{Module}.dll", moduleBytes));
+            ($"{NuGetPackageWriter.ModuleFolder}/{Module}.dll", moduleBytes),
+        };
+        foreach (var (relative, bytes) in assets ?? [])
+            entries.Add((NuGetPackageWriter.ModuleAssetEntryPathFor(relative), bytes));
+        WriteZip(Path.Combine(modules, bundleName), [.. entries]);
         File.WriteAllLines(
             Path.Combine(modules, PublishedBundleCatalogue.ModulesIndexFileName), [bundleName]);
 
@@ -283,9 +326,13 @@ public class ServedModuleBytesTest : IDisposable
             Path.Combine(source, ShippedPrebuiltBundles.CompletionSentinelFileName), Package + ".zip\n");
     }
 
-    private static byte[] Read(ServedModuleFile file)
+    private static byte[] Read(ServedModuleFile file) => Drain(file.Open);
+
+    private static byte[] ReadAsset(ServedModuleAsset asset) => Drain(asset.Open);
+
+    private static byte[] Drain(Func<Stream> open)
     {
-        using var stream = file.Open();
+        using var stream = open();
         using var buffer = new MemoryStream();
         stream.CopyTo(buffer);
         return buffer.ToArray();

--- a/test/Memex.Portal.Shared.Test/ServedModuleBytesTest.cs
+++ b/test/Memex.Portal.Shared.Test/ServedModuleBytesTest.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Text;
+using MeshWeaver.Compiler;
+using MeshWeaver.Hosting;
+using MeshWeaver.Plugin.Packaging;
+using MeshWeaver.PluginCatalog;
+using Xunit;
+
+namespace Memex.Portal.Shared.Test;
+
+/// <summary>
+/// ONE PRODUCER IN TIME (#3244): a bundle download must carry the build of the module its own
+/// assemblies were compiled against.
+///
+/// <para>🚨 <b>Why this is pinned as a pure decision.</b> Every branch of it fails SILENTLY. Serving
+/// the shelf's build beside assemblies sealed against another one returns 200, writes a
+/// well-formed archive, lands cleanly on the consumer — and is then declined type by type at the
+/// consumer's boot ("dependency record mismatch — built against mvid:…, live is mvid:…"), which is
+/// how memex.meshweaver.cloud adopted 0 of 4 SocialMedia bundles on ci.7621 with no diff in any
+/// repo. Nothing upstream of the consumer's log can see it: <c>ReleaseAvailability</c> compares the
+/// SEALED module set against the sealed bundles' records and passes, because both halves it reads
+/// come from the same publication while the instance runs the registry's content-versioned shelf.
+/// Same reasoning, same shape, as <see cref="PluginBundleLaneResolutionTest"/> for the NodeType half
+/// of the very same handler.</para>
+///
+/// <para>The MVIDs are REAL: each fixture's module bytes are a genuine assembly this test process
+/// has loaded, so the PE reads under test read what they would read in production. Two different
+/// assemblies give two different builds without having to fabricate metadata.</para>
+/// </summary>
+public class ServedModuleBytesTest : IDisposable
+{
+    private const string Module = "MeshWeaver.Widget";
+    private const string Package = "Widget";
+    private const string Identity = "s0123456789abcdef0123456789abcdef";
+    private const string Source = "plugins";
+
+    /// <summary>The build the SEAL carries — what the served assemblies will record.</summary>
+    private static byte[] SealedBytes => File.ReadAllBytes(typeof(ReleaseAvailability).Assembly.Location);
+
+    private static string SealedMvid => MvidOf(typeof(ReleaseAvailability).Assembly);
+
+    /// <summary>A DIFFERENT build — what the registry's own content-versioned shelf holds.</summary>
+    private static byte[] ShelfBytes => File.ReadAllBytes(typeof(BundleReader).Assembly.Location);
+
+    private static string ShelfMvid => MvidOf(typeof(BundleReader).Assembly);
+
+    private static string MvidOf(System.Reflection.Assembly assembly) =>
+        CompiledDependencies.MvidScheme + assembly.ManifestModule.ModuleVersionId.ToString("N");
+
+    private readonly string root =
+        Path.Combine(Path.GetTempPath(), "mw-served-module-" + Guid.NewGuid().ToString("N"));
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        try { Directory.Delete(root, recursive: true); }
+        catch { /* temp cleanup is the OS's problem, never a test failure */ }
+        GC.SuppressFinalize(this);
+    }
+
+    /// <summary>
+    /// THE defect. The shelf holds one build, the assemblies about to be shipped record another, and
+    /// the publication sealed for the caller's identity carries the recorded one — so the recorded
+    /// one is what goes in the archive.
+    /// </summary>
+    [Fact]
+    public void WhenTheShelfIsNotTheRecordedBuild_TheSealedBuildIsServed()
+    {
+        var shelf = Shelf(ShelfBytes);
+        PublishedRoot(bundleName: ServedModuleBytes.BundleNameFor(Package), moduleBytes: SealedBytes);
+
+        var served = ServedModuleBytes.Resolve(
+            Module, Package, shelf.Files, shelf.Assets,
+            new RecordedModuleId(SealedMvid, null),
+            PublishedRootPath, Identity);
+
+        Assert.Null(served.Divergence);
+        Assert.Equal(Module + ".dll", served.Files[0].FileName);
+        Assert.Equal(SealedBytes, Read(served.Files[0]));
+        Assert.Contains(Source, served.Provenance, StringComparison.Ordinal);
+        Assert.Contains(Identity, served.Provenance, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The seal is found even when the module bundle is NOT named by the pack lane's convention —
+    /// the naming is a contract of the producing lane, and a control that could only see
+    /// <c>&lt;lower(package)&gt;.module.nupkg</c> would report "no matching build" for a seal that
+    /// carries exactly the right bytes under another name.
+    /// </summary>
+    [Fact]
+    public void TheSealedBuildIsFound_EvenUnderAnUnconventionalBundleName()
+    {
+        var shelf = Shelf(ShelfBytes);
+        PublishedRoot(bundleName: "essentials.module.nupkg", moduleBytes: SealedBytes);
+
+        var served = ServedModuleBytes.Resolve(
+            Module, Package, shelf.Files, shelf.Assets,
+            new RecordedModuleId(SealedMvid, null),
+            PublishedRootPath, Identity);
+
+        Assert.Null(served.Divergence);
+        Assert.Equal(SealedBytes, Read(served.Files[0]));
+    }
+
+    /// <summary>
+    /// The healthy case, and the one that must not change: the shelf already IS the recorded build,
+    /// so the shelf's own bytes are served and no publication is consulted.
+    /// </summary>
+    [Fact]
+    public void WhenTheShelfIsTheRecordedBuild_TheShelfIsServed()
+    {
+        var shelf = Shelf(ShelfBytes);
+        PublishedRoot(bundleName: ServedModuleBytes.BundleNameFor(Package), moduleBytes: SealedBytes);
+
+        var served = ServedModuleBytes.Resolve(
+            Module, Package, shelf.Files, shelf.Assets,
+            new RecordedModuleId(ShelfMvid, null),
+            PublishedRootPath, Identity);
+
+        Assert.Null(served.Divergence);
+        Assert.Equal(ShelfBytes, Read(served.Files[0]));
+        Assert.Contains("shelf", served.Provenance, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Nothing in the bundle binds the module, so nothing constrains which build ships: the shelf
+    /// answers exactly as it did before this decision existed. A module-only package has no NodeType
+    /// records at all, and re-pointing it at a seal would be a change with no evidence behind it.
+    /// </summary>
+    [Fact]
+    public void WhenNothingRecordsTheModule_TheShelfIsServedUnchanged()
+    {
+        var shelf = Shelf(ShelfBytes);
+        PublishedRoot(bundleName: ServedModuleBytes.BundleNameFor(Package), moduleBytes: SealedBytes);
+
+        var served = ServedModuleBytes.Resolve(
+            Module, Package, shelf.Files, shelf.Assets,
+            new RecordedModuleId(null, null),
+            PublishedRootPath, Identity);
+
+        Assert.Null(served.Divergence);
+        Assert.Equal(ShelfBytes, Read(served.Files[0]));
+    }
+
+    /// <summary>
+    /// No publication for this identity carries the recorded build. The bytes served are unchanged —
+    /// the registry cannot conjure a build it does not hold — but the answer is NAMED, quoting both
+    /// MVIDs, so "this lane cannot be satisfied" is stated by the producer instead of being
+    /// discovered as a per-type decline in a consumer's log.
+    /// </summary>
+    [Fact]
+    public void WhenNoSealCarriesTheRecordedBuild_TheDivergenceIsNamed()
+    {
+        var shelf = Shelf(ShelfBytes);
+        PublishedRoot(
+            bundleName: ServedModuleBytes.BundleNameFor(Package),
+            moduleBytes: ShelfBytes);
+        var absent = CompiledDependencies.MvidScheme + new string('a', 32);
+
+        var served = ServedModuleBytes.Resolve(
+            Module, Package, shelf.Files, shelf.Assets,
+            new RecordedModuleId(absent, null),
+            PublishedRootPath, Identity);
+
+        Assert.NotNull(served.Divergence);
+        Assert.Contains(absent, served.Divergence!, StringComparison.Ordinal);
+        Assert.Contains(ShelfMvid, served.Divergence!, StringComparison.Ordinal);
+        Assert.Equal(ShelfBytes, Read(served.Files[0]));
+    }
+
+    /// <summary>
+    /// A deployment that mounts no published bundle root has one producer by construction — the
+    /// decision must not fault there, it must answer the shelf.
+    /// </summary>
+    [Fact]
+    public void WithNoPublishedRoot_TheShelfIsServed()
+    {
+        var shelf = Shelf(ShelfBytes);
+
+        var served = ServedModuleBytes.Resolve(
+            Module, Package, shelf.Files, shelf.Assets,
+            new RecordedModuleId(SealedMvid, null),
+            publishedRoot: null, Identity);
+
+        Assert.NotNull(served.Divergence);
+        Assert.Equal(ShelfBytes, Read(served.Files[0]));
+    }
+
+    /// <summary>
+    /// Two assemblies in one bundle recording two builds of one module cannot both be satisfied, so
+    /// the answer is the named disagreement rather than a silent pick — choosing either would
+    /// decline the other's NodeTypes.
+    /// </summary>
+    [Fact]
+    public void AssembliesRecordingTwoBuilds_AreNamedRatherThanResolved()
+    {
+        var recorded = ServedModuleBytes.RecordedFor(
+            [
+                new Dictionary<string, string>(StringComparer.Ordinal) { [Module] = SealedMvid },
+                new Dictionary<string, string>(StringComparer.Ordinal) { [Module] = ShelfMvid },
+            ],
+            Module);
+
+        Assert.Null(recorded.Mvid);
+        Assert.NotNull(recorded.Disagreement);
+        Assert.Contains(SealedMvid, recorded.Disagreement!, StringComparison.Ordinal);
+        Assert.Contains(ShelfMvid, recorded.Disagreement!, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// The reading that drives everything above: the single <c>mvid:</c> the served assemblies agree
+    /// on. Reserved '!' keys and <c>ref:</c> ids are not module builds and must not be read as one.
+    /// </summary>
+    [Fact]
+    public void RecordedFor_ReadsTheAgreedModuleBuildAndNothingElse()
+    {
+        var recorded = ServedModuleBytes.RecordedFor(
+            [
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [Module] = SealedMvid,
+                    ["MeshWeaver.Graph"] = CompiledDependencies.RefAsmScheme + "surface",
+                    [CompiledDependencies.ToolchainKey] = CompiledDependencies.MvidScheme + "toolchain",
+                },
+                new Dictionary<string, string>(StringComparer.Ordinal) { [Module] = SealedMvid },
+                null,
+            ],
+            Module);
+
+        Assert.Equal(SealedMvid, recorded.Mvid);
+        Assert.Null(recorded.Disagreement);
+
+        var refOnly = ServedModuleBytes.RecordedFor(
+            [
+                new Dictionary<string, string>(StringComparer.Ordinal)
+                {
+                    [Module] = CompiledDependencies.RefAsmScheme + "surface",
+                },
+            ],
+            Module);
+        Assert.Null(refOnly.Mvid);
+        Assert.Null(refOnly.Disagreement);
+    }
+
+    private string PublishedRootPath => Path.Combine(root, "published");
+
+    /// <summary>This registry's own <c>modules/</c> shelf, holding one build of the module.</summary>
+    private (IReadOnlyList<string> Files, IReadOnlyList<(string RelativePath, string FullPath)> Assets)
+        Shelf(byte[] bytes)
+    {
+        var folder = Path.Combine(root, "shelf", "modules", Module);
+        Directory.CreateDirectory(folder);
+        var entry = Path.Combine(folder, Module + ".dll");
+        File.WriteAllBytes(entry, bytes);
+        return ([entry], []);
+    }
+
+    /// <summary>A SEALED publication for <see cref="Identity"/> whose module set carries one bundle
+    /// declaring <see cref="Module"/> at the given build.</summary>
+    private void PublishedRoot(string bundleName, byte[] moduleBytes)
+    {
+        var source = Path.Combine(PublishedRootPath, Identity, Source);
+        var modules = Path.Combine(source, PublishedBundleCatalogue.ModulesDirectoryName);
+        Directory.CreateDirectory(modules);
+
+        WriteZip(
+            Path.Combine(modules, bundleName),
+            (NuGetPackageWriter.ManifestEntry,
+                Encoding.UTF8.GetBytes($$$"""{"plugin":"{{{Package}}}","module":{"assemblyName":"{{{Module}}}"}}""")),
+            ($"{NuGetPackageWriter.ModuleFolder}/{Module}.dll", moduleBytes));
+        File.WriteAllLines(
+            Path.Combine(modules, PublishedBundleCatalogue.ModulesIndexFileName), [bundleName]);
+
+        // The seal itself — SealedModulesOf refuses a module set whose publication is torn.
+        WriteZip(
+            Path.Combine(source, Package + ".zip"),
+            (NuGetPackageWriter.ManifestEntry, Encoding.UTF8.GetBytes("{}")));
+        File.WriteAllText(
+            Path.Combine(source, ShippedPrebuiltBundles.CompletionSentinelFileName), Package + ".zip\n");
+    }
+
+    private static byte[] Read(ServedModuleFile file)
+    {
+        using var stream = file.Open();
+        using var buffer = new MemoryStream();
+        stream.CopyTo(buffer);
+        return buffer.ToArray();
+    }
+
+    private static void WriteZip(string path, params (string Entry, byte[] Bytes)[] entries)
+    {
+        using var file = File.Create(path);
+        using var zip = new ZipArchive(file, ZipArchiveMode.Create);
+        foreach (var (entry, bytes) in entries)
+        {
+            using var stream = zip.CreateEntry(entry).Open();
+            stream.Write(bytes);
+        }
+    }
+}


### PR DESCRIPTION
Closes #3244.

Pairs-with: none — additive only. This diff removes no `public` top-level type and no public member from `src/`; it ADDS `MeshWeaver.PluginCatalog.ServedModuleBytes` (+ `RecordedModuleId`, `ServedModuleFile`, `ServedModuleAsset`, `ServedModule`). The three methods whose signatures changed (`Assemble`, `ModuleFiles`, `BuildResult`) are `private` and live in `memex/`, not `src/`. The served manifest gains two fields (`module.provenance`, `module.divergence`); `BundleReader` deserializes with plain `JsonSerializerDefaults.Web` and no `JsonUnmappedMemberHandling.Disallow`, so a consumer on an older pin ignores them.

## Re-measured the issue's premise first — both stated facts still hold, one has moved

The maintainer's own comment on #3244 (07:15Z today) said to re-measure after Plugins#1268, so I did, on `main` at `90755f2f8`:

| the issue said | measured now |
|---|---|
| core CD's `plugins-modules` rebuilds the modules per platform release to feed the Plugins seal | **still true, and the set GREW from 2 to 4** — #3290 (merged 10:34Z) added `MeshWeaver.Maps` and `MeshWeaver.Payments.Stripe`; `main-cd.yml` still passes `publish: false`, so those bytes go to the seal and never to the shelf |
| option 1 is blocked — core holds no registry credential | **still true**: `MW_REGISTRY_KEY` appears once in the repo, in `node-repo-publish-bake.yml:477`, validated as *the caller's* secret |
| the registry's package endpoint serves the module's own lane's last publication | **still true, and this is the exact line**: `PluginBundleEndpoints.ModuleFiles` resolved the module through `ModuleBundleSource.Collect(landing.BaseDirectory, …)` — the registry's own shelf — with the requested `identity` never consulted, while the NodeType half of the same handler resolves per-identity through `Release` nodes |

So the premise has NOT drifted. Plugins#1268 removed a *second producer in SPACE* for one module (the views shipping both in the image and in the module); the time axis this issue is about is untouched by it, and #3290 widened it to four modules.

**Fleet state, stated rather than fought:** core CD has not published since 09:31Z (7747, and that run's `Plugins: bake + seal` was `skipped` — `publish != true`); 7758 dies in `plugins-modules` on the two module packs #3290 added. So there is no live sealed publication to observe this against end-to-end today. That is why the guard is a pinned decision over real files and real MVIDs rather than an end-to-end probe.

## The defect, in one line

`Assemble` honoured the caller's lane for NodeType assemblies and ignored it for module bytes.

```
GET /api/plugins/bundles/{pkg}/{version}?identity=X&arch=…
  ├── NodeType assemblies → resolved through each type's Release node FOR X      (#1751)
  └── module section      → the registry's own modules/<name>/, identity-blind   (Plugins#931)
```

The shelf's version does not move when a rebuild changes the bytes, so both halves are internally consistent and can still be two different builds. `ReleaseAvailability.SealedSetProblem` (#3242) compares the sealed bundles' dependency records against the *sealed* module set — two halves of one publication — and passes; the instance runs neither, and declines every NodeType at adoption (`dependency record mismatch — built against mvid:A, live is mvid:B`). That is #3174 / ci.7621: SocialMedia adopted 0/4, `/Posts` empty, no diff in any repo.

## The fix: serve what the archive's own assemblies record

The archive already states which build it needs — every compiled type carries its `CompiledDependencies` record, and for an installed module that id is `mvid:` + the raw MVID. `ServedModuleBytes.Resolve` hands over the bytes that ARE that build:

| the served assemblies record | what is served |
|---|---|
| nothing for this module | the shelf, unchanged — nothing binds it, so nothing constrains it |
| the build the shelf holds | the shelf (one PE header read; the healthy path costs nothing more) |
| a build a publication sealed for this identity carries | **those** bytes, off `<root>/<identity>/<source>/modules/<bundle>` |
| a build nobody holds | the shelf, plus `module.divergence` in the manifest and a warning naming both MVIDs |
| two builds, disagreeing among themselves | the shelf, plus the named disagreement |

Everything it needs already existed: the seal carries its composed module bundles under `modules/` with their own `_index` (#2707), `PublishedBundleCatalogue.SealedModulesOf` / `SealedModuleAssembliesOf` already read them, and the registry already mounts the root (`PreWarm:PrebuiltBundleRoot`) and already serves them to gates. This is the same source of truth the gate lane has taken since 2026-08-30 (`compose-sealed-modules.sh`), now on the serve path too.

## Alternatives considered, and why they were rejected

1. **Option 1 as filed — the seal composes the registry's bytes (`registry-modules` in core CD).** Rejected as *not available*, not as wrong: it needs `MW_REGISTRY_KEY` provisioned to core, which is a credential decision. It remains the better end state (one producer at the SOURCE rather than a resolution at serve time) and the doc says so.
2. **Option 2 as filed — the INSTANCE fetches from `prebuilt/{identity}/{source}/modules`.** Rejected on a security ground the issue does not mention: that route is gated on a **whole-source** grant, and `PrebuiltDecision` refuses a plan-scoped one on purpose — *"a sealed publication carries every plan's bundles, so a plan-scoped `<source>/*@pro` … must never fetch the publication whole"*. Giving every installation `plugins/*` to fix a build-identity problem would hand every install every plan's bundles. It also needs the instance to know its package's SOURCE, and converges only as fast as installs update.
3. **"Prefer the seal whenever one exists."** Rejected as *wrong*, not merely coarse: a registry that COMPILED its own NodeTypes records its own live module, and the shelf is then the correct answer. Resolving by the recorded id is right in both directions; a preference order is right in one.
4. **Refusing the download when the builds disagree.** Rejected: the registry cannot conjure a build it does not hold, and withholding the module is strictly worse than today's degraded-but-working outcome (decline → compile from source). The case is NAMED on the wire instead — which is the part that was missing.

## Guard, mutation-proved

`test/Memex.Portal.Shared.Test/ServedModuleBytesTest.cs` — 9 cases, pinned as a pure decision over real files with REAL MVIDs (each fixture's module bytes are a genuine assembly the test process has loaded), for the same reason `PluginBundleLaneResolutionTest` pins `ResolveStoreVersion`: every branch fails silently.

Mutation: `Resolve` reverted to the pre-#3244 behaviour (`return shelf;` before the MVID comparison), rebuilt, re-run — 4 of 8 red, including the headline case:

```
  Failed …ServedModuleBytesTest.WhenTheShelfIsNotTheRecordedBuild_TheSealedBuildIsServed [29 ms]
   Assert.Equal() Failure: Collections differ
                      ↓ (pos 136)
Expected: [···, 3, 0, 27, 70, 131, ···]
Actual:   [···, 3, 0, 192, 113, 72, ···]
  Failed …ServedModuleBytesTest.TheSealedBuildIsFound_EvenUnderAnUnconventionalBundleName
  Failed …ServedModuleBytesTest.WhenNoSealCarriesTheRecordedBuild_TheDivergenceIsNamed
   Assert.NotNull() Failure: Value is null
  Failed …ServedModuleBytesTest.WithNoPublishedRoot_TheShelfIsServed
Failed!  - Failed: 4, Passed: 4, Total: 8
```

Mutation reverted; `Passed! - Failed: 0, Passed: 9`.

A second, separate mutation covers the #2221 shape — switching which producer supplies the module must not drop its static web assets, and nothing else fails when they are dropped. Returning `[]` for the sealed bundle's assets:

```
  Failed …ServedModuleBytesTest.TheSealedBuildsStaticAssetsRideWithIt [20 ms]
   Assert.Equal() Failure: Collections differ
Failed!  - Failed: 1, Passed: 8, Total: 9
```

Reverted; green again. The assets ARE in the sealed bundle — `ModulePackCommand` writes them at `meshweaver/moduleassets/`, and `node-repo-module-pack.yml:1864` already refuses a bundle whose source tree has `wwwroot/` or `*.razor.css` and that declares no `staticAssets`.

## Verification

`dotnet build -c Release -warnaserror`, one project per invocation, all `0 Error(s)`:
`MeshWeaver.PluginCatalog`, `Memex.Portal.Shared`, `Memex.Portal.Shared.Test`, `MeshWeaver.Documentation.Test`, and every other `MeshWeaver.PluginCatalog` dependent (`MeshWeaver.PluginTester`, `MeshWeaver.ComboVerifier`, `MeshWeaver.ComboAssembler`).

Tests: `Passed! - Failed: 0, Passed: 98` over `PluginBundle* · Prebuilt* · SealedSet* · ServedModule* · ReleaseGate* · ModuleUpdateIdentity* · ModulePublish* · BuildPrincipal*`; `DocumentationLinkIntegrityTest` + What's New green after the doc edits.

## Work product conserved

`Doc/Architecture/ModuleBuildArchitecture` — "The two controls" becomes **"The three controls"**, a new section states the rule, the table and the three load-bearing properties, and **"What the gate still cannot see"** is rewritten to the honest residue: nothing here runs until the instance decides to DOWNLOAD, and `ModuleUpdateDecision` takes that from the index's advertised *framework* identity, never the module MVID — so the ordinary path converges (a platform release triggers the owning repo's lane, republishing the module and moving the advertised identity, which is exactly when the two builds diverge), while a seal appearing for the running identity with the shelf sitting still does not by itself trigger a re-land. Plus the credential decision that option 1 still waits on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
