### PR TITLE
fix(cd): core asserts the webhook credentials and never passes them — every publication seals unregistered

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2286,6 +2286,14 @@ jobs:
       # from here would wake the same satellites twice for the same identity.
       upstream-sources: ''
       dispatch-dependents: false
+      # 🚨 THE ONE EVENT CORE EMITS. The preflight above already asserts vars.PLATFORM_WEBHOOK_URL
+      # and secrets.PLATFORM_WEBHOOK_SECRET are set — and then this call did not pass either, so
+      # every publication sealed and was NEVER registered: "the publication is sealed but memex was
+      # NOT told — provision on the calling repository" on a repository that HAS provisioned it
+      # (run 33883938454, 2026-09-04). Asserting an input EXISTS is not asserting it ARRIVES.
+      # Without this, memex never fans the release out and every satellite falls back to its
+      # schedule poll — silent, slow, and invisible from here.
+      webhook-url: ${{ vars.PLATFORM_WEBHOOK_URL }}
     secrets:
       # No acr-* secrets: the platform holds none, and the reusable bake pulls the image through
       # the same OIDC identity that publishes to storage (its 'oidc' registry mode).
@@ -2295,6 +2303,11 @@ jobs:
       # The content checkout of the private Plugins repo — see plugins-modules.
       content-app-id: ${{ secrets.DEPENDENT_DISPATCH_APP_ID }}
       content-app-private-key: ${{ secrets.DEPENDENT_DISPATCH_APP_PRIVATE_KEY }}
+      # Signs X-Hub-Signature-256 on the publication record. Must be byte-identical to the control
+      # instance's Hosting:PlatformWebhookSecret — a mismatch is INVISIBLE from here (the POST still
+      # answers 2xx and the watcher drops every delivery as unverifiable), which is why the preflight
+      # asserts it and why it must actually reach this lane.
+      webhook-secret: ${{ secrets.PLATFORM_WEBHOOK_SECRET }}
 
   verify-images:
     name: "Verify every image shipped"


### PR DESCRIPTION
## What is broken

`main-cd.yml`'s `plugins-bake` job calls `node-repo-publish-bake.yml`, which declares `webhook-url`
(input, L316) and `webhook-secret` (secret, L369) and reads them in **Register the publication with
memex** (L1231-1232). **The call passed neither.**

Meanwhile the same file's preflight (L291-302) asserts both are provisioned, and spells out the
consequence of their absence:

> WITHOUT it no release event ever reaches the mesh — and that POST is the ONE event core emits:
> memex fans it out to the node repos, so without it every satellite falls back to its schedule poll

So core validates the credentials and then hands the consuming job empty strings.

## Measured

Run [33883938454](https://github.com/Systemorph/MeshWeaver/actions/runs/33883938454), 2026-09-04:

| job | result |
|---|---|
| `Module bundle (AI / Maps / Markdown.Collaboration / Payments.Stripe)` | ✅ all four |
| `Bake + publish NodeType assemblies to portal storage` | ✅ |
| **`Register the publication with memex`** | ❌ |

```
##[error]the publication is sealed but memex was NOT told — provision on the calling repository,
         then re-run:
  • webhook-url (input) — the control instance's inbox … (core CD: vars.PLATFORM_WEBHOOK_URL)
```

…on a repository where `vars.PLATFORM_WEBHOOK_URL` **is** set (`len=63`) and
`secrets.PLATFORM_WEBHOOK_SECRET` **does** exist. The gate is correct and fails closed. The wiring
was the defect.

**Impact is a lost notification, not lost bytes.** The publication seals; dependents simply are not
told, so each waits for its schedule poll. That is invisible from core — no red, just latency —
which is why it survived.

## The general shape

🚨 **Asserting that an input EXISTS is not asserting that it ARRIVES.** The preflight proved the
variable was set on the repository; nothing proved the value reached the consumer. Those are two
different claims, and only the second one is what the pipeline depends on. This is the same family
as a gate that checks its own configuration rather than its outcome.

## Verification

Structural, not textual — the workflow parses and both values resolve onto the right job:

```
job 'plugins-bake' uses ./.github/workflows/node-repo-publish-bake.yml
  with.webhook-url      : PRESENT
  secrets.webhook-secret: PRESENT
```

I did not add a guard asserting the record was accepted: the lane **already** fails RED after a
successful publish when either value is empty (that refusal is exactly what surfaced this), so the
detector exists and works — it was starved of input, not missing.

## Follow-up worth doing separately

A mismatched (rather than empty) `webhook-secret` is explicitly invisible: the POST still answers
2xx and the watcher drops every delivery as unverifiable. Nothing here can see that, and it deserves
its own issue rather than a rider on this fix.
