### PR TITLE
docs: a control whose green is guaranteed by construction is not a control

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
@@ -1,0 +1,159 @@
+---
+Name: Controls That Cannot Fail
+Category: Architecture
+Description: A control whose green is guaranteed by construction is not a control. Six measured instances from one day — a test, a detector, an identity anchor, a preflight, a watcher and a CD verdict — and the one question that catches all six.
+Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="9"/><path d="M8 12h8"/><path d="M12 8v8" opacity="0.25"/></svg>
+---
+
+# Controls That Cannot Fail
+
+A control — a test, a gate, a detector, a preflight, a watcher, a status verdict — earns its green by
+being **able to go red**. When it cannot, its green stops carrying information, and the failure mode
+is the worst one available: *nothing happens*. No alarm, no red tick, no line in a log. The control
+silently disappears and the wall stays green.
+
+> **The question that catches all six instances below:**
+> *"What makes this go red? Have I seen it do that?"*
+>
+> If the honest answer is "I've never seen it fail" or "it would fail if X, and X can't happen here",
+> you have a decoration, not a control.
+
+This is the general form of two rules stated elsewhere as absolutes — a CI gate must never carry a
+skip-trapdoor ([Reading CI Signals](/Doc/Architecture/ReadingCiSignals)), and a regression test is only
+a pin if it fails against the defect ([Negative Controls](/Doc/Architecture/NegativeControls)). Both are
+instances. The family is larger, and it is worth recognising by shape.
+
+## The shapes
+
+| Shape | What it looks like | Why the green is empty |
+|---|---|---|
+| **Served by the thing under isolation** | a precondition probe satisfied by the transport the test then removes | green before the isolation exists, so it says nothing about after |
+| **Never run against a broken subject** | a detector shipped alongside its own fix | it has only been observed passing on healthy code |
+| **Asserting existence, not arrival** | a preflight that checks an input is provisioned | provisioned ≠ passed on to the job that needs it |
+| **Green-and-wrong** | an anchor that emits a non-blank but meaningless value | red stops the line; a wrong value travels |
+| **Blindness rendered as health** | a watcher whose read failure and whose "no matches" look identical | "I cannot see" is reported as "nothing is wrong" |
+| **One word covering three states** | `completed/success` over checked-and-passed, never-ran, and ran-and-did-nothing | the verdict is not the outcome |
+
+## Six measured instances
+
+All six were found in a single day, across tests, CI, publication and ops. Each is stated with what
+was *measured*, not with what was suspected.
+
+### 1. A control served by the transport the test then destroyed
+
+`PodHubTransportTest.CrossSiloNack_ReachesASenderWhoseStreamSubscriptionIsGone` erases a sender's
+stream subscription and asserts a NACK still arrives over the *directed* pod-hub transport. Its
+precondition probe posted a message and waited for it to arrive — proving **reachability**, which
+during that window is served by the **stream it was about to erase**.
+
+Worse, the probe was *adversarial*: it posts from the other silo in a loop, and each failed directed
+call mints a throw-away activation there that the owner's next `Attach` must bounce off, restarting
+its backoff. The louder the control ran, the longer the asserted condition took to become true.
+
+**Measured:** with one bounce forced and the claim backoff pinned long, the probe goes green in under
+a second while `PodHubClaimSettled` has demonstrably not completed — six runs, six times.
+[#3298](https://github.com/Systemorph/MeshWeaver/issues/3298), fixed in #3313. Full treatment:
+[Negative Controls](/Doc/Architecture/NegativeControls) §4 and
+[Orleans Test Routing Pattern](/Doc/Architecture/OrleansTestRoutingPattern).
+
+### 2. A detector that passes with the production fix removed
+
+`NackReachesTheWaiterDuringTeardownTest.OwnerDisposingUnderMeshTeardown_StillAnswersTheWaitingCaller`
+blocked two pull requests and dequeued a merge-queue group. Run with both `HierarchicalRouting` call
+sites disabled — the shipped fix removed — the suite printed:
+
+```
+Failed! - Failed: 1, Passed: 1
+```
+
+That `Passed: 1` **is the field detector**, green with the defect fully present, having itself logged
+the refusal it exists to complain about. Fixed in #3309 (tests and docs only; the production fix was
+#3302).
+
+**Rule:** a detector must be run against a subject you broke *on purpose*, or you have only measured
+that it runs.
+
+### 3. An identity anchor that went green stating four identities for one platform
+
+#3293 fixed a genuine RED — the identity anchor was read from the module's own publish output, which
+is absent for any module not transitively referencing `MeshWeaver.Compiler` — and introduced a
+**silent** failure by passing `-p:Version="$VERSION"` to the replacement build. MSBuild writes
+`Version` into the assembly, so the anchor became per-module:
+
+```
+-p:Version=1.3.18 (AI)         → 34337c31960d47f5b5251d32ef923fc6
+-p:Version=1.0.24 (Essentials) → 7c1c4f70de084da78659e6bda495e1c5
+no override, run A             → 71cc81badb364c5d8558ac5e7db6a44e
+no override, run B             → 71cc81badb364c5d8558ac5e7db6a44e   ← identical
+```
+
+Four bundles, four identities, one platform. All non-blank, all green, **none matchable by any
+consumer**. Fixed in #3306; the class was filed as
+[#3308](https://github.com/Systemorph/MeshWeaver/issues/3308).
+
+**Rule:** green-and-wrong is worse than red. The red stopped the pack; this stopped nothing.
+
+### 4. A preflight that asserts a credential exists and never passes it on
+
+`main-cd.yml` asserted that `vars.PLATFORM_WEBHOOK_URL` and `secrets.PLATFORM_WEBHOOK_SECRET` were
+provisioned — with a comment explaining that without them *"every satellite falls back to its schedule
+poll"* — and then called `node-repo-publish-bake.yml` passing **neither**. Every publication sealed
+and was never registered. The job's own error read *"provision on the calling repository"*, on a
+repository where the variable is set (`len=63`) and the secret exists. Fixed in #3311.
+
+**Rule:** asserting that an input **exists** is not asserting that it **arrives**. Only the second is
+what the pipeline depends on.
+
+### 5. Watchers rendering "I cannot see" as "nothing is wrong"
+
+Four successive revisions of a PR watcher, each silent on a state its author had not imagined:
+
+- could not distinguish "queued and building" from "ejected again" — so it reported a pull request as
+  merging while it sat rejected for ~15 minutes;
+- read latest-`main` while `main` outran CD, so it could never see the run carrying the verification;
+- a *queued* run masked the *running* one;
+- `gh api --jq` silently rejects `--arg` (`accepts 1 arg(s), received 4`) and returns nothing — which
+  reads exactly like "no matching runs".
+
+Only the last was caught quickly, and only because an explicit **blind-detector** had been added that
+refuses to interpret an empty result.
+
+**Rule:** report *read failure* and *no matches* as distinct states, and give every watcher its own
+control arm. A monitor that greps only for the success marker stays silent through a crash.
+
+### 6. One verdict covering three different outcomes
+
+A green `CD delivered` sat over a **skipped** `bake + seal`, and four consecutive green scheduled CD
+runs published nothing. `completed/success` covered all of: *checked and passed*, *never ran*, and
+*ran and deliberately did nothing* — indistinguishable without opening the job list.
+
+**Rule:** a run's conclusion is not the outcome. Read the job that does the work; see
+[Reading CI Signals](/Doc/Architecture/ReadingCiSignals) and
+[How to tell if CD actually published](/Doc/Architecture/ContinuousDeliveryContract).
+
+## What to do about it
+
+1. **Break the subject on purpose, once.** Revert only the fixing lines, or disable the mechanism, and
+   watch the control go red with the message you predicted. Record that output — the red run is the
+   evidence, the green one is not. The procedure is in
+   [Negative Controls](/Doc/Architecture/NegativeControls).
+2. **Ask what serves the precondition while the isolation is absent.** If the answer is "the thing I am
+   about to remove", the probe cannot fail.
+3. **Separate "cannot see" from "nothing there".** Every watcher, every query-backed gate, needs a
+   distinct blind state that is loud.
+4. **Assert arrival, not existence.** For an input, the property that matters is that it reached the
+   consumer — pass it and have the consumer confirm.
+5. **Prefer a red that stops the line to a value that travels.** A refusal is recoverable; a
+   plausible-looking wrong value is not.
+6. **Do not promote an experiment into a guard by default.** An experiment that pins a cause and a test
+   that guards against regression are different artifacts. If the experiment's setup depends on an
+   ordering you cannot *enforce*, committing it manufactures the next flake — record it in the change
+   instead.
+
+## See also
+
+- [Negative Controls](/Doc/Architecture/NegativeControls) — the procedure, and four tests that proved nothing.
+- [Reading CI Signals](/Doc/Architecture/ReadingCiSignals) — skipped and absent contexts, and what a green wall does not mean.
+- [Cross-Repo Pair Gate](/Doc/Architecture/CrossRepoPairGate) — a gate that sees two of seven break shapes, and says so.
+- [Orleans Test Routing Pattern](/Doc/Architecture/OrleansTestRoutingPattern) — the pod-hub claim, and why reachability cannot stand in for it.
+- [Writing Tests](/Doc/Architecture/WritingTests) — the golden rules these controls are expressed against.

--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
@@ -73,12 +73,15 @@ the refusal it exists to complain about. Fixed in #3309 (tests and docs only; th
 **Rule:** a detector must be run against a subject you broke *on purpose*, or you have only measured
 that it runs.
 
-### 3. An identity anchor that went green stating four identities for one platform
+### 3. A fix for a red that replaced it with a silent one, in the same edit
 
-#3293 fixed a genuine RED — the identity anchor was read from the module's own publish output, which
-is absent for any module not transitively referencing `MeshWeaver.Compiler` — and introduced a
-**silent** failure by passing `-p:Version="$VERSION"` to the replacement build. MSBuild writes
-`Version` into the assembly, so the anchor became per-module:
+This is the entry that explains why the family deserves a page, so read it as one story rather than
+two issues.
+
+#3293 fixed a genuine **RED**: the identity anchor was read from the module's own publish output,
+which is absent for any module not transitively referencing `MeshWeaver.Compiler`, so the pack
+stopped. The same edit passed `-p:Version="$VERSION"` to the replacement build, "to match the module
+build's flags". MSBuild writes `Version` into the assembly, so the anchor became per-module:
 
 ```
 -p:Version=1.3.18 (AI)         → 34337c31960d47f5b5251d32ef923fc6
@@ -91,7 +94,19 @@ Four bundles, four identities, one platform. All non-blank, all green, **none ma
 consumer**. Fixed in #3306; the class was filed as
 [#3308](https://github.com/Systemorph/MeshWeaver/issues/3308).
 
-**Rule:** green-and-wrong is worse than red. The red stopped the pack; this stopped nothing.
+Three things make this the sharpest instance on the page, and its author states all three plainly:
+
+- **The fix caused it.** This was not a weak check somebody inherited — a correct repair for a red
+  introduced a silent failure in the same edit.
+- **It was written by someone hunting exactly this defect class that day**, who *noticed* the
+  per-module-MVID risk while writing it, reasoned it was pre-existing and out of scope, and shipped
+  anyway. Another session measured it hours later.
+- **Nothing told anyone.** The red had stopped the pack, so its absence was felt immediately. The
+  replacement stopped nothing.
+
+**Rule:** green-and-wrong is worse than red, and that asymmetry is the whole subject of this page — a
+red is self-reporting, a plausible wrong value is not. Stated as its author put it: *the fix removed
+the symptom and left a better-disguised version of the defect.*
 
 ### 4. A preflight that asserts a credential exists and never passes it on
 
@@ -115,8 +130,12 @@ Four successive revisions of a PR watcher, each silent on a state its author had
 - `gh api --jq` silently rejects `--arg` (`accepts 1 arg(s), received 4`) and returns nothing — which
   reads exactly like "no matching runs".
 
-Only the last was caught quickly, and only because an explicit **blind-detector** had been added that
-refuses to interpret an empty result.
+Only the last was caught quickly, and only because an explicit **blind-detector** — one that refuses
+to interpret an empty result — had been added by then. Its author asks that this not read as
+foresight: the detector arrived on **revision four**, after three earlier watchers had already misled
+both them and their user, one of which reported a pull request as merging while it sat
+`queue-rejected` for about fifteen minutes. A remedy that took four attempts is more useful to a
+reader than one that looks like instinct.
 
 **Rule:** report *read failure* and *no matches* as distinct states, and give every watcher its own
 control arm. A monitor that greps only for the success marker stays silent through a crash.
@@ -124,8 +143,18 @@ control arm. A monitor that greps only for the success marker stays silent throu
 ### 6. One verdict covering three different outcomes
 
 A green `CD delivered` sat over a **skipped** `bake + seal`, and four consecutive green scheduled CD
-runs published nothing. `completed/success` covered all of: *checked and passed*, *never ran*, and
-*ran and deliberately did nothing* — indistinguishable without opening the job list.
+runs published nothing. The job list is the undeniable artifact:
+
+```
+event=schedule → completed/success
+  Promote                            skipped
+  pack                               skipped
+  bake + seal                        skipped
+  Notify platform-update registry    skipped
+```
+
+`completed/success` covered all of: *checked and passed*, *never ran*, and *ran and deliberately did
+nothing* — indistinguishable without opening that list.
 
 **Rule:** a run's conclusion is not the outcome. Read the job that does the work; see
 [Reading CI Signals](/Doc/Architecture/ReadingCiSignals) and

--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
@@ -12,11 +12,19 @@ being **able to go red**. When it cannot, its green stops carrying information, 
 is the worst one available: *nothing happens*. No alarm, no red tick, no line in a log. The control
 silently disappears and the wall stays green.
 
-> **The question that catches all six instances below:**
-> *"What makes this go red? Have I seen it do that?"*
+> **The diagnostic, in two halves. The second is the one that does the work.**
 >
-> If the honest answer is "I've never seen it fail" or "it would fail if X, and X can't happen here",
-> you have a decoration, not a control.
+> 1. *"If the subject of this check were broken right now, what would this print?"*
+> 2. *"And have I run it against a subject I broke on purpose?"*
+
+**Every one of the six instances below passes the first question by reasoning, and fails the second.**
+That is not a coincidence, and it is the reason the first question alone is not enough: reasoning about
+a control is done by the person who built it, in the model they built it from, and a control fails
+precisely where that model is wrong. Instance 1 is the cleanest proof — its probe was *adversarially
+self-defeating*, actively delaying the state it asserted, which no amount of reading it would predict.
+
+So the second half is not a formality after the first. It is the only one of the two that consults
+reality.
 
 This is the general form of two rules stated elsewhere as absolutes — a CI gate must never carry a
 skip-trapdoor ([Reading CI Signals](/Doc/Architecture/ReadingCiSignals)), and a regression test is only
@@ -162,9 +170,10 @@ nothing* — indistinguishable without opening that list.
 
 ## What to do about it
 
-1. **Break the subject on purpose, once.** Revert only the fixing lines, or disable the mechanism, and
-   watch the control go red with the message you predicted. Record that output — the red run is the
-   evidence, the green one is not. The procedure is in
+1. **Break the subject on purpose, once — this is the whole discipline.** Revert only the fixing
+   lines, or disable the mechanism, and watch the control go red with the message you predicted.
+   Record that output — the red run is the evidence, the green one is not. Reasoning that it *would*
+   go red is what all six instances below had. The procedure is in
    [Negative Controls](/Doc/Architecture/NegativeControls).
 2. **Ask what serves the precondition while the isolation is absent.** If the answer is "the thing I am
    about to remove", the probe cannot fail.

--- a/src/MeshWeaver.Documentation/Data/Architecture/NegativeControls.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NegativeControls.md
@@ -46,7 +46,7 @@ way" — each track creating its own node — and both the old and new test shap
 said so, and named the remaining exposure as timing-dependent and therefore not demonstrable without
 rigging the clock. A negative control that comes out neutral is a result, not a failure to report.
 
-## Three tests that proved nothing
+## Four tests that proved nothing
 
 Each of these was written in good faith, passed, and was believed. What broke them is not
 carelessness — it is that the assertion measured something adjacent to the property.
@@ -151,6 +151,60 @@ the negative-control table for the two live sites.
 not a proof. Sampling probes belong in discovery, never in the regression suite as the guard for a
 specific defect.
 
+### 4. The control was served by the transport the test then destroyed
+
+The first three measured something *adjacent* to the property. This one is worse, and it is the shape
+to learn: the control was **guaranteed green by construction**, and it was **actively preventing** the
+state the test went on to assert.
+
+`PodHubTransportTest.CrossSiloNack_ReachesASenderWhoseStreamSubscriptionIsGone` erases a sender's
+Orleans stream subscription and asserts that a router's NACK still reaches it — over the *directed*
+pod-hub transport, which is the whole point. Before erasing, it proved the address was live:
+
+```csharp
+// "Prove the pod-hub claim is LIVE before erasing anything — by a cross-silo delivery ARRIVING"
+await WaitUntil(async () => {
+    SiloMeshHub(cluster, 1).Post(new PingRequest(), o => o.WithTarget(sender));
+    return inbox.Any(d => Describes(d, nameof(PingRequest)));
+}, …);
+```
+
+That comment states the intent exactly. The code does not do it. `RegisterStream` establishes **two**
+things on different clocks — the local route synchronously, and the cluster-wide **pod-hub claim**
+asynchronously, on a capped backoff with no give-up. The probe asserts **reachability**, and during
+the window that matters reachability is served by the **stream** — the transport erased three lines
+later. So the probe was green whether or not the claim had landed.
+
+**And it fought the claim it appeared to prove.** The probe posts from the *other* silo in a loop.
+Each post whose directed call finds no claim mints a throw-away `IPodHubGrain` activation on that
+silo — `[PreferLocalPlacement]` places an unactivated grain on the **caller** — and the owner's next
+`Attach` lands on that activation, answers `false`, and restarts its backoff. The louder the control
+ran, the longer the condition took to become true.
+
+The failure was therefore intermittent and **independent of the diff**: two heads of one pull request
+differing only in a string-assertion test in another assembly disagreed on it, which is what got it
+filed as a platform race ([#3298](https://github.com/Systemorph/MeshWeaver/issues/3298)).
+
+**Measured.** With one bounce forced and the claim's backoff pinned long, the probe goes green in
+under a second while `PodHubClaimSettled` has demonstrably not completed — six runs, six times. That
+experiment was deliberately **not** committed: its setup depends on an activation-lifetime ordering
+that cannot be *enforced*, so as a permanent test it would have become the next flake. An experiment
+that pins a cause and a test that guards it are different artifacts, and the first does not have to
+become the second.
+
+The cure is to wait on the condition itself — `PodHubClaimSettled`, the positive signal for "the claim
+stopped attempting" — which a sibling test already did. See
+[Orleans Test Routing Pattern](/Doc/Architecture/OrleansTestRoutingPattern) → *"Reachability is not a
+claim"*.
+
+**The lesson to carry:** when a test *isolates* one mechanism in order to assert another, ask what
+serves the precondition probe **while the isolation is not yet in place**. If the answer is "the thing
+I am about to remove", the probe cannot fail, and its greenness is not evidence of anything. The
+generalisation is broader than tests: any control whose green is guaranteed by construction — a
+detector that still passes with the fix removed, a gate that skips when its input is missing, a
+watcher that renders "I cannot see" as "nothing is wrong" — is the same defect wearing a control's
+clothes.
+
 ## What a good control looks like in a PR
 
 Name the test, show the reverted state, show the message.
@@ -193,4 +247,5 @@ test.
 - [Reactive Test Assertions](/Doc/Architecture/ReactiveTestAssertions) — the assertion API these controls are expressed in.
 - [Subscription Ownership](/Doc/Architecture/SubscriptionOwnership) — the leak case in full, with its control table.
 - [Silent Completion](/Doc/Architecture/SilentCompletion) — the failure shape whose only symptom is a timeout, so its pin *is* a timeout.
+- [Orleans Test Routing Pattern](/Doc/Architecture/OrleansTestRoutingPattern) — the pod-hub claim, and why a reachability probe cannot stand in for it.
 - [Change-Feed Isolation](/Doc/Architecture/ChangeFeedIsolation) — a control that ruled out two competing hypotheses for free.


### PR DESCRIPTION
Six controls found across one day — in tests, CI, publication and ops — that looked like six unrelated
problems and are **one shape**. Docs only.

> A control earns its green by being **able to go red**. When it cannot, the failure mode is the worst
> available: *nothing happens*. No alarm, no red tick, no log line. The control silently disappears and
> the wall stays green.

Two rules already stated as absolutes are instances of this — a CI gate must not carry a
skip-trapdoor, and a regression test is only a pin if it fails against the defect. The new page is the
**hub for the family** and links down to both rather than restating either.

## Why a new page rather than appending to `NegativeControls`

Five of the six are not tests. A preflight, an identity anchor, a watcher and a CD verdict do not
belong on a page whose subject is "a regression test is only a pin if it fails against the defect".

So: `ControlsThatCannotFail` carries the family, the shape table, and all six instances.
`NegativeControls` gains **one** of them as a fourth worked example — the pod-hub probe — because that
one genuinely is a test.

## The shapes

| Shape | Why the green is empty |
|---|---|
| Served by the thing under isolation | green before the isolation exists, so it says nothing about after |
| Never run against a broken subject | only ever observed passing on healthy code |
| Asserting existence, not arrival | provisioned ≠ passed on to the job that needs it |
| Green-and-wrong | red stops the line; a wrong value travels |
| Blindness rendered as health | "I cannot see" reported as "nothing is wrong" |
| One word covering three states | the verdict is not the outcome |

## Provenance, and what I verified

Instance 1 is mine (#3298 → #3313). **Instances 2–6 were measured by the core-CD session** and are
quoted from the runs they named. Before publishing I checked each cited reference matched its
description rather than transcribing a summary — #3309, #3306, #3311, #3293 all merged with matching
titles, #3308 closed. They confirmed the MVID table, the `Failed! - Failed: 1, Passed: 1` line and the
`len=63` detail are accurate as quoted.

The second commit applies **three tightenings they asked for after reading the draft**, and each makes
the page less flattering:

- **Instance 3 is one story, and the fix caused it.** #3293 repaired a genuine red and introduced the
  silent failure in the same edit — written by someone who had spent that day hunting this exact
  defect class, who *noticed* the per-module-MVID risk, reasoned it out of scope, and shipped anyway.
  That asymmetry is the point of the whole page: the red stopped the pack so its absence was felt at
  once; the replacement stopped nothing. Their sentence closes the entry — *the fix removed the symptom
  and left a better-disguised version of the defect.*
- **The blind-detector was not foresight.** It arrived on revision four, after three earlier watchers
  had misled its author and their user. They asked for it to say so; a remedy that took four attempts
  teaches more than one that reads as instinct.
- **Instance 6 now quotes the job list**, not prose: `event=schedule → completed/success` with
  `Promote`, `pack`, `bake + seal` and `Notify platform-update registry` all **skipped**.

## Verification

`MeshWeaver.Documentation.Test` — **257 passed**, including `DocumentationLinkIntegrityTest`; re-run
after the tightenings. Every link target confirmed present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
