### PR TITLE
fix(#3310): assert the OUTCOME — one run, one platform, ONE framework identity

### DIFF
--- a/.github/scripts/node-repo-pack-verify.py
+++ b/.github/scripts/node-repo-pack-verify.py
@@ -64,6 +64,16 @@ its own, and `--test-receipts` / `--tests-result` make the pairing checkable: a 
 with no test receipt, a test receipt for a module that delegated nothing, and a tests lane that
 did not succeed are each RED, under this job's own unchanged context name. `bundles-built` is
 deliberately untouched by all of it.
+
+🚨 AND ONE RUN STATES ONE FRAMEWORK IDENTITY (#3310). Every guard on the identity anchor is
+CONFIG-level — it asserts the lane's text or the anchor's location — so none of them can see a run
+END UP stating a different identity per module, which is what any per-module property reaching the
+anchor build produces, silently and green. The identity names the PLATFORM build and a lane pins
+ONE platform, so this job — the only one that sees the whole wave — reads the value each receipt
+carries and refuses a lane whose bundles disagree. A receipt that states NO identity was written by
+a lane older than this script (a caller pins the LANE and `platform-ref` separately, on purpose)
+and is a DISTINCT, NAMED refusal carrying the remedy: "absent" must never read as "agrees", which is
+the same mistake as a skipped gate reading as a passed one.
 """
 from __future__ import annotations
 
@@ -348,6 +358,84 @@ def test_lane(receipts: dict[str, dict], test_receipts: dict[str, dict], broken:
         notes.append(f"suites: {len(delegated)} ran in the tests lane beside the pack matrix, "
                      f"{len(inline)} inline in the pack job (this call publishes, so a red suite "
                      f"cannot publish), {len(none)} not owed a run by the selection")
+    return errors, notes
+
+
+IDENTITY_FIELD = "frameworkIdentity"
+"""The framework identity the receipt's bundle STATES, read off the packed manifest's
+`frameworkMvid` by the leg that produced the bytes (build or reuse alike)."""
+
+
+def identity_agreement(receipts: dict[str, dict]) -> tuple[list[str], list[str]]:
+    """(errors, notes) — does every bundle this lane packed state the SAME framework identity?
+
+    🚨 THIS IS THE ONLY OUTCOME-LEVEL CHECK ON THE IDENTITY, and the failure it catches is SILENT
+    (#3310). The identity names the PLATFORM build, and a lane pins ONE platform — so a lane whose
+    bundles state two identities has produced bundles no consumer can compare against a single
+    platform, and it did so while every existing guard stayed green. Those guards are CONFIG-level:
+    `ModuleIdentityPublishGuard` asserts the lane's TEXT (the anchor is built from the pinned
+    platform source and that command line carries no `-p:Version`) and `ModulePackCommand` asserts
+    the anchor's LOCATION. Neither can see the run END UP stating more than one value — a second
+    per-module property reaching the anchor build (`-p:InformationalVersion`, `-p:SourceRevisionId`,
+    a `Directory.Build.props` edit keyed on the module), a future arm deriving the anchor a third
+    way, or a caller passing `--framework-mvid` per module would leave them all passing while the
+    bundles pack, the manifests carry well-formed 32-hex values, and every non-blank assertion
+    downstream succeeds. Measured twice already: #3211's `(unrecorded)` fleet, then run 33874892203
+    packing TWO identities for one platform.
+
+    🚨 AND AN ABSENT IDENTITY IS A NAMED REFUSAL, NEVER "AGREES". A receipt carrying no identity
+    was written by a module-pack lane older than this verifier — a caller may pin the LANE
+    (`uses: …/node-repo-module-pack.yml@<sha>`) and `platform-ref` (which is where this script is
+    read from) separately and on purpose. Reading that silence as agreement would make this gate
+    answer "one identity" from a set that stated none, which is exactly the class of mistake the
+    gate exists to remove, so it is refused and NAMED with the remedy.
+
+    Scoped to THIS call's receipts (lane stamp + declared matrix, applied by `own_receipts`): a repo
+    calling the lane twice pins one platform PER CALL, so two calls may legitimately differ."""
+    errors: list[str] = []
+    notes: list[str] = []
+    if not receipts:
+        return errors, notes
+
+    stated: dict[str, str] = {}
+    silent: list[str] = []
+    for module in sorted(receipts):
+        value = receipts[module].get(IDENTITY_FIELD)
+        value = value.strip() if isinstance(value, str) else ""
+        if value:
+            stated[module] = value
+        else:
+            silent.append(module)
+
+    if silent:
+        errors.append(
+            f"{len(silent)} receipt(s) state NO framework identity, so this lane cannot say whether "
+            f"its bundles agree — and an unstated identity must never read as agreement (#3310): "
+            + ", ".join(silent)
+            + ". The receipts were written by a module-pack lane older than this verifier: move the "
+              "caller's `uses: Systemorph/MeshWeaver/.github/workflows/node-repo-module-pack.yml@<sha>` "
+              "to a commit that records `frameworkIdentity` (the same commit as its `platform-ref` "
+              "is the safe choice — the two are pinned separately).")
+
+    distinct = sorted(set(stated.values()))
+    if len(distinct) > 1:
+        by_identity = {
+            identity: sorted(m for m, v in stated.items() if v == identity)
+            for identity in distinct
+        }
+        errors.append(
+            f"this lane's bundles state {len(distinct)} DIFFERENT framework identities, and a lane "
+            f"pins ONE platform — so at least one of them names a platform build that does not "
+            f"exist, which every consumer then fails to match on every reconcile, forever (#3310, "
+            f"#3154): "
+            + "; ".join(f"{identity} ← " + ", ".join(by_identity[identity]) for identity in distinct)
+            + ". Something per-module is reaching the identity anchor (a `-p:Version`-shaped "
+              "property on the anchor build, an arm deriving the anchor from the module's own "
+              "output, or a caller passing --framework-mvid per module).")
+
+    if not errors:
+        notes.append(f"all {len(stated)} bundle(s) this call packed state ONE framework identity: "
+                     f"{distinct[0]}")
     return errors, notes
 
 
@@ -653,6 +741,93 @@ def self_test() -> int:
         check("test receipts whose pack legs produced NO receipt are the COUNT gate's finding, "
               "not this one's — it must not misname the cause", not errs, f"{errs}")
 
+        # ── ONE RUN, ONE PLATFORM, ONE IDENTITY ───────────────────────────────────────────
+        # 🚨 The mutations here are the ONLY place the identity defect can be made to fail. Every
+        # other guard on it reads the lane's TEXT, and the failure they cannot see is silent: the
+        # bundles pack, the manifests carry well-formed 32-hex values, and a run states one
+        # identity PER MODULE. Reinstating `-p:Version="$VERSION"` on the anchor build produces
+        # EXACTLY the first mutation below (measured on that command: -p:Version=1.3.18 →
+        # 34337c31…, -p:Version=1.0.24 → 7c1c4f70…, no override → 71cc81ba… twice).
+        print("one run, one platform, ONE identity — the outcome the config-level guards cannot "
+              "see (#3310):")
+        ONE = "71cc81badb364c5d8558ac5e7db6a44e"
+        OTHER = "34337c31960d47f5b5251d32ef923fc6"
+
+        def idr(identity: str) -> dict[str, dict]:
+            return {m: {"lane": "floor-abc123", "module": m, IDENTITY_FIELD: identity}
+                    for m in three}
+
+        agreed = idr(ONE)
+        errs, nts = identity_agreement(agreed)
+        check("every bundle states the same identity ⇒ pass, and the note SAYS which",
+              not errs and any(ONE in n for n in nts), f"{errs} {nts}")
+
+        disagreeing = dict(agreed)
+        disagreeing["MeshWeaver.Mcp"] = {"lane": "floor-abc123", "module": "MeshWeaver.Mcp",
+                                         IDENTITY_FIELD: OTHER}
+        errs, _ = identity_agreement(disagreeing)
+        check("a per-module identity (what reinstating -p:Version on the anchor build produces) "
+              "⇒ RED, naming the modules AND their identities",
+              any("DIFFERENT framework identities" in e and ONE in e and OTHER in e
+                  and "MeshWeaver.Mcp" in e and "MeshWeaver.AI" in e for e in errs), f"{errs}")
+
+        for value, label in ((None, "an absent"), ("", "an empty"), ("   ", "a whitespace")):
+            silent = dict(agreed)
+            silent["MeshWeaver.Teams"] = {"lane": "floor-abc123", "module": "MeshWeaver.Teams"}
+            if value is not None:
+                silent["MeshWeaver.Teams"][IDENTITY_FIELD] = value
+            errs, nts = identity_agreement(silent)
+            check(f"{label} identity is a NAMED refusal, never a silent 'agrees' — and the "
+                  f"remedy is in the message",
+                  any("state NO framework identity" in e and "MeshWeaver.Teams" in e
+                      and "node-repo-module-pack.yml@" in e for e in errs)
+                  and not nts, f"{errs} {nts}")
+
+        # Both findings at once: a lane may be BOTH stale and disagreeing, and reporting only the
+        # first would send the reader after the wrong one.
+        both = dict(disagreeing)
+        both["MeshWeaver.Teams"] = {"lane": "floor-abc123", "module": "MeshWeaver.Teams"}
+        errs, _ = identity_agreement(both)
+        check("a lane that is BOTH stale and disagreeing reports both findings",
+              len(errs) == 2, f"{errs}")
+
+        # 🚨 PER LANE, because a repo calling this workflow twice pins one platform PER CALL. The
+        # filter is `own_receipts` — the same one the count gate and the tests lane apply — so a
+        # sibling call's identity can neither red this one nor satisfy it.
+        with_sibling = dict(agreed)
+        with_sibling["MeshWeaver.Ghost"] = {"lane": "rest-def456", "module": "MeshWeaver.Ghost",
+                                            IDENTITY_FIELD: OTHER}
+        errs, _ = identity_agreement(own_receipts(with_sibling, "floor-abc123", set(three)))
+        check("a SIBLING call's differing identity is not this call's to judge (two calls, two "
+              "pins) ⇒ pass", not errs, f"{errs}")
+        errs, _ = identity_agreement(own_receipts(with_sibling, "", None))
+        check("…and without the lane filter that same set IS the disagreement — the scope is what "
+              "makes the pass legitimate, not the absence of a finding",
+              any("DIFFERENT framework identities" in e for e in errs), f"{errs}")
+
+        check("an empty selection has nothing to disagree about ⇒ pass, silently",
+              identity_agreement({}) == ([], []))
+
+        # And end-to-end, off files on disk, through the same reader the gate uses — a check that
+        # only ever ran on hand-built dicts would not prove the FIELD NAME the lane writes.
+        idd = Path(tmp) / "identity"
+        idd.mkdir()
+        for m in three:
+            (idd / f"{m}.json").write_text(json.dumps(
+                {"lane": "floor-abc123", "package": m.split(".")[-1], "module": m,
+                 "version": "1.2.3", IDENTITY_FIELD: ONE}), encoding="utf-8")
+        parsed, _ = read_receipts(idd)
+        errs, nts = identity_agreement(own_receipts(parsed, "floor-abc123", set(three)))
+        check("read off real receipt FILES, the field the lane writes is the field this reads",
+              not errs and any(ONE in n for n in nts), f"{errs} {nts}")
+        (idd / "MeshWeaver.Teams.json").write_text(json.dumps(
+            {"lane": "floor-abc123", "package": "Teams", "module": "MeshWeaver.Teams",
+             "version": "1.2.3", IDENTITY_FIELD: OTHER}), encoding="utf-8")
+        parsed, _ = read_receipts(idd)
+        errs, _ = identity_agreement(own_receipts(parsed, "floor-abc123", set(three)))
+        check("…and one file mutated to a second identity turns it RED",
+              any("DIFFERENT framework identities" in e for e in errs), f"{errs}")
+
     if failures:
         print(f"\n::error title=node-repo-pack-verify self-test failed::{len(failures)} case(s) — "
               "this gate is the only thing standing between a narrowed matrix and a silently "
@@ -663,11 +838,15 @@ def self_test() -> int:
           "receipt LANE cases (own stamp counts, a sibling lane's does not — even for a module "
           "both calls declared), 12 built-marker cases (foreign lane, unstamped, no closure, no "
           "bundle, corrupt, zero markers — every one fail-closed — plus #2710's red-suite "
-          "survival), 5 empty-selection cases including the scope=full contradiction lock, and 11 "
+          "survival), 5 empty-selection cases including the scope=full contradiction lock, 11 "
           "TESTS-LANE cases (a failed or cancelled lane is red, a skipped lane with delegated "
           "suites is red because the suite then ran NOWHERE, a missing or corrupt test receipt is "
           "red, the inline/lane halves disagreeing is red — and the publishing, nothing-owed, "
-          "older-caller and pack-failed shapes must stay green) — all green.")
+          "older-caller and pack-failed shapes must stay green), and 10 IDENTITY cases (two "
+          "identities in one lane is red naming both, an absent/empty/whitespace identity is a "
+          "distinct NAMED refusal rather than 'agrees', both findings are reported together, the "
+          "check is scoped per LANE, and the field is read end-to-end off real receipt files) — "
+          "all green.")
     return 0
 
 
@@ -730,8 +909,8 @@ def main() -> int:
     # 🚨 AFTER the bundles-built answer and deliberately unable to change it: a red suite must red
     # THIS context and must NOT read as "bundle missing" to a gate that only composes the bundle
     # (#2710, Plugins#937). Those are two different questions and this is the second one.
+    declared_set = parse_declared(args.declared)
     if args.test_receipts or args.tests_result:
-        declared_set = parse_declared(args.declared)
         t_receipts, t_broken = (read_receipts(Path(args.test_receipts))
                                 if args.test_receipts else ({}, []))
         t_errors, t_notes = test_lane(own_receipts(receipts, args.lane, declared_set),
@@ -741,6 +920,17 @@ def main() -> int:
         errors.extend(t_errors)
         if t_errors:
             code = 1
+
+    # 🚨 THE THIRD QUESTION, and the only one asked of the OUTCOME: did this lane's bundles end up
+    # stating ONE framework identity? Unconditional — there is no flag to forget and no input to
+    # test, because the evidence is the receipts this job already downloaded. Like the tests-lane
+    # accounting it runs after `bundles_built` and cannot change it: bundles that disagree are
+    # complete and composable, and mis-stating them as missing would misname the cause (#2710).
+    i_errors, i_notes = identity_agreement(own_receipts(receipts, args.lane, declared_set))
+    notes.extend(i_notes)
+    errors.extend(i_errors)
+    if i_errors:
+        code = 1
     for note in notes:
         print(f"✓ {note}")
     for error in errors:

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -69,6 +69,13 @@ name: node-repo module pack
 # the receipts and the selection disagree. That is invariant #4 for a matrix allowed to change
 # size, and it is the only reason a narrowed matrix is safe to require.
 #
+# 🚨 AND SO IS THE FRAMEWORK IDENTITY (#3310). The receipt also carries the identity its bundle
+# STATES — read off the packed bytes, on the build and reuse legs alike — because a lane pins ONE
+# platform and every guard on the anchor is CONFIG-level: they assert the lane's text and the
+# anchor's location, and cannot see a run END UP stating one identity per module. `verify` refuses
+# a lane whose bundles disagree, and refuses an absent identity SEPARATELY and by name — "absent"
+# reading as "agrees" is the same mistake as a skipped gate reading as a passed one.
+#
 # A caller that ships neither scripts/affected-modules.py nor scripts/project-closure.py is simply
 # not narrowable: the scope script says FULL and says why. Nothing to opt into, nothing to skip.
 #
@@ -2236,16 +2243,40 @@ jobs:
           TESTS: ${{ steps.plan.outputs.need_test != 'true' && 'none' || (inputs.publish && 'inline' || 'lane') }}
           LEDGER_KEY: ${{ steps.plan.outputs.key }}
           LEDGER_DECISION: ${{ steps.plan.outputs.decision }}
+          # 🚨 THE BYTES THIS LEG PRODUCED, whichever leg produced them (#3310). Same expression as
+          # the publish step's: the build leg's packed bundle, or the artifact the reuse leg
+          # downloaded and sha256-verified. The identity is read off THESE bytes, so a reuse leg is
+          # accounted for exactly like a build leg.
+          BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/receipts"
           [ -n "$LANE" ]  || { echo "::error::the lane key is empty — the select job did not produce one, so this receipt could not be attributed to this call."; exit 1; }
           [ -n "$TESTS" ] || { echo "::error::this leg recorded no owner for $MODULE's suite — a receipt that cannot say whether the suite ran here, ran in the tests lane, or was not owed leaves 'it ran nowhere' reading as green."; exit 1; }
+          # ───────── THE FRAMEWORK IDENTITY THIS BUNDLE STATES, ON THE RECEIPT (#3310) ─────────
+          # 🚨 THE ONLY EVIDENCE THAT LETS `verify` SEE THE OUTCOME. #3293 and #3306 made the anchor
+          # correct and their guards assert the lane's TEXT and the anchor's LOCATION — neither can
+          # see a run END UP stating more than one identity, which is what a per-module property
+          # reaching the anchor build produces, silently: the bundle packs, the manifest carries a
+          # well-formed 32-hex value, and every non-blank assertion downstream passes. `verify` is
+          # the only place that sees the whole wave, and this field is what it reads.
+          # Read off the BYTES, never from a step output: the packer's exit code, the inspection's
+          # tick and the value in the artifact are three different claims, and only the third is the
+          # one a consumer will compare against.
+          [ -n "${BUNDLE:-}" ] || { echo "::error::this leg produced no bundle path — neither the build nor the reuse leg recorded one, so there are no bytes to read $MODULE's framework identity off. A receipt that cannot state the identity would leave a run's bundles disagreeing (#3310) unfalsifiable."; exit 1; }
+          if ! manifest_json="$(unzip -p "$BUNDLE" meshweaver/manifest.json)" || [ -z "$manifest_json" ]; then
+            echo "::error::cannot read meshweaver/manifest.json out of $BUNDLE (see unzip's message above) — refusing to write a receipt for bytes this lane could not check (#3310)"
+            exit 1
+          fi
+          IDENTITY="$(printf '%s' "$manifest_json" | jq -r '.frameworkMvid // ""' | tr -d '[:space:]')"
+          [ -n "$IDENTITY" ] || { echo "::error::$MODULE's bundle states no framework identity (manifest .frameworkMvid is $(printf '%s' "$manifest_json" | jq -c '.frameworkMvid')) — the receipt would attest nothing and 'the run's bundles agree' would be vacuously true for it (#3310). On a BUILD leg the pack step names the anchor and this manifest did not get it; on a REUSE leg these bytes were packed before the identity was recorded — rebuild them."; exit 1; }
+          echo "$MODULE states framework identity $IDENTITY"
           jq -n --arg l "$LANE" --arg p "$PACKAGE" --arg m "$MODULE" \
                 --arg v "$VERSION" --arg c "$COMPILER" --arg t "$TESTS" \
                 --argjson pub "$PUBLISHED" \
                 --arg lk "$LEDGER_KEY" --arg ld "$LEDGER_DECISION" \
-             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, tests:$t, published:$pub, ledger:{key:$lk, decision:$ld}}' \
+                --arg fid "$IDENTITY" \
+             '{lane:$l, package:$p, module:$m, version:$v, compiler:$c, tests:$t, published:$pub, frameworkIdentity:$fid, ledger:{key:$lk, decision:$ld}}' \
              > "$RUNNER_TEMP/receipts/$MODULE.json"
           cat "$RUNNER_TEMP/receipts/$MODULE.json"
       - name: Upload the receipt
@@ -2513,6 +2544,12 @@ jobs:
   # cancelled tests lane is RED here, under the same context name a repo's protection already
   # requires, and a module whose pack leg DELEGATED its suite but produced no test receipt is RED
   # too. Moving the suite off the consumer's critical path may not move it out of the gate.
+  # 🚨 AND IT IS THE ONLY PLACE THAT SEES THE WHOLE WAVE (#3310). The receipts carry the framework
+  # identity each bundle STATES, so this job — and nothing before it — can assert the one property
+  # that is true by definition: a lane pins ONE platform, so its bundles state ONE identity. Every
+  # other guard on that identity reads the lane's TEXT and stays green while a run states one
+  # identity per module. A receipt that states none is refused SEPARATELY and by name: "absent"
+  # reading as "agrees" is this gate's own failure mode, not an edge case.
   verify:
     name: All selected bundles built
     needs: [select, pack, tests]

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -98,6 +98,12 @@ things say so rather than a comment:
 dropped *before* any suite, so a red suite still does not read as "bundle missing" to a gate that
 only COMPOSES the bundle (#2710, Plugins#937). Those are two different questions.
 
+The receipt carries one more thing, and it is the lane's only OUTCOME-level assertion: the
+**framework identity the bundle states**, read off the packed manifest on the build and reuse legs
+alike. A lane pins one platform, so `verify` refuses a lane whose bundles state more than one — and
+refuses an absent identity separately and by name, because "absent" must never read as "agrees".
+See [The Module Identity Anchor](/Doc/Architecture/ModuleIdentityAnchor).
+
 ## Every stage asserts its OWN postcondition — never the next one's
 
 A stage's exit code answers *"did my work throw?"*. It does not answer *"did I produce what the

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleIdentityAnchor.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleIdentityAnchor.md
@@ -196,22 +196,54 @@ writing down: a satellite pins the LANE (`uses: …@<sha>`) and `platform-ref` S
 purpose, so a lane edit alone does NOT move a satellite's key. That is safe here only because this
 edit cannot change what the image arm packs; a future edit to the image arm would need the bump.
 
-## The guards are CONFIG-level — what still cannot fail
+## The config-level guards, and the outcome-level one that closes them
 
-Worth stating plainly, because it is the same class of gap this page documents. Both guards assert
-the lane's *text* or the anchor's *location*; **neither can see the outcome fail.** A different
-mechanism that reintroduces a per-module identity — another per-module property reaching that command
-line, a future arm deriving the anchor a third way, a caller passing `--framework-mvid` per module —
-would leave every guard here green, and the failure is silent: the bundle packs, the manifest carries
-a well-formed 32-hex value, and every non-blank assertion passes.
+Worth stating plainly, because it is the same class of gap this page documents. `ModuleIdentityPublishGuard`
+asserts the lane's *text* and `ModulePackCommand` asserts the anchor's *location*; **neither can see
+the outcome fail.** A different mechanism that reintroduces a per-module identity — another per-module
+property reaching that command line (`-p:InformationalVersion`, `-p:SourceRevisionId`, a
+`Directory.Build.props` edit keyed on the module), a future arm deriving the anchor a third way, a
+caller passing `--framework-mvid` per module — would leave every one of them green, and the failure
+is silent: the bundle packs, the manifest carries a well-formed 32-hex value, and every non-blank
+assertion passes. That shape reached production twice — #3211's `(unrecorded)` fleet, then run
+`33874892203` stating two identities for one platform.
 
-The check that would catch it is one assertion at the only place that sees the whole wave: **every
-bundle a run packs states the SAME identity**, which is true by definition — the identity names the
-platform build, and a run has one platform. The receipt `verify` already collects would carry the
-value, and `All selected bundles built` would refuse a lane whose bundles disagree. That is
-[#3310](https://github.com/Systemorph/MeshWeaver/issues/3310); it is not folded in here because it
-changes the receipt schema and the shared `node-repo-pack-verify.py`, which every satellite consumes
-at its own pin — and an absent field there must not read as "agrees".
+**So the lane now asserts the OUTCOME, at the only place that sees the whole wave: every bundle a
+run packs states the SAME framework identity** ([#3310](https://github.com/Systemorph/MeshWeaver/issues/3310)).
+That is true by definition — the identity names the platform build, and a lane pins one platform.
+
+| where | what it does |
+|---|---|
+| `pack` → **Drop the receipt** | reads `.frameworkMvid` out of `meshweaver/manifest.json` **on the bytes this leg produced** (`steps.bundle.outputs.path \|\| steps.reused.outputs.path`) and writes it to the receipt as `frameworkIdentity`. A leg whose bundle states none does not get a receipt — it fails, naming which leg it was |
+| `verify` → `node-repo-pack-verify.py` `identity_agreement` | over **this call's** receipts (lane stamp + declared matrix): more than one distinct identity is RED, naming every module and its identity, under the lane's one stable context `All selected bundles built` |
+
+Three properties, each deliberate:
+
+- **The receipt is read off the BYTES, not off a step output.** The packer's exit code, the
+  inspection's tick and the value in the artifact are three different claims, and only the third is
+  what a consumer compares against. Reading the bundle also covers the **reuse** leg, which the
+  inspection cannot: that leg hands over an artifact an earlier run packed, and the publish-side
+  refusal already sits there for the same reason.
+- **An absent identity is a distinct, NAMED refusal — never "agrees".** Reading silence as agreement
+  would let the gate answer "one identity" from a set that stated none, which is the same mistake as
+  a skipped gate rendering like a passed one. It happens for exactly one reason and the message says
+  so: a caller pins the LANE (`uses: …/node-repo-module-pack.yml@<sha>`) and `platform-ref` — which
+  is where the *script* is read from — **separately and on purpose**, so a caller whose `platform-ref`
+  is newer than its `uses:` ref runs a verifier its own lane predates. Measured 2026-09-04:
+  MeshWeaver.Plugins pins `uses:@c41a34fd` (05:57Z) against `MW_PLATFORM_REF 7d644de9` (11:07Z);
+  MeshWeaver.SocialMedia pins both to `fec69fc6`. The remedy is one line — move the `uses:` ref with
+  the platform ref — and it surfaces on the caller's own pin bump, never on an unrelated author's PR.
+- **It is scoped per LANE, and unconditional within one.** A repo calling the workflow twice
+  (Plugins' `modules-floor` + `modules-rest`) pins one platform per CALL, so the existing lane
+  stamp already scopes it; there is no flag to pass and no input to test, because the evidence is
+  the receipts `verify` had already downloaded. `bundles-built` is untouched: bundles that disagree
+  are still complete and composable, and calling them missing would misname the cause (#2710).
+
+**The mutation is the point.** `node-repo-pack-verify.py --self-test` runs on every lane run and
+turns a green fixture red ten different ways here — two identities in one lane (what reinstating
+`-p:Version="$VERSION"` on the anchor build produces, measured: `-p:Version=1.3.18` →
+`34337c31…`, `-p:Version=1.0.24` → `7c1c4f70…`, no override → `71cc81ba…` twice), an
+absent/empty/whitespace identity, both findings at once, and the lane-scoping in both directions.
 
 ## Still open, deliberately not changed here
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-release-can-no-longer-ship-modules-that-disagree.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-release-can-no-longer-ship-modules-that-disagree.md
@@ -1,0 +1,37 @@
+---
+Name: A release can no longer ship modules that disagree about the platform
+Category: Feature
+Description: Every plugin module a release builds records which platform build it was compiled against, and your portal compares that record to decide whether an update is really new. The release pipeline now checks the records themselves — a release whose modules name different platform builds is stopped, instead of shipping bundles no portal can recognise.
+Icon: Checkmark
+Order: -20260905
+---
+
+# A release can no longer ship modules that disagree about the platform
+
+Plugins reach your portal as **modules** — bundles the portal downloads and loads on its own,
+separately from the portal image. Each bundle records which build of the platform it was compiled
+against, and your portal uses that record to answer one question: *is this bundle actually newer
+than what I already have?* A version number alone cannot answer it, because the same source rebuilt
+against a newer platform republishes under the same version.
+
+That record only works if it is **true**. A release builds one platform and many modules, so every
+module from one release must name the same platform build. When they disagree, at least one of them
+names a platform that never existed — and your portal, unable to match it, quietly answers "I
+already have this" on every check, forever. Nothing looks wrong from the outside: the bundles are
+well-formed, the records are present, and the release reports success.
+
+That happened twice. Both times it was fixed at the source — where the record comes from — and both
+times the checks that were added asked the pipeline *how* it was configured, never *what it
+produced*. A configuration check cannot see the result go wrong by a route nobody anticipated.
+
+## What changes
+
+The release pipeline now checks the outcome. Every module bundle a release builds hands its recorded
+platform build forward, and the step that confirms a release is complete refuses one whose modules
+disagree — naming each module and the platform it claims. A bundle that cannot state its platform at
+all is refused separately and by name, rather than counted as "agrees": a record nobody wrote must
+never read as a record everyone matches.
+
+For you this means the safeguard now fails on the thing that actually harms you — a release that
+would leave your portal unable to recognise its own updates — and not merely on the one route that
+caused it the last two times.

--- a/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ModuleIdentityPublishGuard.cs
@@ -40,11 +40,20 @@ namespace MeshWeaver.Documentation.Test;
 /// on the step that actually publishes — the inspection runs on the BUILD leg only, while the reuse
 /// leg hands over an artifact an earlier run packed, so a guard bound to the inspection alone would
 /// pass while pre-#3211 bytes went to the registry.</para>
+///
+/// <para>🚨 <b>And every one of those is CONFIG-level</b> — the lane's text, the anchor's location.
+/// None can see the run END UP stating a different identity per module, which is the SILENT half
+/// (#3310): the bundle packs, the manifest carries a well-formed 32-hex value, and every non-blank
+/// assertion downstream passes. That is asserted on the OUTCOME instead, in
+/// <c>node-repo-pack-verify.py</c>'s <c>identity_agreement</c> over the receipts <c>verify</c>
+/// already collects; the last test here is the ratchet on the evidence trail that check depends on,
+/// not the check itself.</para>
 /// </summary>
 public class ModuleIdentityPublishGuard
 {
     private const string Lane = ".github/workflows/node-repo-module-pack.yml";
     private const string KeyScript = ".github/scripts/module-build-key.py";
+    private const string Verifier = ".github/scripts/node-repo-pack-verify.py";
 
     [Fact]
     public void ThePackStep_NamesTheIdentityAnchor_AndFailsRedWhenThereIsNone()
@@ -137,6 +146,57 @@ public class ModuleIdentityPublishGuard
 
         // An unreadable manifest is a refusal too — "could not check" must never render as "checked".
         Assert.Contains("refusing to publish bytes whose manifest this lane could not check", pack, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// 🚨 THE OUTCOME-LEVEL HALF (#3310). Every assertion above reads the lane's TEXT or the
+    /// anchor's LOCATION, so none of them can see a run END UP stating a different identity per
+    /// module — the silent shape: the bundle packs, the manifest carries a well-formed 32-hex
+    /// value, and every non-blank assertion downstream passes. The one check that sees it is an
+    /// agreement assertion over the whole wave, and it needs the value on the RECEIPT.
+    ///
+    /// <para>This test is the ratchet on that evidence trail, not the check itself — the check is
+    /// <c>identity_agreement</c> in the verifier, whose <c>--self-test</c> runs on every lane run
+    /// and mutates a green run into both failures. What is asserted here is that the trail cannot
+    /// be quietly cut: the receipt step reads the identity off the BYTES (so a reuse leg is
+    /// accounted for exactly like a build leg — the inspection above runs on the build leg alone),
+    /// refuses to write a receipt that states none, and the verifier still refuses BOTH a
+    /// disagreement AND an absent value. An absent identity reading as "agrees" would be the same
+    /// mistake as a skipped gate reading as a passed one.</para>
+    /// </summary>
+    [Fact]
+    public void TheReceiptCarriesTheStatedIdentity_AndVerifyRefusesBothDisagreementAndSilence()
+    {
+        var pack = JobBody("pack");
+
+        // Off the BYTES this leg produced — the build leg's packed bundle or the artifact the
+        // reuse leg downloaded and sha256-verified — never from a step output. The packer's exit
+        // code, the inspection's tick and the value in the artifact are three different claims,
+        // and only the third is what a consumer compares against.
+        var receipt = pack[pack.IndexOf("name: Drop the receipt", StringComparison.Ordinal)..];
+        Assert.Contains("BUNDLE: ${{ steps.bundle.outputs.path || steps.reused.outputs.path }}",
+            receipt, StringComparison.Ordinal);
+        Assert.Contains("unzip -p \"$BUNDLE\" meshweaver/manifest.json", receipt, StringComparison.Ordinal);
+        Assert.Contains("jq -r '.frameworkMvid // \"\"' | tr -d '[:space:]'", receipt, StringComparison.Ordinal);
+        // A receipt that cannot state the identity is REFUSED, not written blank: a blank field
+        // would make "this lane's bundles agree" vacuously true for that module, which is the very
+        // reading this whole change removes.
+        Assert.Contains("states no framework identity", receipt, StringComparison.Ordinal);
+        Assert.Contains("frameworkIdentity:$fi", receipt, StringComparison.Ordinal);
+
+        // And the verifier that reads it still asks BOTH questions. `verify` is the lane's one
+        // stable context (`All selected bundles built`) — the context a repo's branch protection
+        // requires — so this is where the outcome becomes falsifiable.
+        var verifier = File.ReadAllText(Path.Combine(FindRepoRoot(), Verifier));
+        Assert.Contains("def identity_agreement(", verifier, StringComparison.Ordinal);
+        Assert.Contains("IDENTITY_FIELD = \"frameworkIdentity\"", verifier, StringComparison.Ordinal);
+        Assert.Contains("DIFFERENT framework identities", verifier, StringComparison.Ordinal);
+        Assert.Contains("state NO framework identity", verifier, StringComparison.Ordinal);
+        // 🚨 UNCONDITIONAL in main(): no flag to forget, no input to test. A check reached only
+        // when a caller remembers to pass something is the skip-trapdoor in another costume.
+        Assert.Contains("i_errors, i_notes = identity_agreement(own_receipts(receipts, args.lane, declared_set))",
+            verifier, StringComparison.Ordinal);
+        Assert.Contains("if i_errors:", verifier, StringComparison.Ordinal);
     }
 
     /// <summary>


### PR DESCRIPTION
Closes #3310.

## The gap

#3293 and #3306 made the module identity anchor correct. Both their guards are **CONFIG-level**:
`ModuleIdentityPublishGuard` asserts the lane's *text* (the anchor is built from the pinned platform
source; that command line carries no `-p:Version`), `ModulePackCommand` asserts the anchor's
*location*. **Neither can see the outcome fail** — and the failure is silent: the bundle packs, the
manifest carries a well-formed 32-hex value, and every non-blank assertion downstream passes. It
reached production twice: #3211's `(unrecorded)` fleet, then run `33874892203` stating two
identities for one platform.

## The check

The identity names the **platform** build and a lane pins **one** platform, so "every bundle a run
packs states the SAME identity" is true by definition — and it belongs at the only place that sees
the whole wave.

| where | what |
|---|---|
| `pack` → **Drop the receipt** | reads `.frameworkMvid` out of `meshweaver/manifest.json` on the bytes **this leg produced** (`steps.bundle.outputs.path \|\| steps.reused.outputs.path` — the publish gate's own expression, so the **reuse** leg is accounted for exactly like a build leg, which the inspection cannot do) and writes it as `frameworkIdentity`. A leg whose bundle states none gets no receipt: it fails, naming which leg |
| `verify` → `identity_agreement` | unconditional in `main()`, over **this call's** receipts (existing lane stamp + declared matrix). More than one distinct identity is RED under `All selected bundles built`, naming every module and its identity |

**An absent identity is a distinct, NAMED refusal — never "agrees".** Reading silence as agreement
would let the gate answer "one identity" from a set that stated none: the same mistake as a skipped
gate rendering like a passed one.

`bundles-built` is untouched — bundles that disagree are complete and composable, and calling them
missing would misname the cause (#2710).

## Scope: who consumes this, measured

The receipt schema and `node-repo-pack-verify.py` are shared, so I measured the blast radius rather
than assuming it. **Three callers; the two external ones are at pins, so nothing moves on merge:**

| caller | `uses: …/node-repo-module-pack.yml@` | `platform-ref` (where the script is read from) |
|---|---|---|
| core `main-cd` → `plugins-modules` | `./.github/workflows/…` — **always this run's own commit** | `needs.gate.outputs.sha` — the same commit. Immune by construction, and it exercises the new check on the next CD run over the 4-module compose set |
| MeshWeaver.Plugins | `c41a34fd` — core #3268, 2026-09-04 05:57Z | `7d644de9` — core #3292, 2026-09-04 11:07Z |
| MeshWeaver.SocialMedia | `fec69fc6` | `fec69fc6` (same commit) |

Education, Reinsurance and Manufacturing do not call this lane. The two refs are pinned separately
**on purpose** (Plugins' own comment says so), so a caller whose `platform-ref` overtakes its `uses:`
ref runs a verifier its own lane predates — that is the one and only cause of an absent identity,
the refusal message names it, and the remedy is one line: move the `uses:` ref with the platform ref.
It surfaces on the caller's own pin bump, never on an unrelated author's PR.

## Mutation proof

A guard nobody has seen fail proves nothing, so each half was broken on purpose.

**1. The real defect, driven through the CLI exactly as `verify` does** — two receipts stating
different identities, which is precisely what reinstating `-p:Version="$VERSION"` on the anchor build
produces (measured on that command in #3176: `1.3.18` → `34337c31…`, `1.0.24` → `7c1c4f70…`, no
override → `71cc81ba…` twice):

```
✓ 2 of 2 selected module bundle(s) built; 2 published to the registry
✓ bundles-built: true — 2 of 2 selected bundle(s) exist as this call's artifacts…
::error title=Module bundles incomplete::this lane's bundles state 2 DIFFERENT framework identities,
and a lane pins ONE platform — so at least one of them names a platform build that does not exist,
which every consumer then fails to match on every reconcile, forever (#3310, #3154):
34337c31960d47f5b5251d32ef923fc6 ← MeshWeaver.AI; 7c1c4f70de084da78659e6bda495e1c5 ←
MeshWeaver.Markdown.Collaboration. Something per-module is reaching the identity anchor…
EXIT=1
```

**2. The stale-lane half** — one receipt with no identity:

```
::error title=Module bundles incomplete::1 receipt(s) state NO framework identity, so this lane
cannot say whether its bundles agree — and an unstated identity must never read as agreement
(#3310): MeshWeaver.Markdown.Collaboration. The receipts were written by a module-pack lane older
than this verifier: move the caller's `uses: …/node-repo-module-pack.yml@<sha>` to a commit that
records `frameworkIdentity`…
EXIT=1
```

**3. "Absent reads as agrees", reproduced.** Deleting the `if silent:` refusal from
`identity_agreement` made the self-test print, over a set where one bundle stated none:

```
✗ an absent identity is a NAMED refusal, never a silent 'agrees': [] ['all 2 bundle(s) this call
  packed state ONE framework identity: 71cc81badb364c5d8558ac5e7db6a44e']
::error title=node-repo-pack-verify self-test failed::4 case(s)
```

**4. The C# ratchet, both directions.** Removing `frameworkIdentity:$fid` from the lane →
`Assert.Contains() Failure: Sub-string not found … Not found: "frameworkIdentity:$fid"`. Removing
`if i_errors:` from the verifier (the check runs but never gates — "reports, does not fail") →
`Not found: "if i_errors:"`. Both `Failed: 1, Passed: 0`; both restored.

The 10 self-test cases run on **every** lane run (the `select` job already executes
`node-repo-pack-verify.py --self-test`), so this is not a guard that has to be remembered.

## Verification

```
dotnet build src/MeshWeaver.Documentation/MeshWeaver.Documentation.csproj -c Release -warnaserror
    0 Warning(s)    0 Error(s)
dotnet build test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj -c Release -warnaserror
    0 Warning(s)    0 Error(s)
dotnet test  test/MeshWeaver.Documentation.Test  -c Release --no-build
    Passed!  - Failed: 0, Passed: 258, Skipped: 0, Total: 258
python3 .github/scripts/node-repo-pack-verify.py --self-test        → EXIT=0
python3 .github/scripts/check-workflow-shell.py                     → 0 live findings
python3 .github/scripts/check-workflow-timeouts.py                  → 66 jobs, 0 violations
```

`check-workflow-shell.py` earned its keep here: the first draft passed `--arg fi "$IDENTITY"` to
`jq` and shellcheck read `fi` as the shell keyword (SC1010). Renamed to `fid` rather than
allow-listed.

## Docs

`Doc/Architecture/ModuleIdentityAnchor` — the section that said "the guards are CONFIG-level, what
still cannot fail" now documents the check that closes it, the three deliberate properties, and the
pin asymmetry measured above. `Doc/Architecture/ModuleBuildArchitecture` gains the one-line pointer
beside the receipts it already describes. What's New: *A release can no longer ship modules that
disagree about the platform*.

Pairs-with: none — no `public` type or member leaves `src/`; the diff is CI, docs and one guard test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
