### PR TITLE
docs(#3312): a 2xx from the webhook inbox is a receipt for the wrong thing

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseEventBus.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseEventBus.md
@@ -57,7 +57,7 @@ is open:
 | joint | switched on by | when it is open |
 |---|---|---|
 | the inbox accepts the release event | `WebhookInbox__Targets__N` on the control instance | 404 — byte-identical to a wrong URL |
-| the delivery verifies | `Hosting__PlatformWebhookSecret` | the watcher drops it as unverifiable; the POST already answered 2xx |
+| the delivery verifies | `Hosting__PlatformWebhookSecret` | the watcher drops it as unverifiable; the POST already answered 2xx — the mismatched-secret hole, still open: [Webhook Inbox](/Doc/Architecture/WebhookInbox) → "What a 2xx does NOT prove" (#3312) |
 | the verified release fans out | a caller of `Broadcast(...)` (since 2026-09-03: `PlatformBuildInboxWatcher`, MeshWeaver.Plugins) and at least one `Hosting/Deployment` record naming a registry source | `0 dispatched, 0 failed` — now a WARNING naming the records on the control instance |
 
 Two lessons the rest of this design should inherit. **A key the code reads and no chart renders can

--- a/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
@@ -56,6 +56,62 @@ A plugin that receives webhooks:
    events replay naturally on the next start, so every action taken from an event must be
    idempotent.
 
+## 🚨 What a 2xx does NOT prove — the mismatched-secret hole (open, #3312)
+
+**A 2xx from this endpoint means "I stored bytes", never "a consumer accepted them".** That is an
+honest answer — the inbox verifies nothing by design — but two callers currently read it as
+acceptance, and one of them is the platform's own release path:
+
+- `main-cd.yml` → `notify-platform-update` signs the platform-build fact with
+  `secrets.PLATFORM_WEBHOOK_SECRET`;
+- `node-repo-publish-bake.yml` → `register-publication` signs the publication record with the
+  caller's `webhook-secret`.
+
+Both verify against the control instance's `Hosting:PlatformWebhookSecret`, in the Hosting plugin's
+watcher — **after** the POST has already answered. So from CI three states exist and only two are
+distinguishable:
+
+| state | what CI sees | what actually happens |
+|---|---|---|
+| secret correct | 2xx, job green | record stored, dependents notified |
+| secret **mismatched** | **2xx, job green** | the watcher drops every delivery as unverifiable; nobody is notified |
+| secret empty | RED, named | caught at the caller — fixed in #3311 |
+
+The empty case was found precisely because it fails **closed**. The mismatch fails **open** and is
+byte-identical to success, so it can persist indefinitely while every dependent quietly falls back
+to its schedule poll — the same consequence #3311 fixed, with nothing anywhere going red. The
+property that would close it: **a run that publishes must be able to fail because the record was not
+ACCEPTED, not merely because it was not sent.**
+
+### Why it is still open, and what it costs
+
+The verdict has to come from something holding the shared secret, and the only thing that holds it
+is the consuming plugin — after the response. Three shapes were considered; each is blocked, and the
+blocker is worth writing down so the next attempt does not re-derive it:
+
+1. **Teach the inbox an optional per-target signature requirement.** The generic shape — a target
+   may declare that deliveries must carry a verifying `X-Hub-Signature-256`, with the secret named
+   by CONFIGURATION KEY (`Hosting:PlatformWebhookSecret`, the key already provisioned) so no secret
+   value is duplicated and the two ends cannot drift. A mismatch then answers 401, an accepted
+   delivery answers a body stating `signature: verified`, and the lanes assert **the verdict**
+   rather than the status code — so an instance that declares no requirement is refused by name too,
+   never read as "verified". This is the right fix, and it is blocked on **delivery, not design**:
+   the declaration is instance configuration, the portal host ships no `appsettings.json` in this
+   repo (it lives in MeshWeaver.Plugins), and a chart value reaches a running portal only through
+   `helm upgrade` from the private `Systemorph/Memex` env folders — never through the self-update,
+   which is a `set image`. Landing the lane half before the instance half would red core CD on every
+   publish, indefinitely.
+2. **Read the record back.** The lane cannot: the inbox is anonymous to WRITE only, and reading a
+   registration needs a mesh credential in CI plus a surface that does not exist.
+3. **Wait for the consequence** — poll the satellites for the `repository_dispatch` the broadcast
+   produces. Rejected on two counts: it is a timeout-bounded poll (the bound, not the fact, would
+   decide the verdict), and it makes core's CD verdict depend on other repositories' state, which is
+   the CI-to-CI coupling `main-cd.yml` has already deleted twice.
+
+Until (1) lands, the residual is tracked by #3312 and #2235, and the honest statement in both lanes'
+step summaries stands: *the mesh STORED the delivery; whether the wave ran is read on the instance
+and on the dependents, never here.*
+
 ## Where the code lives
 
 - `memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs` — the anonymous `POST /api/hooks/{target}`


### PR DESCRIPTION
Refs #3312 (**does not close it** — see below), #2235, #3311.

## What this is

The investigation for #3312, committed instead of left in an issue thread.

#3312 asks for the property *"a run that publishes must be able to fail because the record was not
ACCEPTED, not merely because it was not sent."* Anything that can produce that verdict has to hold
the shared secret, and the only thing that holds it is the consuming plugin's watcher
(`Hosting:PlatformWebhookSecret`, MeshWeaver.Plugins) — **after** the POST has already answered. The
inbox verifies nothing by design, so its 2xx is an honest answer to a different question; the bug is
that two callers read it as acceptance, and one of them is the platform's release path.

## Why the fix is not in this PR

The right shape is the issue's own: teach the inbox an **optional per-target signature requirement**,
with the secret named by *configuration key* (`Hosting:PlatformWebhookSecret`, already provisioned —
naming the key rather than copying the value means the two ends cannot drift), a 401 on mismatch, a
verdict in the accepted response, and both lanes asserting **the verdict** rather than `2*` so an
instance declaring no requirement is refused by name too.

It is blocked on **delivery, not design**, and each step is measured:

* the portal host ships **no `appsettings.json` in this repo** — `find memex -name 'appsettings*.json'`
  returns nothing; the host lives in MeshWeaver.Plugins — so the declaration cannot ride in with the
  image;
* **no workflow here runs `helm upgrade`** — `grep -rn "helm upgrade" .github/workflows/` is empty;
  the only automated helm path is `deploy/homebrew/bin/memex-local`, the local install. The
  self-update is a `set image`, and the env overlays live in the private `Systemorph/Memex` repo;
* so the lane half would land before the instance half, and `notify-platform-update` would red on
  **every** publish until someone ran `helm upgrade` by hand — indefinitely, not for one run.

Shipping the inbox capability alone would be a guard nobody has ever seen fail, which is the defect
#3312 is about. So: the finding lands, the issue stays open, and the two halves are spelled out in
order in the issue comment.

## The change

* `Doc/Architecture/WebhookInbox` → new section **"What a 2xx does NOT prove — the mismatched-secret
  hole"**: the three-state table (correct / mismatched / empty, and which of them CI can see), the
  two callers that read a 2xx as acceptance, the property that closes it, and the three candidate
  shapes with the blocker for each (including the two that were rejected on principle — a read-back
  the anonymous lane cannot make, and a timeout-bounded poll of the satellites, which would let the
  *bound* decide the verdict and re-introduce the CI-to-CI coupling `main-cd.yml` has deleted twice).
* `Doc/Architecture/ReleaseEventBus` → the three-joints table's "the delivery verifies" row now
  points there, which is where the next reader will be standing.

No What's New entry: nothing user-visible changes.

## Verification

```
dotnet build test/MeshWeaver.Documentation.Test/MeshWeaver.Documentation.Test.csproj -c Release -warnaserror
    0 Warning(s)    0 Error(s)
dotnet test  test/MeshWeaver.Documentation.Test  -c Release --no-build
    Passed!  - Failed: 0, Passed: 257, Skipped: 0, Total: 257
```

`DocumentationLinkIntegrityTest` covers the new `/Doc/Architecture/WebhookInbox` link.

Pairs-with: none — docs only; no `public` type or member leaves `src/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
