### PR TITLE
fix(#890): the emit canary asked for a core dump this defect cannot produce — dissect the null instead

### DIFF
--- a/src/MeshWeaver.Compiler/EmitPipeline.cs
+++ b/src/MeshWeaver.Compiler/EmitPipeline.cs
@@ -1,3 +1,4 @@
+using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
@@ -370,7 +371,9 @@ public static class EmitPipeline
                 + "— the shared reference set cannot emit, but the pristine control could not be "
                 + "BUILT, so this says nothing about whether the reference set is the cause";
 
-        return Verdict(shared, EmitCanary(() => pristineRefs));
+        // Leg 3 runs only on the two verdicts that mean "the control could not emit either", and
+        // it is passed as a FACTORY so Verdict stays pure and unit-testable.
+        return Verdict(shared, EmitCanary(() => pristineRefs), () => DissectTheNull(() => faulted.References));
     }
 
     /// <summary>
@@ -421,6 +424,191 @@ public static class EmitPipeline
         }
     }
 
+    /// <summary>The internal Roslyn symbol behind a public <c>ISymbol</c> wrapper. Reached by
+    /// reflection because Roslyn exposes no public route to it — <c>EmitCanaryDissectionTest</c>
+    /// is what stops a Roslyn rename from retiring leg 3 in silence.</summary>
+    private const string UnderlyingSymbolProperty = "UnderlyingSymbol";
+
+    /// <summary>The interface whose explicit implementation on <c>NamedTypeSymbol</c> is the exact
+    /// frame every #890 stack dies in.</summary>
+    private const string CciTypeDefinitionMember = "Microsoft.Cci.ITypeDefinitionMember";
+
+    /// <summary>The getter on <see cref="CciTypeDefinitionMember"/> that reads null.</summary>
+    private const string ContainingTypeDefinitionGetter = "get_ContainingTypeDefinition";
+
+    /// <summary>
+    /// Leg 3 — DISSECT the null, instead of asking for a core dump nobody can produce.
+    ///
+    /// <para>Every #890 stack dies in the same two frames:
+    /// <c>NamedTypeSymbol.Microsoft.Cci.ITypeDefinitionMember.get_ContainingTypeDefinition()</c>,
+    /// which in a Release Roslyn reduces to <c>return this.ContainingType.GetCciAdapter();</c>,
+    /// called from <c>MetadataWriter.GetConsolidatedTypeParameters</c> — whose guard
+    /// (<c>AsNestedTypeDefinitionImpl</c>) read that same <c>ContainingType</c> as NON-null
+    /// microseconds earlier. Legs 1 and 2 establish that the process can no longer EMIT. Neither
+    /// asks the far cheaper question: <b>can it still perform the READ that the emit dies on?</b>
+    /// This leg does, on symbols bound after the fault, and its answer is the discriminator the
+    /// <c>BELOW-ROSLYN</c> verdict itself flags as residual.</para>
+    ///
+    /// <list type="bullet">
+    ///   <item><c>dissect=SYMBOL-GRAPH-BROKEN</c> — the ordinary <c>ContainingType</c> property
+    ///     reads null for a nested SOURCE type of a compilation created AFTER the fault. The
+    ///     broken read is then the property itself, not anything about emit, and every consumer of
+    ///     a nested symbol in this process is affected — not only <c>Emit</c>.</item>
+    ///   <item><c>dissect=REPRODUCED-OUTSIDE-EMIT</c> — the public property reads correctly but the
+    ///     Cci explicit interface implementation does not, called DIRECTLY. #890 then reproduces in
+    ///     one property call with no emit, no metadata writer and no PE stream: the smallest repro
+    ///     this defect has ever had, and the one a <c>dotnet/runtime</c> report needs.</item>
+    ///   <item><c>dissect=READS-HEALTHY</c> — BOTH reads return the right answer, on freshly bound
+    ///     symbols, microseconds after <c>Emit</c> threw on exactly this shape. A corrupted object
+    ///     graph does not predict that; code that is only wrong when reached from
+    ///     <c>MetadataWriter</c>'s own call site does — which is what the split-arm
+    ///     <c>DOTNET_TieredPGO=0</c> re-run tests.</item>
+    ///   <item><c>dissect=UNAVAILABLE(…)</c> — the probe could not run (a Roslyn shape change, an
+    ///     unbindable canary). Its OWN verdict, never folded into the others: the
+    ///     <c>INCONCLUSIVE</c> lesson one layer further in.</item>
+    /// </list>
+    ///
+    /// <para>🚨 A local control (our own nested generic + explicit interface implementation) was
+    /// considered and deliberately left out. Its failing branch would be informative, but its
+    /// passing branch is not — a different jitted method reading correctly says nothing about
+    /// Roslyn's — and a probe whose green means nothing is exactly the shape this file keeps
+    /// removing.</para>
+    ///
+    /// <para>Never throws, like every other leg. Cost is one parse and two property reads, only
+    /// ever on a path that has already failed.</para>
+    /// </summary>
+    /// <param name="references">The reference set to bind the canary source against — the FAULTED
+    /// compilation's own, so the read runs under the conditions the failed emit ran under.</param>
+    internal static string DissectTheNull(Func<IEnumerable<MetadataReference>> references)
+    {
+        INamedTypeSymbol? leaf;
+        string symbolLeg;
+        try
+        {
+            var dissection = CSharpCompilation.Create(
+                "MeshWeaverEmitCanaryDissection",
+                syntaxTrees: [CSharpSyntaxTree.ParseText(EmitCanarySource)],
+                references: references(),
+                options: new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+            leaf = dissection.GetTypeByMetadataName("MwEmitCanary`1+Inner`1+Leaf`1");
+            if (leaf is null)
+                return "dissect=UNAVAILABLE(the canary source did not bind "
+                    + "MwEmitCanary<T>.Inner<U>.Leaf<V>, so no read was attempted)";
+
+            // The ordinary, public route to the very property the NRE is thrown from.
+            var inner = leaf.ContainingType;
+            var outer = inner?.ContainingType;
+            symbolLeg = inner is null ? "symbol:NULL@Leaf.ContainingType"
+                : outer is null ? "symbol:NULL@Inner.ContainingType"
+                : "symbol:OK";
+        }
+        catch (Exception bindError)
+        {
+            return $"dissect=UNAVAILABLE({bindError.GetType().Name} at {ThrowSite(bindError)} while "
+                + "binding the canary source, so no read was attempted)";
+        }
+
+        var cciLeg = ProbeCciContainingTypeDefinition(leaf);
+
+        if (symbolLeg != "symbol:OK")
+            return $"dissect=SYMBOL-GRAPH-BROKEN {symbolLeg} {cciLeg} — ContainingType reads NULL "
+                + "for a nested SOURCE type on a compilation created AFTER the fault, through the "
+                + "ordinary property and with no emit involved. The broken read is the property, "
+                + "not the metadata writer; every consumer of a nested symbol in this process is "
+                + "affected";
+
+        if (cciLeg.StartsWith("cci:UNAVAILABLE", StringComparison.Ordinal))
+            return $"dissect=UNAVAILABLE {symbolLeg} {cciLeg} — the public read succeeded but the "
+                + "Cci leg could not be reached, so the discriminator did not run";
+
+        if (cciLeg.StartsWith("cci:OK", StringComparison.Ordinal))
+            return $"dissect=READS-HEALTHY {symbolLeg} {cciLeg} — BOTH reads, including the exact "
+                + "ITypeDefinitionMember.ContainingTypeDefinition frame every #890 stack dies in, "
+                + "return the right answer when called DIRECTLY on symbols bound after the fault. "
+                + "A corrupted object graph does not predict that; code that is wrong only when "
+                + "reached from MetadataWriter's call site does — run the split-arm "
+                + "DOTNET_TieredPGO=0 re-run";
+
+        return $"dissect=REPRODUCED-OUTSIDE-EMIT {symbolLeg} {cciLeg} — the public ContainingType "
+            + "reads correctly while the Cci explicit interface implementation on the SAME symbol "
+            + "does not, called directly. #890 reproduces here in ONE property call, with no emit, "
+            + "no metadata writer and no PE stream: take these two readings to dotnet/runtime";
+    }
+
+    /// <summary>
+    /// Calls <c>NamedTypeSymbol.Microsoft.Cci.ITypeDefinitionMember.get_ContainingTypeDefinition()</c>
+    /// on the internal symbol behind <paramref name="publicSymbol"/> — the exact method on every
+    /// #890 stack — and reports what it answered.
+    ///
+    /// <para>Reflection is unavoidable: <c>Microsoft.Cci</c> and the internal symbol model are both
+    /// internal to Roslyn, and the public <c>ISymbol</c> wrapper does not implement the interface.
+    /// Every step that can fail to RESOLVE reports <c>cci:UNAVAILABLE(why)</c> — distinct from
+    /// <c>cci:NULL</c> (it resolved and answered null) and <c>cci:THREW</c> (it resolved and threw),
+    /// because "I could not look" and "I looked and it was broken" must never share a token.</para>
+    ///
+    /// <para>The base-type walk matters: <c>UnderlyingSymbol</c> is declared on a base of the
+    /// public wrapper, and <c>Type.GetProperty</c> does not return non-public members of base
+    /// classes.</para>
+    /// </summary>
+    private static string ProbeCciContainingTypeDefinition(INamedTypeSymbol publicSymbol)
+    {
+        object? underlying = null;
+        try
+        {
+            for (var declaring = publicSymbol.GetType(); declaring is not null && underlying is null;
+                 declaring = declaring.BaseType)
+            {
+                underlying = declaring
+                    .GetProperty(UnderlyingSymbolProperty,
+                        BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.DeclaredOnly)
+                    ?.GetValue(publicSymbol);
+            }
+        }
+        catch (Exception reflectionError)
+        {
+            return $"cci:UNAVAILABLE({reflectionError.GetType().Name} reaching {UnderlyingSymbolProperty})";
+        }
+
+        if (underlying is null)
+            return $"cci:UNAVAILABLE(no {UnderlyingSymbolProperty} on {publicSymbol.GetType().Name})";
+
+        MethodInfo target;
+        try
+        {
+            var implementation = underlying.GetType();
+            var cci = implementation.GetInterfaces()
+                .FirstOrDefault(i => i.FullName == CciTypeDefinitionMember);
+            if (cci is null)
+                return $"cci:UNAVAILABLE({implementation.Name} does not implement {CciTypeDefinitionMember})";
+
+            var map = implementation.GetInterfaceMap(cci);
+            var index = Array.FindIndex(map.InterfaceMethods,
+                m => m.Name == ContainingTypeDefinitionGetter);
+            if (index < 0)
+                return $"cci:UNAVAILABLE({CciTypeDefinitionMember} has no {ContainingTypeDefinitionGetter})";
+            target = map.TargetMethods[index];
+        }
+        catch (Exception mapError)
+        {
+            return $"cci:UNAVAILABLE({mapError.GetType().Name} mapping {CciTypeDefinitionMember})";
+        }
+
+        try
+        {
+            return target.Invoke(underlying, null) is null ? "cci:NULL" : "cci:OK";
+        }
+        catch (TargetInvocationException wrapped) when (wrapped.InnerException is not null)
+        {
+            var actual = wrapped.InnerException;
+            return $"cci:THREW {actual.GetType().Name} at {ThrowSite(actual)}";
+        }
+        catch (Exception probeError)
+        {
+            return $"cci:THREW {probeError.GetType().Name} at {ThrowSite(probeError)}";
+        }
+    }
+
     /// <summary>
     /// Reduces the two canary legs to the one-line verdict. Pure — no Roslyn, no process state —
     /// so every branch is unit-testable (<c>EmitCanaryVerdictTest</c>).
@@ -437,10 +625,28 @@ public static class EmitPipeline
     /// When the sites differ the verdict is <c>DIVERGENT</c>: both sites are named and the strong
     /// claim is withheld, exactly as <c>INCONCLUSIVE</c> withholds it when the control never
     /// ran.</para>
+    ///
+    /// <para>🚨 <b>A remedy nobody can execute is not a remedy.</b> The <c>BELOW-ROSLYN</c> branch
+    /// told triage to *"capture a core dump and re-run with tiering disabled"* from 2026-08-28, and
+    /// the dump half is <b>unfollowable by construction</b>: <c>DOTNET_DbgEnableMiniDump</c> fires
+    /// on a SIGNAL, and this process never signals — it throws, logs, keeps running, and is killed
+    /// by the harness wall-clock cap as <c>exit=124</c> (SIGTERM), which writes no dump. Nine
+    /// occurrences carried that advice and produced exactly zero dumps. The branch now names the
+    /// half that IS followable (a split-arm tiering re-run) and hands over leg 3's
+    /// <c>dissect=</c> reading, which takes in-process the measurement the dump was being asked
+    /// for. This is the same defect as a gate that cannot fail, worn as prose.</para>
     /// </summary>
     /// <param name="shared">Leg 1's outcome token — the same reference set as the failed compile.</param>
     /// <param name="pristine">Leg 2's outcome token — brand-new references.</param>
-    internal static string Verdict(string shared, string pristine)
+    /// <param name="dissect">
+    /// Leg 3 (<see cref="DissectTheNull"/>), as a FACTORY so this method stays pure and every
+    /// branch stays unit-testable. Invoked ONLY on the two verdicts that mean "the control could
+    /// not emit either" — <c>BELOW-ROSLYN</c> and <c>DIVERGENT</c> — never on <c>REFERENCES</c>,
+    /// where the pristine leg emitted and the symbol graph is demonstrably intact. <c>null</c>
+    /// (the unit-test shape) reports <c>dissect=NOT-RUN</c> rather than silently omitting it: an
+    /// absent reading must be visible as absent.
+    /// </param>
+    internal static string Verdict(string shared, string pristine, Func<string>? dissect = null)
     {
         if (pristine.StartsWith("OK", StringComparison.Ordinal))
             return $"canary=REFERENCES shared:{shared} pristine:{pristine} — the same source emits fine "
@@ -462,7 +668,7 @@ public static class EmitPipeline
                 + "one process-wide fault, so the below-Roslyn verdict is withheld — COMPARE THE "
                 + "TWO SITES: one corruption can surface a frame apart, but two unrelated faults "
                 + "look exactly like this as well, and only the sites tell them apart. Start with "
-                + "whichever site is not the emit itself";
+                + "whichever site is not the emit itself. " + Dissection(dissect);
 
         return $"canary=BELOW-ROSLYN shared:{shared} pristine:{pristine} — a trivial compilation "
             + "with freshly parsed source and an IMAGE-BACKED CoreLib (fresh managed bytes, "
@@ -470,9 +676,35 @@ public static class EmitPipeline
             + $"shared set) cannot emit either, and BOTH legs died in the same frame ({sharedSite}) "
             + "⇒ nothing about the reference set OR its file mappings explains this; the "
             + "broken state is below Roslyn (CLR heap / JIT / GC), so no reference-set change can "
-            + "fix it — capture a core dump and re-run with tiering disabled. RESIDUAL: both legs "
-            + "still run on the one CLR, so this does not separate a corrupted heap from a "
-            + "miscompiled Roslyn method — compare the dump's faulting address against #613";
+            + "fix it. 🚨 DO NOT go looking for a core dump: DOTNET_DbgEnableMiniDump fires on a "
+            + "SIGNAL and this process never signals — it throws, logs, keeps running, and is "
+            + "killed by the harness wall-clock cap (exit=124 = SIGTERM), which writes none. The "
+            + "followable measurement is a SPLIT-ARM re-run with DOTNET_TieredPGO=0 (sharper) or "
+            + "DOTNET_TieredCompilation=0 — at ~1% per run one clean arm proves nothing — read "
+            + "together with the dissect= reading below. RESIDUAL: both legs still run on the one "
+            + "CLR, so this does not separate a corrupted heap from a miscompiled Roslyn method; "
+            + "#613 is the SIGNALLING twin and is where a faulting address actually comes from. "
+            + Dissection(dissect);
+    }
+
+    /// <summary>
+    /// Runs leg 3 and reduces it to the token appended to the verdict, or says it did not run.
+    /// Never throws: <paramref name="dissect"/> is already total, and a diagnostic that can fault
+    /// while reporting a fault destroys the evidence it exists to preserve.
+    /// </summary>
+    private static string Dissection(Func<string>? dissect)
+    {
+        if (dissect is null)
+            return "dissect=NOT-RUN (no probe supplied)";
+        try
+        {
+            return dissect();
+        }
+        catch (Exception probeError)
+        {
+            return $"dissect=UNAVAILABLE({probeError.GetType().Name} — the probe itself faulted, "
+                + "so it says nothing either way)";
+        }
     }
 
     /// <summary>

--- a/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DebuggingNativeCrashes.md
@@ -732,15 +732,28 @@ swallows only the *logging* failure.
 
 `#890` is the same "one 8-byte word reads as zero" shape surfacing in **managed** code: Roslyn's
 `Emit` throws `NullReferenceException` from `Cci.MetadataWriter`, reading a `ContainingType` that
-the guard immediately above it had just read as non-null. Its canary's verdict has told triage to
-*"capture a core dump and re-run with tiering disabled"* since 2026-08-28, and **not one has ever
-arrived** — because the advice is unfollowable by construction:
+the guard immediately above it had just read as non-null. Its canary's verdict told triage to
+*"capture a core dump and re-run with tiering disabled"* from 2026-08-28 to 2026-09-04, and **not
+one ever arrived** — because the advice was unfollowable by construction:
 
 `DOTNET_DbgEnableMiniDump` fires on a **signal**. The #890 process never crashes; it throws a
 managed exception, logs it, and keeps running until CI's 8-minute cap kills it — `exit=124`, which
 is `timeout --signal=TERM`, which produces **no dump**. Every occurrence in the 9-event
 2026-08-22→08-29 sweep ends `exit=124` or `TESTFAIL`. **The dump route belongs to this page's family
 (#613), not to #890.**
+
+🚨 **The verdict no longer asks for one.** `EmitPipeline.Verdict`'s `BELOW-ROSLYN` branch now names
+the half of that advice that IS followable — a **split-arm** `DOTNET_TieredPGO=0` /
+`DOTNET_TieredCompilation=0` re-run — and hands over a third canary leg that takes in-process the
+measurement the dump was being asked for: `dissect=`, which performs the failing *read*
+(`ContainingType`, then the `Cci.ITypeDefinitionMember.ContainingTypeDefinition` frame the stack
+dies in) directly on symbols bound after the fault. `READS-HEALTHY` there is positive evidence
+**against** a corrupted object graph and **for** code that is wrong only at `MetadataWriter`'s call
+site; `REPRODUCED-OUTSIDE-EMIT` would collapse #890 to a one-call repro. See
+[NodeTypeCompilation → Leg 3](/Doc/Architecture/NodeTypeCompilation). The general lesson is this
+page's own: **a remedy nobody can execute is not a remedy** — it is a gate that cannot fail, wearing
+prose. Check that the artifact you are telling the next reader to fetch is one this failure mode can
+actually produce.
 
 What #890 *can* contribute that a dump cannot is a measurement #613 has no way to take, because a
 crashed process has no "after": **the fault is total and permanent.** On run `33322993649` shard 1,

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -920,15 +920,74 @@ Two readings that look right and are not:
   (`NodeTypeReleaseGateTest`, `CodeEditRecompileTest`). **Discriminate on the verdict, never on the
   suite name plus the exit code**; folding a live wedge into a known-upstream defect hides it.
 
-> 🚨 **The core dump the canary asks for cannot be captured this way.** `DOTNET_DbgEnableMiniDump`
-> fires on a *signal*, and this process never crashes — it throws a managed exception and keeps
-> running until CI's per-suite wall-clock cap kills it (`exit=124`, no dump): 8 minutes on core's
-> shards, **15 minutes** on MeshWeaver.Plugins' `Portal hosts` shards, so the cap is a property of
-> the harness and not a fingerprint to grep for. That is why weeks of
+> 🚨 **The core dump the canary used to ask for cannot be captured this way.**
+> `DOTNET_DbgEnableMiniDump` fires on a *signal*, and this process never crashes — it throws a
+> managed exception and keeps running until CI's per-suite wall-clock cap kills it (`exit=124`, no
+> dump): 8 minutes on core's shards, **15 minutes** on MeshWeaver.Plugins' `Portal hosts` shards,
+> so the cap is a property of the harness and not a fingerprint to grep for. That is why weeks of
 > "capture a core dump" produced none. Its SIGSEGV twin,
 > [#613](https://github.com/Systemorph/MeshWeaver/issues/613), *does* dump — see
 > [Debugging Native Crashes](/Doc/Architecture/DebuggingNativeCrashes) for the invariant the two share (a single
 > 8-byte word reading exactly zero while its block stays coherent) and for how to read one.
+> **The verdict no longer asks for one** — see leg 3 below.
+
+#### Leg 3 — DISSECT the null, because the dump route is closed
+
+The verdict's own text called the remaining ambiguity a RESIDUAL: *"both legs still run on the one
+CLR, so this does not separate a corrupted heap from a miscompiled Roslyn method"*, and it resolved
+that by asking for a core dump — **an instruction that cannot be carried out on this defect at all**,
+for the reason in the box above. From 2026-08-28 to 2026-09-04 every occurrence carried it and
+produced **zero** dumps. A remedy nobody can execute is the prose form of a gate that cannot fail:
+it looks like a next step and it is a dead end.
+
+Legs 1 and 2 both ask *can this process EMIT?* Neither asks the far cheaper question the stack
+points straight at — **can it still perform the READ the emit dies on?** Every #890 stack ends in
+`NamedTypeSymbol.Microsoft.Cci.ITypeDefinitionMember.get_ContainingTypeDefinition()`, which in a
+Release Roslyn reduces to `return this.ContainingType.GetCciAdapter();`, called from
+`MetadataWriter.GetConsolidatedTypeParameters` — whose guard (`AsNestedTypeDefinitionImpl`) read
+that *same* `ContainingType` as non-null microseconds earlier. Leg 3 makes both of those reads
+directly, on symbols bound **after** the fault, with no emit, no metadata writer and no PE stream:
+
+| verdict | what it means | where it sends triage |
+|---|---|---|
+| `dissect=SYMBOL-GRAPH-BROKEN` | the ordinary `ContainingType` property reads **null** for a nested source type | the broken read is the property, not emit — every consumer of a nested symbol in the process is affected |
+| `dissect=REPRODUCED-OUTSIDE-EMIT` | the public property reads correctly, the Cci explicit interface implementation on the **same symbol** does not | #890 in ONE property call — the smallest repro it has ever had, and what a `dotnet/runtime` report needs |
+| `dissect=READS-HEALTHY` | **both** reads answer correctly, microseconds after `Emit` threw on this exact shape | a corrupted object graph does not predict that; code that is wrong only when reached from `MetadataWriter`'s call site does — run the split-arm `DOTNET_TieredPGO=0` re-run |
+| `dissect=UNAVAILABLE(…)` | the probe could not run | its **own** verdict, never folded into the others |
+
+🚨 **`UNAVAILABLE` is the branch that has to stay impossible on a healthy process.** Leg 3 reaches
+Roslyn's internal symbol model by reflection (`PublicModel.Symbol.UnderlyingSymbol`, then the
+interface map for `Microsoft.Cci.ITypeDefinitionMember`), because there is no public route to the
+method the stack dies in. A Roslyn rename would turn every future occurrence into a permanent
+non-answer with nothing going red — the same way a file-backed leg 2 silently stopped being a
+control. `EmitCanaryDissectionTest.OnAHealthyProcess_BothReadsResolveAndAnswerCorrectly` is what
+refuses that: it asserts `symbol:OK` **and** `cci:OK`, and renaming the reflected member turns it
+red naming the member (measured — `cci:UNAVAILABLE(no UnderlyingSymbol… on NonErrorNamedTypeSymbol)`).
+
+A local control — our own nested generic plus an explicit interface implementation — was considered
+and deliberately left out. Its *failing* branch would be informative; its *passing* branch is not,
+because a different jitted method reading correctly says nothing about Roslyn's, and a probe whose
+green means nothing is the shape this canary keeps having to remove.
+
+**What the verdict says instead of "capture a dump":** re-run **SPLIT-ARM** with
+`DOTNET_TieredPGO=0` (sharper) or `DOTNET_TieredCompilation=0`, and read it together with the
+`dissect=` line. At ~1 % per run a single clean arm proves nothing — that caveat is part of the
+instruction, because an experiment stated without it gets read as a fix.
+
+#### The rate has not moved — a null here is worth ~half a coin toss
+
+Continuing where the 2026-09-03→04 sweep ended, **2026-09-04T06:34Z → 22:01Z** on MeshWeaver.Plugins
+`Plugin Catalog CI`: **73** completed runs, **287** `Portal hosts (shard N)` jobs, all **93**
+non-success shard logs fetched (**0** unfetchable), detector calibrated first against the known
+occurrence (job `100666643224` → **56** `canary=BELOW-ROSLYN`, **20** `PROCESS CANNOT EMIT`, the
+counts that occurrence's own report published). **0 occurrences.**
+
+🚨 **That null is not evidence of anything.** At the last measured ~1 %/run, P(0 in 73) ≈ 48 % — a
+coin toss. The positive control holds (the exposure suite `MeshWeaver.Hosting.Monolith.Test` really
+did run in the window: runs `33881146362`, `33879617931`, `33879408750`), so the sweep had somewhere
+to look; it simply did not look at enough runs to say anything. The last confirmed occurrence is
+`33760859754`, 2026-09-03. **Read a #890 sweep the way the 2026-08-09 close should have been read:
+state the expected count beside the observed one, or do not state the null.**
 
 ### Framework-version freezing
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-compile-that-cannot-run-says-what-to-do-next.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-04-a-compile-that-cannot-run-says-what-to-do-next.md
@@ -1,0 +1,36 @@
+---
+Name: A compile that could not run now says what to do about it
+Category: Fix
+Description: When a compile aborts because the whole process has lost the ability to produce an assembly, the message it leaves behind used to end with an instruction nobody could carry out — fetch a crash dump that this kind of failure never produces. It now reports what was actually measured inside the failing process, and names a next step that can be taken.
+Icon: Bug
+Order: -20260904
+---
+
+# A compile that could not run now says what to do about it
+
+Very occasionally a portal or a test host loses the ability to build **any** assembly at all. It is
+not your code: from that moment every compile in that process fails the same way, including ones
+that were succeeding a second earlier, while everything that only needs to *check* code carries on
+returning correct errors and warnings. MeshWeaver already recognises this and refuses to blame the
+NodeType — the type is left as **unavailable**, not as broken, so the next healthy process picks it
+up again.
+
+What it did not do well was explain itself. The diagnostic it left behind ended with *"capture a
+core dump"* — and this particular failure can never produce one. A dump is written when a process is
+killed by the operating system; this process is not killed, it keeps running until its host gives up
+on it. So the one concrete instruction in the message was a dead end, every time, for a week.
+
+## What changes
+
+**The message reports a measurement instead of asking for an artifact.** At the moment the failure
+happens, the process now re-runs the exact read the failure came from — twice, by two different
+routes — and records what each answered. That is the evidence the crash dump was being asked for,
+taken in the place where it is available: inside the failing process, at the instant it fails, in the
+log that is already collected.
+
+**And it names a step that can actually be taken.** Instead of the impossible one, the message now
+says which setting to re-run with, and warns that a single clean re-run proves nothing at this
+failure's rate — so nobody reads one quiet run as a fix.
+
+Nothing about a healthy compile changes, and nothing about the way a genuinely broken NodeType is
+reported changes: real compile errors are still real compile errors.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/EmitCanaryDissectionTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/EmitCanaryDissectionTest.cs
@@ -1,0 +1,151 @@
+using MeshWeaver.Compiler;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// Leg 3 of the emit canary — the DISSECTION (#890) — and the remedy the verdict hands out.
+///
+/// <para><b>The two bugs this file pins.</b></para>
+///
+/// <para><b>1. A remedy nobody can execute.</b> From 2026-08-28 the <c>BELOW-ROSLYN</c> verdict
+/// told CI triage to *"capture a core dump and re-run with tiering disabled"*. The dump half is
+/// unfollowable by construction: <c>DOTNET_DbgEnableMiniDump</c> fires on a SIGNAL, and a #890
+/// process never signals — it throws a managed exception, logs it, keeps running, and is killed by
+/// the harness wall-clock cap as <c>exit=124</c> (SIGTERM), which writes no dump. Nine occurrences
+/// carried that advice and produced exactly zero dumps. A diagnostic whose remedy cannot be
+/// performed is the prose form of a gate that cannot fail.</para>
+///
+/// <para><b>2. The residual the verdict named and did not measure.</b> <c>BELOW-ROSLYN</c> says in
+/// its own text that it *"does not separate a corrupted heap from a miscompiled Roslyn method"*.
+/// Legs 1 and 2 both ask "can this process EMIT?"; neither asks the far cheaper question the stack
+/// points straight at — <b>can it still perform the READ that the emit dies on?</b> Leg 3 asks it,
+/// through the ordinary <c>ContainingType</c> property and through the very
+/// <c>Cci.ITypeDefinitionMember.ContainingTypeDefinition</c> frame every #890 stack ends in.</para>
+///
+/// <para>🚨 <b>The load-bearing test here is the healthy-process one.</b> Leg 3 reaches internal
+/// Roslyn shapes by reflection, so a Roslyn rename would turn every future occurrence into
+/// <c>dissect=UNAVAILABLE</c> — the discriminator retired, silently, with nothing going red. That
+/// is the same failure mode <see cref="EmitCanaryControlTest.TheControl_CanStillEmitTheCanarySource"/>
+/// exists to refuse for leg 2.</para>
+/// </summary>
+public class EmitCanaryDissectionTest
+{
+    private const string Site = "MetadataWriter.GetConsolidatedTypeParameters";
+
+    private static string Threw(string site = Site)
+        => $"THREW NullReferenceException at {site}: Object reference not set to an instance of an object.";
+
+    /// <summary>
+    /// 🚨 The non-vacuity guard. On a healthy process BOTH reads must resolve and answer
+    /// correctly — if either leg degrades to <c>UNAVAILABLE</c>, leg 3 has stopped measuring
+    /// anything and every future #890 occurrence reports a non-answer.
+    /// </summary>
+    [Fact]
+    public void OnAHealthyProcess_BothReadsResolveAndAnswerCorrectly()
+    {
+        var dissection = EmitPipeline.DissectTheNull(() => CompileReferences.Default);
+
+        dissection.Should().Contain("symbol:OK",
+            "the ordinary ContainingType property must read the nested canary type's container on "
+            + "a healthy process — a NULL here would be the fault itself, and an UNAVAILABLE means "
+            + "the canary source stopped binding");
+
+        dissection.Should().Contain("cci:OK",
+            "the Cci explicit interface implementation is the EXACT frame every #890 stack dies "
+            + "in, and it is reached by reflection through internal Roslyn shapes. If a Roslyn "
+            + "rename breaks that reach, this is the only thing that says so — otherwise leg 3 "
+            + "answers UNAVAILABLE for ever and #890's discriminator is gone with nothing red");
+
+        dissection.Should().StartWith("dissect=READS-HEALTHY",
+            "both legs resolved and answered, so the verdict must be the one that says the reads "
+            + "work — never UNAVAILABLE, which would mean the probe never ran");
+    }
+
+    /// <summary>
+    /// 🚨 The regression this file exists for. The remedy must be one a CI reader can actually
+    /// carry out; the dump route is dead on this defect and cannot be revived by asking louder.
+    /// </summary>
+    [Fact]
+    public void TheBelowRoslynRemedy_IsFollowable_NotACoreDumpThatCannotBeProduced()
+    {
+        var verdict = EmitPipeline.Verdict(Threw(), Threw(), () => "dissect=READS-HEALTHY");
+
+        verdict.Should().StartWith("canary=BELOW-ROSLYN");
+
+        verdict.Should().NotContain("capture a core dump",
+            "DOTNET_DbgEnableMiniDump fires on a SIGNAL and this process never signals — it is "
+            + "killed by the wall-clock cap as exit=124/SIGTERM, so that instruction produced zero "
+            + "dumps across nine occurrences. A remedy nobody can execute is not a remedy");
+
+        verdict.Should().Contain("DOTNET_TieredPGO=0",
+            "the half of the old advice that IS followable has to be named explicitly, or triage "
+            + "is left with nothing to do");
+
+        verdict.Should().Contain("SPLIT-ARM",
+            "at ~1% per run a single clean arm proves nothing, and an experiment stated without "
+            + "that caveat gets read as a fix");
+    }
+
+    /// <summary>
+    /// The dissection is data, not a claim, so it travels with BOTH verdicts that mean "the control
+    /// could not emit either" — including DIVERGENT, which deliberately withholds the strong claim.
+    /// </summary>
+    [Theory]
+    [InlineData("canary=BELOW-ROSLYN", Site)]
+    [InlineData("canary=DIVERGENT", "SomewhereElse.Method")]
+    public void EveryVerdictThatMeansTheControlFailed_CarriesTheDissection(string expected, string pristineSite)
+    {
+        var verdict = EmitPipeline.Verdict(Threw(), Threw(pristineSite), () => "dissect=STUB-READING");
+
+        verdict.Should().StartWith(expected);
+        verdict.Should().Contain("dissect=STUB-READING",
+            "the reading is the measurement the core dump was being asked for; a verdict that "
+            + "drops it hands triage the residual and none of the evidence");
+    }
+
+    /// <summary>
+    /// REFERENCES means the pristine leg EMITTED, so the symbol graph is demonstrably intact and
+    /// there is nothing to dissect. Running it anyway would print a reassuring READS-HEALTHY beside
+    /// a verdict that is not about the reads at all.
+    /// </summary>
+    [Fact]
+    public void TheReferencesVerdict_DoesNotRunTheDissection()
+    {
+        var invocations = 0;
+
+        var verdict = EmitPipeline.Verdict(Threw(), "OK", () => { invocations++; return "dissect=STUB"; });
+
+        verdict.Should().StartWith("canary=REFERENCES");
+        invocations.Should().Be(0,
+            "the pristine leg emitted, so the reads are known good and the probe has nothing to add");
+        verdict.Should().NotContain("dissect=");
+    }
+
+    /// <summary>
+    /// A diagnostic that faults while diagnosing destroys the evidence it exists to preserve. Leg 3
+    /// is total by construction, and the verdict is total even if a future leg 3 stops being.
+    /// </summary>
+    [Fact]
+    public void AProbeThatFaults_DegradesToUnavailable_AndNeverEscapes()
+    {
+        var verdict = EmitPipeline.Verdict(Threw(), Threw(),
+            () => throw new InvalidOperationException("probe blew up"));
+
+        verdict.Should().StartWith("canary=BELOW-ROSLYN");
+        verdict.Should().Contain("dissect=UNAVAILABLE(InvalidOperationException",
+            "'I could not look' and 'I looked and it was broken' must never share a token");
+    }
+
+    /// <summary>
+    /// The unit-test shape of <c>Verdict</c> takes no probe. An absent reading must be visible as
+    /// absent rather than silently omitted — otherwise a wiring mistake that stops passing the
+    /// probe looks identical to a probe that ran and found nothing.
+    /// </summary>
+    [Fact]
+    public void NoProbeSupplied_SaysSo_RatherThanOmittingTheReading()
+    {
+        EmitPipeline.Verdict(Threw(), Threw())
+            .Should().Contain("dissect=NOT-RUN");
+    }
+}


### PR DESCRIPTION
## The premise still holds — measured first, before touching code

Issue [#890](https://github.com/Systemorph/MeshWeaver/issues/890) is the oldest open one (2026-08-07)
and its premise has **not** drifted. Continuing exactly where PR #3284's sweep ended:

| | |
|---|---|
| window | `2026-09-04T06:34:14Z → 22:01Z` (MeshWeaver.Plugins `Plugin Catalog CI`) |
| completed runs | **73** |
| `Portal hosts (shard N)` jobs | **287** |
| non-success shard logs fetched / unfetchable | **93 / 0** |
| occurrences | **0** |

🚨 **And that zero says nothing.** At the last measured ~1 %/run, P(0 in 73) ≈ **48 %** — a coin
toss. The detector was calibrated *before* the null was believed (job `100666643224`, the 2026-09-03
occurrence → **56** `canary=BELOW-ROSLYN` / **20** `PROCESS CANNOT EMIT`, the counts that
occurrence's own report published), and the positive control holds — the exposure suite
`MeshWeaver.Hosting.Monolith.Test` really did run in the window (runs `33881146362`, `33879617931`,
`33879408750`). The last confirmed occurrence is **39 hours old**. **#890 stays open.**

## What this fixes

Two defects, both in `EmitPipeline`'s canary, both live since 2026-08-28.

### 1. The `BELOW-ROSLYN` verdict handed out a remedy nobody can execute

It told CI triage to *"capture a core dump and re-run with tiering disabled"*. The dump half is
**unfollowable by construction**: `DOTNET_DbgEnableMiniDump` fires on a **signal**, and a #890
process never signals — it throws, logs, keeps running, and is killed by the harness wall-clock cap
as `exit=124` (SIGTERM), which writes no dump. `DebuggingNativeCrashes.md` recorded on 2026-09-04
that nine occurrences carried that advice and **not one dump ever arrived**. A remedy that cannot be
performed is the prose form of a gate that cannot fail: it looks like a next step and it is a dead
end. The branch now names the half that **is** followable — a **split-arm** `DOTNET_TieredPGO=0` /
`DOTNET_TieredCompilation=0` re-run, with the "at ~1 %/run one clean arm proves nothing" caveat
carried in the instruction rather than left to the reader.

### 2. The verdict named a RESIDUAL it never measured — and the measurement is cheap

Its own text says *"both legs still run on the one CLR, so this does not separate a corrupted heap
from a miscompiled Roslyn method"*. Legs 1 and 2 both ask **can this process EMIT?** Neither asks the
far cheaper question the stack points straight at: **can it still perform the READ the emit dies
on?**

Every #890 stack ends in
`NamedTypeSymbol.Microsoft.Cci.ITypeDefinitionMember.get_ContainingTypeDefinition()`, which in a
Release Roslyn reduces to `return this.ContainingType.GetCciAdapter();`, called from
`MetadataWriter.GetConsolidatedTypeParameters` — whose guard (`AsNestedTypeDefinitionImpl`) read that
*same* `ContainingType` as non-null microseconds earlier. **Leg 3 (`DissectTheNull`) makes both of
those reads directly**, on symbols bound *after* the fault, with no emit, no metadata writer and no
PE stream:

| verdict | what it means |
|---|---|
| `dissect=SYMBOL-GRAPH-BROKEN` | the ordinary `ContainingType` property reads **null** — the broken read is the property, not emit, and every consumer of a nested symbol is affected |
| `dissect=REPRODUCED-OUTSIDE-EMIT` | public property fine, the Cci explicit interface implementation on the **same symbol** is not — #890 in ONE property call, the smallest repro it has ever had |
| `dissect=READS-HEALTHY` | **both** answer correctly, microseconds after `Emit` threw on this exact shape — evidence *against* a corrupted object graph and *for* code that is wrong only at `MetadataWriter`'s call site, which is what the split-arm tiering run tests |
| `dissect=UNAVAILABLE(…)` | the probe could not run — its **own** verdict, never folded into the others |

It rides the sink that already works (the verdict string, appended in the one reporting funnel), so
it arrives on the next occurrence with no new collection, no artifact and no dump.

**A local control was considered and deliberately left out**: our own nested generic plus an explicit
interface implementation. Its *failing* branch would be informative; its *passing* branch is not — a
different jitted method reading correctly says nothing about Roslyn's — and a probe whose green means
nothing is exactly the shape this canary keeps having to remove.

## Guards, mutation-proven

Both quotes are the observed failure text, not paraphrases.

**Mutation B — the non-vacuity guard.** Leg 3 reaches Roslyn's internal symbol model by reflection
(there is no public route to the method the stack dies in), so a Roslyn rename would turn every
future occurrence into a permanent non-answer with **nothing going red** — exactly how a file-backed
leg 2 silently stopped being a control. Renaming `UnderlyingSymbol` →
`UnderlyingSymbolRenamedByRoslyn`:

```
Failed EmitCanaryDissectionTest.OnAHealthyProcess_BothReadsResolveAndAnswerCorrectly [135 ms]
  Expected "dissect=UNAVAILABLE symbol:OK cci:UNAVAILABLE(no UnderlyingSymbolRenamedByRoslyn on
  NonErrorNamedTypeSymbol) — the public read succeeded but the Cci leg could not be reached, so the
  discriminator did not run" to contain "cci:OK" because the Cci explicit interface implementation
  is the EXACT frame every #890 stack dies in … If a Roslyn rename breaks that reach, this is the
  only thing that says so — otherwise leg 3 answers UNAVAILABLE for ever and #890's discriminator is
  gone with nothing red.
```

**Mutation A — the remedy guard.** Restoring the old "capture a core dump" clause:

```
Failed EmitCanaryDissectionTest.TheBelowRoslynRemedy_IsFollowable_NotACoreDumpThatCannotBeProduced
  Did not expect "canary=BELOW-ROSLYN … The followable measurement is to capture a core dump and
  re-run with tiering disabled …" to contain "capture a core dump" because DOTNET_DbgEnableMiniDump
  fires on a SIGNAL and this process never signals — it is killed by the wall-clock cap as
  exit=124/SIGTERM, so that instruction produced zero dumps across nine occurrences. A remedy nobody
  can execute is not a remedy.
```

Both restored; the suite is green.

## Verification

- `dotnet build -c Release -warnaserror`, one project per invocation — `src/MeshWeaver.Compiler`,
  `src/MeshWeaver.Compiler.Pipeline`, `src/MeshWeaver.Documentation`,
  `test/MeshWeaver.Compiler.Pipeline.Test`, `test/MeshWeaver.Documentation.Test`: each
  **`0 Warning(s), 0 Error(s)`**.
- `MeshWeaver.Compiler.Pipeline.Test` in full: **611 passed, 0 failed**.
- `DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest`, `NoConflictMarkersGuard`: **3
  passed**.
- 🚨 One methodology note worth keeping: a `--no-build` run of the full suite reported a **false
  FAIL** because the mutation-A binary was still in the test's output directory — the same trap as
  the false pass, pointing the other way. The green above is from a run that built.

## Not included

- **No fix for the NRE.** It is below Roslyn and no compile-side change reaches it. This PR makes the
  next occurrence answer the question the verdict has been naming and not measuring.
- **No claim that the tiering hypothesis is settled** — it is still untested, and the split-arm
  experiment is now the instruction rather than an aside.
- The second still-open defect from #3284's write-up (the shard's `exit=124` remedy saying *"find the
  wedged test"* while the same log carries 20 copies of `PROCESS CANNOT EMIT (#890)`) lives in
  MeshWeaver.Plugins' `classify-test-run.py`, not here — core's `dotnet-test.yml` carries no such
  remedy text (checked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
