### PR TITLE
A cell finds its own runs without the last-execution stamp (#3301)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ScriptExecution.md
@@ -161,7 +161,36 @@ Two things make that an honest answer rather than a shrug.
 
 `Error` rather than `Warning` is deliberate and costs nothing extra: both levels ship to Loki and the path is exceptional, so the only thing that changes is that it trips error-rate alerting. That is the right classification — nothing retries the write, the loss is permanent, and the visible consequence is a cell that tells a human it has never run. "Degraded but self-correcting" is what `Warning` claims, and none of it holds here.
 
-What is still **not** covered: a viewer looking at a cell after a reload cannot tell `NeverRun` from "ran, not recorded". Closing that needs a surface that finds a cell's runs by `ActivityLog.HubPath` rather than by the stamp — a read that does not depend on the stamp, not another write. See [issue #3301](https://github.com/Systemorph/MeshWeaver/issues/3301).
+#### Recovering the run for the READER — follow the edge, do not write another marker
+
+The three candidates above all fail for the same reason: they are **writes**. What the reader needs is a **read**, and the edge to read along already exists. `CodeRunHistory.ResolveOutputCurrency` (`MeshWeaver.Mesh.Contract`, beside the currency rule it extends) walks it:
+
+```csharp
+// The verdict a cell can substantiate when its own stamp cannot supply one.
+// Reactive like every other read — one verdict, then completion.
+code.ResolveOutputCurrency(cellPath, viewerHome, meshService)
+    .Subscribe(verdict => { /* NeverRun · Unverified · Stale · Current */ });
+```
+
+| Step | What happens | Cost |
+|---|---|---|
+| 1 | `OutputCurrency()` — the stamp. Anything but `NeverRun` is returned unchanged. | **no query** |
+| 2 | Only on `NeverRun`: one listing for an Activity naming this cell on `HubPath`. A hit ⇒ `Unverified`. | one row |
+| 3 | No hit ⇒ `NeverRun`, exactly as today. | — |
+
+Three properties are what make this the right shape rather than merely a working one.
+
+**It is a listing by predicate, not a point read.** `Query` is eventually consistent, so it may never decide what a *specific known node* contains — that stays `GetMeshNodeStream`'s job. Here a stale negative is harmless by construction: the worst outcome is the answer the cell already gives today.
+
+**A recovered run is `Unverified`, never `Current`.** The Activity records *that* the cell ran, never *what* it ran — no fingerprint travels with it. That is the same evidence a stamp which landed without its hash leaves, so it gets the same fail-closed verdict, for the same reason.
+
+**It runs only where it can change the outcome.** A notebook of cells that ran normally costs zero queries, because step 1 answers first. This is the whole reason the lookup hangs off `NeverRun` rather than being a general "find this cell's runs" call every view makes.
+
+**Where it looks.** The run lands under `{activityParent}/_Activity`, and `CodeNodeType.ResolveActivityParent` picks that parent in three layers: the Code node's own `CodeConfiguration.ActivityParentPath`, then the partition's `PartitionDefinition.DefaultActivityParentPath`, then the partition root — with the `{viewer}` sentinel at either configured layer expanding to the calling user's home. `CodeRunHistory.ActivityNamespaces` reconstructs the layers it can see from the cell alone — the node's own `ActivityParentPath` with `{viewer}` expanded, the partition root, and the reading viewer's home — deduplicated into a single union query, usually one namespace. A partition-level `DefaultActivityParentPath` pointing somewhere else is **not** covered: that lookup is a live query on the partition registry, which `MeshWeaver.Mesh.Contract` sits below. Where it applies the listing finds nothing and the verdict falls back to `NeverRun` — the answer the cell gives today, so the gap costs nothing that was already working. A caller that has already resolved the parent (the dispatcher has, via `CodeNodeType.ResolveActivityParent`) skips the derivation and calls `CodeRunHistory.RunsQuery` with the namespace it resolved.
+
+🚨 **Two cross-assembly agreements hold this together, and neither is visible to a compiler.** The lookup filters on `nodeType:Activity` and expands the `{viewer}` sentinel — both declared in assemblies it sits *below* (`GraphNodeTypeNames.Activity`, `CodeNodeType.ResolveActivityParent`). A rename on either side would leave the query looking for something nothing writes: zero rows, every recovered cell silently back to `NeverRun`, no compiler error anywhere. `CodeRunHistoryTest` pins both — the node-type name by equality, the sentinel by *driving the dispatcher's own resolver* and requiring the answer the lookup assumes.
+
+**What remains uncovered.** The lookup answers *whether* the cell ran, not *what it produced*: it deliberately does not re-point the output pane at the recovered activity. And an operator still gets the `Error` under event id `3249` — the stamp failing is a real fault, and a reader who can no longer see the consequence is not a reason to stop reporting it.
 
 ### 2. From application code — `SubmitCodeRequest` directly
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-cell-can-find-its-own-runs-again.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-cell-can-find-its-own-runs-again.md
@@ -1,0 +1,43 @@
+---
+Name: A cell that ran no longer claims it never did
+Category: Fix
+Description: When the bookkeeping write that records a script run failed, the cell reported itself as never run after the next page load — even though the run had happened and its log was still there. The cell now finds the run itself, and says its output is unverified rather than pretending there is none.
+Icon: History
+Order: -20260905
+---
+
+# A cell that ran no longer claims it never did
+
+Press **Run** on a code cell and two separate things are written. The run itself gets its own
+record — the activity, with its log, its status and everything the script printed. Separately, a
+short note is written back onto the cell: *this cell was run, at this time, by this person, and
+here is where the log lives*.
+
+That second note is what the cell reads on your next visit. It is one small write, and very
+occasionally it does not land — a busy moment at startup, a refused write, content the platform
+cannot read back. When that happened, the note was simply absent, and the cell had nothing left to
+tell you with.
+
+So it told you the only thing it could see: **nothing had ever run here.**
+
+That was wrong, and it was wrong in the least helpful direction. The run had happened. Its log was
+still sitting in your activity list, complete. The only thing missing was the cell's pointer to it —
+and the cell reported that missing pointer as a missing run.
+
+## What happens now
+
+The cell looks for its own runs instead of relying on the note. Every run writes down which cell it
+came from, before it starts, so the trail back exists whether or not the note was ever written.
+
+- A cell whose note is intact behaves exactly as before — nothing extra happens, and nothing got
+  slower.
+- A cell whose note went missing now finds the run and says so, marking its output **unverified**:
+  the run is real, but nothing recorded which version of the code it ran, so the cell will not
+  claim the output matches what you are looking at.
+- A cell nobody has ever run still says nothing at all. An unrun cell has no output to be wrong
+  about, and it should not carry a warning.
+
+"Unverified" rather than "up to date" is deliberate. The recovered run proves *that* the cell ran;
+it does not prove *what* it ran. Telling you the output is current when nothing substantiates that
+would be a wrong claim, not merely a missing one — so the cell tells you what it actually knows and
+lets you decide whether to run it again.

--- a/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/CodeNodeType.cs
@@ -152,8 +152,11 @@ public static class CodeNodeType
                 return unresolved switch
                 {
                     null => partitionRoot,
-                    "{viewer}" when !string.IsNullOrEmpty(viewerHome) => viewerHome!,
-                    "{viewer}" => partitionRoot,
+                    // Spelled through the constant, not the literal: the #3301 lookup that finds a
+                    // cell's runs when the stamp did not land has to expand the sentinel THE SAME
+                    // WAY, and two literals in two assemblies are free to drift silently.
+                    CodeRunHistory.ViewerHomeSentinel when !string.IsNullOrEmpty(viewerHome) => viewerHome!,
+                    CodeRunHistory.ViewerHomeSentinel => partitionRoot,
                     var p => p
                 };
             });

--- a/src/MeshWeaver.Mesh.Contract/CodeOutputCurrency.cs
+++ b/src/MeshWeaver.Mesh.Contract/CodeOutputCurrency.cs
@@ -1,3 +1,7 @@
+using System.Collections.Immutable;
+using System.Reactive.Linq;
+using MeshWeaver.Mesh.Services;
+
 namespace MeshWeaver.Mesh;
 
 /// <summary>
@@ -124,4 +128,166 @@ public static class CodeOutputCurrencyExtensions
     /// <param name="code">The cell's configuration.</param>
     public static bool ProvesOutputIsCurrent(this CodeConfiguration? code) =>
         code.OutputCurrency() is CodeOutputCurrency.Current;
+}
+
+/// <summary>
+/// The half of the verdict that does NOT depend on the last-execution stamp (#3301).
+///
+/// <para><b>The gap this closes.</b> A cell reads its own run history from ONE denormalised
+/// pointer — the stamp that writes <see cref="CodeConfiguration.LastExecutedAt"/>,
+/// <see cref="CodeConfiguration.LastExecutedBy"/>, <see cref="CodeConfiguration.LastActivityPath"/>
+/// and <see cref="CodeConfiguration.LastExecutedCodeHash"/> together. When that write does not land
+/// (#3249: the workspace not ready, a refused partition write, content that cannot be read as a
+/// <see cref="CodeConfiguration"/>) the pointer is simply absent, and after a page reload the cell
+/// is indistinguishable from one nobody has ever run. <see cref="CodeOutputCurrencyExtensions.OutputCurrency"/>
+/// answers <see cref="CodeOutputCurrency.NeverRun"/> — correctly, from the evidence it has — and the
+/// reader is told the run never happened.</para>
+///
+/// <para><b>Why a READ is the fix and a write is not.</b> The run is not lost. The dispatcher
+/// creates the Activity node BEFORE it dispatches and stamps the originating cell onto it
+/// (<c>ActivityLog.HubPath</c> = the Code node's path), so the cell → run edge is durable; it is
+/// only missing in the direction the view reads it. Every scheme that recovers it by putting a
+/// marker on the CELL is a second write to the node whose first write just failed — recovery in the
+/// same failure domain — which is why <c>Doc/Architecture/ScriptExecution</c> → "When the stamp does
+/// not land" rules all three out. Following the edge backwards needs no write at all.</para>
+///
+/// <para><b>Why this is a legitimate query.</b> It is a LISTING BY PREDICATE, where a stale negative
+/// is harmless: the worst outcome is the answer the cell already gives today. It is emphatically not
+/// the forbidden shape — reading one known node's content by path — which stays
+/// <c>GetMeshNodeStream</c>'s job.</para>
+///
+/// <para><b>And why it is not run on every cell.</b> <see cref="ResolveOutputCurrency"/> consults
+/// the mesh ONLY where the stamp answers <see cref="CodeOutputCurrency.NeverRun"/> — the one state
+/// where the lookup can change the outcome. A notebook of cells that ran normally costs zero
+/// queries.</para>
+/// </summary>
+public static class CodeRunHistory
+{
+    /// <summary>
+    /// The <c>nodeType</c> a run's Activity node carries. Spelled as a literal because
+    /// <c>MeshWeaver.Mesh.Contract</c> sits BELOW <c>MeshWeaver.Graph.Contract</c>, where
+    /// <c>GraphNodeTypeNames.Activity</c> declares it — the two are pinned equal by
+    /// <c>CodeRunHistoryTest.TheActivityNodeTypeNameMatchesTheGraphVocabulary</c> rather than left to
+    /// agree by luck.
+    /// </summary>
+    public const string ActivityNodeTypeName = "Activity";
+
+    /// <summary>
+    /// The sentinel a Code node (or a <c>PartitionDefinition</c>) may put in
+    /// <see cref="CodeConfiguration.ActivityParentPath"/> to mean "the VIEWER's home partition, not
+    /// mine" — expanded by <c>CodeNodeType.ResolveActivityParent</c> at dispatch, and expanded the
+    /// same way here so the lookup searches where the run actually landed.
+    /// </summary>
+    public const string ViewerHomeSentinel = "{viewer}";
+
+    /// <summary>
+    /// The one spelling of "this cell's own runs": Activity satellites in
+    /// <paramref name="activityNamespace"/> whose <c>ActivityLog.HubPath</c> is
+    /// <paramref name="cellPath"/>.
+    ///
+    /// <para>Ordered newest-first and capped at one row: the question is EXISTENCE, so listing every
+    /// run of a cell that has run a thousand times would pay for nine hundred and ninety-nine rows
+    /// nobody reads.</para>
+    /// </summary>
+    /// <param name="cellPath">Path of the Code node — the value the dispatcher wrote to <c>HubPath</c>.</param>
+    /// <param name="activityNamespace">The <c>{parent}/_Activity</c> namespace to look in.</param>
+    public static string RunsQuery(string cellPath, string activityNamespace) =>
+        $"namespace:{activityNamespace} nodeType:{ActivityNodeTypeName} "
+        + $"content.hubPath:{cellPath} sort:LastModified-desc limit:1";
+
+    /// <summary>
+    /// The <c>_Activity</c> namespaces a cell's runs can land in, derived from the data at hand —
+    /// the cell's own <see cref="CodeConfiguration.ActivityParentPath"/> (with
+    /// <see cref="ViewerHomeSentinel"/> expanded), its partition root (the default), and the
+    /// viewer's home. Deduplicated, so the common case is a single namespace.
+    ///
+    /// <para>🚨 <b>What this deliberately does NOT cover, stated rather than hidden.</b> A
+    /// <c>PartitionDefinition.DefaultActivityParentPath</c> pointing at a FOURTH place is invisible
+    /// here: that lookup is a live workspace query on the partition registry, which this assembly
+    /// sits below. Where it applies, the lookup finds nothing and the verdict falls back to
+    /// <see cref="CodeOutputCurrency.NeverRun"/> — exactly what the cell says today, so the gap
+    /// costs nothing that was already working. A caller that has ALREADY resolved the parent (the
+    /// dispatcher does, through <c>CodeNodeType.ResolveActivityParent</c>) skips this derivation and
+    /// calls <see cref="RunsQuery"/> with the namespace it resolved.</para>
+    /// </summary>
+    /// <param name="cellPath">Path of the Code node.</param>
+    /// <param name="code">The cell's configuration, for its activity-parent override.</param>
+    /// <param name="viewerHome">The reading viewer's home partition, if known.</param>
+    public static ImmutableArray<string> ActivityNamespaces(
+        string? cellPath, CodeConfiguration? code, string? viewerHome)
+    {
+        if (string.IsNullOrEmpty(cellPath))
+            return [];
+
+        var partitionRoot = cellPath.Split('/', StringSplitOptions.RemoveEmptyEntries).FirstOrDefault();
+        if (string.IsNullOrEmpty(partitionRoot))
+            return [];
+
+        var home = string.IsNullOrEmpty(viewerHome) ? null : viewerHome;
+        var configured = code?.ActivityParentPath switch
+        {
+            null or "" => null,
+            ViewerHomeSentinel => home ?? partitionRoot,
+            var p => p,
+        };
+
+        return new[] { configured, partitionRoot, home }
+            .Where(parent => !string.IsNullOrEmpty(parent))
+            .Select(parent => $"{parent}/{ActivityNodeGuard.ActivitySegment}")
+            .Distinct(StringComparer.Ordinal)
+            .ToImmutableArray();
+    }
+
+    /// <summary>
+    /// The cell's currency verdict, recovered from the mesh when its own stamp cannot supply one.
+    ///
+    /// <list type="number">
+    ///   <item><see cref="CodeOutputCurrencyExtensions.OutputCurrency"/> first. Anything but
+    ///   <see cref="CodeOutputCurrency.NeverRun"/> is returned unchanged and costs NO query — the
+    ///   stamp is the fast path and stays it.</item>
+    ///   <item>Only on <see cref="CodeOutputCurrency.NeverRun"/>: one listing over the cell's
+    ///   candidate <c>_Activity</c> namespaces for a run that names this cell. A hit means a run
+    ///   happened; nothing about that run says WHAT it ran, so the honest verdict is
+    ///   <see cref="CodeOutputCurrency.Unverified"/> — the same fail-closed answer as a stamp that
+    ///   landed without its fingerprint, and for the same reason.</item>
+    ///   <item>No hit ⇒ <see cref="CodeOutputCurrency.NeverRun"/>, unchanged. A cell nobody has run
+    ///   still says nothing, and a viewer who cannot SEE the activity (the query is access-filtered
+    ///   like every other) gets the same silence rather than a claim about data they may not read.</item>
+    /// </list>
+    ///
+    /// <para><b>One-shot by construction.</b> The result is the query's <c>Initial</c> snapshot and
+    /// then completion — this is a read, not a binding. A live subscription per never-run cell is
+    /// the cost the issue's own analysis rules out, and a stale negative here is harmless by the
+    /// same argument that makes the listing legitimate at all. A view keeps its liveness from the
+    /// node stream it is already bound to: when a later run stamps the cell, the node emits and the
+    /// caller re-resolves.</para>
+    /// </summary>
+    /// <param name="code">The cell's configuration.</param>
+    /// <param name="cellPath">Path of the Code node.</param>
+    /// <param name="viewerHome">The reading viewer's home partition, if known.</param>
+    /// <param name="meshService">The mesh's query surface.</param>
+    /// <returns>Exactly one verdict, then completion.</returns>
+    public static IObservable<CodeOutputCurrency> ResolveOutputCurrency(
+        this CodeConfiguration? code,
+        string? cellPath,
+        string? viewerHome,
+        IMeshService meshService)
+    {
+        var stamped = code.OutputCurrency();
+        if (stamped is not CodeOutputCurrency.NeverRun)
+            return Observable.Return(stamped);
+
+        var namespaces = ActivityNamespaces(cellPath, code, viewerHome);
+        if (namespaces.Length == 0)
+            return Observable.Return(CodeOutputCurrency.NeverRun);
+
+        return meshService
+            .Query<MeshNode>(MeshQueryRequest.FromQueries(
+                namespaces.Select(ns => RunsQuery(cellPath!, ns))))
+            .Where(change => change.ChangeType is QueryChangeType.Initial)
+            .Take(1)
+            .Select(change => change.Items.Count > 0
+                ? CodeOutputCurrency.Unverified
+                : CodeOutputCurrency.NeverRun);
+    }
 }

--- a/test/MeshWeaver.Graph.Test/CodeCellCurrencyThroughTheMeshTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeCellCurrencyThroughTheMeshTest.cs
@@ -110,7 +110,114 @@ public class CodeCellCurrencyThroughTheMeshTest(ITestOutputHelper output) : Mono
             "the visible output belongs to source the reader is no longer looking at");
     }
 
+    /// <summary>
+    /// #3301, the whole issue in one case: a run whose last-execution stamp NEVER LANDED is still
+    /// found, because the Activity node the dispatcher created before dispatching names the cell on
+    /// <c>ActivityLog.HubPath</c>.
+    ///
+    /// <para><b>The repro is deterministic, not simulated.</b> Two cells really run through
+    /// <c>ExecuteScriptRequest</c>, so two real Activity nodes exist in the same <c>_Activity</c>
+    /// namespace. Then one cell's stamp is WIPED — which is exactly the state #3249's failure paths
+    /// leave behind (the write is one node write; it lands whole or not at all). From that point the
+    /// cell is, to every reader, indistinguishable from one nobody ever ran.</para>
+    ///
+    /// <para><b>Three arms, because a lookup that always says "ran" would be worthless.</b> The
+    /// wiped cell must be recovered as <see cref="CodeOutputCurrency.Unverified"/>; a cell that
+    /// genuinely never ran must stay <see cref="CodeOutputCurrency.NeverRun"/>; and the second,
+    /// still-stamped cell proves the <c>content.hubPath</c> predicate is doing the work rather than
+    /// the namespace listing finding any activity at all.</para>
+    /// </summary>
+    [Fact(Timeout = 180_000)]
+    public async Task ARunWhoseStampNeverLandedIsStillFoundByTheActivityItWrote()
+    {
+        var meshService = Mesh.ServiceProvider.GetRequiredService<IMeshService>();
+        var options = Mesh.JsonSerializerOptions;
+
+        // Two cells, both genuinely run: the second one's Activity shares the _Activity namespace,
+        // so a lookup that merely listed the namespace would pass on the wrong evidence.
+        var wiped = await CreateCell(new CodeConfiguration { Code = Source, IsExecutable = true });
+        var neighbour = await CreateCell(new CodeConfiguration { Code = Source, IsExecutable = true });
+        await Run(wiped);
+        await Run(neighbour);
+
+        // The stamp is one write to one node — it lands whole or not at all. Removing it reproduces
+        // the state every #3249 failure path leaves behind.
+        await Mesh.GetWorkspace().GetMeshNodeStream(wiped)
+            .Update(current => current with
+            {
+                Content = (current.ContentAs<CodeConfiguration>(options) ?? new CodeConfiguration())
+                    with
+                    {
+                        LastExecutedAt = null,
+                        LastExecutedBy = null,
+                        LastActivityPath = null,
+                        LastExecutedCodeHash = null,
+                    },
+            })
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await();
+
+        var stampless = await ReadCell(wiped, c => c is
+        {
+            Code: Source, LastExecutedAt: null, LastActivityPath: null, LastExecutedCodeHash: null,
+        });
+
+        // The defect, asserted rather than assumed: from the cell alone, the run is gone.
+        stampless.OutputCurrency().Should().Be(CodeOutputCurrency.NeverRun,
+            "with no stamp the cell carries no evidence of its own run — this is the state a reader "
+            + "sees after a reload, and it is indistinguishable from a cell nobody ever ran (#3301)");
+
+        // The fix: the run is found by the edge the DISPATCHER wrote.
+        var recovered = await stampless
+            .ResolveOutputCurrency(wiped, viewerHome: null, meshService)
+            .Timeout(Bound)
+            .Await();
+        recovered.Should().Be(CodeOutputCurrency.Unverified,
+            "the Activity node created before the dispatch still names this cell on HubPath, so the "
+            + "run is not lost — only the cell's pointer to it is. A run with nothing recording WHAT "
+            + "it ran is Unverified, the same fail-closed verdict as a stamp that arrived without "
+            + "its fingerprint");
+
+        // Non-vacuity: a cell that genuinely never ran must still say so, or the lookup is a rubber
+        // stamp that would report every unrun cell in the mesh as having run.
+        var untouched = await CreateCell(new CodeConfiguration { Code = Source, IsExecutable = true });
+        var untouchedCell = await ReadCell(untouched, c => c is { Code: Source });
+        var untouchedVerdict = await untouchedCell
+            .ResolveOutputCurrency(untouched, viewerHome: null, meshService)
+            .Timeout(Bound)
+            .Await();
+        untouchedVerdict.Should().Be(CodeOutputCurrency.NeverRun,
+            "no Activity anywhere names this cell — and the neighbour's run, which lives in the very "
+            + "same _Activity namespace, must not be mistaken for it. A verdict that could not come "
+            + "out NeverRun here would prove nothing above");
+
+        // The stamped neighbour never reaches the lookup at all — the stamp answers first, which is
+        // what keeps a notebook of normal cells at zero queries.
+        var neighbourCell = await ReadCell(neighbour, c => c is { LastExecutedCodeHash: not null and not "" });
+        var neighbourVerdict = await neighbourCell
+            .ResolveOutputCurrency(neighbour, viewerHome: null, meshService)
+            .Timeout(Bound)
+            .Await();
+        neighbourVerdict.Should().Be(CodeOutputCurrency.Current,
+            "a cell whose stamp landed is judged by the stamp, unchanged and without a query");
+    }
+
     // ── helpers ──
+
+    private async Task Run(string path)
+    {
+        var dispatch = await RequestHub
+            .Observe<ExecuteScriptResponse>(new ExecuteScriptRequest(), o => o.WithTarget(new Address(path)))
+            .FirstAsync()
+            .Timeout(Bound)
+            .Await();
+        dispatch.Message.Success.Should().BeTrue(
+            $"the run of '{path}' must be accepted before anything about it can be asserted");
+        // The stamp is what makes the run observable from the cell; waiting on it also guarantees
+        // the Activity node exists before the lookup goes looking for it.
+        await ReadCell(path, c => c is { LastExecutedCodeHash: not null and not "" });
+    }
 
     private async Task<string> CreateCell(CodeConfiguration content)
     {

--- a/test/MeshWeaver.Graph.Test/CodeRunHistoryTest.cs
+++ b/test/MeshWeaver.Graph.Test/CodeRunHistoryTest.cs
@@ -1,0 +1,145 @@
+using System;
+using System.Linq;
+using System.Reactive.Linq;
+using System.Threading.Tasks;
+using MeshWeaver.Fixture;
+using MeshWeaver.Graph.Configuration;
+using MeshWeaver.Mesh;
+using Xunit;
+
+namespace MeshWeaver.Graph.Test;
+
+/// <summary>
+/// #3301 — the pure half of "a cell can find its own runs without the last-execution stamp".
+///
+/// <para><b>What is being pinned.</b> <see cref="CodeRunHistory"/> follows the cell → run edge that
+/// the DISPATCHER writes (<c>ActivityLog.HubPath</c> = the Code node's path) instead of the
+/// denormalised pointer the STAMP writes. Two things have to hold for that to work at all, and
+/// neither is visible to a compiler: the query has to name the vocabulary the dispatcher actually
+/// used, and the <c>{viewer}</c> sentinel has to expand to the same place on both sides. Both are
+/// cross-ASSEMBLY agreements — <c>MeshWeaver.Mesh.Contract</c> sits below
+/// <c>MeshWeaver.Graph</c>/<c>MeshWeaver.Graph.Contract</c>, so the lookup cannot reference the
+/// dispatcher's own constants and would otherwise agree with it only by luck.</para>
+///
+/// <para>The through-the-mesh half — that a real run really is found after its stamp is wiped — is
+/// <see cref="CodeCellCurrencyThroughTheMeshTest.ARunWhoseStampNeverLanded_IsStillFoundByTheActivityItWrote"/>.</para>
+/// </summary>
+public class CodeRunHistoryTest
+{
+    private const string Cell = "acme/notebook/cell-7";
+
+    /// <summary>
+    /// 🚨 The lookup filters on <c>nodeType:Activity</c>, and that string is DECLARED in
+    /// <c>MeshWeaver.Graph.Contract</c> — an assembly the lookup cannot reference. A rename there
+    /// would leave <see cref="CodeRunHistory.RunsQuery"/> querying a node type nothing writes any
+    /// more: zero rows, every recovered cell silently back to <see cref="CodeOutputCurrency.NeverRun"/>,
+    /// and no compiler error anywhere. This test is the only thing that would notice.
+    /// </summary>
+    [Fact]
+    public void TheActivityNodeTypeNameMatchesTheGraphVocabulary() =>
+        CodeRunHistory.ActivityNodeTypeName.Should().Be(GraphNodeTypeNames.Activity,
+            "the lookup's nodeType filter must name the type the dispatcher actually creates — "
+            + "MeshWeaver.Mesh.Contract cannot reference GraphNodeTypeNames, so this equality is "
+            + "the only thing holding the two spellings together");
+
+    /// <summary>
+    /// 🚨 The other cross-assembly agreement, pinned BEHAVIOURALLY rather than by comparing two
+    /// literals: the sentinel <see cref="CodeRunHistory.ActivityNamespaces"/> expands must be the
+    /// one <c>CodeNodeType.ResolveActivityParent</c> expands, and to the same target. Drive the
+    /// dispatcher's own resolver and require the answer the lookup assumes.
+    /// </summary>
+    [Fact]
+    public async Task TheViewerSentinelExpandsTheSameWayOnBothSides()
+    {
+        var resolved = await CodeNodeType.ResolveActivityParent(
+                Observable.Return<PartitionDefinition?>(null),
+                CodeRunHistory.ViewerHomeSentinel,
+                viewerHome: "rbuergi",
+                partitionRoot: "acme",
+                lookupBudget: TimeSpan.FromSeconds(5))
+            .FirstAsync()
+            .Timeout(TimeSpan.FromSeconds(10))
+            .Await();
+
+        resolved.Should().Be("rbuergi",
+            "the dispatcher writes the run into the VIEWER's home when the sentinel is configured, "
+            + "so a lookup that expanded it to the cell's own partition would search the one place "
+            + "the activity is not");
+
+        CodeRunHistory.ActivityNamespaces(
+                Cell,
+                new CodeConfiguration { ActivityParentPath = CodeRunHistory.ViewerHomeSentinel },
+                viewerHome: "rbuergi")
+            .Should().Contain($"{resolved}/_Activity",
+                "the lookup must search exactly where the resolver said the run was written");
+    }
+
+    /// <summary>
+    /// The default: no override, so the dispatcher writes to the cell's own partition root and the
+    /// lookup searches exactly one namespace. The common case must not fan out.
+    /// </summary>
+    [Fact]
+    public void WithNoOverrideTheLookupSearchesOnlyTheCellsOwnPartition() =>
+        CodeRunHistory.ActivityNamespaces(Cell, new CodeConfiguration(), viewerHome: null)
+            .Should().Equal("acme/_Activity");
+
+    /// <summary>
+    /// A viewer reading someone else's cell adds their own home — the place a <c>{viewer}</c>-routed
+    /// run would have landed — and nothing else. Two namespaces, one union query.
+    /// </summary>
+    [Fact]
+    public void AForeignViewerAlsoSearchesTheirOwnHome() =>
+        CodeRunHistory.ActivityNamespaces(Cell, new CodeConfiguration(), viewerHome: "rbuergi")
+            .Should().Equal("acme/_Activity", "rbuergi/_Activity");
+
+    /// <summary>
+    /// The viewer reading a cell in their OWN partition must not produce the same namespace twice —
+    /// a duplicated query is a duplicated read for an answer that cannot differ.
+    /// </summary>
+    [Fact]
+    public void TheViewersOwnPartitionIsNotSearchedTwice() =>
+        CodeRunHistory.ActivityNamespaces(Cell, new CodeConfiguration(), viewerHome: "acme")
+            .Should().Equal("acme/_Activity");
+
+    /// <summary>
+    /// An explicit <see cref="CodeConfiguration.ActivityParentPath"/> is where the dispatcher writes,
+    /// so it is searched — and the partition root stays in the set, because runs recorded BEFORE the
+    /// override was configured are still there and still this cell's.
+    /// </summary>
+    [Fact]
+    public void AnExplicitActivityParentIsSearchedAlongsideThePartitionRoot() =>
+        CodeRunHistory.ActivityNamespaces(
+                Cell,
+                new CodeConfiguration { ActivityParentPath = "acme/runs" },
+                viewerHome: null)
+            .Should().Equal("acme/runs/_Activity", "acme/_Activity");
+
+    /// <summary>A path that names no partition cannot be looked up — and must not produce a query
+    /// with an empty namespace, which is the unanchored cross-schema shape a provider refuses.</summary>
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("/")]
+    public void APathThatNamesNoPartitionYieldsNoQuery(string? cellPath) =>
+        CodeRunHistory.ActivityNamespaces(cellPath, new CodeConfiguration(), viewerHome: null)
+            .Should().BeEmpty();
+
+    /// <summary>
+    /// The query's shape, spelled out once: the run is found by the edge the DISPATCHER wrote, it is
+    /// anchored to a namespace (never an unanchored cross-partition scan), and it asks for existence
+    /// — newest first, one row — not for the cell's whole run history.
+    /// </summary>
+    [Fact]
+    public void TheQueryFindsRunsByTheDispatchersEdgeAndAsksOnlyForExistence()
+    {
+        var query = CodeRunHistory.RunsQuery(Cell, "acme/_Activity");
+
+        query.Should().Contain($"content.hubPath:{Cell}",
+            "HubPath is the cell → run edge the dispatcher stamps onto the Activity node BEFORE it "
+            + "dispatches — the whole point is that it survives a failed last-execution stamp");
+        query.Should().Contain("namespace:acme/_Activity",
+            "an unanchored query names no partition and is refused rather than fanned out");
+        query.Should().Contain("limit:1").And.Contain("sort:LastModified-desc",
+            "the question is existence, so a cell with a thousand runs must still cost one row");
+    }
+}


### PR DESCRIPTION
Closes #3301.

`Pairs-with: none` — this PR removes no public type and no public member. It **adds** one type
(`CodeRunHistory`) and two constants; nothing outside core is asked to change, and the two names are
free in MeshWeaver.Plugins (`gh api search/code … repo:Systemorph/MeshWeaver.Plugins` → `total_count 0`,
measured 2026-09-05). No `<see cref>` becomes ambiguous: `ResolveOutputCurrency` is a new NAME, not a
new overload — deliberately, because #3305's `RunActivity(…, LogMessage)` overload turned an
unqualified cref into `CS0419` in three Plugins files (Plugins#1338) and that break shape has no gate.

## The defect, and why #3300 did not close it

A cell reads its own run history from ONE denormalised pointer: the last-execution stamp
(`LastExecutedAt` / `LastExecutedBy` / `LastActivityPath` / `LastExecutedCodeHash`), written
fire-and-forget after the dispatch. It is one write to one node — it lands whole or not at all — so
when it fails (#3249: workspace not ready, a refused partition write, content unreadable) the cell is,
after the next page load, **indistinguishable from a cell nobody has ever run**.

#3300 made that failure *reported* (one `Error`, event id `3249`) and wrote up why recovering it on
the cell is impossible from the dispatching hub: all three candidate shapes are a **second write to
the node whose first write just failed**, i.e. recovery in the same failure domain. That argument is
correct and stands. It simply says nothing about the **reader** — because the reader's fix is not a
write.

**The run is not lost.** `CodeNodeType.HandleExecuteScript` creates the Activity node *before* it
dispatches and stamps the originating cell onto it (`ActivityLog.HubPath = hub.Address.Path`). The
cell → run edge is durable; it was only missing in the direction the view reads it. Nothing followed
it back.

## The fix — one read, along the edge that already exists

`CodeRunHistory` (`src/MeshWeaver.Mesh.Contract/CodeOutputCurrency.cs`, beside the currency rule it
extends, as the issue asked):

| step | | cost |
|---|---|---|
| 1 | `OutputCurrency()` — the stamp. Anything but `NeverRun` returns unchanged. | **no query** |
| 2 | Only on `NeverRun`: one listing for an Activity naming this cell on `HubPath` → `Unverified`. | one row |
| 3 | No hit → `NeverRun`, exactly as today. | — |

- **A listing by predicate, not a point read.** A stale negative is harmless by construction — the
  worst outcome is the answer the cell already gives today. Reading a *specific known node* stays
  `GetMeshNodeStream`'s job.
- **A recovered run is `Unverified`, never `Current`.** The Activity records *that* the cell ran,
  never *what* it ran. Same evidence as a stamp that landed without its fingerprint, so the same
  fail-closed verdict — claiming currency here would be the wrong claim the #3249 rule exists to
  prevent.
- **It runs only where it can change the outcome.** The issue's cost paragraph asked for exactly
  this: a notebook of normally-stamped cells costs **zero** queries, because step 1 answers first.
- Reactive end to end (`IObservable<CodeOutputCurrency>`, one verdict then completion) — no `async`,
  no `Task<T>`, no `.Result`. Immutable collections throughout (`ImmutableArray<string>`).

**Where it looks.** `ActivityNamespaces` reconstructs the layers visible from the cell alone — its own
`ActivityParentPath` (with `{viewer}` expanded), the partition root, the reading viewer's home —
deduplicated into ONE union query, usually one namespace. Stated in the code and the doc: a
partition-level `DefaultActivityParentPath` pointing at a fourth place is **not** covered (that lookup
is a live partition-registry query, which `Mesh.Contract` sits below). Where it applies the listing
finds nothing and the verdict falls back to `NeverRun` — today's answer — so the gap costs nothing
that was already working.

## Two cross-assembly agreements, both pinned — because no compiler sees them

The lookup filters on `nodeType:Activity` and expands `{viewer}`, and both are declared in assemblies
it sits *below*. A rename on either side would leave the query looking for something nothing writes:
zero rows, every recovered cell silently back to `NeverRun`, **no compiler error anywhere**.

- `CodeRunHistoryTest.TheActivityNodeTypeNameMatchesTheGraphVocabulary` — equality against
  `GraphNodeTypeNames.Activity`.
- `CodeRunHistoryTest.TheViewerSentinelExpandsTheSameWayOnBothSides` — pinned *behaviourally*: it
  drives `CodeNodeType.ResolveActivityParent` and requires the answer the lookup assumes. The
  dispatcher now spells the sentinel through `CodeRunHistory.ViewerHomeSentinel` instead of a second
  literal.

## Verification

**Deterministic repro, through a real mesh** —
`CodeCellCurrencyThroughTheMeshTest.ARunWhoseStampNeverLandedIsStillFoundByTheActivityItWrote`. Two
cells really run through `ExecuteScriptRequest`, so two real Activities share one `_Activity`
namespace; one cell's stamp is then WIPED, reproducing exactly what #3249's failure paths leave
behind. Four arms, so the test cannot pass vacuously: the wiped cell reads `NeverRun` from its own
content (the defect, asserted); it resolves to `Unverified` (the fix); a cell that genuinely never ran
still resolves to `NeverRun` (non-vacuity — and the neighbour's activity in the same namespace must
not be mistaken for it); the still-stamped neighbour resolves to `Current` without a query.

**Mutation-proved, twice — the guard was made to fail on purpose and quoted:**

1. Drop `content.hubPath:{cellPath}` from `RunsQuery` → 2 failures:
   > Expected value to be NeverRun because no Activity anywhere names this cell — and the neighbour's
   > run, which lives in the very same `_Activity` namespace, must not be mistaken for it. … **but
   > found Unverified.**

   > Expected "namespace:acme/_Activity nodeType:Activity sort:LastModified-desc limit:1" to contain
   > "content.hubPath:acme/notebook/cell-7" because HubPath is the cell → run edge the dispatcher
   > stamps onto the Activity node BEFORE it dispatches…

2. Make `ResolveOutputCurrency` never consult the mesh (the pre-fix behaviour) → 1 failure:
   > Expected value to be Unverified because the Activity node created before the dispatch still names
   > this cell on HubPath, so the run is not lost — only the cell's pointer to it is. … **but found
   > NeverRun.**

Both mutations reverted; the suite is green again.

**Builds — `dotnet build -c Release -warnaserror`, one project per invocation, all `0 Error(s)` / `0 Warning(s)`:**
`MeshWeaver.Mesh.Contract` · `MeshWeaver.Graph` · `MeshWeaver.Documentation` · `MeshWeaver.Graph.Test` ·
`MeshWeaver.Documentation.Test`.

**Tests:** `MeshWeaver.Graph.Test` currency + run-history suites — 30/30 passed.
`DocumentationLinkIntegrityTest`, `WhatsNewEntryIntegrityTest`, `UnkeyedActivityLogMessageRatchetGuard`
— 9/9 passed. Full `MeshWeaver.Documentation.Test` guard suite green.

## Work products committed

- `Doc/Architecture/ScriptExecution` → new subsection *"Recovering the run for the READER — follow the
  edge, do not write another marker"*, replacing the "what is still not covered" paragraph that
  pointed at this issue. It states the cost model, the namespace derivation, the two cross-assembly
  agreements, and what remains uncovered.
- What's New entry (`Category: Fix`): *A cell that ran no longer claims it never did*.

## Not in scope

- The output pane is deliberately **not** re-pointed at a recovered activity — this answers *whether*
  the cell ran, not *what it produced*.
- The operator still gets the `3249` `Error`. The stamp failing is a real fault; a reader who can no
  longer see the consequence is not a reason to stop reporting it.
- The Plugins half (`CodeViews.IsOutputStale` rendering the recovered verdict) follows a core pin
  bump — `MW_PLATFORM_REF` is `7d644de95` and this change is not in it yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
