### PR TITLE
test(ComboGate): wait until a recorded verdict is READABLE — the gate read before the write was visible

### DIFF
--- a/test/Memex.Portal.Shared.Test/ComboGateRollTest.cs
+++ b/test/Memex.Portal.Shared.Test/ComboGateRollTest.cs
@@ -602,11 +602,33 @@ public class ComboGateRollTest(ITestOutputHelper output) : MonolithMeshTestBase(
             .Await(TestContext.Current.CancellationToken);
     }
 
-    private Task Record(ComboVerification verdict) =>
-        UpdatePolicyNodeType.RecordVerification(Mesh, verdict)
+    /// <summary>
+    /// Records a verdict and waits until it is READABLE — not merely until the write's own
+    /// observable emitted.
+    ///
+    /// <para>🚨 The gate under test reads the policy through its own stream, and
+    /// <c>stream.Update</c> completing says the patch was accepted, not that every reader can see
+    /// it. When the check ran before the verdict was visible, the gate honestly reported the state
+    /// it could see — "no combo verification has been recorded for this candidate" — and the
+    /// assertion then failed on text that was never about a defect. Measured twice on 2026-09-04
+    /// (runs 33863349195 and the shard-5 red on #3319, a PR whose whole diff is two YAML files and
+    /// two Markdown docs and therefore cannot reach this test at all).</para>
+    ///
+    /// <para>So the record is followed by a read-back on the SAME predicate a real reader uses: the
+    /// verification for this candidate tag is present in the content. That is the condition the
+    /// test actually depends on, and waiting on it removes the race without widening any bound —
+    /// the same cure as the other timing assertions fixed in this repo today.</para>
+    /// </summary>
+    private async Task Record(ComboVerification verdict)
+    {
+        await UpdatePolicyNodeType.RecordVerification(Mesh, verdict)
             .FirstAsync()
             .Timeout(Budget)
             .Await(TestContext.Current.CancellationToken);
+
+        await WaitForContent(c => c.ComboVerifications.Any(
+            v => string.Equals(v.CandidateTag, verdict.CandidateTag, StringComparison.OrdinalIgnoreCase)));
+    }
 
     /// <summary>The first reconciled content matching <paramref name="predicate"/> — the
     /// wait-on-the-condition read, never a bare first emission (which can predate the write).</summary>


### PR DESCRIPTION
## Why

`ComboGateRollTest` failed twice on 2026-09-04, on two different methods:

| run | method | assertion |
|---|---|---|
| 33863349195 | `ANotVerifiableVerdict_NeitherClearsNorRefuses_AndTheUnverifiedRollIsRecorded` | verdict text lacked `could NOT answer` |
| shard 5 on **#3319** | `ARedVerdict_BlocksTheRoll_AndNamesTheModuleThatWouldBreak` | *"a refusal that leaves no trace is the silent freeze this gate must never become … found False"* |

**#3319's entire diff is two YAML files and two Markdown docs** — `deploy/aks/scripts/values.observability.yaml`, `deploy/helm/templates/memex-portal/deployment.yaml`, and two files under `src/MeshWeaver.Documentation/Data/Architecture/`. It cannot reach `Memex.Portal.Shared.Test` at all. That settles attribution without argument: this is the test's own race, and both failures are the same one wearing different assertions.

## The mechanism

```csharp
private Task Record(ComboVerification verdict) =>
    UpdatePolicyNodeType.RecordVerification(Mesh, verdict).FirstAsync()…
```

A completing `stream.Update` says the patch was **accepted** — not that every reader can see it. The gate under test reads the policy through its own stream. When the check ran before the verdict was visible, the gate *honestly* reported the state it could see —

> no combo verification has been recorded for '9999.0.0-ci.1' on this instance

— and the assertion failed on text that was never about a defect. Both observed failures are that same read-after-write gap, surfacing through whichever assertion happened to inspect the verdict text.

## What changes

`Record` now waits until the verdict is **readable**, on the same predicate a real reader uses — the verification for this candidate tag is present in the content.

No bound is widened, no retry is added, and the assertions are untouched. The test simply waits for the condition it actually depends on, which is the same cure `CascadeTest` and `DisposalRaceNackTest` got today.

## A correction to the record

When the first of these failed on #3291, I attributed it to that PR's late-verdict change. **That attribution was wrong** — the class flakes on a diff that cannot reach it. #3291's revert stands on its own evidence (`SubscribeDuringRecycleTest`'s documented contract, plus the measurement that the gate cleared none of #3261's reds), not on this failure.

## Verification

`Memex.Portal.Shared.Test` → `ComboGateRollTest` **7/7** in Release.

Pairs-with: none — test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
