### PR TITLE
docs: instance 5, repeated by this page's author under an hour after writing it

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
@@ -161,6 +161,29 @@ reader than one that looks like instinct.
 **Rule:** report *read failure* and *no matches* as distinct states, and give every watcher its own
 control arm. A monitor that greps only for the success marker stays silent through a crash.
 
+🚨 **This entry was repeated by the author of this page, against this page, under an hour after
+writing it.** A watcher built to follow three pull requests computed `pending = count(status !=
+completed)` over the check list and called zero-pending green. On a freshly pushed head the list is
+**empty** — no checks created yet — so it reported *ALL CHECKS GREEN* for a pull request whose
+required contexts did not exist. Same shape as the four above: an absence rendered as health.
+
+The cure is the one this page already gives for CI verdicts, applied one level in — **evaluate the
+required contexts BY NAME**, so a context that is missing reports *not created yet* and can never
+read as a passing one:
+
+| state | reported as |
+|---|---|
+| context absent from the list | `not created yet` |
+| context present, not completed | `running` |
+| context present, `success` / `skipped` / `neutral` | satisfied |
+| the read itself failed | `READ-FAILED` |
+
+**The generalisation is the uncomfortable one:** *the author of an entry is not immune to it, and the
+interval between writing it and repeating it can be under an hour.* This defect is not carelessness
+and cannot be fixed by care. A control is reasoned about by the person who built it, in the model
+they built it from — which is why the second half of this page's diagnostic asks you to go and break
+the subject rather than to think harder about it.
+
 ### 6. One verdict covering three different outcomes
 
 A green `CD delivered` sat over a **skipped** `bake + seal`, and four consecutive green scheduled CD


### PR DESCRIPTION
Strengthens **instance 5** in `ControlsThatCannotFail` rather than adding a ninth entry — same reason
the null-calibration rule went *inside* instance 2. It is the same mechanism, and a new entry would
trade a thesis for a topic.

## What happened

A watcher built to follow three pull requests computed:

```
pending = count(status != completed)
```

…and called zero-pending green. On a freshly pushed head that list is **empty** — no checks created
yet — so it reported **ALL CHECKS GREEN** for a pull request whose required contexts did not exist.
An absence rendered as health, which is exactly what the entry above it describes.

It happened **under an hour after that entry was written, by the person who wrote it.**

## The cure, and why it is the same one

The page already prescribes this for CI verdicts; here it is applied one level in — **evaluate the
required contexts by NAME**, so a missing one cannot read as a passing one:

| state | reported as |
|---|---|
| context absent from the list | `not created yet` |
| context present, not completed | `running` |
| context present, `success` / `skipped` / `neutral` | satisfied |
| the read itself failed | `READ-FAILED` |

Collapsing any two of those four is how this happens. The old watcher collapsed the first into the
third.

## Why it belongs on the page

> **The author of an entry is not immune to it, and the interval between writing it and repeating it
> can be under an hour.**

That is the strongest argument this page has for existing. The defect is **not carelessness and cannot
be fixed by care**: a control is reasoned about by the person who built it, in the model they built it
from, so it fails exactly where that model is wrong. Which is why the second half of the page's
diagnostic asks you to *go and break the subject* rather than to think harder about it.

The line is the core-CD session's, offered on reading the incident; the instance is mine.

## Verification

`MeshWeaver.Documentation.Test` builds `0 Error(s)` at Release + `-warnaserror`;
`DocumentationLinkIntegrityTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
