### PR TITLE
fix(#3333): a settled assertion has already unsubscribed

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ReactiveTestAssertions.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReactiveTestAssertions.md
@@ -133,6 +133,35 @@ In practice that means the following substitutions:
 
 A hand-rolled `.Result` / `.Wait()` / `.GetAwaiter().GetResult()` in a test body is the failure mode from the other direction — it holds the sync-context thread and bypasses the pooled subscribe. Always go through `.Should()`.
 
+### 2.1 A settled assertion has already unsubscribed
+
+**When the `await` returns, the assertion is no longer a subscriber.** You may rely on that with no
+grace period, no poll and no retry — which matters whenever the very next thing the test measures is
+*"is anything still watching this?"*:
+
+```csharp
+await Cache.GetStream(path, options).Materialize().Should().Match(n => n.Kind == NotificationKind.OnError);
+
+// Legitimate: the only subscriber was the assertion above, and it is gone.
+Cache.ReleaseIfUnwatched(path).Should().BeTrue();
+```
+
+That question is common — a refcounted cache entry that may only be reclaimed unwatched, a released
+claim, an idle sweep that skips a live path — and until 2026-09-05 the guarantee did not hold.
+`ReactiveWait.First` disposed as a **continuation on the settled task**, which structurally cannot
+get there first: the task carries `RunContinuationsAsynchronously`, so `TrySetResult` queues the
+awaiting test immediately, while `Take(1)` disposes its upstream from inside `ForwardOnCompleted` —
+*after* it has pushed the value into the handler. The unsubscribe was always last, by a few
+instructions, and a loaded runner is enough to lose that race.
+`ChangeFeedResetReleasesUpstreamTest.ControlArm_ReleaseIfUnwatched_…` did lose it: the entry it asked
+the cache to release was pinned by the assertion that had just returned. The wait now disposes inside
+the handler, ahead of the settle; `AssertionUnsubscribesBeforeItSettlesTest` pins it.
+
+The converse still holds and is deliberate: a fault arriving **after** a wait has settled can no
+longer be carried by the task, so it is traced rather than dropped — never rethrown into an unrelated
+test, and never left to surface on the finalizer as an `UnobservedTaskException` (xUnit v3 escalates
+those to a Catastrophic failure that poisons the next class).
+
 **The mirror-image mistake is dropping the `await`.** `obs.Should().Emit();` as a bare statement is a discarded `Task<T>`: it subscribes and returns immediately, so the test asserts nothing and proceeds on a race. In an expression position the compiler usually catches it (`Task<MeshNode?>` will not bind to `MeshNode?`), but as a statement it is silent.
 
 ---

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-an-assertion-that-has-returned-is-no-longer-watching.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-an-assertion-that-has-returned-is-no-longer-watching.md
@@ -1,0 +1,31 @@
+---
+Name: An assertion that has returned is no longer watching
+Category: Fix
+Description: Tests written with the reactive assertions can now measure whether anything is still subscribed to a stream, immediately after awaiting an assertion on it. The wait releases its own subscription before it hands control back, instead of a moment afterwards — so a test no longer intermittently measures itself.
+Icon: Checkmark
+Order: -20260905
+---
+
+# An assertion that has returned is no longer watching
+
+`await stream.Should().Within(...).Emit()` reads as one thing: *wait for this, then carry on*. The
+"carry on" half quietly meant something weaker. The wait handed control back to the test and released
+its subscription **a moment later**, on another thread.
+
+Almost always that gap is invisible. It is not invisible to a test whose next question is *"is
+anything still subscribed to this?"* — and that question is common, because it is how you check that
+a cache entry can be reclaimed, that a claim was released, or that an idle sweep is allowed to run.
+Such a test would ask, get the answer "yes, something is", and fail; and because the gap is a handful
+of instructions wide, it would only do so on a loaded machine, a few runs in a hundred. One landed in
+this repository's own suite: a cached stream entry refused to be released because the only thing
+still holding it was the assertion that had just returned.
+
+## What changes
+
+The wait now releases its subscription **before** it settles, so *"the assertion returned"* means
+*"the assertion is no longer watching"*. A test may rely on that with no grace period, no polling,
+and no retry.
+
+Nothing else about the assertions changes: they still never resume your test on the thread that
+signalled, and a fault arriving after a wait has already settled is still reported rather than
+dropped.

--- a/src/MeshWeaver.Reactive.Assertions/ReactiveWait.cs
+++ b/src/MeshWeaver.Reactive.Assertions/ReactiveWait.cs
@@ -42,14 +42,13 @@ internal static class ReactiveWait
     /// Subscribes to <paramref name="source"/> and returns a task that settles on its first
     /// notification: the value, its completion (with <c>default</c>), or its fault.
     ///
-    /// <para>The subscription deliberately OUTLIVES the returned task. Unsubscribing on settle is
-    /// what Rx's bridge does and what loses a fault arriving just after a timeout fired — an
-    /// unobserved exception, surfaced on the finalizer as
-    /// <see cref="TaskScheduler.UnobservedTaskException"/>, which xUnit v3 escalates to a
-    /// Catastrophic failure that poisons the NEXT test class. Here the error arm stays attached
-    /// and a late fault is traced instead. Every source this is pointed at terminates (each call
-    /// site ends in <c>FirstAsync</c>, <c>ToList</c>, <c>IgnoreElements</c> or <c>Timeout</c>), so
-    /// the subscription releases itself.</para>
+    /// <para><b>The wait unsubscribes BEFORE it settles</b>, so "this assertion has returned"
+    /// implies "this assertion is no longer a subscriber". Tests assert on that: a subject whose
+    /// point is that nobody is watching any more (a refcounted cache entry, a released claim)
+    /// cannot be measured by a caller that is still attached. A late fault — one arriving after
+    /// the task settled, which the task can no longer carry — is traced rather than orphaned, so
+    /// it never reaches the finalizer as a <see cref="TaskScheduler.UnobservedTaskException"/>
+    /// (xUnit v3 escalates those to a Catastrophic failure that poisons the NEXT test class).</para>
     /// </summary>
     /// <typeparam name="T">The source's element type.</typeparam>
     /// <param name="source">The (terminating) source to wait on.</param>
@@ -66,14 +65,43 @@ internal static class ReactiveWait
         // later one starves — NodeTypeCompileParkTest.RecycleRetry, ~40% of main runs after #2748,
         // reported as "Last of N emission(s), none matched" at the full timeout.
         //
+        // 🚨 AND IT DISPOSES *INSIDE THE HANDLER*, AHEAD OF THE SETTLE — never as a continuation
+        // on `completion.Task`. A continuation cannot get there first, and the gap is not
+        // theoretical:
+        //
+        //   * `RunContinuationsAsynchronously` QUEUES the awaiter the instant TrySetResult runs,
+        //     so the test thread is already released while the producer thread is still unwinding;
+        //   * the operator chain every call site builds ends `…Take(1).ToList().Timeout(…)`, and
+        //     `Take(1)` disposes its upstream from inside `ForwardOnCompleted` — which runs AFTER
+        //     it has pushed the value through `ToList` into the handler here. So the unsubscribe
+        //     is structurally LAST, not merely late.
+        //
+        // A test that then measures "is anything still subscribed?" reads its own wait.
+        // ChangeFeedResetReleasesUpstreamTest.ControlArm_ReleaseIfUnwatched_… did exactly that:
+        // `MeshNodeStreamCache.ReleaseIfUnwatched` refuses an entry with a live subscriber
+        // (`Entry.TryMarkIdleEvicted`), and the only subscriber left was this wait, so the release
+        // returned false and the control arm failed on a state it had never observed
+        // (run 33937167117, shard 4). Disposing here puts the unsubscribe on the producer's thread
+        // ahead of the settle — where Rx's own First/Take put it — so "the wait settled" IMPLIES
+        // "the wait unsubscribed", and an assertion may rely on that.
+        //
+        // A source that emits synchronously during Subscribe is covered too, and by construction:
+        // the caller has no task to await until `First` returns, and `SingleAssignmentDisposable`
+        // disposes the real subscription the moment it is assigned — before that return.
+        //
         // The late-fault trace below therefore only covers faults arriving BEFORE disposal, which
         // is the honest trade: a fault from a stream nobody is asserting on any more is noise, and
         // keeping the subscription alive to catch it is what broke the suite.
         var subscription = new SingleAssignmentDisposable();
         subscription.Disposable = source.Subscribe(
-            value => completion.TrySetResult(value),
+            value =>
+            {
+                subscription.Dispose();
+                completion.TrySetResult(value);
+            },
             error =>
             {
+                subscription.Dispose();
                 // Before the task settled this IS the answer; after it, the task can no longer
                 // carry it — so it goes to the trace rather than nowhere.
                 if (completion.TrySetException(error))
@@ -82,14 +110,12 @@ internal static class ReactiveWait
                     "ReactiveWait: the asserted stream faulted AFTER the wait settled — reported, "
                     + "not orphaned: {0}: {1}", error.GetType().Name, error.Message);
             },
-            () => completion.TrySetResult(default));
+            () =>
+            {
+                subscription.Dispose();
+                completion.TrySetResult(default);
+            });
 
-        _ = completion.Task.ContinueWith(
-            (_, state) => ((IDisposable)state!).Dispose(),
-            subscription,
-            CancellationToken.None,
-            TaskContinuationOptions.ExecuteSynchronously,
-            TaskScheduler.Default);
         return completion.Task;
     }
 }

--- a/test/MeshWeaver.Testing.Xunit.Test/AssertionUnsubscribesBeforeItSettlesTest.cs
+++ b/test/MeshWeaver.Testing.Xunit.Test/AssertionUnsubscribesBeforeItSettlesTest.cs
@@ -1,0 +1,79 @@
+using Xunit;
+using System.Reactive.Concurrency;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+
+namespace MeshWeaver.Testing.Xunit.Test;
+
+/// <summary>
+/// The contract <c>ReactiveWait</c> owes every assertion built on it: <b>when the wait settles it
+/// has already unsubscribed</b>. Tests measure things whose whole subject is "nobody is watching
+/// this any more" — a refcounted cache entry, a released claim, an idle sweep that may only reap
+/// an unwatched path — and such a test cannot be correct if the assertion it just awaited is
+/// still attached to the subject it is about to measure.
+///
+/// <para>This was not hypothetical. <c>ReactiveWait</c> disposed as a CONTINUATION on the settled
+/// task, and the continuation cannot get there first: the task is created with
+/// <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/>, so <c>TrySetResult</c> queues
+/// the awaiting test the instant it runs, while the unsubscribe was still travelling back up the
+/// producer's stack (<c>Take(1)</c> disposes its upstream from inside <c>ForwardOnCompleted</c>,
+/// i.e. AFTER it has pushed the value into the handler). MeshWeaver#3332's shard-4 red was exactly
+/// that: <c>ChangeFeedResetReleasesUpstreamTest.ControlArm_ReleaseIfUnwatched_…</c> asked
+/// <c>MeshNodeStreamCache.ReleaseIfUnwatched</c> to claim an entry whose only remaining subscriber
+/// was the wait that had just returned, and the release refused it (run 33937167117).</para>
+/// </summary>
+public class AssertionUnsubscribesBeforeItSettlesTest
+{
+    /// <summary>
+    /// How long the source's teardown holds the producer's thread, waiting to be told the awaiting
+    /// test has already run. This is deliberate FAULT INJECTION, not a wait for propagation: the
+    /// real window between "settle" and "unsubscribe" is a handful of instructions wide, so on a
+    /// quiet machine the producer wins it nearly every time and a guard written without this would
+    /// pass while the defect was present — a guard that cannot fail. Widening the window makes the
+    /// ORDER observable. On correct code nothing is ever signalled, so this bound is also the
+    /// (one-off) price the healthy path pays.
+    /// </summary>
+    private static readonly TimeSpan TeardownHold = TimeSpan.FromMilliseconds(50);
+
+    [Fact]
+    public async Task AWaitThatHasSettled_HasAlreadyReleasedItsSubscription()
+    {
+        var relay = new Subject<int>();
+        var subscribers = 0;
+        var awaiterRan = 0;
+
+        // A source that COUNTS its live subscribers, exactly like the refcounted shared views a
+        // real test measures, and that holds the producer inside teardown long enough for a
+        // prematurely-resumed awaiter to read the count while it is still 1.
+        var counted = Observable.Create<int>(observer =>
+        {
+            Interlocked.Increment(ref subscribers);
+            var inner = relay.Subscribe(observer);
+            return Disposable.Create(() =>
+            {
+                SpinWait.SpinUntil(() => Volatile.Read(ref awaiterRan) == 1, TeardownHold);
+                inner.Dispose();
+                Interlocked.Decrement(ref subscribers);
+            });
+        });
+
+        // Emit() subscribes synchronously before it hands back the task, so the source is live here.
+        var waiting = counted.Should().Within(TimeSpan.FromSeconds(30)).Emit();
+        Volatile.Read(ref subscribers).Should().Be(1,
+            "precondition: the assertion subscribed when it was armed, so there is a refcount to release");
+
+        // The value must arrive on a thread that is NOT the one the awaiter resumes on — the defect
+        // IS the producer and the awaiter running concurrently. TaskPoolScheduler, not Task.Run:
+        // this package's discipline is Rx end to end.
+        TaskPoolScheduler.Default.Schedule(() => relay.OnNext(42));
+
+        var value = await waiting;
+        Volatile.Write(ref awaiterRan, 1);
+
+        value.Should().Be(42, "the wait settles on the source's first value");
+        Volatile.Read(ref subscribers).Should().Be(0,
+            "the wait had already unsubscribed when it settled — an assertion whose subject is "
+            + "'is anything still watching?' reads this, and reads it with no grace period");
+    }
+}


### PR DESCRIPTION
Fixes the change-feed half of #3333 — and, because the defect is in shared test infrastructure,
closes the same race for **every** assertion in the fleet.

## The defect

`ReactiveWait.First` is what every terminal assertion in `MeshWeaver.Reactive.Assertions` is built
on. It disposed its subscription as a **continuation on the settled task**, and a continuation
structurally cannot get there first:

* the task carries `RunContinuationsAsynchronously`, so `TrySetResult` **queues the awaiting test**
  the instant it runs;
* every call site builds `…Take(1).ToList().Timeout(…)`, and `Take(1)` disposes its upstream from
  inside `ForwardOnCompleted` — i.e. **after** it has pushed the value down into the handler.

So the unsubscribe was always last, by a handful of instructions, and the awaiting test resumed while
the assertion was still attached to the stream it was about to measure. On a quiet machine the
producer wins that race. Under six concurrent shards it does not.

## What it broke

`MeshNodeStreamCache.ReleaseIfUnwatched` refuses an entry that still has a live subscriber
(`Entry.TryMarkIdleEvicted`). At `ChangeFeedResetReleasesUpstreamTest.cs:178` the only subscriber left
was **the assertion on line 124** — the one that had just returned. The release returned `false` and
the control arm failed on a state it had never observed (run
[33937167117](https://github.com/Systemorph/MeshWeaver/actions/runs/33937167117), shard 4).

This was latent for every assertion whose subject is *"is anything still watching this?"* — a
refcounted cache entry, a released claim, an idle sweep that may only reap an unwatched path. Not
just this one test.

## The fix

Dispose **inside the handler, ahead of the settle**, so *"the wait settled"* implies *"the wait
unsubscribed"*.

A source that emits synchronously during `Subscribe` is covered by construction: the caller has no
task to await until `First` returns, and `SingleAssignmentDisposable` disposes the real subscription
on assignment — before that return. The late-fault behaviour is unchanged: a fault the task can no
longer carry is still traced, never orphaned onto the finalizer as an `UnobservedTaskException`.

The XML doc claimed the opposite (*"the subscription deliberately OUTLIVES the returned task"*). It
predated disposal being added at all and contradicted the body; rewritten to state the contract tests
may now rely on.

## The guard

`AssertionUnsubscribesBeforeItSettlesTest` **fails on the unpatched code** and passes on the fix:

```
Expected value to be 0 because the wait had already unsubscribed when it settled …, but found 1.
```

It widens the window deliberately — the real one is a few instructions, so on a quiet machine a guard
written without that would have passed while the defect was present. A guard that cannot fail is not
a guard.

## Verification (local, Release, `-warnaserror`)

| suite | result |
|---|---|
| `MeshWeaver.Testing.Xunit.Test` | 21/21 (incl. the new guard) |
| `MeshWeaver.Hosting.Test` (the failing one) | **350/350** |
| `MeshWeaver.Data.Test` | 475/475 |
| `MeshWeaver.Messaging.Hub.Test` | 367/367 |
| `MeshWeaver.Layout.Test` | 445/445 |
| `DocumentationLinkIntegrityTest` | green |

1,658 tests across the suites most dependent on the helper, zero failures.

## What this does NOT fix

**#3333's other arm, `BakeEquivalenceTest`, is untouched** — and its stated cause is corrected
[on the issue](https://github.com/Systemorph/MeshWeaver/issues/3333#issuecomment-5548805102). The
`… is shutting down (RunLevel=DisposeHostedHubs)` warnings land **110 ms after** the assertion had
already failed (`01:51:46.606` vs `01:51:46.716`), so they are the harness's own
`.Finally(harness.Dispose)` reacting to the fault — not #2543, and not the cause. The real shape is a
read-before-write in `BakeOutput.CollectOne`: the node advertised a `LastCompiledVersion` the assembly
store did not yet hold. That one still wants an owner.

`Pairs-with: none` — no public type or member leaves `src/`; this is a method body, its XML doc, one
doc page, a What's New entry and one new test.

Refs #3333
