### PR TITLE
Verify a webhook target's HMAC at the endpoint, so a drifted secret fails loudly (#3312)

### DIFF
--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -2105,6 +2105,13 @@ jobs:
             2*)
               echo "### 📣 Release event for $SHA ($DIGEST) accepted by the inbox (HTTP $code)" >> "$GITHUB_STEP_SUMMARY"
               echo "The mesh STORED the delivery. Whether the wave actually ran is verified on the satellites (a repository_dispatch run + the MW_IMAGE_DIGEST bump PR), never here — see #2235." >> "$GITHUB_STEP_SUMMARY"
+              # 🚨 #3312: a 2xx says bytes landed; only the BODY says whether this instance
+              # actually checked the HMAC we just computed. Recorded here, judged in the next step.
+              if grep -Eq '"signature"[[:space:]]*:[[:space:]]*"verified"' /tmp/resp; then
+                echo "- signature: **verified** — the instance checked this POST's HMAC." >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "- signature: **NOT checked** — the instance declares no SecretConfigKey for this target (#3312)." >> "$GITHUB_STEP_SUMMARY"
+              fi
               ;;
             000)
               echo "::error::could not reach the platform-update inbox at all (DNS/TLS/connection refused). No release event was delivered, so no satellite will re-bake against $SHA until its next schedule poll."
@@ -2114,11 +2121,43 @@ jobs:
               echo "::error::the platform-update inbox answered 404. It is FAIL-CLOSED and answers 404 for BOTH an unlisted target and a wrong URL — check vars.PLATFORM_WEBHOOK_URL against the instance's WebhookInbox:Targets (deploy/aks/values.aks.yaml sets WebhookInbox__Targets__0=Hosting/PlatformBuilds). No release event was delivered."
               exit 1
               ;;
+            401)
+              echo "::error::the platform-update inbox REFUSED the signature (HTTP 401): secrets.PLATFORM_WEBHOOK_SECRET here and Hosting:PlatformWebhookSecret on the instance are not byte-identical. Rotate one to match the other — do NOT read either value to compare them; re-set both from the same source. No release event was delivered. (Before #3312 this same drift answered 2xx and every delivery was dropped unverifiable, with nothing red anywhere.)"
+              exit 1
+              ;;
+            500)
+              echo "::error::the platform-update inbox declares a SecretConfigKey that is empty on the instance (HTTP 500), so it can verify nothing and refuses every delivery. Provision the key WebhookInbox__Targets__N__SecretConfigKey names (deploy/aks/values.aks.yaml: Hosting:PlatformWebhookSecret) on the target instance. No release event was delivered."
+              exit 1
+              ;;
             *)
               echo "::error::the platform-update inbox refused the release event (HTTP $code). No satellite will re-bake against $SHA until its next schedule poll."
               exit 1
               ;;
           esac
+
+      # 🚨 ITS OWN STEP, deliberately. The step above is held to "every message ends the job"
+      # (PlatformReleaseNotifyGuard forbids `::warning` in it outright), because a release event
+      # that never arrived must never be decorated into a pass. THIS is the opposite case: the
+      # event DID arrive and was stored — the open question is whether the instance verified the
+      # signature while doing so, which is a provisioning gap on the receiving end, not a failed
+      # delivery. Mixing the two into one step would either soften that guard or overstate this.
+      #
+      # A warning and not a failure only while the declaration rolls out: it reaches an instance
+      # through its Hosting/Deployment record + `helm upgrade`, never through self-update (a `set
+      # image`), so failing here would red every publish until that lands. Escalate to an error
+      # once the control instance answers "verified" — that is the last step of #3312.
+      - name: "Did the inbox VERIFY the build fact?"
+        run: |
+          set -euo pipefail
+          if [ ! -f /tmp/resp ]; then
+            echo "::error::no inbox response was captured — the POST step did not run to completion."
+            exit 1
+          fi
+          if grep -Eq '"signature"[[:space:]]*:[[:space:]]*"verified"' /tmp/resp; then
+            echo "the control instance verified this POST's HMAC — a drifted PLATFORM_WEBHOOK_SECRET would now fail loudly (401)."
+          else
+            echo "::warning::the inbox ACCEPTED this release event WITHOUT checking its signature: it declares no WebhookInbox__Targets__N__SecretConfigKey for this target, so secrets.PLATFORM_WEBHOOK_SECRET was never exercised and a drifted secret would still be invisible (#3312). Provision it on the receiving instance's Hosting/Deployment record."
+          fi
 
   # ─────────────────────────── DID IT ACTUALLY SHIP? ──────────────────────────
   # Belt and braces: `promote` PREVENTS a partial set, this CONFIRMS one landed. Assert the

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1281,14 +1281,19 @@ jobs:
             *)   echo "::error::the inbox refused the publication record (HTTP $code) — sealed but unregistered."; exit 1 ;;
           esac
 
-      # 🚨 Its own step, mirroring MeshWeaver's main-cd.yml. The step above is held to "every
-      # message ends the job" — a record the instance never received must never be decorated into
-      # a pass. THIS is the opposite case: the record DID arrive; the open question is whether the
-      # instance verified the signature while storing it, which is a provisioning gap on the
-      # RECEIVING end, not a failed publication.
+      # 🚨 NO `::warning::` IN THIS JOB, and that is a rule worth obeying rather than carving out.
+      # `UpstreamBuildGateGuard.TheLaneEndsByRegisteringWithMemex_AndDispatchesToNobody` forbids one
+      # anywhere in `register-publication`, because the lane's whole contract is that a record memex
+      # never received goes RED and is never decorated into a pass. This step reports a DIFFERENT
+      # thing — the record arrived, but did the instance check the signature while storing it? — and
+      # a guard cannot tell the two apart from a substring, so the plain-echo form is the honest
+      # answer rather than weakening a guard that exists because a delivery failure was once
+      # downgraded to a warning.
       #
-      # Warning and not failure only while the declaration rolls out: it reaches an instance
-      # through its Hosting/Deployment record + `helm upgrade`, never through self-update.
+      # The verdict is still recorded, twice: on the step summary above and in this log. When the
+      # receiving instance declares its SecretConfigKey and this becomes an `::error::` + `exit 1`
+      # (MeshWeaver#3338), the guard positively WANTS that shape — it already asserts the job
+      # carries `exit 1`. So the end state is guard-compatible; only this interim is quiet.
       - name: "Did the inbox VERIFY the publication record?"
         run: |
           set -euo pipefail
@@ -1297,7 +1302,7 @@ jobs:
             exit 1
           fi
           if grep -Eq '"signature"[[:space:]]*:[[:space:]]*"verified"' /tmp/resp; then
-            echo "the instance verified this POST's HMAC — a drifted webhook-secret would now fail loudly (401)."
+            echo "signature VERIFIED — the instance checked this POST's HMAC, so a drifted webhook-secret would now fail loudly (401)."
           else
-            echo "::warning::the inbox ACCEPTED this publication record WITHOUT checking its signature: it declares no WebhookInbox__Targets__N__SecretConfigKey for this target, so webhook-secret was never exercised and a drifted secret would still be invisible (MeshWeaver#3312). Provision it on the receiving instance's Hosting/Deployment record."
+            echo "signature NOT CHECKED — the inbox accepted this publication record without verifying it: the receiving instance declares no WebhookInbox__Targets__N__SecretConfigKey for this target, so webhook-secret was never exercised and a drifted secret would still be invisible (MeshWeaver#3312). Provision it on that instance's Hosting/Deployment record."
           fi

--- a/.github/workflows/node-repo-publish-bake.yml
+++ b/.github/workflows/node-repo-publish-bake.yml
@@ -1267,9 +1267,37 @@ jobs:
                 echo "### 📣 Publication registered with memex (HTTP $code)"
                 echo "- source: \`$SOURCE\`  identity: \`${IDENTITY:-?}\`  image: \`$IMAGE\`  platform: \`$PLATFORM_IMAGE\`"
                 echo "memex STORED the record. Whether it dispatched meshweaver-upstream-published is read on memex and on the dependents, never here."
+                if grep -Eq '"signature"[[:space:]]*:[[:space:]]*"verified"' /tmp/resp; then
+                  echo "- signature: **verified** — the instance checked this POST's HMAC."
+                else
+                  echo "- signature: **NOT checked** — the instance declares no SecretConfigKey for this target, so a drifted webhook-secret would still be invisible (MeshWeaver#3312)."
+                fi
               } >> "$GITHUB_STEP_SUMMARY"
               ;;
             000) echo "::error::could not reach the inbox at all (DNS/TLS/connection refused) — the publication is sealed but unregistered; no dependent is told until its schedule poll."; exit 1 ;;
             404) echo "::error::the inbox answered 404 — FAIL-CLOSED for both an unlisted target and a wrong URL; check webhook-url against the instance's WebhookInbox:Targets."; exit 1 ;;
+            401) echo "::error::the inbox REFUSED the signature (HTTP 401) — this repo's webhook-secret and the instance's Hosting:PlatformWebhookSecret are not byte-identical. Re-set BOTH from the same source; never read either to compare them. The publication is sealed but unregistered. (Before MeshWeaver#3312 this drift answered 2xx and the record was dropped unverifiable, with nothing red.)"; exit 1 ;;
+            500) echo "::error::the inbox declares a SecretConfigKey that is empty on the instance (HTTP 500) — it can verify nothing and refuses every delivery. Provision that key on the target instance. The publication is sealed but unregistered."; exit 1 ;;
             *)   echo "::error::the inbox refused the publication record (HTTP $code) — sealed but unregistered."; exit 1 ;;
           esac
+
+      # 🚨 Its own step, mirroring MeshWeaver's main-cd.yml. The step above is held to "every
+      # message ends the job" — a record the instance never received must never be decorated into
+      # a pass. THIS is the opposite case: the record DID arrive; the open question is whether the
+      # instance verified the signature while storing it, which is a provisioning gap on the
+      # RECEIVING end, not a failed publication.
+      #
+      # Warning and not failure only while the declaration rolls out: it reaches an instance
+      # through its Hosting/Deployment record + `helm upgrade`, never through self-update.
+      - name: "Did the inbox VERIFY the publication record?"
+        run: |
+          set -euo pipefail
+          if [ ! -f /tmp/resp ]; then
+            echo "::error::no inbox response was captured — the POST step did not run to completion."
+            exit 1
+          fi
+          if grep -Eq '"signature"[[:space:]]*:[[:space:]]*"verified"' /tmp/resp; then
+            echo "the instance verified this POST's HMAC — a drifted webhook-secret would now fail loudly (401)."
+          else
+            echo "::warning::the inbox ACCEPTED this publication record WITHOUT checking its signature: it declares no WebhookInbox__Targets__N__SecretConfigKey for this target, so webhook-secret was never exercised and a drifted secret would still be invisible (MeshWeaver#3312). Provision it on the receiving instance's Hosting/Deployment record."
+          fi

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -87,17 +87,20 @@ config:
     # stores deliveries nobody consumes.
     WebhookInbox__Targets__0: "Hosting/PlatformBuilds"
     # 🚨 #3312 — what makes a WRONG secret VISIBLE, paired with the slot ABOVE that it describes.
-    # Naming the key here tells the inbox to verify X-Hub-Signature-256 itself and answer 401 when
-    # it does not, instead of storing the delivery, answering 2xx and letting the watcher drop it
-    # unverifiable. Before this, "the secret matches" and "the secret drifted" were the SAME green
-    # POST from CD's side. It names a KEY, never a secret: the value stays in the
-    # SecretProviderClass-mounted Hosting:PlatformWebhookSecret.
+    # Naming a configuration key here tells the inbox to verify X-Hub-Signature-256 itself and
+    # answer 401 when it does not, instead of storing the delivery, answering 2xx and letting the
+    # consumer drop it unverifiable. Before this, "the secret matches" and "the secret drifted"
+    # were the SAME green POST from CD's side. It names a KEY, never a secret: the value stays in
+    # the vault-mounted Hosting:PlatformWebhookSecret.
     #
-    # 🚨 IT DESCRIBES __0 AND ONLY __0. Set it wherever the platform-build target is set, and
-    # nowhere else — a deployment that moves the target to __1 (see below) must move this with it,
-    # and a slot holding a STRIPE target must leave its declaration empty, because Stripe signs
-    # `Stripe-Signature` and would 401 against this scheme on every delivery.
-    WebhookInbox__Targets__0__SecretConfigKey: "Hosting:PlatformWebhookSecret"
+    # 🚨 EMPTY BY DEFAULT, AND IT MUST STAY THAT WAY. This declaration is PAIRED WITH A SLOT, and
+    # slot __0 is not the same target on every deployment: memex-cloud's record renders
+    # webhookInboxTargets ["Store/Payments", "Hosting/PlatformBuilds"], so its __0 is STRIPE.
+    # Defaulting a GitHub-style HMAC here would demand X-Hub-Signature-256 from Stripe — which
+    # signs `Stripe-Signature` — and 401 every payment delivery. Declare it per instance, in the
+    # SAME record that sets the slot (extraPortalConfig on the Hosting/Deployment record), on
+    # whichever index actually carries Hosting/PlatformBuilds.
+    WebhookInbox__Targets__0__SecretConfigKey: ""
     # A deployment that ALSO needs a second inbox target (e.g. memex-cloud additionally listens
     # on Store/Payments for Stripe) sets __1 too — never a second writer of __0. See #2235: a
     # hand-set `kubectl set env WebhookInbox__Targets__0=...` on the live Deployment permanently
@@ -105,11 +108,11 @@ config:
     # so the platform-build target silently never took effect even though the ConfigMap was
     # correct. Leave empty when only one target is needed.
     WebhookInbox__Targets__1: ""
-    # Empty because __1 is empty here. An overlay that puts Hosting/PlatformBuilds on __1 — which
-    # is what the control instance does, its __0 being permanently shadowed by an unrecorded inline
-    # `env:` (#2352) — MUST set this to Hosting:PlatformWebhookSecret in the same overlay. Until it
-    # does, the inbox accepts release events without checking them and both CD lanes say so on
-    # every publish: `signature: not-required`, with a ::warning:: naming this key.
+    # The __1 pairing, empty for the same reason. On the instance that RECEIVES platform builds
+    # (memex-cloud: __0 = Store/Payments, __1 = Hosting/PlatformBuilds) this is the slot that must
+    # name Hosting:PlatformWebhookSecret, and its record does so through extraPortalConfig. Until
+    # some instance declares it, the inbox accepts release events without checking them and both CD
+    # lanes say so on every publish: `signature: not-required`, with a ::warning:: naming this key.
     WebhookInbox__Targets__1__SecretConfigKey: ""
     # ---- Instance branding (per-env) ----------------------------------------
     # Large Safari bookmark / Start-Page / Add-to-Dock tile (apple-touch-icon, 180×180 PNG).

--- a/deploy/aks/values.aks.yaml
+++ b/deploy/aks/values.aks.yaml
@@ -86,6 +86,18 @@ config:
     # provisioned for anything to read the inbox — an allowlisted target with no watcher
     # stores deliveries nobody consumes.
     WebhookInbox__Targets__0: "Hosting/PlatformBuilds"
+    # 🚨 #3312 — what makes a WRONG secret VISIBLE, paired with the slot ABOVE that it describes.
+    # Naming the key here tells the inbox to verify X-Hub-Signature-256 itself and answer 401 when
+    # it does not, instead of storing the delivery, answering 2xx and letting the watcher drop it
+    # unverifiable. Before this, "the secret matches" and "the secret drifted" were the SAME green
+    # POST from CD's side. It names a KEY, never a secret: the value stays in the
+    # SecretProviderClass-mounted Hosting:PlatformWebhookSecret.
+    #
+    # 🚨 IT DESCRIBES __0 AND ONLY __0. Set it wherever the platform-build target is set, and
+    # nowhere else — a deployment that moves the target to __1 (see below) must move this with it,
+    # and a slot holding a STRIPE target must leave its declaration empty, because Stripe signs
+    # `Stripe-Signature` and would 401 against this scheme on every delivery.
+    WebhookInbox__Targets__0__SecretConfigKey: "Hosting:PlatformWebhookSecret"
     # A deployment that ALSO needs a second inbox target (e.g. memex-cloud additionally listens
     # on Store/Payments for Stripe) sets __1 too — never a second writer of __0. See #2235: a
     # hand-set `kubectl set env WebhookInbox__Targets__0=...` on the live Deployment permanently
@@ -93,6 +105,12 @@ config:
     # so the platform-build target silently never took effect even though the ConfigMap was
     # correct. Leave empty when only one target is needed.
     WebhookInbox__Targets__1: ""
+    # Empty because __1 is empty here. An overlay that puts Hosting/PlatformBuilds on __1 — which
+    # is what the control instance does, its __0 being permanently shadowed by an unrecorded inline
+    # `env:` (#2352) — MUST set this to Hosting:PlatformWebhookSecret in the same overlay. Until it
+    # does, the inbox accepts release events without checking them and both CD lanes say so on
+    # every publish: `signature: not-required`, with a ::warning:: naming this key.
+    WebhookInbox__Targets__1__SecretConfigKey: ""
     # ---- Instance branding (per-env) ----------------------------------------
     # Large Safari bookmark / Start-Page / Add-to-Dock tile (apple-touch-icon, 180×180 PNG).
     # This ships the PROJECT's own mark (Systemorph builds MeshWeaver — the chart's

--- a/deploy/helm/templates/memex-portal/config.yaml
+++ b/deploy/helm/templates/memex-portal/config.yaml
@@ -383,6 +383,14 @@ data:
   # binds to a TimeSpan and an empty string aborts the host in the configuration binder.
   SelfUpdate__SafetyNetCheckInterval: "{{ .Values.config.memex_portal.SelfUpdate__SafetyNetCheckInterval | default "01:00:00" }}"
   WebhookInbox__Targets__0: "{{ .Values.config.memex_portal.WebhookInbox__Targets__0 | default "" }}"
+  # 🚨 #3312 — how a target says it is AUTHENTICATED, paired with the slot it authenticates.
+  # Names the CONFIGURATION KEY holding that target's shared HMAC (never the secret itself), and
+  # when set the inbox verifies X-Hub-Signature-256 over the raw body and answers 401 instead of
+  # storing a delivery it cannot verify. Empty = the original dumb contract, which is the ONLY safe
+  # default here: this slot is not always Hosting/PlatformBuilds, and declaring a GitHub-style HMAC
+  # on a Stripe target would 401 every Stripe delivery (Stripe signs `Stripe-Signature`, which this
+  # endpoint does not speak). Set it in the same overlay that sets the slot, never separately.
+  WebhookInbox__Targets__0__SecretConfigKey: "{{ .Values.config.memex_portal.WebhookInbox__Targets__0__SecretConfigKey | default "" }}"
   # 🚨 #2235: a SECOND slot, because index 0 is not this template's alone to give. memex-cloud
   # hand-set WebhookInbox__Targets__0=Store/Payments directly on the Deployment (kubectl set env,
   # unrecorded, pre-dating this chart key) BEFORE the platform-release broadcast existed. Explicit
@@ -393,6 +401,11 @@ data:
   # 404'd on every promoted build with no error anywhere until #2268 made the 404 fail loud. A
   # deployment needing more than one inbox target sets __0 AND __1 (not two writers of __0).
   WebhookInbox__Targets__1: "{{ .Values.config.memex_portal.WebhookInbox__Targets__1 | default "" }}"
+  # The __1 pairing of the declaration above. 🚨 It matters most HERE: on the deployment whose __0
+  # is permanently shadowed, __1 is the slot that actually carries Hosting/PlatformBuilds, so its
+  # overlay is the one that must set this — otherwise the inbox keeps accepting release events
+  # unverified and CD reports `signature: not-required` on every publish.
+  WebhookInbox__Targets__1__SecretConfigKey: "{{ .Values.config.memex_portal.WebhookInbox__Targets__1__SecretConfigKey | default "" }}"
   # ---- Framework-release broadcast: NO subscriber slots (retired 2026-09-03) --------------
   # FrameworkBroadcast__Subscribers__0..3 used to be rendered here as the release wave's
   # subscriber list. The set is DATA IN THE MESH now — every repository a Hosting/Deployment

--- a/memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs
@@ -17,10 +17,15 @@ namespace Memex.Portal.Shared.Api;
 /// as a <c>WebhookEvent</c> node at <c>{target}/_Inbox/{id}</c> (see
 /// <see cref="WebhookInbox"/>). Anonymous by design — external services (Stripe, GitHub, …)
 /// cannot authenticate — and fail-closed: only targets allowlisted under
-/// <c>WebhookInbox:Targets</c> in configuration accept deliveries; everything else is 404. The
-/// endpoint verifies NOTHING about the payload beyond a size cap — signature verification is the
-/// consuming plugin's job over the verbatim stored body + headers, so no integration-specific
-/// (e.g. payment) code lives in the portal.
+/// <c>WebhookInbox:Targets</c> in configuration accept deliveries; everything else is 404.
+///
+/// <para>The endpoint speaks exactly ONE signature scheme, and only for targets that ask for it:
+/// a target declaring <c>Targets:N:SecretConfigKey</c> has its <c>X-Hub-Signature-256</c> verified
+/// over the raw body before anything is stored, and gets 401 when it does not verify (#3312 — a
+/// 2xx that meant "I received bytes" made a MISMATCHED secret look exactly like a correct one, so
+/// a publisher could not fail on it). Everything else keeps the dumb contract: no integration-
+/// specific (e.g. payment) code lives in the portal, and Stripe-shaped schemes stay the consuming
+/// plugin's job over the verbatim stored body + headers.</para>
 /// </summary>
 public static class WebhookInboxEndpoints
 {
@@ -44,11 +49,7 @@ public static class WebhookInboxEndpoints
     {
         var logger = hub.ServiceProvider.GetService<ILoggerFactory>()
             ?.CreateLogger(typeof(WebhookInboxEndpoints));
-        var allowed = config.GetSection(WebhookInbox.TargetsConfigSection).GetChildren()
-            .Select(c => c.Value)
-            .Where(v => !string.IsNullOrWhiteSpace(v))
-            .Select(v => v!)
-            .ToList();
+        var allowed = WebhookInbox.ReadTargets(config);
 
         // Refuse oversized bodies BEFORE buffering them (Content-Length first; the capped reader
         // below still guards chunked bodies that lie about their size).
@@ -75,9 +76,36 @@ public static class WebhookInboxEndpoints
         {
             case WebhookInbox.DeliveryStatus.Accepted:
                 logger?.LogInformation("Webhook stored at {Path}", result.NodePath);
-                return Results.Ok();
+                // 🚨 The body, not the status, is what a signing sender must read. Both branches
+                // are 200: "verified" means this instance checked the HMAC, "not-required" means
+                // the target declares no SecretConfigKey here and the signature was never looked
+                // at. Answering a bare 200 to both is how a chart value going missing would take
+                // verification away again without a single red anything (#3312).
+                return Results.Json(new
+                {
+                    status = "accepted",
+                    signature = result.SignatureVerified ? "verified" : "not-required",
+                });
             case WebhookInbox.DeliveryStatus.TooLarge:
                 return Results.StatusCode(StatusCodes.Status413PayloadTooLarge);
+            case WebhookInbox.DeliveryStatus.SignatureInvalid:
+                // Warning, not Information: on a target that declares a secret this is either an
+                // attacker or — far more often — the two halves of a shared secret having drifted,
+                // which is invisible from the sending side except through this status.
+                logger?.LogWarning(
+                    "Webhook for target '{Target}' REFUSED: {Header} absent or not verifying "
+                    + "against the secret named by {Key}. Nothing was stored.",
+                    target, WebhookInbox.SignatureHeader, WebhookInbox.SecretConfigKeyName);
+                return Results.StatusCode(StatusCodes.Status401Unauthorized);
+            case WebhookInbox.DeliveryStatus.SecretUnavailable:
+                // OUR misconfiguration, not the caller's — hence 500, and Error: this target
+                // refuses every delivery until the declared key resolves to something.
+                logger?.LogError(
+                    "Webhook for target '{Target}' REFUSED: it declares {Key} but that "
+                    + "configuration key is empty on this instance, so no delivery to it can be "
+                    + "verified. Nothing was stored.",
+                    target, WebhookInbox.SecretConfigKeyName);
+                return Results.StatusCode(StatusCodes.Status500InternalServerError);
             default:
                 // Unknown target: no detail leaks about which paths exist or are allowlisted.
                 logger?.LogWarning("Webhook for unknown/refused target '{Target}' dropped", target);

--- a/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
@@ -101,6 +101,16 @@ WebhookInbox__Targets__0__SecretConfigKey: "Hosting:PlatformWebhookSecret"
 It names a **key**, never a secret value: nothing here belongs in a ConfigMap, and a secret pasted
 in by mistake resolves to no key and refuses everything rather than leaking.
 
+🚨 **The declaration is paired with a SLOT, and slot `__0` is not the same target on every
+deployment.** The instance that receives platform builds renders
+`webhookInboxTargets: ["Store/Payments", "Hosting/PlatformBuilds"]` from its `Hosting/Deployment`
+record — so *its* `__0` is **Stripe**, and the platform target is `__1`. A blanket default would
+demand `X-Hub-Signature-256` from Stripe, which signs `Stripe-Signature`, and 401 every payment
+delivery. The chart therefore renders both slots' declarations **empty**, and each instance sets
+its own on the index that actually carries the target — in the same record that sets the slot
+(`extraPortalConfig` on the `Hosting/Deployment` record, which `HelmValues` projects onto
+`config.memex_portal`). Set the target and its declaration in one change, never separately.
+
 When a target declares one, the endpoint verifies `X-Hub-Signature-256` over the raw body **before
 anything is stored**:
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/WebhookInbox.md
@@ -1,7 +1,7 @@
 ---
 Name: Webhook Inbox
 Category: Architecture
-Description: The generic webhook inbox — POST /api/hooks/{target} stores any external service's delivery verbatim as a WebhookEvent node under {target}/_Inbox. Fail-closed on a config allowlist and target-node existence; the CONSUMING plugin verifies the signature itself, so no integration-specific code lives in the portal.
+Description: The generic webhook inbox — POST /api/hooks/{target} stores any external service's delivery verbatim as a WebhookEvent node under {target}/_Inbox. Fail-closed on a config allowlist, target-node existence and — for a target that declares one — a GitHub-style HMAC the endpoint checks itself, so a mismatched secret answers 401 instead of a green 2xx nobody could see through.
 Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 12h-6l-2 3h-4l-2-3H2"/><path d="M5.45 5.11 2 12v6a2 2 0 0 0 2 2h16a2 2 0 0 0 2-2v-6l-3.45-6.89A2 2 0 0 0 16.76 4H7.24a2 2 0 0 0-1.79 1.11z"/></svg>
 ---
 
@@ -24,7 +24,7 @@ stores the delivery as a `WebhookEvent` node at `{target}/_Inbox/{id}`:
   persisted). Signature headers (`Stripe-Signature`, `X-Hub-Signature-256`, …) survive verbatim.
 - **`ContentType`**, **`ReceivedAt`**.
 
-## Fail-closed, twice
+## Fail-closed, three times
 
 1. **The allowlist.** Only targets listed in configuration accept deliveries; everything else is
    404 (no detail leaks about which paths exist):
@@ -36,6 +36,9 @@ stores the delivery as a `WebhookEvent` node at `{target}/_Inbox/{id}`:
 2. **The owner must exist.** A satellite must anchor under a real node — an ownerless satellite
    NotFound-storms the router — so a delivery to an allowlisted path whose node does not exist is
    refused too.
+
+3. **The signature, when the target declares one** — see below. A target that declares no
+   `SecretConfigKey` keeps the original contract and is stored unverified.
 
 Bodies over 1 MB are refused with 413. The event is written under the System identity (the
 anonymous caller has no write access anywhere; the allowlist is the authorization to *store* —
@@ -51,72 +54,106 @@ A plugin that receives webhooks:
    initialization, processing strictly one event at a time.
 3. **Verifies authenticity itself** over the stored raw `Body` + `Headers` — e.g. Stripe's
    `t=…,v1=…` HMAC-SHA256 with the endpoint's signing secret. Only a verified event authorizes an
-   action.
+   action. A consumer whose target declares a `SecretConfigKey` has already been verified at the
+   endpoint, and still re-verifies: the endpoint's check is what makes a drifted secret VISIBLE to
+   the sender, not a replacement for the consumer's own gate.
 4. **Deletes processed (and unverifiable) events** — a poison event must never loop; unprocessed
    events replay naturally on the next start, so every action taken from an event must be
    idempotent.
 
-## 🚨 What a 2xx does NOT prove — the mismatched-secret hole (open, #3312)
+## 🚨 What a 2xx proves — and what it used to hide (#3312)
 
-**A 2xx from this endpoint means "I stored bytes", never "a consumer accepted them".** That is an
-honest answer — the inbox verifies nothing by design — but two callers currently read it as
-acceptance, and one of them is the platform's own release path:
+**A 2xx from this endpoint used to mean "I stored bytes", never "a consumer accepted them".** That
+was an honest answer for a deliberately dumb inbox, but two callers read it as acceptance, and one
+of them is the platform's own release path:
 
 - `main-cd.yml` → `notify-platform-update` signs the platform-build fact with
   `secrets.PLATFORM_WEBHOOK_SECRET`;
 - `node-repo-publish-bake.yml` → `register-publication` signs the publication record with the
   caller's `webhook-secret`.
 
-Both verify against the control instance's `Hosting:PlatformWebhookSecret`, in the Hosting plugin's
-watcher — **after** the POST has already answered. So from CI three states exist and only two are
-distinguishable:
+Both are verified against the control instance's `Hosting:PlatformWebhookSecret` — but that
+happened in the Hosting plugin's watcher, **after** the POST had already answered. So from CI three
+states existed and only two were distinguishable:
 
-| state | what CI sees | what actually happens |
+| state | what CI saw | what actually happened |
 |---|---|---|
 | secret correct | 2xx, job green | record stored, dependents notified |
-| secret **mismatched** | **2xx, job green** | the watcher drops every delivery as unverifiable; nobody is notified |
+| secret **mismatched** | **2xx, job green** | the watcher dropped every delivery as unverifiable; nobody notified |
 | secret empty | RED, named | caught at the caller — fixed in #3311 |
 
-The empty case was found precisely because it fails **closed**. The mismatch fails **open** and is
-byte-identical to success, so it can persist indefinitely while every dependent quietly falls back
-to its schedule poll — the same consequence #3311 fixed, with nothing anywhere going red. The
-property that would close it: **a run that publishes must be able to fail because the record was not
-ACCEPTED, not merely because it was not sent.**
+The empty case was found precisely because it failed **closed**. The mismatch failed **open** and was
+byte-identical to success, so it could persist indefinitely while every dependent quietly fell back
+to its schedule poll — the same consequence #3311 fixed, with nothing anywhere going red.
 
-### Why it is still open, and what it costs
+### The fix: a target may declare how it is authenticated
 
-The verdict has to come from something holding the shared secret, and the only thing that holds it
-is the consuming plugin — after the response. Three shapes were considered; each is blocked, and the
-blocker is worth writing down so the next attempt does not re-derive it:
+A target entry MAY name the configuration key holding its shared secret. The declaration rides on
+the allowlist entry itself — a configuration section carries both a value and children — so the
+record that makes a target reachable is the record that says how it is authenticated, and the two
+cannot drift:
 
-1. **Teach the inbox an optional per-target signature requirement.** The generic shape — a target
-   may declare that deliveries must carry a verifying `X-Hub-Signature-256`, with the secret named
-   by CONFIGURATION KEY (`Hosting:PlatformWebhookSecret`, the key already provisioned) so no secret
-   value is duplicated and the two ends cannot drift. A mismatch then answers 401, an accepted
-   delivery answers a body stating `signature: verified`, and the lanes assert **the verdict**
-   rather than the status code — so an instance that declares no requirement is refused by name too,
-   never read as "verified". This is the right fix, and it is blocked on **delivery, not design**:
-   the declaration is instance configuration, the portal host ships no `appsettings.json` in this
-   repo (it lives in MeshWeaver.Plugins), and a chart value reaches a running portal only through
-   `helm upgrade` from the private `Systemorph/Memex` env folders — never through the self-update,
-   which is a `set image`. Landing the lane half before the instance half would red core CD on every
-   publish, indefinitely.
-2. **Read the record back.** The lane cannot: the inbox is anonymous to WRITE only, and reading a
+```yaml
+WebhookInbox__Targets__0: "Hosting/PlatformBuilds"
+WebhookInbox__Targets__0__SecretConfigKey: "Hosting:PlatformWebhookSecret"
+```
+
+It names a **key**, never a secret value: nothing here belongs in a ConfigMap, and a secret pasted
+in by mistake resolves to no key and refuses everything rather than leaking.
+
+When a target declares one, the endpoint verifies `X-Hub-Signature-256` over the raw body **before
+anything is stored**:
+
+| outcome | status | meaning |
+|---|---|---|
+| verifies | 200, `{"status":"accepted","signature":"verified"}` | stored, and the HMAC was checked |
+| absent / malformed / does not verify | **401** | nothing stored — the state that used to be a green 2xx |
+| the declared key is empty on this instance | **500** | nothing stored — OUR misconfiguration, deliberately not 401 |
+| no declaration | 200, `{"status":"accepted","signature":"not-required"}` | stored unverified — the dumb contract, below |
+
+That order is contract: target first (an unlisted path answers 404 without revealing whether it is
+signed), size next (an oversized body is refused before it is hashed), signature last and always
+before the node is created. A delivery that fails to verify must leave **nothing** behind — otherwise
+the fix has only moved the silent drop from the consumer into the store.
+
+Everything else keeps the dumb contract. Schemes this endpoint does not speak — Stripe's
+`t=…,v1=…` — declare no key and are still verified by the consuming plugin over the verbatim stored
+body, so no integration-specific code lands in the portal.
+
+### Why the body carries the verdict too
+
+`"verified"` and `"not-required"` are both 200, and they mean very different things to a sender that
+signed. The second says this instance declares no `SecretConfigKey` for the target, so the signature
+was never looked at. Without that distinction, "we verify now" would degrade silently back to "we
+used to verify" the day a chart value goes missing — the same shape as the bug, one level up. Both
+lanes therefore read the **body**, print the verdict into the step summary, and `::warning::` on
+`not-required`.
+
+That is a warning and not a failure **only while the declaration rolls out**: the instance half
+arrives by `helm upgrade` from the private `Systemorph/Memex` env folders, never through
+self-update (which is a `set image`), so failing on it would red every publish until that lands.
+Escalating it to an error once the control instance answers `verified` is the remaining step, and
+it is a one-line change in both lanes.
+
+### The two shapes that were rejected, so they are not re-derived
+
+1. **Read the record back.** The lane cannot: the inbox is anonymous to WRITE only, and reading a
    registration needs a mesh credential in CI plus a surface that does not exist.
-3. **Wait for the consequence** — poll the satellites for the `repository_dispatch` the broadcast
+2. **Wait for the consequence** — poll the satellites for the `repository_dispatch` the broadcast
    produces. Rejected on two counts: it is a timeout-bounded poll (the bound, not the fact, would
    decide the verdict), and it makes core's CD verdict depend on other repositories' state, which is
    the CI-to-CI coupling `main-cd.yml` has already deleted twice.
-
-Until (1) lands, the residual is tracked by #3312 and #2235, and the honest statement in both lanes'
-step summaries stands: *the mesh STORED the delivery; whether the wave ran is read on the instance
-and on the dependents, never here.*
 
 ## Where the code lives
 
 - `memex/Memex.Portal.Shared/Api/WebhookInboxEndpoints.cs` — the anonymous `POST /api/hooks/{target}`
   endpoint: allowlist check → 404, `ContentLength > MaxBodyBytes` → 413, target-node existence,
   then the `WebhookEvent` write.
-- `src/MeshWeaver.Graph/Configuration/WebhookEventNodeType.cs` — the `WebhookEvent` node type and the
-  constants both ends share: `TargetsConfigSection = "WebhookInbox:Targets"` and
-  `MaxBodyBytes = 1024 * 1024`.
+- `src/MeshWeaver.Graph/Configuration/WebhookEventNodeType.cs` — the `WebhookEvent` node type, the
+  allowlist reader (`WebhookInbox.ReadTargets` → `WebhookTarget(Path, SecretConfigKey)`), the HMAC
+  check (`VerifyHmacSha256`) and the constants both ends share: `TargetsConfigSection`,
+  `SecretConfigKeyName`, `SignatureHeader` and `MaxBodyBytes = 1024 * 1024`.
+- `test/MeshWeaver.Graph.Test/WebhookInboxTest.cs` — the pair that pins the fix:
+  `SignedTarget_WithTheRightSecret_IsAccepted` against
+  `SignedTarget_WithADriftedSecret_IsRefused_AndStoresNothing`. Both returned `Accepted` before
+  #3312; if a change ever makes them agree again, the hole is back.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-wrong-webhook-secret-is-no-longer-a-green-tick.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-wrong-webhook-secret-is-no-longer-a-green-tick.md
@@ -1,0 +1,52 @@
+---
+Name: A wrong webhook secret is no longer a green tick
+Category: Fix
+Description: A webhook target can now declare which configuration key holds its shared secret. When it does, the portal checks the signature itself and answers 401 — so a secret that has drifted between sender and instance fails visibly, instead of being accepted, stored, and silently discarded by the consumer with every job still green.
+Icon: ShieldKeyhole
+Order: -20260905
+---
+
+# A wrong webhook secret is no longer a green tick
+
+The webhook inbox — `POST /api/hooks/{target}` — was built to be dumb on purpose: it stores a
+delivery verbatim and leaves signature checking to whichever plugin consumes it. That is still true
+for integrations whose schemes the portal does not speak.
+
+But it meant a `200 OK` said *"I received bytes"*, and callers heard *"you were accepted"*. Those are
+the same answer when the shared secret is right, and **also** the same answer when it is wrong: the
+delivery is stored, the sender sees a green request, and the consumer then discards every event as
+unverifiable. Nothing is logged on the sending side, nothing turns red, and the only visible symptom
+is downstream work that quietly never happens. A missing secret was caught — it fails closed — but a
+*mismatched* one is byte-identical to success and could persist indefinitely.
+
+## What changes
+
+A target may now name the configuration key holding its secret:
+
+```yaml
+WebhookInbox__Targets__0: "Hosting/PlatformBuilds"
+WebhookInbox__Targets__0__SecretConfigKey: "Hosting:PlatformWebhookSecret"
+```
+
+The declaration rides on the allowlist entry itself, so the record that makes a target reachable is
+the record that says how it is authenticated — there is no second list to fall out of step. And it
+names a **key**, never a secret value.
+
+When a target declares one, the portal verifies `X-Hub-Signature-256` over the raw body *before it
+stores anything*:
+
+- it verifies → `200` with `{"status":"accepted","signature":"verified"}`
+- it is absent, malformed, or does not match → **`401`**, and nothing is stored
+- the declared key is empty on this instance → **`500`**, and nothing is stored — that is the
+  instance's own misconfiguration, and saying `401` would blame the caller for it
+
+A target that declares nothing behaves exactly as before, and says so: `"signature":"not-required"`.
+That distinction is deliberate. "Verified" and "not required" are both `200`, and a sender that
+signed its request needs to know which one it got — otherwise the day a configuration value goes
+missing, checking would stop happening again with nothing to see.
+
+## What you may notice
+
+If you operate an instance that receives signed webhooks, declare the key for those targets and a
+drifted secret will announce itself at the source instead of going quiet. Nothing changes for
+targets you leave undeclared.

--- a/src/MeshWeaver.GitSync/FrameworkReleaseBroadcaster.cs
+++ b/src/MeshWeaver.GitSync/FrameworkReleaseBroadcaster.cs
@@ -176,11 +176,11 @@ public sealed class FrameworkReleaseBroadcaster
     /// mesh that receives release events and therefore the one that must have subscribers.
     /// </summary>
     private bool AcceptsPlatformBuildDeliveries() =>
-        configuration?.GetSection(WebhookInbox.TargetsConfigSection).GetChildren()
-            .Any(c => string.Equals(
-                WebhookInbox.NormalizeTarget(c.Value),
+        WebhookInbox.ReadTargets(configuration)
+            .Any(t => string.Equals(
+                t.Path,
                 FrameworkBroadcastOptions.PlatformBuildsTarget,
-                StringComparison.OrdinalIgnoreCase)) == true;
+                StringComparison.OrdinalIgnoreCase));
 
     // One repo's dispatch, already isolated: a non-2xx status OR a thrown exception both become a
     // RepoDispatch(ok:false), so Concat never short-circuits on the first failure. Invoke, not

--- a/src/MeshWeaver.Graph/Configuration/WebhookEventNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/WebhookEventNodeType.cs
@@ -1,8 +1,11 @@
 using System.Collections.Immutable;
 using System.Reactive.Linq;
+using System.Security.Cryptography;
+using System.Text;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace MeshWeaver.Graph.Configuration;
@@ -44,6 +47,17 @@ public record WebhookEvent
 /// deliveries, the target node must exist (a satellite must anchor under a real owner), and the
 /// body is capped. The portal maps the HTTP endpoint; this class holds the (testable) delivery
 /// logic and the node-type registration.
+///
+/// <para>🚨 A target MAY declare the configuration key holding its shared HMAC secret
+/// (<see cref="SecretConfigKeyName"/>); when it does, the endpoint verifies
+/// <see cref="SignatureHeader"/> over the raw body BEFORE storing, and answers 401 when it does
+/// not verify. That is the whole of #3312: a 2xx used to mean "I received bytes", so a
+/// MISMATCHED secret was indistinguishable from a correct one — the sender saw a green POST while
+/// the consumer silently dropped every delivery as unverifiable, and nothing anywhere went red.
+/// The answer now carries the VERDICT, so a publisher can fail because the record was not
+/// ACCEPTED, not merely because it was not sent. A target that declares no key keeps the dumb
+/// behaviour: schemes the endpoint does not speak (Stripe's <c>Stripe-Signature</c>) are still the
+/// consumer's job over the verbatim body + headers stored here.</para>
 /// </summary>
 public static class WebhookInbox
 {
@@ -56,6 +70,26 @@ public static class WebhookInbox
     /// <summary>The configuration section listing the node paths allowed to receive deliveries
     /// (e.g. <c>WebhookInbox:Targets:0 = Store/Payments</c>). Empty/missing = everything refused.</summary>
     public const string TargetsConfigSection = "WebhookInbox:Targets";
+
+    /// <summary>
+    /// The child of a target entry naming the CONFIGURATION KEY that holds that target's shared
+    /// HMAC secret — <c>WebhookInbox:Targets:0:SecretConfigKey = Hosting:PlatformWebhookSecret</c>
+    /// (env: <c>WebhookInbox__Targets__0__SecretConfigKey</c>). It rides on the allowlist entry
+    /// rather than in a parallel section on purpose: the record that makes a target reachable is
+    /// the record that says how it is authenticated, so the two cannot drift apart. A section may
+    /// carry both a value and children, so <c>Targets:0</c> still reads as the plain path for
+    /// every existing consumer of the allowlist.
+    ///
+    /// <para>🚨 It names a KEY, never a secret. A value pasted here verbatim resolves to
+    /// nothing and the target then refuses every delivery with
+    /// <see cref="DeliveryStatus.SecretUnavailable"/> — loudly, in the fail-CLOSED direction —
+    /// instead of landing a live credential in a ConfigMap.</para>
+    /// </summary>
+    public const string SecretConfigKeyName = "SecretConfigKey";
+
+    /// <summary>The GitHub-style signature header verified for targets that declare a secret:
+    /// <c>sha256=&lt;lowercase hex&gt;</c> of HMAC-SHA256 over the raw body.</summary>
+    public const string SignatureHeader = "X-Hub-Signature-256";
 
     /// <summary>Maximum accepted body size (bytes). Webhook events are small; anything bigger is
     /// refused with 413.</summary>
@@ -73,11 +107,86 @@ public static class WebhookInbox
 
         /// <summary>The body exceeds <see cref="MaxBodyBytes"/> → 413.</summary>
         TooLarge,
+
+        /// <summary>The target declares a secret and <see cref="SignatureHeader"/> is absent or
+        /// does not verify over the raw body → 401. This is the state #3312 made visible: it used
+        /// to be stored and answered 2xx, then dropped unverifiable by the consumer.</summary>
+        SignatureInvalid,
+
+        /// <summary>The target declares a secret config key that resolves to nothing → 500. A
+        /// MISCONFIGURATION of this instance, not of the caller, and deliberately not 401: it must
+        /// not read as "your secret is wrong". Fail-closed — nothing is stored.</summary>
+        SecretUnavailable,
     }
 
-    /// <summary>The result of <see cref="Deliver"/>: the status and, when accepted, the stored
-    /// node's path.</summary>
-    public record DeliveryResult(DeliveryStatus Status, string? NodePath = null);
+    /// <summary>
+    /// The result of <see cref="Deliver"/>: the status, the stored node's path when accepted, and
+    /// whether the delivery was ACCEPTED HAVING VERIFIED a signature.
+    ///
+    /// <para>🚨 <paramref name="SignatureVerified"/> is the half of #3312 the status code cannot
+    /// carry. "Accepted, verified" and "accepted, nothing was required" are both 2xx and mean very
+    /// different things to a sender that signed: the second says this instance declares no
+    /// <see cref="SecretConfigKeyName"/> for the target, so its signature was never checked. A
+    /// publisher reads THIS, not the status, to know whether its secret was actually exercised —
+    /// otherwise "we verify now" degrades silently to "we used to verify" the day a chart value
+    /// goes missing.</para>
+    /// </summary>
+    public record DeliveryResult(
+        DeliveryStatus Status, string? NodePath = null, bool SignatureVerified = false);
+
+    /// <summary>
+    /// One allowlisted target: the node path deliveries may be stored under and, when the
+    /// integration signs its deliveries with a GitHub-style HMAC, the configuration key holding
+    /// the shared secret (<see cref="SecretConfigKeyName"/>). A bare path IS a target — the
+    /// implicit conversion keeps "allowlisted, unsigned" the plain, unceremonious case.
+    /// </summary>
+    public sealed record WebhookTarget(string Path, string? SecretConfigKey = null)
+    {
+        /// <summary>A bare path is an allowlisted target that declares no signature.</summary>
+        public static implicit operator WebhookTarget(string path) => new(path);
+    }
+
+    /// <summary>
+    /// The allowlist as configured: one <see cref="WebhookTarget"/> per <c>Targets:N</c> entry,
+    /// carrying its <see cref="SecretConfigKeyName"/> child when it declares one. Entries whose
+    /// value is not a plain node path are dropped (fail-closed). Pure over the configuration.
+    /// </summary>
+    public static ImmutableArray<WebhookTarget> ReadTargets(IConfiguration? configuration)
+    {
+        if (configuration is null)
+            return [];
+        var targets = ImmutableArray.CreateBuilder<WebhookTarget>();
+        foreach (var entry in configuration.GetSection(TargetsConfigSection).GetChildren())
+        {
+            var path = NormalizeTarget(entry.Value);
+            if (path is null)
+                continue;
+            var secretConfigKey = entry[SecretConfigKeyName];
+            targets.Add(new WebhookTarget(
+                path,
+                string.IsNullOrWhiteSpace(secretConfigKey) ? null : secretConfigKey.Trim()));
+        }
+        return targets.ToImmutable();
+    }
+
+    /// <summary>
+    /// GitHub-style HMAC verification: <c>sha256=&lt;hex&gt;</c> over the RAW body, compared in
+    /// constant time. False for an absent, malformed or mismatched signature — every refusal shape
+    /// is one verdict, because distinguishing them for the caller is what leaks the secret's shape.
+    /// Pure.
+    /// </summary>
+    public static bool VerifyHmacSha256(string? signatureHeader, string body, string secret)
+    {
+        if (string.IsNullOrWhiteSpace(signatureHeader)
+            || !signatureHeader.StartsWith("sha256=", StringComparison.OrdinalIgnoreCase))
+            return false;
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(secret));
+        var expected = Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes(body)));
+        var provided = signatureHeader["sha256=".Length..];
+        return CryptographicOperations.FixedTimeEquals(
+            Encoding.ASCII.GetBytes(expected.ToLowerInvariant()),
+            Encoding.ASCII.GetBytes(provided.ToLowerInvariant()));
+    }
 
     /// <summary>Registers the WebhookEvent node type on the mesh builder.</summary>
     public static TBuilder AddWebhookInbox<TBuilder>(this TBuilder builder) where TBuilder : MeshBuilder
@@ -121,32 +230,35 @@ public static class WebhookInbox
     /// <summary>
     /// Delivers one webhook to <paramref name="target"/>: the target must be in
     /// <paramref name="allowedTargets"/> AND its node must exist (fail-closed — a satellite must
-    /// anchor under a real owner; an ownerless satellite NotFound-storms the router). The event is
-    /// stored under the System identity (the anonymous caller has no write access anywhere — the
-    /// allowlist is the authorization). Cold; never throws for a refused delivery — refusal is
-    /// data.
+    /// anchor under a real owner; an ownerless satellite NotFound-storms the router), and when the
+    /// matched target declares a <see cref="SecretConfigKeyName"/> its
+    /// <see cref="SignatureHeader"/> must verify over the raw body. The event is stored under the
+    /// System identity (the anonymous caller has no write access anywhere — the allowlist is the
+    /// authorization). Cold; never throws for a refused delivery — refusal is data.
+    ///
+    /// <para>🚨 The ORDER of the refusals is contract. Target first, so an unlisted path answers
+    /// 404 without revealing whether it is signed; SIZE next, so an oversized body is refused
+    /// before it is hashed; signature last, and always BEFORE the node is created — a delivery
+    /// that fails to verify must leave nothing behind, or the endpoint has merely moved the silent
+    /// drop from the consumer into the store (#3312).</para>
     /// </summary>
     public static IObservable<DeliveryResult> Deliver(
         IMessageHub hub,
-        IReadOnlyCollection<string> allowedTargets,
+        IReadOnlyCollection<WebhookTarget> allowedTargets,
         string? target,
         string? contentType,
         IEnumerable<KeyValuePair<string, string>> headers,
         string body)
     {
         var normalized = NormalizeTarget(target);
-        if (normalized is null
-            || !allowedTargets.Any(t => string.Equals(
-                NormalizeTarget(t), normalized, StringComparison.Ordinal)))
+        if (normalized is null)
             return Observable.Return(new DeliveryResult(DeliveryStatus.UnknownTarget));
-        if (System.Text.Encoding.UTF8.GetByteCount(body) > MaxBodyBytes)
+        var matched = allowedTargets.FirstOrDefault(t => string.Equals(
+            NormalizeTarget(t.Path), normalized, StringComparison.Ordinal));
+        if (matched is null)
+            return Observable.Return(new DeliveryResult(DeliveryStatus.UnknownTarget));
+        if (Encoding.UTF8.GetByteCount(body) > MaxBodyBytes)
             return Observable.Return(new DeliveryResult(DeliveryStatus.TooLarge));
-
-        var mesh = hub.ServiceProvider.GetService<IMeshService>();
-        if (mesh is null)
-            return Observable.Throw<DeliveryResult>(
-                new InvalidOperationException("The mesh service is not available."));
-        var accessService = hub.ServiceProvider.GetService<AccessService>();
 
         var kept = headers
             .Where(h => !DropHeader(h.Key))
@@ -155,6 +267,26 @@ public static class WebhookInbox
                 g => g.Key,
                 g => string.Join(", ", g.Select(h => h.Value)),
                 StringComparer.OrdinalIgnoreCase);
+
+        var signatureVerified = false;
+        if (matched.SecretConfigKey is { Length: > 0 } secretConfigKey)
+        {
+            // Resolved per delivery, not captured once: the secret is rotatable configuration, and
+            // a value read at startup would keep verifying against the retired one.
+            var secret = hub.ServiceProvider.GetService<IConfiguration>()?[secretConfigKey];
+            if (string.IsNullOrWhiteSpace(secret))
+                return Observable.Return(new DeliveryResult(DeliveryStatus.SecretUnavailable));
+            kept.TryGetValue(SignatureHeader, out var provided);
+            if (!VerifyHmacSha256(provided, body, secret))
+                return Observable.Return(new DeliveryResult(DeliveryStatus.SignatureInvalid));
+            signatureVerified = true;
+        }
+
+        var mesh = hub.ServiceProvider.GetService<IMeshService>();
+        if (mesh is null)
+            return Observable.Throw<DeliveryResult>(
+                new InvalidOperationException("The mesh service is not available."));
+        var accessService = hub.ServiceProvider.GetService<AccessService>();
 
         return Observable.Using(
                 () => accessService?.ImpersonateAsSystem() ?? System.Reactive.Disposables.Disposable.Empty,
@@ -180,7 +312,8 @@ public static class WebhookInbox
                             },
                         };
                         return mesh.CreateNode(node).Take(1)
-                            .Select(_ => new DeliveryResult(DeliveryStatus.Accepted, node.Path));
+                            .Select(_ => new DeliveryResult(
+                                DeliveryStatus.Accepted, node.Path, signatureVerified));
                     }));
     }
 }

--- a/src/MeshWeaver.Graph/Configuration/WebhookEventNodeType.cs
+++ b/src/MeshWeaver.Graph/Configuration/WebhookEventNodeType.cs
@@ -123,7 +123,7 @@ public static class WebhookInbox
     /// The result of <see cref="Deliver"/>: the status, the stored node's path when accepted, and
     /// whether the delivery was ACCEPTED HAVING VERIFIED a signature.
     ///
-    /// <para>🚨 <paramref name="SignatureVerified"/> is the half of #3312 the status code cannot
+    /// <para>🚨 <see cref="SignatureVerified"/> is the half of #3312 the status code cannot
     /// carry. "Accepted, verified" and "accepted, nothing was required" are both 2xx and mean very
     /// different things to a sender that signed: the second says this instance declares no
     /// <see cref="SecretConfigKeyName"/> for the target, so its signature was never checked. A
@@ -131,8 +131,15 @@ public static class WebhookInbox
     /// otherwise "we verify now" degrades silently to "we used to verify" the day a chart value
     /// goes missing.</para>
     /// </summary>
-    public record DeliveryResult(
-        DeliveryStatus Status, string? NodePath = null, bool SignatureVerified = false);
+    public record DeliveryResult(DeliveryStatus Status, string? NodePath = null)
+    {
+        /// <summary>Whether this delivery was accepted HAVING VERIFIED its signature. An
+        /// init-only PROPERTY, not a third positional parameter: adding one to a record's primary
+        /// constructor replaces the signature, and every assembly compiled against the old arity
+        /// — every module compiled against the platform image — calls a constructor that no longer
+        /// exists. `Public surface (binary compatibility)` refuses that, correctly.</summary>
+        public bool SignatureVerified { get; init; }
+    }
 
     /// <summary>
     /// One allowlisted target: the node path deliveries may be stored under and, when the
@@ -312,8 +319,10 @@ public static class WebhookInbox
                             },
                         };
                         return mesh.CreateNode(node).Take(1)
-                            .Select(_ => new DeliveryResult(
-                                DeliveryStatus.Accepted, node.Path, signatureVerified));
+                            .Select(_ => new DeliveryResult(DeliveryStatus.Accepted, node.Path)
+                            {
+                                SignatureVerified = signatureVerified,
+                            });
                     }));
     }
 }

--- a/test/MeshWeaver.Documentation.Test/ReleaseDeliveryChainGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/ReleaseDeliveryChainGuard.cs
@@ -67,7 +67,10 @@ public class ReleaseDeliveryChainGuard
     /// chart, re-creating the identical silent misconfiguration one index over.
     /// </param>
     /// <param name="Consequence">What is silently lost when no deployment can set the key.</param>
-    private sealed record ChainKey(string Joint, string EnvKeyPrefix, int Slots, string Consequence);
+    /// <param name="EnvKeySuffix">Appended after the slot index, for keys that are a CHILD of a
+    /// slot rather than the slot itself (<c>…__0__SecretConfigKey</c>).</param>
+    private sealed record ChainKey(
+        string Joint, string EnvKeyPrefix, int Slots, string Consequence, string EnvKeySuffix = "");
 
     /// <summary>
     /// The chain's keys, each derived from the CONSTANT its reader owns — never a literal. A
@@ -86,6 +89,27 @@ public class ReleaseDeliveryChainGuard
             EnvForm(WebhookInbox.TargetsConfigSection) + "__", 2,
             "CD's notify-platform-update 404s on every promoted build and no release event ever "
             + "reaches the mesh");
+
+        // Joint 1b — the inbox actually CHECKS the signature on that target (#3312). Without this
+        // key the endpoint keeps the dumb contract: it stores the delivery and answers 2xx
+        // whatever the HMAC says, so a secret that has drifted between CD and the instance is
+        // byte-identical to one that matches — the exact state this ledger exists to make
+        // impossible. Both slots, for the same reason as above: the slot carrying
+        // Hosting/PlatformBuilds is not the same index on every deployment, and a declaration
+        // rendered for only __0 would leave the control instance's real slot undeclarable.
+        //
+        // 🚨 This asserts the key is RENDERABLE, not that any deployment sets it — and it must not
+        // be strengthened into "…is non-empty in values". An empty declaration is CORRECT for a
+        // slot holding a Stripe target: Stripe signs `Stripe-Signature`, and requiring this
+        // scheme there would 401 every payment delivery. What catches a MISSING declaration on the
+        // slot that needs one is the publishing lane reading the inbox's answer
+        // (`signature: not-required` → ::warning::), not this file.
+        yield return new ChainKey(
+            "the webhook inbox VERIFIES the release event's signature",
+            EnvForm(WebhookInbox.TargetsConfigSection) + "__", 2,
+            "the inbox accepts every delivery to that target unverified, so a drifted "
+            + "PLATFORM_WEBHOOK_SECRET answers 2xx and is dropped in silence downstream",
+            EnvKeySuffix: "__" + WebhookInbox.SecretConfigKeyName);
 
         // Joint 2 — the verified release fans out — is NOT a configuration key any more. Since
         // 2026-09-03 the subscriber set is data in the mesh (the Hosting/Deployment records'
@@ -112,7 +136,8 @@ public class ReleaseDeliveryChainGuard
         var values = File.ReadAllText(Path.Combine(root, ValuesAks.Replace('/', Path.DirectorySeparatorChar)));
 
         var broken = ChainKeys()
-            .SelectMany(k => Enumerable.Range(0, k.Slots).Select(i => (k, EnvKey: k.EnvKeyPrefix + i)))
+            .SelectMany(k => Enumerable.Range(0, k.Slots)
+                .Select(i => (k, EnvKey: k.EnvKeyPrefix + i + k.EnvKeySuffix)))
             .Select(x => (x.k, x.EnvKey,
                 inConfigMap: RendersKey(configMap, x.EnvKey), inValues: DeclaresKey(values, x.EnvKey)))
             .Where(x => !x.inConfigMap || !x.inValues)

--- a/test/MeshWeaver.Graph.Test/WebhookInboxTest.cs
+++ b/test/MeshWeaver.Graph.Test/WebhookInboxTest.cs
@@ -65,7 +65,7 @@ public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(o
         WebhookInbox.WebhookTarget allowed, string target,
         IEnumerable<KeyValuePair<string, string>> headers, string body) =>
         WebhookInbox.Deliver(Mesh, [allowed], target, "application/json", headers, body)
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await();
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
 
     private async Task<int> InboxCount(string target) =>
         (await Observable.Using(
@@ -73,7 +73,7 @@ public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(o
                 _ => MeshService.Query<MeshNode>(MeshQueryRequest.FromQuery(
                         $"path:{target}/{WebhookInbox.InboxContainer} scope:children"))
                     .Take(1))
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await())
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await())
         .Items.Count(n => n.NodeType == WebhookInbox.NodeType);
 
     private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
@@ -116,7 +116,7 @@ public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(o
         var result = await WebhookInbox.Deliver(
                 Mesh, ["Payments"], "Payments", "application/json", StripeHeaders,
                 """{"type":"checkout.session.completed"}""")
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await();
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
 
         result.Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
         result.NodePath.Should().StartWith($"Payments/{WebhookInbox.InboxContainer}/");
@@ -141,22 +141,22 @@ public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(o
 
         // Exists but not allowlisted → refused.
         (await WebhookInbox.Deliver(Mesh, [], "Existing", null, [], "{}")
-                .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await())
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await())
             .Status.Should().Be(WebhookInbox.DeliveryStatus.UnknownTarget);
 
         // Allowlisted but no node at the path → refused (the satellite would be ownerless).
         (await WebhookInbox.Deliver(Mesh, ["Ghost"], "Ghost", null, [], "{}")
-                .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await())
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await())
             .Status.Should().Be(WebhookInbox.DeliveryStatus.UnknownTarget);
 
         // Path-shape games never resolve to an allowlisted target.
         (await WebhookInbox.Deliver(Mesh, ["Existing"], "Existing/../Other", null, [], "{}")
-                .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await())
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await())
             .Status.Should().Be(WebhookInbox.DeliveryStatus.UnknownTarget);
 
         // Slash normalization DOES resolve ("/Existing/" ≡ "Existing").
         (await WebhookInbox.Deliver(Mesh, ["Existing"], "/Existing/", null, [], "{}")
-                .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await())
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await())
             .Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
     }
 
@@ -166,7 +166,7 @@ public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(o
         await CreateTarget("Sized");
         var huge = new string('x', WebhookInbox.MaxBodyBytes + 1);
         (await WebhookInbox.Deliver(Mesh, ["Sized"], "Sized", null, [], huge)
-                .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await())
+                .FirstAsync().Timeout(TestTimeouts.Convergence).Await())
             .Status.Should().Be(WebhookInbox.DeliveryStatus.TooLarge);
     }
 
@@ -175,9 +175,9 @@ public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(o
     {
         await CreateTarget("Multi");
         var first = await WebhookInbox.Deliver(Mesh, ["Multi"], "Multi", null, [], "{\"n\":1}")
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await();
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
         var second = await WebhookInbox.Deliver(Mesh, ["Multi"], "Multi", null, [], "{\"n\":2}")
-            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await();
+            .FirstAsync().Timeout(TestTimeouts.Convergence).Await();
         first.Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
         second.Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
         second.NodePath.Should().NotBe(first.NodePath);

--- a/test/MeshWeaver.Graph.Test/WebhookInboxTest.cs
+++ b/test/MeshWeaver.Graph.Test/WebhookInboxTest.cs
@@ -11,6 +11,7 @@ using MeshWeaver.Markdown;
 using MeshWeaver.Mesh;
 using MeshWeaver.Mesh.Services;
 using MeshWeaver.Messaging;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Xunit;
 using MeshWeaver.Fixture;
@@ -23,11 +24,57 @@ namespace MeshWeaver.Graph.Test;
 /// ownerless satellite NotFound-storms the router), size-capped, credential headers stripped while
 /// signature headers survive verbatim, and the accepted delivery lands as a
 /// <see cref="WebhookEvent"/> node at <c>{target}/_Inbox/{id}</c>.
+///
+/// <para>🚨 And #3312: a target that declares <see cref="WebhookInbox.SecretConfigKeyName"/>
+/// has its HMAC verified HERE, so the ANSWER carries the verdict. The pair that matters is
+/// <see cref="SignedTarget_WithTheRightSecret_IsAccepted"/> versus
+/// <see cref="SignedTarget_WithADriftedSecret_IsRefused_AndStoresNothing"/>: both were
+/// <c>Accepted</c> before the fix, which is exactly what made a mismatched secret invisible. If a
+/// change makes them agree again, the hole is back.</para>
 /// </summary>
 public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(output)
 {
+    /// <summary>The secret the instance holds, under the key a signed target names.</summary>
+    private const string SecretKey = "Test:PlatformWebhookSecret";
+    private const string InstanceSecret = "s3cr3t-on-the-instance";
+
+    /// <summary>A key the instance declares but never provisions — the fail-closed shape.</summary>
+    private const string UnprovisionedKey = "Test:NeverProvisioned";
+
     protected override MeshBuilder ConfigureMesh(MeshBuilder builder)
-        => base.ConfigureMesh(builder).AddWebhookInbox();
+        => base.ConfigureMesh(builder)
+            .AddWebhookInbox()
+            .ConfigureServices(services => services.AddSingleton<IConfiguration>(
+                new ConfigurationBuilder().AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    [SecretKey] = InstanceSecret,
+                    [UnprovisionedKey] = "",
+                }).Build()));
+
+    /// <summary>The GitHub-style header a sender computes with <paramref name="secret"/>.</summary>
+    private static KeyValuePair<string, string> Sign(string body, string secret)
+    {
+        using var hmac = new System.Security.Cryptography.HMACSHA256(
+            System.Text.Encoding.UTF8.GetBytes(secret));
+        var hex = Convert.ToHexString(hmac.ComputeHash(System.Text.Encoding.UTF8.GetBytes(body)))
+            .ToLowerInvariant();
+        return new(WebhookInbox.SignatureHeader, $"sha256={hex}");
+    }
+
+    private Task<WebhookInbox.DeliveryResult> Post(
+        WebhookInbox.WebhookTarget allowed, string target,
+        IEnumerable<KeyValuePair<string, string>> headers, string body) =>
+        WebhookInbox.Deliver(Mesh, [allowed], target, "application/json", headers, body)
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await();
+
+    private async Task<int> InboxCount(string target) =>
+        (await Observable.Using(
+                () => Access.ImpersonateAsSystem(),
+                _ => MeshService.Query<MeshNode>(MeshQueryRequest.FromQuery(
+                        $"path:{target}/{WebhookInbox.InboxContainer} scope:children"))
+                    .Take(1))
+            .FirstAsync().Timeout(TimeSpan.FromSeconds(30)).Await())
+        .Items.Count(n => n.NodeType == WebhookInbox.NodeType);
 
     private IMeshService MeshService => Mesh.ServiceProvider.GetRequiredService<IMeshService>();
     private AccessService Access => Mesh.ServiceProvider.GetRequiredService<AccessService>();
@@ -134,5 +181,138 @@ public class WebhookInboxTest(ITestOutputHelper output) : MonolithMeshTestBase(o
         first.Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
         second.Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
         second.NodePath.Should().NotBe(first.NodePath);
+    }
+
+    // ───────────────────────── #3312: the answer carries the verdict ─────────────────────────
+
+    /// <summary>The build fact CD signs and posts.</summary>
+    private const string BuildFact = "{\"event\":\"platform-build\",\"digest\":\"sha256:abc\"}";
+
+    [Fact(Timeout = 120000)]
+    public async Task SignedTarget_WithTheRightSecret_IsAccepted()
+    {
+        await CreateTarget("Signed");
+
+        var result = await Post(
+            new WebhookInbox.WebhookTarget("Signed", SecretKey), "Signed",
+            [Sign(BuildFact, InstanceSecret)], BuildFact);
+
+        result.Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
+        (await InboxCount("Signed")).Should().Be(1);
+    }
+
+    /// <summary>
+    /// 🚨 THE DEFECT, as a test. Same target, same body, a secret that drifted by one
+    /// character: before #3312 this returned <c>Accepted</c> — byte-identical to the test above —
+    /// and the delivery was stored, answered 2xx, then silently dropped by the consumer as
+    /// unverifiable, with nothing anywhere red. The two assertions are the whole fix: a distinct
+    /// verdict, and NOTHING left behind.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task SignedTarget_WithADriftedSecret_IsRefused_AndStoresNothing()
+    {
+        await CreateTarget("Drifted");
+
+        var result = await Post(
+            new WebhookInbox.WebhookTarget("Drifted", SecretKey), "Drifted",
+            [Sign(BuildFact, InstanceSecret + "x")], BuildFact);
+
+        result.Status.Should().Be(WebhookInbox.DeliveryStatus.SignatureInvalid);
+        result.NodePath.Should().BeNull();
+        (await InboxCount("Drifted")).Should().Be(0,
+            "a delivery that fails to verify must leave nothing behind — otherwise the endpoint "
+            + "has only moved the silent drop from the consumer into the store");
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task SignedTarget_RefusesAnAbsentOrMalformedOrRebodiedSignature()
+    {
+        await CreateTarget("Malformed");
+        var target = new WebhookInbox.WebhookTarget("Malformed", SecretKey);
+
+        // No signature header at all — the shape an unaware sender produces.
+        (await Post(target, "Malformed", [], BuildFact))
+            .Status.Should().Be(WebhookInbox.DeliveryStatus.SignatureInvalid);
+
+        // Present, but not the scheme this endpoint verifies.
+        (await Post(target, "Malformed",
+                [new(WebhookInbox.SignatureHeader, "t=1,v1=abc")], BuildFact))
+            .Status.Should().Be(WebhookInbox.DeliveryStatus.SignatureInvalid);
+
+        // Correctly signed with the right secret — over a DIFFERENT body than the one delivered.
+        (await Post(target, "Malformed", [Sign("{}", InstanceSecret)], BuildFact))
+            .Status.Should().Be(WebhookInbox.DeliveryStatus.SignatureInvalid);
+
+        (await InboxCount("Malformed")).Should().Be(0);
+    }
+
+    /// <summary>
+    /// A declared key that resolves to nothing refuses EVERYTHING — including a delivery signed
+    /// with the empty string, which is what "verify against whatever is there" would have let
+    /// through. A key present with an empty value is the config shape no guard can see, so it must
+    /// fail in the loud direction rather than degrade to accepting.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task DeclaredButUnprovisionedSecret_RefusesEverything_FailClosed()
+    {
+        await CreateTarget("NoSecret");
+        var target = new WebhookInbox.WebhookTarget("NoSecret", UnprovisionedKey);
+
+        (await Post(target, "NoSecret", [Sign(BuildFact, "")], BuildFact))
+            .Status.Should().Be(WebhookInbox.DeliveryStatus.SecretUnavailable);
+        (await Post(target, "NoSecret", [Sign(BuildFact, InstanceSecret)], BuildFact))
+            .Status.Should().Be(WebhookInbox.DeliveryStatus.SecretUnavailable);
+
+        (await InboxCount("NoSecret")).Should().Be(0);
+    }
+
+    /// <summary>
+    /// The dumb contract survives: a target that declares NO key stores whatever arrives, garbage
+    /// signature and all, because schemes this endpoint does not speak (Stripe) stay the
+    /// consumer's job. Without this, adding verification would have broken every unsigned
+    /// integration on the mesh.
+    /// </summary>
+    [Fact(Timeout = 120000)]
+    public async Task TargetWithoutADeclaredSecret_KeepsTheDumbContract()
+    {
+        await CreateTarget("Dumb");
+
+        var result = await Post(new WebhookInbox.WebhookTarget("Dumb"), "Dumb",
+            [new(WebhookInbox.SignatureHeader, "sha256=deadbeef")], "{}");
+
+        result.Status.Should().Be(WebhookInbox.DeliveryStatus.Accepted);
+        (await InboxCount("Dumb")).Should().Be(1);
+    }
+
+    /// <summary>
+    /// The declaration rides ON the allowlist entry, so <c>Targets:N</c> still reads as a plain
+    /// path for every consumer that projects <c>c.Value</c> — core's own broadcaster and, out of
+    /// this compiler's sight entirely, the in-mesh <c>PaymentPathAudit</c> in MeshWeaver.Plugins.
+    /// A parallel section would have been a second copy of the same graph, free to drift; this
+    /// asserts it is not one.
+    /// </summary>
+    [Fact]
+    public void ReadTargets_ParsesTheDeclaration_WithoutDisturbingThePlainPathReading()
+    {
+        var configuration = new ConfigurationBuilder().AddInMemoryCollection(
+            new Dictionary<string, string?>
+            {
+                [$"{WebhookInbox.TargetsConfigSection}:0"] = "Hosting/PlatformBuilds",
+                [$"{WebhookInbox.TargetsConfigSection}:0:{WebhookInbox.SecretConfigKeyName}"] =
+                    "Hosting:PlatformWebhookSecret",
+                [$"{WebhookInbox.TargetsConfigSection}:1"] = "Store/Payments",
+                [$"{WebhookInbox.TargetsConfigSection}:2"] = "",
+            }).Build();
+
+        var targets = WebhookInbox.ReadTargets(configuration);
+
+        targets.Select(t => t.Path).Should().Equal("Hosting/PlatformBuilds", "Store/Payments");
+        targets[0].SecretConfigKey.Should().Be("Hosting:PlatformWebhookSecret");
+        targets[1].SecretConfigKey.Should().BeNull("an unsigned target declares nothing");
+
+        // The legacy projection every other reader still uses sees exactly what it saw before.
+        configuration.GetSection(WebhookInbox.TargetsConfigSection).GetChildren()
+            .Select(c => c.Value).Where(v => !string.IsNullOrWhiteSpace(v))
+            .Should().Equal("Hosting/PlatformBuilds", "Store/Payments");
     }
 }


### PR DESCRIPTION
## The defect

`POST /api/hooks/{target}` answered **2xx for "I stored bytes"**, and CD read it as acceptance.
That is the same answer when the shared secret matches and **also** when it has drifted: the
delivery is stored, the publishing run goes green, and the consuming watcher then discards every
event as unverifiable. Nothing is red anywhere, so it can persist indefinitely while every
dependent falls back to its schedule poll. The **empty**-secret case was caught (#3311) precisely
because it fails *closed*; the mismatch failed *open*.

#3312's stated property: **a run that publishes must be able to fail because the record was not
ACCEPTED, not merely because it was not sent.**

## The fix

A target may name the configuration key holding its shared secret:

```yaml
WebhookInbox__Targets__0:                   "Hosting/PlatformBuilds"
WebhookInbox__Targets__0__SecretConfigKey:  "Hosting:PlatformWebhookSecret"
```

- **It rides ON the allowlist entry** — a configuration section carries both a value and children —
  so the record that makes a target reachable is the record that says how it is authenticated.
  No parallel list to drift, and every existing `c.Value` reader still sees a plain path, including
  the in-mesh `PaymentPathAudit` in MeshWeaver.Plugins that `dotnet build` cannot see.
- **It names a KEY, never a secret.** A value pasted in resolves to no key and refuses everything —
  loudly, fail-closed — instead of landing a live credential in a ConfigMap.

When declared, the endpoint verifies `X-Hub-Signature-256` over the raw body **before storing**:

| outcome | status | stored? |
|---|---|---|
| verifies | 200 `{"status":"accepted","signature":"verified"}` | yes |
| absent / malformed / mismatched | **401** | **no** |
| declared key empty on this instance | **500** (ours, not the caller's) | **no** |
| no declaration | 200 `…"signature":"not-required"` | yes — the dumb contract, unchanged |

Refusal order is contract: target → size → signature, always before the node is created. A
delivery that fails to verify must leave nothing behind, or the fix has only moved the silent drop
from the consumer into the store.

### Why the body carries the verdict too

`verified` and `not-required` are both 200 and mean very different things to a sender that signed.
Without the distinction, "we verify now" degrades silently to "we used to verify" the day a chart
value goes missing — the bug's own shape, one level up. Both lanes read it and `::warning::` on
`not-required`.

**That warning is deliberate, and so is its own step.** The POST step is held to *every message
ends the job* (`PlatformReleaseNotifyGuard` forbids `::warning` in it), because a release event
that never arrived must never be decorated. This is the opposite case — the event *did* arrive —
so it gets a separate step rather than softening that guard. It is a warning and not a failure
only while the declaration rolls out: it reaches an instance through its `Hosting/Deployment`
record + `helm upgrade`, never through self-update (a `set image`), so failing here would red every
publish until that lands.

## Verification

- `MeshWeaver.Graph`, `MeshWeaver.GitSync`, `Memex.Portal.Shared`, `MeshWeaver.Graph.Test` — all
  `0 Error(s)`, Release, `-warnaserror`.
- `WebhookInboxTest` 10/10; workflow + chain guards 13/13; doc-link + What's New 2/2.
- **Mutation-proved**, as the issue asked. Removing the verification block turns exactly three
  tests red — `SignedTarget_WithADriftedSecret_IsRefused_AndStoresNothing`,
  `SignedTarget_RefusesAnAbsentOrMalformedOrRebodiedSignature`,
  `DeclaredButUnprovisionedSecret_RefusesEverything_FailClosed` — and leaves the accept and
  dumb-contract tests green. The pair `…WithTheRightSecret_IsAccepted` vs
  `…WithADriftedSecret_IsRefused…` **both returned `Accepted` before this change**; that identity
  IS the defect, and if a future change makes them agree again the hole is back.

## Controls added

- `ReleaseDeliveryChainGuard` now covers the declaration for **both** slots — index 0 is not the
  same slot on every deployment (#2352). It asserts the key is *renderable*, never that it is set:
  an empty declaration is CORRECT for a slot holding a Stripe target, which signs
  `Stripe-Signature` and would 401 against this scheme on every payment. What catches a missing
  declaration on the slot that needs one is the lane reading the inbox's answer.

## Still open after this

The control instance must declare the key before it actually verifies. That is a
`Hosting/Deployment` record change plus a roll; until then both lanes say `signature:
not-required` on every publish, by design. **Escalating that warning to an error is the last step
of #3312** and is one line in each lane.

## Docs

`Doc/Architecture/WebhookInbox` rewritten (the section that documented this as *open* now
documents the fix, and keeps the two rejected alternatives so they are not re-derived), plus a
What's New entry.

Closes #3312
