### PR TITLE
Arm the registry's own 400: a bundle stating no framework identity is refused (#3240)

### DIFF
--- a/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
+++ b/memex/Memex.Portal.Shared/Api/PluginBundleEndpoints.cs
@@ -464,23 +464,19 @@ public static class PluginBundleEndpoints
                     return Results.Json(new { error = decline }, statusCode: StatusCodes.Status400BadRequest);
                 }
 
-                // 🚨 #3211 — the arming signal for the LAST refusal, named per publisher.
-                // A bundle stating no framework identity shelves a null, the index advertises a
-                // null, and ModuleUpdateDecision (#3154) then answers "already landed — the
-                // identity could not be checked" for this module on every reconcile of every
-                // installation, forever: an unknown on the SERVED side is the one landing cannot
-                // heal. The producer's own lane already refuses to pack or POST such a bundle, so
-                // reaching here means a publisher on a pin older than #3211. This line is what says
-                // WHICH — the measurement the registry-side 400 waits on, rather than a refusal
-                // armed on faith that would take the fleet's publishes down with it.
-                if (string.IsNullOrWhiteSpace(accepted.FrameworkMvid))
-                    logger?.LogWarning(
-                        "Module publish for {Plugin}: '{Module}' version {Version} states NO "
-                        + "framework identity, so it shelves a null and every consumer of it will "
-                        + "answer 'up to date — identity could not be checked' on every reconcile "
-                        + "(#3154). Its producer packs on a lane older than MeshWeaver#3211; bump "
-                        + "that repo's node-repo-module-pack.yml pin. This becomes a 400.",
-                        plugin, accepted.Module, accepted.Version ?? "(unversioned)");
+                // 🚨 #3211's last refusal is ARMED (#3240), and it lives in ModulePublish.Validate
+                // above — so an unstated framework identity has already left through the 400 path a
+                // few lines up, named, and `accepted.FrameworkMvid` is non-blank from here on.
+                //
+                // A WARNING used to stand here instead. It was the runway, not the fix: it named
+                // WHICH publisher was still emitting nulls so the refusal could be armed on
+                // evidence rather than on faith (arming it while producers still packed
+                // "built-against MVID (unrecorded)" would have taken the fleet's publishes down
+                // instead of the nulls). Both halves of #3240's criterion were measured on
+                // 2026-09-05 — every producer's pin past #3237, and a full publish wave from each
+                // stating an identity — so the runway is spent and the warning is gone with it.
+                // Do NOT reintroduce a warning here: a null that is merely logged is a null that
+                // gets shelved, and this is the one place that can still refuse it.
 
                 ModuleLandingOutcome outcome;
                 try

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -205,12 +205,26 @@ moved `1` → `2` in `module-build-key.py` for the same reason — the lane now 
 for the same source, so every recorded key is invalidated and no run reuses a bundle whose publish
 would be refused.
 
-**Still to arm: the registry's own 400.** `ModulePublish.Validate` accepts a manifest stating no
-identity, and `ShelveModule` shelves the null the index then advertises. Arming that refusal before
-every producer's `node-repo-module-pack.yml` pin has moved would take the fleet's publishes down
-rather than the nulls — the pin is bumped deliberately, per repo, in its own PR. Until then the
-publish endpoint logs a warning naming the package, the module and the version, which is the
-measurement the arming step reads. The criterion and the two repos it waits on are #3240.
+**Armed 2026-09-05: the registry's own 400 (#3240).** `ModulePublish.Validate` now refuses a
+manifest stating no identity, by name, through the publish route's existing 400 — so the registry no
+longer depends on its producers being correct, which is the only version of this check that is worth
+having. A registry that trusts its publishers is not a registry.
+
+It was deliberately NOT armed when the producer-side refusals landed (#3237), and the reason is the
+reusable part: arming a refusal before every producer can satisfy it takes the fleet's publishes
+down instead of the nulls. On 2026-09-03 every one of MeshWeaver.Plugins' 34 bundles still packed
+`built-against MVID (unrecorded)` (run 33773265959). The runway was a WARNING at the publish
+endpoint naming the package, module and version — a measurement, not a fix — and the arming
+criterion was that it fall silent. Both halves, measured on 2026-09-05:
+
+| half | measurement |
+|---|---|
+| every publishing repo pins `node-repo-module-pack.yml` past #3237 (`da2bb12d3`, 09-03 17:49Z) | MeshWeaver.Plugins `c41a34fda` (09-04 05:57Z), MeshWeaver.SocialMedia `fec69fc66` (09-03 21:27Z). Education and Reinsurance do not call the lane. |
+| a full publish wave from each, stating an identity | Plugins run 33941672487 (09-05 03:31Z) `built against: g7d644de95…`; SocialMedia run 33941835795 (09-05 03:27Z) `built against: cef92e9759…`. Both `publish: true`, both jobs green, so the producer-side refusal never fired. |
+
+🚨 The refusal is shape-**agnostic** on purpose: an image-pinned lane states `g<sha>`, a from-source
+lane a 32-hex MVID, and `FrameworkIdentity` documents a third (`s<hash>`). Only ABSENCE is refused.
+Narrowing it to one shape would red a lane that is stating its identity perfectly well.
 
 ## Content-addressed outputs = the module build ledger (as built, 2026-09-02)
 
@@ -760,9 +774,10 @@ producer of the same publication and is removed — a follow-up, not part of thi
   `ModuleUpdateDecision` compares the served bundle's framework identity, not the version alone.
   The producer half landed with #3211 — a bundle that cannot state what it was built against is
   refused at the packer, at the pack step and at the hand-over (see *A bundle states what it was
-  built against — or it is not published*, above). Still open:
-  arming the registry's own 400 in `ModulePublish.Validate`, which waits on every producer's lane
-  pin having moved; and pinning satellites' `MW_PLATFORM_REF` to the promoted set so keys survive
+  built against — or it is not published*, above). The registry's own 400 in
+  `ModulePublish.Validate` is **armed** as of 2026-09-05 (#3240) — it waited on every producer's
+  lane pin having moved AND on a publish wave from each stating an identity, both measured before
+  arming. Still open: pinning satellites' `MW_PLATFORM_REF` to the promoted set so keys survive
   core commits.
 * **`pack-module`, `compile-check` and test verbs inside the tester** — the last runner-side
   `dotnet`/python uses move into the image the fleet already ships.

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-module-cannot-be-published-without-saying-what-it-was-built-against.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-module-cannot-be-published-without-saying-what-it-was-built-against.md
@@ -1,0 +1,38 @@
+---
+Name: A module cannot be published without saying what it was built against
+Category: Fix
+Description: The registry now refuses a module bundle that states no framework identity, instead of storing it and advertising an unknown. Publishing such a bundle answers a named error saying exactly what to change — and installations stop being told "already up to date" about a module they have never actually matched.
+Icon: ShieldCheckmark
+Order: -20260905
+---
+
+# A module cannot be published without saying what it was built against
+
+A module bundle carries the identity of the framework build its bytes were compiled against. That
+field is not a label: it is how an installation decides whether the module it already has is the one
+being offered. A module's *version* describes its content, so rebuilding unchanged source against a
+newer framework republishes under the **same** version — and then the framework identity is the only
+thing that tells the rebuild apart from a no-op.
+
+If a bundle arrives without one, the registry used to store it anyway and advertise the blank. Every
+installation asking "do I need this?" then got the same answer forever: *already landed — the
+identity could not be checked*. Not an error, not a retry; just a module that quietly never updated
+again. And it could not be repaired from the receiving end, because the missing information was on
+the serving side.
+
+## What changes
+
+Publishing a bundle that states no framework identity is now **refused**, with an error that names
+the fault and the remedy rather than only the fault. Nothing is stored, so there is no blank left
+behind to clean up later.
+
+Anything that states one is unaffected. Several forms are legitimate — a commit, a build MVID — and
+the check does not care which; it only refuses *absence*.
+
+## Why it did not simply always do this
+
+The producers had to be able to satisfy it first. A refusal armed while publishers were still
+building bundles that could not state an identity would have stopped every publish in the fleet
+instead of stopping the blanks — the opposite of the intended effect. So the check waited behind a
+measurement, and was armed once every publisher had actually completed a publish stating its
+identity.

--- a/src/MeshWeaver.PluginCatalog/ModulePublish.cs
+++ b/src/MeshWeaver.PluginCatalog/ModulePublish.cs
@@ -47,14 +47,11 @@ public static class ModulePublish
     /// republishes under the same version and the identity is the only thing that tells that
     /// rebuild from a no-op.</para>
     ///
-    /// <para>Null here is therefore a permanent skip-and-say-so for every consumer of the bundle —
-    /// an unknown on the SERVED side cannot be healed by landing, only an unknown on the landed
-    /// side can. #3211 closes that where it is created: the packer refuses to write a bundle that
-    /// states no identity (<c>module-pack</c> exit 2) and the module-pack lane refuses to POST one.
-    /// Arming the same refusal HERE — a named 400 out of <see cref="Validate"/> — is the last step,
-    /// and it waits on the fleet: measured 2026-09-03 on MeshWeaver.Plugins run 33773265959, all 34
-    /// bundles packed <c>built-against MVID (unrecorded)</c>, so a refusal armed before every
-    /// producer's pin has moved would take the fleet's publishes down rather than the null.</para>
+    /// <para>Null here would therefore be a permanent skip-and-say-so for every consumer of the
+    /// bundle — an unknown on the SERVED side cannot be healed by landing, only an unknown on the
+    /// landed side can. #3211 closes that where it is created (the packer refuses to write such a
+    /// bundle, the lane refuses to POST one) and, since #3240, <see cref="Validate"/> refuses it
+    /// HERE too, as a named 400. So this value is never null on an accepted upload.</para>
     /// </param>
     /// <param name="Files">The module's closure: file name + bytes, entry DLL included.</param>
     public sealed record Accepted(
@@ -163,6 +160,42 @@ public static class ModulePublish
         var entry = module + ".dll";
         if (!files.Any(f => string.Equals(f.FileName, entry, StringComparison.OrdinalIgnoreCase)))
             return (null, $"the bundle carries no entry assembly '{entry}'");
+
+        // 🚨 ARMED 2026-09-05 (#3240) — the LAST refusal of #3211, and the registry's own.
+        //
+        // A bundle stating no framework identity shelves a null, the index advertises a null, and
+        // ModuleUpdateDecision (#3154) then answers "already landed — the identity could not be
+        // checked" for this module on every reconcile of every installation, FOREVER: an unknown on
+        // the SERVED side is the one landing cannot heal. The producer already refuses to pack or
+        // POST such a bundle, but a registry that trusts its producers is not a registry — this is
+        // the check that does not depend on which lane, which pin, or which repo sent the bytes.
+        //
+        // 🚨 IT WAS DELIBERATELY NOT ARMED UNTIL BOTH HALVES OF #3240'S CRITERION WERE MEASURED,
+        // because arming it early takes the fleet's publishes down instead of the nulls (measured
+        // 2026-09-03: MeshWeaver.Plugins run 33773265959 packed all 34 bundles "built-against MVID
+        // (unrecorded)"). Both halves, measured 2026-09-05:
+        //
+        //   1. every repo that publishes modules pins node-repo-module-pack.yml PAST #3237
+        //      (da2bb12d3, 09-03 17:49Z) — MeshWeaver.Plugins at c41a34fda (09-04 05:57Z) and
+        //      MeshWeaver.SocialMedia at fec69fc66 (09-03 21:27Z); Education and Reinsurance do not
+        //      call the lane at all;
+        //   2. a full publish wave from EACH completed since, `publish: true`, stating an identity:
+        //      Plugins run 33941672487 (09-05 03:31Z) "built against: g7d644de95…" and SocialMedia
+        //      run 33941835795 (09-05 03:27Z) "built against: cef92e9759…". Both publish jobs
+        //      succeeded, so the producer-side refusal never fired.
+        //
+        // Both token shapes are fine here and the check must stay shape-AGNOSTIC: an image-pinned
+        // lane states `g<sha>`, a from-source lane a 32-hex MVID, and FrameworkIdentity documents a
+        // third (`s<hash>`). The only thing that is never acceptable is ABSENCE — a value this
+        // registry would shelve as null.
+        if (string.IsNullOrWhiteSpace(manifest.FrameworkMvid))
+            return (null,
+                $"the bundle states no framework identity (manifest frameworkMvid is absent), so "
+                + $"the registry would shelve a null for '{module}' and advertise a null on the "
+                + "index — and every consumer would then answer 'already landed, the identity "
+                + "could not be checked' on every reconcile, forever (#3154, #3211). Its producer "
+                + "packs on a lane older than MeshWeaver#3211: bump that repo's "
+                + "node-repo-module-pack.yml pin and re-publish.");
 
         return (new Accepted(
             module,

--- a/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
+++ b/test/Memex.Portal.Shared.Test/ModulePublishShelfTest.cs
@@ -53,14 +53,16 @@ public class ModulePublishShelfTest : IDisposable
         catch { /* temp cleanup is the OS's problem, never a test failure */ }
     }
 
-    /// <summary>A packed module bundle the route can read, declaring the given floor.</summary>
-    private static byte[] Bundle(string? minMeshVersion)
+    /// <summary>A packed module bundle the route can read, declaring the given floor. A null
+    /// <paramref name="frameworkMvid"/> omits the field entirely — the shape a producer on a lane
+    /// older than #3211 uploads, and the one the registry refuses since #3240.</summary>
+    private static byte[] Bundle(string? minMeshVersion, string? frameworkMvid = "test-build")
     {
         var manifestJson = JsonSerializer.Serialize(new
         {
             plugin = "SpeechPkg",
             version = "1.0.0",
-            frameworkMvid = "test-build",
+            frameworkMvid,
             module = new
             {
                 assemblyName = "MeshWeaver.Speech",
@@ -83,7 +85,8 @@ public class ModulePublishShelfTest : IDisposable
         return buffer.ToArray();
     }
 
-    private async Task<HttpResponseMessage> Publish(string? minMeshVersion)
+    private async Task<HttpResponseMessage> Publish(
+        string? minMeshVersion, string? frameworkMvid = "test-build")
     {
         var builder = WebApplication.CreateBuilder();
         builder.WebHost.UseTestServer();
@@ -104,7 +107,7 @@ public class ModulePublishShelfTest : IDisposable
             HttpMethod.Post,
             PluginBundleEndpoints.RoutePrefix + "/SpeechPkg?packagePath=Plugins/SpeechPkg");
         request.Headers.TryAddWithoutValidation("Authorization", "Bearer " + Token);
-        request.Content = new ByteArrayContent(Bundle(minMeshVersion));
+        request.Content = new ByteArrayContent(Bundle(minMeshVersion, frameworkMvid));
         return await client.SendAsync(request);
     }
 
@@ -169,5 +172,56 @@ public class ModulePublishShelfTest : IDisposable
         var list = ModuleActivationSidecar.Read(root);
         Assert.True(list.PendingRestart, "an activated landing loads at the next restart");
         Assert.Equal("0.0.1", Assert.Single(list.Entries).MinMeshVersion);
+    }
+
+    /// <summary>
+    /// 🚨 #3240 — THE REGISTRY'S OWN 400, armed 2026-09-05. A bundle that states no framework
+    /// identity is REFUSED, by name, instead of shelving a null that the index then advertises.
+    ///
+    /// <para>Why the registry checks something its producers already refuse: a null on the SERVED
+    /// side is the one unknown landing cannot heal. <c>ModuleUpdateDecision</c> (#3154) compares
+    /// (version, framework identity) on every reconcile of every installation, and a module's
+    /// version encodes CONTENT only — so a rebuild of unchanged source against a new platform
+    /// republishes under the SAME version and the identity is the only thing that distinguishes it
+    /// from a no-op. Shelve one null and every consumer of that module answers "already landed, the
+    /// identity could not be checked" forever. A registry that trusts its publishers is not a
+    /// registry.</para>
+    ///
+    /// <para>The refusal must stay shape-AGNOSTIC — `g&lt;sha&gt;`, a 32-hex MVID and `s&lt;hash&gt;`
+    /// are all identities a lane legitimately states. Only ABSENCE is refused, which is what
+    /// <see cref="AStatedIdentityOfAnyShape_IsAccepted"/> pins from the other side.</para>
+    /// </summary>
+    [Fact]
+    public async Task ABundleStatingNoFrameworkIdentity_IsRefused_AndNothingIsShelved()
+    {
+        using var response = await Publish(minMeshVersion: null, frameworkMvid: null);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        using var body = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+        var error = body.RootElement.GetProperty("error").GetString();
+        Assert.Contains("states no framework identity", error);
+        // The remedy is named, not merely the fault — the publisher has to know what to change.
+        Assert.Contains("node-repo-module-pack.yml", error);
+
+        // 🚨 NOTHING was shelved. A refusal that still wrote the bytes would leave the null on the
+        // shelf and only change the status code the publisher sees.
+        Assert.Empty(ModuleActivationSidecar.Read(root).Entries);
+    }
+
+    /// <summary>
+    /// The other side of the same refusal: an identity of a shape the from-source lane produces (a
+    /// bare 32-hex MVID) is accepted and survives verbatim. Without this, narrowing the check to
+    /// one token shape would look like a passing test while redding a lane that states its identity
+    /// perfectly well.
+    /// </summary>
+    [Fact]
+    public async Task AStatedIdentityOfAnyShape_IsAccepted()
+    {
+        const string mvid = "cef92e9759e940ea8a1aa73173b12227";
+        using var response = await Publish(minMeshVersion: null, frameworkMvid: mvid);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var entry = Assert.Single(ModuleActivationSidecar.Read(root).Entries);
+        Assert.Equal(mvid, entry.FrameworkMvid);
     }
 }


### PR DESCRIPTION
## What this closes

#3211 closed the **producer** side — the packer refuses to write a bundle stating no framework
identity, the pack step refuses to pack without naming the anchor, and the lane refuses to POST one.
#3237 deliberately stopped there, and the reason is the reusable part: **arming a refusal before
every producer can satisfy it takes the fleet's publishes down instead of the nulls.** On 2026-09-03
all 34 of MeshWeaver.Plugins' bundles still packed `built-against MVID (unrecorded)` (run
33773265959).

The runway was a **warning** at the publish endpoint naming the publisher — a measurement, not a
fix — and #3240's arming criterion was that it fall silent.

## Both halves of the criterion, measured before changing anything

**1 — every publishing repo's `node-repo-module-pack.yml` pin is past #3237** (`da2bb12d3`,
2026-09-03 17:49Z), checked with `git merge-base --is-ancestor` in *both* directions:

| repo | pin | date | verdict |
|---|---|---|---|
| MeshWeaver.Plugins | `c41a34fda` | 09-04 05:57Z | past ✅ |
| MeshWeaver.SocialMedia | `fec69fc66` | 09-03 21:27Z | past ✅ |

Education and Reinsurance do not call the lane at all.

**2 — a full publish wave from each has completed since, stating an identity**, and the
producer-side refusal never fired:

| repo | run | when | `built against:` |
|---|---|---|---|
| MeshWeaver.Plugins | 33941672487 | 09-05 03:31Z | `g7d644de95…` |
| MeshWeaver.SocialMedia | 33941835795 | 09-05 03:27Z | `cef92e9759…` |

Both `publish: true`, both jobs green.

🚨 Worth recording how close this came to a false read: MeshWeaver.Plugins' recent `main` runs are
**red**, and "no successful run" would have looked like "no evidence". The failures are in
`test-repos` and a ratchet — the **module-pack lane succeeded**, `publish: true`, wave complete. An
absent wave is not a quiet window, and a red workflow is not an absent wave.

## The change

`ModulePublish.Validate` returns a named refusal through the route's existing 400 path. The runway
warning is deleted, with a note not to reintroduce one: a null that is merely logged is a null that
gets **shelved**, and this is the last place that can refuse it. A registry that trusts its
publishers is not a registry.

🚨 **The check is shape-agnostic and must stay so.** An image-pinned lane states `g<sha>`, a
from-source lane a 32-hex MVID, and `FrameworkIdentity` documents a third (`s<hash>`). Only
**absence** is refused — narrowing it to one shape would red a lane that is stating its identity
perfectly well. `AStatedIdentityOfAnyShape_IsAccepted` pins that from the other side.

## Verification

- `PluginCatalog`, `Memex.Portal.Shared`, `Memex.Portal.Shared.Test`, `Documentation.Test` — all
  `0 Error(s)`, Release, `-warnaserror`.
- `ModulePublishShelfTest` **4/4**; `DocumentationLinkIntegrityTest` green after the doc edits.
- **Mutation-proved:** removing the refusal fails exactly
  `ABundleStatingNoFrameworkIdentity_IsRefused_AndNothingIsShelved` and leaves the other three
  green — including the shape-agnostic acceptance, so the test cannot pass by refusing everything.
- The refusal test also asserts **nothing was shelved**: a refusal that still wrote the bytes would
  only change the status code the publisher sees.

## Docs

`ModuleBuildArchitecture` → *"Still to arm"* now records the arming and the evidence table, and the
Roadmap entry is closed. What's New entry added (`Category: Fix`).

Closes #3240
