### PR TITLE
The store address moves together: stamp the version the upload used, or keep the previous one (#3333)

### DIFF
--- a/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
+++ b/src/MeshWeaver.Compiler.Pipeline/NodeTypeCompilationHelpers.cs
@@ -2745,9 +2745,15 @@ internal static class NodeTypeCompilationHelpers
     /// <param name="def">The NodeType definition as currently persisted.</param>
     /// <param name="result">The successful compile's result (assembly + store coordinates).</param>
     /// <param name="currentNodeVersion">
-    /// Fallback for <see cref="NodeTypeDefinition.LastCompiledVersion"/> when the result carries no
-    /// store version — must be the version of the node the stamp lands on (see the inline note:
-    /// the stamped version must MATCH the version the <c>IAssemblyStore</c> upload used).
+    /// The version of the node this stamp lands on.
+    ///
+    /// <para>🚨 #3333 — it is deliberately NOT the fallback for
+    /// <see cref="NodeTypeDefinition.LastCompiledVersion"/> any more, and wiring it back is the
+    /// defect. A null <c>result.Version</c> does not mean "the version is missing", it means the
+    /// <c>IAssemblyStore</c> upload did not happen — so there is no store key to name, and naming
+    /// this one claims bytes that were never written. The fallback is
+    /// <c>def.LastCompiledVersion</c>, which keeps the (collection, path, version) triple moving
+    /// together. See the inline note at the stamp.</para>
     /// </param>
     /// <param name="activityPath">The CONFIRMED compile-activity path, or null when none was created.</param>
     /// <param name="releasePath">The CONFIRMED release-node path, or null when the create didn't land.</param>
@@ -2778,7 +2784,30 @@ internal static class NodeTypeCompilationHelpers
             // (set by UploadToStoreIfNeeded — the captured node Version at compile kickoff).
             // A different version here would point activation at a store key that has no
             // bytes — TryGetAssemblyPath miss, activation falls back to the default config.
-            LastCompiledVersion = result.Version ?? currentNodeVersion,
+            //
+            // 🚨 #3333 — THE FALLBACK IS `def.`, NOT `currentNodeVersion`, and the difference is
+            // the whole defect. `result.Version` is set in exactly ONE place: the projection over
+            // a SUCCESSFUL `PutWithLocation`. Every other path out of UploadToStoreIfNeeded returns
+            // the result WITHOUT it — no assembly location, no NodeType configurations, a
+            // NullAssemblyStore, unreadable bytes, or an upload that faulted or timed out (which is
+            // deliberately non-terminal: an upload failure has never failed a compile). So a null
+            // here does not mean "we forgot the version", it means NOTHING WAS STORED.
+            //
+            // Falling back to `currentNodeVersion` then stamped the node's version AT STAMP TIME as
+            // if it were a store key, while the sibling fields beside it kept the PREVIOUS upload's
+            // address (`result.Collection ?? def.LatestAssemblyCollection`, and the same for the
+            // path and the MVID). That splits the triple that addresses one blob: old collection,
+            // old path, new version — a key the store never held. NodeTypeBatchBake states the
+            // invariant this broke in as many words: "LastCompiledVersion always names a store key
+            // that has bytes", justified by "it uploaded the node it was handed" — true only when
+            // an upload actually happened.
+            //
+            // Keeping the previous value keeps the triple COHERENT: no upload, no change to any of
+            // the three. And null stays honest — every reader already applies its own
+            // `?? node.Version` (MeshOperations, MeshDataSource, NodeTypeDataModelAreas,
+            // NodeTypeEnrichmentHelpers), so the guess lives at the read, where it is a heuristic,
+            // instead of being frozen into the node as a claim.
+            LastCompiledVersion = result.Version ?? def.LastCompiledVersion,
             LastCompilationActivityPath = activityPath,
             LatestReleasePath = releasePath ?? def.LatestReleasePath,
             ReleaseNotes = releasePath is not null ? null : def.ReleaseNotes,

--- a/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/NodeTypeCompilation.md
@@ -151,6 +151,32 @@ status-guarded flip to `Pending`, which the watcher turns into the one activity 
 **waits** for that compile to settle before hydrating the answer. The status field is the
 single-flight lock.
 
+### The store address is a TRIPLE, and it moves together or not at all
+
+`LatestAssemblyCollection`, `LatestAssemblyPath` and `LastCompiledVersion` are not three independent
+facts — together they address one blob, and `NodeTypeBatchBake` relies on that in as many words:
+*"LastCompiledVersion always names a store key that has bytes."*
+
+`ApplyCompileSuccess` takes each of them from the compile result, falling back to the value already
+on the definition when the result carries none. That fallback is the contract: **a compile whose
+upload did not happen must leave the previous address exactly as it found it.** The upload is
+allowed not to happen — a `NullAssemblyStore`, unreadable bytes, or a fault or timeout, which is
+deliberately non-terminal because an upload failure has never failed a compile — and
+`result.Version` is set in exactly one place, the projection over a successful `PutWithLocation`. So
+a null there does not mean *"the version is missing"*, it means **nothing was stored**.
+
+🚨 Until #3333, `LastCompiledVersion` alone broke that symmetry: it fell back to the node's version
+*at stamp time* rather than to the previous stamp. A skipped upload then produced old collection +
+old path + **new version** — a key the store never held, so `TryGetAssemblyPath` misses and
+activation silently falls back to the default configuration, the #1368 outcome by a different road.
+Because the stamp takes its value from the same projection that performs the `Put`, that fallback
+was the *only* way the recorded version could disagree with the stored one.
+
+Null is the honest value when nothing was ever uploaded, and it costs nothing: every reader already
+applies its own `?? node.Version` (`MeshOperations`, `MeshDataSource`, `NodeTypeDataModelAreas`,
+`NodeTypeEnrichmentHelpers`), so the guess belongs at the read — where it is a heuristic — rather
+than frozen into the node as a claim about the store.
+
 > 🚨 **The wait must be ORDERED AGAINST THE DISPATCH.** `CompilationStatus == null` reads as
 > *settled*, and correctly so: for a static-only type, or one that already has a usable build,
 > "never compiled" is a final answer and `EnsureCompileDispatched` deliberately leaves those alone.

--- a/test/MeshWeaver.Compiler.Pipeline.Test/NodeTypeCompileStampTest.cs
+++ b/test/MeshWeaver.Compiler.Pipeline.Test/NodeTypeCompileStampTest.cs
@@ -83,14 +83,30 @@ public class NodeTypeCompileStampTest
             .Should().BeTrue("the whole point of the stamp is that lazy activation finds a usable build");
     }
 
+    /// <summary>
+    /// 🚨 #3333 — the three fields that ADDRESS one blob move together, or not at all.
+    ///
+    /// <para>A null <c>result.Version</c> does not mean "the version is missing": it is set in
+    /// exactly one place, the projection over a successful <c>PutWithLocation</c>, so a null means
+    /// the upload did NOT happen (no store, unreadable bytes, or a fault/timeout — deliberately
+    /// non-terminal, since an upload failure has never failed a compile). This test used to assert
+    /// the opposite and was named for it (<c>…AndFallsBackToTheNodeVersion</c>), while its own body
+    /// asserted the collection and path keep their PREVIOUS values two lines below — the same
+    /// incoherence the code had: old collection, old path, brand-new version, naming a store key
+    /// that was never written. <c>NodeTypeBatchBake</c> states the invariant that breaks in as many
+    /// words: "LastCompiledVersion always names a store key that has bytes".</para>
+    /// </summary>
     [Fact]
-    public void Success_WithoutStoreCoordinates_KeepsThePreviousAssemblyReference_AndFallsBackToTheNodeVersion()
+    public void Success_WithoutStoreCoordinates_KeepsThePreviousAssemblyReference_AndTheVersionThatAddressesIt()
     {
         var result = SuccessResult(storeVersion: null) with { Collection = null, ContentPath = null };
         var stamped = NodeTypeCompilationHelpers.ApplyCompileSuccess(
-            PreviouslyBroken(), result, currentNodeVersion: 3, activityPath: null, releasePath: null);
+            PreviouslyBroken() with { LastCompiledVersion = 5 },
+            result, currentNodeVersion: 3, activityPath: null, releasePath: null);
 
-        stamped.LastCompiledVersion.Should().Be(3L);
+        stamped.LastCompiledVersion.Should().Be(5L,
+            "nothing was uploaded, so the previous store key is still the only one with bytes — "
+            + "stamping the node's current version (3) would name a key the store never held");
         stamped.LatestAssemblyCollection.Should().Be("old-collection",
             "a producer without a store must not erase the previous durable reference");
         stamped.LatestAssemblyPath.Should().Be("old/path.dll");
@@ -98,6 +114,26 @@ public class NodeTypeCompileStampTest
             "no new release landed, so the previous one stays");
         stamped.ReleaseNotes.Should().Be("notes for the pending release",
             "un-consumed notes must survive until a release actually carries them");
+    }
+
+    /// <summary>
+    /// The same rule where there is no previous upload either: the stamp stays NULL rather than
+    /// acquiring a version out of the node. Null is honest — it says "no store bytes" — and every
+    /// reader already applies its own <c>?? node.Version</c> (MeshOperations, MeshDataSource,
+    /// NodeTypeDataModelAreas, NodeTypeEnrichmentHelpers), so the guess belongs at the READ, where
+    /// it is a heuristic, not frozen into the node as a claim about the store.
+    /// </summary>
+    [Fact]
+    public void Success_WithNoUploadEverHavingHappened_LeavesTheStoreVersionUnstated()
+    {
+        var result = SuccessResult(storeVersion: null) with { Collection = null, ContentPath = null };
+        var stamped = NodeTypeCompilationHelpers.ApplyCompileSuccess(
+            PreviouslyBroken(), result, currentNodeVersion: 3, activityPath: null, releasePath: null);
+
+        stamped.LastCompiledVersion.Should().BeNull(
+            "no upload has ever happened for this type, so there is no store key to name");
+        stamped.CompilationStatus.Should().Be(CompilationStatus.Ok,
+            "an upload that did not happen has never failed a compile — that contract is unchanged");
     }
 
     // ---- ApplyCompileFailure ------------------------------------------------------------------


### PR DESCRIPTION
## The defect

`ApplyCompileSuccess` takes the three fields that **address one blob** from the compile result, each
falling back to the value already on the definition — except one:

```csharp
LatestAssemblyCollection = result.Collection  ?? def.LatestAssemblyCollection,
LatestAssemblyPath       = result.ContentPath ?? def.LatestAssemblyPath,
LatestAssemblyMvid       = …                  ?? def.LatestAssemblyMvid,
LastCompiledVersion      = result.Version     ?? currentNodeVersion,   // ← not def.*
```

`result.Version` is set in **exactly one place**: the projection over a successful
`PutWithLocation`. Every other path out of `UploadToStoreIfNeeded` returns the result without it —
no assembly location, no NodeType configurations, a `NullAssemblyStore`, unreadable bytes, or an
upload that faulted or timed out (deliberately non-terminal, because *an upload failure has never
failed a compile*). **So a null does not mean "the version is missing" — it means nothing was
stored.**

Falling back to `currentNodeVersion` stamped the node's version *at stamp time* as if it were a
store key, while its two siblings kept the **previous** upload's address. Old collection + old path
+ new version is a key the store never held: `TryGetAssemblyPath` misses and activation silently
falls back to the default configuration — #1368's outcome by a different road.

`NodeTypeBatchBake` states the invariant that broke, in as many words:

> `LastCompiledVersion` always names a store key that has bytes

justified by *"it uploaded the node it was handed"* — true only when an upload actually happened.

## Why this is the shape #3333 was left with

Because the stamp reads its value from the same projection that performs the `Put`, stamp == Put
version **whenever an upload happened**. So this fallback was the *only* way the recorded version
could disagree with the stored one — which is precisely the single row left standing in #3333's
elimination table after mesh-teardown, cross-test eviction, in-run retention and framework-tag
mismatch were each excluded by measurement.

🚨 **I am not claiming this caused the observed `BakeEquivalenceTest` failure.** That run's store is
gone, so whether it took the no-upload path cannot be established post-hoc. What *is* established:
the shape existed, it was the only remaining mechanism for the stated mismatch, and it is now
closed. Hence `Refs #3333`, not `Closes`.

## The existing test pinned the defect

`Success_WithoutStoreCoordinates_KeepsThePreviousAssemblyReference_AndFallsBackToTheNodeVersion`
asserted the version jumps — while asserting, two lines below, that the collection and path do
**not**. The same incoherence as the code, written down as expected behaviour. Rewritten to
`…AndTheVersionThatAddressesIt`, with a second case for "nothing ever uploaded" staying `null`.

`null` is honest and costs nothing: every reader already applies its own `?? node.Version`
(`MeshOperations`, `MeshDataSource`, `NodeTypeDataModelAreas`, `NodeTypeEnrichmentHelpers`), so the
guess belongs at the **read**, where it is a heuristic, instead of being frozen into the node as a
claim about the store.

## Verification

- `MeshWeaver.Compiler.Pipeline`, `MeshWeaver.Hosting`, `MeshWeaver.Compiler.Pipeline.Test` — all
  `0 Error(s)`, Release, `-warnaserror`.
- `MeshWeaver.Compiler.Pipeline.Test` **612/612**; `DocumentationLinkIntegrityTest` green.
- **Mutation-proved:** restoring `?? currentNodeVersion` fails exactly the two new tests and leaves
  the other six green.

## Notes

- `currentNodeVersion` stays in the signature — it is `internal`, but removing it means touching
  nine call sites inside a behaviour fix. Its doc now says it is deliberately **not** the fallback,
  because an unused parameter next to the field it used to feed is a loaded gun.
- Doc: `NodeTypeCompilation` gains *"The store address is a TRIPLE, and it moves together or not at
  all"*, beside the #1368 section it shares an outcome with.

Refs #3333
