### PR TITLE
Pin the managed SQLitePCLRaw trio at 3.x — the prerequisite half of #3328

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -101,16 +101,55 @@
     <PackageVersion Include="Microsoft.AspNetCore.DataProtection" Version="10.0.10" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.10" />
-    <!-- Pin the patched native SQLite engine: Microsoft.Data.Sqlite 10.0.0 pulls
+    <!-- 🚨 THE SQLitePCLRaw FAMILY IS PINNED AS A SET — native AND the managed trio (#3328).
+         Pin the patched native engine first: Microsoft.Data.Sqlite pulls
          SQLitePCLRaw.lib.e_sqlite3 2.1.11 transitively, which bundles a SQLite engine with the
          high-severity vuln GHSA-2m69-gcr7-jv3q (NU1903). The native engine package is versioned to
-         track the bundled SQLite version, so any 3.50+ engine is past the vulnerable range. The
-         provider P/Invokes the engine by ABI-stable export name, so the native lib drops in under
-         the 2.1.x managed layer. Deliberately version-AGNOSTIC prose: naming a specific version
-         here goes stale the moment the pin below is bumped (it said 3.50.3 while the pin read
-         3.53.3). The pin is the source of truth; this comment explains WHY it exists.
-         Pinned explicitly in the Sqlite projects. -->
+         track the bundled SQLite version, so any 3.50+ engine is past the vulnerable range.
+         Deliberately version-AGNOSTIC prose: naming a specific version here goes stale the moment a
+         pin below is bumped (it once said 3.50.3 while the pin read 3.53.3). The pins are the
+         source of truth; this comment explains WHY they exist.
+
+         🚨 AND THE MANAGED TRIO IS PINNED TOO, at the 3.x family — because leaving it unpinned made
+         the PLATFORM IMAGE internally inconsistent, and that fails EVERY module compile in EVERY
+         satellite with no repo change to blame. Measured on the 3.0.0-rc9.ci.7779 image
+         (MeshWeaver.Plugins#1349, four bundles):
+
+             error MSB3277: conflict between "SQLitePCLRaw.core, Version=2.1.11.2622" and
+             "SQLitePCLRaw.core, Version=3.0.2.2801"
+               depends on 2.1.11.2622: platform-refs-effective/SQLitePCLRaw.core.dll   ← /app ships this
+               depends on 3.0.2.2801:  platform-refs-effective/Microsoft.CodeAnalysis.Workspaces.dll
+
+         Both sides are INSIDE /app. Roslyn's Workspaces assembly (its optional SQLite persistent
+         storage) is compiled against core 3.0.2, while /app shipped 2.1.11 because that is what
+         Microsoft.Data.Sqlite asks for. 🚨 The 3.0.2 side is an ASSEMBLY reference baked into
+         Roslyn's metadata, NOT a package edge — no package in the closure depends on it, and
+         lib.e_sqlite3 3.53.3 has empty dependency groups. So pinning the managed trio at 2.1.11
+         would be a no-op: 2.1.11 is already what resolves, and it is the LOSING side.
+
+         3.x is also the coherent pairing — 3.x managed beside a 3.53.3 native — where 2.1.x managed
+         under a 3.53.3 native was only ever the CVE workaround. Verified, not assumed:
+         Microsoft.Data.Sqlite 10.0.10 against SQLitePCLRaw.core/provider/bundle 3.0.2 and
+         lib 3.53.3 builds with NO MSB3277, loads core 3.0.2.2801, reports engine 3.53.3 and
+         round-trips a query.
+
+         🚨 THESE THREE ARE INERT ON THEIR OWN — do not read them as the fix landed. Under Central
+         Package Management a bare <PackageVersion> does NOT pin a PURE TRANSITIVE; it binds only
+         where something references the package directly. Measured on this very edit: building
+         MeshWeaver.Plugins' MeshWeaver.Hosting.Sqlite against this tree still resolved
+         core/provider/bundle 2.1.11, while lib.e_sqlite3 took 3.53.3 — because that project alone
+         carries an explicit <PackageReference> for it ("Explicit so nearest-wins beats the
+         transitive"). The remedy is the narrow one this file already prescribes for
+         DataProtection: a VERSIONLESS <PackageReference> in the project the package flows through
+         (MeshWeaver.Hosting.Sqlite, beside the lib one), which makes this central pin bite for that
+         project — NOT repo-wide CentralPackageTransitivePinningEnabled, whose blast radius is
+         resolution-wide and belongs in its own PR. That half lives in MeshWeaver.Plugins and is
+         gated on this commit reaching its MW_PLATFORM_REF: a versionless reference to a package
+         with no PackageVersion in the pinned core is a CPM error. See #3328. -->
     <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
+    <PackageVersion Include="SQLitePCLRaw.core" Version="3.0.2" />
+    <PackageVersion Include="SQLitePCLRaw.provider.e_sqlite3" Version="3.0.2" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.2" />
     <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.2.0" />


### PR DESCRIPTION
## What this is, and what it is not

The platform image's **own** reference set is internally inconsistent, which fails every module
compile in every satellite with no repo change to blame (MeshWeaver.Plugins#1349 is blocked on it).
Both sides of the conflict resolve inside `/app`:

```
error MSB3277: "SQLitePCLRaw.core, Version=2.1.11.2622" vs "…3.0.2.2801"
  depends on 2.1.11: platform-refs-effective/SQLitePCLRaw.core.dll
  depends on 3.0.2:  platform-refs-effective/Microsoft.CodeAnalysis.Workspaces.dll
```

**🚨 This PR is INERT on its own.** It is the prerequisite, not the fix, and the props comment says
so — see below. `Refs #3328`, not `Closes`.

## Why the issue's suggested fix would not have worked

The issue proposes pinning the managed trio at **2.1.11**. Measured, that is a no-op:

| claim | measurement |
|---|---|
| a package pulls `core 3.0.2` | **false** — `Microsoft.CodeAnalysis.Workspaces.Common` declares no SQLitePCLRaw dependency in any cached version (4.14.0, 5.0.0, 5.3.0, 5.6.0, 5.9.0); the only packages depending on the family are `Microsoft.Data.Sqlite*`, all asking `2.1.11` |
| `lib.e_sqlite3 3.53.3` drags in managed 3.x | **false** — empty dependency groups; native-only, exactly as its pin comment claims |
| the 3.0.2 side | an **assembly** reference baked into Roslyn's metadata (its optional SQLite persistent storage), with `[]` for project items |

`2.1.11` is already what resolves and ships — it is the **losing** side. Pinning it changes nothing
and the same MSB3277 returns, with a pin that now *looks* like the fix.

## The open question the issue flagged, settled by experiment

> *Versions to be confirmed against what `Microsoft.Data.Sqlite 10.0.10` expects*

A probe referencing MDS 10.0.10 with `core`/`provider.e_sqlite3`/`bundle_e_sqlite3` **3.0.2** and
`lib.e_sqlite3` **3.53.3**:

```
SQLitePCLRaw.core loaded: 3.0.2.2801
engine: 3.53.3
roundtrip: 42
```

No MSB3277, and the CVE-patched engine is unchanged. `MeshWeaver.Hosting.Sqlite` uses only
`SqliteConnection`/`SqliteCommand` — no `LoadExtension`, no native extension — so the probe
exercised the surface the backend actually uses. 3.x managed beside a 3.53.3 native is also the
*coherent* pairing; 2.1.x-managed-under-3.53.3-native was only ever the CVE workaround.

## 🚨 Why it is inert, measured on this very edit

Under Central Package Management a bare `<PackageVersion>` does **not** pin a **pure transitive**.
Building MeshWeaver.Plugins' `MeshWeaver.Hosting.Sqlite` against this tree
(`-p:MeshWeaverRoot=<this worktree>`) still resolved:

```
SQLitePCLRaw.core/2.1.11              ← unchanged: pure transitive, bare pin inert
SQLitePCLRaw.provider.e_sqlite3/2.1.11
SQLitePCLRaw.bundle_e_sqlite3/2.1.11
SQLitePCLRaw.lib.e_sqlite3/3.53.3     ← took the pin: that project references it EXPLICITLY
```

The one that moved is the one with an explicit `<PackageReference>`. That is the whole mechanism,
and it is why this PR alone changes nothing at runtime.

## The other half, and why it is not here

The remedy is the narrow one `Directory.Packages.props` already prescribes for DataProtection: a
**versionless `<PackageReference>`** in the project the package flows through
(`MeshWeaver.Hosting.Sqlite`, beside the existing `lib.e_sqlite3` one) — **not** repo-wide
`CentralPackageTransitivePinningEnabled`, whose blast radius is resolution-wide and belongs in its
own PR.

That half lives in **MeshWeaver.Plugins** and is gated on this commit reaching its
`MW_PLATFORM_REF`: a versionless reference to a package with no `PackageVersion` in the pinned core
is a CPM error. Plugins holds **zero** pins of its own — `src/Directory.Packages.props` purely
imports core's — so it cannot be short-circuited there without introducing a second place pins live.

## Verification

`MeshWeaver.Graph.Contract` — `0 Error(s) 0 Warning(s)`, Release, `-warnaserror`. Nothing in core
references SQLite at all, so nothing in core resolves differently; the props file parsing and the
Plugins-side resolution measurement above are the real checks.

Refs #3328
