### PR TITLE
The core twins name the guard that enforces them; shape 7's worst form is written down (#3345)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
@@ -176,6 +176,44 @@ dependent's own CI reacting to core's release event.
 | 6 | a public **member** leaves a type that **stays** (field, const, method, property, event, positional record parameter, enum constant, interface member, nested type) | #3137 — `CacheDuration`/`NegativeCacheDuration`; `CS0117`; `Portal hosts (shard 0)` red on every Plugins PR for three hours, *"nothing was tested"* | **yes** (since #3103) | yes |
 | 7 | a public method's **BEHAVIOUR** changes behind an **unchanged signature** — same name, same parameters, different answer | #3276 — `CatalogLayoutAreas.RenderFromSource` began rendering the category landing instead of the flat package list; two `MeshWeaver.PluginCatalog.Test` render tests in Plugins went red, found 48 commits later by a pin bump | no — nothing is added or removed, so no surface detector can see it | **only if the dependent actually rebuilds against the release — a PINNED dependent does not** (below) |
 
+### Shape 7's worst form: the dependent holds a COPY of the test (#3345)
+
+Shape 7 is invisible to every surface detector by construction. It gets worse when the behaviour
+that changed is pinned by a test the dependent keeps its **own copy of** — and that is not
+hypothetical, it is the arrangement two teardown tests are in today:
+
+| file | lives in |
+|---|---|
+| `NackReachesTheWaiterDuringTeardownTest` | `test/MeshWeaver.Graph.Test/` **and** `MeshWeaver.Plugins/src/MeshWeaver.Hosting.Monolith.Test/` |
+| `LateNackReenqueueTest` | the same two places |
+
+They are duplicated on purpose: core's CI cannot stand up a monolith mesh, so the copy that actually
+exercises the behaviour lives in the dependent, and the copy that keeps core honest lives here. What
+made #3345 expensive is what held them together — **a comment, on core's copy only**:
+
+> `// Core twin of MeshWeaver.Plugins/… Keep the two in step.`
+
+The person who needed to read that was whoever edited the Plugins copy. The person who saw it was
+whoever edited core's. #3291 rewrote core's twins to the no-forced-teardown contract and left the
+Plugins originals asserting the contract it had just deleted. Nothing was red — a pinned dependent
+does not rebuild on core's release event (see the row above) — until the pin bump, one day later,
+produced a 55-second `VERDICT_TIMEOUT` in a suite whose name points at the mesh. It was filed here
+as a core regression and bisected across five commits before the premise fell over.
+
+**The control is `TeardownTwinParityTest`, and it lives in the dependent** — the only side that can
+see both files, because it builds against `$(MeshWeaverRoot)` at `MW_PLATFORM_REF`. It compares each
+body below the `namespace` line against the core checkout **at the pin, never core's `main`**, so it
+reddens exactly in the change that MOVES the pin, which is the change that owes the update, and it
+is silent in every change that does not. A missing platform checkout FAILS rather than skips.
+
+Two rules follow, and they generalise past these two files:
+
+- **A duplicated test needs a parity guard, not a comment.** Prose that asks a future reader to keep
+  two files in step is a control that only fires when someone is already looking at the right one.
+- **The marker goes on BOTH copies.** A one-sided note is addressed to the party who does not need
+  it. Core's twins now name the guard that enforces them.
+
+
 ## Member-level detection (the sixth shape)
 
 `check-type-forwards.py` indexes, under each public top-level type, the **names** of its public

--- a/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
+++ b/test/MeshWeaver.Graph.Test/LateNackReenqueueTest.cs
@@ -16,6 +16,15 @@ using MeshWeaver.Fixture;
 // Core twin of MeshWeaver.Plugins/src/MeshWeaver.Hosting.Monolith.Test/LateNackReenqueueTest.cs (ported 2026-09-02):
 // core's own CI cannot run the Plugins-hosted suite, so the 2026-09-02 regression of the owner-disposing
 // NACK (PR #3070) reached main unseen. Keep the two in step.
+//
+// 🚨 EDITING THIS FILE? The Plugins copy is a separate file and this comment cannot make anyone open
+// it — #3345: #3291 rewrote this twin to the no-forced-teardown contract, left the Plugins one
+// asserting the contract it had just deleted, and the pin bump a day later produced a 55-second
+// VERDICT_TIMEOUT that was filed as a core regression and bisected across five commits. What holds
+// the two together now is Plugins' TeardownTwinParityTest, which compares this body against its own
+// below the namespace line, at MW_PLATFORM_REF. It reddens in the PIN BUMP, not here — so a change
+// to this file is not done until the Plugins copy carries it too.
+// See Doc/Architecture/CrossRepoPairGate → "Shape 7's worst form".
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>

--- a/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
+++ b/test/MeshWeaver.Graph.Test/NackReachesTheWaiterDuringTeardownTest.cs
@@ -18,6 +18,15 @@ using System.Collections.Concurrent;
 // Core twin of MeshWeaver.Plugins/src/MeshWeaver.Hosting.Monolith.Test/NackReachesTheWaiterDuringTeardownTest.cs (ported 2026-09-02):
 // core's own CI cannot run the Plugins-hosted suite, so the 2026-09-02 regression of the owner-disposing
 // NACK (PR #3070) reached main unseen. Keep the two in step.
+//
+// 🚨 EDITING THIS FILE? The Plugins copy is a separate file and this comment cannot make anyone open
+// it — #3345: #3291 rewrote this twin to the no-forced-teardown contract, left the Plugins one
+// asserting the contract it had just deleted, and the pin bump a day later produced a 55-second
+// VERDICT_TIMEOUT that was filed as a core regression and bisected across five commits. What holds
+// the two together now is Plugins' TeardownTwinParityTest, which compares this body against its own
+// below the namespace line, at MW_PLATFORM_REF. It reddens in the PIN BUMP, not here — so a change
+// to this file is not done until the Plugins copy carries it too.
+// See Doc/Architecture/CrossRepoPairGate → "Shape 7's worst form".
 namespace MeshWeaver.Graph.Test;
 
 /// <summary>


### PR DESCRIPTION
## #3345 is not a regression — the control was

Filed here as *"a disposing owner stops answering its waiter"* after Plugins' pin bump went red on
two teardown tests. I bisected five commits of #3291 before the premise fell over.

`NackReachesTheWaiterDuringTeardownTest` and `LateNackReenqueueTest` exist in **both** repos on
purpose — core's CI cannot stand up a monolith mesh, so the copy that exercises the behaviour lives
in Plugins and the copy that keeps core honest lives here. #3291 rewrote **this side's** copies to
the no-forced-teardown contract (the maintainer directive of 2026-09-04) and left the Plugins
originals asserting the contract it had just deleted.

Test project held constant, only `MeshWeaverRoot` varying:

| core commit | | result |
|---|---|---|
| `6163dfacb` | #3291's branch point | **2/2 pass** |
| `f92305ae1` | #3291, commit 1 of 5 | **0/2 fail** |
| `7d644de95` | the pin being replaced | 2/2 pass |
| `d99165850` | the pin being taken | 0/2 fail |

One commit, and one clause: core's parked turn releases itself on `|| owner.IsShuttingDown`; the
Plugins copy waited for the test's own `finally`. With the 8 s force-teardown deleted, a turn blind
to the shutdown holds the owner at `DisposeHostedHubs` — honestly pending — and the caller burns its
verdict budget.

## What actually failed

The twins were held together by a comment, and **it sat on this side only** — on the copy whose
editor already knew. The reader who needed it was whoever edited the Plugins copy. A pinned
dependent does not rebuild on core's release event, so nothing was red until the bump a day later
produced a 55-second `VERDICT_TIMEOUT` in a suite whose name points at the mesh.

## This PR is the half that belongs here

The enforcing guard has to live in the dependent — the only side that can see both files, because it
builds against `$(MeshWeaverRoot)` at `MW_PLATFORM_REF`. That is
Systemorph/MeshWeaver.Plugins#1359's `TeardownTwinParityTest`, which compares each body below the
`namespace` line against the core checkout **at the pin, never `main`**, so it reddens in the pin
bump — the change that owes the update — and is silent otherwise. A missing platform checkout
**fails** rather than skips.

Here:

- **Both twins carry the marker pointing at that guard**, so a core editor learns the change is not
  done until the Plugins copy carries it too. The block sits *above* the `namespace`, which is
  exactly what the guard excludes — verified by running the guard against this worktree: **4/4**,
  rather than assumed.
- **`CrossRepoPairGate.md` gains "Shape 7's worst form: the dependent holds a COPY of the test"** —
  the incident, why a pinned dependent stays silent until the bump, and the two rules that
  generalise past these two files: a duplicated test needs a parity guard rather than a comment, and
  the marker goes on **both** copies.

## Verification

- `DocumentationLinkIntegrityTest` — passes.
- `MeshWeaver.Graph.Test` — clean under `-c Release -warnaserror`.
- The Plugins parity guard against this worktree — 4/4 (proves the comment edit is parity-safe).

Pairs-with: none — docs and comments only; this diff removes no public surface.

Refs #3345, #3291
