### PR TITLE
Four catalog keys the thread message views need to stop shipping English literals (#3203)

### DIFF
--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -202,6 +202,8 @@
   "chat.allocatingAgent": "Agent wird zugewiesen…",
   "chat.creatingConversation": "Unterhaltung wird erstellt und weitergeleitet",
   "chat.composerPlaceholder": "Nachricht eingeben… Mit @ auf Nodes verweisen",
+  "chat.editPromptPlaceholder": "Nachricht eingeben…",
+  "chat.authorEditing": "{0} (wird bearbeitet)",
   "chat.you": "Du",
   "chat.assistant": "Assistent",
   "chat.streaming": "Wird übertragen…",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -204,6 +204,8 @@
   "chat.composerPlaceholder": "Nachricht eingeben… Mit @ auf Nodes verweisen",
   "chat.editPromptPlaceholder": "Nachricht eingeben…",
   "chat.authorEditing": "{0} (wird bearbeitet)",
+  "chat.typeEditing": "Bearbeitung",
+  "chat.typeUser": "Benutzer",
   "chat.you": "Du",
   "chat.assistant": "Assistent",
   "chat.streaming": "Wird übertragen…",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -204,6 +204,8 @@
   "chat.composerPlaceholder": "Type a message... Use @ to reference nodes",
   "chat.editPromptPlaceholder": "Type your message...",
   "chat.authorEditing": "{0} (editing)",
+  "chat.typeEditing": "Editing",
+  "chat.typeUser": "User",
   "chat.you": "You",
   "chat.assistant": "Assistant",
   "chat.streaming": "Streaming...",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -202,6 +202,8 @@
   "chat.allocatingAgent": "Allocating agent…",
   "chat.creatingConversation": "Creating conversation and redirecting",
   "chat.composerPlaceholder": "Type a message... Use @ to reference nodes",
+  "chat.editPromptPlaceholder": "Type your message...",
+  "chat.authorEditing": "{0} (editing)",
   "chat.you": "You",
   "chat.assistant": "Assistant",
   "chat.streaming": "Streaming...",


### PR DESCRIPTION
`ThreadMessageLayoutAreas` (MeshWeaver.Plugins — the AI engine lives there since #2276) renders four
strings that no viewer setting can change. Two already have keys here — `chat.you`, `chat.assistant`
— and these are the two that did not:

| key | en | de |
|---|---|---|
| `chat.authorEditing` | `{0} (editing)` | `{0} (wird bearbeitet)` |
| `chat.editPromptPlaceholder` | `Type your message...` | `Nachricht eingeben…` |

`chat.authorEditing` is **parameterised** rather than an `(editing)` suffix appended to a name in
code: German puts the marker in a different shape, and a concatenated suffix is not something a
translator can reorder.

Placed beside `chat.composerPlaceholder` and `chat.you`. The catalogs are grouped, not sorted, so
inserting there keeps this a 4-line diff instead of a whole-file re-sort.

The consuming half reads them through the `LocalizedOr`/`OrAuthored` fallback, which returns the
authored English when the catalog answers with the key itself — so a mesh whose image predates these
entries shows English rather than a raw `chat.authorEditing` token, and German the moment the image
carries them. The two halves may land in either order.

I owe the mirror handover once this merges: `npm run sync:i18n -- --ref <merged sha>` in
MeshWeaver.Plugins, since the guard there compares against a pinned core commit and would otherwise
go quietly stale.

**Verified:** `MeshWeaver.Messaging.Hub.Test` 58/58, `LocalizationTest` included.

Pairs-with: none — this adds catalog entries and removes no public surface.

Refs #3203