### PR TITLE
Restore the SQLitePCLRaw.lib.e_sqlite3 pin #3344 removed with the three it meant to withdraw

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -123,6 +123,7 @@
          measured in a restore graph — so it silently swaps the native engine out from under the
          pin below and the CVE fix stops being the thing supplying the engine. #3342 pinned it and
          was withdrawn for exactly this. -->
+    <PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
     <PackageVersion Include="ModelContextProtocol" Version="1.4.1" />
     <PackageVersion Include="ModelContextProtocol.AspNetCore" Version="1.2.0" />
     <PackageVersion Include="ModelContextProtocol.Core" Version="1.2.0" />


### PR DESCRIPTION
## Core CD has published no sealed set since 09:27Z, and this is why

#3344 withdrew #3342's three managed pins (`core` / `provider.e_sqlite3` / `bundle_e_sqlite3`) and
took a **fourth** line with them:

```xml
<PackageVersion Include="SQLitePCLRaw.lib.e_sqlite3" Version="3.53.3" />
```

That line was never #3342's. It has been here since `fb9dc0e01` (2026-06-29), and it is load-bearing
twice:

1. **It breaks the portal image build.** MeshWeaver.Plugins' `MeshWeaver.Hosting.Sqlite.csproj`
   carries a *versionless* `<PackageReference Include="SQLitePCLRaw.lib.e_sqlite3" />`, and that
   repo's `src/Directory.Packages.props` **imports this file** — so removing the entry here removed
   it there. `error NU1010: PackageReference items do not define a corresponding PackageVersion item`.
2. **It is the CVE pin.** Without it the package falls back to the transitive 2.1.11 —
   GHSA-2m69-gcr7-jv3q, high severity — surfacing as `NU1903` in `Memex.Portal.Gui` and
   `Memex.Portal.Distributed`.

## Why nothing was red before the merge

Core's own PR CI never restores the plugins tree. `main-cd` does, because it builds the portal image
out of `plugins-repo`. The timing is exact:

| | |
|---|---|
| #3344 merged | **10:01:41Z** |
| main-cd #7813 | **10:05:09Z** — failed, `Plugins: bake + seal` **skipped** |
| main-cd #7814 | 10:26:06Z — failed the same way |
| last sealed set | **#7811, 09:27:02Z** |

Plugins#1359, #3327, #3328 and #3345 are all waiting on a sealed set, so this is the blocker under
all of them.

The comment block above the line survived intact and still reads *"the pin below"* and *"The pin is
the source of truth"* — pointing at a line that was no longer there. That is what made the removal
look deliberate.

## Verification — measured, not reasoned

Restoring MeshWeaver.Plugins' `MeshWeaver.Hosting.Sqlite` project against each tree:

| `MeshWeaverRoot` | result |
|---|---|
| core `main` (`dca0c30e1`) | **exit 1** — `NU1010`, exactly CD's error |
| core `main` + this commit | **exit 0** |

The managed trio stays unpinned, exactly as #3344 decided: nothing in this repo's `src/` consumes
SQLitePCLRaw, and that fix belongs beside its reason as the `VersionOverride` in Plugins#1351.

Pairs-with: none — restores a package version entry; removes no public surface.

Refs #3344, #3342, #3328