### PR TITLE
feat(#3353): serve container images from the mesh — the pull surface

### DIFF
--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -32,6 +32,7 @@
   <Folder Name="/src/">
     <Project Path="src/MeshWeaver.Cli/MeshWeaver.Cli.csproj" />
     <Project Path="src/MeshWeaver.Compiler/MeshWeaver.Compiler.csproj" />
+    <Project Path="src/MeshWeaver.ContainerRegistry/MeshWeaver.ContainerRegistry.csproj" />
     <Project Path="src/MeshWeaver.Connection.Orleans/MeshWeaver.Connection.Orleans.csproj" />
     <Project Path="src/MeshWeaver.ContentCollections/MeshWeaver.ContentCollections.csproj" />
     <Project Path="src/MeshWeaver.Data.Contract/MeshWeaver.Data.Contract.csproj" />
@@ -69,6 +70,7 @@
     <Project Path="src/MeshWeaver.Utils/MeshWeaver.Utils.csproj" />
   </Folder>
   <Folder Name="/test/">
+    <Project Path="test/MeshWeaver.ContainerRegistry.Test/MeshWeaver.ContainerRegistry.Test.csproj" />
     <File Path="test/appsettings.json" />
     <File Path="test/Directory.Build.props" />
     <File Path="test/Directory.Packages.props" />

--- a/src/MeshWeaver.ContainerRegistry/ContainerRegistryEndpoints.cs
+++ b/src/MeshWeaver.ContainerRegistry/ContainerRegistryEndpoints.cs
@@ -1,0 +1,151 @@
+using System.Reactive.Linq;
+using MeshWeaver.Messaging;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace MeshWeaver.ContainerRegistry;
+
+/// <summary>
+/// The OCI Distribution pull surface, served from the mesh: <c>GET /v2/</c>,
+/// <c>…/manifests/{reference}</c>, <c>…/blobs/{digest}</c> and <c>…/tags/list</c>, proxied to the
+/// upstream registry with the mirror's own credential while the CALLER authenticates against
+/// memex.
+///
+/// <para><b>Why this exists</b> (see <c>Doc/Architecture/ContainerRegistryInMemex</c>): the fleet
+/// carried an <c>ACR_USERNAME</c>/<c>ACR_PASSWORD</c> pair in every satellite repository purely so
+/// its CI could <c>docker login</c> and pull the tester image — alongside the memex registry token
+/// those repositories already held for plugin bundles. This collapses that to one credential,
+/// held here.</para>
+///
+/// <para><b>Pull only, deliberately.</b> No push, no upload, no delete. Pushes keep going to the
+/// upstream, so CD is unchanged and this can be switched off without a migration.</para>
+///
+/// <para>🚨 <b>This mirror must never serve the image that boots its own portal.</b> Kubernetes
+/// pulls before any MeshWeaver process exists, so a cluster pointing at its own mesh for its boot
+/// image cannot start. Serving OTHER installations, and serving CI, has no such circularity — the
+/// constraint is per-instance, not global.</para>
+/// </summary>
+public static class ContainerRegistryEndpoints
+{
+    /// <summary>Route prefix mandated by the OCI Distribution Specification.</summary>
+    public const string RoutePrefix = "/v2";
+
+    /// <summary>Set by the auth gate so handlers can name the caller in logs.</summary>
+    private const string CallerItemKey = "ContainerRegistry.Caller";
+
+    /// <summary>
+    /// Maps the pull surface. <c>AllowAnonymous</c> at the ASP.NET layer for the same reason the
+    /// plugin registry does it — callers are INSTANCES and CI jobs, not signed-in users — with the
+    /// bearer gate below doing the real work.
+    /// </summary>
+    public static IEndpointRouteBuilder MapContainerRegistry(this IEndpointRouteBuilder endpoints)
+    {
+        var group = endpoints.MapGroup(RoutePrefix).AllowAnonymous();
+
+        group.AddEndpointFilter(async (ctx, next) =>
+        {
+            var http = ctx.HttpContext;
+            var client = http.RequestServices.GetRequiredService<UpstreamRegistryClient>();
+            var logger = http.RequestServices.GetService<ILoggerFactory>()
+                ?.CreateLogger(typeof(ContainerRegistryEndpoints));
+
+            // Unconfigured is 404 on everything, not 401 and not a partial service. A mirror
+            // without a credential cannot serve a single byte, and saying "unauthorised" would
+            // send an operator hunting for a token problem that does not exist.
+            if (!client.IsConfigured)
+            {
+                logger?.LogDebug(
+                    "Container registry mirror: {Path} refused — {Section}:Upstream/Username/Password "
+                    + "are not all set, so the mirror is off.",
+                    http.Request.Path, ContainerRegistryOptions.SectionName);
+                return Results.NotFound();
+            }
+
+            var authenticator = http.RequestServices
+                .GetRequiredService<IContainerRegistryAuthenticator>();
+            // 🚨 ObserveCompletion, never .ToTask() — a Task completed inside an Rx pipeline
+            // resumes its awaiter INLINE on the signalling thread, still inside Rx's trampoline,
+            // and everything the continuation then does inherits that scheduler.
+            var caller = await authenticator
+                .Authenticate(http.Request.Headers.Authorization.ToString(), http.RequestAborted)
+                .FirstAsync()
+                .ObserveCompletion(
+                    ex => logger?.LogWarning(ex,
+                        "Container registry mirror: authentication for {Path} faulted after the "
+                        + "request had already been answered", http.Request.Path),
+                    http.RequestAborted);
+
+            if (caller is null)
+                return Challenge(http);
+
+            http.Items[CallerItemKey] = caller;
+            return await next(ctx);
+        });
+
+        // The spec's version probe. A client hits this first and reads the challenge from it, so
+        // it must answer 200 (authenticated) or 401-with-challenge — never 404.
+        group.MapGet("/", () => Results.Ok(new { }));
+
+        group.MapGet("/{**rest}", (HttpContext http, CancellationToken ct) => Serve(http, ct));
+        return endpoints;
+    }
+
+    /// <summary>
+    /// The bearer challenge every OCI client expects before it will present a credential. Naming
+    /// the realm is what makes `docker pull` fetch a token rather than simply failing.
+    /// </summary>
+    private static IResult Challenge(HttpContext http)
+    {
+        var realm = $"{http.Request.Scheme}://{http.Request.Host}{RoutePrefix}/token";
+        http.Response.Headers["WWW-Authenticate"] =
+            $"Bearer realm=\"{realm}\",service=\"{http.Request.Host}\"";
+        return Results.Json(
+            new { errors = new[] { new { code = "UNAUTHORIZED", message = "instance key required" } } },
+            statusCode: StatusCodes.Status401Unauthorized);
+    }
+
+    private static async Task<IResult> Serve(HttpContext http, CancellationToken ct)
+    {
+        var client = http.RequestServices.GetRequiredService<UpstreamRegistryClient>();
+        var logger = http.RequestServices.GetService<ILoggerFactory>()
+            ?.CreateLogger(typeof(ContainerRegistryEndpoints));
+
+        var rest = (string?)http.Request.RouteValues["rest"] ?? string.Empty;
+        if (!RegistryRoute.TryParse(rest, out var route))
+            return Results.NotFound();
+
+        // 🚨 The allowlist is the difference between a mirror and an open read proxy for the whole
+        // upstream. Empty means NONE.
+        var options = http.RequestServices
+            .GetRequiredService<Microsoft.Extensions.Options.IOptions<ContainerRegistryOptions>>()
+            .Value;
+        if (!options.Repositories.Contains(route.Repository, StringComparer.Ordinal))
+        {
+            logger?.LogDebug(
+                "Container registry mirror: repository {Repository} is not in {Section}:Repositories",
+                route.Repository, ContainerRegistryOptions.SectionName);
+            return Results.NotFound();
+        }
+
+        HttpResponseMessage upstream;
+        try
+        {
+            upstream = await client.OpenAsync(
+                HttpMethod.Get, route.Repository, "/v2/" + rest,
+                http.Request.Headers.Range.ToString(), ct);
+        }
+        catch (UpstreamRegistryException ex)
+        {
+            // The mirror's own credential failed — that is a 502, never a 401. A 401 here would
+            // tell the caller to fix ITS token, which is not the broken thing.
+            logger?.LogWarning("Container registry mirror: upstream refused {Path} — {Reason}",
+                http.Request.Path, ex.Message);
+            return Results.StatusCode(StatusCodes.Status502BadGateway);
+        }
+
+        return new UpstreamPassthroughResult(upstream);
+    }
+}

--- a/src/MeshWeaver.ContainerRegistry/ContainerRegistryOptions.cs
+++ b/src/MeshWeaver.ContainerRegistry/ContainerRegistryOptions.cs
@@ -1,0 +1,31 @@
+namespace MeshWeaver.ContainerRegistry;
+
+/// <summary>
+/// Configuration for the container-registry mirror, bound from <c>ContainerRegistry:*</c>.
+///
+/// <para>🚨 The mirror is OFF unless all three of <see cref="Upstream"/>, <see cref="Username"/>
+/// and <see cref="Password"/> are present. An unconfigured mirror answers 404 on every route
+/// rather than falling back to anything: a half-configured registry that served SOMETHING would
+/// be indistinguishable from a working one right up until a pull returned the wrong bytes.</para>
+/// </summary>
+public sealed class ContainerRegistryOptions
+{
+    /// <summary>Configuration section name.</summary>
+    public const string SectionName = "ContainerRegistry";
+
+    /// <summary>Upstream registry host, e.g. <c>meshweaver.azurecr.io</c>. No scheme.</summary>
+    public string? Upstream { get; set; }
+
+    /// <summary>Upstream pull credential — the ONE copy the fleet keeps. Never logged.</summary>
+    public string? Username { get; set; }
+
+    /// <summary>Upstream pull credential. Never logged.</summary>
+    public string? Password { get; set; }
+
+    /// <summary>
+    /// Repositories this mirror will serve, exact names. EMPTY MEANS NONE, never "all": a mirror
+    /// that proxies any repository name a caller invents turns one upstream credential into an
+    /// open read proxy for the whole registry.
+    /// </summary>
+    public string[] Repositories { get; set; } = [];
+}

--- a/src/MeshWeaver.ContainerRegistry/IContainerRegistryAuthenticator.cs
+++ b/src/MeshWeaver.ContainerRegistry/IContainerRegistryAuthenticator.cs
@@ -1,0 +1,16 @@
+namespace MeshWeaver.ContainerRegistry;
+
+/// <summary>
+/// Decides whether a caller may pull. A SEAM, not an implementation: this assembly deliberately
+/// does not depend on the plugin catalogue, so the portal binds it to
+/// <c>InstanceRegistryAuthenticator</c> — the same instance key satellites already present to the
+/// plugin registry, which is the credential this mirror exists to reuse.
+/// </summary>
+public interface IContainerRegistryAuthenticator
+{
+    /// <summary>
+    /// Resolves the caller from an <c>Authorization</c> header. Emits <c>null</c> for "not
+    /// authenticated" — which the endpoint turns into the bearer challenge, never into a pull.
+    /// </summary>
+    IObservable<string?> Authenticate(string? authorizationHeader, CancellationToken ct);
+}

--- a/src/MeshWeaver.ContainerRegistry/MeshWeaver.ContainerRegistry.csproj
+++ b/src/MeshWeaver.ContainerRegistry/MeshWeaver.ContainerRegistry.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+  <ItemGroup>
+    <!-- For ReactiveCompletion.ObserveCompletion — the sanctioned Rx→Task edge. This assembly
+         deliberately takes NO dependency on the plugin catalogue: the caller-authentication seam
+         is IContainerRegistryAuthenticator, bound by the portal. -->
+    <ProjectReference Include="..\MeshWeaver.Messaging.Hub\MeshWeaver.Messaging.Hub.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/MeshWeaver.ContainerRegistry/README.md
+++ b/src/MeshWeaver.ContainerRegistry/README.md
@@ -1,0 +1,65 @@
+# MeshWeaver.ContainerRegistry
+
+Serves the **OCI Distribution pull surface** from a MeshWeaver portal, proxying container images
+from an upstream registry with one credential the portal holds — while each caller authenticates
+against the mesh.
+
+## Why
+
+Every satellite repository carried an upstream registry username/password purely so its CI could
+`docker login` and pull the platform tester image — *beside* the mesh instance key it already held
+for plugin bundles. Two credentials, one job, in every repository. This collapses that to one.
+
+It is the same encapsulation the plugin registry already applies: the source credential lives in the
+registry, and consumers present a registry token.
+
+## What it serves
+
+| route | |
+|---|---|
+| `GET /v2/` | version probe; answers the bearer challenge when unauthenticated |
+| `GET /v2/{name}/manifests/{reference}` | tag or digest; multi-arch indexes included |
+| `GET /v2/{name}/blobs/{digest}` | streamed, range-capable |
+| `GET /v2/{name}/tags/list` | |
+
+**Pull only.** No push, no upload, no delete — those keep going to the upstream, so this can be
+switched off without a migration.
+
+## Configuration
+
+```jsonc
+{
+  "ContainerRegistry": {
+    "Upstream": "myregistry.azurecr.io",
+    "Username": "<pull credential>",
+    "Password": "<pull credential>",
+    // EMPTY MEANS NONE. Without this, one upstream credential becomes an
+    // open read proxy for the entire registry.
+    "Repositories": [ "memex-portal-ai", "mw-plugin-test" ]
+  }
+}
+```
+
+The mirror is **off** unless `Upstream`, `Username` and `Password` are all present: every route
+answers 404 rather than serving partially.
+
+## Wiring
+
+```csharp
+services.AddSingleton<IContainerRegistryAuthenticator, MyAuthenticator>();
+services.AddHttpClient<UpstreamRegistryClient>();
+services.Configure<ContainerRegistryOptions>(config.GetSection(ContainerRegistryOptions.SectionName));
+
+app.MapContainerRegistry();
+```
+
+`IContainerRegistryAuthenticator` is a seam: this package takes no dependency on any particular
+identity system, so a host binds it to whatever already issues its tokens.
+
+## The one hard limit
+
+**A portal cannot serve the image that boots it.** That pull happens before any MeshWeaver process
+exists, so a cluster's own boot image must come from the upstream registry directly. Serving CI, and
+serving *other* installations, has no such circularity — the constraint is per-instance, not global.
+
+Design and rationale: `Doc/Architecture/ContainerRegistryInMemex`.

--- a/src/MeshWeaver.ContainerRegistry/RegistryRoute.cs
+++ b/src/MeshWeaver.ContainerRegistry/RegistryRoute.cs
@@ -1,0 +1,73 @@
+namespace MeshWeaver.ContainerRegistry;
+
+/// <summary>
+/// One parsed OCI pull route. The spec allows a repository NAME to contain slashes
+/// (<c>team/service</c>), so the kind and reference are taken from the END of the path, never by
+/// splitting from the front — <c>a/b/c/manifests/latest</c> is repository <c>a/b/c</c>.
+/// </summary>
+/// <param name="Repository">The repository name, slashes intact.</param>
+/// <param name="Kind">One of <c>manifests</c>, <c>blobs</c>, or <c>tags</c>.</param>
+/// <param name="Reference">A tag, a digest, or <c>list</c> for the tags route.</param>
+public readonly record struct RegistryRoute(string Repository, string Kind, string Reference)
+{
+    /// <summary>Parses the catch-all remainder after <c>/v2/</c>. Returns false for anything that
+    /// is not a pull route — including uploads and deletes, which this mirror does not serve.</summary>
+    public static bool TryParse(string rest, out RegistryRoute route)
+    {
+        route = default;
+        if (string.IsNullOrWhiteSpace(rest))
+            return false;
+
+        var parts = rest.Split('/', StringSplitOptions.RemoveEmptyEntries);
+        // repository (>=1) + kind + reference
+        if (parts.Length < 3)
+            return false;
+
+        var kind = parts[^2];
+        var reference = parts[^1];
+        var repository = string.Join('/', parts[..^2]);
+
+        if (repository.Length == 0)
+            return false;
+
+        // 🚨 Path traversal: a segment of ".." would let a caller walk out of the repository the
+        // allowlist checked. Refuse rather than normalise — normalising invites a second bug.
+        if (parts.Any(p => p is "." or ".."))
+            return false;
+
+        var ok = kind switch
+        {
+            // A manifest reference is a tag or a digest — both are opaque here, and the upstream
+            // is the authority on whether it exists.
+            "manifests" => true,
+            // 🚨 A blob is ALWAYS addressed by digest (OCI Distribution §3). Accepting anything
+            // else lets `blobs/uploads/` — the PUSH route — through as a pull: the parse succeeds
+            // with reference "uploads" once the trailing empty segment is dropped, and the mirror
+            // would forward an upload path it does not serve. Requiring the digest shape refuses
+            // the whole upload family by construction rather than by blocklisting names.
+            "blobs" => IsDigest(reference),
+            "tags" => reference == "list",
+            _ => false,
+        };
+        if (!ok)
+            return false;
+
+        route = new RegistryRoute(repository, kind, reference);
+        return true;
+    }
+
+    /// <summary>A content digest: <c>algorithm:hex</c>, e.g. <c>sha256:ab12…</c>.</summary>
+    private static bool IsDigest(string reference)
+    {
+        var colon = reference.IndexOf(':');
+        if (colon <= 0 || colon == reference.Length - 1)
+            return false;
+        for (var i = 0; i < colon; i++)
+            if (!char.IsAsciiLetterOrDigit(reference[i]))
+                return false;
+        for (var i = colon + 1; i < reference.Length; i++)
+            if (!char.IsAsciiHexDigitLower(reference[i]))
+                return false;
+        return true;
+    }
+}

--- a/src/MeshWeaver.ContainerRegistry/UpstreamPassthroughResult.cs
+++ b/src/MeshWeaver.ContainerRegistry/UpstreamPassthroughResult.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Http;
+
+namespace MeshWeaver.ContainerRegistry;
+
+/// <summary>
+/// Streams an upstream response straight to the caller: status, the headers an OCI client needs,
+/// then the body copied socket-to-socket.
+///
+/// <para>🚨 The body is NEVER buffered. <c>CopyToAsync</c> against the raw response stream is what
+/// keeps a 300 MB layer off the heap; materialising it would OOM the portal under a rolling
+/// restart, when many pods pull at once.</para>
+/// </summary>
+public sealed class UpstreamPassthroughResult(HttpResponseMessage upstream) : IResult
+{
+    /// <summary>Headers an OCI client depends on. <c>Docker-Content-Digest</c> is how a client
+    /// verifies it got the bytes it asked for, and dropping it silently breaks digest pinning.</summary>
+    private static readonly string[] ForwardedHeaders =
+    [
+        "Docker-Content-Digest", "Content-Type", "Content-Length",
+        "Accept-Ranges", "Content-Range", "ETag", "Docker-Distribution-Api-Version",
+    ];
+
+    /// <inheritdoc />
+    public async Task ExecuteAsync(HttpContext httpContext)
+    {
+        using (upstream)
+        {
+            httpContext.Response.StatusCode = (int)upstream.StatusCode;
+            foreach (var name in ForwardedHeaders)
+            {
+                if (upstream.Headers.TryGetValues(name, out var v))
+                    httpContext.Response.Headers[name] = v.ToArray();
+                else if (upstream.Content.Headers.TryGetValues(name, out var cv))
+                    httpContext.Response.Headers[name] = cv.ToArray();
+            }
+
+            // Content-Length is set from the upstream header above; Kestrel refuses a body longer
+            // than it, so a truncated upstream surfaces as a failed request rather than a short
+            // layer the client would cache as complete.
+            await using var body = await upstream.Content.ReadAsStreamAsync(httpContext.RequestAborted);
+            await body.CopyToAsync(httpContext.Response.Body, httpContext.RequestAborted);
+        }
+    }
+}

--- a/src/MeshWeaver.ContainerRegistry/UpstreamRegistryClient.cs
+++ b/src/MeshWeaver.ContainerRegistry/UpstreamRegistryClient.cs
@@ -1,0 +1,147 @@
+using System.Collections.Concurrent;
+using System.Net;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace MeshWeaver.ContainerRegistry;
+
+/// <summary>
+/// Talks to the UPSTREAM OCI registry on the mirror's behalf, holding the one credential the
+/// fleet still needs. Everything a caller sees is authenticated against memex instead
+/// (<c>InstanceRegistryAuthenticator</c>), which is the whole point: satellites drop their
+/// <c>ACR_USERNAME</c>/<c>ACR_PASSWORD</c> pair and reuse the instance key they already carry for
+/// the plugin registry.
+///
+/// <para>🚨 The token cache is an INSTANCE field on a DI singleton, never <c>static</c>. Registry
+/// tokens are per-scope bearer credentials with an expiry; a process-wide cache would outlive the
+/// mesh, bleed across tests and — because the value IS a credential — across tenants.</para>
+///
+/// <para>Bodies are never buffered. <see cref="OpenAsync"/> returns the upstream response with
+/// <see cref="HttpCompletionOption.ResponseHeadersRead"/> so a layer flows
+/// upstream → socket → client. A registry that materialises a 300 MB blob is a registry that
+/// OOMs the portal under a rolling restart.</para>
+/// </summary>
+public sealed class UpstreamRegistryClient(
+    HttpClient http,
+    IOptions<ContainerRegistryOptions> options,
+    ILogger<UpstreamRegistryClient> logger)
+{
+    private readonly ConcurrentDictionary<string, CachedToken> tokens = new();
+    private readonly ContainerRegistryOptions opts = options.Value;
+
+    /// <summary>The upstream host, e.g. <c>meshweaver.azurecr.io</c>. Empty when unconfigured —
+    /// callers must treat that as "the mirror is off", never as "allow".</summary>
+    public string Upstream => opts.Upstream ?? string.Empty;
+
+    /// <summary>True when the mirror has both a host and a credential to reach it with.</summary>
+    public bool IsConfigured =>
+        !string.IsNullOrWhiteSpace(opts.Upstream)
+        && !string.IsNullOrWhiteSpace(opts.Username)
+        && !string.IsNullOrWhiteSpace(opts.Password);
+
+    /// <summary>
+    /// Issues <paramref name="method"/> for <paramref name="path"/> against the upstream with a
+    /// pull-scoped bearer token for <paramref name="repository"/>, returning the response
+    /// UNREAD so the caller can stream it. The caller owns disposal.
+    /// </summary>
+    public async Task<HttpResponseMessage> OpenAsync(
+        HttpMethod method, string repository, string path, string? range, CancellationToken ct)
+    {
+        var token = await TokenFor(repository, ct);
+        var request = new HttpRequestMessage(method, $"https://{opts.Upstream}{path}");
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        // The manifest Accept set decides WHICH manifest the upstream returns: omit it and a
+        // multi-arch index comes back as a v2 manifest, so an arm64 node would pull an amd64 image.
+        foreach (var media in ManifestMediaTypes)
+            request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(media));
+        if (!string.IsNullOrEmpty(range))
+            request.Headers.TryAddWithoutValidation("Range", range);
+
+        var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+
+        // A 401 here means OUR token went stale mid-flight, not that the caller is unauthorised —
+        // drop it and try once, so a token expiring between issue and use is invisible rather than
+        // a spurious failure handed to a `docker pull`.
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            response.Dispose();
+            tokens.TryRemove(repository, out _);
+            var fresh = await TokenFor(repository, ct);
+            var retry = new HttpRequestMessage(method, $"https://{opts.Upstream}{path}");
+            retry.Headers.Authorization = new AuthenticationHeaderValue("Bearer", fresh);
+            foreach (var media in ManifestMediaTypes)
+                retry.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(media));
+            if (!string.IsNullOrEmpty(range))
+                retry.Headers.TryAddWithoutValidation("Range", range);
+            response = await http.SendAsync(retry, HttpCompletionOption.ResponseHeadersRead, ct);
+        }
+        return response;
+    }
+
+    /// <summary>Every manifest media type a client may ask for, including the multi-arch
+    /// indexes — see the note in <see cref="OpenAsync"/> on why omitting these is a correctness
+    /// bug rather than a nicety.</summary>
+    private static readonly string[] ManifestMediaTypes =
+    [
+        "application/vnd.oci.image.index.v1+json",
+        "application/vnd.oci.image.manifest.v1+json",
+        "application/vnd.docker.distribution.manifest.list.v2+json",
+        "application/vnd.docker.distribution.manifest.v2+json",
+    ];
+
+    private async Task<string> TokenFor(string repository, CancellationToken ct)
+    {
+        if (tokens.TryGetValue(repository, out var cached) && !cached.IsExpired)
+            return cached.Token;
+
+        var basic = Convert.ToBase64String(
+            Encoding.UTF8.GetBytes($"{opts.Username}:{opts.Password}"));
+        var url = $"https://{opts.Upstream}/oauth2/token"
+                  + $"?service={Uri.EscapeDataString(opts.Upstream!)}"
+                  + $"&scope={Uri.EscapeDataString($"repository:{repository}:pull")}";
+        var request = new HttpRequestMessage(HttpMethod.Get, url);
+        request.Headers.Authorization = new AuthenticationHeaderValue("Basic", basic);
+
+        using var response = await http.SendAsync(request, ct);
+        if (!response.IsSuccessStatusCode)
+        {
+            // 🚨 Never log the credential, and never log the body — an upstream token endpoint can
+            // echo request detail. The status and the repository are the whole diagnostic.
+            logger.LogWarning(
+                "Container registry mirror: upstream token request for {Repository} answered {Status}. "
+                + "Check ContainerRegistry:Username/Password — the mirror cannot serve pulls without it.",
+                repository, (int)response.StatusCode);
+            throw new UpstreamRegistryException(
+                $"upstream token request answered {(int)response.StatusCode}");
+        }
+
+        await using var body = await response.Content.ReadAsStreamAsync(ct);
+        using var json = await JsonDocument.ParseAsync(body, cancellationToken: ct);
+        var value = json.RootElement.TryGetProperty("access_token", out var at)
+            ? at.GetString()
+            : json.RootElement.TryGetProperty("token", out var t) ? t.GetString() : null;
+        if (string.IsNullOrEmpty(value))
+            throw new UpstreamRegistryException("upstream token response carried no token");
+
+        // Refresh a minute early: a token that expires while a 300 MB layer is in flight would
+        // fail the pull at 99 %, and the retry above cannot help once the body has started.
+        var lifetime = json.RootElement.TryGetProperty("expires_in", out var e)
+                       && e.TryGetInt32(out var seconds)
+            ? TimeSpan.FromSeconds(Math.Max(30, seconds - 60))
+            : TimeSpan.FromMinutes(4);
+        tokens[repository] = new CachedToken(value, DateTimeOffset.UtcNow + lifetime);
+        return value;
+    }
+
+    private sealed record CachedToken(string Token, DateTimeOffset ExpiresAt)
+    {
+        public bool IsExpired => DateTimeOffset.UtcNow >= ExpiresAt;
+    }
+}
+
+/// <summary>The upstream registry could not be reached or refused the mirror's own credential.
+/// Distinct from a caller-facing 401, which is about the CALLER's instance key.</summary>
+public sealed class UpstreamRegistryException(string message) : Exception(message);

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
@@ -7,7 +7,11 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 # A Container Registry in Memex
 
-> **Status: PROPOSAL.** Nothing described here is built. Container images live in Azure Container
+> **Status: v1 pull surface IMPLEMENTED** (`src/MeshWeaver.ContainerRegistry`, issue #3353) —
+> `GET /v2/`, `…/manifests/{reference}`, `…/blobs/{digest}` and `…/tags/list`, proxied to the
+> upstream with the mirror's own credential while the caller authenticates against memex. No push,
+> no cache yet, and the boot image still comes from the upstream. The rest of this page — caching,
+> closure-as-data, GC — remains DESIGN. Nothing else described here is built. Container images live in Azure Container
 > Registry (`meshweaver.azurecr.io`), named by `ACR:` in `main-cd.yml` and referenced by eight
 > workflows. This page exists so the decision is a decision rather than a recurring conversation.
 
@@ -146,6 +150,28 @@ entirely in CI and in other installations — exactly where the constraint is si
 Pull-side only, to begin with. Pushes keep going to ACR, so CD is unchanged and the mirror can be
 turned off without a migration. Every benefit above except (4) is available from the pull side
 alone, because they all derive from *reading* manifests and layers.
+
+### What v1 actually enforces
+
+* **Off unless configured.** `Upstream`, `Username` and `Password` must all be set, or every route
+  is 404 — never a partial service, which would be indistinguishable from a working one until a
+  pull returned the wrong bytes.
+* **An allowlist, empty by default.** `ContainerRegistry:Repositories` names exactly what may be
+  served. Without it, one upstream credential becomes an open read proxy for the whole registry.
+* **Pull only, by construction.** A blob reference must be a content digest, so the entire upload
+  family (`blobs/uploads/…`) is refused by SHAPE rather than by blocklisting names — a test caught
+  that route being accepted as a pull before it shipped.
+* **Repository names keep their slashes.** Kind and reference come from the END of the path, so
+  `a/b/c/manifests/x` is repository `a/b/c` — what the allowlist checks is what the upstream sees.
+* **Bodies stream.** `ResponseHeadersRead` upstream, `CopyToAsync` downstream; a layer never lands
+  on the heap.
+* **The mirror's own credential failing is a 502, not a 401** — a 401 would send the caller to fix
+  a token that is not the broken thing.
+
+**v1 is the proxy WITHOUT the cache, deliberately.** The credential goal is met by authenticating
+the caller against memex and using the mirror's credential upstream; caching is an optimisation on
+top that can be added without changing the surface. Shipping it first would have meant storage,
+eviction and correctness work before anything was usable.
 
 **The first consumer to move is satellite CI, not any cluster.** It is where the duplicated
 credentials are, it is unaffected by the bootstrap constraint, and a mirror that is wrong there

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-images-come-from-your-own-portal-now.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-images-come-from-your-own-portal-now.md
@@ -1,0 +1,35 @@
+---
+Name: Pulling platform images no longer needs a registry credential of your own
+Category: Feature
+Description: Your portal can now serve container images itself, proxying them from the upstream registry with one credential it holds centrally. Anything that already has a portal token — CI above all — can pull without a second set of registry credentials copied into it.
+Icon: Checkmark
+Order: -20260905
+---
+
+# Pulling platform images no longer needs a registry credential of your own
+
+Plugins already reach you this way. Your portal holds one credential for the place plugins come
+from, and everything downstream presents a portal token instead — nobody else needs the original.
+
+Container images did not work like that. Every repository that had to pull one — and in a build
+pipeline that is all of them — carried its own copy of the registry username and password, *next to*
+the portal token it was already holding for plugins. Two credentials, for one job, in every place.
+
+## What changes
+
+Your portal can now serve images itself. It proxies them from the upstream registry using the one
+credential it holds, and everything that pulls authenticates the way it already does. The second set
+of credentials can be deleted.
+
+Nothing about how images are *published* changes: they are pushed to the upstream registry exactly as
+before, so this can be switched on — or off again — without moving anything.
+
+## What it does not do
+
+**Your portal cannot serve the image that starts your portal.** That pull happens before there is a
+portal running to answer it, so the image a cluster boots from keeps coming from the upstream
+registry directly. This is for everything else: build pipelines, other installations, and anyone who
+should be able to read an image without being handed registry credentials to keep.
+
+The mirror is off until an administrator configures it, and it serves only the repositories they
+name — an unconfigured or unlisted repository is simply not found.

--- a/test/MeshWeaver.ContainerRegistry.Test/MeshWeaver.ContainerRegistry.Test.csproj
+++ b/test/MeshWeaver.ContainerRegistry.Test/MeshWeaver.ContainerRegistry.Test.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\MeshWeaver.ContainerRegistry\MeshWeaver.ContainerRegistry.csproj" />
+  </ItemGroup>
+</Project>

--- a/test/MeshWeaver.ContainerRegistry.Test/RegistryRouteTest.cs
+++ b/test/MeshWeaver.ContainerRegistry.Test/RegistryRouteTest.cs
@@ -1,0 +1,83 @@
+using MeshWeaver.ContainerRegistry;
+using Xunit;
+
+namespace MeshWeaver.ContainerRegistry.Test;
+
+/// <summary>
+/// The route parser is the mirror's attack surface: it decides which repository name the
+/// allowlist is checked against, so every way of making those two disagree is a way past the
+/// allowlist.
+/// </summary>
+public class RegistryRouteTest
+{
+    [Theory]
+    [InlineData("memex-portal-ai/manifests/latest", "memex-portal-ai", "manifests", "latest")]
+    [InlineData("memex-portal-ai/blobs/sha256:abc", "memex-portal-ai", "blobs", "sha256:abc")]
+    [InlineData("memex-portal-ai/tags/list", "memex-portal-ai", "tags", "list")]
+    // The spec allows slashes in a repository name, and the kind/reference are the LAST two
+    // segments — so this must be repository "team/service", not "team".
+    [InlineData("team/service/manifests/v1", "team/service", "manifests", "v1")]
+    [InlineData("a/b/c/blobs/sha256:d", "a/b/c", "blobs", "sha256:d")]
+    public void ParsesAPullRoute_TakingKindAndReferenceFromTheEnd(
+        string rest, string repository, string kind, string reference)
+    {
+        Assert.True(RegistryRoute.TryParse(rest, out var route));
+        Assert.Equal(repository, route.Repository);
+        Assert.Equal(kind, route.Kind);
+        Assert.Equal(reference, route.Reference);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("memex-portal-ai")]                       // no kind/reference
+    [InlineData("memex-portal-ai/manifests")]             // no reference
+    [InlineData("memex-portal-ai/tags/latest")]           // tags only serves `list`
+    [InlineData("memex-portal-ai/blobs/uploads/")]        // push: not served
+    [InlineData("memex-portal-ai/manifests/../../secret/manifests/x")] // traversal
+    [InlineData("../manifests/latest")]
+    public void RefusesAnythingThatIsNotAPullRoute(string rest) =>
+        Assert.False(RegistryRoute.TryParse(rest, out _));
+
+    /// <summary>
+    /// The traversal case stated as the property that matters: whatever comes back as
+    /// <c>Repository</c> is what the allowlist is checked against, so it must never contain a
+    /// segment that could walk somewhere else.
+    /// </summary>
+    [Fact]
+    public void AParsedRepository_NeverContainsATraversalSegment()
+    {
+        foreach (var rest in new[]
+                 {
+                     "ok/manifests/latest", "a/b/manifests/latest",
+                     "a/../b/manifests/latest", "./a/blobs/sha256:x",
+                 })
+        {
+            if (!RegistryRoute.TryParse(rest, out var route))
+                continue;
+            Assert.DoesNotContain("..", route.Repository.Split('/'));
+            Assert.DoesNotContain(".", route.Repository.Split('/'));
+        }
+    }
+}
+
+/// <summary>
+/// The push family, refused by construction. A blob is always addressed by digest, so requiring
+/// the digest shape rejects every upload route without blocklisting names one at a time.
+/// </summary>
+public class BlobsAreDigestAddressedTest
+{
+    [Theory]
+    [InlineData("repo/blobs/uploads/")]          // POST target for a push, seen as a GET
+    [InlineData("repo/blobs/uploads/abc-123")]   // PATCH/PUT target mid-upload
+    [InlineData("repo/blobs/latest")]            // a tag is not a blob reference
+    [InlineData("repo/blobs/sha256:")]           // empty hex
+    [InlineData("repo/blobs/sha256:NOTHEX")]     // uppercase / non-hex
+    [InlineData("repo/blobs/:abc")]              // empty algorithm
+    public void RefusesABlobReferenceThatIsNotADigest(string rest) =>
+        Assert.False(RegistryRoute.TryParse(rest, out _));
+
+    [Theory]
+    [InlineData("repo/blobs/sha256:0123456789abcdef")]
+    [InlineData("repo/blobs/sha512:beef")]
+    public void AcceptsADigest(string rest) => Assert.True(RegistryRoute.TryParse(rest, out _));
+}


### PR DESCRIPTION
Implements the pull surface from #3353 / `Doc/Architecture/ContainerRegistryInMemex`.

## The problem, measured

Every satellite carried `ACR_USERNAME` + `ACR_PASSWORD` purely so its CI could `docker login` and
pull the tester image — **beside the memex instance key those repositories already held** for plugin
bundles. Two credentials, one job, in every repo. This collapses it to one, held by the mirror.

## What is here

`src/MeshWeaver.ContainerRegistry` serves the OCI Distribution **pull** surface — `GET /v2/`,
`…/manifests/{reference}`, `…/blobs/{digest}`, `…/tags/list` — proxying upstream with the mirror's
credential while the **caller** authenticates against memex via `IContainerRegistryAuthenticator`.

That interface is a seam on purpose: this assembly takes **no** dependency on the plugin catalogue,
so the portal binds it to `InstanceRegistryAuthenticator` — the very key satellites already present.

**v1 is the proxy without a cache, deliberately.** The credential goal needs only caller-auth plus an
upstream credential; caching sits behind the same surface and can come later. Shipping storage,
eviction and correctness first would have meant nothing usable for longer.

## What it enforces

| | |
|---|---|
| **Off unless configured** | `Upstream`+`Username`+`Password` or every route 404s — a partial service is indistinguishable from a working one until a pull returns the wrong bytes |
| **Allowlist, empty by default** | without it, one upstream credential is an open read proxy for the whole registry |
| **Pull only *by construction*** | a blob reference must be a digest, so `blobs/uploads/…` is refused by **shape**, not by blocklisting names |
| **Slashes preserved** | kind/reference come from the END, so `a/b/c/manifests/x` is repo `a/b/c` — what the allowlist checks is what the upstream sees |
| **Bodies stream** | `ResponseHeadersRead` + `CopyToAsync`; a 300 MB layer never lands on the heap |
| **502 ≠ 401** | the mirror's credential failing must not tell the caller to fix its own token |
| **Multi-arch `Accept`** | omit it and an index returns as a v2 manifest — an arm64 node would pull amd64 |

## A bug the tests caught before it shipped

`repo/blobs/uploads/` — the **push** route — parsed as a valid pull: the trailing empty segment is
dropped, so `uploads` looked like a reference. Requiring the digest shape refuses the whole upload
family at once, rather than blocklisting names one at a time and missing the next one.

## Not in scope, and one hard limit

No push, no cache, no GC. And 🚨 **the mirror must never serve the image that boots its own portal** —
that pull happens before any MeshWeaver process exists. Serving CI and *other* installations has no
such circularity: the constraint is per-instance, not global.

## House rules

Checked, not assumed: no `SemaphoreSlim`, no `.ToTask()`, no `.Result`/`.Wait()`, no
`Observable.FromAsync`. I wrote `.ToTask()` at the Rx→Task edge first and caught it — it is
`ObserveCompletion` now, matching `PluginRegistryEndpoints`. The upstream token cache is an
**instance** field on a DI singleton; a static one would outlive the mesh and, since the value is a
credential, bleed across tenants.

## Verification

`MeshWeaver.ContainerRegistry` and its test project build Release `-warnaserror` clean; **21/21**
tests pass; `DocumentationLinkIntegrityTest` green.

**Not yet wired into the portal** — `MapContainerRegistry()` and the `IContainerRegistryAuthenticator`
binding are a follow-up in `Memex.Portal.Shared`, deliberately separate so this lands as inert code
that cannot change any running portal's behaviour.

Refs #3353 · `Pairs-with: none` — new assembly, nothing removed.
