### PR TITLE
build-project: --bind-to-image stamps a module with the image's own binding identity

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -173,13 +173,17 @@ name: node-repo module pack
 #   1. The PINNED image must carry the `build-project` verb (MeshWeaver#2850 merged AND an image
 #      built from it AND `platform-image-digest` moved to that image). Before that, the container
 #      run exits non-zero on an unknown argument.
-#   2. `build-project` must stamp the project's <AssemblyVersion>. It runs no MSBuild targets, so
-#      the SDK's GenerateAssemblyInfo does not happen and Roslyn's default identity is emitted —
-#      shipping 0.0.0.0 into a 3.0.0.0 process is MeshWeaver#143 exactly: it does not fail at build,
-#      it fails at runtime binding, in another repo, naming a version nobody wrote down. The build
-#      step compares the emitted identity against the one the builder itself read out of the image
-#      and FAILS on drift, so this cannot ship silently — but until the builder honours the
-#      property, that check is what a `container` entry will hit.
+#   2. `build-project` must carry `--bind-to-image`: the builder stamps every module with the
+#      IMAGE's own AssemblyVersion/FileVersion as immutable globals, because a module built here
+#      loads into that image's process and any other identity is MeshWeaver#143 exactly — it does
+#      not fail at build, it fails at runtime binding, in another repo, naming a version nobody
+#      wrote down. It cannot come from the repository: the evaluator runs no MSBuild property
+#      functions, so a module repo cannot DERIVE the platform's identity in its props (Plugins
+#      tried; every module came out 1.0.0.0), and a LITERAL there is right for one platform and
+#      wrong the day the line moves (3.0.0 → 3.1.0 reddened every image build in the fleet). The
+#      global build step probes the tester for the flag and FAILS naming the pin to move when the
+#      pinned image predates it; the pack step still compares the emitted identity against the one
+#      the builder read out of the image, so drift cannot ship silently either way.
 #
 # ──────────── The .NET SDK is a DECLARED need (`dotnet-sdk`) ────────────
 # 🚨 "make installing dotnet sdk a feature flag" (maintainer, 2026-08-31).
@@ -1023,6 +1027,15 @@ jobs:
           [ "${#superseded[@]}" -eq 0 ] || echo "superseding ${#superseded[@]} image assembl(y|ies) from the reference set: ${SUPERSEDED}"
           args=()
           for prj in "${projects[@]}"; do args+=("/repo/$prj"); done
+          # 🚨 The binding identity comes from the IMAGE, never from the repository (header,
+          # precondition 2). A tester that predates the flag would exit 2 on an unknown option with
+          # a message naming nothing; probe its usage first and name the pin that has to move.
+          if ! docker run --rm --platform linux/amd64 --user "$(id -u):$(id -g)" -e HOME=/tmp \
+               -v "$tester_app:/tester:ro" --entrypoint dotnet "$img" \
+               /tester/mw-plugin-test.dll build-project --help 2>&1 | grep -q -- '--bind-to-image'; then
+            echo "::error::the pinned tester (tester-image-digest $TESTER_DIGEST) has no 'build-project --bind-to-image', so it cannot stamp modules with the image's own AssemblyVersion — every module would fail the binding-identity check, or bind to a literal that is wrong for this platform. Move tester-image-digest and platform-image-digest TOGETHER to a set built from MeshWeaver main after the flag landed."
+            exit 1
+          fi
           echo "global build: ${#projects[@]} container entr(y|ies) in ONE workspace — ${projects[*]}"
           # AS THE RUNNER'S UID (a root-owned /out is unwritable to later steps); HOME=/tmp keeps
           # runtime probes off read-only image paths. No --extra-refs, ever, on this lane.
@@ -1032,7 +1045,7 @@ jobs:
             -v "$tester_app:/tester:ro" \
             -v "$out:/out" \
             --entrypoint dotnet "$img" \
-            /tester/mw-plugin-test.dll build-project "${args[@]}" --output /out ${accepts[@]+"${accepts[@]}"} ${superseded[@]+"${superseded[@]}"} 2>&1 | tee "$out/workspace-build.log"
+            /tester/mw-plugin-test.dll build-project "${args[@]}" --output /out --bind-to-image ${accepts[@]+"${accepts[@]}"} ${superseded[@]+"${superseded[@]}"} 2>&1 | tee "$out/workspace-build.log"
           echo "built=true" >> "$GITHUB_OUTPUT"
       # 🚨 THE PLATFORM CHECKOUT LANDS **AFTER** THE BUILD, ON PURPOSE. This job mounts
       # `$GITHUB_WORKSPACE` at `/repo:ro` for the container build, so anything checked out beside

--- a/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ModuleBuildArchitecture.md
@@ -123,7 +123,7 @@ selected entry**:
 |---|---|
 | `<Module>/<Module>.dll` | present and non-empty (a truncated emit reads as "the file is there") |
 | `<Module>.closure.txt` | present — without it a pack job cannot know which in-tree siblings ride *this* bundle, and a glob would ride every other module's |
-| `platform AssemblyVersion` in the build log | readable — it is the expected side of the binding-identity check every pack job runs |
+| `platform AssemblyVersion` in the build log | readable — it is the expected side of the binding-identity check every pack job runs, and since `--bind-to-image` it is also the value the builder STAMPED: a module's `AssemblyVersion`/`FileVersion` come from the image, never from the repository's props (the evaluator runs no MSBuild property functions, so a repository cannot derive them, and a literal is right for one platform only) |
 
 Three properties make it a postcondition rather than a second opinion:
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-module-built-in-the-image-carries-the-images-identity.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-module-built-in-the-image-carries-the-images-identity.md
@@ -1,0 +1,23 @@
+---
+Name: A module built inside the platform image carries the image's own binding identity
+Category: Fix
+Description: The in-image module builder now stamps every module with the platform's own assembly version, so a module repository no longer has to hand-copy that number — and cannot ship one that binds to the wrong platform.
+Icon: Checkmark
+Order: -20260905
+---
+
+# A module built inside the platform image carries the image's own binding identity
+
+A module compiled inside the platform image loads into that image's process and is bound by its
+assemblies, so it must carry the platform's assembly version exactly. Until now that number had to
+be written into the module repository as a literal, and checked after the fact. The day the
+platform line moved from 3.0.0 to 3.1.0, every image build in the fleet went red on that literal;
+a repository that tried to derive the number instead found the in-image builder runs no MSBuild
+property functions, and every module came out `1.0.0.0`.
+
+The builder now takes `--bind-to-image` and stamps `AssemblyVersion` and `FileVersion` with the
+identity it reads out of the image itself, as immutable globals. The module-pack lane passes the
+flag, probes the pinned tester for it and refuses with the pin to move when the tester predates it,
+and still compares the emitted identity against the image's afterwards. A module repository's own
+value is no longer consulted on that path; an explicit `-p:AssemblyVersion=` from a caller still
+wins.

--- a/test/MeshWeaver.PluginTester.Test/ProjectAssemblyIdentityTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ProjectAssemblyIdentityTest.cs
@@ -205,6 +205,71 @@ public class ProjectAssemblyIdentityTest : IDisposable
         AttributeValue(path, "System.Reflection.AssemblyFileVersionAttribute").Should().Be("3.0.0.0");
     }
 
+    /// <summary>
+    /// <c>--bind-to-image</c>: the emitted identity is the IMAGE's, whatever the project or its
+    /// <c>Directory.Build.props</c> say. A module built inside a platform image loads into that
+    /// image's process, and the evaluator runs no MSBuild property functions, so a repository cannot
+    /// derive the value itself — MeshWeaver.Plugins tried and every module came out 1.0.0.0, and its
+    /// literal 3.0.0.0 reddened every image build the day the platform line moved to 3.1.0.
+    /// </summary>
+    [Fact]
+    public async Task BindToImageStampsTheImagesOwnIdentityOverThePropsLiteral()
+    {
+        Write("Directory.Build.props", """
+            <Project>
+              <PropertyGroup>
+                <AssemblyVersion>9.9.9.9</AssemblyVersion>
+                <FileVersion>9.9.9.9</FileVersion>
+              </PropertyGroup>
+            </Project>
+            """);
+        var project = Library("    <Nullable>enable</Nullable>");
+        var image = AssemblyName.GetAssemblyName(Path.Combine(AppDirectory(), "MeshWeaver.ShortGuid.dll")).Version!;
+        image.Should().NotBe(new Version(9, 9, 9, 9), "the fixture must be able to tell the two apart");
+
+        var (name, path) = await Emit(OptionsFor(project) with { BindToImage = true });
+
+        name.Version.Should().Be(image,
+            "the image is the process the module loads into; its identity is the only one that binds");
+        AttributeValue(path, "System.Reflection.AssemblyFileVersionAttribute").Should().Be(image.ToString());
+    }
+
+    /// <summary>
+    /// A caller's explicit global still wins under <c>--bind-to-image</c>: a global that silently
+    /// changed value would be the defect globals exist to prevent.
+    /// </summary>
+    [Fact]
+    public async Task BindToImageYieldsToAnExplicitGlobalProperty()
+    {
+        var project = Library("    <Nullable>enable</Nullable>");
+
+        var (name, _) = await Emit(OptionsFor(project) with
+        {
+            BindToImage = true,
+            Properties = new Dictionary<string, string> { ["AssemblyVersion"] = "2.0.0.0" },
+        });
+
+        name.Version.Should().Be(new Version(2, 0, 0, 0));
+    }
+
+    /// <summary>Without the flag the evaluator keeps its SDK-parity semantics: the props literal wins.</summary>
+    [Fact]
+    public async Task WithoutBindToImageThePropsLiteralStillWins()
+    {
+        Write("Directory.Build.props", """
+            <Project>
+              <PropertyGroup>
+                <AssemblyVersion>9.9.9.9</AssemblyVersion>
+              </PropertyGroup>
+            </Project>
+            """);
+        var project = Library("    <Nullable>enable</Nullable>");
+
+        var (name, _) = await Emit(OptionsFor(project));
+
+        name.Version.Should().Be(new Version(9, 9, 9, 9));
+    }
+
     // ── the SDK's derivation rules, as measured against SDK 10.0.400 ───────────────────────────
 
     /// <summary>

--- a/test/MeshWeaver.PluginTester.Test/ProjectAssemblyIdentityTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/ProjectAssemblyIdentityTest.cs
@@ -252,6 +252,25 @@ public class ProjectAssemblyIdentityTest : IDisposable
         name.Version.Should().Be(new Version(2, 0, 0, 0));
     }
 
+    /// <summary>
+    /// A present-but-EMPTY global is not an override: the evaluator ignores empty values, so treating
+    /// it as one would fall through to the SDK derivation and defeat the flag without a word.
+    /// </summary>
+    [Fact]
+    public async Task BindToImageTreatsAnEmptyGlobalAsNotSupplied()
+    {
+        var project = Library("    <Nullable>enable</Nullable>");
+        var image = AssemblyName.GetAssemblyName(Path.Combine(AppDirectory(), "MeshWeaver.ShortGuid.dll")).Version!;
+
+        var (name, _) = await Emit(OptionsFor(project) with
+        {
+            BindToImage = true,
+            Properties = new Dictionary<string, string> { ["AssemblyVersion"] = "", ["FileVersion"] = "  " },
+        });
+
+        name.Version.Should().Be(image);
+    }
+
     /// <summary>Without the flag the evaluator keeps its SDK-parity semantics: the props literal wins.</summary>
     [Fact]
     public async Task WithoutBindToImageThePropsLiteralStillWins()

--- a/tools/MeshWeaver.PluginTester/Program.cs
+++ b/tools/MeshWeaver.PluginTester/Program.cs
@@ -212,6 +212,7 @@ static async Task<int> RunBuildProject(string[] args)
     var superseded = new List<string>();
     var properties = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
     var allowWarnings = false;
+    var bindToImage = false;
     var maxParallel = Math.Max(1, Environment.ProcessorCount);
     for (var i = 0; i < args.Length; i++)
     {
@@ -270,6 +271,9 @@ static async Task<int> RunBuildProject(string[] args)
             case "--verbose":
                 verbose = true;
                 break;
+            case "--bind-to-image":
+                bindToImage = true;
+                break;
             // The no-warn policy is ON by default; both spellings of the opt-out are accepted
             // because both are documented, and a flag that silently means nothing is worse than a
             // flag that does not exist.
@@ -317,6 +321,7 @@ static async Task<int> RunBuildProject(string[] args)
         Accept = accept,
         SupersededImageAssemblies = superseded,
         Properties = properties,
+        BindToImage = bindToImage,
         AllowWarnings = allowWarnings,
         Verbose = verbose,
         MaxParallel = maxParallel,
@@ -344,7 +349,7 @@ static string BuildProjectUsage() =>
     + "[--shared-frameworks <dir>] [--prebuilt <dir>]... "
     + "[--extra-refs <dir>]... [--generators <dir|dll>]... [--razor-generators <dir>] "
     + "[--accept <construct>]... [--superseded-image-assembly <name>]... "
-    + "[-p:Name=Value]... [--allow-warnings] [--max-parallel <n>]\n"
+    + "[-p:Name=Value]... [--bind-to-image] [--allow-warnings] [--max-parallel <n>]\n"
     + "  Compiles a .NET project with NO dotnet SDK and NO NuGet restore: the .csproj is evaluated "
     + "without MSBuild, every reference is resolved from this container's /app (and its .deps.json), "
     + "ProjectReferences inside the source root are built first in dependency order, and Roslyn runs "
@@ -356,7 +361,11 @@ static string BuildProjectUsage() =>
     + "quietly emitting an assembly with no components in it. The emitted assembly carries the "
     + "identity GenerateAssemblyInfo would have given it (AssemblyVersion/FileVersion/"
     + "InformationalVersion and the rest); -p:Name=Value supplies the properties it is derived "
-    + "from, SourceRevisionId included — this builder runs no git.";
+    + "from, SourceRevisionId included — this builder runs no git. --bind-to-image stamps "
+    + "AssemblyVersion and FileVersion with the IMAGE's own binding identity (immutable globals; an "
+    + "explicit -p: still wins), because a module built here loads into this image's process and "
+    + "any other identity is a runtime FileNotFoundException — the evaluator runs no MSBuild "
+    + "property functions, so a project cannot derive that value itself.";
 
 static string BuildUsage() =>
     "usage: mw-plugin-test build <repo-root> [<package>... | all] [--module <dll>]... [--out <dir>] "

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -165,6 +165,25 @@ public static class ProjectBuild
         public IReadOnlyList<string> PrebuiltDirectories { get; init; } = [];
 
         /// <summary>
+        /// Stamp every emitted assembly with the IMAGE's own binding identity: <c>AssemblyVersion</c>
+        /// and <c>FileVersion</c> become immutable globals set to
+        /// <see cref="ContainerReferenceSet.PlatformAssemblyVersion"/> unless the caller passed them
+        /// in <see cref="Properties"/>, which still wins. A module built inside a platform image loads
+        /// into that image's process and is bound BY its assemblies, so any other identity is a runtime
+        /// <c>FileNotFoundException</c> (MeshWeaver#143) — which is why the pack lane's postcondition
+        /// refuses drift outright. Off by default, so the SDK-parity semantics of the evaluator (an
+        /// explicit <c>AssemblyVersion</c> in the project wins, else the SDK's derivation) stay
+        /// measurable; the lane turns it on.
+        /// <para>Why the builder and not the project file: the evaluator runs no MSBuild property
+        /// functions, so a module repository cannot DERIVE its identity from the platform in its
+        /// props — MeshWeaver.Plugins tried, and every module came out <c>1.0.0.0</c> — while a literal
+        /// there is right for exactly one platform and wrong the day the line moves (3.0.0 → 3.1.0
+        /// reddened every image build in the fleet). The image knows its own identity; nothing else
+        /// has to.</para>
+        /// </summary>
+        public bool BindToImage { get; init; }
+
+        /// <summary>
         /// Image assemblies whose copy in the container is SUPERSEDED for this run: this
         /// repository's source now defines types they still contain, so referencing them would
         /// import a second definition of a type being compiled here (CS0436).
@@ -303,6 +322,36 @@ public static class ProjectBuild
                 $"{ex.GetType().Name}: {ex.Message}")));
     }
 
+    /// <summary>
+    /// The global property set with the image's binding identity added — see
+    /// <see cref="Options.BindToImage"/>. A caller-supplied <c>AssemblyVersion</c> or
+    /// <c>FileVersion</c> is left alone and said so, because a global that silently changes value
+    /// is the defect globals exist to prevent.
+    /// </summary>
+    private static IReadOnlyDictionary<string, string> BoundToImage(
+        IReadOnlyDictionary<string, string> properties, string platformAssemblyVersion, Sink sink)
+    {
+        var bound = new Dictionary<string, string>(properties, StringComparer.OrdinalIgnoreCase);
+        var stamped = new List<string>(2);
+        var kept = new List<string>(2);
+        foreach (var name in new[] { "AssemblyVersion", "FileVersion" })
+        {
+            if (bound.TryGetValue(name, out var explicitValue))
+                kept.Add($"{name}={explicitValue}");
+            else
+            {
+                bound[name] = platformAssemblyVersion;
+                stamped.Add(name);
+            }
+        }
+        if (stamped.Count > 0)
+            sink.Info($"binding identity: {string.Join(" and ", stamped)} = {platformAssemblyVersion}, the image's own "
+                + "(--bind-to-image; an immutable global, so a project's own value cannot drift from the process it loads into)");
+        if (kept.Count > 0)
+            sink.Info($"binding identity: caller-supplied {string.Join(", ", kept)} kept over the image's {platformAssemblyVersion}");
+        return bound;
+    }
+
     private static IObservable<Report> RunCore(Options options)
     {
         var wall = Stopwatch.StartNew();
@@ -335,6 +384,11 @@ public static class ProjectBuild
             $"reference set: {container.AssembliesByName.Count} assembl(y|ies) from {container.AppDirectory} "
             + $"+ the shared framework; {container.PackageVersions.Count} package version(s) from the image's "
             + $"deps.json; platform AssemblyVersion {container.PlatformAssemblyVersion}");
+
+        if (options.BindToImage)
+        {
+            options = options with { Properties = BoundToImage(options.Properties, container.PlatformAssemblyVersion, sink) };
+        }
 
         Graph graph;
         try

--- a/tools/MeshWeaver.PluginTester/ProjectBuild.cs
+++ b/tools/MeshWeaver.PluginTester/ProjectBuild.cs
@@ -336,7 +336,10 @@ public static class ProjectBuild
         var kept = new List<string>(2);
         foreach (var name in new[] { "AssemblyVersion", "FileVersion" })
         {
-            if (bound.TryGetValue(name, out var explicitValue))
+            // Present-but-empty (`-p:AssemblyVersion=`) is NOT an override: the evaluator ignores an
+            // empty value (`Length: > 0`) and would fall through to the SDK derivation, defeating the
+            // flag in a way no log line would name. Only a value that would actually be used counts.
+            if (bound.TryGetValue(name, out var explicitValue) && !string.IsNullOrWhiteSpace(explicitValue))
                 kept.Add($"{name}={explicitValue}");
             else
             {


### PR DESCRIPTION
## Summary

The first CD run of the 3.1.0 line (33970199725) failed every portal image build on a Plugins-side guard: `src/Directory.Build.props` there hard-codes `AssemblyVersion` 3.0.0.0 and verifies it against the platform's `$(_VersionNumeric).0`. Plugins#1367 replaced the literal with an evaluation-time derivation — correct under MSBuild, and **empty under the in-image builder**, whose SDK-free evaluator runs no MSBuild property functions: every module on its first run came out `1.0.0.0` and failed the pack lane's binding-identity check. A literal is right for exactly one platform and wrong the day the line moves; a derivation cannot run where the module is actually built. The value has to come from the image.

**`build-project --bind-to-image`**: the builder stamps every emitted assembly with the image's own `AssemblyVersion` and `FileVersion` (`ContainerReferenceSet.PlatformAssemblyVersion`) as immutable globals — a module built inside a platform image loads into that image's process and is bound by its assemblies, so no other identity can be right. A caller's explicit `-p:AssemblyVersion=` still wins (a global that silently changes value is the defect globals exist to prevent). Off by default, so the evaluator's SDK-parity semantics stay measurable; the pack lane turns it on.

**`node-repo-module-pack.yml`**: the global build passes `--bind-to-image`, and first probes the pinned tester's usage for the flag, failing RED with the pin to move when the tester predates it (an unknown option would exit 2 naming nothing). The per-module postcondition (emitted identity == the image's) is unchanged and now passes by construction.

## Verification

- `test/MeshWeaver.PluginTester.Test -c Release -warnaserror`: 0 warnings, 0 errors; `ProjectAssemblyIdentityTest` **26/26** (three new: the flag stamps the image's identity over a props literal `9.9.9.9`; an explicit global still wins under the flag; without the flag the props literal still wins).
- `actionlint` on the lane: the same 7 pre-existing shellcheck infos as on main, nothing new; `check-workflow-shell.py --root .` 0 live findings; `check-workflow-timeouts.py` 65 jobs, 0 violations.
- `test/MeshWeaver.Documentation.Test -c Release -warnaserror` (What's New + doc guards): see the check below.

## Landing order (MeshWeaver#3355)

1. Plugins#1367 (derivation for the MSBuild path + a literal fallback the pre-flag evaluator reaches) merges first — that alone turns core CD green.
2. This PR merges; the next sealed set carries a tester with the flag.
3. Plugins bumps its pins onto that set (`tester-image-digest` + `platform-image-digest` together, plus this lane's sha); its literal fallback then becomes unreachable and goes.

A satellite that bumps the lane sha before the tester digest is refused by the probe with the pin named — never a silent 1.0.0.0.

Pairs-with: none — this adds an option and removes no public surface; Plugins#1367 is the consumer-side half and lands first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuXoLRvG9TfKh5mgnjGfmo
