### PR TITLE
fix(memex-local): the mounted checkouts reconcile on every boot, not once

### DIFF
--- a/deploy/homebrew/bin/memex-local
+++ b/deploy/homebrew/bin/memex-local
@@ -79,6 +79,9 @@ readonly MEMEX_LOCAL_VERSION="0.2.0"
 
 readonly LOCAL_HOME="${MEMEX_LOCAL_HOME:-$HOME/.memex-local}"
 readonly OVERLAY="$LOCAL_HOME/values.local.yaml"
+# The feature flag helm_deploy declares the mounted checkouts under, so they land on the RECONCILED
+# lane (re-asserted on every boot) and not only on the seed-once one — see the block in helm_deploy.
+readonly MOUNTED_FLAG="mountedCheckouts"
 # ── REGISTRY MODE — this install CONSUMES a remote plugin registry ──────────────────────────────
 # Written by `memex-local registry <url> [--key mwr_…] [--id ID]`, read by helm_deploy as one more
 # values file (passed AFTER the user's overlay, so it wins). Its presence IS the mode switch: with it
@@ -718,11 +721,29 @@ helm_deploy() {
   # --from-acr / --skip-image run, as the info line above says), plugin_args/install_names whenever
   # no plugin checkout was found. So the deploy died on "unbound variable" for exactly the paths the
   # script itself documents as normal. This tool is macOS-only; the guard is not optional here.
+  # 🚨 installByDefault is a SEED lane, and a seed says nothing about a portal that is already
+  # populated: InstanceAutoRegistrationService records what it delivered on
+  # Plugins/_DefaultInstallLedger and never re-asserts it ("the seed must not fight an operator").
+  # That is right for a deployment seeding itself and wrong here, where the whole point is to MIRROR
+  # a working tree — the mounted repos were installed once and then stopped tracking their
+  # checkouts, silently: measured on 2026-09-05, a portal still served a course as of 2026-08-31
+  # while the mount had moved on for a week, with every boot reporting "0 written, 0 unchanged"
+  # (MeshWeaver#3359). Neither auto-update mechanism covers this shape either — PluginUpdateWatcher
+  # needs GitHub webhooks a local install never receives, and RegistryUpdateReconciler does nothing
+  # without a registry — so the boot is the only occasion there is.
+  #
+  # The same patterns therefore ALSO go on the environment's own composition lane (a feature flag,
+  # MeshWeaver#1735), which is exempt from the seed ledger and re-asserts on every boot. It costs
+  # nothing when nothing changed: CatalogLayoutAreas.InstallOrUpdateCore short-circuits on the
+  # package's manifest.lock hash and no node travels. Both lanes are set, not one: the seed still
+  # establishes a FRESH install, and the flag keeps it honest afterwards.
   local n i=0
   for n in ${install_names[@]+"${install_names[@]}"}; do
     plugin_args+=(--set "pluginCatalog.installByDefault[$i]=$n/*")
+    plugin_args+=(--set "features.$MOUNTED_FLAG.packages[$i]=$n/*")
     i=$((i + 1))
   done
+  [ "$i" -gt 0 ] && plugin_args+=(--set "features.$MOUNTED_FLAG.enabled=true")
 
   # Layering: chart defaults < TRACKED local defaults (ship with the brew package, so existing
   # installs pick up new behaviour — e.g. the adopt-only startup — on upgrade)


### PR DESCRIPTION
Fixes #3359 (the first of its three options; the catalog-node option is blocked by a separate defect, see the issue comment).

## What was wrong

`helm_deploy` put every discovered checkout on `pluginCatalog.installByDefault`, which `InstanceAutoRegistrationService` treats as a **seed**: what it delivers is recorded on `Plugins/_DefaultInstallLedger` and never re-asserted, because *"the seed must not fight an operator"*. Right for a deployment seeding itself; wrong for a portal whose entire purpose is to mirror a working tree.

Nothing else covers this shape. `PluginUpdateWatcher` needs a GitHub `workflow_run` webhook a local install never receives; `RegistryUpdateReconciler` says in its own doc that it does nothing when no registry is configured. The boot is the only occasion there is, and the seed lane skips it — so a self-registry portal installs its checkouts once and then silently stops tracking them, while every boot reports `0 written, 0 unchanged` and the log reads healthy.

## The change

One loop, two lanes instead of one: the same source patterns also go on the environment's own composition lane (a feature flag, #1735), which is exempt from the seed ledger and re-asserts on every boot.

```
--set pluginCatalog.installByDefault[i]=<Name>/*     (unchanged — establishes a FRESH install)
--set features.mountedCheckouts.packages[i]=<Name>/* (new — keeps it honest afterwards)
--set features.mountedCheckouts.enabled=true         (only when at least one repo is mounted)
```

It costs nothing when nothing changed: `CatalogLayoutAreas.InstallOrUpdateCore` short-circuits on the package's `manifest.lock` hash and no node travels. Registry mode is untouched — it mounts no checkout, the name list is empty, no flag is emitted. An operator who wants out sets `features.mountedCheckouts.enabled: false` in their overlay, which the flag lane already reads as an exclusion that outranks every other signal.

## Measured, on a real install

Same portal, before and after the redeploy:

- **before** — `[DefaultInstall] 41 package(s), in dependency order — AI, Edu, Publish, AgenticEngineering, …`; no `Store`, no course.
- **after** — `[DefaultInstall] 76 package(s), in dependency order — Store, AI, Edu, AdvancedBusinessRules, AgenticBusiness, Publish, Video, AgenticEngineering, AgenticOffice, AgenticPrimer, AgenticPrimerDe, …`
- and the drift it had been hiding, on the very first boot under the fix: **`[DefaultInstall] Store → Store: 167 written, 1 unchanged`**.

The ConfigMap renders as intended (`Features__Flags__mountedCheckouts__Enabled: "true"` plus one `__Packages__N` per mounted source), the commercial-skip warning is unchanged (same 16 packages, same reasons), and `bash -n` passes.

Held as a **draft**: this changes what every developer's `memex-local update` does on the next run, and it deserves a maintainer's eye before it lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HKEkt3bwipBcsvuGXQWV7F
