### PR TITLE
Rename the OCI mirror to MeshWeaver.ContainerImages — the name was already taken (#3361)

### DIFF
--- a/MeshWeaver.slnx
+++ b/MeshWeaver.slnx
@@ -32,7 +32,7 @@
   <Folder Name="/src/">
     <Project Path="src/MeshWeaver.Cli/MeshWeaver.Cli.csproj" />
     <Project Path="src/MeshWeaver.Compiler/MeshWeaver.Compiler.csproj" />
-    <Project Path="src/MeshWeaver.ContainerRegistry/MeshWeaver.ContainerRegistry.csproj" />
+    <Project Path="src/MeshWeaver.ContainerImages/MeshWeaver.ContainerImages.csproj" />
     <Project Path="src/MeshWeaver.Connection.Orleans/MeshWeaver.Connection.Orleans.csproj" />
     <Project Path="src/MeshWeaver.ContentCollections/MeshWeaver.ContentCollections.csproj" />
     <Project Path="src/MeshWeaver.Data.Contract/MeshWeaver.Data.Contract.csproj" />
@@ -70,7 +70,7 @@
     <Project Path="src/MeshWeaver.Utils/MeshWeaver.Utils.csproj" />
   </Folder>
   <Folder Name="/test/">
-    <Project Path="test/MeshWeaver.ContainerRegistry.Test/MeshWeaver.ContainerRegistry.Test.csproj" />
+    <Project Path="test/MeshWeaver.ContainerImages.Test/MeshWeaver.ContainerImages.Test.csproj" />
     <File Path="test/appsettings.json" />
     <File Path="test/Directory.Build.props" />
     <File Path="test/Directory.Packages.props" />

--- a/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageEndpoints.cs
@@ -6,7 +6,7 @@ using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
-namespace MeshWeaver.ContainerRegistry;
+namespace MeshWeaver.ContainerImages;
 
 /// <summary>
 /// The OCI Distribution pull surface, served from the mesh: <c>GET /v2/</c>,
@@ -28,20 +28,20 @@ namespace MeshWeaver.ContainerRegistry;
 /// image cannot start. Serving OTHER installations, and serving CI, has no such circularity — the
 /// constraint is per-instance, not global.</para>
 /// </summary>
-public static class ContainerRegistryEndpoints
+public static class ContainerImageEndpoints
 {
     /// <summary>Route prefix mandated by the OCI Distribution Specification.</summary>
     public const string RoutePrefix = "/v2";
 
     /// <summary>Set by the auth gate so handlers can name the caller in logs.</summary>
-    private const string CallerItemKey = "ContainerRegistry.Caller";
+    private const string CallerItemKey = "ContainerImages.Caller";
 
     /// <summary>
     /// Maps the pull surface. <c>AllowAnonymous</c> at the ASP.NET layer for the same reason the
     /// plugin registry does it — callers are INSTANCES and CI jobs, not signed-in users — with the
     /// bearer gate below doing the real work.
     /// </summary>
-    public static IEndpointRouteBuilder MapContainerRegistry(this IEndpointRouteBuilder endpoints)
+    public static IEndpointRouteBuilder MapContainerImages(this IEndpointRouteBuilder endpoints)
     {
         var group = endpoints.MapGroup(RoutePrefix).AllowAnonymous();
 
@@ -50,7 +50,7 @@ public static class ContainerRegistryEndpoints
             var http = ctx.HttpContext;
             var client = http.RequestServices.GetRequiredService<UpstreamRegistryClient>();
             var logger = http.RequestServices.GetService<ILoggerFactory>()
-                ?.CreateLogger(typeof(ContainerRegistryEndpoints));
+                ?.CreateLogger(typeof(ContainerImageEndpoints));
 
             // Unconfigured is 404 on everything, not 401 and not a partial service. A mirror
             // without a credential cannot serve a single byte, and saying "unauthorised" would
@@ -60,12 +60,12 @@ public static class ContainerRegistryEndpoints
                 logger?.LogDebug(
                     "Container registry mirror: {Path} refused — {Section}:Upstream/Username/Password "
                     + "are not all set, so the mirror is off.",
-                    http.Request.Path, ContainerRegistryOptions.SectionName);
+                    http.Request.Path, ContainerImageOptions.SectionName);
                 return Results.NotFound();
             }
 
             var authenticator = http.RequestServices
-                .GetRequiredService<IContainerRegistryAuthenticator>();
+                .GetRequiredService<IContainerImageAuthenticator>();
             // 🚨 ObserveCompletion, never .ToTask() — a Task completed inside an Rx pipeline
             // resumes its awaiter INLINE on the signalling thread, still inside Rx's trampoline,
             // and everything the continuation then does inherits that scheduler.
@@ -111,7 +111,7 @@ public static class ContainerRegistryEndpoints
     {
         var client = http.RequestServices.GetRequiredService<UpstreamRegistryClient>();
         var logger = http.RequestServices.GetService<ILoggerFactory>()
-            ?.CreateLogger(typeof(ContainerRegistryEndpoints));
+            ?.CreateLogger(typeof(ContainerImageEndpoints));
 
         var rest = (string?)http.Request.RouteValues["rest"] ?? string.Empty;
         if (!RegistryRoute.TryParse(rest, out var route))
@@ -120,13 +120,13 @@ public static class ContainerRegistryEndpoints
         // 🚨 The allowlist is the difference between a mirror and an open read proxy for the whole
         // upstream. Empty means NONE.
         var options = http.RequestServices
-            .GetRequiredService<Microsoft.Extensions.Options.IOptions<ContainerRegistryOptions>>()
+            .GetRequiredService<Microsoft.Extensions.Options.IOptions<ContainerImageOptions>>()
             .Value;
         if (!options.Repositories.Contains(route.Repository, StringComparer.Ordinal))
         {
             logger?.LogDebug(
                 "Container registry mirror: repository {Repository} is not in {Section}:Repositories",
-                route.Repository, ContainerRegistryOptions.SectionName);
+                route.Repository, ContainerImageOptions.SectionName);
             return Results.NotFound();
         }
 

--- a/src/MeshWeaver.ContainerImages/ContainerImageOptions.cs
+++ b/src/MeshWeaver.ContainerImages/ContainerImageOptions.cs
@@ -1,17 +1,17 @@
-namespace MeshWeaver.ContainerRegistry;
+namespace MeshWeaver.ContainerImages;
 
 /// <summary>
-/// Configuration for the container-registry mirror, bound from <c>ContainerRegistry:*</c>.
+/// Configuration for the container-registry mirror, bound from <c>ContainerImages:*</c>.
 ///
 /// <para>🚨 The mirror is OFF unless all three of <see cref="Upstream"/>, <see cref="Username"/>
 /// and <see cref="Password"/> are present. An unconfigured mirror answers 404 on every route
 /// rather than falling back to anything: a half-configured registry that served SOMETHING would
 /// be indistinguishable from a working one right up until a pull returned the wrong bytes.</para>
 /// </summary>
-public sealed class ContainerRegistryOptions
+public sealed class ContainerImageOptions
 {
     /// <summary>Configuration section name.</summary>
-    public const string SectionName = "ContainerRegistry";
+    public const string SectionName = "ContainerImages";
 
     /// <summary>Upstream registry host, e.g. <c>meshweaver.azurecr.io</c>. No scheme.</summary>
     public string? Upstream { get; set; }

--- a/src/MeshWeaver.ContainerImages/IContainerImageAuthenticator.cs
+++ b/src/MeshWeaver.ContainerImages/IContainerImageAuthenticator.cs
@@ -1,4 +1,4 @@
-namespace MeshWeaver.ContainerRegistry;
+namespace MeshWeaver.ContainerImages;
 
 /// <summary>
 /// Decides whether a caller may pull. A SEAM, not an implementation: this assembly deliberately
@@ -6,7 +6,7 @@ namespace MeshWeaver.ContainerRegistry;
 /// <c>InstanceRegistryAuthenticator</c> — the same instance key satellites already present to the
 /// plugin registry, which is the credential this mirror exists to reuse.
 /// </summary>
-public interface IContainerRegistryAuthenticator
+public interface IContainerImageAuthenticator
 {
     /// <summary>
     /// Resolves the caller from an <c>Authorization</c> header. Emits <c>null</c> for "not

--- a/src/MeshWeaver.ContainerImages/MeshWeaver.ContainerImages.csproj
+++ b/src/MeshWeaver.ContainerImages/MeshWeaver.ContainerImages.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <!-- For ReactiveCompletion.ObserveCompletion — the sanctioned Rx→Task edge. This assembly
          deliberately takes NO dependency on the plugin catalogue: the caller-authentication seam
-         is IContainerRegistryAuthenticator, bound by the portal. -->
+         is IContainerImageAuthenticator, bound by the portal. -->
     <ProjectReference Include="..\MeshWeaver.Messaging.Hub\MeshWeaver.Messaging.Hub.csproj" />
   </ItemGroup>
 </Project>

--- a/src/MeshWeaver.ContainerImages/README.md
+++ b/src/MeshWeaver.ContainerImages/README.md
@@ -1,4 +1,4 @@
-# MeshWeaver.ContainerRegistry
+# MeshWeaver.ContainerImages
 
 Serves the **OCI Distribution pull surface** from a MeshWeaver portal, proxying container images
 from an upstream registry with one credential the portal holds — while each caller authenticates
@@ -29,7 +29,7 @@ switched off without a migration.
 
 ```jsonc
 {
-  "ContainerRegistry": {
+  "ContainerImages": {
     "Upstream": "myregistry.azurecr.io",
     "Username": "<pull credential>",
     "Password": "<pull credential>",
@@ -46,14 +46,14 @@ answers 404 rather than serving partially.
 ## Wiring
 
 ```csharp
-services.AddSingleton<IContainerRegistryAuthenticator, MyAuthenticator>();
+services.AddSingleton<IContainerImageAuthenticator, MyAuthenticator>();
 services.AddHttpClient<UpstreamRegistryClient>();
-services.Configure<ContainerRegistryOptions>(config.GetSection(ContainerRegistryOptions.SectionName));
+services.Configure<ContainerImageOptions>(config.GetSection(ContainerImageOptions.SectionName));
 
-app.MapContainerRegistry();
+app.MapContainerImages();
 ```
 
-`IContainerRegistryAuthenticator` is a seam: this package takes no dependency on any particular
+`IContainerImageAuthenticator` is a seam: this package takes no dependency on any particular
 identity system, so a host binds it to whatever already issues its tokens.
 
 ## The one hard limit

--- a/src/MeshWeaver.ContainerImages/RegistryRoute.cs
+++ b/src/MeshWeaver.ContainerImages/RegistryRoute.cs
@@ -1,4 +1,4 @@
-namespace MeshWeaver.ContainerRegistry;
+namespace MeshWeaver.ContainerImages;
 
 /// <summary>
 /// One parsed OCI pull route. The spec allows a repository NAME to contain slashes

--- a/src/MeshWeaver.ContainerImages/UpstreamPassthroughResult.cs
+++ b/src/MeshWeaver.ContainerImages/UpstreamPassthroughResult.cs
@@ -1,6 +1,6 @@
 using Microsoft.AspNetCore.Http;
 
-namespace MeshWeaver.ContainerRegistry;
+namespace MeshWeaver.ContainerImages;
 
 /// <summary>
 /// Streams an upstream response straight to the caller: status, the headers an OCI client needs,

--- a/src/MeshWeaver.ContainerImages/UpstreamRegistryClient.cs
+++ b/src/MeshWeaver.ContainerImages/UpstreamRegistryClient.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
-namespace MeshWeaver.ContainerRegistry;
+namespace MeshWeaver.ContainerImages;
 
 /// <summary>
 /// Talks to the UPSTREAM OCI registry on the mirror's behalf, holding the one credential the
@@ -26,11 +26,11 @@ namespace MeshWeaver.ContainerRegistry;
 /// </summary>
 public sealed class UpstreamRegistryClient(
     HttpClient http,
-    IOptions<ContainerRegistryOptions> options,
+    IOptions<ContainerImageOptions> options,
     ILogger<UpstreamRegistryClient> logger)
 {
     private readonly ConcurrentDictionary<string, CachedToken> tokens = new();
-    private readonly ContainerRegistryOptions opts = options.Value;
+    private readonly ContainerImageOptions opts = options.Value;
 
     /// <summary>The upstream host, e.g. <c>meshweaver.azurecr.io</c>. Empty when unconfigured —
     /// callers must treat that as "the mirror is off", never as "allow".</summary>
@@ -112,7 +112,7 @@ public sealed class UpstreamRegistryClient(
             // echo request detail. The status and the repository are the whole diagnostic.
             logger.LogWarning(
                 "Container registry mirror: upstream token request for {Repository} answered {Status}. "
-                + "Check ContainerRegistry:Username/Password — the mirror cannot serve pulls without it.",
+                + "Check ContainerImages:Username/Password — the mirror cannot serve pulls without it.",
                 repository, (int)response.StatusCode);
             throw new UpstreamRegistryException(
                 $"upstream token request answered {(int)response.StatusCode}");

--- a/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ContainerRegistryInMemex.md
@@ -7,7 +7,15 @@ Icon: <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 
 
 # A Container Registry in Memex
 
-> **Status: v1 pull surface IMPLEMENTED** (`src/MeshWeaver.ContainerRegistry`, issue #3353) —
+> **Status: v1 pull surface IMPLEMENTED** (`src/MeshWeaver.ContainerImages`, issue #3353) —
+>
+> 🚨 The assembly is **`MeshWeaver.ContainerImages`, deliberately NOT `MeshWeaver.ContainerRegistry`**
+> — MeshWeaver.Plugins already ships an assembly of that name (the plugin registry module), in the
+> same namespace, declaring its own `ContainerRegistryEndpoints`, `ContainerRegistryOptions` and an
+> identical `MapContainerRegistry(this IEndpointRouteBuilder)`. Two assemblies of one name is the
+> one-producer FATAL by name; two identical fully-qualified types is `CS0433`; two identical
+> extension signatures is `CS0121`. The config section moved to `ContainerImages:` for the same
+> reason. Renamed in #3361 while nothing referenced it yet — which is the only cheap moment.
 > `GET /v2/`, `…/manifests/{reference}`, `…/blobs/{digest}` and `…/tags/list`, proxied to the
 > upstream with the mirror's own credential while the caller authenticates against memex. No push,
 > no cache yet, and the boot image still comes from the upstream. The rest of this page — caching,
@@ -156,7 +164,7 @@ alone, because they all derive from *reading* manifests and layers.
 * **Off unless configured.** `Upstream`, `Username` and `Password` must all be set, or every route
   is 404 — never a partial service, which would be indistinguishable from a working one until a
   pull returned the wrong bytes.
-* **An allowlist, empty by default.** `ContainerRegistry:Repositories` names exactly what may be
+* **An allowlist, empty by default.** `ContainerImages:Repositories` names exactly what may be
   served. Without it, one upstream credential becomes an open read proxy for the whole registry.
 * **Pull only, by construction.** A blob reference must be a content digest, so the entire upload
   family (`blobs/uploads/…`) is refused by SHAPE rather than by blocklisting names — a test caught

--- a/test/MeshWeaver.ContainerImages.Test/MeshWeaver.ContainerImages.Test.csproj
+++ b/test/MeshWeaver.ContainerImages.Test/MeshWeaver.ContainerImages.Test.csproj
@@ -3,6 +3,6 @@
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\src\MeshWeaver.ContainerRegistry\MeshWeaver.ContainerRegistry.csproj" />
+    <ProjectReference Include="..\..\src\MeshWeaver.ContainerImages\MeshWeaver.ContainerImages.csproj" />
   </ItemGroup>
 </Project>

--- a/test/MeshWeaver.ContainerImages.Test/RegistryRouteTest.cs
+++ b/test/MeshWeaver.ContainerImages.Test/RegistryRouteTest.cs
@@ -1,7 +1,7 @@
-using MeshWeaver.ContainerRegistry;
+using MeshWeaver.ContainerImages;
 using Xunit;
 
-namespace MeshWeaver.ContainerRegistry.Test;
+namespace MeshWeaver.ContainerImages.Test;
 
 /// <summary>
 /// The route parser is the mirror's attack surface: it decides which repository name the


### PR DESCRIPTION
#3357 added `src/MeshWeaver.ContainerRegistry` (the read-through OCI pull surface). MeshWeaver.Plugins
has shipped an assembly of that **exact** name for a while — the plugin registry module — and the
collision is not merely the folder name:

| collision | consequence |
|---|---|
| same **assembly** name | two `MeshWeaver.ContainerRegistry.dll` in one process — the one-producer FATAL (#3327's class) by *name* |
| same **namespace + types** | `MeshWeaver.ContainerRegistry.ContainerRegistryEndpoints` and `.ContainerRegistryOptions` exist in **both** → `CS0433` |
| identical **extension** | both declare `MapContainerRegistry(this IEndpointRouteBuilder)` → `CS0121` |
| same **config section** | both bind `ContainerRegistry:*`, for different option shapes |

Neither repo's build sees the other, so nothing was red in either. What went red is the first thing
that looks across them — Plugins' `Migrated suites keep core's coverage` gate, which pairs suites by
name and demanded three `RegistryRoute` tests be ported into a module that has no `RegistryRoute`.
That gate did exactly its job.

## Why core's half, and why now

Core's is the side nothing references yet — `MeshWeaver.slnx` and its own test project, nothing else.
That window is the only cheap moment, and it closes the first time a host takes a dependency.

```
src/MeshWeaver.ContainerRegistry       → src/MeshWeaver.ContainerImages
test/MeshWeaver.ContainerRegistry.Test → test/MeshWeaver.ContainerImages.Test
namespace MeshWeaver.ContainerRegistry → MeshWeaver.ContainerImages
ContainerRegistryEndpoints             → ContainerImageEndpoints
ContainerRegistryOptions               → ContainerImageOptions
IContainerRegistryAuthenticator        → IContainerImageAuthenticator
MapContainerRegistry()                 → MapContainerImages()
config section "ContainerRegistry"     → "ContainerImages"
```

## 🚨 The config section moved too — verified safe, not assumed

Renaming a config key is normally a silent deletion. It is safe here **because nothing binds it yet**:
no `ContainerRegistry__*` / `ContainerRegistry:` key anywhere under `deploy/`, and memex-cloud's live
`memex-portal-config` ConfigMap carries none (checked by key **name** only). Leaving it would have had
the mirror and the registry module reading one section for two different option shapes.

## Deliberately not renamed

`Doc/Architecture/ContainerRegistryInMemex` keeps its filename — renaming a doc page breaks every link
into it, and `DocumentationLinkIntegrityTest` is the gate that says so. The page now records **why**
the assembly is not called `ContainerRegistry`, so nobody renames it back.

## Verification

- `MeshWeaver.ContainerImages`, its test project, and `MeshWeaver.Documentation.Test` all build clean
  under `-c Release -warnaserror`
- suite **21/21**
- `DocumentationLinkIntegrityTest` passes
- repo-wide sweep for `MeshWeaver.ContainerRegistry` returns **only** the explanatory note

Pairs-with: none — renames a project nothing outside this repo references; the Plugins assembly of the
old name is untouched and keeps its surface.

Closes #3361