### PR TITLE
module-pack: the --bind-to-image probe captures the tester's usage before judging it (no grep -q on a live pipe)

### DIFF
--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1030,10 +1030,27 @@ jobs:
           # 🚨 The binding identity comes from the IMAGE, never from the repository (header,
           # precondition 2). A tester that predates the flag would exit 2 on an unknown option with
           # a message naming nothing; probe its usage first and name the pin that has to move.
-          if ! docker run --rm --platform linux/amd64 --user "$(id -u):$(id -g)" -e HOME=/tmp \
-               -v "$tester_app:/tester:ro" --entrypoint dotnet "$img" \
-               /tester/mw-plugin-test.dll build-project --help 2>&1 | grep -q -- '--bind-to-image'; then
-            echo "::error::the pinned tester (tester-image-digest $TESTER_DIGEST) has no 'build-project --bind-to-image', so it cannot stamp modules with the image's own AssemblyVersion — every module would fail the binding-identity check, or bind to a literal that is wrong for this platform. Move tester-image-digest and platform-image-digest TOGETHER to a set built from MeshWeaver main after the flag landed."
+          #
+          # 🚨 CAPTURE, then test — never `docker run … | grep -q` under `pipefail`. `grep -q` exits
+          # on the first match and closes the pipe; `docker run` then dies with EPIPE on its next
+          # write, and pipefail reports the PIPE as failed although the flag was printed. That fired
+          # on Plugins#1371's second run and passed on its first — the same tester, the same image
+          # (measured: both print the flag when run by hand). A probe that swallows the output it
+          # judges also cannot say WHY it failed, which is the other half of this shape.
+          set +e
+          usage=$(docker run --rm --platform linux/amd64 --user "$(id -u):$(id -g)" -e HOME=/tmp \
+                    -v "$tester_app:/tester:ro" --entrypoint dotnet "$img" \
+                    /tester/mw-plugin-test.dll build-project --help 2>&1)
+          probe_rc=$?
+          set -e
+          if [ "$probe_rc" -ne 0 ]; then
+            printf '%s\n' "$usage" | tail -n 20
+            echo "::error::the pinned tester could not run inside the pinned image (exit $probe_rc, output above) — 'build-project --help' is the cheapest thing it does, so this is the tester app (tester-image-digest $TESTER_DIGEST, restored at $tester_app) or the platform image ($DIGEST), not the flag. A cache entry restored broken reads exactly like this: delete the tester-app-<digest> cache entry and rerun before moving any pin."
+            exit 1
+          fi
+          if ! printf '%s\n' "$usage" | grep -q -- '--bind-to-image'; then
+            printf '%s\n' "$usage" | head -n 5
+            echo "::error::the pinned tester (tester-image-digest $TESTER_DIGEST) has no 'build-project --bind-to-image' (its usage is above), so it cannot stamp modules with the image's own AssemblyVersion — every module would fail the binding-identity check, or bind to a literal that is wrong for this platform. Move tester-image-digest and platform-image-digest TOGETHER to a set built from MeshWeaver main after the flag landed."
             exit 1
           fi
           echo "global build: ${#projects[@]} container entr(y|ies) in ONE workspace — ${projects[*]}"

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -1037,13 +1037,14 @@ jobs:
           # on Plugins#1371's second run and passed on its first — the same tester, the same image
           # (measured: both print the flag when run by hand). A probe that swallows the output it
           # judges also cannot say WHY it failed, which is the other half of this shape.
-          set +e
-          usage=$(docker run --rm --platform linux/amd64 --user "$(id -u):$(id -g)" -e HOME=/tmp \
-                    -v "$tester_app:/tester:ro" --entrypoint dotnet "$img" \
-                    /tester/mw-plugin-test.dll build-project --help 2>&1)
-          probe_rc=$?
-          set -e
-          if [ "$probe_rc" -ne 0 ]; then
+          # `if out=$(…)` captures output AND exit status without toggling errexit — the shape the
+          # framework-identity probe below already uses.
+          if usage=$(docker run --rm --platform linux/amd64 --user "$(id -u):$(id -g)" -e HOME=/tmp \
+                       -v "$tester_app:/tester:ro" --entrypoint dotnet "$img" \
+                       /tester/mw-plugin-test.dll build-project --help 2>&1); then
+            :
+          else
+            probe_rc=$?
             printf '%s\n' "$usage" | tail -n 20
             echo "::error::the pinned tester could not run inside the pinned image (exit $probe_rc, output above) — 'build-project --help' is the cheapest thing it does, so this is the tester app (tester-image-digest $TESTER_DIGEST, restored at $tester_app) or the platform image ($DIGEST), not the flag. A cache entry restored broken reads exactly like this: delete the tester-app-<digest> cache entry and rerun before moving any pin."
             exit 1


### PR DESCRIPTION
## Summary

The `--bind-to-image` probe added in #3358 was written as `docker run … build-project --help 2>&1 | grep -q -- '--bind-to-image'` inside a step that runs under `set -euo pipefail`. `grep -q` exits on its first match and closes the pipe; `docker run` then dies with EPIPE on its next write and `pipefail` reports the pipeline as failed although the flag was printed. It is a coin toss on timing: MeshWeaver.Plugins#1371's first run passed the probe and its second failed it with the same tester and the same image, and both print the flag when run by hand (`3.1.0-ci.7835`'s tester inside its own portal image). The probe also swallowed the output it judged, so the failure could not say why.

Now the usage is captured first (`usage=$(docker run …)`, no live pipe). A non-zero exit prints the tail and names the tester app and platform image, saying that a cache entry restored broken reads exactly like this; only a clean run whose usage lacks the flag names the pin to move.

## Verification

- `actionlint`: the same 7 pre-existing shellcheck infos as main, nothing new; `check-workflow-shell.py --root .` 0 live findings; `check-workflow-timeouts.py` 65 jobs, 0 violations.
- Shape proven locally: a `pipefail` pipeline into `grep -q` returns 141 (SIGPIPE) on a producer that keeps writing after the match.

No What's New entry: CI lane plumbing, nothing a user can notice.

Pairs-with: none — a workflow-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuXoLRvG9TfKh5mgnjGfmo
