### PR TITLE
fix: the conflict-marker guard survives a dangling symlink, and names it

### DIFF
--- a/test/MeshWeaver.Documentation.Test/NoConflictMarkersGuard.cs
+++ b/test/MeshWeaver.Documentation.Test/NoConflictMarkersGuard.cs
@@ -89,6 +89,7 @@ public class NoConflictMarkersGuard
             + "scan the repository. Refusing to report a clean tree over a read that found nothing.");
 
         var offenders = new List<string>();
+        var symlinks = new List<string>();
         foreach (var relative in tracked)
         {
             if (BinaryExtensions.Contains(Path.GetExtension(relative)))
@@ -97,6 +98,25 @@ public class NoConflictMarkersGuard
             var full = Path.Combine(root, relative);
             if (!File.Exists(full))
                 continue;   // a delete staged but not yet written to disk
+
+            // 🚨 A SYMLINK IS NOT THIS GUARD'S BUSINESS, AND A DANGLING ONE USED TO KILL IT.
+            // `File.Exists` answers TRUE for a tracked symlink entry while `File.OpenRead` throws
+            // `FileNotFoundException` on the missing target, so the scan died on the first one and
+            // never reached its assertion — reporting a stack trace under the name
+            // "NoTrackedFileCarriesAnUnresolvedConflictMarker", which reads as a merge problem and
+            // is not one. MeshWeaver#3343 sat red for a day on exactly that: it had committed 37
+            // absolute symlinks into a developer's own checkout, and the guard named none of them.
+            //
+            // A symlink's CONTENT is its target path; it cannot carry a conflict marker, so
+            // skipping it loses no coverage. What it must not do is fail silently — a link is
+            // still something nobody meant to commit, which is why the sibling assertion below
+            // reports them rather than this loop swallowing them.
+            var info = new FileInfo(full);
+            if (info.LinkTarget is not null)
+            {
+                symlinks.Add($"{relative} → {info.LinkTarget}");
+                continue;
+            }
 
             // Extension lists are guesses; a NUL byte is evidence. Catches an unlisted binary
             // without the blocklist having to know its name.
@@ -110,6 +130,18 @@ public class NoConflictMarkersGuard
                     offenders.Add($"{relative}:{i + 1}  {lines[i].Trim()}");
             }
         }
+
+        // Reported SEPARATELY from the markers, and after them, because they are a different
+        // defect with a different fix. An ABSOLUTE link is never legitimate here — it names one
+        // machine's filesystem — and this repository tracks none at all, so the bar is simply zero.
+        Assert.True(
+            symlinks.Count == 0,
+            "Tracked symlink(s), which this repository does not use:\n  "
+            + string.Join("\n  ", symlinks)
+            + "\n\nThese are almost always local dev-convenience links caught by a `git add -A` — "
+            + "an absolute one names the committer's own checkout and resolves nowhere else, so "
+            + "every other clone and every CI run gets a dangling entry. `git rm --cached` them, "
+            + "and consider a .gitignore entry so the next `add -A` cannot repeat it.");
 
         Assert.True(
             offenders.Count == 0,


### PR DESCRIPTION
**A guard that crashes reports the wrong defect.** Found while draining #3343, which sat red for a
day on a failure that named the wrong thing entirely.

## What happened

`File.Exists` answers **true** for a tracked symlink entry while `File.OpenRead` throws
`FileNotFoundException` on a missing target. So `LooksBinary` died on the first dangling link and the
scan never reached its assertion — surfacing a stack trace under the name
`NoTrackedFileCarriesAnUnresolvedConflictMarker`:

```
System.IO.FileNotFoundException : Could not find file
  '.../src/MeshWeaver.AI.AzureFoundry/MeshWeaver.AI.AzureFoundry'
   at NoConflictMarkersGuard.LooksBinary(String path)
   at NoConflictMarkersGuard.NoTrackedFileCarriesAnUnresolvedConflictMarker()
```

#3343 had committed **37 absolute symlinks into a developer's own checkout** — the untracked
dev-convenience links (`?? src/MeshWeaver.AI/`, …) that a `git add -A` sweeps up. The guard named
none of them. It just threw on the first, and the resulting red reads as "you have a merge conflict"
on a PR about `DeleteMany`.

## Two changes, deliberately separate

1. **A symlink is skipped for marker scanning.** Its content is its target path; it cannot carry a
   conflict marker, so no coverage is lost.
2. **A symlink is reported**, by its own assertion with its own message. Skipping it silently would
   trade a crash for the other failure this repo keeps re-learning — a check that passes having
   quietly not looked. This tree tracks **zero** symlinks, so the bar is zero, and the message says
   what to do.

```
Tracked symlink(s), which this repository does not use:
  dangling-link-probe → /nonexistent/path/that/does/not/exist

These are almost always local dev-convenience links caught by a `git add -A` — an absolute one
names the committer's own checkout and resolves nowhere else, so every other clone and every CI
run gets a dangling entry. `git rm --cached` them, and consider a .gitignore entry …
```

## Verified both directions

Not just the green one: clean tree **passes**, and with a dangling symlink staged the guard
**reports it** rather than throwing. Full `MeshWeaver.Documentation.Test` suite **269/269**.

Refs #3343 · `Pairs-with: none` — one test file.
