### PR TITLE
release: 3.0.0 is cut first, then the line moves to 3.1.0 — PlatformVersion back to 3.0.0

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -38,7 +38,7 @@ and the version mechanics in
 | | CONTINUOUS (steady-state) | OFFICIAL (a release) |
 |---|---|---|
 | **Trigger** | merge to `main` | push an **annotated** tag `v<major>.<minor>.<patch>` on a promoted, sealed commit |
-| **Version** | `3.1.0-ci.<run#>` (build-numbered, monotonic from `$GITHUB_RUN_NUMBER`) | clean `3.1.0` — **the same bytes**, retagged |
+| **Version** | `3.0.0-ci.<run#>` (build-numbered, monotonic from `$GITHUB_RUN_NUMBER`) | clean `3.0.0` — **the same bytes**, retagged |
 | **Workflow** | `main-cd.yml` (after `MeshWeaver Build and Test` passes) | `release.yml` |
 | **Docker** | **multi-arch** (`linux-x64;linux-arm64` → OCI image-index) → ACR | ACR retag + GHCR mirror, by digest |
 | **Bake / seal** | ✅ platform content + Plugins modules, sealed per framework identity | ✅ inherited — `_releases/<clean>` copies the identity marker |
@@ -58,9 +58,9 @@ continuous builds ARE the pre-releases, and `PlatformVersion` always names the n
      | xargs -I{} gh api "repos/Systemorph/MeshWeaver/actions/runs/{}/jobs?per_page=100" \
        --jq '.jobs[] | select(.name | test("Promote|Verify every|bake \\+ seal")) | "\(.name): \(.conclusion)"'
    ```
-2. **`PlatformVersion` at that commit equals the tag** (`3.1.0` ↔ `v3.1.0`). The lane refuses a
+2. **`PlatformVersion` at that commit equals the tag** (`3.0.0` ↔ `v3.0.0`). The lane refuses a
    mismatch; so does it refuse a `-rc`/`-beta` suffix and a lightweight tag.
-3. **The notes page exists at that commit**: `src/MeshWeaver.Documentation/Data/ReleaseNotes/3_1_0/index.md`
+3. **The notes page exists at that commit**: `src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0/index.md`
    (`Category: Release Notes`). The GitHub Release is published FROM it.
 4. **Secrets present** (can't be read; confirm with the operator): `AZURE_CLIENT_ID`/`AZURE_TENANT_ID`/
    `AZURE_SUBSCRIPTION_ID` (OIDC → ACR + the artifact stores, via the `release` environment),
@@ -143,19 +143,20 @@ az aks command invoke -g "$AKS_RG" -n "$AKS_CLUSTER" --command \
 
 ```bash
 # 0. Pick the commit: on main, its CD run SEALED (preconditions above), PlatformVersion == the tag.
-grep -m1 '<PlatformVersion Condition' Directory.Build.props          # e.g. 3.1.0
+grep -m1 '<PlatformVersion Condition' Directory.Build.props          # e.g. 3.0.0
 # 1. Make sure the notes page is committed at that commit:
-#    src/MeshWeaver.Documentation/Data/ReleaseNotes/3_1_0/index.md
-# 2. Tag it ANNOTATED and push — this is the whole release:
-git tag -a v3.1.0 -m "MeshWeaver 3.1.0" <sha> && git push origin v3.1.0
+#    src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0/index.md
+# 2. Tag it ANNOTATED and push — this is the whole release (maintainer: only once every open
+#    issue is closed):
+git tag -a v3.0.0 -m "MeshWeaver 3.0.0" <sha> && git push origin v3.0.0
 #    → release.yml: resolves the sealed set for <sha> → asserts complete + sealed → writes
-#      _releases/3.1.0 → retags memex-migration, mw-plugin-test, memex-portal-ai (last) → mirrors
-#      to GHCR → publishes the GitHub Release → opens "release: PlatformVersion 3.1.0 → 3.2.0".
+#      _releases/3.0.0 → retags memex-migration, mw-plugin-test, memex-portal-ai (last) → mirrors
+#      to GHCR → publishes the GitHub Release → opens "release: PlatformVersion 3.0.0 → 3.1.0".
 # 3. Merge that bump PR the same day. Until it merges, continuous builds sort BELOW the release.
-gh api "repos/Systemorph/MeshWeaver/pulls?state=open&head=Systemorph:release/open-3.2.0-line" --jq '.[].html_url'
+gh api "repos/Systemorph/MeshWeaver/pulls?state=open&head=Systemorph:release/open-3.1.0-line" --jq '.[].html_url'
 ```
 
-What the lane REFUSES, each with a red step naming the fix: a non-clean version (`v3.1.0-rc1`),
+What the lane REFUSES, each with a red step naming the fix: a non-clean version (`v3.0.0-rc14`),
 a lightweight tag, a commit not on `main`, a `PlatformVersion` mismatch, a commit `main-cd` never
 promoted, a set whose bake is not sealed, and a release with no notes page.
 
@@ -177,7 +178,7 @@ az acr repository show-tags -n meshweaver --repository memex-portal-ai -o tsv | 
 az aks command invoke -g "$AKS_RG" -n "$AKS_CLUSTER" --command \
   "kubectl -n <ns> get deploy memex-portal-deployment -o jsonpath='{.spec.template.spec.containers[0].image}'"
 # The release's identity marker (what a Stable install's gate reads):
-.github/scripts/check-release-availability.sh 3.1.0 meshweaver-content plugins   # needs BAKE_PUBLISH_TARGETS + az login
+.github/scripts/check-release-availability.sh 3.0.0 meshweaver-content plugins   # needs BAKE_PUBLISH_TARGETS + az login
 ```
 
 ## Verify a release is healthy (before declaring done)

--- a/.github/workflows/main-cd.yml
+++ b/.github/workflows/main-cd.yml
@@ -10,8 +10,8 @@ name: Continuous Delivery (main)
 # tests. workflow_run starts after the named workflow COMPLETES; the `if` below filters to a
 # successful run that came from a push to main (not a PR run, not a failed run).
 #
-# This is the CONTINUOUS channel (build-numbered 3.1.0-ci.<build> baked in, images tagged by
-# commit SHA). The RELEASED channel — the clean 3.1.0 — is NOT a second build: release.yml, fired
+# This is the CONTINUOUS channel (build-numbered 3.0.0-ci.<build> baked in, images tagged by
+# commit SHA). The RELEASED channel — the clean 3.0.0 — is NOT a second build: release.yml, fired
 # by pushing a v*.*.* tag, PROMOTES the sealed set this workflow already published for that commit
 # (retags the images, copies the release marker, publishes the GitHub Release). Nothing ships to
 # NuGet any more. "Freeze a release" = push a tag; "merge to main" = this workflow.

--- a/.github/workflows/node-repo-module-pack.yml
+++ b/.github/workflows/node-repo-module-pack.yml
@@ -180,7 +180,7 @@ name: node-repo module pack
 #      wrote down. It cannot come from the repository: the evaluator runs no MSBuild property
 #      functions, so a module repo cannot DERIVE the platform's identity in its props (Plugins
 #      tried; every module came out 1.0.0.0), and a LITERAL there is right for one platform and
-#      wrong the day the line moves (3.0.0 → 3.1.0 reddened every image build in the fleet). The
+#      wrong the day the line moves (the 2026-09-05 bump to 3.1.0 reddened every image build in the fleet). The
 #      global build step probes the tester for the flag and FAILS naming the pin to move when the
 #      pinned image predates it; the pack step still compares the emitted identity against the one
 #      the builder read out of the image, so drift cannot ship silently either way.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ name: Release (promote a sealed set)
 #      tag whose commit carries a different PlatformVersion, a commit main-cd never promoted, a set
 #      whose content bake is not sealed, a release with no committed release-notes page;
 #   2. copies the release marker  _releases/<ci-version> → _releases/<clean>  on every artifact
-#      store, so the gates that ask "which framework identity is release 3.1.0?" get the answer the
+#      store, so the gates that ask "which framework identity is release 3.0.0?" get the answer the
 #      continuous build recorded (publish-bake-bundles.sh; Doc/Architecture/ReleaseGates);
 #   3. retags the promoted images  <short-sha> → <clean>  in ACR, memex-portal-ai LAST — the same
 #      ordering main-cd's promote uses, because that tag is the one write a Stable self-updater

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -44,44 +44,46 @@
     <!-- Suppress FluentAssertions license warning for open source project -->
     <FLUENTASSERTIONS_SUPPRESS_WARNING>true</FLUENTASSERTIONS_SUPPRESS_WARNING>
     <!-- Maintained platform version — the ONE number, set centrally here. It names the NEXT
-         release: the line is 3.1.0, every continuous build is 3.1.0-ci.<run> (_CiSep below), and
-         the release itself is the clean 3.1.0 — not a rebuild, a PROMOTION of a sealed continuous
+         release: the line is 3.0.0, every continuous build is 3.0.0-ci.<run> (_CiSep below), and
+         the release itself is the clean 3.0.0 — not a rebuild, a PROMOTION of a sealed continuous
          set (release.yml retags the promoted images and copies the release marker when the tag
-         v3.1.0 is pushed; Doc/Architecture/ReleaseProcess). Override at build time with
+         v3.0.0 is pushed; Doc/Architecture/ReleaseProcess). Override at build time with
          -p:PlatformVersion= only for experiments; CI builds are COMMIT-DETERMINISTIC (issue #1660
          WS3 — see the InformationalVersion note below), and NodeType cache invalidation keys on the
          commit identity, not on a per-build stamp.
 
+         No pre-release label, ever (maintainer, 2026-09-05: "I don't want this rc business any
+         more"): `-ci.N` is the only one, and it is the channel marker, never a version. The
+         release is cut only when every open issue is closed (maintainer, same day); until then
+         main keeps producing 3.0.0-ci.<n> sets, and the day v3.0.0 is tagged release.yml opens the
+         PR that moves this number to 3.1.0.
+
          ORDERING, which the self-updater (VersionSelect, SemVer2 via NuGetVersion) relies on:
 
-             3.0.0-rc9.ci.7818  <  3.0.0-rc13  <  3.1.0-ci.1  <  3.1.0-ci.7900  <  3.1.0  <  3.2.0-ci.1
+             3.0.0-ci.7900  <  3.0.0-preview1  <  3.0.0-rc9.ci.7818  <  3.0.0-rc13  <  3.0.0  <  3.1.0-ci.1
 
-         so every install on the retired rc line rolls forward onto the first 3.1.0 continuous
-         build, a Stable install takes the clean 3.1.0 and nothing before it, and the moment 3.1.0
-         is tagged this number MUST move to 3.2.0 so continuous builds sort above the release again
-         (release.yml opens that PR itself; a continuous build stamped with an already-released
-         number is the defect the .ci.<n> suffix exists to prevent). No pre-release label: `-ci.N`
-         is the only one, and it is the channel marker, never a version.
+         🚨 Read that carefully: a 3.0.0-ci.<n> build sorts BELOW every 3.0.0-rc* image that is
+         already in the registry (SemVer §11.4 compares pre-release identifiers as text, and "ci"
+         < "preview1" < "rc"). So until the clean 3.0.0 exists, a Continuous install already on an
+         rc build sees nothing newer and stays put — never rolls back, never rolls forward. The
+         clean 3.0.0 outranks every rc, so the release is what moves the fleet; after it, 3.1.0-ci.<n>
+         outranks 3.0.0 and continuous rolling resumes. That is the price of releasing the number
+         the rc line was named for, and it is paid once. (Two 3.1.0-ci sets, 7832 and 7835, were
+         published while this file briefly read 3.1.0 on 2026-09-05; an install that took one of
+         them will not take the clean 3.0.0 — it waits for the first 3.1.0-ci build after the bump.)
 
-         🚨 There is no rc line any more (maintainer, 2026-09-05). The 3.0.0 line shipped rc1–rc13
-         as tags and NuGet packages and was never cut clean; rc10–rc13 were tagged while this
-         property still read rc9, and under SemVer §11.4 "rc13" sorts BELOW "rc2", so nuget.org
-         listed rc9 as the newest pre-release for the whole run. That is why the line was closed
-         rather than graduated: 3.1.0-ci.<n> outranks every 3.0.0-* by its minor number, no matter
-         how the labels compare. NuGet publication is retired with it — in-mesh source compiles
-         against the IMAGE, never against a feed (Doc/Architecture/PluginPackaging) — and the
-         packages already on nuget.org stay listed as history. Do not "fill in" a v3.0.0 tag: the
-         version never shipped clean, and minting it now would publish a superseded set for real.
-
-         History of the 3.0.0-rc line, kept because the release marker and bake identity notes
-         elsewhere cite these versions: rc3 2026-08-16 · rc4 never tagged (its packages would
-         have shipped the fourteen driver DLLs being retired, #1882) · rc5 2026-08-19, tagged tree
-         could not boot (Modules:Assemblies listed removed DLLs; #1901) · rc6 2026-08-20, first
-         bootable release whose module bundles carry their own closures (#1914/#1919/#1923) · rc7
-         2026-08-22, the Blazor view packs and Speech leave the app closure (#2018/#2021/#2028) ·
-         rc8 2026-08-29, the registry shelf accepts modules for newer platforms (#2069/#2068) ·
-         rc9–rc13 2026-08-30/31, the plugin build CLI (#2834–#2858). -->
-    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.1.0</PlatformVersion>
+         The rc line, kept because the release marker and bake identity notes elsewhere cite these
+         versions: rc3 2026-08-16 · rc4 never tagged (its packages would have shipped the fourteen
+         driver DLLs being retired, #1882) · rc5 2026-08-19, tagged tree could not boot
+         (Modules:Assemblies listed removed DLLs; #1901) · rc6 2026-08-20, first bootable release
+         whose module bundles carry their own closures (#1914/#1919/#1923) · rc7 2026-08-22, the
+         Blazor view packs and Speech leave the app closure (#2018/#2021/#2028) · rc8 2026-08-29,
+         the registry shelf accepts modules for newer platforms (#2069/#2068) · rc9–rc13
+         2026-08-30/31, the plugin build CLI (#2834–#2858); rc10–rc13 were tagged while this read
+         rc9, and "rc13" sorts below "rc2", so nuget.org listed rc9 as the newest for the whole
+         run. NuGet publication is retired: in-mesh source compiles against the IMAGE, never against
+         a feed (Doc/Architecture/PluginPackaging); the packages on nuget.org stay as history. -->
+    <PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0</PlatformVersion>
   </PropertyGroup>
   <!-- Multi-arch container publish race fix (main-cd / release-images / edge-images pass
        -p:ContainerRuntimeIdentifiers="linux-x64;linux-arm64"). The SDK's _PublishMultiArchContainers
@@ -180,13 +182,13 @@
            Text="Container publish for RuntimeIdentifier '$(_MeshWeaverFailedLegRid)' reported success but produced NO image — CreateNewImage set no Manifest/Config/Digest. That task logs a swallowed cancellation as the bare warning 'The operation was canceled.' and still returns true, so the true fault is the warning IMMEDIATELY ABOVE this error, not this target. In CI it is a stalled connect (Microsoft.NET.Build.Containers hard-codes SocketsHttpHandler.ConnectTimeout=30s and drops the inner TimeoutException, so no host is logged): check the base registry '$(ContainerBaseRegistry)/$(ContainerBaseName):$(ContainerBaseTag)' and the output registry '$(ContainerRegistry)/$(ContainerRepository)', and look for a ~30 s gap in the timestamps before the warning. Do NOT respond by dropping a RID, disabling the image index, wrapping the publish in a retry, or suppressing this error — see issue #1026." />
   </Target>
   <!-- Two version channels — CONTINUOUS (CI) vs RELEASED (the promotion):
-       • RELEASED  (-p:PublicRelease=true): clean $(PlatformVersion), e.g. 3.1.0. Nothing BUILDS
+       • RELEASED  (-p:PublicRelease=true): clean $(PlatformVersion), e.g. 3.0.0. Nothing BUILDS
          with this flag any more — release.yml promotes an already-built continuous set by
          retagging it (the bytes are the ci build's); the flag survives for local experiments.
          The tag v$(PlatformVersion) is what the promotion keys on and what data-sync
          (DataSyncSetup.md §3) pulls content from once a release exists.
        • CONTINUOUS (default — CI pipeline and local dev): append a build number, e.g.
-         3.1.0-ci.7900, so continuous images are DISTINGUISHABLE from the release and a
+         3.0.0-ci.7900, so continuous images are DISTINGUISHABLE from the release and a
          local-deploy build always carries a build number.
        🚨 $(Version) — the run-numbered string — feeds NuGet package versions and Docker image
        tags ONLY. It must NOT reach any COMPILED attribute: under CIRun every compiled input is
@@ -212,13 +214,13 @@
   <!-- Pure functions of $(PlatformVersion). OUTSIDE the guard below, because the COMPILED
        attributes derive from them and must not vary with whether a caller supplied -p:Version=. -->
   <PropertyGroup>
-    <!-- Numeric version core: PlatformVersion with any pre-release label stripped (3.1.0 → 3.1.0;
-         a hypothetical 3.1.0-x → 3.1.0). The default carries no label since the rc line closed. -->
+    <!-- Numeric version core: PlatformVersion with any pre-release label stripped (3.0.0 → 3.0.0;
+         a hypothetical 3.0.0-x → 3.0.0). The default carries no label since the rc line closed. -->
     <_VersionDash>$(PlatformVersion.IndexOf('-'))</_VersionDash>
     <_VersionNumeric Condition="'$(_VersionDash)' == '-1'">$(PlatformVersion)</_VersionNumeric>
     <_VersionNumeric Condition="'$(_VersionDash)' != '-1'">$(PlatformVersion.Substring(0, $(_VersionDash)))</_VersionNumeric>
-    <!-- Pre-release separator for the ci.N suffix: a clean line (3.1.0, the default) starts the
-         pre-release with '-ci.N'; a labelled override (3.1.0-x) appends '.ci.N'. Both are valid
+    <!-- Pre-release separator for the ci.N suffix: a clean line (3.0.0, the default) starts the
+         pre-release with '-ci.N'; a labelled override (3.0.0-x) appends '.ci.N'. Both are valid
          SemVer. 🚨 Consumers that parse the build number back out of a version must accept BOTH
          separators ([.-]ci.<n>): the retired rc line used '.ci.' and its tags are still in ACR. -->
     <_CiSep Condition="'$(_VersionDash)' == '-1'">-</_CiSep>
@@ -289,7 +291,7 @@
          full bake runs ONCE per commit, on CI; pods adopt. -->
     <InformationalVersion Condition="'$(CIRun)' == 'true'">$(PlatformVersion)</InformationalVersion>
     <InformationalVersion Condition="'$(CIRun)' != 'true'">$(Version)</InformationalVersion>
-    <!-- 🔴 AssemblyVersion is STABLE within a line ($(_VersionNumeric).0, i.e. 3.1.0.0) — it is the
+    <!-- 🔴 AssemblyVersion is STABLE within a line ($(_VersionNumeric).0, i.e. 3.0.0.0) — it is the
          RUNTIME ASSEMBLY-BINDING identity, so it
          MUST be identical across every assembly in a coherent build. `_BuildNumber` is
          seconds-since-midnight/2 evaluated PER PROJECT at MSBuild time, so a time-based

--- a/src/MeshWeaver.Documentation/Data/Architecture/AuthoringDocumentation.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/AuthoringDocumentation.md
@@ -16,7 +16,7 @@ Documentation lives as markdown files under `src/MeshWeaver.Documentation/Data/`
 | `Data/Architecture.md` | `Doc/Architecture` |
 | `Data/Architecture/AsynchronousCalls.md` | `Doc/Architecture/AsynchronousCalls` |
 | `Data/GUI/ContainerControl/Stack.md` | `Doc/GUI/ContainerControl/Stack` |
-| `Data/ReleaseNotes/3_1_0/index.md` | `Doc/ReleaseNotes/3_1_0` (an `index.md` *is* its folder's node) |
+| `Data/ReleaseNotes/3_0_0/index.md` | `Doc/ReleaseNotes/3_0_0` (an `index.md` *is* its folder's node) |
 
 Note the pairing: `Architecture.md` is the **index node** and the folder `Architecture/` holds its children. Agent definitions follow the same scheme under the **`Agent`** partition (`content/ai/Agent/Researcher.md` → `Agent/Researcher`), and skills under the **`Skill`** partition (`content/ai/Skill/code.md` → `Skill/code`).
 

--- a/src/MeshWeaver.Documentation/Data/Architecture/DataSyncSetup.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DataSyncSetup.md
@@ -157,7 +157,7 @@ The source enumerates nodes read from a **public GitHub repository** over HTTP �
 list the tree, fetch each authored MeshNode file's content, map file→node. Pin the
 ref to the **commit the binary was built from** — every CI assembly carries it as
 `AssemblyMetadata("MeshWeaverCommitHash")` — or, on a clean release, to the immutable
-tag `v$(PlatformVersion)` (e.g. `v3.1.0`), which names the same tree. Set
+tag `v$(PlatformVersion)` (e.g. `v3.0.0`), which names the same tree. Set
 `Versioned = true`, so the fingerprint changes exactly when the source commit changes
 and a boot at the same commit is a no-op (§3). No clone, no working copy: the GitHub
 REST API (`git/trees/{ref}?recursive=1` for the listing) + `raw.githubusercontent.com`
@@ -167,9 +167,9 @@ REST API (`git/trees/{ref}?recursive=1` for the listing) + `raw.githubuserconten
 > 🥚 **Which ref: the stamped commit, or the release tag.** A binary CAN know its own
 > commit: CI stamps `$(GITHUB_SHA)` / `SourceRevisionId` into every assembly
 > (`Directory.Build.props` → `MeshWeaverCommitHash`), because the hash names the tree
-> being built, not the build. A continuous build (`3.1.0-ci.<n>`) therefore syncs from
+> being built, not the build. A continuous build (`3.0.0-ci.<n>`) therefore syncs from
 > that commit — there is no tag for it, and there never will be. A clean release
-> (`3.1.0`) may sync from `v$(PlatformVersion)` instead; it resolves to the same tree,
+> (`3.0.0`) may sync from `v$(PlatformVersion)` instead; it resolves to the same tree,
 > because a release is a promotion of a continuous build, never a rebuild
 > ([ReleaseProcess.md](/Doc/Architecture/ReleaseProcess)). A release tag must be
 > **immutable** (annotated, never force-moved) so the fingerprint is sound.
@@ -238,7 +238,7 @@ redeploy:
   "targetPartition": "Doc",
   "source":  "github",
   "url":     "https://github.com/Systemorph/MeshWeaver",
-  "ref":     "v3.1.0",       // immutable release tag (or the stamped commit) = the version gate (§3, §4c)
+  "ref":     "v3.0.0",       // immutable release tag (or the stamped commit) = the version gate (§3, §4c)
   "path":    "src/MeshWeaver.Documentation/Data",
   "enabled": true
 }
@@ -250,7 +250,7 @@ stamped commit on a continuous build (§4c) — never a moving branch, so the fi
 single canonical GitHub tree URL:
 
 ```
-https://github.com/Systemorph/MeshWeaver/tree/v3.1.0/src/MeshWeaver.Documentation/Data
+https://github.com/Systemorph/MeshWeaver/tree/v3.0.0/src/MeshWeaver.Documentation/Data
 ```
 
 Bumping the sync to a newer release is one edit to the config node's `ref` (or, for

--- a/src/MeshWeaver.Documentation/Data/Architecture/DeploymentOptions.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/DeploymentOptions.md
@@ -97,7 +97,7 @@ Claude is **not** a shared org key. Each user connects the co-hosted **Claude Co
 Anything in `.cs` (e.g. the Claude Code PTY fix, the static-catalog behaviour) only ships in a **new image**:
 
 1. **Build + push.** Three paths, and the normal one is the first:
-   - **Continuous (default):** merge to `main` → `main-cd.yml` builds and pushes `3.1.0-ci.<n>` to **ACR** (`meshweaver.azurecr.io`). This is what the portals self-update onto. It also runs on an hourly reconcile schedule and `workflow_dispatch`.
+   - **Continuous (default):** merge to `main` → `main-cd.yml` builds and pushes `3.0.0-ci.<n>` to **ACR** (`meshweaver.azurecr.io`). This is what the portals self-update onto. It also runs on an hourly reconcile schedule and `workflow_dispatch`.
    - **Official release:** push an annotated `v*.*.*` tag on a promoted, sealed commit → `release.yml` retags that set with the clean version in ACR and mirrors it to **GHCR**. Nothing is rebuilt ([Release Process](/Doc/Architecture/ReleaseProcess)).
    - **Manual (break-glass):** `dotnet publish -t:PublishContainer` straight to ACR — see [DeploymentAKS.md](/Doc/Architecture/DeploymentAKS) §1. 🚨 Only usable with the self-updater paused, because a non-SemVer tag is not a self-update candidate and the poller will roll the Deployment back off it.
 2. **Roll the cluster to it.** Because the API server is private, run server-side via `az aks command invoke`:

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseProcess.md
@@ -24,7 +24,7 @@ One number, two channels, one set of bytes. The whole scheme lives in
 
 ```xml
 <!-- Directory.Build.props -->
-<PlatformVersion Condition="'$(PlatformVersion)' == ''">3.1.0</PlatformVersion>
+<PlatformVersion Condition="'$(PlatformVersion)' == ''">3.0.0</PlatformVersion>
 ```
 
 The single maintained version names the **next release**. Every continuous build derives its
@@ -32,36 +32,43 @@ version from it by appending the CI run number as the one and only pre-release i
 
 | Build | Version | Where it comes from |
 |---|---|---|
-| continuous (CI) | `3.1.0-ci.7900` | `main-cd.yml`, every green merge to `main` |
-| local | `3.1.0-ci.0` | any `dotnet build` on a developer machine |
-| release | `3.1.0` | `release.yml`, on the annotated tag `v3.1.0` — a **promotion** of one of the continuous builds above |
+| continuous (CI) | `3.0.0-ci.7900` | `main-cd.yml`, every green merge to `main` |
+| local | `3.0.0-ci.0` | any `dotnet build` on a developer machine |
+| release | `3.0.0` | `release.yml`, on the annotated tag `v3.0.0` — a **promotion** of one of the continuous builds above |
 
 The ordering is what the self-updater relies on (`VersionSelect`, SemVer 2 via `NuGetVersion`):
 
 ```
-3.0.0-rc9.ci.7818  <  3.0.0-rc13  <  3.1.0-ci.1  <  3.1.0-ci.7900  <  3.1.0  <  3.2.0-ci.1
+3.0.0-ci.7900  <  3.0.0-preview1  <  3.0.0-rc9.ci.7818  <  3.0.0-rc13  <  3.0.0  <  3.1.0-ci.1
 ```
 
-Three consequences, all load-bearing:
+Four consequences, all load-bearing:
 
-- **Continuous installs always move forward.** `3.1.0-ci.<n>` outranks every `3.0.0-*` by its
-  minor number, and `<n>` is the GitHub Actions run number, monotonic per workflow. 🔴 Do not
-  replace it with anything that can reset (the old seconds-since-midnight number made a morning
-  build sort below the previous evening's).
+- **`<n>` is the GitHub Actions run number**, monotonic per workflow, so within a line newer
+  builds sort higher. 🔴 Do not replace it with anything that can reset (the old
+  seconds-since-midnight number made a morning build sort below the previous evening's).
 - **A Stable install takes the clean release and nothing before it.** `Stable` selects
   `!IsPrerelease`; the only clean tags are the promoted ones.
-- **The number must move the day a release is tagged.** `3.1.0-ci.7950` sorts *below* `3.1.0`, so
+- **The number must move the day a release is tagged.** `3.0.0-ci.7950` sorts *below* `3.0.0`, so
   a continuous build stamped with an already-released number would stop every Continuous install
-  from rolling forward. `release.yml` opens the pull request that moves the line to `3.2.0` itself;
+  from rolling forward. `release.yml` opens the pull request that moves the line to `3.1.0` itself;
   rc6 shipped with the props still reading rc6 and rc10–rc13 were tagged with them on rc9, which is
   why that bump is no longer a human step.
+- 🚨 **Until `3.0.0` is cut, a `3.0.0-ci.<n>` build sorts BELOW every `3.0.0-rc*` image already in
+  the registry** — SemVer §11.4 compares pre-release identifiers as text, and `ci` < `preview1` <
+  `rc`. A Continuous install already on an rc build therefore sees nothing newer and stays put
+  (never rolls back, never rolls forward) until the clean `3.0.0` lands, which outranks every rc.
+  That is the price of releasing the number the rc line was named for, paid once; after the
+  release, `3.1.0-ci.<n>` outranks `3.0.0` and continuous rolling resumes. Two `3.1.0-ci` sets
+  (7832, 7835) exist from the hours on 2026-09-05 when the props briefly read 3.1.0; an install
+  that took one of them will not take the clean `3.0.0` and waits for the first `3.1.0-ci` build.
 
-> 🚨 **There is no rc line.** The `3.0.0-rc1` … `3.0.0-rc13` labels were retired on 2026-09-05 and
-> `3.0.0` was never cut clean. Two reasons, one of them a trap worth remembering: SemVer §11.4
-> compares pre-release identifiers as text, so `rc13 < rc2`, and nuget.org listed `rc9` as the
-> newest pre-release for the whole run; and a "candidate" that is rebuilt on tagging is not a
-> candidate of anything (§4). A clean line has neither problem: the build number is the only
-> pre-release identifier, and it compares numerically. Do not "fill in" `v3.0.0`.
+> 🚨 **There is no rc line and there will be none** (maintainer, 2026-09-05). `3.0.0-rc1` …
+> `3.0.0-rc13` were tagged and rebuilt on tagging, which made each "candidate" a candidate of
+> nothing (§4), and SemVer sorted `rc13` below `rc2`, so nuget.org listed `rc9` as the newest
+> pre-release for the whole run. The clean line has neither problem: the build number is the only
+> pre-release identifier, and it compares numerically. The release is cut **only when every open
+> issue is closed** (maintainer, same day); until then main keeps producing `3.0.0-ci.<n>` sets.
 
 It is also the **data-sync content-version**: a continuous build syncs its docs and seed nodes
 from the commit stamped into its assemblies, a release from the tag `v$(PlatformVersion)` that
@@ -77,18 +84,18 @@ the *compiled attributes* is what makes a promotion possible at all:
 
 | | Flag | `Version` / image tag | `AssemblyVersion` | `FileVersion` | `InformationalVersion` |
 |---|---|---|---|---|---|
-| **CONTINUOUS** | *(default)* | `3.1.0-ci.<run>` | `3.1.0.0` | `3.1.0.0` | `3.1.0+<sha>` under `CIRun` |
-| **RELEASED** | `-p:PublicRelease=true` | `3.1.0` | `3.1.0.0` | `3.1.0.0` | `3.1.0+<sha>` under `CIRun` |
+| **CONTINUOUS** | *(default)* | `3.0.0-ci.<run>` | `3.0.0.0` | `3.0.0.0` | `3.0.0+<sha>` under `CIRun` |
+| **RELEASED** | `-p:PublicRelease=true` | `3.0.0` | `3.0.0.0` | `3.0.0.0` | `3.0.0+<sha>` under `CIRun` |
 
 - **Nothing builds under `PublicRelease` any more.** The flag survives for local experiments; a
-  release is a continuous image retagged, so the bytes inside a `3.1.0` image report the
-  `3.1.0-ci.<n>` build they are, via `MESHWEAVER_PLATFORM_VERSION` in the image config. That is
+  release is a continuous image retagged, so the bytes inside a `3.0.0` image report the
+  `3.0.0-ci.<n>` build they are, via `MESHWEAVER_PLATFORM_VERSION` in the image config. That is
   deliberate: the release *is* that build.
-- **`AssemblyVersion` is STABLE within a line** (`3.1.0.0`) — the runtime assembly-binding
+- **`AssemblyVersion` is STABLE within a line** (`3.0.0.0`) — the runtime assembly-binding
   identity, identical across every assembly in one build. A per-project time-based number once
   made `Memex.Database.Migration` bind to `MeshWeaver.Documentation, Version=3.0.0.280` while the
   packaged DLL carried another number (#143); binding identity must not depend on wall-clock
-  time. It moves with the line (`3.2.0.0` after the next bump), which is fine: module bundles are
+  time. It moves with the line (`3.1.0.0` after the next bump), which is fine: module bundles are
   keyed by framework identity and re-baked per set, never bound by assembly version.
 - **`FileVersion` is pinned** for the same reason `InformationalVersion` is: both are *compiled*
   attributes, and CI compile inputs are **commit-deterministic**
@@ -113,7 +120,7 @@ the *compiled attributes* is what makes a promotion possible at all:
 ## 3. Commands
 
 ```bash
-# CONTINUOUS — CI and local. Nothing to add → 3.1.0-ci.<run> (3.1.0-ci.0 locally)
+# CONTINUOUS — CI and local. Nothing to add → 3.0.0-ci.<run> (3.0.0-ci.0 locally)
 dotnet build
 
 # What CI computes for an image (the same call main-cd.yml makes):
@@ -121,7 +128,7 @@ dotnet msbuild src/MeshWeaver.Mesh.Contract/MeshWeaver.Mesh.Contract.csproj \
   -getProperty:Version -p:CIRun=true -nologo
 
 # RELEASE — no command builds one. Push an annotated tag on a promoted, sealed commit:
-git tag -a v3.1.0 -m "MeshWeaver 3.1.0" <sha> && git push origin v3.1.0
+git tag -a v3.0.0 -m "MeshWeaver 3.0.0" <sha> && git push origin v3.0.0
 ```
 
 ### What `release.yml` does on that tag — and what it refuses
@@ -132,17 +139,17 @@ The lane **promotes**; it compiles nothing. In order:
    `main`, a commit whose `PlatformVersion` differs from the tag, and a version with no committed
    notes page at `Doc/ReleaseNotes/<x_y_z>`.
 2. **Resolves the continuous set** for the commit from the tags on `memex-portal-ai:<short-sha>`
-   (`3.1.0-ci.<n>` and the `<core>-p<plugins>` pair tag), and refuses a commit `main-cd` never
+   (`3.0.0-ci.<n>` and the `<core>-p<plugins>` pair tag), and refuses a commit `main-cd` never
    promoted — *"wait for CD, confirm `Plugins: bake + seal`, push the tag again"*.
 3. **Asserts the set is complete** (`check-image-set.sh`) **and sealed** for both the platform
    content and the Plugins modules (`check-release-availability.sh`).
-4. **Records the release marker** `_releases/3.1.0` on every artifact store, holding the same
+4. **Records the release marker** `_releases/3.0.0` on every artifact store, holding the same
    framework identity the continuous build recorded, and re-asserts availability under the clean
    name — the very question a Stable install's gate asks ([ReleaseGates](/Doc/Architecture/ReleaseGates)).
 5. **Retags** `memex-migration`, `mw-plugin-test`, then `memex-portal-ai` last (`<short-sha>` →
-   `3.1.0`, manifest-only, seconds), and mirrors the three to GHCR.
+   `3.0.0`, manifest-only, seconds), and mirrors the three to GHCR.
 6. **Publishes the GitHub Release** from the notes page.
-7. **Opens the pull request** that moves `PlatformVersion` to `3.2.0`.
+7. **Opens the pull request** that moves `PlatformVersion` to `3.1.0`.
 
 Everything the lane needs is asserted RED by a `preflight` job — no `continue-on-error`, no
 `if: secret != ''` (AGENTS.md: a gate never tests its own inputs).
@@ -151,14 +158,14 @@ Everything the lane needs is asserted RED by a `preflight` job — no `continue-
 
 ## 4. The workflow — continuous → release → next line
 
-1. **Iterate.** Every green merge ships `3.1.0-ci.<n>`; Continuous installs roll onto it.
+1. **Iterate.** Every green merge ships `3.0.0-ci.<n>` (see the ordering note in §1 for who rolls onto it).
 2. **Pick the build to release.** A commit whose CD run has `Promote`, `Verify every image
    shipped` **and** `Plugins: bake + seal` green — read the seal JOB, never the run's conclusion
    ([ContinuousDeliveryContract](/Doc/Architecture/ContinuousDeliveryContract)). Commit its notes
-   page, `Doc/ReleaseNotes/3_1_0`, first: the lane will not release without it.
-3. **Tag it, annotated.** `git tag -a v3.1.0 -m "MeshWeaver 3.1.0" <sha> && git push origin v3.1.0`.
+   page, `Doc/ReleaseNotes/3_0_0`, first: the lane will not release without it.
+3. **Tag it, annotated.** `git tag -a v3.0.0 -m "MeshWeaver 3.0.0" <sha> && git push origin v3.0.0`.
    The lane promotes the set (§3); Stable installs pick it up on their next check.
-4. **Merge the bump.** The lane's pull request moves the line to `3.2.0`; auto-arm enqueues it.
+4. **Merge the bump.** The lane's pull request moves the line to `3.1.0`; auto-arm enqueues it.
    Until it merges, no continuous build may be relied on to roll a Continuous install forward.
 
 > **Tagging discipline.** A version tag must be **immutable** (annotated, never force-moved): the

--- a/src/MeshWeaver.Documentation/Data/Architecture/ReleaseStrategy.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ReleaseStrategy.md
@@ -53,31 +53,32 @@ a reviewer enforce (c)+(d). The checklist is in `.github/pull_request_template.m
 
 ## 2. Versions: current-build vs official
 
-The one number is `PlatformVersion` in `Directory.Build.props` — **today `3.1.0`**, the *next*
+The one number is `PlatformVersion` in `Directory.Build.props` — **today `3.0.0`**, the *next*
 release. Every build derives its version from it ([details](/Doc/Architecture/ReleaseProcess)):
 
-- **Current build (continuous):** `3.1.0-ci.<n>` — the default. `<n>` is the **GitHub Actions run
+- **Current build (continuous):** `3.0.0-ci.<n>` — the default. `<n>` is the **GitHub Actions run
   number** (monotonic), so newer builds always sort higher. 🔴 This monotonicity is load-bearing: the
   self-updater picks the *newest* version, and the old seconds-since-midnight build number reset at
   midnight (a morning build would sort below the prior evening's). Do not revert it.
-- **Official release:** clean `3.1.0` — **the same bytes as one continuous build**, promoted by
-  `release.yml` when the annotated tag `v3.1.0` is pushed on a commit `main-cd` has promoted and
-  sealed. Nothing is rebuilt.
+- **Official release:** clean `3.0.0` — **the same bytes as one continuous build**, promoted by
+  `release.yml` when the annotated tag `v3.0.0` is pushed on a commit `main-cd` has promoted and
+  sealed. Nothing is rebuilt. Cut only when every open issue is closed.
 
-> 🚨 **No pre-release label on the core, and no rc line.** `3.1.0-ci.<n>` sorts above every
-> `3.0.0-*` by its minor number, below the clean `3.1.0`, and below the next line's first
-> `3.2.0-ci.1` — which is why the bump to `3.2.0` happens the day `3.1.0` is tagged (the lane opens
-> that pull request). The rc labels were retired on 2026-09-05: SemVer compares them as text, so
-> `rc13` sorted below `rc2`. See [Release Process & Versioning](/Doc/Architecture/ReleaseProcess) §1.
+> 🚨 **No pre-release label on the core, and no rc line.** `3.0.0-ci.<n>` sorts below the clean
+> `3.0.0` and below the next line's first `3.1.0-ci.1` — which is why the bump to `3.1.0` happens
+> the day `3.0.0` is tagged (the lane opens that pull request). It also sorts below the
+> `3.0.0-rc*` images already in the registry, so until the release lands a Continuous install on an
+> rc build stays where it is. The rc labels were retired on 2026-09-05: SemVer compares them as
+> text, so `rc13` sorted below `rc2`. See [Release Process & Versioning](/Doc/Architecture/ReleaseProcess) §1.
 
 ### Cutting an official release and starting the next line
 
-1. **Cut the official release:** commit the notes page `Doc/ReleaseNotes/3_1_0`, then push an
-   annotated `v3.1.0` tag on a promoted, sealed commit. `release.yml` retags that commit's set
+1. **Cut the official release:** commit the notes page `Doc/ReleaseNotes/3_0_0`, then push an
+   annotated `v3.0.0` tag on a promoted, sealed commit. `release.yml` retags that commit's set
    with the clean version in ACR, mirrors it to GHCR, records the release marker and publishes the
    GitHub Release. Stable installs pick it up.
 2. **Start the next line:** merge the pull request the lane opened —
-   `PlatformVersion` `3.1.0` → `3.2.0`. Continuous builds are now `3.2.0-ci.<n>`, above the release.
+   `PlatformVersion` `3.0.0` → `3.1.0`. Continuous builds are now `3.1.0-ci.<n>`, above the release.
 
 ---
 
@@ -88,8 +89,8 @@ string** — that tag is what each install compares.
 
 | Channel | Trigger | Version baked + image tag | Workflow |
 |---|---|---|---|
-| **Continuous** | green merge to `main` | `3.1.0-ci.<run#>` (+ short SHA + moving `main`) | `main-cd.yml` |
-| **Official** | push an annotated `v*.*.*` tag on a promoted, sealed commit | clean `3.1.0` — the continuous set **retagged** in ACR and mirrored to GHCR; nothing rebuilt | `release.yml` |
+| **Continuous** | green merge to `main` | `3.0.0-ci.<run#>` (+ short SHA + moving `main`) | `main-cd.yml` |
+| **Official** | push an annotated `v*.*.*` tag on a promoted, sealed commit | clean `3.0.0` — the continuous set **retagged** in ACR and mirrored to GHCR; nothing rebuilt | `release.yml` |
 
 So the continuous build produces all images, the release names one of them, and a running install
 only has to list ACR tags and pick the best per its policy. (`main-cd.yml` still rolls the environments once as
@@ -205,20 +206,20 @@ not `kubectl set image` by hand. The manual [AKS runbook](/Doc/Architecture/Depl
 
 | Step | Action | What ships | Who rolls to it |
 |---|---|---|---|
-| **a** | **Merge to `main`** (preconditions §1 green) | `main-cd.yml` builds the **multi-arch** image set (amd64 + arm64), tags it `3.1.0-ci.<run#>` (+ short SHA + moving `main`), pushes to **ACR**, bakes and seals | **Continuous** installs (dev/test) |
-| **b** | **Push the annotated tag `v3.1.0`** on a promoted, sealed commit | `release.yml` retags that set `3.1.0` in ACR, mirrors it to GHCR, records `_releases/3.1.0`, publishes the GitHub Release | **Stable** installs (prod) |
-| **c** | **Merge the bump** the lane opened (`PlatformVersion` → `3.2.0`) | continuous builds become `3.2.0-ci.<n>` | opens the next development line |
+| **a** | **Merge to `main`** (preconditions §1 green) | `main-cd.yml` builds the **multi-arch** image set (amd64 + arm64), tags it `3.0.0-ci.<run#>` (+ short SHA + moving `main`), pushes to **ACR**, bakes and seals | **Continuous** installs (dev/test) |
+| **b** | **Push the annotated tag `v3.0.0`** on a promoted, sealed commit | `release.yml` retags that set `3.0.0` in ACR, mirrors it to GHCR, records `_releases/3.0.0`, publishes the GitHub Release | **Stable** installs (prod) |
+| **c** | **Merge the bump** the lane opened (`PlatformVersion` → `3.1.0`) | continuous builds become `3.1.0-ci.<n>` | opens the next development line |
 
 ```bash
 # (a) ship a continuous build — just merge; CI builds + pushes + seals the image set
 git switch main && git pull
 
 # (b) cut the official release — an immutable, ANNOTATED tag on a commit whose CD run sealed
-#     (Doc/ReleaseNotes/3_1_0 must already be committed; the lane refuses a release without notes)
-git tag -a v3.1.0 -m "MeshWeaver 3.1.0" <sha> && git push origin v3.1.0
+#     (Doc/ReleaseNotes/3_0_0 must already be committed; the lane refuses a release without notes)
+git tag -a v3.0.0 -m "MeshWeaver 3.0.0" <sha> && git push origin v3.0.0
 
 # (c) open the next line — merge the pull request release.yml opened:
-#     release: PlatformVersion 3.1.0 → 3.2.0
+#     release: PlatformVersion 3.0.0 → 3.1.0
 ```
 
 > **(a) can look shipped and produce no image.** CD reacts to *MeshWeaver Build and Test* completing

--- a/src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0/index.md
+++ b/src/MeshWeaver.Documentation/Data/ReleaseNotes/3_0_0/index.md
@@ -1,18 +1,18 @@
 ---
-Name: MeshWeaver 3.1.0
+Name: MeshWeaver 3.0.0
 Category: Release Notes
 Description: The first clean release of the 3.x line — a modular platform that installs, updates and verifies itself; a tabbed home with apps and threads; live language services for NodeType authoring; German throughout; and a release that is a promotion of a tested continuous build, never a rebuild.
 Icon: Rocket
 ---
 
-# MeshWeaver 3.1.0
+# MeshWeaver 3.0.0
 
-**3.1.0 is the first clean release of the 3.x line.** The line ran as `3.0.0-rc1` through
-`3.0.0-rc13` between 2026-08-13 and 2026-08-31 and was never cut clean: the candidates were
-rebuilt on tagging rather than promoted, and SemVer sorts `rc13` below `rc2`, so the last four were
-invisible to anything that asked for "the newest". Both defects are gone with this release, and the
-number moved to `3.1.0` so that every continuous build since sorts above every `3.0.0-*` ever
-published (details in [Release Process & Versioning](/Doc/Architecture/ReleaseProcess)).
+**3.0.0 is the first clean release of the 3.x line.** It ran as `3.0.0-rc1` through `3.0.0-rc13`
+between 2026-08-13 and 2026-08-31, and none of those was a release of this build: each candidate
+was rebuilt on tagging rather than promoted, and SemVer sorts `rc13` below `rc2`, so the last four
+were invisible to anything that asked for "the newest". Both defects are gone: `3.0.0` is one
+sealed continuous build, `3.0.0-ci.<n>`, given its clean name, and there are no candidates any more
+(details in [Release Process & Versioning](/Doc/Architecture/ReleaseProcess)).
 
 Everything below shipped as continuous builds and has been running on production portals for
 weeks. The day-by-day record — 837 entries since 2026-07-08, 668 of them fixes — is the
@@ -22,10 +22,10 @@ weeks. The day-by-day record — 837 entries since 2026-07-08, 668 of them fixes
 
 ## A release is a promotion
 
-`3.1.0` is the same bytes as one `3.1.0-ci.<n>` build. Pushing the annotated tag resolves that
+`3.0.0` is the same bytes as one `3.0.0-ci.<n>` build. Pushing the annotated tag resolves that
 build's already-promoted, already-sealed image set, retags it with the clean version, copies the
 release marker under that name, publishes this page as the GitHub Release, and opens the pull
-request that moves the line to `3.2.0`. Nothing is compiled twice, so what is released is exactly
+request that moves the line to `3.1.0`. Nothing is compiled twice, so what is released is exactly
 what was tested, baked and sealed. NuGet publication is retired with the rc line: modules compile
 against the platform image, never against a package feed.
 
@@ -175,12 +175,13 @@ concurrency gates.
 
 ## Upgrading from a 3.0.0-rc build
 
-- **Nothing to do for a running installation.** Every `3.1.0-ci.<n>` build sorts above every
-  `3.0.0-*`, so a Continuous install rolls forward on its own; a Stable install takes `3.1.0`.
-  Module bundles are keyed by framework identity and re-baked per set, so the assembly version
-  moving to `3.1.0.0` changes nothing an install adopts.
+- **Nothing to do for a running installation.** The clean `3.0.0` sorts above every `3.0.0-rc*`
+  build, so a Continuous install rolls forward onto it on its own, and a Stable install takes it as
+  its first release. After it, the line moves to `3.1.0-ci.<n>` and continuous rolling resumes.
+  Module bundles are keyed by framework identity and re-baked per set, so nothing an install
+  adopts changes with the name.
 - **Module floors are satisfied.** A module declaring `minMeshVersion: 3.0.0-rc8` (or any
-  `3.0.0-*`) runs on `3.1.0`; the floor is judged as a regression check, never absolutely
+  `3.0.0-*`) runs on `3.0.0`; the floor is judged as a regression check, never absolutely
   ([Release gates](/Doc/Architecture/ReleaseGates)).
 - **NuGet is retired.** The last packages on nuget.org are `3.0.0-rc13` for the framework and
   `3.0.0-rc7` for `MeshWeaver.Hosting.PostgreSql`, `MeshWeaver.AI` and `MeshWeaver.Blazor`, which

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-module-built-in-the-image-carries-the-images-identity.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-a-module-built-in-the-image-carries-the-images-identity.md
@@ -11,7 +11,7 @@ Order: -20260905
 A module compiled inside the platform image loads into that image's process and is bound by its
 assemblies, so it must carry the platform's assembly version exactly. Until now that number had to
 be written into the module repository as a literal, and checked after the fact. The day the
-platform line moved from 3.0.0 to 3.1.0, every image build in the fleet went red on that literal;
+platform line was bumped to 3.1.0 for a few hours, every image build in the fleet went red on that literal;
 a repository that tried to derive the number instead found the in-image builder runs no MSBuild
 property functions, and every module came out `1.0.0.0`.
 

--- a/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-the-3-0-0-release-is-a-promotion.md
+++ b/src/MeshWeaver.Documentation/Data/WhatsNew/2026-09-05-the-3-0-0-release-is-a-promotion.md
@@ -1,26 +1,29 @@
 ---
-Name: The 3.1.0 line — a release is a promotion, not a rebuild
+Name: The clean 3.0.0 — a release is a promotion, not a rebuild
 Category: Feature
-Description: Every continuous build is now 3.1.0-ci.<n> and the next release is the clean 3.1.0, cut by promoting a sealed continuous set rather than building again. The rc line is closed and NuGet publication retired — modules compile against the image, never a package feed.
+Description: Every continuous build is now 3.0.0-ci.<n> and the release is the clean 3.0.0, cut by promoting a sealed continuous set rather than building again — after which the line moves to 3.1.0. The rc labels are gone and NuGet publication retired — modules compile against the image, never a package feed.
 Icon: Rocket
 Order: -20260905
 ---
 
-# The 3.1.0 line — a release is a promotion, not a rebuild
+# The clean 3.0.0 — a release is a promotion, not a rebuild
 
 The version you see under **Settings → About** changes shape today: continuous builds read
-`3.1.0-ci.<n>`, and the release that follows will be a plain `3.1.0`. The `-rc` labels that ran
-from `3.0.0-rc1` to `3.0.0-rc13` are gone, and so is the reason they existed.
+`3.0.0-ci.<n>`, and the release that follows will be a plain `3.0.0`, after which the line moves to
+`3.1.0-ci.<n>`. The `-rc` labels that ran from `3.0.0-rc1` to `3.0.0-rc13` are gone, and so is the
+reason they existed.
 
 ## What changes for an install
 
-- **Continuous installs** roll forward onto the first `3.1.0-ci.<n>` build exactly as before —
-  `3.1.0` outranks every `3.0.0-*` by its minor number, so nothing is held or rolled back.
-- **Stable installs** wait for the clean `3.1.0`. When it lands it is the *same bytes* as the
+- **Continuous installs** already on a `3.0.0-rc*` build stay where they are until the clean
+  `3.0.0` lands — SemVer sorts a `3.0.0-ci.<n>` build below an rc build, so nothing rolls back and
+  nothing rolls forward in between; the release outranks every rc, and after it `3.1.0-ci.<n>`
+  builds keep the roll going.
+- **Stable installs** wait for the clean `3.0.0`. When it lands it is the *same bytes* as the
   continuous build it was cut from: the release lane no longer compiles anything. It resolves the
   tagged commit's already-promoted, already-sealed set, retags the images with the clean version,
   copies the release marker under that name, publishes the GitHub Release from the committed
-  release notes, and opens the pull request that moves the line to `3.2.0`.
+  release notes, and opens the pull request that moves the line to `3.1.0`.
 - **Module authors** compile against the platform image, as they have since bundles replaced
   packages. NuGet publication is retired with the rc line; the packages already on nuget.org stay
   listed as history and nothing in the fleet restores from them.
@@ -35,7 +38,7 @@ second producer: what is tagged is what was tested, baked and sealed.
 
 The rc labels had a smaller problem with a large effect. SemVer compares pre-release identifiers as
 text, so `rc13` sorts *below* `rc2`, and nuget.org listed `rc9` as the newest pre-release for the
-whole run. A clean line has no such edge: `3.1.0-ci.7900 < 3.1.0 < 3.2.0-ci.1`, and the build number
+whole run. A clean line has no such edge: `3.0.0-ci.7900 < 3.0.0 < 3.1.0-ci.1`, and the build number
 is the only pre-release identifier left.
 
 Full mechanics: [Release Process & Versioning](/Doc/Architecture/ReleaseProcess) and


### PR DESCRIPTION
## Summary

Maintainer, this evening: *"let's then release 3.0.0 and then cut to 3.1.0. that was the intention"* — *"i don't want this rc business any more"* — *"i want to release it only when we have solved all issues"*.

- `PlatformVersion` **3.1.0 → 3.0.0**. Continuous builds are `3.0.0-ci.<n>`; the release is the clean `3.0.0`, a promotion of a sealed set (#3354's `release.yml`, unchanged), cut only once every open issue in #3355 is closed; the lane then opens the bump to `3.1.0`. No pre-release label anywhere. NuGet stays retired.
- `Doc/ReleaseNotes/3_1_0` → `3_0_0` (the page describes the 3.x line, which 3.0.0 is); the What's New entry from #3354 is renamed and reworded; `ReleaseProcess`, `ReleaseStrategy`, the `/release` skill and the props comment describe the 3.0.0-first order.

**The ordering cost, stated rather than hidden.** A `3.0.0-ci.<n>` build sorts *below* the `3.0.0-rc*` images already in ACR (SemVer §11.4 compares `ci` < `rc` as text), so until the clean `3.0.0` lands a Continuous install on an rc build stays put — never back, never forward. The clean `3.0.0` outranks every rc and is what moves the fleet; after it `3.1.0-ci.<n>` resumes rolling. Production is frozen (`UpdatePolicy None`) anyway. The two `3.1.0-ci` sets published while the props briefly read 3.1.0 (7832, 7835) outrank `3.0.0`; an install that took one will skip the release and wait for the first `3.1.0-ci` build after the bump. Whether to hide those two version tags in ACR is the maintainer's call (digests stay; Plugins pins by digest).

## Verification

- `dotnet msbuild -getProperty:Version`: `3.0.0-ci.7900` (CIRun, run 7900), `3.0.0` (PublicRelease); `AssemblyVersion` `3.0.0.0`.
- `test/MeshWeaver.Documentation.Test -c Release -warnaserror`: 0 warnings, 0 errors; **269/269** on an assembly that embeds the renamed What's New entry (link integrity over the moved notes page).
- `release.yml` needs no change: it refuses a tag whose version ≠ `PlatformVersion`, so `v3.0.0` on a commit at 3.0.0 with a `3.0.0-ci.<n>` sealed set is exactly what it accepts, and its next-line computation yields 3.1.0.

Plugins is unaffected (pins by digest; its `AssemblyVersion` follows the platform in hand since #1367).

Pairs-with: none — a version-number change removes no public surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JuXoLRvG9TfKh5mgnjGfmo
