### PR TITLE
Two keys for the code cell's provenance sentence — the last unowned line on that toolbar (#3203)

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ChromeAndContentLanguage.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ChromeAndContentLanguage.md
@@ -350,13 +350,14 @@ live — core owns the rule and one unowned pair.
 
 **Outstanding.**
 
-1. **Five `CodeViews` literals still render English for a German viewer** — the dialog title *"Save
-   Failed"* (5 sites), `"Code Files"`, `"Loading code…"`, `"Enter display name…"` and *"never
-   executed"*, all in `MeshWeaver.Plugins/src/MeshWeaver.Graph.Views/CodeViews.cs`. Their **core
-   catalog keys now exist** (`code.saveFailed`, `code.codeFiles`, `code.loadingCode`,
-   `code.enterDisplayName`, `code.neverExecuted`) — none had one before, which is why this could not
-   ship from Plugins alone. What remains is consuming them there. Tracked as
-   [MeshWeaver.Plugins#1308](https://github.com/Systemorph/MeshWeaver.Plugins/issues/1308).
+1. ~~**Five `CodeViews` literals still render English for a German viewer**~~ — **DONE**
+   (MeshWeaver.Plugins#1360): the dialog title *"Save Failed"*, `"Code Files"`, `"Loading code…"`,
+   `"Enter display name…"` and *"never executed"* all consume their core keys now, through
+   `CodeViews.Localized`/`OrAuthored` — the fallback that lets the catalog half and the consuming
+   half land in either order.
+
+   **What is left of this item is the PROVENANCE SENTENCE around `code.neverExecuted`**, described
+   below. Its keys did not exist either; they do now (`code.lastRun`, `code.lastRunBy`).
 
    🚨 **`code.neverExecuted` does not finish its own line, and that is worth knowing before the fix
    is called done.** Measured at MeshWeaver.Plugins `d3b5ae01`, the provenance text is a ternary

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.de.json
@@ -27,6 +27,8 @@
   "code.loadingCode": "Code wird geladen…",
   "code.enterDisplayName": "Anzeigenamen eingeben…",
   "code.neverExecuted": "nie ausgeführt",
+  "code.lastRun": "zuletzt ausgeführt {0}",
+  "code.lastRunBy": "zuletzt ausgeführt {0} von {1}",
   "common.send": "Senden",
   "common.sending": "Wird gesendet…",
   "common.copy": "Kopieren",

--- a/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
+++ b/src/MeshWeaver.Messaging.Hub/Localization/strings.en.json
@@ -27,6 +27,8 @@
   "code.loadingCode": "Loading code…",
   "code.enterDisplayName": "Enter display name…",
   "code.neverExecuted": "never executed",
+  "code.lastRun": "last run {0}",
+  "code.lastRunBy": "last run {0} by {1}",
   "common.send": "Send",
   "common.sending": "Sending...",
   "common.copy": "Copy",


### PR DESCRIPTION
`CodeViews` renders *"last run &lt;when&gt; by &lt;who&gt;"* from bare literals, with only the timestamp
owned — and that timestamp is deliberately **invariant** rather than the viewer's culture. That was
the right call, and its own comment says why: formatting the time in the reader's language while
*"last run"* and *"by"* stayed English would manufacture exactly the mixed-language line #3203 exists
to remove.

The condition that comment named — *"when the pin carries the keys"* — is now met. But the keys for
the **sentence** never existed. These are them:

| key | en | de |
|---|---|---|
| `code.lastRun` | `last run {0}` | `zuletzt ausgeführt {0}` |
| `code.lastRunBy` | `last run {0} by {1}` | `zuletzt ausgeführt {0} von {1}` |

**Parameterised, and that is the point.** German puts the actor after the verb phrase, so the
translator has to control the whole word order. Concatenating a localized *"by"* onto a localized
*"last run"* in code would hard-code English order into every language.

Placed beside `code.neverExecuted` — the other branch of the same ternary.

The consuming half is MeshWeaver.Plugins and may land in either order: `CodeViews` reads through
`Localized`/`OrAuthored`, which returns the authored English when the catalog answers with the key
itself, so a mesh whose image predates these entries shows English rather than a raw
`code.lastRunBy` token.

## Also: a stale "Outstanding" entry corrected

`ChromeAndContentLanguage` still listed *"Five `CodeViews` literals still render English for a German
viewer"* as outstanding. MeshWeaver.Plugins#1360 consumed all five. What actually remained of that
item is this provenance sentence — which is now what the entry says, rather than something a reader
would have to re-derive.

**Verified:** `MeshWeaver.Messaging.Hub.Test` 58/58 (`LocalizationTest` included);
`DocumentationLinkIntegrityTest` passes.

Pairs-with: none — adds catalog entries and a doc correction; removes no public surface.

Refs #3203