### PR TITLE
ci(#3349): refuse a PackageVersion removal nobody has checked against the satellites

### DIFF
--- a/.github/workflows/dotnet-test.yml
+++ b/.github/workflows/dotnet-test.yml
@@ -2246,6 +2246,77 @@ jobs:
           --surface-json "$RUNNER_TEMP/surface.json" \
           --pr-body-file "$RUNNER_TEMP/pr-body.md"
 
+  package-pin-removal:
+    name: "Satellite package pins (removal declared)"
+    # 🚨 THE GAP THIS CLOSES (#3349, measured on #3344). MeshWeaver.Plugins'
+    # `src/Directory.Packages.props` IMPORTS this repo's, so a satellite project may carry a
+    # versionless `<PackageReference Include="X" />` whose ONLY version source is an entry here.
+    # Remove that entry — even as collateral in an unrelated withdrawal — and the satellite stops
+    # restoring with NU1010, while BOTH repos stay green: nothing here consumes the package, and
+    # the satellite pins this repo at MW_PLATFORM_REF so its CI reads the old list until somebody
+    # moves the pin, on a different day. `main-cd` is the first lane that notices, and by then the
+    # damage is that no set seals — #3344 sealed nothing for ~80 minutes and reintroduced
+    # GHSA-2m69-gcr7-jv3q as NU1903. Doc/Architecture/CrossRepoPairGate → "An eighth shape".
+    #
+    # 🚨 WHY A DECLARATION AND NOT THE RESTORE THE ISSUE PROPOSED. Checking out
+    # MeshWeaver.Plugins here and restoring it is banned outright:
+    # PlatformNeverDependsOnPluginsGuard.ThePullRequestGate_ReachesIntoNoPluginRepository asserts
+    # this file contains ZERO actionable cross-repo hits, and both `repository:
+    # Systemorph/MeshWeaver.Plugins` and any line reading `plugins-repo` are hits. The ban is the
+    # point, not an obstacle: a gate on core's own pull requests whose verdict depends on a
+    # sibling's moving HEAD makes the SAME diff go red or green with no change of its own. So this
+    # gate does what the repo already does for the same SHAPE one category over — `Pairs-with:`
+    # for public surface — and asks the author to DECLARE what they checked.
+    #
+    # 🚨 NO SKIP-TRAPDOOR:
+    #   * the detector's self-test runs FIRST and fails this job — an unproven gate is no gate;
+    #   * no path filter — a pull request that touches nothing else would otherwise "pass" by not
+    #     running, and the props file is exactly what such a pull request edits;
+    #   * no `continue-on-error:` and no `if:` asking whether a secret is set — this gate needs NO
+    #     credential at all, which is why it also runs on FORK pull requests where the
+    #     credentialed gates cannot. The one exemption is on the EVENT: `merge_group` carries no
+    #     pull-request body, and a pull request cannot reach the queue without this job green,
+    #     since it is a `needs:` of the required check;
+    #   * an UNDECIDABLE read (a shallow fetch missing the merge base, a moved props file) exits
+    #     RED naming why — "couldn't tell" and "nothing was removed" must never be one colour.
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        # The gate compares HEAD against the merge base, so the base commit must be present.
+        fetch-depth: 0
+
+    - name: "Prove the pin gate is not vacuous (self-test)"
+      run: python3 scripts/check-package-pin-removal.py --self-test
+
+    # A pull-request body is attacker-controlled text: it goes to a FILE through the environment,
+    # never interpolated into a shell command.
+    - name: Capture the pull-request body
+      env:
+        PR_BODY: ${{ github.event.pull_request.body }}
+      run: |
+        set -euo pipefail
+        printf '%s' "${PR_BODY:-}" > "$RUNNER_TEMP/pr-body.md"
+        echo "Pull-request body: $(wc -c < "$RUNNER_TEMP/pr-body.md") bytes."
+
+    - name: "Every removed PackageVersion is declared"
+      run: |
+        set -euo pipefail
+        git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
+        # 🚨 The MERGE BASE, not the base branch tip — the same reasoning as every other diff gate
+        # here. Against the tip, an entry somebody else removed on main while this pull request is
+        # open reads as THIS pull request removing it, and the gate would demand a declaration for
+        # a change it did not make.
+        base=$(git merge-base "origin/${{ github.base_ref }}" HEAD)
+        echo "Comparing the central package list against merge base $base"
+        python3 scripts/check-package-pin-removal.py \
+          --base "$base" \
+          --pr-body-file "$RUNNER_TEMP/pr-body.md"
+
   collect-results:
     name: "Consolidate test results"
     # plugin-gate is a NEEDS so this required check cannot go green while the plugins are
@@ -2279,7 +2350,7 @@ jobs:
     # hours after the merge that causes it (#2689 records five incidents). Nothing on the causing
     # pull request goes red, so if this gate could not fail the required check it would be a
     # notification rather than a gate — and a notification is what the fleet already had.
-    needs: [precheck, build, test, doc-gate, licence-gate, clients-gate, record-signatures, workflow-shell, shared-rules, cross-repo-pair]
+    needs: [precheck, build, test, doc-gate, licence-gate, clients-gate, record-signatures, workflow-shell, shared-rules, cross-repo-pair, package-pin-removal]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 45
@@ -2629,6 +2700,19 @@ jobs:
         echo "::error::The 'Cross-repo pair (public surface)' gate concluded '${{ needs.cross-repo-pair.result }}' — see that job, which names the public types this diff removes from src/ and the state of every declared counterpart."
         echo "::error::This pull request removes public surface, which can red a plugin repo's trunk hours later on pull requests that did not make the change (#2689). Declare the counterpart in the PR BODY as 'Pairs-with: Systemorph/MeshWeaver.Plugins#904', or 'Pairs-with: none — <reason>' when no other repository is affected."
         echo "::error::ORDERING IS THE INVARIANT: the deleting half lands LAST. Merge the counterpart into its repo's default branch first, then re-run. Rationale: Doc/Architecture/CrossRepoPairGate."
+        exit 1
+
+    # ── …and an UNDECLARED PACKAGE-PIN REMOVAL decides it too (#3349) ───────────────────────
+    # `!= 'success'` rather than `== 'failure'`: a job that was skipped or cancelled produced no
+    # verdict, and no verdict must never read as passed. The event predicate is kept IDENTICAL to
+    # the gate's own `if:` so the two can never disagree about who is exempt — `pull_request` only,
+    # because the gate's second input is the pull-request BODY and a merge_group event carries none.
+    - name: Fail if a removed package pin was not declared
+      if: github.event_name == 'pull_request' && needs.package-pin-removal.result != 'success'
+      run: |
+        echo "::error::The 'Satellite package pins (removal declared)' gate concluded '${{ needs.package-pin-removal.result }}' — see that job, which names every PackageVersion this diff removes and whether it was declared."
+        echo "::error::A satellite consumes 47 of this repo's central pins VERSIONLESS, so removing one here stops MeshWeaver.Plugins restoring (NU1010) while both repos stay green — #3344 sealed nothing for ~80 minutes and reintroduced a CVE."
+        echo "::error::Check each removal with: grep -rn 'PackageReference Include=\"<id>\"' ../MeshWeaver.Plugins/src/*/*.csproj — then declare it in the PR BODY as 'Satellite-pins: <id> — what you checked'. Rationale: Doc/Architecture/CrossRepoPairGate."
         exit 1
 
     - name: Fail if the clients gate failed

--- a/scripts/check-package-pin-removal.py
+++ b/scripts/check-package-pin-removal.py
@@ -1,0 +1,351 @@
+#!/usr/bin/env python3
+"""Refuse a `PackageVersion` removal that nobody has checked against the satellites (#3349).
+
+THE SHAPE (CrossRepoPairGate → "An eighth shape", measured on #3344).
+`MeshWeaver.Plugins/src/Directory.Packages.props` IMPORTS this repo's `Directory.Packages.props`,
+so a satellite project may carry a versionless `<PackageReference Include="X" />` whose ONLY
+version source is an entry here. Remove that entry — even as collateral in an unrelated withdrawal
+— and the satellite stops restoring with `NU1010`.
+
+Both repos stay green while it is broken. Nothing here consumes the package, so no compile, test or
+gate in this repo can miss it; and the satellite pins this repo at `MW_PLATFORM_REF`, so ITS CI
+reads the old list until somebody moves the pin, on a different day, in a different pull request.
+The first lane that notices is `main-cd`, and by then the damage is that no set seals: #3344 cost
+~80 minutes of sealing nothing, and the same line was the CVE remedy for GHSA-2m69-gcr7-jv3q, so
+the removal was a security regression too.
+
+WHY A DECLARATION AND NOT A DERIVATION.
+The control the issue proposed — check out MeshWeaver.Plugins in core's pull-request lane and
+`dotnet restore` it — cannot be built here. `PlatformNeverDependsOnPluginsGuard.
+ThePullRequestGate_ReachesIntoNoPluginRepository` bans exactly that: both `repository:
+Systemorph/MeshWeaver.Plugins` and any line reading `plugins-repo` are actionable hits, and the
+pull-request gate must contain none. That ban is not incidental — a core verdict that depends on a
+sibling's moving HEAD makes the SAME diff go red or green with no change of its own, which is the
+failure the guard exists to prevent.
+
+A hand-maintained list of the load-bearing entries is the other obvious control, and it was written
+and discarded before this one: 47 of the satellite's 49 versionless references resolve here, so the
+list would go red on core pull requests whenever Plugins legitimately drops a dependency — taxing
+every unrelated change in this repo for a fact that lives in another one.
+
+So this gate does what the repo already does for the same SHAPE one category over. A change here
+that can silently break a satellite must be DECLARED in the pull-request body, exactly as
+`Pairs-with:` declares a public-surface counterpart. It is core-only: no checkout, no API read, no
+credential, no ledger entry, and nothing that can go red on somebody else's HEAD.
+
+WHAT IT CANNOT DO, said plainly. It does not know whether a removed pin is load-bearing — it makes a
+human find out, by running the grep the doc names. That is weaker than deriving the answer and is
+the honest cost of staying inside the dependency direction. It would have caught #3344, which
+removed an entry.
+
+DECLARATION SYNTAX (in the pull-request body, not in a fence):
+
+    Satellite-pins: <PackageId>[, <PackageId>…] — <what you checked and what you found>
+
+Every removed id must be named across the declarations. There is no blanket form, deliberately:
+"none of them matter" is the sentence that produced #3344.
+
+Usage:
+    check-package-pin-removal.py --base <sha> --pr-body-file <file>
+    check-package-pin-removal.py --self-test
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+PROPS = "Directory.Packages.props"
+
+# `<PackageVersion Include="X" Version="Y" />`, tolerant of attribute order and whitespace.
+PACKAGE_VERSION_RE = re.compile(r"""<PackageVersion\b[^>]*?\bInclude\s*=\s*["']([^"']+)["']""", re.I)
+
+HTML_COMMENT_RE = re.compile(r"<!--.*?-->", re.S)
+FENCE_RE = re.compile(r"^\s*(```+|~~~+)")
+
+# The em dash is what the doc and the sibling gate use; accept the ASCII forms too so a declaration
+# is never rejected over typography. The reason after it must be non-empty.
+DECLARATION_RE = re.compile(
+    r"^\s*Satellite-pins\s*:\s*(?P<ids>[^\r\n]*?)\s*(?:—|--|-)\s*(?P<reason>\S[^\r\n]*)$",
+    re.I,
+)
+
+
+def strip_non_prose(body: str) -> str:
+    """Remove HTML comments and fenced code blocks.
+
+    Both can only REMOVE candidate declarations, so this fails closed: quoting the syntax in a
+    fence (as this script's own docstring and the doc page do) never declares anything, and hiding
+    a real declaration in one makes the gate red rather than green.
+    """
+    body = HTML_COMMENT_RE.sub("", body)
+    out: list[str] = []
+    fence: str | None = None
+    for line in body.replace("\r\n", "\n").split("\n"):
+        m = FENCE_RE.match(line)
+        if m:
+            marker = m.group(1)
+            if fence is None:
+                fence = marker
+                continue
+            if marker == fence:
+                fence = None
+            continue
+        if fence is None:
+            out.append(line)
+    return "\n".join(out)
+
+
+def declared_ids(body: str) -> set[str]:
+    """Package ids named in `Satellite-pins:` declarations, case-preserved."""
+    found: set[str] = set()
+    for line in strip_non_prose(body or "").split("\n"):
+        # A quoted reply is somebody else's text being cited, not this author's declaration.
+        if line.lstrip().startswith(">"):
+            continue
+        m = DECLARATION_RE.match(line)
+        if not m:
+            continue
+        for raw in m.group("ids").split(","):
+            token = raw.strip().strip("`")
+            if token:
+                found.add(token)
+    return found
+
+
+def ids_in(text: str) -> set[str]:
+    return set(PACKAGE_VERSION_RE.findall(text))
+
+
+class Undecidable(Exception):
+    """The gate could not READ its subject.
+
+    🚨 Raised, never swallowed, and never folded into "nothing was removed". A shallow fetch that
+    does not contain the merge base, a renamed or moved props file, a git failure — each of those
+    means the answer is UNKNOWN, and reporting unknown as clean is the skip-trapdoor shape
+    AGENTS.md bans: it makes "the gate never ran" and "the gate passed" the same colour. #3344
+    slipped through precisely because every check was green over a fact nothing could see.
+    """
+
+
+def _git(args: list[str], cwd: Path) -> str:
+    proc = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise Undecidable(
+            f"`git {' '.join(args)}` failed ({proc.returncode}): {proc.stderr.strip() or '(no stderr)'}"
+        )
+    return proc.stdout
+
+
+def removed_ids(base: str, root: Path) -> tuple[set[str], int, int]:
+    """Ids present in the props file at `base` and absent at HEAD, plus both counts.
+
+    The counts are returned so the caller can refuse a STARVED read. A regex that stops matching —
+    an attribute rewritten, the file moved — would otherwise report "nothing removed" forever,
+    which is this gate reporting a clean tree while blind.
+    """
+    if not _git(["cat-file", "-t", base], root).strip():
+        raise Undecidable(f"{base} does not name an object in this checkout")
+
+    # `git show <base>:<path>` distinguishes "absent at base" from "base not fetched" only in its
+    # stderr, and both are Undecidable here — the file has existed since the repo did, so either
+    # answer means the read is wrong rather than that the list was empty.
+    before_text = _git(["show", f"{base}:{PROPS}"], root)
+
+    head_path = root / PROPS
+    if not head_path.is_file():
+        raise Undecidable(
+            f"{PROPS} is absent from the working tree — if it moved, this gate is pointed at the "
+            "wrong path and must be updated with it"
+        )
+    before = ids_in(before_text)
+    after = ids_in(head_path.read_text(encoding="utf-8"))
+    return before - after, len(before), len(after)
+
+
+def evaluate(removed: set[str], body: str) -> tuple[int, list[str]]:
+    """0 and an empty report when the diff is acceptable; 1 and the reasons when it is not."""
+    if not removed:
+        return 0, []
+
+    declared = {d.casefold() for d in declared_ids(body)}
+    undeclared = sorted(p for p in removed if p.casefold() not in declared)
+    if not undeclared:
+        return 0, []
+
+    lines = [
+        "This pull request REMOVES central package version(s) that a satellite may consume",
+        "versionless. Nothing in this repository can detect that, and the satellite pins this repo,",
+        "so both stay green while it is broken — see Doc/Architecture/CrossRepoPairGate → \"An",
+        "eighth shape\" (#3344 cost ~80 minutes of sealing nothing, and reintroduced a CVE).",
+        "",
+        "Undeclared removal(s):",
+    ]
+    lines += [f"  • {p}" for p in undeclared]
+    lines += [
+        "",
+        "Check each against the satellite, then declare it in the PULL REQUEST BODY:",
+        "",
+        "    grep -rn 'PackageReference Include=\"<id>\"' ../MeshWeaver.Plugins/src/*/*.csproj",
+        "",
+        "A versionless hit is a BLOCKER — keep the entry, or remove the reference there first.",
+        "Then add one line per id (outside any code fence):",
+        "",
+        "    Satellite-pins: <id> — what you checked and what you found",
+        "",
+        "There is deliberately no blanket form: \"none of them matter\" is the sentence that",
+        "produced #3344.",
+    ]
+    return 1, lines
+
+
+# ── self-test ────────────────────────────────────────────────────────────────────────────────────
+# 🚨 An unproven gate is no gate. This exercises BOTH directions — it must fire on an undeclared
+# removal and stay silent on an ordinary diff — plus the shapes that decide whether the matcher is
+# honest: a declaration inside a fence, a quoted reply, case folding, and a starved read.
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def check(name: str, got, want) -> None:
+        if got != want:
+            failures.append(f"  {name}: got {got!r}, want {want!r}")
+
+    # The extractor sees the real shape, in both attribute orders.
+    props = (
+        '<Project><ItemGroup>\n'
+        '  <PackageVersion Include="A.B" Version="1.0" />\n'
+        "  <PackageVersion Version=\"2.0\" Include='C.D' />\n"
+        '  <PackageVersion  Include = "E.F"  Version="3" />\n'
+        '</ItemGroup></Project>\n'
+    )
+    check("extract", ids_in(props), {"A.B", "C.D", "E.F"})
+    check("extract ignores PackageReference", ids_in('<PackageReference Include="X" />'), set())
+
+    # Fires on an undeclared removal.
+    rc, report = evaluate({"SQLitePCLRaw.lib.e_sqlite3"}, "an ordinary body")
+    check("undeclared removal fires", rc, 1)
+    check("names the package", any("SQLitePCLRaw.lib.e_sqlite3" in l for l in report), True)
+
+    # Silent when nothing was removed, whatever the body says.
+    check("no removal is silent", evaluate(set(), "")[0], 0)
+
+    # Accepts a declaration, including several ids on one line and case differences.
+    body = "Satellite-pins: SQLitePCLRaw.lib.e_sqlite3, Other.Pkg — grepped both, no versionless hit"
+    check("declared passes", evaluate({"SQLitePCLRaw.lib.e_sqlite3", "Other.Pkg"}, body)[0], 0)
+    check(
+        "declaration is case-insensitive",
+        evaluate({"sqlitepclraw.lib.e_sqlite3"}, body)[0],
+        0,
+    )
+
+    # A PARTIAL declaration is not a pass — the undeclared one still fires and is named alone.
+    rc, report = evaluate({"SQLitePCLRaw.lib.e_sqlite3", "Missing.One"}, body)
+    check("partial declaration fires", rc, 1)
+    check("names only the undeclared", any("Missing.One" in l for l in report), True)
+    check("does not name the declared", all("SQLitePCLRaw" not in l for l in report), True)
+
+    # …and the shapes that must NOT count as a declaration.
+    fenced = "```\nSatellite-pins: P — quoted in a fence\n```"
+    check("fenced declaration is not one", evaluate({"P"}, fenced)[0], 1)
+    check("commented declaration is not one", evaluate({"P"}, "<!-- Satellite-pins: P — no -->")[0], 1)
+    check("quoted reply is not one", evaluate({"P"}, "> Satellite-pins: P — somebody else")[0], 1)
+    check("reasonless declaration is not one", evaluate({"P"}, "Satellite-pins: P")[0], 1)
+    check("empty reason is not one", evaluate({"P"}, "Satellite-pins: P — ")[0], 1)
+
+    # A declaration naming a DIFFERENT package does not cover this one.
+    check("wrong id does not cover", evaluate({"P"}, "Satellite-pins: Q — checked Q")[0], 1)
+
+    # 🚨 UNDECIDABLE IS RAISED, NOT RETURNED AS CLEAN. A bad base and a moved props file must both
+    # reach the caller as an exception; if either ever degraded to "nothing removed", this gate
+    # would pass on no evidence — the failure it exists to prevent.
+    import tempfile
+
+    with tempfile.TemporaryDirectory() as tmp:
+        empty = Path(tmp)
+        subprocess.run(["git", "init", "-q"], cwd=empty, check=True)
+        raised = False
+        try:
+            removed_ids("deadbeefdeadbeefdeadbeefdeadbeefdeadbeef", empty)
+        except Undecidable:
+            raised = True
+        check("unknown base raises Undecidable", raised, True)
+
+    root = Path(__file__).resolve().parent.parent
+    if (root / ".git").exists() and (root / PROPS).is_file():
+        # The real tree: HEAD against itself removes nothing, and the count is far above the floor.
+        removed_here, before_here, _ = removed_ids("HEAD", root)
+        check("HEAD vs HEAD removes nothing", removed_here, set())
+        check("the real list is read, not starved", before_here >= 50, True)
+
+    if failures:
+        print("self-test FAILED:", file=sys.stderr)
+        print("\n".join(failures), file=sys.stderr)
+        return 1
+    print("✓ check-package-pin-removal self-test: fires on an undeclared removal, stays silent on "
+          "an ordinary diff, and refuses a fenced, commented, quoted, reasonless or mis-named "
+          "declaration.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Refuse an undeclared PackageVersion removal (#3349).")
+    ap.add_argument("--base", help="merge-base sha to compare the package list against")
+    ap.add_argument("--pr-body-file", help="file holding the pull-request body")
+    ap.add_argument("--self-test", action="store_true", help="prove the gate is not vacuous")
+    args = ap.parse_args()
+
+    if args.self_test:
+        return self_test()
+    if not args.base or not args.pr_body_file:
+        ap.error("--base and --pr-body-file are required unless --self-test is given")
+
+    root = Path(__file__).resolve().parent.parent
+    try:
+        removed, before, after = removed_ids(args.base, root)
+    except Undecidable as e:
+        # 🚨 UNKNOWN IS RED. Never "no removal detected" — see Undecidable's remarks.
+        print(
+            f"::error::This gate could not read {PROPS} at the merge base, so it does not know "
+            f"whether a PackageVersion was removed: {e}. That is UNDECIDED, not clean — a shallow "
+            "fetch that misses the merge base, or a moved props file, would otherwise report a "
+            "clean tree forever. Fetch enough history (the lane fetches --depth=200) or repoint "
+            "the gate, then re-run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 🚨 A STARVED READ IS NOT A CLEAN ONE. If the props file suddenly declares almost nothing, the
+    # matcher has stopped seeing its subject and "nothing was removed" is meaningless. main carried
+    # 240+ entries when this was written; 50 is far below any legitimate tree and far above zero.
+    if before < 50:
+        print(
+            f"::error::{PROPS} declared only {before} PackageVersion entries at {args.base} — this "
+            "gate reads the list with a regex, and a count that low means it has stopped matching "
+            "rather than that the list shrank. Fix the matcher; do not trust this run.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"{PROPS}: {before} entries at {args.base[:9]}, {after} at HEAD, {len(removed)} removed.")
+    if not removed:
+        print("No PackageVersion removed — nothing to declare.")
+        return 0
+
+    body = Path(args.pr_body_file).read_text(encoding="utf-8")
+    rc, report = evaluate(removed, body)
+    if rc == 0:
+        print("Every removed entry is declared: " + ", ".join(sorted(removed)))
+        return 0
+
+    print("::error::" + report[0])
+    for line in report[1:]:
+        print(line)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/CrossRepoPairGate.md
@@ -255,23 +255,60 @@ was gone, which is what made the deletion read as deliberate in review.
 resolve their version from an entry here. Any one of them can be deleted with every core check
 green, and Plugins stops restoring.
 
-**There is NO guard for this yet, and a list would be the wrong one.** The obvious control — naming
-the load-bearing entries in a test here — was written, measured against that number, and discarded:
-a hand-maintained list of 47 goes red on core PRs whenever *Plugins* legitimately drops a
-dependency, taxing every unrelated change in this repo for a fact that lives in another one.
+**Two obvious controls are wrong, and knowing why is what makes the third one right.**
 
-The control that fits the shape is a **restore of the satellite tree in core's PR lane** — the same
-`actions/checkout` of `Systemorph/MeshWeaver.Plugins` that `main-cd` already does, followed by a
-`dotnet restore` of the projects that import this file. It is cheap (the failure is a restore
-diagnostic, not a build) and it derives the answer instead of remembering it. Until it exists,
-**this shape is uncovered**: when you remove an entry from `Directory.Packages.props`, grep the
-satellite for it by hand —
+*A list of the load-bearing entries* was written, measured against that number, and discarded: a
+hand-maintained list of 47 goes red on core PRs whenever *Plugins* legitimately drops a dependency,
+taxing every unrelated change in this repo for a fact that lives in another one.
+
+*A restore of the satellite tree in core's PR lane* — `actions/checkout` of
+`Systemorph/MeshWeaver.Plugins` followed by a `dotnet restore`, the way `main-cd` does — derives the
+answer instead of remembering it, and is the control this page recommended until #3349.
+**It cannot be built here.** `PlatformNeverDependsOnPluginsGuard.ThePullRequestGate_ReachesIntoNoPluginRepository`
+asserts that `dotnet-test.yml` contains zero actionable cross-repo hits, and both
+`repository: Systemorph/MeshWeaver.Plugins` and any line reading `plugins-repo` are hits. That ban
+is the point rather than an obstacle: a gate on core's own pull requests whose verdict depends on a
+sibling's moving HEAD makes the *same* diff go red or green with no change of its own, and re-adding
+a checkout silently restores the external input that workflow was deliberately cleared of.
+
+### The gate that ships: declare the removal (#3349)
+
+`Satellite package pins (removal declared)` fires **only when the diff removes a `PackageVersion`**
+and requires the pull-request body to name each removed id:
+
+```
+Satellite-pins: <PackageId>[, <PackageId>…] — <what you checked and what you found>
+```
+
+It is the same instrument this page already describes for public surface, applied to the same shape
+one category over: a package pin is a `Pairs-with:` case that happens not to be C#. Core-only — no
+checkout, no API read, no credential, no ledger entry, nothing that can go red on somebody else's
+HEAD — so it also runs on **fork** pull requests, where the credentialed gates cannot.
+
+**What it does not do, stated plainly:** it does not know whether a removed pin is load-bearing. It
+makes a human find out, with the grep below, and say what they found. That is weaker than deriving
+the answer and is the honest price of staying inside the dependency direction. There is deliberately
+**no blanket form** — *"none of them matter"* is the sentence that produced #3344.
 
 ```
 grep -rn 'PackageReference Include="<id>"' ../MeshWeaver.Plugins/src/*/*.csproj
 ```
 
-— and treat a versionless hit as a blocker.
+A versionless hit is a **blocker**: keep the entry, or remove the reference there first.
+
+**Proven against the incident, not just against fixtures.** Replaying #3344's own commit
+(`c08fee100`) with its three *intended* withdrawals declared, the gate reds naming exactly the
+fourth:
+
+```
+Undeclared removal(s):
+  • SQLitePCLRaw.lib.e_sqlite3
+```
+
+That is the collateral removal that cost ~80 minutes of sealing nothing and reintroduced the CVE.
+An **undecidable** read — a shallow fetch missing the merge base, a moved props file, a matcher that
+stopped matching — exits RED naming why, never "nothing was removed": *couldn't tell* and *clean*
+must never be one colour, which is the failure that let #3344 through with every check green.
 
 
 ## Member-level detection (the sixth shape)


### PR DESCRIPTION
Closes #3349.

## Not the control the issue specified, and the reason is the interesting part

#3349 proposed checking out `Systemorph/MeshWeaver.Plugins` in core's pull-request lane and running
`dotnet restore`. **That cannot be built here.**
`PlatformNeverDependsOnPluginsGuard.ThePullRequestGate_ReachesIntoNoPluginRepository` asserts
`dotnet-test.yml` contains **zero** actionable cross-repo hits, and its matcher counts exactly the two
things that control needs:

```
repository: Systemorph/MeshWeaver.Plugins     ← actionable
plugins-repo                                  ← actionable (anything reading the checked-out tree)
```

It would have failed on its first run. And the ban is the point rather than an obstacle — the guard
names the precise harm the proposal causes:

> *"a gate on core's own pull requests whose verdict depends on another repository's moving HEAD
> makes the SAME diff go red or green with no change of its own"* … *"Re-adding a checkout silently
> undoes both."*

The repo had already weighed that trade and decided against it. (The issue author has verified this
independently and corrected #3349.)

## What ships instead

The same instrument this repo already uses for the same **shape** one category over. A change here
that can silently break a satellite gets **declared** — exactly as `Pairs-with:` declares a
public-surface counterpart. A package pin is that shape without being C#.

The gate fires **only when the diff removes a `PackageVersion`**, and requires each removed id in the
PR body:

```
Satellite-pins: <PackageId>[, <PackageId>…] — <what you checked and what you found>
```

There is deliberately **no blanket form**: *"none of them matter"* is the sentence that produced #3344.

**Core-only** — no checkout, no API read, no credential, no ledger entry, nothing that can go red on
somebody else's HEAD. A consequence worth having: it also runs on **fork** pull requests, where the
credentialed gates cannot.

**What it does not do, stated plainly.** It does not know whether a removed pin is load-bearing; it
makes a human find out and say what they found. That is weaker than deriving the answer, and it is
the honest price of staying inside the dependency direction. #3344 *removed an entry*, so it fires.

## Proven against the incident, not against fixtures

Replaying #3344's own commit (`c08fee100`) against its parent, with the three withdrawals it
**intended** declared, the gate reds naming exactly the fourth:

```
Undeclared removal(s):
  • SQLitePCLRaw.lib.e_sqlite3
```

That is the collateral removal that cost ~80 minutes of sealing nothing and reintroduced
GHSA-2m69-gcr7-jv3q. With an empty body it names all four.

**Premise verified rather than assumed:** `MeshWeaver.Hosting.Sqlite.csproj` consumes that package
**versionless**, and core references it in **no** csproj — the satellite-only case exactly.

## Fails closed

An **undecidable** read raises and exits RED naming why — a shallow fetch missing the merge base, a
moved props file, a git failure — never *"nothing was removed"*. A **starved** list (< 50 entries
where `main` has 151) is refused as a broken matcher rather than trusted as a shrunken list.
*Couldn't tell* and *clean* must never be one colour; that is how #3344 passed with every check green.

## Non-vacuity

`--self-test` runs first and fails the job. It proves both directions plus the shapes that decide
whether the matcher is honest: fenced, commented, quoted, reasonless and mis-named declarations are
all refused; a **partial** declaration names only what is still undeclared; and the undecidable paths
raise rather than return clean. It also reads the **real** tree, so a matcher that stopped matching
fails the self-test rather than reporting a clean diff.

## Docs

`CrossRepoPairGate` → *"An eighth shape"* said **"There is NO guard for this yet"** and recommended
the checkout. Both are now false; the section is rewritten to say which two controls are wrong and
why, and to carry the replay above.

## Verification

| | |
|---|---|
| `check-workflow-timeouts.py` | 66 jobs, **0 violations**, cap 45 min |
| `check-workflow-shell.py` | clean |
| `Documentation.Test` guards | **10/10**, incl. `PlatformNeverDependsOnPluginsGuard` |
| `DocumentationLinkIntegrityTest` | pass |
| the gate on its own diff | `0 removed — nothing to declare` |

Satellite-pins: none removed by this change — the gate's own run on this diff reports "0 removed", so there is nothing to declare

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
