### PR TITLE
docs: a head-truncated view of ordered output is biased, not merely partial

### DIFF
--- a/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
+++ b/src/MeshWeaver.Documentation/Data/Architecture/ControlsThatCannotFail.md
@@ -42,7 +42,7 @@ instances. The family is larger, and it is worth recognising by shape.
 | **Blindness rendered as health** | a watcher whose read failure and whose "no matches" look identical | "I cannot see" is reported as "nothing is wrong" |
 | **One word covering three states** | `completed/success` over checked-and-passed, never-ran, and ran-and-did-nothing | the verdict is not the outcome |
 | **A tool that collapses several failures into one exit code** | `git cat-file -e "$sha:$path" \|\| echo ABSENT` | absent-path, bad-sha, missing-object and bad-quoting all read the same |
-| **A measurement that truncates and answers anyway** | a profiler capping at N objects and reporting the partial total | the wrong number is *plausible*, so it closes the investigation |
+| **A measurement that truncates and answers anyway** | a profiler capping at N objects; `\| head -10` on a sorted sweep | the wrong number is *plausible* — and on ordered output the survivors are biased, so a partial view reads as a clean one |
 | **A writer whose failure mode is a SUCCESS line** | a generator that skips its work and prints a summary anyway | nothing distinguishes "wrote it" from "declined to" |
 
 ## Eight measured instances
@@ -139,7 +139,23 @@ looks like an answer. Trusting it produces a confident, wrong conclusion — *th
 elsewhere* — which is strictly worse than no measurement, because it closes the investigation.
 
 Same shape as an anchor emitting a meaningless-but-non-blank value, one layer down: one number
-covering *"this is the heap"* and *"this is as much of the heap as the tool chose to walk"*. **The cure
+covering *"this is the heap"* and *"this is as much of the heap as the tool chose to walk"*.
+
+🚨 **And it happens in the shell, where the truncation is BIASED toward exactly the answer you were
+hoping for.** A sweep for ambient-culture uses in a satellite repo was run as `git grep … | head -10`
+and reported **zero** production offenders. The sweep had **19** lines and the real offender was
+number **18** — because comments and test files sort early, clustering in doc-heavy and `*.Test`
+paths, so the first ten lines were *all* commentary and tests. The truncated view did not look
+partial; it looked clean. The same person had been caught by the same shape four hours earlier, in a
+different costume: `… | tee list.txt | head -30` let `head` close the pipe, `SIGPIPE` truncated what
+`tee` wrote, and a satellite-only package sweep reported **31** where the truth was **49** — with the
+tell being that the one package which had just taken CD down was missing from its own sweep.
+
+This is the ordinary case, not an exotic one: `grep`, `git grep`, `ls` and `find` all emit in a sorted
+or otherwise structured order, so **a head-truncated view is a systematically unrepresentative
+sample, not a random one** — and the bias points toward whichever files sort first, which is usually
+the ones you were not looking for. **Count first (`| wc -l`), filter comments and tests INSIDE the
+pipeline, and treat `head` as a way to eyeball SHAPE — never as a way to establish ABSENCE.** **The cure
 here is not "go break the subject" but a second instrument that can DISAGREE** — which is what caught
 it. (A companion from the same session fails the honest way and is worth the contrast: SOS
 `dumpobj`/`gcroot` **segfault** on that process, so field-following had to move to ClrMD. A tool that


### PR DESCRIPTION
Strengthens the truncation row in `ControlsThatCannotFail` rather than adding an instance — it is the
same shape as the `dotnet-gcdump` entry it sits beside, one layer down: in the **shell**, not the
profiler.

## The new part is *why* it fools people

Not "someone forgot the output was truncated". A sweep for ambient-culture uses in a satellite ran as:

```
git grep 'CultureInfo\.Current' -- 'src/**/*.cs' | head -10
```

…and reported **zero** production offenders. The sweep had **19** lines. The real offender was number
**18**.

Comments and test files **sort early** — they cluster in doc-heavy and `*.Test` paths — so the first
ten lines were entirely commentary and tests. **The truncated view did not look partial. It looked
clean.**

Same person, same day, four hours earlier, different costume:

```
… | tee list.txt | head -30
```

`head` closed the pipe, `SIGPIPE` truncated what `tee` wrote, and a satellite-only package sweep
reported **31** where the truth was **49** — the tell being that the one package which had just taken
CD down was missing from its own sweep.

## So the rule is sharper than "beware truncation"

`grep`, `git grep`, `ls` and `find` all emit in sorted or otherwise structured order. That makes a
head-truncated view a **systematically unrepresentative** sample rather than a random one — and the
bias points at whatever sorts first, which is usually the thing you were *not* looking for.

> **Count first (`| wc -l`), filter comments and tests INSIDE the pipeline, and treat `head` as a way
> to eyeball SHAPE — never as a way to establish ABSENCE.**

## Provenance

The measurements are the core-CD session's, from its own retraction of a sweep it had handed me as
fact. The offender that sweep missed is real — `ConfiguredExcelImporter.GetCellDouble` falling back to
`CultureInfo.CurrentCulture`, filed as MeshWeaver.Plugins#1375, and guarded as the single known-debt
entry in MeshWeaver.Plugins#1376.

## Verification

`DocumentationLinkIntegrityTest` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
