### PR TITLE
test(#3370): the bake assertions print WHY, instead of the first 50 characters

### DIFF
--- a/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
@@ -207,7 +207,13 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
             });
             output.WriteLine("── compiler-driven bake ──");
             output.WriteLine(treeLog.ToString());
-            Assert.Null(treeReport.FatalError);
+            // 🚨 Assert.True with the message, NOT Assert.Null — xUnit renders a failing
+            // Assert.Null by truncating the value at 50 characters, so the ONE string that says why
+            // the bake failed arrives cut mid-word ("…bake: 'Widget/Thing' cl"···) and appears
+            // nowhere else in the log (#3370). The reader gets the failure without the diagnosis,
+            // and the next occurrence costs them the same dead end. This prints the whole message on
+            // failure and nothing on success.
+            Assert.True(treeReport.FatalError is null, treeReport.FatalError);
             Assert.All(treeReport.Types, t => Assert.Null(t.Error));
 
             // ── the MESH-driven bake: exactly what CI runs today ──
@@ -222,7 +228,8 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
             }).FirstAsync().Await();
             output.WriteLine("── mesh-driven bake ──");
             output.WriteLine(meshLog.ToString());
-            Assert.Null(meshReport.FatalError);
+            // Same reasoning as the compiler-driven arm above (#3370).
+            Assert.True(meshReport.FatalError is null, meshReport.FatalError);
 
             var mesh = ReadBakeDirectory(meshDir);
             var tree = ReadBakeDirectory(treeDir);


### PR DESCRIPTION
Part of #3370. **Does not fix the flake — makes it diagnosable**, which is currently the blocker to
fixing it.

## The problem

`BakeEquivalenceTest` asserted `Assert.Null(report.FatalError)` on both arms. xUnit renders a failing
`Assert.Null` by truncating the value at **50 characters**, so when the mesh-driven bake fatalled on
shard 3 the entire diagnosis available to the reader was:

```
Assert.Null() Failure: Value is not null
Expected: null
Actual:   "InvalidOperationException: bake: 'Widget/Thing' cl"···
```

Measured: that string is exactly **50** characters. The reason is cut mid-word — `cl…` — and appears
**nowhere else** in the log: not in stdout, not in the trx. The reader gets the failure without the
diagnosis, and a second occurrence leaves them exactly as far along as the first.

#3370 *is* that occurrence, and it is why that issue is filed without a root cause.

## The change

```csharp
Assert.True(report.FatalError is null, report.FatalError);
```

Prints the whole message on failure, nothing on success.

**Applied to both arms.** The compiler-driven assertion has the identical exposure and simply has not
fired yet — which is the worse of the two states to leave alone, since it will fire first for someone
who has no reason to suspect the assertion rather than the bake.

## Why this is worth a PR of its own

It is the same shape the repo has been naming all week: a control that detects correctly and then
hands the reader something they cannot act on. The bake test *did* its job — it caught a real
divergence between the two bakes. It then reported it in a form that cannot be investigated.

## Verification

Release + `-warnaserror`, `0 Error(s)`. `BakeEquivalenceTest` **2/2 pass**, so the green path is
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RpJi9EZHtGYQCahUwWa7jH
