### PR TITLE
fix(#3333): the bake failure says what it claims — Assert.Null truncates it

### DIFF
--- a/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
+++ b/test/MeshWeaver.PluginTester.Test/BakeEquivalenceTest.cs
@@ -207,8 +207,8 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
             });
             output.WriteLine("── compiler-driven bake ──");
             output.WriteLine(treeLog.ToString());
-            Assert.Null(treeReport.FatalError);
-            Assert.All(treeReport.Types, t => Assert.Null(t.Error));
+            Assert.True(treeReport.FatalError is null, treeReport.FatalError);
+            Assert.All(treeReport.Types, t => Assert.True(t.Error is null, $"{t.NodePath}: {t.Error}"));
 
             // ── the MESH-driven bake: exactly what CI runs today ──
             var meshReport = await PluginGateRunner.Run(new GateOptions
@@ -222,7 +222,14 @@ public class BakeEquivalenceTest(ITestOutputHelper output)
             }).FirstAsync().Await();
             output.WriteLine("── mesh-driven bake ──");
             output.WriteLine(meshLog.ToString());
-            Assert.Null(meshReport.FatalError);
+            // 🚨 Assert.True(…, message) rather than Assert.Null — xUnit renders a failed
+            // Assert.Null as `Actual: "…"···`, truncated at ~50 characters, and this bake's fatal
+            // errors are long by design: they name the type, the version claimed and what the store
+            // actually holds. #3333 has three sightings of this test, ALL reading
+            // `InvalidOperationException: bake: 'Widget/Thing' cl`···, and the version — the one
+            // fact that would settle whether the stamp or the store is wrong — has been cut off
+            // every time. A diagnostic nobody can read is not a diagnostic.
+            Assert.True(meshReport.FatalError is null, meshReport.FatalError);
 
             var mesh = ReadBakeDirectory(meshDir);
             var tree = ReadBakeDirectory(treeDir);


### PR DESCRIPTION
`BakeEquivalenceTest` has failed **three** times (#3332, #3366, #3369) and every sighting reads identically:

```
Assert.Null() Failure: Value is not null
Actual:   "InvalidOperationException: bake: 'Widget/Thing' cl"···
```

xUnit truncates a failed `Assert.Null` at ~50 characters. This bake's fatal errors are long **by design** — they name the type, the version claimed, and what the store actually holds:

> `bake: '{typePath}' claims a usable build at v{version} but the run's assembly store has NO bytes for it`

**The version is the one fact that decides whether the stamp is wrong or the store is**, and it has been cut off every time. Three investigations reasoned around it; the most recent concluded — wrongly — that `8614af280` had fixed the cause, because a green re-run was the only other evidence available. #3369 then failed on a tree that *contains* that fix.

`Assert.True(x is null, x)` prints it in full. Same for the tree-side report and the per-type errors, which also name the node path.

**This does not fix the flake.** It makes the next sighting diagnosable instead of a fourth round of inference — which is what is actually blocking progress on #3333.

Verified: `BakeEquivalenceTest` 2/2, Release `-warnaserror` clean.

Refs #3333 · `Pairs-with: none` — one test file.